### PR TITLE
fix(feed): cap SSR fetch budget at 5s so a slow backend can't stall page render

### DIFF
--- a/packages/web/app/feed/page.tsx
+++ b/packages/web/app/feed/page.tsx
@@ -38,10 +38,13 @@ type FeedProps = {
 const SSR_FETCH_TIMEOUT_MS = 5_000;
 
 function withSsrTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), SSR_FETCH_TIMEOUT_MS)),
-  ]);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<T>((resolve) => {
+    timer = setTimeout(() => resolve(fallback), SSR_FETCH_TIMEOUT_MS);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
 }
 
 export default async function FeedPage({ searchParams }: FeedProps) {

--- a/packages/web/app/feed/page.tsx
+++ b/packages/web/app/feed/page.tsx
@@ -25,6 +25,25 @@ type FeedProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
+// SSR fetch budget: if the cold-path GraphQL handshake doesn't return
+// within this window, fall back to `initialFeedResult = null` and let the
+// client take over. The page still renders quickly; the client's React
+// Query hook fetches the real data once it mounts.
+//
+// Previously this page had no SSR timeout. On cold cache against a slow
+// backend (e.g. CI's local-pub/sub mode without REDIS_URL), the SSR fetch
+// could exceed Playwright's 30s navigation timeout — the recurring
+// shard-4 flake mode in the bottom-tab-bar persistence test, which falls
+// back to `page.goto('/feed')` after the click-doesn't-navigate symptom.
+const SSR_FETCH_TIMEOUT_MS = 5_000;
+
+function withSsrTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), SSR_FETCH_TIMEOUT_MS)),
+  ]);
+}
+
 export default async function FeedPage({ searchParams }: FeedProps) {
   const params = await searchParams;
 
@@ -42,18 +61,25 @@ export default async function FeedPage({ searchParams }: FeedProps) {
 
   if (authToken) {
     const feedPromise =
-      tab === 'sessions' ? cachedSessionGroupedFeed(boardUuid, true).catch(() => null) : Promise.resolve(null);
-    const boardsPromise = serverMyBoards(authToken);
+      tab === 'sessions'
+        ? withSsrTimeout(
+            cachedSessionGroupedFeed(boardUuid, true).catch(() => null),
+            null,
+          )
+        : Promise.resolve(null);
+    const boardsPromise = withSsrTimeout(
+      serverMyBoards(authToken).catch(() => null),
+      null,
+    );
 
     const [feedResult, boardsResult] = await Promise.all([feedPromise, boardsPromise]);
     initialFeedResult = feedResult;
     initialMyBoards = boardsResult;
   } else if (tab === 'sessions') {
-    try {
-      initialFeedResult = await cachedSessionGroupedFeed(boardUuid, false);
-    } catch {
-      // Feed fetch failed, client will retry
-    }
+    initialFeedResult = await withSsrTimeout(
+      cachedSessionGroupedFeed(boardUuid, false).catch(() => null),
+      null,
+    );
   }
 
   const locale = await getLocale();

--- a/packages/web/app/feed/page.tsx
+++ b/packages/web/app/feed/page.tsx
@@ -25,16 +25,7 @@ type FeedProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
-// SSR fetch budget: if the cold-path GraphQL handshake doesn't return
-// within this window, fall back to `initialFeedResult = null` and let the
-// client take over. The page still renders quickly; the client's React
-// Query hook fetches the real data once it mounts.
-//
-// Previously this page had no SSR timeout. On cold cache against a slow
-// backend (e.g. CI's local-pub/sub mode without REDIS_URL), the SSR fetch
-// could exceed Playwright's 30s navigation timeout — the recurring
-// shard-4 flake mode in the bottom-tab-bar persistence test, which falls
-// back to `page.goto('/feed')` after the click-doesn't-navigate symptom.
+// Cap cold-path SSR at 5s; on timeout, fall back to client-side fetch.
 const SSR_FETCH_TIMEOUT_MS = 5_000;
 
 function withSsrTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {


### PR DESCRIPTION
## Summary

`/feed` page.tsx previously awaited `cachedSessionGroupedFeed()` and `serverMyBoards()` without a deadline. On a cold `unstable_cache` against a slow backend, the SSR fetch could exceed Playwright's 30s navigation timeout — the shard-4 flake mode where `bottom-tab-bar.spec.ts`'s fallback `page.goto('/feed')` blew past `domcontentloaded`.

This wraps both SSR fetches in `withSsrTimeout(... , null)` with a **5s budget**. If the GraphQL call (or its `unstable_cache` revalidation) takes longer, SSR falls through to `initialFeedResult = null` / `initialMyBoards = null`. The client React Query hooks already handle the null-initial case and refetch on mount, so the user sees the page shell first instead of waiting for `next start` to complete the SSR fetch.

## Important non-changes

- **Cache hit path is untouched.** After the first warm hit (capped at 24h for unauthenticated, 5 min for authenticated per the existing `revalidate` setting), SSR is fast and the timeout never fires.
- **The GraphQLClient still has no global timeout.** Adding one would change behavior for every caller; this PR keeps the change scoped to `/feed`, the actual flake source.
- **The Next 16 click-doesn't-navigate symptom on the bottom tab bar is a separate issue.** I couldn't reproduce it without running the dev server in this session, so a root-cause fix for the tab-click bug is a follow-up. The fallback `page.goto` in the test was the visible failure mode; this fix removes that failure mode regardless of whether the underlying click slip still happens.

## Context

Fifth of a multi-PR e2e reliability overhaul.
- PR 1 #2097 — infra
- PR 2 #2098 — wait helpers
- PR 3 #2099 — globalSetup
- PR 4 #2101 — deterministic seed
- PR 5 (this) — /feed slow-load fix
- PR 6 #2102 — spec fixes
- PR 7 #2100 — flake reporter

## Test plan

- [x] `vp run typecheck:web` — clean
- [x] `vp lint packages/web/app/feed/page.tsx` — clean
- [ ] Manual: production-start the web package and `time curl -o /dev/null http://localhost:3000/feed` should return < 6s even with a cold backend.
- [ ] CI on this PR
- [ ] After merge: shard-4 of subsequent PRs no longer trips the `bottom-tab-bar` test's 30s `page.goto('/feed')` timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
