### PR TITLE
ci(e2e): post a flake report to PRs after every E2E run

### DIFF
--- a/.github/workflows/flake-report.yml
+++ b/.github/workflows/flake-report.yml
@@ -1,0 +1,152 @@
+name: E2E Flake Report
+
+# Runs after E2E Tests on a PR. Aggregates the per-shard JSON reports the
+# Playwright JSON reporter emits and surfaces every test that passed only
+# after a retry — the canonical signal for "this test is flaky." Posts a
+# sticky PR comment so the flake state is visible without digging into
+# the HTML reports.
+#
+# This is informational, not a merge gate. Failure of this workflow never
+# blocks a PR.
+
+on:
+  workflow_run:
+    workflows: ['E2E Tests']
+    types: [completed]
+
+jobs:
+  report:
+    name: Build flake report
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The PR's head SHA so the comment is associated with the right
+          # commit, not the merge commit.
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Resolve PR number for this workflow_run
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          # workflow_run doesn't carry the PR number directly. Look it up by
+          # head SHA. Skip the report if no open PR matches (push-to-main runs).
+          PR=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+            --jq '.[] | select(.state == "open") | .number' | head -n 1)
+          if [ -z "$PR" ]; then
+            echo "No open PR for SHA ${HEAD_SHA}; skipping report"
+            echo "pr=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "pr=${PR}" >> "$GITHUB_OUTPUT"
+
+      - name: Download all Playwright report artifacts
+        if: steps.pr.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          mkdir -p reports
+          # The e2e-tests workflow uploads `playwright-report-shard-N` per
+          # shard. Pull every one — gh names the directory after the
+          # artifact, so each shard's results.json lives at
+          # reports/playwright-report-shard-N/results.json.
+          gh run download "${RUN_ID}" \
+            --repo "${REPO}" \
+            --dir reports \
+            --pattern 'playwright-report-shard-*' || true
+          ls -R reports || true
+
+      - name: Compute flake list
+        if: steps.pr.outputs.pr != ''
+        id: flake
+        run: |
+          node << 'NODEEOF'
+          const fs = require('fs');
+          const path = require('path');
+
+          const root = 'reports';
+          const flaky = []; // { project, file, title, retries }
+          const failed = []; // { project, file, title }
+
+          function walkSpecs(node, projectName) {
+            if (!node) return;
+            if (Array.isArray(node.suites)) for (const child of node.suites) walkSpecs(child, projectName);
+            if (Array.isArray(node.specs)) for (const spec of node.specs) {
+              for (const test of spec.tests || []) {
+                const project = test.projectName || projectName || 'unknown';
+                const results = test.results || [];
+                if (results.length === 0) continue;
+                const lastStatus = test.status || results[results.length - 1].status;
+                const anyFailed = results.some((r) => r.status === 'failed' || r.status === 'timedOut');
+                if (lastStatus === 'expected' && anyFailed) {
+                  flaky.push({ project, file: spec.file, title: spec.title, retries: results.length - 1 });
+                } else if (lastStatus !== 'expected' && lastStatus !== 'skipped') {
+                  failed.push({ project, file: spec.file, title: spec.title });
+                }
+              }
+            }
+          }
+
+          if (!fs.existsSync(root)) {
+            console.log('No reports directory; nothing to report');
+            fs.writeFileSync('flake-summary.md', '');
+            return;
+          }
+
+          for (const dir of fs.readdirSync(root)) {
+            const file = path.join(root, dir, 'results.json');
+            if (!fs.existsSync(file)) continue;
+            try {
+              const json = JSON.parse(fs.readFileSync(file, 'utf8'));
+              for (const suite of json.suites || []) walkSpecs(suite, suite.title);
+            } catch (err) {
+              console.warn(`Failed to parse ${file}: ${err.message}`);
+            }
+          }
+
+          const lines = ['### E2E Flake Report', ''];
+          if (flaky.length === 0 && failed.length === 0) {
+            lines.push('No flaky tests detected — every spec passed on its first attempt.');
+          } else {
+            if (flaky.length > 0) {
+              lines.push(`**${flaky.length} test${flaky.length === 1 ? '' : 's'} passed only after a retry:**`, '');
+              flaky
+                .sort((a, b) => b.retries - a.retries || a.file.localeCompare(b.file))
+                .forEach((entry) => {
+                  lines.push(`- \`[${entry.project}]\` ${entry.file} — *${entry.title}* (retried ${entry.retries}×)`);
+                });
+              lines.push('');
+            }
+            if (failed.length > 0) {
+              lines.push(`**${failed.length} test${failed.length === 1 ? '' : 's'} failed all retries:**`, '');
+              failed.forEach((entry) => {
+                lines.push(`- \`[${entry.project}]\` ${entry.file} — *${entry.title}*`);
+              });
+              lines.push('');
+            }
+            lines.push(
+              '> Flaky tests still pass the build, but every retry is debt. ' +
+                'See `packages/web/e2e/SEED_CONTRACT.md` for what each spec assumes.',
+            );
+          }
+
+          fs.writeFileSync('flake-summary.md', lines.join('\n'));
+          console.log(lines.join('\n'));
+          NODEEOF
+
+      - name: Upsert sticky PR comment
+        if: steps.pr.outputs.pr != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.pr }}
+          header: e2e-flake-report
+          path: flake-summary.md

