### PR TITLE
[codex] Clean up telemetry wrappers

### DIFF
--- a/packages/web/app/components/providers/__tests__/vercel-telemetry.test.tsx
+++ b/packages/web/app/components/providers/__tests__/vercel-telemetry.test.tsx
@@ -1,0 +1,56 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { VercelAnalytics, VercelSpeedInsights } from '../vercel-telemetry';
+
+type TelemetryEvent = { url: string };
+type BeforeSend = (event: TelemetryEvent) => TelemetryEvent | null;
+
+const mocks = vi.hoisted(() => ({
+  analyticsBeforeSend: undefined as BeforeSend | undefined,
+  speedBeforeSend: undefined as BeforeSend | undefined,
+}));
+
+vi.mock('@vercel/analytics/react', () => ({
+  Analytics: (props: { beforeSend?: BeforeSend }) => {
+    mocks.analyticsBeforeSend = props.beforeSend;
+    return null;
+  },
+}));
+
+vi.mock('@vercel/speed-insights/next', () => ({
+  SpeedInsights: (props: { beforeSend?: BeforeSend }) => {
+    mocks.speedBeforeSend = props.beforeSend;
+    return null;
+  },
+}));
+
+function expectAdminFilter(beforeSend: BeforeSend | undefined): void {
+  expect(beforeSend).toBeTypeOf('function');
+
+  const adminEvent = { url: '/fr/admin/retention?range=30' };
+  const lookalikeEvent = { url: '/administrator' };
+  const nestedAdminEvent = { url: '/b/admin' };
+
+  expect(beforeSend?.(adminEvent)).toBeNull();
+  expect(beforeSend?.(lookalikeEvent)).toBe(lookalikeEvent);
+  expect(beforeSend?.(nestedAdminEvent)).toBe(nestedAdminEvent);
+}
+
+describe('Vercel telemetry providers', () => {
+  beforeEach(() => {
+    mocks.analyticsBeforeSend = undefined;
+    mocks.speedBeforeSend = undefined;
+  });
+
+  it('wires the admin page filter into Vercel Analytics', () => {
+    render(<VercelAnalytics />);
+
+    expectAdminFilter(mocks.analyticsBeforeSend);
+  });
+
+  it('wires the admin page filter into Speed Insights', () => {
+    render(<VercelSpeedInsights />);
+
+    expectAdminFilter(mocks.speedBeforeSend);
+  });
+});

--- a/packages/web/app/components/providers/vercel-telemetry.tsx
+++ b/packages/web/app/components/providers/vercel-telemetry.tsx
@@ -9,8 +9,7 @@ import { isAdminAnalyticsUrl } from '@/app/lib/analytics-paths';
 // passed from a Server Component (RootLayout) to a Client Component, so the
 // configuration lives here in the client boundary.
 const dropAdminEvents = <Event extends { url: string }>(event: Event): Event | null => {
-  const baseUrl = typeof window === 'undefined' ? undefined : window.location.origin;
-  return isAdminAnalyticsUrl(event.url, baseUrl) ? null : event;
+  return isAdminAnalyticsUrl(event.url) ? null : event;
 };
 
 export function VercelAnalytics() {

--- a/packages/web/app/lib/__tests__/analytics.server.test.ts
+++ b/packages/web/app/lib/__tests__/analytics.server.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { track } from '../analytics.server';
+
+vi.mock('server-only', () => ({}));
+
+const mockVercelTrack = vi.hoisted(() => vi.fn());
+vi.mock('@vercel/analytics/server', () => ({
+  track: (...args: Parameters<typeof mockVercelTrack>) => mockVercelTrack(...args),
+}));
+
+describe('server analytics wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVercelTrack.mockResolvedValue(undefined);
+  });
+
+  it('delegates event names, properties, and headers to Vercel server analytics', async () => {
+    const headers = new Headers({
+      'user-agent': 'vitest',
+      'x-forwarded-for': '127.0.0.1',
+    });
+
+    await track(
+      'Climb Search Cache Invalidated',
+      {
+        boardName: 'kilter',
+        layoutId: 1,
+        source: 'internal-route',
+      },
+      { headers },
+    );
+
+    expect(mockVercelTrack).toHaveBeenCalledTimes(1);
+    expect(mockVercelTrack).toHaveBeenCalledWith(
+      'Climb Search Cache Invalidated',
+      {
+        boardName: 'kilter',
+        layoutId: 1,
+        source: 'internal-route',
+      },
+      { headers },
+    );
+  });
+});

