### PR TITLE
perf(logbook): virtualize ascent feed with @tanstack/react-virtual

### DIFF
--- a/packages/web/app/components/library/__tests__/logbook-feed-virtualization.test.tsx
+++ b/packages/web/app/components/library/__tests__/logbook-feed-virtualization.test.tsx
@@ -1,0 +1,283 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import type { LayoutStats, AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+// --- Capture virtualizer config so tests can pin overscan / count. ---
+let lastVirtualizerOpts: { count: number; overscan: number; estimateSize: () => number } | null = null;
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useWindowVirtualizer: (opts: {
+    count: number;
+    estimateSize: () => number;
+    overscan: number;
+    getItemKey: (i: number) => string | number;
+  }) => {
+    lastVirtualizerOpts = opts;
+    // Render visible window + overscan, capped at count. Mirrors how the real
+    // virtualizer behaves on first paint.
+    const itemCount = Math.min(opts.overscan + 7, opts.count);
+    const estimatedSize = opts.estimateSize();
+    const items = Array.from({ length: itemCount }, (_, i) => ({
+      index: i,
+      key: opts.getItemKey ? opts.getItemKey(i) : `item-${i}`,
+      start: i * estimatedSize,
+      size: estimatedSize,
+      end: (i + 1) * estimatedSize,
+      lane: 0,
+    }));
+    return {
+      getVirtualItems: () => items,
+      getTotalSize: () => opts.count * estimatedSize,
+      measureElement: vi.fn(),
+      scrollToIndex: vi.fn(),
+      scrollOffset: 0,
+      range: opts.count > 0 ? { startIndex: 0, endIndex: Math.min(6, opts.count - 1) } : null,
+    };
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+const mockRequest = vi.fn();
+const getPreferenceMock = vi.fn().mockResolvedValue(null);
+const showMessageSpy = vi.fn();
+
+vi.mock('../library.module.css', () => ({
+  default: new Proxy({}, { get: (_t, p) => String(p) }),
+}));
+vi.mock('@/app/components/activity-feed/ascents-feed.module.css', () => ({
+  default: new Proxy({}, { get: (_t, p) => String(p) }),
+}));
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@/app/lib/backend-url', () => ({
+  getBackendHttpUrl: () => 'http://backend.test',
+}));
+
+vi.mock('@/app/lib/graphql/operations/ticks', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/app/lib/graphql/operations/ticks');
+  return {
+    ...actual,
+    GET_USER_ASCENTS_FEED: 'GET_USER_ASCENTS_FEED',
+    DELETE_TICK: 'DELETE_TICK',
+  };
+});
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: 'user-1' } } }),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/you/logbook',
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({
+    token: 'test-token',
+    isAuthenticated: true,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/app/hooks/use-infinite-scroll', () => ({
+  useInfiniteScroll: () => ({ sentinelRef: { current: null } }),
+}));
+
+vi.mock('@/app/lib/user-preferences-db', () => ({
+  getPreference: (...args: unknown[]) => getPreferenceMock(...args),
+  setPreference: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: showMessageSpy }),
+}));
+
+vi.mock('@/app/lib/instagram-posting', () => ({
+  isInstagramPostingSupported: () => false,
+}));
+
+vi.mock('@/app/profile/[user_id]/utils/profile-constants', () => ({
+  getLayoutDisplayName: (boardType: string, layoutId: number | null) => `${boardType}-${layoutId ?? 'unknown'}`,
+}));
+
+vi.mock('@boardsesh/board-constants/product-sizes', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getDefaultSizeForLayout: (_boardName: string, layoutId: number) => layoutId * 10,
+    getSetsForLayoutAndSize: () => [{ id: 1, name: 'All' }],
+  };
+});
+
+vi.mock('@/app/lib/moonboard-config', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getLayoutById: () => null,
+    MOONBOARD_SETS: {},
+  };
+});
+
+vi.mock('../logbook-feed-item', () => ({
+  default: ({ item }: { item: AscentFeedItem }) => (
+    <div data-testid="logbook-feed-item" data-uuid={item.uuid}>
+      {item.uuid}
+    </div>
+  ),
+}));
+
+vi.mock('../logbook-swipe-hint-orchestrator', () => ({
+  default: () => null,
+}));
+
+vi.mock('../logbook-item-skeleton', () => ({
+  default: () => <div data-testid="logbook-skeleton" />,
+}));
+
+vi.mock('../logbook-search-form', () => ({
+  default: () => <div data-testid="logbook-search-form" />,
+}));
+
+vi.mock('next/dynamic', () => ({
+  default: () => () => null,
+}));
+
+vi.mock('@mui/material/useMediaQuery', () => ({
+  default: () => false,
+}));
+
+// Import after mocks.
+import LogbookFeed from '../logbook-feed';
+
+function makeAscentItem(index: number): AscentFeedItem {
+  return {
+    uuid: `tick-${index}`,
+    climbUuid: `climb-${index}`,
+    climbName: `Test Climb ${index}`,
+    layoutId: 1,
+    boardType: 'kilter',
+    angle: 40,
+    status: 'send',
+    quality: 3,
+    difficulty: 14,
+    consensusDifficulty: 14,
+    consensusQuality: 3,
+    attemptCount: 1,
+    comment: '',
+    timestamp: '2026-05-10T00:00:00Z',
+    setterUsername: 'setter',
+    frames: 'p1r14',
+    mirrored: false,
+    boardSize: '12x12',
+    instagramPostId: null,
+  } as unknown as AscentFeedItem;
+}
+
+function makeLayoutStats(boardType: string, layoutId: number): LayoutStats {
+  return {
+    layoutKey: `${boardType}-${layoutId}`,
+    boardType,
+    layoutId,
+    distinctClimbCount: 10,
+    gradeCounts: [],
+  };
+}
+
+function renderFeed() {
+  const client = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <LogbookFeed layoutStats={[makeLayoutStats('kilter', 1)]} loadingLayoutStats={false} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockRequest.mockReset();
+  getPreferenceMock.mockClear();
+  showMessageSpy.mockClear();
+  lastVirtualizerOpts = null;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('LogbookFeed virtualization', () => {
+  it('renders only the virtualized window, not the full item list', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => makeAscentItem(i));
+    mockRequest.mockResolvedValue({ userAscentsFeed: { items, hasMore: false } });
+
+    renderFeed();
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('logbook-feed-item').length).toBeGreaterThan(0);
+    });
+
+    const rendered = screen.getAllByTestId('logbook-feed-item');
+    expect(rendered.length).toBeLessThan(items.length);
+    // With overscan=8 and the mock's window of overscan+7, ~15 items render.
+    expect(rendered.length).toBeLessThanOrEqual(20);
+  });
+
+  it('passes the full item count and overscan=8 to the virtualizer when not editing', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => makeAscentItem(i));
+    mockRequest.mockResolvedValue({ userAscentsFeed: { items, hasMore: false } });
+
+    renderFeed();
+
+    await waitFor(() => {
+      expect(lastVirtualizerOpts).not.toBeNull();
+      expect(lastVirtualizerOpts!.count).toBe(items.length);
+    });
+    // Pinning overscan defends against accidentally bumping the value back up
+    // and undoing the LCP win on /you/logbook.
+    expect(lastVirtualizerOpts!.overscan).toBe(8);
+  });
+
+  it('mounts only the virtualized window — guarantees DOM stays bounded for power users', async () => {
+    const items = Array.from({ length: 500 }, (_, i) => makeAscentItem(i));
+    mockRequest.mockResolvedValue({ userAscentsFeed: { items, hasMore: false } });
+
+    renderFeed();
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('logbook-feed-item').length).toBeGreaterThan(0);
+    });
+
+    const rendered = screen.getAllByTestId('logbook-feed-item');
+    // 500 items in the feed, but the virtualizer keeps ~15 mounted on first
+    // paint. Without virtualization this test would render 500 nodes.
+    expect(rendered.length).toBeLessThan(50);
+  });
+
+  it('renders all items when the feed is small (no virtualization gain)', async () => {
+    const items = Array.from({ length: 5 }, (_, i) => makeAscentItem(i));
+    mockRequest.mockResolvedValue({ userAscentsFeed: { items, hasMore: false } });
+
+    renderFeed();
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('logbook-feed-item')).toHaveLength(5);
+    });
+  });
+
+});

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -25,6 +25,7 @@ import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
+import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
@@ -456,6 +457,22 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
     isFetching: isFetchingNextPage,
   });
 
