### PR TITLE
Exclude /admin pages from Vercel Analytics and Speed Insights

### DIFF
--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -71,7 +71,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang={LOCALE_HTML_LANG[locale]} data-theme="dark" suppressHydrationWarning>
       <body suppressHydrationWarning>
-        <Analytics />
+        <Analytics beforeSend={(event) => (event.url.includes('/admin') ? null : event)} />
         <QueryClientProvider>
           <SessionProviderWrapper>
             <AppRouterCacheProvider>
@@ -100,7 +100,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             </AppRouterCacheProvider>
           </SessionProviderWrapper>
         </QueryClientProvider>
-        <SpeedInsights />
+        <SpeedInsights beforeSend={(event) => (event.url.includes('/admin') ? null : event)} />
         {process.env.NODE_ENV === 'development' && <VercelToolbar />}
       </body>
     </html>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Added `beforeSend` filter to `<Analytics>` that returns `null` for any event whose URL contains `/admin`, dropping it before it reaches Vercel
- Same filter applied to `<SpeedInsights>` so admin pages are excluded from performance metrics too

## Test plan

- [ ] Visit an admin page (e.g. `/admin`) and confirm no page view appears in the Vercel Analytics dashboard
- [ ] Visit a normal page (e.g. `/`) and confirm page views still appear

https://claude.ai/code/session_01Dtp8Cv5goqnNsbA37zQn1W
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dtp8Cv5goqnNsbA37zQn1W)_