--- a/.github/workflows/flake-report.yml
+++ b/.github/workflows/flake-report.yml
@@ -23,11 +23,7 @@ jobs:
       pull-requests: write
       actions: read
     steps:
-      - uses: actions/checkout@v6
-        with:
-          # The PR's head SHA so the comment is associated with the right
-          # commit, not the merge commit.
-          ref: ${{ github.event.workflow_run.head_sha }}
+      # No checkout — the node script below reads only artifact JSON.
 
       - name: Resolve PR number for this workflow_run
         id: pr
@@ -55,19 +51,16 @@ jobs:
           RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           mkdir -p reports
-          # The e2e-tests workflow uploads `playwright-report-shard-N` per
-          # shard. Pull every one — gh names the directory after the
-          # artifact, so each shard's results.json lives at
-          # reports/playwright-report-shard-N/results.json.
-          #
-          # Don't swallow errors: if the artifact name pattern stops
-          # matching (upstream workflow rename), we want the workflow to
-          # surface the failure rather than silently posting "no flakes."
+          # The e2e-tests workflow uploads `playwright-report-shard-N`
+          # artifacts. `gh run download` exits 0 even when zero artifacts
+          # match the pattern (empty reports/ dir), so the empty-state
+          # handler below picks that case up. Network/auth failures still
+          # exit nonzero and fail this step — preferable to silently
+          # posting a misleading "no flakes" comment.
           gh run download "${RUN_ID}" \
             --repo "${REPO}" \
             --dir reports \
-            --pattern 'playwright-report-shard-*' \
-            || echo "::warning::No matching artifacts; flake report will be empty"
+            --pattern 'playwright-report-shard-*'
           ls -R reports || true
 
       - name: Compute flake list
@@ -82,8 +75,11 @@ jobs:
           const path = require('path');
 
           const root = 'reports';
-          const flaky = []; // { project, file, title, retries }
-          const failed = []; // { project, file, title }
+          // Dedup by (project, file, title) so a test that appears in
+          // multiple shards' JSON (shard split misconfig, retried after a
+          // shard re-run) doesn't show up twice in the report.
+          const flakyMap = new Map();
+          const failedMap = new Map();
 
           function walkSpecs(node, projectName) {
             if (!node) return;
@@ -100,10 +96,11 @@ jobs:
                 // detection doesn't accidentally fall through into the
                 // failed bucket.
                 const status = test.status;
+                const key = `${project}::${spec.file}::${spec.title}`;
                 if (status === 'flaky') {
-                  flaky.push({ project, file: spec.file, title: spec.title, retries: results.length - 1 });
+                  flakyMap.set(key, { project, file: spec.file, title: spec.title, retries: results.length - 1 });
                 } else if (status === 'unexpected') {
-                  failed.push({ project, file: spec.file, title: spec.title });
+                  failedMap.set(key, { project, file: spec.file, title: spec.title });
                 }
               }
             }
@@ -128,6 +125,9 @@ jobs:
               console.warn(`Failed to parse ${file}: ${err.message}`);
             }
           }
+
+          const flaky = Array.from(flakyMap.values());
+          const failed = Array.from(failedMap.values());
 
           const lines = ['### E2E Flake Report', ''];
           if (flaky.length === 0 && failed.length === 0) {

--- a/.github/workflows/flake-report.yml
+++ b/.github/workflows/flake-report.yml
@@ -59,15 +59,23 @@ jobs:
           # shard. Pull every one — gh names the directory after the
           # artifact, so each shard's results.json lives at
           # reports/playwright-report-shard-N/results.json.
+          #
+          # Don't swallow errors: if the artifact name pattern stops
+          # matching (upstream workflow rename), we want the workflow to
+          # surface the failure rather than silently posting "no flakes."
           gh run download "${RUN_ID}" \
             --repo "${REPO}" \
             --dir reports \
-            --pattern 'playwright-report-shard-*' || true
+            --pattern 'playwright-report-shard-*' \
+            || echo "::warning::No matching artifacts; flake report will be empty"
           ls -R reports || true
 
       - name: Compute flake list
         if: steps.pr.outputs.pr != ''
         id: flake
+        env:
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           node << 'NODEEOF'
           const fs = require('fs');
@@ -101,9 +109,12 @@ jobs:
             }
           }
 
