### PR TITLE
ci(e2e): stop double-running screenshot specs + trace on all retries

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -357,7 +357,12 @@ jobs:
           NEXT_PUBLIC_WS_URL: ws://localhost:8080/graphql
 
       - name: Run Playwright shard ${{ matrix.shard }}/8
-        run: bunx playwright test --shard=${{ matrix.shard }}/8
+        # `--project=chromium` keeps screenshot specs (app-store/help/layout)
+        # out of the functional shards. Those projects already run in the
+        # dedicated `screenshots` job below; without this filter every
+        # screenshot test ran twice per PR and contributed double to the
+        # flake budget.
+        run: bunx playwright test --project=chromium --shard=${{ matrix.shard }}/8
         working-directory: packages/web
         env:
           PLAYWRIGHT_TEST_BASE_URL: http://localhost:3000

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -25,8 +25,10 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:3000',
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    /* Trace every retry, not just the first. With `retries: 3`, the previous
+     * `on-first-retry` setting meant retries 2 and 3 produced no trace —
+     * exactly when a test is most stuck and the trace is most useful. */
+    trace: 'on-all-retries',
     /* Capture a screenshot on failure for easier CI debugging */
     screenshot: 'only-on-failure',
     /* Timeout for individual actions (click, fill, etc.) */


### PR DESCRIPTION
## Summary

Two infra-only changes that drop the e2e flake floor without touching specs:

1. **Functional shards now run only `--project=chromium`.** The screenshot projects (`app-store-screenshots`, `help-screenshots`, `layout-screenshots`) are already covered by the dedicated `screenshots` job. Without the project filter every screenshot test ran twice per PR and counted twice toward the flake budget — the recurring shard-7 failures of `06-party-mode` and `party mode active session` were both screenshot specs being re-executed inside an e2e shard.
2. **`trace: 'on-all-retries'`** in `playwright.config.ts`. With `retries: 3` the old `on-first-retry` setting meant retries 2 and 3 produced no trace — exactly when a test is most stuck and the trace is most valuable.

Test count change in the chromium shards: 70 → 47, balanced across 8 shards (~6 tests per shard).

## Context

Last 60 runs of E2E Tests on `main` and PRs: **47% failure / 30% cancelled / 15% success**. Failures cluster in a handful of specs:

- `grid-mode-ascent-badge.spec.ts` (~20/30 of recent failed runs) — flaky data dependency
- `bottom-tab-bar.spec.ts:215` (~15/30) — Next 16 nav bug + slow `/feed` load
- `help-screenshots.spec.ts:190 party mode active session` (~10/30) — real backend session, no mock
- `app-store-screenshots.spec.ts:176 06-party-mode` (~8/30) — event dispatched before listener mounts

This PR addresses **none** of those root causes — it just stops the screenshot specs from contributing twice. Subsequent PRs will fix the specs themselves and tackle the underlying product bugs (Next 16 + MUI 7 nav, /feed slow SSR).

## Test plan

- [x] `vp lint packages/web/playwright.config.ts` — clean
- [x] `bunx playwright test --project=chromium --list` confirms 47 tests
- [ ] CI on this PR completes without the doubled screenshot failures
- [ ] Future failed retries land with full trace data attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)