### PR TITLE
[codex] Fix native logbook export delivery

### DIFF
--- a/mobile/android/app/capacitor.build.gradle
+++ b/mobile/android/app/capacitor.build.gradle
@@ -15,7 +15,9 @@ dependencies {
     implementation project(':capacitor-community-safe-area')
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
+    implementation project(':capacitor-filesystem')
     implementation project(':capacitor-geolocation')
+    implementation project(':capacitor-share')
 
 }
 

--- a/mobile/android/app/src/main/res/xml/file_paths.xml
+++ b/mobile/android/app/src/main/res/xml/file_paths.xml
@@ -2,4 +2,5 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="my_images" path="Pictures/" />
     <cache-path name="my_cache_images" path="images/" />
+    <cache-path name="logbook_exports" path="exports/" />
 </paths>

--- a/mobile/android/capacitor.settings.gradle
+++ b/mobile/android/capacitor.settings.gradle
@@ -20,5 +20,11 @@ project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/
 include ':capacitor-browser'
 project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
 
+include ':capacitor-filesystem'
+project(':capacitor-filesystem').projectDir = new File('../node_modules/@capacitor/filesystem/android')
+
 include ':capacitor-geolocation'
 project(':capacitor-geolocation').projectDir = new File('../node_modules/@capacitor/geolocation/android')
+
+include ':capacitor-share'
+project(':capacitor-share').projectDir = new File('../node_modules/@capacitor/share/android')

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -13,9 +13,11 @@
         "@capacitor/app": "^8",
         "@capacitor/browser": "^8",
         "@capacitor/core": "^8",
+        "@capacitor/filesystem": "^8",
         "@capacitor/geolocation": "8.1.0",
         "@capacitor/ios": "^8",
         "@capacitor/motion": "^8",