-          if (!fs.existsSync(root)) {
-            console.log('No reports directory; nothing to report');
-            fs.writeFileSync('flake-summary.md', '');
+          if (!fs.existsSync(root) || fs.readdirSync(root).length === 0) {
+            const runUrl = `https://github.com/${process.env.REPO}/actions/runs/${process.env.RUN_ID}`;
+            fs.writeFileSync(
+              'flake-summary.md',
+              `### E2E Flake Report\n\nNo shard artifacts found — the upstream [E2E run](${runUrl}) may have been cancelled or its artifact names changed.\n`,
+            );
             return;
           }
 

--- a/.github/workflows/flake-report.yml
+++ b/.github/workflows/flake-report.yml
@@ -85,11 +85,16 @@ jobs:
                 const project = test.projectName || projectName || 'unknown';
                 const results = test.results || [];
                 if (results.length === 0) continue;
-                const lastStatus = test.status || results[results.length - 1].status;
-                const anyFailed = results.some((r) => r.status === 'failed' || r.status === 'timedOut');
-                if (lastStatus === 'expected' && anyFailed) {
+                // Playwright's `test.status` is the overall outcome:
+                // `expected` (pass first try), `flaky` (failed once or more
+                // then passed), `unexpected` (failed all retries), or
+                // `skipped`. Branch on those four explicitly so flake
+                // detection doesn't accidentally fall through into the
+                // failed bucket.
+                const status = test.status;
+                if (status === 'flaky') {
                   flaky.push({ project, file: spec.file, title: spec.title, retries: results.length - 1 });
-                } else if (lastStatus !== 'expected' && lastStatus !== 'skipped') {
+                } else if (status === 'unexpected') {
                   failed.push({ project, file: spec.file, title: spec.title });
                 }
               }

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -18,8 +18,11 @@ export default defineConfig({
   /* Raise the default assertion timeout from Playwright's 5 s to 10 s */
   expect: { timeout: 10_000 },
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  /* In CI: emit both the HTML report (uploaded as an artifact) and GitHub Annotations */
-  reporter: process.env.CI ? [['html'], ['github']] : 'html',
+  /* In CI: emit HTML (artifact), GitHub Annotations, and a JSON file the
+   * flake-report workflow consumes to surface tests that passed-on-retry. */
+  reporter: process.env.CI
+    ? [['html'], ['github'], ['json', { outputFile: 'playwright-report/results.json' }]]
+    : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
## Summary

Adds a JSON reporter to `playwright.config.ts` (CI only) and a companion `.github/workflows/flake-report.yml` that fires off `workflow_run` from `E2E Tests`, downloads every shard's `playwright-report-shard-N` artifact, parses the per-shard `results.json`, and posts a sticky PR comment listing:

- tests that **passed only after a retry** (canonical flake signal)
- tests that **failed all retries** (broken, not flaky)

When neither list has entries, the comment says so explicitly — green runs leave a positive signal in the PR, not silence.

The report is informational and never fails the build. The workflow uses `workflow_run` so it runs after `E2E Tests` completes and inherits the original PR SHA via a `head_sha` → PR number lookup. Push-to-main runs are skipped.

## Why

With `retries: 3`, flake currently hides as "passing" — there's no surface in the PR UI that says "this test only passed on attempt 2 of 3." This adds that surface so flake regressions are visible during code review, not three weeks later when the test starts failing all retries.

## Context

Last of a multi-PR e2e reliability overhaul.
- PR 1 #2097 — infra-only (project filter + trace on retries)
- PR 2 #2098 — wait helpers + drop `networkidle`
- PR 3 #2099 — globalSetup + seed contract
- PR 7 (this) — flake reporter

## Test plan

- [x] `vp lint packages/web/playwright.config.ts` — clean
- [x] `bunx playwright test --list` confirms 70 tests still discovered
- [ ] CI on this PR triggers the flake-report workflow on completion
- [ ] Sticky comment renders the "no flakes" message on a green run

🤖 Generated with [Claude Code](https://claude.com/claude-code)