### PR TITLE
test(e2e): add globalSetup with login + warmup, document seed contract

### DIFF
--- a/packages/web/e2e/SEED_CONTRACT.md
+++ b/packages/web/e2e/SEED_CONTRACT.md
@@ -1,0 +1,59 @@
+# Seed Contract for e2e tests
+
+This file documents the database state every Playwright spec assumes. It is the
+single source of truth for what the seeded `boardsesh-dev-db` Docker image must
+provide. **Anything not listed here is fair game to break** — if a spec
+implicitly depends on data outside this contract, the spec needs to either pin
+the data explicitly or move the requirement into this contract.
+
+`global-setup.ts` validates the high-level contract entries before any worker
+starts and fails fast with a precise error message if a check trips.
+
+## Test user
+
+- **Email:** `test@boardsesh.com` (override with `TEST_USER_EMAIL`)
+- **Password:** `test` (override with `TEST_USER_PASSWORD`)
+- Must exist as an active, non-deleted user.
+- Login via `/auth/login` must succeed and redirect to `/`.
+
+## Default test board
+
+The board most specs land on:
+
+- URL: `/kilter/original/12x12-square/screw_bolt/40/list`
+- Must render at least one element matching `#onboarding-climb-card` or
+  `[data-testid="climb-card"]` within 30 s of a cold load.
+- Must expose at least two onboarding-tagged rows (`#onboarding-climb-card` and
+  `#onboarding-climb-card-2`) so `app-store-screenshots.spec.ts:04-queue` can
+  populate three queue items.
+
+## Per-spec assumptions
+
+| Spec | Additional data needed | Status |
+| --- | --- | --- |
+| `grid-mode-ascent-badge.spec.ts` | Test user has ≥1 ascent (flash or send) on a climb returned by `?showOnlyCompleted=true` at angle 40 on `kilter/original/12x12-square/screw_bolt`. The seed currently distributes ~2000 random ticks across ~10k climb/angle combos — this is **non-deterministic** and the source of the recurring flake. Will become deterministic in a follow-up PR that pins specific climb UUIDs. | ⚠️ flaky (PR follow-up) |
+| `bottom-tab-bar.spec.ts` | Default test board contract (above). | ✅ |
+| `queue-persistence.spec.ts` | Default test board contract (above). `/playlists` and `/feed` reachable for the warmup. | ✅ |
+| `help-screenshots.spec.ts` (unauthenticated) | Default test board contract. | ✅ |
+| `help-screenshots.spec.ts` (authenticated) | Test user contract. The `party mode active session` test additionally creates a real party session against the local backend — this is timing-sensitive and slated for follow-up to use the dummy sesh mount instead. | ⚠️ |
+| `app-store-screenshots.spec.ts` | Default test board contract. The `06-party-mode` test requires `OnboardingDummySeshMount` to be globally mounted; it dispatches `onboarding:open-dummy-sesh` and expects a swipeable drawer to open. | ✅ (with retry-dispatch from PR 2) |
+| `layout-screenshots.spec.ts` | One climb card present on every supported Kilter/Tension layout URL. | ✅ |
+| `climb-setter-zoom.spec.ts` | `/create` route reachable; board renderer mounts an SVG inside `[data-testid="climb-setter-board"]`. | ✅ |
+| `i18n-locale-routing.spec.ts`, `i18n-locale-navigation.spec.ts` | English and Spanish locale catalogs present (covered by the in-repo `packages/web/i18n/locales/` checked into git). | ✅ |
+| `activity-feed-infinite-scroll.spec.ts` | `/feed` returns more than one page of activity items for the test user. | ⚠️ (data assumption not yet enforced) |
+
+## Updating the contract
+
+When adding a new spec:
+
+1. List the data it depends on in this file.
+2. If the dependency is novel (a specific climb UUID, a specific user state),
+   add a deterministic insertion to the seed script (path TBC, currently
+   `packages/db/scripts/`) and bump the dev-DB Docker image version.
+3. If the contract entry is broad enough that `global-setup.ts` could verify
+   it cheaply, add the check there too.
+
+The dev-DB image is rebuilt automatically when files in `packages/db/docker/`,
+`packages/db/scripts/`, `packages/db/src/schema/`, `packages/db/drizzle/`, or
+`packages/db/package.json` change on `main` (see CLAUDE.md → "Pre-built
+database image").

--- a/packages/web/e2e/global-setup.ts
+++ b/packages/web/e2e/global-setup.ts
@@ -1,0 +1,69 @@
+import { chromium, type FullConfig } from '@playwright/test';
+
+const BOARD_URL = '/kilter/original/12x12-square/screw_bolt/40/list';
+const WARMUP_PATHS = ['/playlists', '/feed'] as const;
+const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL ?? 'test@boardsesh.com';
+const TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD ?? 'test';
+
+class SetupError extends Error {
+  constructor(message: string, hint?: string) {
+    super(hint ? `${message}\n\nHint: ${hint}` : message);
+    this.name = 'E2E global-setup failed';
+  }
+}
+
+export default async function globalSetup(config: FullConfig): Promise<void> {
+  const baseURL = config.projects[0]?.use.baseURL ?? process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'http://localhost:3000';
+
+  const browser = await chromium.launch();
+  try {
+    const context = await browser.newContext({ baseURL });
+    const page = await context.newPage();
+
+    // 1. Server reachable + board route renders climb cards
+    try {
+      await page.goto(BOARD_URL, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+      await page.waitForSelector('#onboarding-climb-card, [data-testid="climb-card"]', { timeout: 30_000 });
+    } catch (cause) {
+      throw new SetupError(
+        `Board URL ${BOARD_URL} did not render any climb cards within 30s.`,
+        'Confirm the dev server is up at ' +
+          baseURL +
+          ' and the dev DB image is current (`docker compose down -v && vp run db:up`). ' +
+          `Underlying error: ${cause instanceof Error ? cause.message : String(cause)}`,
+      );
+    }
+
+    // 2. Test user can log in
+    try {
+      await page.goto(`/auth/login?callbackUrl=${encodeURIComponent('/')}`, { waitUntil: 'domcontentloaded' });
+      await page.getByLabel('Email').fill(TEST_USER_EMAIL);
+      await page.getByLabel('Password').fill(TEST_USER_PASSWORD);
+      await page.getByRole('button', { name: 'Login' }).click();
+      await page.waitForURL('/', { timeout: 20_000 });
+    } catch (cause) {
+      throw new SetupError(
+        `Test user ${TEST_USER_EMAIL} failed to log in.`,
+        'Confirm the seeded dev DB image includes this user (the boardsesh-dev-db image ships ' +
+          'test@boardsesh.com / test by default). Set TEST_USER_EMAIL/TEST_USER_PASSWORD if you ' +
+          `intend to use a different account. Underlying error: ${cause instanceof Error ? cause.message : String(cause)}`,
+      );
+    }
+
+    // 3. Pre-warm the SSR routes that queue-persistence and bottom-tab-bar
+    //    navigate to. Both call cached GraphQL on the server and trigger
+    //    Next.js's compile-on-first-hit in dev. Without this, the first
+    //    navigation in a test races a cold backend round-trip against the
+    //    per-navigation timeout — the recurring shard-5 / shard-4 flake mode.
+    for (const path of WARMUP_PATHS) {
+      await page.goto(path, { timeout: 60_000, waitUntil: 'domcontentloaded' }).catch(() => {
+        // Soft-fail: warmup is best-effort. If a warmup route is genuinely
+        // broken the spec that depends on it will surface the failure.
+      });
+    }
+
+    await context.close();
+  } finally {
+    await browser.close();
+  }
+}

--- a/packages/web/e2e/queue-persistence.spec.ts
+++ b/packages/web/e2e/queue-persistence.spec.ts
@@ -47,26 +47,9 @@ function bottomTabButton(page: Page, name: string, exact = false) {
 test.describe('Queue Persistence - Local Mode', () => {
   const boardUrl = '/kilter/original/12x12-square/screw_bolt/40/list';
 
-  // Warm the SSR routes the persistence tests navigate to. Both pages call
-  // cached GraphQL on the server (cachedDiscoverPlaylists, cachedSessionGroupedFeed)
-  // and trigger Next.js's dev-mode compile-on-first-hit. Without this, the
-  // first navigation to either route during a test races a cold-path
-  // backend round-trip against the per-navigation timeout — which is the
-  // shard-5 flake mode this suite kept tripping. Once warmed, the
-  // unstable_cache returns in well under 1 s for the rest of the run.
-  test.beforeAll(async ({ browser, baseURL }) => {
-    // Manually-created contexts don't inherit `use.baseURL` from the project
-    // config, so relative gotos would otherwise fail with an invalid URL.
-    const context = await browser.newContext({ baseURL });
-    const warmupPage = await context.newPage();
-    try {
-      await warmupPage.goto('/playlists', { timeout: 60_000, waitUntil: 'domcontentloaded' });
-      await warmupPage.goto('/feed', { timeout: 60_000, waitUntil: 'domcontentloaded' });
-    } finally {
-      await context.close();
-    }
-  });
-
+  // /playlists and /feed are pre-warmed once by global-setup.ts so the first
+  // navigation during a test doesn't race a cold-path backend round-trip
+  // against the navigation timeout (the recurring shard-5 flake mode).
   test.beforeEach(async ({ page }) => {
     await page.goto(boardUrl);
     await waitForBoardPage(page);

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -5,6 +5,10 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './e2e',
+  /* Verifies server reachability, test-user login, and pre-warms SSR routes
+   * once before any worker starts. Fails fast with a precise error message
+   * if seeded data has drifted. See e2e/SEED_CONTRACT.md. */
+  globalSetup: require.resolve('./e2e/global-setup'),
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
## Summary

Three additions that surface seed-data drift early and replace per-suite warmup with a single one-time pass.

1. **`packages/web/e2e/global-setup.ts`** runs once before any worker boots:
   - Verifies the dev server is up and the default board URL renders climb cards within 30s.
   - Logs the test user in via `/auth/login` and verifies the redirect.
   - Pre-warms `/playlists` and `/feed` so the first navigation to either route during a spec doesn't race a cold-path SSR + GraphQL round-trip.

   When any check fails, throws a `SetupError` with a hint pointing to the most likely cause (stale dev DB image, missing test user, etc.) so failures don't surface as opaque 30s timeouts inside individual specs.
2. **`packages/web/e2e/SEED_CONTRACT.md`** documents what each spec assumes about the seeded user / dev DB image. Known flaky deps (`grid-mode-ascent-badge`'s random tick distribution, the real-backend party session in `help-screenshots`) are explicitly flagged so future readers don't think they're solid.
3. Drops the redundant `beforeAll` warmup in `queue-persistence.spec.ts` — `global-setup` now handles it once per run instead of once per test file.

## Context

Third of a multi-PR e2e reliability overhaul.
- PR 1 #2097 — infra-only (project filter + trace on retries)
- PR 2 #2098 — wait helpers + drop `networkidle` + kill 10s `waitForTimeout`
- PR 3 (this one) — `globalSetup` + seed contract

## Test plan

- [x] `vp lint packages/web/e2e/ packages/web/playwright.config.ts` — 0 warnings, 0 errors
- [x] `bunx playwright test --list` confirms 70 tests still discovered
- [ ] CI on this PR
- [ ] Intentionally break test user (`UPDATE users SET deleted = true`) and verify global-setup fails fast with the hint message

🤖 Generated with [Claude Code](https://claude.com/claude-code)