### PR TITLE
Lock app to portrait orientation

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask"
+            android:screenOrientation="portrait"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/packages/web/app/manifest.ts
+++ b/packages/web/app/manifest.ts
@@ -7,6 +7,7 @@ export default function manifest(): MetadataRoute.Manifest {
     description: 'Track your sends across Kilter, Tension, and MoonBoard. One app for your boards.',
     start_url: '/',
     display: 'standalone',
+    orientation: 'portrait',
     background_color: '#101012',
     theme_color: '#101012',
     icons: [


### PR DESCRIPTION
## Summary
- Android `MainActivity` now sets `android:screenOrientation="portrait"` so the wrapped app no longer follows system rotation.
- PWA manifest declares `orientation: 'portrait'` so home-screen-installed PWAs (Android Chrome, Edge, Samsung Internet) honor the lock.
- iOS was already portrait-only via `Info.plist` — no change there.

## Notes
- Plain mobile browser tabs cannot be reliably locked: Safari rejects `screen.orientation.lock()` outright and Chrome requires fullscreen. The PWA manifest covers the installed case; the uninstalled tab will keep rotating.
- Capacitor `configChanges="orientation|..."` on the activity is kept as-is — once the orientation is fixed, it's harmless and matches the Capacitor template.

## Test plan
- [ ] `vp run typecheck:web` passes (verified locally)
- [ ] `cd mobile && bunx cap sync android && bunx cap run android` — rotate device/emulator, app stays portrait
- [ ] `bunx cap run ios` — regression check, still portrait
- [ ] Install the PWA to an Android phone home screen, rotate — stays portrait
- [ ] Open dev site in a regular phone browser tab — expected to still rotate (known limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)