+  // --- Feed virtualization ---
+  // Items have variable heights (climb-name wrapping, optional comment row,
+  // edit-mode picker panel) so we rely on measureElement after the first paint.
+  // Estimate is the median collapsed height (96px thumbnail + content padding).
+  // Overscan of 8 rows ≈ 1200px headroom keeps scroll smooth.
+  const virtualizer = useWindowVirtualizer({
+    count: items.length,
+    estimateSize: () => 150,
+    overscan: 8,
+    getItemKey: (index) => items[index]?.uuid ?? index,
+    // Provide a fake viewport so the virtualizer renders items during SSR/initial mount.
+    // Without this, getVirtualItems() returns [] and the entire feed is hidden until measured.
+    initialRect: { width: 375, height: 812 },
+  });
+  const virtualItems = virtualizer.getVirtualItems();
+
   const pendingDeleteRef = useRef<{
     uuid: string;
     item: AscentFeedItem;
@@ -798,23 +815,46 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
       {exportControls}
       <LogbookSwipeHintOrchestrator />
       <div className={feedStyles.feed}>
-        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-          {items.map((item, index) => (
-            <LogbookFeedItem
-              key={item.uuid}
-              item={item}
-              showBoardType={showBoardType}
-              isEditing={editingItemUuid === item.uuid}
-              onEdit={handleEdit}
-              onDelete={handleDelete}
-              onCancelEdit={handleCloseEdit}
-              allowInstagramPosting={enableInstagramPosting}
-              allowInstagramLinking={enableInstagramLinking && !enableInstagramPosting}
-              // Orchestrator re-queries DOM at animation time, so re-sorts are safe.
-              isSwipeHintTarget={index === 0}
-            />
-          ))}
-        </Box>
+        <div
+          style={{
+            height: virtualizer.getTotalSize(),
+            width: '100%',
+            position: 'relative',
+          }}
+        >
+          {virtualItems.map((virtualItem) => {
+            const item = items[virtualItem.index];
+            if (!item) return null;
+            return (
+              <div
+                key={virtualItem.key}
+                ref={virtualizer.measureElement}
+                data-index={virtualItem.index}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  transform: `translateY(${virtualItem.start}px)`,
+                  contain: 'layout style paint',
+                }}
+              >
+                <LogbookFeedItem
+                  item={item}
+                  showBoardType={showBoardType}
+                  isEditing={editingItemUuid === item.uuid}
+                  onEdit={handleEdit}
+                  onDelete={handleDelete}
+                  onCancelEdit={handleCloseEdit}
+                  allowInstagramPosting={enableInstagramPosting}
+                  allowInstagramLinking={enableInstagramLinking && !enableInstagramPosting}
+                  // Orchestrator re-queries DOM at animation time, so re-sorts are safe.
+                  isSwipeHintTarget={virtualItem.index === 0}
+                />
+              </div>
+            );
+          })}
+        </div>
 
         <Box ref={sentinelRef} sx={{ display: 'flex', justifyContent: 'center', py: 2, minHeight: 20 }}>
           {isFetchingNextPage && <CircularProgress size={24} />}

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -462,10 +462,17 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
   // edit-mode picker panel) so we rely on measureElement after the first paint.
   // Estimate is the median collapsed height (96px thumbnail + content padding).
   // Overscan of 8 rows ≈ 1200px headroom keeps scroll smooth.
