### PR TITLE
fix(ssr): extract withSsrTimeout helper + apply to /notifications

### DIFF
--- a/packages/web/app/feed/page.tsx
+++ b/packages/web/app/feed/page.tsx
@@ -7,6 +7,7 @@ import { createPageMetadata } from '@/app/lib/seo/metadata';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import I18nProvider from '@/app/components/providers/i18n-provider';
+import { withSsrTimeout } from '@/app/lib/ssr-timeout';
 
 export async function generateMetadata() {
   const { t, locale } = await getServerTranslation('feed');
@@ -24,19 +25,6 @@ const VALID_TABS: FeedTab[] = ['sessions', 'proposals', 'comments'];
 type FeedProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
-
-// Cap cold-path SSR at 5s; on timeout, fall back to client-side fetch.
-const SSR_FETCH_TIMEOUT_MS = 5_000;
-
-function withSsrTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<T>((resolve) => {
-    timer = setTimeout(() => resolve(fallback), SSR_FETCH_TIMEOUT_MS);
-  });
-  return Promise.race([promise, timeoutPromise]).finally(() => {
-    if (timer !== undefined) clearTimeout(timer);
-  });
-}
 
 export default async function FeedPage({ searchParams }: FeedProps) {
   const params = await searchParams;

--- a/packages/web/app/lib/ssr-timeout.ts
+++ b/packages/web/app/lib/ssr-timeout.ts
@@ -1,0 +1,14 @@
+import 'server-only';
+
+// Cap cold-path SSR at this budget; on timeout, fall back to client-side fetch.
+export const SSR_FETCH_TIMEOUT_MS = 5_000;
+
+export function withSsrTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<T>((resolve) => {
+    timer = setTimeout(() => resolve(fallback), SSR_FETCH_TIMEOUT_MS);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}

--- a/packages/web/app/notifications/page.tsx
+++ b/packages/web/app/notifications/page.tsx
@@ -8,6 +8,7 @@ import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import I18nProvider from '@/app/components/providers/i18n-provider';
+import { withSsrTimeout } from '@/app/lib/ssr-timeout';
 
 export async function generateMetadata() {
   const { t, locale } = await getServerTranslation('notifications');
@@ -28,11 +29,13 @@ export default async function NotificationsPage() {
 
   let initialData = null;
   if (authToken) {
-    try {
-      initialData = await serverGroupedNotifications(authToken);
-    } catch (error) {
-      console.error('[notifications/page] SSR fetch failed, falling back to client:', error);
-    }
+    initialData = await withSsrTimeout(
+      serverGroupedNotifications(authToken).catch((error) => {
+        console.error('[notifications/page] SSR fetch failed, falling back to client:', error);
+        return null;
+      }),
+      null,
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary

Follow-up to the e2e-reliability sweep (PRs #2097-#2103). After all 7 PRs merged, the first main run revealed two of the three remaining failures resolve cleanly with one more focused change.

### 1. Extract `withSsrTimeout` to a shared helper

PR #2103 added the inline `withSsrTimeout` to `/feed/page.tsx`. Now that we have a second caller, this PR pulls the implementation into `packages/web/app/lib/ssr-timeout.ts` (with `'server-only'`) — same 5s budget, same `clearTimeout`-in-`finally` semantics.

### 2. Apply `withSsrTimeout` to `/notifications`

`bottom-tab-bar.spec.ts:93` (the notifications-bell test) failed shard 4 on the post-merge main run (`25697838755`). The bell-click is a known unresolved Next 16 nav bug; the test has a fallback `page.goto('/notifications')` for that case. But the fallback **also** timed out — exactly the same slow-SSR pattern as `/feed` had. `serverGroupedNotifications(authToken)` was awaited without a deadline, so a cold backend stalled the page past Playwright's 30s navigation timeout.

This PR wraps that call in `withSsrTimeout` so it falls through to `initialData = null` after 5s and the client refetches via React Query. Same defensive shape as `/feed`.

## What's not in this PR

- The bell-click Next 16 nav bug itself. Still unresolved; deserves its own investigation.
- The `queue-persistence.spec.ts:143` "queue should NOT persist" failure. Different root cause (test assumption likely stale vs the `persistent-session` IndexedDB restore); needs its own follow-up.
- The grid-badge flake. The dev-db image rebuild already succeeded at 21:00 right after PR #2101 merged — the next main CI run will pull the updated image with the deterministic ticks.

## Test plan

- [x] `vp run typecheck:web` — clean
- [x] `vp lint packages/web/app/{feed,notifications}/page.tsx packages/web/app/lib/ssr-timeout.ts` — clean
- [ ] CI on this PR
- [ ] After merge: main run no longer trips bottom-tab-bar shard on the `/notifications` `page.goto` timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
