### PR TITLE
fix(layout): move Vercel Analytics/SpeedInsights into client wrapper

### DIFF
--- a/packages/web/app/components/providers/vercel-telemetry.tsx
+++ b/packages/web/app/components/providers/vercel-telemetry.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import React from 'react';
+import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/next';
+
+// Function props (the beforeSend filter that drops /admin pageviews) cannot be
+// passed from a Server Component (RootLayout) to a Client Component, so the
+// configuration lives here in the client boundary.
+const dropAdminEvents = <Event extends { url: string }>(event: Event): Event | null =>
+  event.url.includes('/admin') ? null : event;
+
+export function VercelAnalytics() {
+  return <Analytics beforeSend={dropAdminEvents} />;
+}
+
+export function VercelSpeedInsights() {
+  return <SpeedInsights beforeSend={dropAdminEvents} />;
+}

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -2,8 +2,7 @@
 import React from 'react';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import ColorModeProvider from './components/providers/color-mode-provider';
-import { Analytics } from '@vercel/analytics/react';
-import { SpeedInsights } from '@vercel/speed-insights/next';
+import { VercelAnalytics, VercelSpeedInsights } from './components/providers/vercel-telemetry';
 import SessionProviderWrapper from './components/providers/session-provider';
 import QueryClientProvider from './components/providers/query-client-provider';
 import { NavigationLoadingProvider } from './components/providers/navigation-loading-provider';
@@ -71,7 +70,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang={LOCALE_HTML_LANG[locale]} data-theme="dark" suppressHydrationWarning>
       <body suppressHydrationWarning>
-        <Analytics beforeSend={(event) => (event.url.includes('/admin') ? null : event)} />
+        <VercelAnalytics />
         <QueryClientProvider>
           <SessionProviderWrapper>
             <AppRouterCacheProvider>
@@ -100,7 +99,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             </AppRouterCacheProvider>
           </SessionProviderWrapper>
         </QueryClientProvider>
-        <SpeedInsights beforeSend={(event) => (event.url.includes('/admin') ? null : event)} />
+        <VercelSpeedInsights />
         {process.env.NODE_ENV === 'development' && <VercelToolbar />}
       </body>
     </html>


### PR DESCRIPTION
## Summary

The recent admin-exclusion change ([#2043](https://github.com/boardsesh/boardsesh/pull/2043)) passed inline arrow `beforeSend` filters from `RootLayout` (a Server Component) directly to `@vercel/analytics`'s `<Analytics>` and `@vercel/speed-insights`'s `<SpeedInsights>` (Client Components). **Functions are not serializable across the RSC boundary**, so every SSR request fails with:

```
Error: Functions cannot be passed directly to Client Components
unless you explicitly expose it by marking it with "use server"...
```

This is breaking the production web server start in CI and **failing all 8 E2E shards on every PR branched off main** since #2043 merged. Reproducible by reading any open PR's `Dump server logs on failure` step (e.g. PR [#2045](https://github.com/boardsesh/boardsesh/pull/2045), PR [#2046](https://github.com/boardsesh/boardsesh/pull/2046) — both blocked by this).

## Fix

Move the configured `<Analytics>` and `<SpeedInsights>` into a small `'use client'` file (`packages/web/app/components/providers/vercel-telemetry.tsx`) so the `beforeSend` callback lives entirely on the client side. `RootLayout` now just renders `<VercelAnalytics />` and `<VercelSpeedInsights />` — no function props cross the server-client boundary.

The admin-exclusion behaviour is preserved: events with `event.url.includes('/admin')` still return `null` to drop them.

## Test plan

- [ ] Lint + typecheck pass (verified locally)
- [ ] E2E shards 1-8 pass (this PR is the actual fix that unblocks them)
- [ ] Visit the homepage in a deploy preview, open the Vercel Speed Insights / Analytics network tab, confirm pageviews still record
- [ ] Visit `/admin/...` and confirm pageviews are dropped (no `_vercel/insights/view` POSTs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)