### PR TITLE
fix(i18n): rename {{count}} to {{value}} in minAscentsOption keys

### DIFF
--- a/packages/web/app/components/playlist-generator/generator-options-form.tsx
+++ b/packages/web/app/components/playlist-generator/generator-options-form.tsx
@@ -193,7 +193,7 @@ const GeneratorOptionsForm: React.FC<GeneratorOptionsFormProps> = ({
             onChange={(minAscents) => updateOption('minAscents', minAscents)}
             ariaLabel={t('generator.options.minAscents')}
             getOptionLabel={(minAscents) =>
-              t('generator.options.minAscentsOption', { count: formatMinAscentsFilterCount(minAscents) })
+              t('generator.options.minAscentsOption', { value: formatMinAscentsFilterCount(minAscents) })
             }
           />
         </MuiBox>

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -202,7 +202,7 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
               onChange={(minAscents) => updateFilters({ minAscents })}
               ariaLabel={t('search.fields.minAscents')}
               getOptionLabel={(minAscents) =>
-                t('search.fields.minAscentsOption', { count: formatMinAscentsFilterCount(minAscents) })
+                t('search.fields.minAscentsOption', { value: formatMinAscentsFilterCount(minAscents) })
               }
             />
           </div>

--- a/packages/web/i18n/locales/en-US/climbs.json
+++ b/packages/web/i18n/locales/en-US/climbs.json
@@ -124,7 +124,7 @@
       "minAscents": "Min Ascents",
       "minRating": "Min Rating",
       "any": "Any",
-      "minAscentsOption": "{{count}}+",
+      "minAscentsOption": "{{value}}+",
       "minRatingOption_one": "{{count}} star and up",
       "minRatingOption_other": "{{count}} stars and up",
       "tallClimbsOnly": "Tall Climbs Only",

--- a/packages/web/i18n/locales/en-US/playlists.json
+++ b/packages/web/i18n/locales/en-US/playlists.json
@@ -159,7 +159,7 @@
       "minAscents": "Min Ascents",
       "minRating": "Min Rating",
       "any": "Any",
-      "minAscentsOption": "{{count}}+",
+      "minAscentsOption": "{{value}}+",
       "minRatingOption_one": "{{count}} star and up",
       "minRatingOption_other": "{{count}} stars and up",
       "climbBias": "Climb Bias",

--- a/packages/web/i18n/locales/fr/climbs.json
+++ b/packages/web/i18n/locales/fr/climbs.json
@@ -124,7 +124,7 @@
       "minAscents": "Enchaînements min",
       "minRating": "Note min",
       "any": "Tous",
-      "minAscentsOption": "{{count}}+",
+      "minAscentsOption": "{{value}}+",
       "minRatingOption_one": "{{count}} étoile et plus",
       "minRatingOption_other": "{{count}} étoiles et plus",
       "tallClimbsOnly": "Blocs hauts uniquement",

--- a/packages/web/i18n/locales/fr/playlists.json
+++ b/packages/web/i18n/locales/fr/playlists.json
@@ -159,7 +159,7 @@
       "minAscents": "Enchaînements min.",
       "minRating": "Note min.",
       "any": "Tous",
-      "minAscentsOption": "{{count}}+",
+      "minAscentsOption": "{{value}}+",
       "minRatingOption_one": "{{count}} étoile et plus",
       "minRatingOption_other": "{{count}} étoiles et plus",
       "climbBias": "Préférence de blocs",


### PR DESCRIPTION
## Summary

Origin/main typecheck and \`Build packages\` jobs have been failing since [#2037](https://github.com/boardsesh/boardsesh/pull/2037) merged, blocking every open PR (mine and others). Reproducible by checking out \`origin/main\` and running \`vp run typecheck:web\`.

The recent climb-quality-filter PR added:

\`\`\`tsx
t('generator.options.minAscentsOption', { count: formatMinAscentsFilterCount(minAscents) })
\`\`\`

\`formatMinAscentsFilterCount\` returns a **string** (\`'1k'\`, \`'500'\`, \`'1500'\`) — never a number. i18next's typed \`t()\` overload narrows the options arg when it sees a literal \`count\` key (it expects a number for plural selection), so the string-typed value trips \`TS2345\` against \`TOptionsBase & $Dictionary\`.

\`minAscentsOption\` doesn't actually use plural rules — the catalog entry is just \`"{{count}}+"\`, a numeric label with a \`+\` suffix. **Renaming the placeholder to \`{{value}}\`** (in en-US, fr catalogs and both call sites) removes the i18next plural-aware overload narrowing and accepts the formatted string.

The neighbouring \`minRatingOption_one\`/\`minRatingOption_other\` keys still use \`{{count}}\` because they genuinely vary by plural form ("1 star" vs "2 stars") — left untouched.

## Files

- \`packages/web/i18n/locales/en-US/climbs.json\` — \`{{count}}+\` → \`{{value}}+\`
- \`packages/web/i18n/locales/en-US/playlists.json\` — same
- \`packages/web/i18n/locales/fr/climbs.json\` — same
- \`packages/web/i18n/locales/fr/playlists.json\` — same
- \`packages/web/app/components/playlist-generator/generator-options-form.tsx:196\` — \`{ count: ... }\` → \`{ value: ... }\`
- \`packages/web/app/components/search-drawer/accordion-search-form.tsx:205\` — same

## Test plan

- [x] \`vp run typecheck:web\` passes locally (was failing before this PR)
- [ ] Visit \`/playlists/generate\` and the search drawer's Min Ascents picker — labels still render as \`"500+"\`, \`"1k+"\` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)