### PR TITLE
test: simplify Save climb button query in duplicate-hold test

### DIFF
--- a/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
@@ -288,9 +288,7 @@ describe('CreateClimbForm', () => {
     });
 
     await waitFor(() => {
-      const saveButton = getSaveButton();
-      expect(saveButton).toBeTruthy();
-      expect(saveButton?.disabled).toBe(true);
+      expect(screen.getByLabelText<HTMLButtonElement>('Save climb').disabled).toBe(true);
     });
   });
 


### PR DESCRIPTION
Replace `getAllByLabelText(...).find(...)` with `getByLabelText<HTMLButtonElement>` so a missing element throws "element not found" instead of a confusing "expected undefined to be true", and remove the unnecessary optional chain.

Redoes #1499.

https://claude.ai/code/session_01KCrY1GfXWx5ZZL8BHiBK5H

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCrY1GfXWx5ZZL8BHiBK5H)_