### PR TITLE
fix(auth): swallow iOS Capacitor "No active window to close!" rejection

### DIFF
--- a/packages/web/app/components/providers/__tests__/session-provider-native-oauth.test.tsx
+++ b/packages/web/app/components/providers/__tests__/session-provider-native-oauth.test.tsx
@@ -303,6 +303,49 @@ describe('SessionProviderWrapper native OAuth deep link', () => {
     expect(mockRemove).toHaveBeenCalled();
   });
 
+  it('swallows "No active window to close!" rejection from Browser.close (iOS)', async () => {
+    // Simulate the iOS Capacitor browser plugin throwing when the SFSafariViewController
+    // was already dismissed by the OS in response to the custom-scheme deep link.
+    // See: https://github.com/ionic-team/capacitor-plugins/issues/1899
+    mockClose.mockRejectedValueOnce(new Error('No active window to close!'));
+    mockSignIn.mockResolvedValue({ url: '/dashboard', error: null });
+    setupCapacitorMock();
+
+    const unhandledRejections: PromiseRejectionEvent[] = [];
+    const captureRejection = (event: PromiseRejectionEvent) => {
+      unhandledRejections.push(event);
+      event.preventDefault();
+    };
+    window.addEventListener('unhandledrejection', captureRejection);
+
+    try {
+      render(
+        <SessionProviderWrapper>
+          <div>child</div>
+        </SessionProviderWrapper>,
+      );
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      await act(async () => {
+        capturedListener?.({
+          url: 'com.boardsesh.app://auth/callback?transferToken=abc123&next=/dashboard',
+        });
+        // Give the deferred async listener body a tick to settle.
+        await new Promise((r) => setTimeout(r, 0));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(mockClose).toHaveBeenCalled();
+      expect(mockLocationAssign).toHaveBeenCalledWith('/dashboard');
+      expect(unhandledRejections).toHaveLength(0);
+    } finally {
+      window.removeEventListener('unhandledrejection', captureRejection);
+    }
+  });
+
   it('removes listener if component unmounts before registration completes', async () => {
     setupCapacitorMock();
     let resolveListener: ((value: { remove: () => Promise<void> }) => void) | null = null;

--- a/packages/web/app/components/providers/session-provider.tsx
+++ b/packages/web/app/components/providers/session-provider.tsx
@@ -6,11 +6,53 @@ import { SessionProvider, signIn } from 'next-auth/react';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
 import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import { closeCapacitorBrowser } from '@/app/lib/ble/capacitor-browser';
 import { NATIVE_OAUTH_CALLBACK_SCHEME } from '@/app/lib/auth/native-oauth-config';
 
 type SessionProviderWrapperProps = {
   children: ReactNode;
 };
+
+async function handleAppUrlOpen(url: string): Promise<void> {
+  if (!url.startsWith(NATIVE_OAUTH_CALLBACK_SCHEME)) {
+    return;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    await closeCapacitorBrowser();
+    window.location.assign('/auth/login?error=OAuthCallback');
+    return;
+  }
+
+  const callbackError = parsed.searchParams.get('error');
+  const transferToken = parsed.searchParams.get('transferToken');
+  const nextPath = parsed.searchParams.get('next') ?? '/';
+  const safeCallbackUrl = nextPath.startsWith('/') ? nextPath : '/';
+
+  if (callbackError || !transferToken) {
+    await closeCapacitorBrowser();
+    window.location.assign('/auth/login?error=OAuthCallback');
+    return;
+  }
+
+  const result = await signIn('native-oauth', {
+    transferToken,
+    callbackUrl: safeCallbackUrl,
+    redirect: false,
+  });
+
+  await closeCapacitorBrowser();
+
+  if (result?.error) {
+    window.location.assign('/auth/login?error=OAuthCallback');
+    return;
+  }
+
+  window.location.assign(result?.url ?? safeCallbackUrl);
+}
 
 export default function SessionProviderWrapper({ children }: SessionProviderWrapperProps) {
   const { t } = useTranslation('settings');
@@ -32,47 +74,14 @@ export default function SessionProviderWrapper({ children }: SessionProviderWrap
     // addListener may return a PluginListenerHandle directly (Capacitor 6+)
     // or a Promise<PluginListenerHandle> (Capacitor 5). Wrap with
     // Promise.resolve to handle both cases safely.
-    const listenerResult = appPlugin.addListener('appUrlOpen', async ({ url }) => {
-      if (!url.startsWith(NATIVE_OAUTH_CALLBACK_SCHEME)) {
-        return;
-      }
-
-      const closeBrowser = () => window.Capacitor?.Plugins?.Browser?.close?.();
-
-      let parsed: URL;
-      try {
-        parsed = new URL(url);
-      } catch {
-        await closeBrowser();
-        window.location.assign('/auth/login?error=OAuthCallback');
-        return;
-      }
-
-      const callbackError = parsed.searchParams.get('error');
-      const transferToken = parsed.searchParams.get('transferToken');
-      const nextPath = parsed.searchParams.get('next') ?? '/';
-      const safeCallbackUrl = nextPath.startsWith('/') ? nextPath : '/';
-
-      if (callbackError || !transferToken) {
-        await closeBrowser();
-        window.location.assign('/auth/login?error=OAuthCallback');
-        return;
-      }
-
-      const result = await signIn('native-oauth', {
-        transferToken,
-        callbackUrl: safeCallbackUrl,
-        redirect: false,
+    const listenerResult = appPlugin.addListener('appUrlOpen', ({ url }) => {
+      // Run the async work but never let it reject into the Capacitor event
+      // bus. addListener does not consume the listener's return value, so an
+      // uncaught rejection here surfaces as an unhandled promise rejection
+      // (and lands in Sentry).
+      void handleAppUrlOpen(url).catch((error) => {
+        console.error('[Native OAuth] Unexpected error handling appUrlOpen:', error);
       });
-
-      await closeBrowser();
-
-      if (result?.error) {
-        window.location.assign('/auth/login?error=OAuthCallback');
-        return;
-      }
-
-      window.location.assign(result?.url ?? safeCallbackUrl);
     });
 
     Promise.resolve(listenerResult)

--- a/packages/web/app/lib/ble/__tests__/capacitor-browser.test.ts
+++ b/packages/web/app/lib/ble/__tests__/capacitor-browser.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
+import { closeCapacitorBrowser } from '../capacitor-browser';
+
+describe('closeCapacitorBrowser', () => {
+  const mockClose = vi.fn();
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockClose.mockReset();
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    Object.defineProperty(window, 'Capacitor', {
+      value: {
+        isNativePlatform: () => true,
+        getPlatform: () => 'ios',
+        Plugins: {
+          Browser: { close: mockClose },
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    Object.defineProperty(window, 'Capacitor', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('resolves silently when the plugin is unavailable', async () => {
+    Object.defineProperty(window, 'Capacitor', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    await expect(closeCapacitorBrowser()).resolves.toBeUndefined();
+  });
+
+  it('calls Browser.close() when available', async () => {
+    mockClose.mockResolvedValue(undefined);
+    await closeCapacitorBrowser();
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+
+  it('swallows the "No active window to close!" iOS error', async () => {
+    mockClose.mockRejectedValue(new Error('No active window to close!'));
+    await expect(closeCapacitorBrowser()).resolves.toBeUndefined();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('swallows the error case-insensitively (defensive)', async () => {
+    mockClose.mockRejectedValue(new Error('NO ACTIVE WINDOW TO CLOSE!'));
+    await expect(closeCapacitorBrowser()).resolves.toBeUndefined();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('swallows the older "No browser is open" phrasing', async () => {
+    mockClose.mockRejectedValue(new Error('No browser is open'));
+    await expect(closeCapacitorBrowser()).resolves.toBeUndefined();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('handles non-Error rejection values', async () => {
+    mockClose.mockRejectedValue('No active window to close!');
+    await expect(closeCapacitorBrowser()).resolves.toBeUndefined();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs but does not throw on unexpected errors', async () => {
+    mockClose.mockRejectedValue(new Error('Plugin not implemented'));
+    await expect(closeCapacitorBrowser()).resolves.toBeUndefined();
+    expect(consoleWarnSpy).toHaveBeenCalledWith('[Capacitor Browser] close() failed unexpectedly:', expect.any(Error));
+  });
+});

--- a/packages/web/app/lib/ble/capacitor-browser.ts
+++ b/packages/web/app/lib/ble/capacitor-browser.ts
@@ -1,0 +1,58 @@
+/**
+ * Safely close the Capacitor in-app browser (SFSafariViewController on iOS,
+ * Chrome Custom Tabs on Android).
+ *
+ * On iOS the plugin throws `Error: No active window to close!` when
+ * `Browser.close()` is called and there is no in-app browser currently
+ * presented. That happens regularly during the native OAuth flow: the OS
+ * dismisses SFSafariViewController automatically when the custom-scheme
+ * deep link fires, so by the time our `appUrlOpen` listener runs the
+ * browser is already gone. The error is benign — there is nothing to do
+ * but ignore it — but it bubbles up as an unhandled promise rejection
+ * (Sentry BOARDSESH-29) on iOS Capacitor builds.
+ *
+ * See: https://github.com/ionic-team/capacitor-plugins/issues/1899
+ */
+
+const NO_ACTIVE_WINDOW_MESSAGES = [
+  'no active window to close',
+  // Older plugin versions phrased it slightly differently; match defensively.
+  'no browser is open',
+];
+
+const isExpectedCloseFailure = (error: unknown): boolean => {
+  if (!error) return false;
+  const message =
+    typeof error === 'string'
+      ? error
+      : error instanceof Error
+        ? error.message
+        : typeof (error as { message?: unknown }).message === 'string'
+          ? (error as { message: string }).message
+          : '';
+  const normalized = message.toLowerCase();
+  return NO_ACTIVE_WINDOW_MESSAGES.some((needle) => normalized.includes(needle));
+};
+
+/**
+ * Call `Browser.close()` if the plugin is available, and swallow the
+ * "no active window to close" error that iOS throws when the in-app
+ * browser was already dismissed. Other errors are logged but never
+ * re-thrown — the caller is in a cleanup path and shouldn't have its
+ * happy path broken by a teardown hiccup.
+ */
+export async function closeCapacitorBrowser(): Promise<void> {
+  if (typeof window === 'undefined') return;
+  const browserPlugin = window.Capacitor?.Plugins?.Browser;
+  if (!browserPlugin || typeof browserPlugin.close !== 'function') return;
+
+  try {
+    await browserPlugin.close();
+  } catch (error) {
+    if (isExpectedCloseFailure(error)) {
+      // Expected on iOS when the OS already dismissed SFSafariViewController.
+      return;
+    }
+    console.warn('[Capacitor Browser] close() failed unexpectedly:', error);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #2066 (Sentry BOARDSESH-29 — 35 events, 33 users).

The error `Error: No active window to close!` was firing as an unhandled promise rejection on iOS WKWebView (Capacitor native app). The string is not in our code — it's thrown by the iOS [`@capacitor/browser`](https://github.com/ionic-team/capacitor-plugins/issues/1899) plugin when `Browser.close()` is called and no SFSafariViewController is presented.

Root cause: in `session-provider.tsx` the `appUrlOpen` listener calls `Browser.close()` after every native OAuth deep-link. On iOS the OS already dismisses SFSafariViewController as soon as the custom-scheme URL fires, so by the time our listener runs the browser is gone. The plugin throws, the rejection escapes because the listener was an `async` callback whose returned promise wasn't consumed by Capacitor, and Sentry catches it via `onunhandledrejection`.

- New `packages/web/app/lib/ble/capacitor-browser.ts`: `closeCapacitorBrowser()` calls the plugin defensively and swallows the known error texts (also handles "No browser is open" for older plugin versions). Other errors are `console.warn`'d but not re-thrown.
- `session-provider.tsx`: extracted the async listener body into a top-level function; the listener callback wraps it in `void handler(url).catch(...)` so nothing can leak out as an unhandled rejection.
- Added unit + integration tests covering the iOS error path.

## Test plan

- [x] `vp check` — passes (lint + format on touched files clean).
- [x] `vp run typecheck:web` — passes.
- [x] `vp test run --project web` for the two affected suites (19 tests pass), including a new test that mocks `Browser.close()` rejecting with "No active window to close!" and asserts no `unhandledrejection` event fires.
- [ ] Native iOS QA (only possible against a Capacitor build): complete a Google/Apple/Facebook sign-in flow on device — no Sentry event; cancel SFSafariViewController mid-flow — no unhandled rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)