### PR TITLE
test(db-seed): pin deterministic test-user ticks for grid-badge spec

### DIFF
--- a/packages/db/scripts/seed-social.ts
+++ b/packages/db/scripts/seed-social.ts
@@ -7,7 +7,12 @@ import { userFollows } from '../src/schema/app/follows.js';
 import { boardseshTicks } from '../src/schema/app/ascents.js';
 import { userBoards, boardFollows } from '../src/schema/app/boards.js';
 import { boardSessions } from '../src/schema/app/sessions.js';
-import { boardClimbs, boardClimbStats, boardDifficultyGrades } from '../src/schema/boards/unified.js';
+import {
+  boardClimbs,
+  boardClimbStats,
+  boardDifficultyGrades,
+  boardProductSizes,
+} from '../src/schema/boards/unified.js';
 import { notifications } from '../src/schema/app/notifications.js';
 import { comments, votes } from '../src/schema/app/social.js';
 import { feedItems } from '../src/schema/app/feed.js';
@@ -841,48 +846,77 @@ async function seedSocialData() {
     // `/kilter/original/12x12-square/screw_bolt/40/list?showOnlyCompleted=true`
     // and asserts that at least one ascent badge renders. With the random
     // tick distribution above, the 2000 test-user ticks rarely include a
-    // climb on this exact (layout, sets, angle) combo — the spec's flake
-    // root cause. Pinning 5 SEND ticks here turns the assumption into a
-    // contract documented in `packages/web/e2e/SEED_CONTRACT.md`.
+    // climb on this exact (layout, sets, angle, size) combo — the spec's
+    // flake root cause. Pinning 5 SEND ticks on climbs that match the
+    // ACTUAL filter the route applies turns the assumption into a contract
+    // documented in `packages/web/e2e/SEED_CONTRACT.md`.
     //
-    // Constraints on the climbs we pick:
+    // Constraints mirror the climb-list filter so the seeded climbs are
+    // guaranteed to appear on the page:
     //   - boardType = kilter
     //   - layoutId = 1 (the "original" Kilter layout)
-    //   - isListed = true (otherwise the climb won't appear in the search)
+    //   - isListed = true
     //   - has board_climb_stats at angle 40
-    //   - requiredSetIds overlaps {1, 20} = Bolt Ons + Screw Ons (the
-    //     "screw_bolt" URL slug)
+    //   - required_set_ids <@ {1, 20}  (subset; matches the route's
+    //     `required_set_ids <@ selected_sets` check)
+    //   - compatible_size_ids && {12x12 size IDs}  (the route enforces
+    //     `size_id = ANY(compatible_size_ids)` for the URL's product size)
     //
     // Ordered by climb UUID so the selection is stable across seed runs.
     console.info('\n  Pinning deterministic e2e grid-badge ticks...');
 
     const KILTER_ORIGINAL_LAYOUT_ID = 1;
+    // Bolt Ons (1) + Screw Ons (20) — the "screw_bolt" URL slug picks both.
     const KILTER_SCREW_BOLT_SET_IDS = [1, 20];
     const GRID_BADGE_ANGLE = 40;
     const GRID_BADGE_TICK_COUNT = 5;
 
-    const gridBadgeClimbs = await db
-      .select({ uuid: boardClimbs.uuid })
-      .from(boardClimbs)
-      .innerJoin(
-        boardClimbStats,
-        and(eq(boardClimbs.uuid, boardClimbStats.climbUuid), eq(boardClimbs.boardType, boardClimbStats.boardType)),
-      )
+    // Resolve product sizes named like "12 x 12" / "12x12" on kilter.
+    // The board URL slug "12x12-square" derives from the size name via
+    // generateSizeSlug(name, description), so we match by name pattern
+    // rather than hard-coding a numeric ID (the ID isn't stable across
+    // dev DB image rebuilds for non-LED layouts).
+    const kilter12x12SizeRows = await db
+      .select({ id: boardProductSizes.id })
+      .from(boardProductSizes)
       .where(
         and(
-          eq(boardClimbs.boardType, 'kilter'),
-          eq(boardClimbs.layoutId, KILTER_ORIGINAL_LAYOUT_ID),
-          eq(boardClimbs.isListed, true),
-          eq(boardClimbStats.angle, GRID_BADGE_ANGLE),
-          sql`${boardClimbs.requiredSetIds} && ${KILTER_SCREW_BOLT_SET_IDS}::int[]`,
+          eq(boardProductSizes.boardType, 'kilter'),
+          sql`(${boardProductSizes.name} ILIKE '12 x 12%' OR ${boardProductSizes.name} ILIKE '12x12%')`,
         ),
-      )
-      .orderBy(boardClimbs.uuid)
-      .limit(GRID_BADGE_TICK_COUNT);
+      );
+    const kilter12x12SizeIds = kilter12x12SizeRows.map((r) => r.id);
+
+    const gridBadgeClimbs =
+      kilter12x12SizeIds.length === 0
+        ? []
+        : await db
+            .select({ uuid: boardClimbs.uuid })
+            .from(boardClimbs)
+            .innerJoin(
+              boardClimbStats,
+              and(
+                eq(boardClimbs.uuid, boardClimbStats.climbUuid),
+                eq(boardClimbs.boardType, boardClimbStats.boardType),
+              ),
+            )
+            .where(
+              and(
+                eq(boardClimbs.boardType, 'kilter'),
+                eq(boardClimbs.layoutId, KILTER_ORIGINAL_LAYOUT_ID),
+                eq(boardClimbs.isListed, true),
+                eq(boardClimbStats.angle, GRID_BADGE_ANGLE),
+                sql`${boardClimbs.requiredSetIds} <@ ${KILTER_SCREW_BOLT_SET_IDS}::int[]`,
+                sql`${boardClimbs.compatibleSizeIds} && ${kilter12x12SizeIds}::int[]`,
+              ),
+            )
+            .orderBy(boardClimbs.uuid)
+            .limit(GRID_BADGE_TICK_COUNT);
 
     if (gridBadgeClimbs.length === 0) {
       console.warn(
-        '  ⚠️  No kilter climbs match the grid-badge fixture filter (layout 1, sets ∩ {1,20}, angle 40). ' +
+        '  ⚠️  No kilter climbs match the grid-badge fixture filter (layout 1, sets ⊆ {1,20}, ' +
+          `compatible with sizes [${kilter12x12SizeIds.join(',') || 'none-found'}], angle 40). ` +
           'The grid-mode-ascent-badge spec will continue to flake until the dev DB image carries climbs ' +
           'on this combo.',
       );

--- a/packages/db/scripts/seed-social.ts
+++ b/packages/db/scripts/seed-social.ts
@@ -1,4 +1,4 @@
-import { eq, sql, and } from 'drizzle-orm';
+import { eq, sql, and, or, ilike, asc } from 'drizzle-orm';
 import { faker } from '@faker-js/faker';
 
 import { users } from '../src/schema/auth/users.js';
@@ -852,15 +852,15 @@ async function seedSocialData() {
     // documented in `packages/web/e2e/SEED_CONTRACT.md`.
     //
     // Constraints mirror the climb-list filter so the seeded climbs are
-    // guaranteed to appear on the page:
+    // guaranteed to appear on the page (mirrors create-climb-filters.ts):
     //   - boardType = kilter
     //   - layoutId = 1 (the "original" Kilter layout)
     //   - isListed = true
     //   - has board_climb_stats at angle 40
-    //   - required_set_ids <@ {1, 20}  (subset; matches the route's
+    //   - required_set_ids <@ ARRAY[1, 20]  (subset; matches the route's
     //     `required_set_ids <@ selected_sets` check)
-    //   - compatible_size_ids && {12x12 size IDs}  (the route enforces
-    //     `size_id = ANY(compatible_size_ids)` for the URL's product size)
+    //   - {chosen size_id} = ANY(compatible_size_ids)  (matches the route's
+    //     `${params.size_id} = ANY(compatible_size_ids)` check)
     //
     // Ordered by climb UUID so the selection is stable across seed runs.
     console.info('\n  Pinning deterministic e2e grid-badge ticks...');
@@ -871,24 +871,31 @@ async function seedSocialData() {
     const GRID_BADGE_ANGLE = 40;
     const GRID_BADGE_TICK_COUNT = 5;
 
-    // Resolve product sizes named like "12 x 12" / "12x12" on kilter.
-    // The board URL slug "12x12-square" derives from the size name via
-    // generateSizeSlug(name, description), so we match by name pattern
-    // rather than hard-coding a numeric ID (the ID isn't stable across
-    // dev DB image rebuilds for non-LED layouts).
-    const kilter12x12SizeRows = await db
+    // Resolve a single product_size_id matching the "12x12-square" slug.
+    // The route URL parsing maps a slug to one size_id, so the seed needs
+    // one ID too — not an array — to mirror the route's
+    // `${size_id} = ANY(compatible_size_ids)` filter exactly. Ordered by
+    // id so re-runs against the same dev DB image are deterministic.
+    const kilter12x12SizeRow = await db
       .select({ id: boardProductSizes.id })
       .from(boardProductSizes)
       .where(
         and(
           eq(boardProductSizes.boardType, 'kilter'),
-          sql`(${boardProductSizes.name} ILIKE '12 x 12%' OR ${boardProductSizes.name} ILIKE '12x12%')`,
+          or(ilike(boardProductSizes.name, '12 x 12%'), ilike(boardProductSizes.name, '12x12%')),
         ),
-      );
-    const kilter12x12SizeIds = kilter12x12SizeRows.map((r) => r.id);
+      )
+      .orderBy(asc(boardProductSizes.id))
+      .limit(1);
+    const kilter12x12SizeId = kilter12x12SizeRow[0]?.id;
+
+    const setIdLiterals = sql.join(
+      KILTER_SCREW_BOLT_SET_IDS.map((id) => sql`${id}`),
+      sql`, `,
+    );
 
     const gridBadgeClimbs =
-      kilter12x12SizeIds.length === 0
+      kilter12x12SizeId === undefined
         ? []
         : await db
             .select({ uuid: boardClimbs.uuid })
@@ -906,8 +913,8 @@ async function seedSocialData() {
                 eq(boardClimbs.layoutId, KILTER_ORIGINAL_LAYOUT_ID),
                 eq(boardClimbs.isListed, true),
                 eq(boardClimbStats.angle, GRID_BADGE_ANGLE),
-                sql`${boardClimbs.requiredSetIds} <@ ${KILTER_SCREW_BOLT_SET_IDS}::int[]`,
-                sql`${boardClimbs.compatibleSizeIds} && ${kilter12x12SizeIds}::int[]`,
+                sql`${boardClimbs.requiredSetIds} <@ ARRAY[${setIdLiterals}]::int[]`,
+                sql`${kilter12x12SizeId} = ANY(${boardClimbs.compatibleSizeIds})`,
               ),
             )
             .orderBy(boardClimbs.uuid)
@@ -916,7 +923,7 @@ async function seedSocialData() {
     if (gridBadgeClimbs.length === 0) {
       console.warn(
         '  ⚠️  No kilter climbs match the grid-badge fixture filter (layout 1, sets ⊆ {1,20}, ' +
-          `compatible with sizes [${kilter12x12SizeIds.join(',') || 'none-found'}], angle 40). ` +
+          `size_id=${kilter12x12SizeId ?? 'none-found'}, angle 40). ` +
           'The grid-mode-ascent-badge spec will continue to flake until the dev DB image carries climbs ' +
           'on this combo.',
       );

--- a/packages/db/scripts/seed-social.ts
+++ b/packages/db/scripts/seed-social.ts
@@ -835,6 +835,81 @@ async function seedSocialData() {
     console.info(`  Fixture ticks: ${fixtureTickRecords.length}`);
 
     // =========================================================================
+    // Step 8.51: Pin deterministic test-user ticks for the e2e grid-badge spec
+    // =========================================================================
+    // `grid-mode-ascent-badge.spec.ts` navigates to
+    // `/kilter/original/12x12-square/screw_bolt/40/list?showOnlyCompleted=true`
+    // and asserts that at least one ascent badge renders. With the random
+    // tick distribution above, the 2000 test-user ticks rarely include a
+    // climb on this exact (layout, sets, angle) combo — the spec's flake
+    // root cause. Pinning 5 SEND ticks here turns the assumption into a
+    // contract documented in `packages/web/e2e/SEED_CONTRACT.md`.
+    //
+    // Constraints on the climbs we pick:
+    //   - boardType = kilter
+    //   - layoutId = 1 (the "original" Kilter layout)
+    //   - isListed = true (otherwise the climb won't appear in the search)
+    //   - has board_climb_stats at angle 40
+    //   - requiredSetIds overlaps {1, 20} = Bolt Ons + Screw Ons (the
+    //     "screw_bolt" URL slug)
+    //
+    // Ordered by climb UUID so the selection is stable across seed runs.
+    console.info('\n  Pinning deterministic e2e grid-badge ticks...');
+
+    const KILTER_ORIGINAL_LAYOUT_ID = 1;
+    const KILTER_SCREW_BOLT_SET_IDS = [1, 20];
+    const GRID_BADGE_ANGLE = 40;
+    const GRID_BADGE_TICK_COUNT = 5;
+
+    const gridBadgeClimbs = await db
+      .select({ uuid: boardClimbs.uuid })
+      .from(boardClimbs)
+      .innerJoin(
+        boardClimbStats,
+        and(eq(boardClimbs.uuid, boardClimbStats.climbUuid), eq(boardClimbs.boardType, boardClimbStats.boardType)),
+      )
+      .where(
+        and(
+          eq(boardClimbs.boardType, 'kilter'),
+          eq(boardClimbs.layoutId, KILTER_ORIGINAL_LAYOUT_ID),
+          eq(boardClimbs.isListed, true),
+          eq(boardClimbStats.angle, GRID_BADGE_ANGLE),
+          sql`${boardClimbs.requiredSetIds} && ${KILTER_SCREW_BOLT_SET_IDS}::int[]`,
+        ),
+      )
+      .orderBy(boardClimbs.uuid)
+      .limit(GRID_BADGE_TICK_COUNT);
+
+    if (gridBadgeClimbs.length === 0) {
+      console.warn(
+        '  ⚠️  No kilter climbs match the grid-badge fixture filter (layout 1, sets ∩ {1,20}, angle 40). ' +
+          'The grid-mode-ascent-badge spec will continue to flake until the dev DB image carries climbs ' +
+          'on this combo.',
+      );
+    } else {
+      const gridBadgeBaseTime = FIXTURE_BASE_TIMESTAMP + 30 * DAY_MS;
+      const gridBadgeRecords = gridBadgeClimbs.map((climb, i) => ({
+        // Stable uuid → re-runs are idempotent via the onConflictDoNothing below.
+        uuid: `fx-tick-grid-badge-${String(i + 1).padStart(2, '0')}`,
+        userId: TEST_USER_ID,
+        boardType: 'kilter' as const,
+        climbUuid: climb.uuid,
+        angle: GRID_BADGE_ANGLE,
+        isMirror: false,
+        status: 'send' as const,
+        attemptCount: 3,
+        quality: 4,
+        difficulty: null,
+        isBenchmark: false,
+        comment: '',
+        climbedAt: new Date(gridBadgeBaseTime + i * 15 * 60 * 1000).toISOString(),
+        boardId: null,
+      }));
+      await db.insert(boardseshTicks).values(gridBadgeRecords).onConflictDoNothing();
+      console.info(`  Grid-badge ticks: ${gridBadgeRecords.length} (test user, kilter layout 1, angle 40)`);
+    }
+
+    // =========================================================================
     // Step 8.55: Seed party mode sessions (real sessions with multiple users)
     // =========================================================================
     console.info('\n  Seeding party mode sessions...');


### PR DESCRIPTION
## Summary

`grid-mode-ascent-badge.spec.ts` navigates to `/kilter/original/12x12-square/screw_bolt/40/list?showOnlyCompleted=true` and asserts that at least one ascent badge renders. The current seed distributes ~2000 random ticks across ~10k climb/angle combinations for the test user — when the random sample doesn't include a climb on this exact `(layout, sets, angle)` combo, the spec sees zero badges and times out. **This is the most flaky spec on the entire suite (~20 of the last 30 failed runs).**

Adds **Step 8.51** to `seed-social.ts` that queries kilter climbs matching:
- `layoutId = 1` (the "original" Kilter layout)
- `isListed = true`
- has `board_climb_stats` at angle 40
- `requiredSetIds` overlaps `{1, 20}` (Bolt Ons + Screw Ons = "screw_bolt")

ordered by climb UUID for stable selection, then inserts 5 SEND ticks for the test user pointing at those climbs. Stable tick UUIDs (`fx-tick-grid-badge-NN`) make the insert idempotent across re-runs via the existing `.onConflictDoNothing()`.

If the matching climb set is empty (e.g. the dev DB image was built without listed climbs on layout 1 at angle 40), the step warns rather than crashes — the spec will continue to flake until the data shows up, but the rest of the seed completes.

## Dev DB rebuild required

`packages/db/scripts/` is one of the paths that triggers `Build and Publish Dev Database Docker Images`, so merging to main publishes a new `boardsesh-dev-db:latest` automatically. Local dev machines need `docker compose down -v && vp run db:up` after pulling to pick up the new ticks.

CI also pulls `:latest` per shard, so the new image takes effect on the next workflow run after image publication.

## Context

Fourth of a multi-PR e2e reliability overhaul. The seed contract for this change is documented in `packages/web/e2e/SEED_CONTRACT.md` (PR #2099).
- PR 1 #2097 — infra
- PR 2 #2098 — wait helpers
- PR 3 #2099 — globalSetup + seed contract
- PR 4 (this) — deterministic seed for grid badge
- PR 7 #2100 — flake reporter

## Test plan

- [x] `vp run typecheck:db` — clean
- [x] `vp lint packages/db/scripts/seed-social.ts` — clean
- [ ] CI on this PR triggers the dev-db image rebuild
- [ ] Pull the new `:latest` and run `bunx playwright test grid-mode-ascent-badge.spec.ts --repeat-each=20` — expect 20/20 pass
- [ ] Once landed, watch shard-4 of subsequent PRs — the grid-badge spec should stop appearing in the recurring-failure list

🤖 Generated with [Claude Code](https://claude.com/claude-code)