+        "@capacitor/share": "^8",
       },
       "devDependencies": {
         "@capacitor/cli": "^8.3.1",
@@ -42,11 +44,15 @@
 
     "@capacitor/core": ["@capacitor/core@8.3.0", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-S4ajn4G/fS3VJj8salxqH/3LO5PPWv1VxGKQ27OCajnDcLJjEg9VXwgMPnlypgkIOqCJ2fmQLtk8GT+BlI9/rw=="],
 
+    "@capacitor/filesystem": ["@capacitor/filesystem@8.1.2", "", { "dependencies": { "@capacitor/synapse": "^1.0.4" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-doaaMfGoFR2hWU6aV6u83I+5ZsGyJVq+Gz4r9lMpJzUKMm1eMu0hLnFdV1aXZlU9FlK/RndFrVD8oRZfNOqWgQ=="],
+
     "@capacitor/geolocation": ["@capacitor/geolocation@8.1.0", "", { "dependencies": { "@capacitor/synapse": "^1.0.4" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-dHeGuVlT3ELxxn8WaoRsGjfx8tmziaC0ZuaKhUBCoKFjOue4fAnmLczCMQsYW7OykgiyBh0pirNPwWZ0/LXB7Q=="],
 
     "@capacitor/ios": ["@capacitor/ios@8.3.0", "", { "peerDependencies": { "@capacitor/core": "^8.3.0" } }, "sha512-5Rtwv8SITKlYTt8lAZG+khnVIdzPtqbocH3eP+JkEmX1vpSMwx4TOKtT8OBz8gpQ+pUJDRp7DBYOv3U6l/obCw=="],
 
     "@capacitor/motion": ["@capacitor/motion@8.0.0", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-eCTe9+ZSVw2dQLQLvq5vfp2GGnMmsAy5jn4boKB93CHEenD9ZZojXZYJn1u4zUWhfj9cGXSxu+2j7WaQbkMlPg=="],
+
+    "@capacitor/share": ["@capacitor/share@8.0.1", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-3cSBKBCJVon54rKDROP2rqGyeGks4pBh9TbaEk9S375Kbek/ZHe72N50zIa0Vn9Eac/SuhwgehO/mmA4CsUOiw=="],
 
     "@capacitor/synapse": ["@capacitor/synapse@1.0.4", "", {}, "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw=="],
 

--- a/mobile/ios/App/Podfile
+++ b/mobile/ios/App/Podfile
@@ -17,7 +17,9 @@ def capacitor_pods
   pod 'CapacitorCommunitySafeArea', :path => '../../node_modules/@capacitor-community/safe-area'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'
+  pod 'CapacitorFilesystem', :path => '../../node_modules/@capacitor/filesystem'
   pod 'CapacitorGeolocation', :path => '../../node_modules/@capacitor/geolocation'
+  pod 'CapacitorShare', :path => '../../node_modules/@capacitor/share'
 end
 
 target 'App' do

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -17,9 +17,11 @@
     "@capacitor/app": "^8",
     "@capacitor/browser": "^8",
     "@capacitor/core": "^8",
+    "@capacitor/filesystem": "^8",
     "@capacitor/geolocation": "8.1.0",
     "@capacitor/ios": "^8",
-    "@capacitor/motion": "^8"
+    "@capacitor/motion": "^8",
+    "@capacitor/share": "^8"
   },
   "devDependencies": {
     "@capacitor/cli": "^8.3.1",

--- a/packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
-import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
+import { render, waitFor, act } from '@testing-library/react';
 import React from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createTestQueryClient } from '@/app/test-utils/test-providers';
@@ -23,10 +23,6 @@ const mockRequest = vi.fn();
 const getPreferenceMock = vi.fn().mockResolvedValue(null);
 const searchFormSpy = vi.fn();
 const showMessageSpy = vi.fn();
-const fetchMock = vi.fn();
-const createObjectURLMock = vi.fn();
-const revokeObjectURLMock = vi.fn();
-const anchorClickMock = vi.fn();
 
 // --- Mocks (must come before component import) ---
 
@@ -134,9 +130,13 @@ vi.mock('../logbook-item-skeleton', () => ({
 }));
 
 vi.mock('../logbook-search-form', () => ({
-  default: (props: { selectedBoards: Array<{ uuid: string }>; boards: Array<{ uuid: string }> }) => {
+  default: (props: {
+    selectedBoards: Array<{ uuid: string }>;
+    boards: Array<{ uuid: string }>;
+    actions?: React.ReactNode;
+  }) => {
     searchFormSpy(props);
-    return <div data-testid="logbook-search-form" />;
+    return <div data-testid="logbook-search-form">{props.actions}</div>;
   },
 }));
 
@@ -177,21 +177,6 @@ beforeEach(() => {
   mockRequest.mockResolvedValue({
     userAscentsFeed: { items: [], hasMore: false },
   });
-  fetchMock.mockReset();
-  createObjectURLMock.mockReset();
-  createObjectURLMock.mockReturnValue('blob:export');
-  revokeObjectURLMock.mockReset();
-  anchorClickMock.mockReset();
-  vi.stubGlobal('fetch', fetchMock);
-  Object.defineProperty(URL, 'createObjectURL', {
-    configurable: true,
-    value: createObjectURLMock,
-  });
-  Object.defineProperty(URL, 'revokeObjectURL', {
-    configurable: true,
-    value: revokeObjectURLMock,
-  });
-  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(anchorClickMock);
   searchFormSpy.mockClear();
   getPreferenceMock.mockClear();
   showMessageSpy.mockClear();
@@ -319,58 +304,5 @@ describe('LogbookFeed — boards URL round-trip', () => {
         .map((b) => b.uuid)
         .sort(),
     ).toEqual(['logbook-kilter-1', 'logbook-tension-9']);
-  });
-
-  it('requests and downloads an Aurora JSON export for a logbook board', async () => {
-    fetchMock
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({ status: 'ready', downloadUrl: '/api/user-data-export/download?boardType=kilter' }),
-          {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          },
-        ),
-      )
-      .mockResolvedValueOnce(
-        new Response('{}', {
-          status: 200,
-          headers: {
-            'Content-Type': 'application/json',
-            'Content-Disposition': 'attachment; filename="boardsesh-kilter-export-2026-W19.json"',
-          },
-        }),
-      );
-
-    renderFeed(false, [makeLayoutStats('kilter', 1)]);
-
-    fireEvent.click(await screen.findByRole('button', { name: /export/i }));
-    fireEvent.click(await screen.findByRole('menuitem', { name: 'Kilter JSON' }));
-
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    });
-
-    expect(fetchMock.mock.calls[0]).toEqual([
-      'http://backend.test/api/user-data-export?boardType=kilter',
-      {
-        method: 'POST',
-        headers: {
-          Authorization: 'Bearer test-token',
-        },
-      },
-    ]);
-    expect(fetchMock.mock.calls[1]).toEqual([
-      'http://backend.test/api/user-data-export/download?boardType=kilter',
-      {
-        headers: {
-          Authorization: 'Bearer test-token',
-        },
-      },
-    ]);
-    expect(createObjectURLMock).toHaveBeenCalled();
-    expect(anchorClickMock).toHaveBeenCalled();
-    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:export');
-    expect(showMessageSpy).toHaveBeenCalledWith('Kilter export downloaded.', 'success');
   });
 });

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -3,13 +3,10 @@
 import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import { FileDownloadOutlined, HistoryOutlined } from '@mui/icons-material';
+import { HistoryOutlined } from '@mui/icons-material';
 import {
   DEFAULT_FILTERS,
   DEFAULT_SORT,
@@ -20,7 +17,6 @@ import {
 } from '@/app/lib/logbook-preferences';
 import { readFiltersFromQuery, readSortFromQuery, filtersToQueryParams } from '@/app/lib/logbook-url-utils';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
-import { getBackendHttpUrl } from '@/app/lib/backend-url';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
@@ -49,7 +45,6 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { isInstagramPostingSupported } from '@/app/lib/instagram-posting';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import { AURORA_BOARDS, type AuroraBoardName } from '@boardsesh/shared-schema';
 import LogbookFeedItem from './logbook-feed-item';
 import LogbookSwipeHintOrchestrator from './logbook-swipe-hint-orchestrator';
 import LogbookSearchForm from './logbook-search-form';
@@ -59,41 +54,6 @@ import feedStyles from '@/app/components/activity-feed/ascents-feed.module.css';
 
 const PAGE_SIZE = 20;
 type StatusMode = 'both' | 'send' | 'attempt';
-
-type UserDataExportStatus = {
-  status: 'not_requested' | 'generating' | 'ready' | 'failed' | 'unavailable';
-  downloadUrl?: string;
-  error?: string;
-};
-
-function isAuroraBoardType(value: string): value is AuroraBoardName {
-  return (AURORA_BOARDS as readonly string[]).includes(value);
-}
-
-function formatBoardTypeLabel(boardType: string): string {
-  return boardType.charAt(0).toUpperCase() + boardType.slice(1);
-}
-
-function getExportFilename(response: Response, boardType: AuroraBoardName): string {
-  const disposition = response.headers.get('Content-Disposition') ?? '';
-  const match = disposition.match(/filename="([^"]+)"/);
-  return match?.[1] ?? `boardsesh-${boardType}-export.json`;
-}
-
-async function parseExportResponse(response: Response): Promise<UserDataExportStatus> {
-  const body = (await response.json().catch(() => null)) as (UserDataExportStatus & { error?: string }) | null;
-  if (!response.ok) {
-    throw new Error(body?.error ?? `Export request failed (${response.status})`);
-  }
-  if (!body) {
-    throw new Error('Export request returned an empty response');
-  }
-  return body;
-}
-
-function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 // ---------- Component ----------
 
@@ -187,8 +147,6 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
   const [editingItemUuid, setEditingItemUuid] = useState<string | null>(null);
   const [preferencesLoaded, setPreferencesLoaded] = useState(false);
   const [boardsInitialized, setBoardsInitialized] = useState(() => !searchParams.get('boards'));
-  const [exportMenuAnchor, setExportMenuAnchor] = useState<HTMLElement | null>(null);
-  const [exportingBoard, setExportingBoard] = useState<AuroraBoardName | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   // Debounced search text
@@ -335,11 +293,6 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
     const types = [...new Set(selectedBoards.map((b) => b.boardType))];
     return types;
   }, [selectedBoards]);
-
-  const exportableBoardTypes = useMemo(() => {
-    const sourceBoards = selectedBoards.length > 0 ? selectedBoards : logbookBoards;
-    return [...new Set(sourceBoards.map((board) => board.boardType))].filter(isAuroraBoardType);
-  }, [logbookBoards, selectedBoards]);
 
   const selectedLayoutIds = useMemo(() => {
     if (selectedBoards.length === 0) return undefined;
@@ -562,110 +515,6 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
     setEditingItemUuid(null);
   }, []);
 
-  const downloadExport = useCallback(
-    async (backendUrl: string, boardType: AuroraBoardName) => {
-      const response = await fetch(`${backendUrl}/api/user-data-export/download?boardType=${boardType}`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-
-      if (!response.ok) {
-        const body = (await response.json().catch(() => null)) as { error?: string } | null;
-        throw new Error(body?.error ?? `Export download failed (${response.status})`);
-      }
-
-      const blob = await response.blob();
-      const filename = getExportFilename(response, boardType);
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      URL.revokeObjectURL(url);
-    },
-    [token],
-  );
-
-  const waitForExport = useCallback(
-    async (backendUrl: string, boardType: AuroraBoardName) => {
-      for (let i = 0; i < 30; i++) {
-        await wait(2000);
-        const response = await fetch(`${backendUrl}/api/user-data-export?boardType=${boardType}`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
-        const status = await parseExportResponse(response);
-
-        if (status.status === 'ready') return status;
-        if (status.status === 'failed' || status.status === 'unavailable') {
-          throw new Error(status.error ?? 'Export generation failed');
-        }
-      }
-
-      throw new Error('Export is still generating. Try again shortly.');
-    },
-    [token],
-  );
-
-  const handleExportMenuOpen = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
-    setExportMenuAnchor(event.currentTarget);
-  }, []);
-
-  const handleExportMenuClose = useCallback(() => {
-    setExportMenuAnchor(null);
-  }, []);
-
-  const handleExportBoard = useCallback(
-    async (boardType: AuroraBoardName) => {
-      handleExportMenuClose();
-
-      const backendUrl = getBackendHttpUrl();
-      if (!backendUrl) {
-        showMessage('Boardsesh could not find the export service URL.', 'error');
-        return;
-      }
-
-      if (!token) {
-        showMessage('Sign in again to export your logbook data.', 'error');
-        return;
-      }
-
-      setExportingBoard(boardType);
-      const boardLabel = formatBoardTypeLabel(boardType);
-
-      try {
-        const response = await fetch(`${backendUrl}/api/user-data-export?boardType=${boardType}`, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
-        let status = await parseExportResponse(response);
-
-        if (status.status === 'generating') {
-          showMessage(`${boardLabel} export is being generated.`, 'info', undefined, 5000);
-          status = await waitForExport(backendUrl, boardType);
-        }
-
-        if (status.status !== 'ready') {
-          throw new Error(status.error ?? 'Export is not ready yet');
-        }
-
-        await downloadExport(backendUrl, boardType);
-        showMessage(`${boardLabel} export downloaded.`, 'success');
-      } catch (error) {
-        showMessage(error instanceof Error ? error.message : 'Export failed', 'error');
-      } finally {
-        setExportingBoard(null);
-      }
-    },
-    [downloadExport, handleExportMenuClose, showMessage, token, waitForExport],
-  );
-
   const showBoardType = selectedBoards.length === 0 || selectedBoards.length > 1;
   const hasFilters =
     selectedBoards.length > 0 ||
@@ -715,32 +564,10 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
     />
   );
 
-  const exportControls = exportableBoardTypes.length > 0 && (
-    <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1.5 }}>
-      <Button
-        variant="outlined"
-        size="small"
-        startIcon={exportingBoard ? <CircularProgress size={16} /> : <FileDownloadOutlined fontSize="small" />}
-        onClick={handleExportMenuOpen}
-        disabled={authLoading || !token || !!exportingBoard}
-      >
-        Export
-      </Button>
-      <Menu anchorEl={exportMenuAnchor} open={!!exportMenuAnchor} onClose={handleExportMenuClose}>
-        {exportableBoardTypes.map((boardType) => (
-          <MenuItem key={boardType} onClick={() => void handleExportBoard(boardType)}>
-            {formatBoardTypeLabel(boardType)} JSON
-          </MenuItem>
-        ))}
-      </Menu>
-    </Box>
-  );
-
   if (isLoading) {
     return (
       <>
         {searchForm}
-        {exportControls}
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
           {Array.from({ length: 5 }).map((_, i) => (
             <LogbookItemSkeleton key={i} />
@@ -771,7 +598,6 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
     return (
       <>
         {searchForm}
-        {exportControls}
         {userId && !authLoading && !token && (
           <Alert severity="warning" sx={{ mb: 2 }}>
             {authError
@@ -795,7 +621,6 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
   return (
     <>
       {searchForm}
-      {exportControls}
       <LogbookSwipeHintOrchestrator />
       <div className={feedStyles.feed}>
         <Box sx={{ display: 'flex', flexDirection: 'column' }}>

--- a/packages/web/app/components/library/logbook-search-form.tsx
+++ b/packages/web/app/components/library/logbook-search-form.tsx
@@ -53,6 +53,7 @@ type LogbookSearchFormProps = {
   onBoardToggle: (board: UserBoard | null) => void;
   filters: LogbookFilterState;
   onFiltersChange: (updater: (prev: LogbookFilterState) => LogbookFilterState) => void;
+  actions?: React.ReactNode;
 };
 
 function getResultTypeSummary(filters: LogbookFilterState): string[] {
@@ -124,6 +125,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
   onBoardToggle,
   filters,
   onFiltersChange,
+  actions,
 }) => {
   const { t } = useTranslation('profile');
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -362,6 +364,7 @@ const LogbookSearchForm: React.FC<LogbookSearchFormProps> = ({
                 </IconButton>
                 {activeFilterCount > 0 && <span className={headerStyles.filterActiveIndicator} />}
               </div>
+              {actions}
             </Box>
           </div>
         </div>

--- a/packages/web/app/components/settings/__tests__/aurora-credentials-section-export.test.tsx
+++ b/packages/web/app/components/settings/__tests__/aurora-credentials-section-export.test.tsx
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import { AURORA_BOARDS } from '@boardsesh/shared-schema';
+import AuroraCredentialsSection from '../aurora-credentials-section';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('server-only', () => ({}));
+
+const mockShowMessage = vi.fn();
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { user: { id: 'test-user', name: 'Test User', email: 'test@example.com' } },
+  }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isAuthenticated: true, isLoading: false, error: null }),
+}));
+
+const requestAndDeliverUserDataExportMock = vi.fn();
+vi.mock('@/app/lib/user-data-export-client', () => ({
+  formatBoardTypeLabel: (boardType: string) => boardType.charAt(0).toUpperCase() + boardType.slice(1),
+  requestAndDeliverUserDataExport: (...args: unknown[]) => requestAndDeliverUserDataExportMock(...args),
+}));
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchMock.mockImplementation((url: RequestInfo | URL) => {
+    const href = String(url);
+    if (href.includes('/api/internal/aurora-credentials/unsynced')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ counts: {} }),
+      });
+    }
+    if (href.includes('/api/internal/aurora-credentials')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ credentials: [] }),
+      });
+    }
+    return Promise.reject(new Error(`Unexpected fetch: ${href}`));
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+describe('AuroraCredentialsSection export actions', () => {
+  it('shows export actions beside board import controls and exports the selected board', async () => {
+    requestAndDeliverUserDataExportMock.mockResolvedValue('downloaded');
+
+    render(<AuroraCredentialsSection />);
+
+    await screen.findByText('Kilter Board');
+    await screen.findByText('Tension Board');
+
+    const exportButtons = screen.getAllByRole('button', { name: 'Export' });
+    expect(exportButtons).toHaveLength(AURORA_BOARDS.length);
+
+    fireEvent.click(exportButtons[0]);
+
+    await waitFor(() => {
+      expect(requestAndDeliverUserDataExportMock).toHaveBeenCalledWith(
+        'kilter',
+        'test-token',
+        expect.objectContaining({ onGenerating: expect.any(Function) }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockShowMessage).toHaveBeenCalledWith('Kilter export downloaded.', 'success');
+    });
+  });
+});

--- a/packages/web/app/components/settings/aurora-credentials-section.module.css
+++ b/packages/web/app/components/settings/aurora-credentials-section.module.css
@@ -57,12 +57,13 @@
 
 .buttonRow {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-top: 16px;
 }
 
 .buttonRow > * {
-  flex: 1;
+  flex: 1 1 120px;
   min-width: 0;
 }
 

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -31,6 +31,7 @@ import LinkOutlined from '@mui/icons-material/LinkOutlined';
 import SyncOutlined from '@mui/icons-material/SyncOutlined';
 import WarningOutlined from '@mui/icons-material/WarningOutlined';
 import EmailOutlined from '@mui/icons-material/EmailOutlined';
+import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined';
 import FileUploadOutlined from '@mui/icons-material/FileUploadOutlined';
 import RadioButtonUncheckedOutlined from '@mui/icons-material/RadioButtonUncheckedOutlined';
 import { useSession } from 'next-auth/react';
@@ -46,6 +47,8 @@ import {
   type StrippedExportData,
 } from '@/app/lib/data-sync/aurora/parse-aurora-export';
 import { AURORA_BOARDS, type AuroraBoardName } from '@boardsesh/shared-schema';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { formatBoardTypeLabel, requestAndDeliverUserDataExport } from '@/app/lib/user-data-export-client';
 import styles from './aurora-credentials-section.module.css';
 
 type BoardUnsyncedCounts = {
@@ -108,8 +111,10 @@ export type BoardCredentialCardProps = {
   onAdd: () => void;
   onRemove: () => void;
   onImportJson: () => void;
+  onExportJson?: () => void;
   isRemoving: boolean;
   isImporting: boolean;
+  isExporting?: boolean;
   userName?: string | null;
   userEmail?: string | null;
 };
@@ -121,8 +126,10 @@ export function BoardCredentialCard({
   onAdd,
   onRemove,
   onImportJson,
+  onExportJson,
   isRemoving,
   isImporting,
+  isExporting = false,
   userName,
   userEmail,
 }: BoardCredentialCardProps) {
@@ -186,6 +193,16 @@ export function BoardCredentialCard({
             >
               {t('aurora.card.import')}
             </Button>
+            {onExportJson && (
+              <Button
+                variant="outlined"
+                startIcon={isExporting ? <CircularProgress size={16} /> : <FileDownloadOutlined />}
+                onClick={onExportJson}
+                disabled={isExporting}
+              >
+                {t('aurora.card.export')}
+              </Button>
+            )}
             {isKilter && (
               <Button
                 variant="outlined"
@@ -270,6 +287,16 @@ export function BoardCredentialCard({
           >
             {t('aurora.card.import')}
           </Button>
+          {onExportJson && (
+            <Button
+              variant="outlined"
+              startIcon={isExporting ? <CircularProgress size={16} /> : <FileDownloadOutlined />}
+              onClick={onExportJson}
+              disabled={isExporting}
+            >
+              {t('aurora.card.export')}
+            </Button>
+          )}
         </div>
       </CardContent>
     </Card>
@@ -319,6 +346,7 @@ export function ImportProgressSteps({ progress }: { progress: ImportProgress | n
 export default function AuroraCredentialsSection() {
   const { t } = useTranslation('settings');
   const { data: session } = useSession();
+  const { token } = useWsAuthToken();
   const { showMessage } = useSnackbar();
   const [credentials, setCredentials] = useState<AuroraCredentialStatus[]>([]);
   const [unsyncedCounts, setUnsyncedCounts] = useState<UnsyncedCounts | null>(null);
@@ -327,6 +355,7 @@ export default function AuroraCredentialsSection() {
   const [selectedBoard, setSelectedBoard] = useState<AuroraBoardName>('kilter');
   const [isSaving, setIsSaving] = useState(false);
   const [removingBoard, setRemovingBoard] = useState<string | null>(null);
+  const [exportingBoard, setExportingBoard] = useState<AuroraBoardName | null>(null);
   const [formValues, setFormValues] = useState({ username: '', password: '' });
 
   // Import state
@@ -556,6 +585,29 @@ export default function AuroraCredentialsSection() {
     resetImportState();
   };
 
+  const handleExportClick = async (boardType: AuroraBoardName) => {
+    setExportingBoard(boardType);
+    const boardLabel = formatBoardTypeLabel(boardType);
+
+    try {
+      const deliveryResult = await requestAndDeliverUserDataExport(boardType, token, {
+        onGenerating: () => {
+          showMessage(t('aurora.export.generating', { boardName: boardLabel }), 'info', undefined, 5000);
+        },
+      });
+
+      if (deliveryResult === 'downloaded') {
+        showMessage(t('aurora.export.downloaded', { boardName: boardLabel }), 'success');
+      } else if (deliveryResult === 'shared') {
+        showMessage(t('aurora.export.readyToSave', { boardName: boardLabel }), 'success');
+      }
+    } catch (error) {
+      showMessage(error instanceof Error ? error.message : t('aurora.export.failed'), 'error');
+    } finally {
+      setExportingBoard(null);
+    }
+  };
+
   const getCredentialForBoard = (boardType: AuroraBoardName) => {
     return credentials.find((credential) => credential.boardType === boardType) || null;
   };
@@ -612,8 +664,10 @@ export default function AuroraCredentialsSection() {
                 onAdd={() => handleAddClick(boardType)}
                 onRemove={() => handleRemove(boardType)}
                 onImportJson={() => handleImportClick(boardType)}
+                onExportJson={() => void handleExportClick(boardType)}
                 isRemoving={removingBoard === boardType}
                 isImporting={isImporting && importingBoard === boardType}
+                isExporting={exportingBoard === boardType}
                 userName={boardType === 'kilter' ? session?.user?.name : undefined}
                 userEmail={boardType === 'kilter' ? session?.user?.email : undefined}
               />

--- a/packages/web/app/lib/__tests__/user-data-export-client.test.ts
+++ b/packages/web/app/lib/__tests__/user-data-export-client.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { requestAndDeliverUserDataExport } from '../user-data-export-client';
+
+vi.mock('@/app/lib/backend-url', () => ({
+  getBackendHttpUrl: () => 'http://backend.test',
+}));
+
+const fetchMock = vi.fn();
+const createObjectURLMock = vi.fn();
+const revokeObjectURLMock = vi.fn();
+const anchorClickMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  createObjectURLMock.mockReset();
+  createObjectURLMock.mockReturnValue('blob:export');
+  revokeObjectURLMock.mockReset();
+  anchorClickMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  Object.defineProperty(URL, 'createObjectURL', {
+    configurable: true,
+    value: createObjectURLMock,
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    configurable: true,
+    value: revokeObjectURLMock,
+  });
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(anchorClickMock);
+  Object.defineProperty(window, 'Capacitor', {
+    configurable: true,
+    writable: true,
+    value: undefined,
+  });
+  Object.defineProperty(navigator, 'share', {
+    configurable: true,
+    value: undefined,
+  });
+  Object.defineProperty(navigator, 'canShare', {
+    configurable: true,
+    value: undefined,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function mockReadyExportResponses() {
+  fetchMock
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ status: 'ready', downloadUrl: '/api/user-data-export/download?boardType=kilter' }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    )
+    .mockResolvedValueOnce(
+      new Response('{}', {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Disposition': 'attachment; filename="boardsesh-kilter-export-2026-W19.json"',
+        },
+      }),
+    );
+}
+
+describe('user data export client', () => {
+  it('requests and downloads an Aurora JSON export in the browser', async () => {
+    mockReadyExportResponses();
+
+    await expect(requestAndDeliverUserDataExport('kilter', 'test-token')).resolves.toBe('downloaded');
+
+    expect(fetchMock.mock.calls[0]).toEqual([
+      'http://backend.test/api/user-data-export?boardType=kilter',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer test-token',
+        },
+      },
+    ]);
+    expect(fetchMock.mock.calls[1]).toEqual([
+      'http://backend.test/api/user-data-export/download?boardType=kilter',
+      {
+        headers: {
+          Authorization: 'Bearer test-token',
+        },
+      },
+    ]);
+    expect(createObjectURLMock).toHaveBeenCalled();
+    expect(anchorClickMock).toHaveBeenCalled();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:export');
+  });
+
+  it('shares an Aurora JSON export through native Capacitor file sharing in the app', async () => {
+    const writeFileMock = vi.fn().mockResolvedValue({ uri: 'file://boardsesh-export.json' });
+    const shareMock = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(window, 'Capacitor', {
+      configurable: true,
+      value: {
+        isNativePlatform: () => true,
+        getPlatform: () => 'ios',
+        Plugins: {
+          Filesystem: { writeFile: writeFileMock },
+          Share: { canShare: vi.fn().mockResolvedValue({ value: true }), share: shareMock },
+        },
+      },
+    });
+    mockReadyExportResponses();
+
+    await expect(requestAndDeliverUserDataExport('kilter', 'test-token')).resolves.toBe('shared');
+
+    expect(writeFileMock).toHaveBeenCalledWith({
+      path: 'exports/boardsesh-kilter-export-2026-W19.json',
+      data: 'e30=',
+      directory: 'CACHE',
+      recursive: true,
+    });
+    expect(shareMock).toHaveBeenCalledWith({
+      title: 'boardsesh-kilter-export-2026-W19.json',
+      text: 'Boardsesh logbook export',
+      url: 'file://boardsesh-export.json',
+      dialogTitle: 'Save export',
+    });
+    expect(createObjectURLMock).not.toHaveBeenCalled();
+    expect(anchorClickMock).not.toHaveBeenCalled();
+  });
+
+  it('does not fall back to a false browser download in a native app without sharing support', async () => {
+    Object.defineProperty(window, 'Capacitor', {
+      configurable: true,
+      value: {
+        isNativePlatform: () => true,
+        getPlatform: () => 'ios',
+        Plugins: {},
+      },
+    });
+    mockReadyExportResponses();
+
+    await expect(requestAndDeliverUserDataExport('kilter', 'test-token')).rejects.toThrow(
+      'Export needs a newer Boardsesh app build on this device.',
+    );
+
+    expect(createObjectURLMock).not.toHaveBeenCalled();
+    expect(anchorClickMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/lib/ble/capacitor-types.d.ts
+++ b/packages/web/app/lib/ble/capacitor-types.d.ts
@@ -56,6 +56,20 @@ type CapacitorDevUrlPlugin = {
   clearUrl(): Promise<void>;
 };
 
+type CapacitorFilesystemPlugin = {
+  writeFile(options: {
+    path: string;
+    data: string;
+    directory?: 'CACHE' | 'DATA' | 'DOCUMENTS' | 'EXTERNAL' | 'EXTERNAL_STORAGE' | 'LIBRARY';
+    recursive?: boolean;
+  }): Promise<{ uri: string }>;
+};
+
+type CapacitorSharePlugin = {
+  canShare?(): Promise<{ value: boolean }>;
+  share(options: { title?: string; text?: string; url?: string; dialogTitle?: string }): Promise<void>;
+};
+
 type CapacitorGlobal = {
   isNativePlatform(): boolean;
   getPlatform(): string;
@@ -68,6 +82,8 @@ type CapacitorGlobal = {
     DevUrl?: CapacitorDevUrlPlugin;
     InAppReview?: CapacitorInAppReviewPlugin;
     Motion?: CapacitorMotionPlugin;
+    Filesystem?: CapacitorFilesystemPlugin;
+    Share?: CapacitorSharePlugin;
     LiveActivity?: {
       isAvailable(): Promise<{ available: boolean }>;
       startSession(options: Record<string, unknown>): Promise<void>;

--- a/packages/web/app/lib/user-data-export-client.ts
+++ b/packages/web/app/lib/user-data-export-client.ts
@@ -1,0 +1,219 @@
+import { getBackendHttpUrl } from '@/app/lib/backend-url';
+import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import type { AuroraBoardName } from '@boardsesh/shared-schema';
+
+type UserDataExportStatus = {
+  status: 'not_requested' | 'generating' | 'ready' | 'failed' | 'unavailable';
+  downloadUrl?: string;
+  error?: string;
+};
+
+export type ExportDeliveryResult = 'downloaded' | 'shared' | 'cancelled';
+
+type ExportOptions = {
+  onGenerating?: () => void;
+};
+
+export function formatBoardTypeLabel(boardType: string): string {
+  return boardType.charAt(0).toUpperCase() + boardType.slice(1);
+}
+
+function getExportFilename(response: Response, boardType: AuroraBoardName): string {
+  const disposition = response.headers.get('Content-Disposition') ?? '';
+  const match = disposition.match(/filename="([^"]+)"/);
+  return match?.[1] ?? `boardsesh-${boardType}-export.json`;
+}
+
+async function parseExportResponse(response: Response): Promise<UserDataExportStatus> {
+  const body = (await response.json().catch(() => null)) as (UserDataExportStatus & { error?: string }) | null;
+  if (!response.ok) {
+    throw new Error(body?.error ?? `Export request failed (${response.status})`);
+  }
+  if (!body) {
+    throw new Error('Export request returned an empty response');
+  }
+  return body;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function sanitizeExportFilename(filename: string): string {
+  return filename.replace(/[\\/:*?"<>|]+/g, '-');
+}
+
+async function blobToBase64(blob: Blob): Promise<string> {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function isShareCancelError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return error.name === 'AbortError' || /cancel/i.test(error.message);
+}
+
+async function shareExportWithWebShare(blob: Blob, filename: string): Promise<ExportDeliveryResult | null> {
+  if (typeof navigator === 'undefined' || typeof File === 'undefined' || !navigator.share || !navigator.canShare) {
+    return null;
+  }
+
+  const file = new File([blob], filename, { type: blob.type || 'application/json' });
+  const shareData: ShareData = {
+    title: filename,
+    text: 'Boardsesh logbook export',
+    files: [file],
+  };
+
+  if (!navigator.canShare(shareData)) return null;
+
+  try {
+    await navigator.share(shareData);
+    return 'shared';
+  } catch (error) {
+    if (isShareCancelError(error)) return 'cancelled';
+    throw error;
+  }
+}
+
+async function shareExportWithCapacitor(blob: Blob, filename: string): Promise<ExportDeliveryResult | null> {
+  if (!isNativeApp()) return null;
+
+  const filesystem = window.Capacitor?.Plugins.Filesystem;
+  const share = window.Capacitor?.Plugins.Share;
+
+  if (!filesystem || !share) {
+    return shareExportWithWebShare(blob, filename);
+  }
+
+  const canShare = await share.canShare?.().catch(() => ({ value: true }));
+  if (canShare?.value === false) return null;
+
+  const data = await blobToBase64(blob);
+  const path = `exports/${sanitizeExportFilename(filename)}`;
+  const { uri } = await filesystem.writeFile({
+    path,
+    data,
+    directory: 'CACHE',
+    recursive: true,
+  });
+
+  try {
+    await share.share({
+      title: filename,
+      text: 'Boardsesh logbook export',
+      url: uri,
+      dialogTitle: 'Save export',
+    });
+    return 'shared';
+  } catch (error) {
+    if (isShareCancelError(error)) return 'cancelled';
+    throw error;
+  }
+}
+
+function downloadExportInBrowser(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+async function deliverExportBlob(blob: Blob, filename: string): Promise<ExportDeliveryResult> {
+  const nativeResult = await shareExportWithCapacitor(blob, filename);
+  if (nativeResult) return nativeResult;
+
+  if (isNativeApp()) {
+    throw new Error('Export needs a newer Boardsesh app build on this device.');
+  }
+
+  downloadExportInBrowser(blob, filename);
+  return 'downloaded';
+}
+
+async function downloadExport(
+  backendUrl: string,
+  token: string,
+  boardType: AuroraBoardName,
+): Promise<ExportDeliveryResult> {
+  const response = await fetch(`${backendUrl}/api/user-data-export/download?boardType=${boardType}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as { error?: string } | null;
+    throw new Error(body?.error ?? `Export download failed (${response.status})`);
+  }
+
+  const blob = await response.blob();
+  const filename = getExportFilename(response, boardType);
+  return deliverExportBlob(blob, filename);
+}
+
+async function waitForExport(
+  backendUrl: string,
+  token: string,
+  boardType: AuroraBoardName,
+): Promise<UserDataExportStatus> {
+  for (let i = 0; i < 30; i++) {
+    await wait(2000);
+    const response = await fetch(`${backendUrl}/api/user-data-export?boardType=${boardType}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const status = await parseExportResponse(response);
+
+    if (status.status === 'ready') return status;
+    if (status.status === 'failed' || status.status === 'unavailable') {
+      throw new Error(status.error ?? 'Export generation failed');
+    }
+  }
+
+  throw new Error('Export is still generating. Try again shortly.');
+}
+
+export async function requestAndDeliverUserDataExport(
+  boardType: AuroraBoardName,
+  token: string | null | undefined,
+  options: ExportOptions = {},
+): Promise<ExportDeliveryResult> {
+  const backendUrl = getBackendHttpUrl();
+  if (!backendUrl) {
+    throw new Error('Boardsesh could not find the export service URL.');
+  }
+
+  if (!token) {
+    throw new Error('Sign in again to export your logbook data.');
+  }
+
+  const response = await fetch(`${backendUrl}/api/user-data-export?boardType=${boardType}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  let status = await parseExportResponse(response);
+
+  if (status.status === 'generating') {
+    options.onGenerating?.();
+    status = await waitForExport(backendUrl, token, boardType);
+  }
+
+  if (status.status !== 'ready') {
+    throw new Error(status.error ?? 'Export is not ready yet');
+  }
+
+  return downloadExport(backendUrl, token, boardType);
+}

--- a/packages/web/i18n/locales/en-US/settings.json
+++ b/packages/web/i18n/locales/en-US/settings.json
@@ -171,6 +171,7 @@
       "notConnected": "Not connected. Link your {{boardName}} account to import your Aurora data, or import from a JSON export file.",
       "link": "Link",
       "import": "Import",
+      "export": "Export",
       "requestData": "Request your data",
       "unlink": "Unlink",
       "unlinkConfirm": {
@@ -178,6 +179,12 @@
         "description": "Are you sure you want to unlink your {{boardName}} account?",
         "ok": "Yes, unlink"
       }
+    },
+    "export": {
+      "generating": "{{boardName}} export is being generated.",
+      "downloaded": "{{boardName}} export downloaded.",
+      "readyToSave": "{{boardName}} export ready to save.",
+      "failed": "Export failed"
     },
     "status": {
       "connected": "Connected",

--- a/packages/web/i18n/locales/es/settings.json
+++ b/packages/web/i18n/locales/es/settings.json
@@ -171,6 +171,7 @@
       "notConnected": "No vinculado. Vincula tu cuenta de {{boardName}} para importar tus datos de Aurora, o impórtalos desde un archivo JSON.",
       "link": "Vincular",
       "import": "Importar",
+      "export": "Exportar",
       "requestData": "Pedir tus datos",
       "unlink": "Desvincular",
       "unlinkConfirm": {
@@ -178,6 +179,12 @@
         "description": "¿Seguro que quieres desvincular tu cuenta de {{boardName}}?",
         "ok": "Sí, desvincular"
       }
+    },
+    "export": {
+      "generating": "Se está generando la exportación de {{boardName}}.",
+      "downloaded": "Exportación de {{boardName}} descargada.",
+      "readyToSave": "Exportación de {{boardName}} lista para guardar.",
+      "failed": "No se pudo exportar"
     },
     "status": {
       "connected": "Vinculado",

--- a/packages/web/i18n/locales/fr/settings.json
+++ b/packages/web/i18n/locales/fr/settings.json
@@ -171,6 +171,7 @@
       "notConnected": "Non lié. Liez votre compte {{boardName}} pour importer vos données Aurora, ou importez depuis un fichier d'export JSON.",
       "link": "Lier",
       "import": "Importer",
+      "export": "Exporter",
       "requestData": "Demander vos données",
       "unlink": "Délier",
       "unlinkConfirm": {
@@ -178,6 +179,12 @@
         "description": "Vraiment délier votre compte {{boardName}} ?",
         "ok": "Oui, délier"
       }
+    },
+    "export": {
+      "generating": "Export {{boardName}} en cours de génération.",
+      "downloaded": "Export {{boardName}} téléchargé.",
+      "readyToSave": "Export {{boardName}} prêt à enregistrer.",
+      "failed": "Export impossible"
     },
     "status": {
       "connected": "Lié",


### PR DESCRIPTION
## Summary

Fixes #2035 and addresses #2036.

- Moves logbook export out of the logbook toolbar and into Settings -> Board Accounts beside the existing Import controls.
- Shares the export delivery logic between browser and native app flows.
- Uses Capacitor Filesystem + Share for native app exports, with browser download as the web fallback.
- Adds the Android file provider cache path needed for sharing generated export files.

## Testing

- `vp test run packages/web/app/lib/__tests__/user-data-export-client.test.ts packages/web/app/components/settings/__tests__/aurora-credentials-section-export.test.tsx packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx --reporter=verbose`
- `bun run --filter=@boardsesh/web typecheck`
- `vp fmt --check packages/web/app/lib/user-data-export-client.ts packages/web/app/lib/__tests__/user-data-export-client.test.ts packages/web/app/components/settings/aurora-credentials-section.tsx packages/web/app/components/settings/aurora-credentials-section.module.css packages/web/app/components/settings/__tests__/aurora-credentials-section-export.test.tsx packages/web/app/components/library/logbook-feed.tsx packages/web/app/components/library/__tests__/logbook-feed-boards-url.test.tsx packages/web/i18n/locales/en-US/settings.json packages/web/i18n/locales/es/settings.json packages/web/i18n/locales/fr/settings.json`
- `git diff --check`
- Browser: exported from Settings -> Board Accounts successfully.
- Android emulator: exported from Settings -> Board Accounts and confirmed the native share sheet opens with `boardsesh-kilter-export.json`.
- iOS: native share path is covered by unit test, but I have not run an iOS device/simulator pass from this setup.