--- a/packages/web/app/lib/__tests__/climb-search-cache.server.test.ts
+++ b/packages/web/app/lib/__tests__/climb-search-cache.server.test.ts
@@ -11,7 +11,7 @@ vi.mock('next/cache', () => ({
 }));
 
 const mockTrack = vi.fn();
-vi.mock('@vercel/analytics/server', () => ({
+vi.mock('@/app/lib/analytics.server', () => ({
   track: (...args: Parameters<typeof mockTrack>) => mockTrack(...args),
 }));
 

--- a/packages/web/app/lib/analytics.server.ts
+++ b/packages/web/app/lib/analytics.server.ts
@@ -1,0 +1,7 @@
+import 'server-only';
+
+import { track as vercelTrack } from '@vercel/analytics/server';
+
+export const track: typeof vercelTrack = (eventName, properties, options) => {
+  return vercelTrack(eventName, properties, options);
+};

--- a/packages/web/app/lib/climb-search-cache.server.ts
+++ b/packages/web/app/lib/climb-search-cache.server.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 
-import { track } from '@vercel/analytics/server';
 import { revalidateTag } from 'next/cache';
+import { track } from '@/app/lib/analytics.server';
 import type { BoardName } from '@/app/lib/types';
 import { getBoardClimbSearchTag } from '@/app/lib/climb-search-cache';
 

--- a/packages/web/app/lib/posthog-alias-storage.ts
+++ b/packages/web/app/lib/posthog-alias-storage.ts
@@ -9,6 +9,8 @@ function readAliasKeys(): string[] {
   if (typeof window === 'undefined') return [];
 
   try {
+    // Synchronous localStorage is intentional: alias dedupe must run before
+    // IndexedDB helpers are available during the identity effect.
     // oxlint-disable-next-line no-restricted-globals -- alias dedupe must persist across reloads before IndexedDB helpers are ready
     const raw = window.localStorage.getItem(POSTHOG_ALIAS_STORAGE_KEY);
     const parsed = raw ? JSON.parse(raw) : [];
@@ -40,6 +42,8 @@ export function recordPosthogAlias(profileId: string, userId: string): void {
     const aliases = readAliasKeys().filter((aliasKey) => aliasKey !== pairKey);
     aliases.push(pairKey);
     const boundedAliases = aliases.slice(-MAX_STORED_ALIAS_PAIRS);
+    // Keep this write synchronous so a successful alias is marked before any
+    // later identity effect can retry the same pair.
     // oxlint-disable-next-line no-restricted-globals -- alias dedupe must persist across reloads before IndexedDB helpers are ready
     window.localStorage.setItem(POSTHOG_ALIAS_STORAGE_KEY, JSON.stringify(boundedAliases));
   } catch {


### PR DESCRIPTION
## Summary
- Remove the explicit `undefined` base URL path from Vercel telemetry `beforeSend` filtering.
- Add a server analytics wrapper and route climb search cache invalidation metrics through it.
- Add provider-level coverage for Vercel Analytics and Speed Insights admin filtering.
- Document why PostHog alias dedupe intentionally uses synchronous localStorage suppressions.

## Validation
- `bun run test:run app/components/providers/__tests__/vercel-telemetry.test.tsx app/lib/__tests__/analytics.server.test.ts app/lib/__tests__/climb-search-cache.server.test.ts app/lib/__tests__/analytics-paths.test.ts app/lib/__tests__/posthog-alias-storage.test.ts`
- `bun run --filter=@boardsesh/web lint`
- `bun run --filter=@boardsesh/web typecheck`
- `bun run --filter=@boardsesh/web test:run`
- `bun run --filter=@boardsesh/web build`