### PR TITLE
perf(list): pin overscan in test, refresh stale comment, sync audit doc

### DIFF
--- a/docs/react-performance-audit.md
+++ b/docs/react-performance-audit.md
@@ -51,12 +51,14 @@ Dynamic style objects created every render. Should be memoized or moved to CSS.
 
 ### No list virtualization / native paint skipping
 
-**Files:** `packages/web/app/components/board-page/climbs-list.tsx:368-419`
+**Files:** `packages/web/app/components/board-page/climbs-list.tsx`
 **Status:** Fixed
 
 Both grid and list modes used `.map()` directly — all items rendered to DOM at once. With infinite scroll, lists can grow to 200+ items.
 
-**Fix applied:** Added `content-visibility: auto` with `contain-intrinsic-size` via CSS classes on each list/grid item wrapper. The browser natively skips layout and paint for off-screen items while keeping them in the DOM for native scroll feel.
+**Fix applied:** List mode now uses `useWindowVirtualizer` from `@tanstack/react-virtual` (`climbs-list.tsx:552-561`) — only items in the visible window plus an overscan buffer mount to the DOM. Grid mode keeps the older `content-visibility: auto` approach (CSS-only paint skipping) because grid items have a stable aspect ratio and benefit from native infinite-scroll feel.
+
+**Overscan tuning:** Reduced from 25 → 10 (~1070px headroom) to cut first-paint mount count by ~40% on `/list` after a Chrome DevTools trace showed the previous value was driving 2 s of style recalc and 2.2 s of forced reflow on initial render. Pinned in `climbs-list-virtualization.test.tsx`.
 
 ### O(n^2) deduplication
 

--- a/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
@@ -120,7 +120,7 @@ vi.mock('@/app/theme/theme-config', () => ({
 }));
 
 // Track calls to useWindowVirtualizer
-let lastVirtualizerOpts: { count: number } | null = null;
+let lastVirtualizerOpts: { count: number; overscan: number } | null = null;
 
 vi.mock('@tanstack/react-virtual', () => ({
   useWindowVirtualizer: (opts: {
@@ -207,7 +207,8 @@ describe('ClimbsList virtualization', () => {
     );
 
     const items = screen.getAllByTestId('climb-list-item');
-    // Mock renders visible items + overscan (6 + 25 + 1 = 32), far fewer than all 100
+    // Mock renders min(overscan + 7, count) items — with overscan=10 that's
+    // ~17 items, far fewer than all 100.
     expect(items.length).toBeLessThan(allClimbs.length);
     expect(items.length).toBeGreaterThan(0);
   });
@@ -242,6 +243,24 @@ describe('ClimbsList virtualization', () => {
     // The virtualizer should receive the full climb count
     expect(lastVirtualizerOpts).not.toBeNull();
     expect(lastVirtualizerOpts!.count).toBe(100);
+  });
+
+  it('pins overscan at 10 — defends the LCP win against accidental bumps', () => {
+    render(
+      <ClimbsList
+        boardDetails={makeBoardDetails()}
+        climbs={allClimbs}
+        isFetching={false}
+        hasMore={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+
+    // With estimateSize=107, overscan=10 is ~1070px headroom — enough for
+    // smooth fast scrolling without bloating the first-paint mount count.
+    // Production traces tied a 25→10 cut directly to a render-delay drop.
+    expect(lastVirtualizerOpts).not.toBeNull();
+    expect(lastVirtualizerOpts!.overscan).toBe(10);
   });
 
   it('renders skeleton when fetching with no climbs', () => {


### PR DESCRIPTION
## Summary

Follow-up to the merged [#2046](https://github.com/boardsesh/boardsesh/pull/2046). Three items from the Claude review on that PR:

1. **Stale test comment** — `climbs-list-virtualization.test.tsx:210` still said `overscan 25, 6+25+1=32`. Updated to reflect the current overscan=10 (~17 items per the mock formula).

2. **No assertion pinning the overscan value** — added `expect(lastVirtualizerOpts!.overscan).toBe(10)`. Without this, a future revert to `overscan: 25` would silently undo the LCP win on `/list`.

3. **Docs not updated** — `docs/react-performance-audit.md` still described the old `content-visibility: auto` mitigation for the climb list. Updated to reflect the current `useWindowVirtualizer` setup and the 25→10 overscan tuning so the audit doc and the code stay in sync.

## Test plan

- [x] All 12 climbs-list virtualization tests pass (verified locally — was 11 before the new assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)