### PR TITLE
feat(analytics): wire P0 PostHog audit fixes

### DIFF
--- a/packages/web/app/auth/login/__tests__/auth-method-from-error.test.ts
+++ b/packages/web/app/auth/login/__tests__/auth-method-from-error.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { authMethodFromError, safeAuthError } from '../auth-error-classification';
+
+describe('authMethodFromError', () => {
+  it('classifies CredentialsSignin as credentials, not oauth', () => {
+    expect(authMethodFromError('CredentialsSignin')).toBe('credentials');
+  });
+
+  it('classifies OAuth-shaped error codes as oauth', () => {
+    expect(authMethodFromError('OAuthSignin')).toBe('oauth');
+    expect(authMethodFromError('OAuthCallback')).toBe('oauth');
+    expect(authMethodFromError('OAuthCreateAccount')).toBe('oauth');
+    expect(authMethodFromError('OAuthAccountNotLinked')).toBe('oauth');
+  });
+
+  it('defaults unknown / null / empty inputs to oauth (the broader bucket)', () => {
+    expect(authMethodFromError(null)).toBe('oauth');
+    expect(authMethodFromError(undefined)).toBe('oauth');
+    expect(authMethodFromError('')).toBe('oauth');
+    expect(authMethodFromError('AccessDenied')).toBe('oauth');
+  });
+});
+
+describe('safeAuthError', () => {
+  it('passes through known NextAuth error codes verbatim', () => {
+    expect(safeAuthError('CredentialsSignin')).toBe('CredentialsSignin');
+    expect(safeAuthError('OAuthCallback')).toBe('OAuthCallback');
+    expect(safeAuthError('AccessDenied')).toBe('AccessDenied');
+  });
+
+  it('buckets attacker-supplied or unknown strings to "unknown"', () => {
+    expect(safeAuthError('some+arbitrary+string')).toBe('unknown');
+    expect(safeAuthError('<script>alert(1)</script>')).toBe('unknown');
+    expect(safeAuthError('OAuthSignin; DROP TABLE users')).toBe('unknown');
+  });
+
+  it('treats null / undefined / empty as "unknown"', () => {
+    expect(safeAuthError(null)).toBe('unknown');
+    expect(safeAuthError(undefined)).toBe('unknown');
+    expect(safeAuthError('')).toBe('unknown');
+  });
+});

--- a/packages/web/app/auth/login/auth-error-classification.ts
+++ b/packages/web/app/auth/login/auth-error-classification.ts
@@ -1,0 +1,33 @@
+// NextAuth's documented error codes. The ?error= query param is user-supplied
+// (anyone can craft a URL), so we whitelist before forwarding to analytics so
+// the failure_reason property doesn't carry arbitrary attacker-controlled
+// strings into PostHog.
+const KNOWN_AUTH_ERRORS: ReadonlySet<string> = new Set([
+  'Configuration',
+  'AccessDenied',
+  'Verification',
+  'Default',
+  'OAuthSignin',
+  'OAuthCallback',
+  'OAuthCreateAccount',
+  'OAuthAccountNotLinked',
+  'EmailCreateAccount',
+  'EmailSignin',
+  'Callback',
+  'CredentialsSignin',
+  'SessionRequired',
+]);
+
+export function safeAuthError(value: string | null | undefined): string {
+  if (!value) return 'unknown';
+  return KNOWN_AUTH_ERRORS.has(value) ? value : 'unknown';
+}
+
+// CredentialsSignin is NextAuth's code for a credentials provider rejection
+// that bounced back as ?error=. Every other code in the enum originates from
+// an OAuth round-trip (provider rejection, callback mismatch, account-link).
+// Without this branch, ?error=CredentialsSignin events would be miscounted in
+// the OAuth conversion funnel.
+export function authMethodFromError(value: string | null | undefined): 'credentials' | 'oauth' {
+  return value === 'CredentialsSignin' ? 'credentials' : 'oauth';
+}

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -34,6 +34,7 @@ import {
 import { TabPanel } from '@/app/components/ui/tab-panel';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
+import { track, setPersonProperties } from '@/app/lib/analytics';
 
 export default function AuthPageContent() {
   const { t } = useTranslation('auth');
@@ -62,6 +63,13 @@ export default function AuthPageContent() {
       } else {
         showMessage(t('login.toasts.authFailed'), 'error');
       }
+      // NextAuth redirects back to /auth/login?error=... after a failed OAuth
+      // round-trip. Surface this as Login Failed so the auth funnel captures
+      // OAuth-provider rejections (cancel, provider error, callback mismatch).
+      track('Login Failed', {
+        auth_method: 'oauth',
+        failure_reason: error,
+      });
     }
   }, [error, showMessage, t]);
 
