### PR TITLE
fix(search): harden searchParamsToUrlParams against null input and corrupt zoneBox

### DIFF
--- a/packages/web/app/lib/__tests__/url-utils.test.ts
+++ b/packages/web/app/lib/__tests__/url-utils.test.ts
@@ -192,6 +192,42 @@ describe('searchParamsToUrlParams', () => {
     expect(result.toString()).toBe('');
   });
 
+  it('should not throw when input itself is null or undefined', () => {
+    // Defense in depth for #2067 — even if a future caller accidentally passes a
+    // nullish value (e.g. uninitialised reducer state), the serializer should
+    // fall back to defaults instead of crashing on `.toString()`.
+    let resultFromUndefined!: URLSearchParams;
+    expect(() => {
+      resultFromUndefined = searchParamsToUrlParams(undefined as unknown as SearchRequestPagination);
+    }).not.toThrow();
+    expect(resultFromUndefined.toString()).toBe('');
+
+    let resultFromNull!: URLSearchParams;
+    expect(() => {
+      resultFromNull = searchParamsToUrlParams(null as unknown as SearchRequestPagination);
+    }).not.toThrow();
+    expect(resultFromNull.toString()).toBe('');
+  });
+
+  it('should not throw when zoneBox has missing edge fields', () => {
+    // Defense in depth: a corrupted zoneBox object with undefined edges should
+    // not crash the serializer with `.toString()` on undefined. We omit the
+    // whole zone filter rather than emitting partial params.
+    const corruptZoneBox = {
+      ...DEFAULT_SEARCH_PARAMS,
+      zoneBox: { edgeLeft: undefined, edgeRight: undefined, edgeBottom: undefined, edgeTop: undefined },
+    } as unknown as SearchRequestPagination;
+
+    let result!: URLSearchParams;
+    expect(() => {
+      result = searchParamsToUrlParams(corruptZoneBox);
+    }).not.toThrow();
+    expect(result.has('zoneEdgeLeft')).toBe(false);
+    expect(result.has('zoneEdgeRight')).toBe(false);
+    expect(result.has('zoneEdgeBottom')).toBe(false);
+    expect(result.has('zoneEdgeTop')).toBe(false);
+  });
+
   describe('with a single undefined numeric field (legacy persisted state)', () => {
     const numericFields = [
       'gradeAccuracy',

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -74,29 +74,33 @@ export function parseBoardRouteParams<T extends BoardRouteParameters>(
 export const searchParamsToUrlParams = (input: SearchRequestPagination): URLSearchParams => {
   // Coalesce any missing/undefined fields to their defaults. Stored recent searches
   // (IndexedDB) and partial filter updates can leak undefined values into this path,
-  // which would otherwise crash on `.toString()`.
-  const gradeAccuracy = input.gradeAccuracy ?? DEFAULT_SEARCH_PARAMS.gradeAccuracy;
-  const maxGrade = input.maxGrade ?? DEFAULT_SEARCH_PARAMS.maxGrade;
-  const minGrade = input.minGrade ?? DEFAULT_SEARCH_PARAMS.minGrade;
-  const minAscents = normalizeMinAscentsFilter(input.minAscents ?? DEFAULT_SEARCH_PARAMS.minAscents);
-  const minRating = normalizeMinRatingFilter(input.minRating ?? DEFAULT_SEARCH_PARAMS.minRating);
-  const sortBy = input.sortBy ?? DEFAULT_SEARCH_PARAMS.sortBy;
-  const sortOrder = input.sortOrder ?? DEFAULT_SEARCH_PARAMS.sortOrder;
-  const name = input.name ?? DEFAULT_SEARCH_PARAMS.name;
-  const onlyClassics = input.onlyClassics ?? DEFAULT_SEARCH_PARAMS.onlyClassics;
-  const onlyTallClimbs = input.onlyTallClimbs ?? DEFAULT_SEARCH_PARAMS.onlyTallClimbs;
-  const settername = input.settername ?? DEFAULT_SEARCH_PARAMS.settername;
-  const setternameSuggestion = input.setternameSuggestion ?? DEFAULT_SEARCH_PARAMS.setternameSuggestion;
-  const holdsFilter = input.holdsFilter ?? DEFAULT_SEARCH_PARAMS.holdsFilter;
-  const hideAttempted = input.hideAttempted ?? DEFAULT_SEARCH_PARAMS.hideAttempted;
-  const hideCompleted = input.hideCompleted ?? DEFAULT_SEARCH_PARAMS.hideCompleted;
-  const showOnlyAttempted = input.showOnlyAttempted ?? DEFAULT_SEARCH_PARAMS.showOnlyAttempted;
-  const showOnlyCompleted = input.showOnlyCompleted ?? DEFAULT_SEARCH_PARAMS.showOnlyCompleted;
-  const onlyDrafts = input.onlyDrafts ?? DEFAULT_SEARCH_PARAMS.onlyDrafts;
-  const projectsOnly = input.projectsOnly ?? DEFAULT_SEARCH_PARAMS.projectsOnly;
-  const zoneBox = input.zoneBox ?? DEFAULT_SEARCH_PARAMS.zoneBox;
-  const page = input.page ?? DEFAULT_SEARCH_PARAMS.page;
-  const pageSize = input.pageSize ?? DEFAULT_SEARCH_PARAMS.pageSize;
+  // which would otherwise crash on `.toString()`. See BOARDSESH-30, BOARDSESH-2Z,
+  // BOARDSESH-31, BOARDSESH-33, BOARDSESH-34, BOARDSESH-38 (all collapsed under #2067).
+  // The `input ?? {}` first line also defends against a hypothetical caller passing
+  // null/undefined — every field is then individually coalesced below.
+  const safeInput = (input ?? {}) as Partial<SearchRequestPagination>;
+  const gradeAccuracy = safeInput.gradeAccuracy ?? DEFAULT_SEARCH_PARAMS.gradeAccuracy;
+  const maxGrade = safeInput.maxGrade ?? DEFAULT_SEARCH_PARAMS.maxGrade;
+  const minGrade = safeInput.minGrade ?? DEFAULT_SEARCH_PARAMS.minGrade;
+  const minAscents = normalizeMinAscentsFilter(safeInput.minAscents ?? DEFAULT_SEARCH_PARAMS.minAscents);
+  const minRating = normalizeMinRatingFilter(safeInput.minRating ?? DEFAULT_SEARCH_PARAMS.minRating);
+  const sortBy = safeInput.sortBy ?? DEFAULT_SEARCH_PARAMS.sortBy;
+  const sortOrder = safeInput.sortOrder ?? DEFAULT_SEARCH_PARAMS.sortOrder;
+  const name = safeInput.name ?? DEFAULT_SEARCH_PARAMS.name;
+  const onlyClassics = safeInput.onlyClassics ?? DEFAULT_SEARCH_PARAMS.onlyClassics;
+  const onlyTallClimbs = safeInput.onlyTallClimbs ?? DEFAULT_SEARCH_PARAMS.onlyTallClimbs;
+  const settername = safeInput.settername ?? DEFAULT_SEARCH_PARAMS.settername;
+  const setternameSuggestion = safeInput.setternameSuggestion ?? DEFAULT_SEARCH_PARAMS.setternameSuggestion;
+  const holdsFilter = safeInput.holdsFilter ?? DEFAULT_SEARCH_PARAMS.holdsFilter;
+  const hideAttempted = safeInput.hideAttempted ?? DEFAULT_SEARCH_PARAMS.hideAttempted;
+  const hideCompleted = safeInput.hideCompleted ?? DEFAULT_SEARCH_PARAMS.hideCompleted;
+  const showOnlyAttempted = safeInput.showOnlyAttempted ?? DEFAULT_SEARCH_PARAMS.showOnlyAttempted;
+  const showOnlyCompleted = safeInput.showOnlyCompleted ?? DEFAULT_SEARCH_PARAMS.showOnlyCompleted;
+  const onlyDrafts = safeInput.onlyDrafts ?? DEFAULT_SEARCH_PARAMS.onlyDrafts;
+  const projectsOnly = safeInput.projectsOnly ?? DEFAULT_SEARCH_PARAMS.projectsOnly;
+  const zoneBox = safeInput.zoneBox ?? DEFAULT_SEARCH_PARAMS.zoneBox;
+  const page = safeInput.page ?? DEFAULT_SEARCH_PARAMS.page;
+  const pageSize = safeInput.pageSize ?? DEFAULT_SEARCH_PARAMS.pageSize;
 
   const params: Record<string, string> = {};
 
@@ -162,7 +166,13 @@ export const searchParamsToUrlParams = (input: SearchRequestPagination): URLSear
   if (projectsOnly !== DEFAULT_SEARCH_PARAMS.projectsOnly) {
     params.projectsOnly = projectsOnly.toString();
   }
-  if (zoneBox) {
+  if (
+    zoneBox &&
+    zoneBox.edgeLeft != null &&
+    zoneBox.edgeRight != null &&
+    zoneBox.edgeBottom != null &&
+    zoneBox.edgeTop != null
+  ) {
     params.zoneEdgeLeft = zoneBox.edgeLeft.toString();
     params.zoneEdgeRight = zoneBox.edgeRight.toString();
     params.zoneEdgeBottom = zoneBox.edgeBottom.toString();


### PR DESCRIPTION
## Summary

- The originating Sentry cluster (#2067) — `t.toString` of undefined on the climb list routes — was already addressed by commit `7e7a079bb` (which `??`-coalesces every numeric field before `.toString()`). Sentry confirms zero events on the latest release for the six toString variants collapsed under #2067.
- This PR is a defense-in-depth follow-up. It plugs two remaining gaps that the previous fix didn't cover:
  - A caller accidentally passing `null`/`undefined` for `input` would still NPE on `input.gradeAccuracy`. Now coalesced to `{}` at the function entry.
  - A corrupted `zoneBox` (e.g. `{ edgeLeft: undefined, ... }` leaking from legacy state) would still crash on `.toString()`. Each edge is now guarded individually; the whole filter is dropped if any edge is missing.
- Adds regression tests for both new cases and cross-refs the six Sentry issue IDs (BOARDSESH-30, 2Z, 31, 33, 34, 38) in the source comment.

Fixes #2067

## Test plan

- [x] `vp test run packages/web/app/lib/__tests__/url-utils.test.ts` — 202 tests pass (200 → 202 with new regressions)
- [x] `vp run typecheck:web` — exits 0
- [x] `vp check` — no lint/format issues introduced (pre-existing formatting issues unrelated to this PR remain on `main`)
- [ ] Manual: load `/kilter/original/12x12-square/screw_bolt/40/list`, tap recent-search pills rapidly on mobile profile, clear filters via search drawer — no `TypeError` in console
- [ ] Manual: drag a zone filter rectangle, clear it, reload with stale zone params — no crash
- [ ] Manual: open IndexedDB devtools and ensure recent-search entries with legacy undefined numeric fields don't crash on pill tap

QA notes: `.boardsesh/qa-notes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)