### PR TITLE
Remove orphaned betaVideos i18n keys and fix missing top margin

### DIFF
--- a/packages/web/app/components/library/post-to-instagram-dialog.tsx
+++ b/packages/web/app/components/library/post-to-instagram-dialog.tsx
@@ -120,7 +120,11 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
       </Box>
     );
   } else {
-    betaVideosContent = <BoardseshBetaList links={dedupedBetaLinks} isLoading={betaLinksLoading} />;
+    betaVideosContent = (
+      <Box sx={{ mt: 1 }}>
+        <BoardseshBetaList links={dedupedBetaLinks} isLoading={betaLinksLoading} />
+      </Box>
+    );
   }
 
   return (

--- a/packages/web/i18n/locales/en-US/feed.json
+++ b/packages/web/i18n/locales/en-US/feed.json
@@ -37,20 +37,7 @@
     "urlLabel": "Beta video URL",
     "urlLabelForClimb": "Beta video URL for {{name}}",
     "defaultHelper": "Paste a public Instagram reel/post or TikTok URL so others can see your beta.",
-    "cancel": "Cancel",
-    "unableToLoad": "Unable to load video",
-    "viewLink": "View",
-    "videoTitle": "Beta video",
-    "videoTitleByUser": "Beta video by {{name}}",
-    "modalTitle": "Beta Video",
-    "modalTitleByUser": "Beta by @{{name}}",
-    "viewOnInstagram": "View on Instagram",
-    "showLess": "Show less",
-    "showMore_one": "Show 1 more video",
-    "showMore_other": "Show {{count}} more videos",
-    "noVideosAvailable": "No beta videos available",
-    "angleSuffix": "{{angle}}°",
-    "unknownUser": "unknown"
+    "cancel": "Cancel"
   },
   "commentFeed": {
     "empty": "No comments yet",

--- a/packages/web/i18n/locales/es/feed.json
+++ b/packages/web/i18n/locales/es/feed.json
@@ -37,20 +37,7 @@
     "urlLabel": "URL del vídeo de beta",
     "urlLabelForClimb": "URL del vídeo de beta para {{name}}",
     "defaultHelper": "Pega una URL pública de Instagram (reel/post) o TikTok para que otros vean tu beta.",
-    "cancel": "Cancelar",
-    "unableToLoad": "No se pudo cargar el vídeo",
-    "viewLink": "Ver",
-    "videoTitle": "Vídeo de beta",
-    "videoTitleByUser": "Vídeo de beta por {{name}}",
-    "modalTitle": "Vídeo de beta",
-    "modalTitleByUser": "Beta de @{{name}}",
-    "viewOnInstagram": "Ver en Instagram",
-    "showLess": "Ver menos",
-    "showMore_one": "Ver 1 vídeo más",
-    "showMore_other": "Ver {{count}} vídeos más",
-    "noVideosAvailable": "No hay vídeos de beta disponibles",
-    "angleSuffix": "{{angle}}°",
-    "unknownUser": "desconocido"
+    "cancel": "Cancelar"
   },
   "commentFeed": {
     "empty": "Sin comentarios todavía",

--- a/packages/web/i18n/locales/fr/feed.json
+++ b/packages/web/i18n/locales/fr/feed.json
@@ -37,20 +37,7 @@
     "urlLabel": "URL de la vidéo beta",
     "urlLabelForClimb": "URL de la vidéo beta pour {{name}}",
     "defaultHelper": "Collez l'URL d'un reel/post Instagram public ou d'une vidéo TikTok pour partager votre beta.",
-    "cancel": "Annuler",
-    "unableToLoad": "Impossible de charger la vidéo",
-    "viewLink": "Voir",
-    "videoTitle": "Vidéo beta",
-    "videoTitleByUser": "Vidéo beta par {{name}}",
-    "modalTitle": "Vidéo beta",
-    "modalTitleByUser": "Beta par @{{name}}",
-    "viewOnInstagram": "Voir sur Instagram",
-    "showLess": "Voir moins",
-    "showMore_one": "Voir 1 vidéo de plus",
-    "showMore_other": "Voir {{count}} vidéos de plus",
-    "noVideosAvailable": "Aucune vidéo beta disponible",
-    "angleSuffix": "{{angle}}°",
-    "unknownUser": "inconnu"
+    "cancel": "Annuler"
   },
   "commentFeed": {
     "empty": "Aucun commentaire pour l'instant",


### PR DESCRIPTION
## Summary

- Removes 13 dead keys from `feed.json` (`unableToLoad`, `viewLink`, `videoTitle`, `videoTitleByUser`, `modalTitle`, `modalTitleByUser`, `viewOnInstagram`, `showLess`, `showMore`, `noVideosAvailable`, `angleSuffix`, `unknownUser`) that were only referenced by the deleted `beta-videos.tsx` component — both `en-US` and `es` catalogs cleaned up
- Wraps `<BoardseshBetaList>` in `<Box sx={{ mt: 1 }}>` inside `post-to-instagram-dialog.tsx` to restore the top spacing that existed when the old `<BetaVideos>` was wrapped in that same Box — fixes the visual regression where the list sat flush against the "Existing Beta Videos" label

## Test plan

- [ ] Open the Post to Instagram dialog for any climb
- [ ] Confirm the "Existing Beta Videos" section has a visible gap between the label and the list/skeletons below it
- [ ] Confirm no i18n fallback warnings for removed keys appear in the browser console
- [ ] CI lint/typecheck passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbLEpzWfsaP6nQW4xuFcbb)_