### PR TITLE
fix(home): guard against function props leaking across RSC boundary

### DIFF
--- a/packages/web/app/components/providers/__tests__/vercel-telemetry.test.tsx
+++ b/packages/web/app/components/providers/__tests__/vercel-telemetry.test.tsx
@@ -53,4 +53,27 @@ describe('Vercel telemetry providers', () => {
 
     expectAdminFilter(mocks.speedBeforeSend);
   });
+
+  // Regression guard for #2061 (Sentry BOARDSESH-65): RootLayout is a Server
+  // Component, so any function prop on these wrappers would be serialized
+  // across the RSC boundary and throw "Functions cannot be passed directly
+  // to Client Components". Keep the wrappers prop-less so contributors
+  // can't accidentally pass `beforeSend` (or any callback) from the layout.
+  it('exports no-arg wrappers so the layout cannot pass function props', () => {
+    expect(VercelAnalytics.length).toBe(0);
+    expect(VercelSpeedInsights.length).toBe(0);
+  });
+
+  it('keeps the beforeSend identity stable across renders', () => {
+    render(<VercelAnalytics />);
+    const first = mocks.analyticsBeforeSend;
+    mocks.analyticsBeforeSend = undefined;
+    render(<VercelAnalytics />);
+
+    // Module-scoped function — same reference each render. Inlining it as
+    // `<Analytics beforeSend={(e) => ...} />` would create a fresh function
+    // each call, which still works at runtime but defeats the stability
+    // contract @vercel/analytics relies on for its `useEffect([beforeSend])`.
+    expect(mocks.analyticsBeforeSend).toBe(first);
+  });
 });

--- a/packages/web/app/components/providers/vercel-telemetry.tsx
+++ b/packages/web/app/components/providers/vercel-telemetry.tsx
@@ -5,9 +5,16 @@ import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { isAdminAnalyticsUrl } from '@/app/lib/analytics-paths';
 
-// Function props (the beforeSend filter that drops /admin pageviews) cannot be
-// passed from a Server Component (RootLayout) to a Client Component, so the
-// configuration lives here in the client boundary.
+// Function props (the beforeSend filter that drops /admin pageviews) cannot
+// be passed from a Server Component (RootLayout) to a Client Component
+// because React Flight tries to JSON-serialize them across the boundary,
+// throwing: "Functions cannot be passed directly to Client Components
+// unless you explicitly expose it by marking it with 'use server'."
+//
+// Regression fixed in #2043 / re-guarded in #2061 (Sentry BOARDSESH-65).
+// Keep `dropAdminEvents` module-scoped and the exported wrappers prop-less
+// — never re-shape these to accept a `beforeSend` from the caller, or the
+// home route SSR will break for every visitor on the next deploy.
 const dropAdminEvents = <Event extends { url: string }>(event: Event): Event | null => {
   return isAdminAnalyticsUrl(event.url) ? null : event;
 };


### PR DESCRIPTION
## Summary
- The home route SSR threw `Functions cannot be passed directly to Client Components` for 25 users / 122 events on May 10 (Sentry BOARDSESH-65). The cause was inline `beforeSend` arrows on `<Analytics>` and `<SpeedInsights>` in `RootLayout` (a Server Component); the runtime fix landed in commit `b879dfee0` by moving both into the existing `'use client'` wrapper at `packages/web/app/components/providers/vercel-telemetry.tsx`.
- This PR is the regression guard, not a runtime change. It expands the comment block on the wrapper to spell out the rule, and adds two tests that fail if anyone re-exposes `beforeSend` as a prop on the wrappers or moves `dropAdminEvents` out of module scope.

## Test plan
- [x] `vp test run packages/web/app/components/providers/__tests__/vercel-telemetry.test.tsx` — 4/4 pass
- [x] `vp run typecheck:web` — clean
- [ ] Load `/` — no console errors, no SSR error in dev server output
- [ ] Load `/es/` — same checks for the Spanish locale
- [ ] Navigate `/` → `/feed` → `/` — no new errors on soft nav
- [ ] Visit `/admin` (signed in as admin) — Vercel Analytics still drops the pageview (no `/_vercel/insights/view` request for the admin URL)

Fixes #2061

🤖 Generated with [Claude Code](https://claude.com/claude-code)