### PR TITLE
fix(i18n): add missing Spanish playlists.library.pin keys

### DIFF
--- a/packages/web/i18n/locales/es/playlists.json
+++ b/packages/web/i18n/locales/es/playlists.json
@@ -23,6 +23,12 @@
       "smart": "Tus selecciones",
       "discover": "Descubre"
     },
+    "pin": {
+      "pinAriaLabel": "Fijar playlist",
+      "unpinAriaLabel": "Desfijar playlist",
+      "pinFailed": "No se pudo fijar la playlist",
+      "unpinFailed": "No se pudo desfijar la playlist"
+    },
     "smart": {
       "fiveStars": {
         "title": "Cinco estrellas",


### PR DESCRIPTION
## Summary

- Adds `library.pin.{pinAriaLabel,unpinAriaLabel,pinFailed,unpinFailed}` to `packages/web/i18n/locales/es/playlists.json`. The English catalog already had this block; the Spanish catalog had no `library.pin` at all, so `/es/.../playlists` was firing runtime missing-key warnings every time a user saw the pin/unpin icon button.
- Fixes [BOARDSESH-61](https://boardsesh.sentry.io/issues/BOARDSESH-61) (`Missing i18n key: playlists:library.pin.unpinAriaLabel`).
- The 20 other "Missing i18n key" Sentry warnings opened over the last week were already fixed in [`b7b4cb622`](https://github.com/boardsesh/boardsesh/commit/b7b4cb622) (merged 2026-05-06). They'll be bulk-resolved in Sentry separately now that the fix is deployed.

## Test plan

- [ ] `vp run check:i18n` passes (no new hardcoded strings).
- [ ] `vp run typecheck:web` passes.
- [ ] In Spanish locale (`/es/.../playlists`), the pin/unpin icon button exposes the Spanish aria-label via the accessibility tree.
- [ ] After deploy, BOARDSESH-61 stops accumulating new events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)