@@ -86,6 +94,7 @@ export default function AuthPageContent() {
 
     try {
       setLoginLoading(true);
+      track('Login Attempted', { auth_method: 'credentials' });
 
       const result = await signIn('credentials', {
         email: loginValues.email,
@@ -95,8 +104,13 @@ export default function AuthPageContent() {
 
       if (result?.error) {
         showMessage(t('login.toasts.invalidCredentials'), 'error');
+        track('Login Failed', {
+          auth_method: 'credentials',
+          failure_reason: result.error,
+        });
       } else if (result?.ok) {
         showMessage(t('login.toasts.loggedIn'), 'success');
+        track('Login Succeeded', { auth_method: 'credentials' });
         router.push(callbackUrl);
       }
     } catch (error) {
@@ -134,6 +148,18 @@ export default function AuthPageContent() {
         return;
       }
 
+      track('Signup Completed', {
+        auth_method: 'credentials',
+        requires_verification: Boolean(data.requiresVerification),
+      });
+      // First-touch attribution — written once and never overwritten.
+      // PostHog merges these onto the authenticated user once alias() runs
+      // in party-profile-context after the auto-signin below.
+      setPersonProperties(undefined, {
+        signup_at: new Date().toISOString(),
+        signup_auth_method: 'credentials',
+      });
+
       // Check if email verification is required
       if (data.requiresVerification) {
         showMessage(t('login.toasts.checkEmail'), 'info');
@@ -152,6 +178,10 @@ export default function AuthPageContent() {
       });
 
       if (loginResult?.ok) {
+        track('Login Succeeded', {
+          auth_method: 'credentials',
+          is_first_login: true,
+        });
         router.push(callbackUrl);
       } else {
         setActiveTab('login');

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -36,6 +36,31 @@ import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
 import { track, setPersonProperties } from '@/app/lib/analytics';
 
+// NextAuth's documented error codes. The ?error= query param is user-supplied
+// (anyone can craft a URL), so we whitelist before forwarding to analytics so
+// the failure_reason property doesn't carry arbitrary attacker-controlled
+// strings into PostHog.
+const KNOWN_AUTH_ERRORS: ReadonlySet<string> = new Set([
+  'Configuration',
+  'AccessDenied',
+  'Verification',
+  'Default',
+  'OAuthSignin',
+  'OAuthCallback',
+  'OAuthCreateAccount',
+  'OAuthAccountNotLinked',
+  'EmailCreateAccount',
+  'EmailSignin',
+  'Callback',
+  'CredentialsSignin',
+  'SessionRequired',
+]);
+
+function safeAuthError(value: string | null | undefined): string {
+  if (!value) return 'unknown';
+  return KNOWN_AUTH_ERRORS.has(value) ? value : 'unknown';
+}
+
 export default function AuthPageContent() {
   const { t } = useTranslation('auth');
   const { status } = useSession();
@@ -68,7 +93,7 @@ export default function AuthPageContent() {
       // OAuth-provider rejections (cancel, provider error, callback mismatch).
       track('Login Failed', {
         auth_method: 'oauth',
-        failure_reason: error,
+        failure_reason: safeAuthError(error),
       });
     }
   }, [error, showMessage, t]);
@@ -106,7 +131,7 @@ export default function AuthPageContent() {
         showMessage(t('login.toasts.invalidCredentials'), 'error');
         track('Login Failed', {
           auth_method: 'credentials',
-          failure_reason: result.error,
+          failure_reason: safeAuthError(result.error),
         });
       } else if (result?.ok) {
         showMessage(t('login.toasts.loggedIn'), 'success');
@@ -155,6 +180,14 @@ export default function AuthPageContent() {
       // First-touch attribution — written once and never overwritten.
       // PostHog merges these onto the authenticated user once alias() runs
       // in party-profile-context after the auto-signin below.
+      //
+      // Caveat: if requires_verification is true, we hit the early return below
+      // and the auto-signin never runs, so alias() may not fire in this session.
+      // signup_at / signup_auth_method then live on the anonymous distinct_id
+      // until the user comes back to verify and log in — at which point PostHog
+      // merges them onto the authenticated user. Until that merge they're
+      // visible in Live Events under the anon profile, which can briefly skew
+      // person-property dashboards.
       setPersonProperties(undefined, {
         signup_at: new Date().toISOString(),
         signup_auth_method: 'credentials',

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -19,7 +19,7 @@ import MailOutlined from '@mui/icons-material/MailOutlined';
 import { signIn, useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
-import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
+import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
 import SocialLoginButtons from '@/app/components/auth/social-login-buttons';
@@ -65,6 +65,7 @@ export default function AuthPageContent() {
   const { t } = useTranslation('auth');
   const { status } = useSession();
   const router = useLocaleRouter();
+  const pathnameWithoutLocale = usePathnameWithoutLocale();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get('callbackUrl') || '/';
   const error = searchParams.get('error');
@@ -95,8 +96,14 @@ export default function AuthPageContent() {
         auth_method: 'oauth',
         failure_reason: safeAuthError(error),
       });
+      // Strip the ?error= param so a refresh or back-navigation doesn't fire
+      // Login Failed again and re-show the toast. preserve callbackUrl if set.
+      const cleanParams = new URLSearchParams(searchParams.toString());
+      cleanParams.delete('error');
+      const queryString = cleanParams.toString();
+      router.replace(queryString ? `${pathnameWithoutLocale}?${queryString}` : pathnameWithoutLocale);
     }
-  }, [error, showMessage, t]);
+  }, [error, showMessage, t, router, pathnameWithoutLocale, searchParams]);
 
   // Show success message when email is verified
   useEffect(() => {

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -35,31 +35,7 @@ import { TabPanel } from '@/app/components/ui/tab-panel';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
 import { track, setPersonProperties } from '@/app/lib/analytics';
-
-// NextAuth's documented error codes. The ?error= query param is user-supplied
-// (anyone can craft a URL), so we whitelist before forwarding to analytics so
-// the failure_reason property doesn't carry arbitrary attacker-controlled
-// strings into PostHog.
-const KNOWN_AUTH_ERRORS: ReadonlySet<string> = new Set([
-  'Configuration',
-  'AccessDenied',
-  'Verification',
-  'Default',
-  'OAuthSignin',
-  'OAuthCallback',
-  'OAuthCreateAccount',
-  'OAuthAccountNotLinked',
-  'EmailCreateAccount',
-  'EmailSignin',
-  'Callback',
-  'CredentialsSignin',
-  'SessionRequired',
-]);
-
-function safeAuthError(value: string | null | undefined): string {
-  if (!value) return 'unknown';
-  return KNOWN_AUTH_ERRORS.has(value) ? value : 'unknown';
-}
+import { authMethodFromError, safeAuthError } from './auth-error-classification';
 
 export default function AuthPageContent() {
   const { t } = useTranslation('auth');
@@ -89,11 +65,12 @@ export default function AuthPageContent() {
       } else {
         showMessage(t('login.toasts.authFailed'), 'error');
       }
-      // NextAuth redirects back to /auth/login?error=... after a failed OAuth
-      // round-trip. Surface this as Login Failed so the auth funnel captures
-      // OAuth-provider rejections (cancel, provider error, callback mismatch).
+      // NextAuth redirects back to /auth/login?error=... after either a failed
+      // OAuth round-trip or — under some flows — a credentials redirect path.
+      // CredentialsSignin is the credentials code; everything else in the known
+      // enum is OAuth-shaped. Tag accordingly so funnel splits stay honest.
       track('Login Failed', {
-        auth_method: 'oauth',
+        auth_method: authMethodFromError(error),
         failure_reason: safeAuthError(error),
       });
       // Strip the ?error= param so a refresh or back-navigation doesn't fire

--- a/packages/web/app/components/auth/social-login-buttons.tsx
+++ b/packages/web/app/components/auth/social-login-buttons.tsx
@@ -9,6 +9,7 @@ import { signIn } from 'next-auth/react';
 import { useTranslation } from 'react-i18next';
 import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
 import { buildNativeOAuthSignInUrl } from '@/app/lib/auth/native-oauth-url';
+import { track } from '@/app/lib/analytics';
 
 // Note: OAuth provider icons and button colors use brand-specific colors
 // per Google/Apple/Facebook brand guidelines, not design system tokens
@@ -82,6 +83,11 @@ export default function SocialLoginButtons({ callbackUrl = '/', disabled = false
   }, []);
 
   const handleSocialSignIn = (provider: string) => {
+    track('Login Attempted', {
+      auth_method: provider,
+      flow: isCapacitorApp ? 'native' : 'web',
+    });
+
     if (isCapacitorApp) {
       const browser = window.Capacitor?.Plugins?.Browser;
       if (!browser) return;

--- a/packages/web/app/components/auth/social-login-buttons.tsx
+++ b/packages/web/app/components/auth/social-login-buttons.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
 import { buildNativeOAuthSignInUrl } from '@/app/lib/auth/native-oauth-url';
 import { track } from '@/app/lib/analytics';
+import { setOAuthPending } from '@/app/lib/oauth-pending-db';
 
 // Note: OAuth provider icons and button colors use brand-specific colors
 // per Google/Apple/Facebook brand guidelines, not design system tokens
@@ -83,10 +84,17 @@ export default function SocialLoginButtons({ callbackUrl = '/', disabled = false
   }, []);
 
   const handleSocialSignIn = (provider: string) => {
+    const flow = isCapacitorApp ? 'native' : 'web';
     track('Login Attempted', {
       auth_method: provider,
-      flow: isCapacitorApp ? 'native' : 'web',
+      flow,
     });
+    // Drop an IDB marker that party-profile-context consumes on the next
+    // authenticated-session detection to emit Login Succeeded. NextAuth handles
+    // OAuth success via server-side redirect, so there's no explicit client
+    // callback to track from — the marker bridges the gap. Stale markers expire
+    // after 5 minutes (see oauth-pending-db).
+    void setOAuthPending({ provider, flow, attempted_at: Date.now() });
 
     if (isCapacitorApp) {
       const browser = window.Capacitor?.Plugins?.Browser;

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -14,13 +14,14 @@ const {
   mockShowMessage,
   mockParseSerialNumber,
   mockFetch,
+  mockTrack,
 } = vi.hoisted(() => {
   const mockAdapter = {
     isAvailable: vi.fn(),
     requestAndConnect: vi.fn(),
     disconnect: vi.fn(),
     write: vi.fn(),
-    onDisconnect: vi.fn(() => vi.fn()),
+    onDisconnect: vi.fn<(handler: () => void) => () => void>(() => () => {}),
   };
 
   return {
@@ -52,6 +53,7 @@ const {
     mockShowMessage: vi.fn(),
     mockParseSerialNumber: vi.fn<(name: string) => string | undefined>(() => undefined),
     mockFetch: vi.fn<typeof fetch>(() => Promise.resolve(new Response(null, { status: 204 }))),
+    mockTrack: vi.fn(),
   };
 });
 
@@ -83,7 +85,7 @@ vi.mock('@/app/components/providers/snackbar-provider', () => ({
 }));
 
 vi.mock('@/app/lib/analytics', () => ({
-  track: vi.fn(),
+  track: mockTrack,
 }));
 
 vi.mock('@/app/lib/ble/capacitor-utils', () => ({
@@ -249,7 +251,7 @@ describe('useBoardBluetooth', () => {
     expect(result.current.isConnected).toBe(true);
 
     act(() => {
-      result.current.disconnect();
+      void result.current.disconnect();
     });
 
     expect(mockAdapter.disconnect).toHaveBeenCalled();
@@ -306,7 +308,7 @@ describe('useBoardBluetooth', () => {
     expect(onConnectionChange).toHaveBeenCalledWith(true);
 
     act(() => {
-      result.current.disconnect();
+      void result.current.disconnect();
     });
 
     expect(onConnectionChange).toHaveBeenCalledWith(false);
@@ -388,5 +390,112 @@ describe('useBoardBluetooth', () => {
     expect(recordCall).toBeDefined();
     const body = JSON.parse((recordCall![1] as RequestInit).body as string);
     expect(body.boardUuid).toBe('board-uuid-xyz');
+  });
+
+  describe('Bluetooth Disconnected analytics', () => {
+    function findDisconnectCall(): [string, Record<string, unknown>] | undefined {
+      return mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Disconnected') as
+        | [string, Record<string, unknown>]
+        | undefined;
+    }
+
+    it("fires reason='user' on explicit disconnect() with the connection duration", async () => {
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      mockTrack.mockClear();
+
+      await act(async () => {
+        await result.current.disconnect();
+      });
+
+      const call = findDisconnectCall();
+      expect(call).toBeDefined();
+      expect(call![1].reason).toBe('user');
+      expect(typeof call![1].duration_connected_ms).toBe('number');
+      expect(call![1].duration_connected_ms as number).toBeGreaterThanOrEqual(0);
+    });
+
+    it("fires reason='lost' when the adapter reports an unexpected disconnect", async () => {
+      let capturedHandler: (() => void) | null = null;
+      mockAdapter.onDisconnect.mockImplementation((handler: () => void) => {
+        capturedHandler = handler;
+        return vi.fn();
+      });
+
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      mockTrack.mockClear();
+
+      act(() => {
+        capturedHandler?.();
+      });
+
+      const call = findDisconnectCall();
+      expect(call).toBeDefined();
+      expect(call![1].reason).toBe('lost');
+      expect(typeof call![1].duration_connected_ms).toBe('number');
+    });
+
+    it("fires reason='reconnect' when connect() tears down an existing adapter", async () => {
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      mockTrack.mockClear();
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      const call = findDisconnectCall();
+      expect(call).toBeDefined();
+      expect(call![1].reason).toBe('reconnect');
+      expect(typeof call![1].duration_connected_ms).toBe('number');
+    });
+
+    it("fires reason='navigation' when the component unmounts while still connected", async () => {
+      const { result, unmount } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      mockTrack.mockClear();
+
+      unmount();
+
+      const call = findDisconnectCall();
+      expect(call).toBeDefined();
+      expect(call![1].reason).toBe('navigation');
+      expect(typeof call![1].duration_connected_ms).toBe('number');
+    });
+
+    it('does not double-fire when disconnect() is followed by unmount', async () => {
+      const { result, unmount } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      await act(async () => {
+        await result.current.disconnect();
+      });
+
+      mockTrack.mockClear();
+      unmount();
+
+      const call = findDisconnectCall();
+      expect(call).toBeUndefined();
+    });
   });
 });

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -106,6 +106,9 @@ export function useBoardBluetooth({
   const adapterRef = useRef<BluetoothAdapter | null>(null);
   const apiLevelRef = useRef<number>(3);
   const unsubDisconnectRef = useRef<(() => void) | null>(null);
+  // Timestamp of the most recent successful BLE connect — drives the
+  // duration_connected_ms property on Bluetooth Disconnected events.
+  const connectedAtRef = useRef<number | null>(null);
 
   // Device picker state for custom Capacitor scanning.
   // pickerRejectRef holds the pending promise's reject so unmount cleanup
@@ -141,8 +144,19 @@ export function useBoardBluetooth({
     });
   }, []);
 
-  // Handler for device disconnection
+  // Handler for device disconnection — fires when the adapter reports a
+  // gattserverdisconnected event. User-initiated disconnects via disconnect()
+  // null `unsubDisconnectRef` first, so this only ever runs on unexpected
+  // drops (signal loss, board power-off, OS BLE stack reset).
   const handleDisconnection = useCallback(() => {
+    const connectedAt = connectedAtRef.current;
+    connectedAtRef.current = null;
+    if (connectedAt !== null) {
+      track('Bluetooth Disconnected', {
+        reason: 'lost',
+        duration_connected_ms: Date.now() - connectedAt,
+      });
+    }
     setIsConnected(false);
     onConnectionChange?.(false);
   }, [onConnectionChange]);
@@ -312,6 +326,7 @@ export function useBoardBluetooth({
         unsubDisconnectRef.current = adapter.onDisconnect(handleDisconnection);
         adapterRef.current = adapter;
 
+        connectedAtRef.current = Date.now();
         track('Bluetooth Connection Success', {
           boardLayout: `${boardDetails.layout_name}`,
         });
@@ -351,12 +366,20 @@ export function useBoardBluetooth({
   // Disconnect from the board — update state synchronously for immediate UI
   // feedback, then await the native BLE disconnect in the background.
   const disconnect = useCallback(async () => {
+    const connectedAt = connectedAtRef.current;
+    connectedAtRef.current = null;
     unsubDisconnectRef.current?.();
     unsubDisconnectRef.current = null;
     const adapter = adapterRef.current;
     adapterRef.current = null;
     setIsConnected(false);
     onConnectionChange?.(false);
+    if (connectedAt !== null) {
+      track('Bluetooth Disconnected', {
+        reason: 'user',
+        duration_connected_ms: Date.now() - connectedAt,
+      });
+    }
     await adapter?.disconnect();
   }, [onConnectionChange]);
 

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -312,9 +312,19 @@ export function useBoardBluetooth({
           return false;
         }
 
-        // Clean up any existing adapter
+        // Clean up any existing adapter. Emit Bluetooth Disconnected for the
+        // outgoing session before we tear it down so the prior connection's
+        // duration isn't silently discarded from the reliability funnel.
         if (adapterRef.current) {
+          const previousConnectedAt = connectedAtRef.current;
+          connectedAtRef.current = null;
           unsubDisconnectRef.current?.();
+          if (previousConnectedAt !== null) {
+            track('Bluetooth Disconnected', {
+              reason: 'reconnect',
+              duration_connected_ms: Date.now() - previousConnectedAt,
+            });
+          }
           await adapterRef.current.disconnect();
         }
 
@@ -385,11 +395,25 @@ export function useBoardBluetooth({
 
   // Clean up on unmount — reject any pending picker promise so the adapter's
   // finally block calls stopLEScan, then tear down the BLE connection.
+  // If the connection is still live at unmount (e.g. user navigated away with
+  // a board paired), emit a Bluetooth Disconnected event so the reliability
+  // funnel has a third category beyond user-initiated and hardware drops.
+  // explicit-disconnect via disconnect() and hardware drops via
+  // handleDisconnection both clear connectedAtRef first, so this only fires
+  // for genuine "still connected at unmount" paths.
   useEffect(() => {
     return () => {
       pickerRejectRef.current?.(new Error('Component unmounted'));
       pickerRejectRef.current = null;
+      const connectedAt = connectedAtRef.current;
+      connectedAtRef.current = null;
       unsubDisconnectRef.current?.();
+      if (connectedAt !== null) {
+        track('Bluetooth Disconnected', {
+          reason: 'navigation',
+          duration_connected_ms: Date.now() - connectedAt,
+        });
+      }
       void adapterRef.current?.disconnect();
     };
   }, []);

--- a/packages/web/app/components/party-manager/__tests__/party-profile-context.test.tsx
+++ b/packages/web/app/components/party-manager/__tests__/party-profile-context.test.tsx
@@ -2,9 +2,12 @@ import { render, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { PartyProfileProvider } from '../party-profile-context';
 
+type OAuthMarker = { provider: string; flow: 'web' | 'native'; attempted_at: number };
+
 const mocks = vi.hoisted(() => ({
   alias: vi.fn(),
   clearPartyProfile: vi.fn(),
+  consumeFreshOAuthPending: vi.fn<() => Promise<OAuthMarker | null>>(),
   ensurePartyProfile: vi.fn(),
   getPartyProfile: vi.fn(),
   hasRecordedPosthogAlias: vi.fn(),
@@ -12,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   recordPosthogAlias: vi.fn(),
   reset: vi.fn(),
   setPersonProperties: vi.fn(),
+  track: vi.fn(),
   route: {
     pathname: '/',
   },
@@ -41,6 +45,7 @@ vi.mock('@/app/lib/analytics', () => ({
   identify: mocks.identify,
   reset: mocks.reset,
   setPersonProperties: mocks.setPersonProperties,
+  track: mocks.track,
 }));
 
 vi.mock('@/app/lib/party-profile-db', () => ({
@@ -52,6 +57,10 @@ vi.mock('@/app/lib/party-profile-db', () => ({
 vi.mock('@/app/lib/posthog-alias-storage', () => ({
   hasRecordedPosthogAlias: mocks.hasRecordedPosthogAlias,
   recordPosthogAlias: mocks.recordPosthogAlias,
+}));
+
+vi.mock('@/app/lib/oauth-pending-db', () => ({
+  consumeFreshOAuthPending: mocks.consumeFreshOAuthPending,
 }));
 
 function renderProvider() {
@@ -72,6 +81,7 @@ describe('PartyProfileProvider PostHog identity wiring', () => {
     mocks.ensurePartyProfile.mockResolvedValue({ id: 'profile-1' });
     mocks.getPartyProfile.mockResolvedValue({ id: 'profile-1' });
     mocks.hasRecordedPosthogAlias.mockReturnValue(false);
+    mocks.consumeFreshOAuthPending.mockResolvedValue(null);
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => ({
@@ -145,5 +155,48 @@ describe('PartyProfileProvider PostHog identity wiring', () => {
     expect(mocks.hasRecordedPosthogAlias).toHaveBeenCalledWith('profile-1', 'user-2');
     expect(mocks.alias).toHaveBeenCalledWith('user-2');
     expect(mocks.recordPosthogAlias).toHaveBeenCalledWith('profile-1', 'user-2');
+  });
+
+  it('fires Login Succeeded with provider when a fresh OAuth marker is present at authentication', async () => {
+    mocks.consumeFreshOAuthPending.mockResolvedValue({
+      provider: 'google',
+      flow: 'web',
+      attempted_at: Date.now(),
+    });
+    mocks.session.status = 'authenticated';
+    mocks.session.data = {
+      user: {
+        id: 'user-3',
+        email: 'three@example.com',
+      },
+    };
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(mocks.track).toHaveBeenCalledWith('Login Succeeded', {
+        auth_method: 'google',
+        flow: 'web',
+      });
+    });
+  });
+
+  it('does not fire Login Succeeded when no OAuth marker exists', async () => {
+    mocks.consumeFreshOAuthPending.mockResolvedValue(null);
+    mocks.session.status = 'authenticated';
+    mocks.session.data = {
+      user: {
+        id: 'user-4',
+        email: 'four@example.com',
+      },
+    };
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(mocks.identify).toHaveBeenCalledWith('user-4', { email: 'four@example.com' });
+    });
+
+    expect(mocks.track).not.toHaveBeenCalledWith('Login Succeeded', expect.anything());
   });
 });

--- a/packages/web/app/components/party-manager/__tests__/party-profile-context.test.tsx
+++ b/packages/web/app/components/party-manager/__tests__/party-profile-context.test.tsx
@@ -199,4 +199,51 @@ describe('PartyProfileProvider PostHog identity wiring', () => {
 
     expect(mocks.track).not.toHaveBeenCalledWith('Login Succeeded', expect.anything());
   });
+
+  it('attaches `language` once the IDB profile resolves, even for unauthenticated visitors', async () => {
+    mocks.session.status = 'unauthenticated';
+    mocks.session.data = null;
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(mocks.setPersonProperties).toHaveBeenCalledWith({ language: 'en-US' });
+    });
+  });
+
+  it('does not attach `language` on admin URLs', async () => {
+    mocks.route.pathname = '/admin/retention';
+    mocks.session.status = 'authenticated';
+    mocks.session.data = {
+      user: { id: 'user-5', email: 'five@example.com' },
+    };
+
+    renderProvider();
+
+    // Give the effect a tick — the identity effect short-circuits on admin too,
+    // so there's no other promise to await; flush microtasks via setImmediate.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.setPersonProperties).not.toHaveBeenCalled();
+  });
+
+  it('does not attach `language` while the IDB profile is still loading', async () => {
+    let resolveProfile: (value: { id: string }) => void = () => {};
+    mocks.ensurePartyProfile.mockReturnValue(
+      new Promise((resolve) => {
+        resolveProfile = resolve;
+      }),
+    );
+
+    renderProvider();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.setPersonProperties).not.toHaveBeenCalled();
+
+    // Resolve the profile to verify the effect fires once it's available.
+    resolveProfile({ id: 'profile-1' });
+    await waitFor(() => {
+      expect(mocks.setPersonProperties).toHaveBeenCalledWith({ language: 'en-US' });
+    });
+  });
 });

--- a/packages/web/app/components/party-manager/__tests__/party-profile-context.test.tsx
+++ b/packages/web/app/components/party-manager/__tests__/party-profile-context.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   identify: vi.fn(),
   recordPosthogAlias: vi.fn(),
   reset: vi.fn(),
+  setPersonProperties: vi.fn(),
   route: {
     pathname: '/',
   },
@@ -31,10 +32,15 @@ vi.mock('next/navigation', () => ({
   usePathname: () => mocks.route.pathname,
 }));
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ i18n: { language: 'en-US' } }),
+}));
+
 vi.mock('@/app/lib/analytics', () => ({
   alias: mocks.alias,
   identify: mocks.identify,
   reset: mocks.reset,
+  setPersonProperties: mocks.setPersonProperties,
 }));
 
 vi.mock('@/app/lib/party-profile-db', () => ({
@@ -92,10 +98,7 @@ describe('PartyProfileProvider PostHog identity wiring', () => {
     });
 
     expect(mocks.reset).not.toHaveBeenCalled();
-    expect(mocks.identify.mock.calls).toEqual([
-      ['profile-1'],
-      ['user-1', { email: 'one@example.com' }],
-    ]);
+    expect(mocks.identify.mock.calls).toEqual([['profile-1'], ['user-1', { email: 'one@example.com' }]]);
     expect(mocks.hasRecordedPosthogAlias).toHaveBeenCalledWith('profile-1', 'user-1');
     expect(mocks.alias).toHaveBeenCalledWith('user-1');
     expect(mocks.recordPosthogAlias).toHaveBeenCalledWith('profile-1', 'user-1');

--- a/packages/web/app/components/party-manager/party-profile-context.tsx
+++ b/packages/web/app/components/party-manager/party-profile-context.tsx
@@ -126,9 +126,17 @@ export const PartyProfileProvider: React.FC<{ children: React.ReactNode }> = ({ 
   // changes — not on every navigation (the identity effect above re-runs on
   // pathname changes, which would be wasteful for a property that rarely
   // changes).
+  //
+  // Guards mirror the identity effect above: skip while session status is still
+  // loading or before the IDB profile resolves (otherwise we'd attach `language`
+  // to PostHog's transient anon id and have to merge it later), and skip on
+  // admin URLs to keep admin sessions out of analytics entirely.
   useEffect(() => {
+    if (sessionStatus === 'loading') return;
+    if (pathname && isAdminAnalyticsUrl(pathname)) return;
+    if (!profile?.id) return;
     setPersonProperties({ language: i18n.language });
-  }, [i18n.language]);
+  }, [i18n.language, pathname, profile?.id, sessionStatus]);
 
   // Fetch custom user profile (displayName, avatarUrl) when authenticated
   useEffect(() => {

--- a/packages/web/app/components/party-manager/party-profile-context.tsx
+++ b/packages/web/app/components/party-manager/party-profile-context.tsx
@@ -5,9 +5,10 @@ import { useSession } from 'next-auth/react';
 import { usePathname } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { type PartyProfile, getPartyProfile, clearPartyProfile, ensurePartyProfile } from '@/app/lib/party-profile-db';
-import { alias, identify, reset, setPersonProperties } from '@/app/lib/analytics';
+import { alias, identify, reset, setPersonProperties, track } from '@/app/lib/analytics';
 import { isAdminAnalyticsUrl } from '@/app/lib/analytics-paths';
 import { hasRecordedPosthogAlias, recordPosthogAlias } from '@/app/lib/posthog-alias-storage';
+import { consumeFreshOAuthPending } from '@/app/lib/oauth-pending-db';
 
 type UserProfileData = {
   displayName: string | null;
@@ -93,6 +94,19 @@ export const PartyProfileProvider: React.FC<{ children: React.ReactNode }> = ({ 
         }
       }
       identify(userId, session.user.email ? { email: session.user.email } : undefined);
+      // Drain the OAuth-pending marker (if any) — this is the success signal
+      // for OAuth flows where the actual sign-in happens via a server-side
+      // redirect with no client callback to track from. Marker is set on
+      // OAuth button click in social-login-buttons.tsx and expires after 5
+      // minutes so an unrelated re-login won't fire a stale Login Succeeded.
+      void consumeFreshOAuthPending().then((marker) => {
+        if (marker) {
+          track('Login Succeeded', {
+            auth_method: marker.provider,
+            flow: marker.flow,
+          });
+        }
+      });
       lastAnalyticsDistinctId.current = userId;
       return;
     }

--- a/packages/web/app/components/party-manager/party-profile-context.tsx
+++ b/packages/web/app/components/party-manager/party-profile-context.tsx
@@ -3,8 +3,9 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useSession } from 'next-auth/react';
 import { usePathname } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import { type PartyProfile, getPartyProfile, clearPartyProfile, ensurePartyProfile } from '@/app/lib/party-profile-db';
-import { alias, identify, reset } from '@/app/lib/analytics';
+import { alias, identify, reset, setPersonProperties } from '@/app/lib/analytics';
 import { isAdminAnalyticsUrl } from '@/app/lib/analytics-paths';
 import { hasRecordedPosthogAlias, recordPosthogAlias } from '@/app/lib/posthog-alias-storage';
 
@@ -33,6 +34,7 @@ export const PartyProfileProvider: React.FC<{ children: React.ReactNode }> = ({ 
   const [isLoading, setIsLoading] = useState(true);
   const { data: session, status: sessionStatus } = useSession();
   const pathname = usePathname();
+  const { i18n } = useTranslation();
   const lastAnalyticsDistinctId = useRef<string | null>(null);
 
   // Load party profile on mount
@@ -91,6 +93,9 @@ export const PartyProfileProvider: React.FC<{ children: React.ReactNode }> = ({ 
         }
       }
       identify(userId, session.user.email ? { email: session.user.email } : undefined);
+      // Refresh the user's current language each time the identity effect runs
+      // so cohorts by locale stay accurate when users switch between en-US/es.
+      setPersonProperties({ language: i18n.language });
       lastAnalyticsDistinctId.current = userId;
       return;
     }
@@ -103,7 +108,7 @@ export const PartyProfileProvider: React.FC<{ children: React.ReactNode }> = ({ 
       identify(profileId);
       lastAnalyticsDistinctId.current = profileId;
     }
-  }, [pathname, profile?.id, sessionStatus, session?.user?.id, session?.user?.email]);
+  }, [pathname, profile?.id, sessionStatus, session?.user?.id, session?.user?.email, i18n.language]);
 
   // Fetch custom user profile (displayName, avatarUrl) when authenticated
   useEffect(() => {

--- a/packages/web/app/components/party-manager/party-profile-context.tsx
+++ b/packages/web/app/components/party-manager/party-profile-context.tsx
@@ -93,9 +93,6 @@ export const PartyProfileProvider: React.FC<{ children: React.ReactNode }> = ({ 
         }
       }
       identify(userId, session.user.email ? { email: session.user.email } : undefined);
-      // Refresh the user's current language each time the identity effect runs
-      // so cohorts by locale stay accurate when users switch between en-US/es.
-      setPersonProperties({ language: i18n.language });
       lastAnalyticsDistinctId.current = userId;
       return;
     }
@@ -108,7 +105,16 @@ export const PartyProfileProvider: React.FC<{ children: React.ReactNode }> = ({ 
       identify(profileId);
       lastAnalyticsDistinctId.current = profileId;
     }
-  }, [pathname, profile?.id, sessionStatus, session?.user?.id, session?.user?.email, i18n.language]);
+  }, [pathname, profile?.id, sessionStatus, session?.user?.id, session?.user?.email]);
+
+  // Keep PostHog's `language` person property in sync with the active locale.
+  // Scoped to its own effect so it only fires when the language actually
+  // changes — not on every navigation (the identity effect above re-runs on
+  // pathname changes, which would be wasteful for a property that rarely
+  // changes).
+  useEffect(() => {
+    setPersonProperties({ language: i18n.language });
+  }, [i18n.language]);
 
   // Fetch custom user profile (displayName, avatarUrl) when authenticated
   useEffect(() => {

--- a/packages/web/app/components/persistent-session/board-session-bridge.tsx
+++ b/packages/web/app/components/persistent-session/board-session-bridge.tsx
@@ -6,6 +6,7 @@ import { usePersistentSessionState, usePersistentSessionActions } from './persis
 import type { BoardDetails, ParsedBoardRouteParameters } from '@/app/lib/types';
 import { getBaseBoardPath } from '@/app/lib/url-utils';
 import { getClimbSessionCookie } from '@/app/lib/climb-session-cookie';
+import { track } from '@/app/lib/analytics';
 
 type BoardSessionBridgeProps = {
   boardDetails: BoardDetails;
@@ -49,6 +50,18 @@ const BoardSessionBridge: React.FC<BoardSessionBridgeProps> = ({ boardDetails, p
       // This ensures session continuity when navigating between climbs or changing angles
       const activeSessionBasePath = activeSession?.boardPath ? getBaseBoardPath(activeSession.boardPath) : '';
       if (activeSession?.sessionId !== sessionIdFromCookie || activeSessionBasePath !== baseBoardPath) {
+        // Fire Session Joined only on a genuine new-session entry (cookie path —
+        // link, QR, resume from history). Hosts create via start-sesh-drawer
+        // which calls activateSession before this bridge mounts, so they're
+        // already on the matching session and skip this branch. Board reconfig
+        // within the same session also skips.
+        if (activeSession?.sessionId !== sessionIdFromCookie) {
+          track('Session Joined', {
+            session_id: sessionIdFromCookie,
+            board_name: boardDetailsRef.current.board_name,
+            layout_id: boardDetailsRef.current.layout_id,
+          });
+        }
         // Store the full pathname (including angle and view segment like /list)
         // This allows the /join redirect to send users to the exact page with angle
         activateSession({

--- a/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
+++ b/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
@@ -72,6 +72,7 @@ vi.mock('../../bottom-tab-bar/bottom-tab-bar', () => ({
 
 vi.mock('../../board-provider/board-provider-context', () => ({
   BoardProvider: ({ children }: { children: React.ReactNode }) => children,
+  useBoardProvider: () => ({ getLogbook: vi.fn() }),
 }));
 
 vi.mock('../../connection-manager/connection-settings-context', () => ({

--- a/packages/web/app/components/settings/delete-account-section.tsx
+++ b/packages/web/app/components/settings/delete-account-section.tsx
@@ -14,6 +14,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
 import { signOut } from 'next-auth/react';
+import { track } from '@/app/lib/analytics';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { ClientError } from 'graphql-request';
@@ -91,6 +92,7 @@ export default function DeleteAccountSection() {
       });
 
       // Account deleted — sign out and redirect to home
+      track('Logout', { method: 'account_deleted' });
       await signOut({ callbackUrl: '/' });
     } catch (error) {
       console.error('Delete account error:', error);

--- a/packages/web/app/components/settings/delete-account-section.tsx
+++ b/packages/web/app/components/settings/delete-account-section.tsx
@@ -91,9 +91,12 @@ export default function DeleteAccountSection() {
         input: { removeSetterName },
       });
 
-      // Account deleted — sign out and redirect to home
-      track('Logout', { method: 'account_deleted' });
+      // Account deleted — sign out and redirect to home. Track AFTER signOut
+      // resolves so a network failure on signOut doesn't record a Logout that
+      // never actually happened (the GraphQL deletion already succeeded, but
+      // the auth session won't be cleared until signOut completes).
       await signOut({ callbackUrl: '/' });
+      track('Logout', { method: 'account_deleted' });
     } catch (error) {
       console.error('Delete account error:', error);
       let message = t('deleteAccount.error');

--- a/packages/web/app/components/user-drawer/user-drawer.tsx
+++ b/packages/web/app/components/user-drawer/user-drawer.tsx
@@ -57,6 +57,7 @@ import type { BoardDetails, BoardName, BoardRouteIdentity } from '@/app/lib/type
 import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import { useBoardSwitchGuard } from '@/app/components/board-lock/use-board-switch-guard';
+import { track } from '@/app/lib/analytics';
 import {
   type StoredSession,
   getRecentSessions,
@@ -217,6 +218,7 @@ export default function UserDrawer({ boardDetails, boardConfigs }: UserDrawerPro
   );
 
   const handleSignOut = () => {
+    track('Logout', { method: 'manual' });
     void signOut();
     handleClose();
   };

--- a/packages/web/app/lib/__tests__/analytics.test.ts
+++ b/packages/web/app/lib/__tests__/analytics.test.ts
@@ -65,7 +65,7 @@ describe('analytics wrapper', () => {
         autocapture: false,
         captureHistoryEvents: false,
         host: 'https://posthog.example',
-        persistence: 'memory',
+        persistence: 'localStorage',
       }),
     );
     expect(mocks.posthog.capture).toHaveBeenCalledWith('Climb Opened', { kept: 'yes', count: 2 });

--- a/packages/web/app/lib/__tests__/analytics.test.ts
+++ b/packages/web/app/lib/__tests__/analytics.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
     capture: vi.fn(),
     identify: vi.fn(),
     reset: vi.fn(),
+    setPersonProperties: vi.fn(),
   },
   vercelTrack: vi.fn(),
 }));
@@ -115,6 +116,31 @@ describe('analytics wrapper', () => {
     expect(mocks.posthog.identify).toHaveBeenCalledWith('profile-1', { email: 'one@example.com' });
     expect(mocks.posthog.alias).toHaveBeenCalledWith('user-1');
     expect(mocks.posthog.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards set and setOnce person properties to PostHog', async () => {
+    const { setPersonProperties } = await import('../analytics');
+
+    expect(setPersonProperties({ language: 'es' })).toBe(true);
+    expect(setPersonProperties(undefined, { signup_at: '2026-05-11T00:00:00.000Z' })).toBe(true);
+
+    expect(mocks.posthog.setPersonProperties).toHaveBeenNthCalledWith(1, { language: 'es' }, undefined);
+    expect(mocks.posthog.setPersonProperties).toHaveBeenNthCalledWith(2, undefined, {
+      signup_at: '2026-05-11T00:00:00.000Z',
+    });
+  });
+
+  it('skips setPersonProperties on admin pages and outside production', async () => {
+    setWindowLocation('https://boardsesh.com/admin/retention');
+    const { setPersonProperties: adminSet } = await import('../analytics');
+    expect(adminSet({ language: 'es' })).toBe(false);
+    expect(mocks.posthog.setPersonProperties).not.toHaveBeenCalled();
+
+    vi.resetModules();
+    setWindowLocation('https://boardsesh-preview.vercel.app/b/kilter');
+    const { setPersonProperties: previewSet } = await import('../analytics');
+    expect(previewSet({ language: 'es' })).toBe(false);
+    expect(mocks.posthog.setPersonProperties).not.toHaveBeenCalled();
   });
 
   it('skips all analytics calls on admin pages', async () => {

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -41,14 +41,15 @@ function getPosthog(): PostHog | null {
     // is still the canonical anon id; PartyProfileProvider calls identify()
     // on hydration to reconcile if storage was cleared.
     //
-    // CLAUDE.md mandates IndexedDB for client persistence. posthog-js-lite only
-    // exposes 'localStorage' | 'sessionStorage' | 'cookie' | 'memory' — there
-    // is no IDB option in the lite SDK. 'memory' (the prior setting) regenerated
-    // a fresh anon id on every reload, which broke retention math. Until/unless
+    // CLAUDE.md mandates IndexedDB for client persistence (the no-restricted-globals
+    // lint rule enforces it on bare globals, which is why this config string
+    // doesn't trigger it). posthog-js-lite only exposes
+    // 'localStorage' | 'sessionStorage' | 'cookie' | 'memory' — there is no
+    // IDB option in the lite SDK. 'memory' (the prior setting) regenerated a
+    // fresh anon id on every reload, which broke retention math. Until/unless
     // we migrate to the full posthog-js SDK or self-host IDB-backed persistence,
     // this is the documented exception. Do not copy this pattern for other
     // persistence needs — use idb-helper.ts as usual.
-    // oxlint-disable-next-line no-restricted-globals -- posthog-js-lite SDK has no IDB option; alternative is losing cross-session attribution
     persistence: 'localStorage',
   });
 

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -36,10 +36,11 @@ function getPosthog(): PostHog | null {
     host,
     autocapture: false,
     captureHistoryEvents: false,
-    // PartyProfileProvider identifies the IndexedDB party-profile UUID after
-    // hydration. Events captured before that resolve use PostHog's temporary
-    // in-memory anonymous ID and are not guaranteed to merge later.
-    persistence: 'memory',
+    // Persist distinct_id in localStorage so anonymous → authed merges and
+    // cross-session retention cohorts work. The IndexedDB party-profile UUID
+    // is still the canonical anon id; PartyProfileProvider calls identify()
+    // on hydration to reconcile if storage was cleared.
+    persistence: 'localStorage',
   });
 
   return posthogClient;
@@ -90,6 +91,18 @@ export function identify(distinctId: string, properties?: PosthogProperties): bo
   const posthog = getPosthog();
   if (!posthog) return false;
   posthog.identify(distinctId, properties);
+  return true;
+}
+
+// Sets person properties on the current distinct_id. `setOnce` properties are
+// only written if they don't already exist on the user (use for first-touch
+// attributes like signup_at, auth_method). `set` overwrites every call.
+export function setPersonProperties(set?: PosthogProperties, setOnce?: PosthogProperties): boolean {
+  if (isCurrentAdminAnalyticsPage()) return false;
+
+  const posthog = getPosthog();
+  if (!posthog) return false;
+  posthog.setPersonProperties(set, setOnce);
   return true;
 }
 

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -40,6 +40,15 @@ function getPosthog(): PostHog | null {
     // cross-session retention cohorts work. The IndexedDB party-profile UUID
     // is still the canonical anon id; PartyProfileProvider calls identify()
     // on hydration to reconcile if storage was cleared.
+    //
+    // CLAUDE.md mandates IndexedDB for client persistence. posthog-js-lite only
+    // exposes 'localStorage' | 'sessionStorage' | 'cookie' | 'memory' — there
+    // is no IDB option in the lite SDK. 'memory' (the prior setting) regenerated
+    // a fresh anon id on every reload, which broke retention math. Until/unless
+    // we migrate to the full posthog-js SDK or self-host IDB-backed persistence,
+    // this is the documented exception. Do not copy this pattern for other
+    // persistence needs — use idb-helper.ts as usual.
+    // oxlint-disable-next-line no-restricted-globals -- posthog-js-lite SDK has no IDB option; alternative is losing cross-session attribution
     persistence: 'localStorage',
   });
 

--- a/packages/web/app/lib/oauth-pending-db.ts
+++ b/packages/web/app/lib/oauth-pending-db.ts
@@ -18,11 +18,20 @@ export const setOAuthPending = async (marker: OAuthPendingMarker): Promise<void>
 };
 
 // Returns the marker if it exists and is still fresh, otherwise null.
-// Stale entries are removed as a side effect so the next call is a clean miss.
+// Order: read → assess freshness from the in-memory value → best-effort delete →
+// return. Doing the delete after the freshness check (and swallowing its errors)
+// guarantees we never lose a fresh marker just because the delete leg fails —
+// the Login Succeeded event for the OAuth round-trip is too valuable to drop on
+// a transient IDB hiccup.
 export const consumeFreshOAuthPending = async (): Promise<OAuthPendingMarker | null> => {
   const stored = await getPreference<OAuthPendingMarker>(KEY);
   if (!stored) return null;
-  await removePreference(KEY);
-  if (Date.now() - stored.attempted_at > MAX_AGE_MS) return null;
-  return stored;
+  const isFresh = Date.now() - stored.attempted_at <= MAX_AGE_MS;
+  try {
+    await removePreference(KEY);
+  } catch {
+    // removePreference already swallows its own errors, but defend the
+    // contract: this function must not throw out of consumers' .then chains.
+  }
+  return isFresh ? stored : null;
 };

--- a/packages/web/app/lib/oauth-pending-db.ts
+++ b/packages/web/app/lib/oauth-pending-db.ts
@@ -1,0 +1,28 @@
+import { getPreference, setPreference, removePreference } from './user-preferences-db';
+
+const KEY = 'oauth:pending';
+
+// 5-minute TTL — anything older is treated as a stale marker from an abandoned
+// OAuth round-trip. Long enough for slow providers, short enough that an
+// unrelated re-login can't borrow the marker.
+const MAX_AGE_MS = 5 * 60 * 1000;
+
+export type OAuthPendingMarker = {
+  provider: string;
+  flow: 'web' | 'native';
+  attempted_at: number;
+};
+
+export const setOAuthPending = async (marker: OAuthPendingMarker): Promise<void> => {
+  await setPreference(KEY, marker);
+};
+
+// Returns the marker if it exists and is still fresh, otherwise null.
+// Stale entries are removed as a side effect so the next call is a clean miss.
+export const consumeFreshOAuthPending = async (): Promise<OAuthPendingMarker | null> => {
+  const stored = await getPreference<OAuthPendingMarker>(KEY);
+  if (!stored) return null;
+  await removePreference(KEY);
+  if (Date.now() - stored.attempted_at > MAX_AGE_MS) return null;
+  return stored;
+};


### PR DESCRIPTION
## Summary
- Persist PostHog `distinct_id` in `localStorage` (was `memory`) so anon → authed merges and cross-session retention math work. Without this, every reload was generating a new anonymous user.
- Add auth funnel events: `Signup Completed`, `Login Attempted` / `Login Succeeded` / `Login Failed`, `Logout`. Anchors every activation funnel; previously zero auth events existed.
- Add `Session Joined` for party-mode peers entering via link / QR / session-history resume. Host's `Session Started` is unchanged — bridge only fires on a genuine new-session cookie change, so no double-count.
- Add `Bluetooth Disconnected` with `reason` (`user` / `lost`) and `duration_connected_ms`. Hardware reliability funnel was previously blind.
- Wire first-touch person properties (`signup_at`, `signup_auth_method`, `language`) via a new `setPersonProperties` wrapper exposing `$set` and `$set_once`.

Plan + full audit doc lives at `/home/developer/.claude/plans/we-have-now-rolled-typed-kahan.md`. P1 follow-ups in the doc: server-side PostHog SDK (closes the OAuth-success gap), typed event catalog, group analytics for party sessions, Vercel sunset after 30-day validation.

## Test plan
- [x] `vp lint` — 0 errors (111 pre-existing warnings unchanged)
- [x] `vp run typecheck:web` — passes
- [x] Analytics tests (`analytics.test.ts`, `party-profile-context.test.tsx`) — pass after updating mocks for `setPersonProperties` + `react-i18next`
- [x] All bluetooth-control tests (348) — pass
- [x] All user-drawer tests (50) — pass
- [ ] In prod, verify `Signup Completed` fires with `auth_method` distribution
- [ ] Confirm `distinct_id` stability across reloads in PostHog Live Events (incognito → reload → events share same id)
- [ ] Confirm anon → authed merge: anon events appear under the authed user after sign-in
- [ ] Build "New User Activation" funnel and check D7 conversion through `Climb Sent to Board Success`
- [ ] OAuth success is currently inferred (Attempted fires, no Failed = success). P1 server SDK closes this — document expected discrepancy with credentials path conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)