### PR TITLE
feat(analytics): proxy PostHog through backend to bypass ad-blockers

### DIFF
--- a/packages/backend/src/__tests__/posthog.test.ts
+++ b/packages/backend/src/__tests__/posthog.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
+import { initCors } from '../handlers/cors';
+import { handlePosthogProxy } from '../handlers/posthog';
+
+type ProxyReq = Parameters<typeof handlePosthogProxy>[0];
+type ProxyRes = Parameters<typeof handlePosthogProxy>[1];
+
+type FakeReqOptions = {
+  method: string;
+  origin?: string;
+  body?: string;
+  contentType?: string;
+  forwardedFor?: string;
+  remoteAddress?: string;
+};
+
+function createFakeReq(options: FakeReqOptions): ProxyReq {
+  const listeners: Record<string, Array<(arg?: unknown) => void>> = {};
+  const headers: Record<string, string> = {};
+  if (options.origin) headers.origin = options.origin;
+  if (options.contentType) headers['content-type'] = options.contentType;
+  if (options.forwardedFor) headers['x-forwarded-for'] = options.forwardedFor;
+
+  const req = {
+    method: options.method,
+    headers,
+    socket: { remoteAddress: options.remoteAddress ?? '127.0.0.1' },
+    destroy: vi.fn(),
+    on(event: string, cb: (arg?: unknown) => void) {
+      (listeners[event] ??= []).push(cb);
+      return req;
+    },
+  };
+
+  // Emit the body once the handler has attached listeners. Use Uint8Array
+  // (a Web standard global) so we don't need to import Node's Buffer here —
+  // the handler concats with Buffer.concat which accepts ArrayBufferView.
+  queueMicrotask(() => {
+    if (options.body !== undefined) {
+      const bytes = new TextEncoder().encode(options.body);
+      listeners.data?.forEach((cb) => cb(bytes));
+    }
+    listeners.end?.forEach((cb) => cb());
+  });
+
+  return req as unknown as ProxyReq;
+}
+
+type FakeRes = {
+  status: number | null;
+  headers: Record<string, string>;
+  body: string | null;
+  setHeader: ReturnType<typeof vi.fn>;
+  writeHead: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+  headersSent: boolean;
+  asProxyRes: ProxyRes;
+};
+
+function createFakeRes(): FakeRes {
+  const captured: Partial<FakeRes> = { status: null, headers: {}, body: null, headersSent: false };
+  const target = {
+    setHeader: vi.fn((key: string, value: string) => {
+      captured.headers![key] = value;
+    }),
+    writeHead: vi.fn((status: number, headerMap?: Record<string, string>) => {
+      captured.status = status;
+      if (headerMap) Object.assign(captured.headers!, headerMap);
+      captured.headersSent = true;
+    }),
+    end: vi.fn((chunk?: unknown) => {
+      if (typeof chunk === 'string') captured.body = chunk;
+      else if (chunk instanceof Uint8Array) captured.body = new TextDecoder().decode(chunk);
+    }),
+    get headersSent() {
+      return captured.headersSent ?? false;
+    },
+  };
+  return {
+    get status() {
+      return captured.status ?? null;
+    },
+    get headers() {
+      return captured.headers ?? {};
+    },
+    get body() {
+      return captured.body ?? null;
+    },
+    get headersSent() {
+      return captured.headersSent ?? false;
+    },
+    setHeader: target.setHeader,
+    writeHead: target.writeHead,
+    end: target.end,
+    asProxyRes: target as unknown as ProxyRes,
+  };
+}
+
+function buildUrl(pathname: string, search = ''): URL {
+  return new URL(`http://localhost:8080${pathname}${search}`);
+}
+
+describe('PostHog Proxy Handler', () => {
+  const fetchMock = vi.fn();
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    initCors('https://boardsesh.com');
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('responds to OPTIONS preflight with CORS headers and no upstream call', async () => {
+    const req = createFakeReq({ method: 'OPTIONS', origin: 'https://boardsesh.com' });
+    const res = createFakeRes();
+
+    await handlePosthogProxy(req, res.asProxyRes, buildUrl('/api/posthog/i/v0/e/'));
+
+    expect(res.status).toBe(200);
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('https://boardsesh.com');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-POST methods with 405', async () => {
+    const req = createFakeReq({ method: 'GET', origin: 'https://boardsesh.com' });
+    const res = createFakeRes();
+
+    await handlePosthogProxy(req, res.asProxyRes, buildUrl('/api/posthog/i/v0/e/'));
+
+    expect(res.status).toBe(405);
+    expect(res.headers.Allow).toBe('POST, OPTIONS');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards a POST to PostHog with body, content-type, query string, and X-Forwarded-For', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{"status":1}', { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+
+    const req = createFakeReq({
+      method: 'POST',
+      origin: 'https://boardsesh.com',
+      body: '{"event":"test"}',
+      contentType: 'text/plain',
+      forwardedFor: '203.0.113.7, 10.0.0.1',
+    });
+    const res = createFakeRes();
+
+    await handlePosthogProxy(req, res.asProxyRes, buildUrl('/api/posthog/i/v0/e/', '?ip=1'));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const callArgs = fetchMock.mock.calls[0] as [string, RequestInit];
+    const upstreamUrl = callArgs[0];
+    const init = callArgs[1];
+    expect(upstreamUrl).toBe('https://us.i.posthog.com/i/v0/e/?ip=1');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('text/plain');
+    expect(headers['X-Forwarded-For']).toBe('203.0.113.7');
+    expect(init.body).toBe('{"event":"test"}');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['Content-Type']).toBe('application/json');
+    expect(res.body).toBe('{"status":1}');
+  });
+
+  it('falls back to socket.remoteAddress for X-Forwarded-For when header is absent', async () => {
+    fetchMock.mockResolvedValue(new Response('1', { status: 200 }));
+
+    const req = createFakeReq({
+      method: 'POST',
+      origin: 'https://boardsesh.com',
+      body: '{}',
+      remoteAddress: '198.51.100.4',
+    });
+    const res = createFakeRes();
+
+    await handlePosthogProxy(req, res.asProxyRes, buildUrl('/api/posthog/i/v0/e/'));
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>)['X-Forwarded-For']).toBe('198.51.100.4');
+  });
+
+  it('returns 404 when the path is exactly the prefix (no upstream target)', async () => {
+    const req = createFakeReq({ method: 'POST', origin: 'https://boardsesh.com', body: '{}' });
+    const res = createFakeRes();
+
+    await handlePosthogProxy(req, res.asProxyRes, buildUrl('/api/posthog'));
+
+    expect(res.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 413 when the body exceeds 64KB', async () => {
+    const oversized = 'a'.repeat(64 * 1024 + 1);
+    const req = createFakeReq({
+      method: 'POST',
+      origin: 'https://boardsesh.com',
+      body: oversized,
+    });
+    const res = createFakeRes();
+
+    await handlePosthogProxy(req, res.asProxyRes, buildUrl('/api/posthog/i/v0/e/'));
+
+    expect(res.status).toBe(413);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('mirrors upstream non-2xx status and content-type back to the caller', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('upstream blew up', { status: 503, headers: { 'content-type': 'text/plain' } }),
+    );
+
+    const req = createFakeReq({ method: 'POST', origin: 'https://boardsesh.com', body: '{}' });
+    const res = createFakeRes();
+
+    await handlePosthogProxy(req, res.asProxyRes, buildUrl('/api/posthog/i/v0/e/'));
+
+    expect(res.status).toBe(503);
+    expect(res.headers['Content-Type']).toBe('text/plain');
+    expect(res.body).toBe('upstream blew up');
+  });
+
+  it('returns 502 when the upstream fetch throws', async () => {
+    fetchMock.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const req = createFakeReq({ method: 'POST', origin: 'https://boardsesh.com', body: '{}' });
+    const res = createFakeRes();
+
+    await handlePosthogProxy(req, res.asProxyRes, buildUrl('/api/posthog/i/v0/e/'));
+
+    expect(res.status).toBe(502);
+    const payload = JSON.parse(res.body ?? '{}') as { error?: string };
+    expect(payload.error).toBe('Upstream unavailable');
+  });
+});

