### PR TITLE
perf: cache view-page SQL, stream /you stats, preload playlist LCP

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/playlists/[playlist_uuid]/page.tsx
@@ -10,6 +10,7 @@ import { getServerTranslation } from '@/app/lib/i18n/server';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import I18nProvider from '@/app/components/providers/i18n-provider';
 import PlaylistDetailContent from '@/app/playlists/[playlist_uuid]/playlist-detail-content';
+import { getPlaylistLcpPreloadUrl } from '@/app/lib/lcp-preload-url';
 import styles from '@/app/components/library/playlist-view.module.css';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -38,8 +39,17 @@ export default async function PlaylistDetailPage(props: { params: Promise<Playli
     const locale = await getLocale();
     const initialMyBoards = authToken ? await serverMyBoards(authToken) : null;
 
+    // Preload the LCP board thumbnail. The route params alone are enough to
+    // derive the URL — no playlist fetch required — so the browser can start
+    // the request before the client chunk hydrates.
+    const lcpPreloadUrl = getPlaylistLcpPreloadUrl({
+      boardType: parsed.board_name,
+      layoutId: parsed.layout_id,
+    });
+
     return (
       <I18nProvider locale={locale} namespaces={['playlists']}>
+        {lcpPreloadUrl && <link rel="preload" as="image" href={lcpPreloadUrl} fetchPriority="high" />}
         <div className={styles.pageContainer}>
           <PlaylistDetailContent
             playlistUuid={params.playlist_uuid}

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -19,6 +19,9 @@ import { buildOgBoardRenderUrl } from '@/app/components/board-renderer/util';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { createPageMetadata } from '@/app/lib/seo/metadata';
 
+export const revalidate = 3600;
+export const dynamicParams = true;
+
 export async function generateMetadata(props: { params: Promise<BoardRouteParametersWithUuid> }): Promise<Metadata> {
   const params = await props.params;
   const { t, locale } = await getServerTranslation('climbs');

--- a/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
@@ -9,6 +9,7 @@ import { generatePlaylistMetadata } from '@/app/lib/seo/playlist-metadata';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import I18nProvider from '@/app/components/providers/i18n-provider';
 import PlaylistDetailContent from '@/app/playlists/[playlist_uuid]/playlist-detail-content';
+import { getPlaylistLcpPreloadUrl } from '@/app/lib/lcp-preload-url';
 import styles from '@/app/components/library/playlist-view.module.css';
 
 type PlaylistDetailPageProps = {
@@ -34,8 +35,14 @@ export default async function BoardSlugPlaylistDetailPage(props: PlaylistDetailP
   const locale = await getLocale();
   const initialMyBoards = authToken ? await serverMyBoards(authToken) : null;
 
+  const lcpPreloadUrl = getPlaylistLcpPreloadUrl({
+    boardType: board.boardType,
+    layoutId: board.layoutId,
+  });
+
   return (
     <I18nProvider locale={locale} namespaces={['playlists']}>
+      {lcpPreloadUrl && <link rel="preload" as="image" href={lcpPreloadUrl} fetchPriority="high" />}
       <div className={styles.pageContainer}>
         <PlaylistDetailContent
           playlistUuid={params.playlist_uuid}

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
@@ -13,6 +13,9 @@ import { buildOgBoardRenderUrl } from '@/app/components/board-renderer/util';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { createPageMetadata } from '@/app/lib/seo/metadata';
 
+export const revalidate = 3600;
+export const dynamicParams = true;
+
 type BoardSlugViewPageProps = {
   params: Promise<{ board_slug: string; angle: string; climb_uuid: string }>;
 };

--- a/packages/web/app/lib/data/climb-detail-data.server.ts
+++ b/packages/web/app/lib/data/climb-detail-data.server.ts
@@ -1,5 +1,6 @@
 import { dbz } from '@/app/lib/db/db';
 import { eq, and } from 'drizzle-orm';
+import { unstable_cache } from 'next/cache';
 import { climbCommunityStatus } from '@/app/lib/db/schema';
 
 type FetchClimbDetailDataParams = {
@@ -8,7 +9,7 @@ type FetchClimbDetailDataParams = {
   angle: number;
 };
 
-export async function fetchClimbDetailData({ boardName, climbUuid, angle }: FetchClimbDetailDataParams) {
+async function fetchClimbDetailDataUncached({ boardName, climbUuid, angle }: FetchClimbDetailDataParams) {
   try {
     const [result] = await dbz
       .select({ communityGrade: climbCommunityStatus.communityGrade })
@@ -26,4 +27,16 @@ export async function fetchClimbDetailData({ boardName, climbUuid, angle }: Fetc
   } catch {
     return { communityGrade: null };
   }
+}
+
+export async function fetchClimbDetailData(params: FetchClimbDetailDataParams) {
+  const cachedFn = unstable_cache(
+    async () => fetchClimbDetailDataUncached(params),
+    ['climb-community', params.boardName, params.climbUuid, String(params.angle)],
+    {
+      revalidate: 3600,
+      tags: [`climb-${params.climbUuid}`],
+    },
+  );
+  return cachedFn();
 }

--- a/packages/web/app/lib/data/queries.ts
+++ b/packages/web/app/lib/data/queries.ts
@@ -6,6 +6,7 @@
  */
 import 'server-only';
 import { cache } from 'react';
+import { unstable_cache } from 'next/cache';
 // oxlint-disable-next-line no-restricted-imports -- raw postgres-js sql usage; migrate to drizzle
 import { rowsFromResult, sql } from '@/app/lib/db/db';
 import { getGradeLabel } from '@boardsesh/db/queries';
@@ -14,8 +15,9 @@ import type { Climb, ParsedBoardRouteParametersWithUuid, BoardName, LayoutId, Si
 import { getSizesForLayoutId, getAllLayouts, getSetsForLayoutAndSize } from '@/app/lib/board-constants';
 import { isNoMatchClimb } from '@/app/lib/no-match-climb';
 
-export const getClimb = cache(async (params: ParsedBoardRouteParametersWithUuid): Promise<Climb> => {
-  const result = rowsFromResult<Climb & { difficulty_id: number | null }>(await sql`
+async function fetchClimbFromDb(params: ParsedBoardRouteParametersWithUuid): Promise<Climb> {
+  const result = rowsFromResult<Climb & { difficulty_id: number | null }>(
+    await sql`
         SELECT climbs.uuid, climbs.setter_username, climbs.user_id as "userId", climbs.name, climbs.description,
         climbs.frames, COALESCE(climb_stats.angle, ${params.angle}) as angle, COALESCE(climb_stats.ascensionist_count, 0) as ascensionist_count,
         ROUND(climb_stats.display_difficulty::numeric, 0) as difficulty_id,
@@ -33,13 +35,26 @@ export const getClimb = cache(async (params: ParsedBoardRouteParametersWithUuid)
         AND climbs.uuid = ${params.climb_uuid}
         AND climbs.frames_count = 1
         limit 1
-      `);
+      `,
+  );
   const row = result[0];
   return {
     ...row,
     difficulty: getGradeLabel(row.difficulty_id),
     is_no_match: isNoMatchClimb(row.description),
   } as Climb;
+}
+
+export const getClimb = cache(async (params: ParsedBoardRouteParametersWithUuid): Promise<Climb> => {
+  const cachedFn = unstable_cache(
+    async () => fetchClimbFromDb(params),
+    ['climb', params.board_name, String(params.layout_id), params.climb_uuid, String(params.angle)],
+    {
+      revalidate: 3600,
+      tags: [`climb-${params.climb_uuid}`],
+    },
+  );
+  return cachedFn();
 });
 
 export type ClimbStatsForAngle = {
@@ -56,7 +71,8 @@ export type ClimbStatsForAngle = {
 export const getClimbStatsForAllAngles = async (
   params: ParsedBoardRouteParametersWithUuid,
 ): Promise<ClimbStatsForAngle[]> => {
-  const result = rowsFromResult<ClimbStatsForAngle & { difficulty_id: number | null }>(await sql`
+  const result = rowsFromResult<ClimbStatsForAngle & { difficulty_id: number | null }>(
+    await sql`
     SELECT
       climb_stats.angle,
       COALESCE(climb_stats.ascensionist_count, 0) as ascensionist_count,
@@ -70,7 +86,8 @@ export const getClimbStatsForAllAngles = async (
     WHERE climb_stats.board_type = ${params.board_name}
     AND climb_stats.climb_uuid = ${params.climb_uuid}
     ORDER BY climb_stats.angle ASC
-  `);
+  `,
+  );
   return result.map((row) => ({
     ...row,
     difficulty: getGradeLabel(row.difficulty_id),

--- a/packages/web/app/you/page.tsx
+++ b/packages/web/app/you/page.tsx
@@ -1,9 +1,14 @@
-import React from 'react';
+import React, { Suspense } from 'react';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import { redirect } from 'next/navigation';
 import { getProfileData } from '../profile/[user_id]/server-profile-data';
 import { fetchProfileStatsData } from '../profile/[user_id]/server-profile-stats';
 import { getYouSession } from './you-auth';
 import YouProgressContent from './you-progress-content';
+import YouProfileHeader from './you-profile-header.server';
+import type { UserProfile } from '@/app/profile/[user_id]/utils/profile-constants';
+import styles from '@/app/profile/[user_id]/profile-page.module.css';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 
@@ -17,18 +22,14 @@ export async function generateMetadata() {
   });
 }
 
-export default async function YouPage() {
-  const session = await getYouSession();
-  if (!session?.user?.id) {
-    redirect('/');
-  }
-  const userId = session.user.id;
-
-  const [initialProfile, statsData] = await Promise.all([
-    getProfileData(userId, userId),
-    fetchProfileStatsData(userId),
-  ]);
-
+async function YouProgressStreaming({
+  userId,
+  initialProfile,
+}: {
+  userId: string;
+  initialProfile: UserProfile | null;
+}) {
+  const statsData = await fetchProfileStatsData(userId);
   return (
     <YouProgressContent
       userId={userId}
@@ -38,5 +39,30 @@ export default async function YouPage() {
       initialAllBoardsTicks={statsData.initialAllBoardsTicks}
       initialLogbook={statsData.initialLogbook}
     />
+  );
+}
+
+export default async function YouPage() {
+  const session = await getYouSession();
+  if (!session?.user?.id) {
+    redirect('/');
+  }
+  const userId = session.user.id;
+
+  const initialProfile = await getProfileData(userId, userId);
+
+  return (
+    <>
+      {initialProfile && <YouProfileHeader profile={initialProfile} />}
+      <Suspense
+        fallback={
+          <Box className={styles.loadingContent}>
+            <CircularProgress size={48} />
+          </Box>
+        }
+      >
+        <YouProgressStreaming userId={userId} initialProfile={initialProfile} />
+      </Suspense>
+    </>
   );
 }

--- a/packages/web/app/you/you-profile-header.server.tsx
+++ b/packages/web/app/you/you-profile-header.server.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import MuiAvatar from '@mui/material/Avatar';
+import MuiCard from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { PersonOutlined } from '@mui/icons-material';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import type { UserProfile } from '@/app/profile/[user_id]/utils/profile-constants';
+import styles from '@/app/profile/[user_id]/profile-page.module.css';
+
+type YouProfileHeaderProps = {
+  profile: UserProfile;
+};
+
+export default async function YouProfileHeader({ profile }: YouProfileHeaderProps) {
+  const { t } = await getServerTranslation('profile');
+  const displayName = profile.profile?.displayName || profile.name || t('page.displayNameFallback');
+  const avatarUrl = profile.profile?.avatarUrl || profile.image;
+
+  return (
+    <MuiCard className={styles.profileCard}>
+      <CardContent>
+        <div className={styles.profileInfo}>
+          <MuiAvatar sx={{ width: 80, height: 80 }} src={avatarUrl ?? undefined}>
+            {!avatarUrl && <PersonOutlined />}
+          </MuiAvatar>
+          <div className={styles.profileDetails}>
+            <Typography variant="h6" component="h1" className={styles.displayName}>
+              {displayName}
+            </Typography>
+            <Typography variant="body2" component="span" color="text.secondary">
+              {t('page.followerCountSummary', {
+                followers: profile.followerCount,
+                following: profile.followingCount,
+              })}
+            </Typography>
+          </div>
+        </div>
+      </CardContent>
+    </MuiCard>
+  );
+}

--- a/packages/web/i18n/locales/en-US/profile.json
+++ b/packages/web/i18n/locales/en-US/profile.json
@@ -29,7 +29,8 @@
   "page": {
     "lastThreeMonths": "Last 3 months",
     "activityChartLabel": "Activity over the last 3 months",
-    "displayNameFallback": "Climber"
+    "displayNameFallback": "Climber",
+    "followerCountSummary": "{{followers}} followers · {{following}} following"
   },
   "nav": {
     "statistics": {


### PR DESCRIPTION
## Summary

Production chrome-devtools traces showed three real bottlenecks across the routes flagged as worst performers in analytics:

| Route | Before | Bottleneck |
|---|---|---|
| `/[board]/.../view/[climb_uuid]` | LCP 874ms, TTFB **705–866ms** | Server-side (2 SQL roundtrips on cold path, likely Vercel cold start) |
| `/[board]/.../playlists/[playlist_uuid]` | LCP **1999ms**, TTFB 174ms | Client chunk took **1.1s** before discovering the LCP board thumbnail |
| `/you` (logged in) | LCP 1574ms, TTFB **807ms** | 6 SQL + ~7 GraphQL roundtrips blocked the whole document |

`/es/.../list` was also in the analytics top-4 but traced fine (LCP 311ms) — its number was inflated by an intermittent 500-error window observed during testing.

## Changes

**View page** (`packages/web/app/.../view/[climb_uuid]/page.tsx` × 2)
- Add `export const revalidate = 3600` + `dynamicParams = true`.
- Wrap `getClimb` and `fetchClimbDetailData` with `unstable_cache` (1h TTL, tagged `climb-${uuid}`). Removes SQL roundtrips on warm cache hits.

**/you** (`packages/web/app/you/page.tsx`)
- New server component `you-profile-header.server.tsx` renders avatar / display name / follower counts above the fold using the cheap, indexed `getProfileData`.
- `fetchProfileStatsData` is deferred behind `<Suspense>` inside an async server-component child so the header HTML streams without waiting on the ~700ms stats fetch.
- Adds `profile.page.followerCountSummary` i18n key (en-US).

**Playlist (board-scoped)** (`packages/web/app/.../playlists/[playlist_uuid]/page.tsx` × 2)
- Emit `<link rel=preload as=image fetchPriority=high>` for the LCP board thumbnail via the existing `getPlaylistLcpPreloadUrl` helper. The route params already encode `boardType` + `layoutId` — no extra fetch needed.
- The full SSR refactor (GET_PLAYLIST + first page of climbs server-side, HydrationBoundary for react-query) is intentionally out of scope here. Follow-up issue described in commit body / drafted separately.

## Tradeoffs / known constraints

- Route-level `revalidate = 3600` is partly neutered because `getServerTranslation` calls `headers()`, which forces dynamic rendering. The `unstable_cache` data-cache wrappers still strip the SQL roundtrips on the warm path. A bigger ISR win would require decoupling the locale read from the dynamic API.
- `unstable_cache` keys include `(boardType, layoutId, climb_uuid, angle)` for view routes. Cache invalidation tag `climb-${uuid}` is unused right now — wire it into the climb-edit mutation when that surface ships, so frame edits don't show stale OG images for up to 1h.
- The new profile header on `/you` is a small UX addition (the page previously had no visible profile row at all). Matches the pattern on `/profile/[user_id]`.

## Test plan

- [ ] Re-trace `/[board]/.../view/[climb_uuid]` cold + warm; expect warm LCP < 300ms after first hit per uuid+angle.
- [ ] Re-trace `/[board]/.../playlists/[playlist_uuid]`; expect load delay < 300ms (was 1.1s) and LCP < 800ms (was 1999ms). View-source should show `<link rel=preload as=image>` for the board thumbnail.
- [ ] Re-trace `/you` logged in; expect TTFB < 200ms and the profile header visible while stats area shows the skeleton, then stats stream in.
- [ ] Manual: navigate between climbs / playlists / `/you` to confirm hydration and interactivity unchanged.
- [ ] `vp check`, `vp run typecheck:web`, and `vp test --project web` all green.

## Out of scope

- Full SSR of board-scoped playlist detail (auth-token graphql plumbing + `HydrationBoundary` wiring) — separate follow-up.
- Vercel × Railway region locality audit. If the function region and DB region differ, every roundtrip adds 50–100ms; worth checking after this PR settles.

## Related

- During testing, prod returned 500s on virtually every server-rendered route for ~10 minutes (digest `332782541`) before self-resolving. Not addressed here, but worth grepping Vercel logs for that digest before declaring perf "fixed."

🤖 Generated with [Claude Code](https://claude.com/claude-code)