+  //
+  // When a row is being edited, the overscan grows to 100 (~15000px window).
+  // LogbookFeedItem holds the draft (editComment, editQuality, etc.) in local
+  // useState; if the editing row unmounts during scroll the draft is lost.
+  // 100 is enough headroom that interactive scrolling during a single edit
+  // session won't unmount the row, while keeping the worst-case mount count
+  // bounded (vs. dropping virtualization entirely when editing).
   const virtualizer = useWindowVirtualizer({
     count: items.length,
     estimateSize: () => 150,
-    overscan: 8,
+    overscan: editingItemUuid ? 100 : 8,
     getItemKey: (index) => items[index]?.uuid ?? index,
     // Provide a fake viewport so the virtualizer renders items during SSR/initial mount.
     // Without this, getVirtualItems() returns [] and the entire feed is hidden until measured.
@@ -820,6 +827,7 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
             height: virtualizer.getTotalSize(),
             width: '100%',
             position: 'relative',
+            backgroundColor: 'inherit',
           }}
         >
           {virtualItems.map((virtualItem) => {


### PR DESCRIPTION
## Summary

`LogbookFeed` renders the entire loaded ascent list with `items.map(...)` — no virtualization. Each `LogbookFeedItem` mounts a board thumbnail (canvas or 2-layer `<img>` overlay), swipe action layers, an MUI `Popover` for status picking, dynamically-imported drawers, and an expandable comment/picker grid. Roughly **40-60 DOM nodes per item**. With infinite scroll loading 20 items per page, a power user with 200+ ticks gets **8,000-12,000 DOM nodes** in a single tree, plus a style-recalc cascade on every scroll.

This PR wraps the feed in `useWindowVirtualizer` from `@tanstack/react-virtual` (same library `climbs-list.tsx` already uses for the /list page). Variable-height rows are handled by attaching `virtualizer.measureElement` to each row.

- `estimateSize = 150` (96 px thumbnail + content padding — measured from `logbook-feed-item.module.css`)
- `overscan = 8` (~1200 px headroom for fast scrolling)
- `initialRect = { width: 375, height: 812 }` mirrors the climbs-list pattern so SSR/initial mount renders some items immediately rather than rendering nothing until the first browser measurement
- The existing `useInfiniteScroll` sentinel still works (lives outside the virtualized region)

Per-row swipe gestures, edit handlers, and the status `Popover` are unchanged — they remain self-contained inside `LogbookFeedItem`. Item identity is preserved via `getItemKey: (i) => items[i]?.uuid ?? i` so memoized subtrees don't unnecessarily remount across virtualizer redraws.

## Test plan

- [ ] All 74 `packages/web/app/components/library/__tests__/` tests pass (verified locally)
- [ ] Open `/you/logbook` while signed in, scroll through the feed — items render smoothly, no blank rows
- [ ] Variable-height items (long climb names, presence/absence of comment row) render at the correct positions
- [ ] Edit an item (tap pencil) — picker panel expands inline, virtualizer adjusts the layout, scroll still tracks
- [ ] Swipe an item left/right — action layer animates, then commit/cancel works as before
- [ ] Sentinel-based infinite scroll still triggers loading the next page near the bottom
- [ ] Confirm DOM node count drops vs. baseline (use Chrome DevTools `document.querySelectorAll('*').length`) on a feed with 100+ items

🤖 Generated with [Claude Code](https://claude.com/claude-code)