### PR TITLE
chore: run vp fmt after graphql codegen

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,7 +75,7 @@ export default defineConfig({
       // print-schema concatenates the modular gql typeDefs into a single SDL
       // file that graphql-codegen reads as its schema input.
       codegen: {
-        command: 'bun packages/shared-schema/scripts/print-schema.ts && graphql-codegen',
+        command: 'bun packages/shared-schema/scripts/print-schema.ts && graphql-codegen && vp fmt',
       },
 
       // --- Build (topological order via dependsOn) ---

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,7 +75,8 @@ export default defineConfig({
       // print-schema concatenates the modular gql typeDefs into a single SDL
       // file that graphql-codegen reads as its schema input.
       codegen: {
-        command: 'bun packages/shared-schema/scripts/print-schema.ts && graphql-codegen && vp fmt',
+        command:
+          'bun packages/shared-schema/scripts/print-schema.ts && graphql-codegen && vp fmt packages/shared-schema/src/generated/ packages/web/app/lib/graphql/generated/',
       },
 
       // --- Build (topological order via dependsOn) ---


### PR DESCRIPTION
## Summary

- Appends `&& vp fmt` to the `codegen` task command in `vite.config.ts` so generated GraphQL files (`graphql.ts`, `gql.ts`, `types.ts`) are always formatted immediately after generation.
- Prevents formatting drift where a `codegen` run without a subsequent `vp fmt` would produce a noisy diff on the next PR.

## Test plan

- [ ] Run `vp run codegen` and confirm the generated files under `packages/shared-schema/src/generated/` and `packages/web/app/lib/graphql/generated/` are already formatted (no diff from `vp fmt` afterwards).

https://claude.ai/code/session_014Kt49vtw9GARQfDSiJ494N

---
_Generated by [Claude Code](https://claude.ai/code/session_014Kt49vtw9GARQfDSiJ494N)_