--- a/packages/backend/src/handlers/posthog.ts
+++ b/packages/backend/src/handlers/posthog.ts
@@ -1,0 +1,112 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+import { applyCorsHeaders } from './cors';
+
+const POSTHOG_UPSTREAM = 'https://us.i.posthog.com';
+const MAX_BODY_BYTES = 64 * 1024;
+const UPSTREAM_TIMEOUT_MS = 5000;
+const PROXY_PATH_PREFIX = '/api/posthog';
+
+function getClientIp(req: IncomingMessage): string | null {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    const first = forwarded.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  return req.socket.remoteAddress ?? null;
+}
+
+function readBody(req: IncomingMessage, limitBytes: number): Promise<Buffer | { tooLarge: true }> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    req.on('data', (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > limitBytes) {
+        resolve({ tooLarge: true });
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+/**
+ * Reverse proxy for PostHog ingestion.
+ *
+ * Forwards POST /api/posthog/<rest> → https://us.i.posthog.com/<rest>, preserving
+ * the query string and request body. The whole point is to make events first-party
+ * so ad-blockers that target *.posthog.com don't drop them.
+ *
+ * posthog-js-lite uses Content-Type: text/plain and no custom headers, so the
+ * browser treats this as a CORS-safelisted "simple" request — no preflight.
+ */
+export async function handlePosthogProxy(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
+  if (!applyCorsHeaders(req, res)) return;
+
+  if (req.method !== 'POST') {
+    res.writeHead(405, { 'Content-Type': 'application/json', Allow: 'POST, OPTIONS' });
+    res.end(JSON.stringify({ error: 'Method not allowed' }));
+    return;
+  }
+
+  const rest = url.pathname.slice(PROXY_PATH_PREFIX.length);
+  if (!rest || !rest.startsWith('/')) {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+    return;
+  }
+
+  const body = await readBody(req, MAX_BODY_BYTES);
+  if ('tooLarge' in body) {
+    res.writeHead(413, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Payload too large' }));
+    return;
+  }
+
+  const upstreamUrl = `${POSTHOG_UPSTREAM}${rest}${url.search}`;
+  const headers: Record<string, string> = {
+    'Content-Type': typeof req.headers['content-type'] === 'string' ? req.headers['content-type'] : 'text/plain',
+  };
+  const clientIp = getClientIp(req);
+  if (clientIp) headers['X-Forwarded-For'] = clientIp;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+  const startedAt = Date.now();
+
+  try {
+    // PostHog ingestion only accepts text payloads (JSON in a text/plain body),
+    // so it's safe to forward as a UTF-8 string. Avoids @types/node BodyInit
+    // friction with Buffer/Uint8Array.
+    const upstream = await fetch(upstreamUrl, {
+      method: 'POST',
+      headers,
+      body: body.toString('utf8'),
+      signal: controller.signal,
+    });
+    const responseBody = Buffer.from(await upstream.arrayBuffer());
+    const contentType = upstream.headers.get('content-type') ?? 'application/json';
+
+    res.writeHead(upstream.status, { 'Content-Type': contentType });
+    res.end(responseBody);
+
+    console.info('[posthog-proxy]', { status: upstream.status, durationMs: Date.now() - startedAt, path: rest });
+  } catch (err) {
+    const aborted = err instanceof Error && err.name === 'AbortError';
+    console.error('[posthog-proxy] upstream error', {
+      aborted,
+      durationMs: Date.now() - startedAt,
+      path: rest,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    if (!res.headersSent) {
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Upstream unavailable' }));
+    }
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -13,6 +13,7 @@ import { handleAvatarUpload } from './handlers/avatars';
 import { handleStaticAvatar, handleStaticBetaThumbnail } from './handlers/static';
 import { handleSyncCron } from './handlers/sync';
 import { handleOcrTestDataUpload } from './handlers/ocr-test-data';
+import { handlePosthogProxy } from './handlers/posthog';
 import { handleUserDataExport, handleUserDataExportDownload } from './handlers/user-data-export';
 import { createYogaInstance } from './graphql/yoga';
 import { setupWebSocketServer } from './websocket/setup';
@@ -95,6 +96,13 @@ export async function startServer(): Promise<ServerResources> {
       // OCR test data upload endpoint (handle OPTIONS for CORS preflight)
       if (pathname === '/api/ocr-test-data' && (req.method === 'POST' || req.method === 'OPTIONS')) {
         await handleOcrTestDataUpload(req, res);
+        return;
+      }
+
+      // PostHog analytics reverse proxy — forwards /api/posthog/* to https://us.i.posthog.com/*
+      // so ad-blockers that target *.posthog.com don't drop our events.
+      if (pathname.startsWith('/api/posthog/') && (req.method === 'POST' || req.method === 'OPTIONS')) {
+        await handlePosthogProxy(req, res, url);
         return;
       }
 
@@ -199,6 +207,7 @@ export async function startServer(): Promise<ServerResources> {
     console.info(`  Avatar upload: ${httpScheme}://0.0.0.0:${PORT}/api/avatars`);
     console.info(`  Avatar files: ${httpScheme}://0.0.0.0:${PORT}/static/avatars/`);
     console.info(`  OCR test data: ${httpScheme}://0.0.0.0:${PORT}/api/ocr-test-data`);
+    console.info(`  PostHog proxy: ${httpScheme}://0.0.0.0:${PORT}/api/posthog/*`);
     console.info(`  User data export: ${httpScheme}://0.0.0.0:${PORT}/api/user-data-export`);
     console.info(`  Sync cron: ${httpScheme}://0.0.0.0:${PORT}/sync-cron`);
 

--- a/packages/web/.env.local
+++ b/packages/web/.env.local
@@ -24,7 +24,9 @@ NEXT_PUBLIC_WS_URL=ws://localhost:8080/graphql
 # so dev/preview never initialises the client even if the key is set).
 # Set NEXT_PUBLIC_POSTHOG_KEY in the Vercel production environment.
 # NEXT_PUBLIC_POSTHOG_KEY=
-NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+# Events default to <backend>/api/posthog (the reverse proxy). Override with
+# NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com to bypass the proxy.
+# NEXT_PUBLIC_POSTHOG_HOST=
 
 # S3 Storage Configuration (optional, for production)
 # When these are set, avatar uploads go to S3 instead of local disk

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -1,6 +1,7 @@
 import { track as vercelTrack } from '@vercel/analytics';
 import { PostHog } from 'posthog-js-lite';
 import { analyticsPathname, isAdminAnalyticsUrl } from './analytics-paths';
+import { getBackendHttpUrl } from './backend-url';
 
 // Mirror @vercel/analytics' AllowedPropertyValues so existing call sites
 // type-check unchanged when they swap to this wrapper.
@@ -24,7 +25,12 @@ function getPosthog(): PostHog | null {
 
   const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
   if (!apiKey) return null;
-  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
+  // Default to the boardsesh backend's PostHog reverse proxy so events look
+  // first-party to ad-blockers. NEXT_PUBLIC_POSTHOG_HOST overrides for incident
+  // recovery (point straight at us.i.posthog.com if the proxy is down).
+  const backendUrl = getBackendHttpUrl();
+  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? (backendUrl ? `${backendUrl}/api/posthog` : null);
+  if (!host) return null;
 
   posthogClient = new PostHog(apiKey, {
     host,


### PR DESCRIPTION
## Summary
- PostHog recommends a reverse proxy so events bypass ad-blockers that block `*.posthog.com`. Their managed Cloudflare beta routes through a third-party not yet listed as a PostHog subprocessor — adding more parts and a privacy footnote we don't need.
- Self-hosting in `packages/backend` fits the project rule of moving REST endpoints out of Next.js and keeps the analytics stack portable (pure Node `http` + `fetch`, no Railway-specific bits).
- The web client uses `posthog-js-lite`, which sends a single endpoint (`POST /i/v0/e/`) as a CORS-safelisted simple request — so the proxy is ~90 lines and adds no preflight overhead.

## Changes
- **`packages/backend/src/handlers/posthog.ts`** (new): forwards `POST /api/posthog/<rest>` → `https://us.i.posthog.com/<rest>`. Preserves query string, sets `X-Forwarded-For` from the original client IP so geolocation still works, 64KB body cap, 5s upstream timeout, mirrors upstream status + content-type.
- **`packages/backend/src/server.ts`**: routes `/api/posthog/*` to the new handler; logs the endpoint at startup.
- **`packages/backend/src/__tests__/posthog.test.ts`** (new): 8 unit tests covering preflight, method rejection, body forwarding, IP fallback, missing path, oversized body, upstream non-2xx passthrough, and upstream error.
- **`packages/web/app/lib/analytics.ts`**: default host now derives from `getBackendHttpUrl()` + `/api/posthog`. `NEXT_PUBLIC_POSTHOG_HOST` stays as an override hatch for incident recovery (point straight at `us.i.posthog.com` if the proxy is down).
- **`packages/web/.env.local`**: dropped the `us.i.posthog.com` default; documented the override.

## Test plan
- [x] `vp run typecheck:backend && vp run typecheck:web`
- [x] `vp test run --project backend` — 879/879 pass, including the 8 new tests
- [x] `vp check --fix` on touched files (pre-commit hook) — clean
- [ ] After deploy: open DevTools Network on prod, fire a `track()` event, confirm the request goes to `<backend>/api/posthog/i/v0/e/?ip=1` (not `us.i.posthog.com`) and that the event appears in the PostHog dashboard.
- [ ] Install uBlock Origin in the browser and repeat — events should still fire. Watch the PostHog event count over 24h; expect a step up equal to the previously-blocked user fraction.

## Notes
- API key (`NEXT_PUBLIC_POSTHOG_KEY`) stays client-side — PostHog public project keys are write-only by design, no security benefit to hiding them.
- Hostname gate in `analytics.ts` is unchanged: dev/preview still won't write to prod PostHog.
- The handler matches `/api/posthog/*`, so adding feature flags (`/decide`) or session replay later doesn't require backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)