### PR TITLE
fix(i18n): coerce angle-selector count + preload profile/feed at root

### DIFF
--- a/packages/web/app/components/board-page/angle-selector.tsx
+++ b/packages/web/app/components/board-page/angle-selector.tsx
@@ -169,7 +169,7 @@ export default function AngleSelector({
                     </Typography>
                   )}
                   <Typography variant="body2" component="span" color="text.secondary" sx={{ fontSize: 10 }}>
-                    {t('angleSelector.sends', { count: stats.ascensionist_count ?? 0 })}
+                    {t('angleSelector.sends', { count: Number(stats.ascensionist_count ?? 0) })}
                   </Typography>
                 </Box>
               </Box>

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -81,7 +81,17 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <ColorModeProvider>
                 <I18nProvider
                   locale={locale}
-                  namespaces={['common', 'playlists', 'session', 'auth', 'settings', 'boards', 'climbs']}
+                  namespaces={[
+                    'common',
+                    'playlists',
+                    'session',
+                    'auth',
+                    'settings',
+                    'boards',
+                    'climbs',
+                    'profile',
+                    'feed',
+                  ]}
                 >
                   <SnackbarProvider>
                     <AuthModalProvider>


### PR DESCRIPTION
## Summary

Three independent bugs hiding behind the static "catalogs have the keys" check:

- **BOARDSESH-54** (`climbs:angleSelector.sends`, 193u / 269e). `ClimbStatsForAngle.ascensionist_count` is typed `string` (`packages/web/app/lib/data/queries.ts:61` — "comes as string from DB"). i18next 23's `t()` skips plural handling when `typeof count !== 'number'` and falls back to the bare key `sends`, which doesn't exist (only `sends_one`/`sends_other` do). Wrap the count in `Number(...)` so plural resolution runs.
- **BOARDSESH-4J–4Z** (`profile:logbook.form.*`, 14 keys, 13u / 20e each). `LogAscentForm` (`useTranslation('profile')`) is mounted from `QueueList` → `LogAscentDrawer`, which renders from the root-level `RootBottomBar` whenever the user has an active queue. The root `I18nProvider` didn't preload `profile`, so on routes that don't add it themselves (like `/docs`) the per-request server i18next has no bundle and fires missing-key.
- **BOARDSESH-59** (`feed:search.minCharsHint`, 4u / 4e). `UnifiedSearchDrawer` is mounted from the root-level `GlobalHeader` and its search-results children use `useTranslation('feed')`. Drawer state can persist across client-side navigations into routes like `/auth/native-start` that don't preload `feed`. Same root-preload fix.

## What's not in this PR

- **BOARDSESH-5X** (`common:ariaLabels.openQueue`) and **BOARDSESH-60/5Z/5Y** (`climbs:create.clear.*`) are left for Sentry's auto-reopen — their namespaces are already in the right preload lists and last-seen events were on or before the b7b4cb622 deploy (2026-05-06), so they look stale. If they auto-reopen within 48h we'll investigate them separately.
- Retyping `ClimbStatsForAngle.ascensionist_count` as `number` at the data-layer boundary — other callers in `queries.ts` may rely on the string shape; out of scope for this fix.

The earlier `?? 0` guard (`9b1a94e4e`) only covered null/undefined; `saveMissingPlurals: false` (`b7b4cb622`) is a red herring — that flag only controls which plural variants get save-missing events, not whether the base lookup falls through.

This also supersedes the "20 other warnings will age out on their own" line in #2060 — they wouldn't have.

## Test plan

- [ ] `vp check` and `vp run typecheck:web` pass locally (both ran clean).
- [ ] Play-view drawer → angle drawer renders "N sends" / "1 send" instead of the raw key `angleSelector.sends`.
- [ ] No `profile:logbook.form.*` Sentry events after deploy on routes without an explicit `profile` preload (e.g. /docs with an active queue → tap into the queue → open log-ascent drawer).
- [ ] No `feed:search.minCharsHint` Sentry events after deploy on `/auth/native-start` etc.
- [ ] 48h watch: BOARDSESH-5X, -60, -5Z, -5Y stay resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)