### PR TITLE
Re-land: improve playlist detail SSR loading experience

### DIFF
--- a/docs/ssr-playlist-hydration.md
+++ b/docs/ssr-playlist-hydration.md
@@ -1,0 +1,63 @@
+# Playlist SSR hydration pattern
+
+How playlist detail pages and smart (generated) playlist pages render real content on the first paint instead of a loading spinner.
+
+## Where the pattern lives
+
+- `packages/web/app/playlists/[playlist_uuid]/page.tsx` — global playlist route
+- `packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx` — board-scoped variant
+- `packages/web/app/discover/[smart_playlist]/[user_id]/page.tsx` — smart (generated) playlist route
+- `packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx` — shared client component
+- `packages/web/app/discover/[smart_playlist]/[user_id]/smart-playlist-content.tsx` — smart client component
+- `packages/web/app/lib/graphql/server-graphql.ts` — `serverPlaylist` / `serverPlaylistClimbs` / `serverSmartPlaylist`
+- `packages/web/app/lib/graphql/ssr-query-seed.ts` — `ssrSeedMatchesQueryKey` helper
+
+## What the server does
+
+1. Fetches the playlist (or smart-playlist metadata) via `serverPlaylist` / `serverSmartPlaylist`.
+2. Fetches the first page of climbs **with the same filter tuple the client will use on first render**:
+   - Global route: no board filter at all.
+   - Board-scoped route: `boardName`, `layoutId`, `sizeId`, `setIds`, `angle` from the matched `UserBoard`.
+   - Smart route: no board filter.
+3. Passes `initialPlaylist` / `initialClimbs` / `initialSmartPlaylist` as props to the client component.
+
+The "same filter tuple" invariant is the load-bearing piece. Each backend resolver narrows by all five board fields, not just `boardName + layoutId` — so an SSR fetch that omits `sizeId`/`setIds`/`angle` returns a strict superset of what the client query would return, and seeding that payload as `initialData` puts wrong-board climbs into the cache. The board-scoped route only seeds `initialClimbs` when `findMatchingBoard(initialMyBoards, boardSlug)` resolves, because that's the only state where we can be sure the client's first query key (`selectedBoard.uuid`) lines up with the SSR fetch.
+
+## What the client does
+
+1. Initialises `selectedBoard` synchronously from `initialMyBoards` so the very first render is already on the right board (no "All boards" → matched-board flash).
+2. Snapshots the query-key components the SSR payload was fetched for into a `useRef`. For playlist detail this is `{ boardUuid, refreshKey }`; for the smart playlist it is `{ boardUuid }`.
+3. Seeds react-query's `initialData` and `initialDataUpdatedAt` only when `ssrSeedMatchesQueryKey(...)` returns `true` for the live query key vs the snapshot.
+4. Suppresses the full-page spinner when the SSR payload provided enough content to render — the gate is `loading || (tokenLoading && !playlist)` rather than `loading || tokenLoading`.
+5. Preserves SSR-rendered content if the first client-side refetch hits a transient error: `setError('load-failed')` is gated on `!hasPlaylistDataRef.current`.
+
+## The two invariants you must keep
+
+1. **The SSR fetch and the client's first query key must use the same filter tuple.** If you add a dimension to the query key (a new chip, a new mode toggle, a server-side hint), you MUST also pass that dimension into the SSR call **or** stop seeding `initialData` when the dimension differs from the SSR-fetched value.
+
+2. **`initialData` is keyed-not-keyed in react-query.** `useInfiniteQuery({ initialData: X })` returns the same `X` for every query key — react-query only consults `initialData` when there is no existing entry for the key, but it still treats it as fresh under `staleTime` (when `initialDataUpdatedAt` is set). That means a naive `initialData: { pages: [initialClimbs], … }` will hydrate every new cache slot — board switches, post-edit `listRefreshKey` bumps, etc. — with the original SSR page and silently skip the fetch.
+
+   Fix: snapshot the key components the SSR fetch was scoped to, and gate both `initialData` and `initialDataUpdatedAt` on the snapshot still matching the live render via `ssrSeedMatchesQueryKey`. When the gate flips false, `initialData` becomes `undefined` and react-query falls back to a real fetch for the new key.
+
+## How to extend the pattern
+
+If you want to SSR a new playlist-shaped surface:
+
+1. Add a `serverXyz(authToken, input)` helper alongside the others in `server-graphql.ts`. Mirror the error-logging fallback (`console.error('serverXyz failed:', error); return null;`).
+2. Re-export from `server-cached-client.ts` so existing import sites keep working.
+3. In the page route, fetch in parallel with `serverMyBoards`. Only fire the climbs/items call if the parent entity resolved (avoid wasting a backend call on 404).
+4. In the client component:
+   - Snapshot the SSR-fetched query-key components in a `useRef` at mount.
+   - Use `ssrSeedMatchesQueryKey` to gate both `initialData` and `initialDataUpdatedAt`.
+   - Skip the full-page spinner when SSR content is present.
+
+## Why each piece is there
+
+- **`hasPlaylistDataRef`** — keeps `playlist` out of `fetchPlaylist`'s `useCallback` deps. Without it, `setPlaylist` → callback recreate → effect rerun → `setPlaylist` → infinite loop. The previous incarnation of this PR (#1794) was reverted (#2095) for exactly this bug.
+- **`ssrInitialClimbsUpdatedAtRef`** — pins `initialDataUpdatedAt` to mount time. Defaulting to `0` would mark the SSR data as epoch-stale and trigger an immediate refetch on every page load.
+- **`ssrClimbsKeyRef`** — captures the snapshot the `ssrSeedMatchesQueryKey` predicate compares against. A `useRef` (not `useState`) so it never changes and never re-renders the component.
+
+## Tests
+
+- `packages/web/app/lib/graphql/__tests__/ssr-query-seed.test.ts` — unit tests for the snapshot predicate.
+- `packages/web/app/lib/graphql/__tests__/server-graphql.test.ts` — unit tests for the server helpers' happy path + error-fallback contract.

--- a/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next';
 import { resolveBoardBySlug } from '@/app/lib/board-slug-utils';
 import { constructBoardSlugPlaylistsUrl } from '@/app/lib/url-utils';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
-import { serverMyBoards } from '@/app/lib/graphql/server-cached-client';
+import { serverMyBoards, serverPlaylist, serverPlaylistClimbs } from '@/app/lib/graphql/server-cached-client';
 import { generatePlaylistMetadata } from '@/app/lib/seo/playlist-metadata';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import I18nProvider from '@/app/components/providers/i18n-provider';
@@ -33,7 +33,20 @@ export default async function BoardSlugPlaylistDetailPage(props: PlaylistDetailP
 
   const authToken = await getServerAuthToken();
   const locale = await getLocale();
-  const initialMyBoards = authToken ? await serverMyBoards(authToken) : null;
+  const [initialMyBoards, initialPlaylist] = await Promise.all([
+    authToken ? serverMyBoards(authToken) : null,
+    serverPlaylist(authToken, params.playlist_uuid),
+  ]);
+
+  const initialClimbs = initialPlaylist
+    ? await serverPlaylistClimbs(authToken, {
+        playlistId: params.playlist_uuid,
+        boardName: board.boardType,
+        layoutId: board.layoutId,
+        page: 0,
+        pageSize: 20,
+      })
+    : null;
 
   const lcpPreloadUrl = getPlaylistLcpPreloadUrl({
     boardType: board.boardType,
@@ -51,6 +64,8 @@ export default async function BoardSlugPlaylistDetailPage(props: PlaylistDetailP
           playlistsBasePath={playlistsBasePath}
           boardSlug={params.board_slug}
           initialMyBoards={initialMyBoards}
+          initialPlaylist={initialPlaylist}
+          initialClimbs={initialClimbs}
         />
       </div>
     </I18nProvider>

--- a/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/playlists/[playlist_uuid]/page.tsx
@@ -10,6 +10,8 @@ import { getLocale } from '@/app/lib/i18n/get-locale';
 import I18nProvider from '@/app/components/providers/i18n-provider';
 import PlaylistDetailContent from '@/app/playlists/[playlist_uuid]/playlist-detail-content';
 import { getPlaylistLcpPreloadUrl } from '@/app/lib/lcp-preload-url';
+import { findMatchingBoard } from '@/app/lib/find-matching-board';
+import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
 import styles from '@/app/components/library/playlist-view.module.css';
 
 type PlaylistDetailPageProps = {
@@ -38,15 +40,31 @@ export default async function BoardSlugPlaylistDetailPage(props: PlaylistDetailP
     serverPlaylist(authToken, params.playlist_uuid),
   ]);
 
-  const initialClimbs = initialPlaylist
-    ? await serverPlaylistClimbs(authToken, {
-        playlistId: params.playlist_uuid,
-        boardName: board.boardType,
-        layoutId: board.layoutId,
-        page: 0,
-        pageSize: 20,
-      })
-    : null;
+  // Only seed initialClimbs when we can guarantee the client's first query
+  // key matches what we fetched. The client keys by `selectedBoard.uuid`,
+  // and selectedBoard is resolved synchronously from `initialMyBoards` via
+  // `findMatchingBoard(boardSlug)`. If we can't pre-resolve that match
+  // (e.g. unauthenticated user, no `initialMyBoards`), the client's first
+  // render keys to `'all'` and a board-filtered SSR payload would land in
+  // the wrong cache slot.
+  //
+  // We also include the full filter tuple (sizeId/setIds/angle) so the SSR
+  // payload exactly matches what the client `queryFn` would request — the
+  // backend narrows results by all five fields, not just boardName+layoutId.
+  const matchedBoard = findMatchingBoard(initialMyBoards, params.board_slug);
+  const initialClimbs =
+    initialPlaylist && matchedBoard
+      ? await serverPlaylistClimbs(authToken, {
+          playlistId: params.playlist_uuid,
+          boardName: matchedBoard.boardType,
+          layoutId: matchedBoard.layoutId,
+          sizeId: matchedBoard.sizeId,
+          setIds: matchedBoard.setIds,
+          angle: matchedBoard.angle ?? getDefaultAngleForBoard(matchedBoard.boardType),
+          page: 0,
+          pageSize: 20,
+        })
+      : null;
 
   const lcpPreloadUrl = getPlaylistLcpPreloadUrl({
     boardType: board.boardType,

--- a/packages/web/app/discover/[smart_playlist]/[user_id]/page.tsx
+++ b/packages/web/app/discover/[smart_playlist]/[user_id]/page.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
-import { serverMyBoards } from '@/app/lib/graphql/server-cached-client';
+import { serverMyBoards, serverSmartPlaylist } from '@/app/lib/graphql/server-cached-client';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import I18nProvider from '@/app/components/providers/i18n-provider';
@@ -43,7 +43,13 @@ export default async function SmartPlaylistPage({ params }: { params: Promise<Ro
 
   const authToken = await getServerAuthToken();
   const { locale } = await getServerTranslation('playlists');
-  const initialMyBoards = authToken ? await serverMyBoards(authToken) : null;
+  const [initialMyBoards, initialSmartPlaylist] = await Promise.all([
+    authToken ? serverMyBoards(authToken) : null,
+    // First render on the client uses `selectedBoard = null` (selectedBoard is
+    // only set when the user picks a board chip), so omit boardName here to
+    // line up with the client's first `useInfiniteQuery` key (`'all'`).
+    serverSmartPlaylist(authToken, { type: preset.type, userId: user_id, page: 0, pageSize: 20 }),
+  ]);
 
   return (
     <I18nProvider locale={locale} namespaces={['playlists', 'climbs', 'feed']}>
@@ -53,6 +59,7 @@ export default async function SmartPlaylistPage({ params }: { params: Promise<Ro
           smartPlaylistSlug={preset.slug}
           userId={user_id}
           initialMyBoards={initialMyBoards}
+          initialSmartPlaylist={initialSmartPlaylist}
         />
       </div>
     </I18nProvider>

--- a/packages/web/app/discover/[smart_playlist]/[user_id]/smart-playlist-content.tsx
+++ b/packages/web/app/discover/[smart_playlist]/[user_id]/smart-playlist-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import MuiButton from '@mui/material/Button';
@@ -15,6 +15,7 @@ import {
   type GetSmartPlaylistQueryResponse,
   type GetSmartPlaylistQueryVariables,
   type SmartPlaylistMeta,
+  type SmartPlaylistResult,
   type SmartPlaylistType,
   GET_SMART_PLAYLIST,
 } from '@/app/lib/graphql/operations/playlists';
@@ -37,9 +38,17 @@ type Props = {
   smartPlaylistSlug: SmartPlaylistSlug;
   userId: string;
   initialMyBoards?: UserBoard[] | null;
+  /** SSR-fetched first page so the hero + climbs paint without a spinner. */
+  initialSmartPlaylist?: SmartPlaylistResult | null;
 };
 
-export default function SmartPlaylistContent({ smartPlaylistType, smartPlaylistSlug, userId, initialMyBoards }: Props) {
+export default function SmartPlaylistContent({
+  smartPlaylistType,
+  smartPlaylistSlug,
+  userId,
+  initialMyBoards,
+  initialSmartPlaylist,
+}: Props) {
   const { t } = useTranslation('playlists');
   const { showMessage } = useSnackbar();
   const { token, isLoading: tokenLoading } = useWsAuthToken();
@@ -47,6 +56,9 @@ export default function SmartPlaylistContent({ smartPlaylistType, smartPlaylistS
 
   const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(() => findMatchingBoard(initialMyBoards));
   const { boards: myBoards, isLoading: boardsLoading } = useMyBoards(true, 50, initialMyBoards);
+  // Mark SSR data fresh so react-query honours staleTime instead of triggering
+  // an immediate refetch (initialDataUpdatedAt defaults to 0 = epoch).
+  const ssrInitialUpdatedAtRef = useRef(initialSmartPlaylist ? Date.now() : 0);
 
   const {
     data: pagedData,
@@ -77,6 +89,18 @@ export default function SmartPlaylistContent({ smartPlaylistType, smartPlaylistS
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => (lastPage.hasMore ? allPages.length : undefined),
     staleTime: 5 * 60 * 1000,
+    // Only seed when selectedBoard is null — that's the only state where the
+    // SSR fetch (no boardName filter) matches the client query key. Once the
+    // user picks a board chip the key changes to `selectedBoard.uuid` and a
+    // fresh fetch is correct.
+    initialData:
+      initialSmartPlaylist && !selectedBoard
+        ? {
+            pages: [initialSmartPlaylist],
+            pageParams: [0],
+          }
+        : undefined,
+    initialDataUpdatedAt: ssrInitialUpdatedAtRef.current,
   });
 
   const allClimbs: Climb[] = useMemo(
@@ -84,7 +108,7 @@ export default function SmartPlaylistContent({ smartPlaylistType, smartPlaylistS
     [pagedData],
   );
 
-  const meta: SmartPlaylistMeta | undefined = pagedData?.pages[0]?.meta;
+  const meta: SmartPlaylistMeta | undefined = pagedData?.pages[0]?.meta ?? initialSmartPlaylist?.meta;
 
   const boardTypes = useMemo(() => {
     const types = new Set<string>();
@@ -113,7 +137,9 @@ export default function SmartPlaylistContent({ smartPlaylistType, smartPlaylistS
     });
   }, [smartPlaylistSlug, smartPlaylistType, userId, t, meta, preset.titleI18nKey, showMessage]);
 
-  if (tokenLoading || isLoading) {
+  // With SSR data we have meta + first page; skip the full-page spinner.
+  // Only gate on tokenLoading when we don't have SSR-seeded content yet.
+  if ((tokenLoading || isLoading) && !meta) {
     return (
       <div className={styles.loadingContainer}>
         <LoadingSpinner size={48} />

--- a/packages/web/app/discover/[smart_playlist]/[user_id]/smart-playlist-content.tsx
+++ b/packages/web/app/discover/[smart_playlist]/[user_id]/smart-playlist-content.tsx
@@ -23,6 +23,7 @@ import { type SmartPlaylistSlug, smartPlaylistByType } from '@/app/lib/smart-pla
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
 import { findMatchingBoard } from '@/app/lib/find-matching-board';
+import { ssrSeedMatchesQueryKey } from '@/app/lib/graphql/ssr-query-seed';
 import { shareWithFallback } from '@/app/lib/share-utils';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { LoadingSpinner } from '@/app/components/ui/loading-spinner';
@@ -98,14 +99,18 @@ export default function SmartPlaylistContent({
     // also avoids re-applying stale SSR data if the user switches away from
     // and back to the default view much later.
     initialData:
-      initialSmartPlaylist && (selectedBoard?.uuid ?? null) === ssrSmartKeyRef.current.boardUuid
+      initialSmartPlaylist &&
+      ssrSeedMatchesQueryKey(true, ssrSmartKeyRef.current, { boardUuid: selectedBoard?.uuid ?? null })
         ? {
             pages: [initialSmartPlaylist],
             pageParams: [0],
           }
         : undefined,
-    initialDataUpdatedAt:
-      (selectedBoard?.uuid ?? null) === ssrSmartKeyRef.current.boardUuid ? ssrInitialUpdatedAtRef.current : 0,
+    initialDataUpdatedAt: ssrSeedMatchesQueryKey(!!initialSmartPlaylist, ssrSmartKeyRef.current, {
+      boardUuid: selectedBoard?.uuid ?? null,
+    })
+      ? ssrInitialUpdatedAtRef.current
+      : 0,
   });
 
   const allClimbs: Climb[] = useMemo(

--- a/packages/web/app/discover/[smart_playlist]/[user_id]/smart-playlist-content.tsx
+++ b/packages/web/app/discover/[smart_playlist]/[user_id]/smart-playlist-content.tsx
@@ -64,6 +64,12 @@ export default function SmartPlaylistContent({
   // same initialData would be reused for every board-chip switch (and any
   // future key changes) instead of triggering a real fetch.
   const ssrSmartKeyRef = useRef({ boardUuid: selectedBoard?.uuid ?? null });
+  // Single source of truth for "is the SSR payload still applicable to the
+  // live query key?" — used to gate both `initialData` and
+  // `initialDataUpdatedAt` so they can never disagree.
+  const ssrSmartApplicable = ssrSeedMatchesQueryKey(!!initialSmartPlaylist, ssrSmartKeyRef.current, {
+    boardUuid: selectedBoard?.uuid ?? null,
+  });
 
   const {
     data: pagedData,
@@ -99,18 +105,13 @@ export default function SmartPlaylistContent({
     // also avoids re-applying stale SSR data if the user switches away from
     // and back to the default view much later.
     initialData:
-      initialSmartPlaylist &&
-      ssrSeedMatchesQueryKey(true, ssrSmartKeyRef.current, { boardUuid: selectedBoard?.uuid ?? null })
+      ssrSmartApplicable && initialSmartPlaylist
         ? {
             pages: [initialSmartPlaylist],
             pageParams: [0],
           }
         : undefined,
-    initialDataUpdatedAt: ssrSeedMatchesQueryKey(!!initialSmartPlaylist, ssrSmartKeyRef.current, {
-      boardUuid: selectedBoard?.uuid ?? null,
-    })
-      ? ssrInitialUpdatedAtRef.current
-      : 0,
+    initialDataUpdatedAt: ssrSmartApplicable ? ssrInitialUpdatedAtRef.current : 0,
   });
 
   const allClimbs: Climb[] = useMemo(
@@ -157,6 +158,14 @@ export default function SmartPlaylistContent({
     );
   }
 
+  // Note: when SSR-seeded `initialData` is in play, react-query keeps the
+  // overall query state as `success` even if a background refetch errors —
+  // `isError` only flips when there's no `data` to fall back to. That means
+  // a transient network blip after hydration leaves the SSR-rendered hero +
+  // climbs on screen instead of replacing them with the error UI. This is
+  // intentional resilience: same trade-off as `fetchPlaylist`'s catch block
+  // in PlaylistDetailContent. The error UI here only fires on a true cold
+  // failure (no SSR, no cache, refetch errored).
   if (isError || !meta) {
     return (
       <div className={styles.errorContainer}>

--- a/packages/web/app/discover/[smart_playlist]/[user_id]/smart-playlist-content.tsx
+++ b/packages/web/app/discover/[smart_playlist]/[user_id]/smart-playlist-content.tsx
@@ -59,6 +59,10 @@ export default function SmartPlaylistContent({
   // Mark SSR data fresh so react-query honours staleTime instead of triggering
   // an immediate refetch (initialDataUpdatedAt defaults to 0 = epoch).
   const ssrInitialUpdatedAtRef = useRef(initialSmartPlaylist ? Date.now() : 0);
+  // Snapshot the key the SSR payload was fetched for. Without this gate, the
+  // same initialData would be reused for every board-chip switch (and any
+  // future key changes) instead of triggering a real fetch.
+  const ssrSmartKeyRef = useRef({ boardUuid: selectedBoard?.uuid ?? null });
 
   const {
     data: pagedData,
@@ -89,18 +93,19 @@ export default function SmartPlaylistContent({
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => (lastPage.hasMore ? allPages.length : undefined),
     staleTime: 5 * 60 * 1000,
-    // Only seed when selectedBoard is null — that's the only state where the
-    // SSR fetch (no boardName filter) matches the client query key. Once the
-    // user picks a board chip the key changes to `selectedBoard.uuid` and a
-    // fresh fetch is correct.
+    // Only seed when the current query key still matches the tuple the SSR
+    // payload was fetched for. Beyond the obvious first-render case this
+    // also avoids re-applying stale SSR data if the user switches away from
+    // and back to the default view much later.
     initialData:
-      initialSmartPlaylist && !selectedBoard
+      initialSmartPlaylist && (selectedBoard?.uuid ?? null) === ssrSmartKeyRef.current.boardUuid
         ? {
             pages: [initialSmartPlaylist],
             pageParams: [0],
           }
         : undefined,
-    initialDataUpdatedAt: ssrInitialUpdatedAtRef.current,
+    initialDataUpdatedAt:
+      (selectedBoard?.uuid ?? null) === ssrSmartKeyRef.current.boardUuid ? ssrInitialUpdatedAtRef.current : 0,
   });
 
   const allClimbs: Climb[] = useMemo(

--- a/packages/web/app/lib/graphql/__tests__/server-graphql.test.ts
+++ b/packages/web/app/lib/graphql/__tests__/server-graphql.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+const { requestMock } = vi.hoisted(() => ({ requestMock: vi.fn() }));
+
+vi.mock('graphql-request', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('graphql-request')>();
+  class MockGraphQLClient {
+    request = requestMock;
+  }
+  return {
+    ...actual,
+    GraphQLClient: MockGraphQLClient,
+  };
+});
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  getGraphQLHttpUrl: () => 'http://test.local/graphql',
+}));
+
+// Import after vi.mock so the mocks are applied to the helpers' transitive deps.
+import {
+  serverMyBoards,
+  serverPlaylist,
+  serverPlaylistClimbs,
+  serverSmartPlaylist,
+  serverUserPlaylists,
+} from '../server-graphql';
+
+describe('server-graphql helpers', () => {
+  beforeEach(() => {
+    requestMock.mockReset();
+  });
+
+  describe('serverPlaylist', () => {
+    it('returns the playlist field from the GraphQL response on success', async () => {
+      const playlist = { uuid: 'pl-1', name: 'Project Picks', boardType: 'kilter' };
+      requestMock.mockResolvedValueOnce({ playlist });
+
+      const result = await serverPlaylist('auth-token', 'pl-1');
+
+      expect(result).toEqual(playlist);
+      expect(requestMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null and logs when the GraphQL request throws', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      requestMock.mockRejectedValueOnce(new Error('network down'));
+
+      const result = await serverPlaylist('auth-token', 'pl-1');
+
+      expect(result).toBeNull();
+      expect(errorSpy).toHaveBeenCalledWith('serverPlaylist failed:', expect.any(Error));
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('serverPlaylistClimbs', () => {
+    it('returns the playlistClimbs payload on success', async () => {
+      const payload = { climbs: [], totalCount: 0, hasMore: false };
+      requestMock.mockResolvedValueOnce({ playlistClimbs: payload });
+
+      const result = await serverPlaylistClimbs('auth-token', { playlistId: 'pl-1', page: 0, pageSize: 20 });
+
+      expect(result).toEqual(payload);
+    });
+
+    it('returns null and logs when the GraphQL request throws', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      requestMock.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await serverPlaylistClimbs(undefined, { playlistId: 'pl-1' });
+
+      expect(result).toBeNull();
+      expect(errorSpy).toHaveBeenCalledWith('serverPlaylistClimbs failed:', expect.any(Error));
+      errorSpy.mockRestore();
+    });
+
+    it('forwards the input as-is so the server fetch matches the client query key', async () => {
+      requestMock.mockResolvedValueOnce({ playlistClimbs: { climbs: [], totalCount: 0, hasMore: false } });
+
+      await serverPlaylistClimbs('auth-token', {
+        playlistId: 'pl-1',
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,20,26',
+        angle: 40,
+        page: 0,
+        pageSize: 20,
+      });
+
+      const [, variables] = requestMock.mock.calls[0];
+      expect(variables.input).toEqual({
+        playlistId: 'pl-1',
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,20,26',
+        angle: 40,
+        page: 0,
+        pageSize: 20,
+      });
+    });
+  });
+
+  describe('serverSmartPlaylist', () => {
+    it('returns the smartPlaylist payload on success', async () => {
+      const payload = {
+        meta: { type: 'FIVE_STARS', userId: 'u1', userName: 'Marco', userAvatar: null, climbCount: 12 },
+        climbs: [],
+        totalCount: 12,
+        hasMore: true,
+      };
+      requestMock.mockResolvedValueOnce({ smartPlaylist: payload });
+
+      const result = await serverSmartPlaylist('auth-token', { type: 'FIVE_STARS', userId: 'u1', page: 0, pageSize: 20 });
+
+      expect(result).toEqual(payload);
+    });
+
+    it('returns null and logs when the GraphQL request throws', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      requestMock.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await serverSmartPlaylist(undefined, { type: 'PROJECTS', userId: 'u1' });
+
+      expect(result).toBeNull();
+      expect(errorSpy).toHaveBeenCalledWith('serverSmartPlaylist failed:', expect.any(Error));
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('error-fallback parity', () => {
+    // These two were already in the file before this PR, but the previous
+    // dynamic-import implementation swallowed errors silently. Asserting the
+    // log here keeps the parity with the new helpers explicit.
+    it('serverMyBoards logs + returns null on failure', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      requestMock.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await serverMyBoards('auth-token');
+
+      expect(result).toBeNull();
+      expect(errorSpy).toHaveBeenCalledWith('serverMyBoards failed:', expect.any(Error));
+      errorSpy.mockRestore();
+    });
+
+    it('serverUserPlaylists logs + returns null on failure', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      requestMock.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await serverUserPlaylists('auth-token');
+
+      expect(result).toBeNull();
+      expect(errorSpy).toHaveBeenCalledWith('serverUserPlaylists failed:', expect.any(Error));
+      errorSpy.mockRestore();
+    });
+  });
+});

--- a/packages/web/app/lib/graphql/__tests__/server-graphql.test.ts
+++ b/packages/web/app/lib/graphql/__tests__/server-graphql.test.ts
@@ -22,6 +22,7 @@ vi.mock('@/app/lib/graphql/client', () => ({
 
 // Import after vi.mock so the mocks are applied to the helpers' transitive deps.
 import {
+  serverGroupedNotifications,
   serverMyBoards,
   serverPlaylist,
   serverPlaylistClimbs,
@@ -53,6 +54,21 @@ describe('server-graphql helpers', () => {
 
       expect(result).toBeNull();
       expect(errorSpy).toHaveBeenCalledWith('serverPlaylist failed:', expect.any(Error));
+      errorSpy.mockRestore();
+    });
+
+    it('returns null without logging when the GraphQL response is { playlist: null } (not-found)', async () => {
+      // The backend returns a 200 + `{ playlist: null }` for an unknown UUID
+      // rather than throwing. We must surface that as `null` so the page
+      // route can render the not-found state — and NOT log it as a failure,
+      // since "playlist doesn't exist" is a normal user outcome.
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      requestMock.mockResolvedValueOnce({ playlist: null });
+
+      const result = await serverPlaylist('auth-token', 'missing-uuid');
+
+      expect(result).toBeNull();
+      expect(errorSpy).not.toHaveBeenCalled();
       errorSpy.mockRestore();
     });
   });
@@ -156,6 +172,17 @@ describe('server-graphql helpers', () => {
 
       expect(result).toBeNull();
       expect(errorSpy).toHaveBeenCalledWith('serverUserPlaylists failed:', expect.any(Error));
+      errorSpy.mockRestore();
+    });
+
+    it('serverGroupedNotifications logs + returns null on failure', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      requestMock.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await serverGroupedNotifications('auth-token');
+
+      expect(result).toBeNull();
+      expect(errorSpy).toHaveBeenCalledWith('serverGroupedNotifications failed:', expect.any(Error));
       errorSpy.mockRestore();
     });
   });

--- a/packages/web/app/lib/graphql/__tests__/ssr-query-seed.test.ts
+++ b/packages/web/app/lib/graphql/__tests__/ssr-query-seed.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vite-plus/test';
+import { ssrSeedMatchesQueryKey } from '../ssr-query-seed';
+
+describe('ssrSeedMatchesQueryKey', () => {
+  it('returns false when no SSR payload is present, even if keys match', () => {
+    expect(
+      ssrSeedMatchesQueryKey(false, { boardUuid: null, refreshKey: 0 }, { boardUuid: null, refreshKey: 0 }),
+    ).toBe(false);
+  });
+
+  it('returns true when the live key tuple matches the snapshot exactly', () => {
+    expect(
+      ssrSeedMatchesQueryKey(true, { boardUuid: 'board-1', refreshKey: 0 }, { boardUuid: 'board-1', refreshKey: 0 }),
+    ).toBe(true);
+  });
+
+  it('returns false when any single key component drifts (board switch)', () => {
+    expect(
+      ssrSeedMatchesQueryKey(true, { boardUuid: null, refreshKey: 0 }, { boardUuid: 'board-1', refreshKey: 0 }),
+    ).toBe(false);
+  });
+
+  it('returns false when a refresh-key bump invalidates the snapshot', () => {
+    expect(
+      ssrSeedMatchesQueryKey(true, { boardUuid: 'board-1', refreshKey: 0 }, { boardUuid: 'board-1', refreshKey: 1 }),
+    ).toBe(false);
+  });
+
+  it('treats null and undefined-coerced-to-null as the same "all boards" key', () => {
+    expect(ssrSeedMatchesQueryKey(true, { boardUuid: null }, { boardUuid: null })).toBe(true);
+  });
+
+  it('compares every snapshot key, not just the first', () => {
+    // boardUuid matches but refreshKey diverges — must still be rejected.
+    expect(
+      ssrSeedMatchesQueryKey(true, { boardUuid: 'b', refreshKey: 0 }, { boardUuid: 'b', refreshKey: 7 }),
+    ).toBe(false);
+  });
+});

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -14,7 +14,13 @@ import type {
 
 // Re-export uncached authenticated server functions so existing imports
 // from this file continue to work without changes.
-export { serverMyBoards, serverUserPlaylists, serverGroupedNotifications } from './server-graphql';
+export {
+  serverMyBoards,
+  serverUserPlaylists,
+  serverGroupedNotifications,
+  serverPlaylist,
+  serverPlaylistClimbs,
+} from './server-graphql';
 
 export const USER_CLIMB_PERCENTILE_CACHE_TAG = 'user-climb-percentile';
 

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -20,6 +20,7 @@ export {
   serverGroupedNotifications,
   serverPlaylist,
   serverPlaylistClimbs,
+  serverSmartPlaylist,
 } from './server-graphql';
 
 export const USER_CLIMB_PERCENTILE_CACHE_TAG = 'user-climb-percentile';

--- a/packages/web/app/lib/graphql/server-graphql.ts
+++ b/packages/web/app/lib/graphql/server-graphql.ts
@@ -3,7 +3,13 @@ import { type RequestDocument, type Variables, GraphQLClient } from 'graphql-req
 import { getGraphQLHttpUrl } from './client';
 import type { GroupedNotificationConnection, UserBoard } from '@boardsesh/shared-schema';
 import type { GetMyBoardsQueryResponse } from '@/app/lib/graphql/operations/boards';
-import type { Playlist, GetAllUserPlaylistsQueryResponse } from '@/app/lib/graphql/operations/playlists';
+import type {
+  Playlist,
+  GetAllUserPlaylistsQueryResponse,
+  GetPlaylistQueryResponse,
+  GetPlaylistClimbsQueryResponse,
+  GetPlaylistClimbsInput,
+} from '@/app/lib/graphql/operations/playlists';
 
 /**
  * Execute a GraphQL query with an auth token (non-cached, per-user data).
@@ -88,4 +94,43 @@ export async function serverGroupedNotifications(
   const data = await executeAuthenticatedGraphQL<Response>(GET_GROUPED_NOTIFICATIONS, { limit, offset }, authToken);
 
   return data.groupedNotifications;
+}
+
+/**
+ * Server-side fetch of a single playlist.
+ */
+export async function serverPlaylist(authToken: string | undefined, playlistId: string): Promise<Playlist | null> {
+  const { GET_PLAYLIST } = await import('@/app/lib/graphql/operations/playlists');
+
+  try {
+    const response = await executeAuthenticatedGraphQL<GetPlaylistQueryResponse>(
+      GET_PLAYLIST,
+      { playlistId },
+      authToken,
+    );
+    return response.playlist;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Server-side fetch of the first page of playlist climbs.
+ */
+export async function serverPlaylistClimbs(
+  authToken: string | undefined,
+  input: GetPlaylistClimbsInput,
+): Promise<GetPlaylistClimbsQueryResponse['playlistClimbs'] | null> {
+  const { GET_PLAYLIST_CLIMBS } = await import('@/app/lib/graphql/operations/playlists');
+
+  try {
+    const response = await executeAuthenticatedGraphQL<GetPlaylistClimbsQueryResponse>(
+      GET_PLAYLIST_CLIMBS,
+      { input },
+      authToken,
+    );
+    return response.playlistClimbs;
+  } catch {
+    return null;
+  }
 }

--- a/packages/web/app/lib/graphql/server-graphql.ts
+++ b/packages/web/app/lib/graphql/server-graphql.ts
@@ -7,11 +7,14 @@ import {
   GET_ALL_USER_PLAYLISTS,
   GET_PLAYLIST,
   GET_PLAYLIST_CLIMBS,
+  GET_SMART_PLAYLIST,
   type Playlist,
   type GetAllUserPlaylistsQueryResponse,
   type GetPlaylistQueryResponse,
   type GetPlaylistClimbsQueryResponse,
   type GetPlaylistClimbsInput,
+  type GetSmartPlaylistInput,
+  type GetSmartPlaylistQueryResponse,
 } from '@/app/lib/graphql/operations/playlists';
 import { GET_GROUPED_NOTIFICATIONS } from '@/app/lib/graphql/operations/notifications';
 
@@ -111,6 +114,29 @@ export async function serverPlaylist(authToken: string | undefined, playlistId: 
     return response.playlist;
   } catch (error) {
     console.error('serverPlaylist failed:', error);
+    return null;
+  }
+}
+
+/**
+ * Server-side fetch of the first page of a smart (generated) playlist.
+ * The resolver doesn't require auth (rate-limited only), but we forward
+ * the caller's token when present so any per-user fields stay consistent
+ * with what the client would see on hydration.
+ */
+export async function serverSmartPlaylist(
+  authToken: string | undefined,
+  input: GetSmartPlaylistInput,
+): Promise<GetSmartPlaylistQueryResponse['smartPlaylist'] | null> {
+  try {
+    const response = await executeAuthenticatedGraphQL<GetSmartPlaylistQueryResponse>(
+      GET_SMART_PLAYLIST,
+      { input },
+      authToken,
+    );
+    return response.smartPlaylist;
+  } catch (error) {
+    console.error('serverSmartPlaylist failed:', error);
     return null;
   }
 }

--- a/packages/web/app/lib/graphql/server-graphql.ts
+++ b/packages/web/app/lib/graphql/server-graphql.ts
@@ -2,14 +2,18 @@ import 'server-only';
 import { type RequestDocument, type Variables, GraphQLClient } from 'graphql-request';
 import { getGraphQLHttpUrl } from './client';
 import type { GroupedNotificationConnection, UserBoard } from '@boardsesh/shared-schema';
-import type { GetMyBoardsQueryResponse } from '@/app/lib/graphql/operations/boards';
-import type {
-  Playlist,
-  GetAllUserPlaylistsQueryResponse,
-  GetPlaylistQueryResponse,
-  GetPlaylistClimbsQueryResponse,
-  GetPlaylistClimbsInput,
+import { GET_MY_BOARDS, type GetMyBoardsQueryResponse } from '@/app/lib/graphql/operations/boards';
+import {
+  GET_ALL_USER_PLAYLISTS,
+  GET_PLAYLIST,
+  GET_PLAYLIST_CLIMBS,
+  type Playlist,
+  type GetAllUserPlaylistsQueryResponse,
+  type GetPlaylistQueryResponse,
+  type GetPlaylistClimbsQueryResponse,
+  type GetPlaylistClimbsInput,
 } from '@/app/lib/graphql/operations/playlists';
+import { GET_GROUPED_NOTIFICATIONS } from '@/app/lib/graphql/operations/notifications';
 
 /**
  * Execute a GraphQL query with an auth token (non-cached, per-user data).
@@ -38,8 +42,6 @@ export async function executeAuthenticatedGraphQL<T = unknown, V extends Variabl
  * NOT cached — personalized data is per-user.
  */
 export async function serverMyBoards(authToken: string): Promise<UserBoard[] | null> {
-  const { GET_MY_BOARDS } = await import('@/app/lib/graphql/operations/boards');
-
   try {
     const response = await executeAuthenticatedGraphQL<GetMyBoardsQueryResponse>(
       GET_MY_BOARDS,
@@ -47,7 +49,8 @@ export async function serverMyBoards(authToken: string): Promise<UserBoard[] | n
       authToken,
     );
     return response.myBoards.boards;
-  } catch {
+  } catch (error) {
+    console.error('serverMyBoards failed:', error);
     return null;
   }
 }
@@ -68,13 +71,13 @@ export async function serverUserPlaylists(
   authToken: string,
   input: { boardType?: string; layoutId?: number; page?: number; pageSize?: number } = {},
 ): Promise<ServerUserPlaylistsResult | null> {
-  const { GET_ALL_USER_PLAYLISTS } = await import('@/app/lib/graphql/operations/playlists');
   type Response = GetAllUserPlaylistsQueryResponse;
 
   try {
     const response = await executeAuthenticatedGraphQL<Response>(GET_ALL_USER_PLAYLISTS, { input }, authToken);
     return response.allUserPlaylists;
-  } catch {
+  } catch (error) {
+    console.error('serverUserPlaylists failed:', error);
     return null;
   }
 }
@@ -88,7 +91,6 @@ export async function serverGroupedNotifications(
   limit: number = 20,
   offset: number = 0,
 ): Promise<GroupedNotificationConnection> {
-  const { GET_GROUPED_NOTIFICATIONS } = await import('@/app/lib/graphql/operations/notifications');
   type Response = { groupedNotifications: GroupedNotificationConnection };
 
   const data = await executeAuthenticatedGraphQL<Response>(GET_GROUPED_NOTIFICATIONS, { limit, offset }, authToken);
@@ -100,8 +102,6 @@ export async function serverGroupedNotifications(
  * Server-side fetch of a single playlist.
  */
 export async function serverPlaylist(authToken: string | undefined, playlistId: string): Promise<Playlist | null> {
-  const { GET_PLAYLIST } = await import('@/app/lib/graphql/operations/playlists');
-
   try {
     const response = await executeAuthenticatedGraphQL<GetPlaylistQueryResponse>(
       GET_PLAYLIST,
@@ -109,7 +109,8 @@ export async function serverPlaylist(authToken: string | undefined, playlistId: 
       authToken,
     );
     return response.playlist;
-  } catch {
+  } catch (error) {
+    console.error('serverPlaylist failed:', error);
     return null;
   }
 }
@@ -121,8 +122,6 @@ export async function serverPlaylistClimbs(
   authToken: string | undefined,
   input: GetPlaylistClimbsInput,
 ): Promise<GetPlaylistClimbsQueryResponse['playlistClimbs'] | null> {
-  const { GET_PLAYLIST_CLIMBS } = await import('@/app/lib/graphql/operations/playlists');
-
   try {
     const response = await executeAuthenticatedGraphQL<GetPlaylistClimbsQueryResponse>(
       GET_PLAYLIST_CLIMBS,
@@ -130,7 +129,8 @@ export async function serverPlaylistClimbs(
       authToken,
     );
     return response.playlistClimbs;
-  } catch {
+  } catch (error) {
+    console.error('serverPlaylistClimbs failed:', error);
     return null;
   }
 }

--- a/packages/web/app/lib/graphql/server-graphql.ts
+++ b/packages/web/app/lib/graphql/server-graphql.ts
@@ -93,12 +93,16 @@ export async function serverGroupedNotifications(
   authToken: string,
   limit: number = 20,
   offset: number = 0,
-): Promise<GroupedNotificationConnection> {
+): Promise<GroupedNotificationConnection | null> {
   type Response = { groupedNotifications: GroupedNotificationConnection };
 
-  const data = await executeAuthenticatedGraphQL<Response>(GET_GROUPED_NOTIFICATIONS, { limit, offset }, authToken);
-
-  return data.groupedNotifications;
+  try {
+    const data = await executeAuthenticatedGraphQL<Response>(GET_GROUPED_NOTIFICATIONS, { limit, offset }, authToken);
+    return data.groupedNotifications;
+  } catch (error) {
+    console.error('serverGroupedNotifications failed:', error);
+    return null;
+  }
 }
 
 /**

--- a/packages/web/app/lib/graphql/ssr-query-seed.ts
+++ b/packages/web/app/lib/graphql/ssr-query-seed.ts
@@ -1,0 +1,33 @@
+/**
+ * Returns true when the SSR-seeded payload is still valid for the live
+ * react-query key — i.e. every key component the SSR fetch was scoped to
+ * still matches the current render.
+ *
+ * Background: when a server component hands a client an SSR payload via
+ * `initialData`, react-query will treat it as fresh under `staleTime`
+ * (provided `initialDataUpdatedAt` is set). That payload is fetched for
+ * ONE specific query-key tuple — a particular board filter, a particular
+ * refresh-key, etc. If the live key drifts away from that tuple (the user
+ * picks a board chip, an edit bumps a refresh-key, …) and we keep returning
+ * the same `initialData`, react-query will quietly hydrate the new cache
+ * slot with data that was never fetched for that key.
+ *
+ * The fix is to snapshot the key components the SSR fetch was scoped to
+ * (capture them in a `useRef` at mount), then gate `initialData` /
+ * `initialDataUpdatedAt` on this predicate.
+ *
+ * @param hasPayload   Whether SSR provided a payload at all.
+ * @param snapshot     Key components captured at mount (matches the SSR fetch).
+ * @param current      Key components on the current render.
+ */
+export function ssrSeedMatchesQueryKey<K extends Record<string, string | number | null>>(
+  hasPayload: boolean,
+  snapshot: K,
+  current: K,
+): boolean {
+  if (!hasPayload) return false;
+  for (const key of Object.keys(snapshot) as Array<keyof K>) {
+    if (snapshot[key] !== current[key]) return false;
+  }
+  return true;
+}

--- a/packages/web/app/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/page.tsx
@@ -18,17 +18,18 @@ export default async function PlaylistDetailPage({ params }: { params: Promise<{
 
   const authToken = await getServerAuthToken();
   const locale = await getLocale();
-  // Fire all three in parallel rather than waiting for `serverPlaylist` to
-  // resolve before starting `serverPlaylistClimbs`. The climbs call is wasted
-  // on a 404, but that's the rare case — on the hot path we save one
-  // backend round-trip.
-  const [initialMyBoards, initialPlaylist, initialClimbsResult] = await Promise.all([
+  // Fetch boards + playlist in parallel, then gate the climbs request on a
+  // successful playlist lookup. Speculatively firing climbs alongside the
+  // playlist would shave one round-trip on the hot path but double the
+  // backend load on 404s — not worth it for a non-existent playlist.
+  const [initialMyBoards, initialPlaylist] = await Promise.all([
     authToken ? serverMyBoards(authToken) : null,
     serverPlaylist(authToken, playlist_uuid),
-    serverPlaylistClimbs(authToken, { playlistId: playlist_uuid, page: 0, pageSize: 20 }),
   ]);
 
-  const initialClimbs = initialPlaylist ? initialClimbsResult : null;
+  const initialClimbs = initialPlaylist
+    ? await serverPlaylistClimbs(authToken, { playlistId: playlist_uuid, page: 0, pageSize: 20 })
+    : null;
 
   return (
     <I18nProvider

--- a/packages/web/app/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/page.tsx
@@ -18,14 +18,17 @@ export default async function PlaylistDetailPage({ params }: { params: Promise<{
 
   const authToken = await getServerAuthToken();
   const locale = await getLocale();
-  const [initialMyBoards, initialPlaylist] = await Promise.all([
+  // Fire all three in parallel rather than waiting for `serverPlaylist` to
+  // resolve before starting `serverPlaylistClimbs`. The climbs call is wasted
+  // on a 404, but that's the rare case — on the hot path we save one
+  // backend round-trip.
+  const [initialMyBoards, initialPlaylist, initialClimbsResult] = await Promise.all([
     authToken ? serverMyBoards(authToken) : null,
     serverPlaylist(authToken, playlist_uuid),
+    serverPlaylistClimbs(authToken, { playlistId: playlist_uuid, page: 0, pageSize: 20 }),
   ]);
 
-  const initialClimbs = initialPlaylist
-    ? await serverPlaylistClimbs(authToken, { playlistId: playlist_uuid, page: 0, pageSize: 20 })
-    : null;
+  const initialClimbs = initialPlaylist ? initialClimbsResult : null;
 
   return (
     <I18nProvider

--- a/packages/web/app/playlists/[playlist_uuid]/page.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Metadata } from 'next';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
-import { serverMyBoards } from '@/app/lib/graphql/server-cached-client';
+import { serverMyBoards, serverPlaylist, serverPlaylistClimbs } from '@/app/lib/graphql/server-cached-client';
 import { generatePlaylistMetadata } from '@/app/lib/seo/playlist-metadata';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import I18nProvider from '@/app/components/providers/i18n-provider';
@@ -18,7 +18,14 @@ export default async function PlaylistDetailPage({ params }: { params: Promise<{
 
   const authToken = await getServerAuthToken();
   const locale = await getLocale();
-  const initialMyBoards = authToken ? await serverMyBoards(authToken) : null;
+  const [initialMyBoards, initialPlaylist] = await Promise.all([
+    authToken ? serverMyBoards(authToken) : null,
+    serverPlaylist(authToken, playlist_uuid),
+  ]);
+
+  const initialClimbs = initialPlaylist
+    ? await serverPlaylistClimbs(authToken, { playlistId: playlist_uuid, page: 0, pageSize: 20 })
+    : null;
 
   return (
     <I18nProvider
@@ -26,7 +33,12 @@ export default async function PlaylistDetailPage({ params }: { params: Promise<{
       namespaces={['common', 'climbs', 'session', 'boards', 'profile', 'feed', 'playlists']}
     >
       <div className={styles.pageContainer}>
-        <PlaylistDetailContent playlistUuid={playlist_uuid} initialMyBoards={initialMyBoards} />
+        <PlaylistDetailContent
+          playlistUuid={playlist_uuid}
+          initialMyBoards={initialMyBoards}
+          initialPlaylist={initialPlaylist}
+          initialClimbs={initialClimbs}
+        />
       </div>
     </I18nProvider>
   );

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -137,6 +137,15 @@ export default function PlaylistDetailContent({
   // Treat SSR-seeded react-query data as fresh under staleTime; without this,
   // initialDataUpdatedAt defaults to 0 and triggers an immediate refetch.
   const ssrInitialClimbsUpdatedAtRef = useRef(initialClimbs ? Date.now() : 0);
+  // Snapshot the query-key components that the SSR climbs payload was fetched
+  // for. `initialData` is shared across keys, so without this gate a board
+  // chip switch or a post-edit `listRefreshKey` bump would re-seed the new
+  // key with the original SSR page and (because `initialDataUpdatedAt` puts
+  // it inside `staleTime`) skip the fetch entirely.
+  const ssrClimbsKeyRef = useRef({
+    boardUuid: selectedBoard?.uuid ?? null,
+    refreshKey: 0,
+  });
   const { token, isLoading: tokenLoading } = useWsAuthToken();
 
   // Fetch user's boards (with SSR initial data to avoid loading skeleton).
@@ -183,7 +192,13 @@ export default function PlaylistDetailContent({
       setPlaylist(response.playlist);
     } catch (err) {
       console.error('Error fetching playlist:', err);
-      setError('load-failed');
+      // Keep the SSR-rendered content on screen if a background refetch
+      // hits a transient network error — we'd rather show slightly stale
+      // data than blow it away with a full-page error state. Only escalate
+      // when we genuinely have nothing to display.
+      if (!hasPlaylistDataRef.current) {
+        setError('load-failed');
+      }
     } finally {
       setLoading(false);
     }
@@ -221,6 +236,15 @@ export default function PlaylistDetailContent({
 
   // === Playlist climbs data fetching (all-boards mode by default) ===
 
+  // Only feed initialData to react-query when the current query key matches
+  // the tuple the SSR climbs page was fetched for. Without this guard, every
+  // new key (board switch, listRefreshKey bump after edits, …) would adopt
+  // the same SSR page as fresh data and skip the actual fetch.
+  const ssrClimbsApplicable =
+    !!initialClimbs &&
+    (selectedBoard?.uuid ?? null) === ssrClimbsKeyRef.current.boardUuid &&
+    listRefreshKey === ssrClimbsKeyRef.current.refreshKey;
+
   const {
     data: climbsData,
     fetchNextPage,
@@ -252,22 +276,27 @@ export default function PlaylistDetailContent({
       } satisfies GetPlaylistClimbsQueryVariables);
       return response.playlistClimbs;
     },
-    enabled: !tokenLoading && !!token,
+    // Public playlists are readable without a token (the backend resolver
+    // gates with verifyPlaylistAccess(userId ?? null)), so don't gate the
+    // query on auth — otherwise signed-out viewers see the SSR first page
+    // and "load more" silently does nothing.
+    enabled: !tokenLoading,
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       if (!lastPage.hasMore) return undefined;
       return allPages.length;
     },
     staleTime: 5 * 60 * 1000,
-    initialData: initialClimbs
+    initialData: ssrClimbsApplicable
       ? {
           pages: [initialClimbs],
           pageParams: [0],
         }
       : undefined,
     // Without this, react-query treats initialData as epoch-stale and fires
-    // an immediate refetch, defeating the SSR optimisation.
-    initialDataUpdatedAt: ssrInitialClimbsUpdatedAtRef.current,
+    // an immediate refetch, defeating the SSR optimisation. Only meaningful
+    // when initialData itself is being supplied.
+    initialDataUpdatedAt: ssrClimbsApplicable ? ssrInitialClimbsUpdatedAtRef.current : 0,
   });
 
   const allClimbs: Climb[] = useMemo(

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -69,6 +69,7 @@ import CommentSection from '@/app/components/social/comment-section';
 import MultiboardClimbList from '@/app/components/climb-list/multiboard-climb-list';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
 import { findMatchingBoard, type BoardConfig } from '@/app/lib/find-matching-board';
+import { ssrSeedMatchesQueryKey } from '@/app/lib/graphql/ssr-query-seed';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import styles from '@/app/components/library/playlist-view.module.css';
 
@@ -240,10 +241,10 @@ export default function PlaylistDetailContent({
   // the tuple the SSR climbs page was fetched for. Without this guard, every
   // new key (board switch, listRefreshKey bump after edits, …) would adopt
   // the same SSR page as fresh data and skip the actual fetch.
-  const ssrClimbsApplicable =
-    !!initialClimbs &&
-    (selectedBoard?.uuid ?? null) === ssrClimbsKeyRef.current.boardUuid &&
-    listRefreshKey === ssrClimbsKeyRef.current.refreshKey;
+  const ssrClimbsApplicable = ssrSeedMatchesQueryKey(!!initialClimbs, ssrClimbsKeyRef.current, {
+    boardUuid: selectedBoard?.uuid ?? null,
+    refreshKey: listRefreshKey,
+  });
 
   const {
     data: climbsData,
@@ -287,12 +288,13 @@ export default function PlaylistDetailContent({
       return allPages.length;
     },
     staleTime: 5 * 60 * 1000,
-    initialData: ssrClimbsApplicable
-      ? {
-          pages: [initialClimbs],
-          pageParams: [0],
-        }
-      : undefined,
+    initialData:
+      ssrClimbsApplicable && initialClimbs
+        ? {
+            pages: [initialClimbs],
+            pageParams: [0],
+          }
+        : undefined,
     // Without this, react-query treats initialData as epoch-stale and fires
     // an immediate refetch, defeating the SSR optimisation. Only meaningful
     // when initialData itself is being supplied.

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -129,6 +129,14 @@ export default function PlaylistDetailContent({
   );
   const lastAccessedUpdatedRef = useRef(false);
   const defaultBoardAppliedRef = useRef(!!selectedBoard);
+  // Tracks whether we have any playlist data (SSR or fetched). Read inside
+  // fetchPlaylist's loading guard to avoid feeding reactive state back into
+  // its dependency list — putting `playlist` in deps creates an infinite
+  // setState → callback-recreate → effect-rerun loop.
+  const hasPlaylistDataRef = useRef(!!initialPlaylist);
+  // Treat SSR-seeded react-query data as fresh under staleTime; without this,
+  // initialDataUpdatedAt defaults to 0 and triggers an immediate refetch.
+  const ssrInitialClimbsUpdatedAtRef = useRef(initialClimbs ? Date.now() : 0);
   const { token, isLoading: tokenLoading } = useWsAuthToken();
 
   // Fetch user's boards (with SSR initial data to avoid loading skeleton).
@@ -157,7 +165,7 @@ export default function PlaylistDetailContent({
     if (tokenLoading) return;
 
     try {
-      if (!playlist) setLoading(true);
+      if (!hasPlaylistDataRef.current) setLoading(true);
       setError(null);
 
       const response = await executeGraphQL<GetPlaylistQueryResponse, GetPlaylistQueryVariables>(
@@ -171,6 +179,7 @@ export default function PlaylistDetailContent({
         return;
       }
 
+      hasPlaylistDataRef.current = true;
       setPlaylist(response.playlist);
     } catch (err) {
       console.error('Error fetching playlist:', err);
@@ -178,7 +187,7 @@ export default function PlaylistDetailContent({
     } finally {
       setLoading(false);
     }
-  }, [playlistUuid, token, tokenLoading, playlist]);
+  }, [playlistUuid, token, tokenLoading]);
 
   useEffect(() => {
     void fetchPlaylist();
@@ -256,6 +265,9 @@ export default function PlaylistDetailContent({
           pageParams: [0],
         }
       : undefined,
+    // Without this, react-query treats initialData as epoch-stale and fires
+    // an immediate refetch, defeating the SSR optimisation.
+    initialDataUpdatedAt: ssrInitialClimbsUpdatedAtRef.current,
   });
 
   const allClimbs: Climb[] = useMemo(
@@ -371,7 +383,10 @@ export default function PlaylistDetailContent({
 
   const generatorAngle = playlist ? getDefaultAngleForBoard(playlist.boardType) : 40;
 
-  if (loading || tokenLoading) {
+  // With SSR data we have content to render, so don't gate on tokenLoading.
+  // Showing the spinner during the first-tick auth bootstrap defeats the
+  // no-spinner goal of seeding initialPlaylist from the server.
+  if (loading || (tokenLoading && !playlist)) {
     return (
       <div className={styles.loadingContainer}>
         <LoadingSpinner size={48} />

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -49,6 +49,7 @@ import {
   type UnpinPlaylistMutationVariables,
   type GetPlaylistClimbsQueryVariables,
   type GetPlaylistClimbsInput,
+  type PlaylistClimbsResult,
 } from '@/app/lib/graphql/operations/playlists';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { shareWithFallback } from '@/app/lib/share-utils';
@@ -97,6 +98,10 @@ type PlaylistDetailContentProps = {
   boardConfig?: BoardConfig;
   /** SSR-fetched user boards for instant board filter selection (avoids flash). */
   initialMyBoards?: UserBoard[] | null;
+  /** SSR-fetched playlist to avoid first-load spinner. */
+  initialPlaylist?: Playlist | null;
+  /** SSR-fetched first page of climbs to avoid first-load spinner. */
+  initialClimbs?: PlaylistClimbsResult | null;
 };
 
 export default function PlaylistDetailContent({
@@ -105,12 +110,14 @@ export default function PlaylistDetailContent({
   boardSlug,
   boardConfig,
   initialMyBoards,
+  initialPlaylist,
+  initialClimbs,
 }: PlaylistDetailContentProps) {
   const router = useLocaleRouter();
   const { showMessage } = useSnackbar();
   const { t } = useTranslation('playlists');
-  const [playlist, setPlaylist] = useState<Playlist | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [playlist, setPlaylist] = useState<Playlist | null>(initialPlaylist ?? null);
+  const [loading, setLoading] = useState(!initialPlaylist);
   const [error, setError] = useState<string | null>(null);
   const [editDrawerOpen, setEditDrawerOpen] = useState(false);
   const [generatorOpen, setGeneratorOpen] = useState(false);
@@ -150,7 +157,7 @@ export default function PlaylistDetailContent({
     if (tokenLoading) return;
 
     try {
-      setLoading(true);
+      if (!playlist) setLoading(true);
       setError(null);
 
       const response = await executeGraphQL<GetPlaylistQueryResponse, GetPlaylistQueryVariables>(
@@ -171,7 +178,7 @@ export default function PlaylistDetailContent({
     } finally {
       setLoading(false);
     }
-  }, [playlistUuid, token, tokenLoading]);
+  }, [playlistUuid, token, tokenLoading, playlist]);
 
   useEffect(() => {
     void fetchPlaylist();
@@ -243,6 +250,12 @@ export default function PlaylistDetailContent({
       return allPages.length;
     },
     staleTime: 5 * 60 * 1000,
+    initialData: initialClimbs
+      ? {
+          pages: [initialClimbs],
+          pageParams: [0],
+        }
+      : undefined,
   });
 
   const allClimbs: Climb[] = useMemo(


### PR DESCRIPTION
## Summary
- Re-lands the SSR work from #1794 (merged then reverted via #2095) with the bugs from the original review now fixed.
- Server-renders playlist details + the first page of climbs for `/playlists/[uuid]` and `/b/[slug]/[angle]/playlists/[uuid]` — no more first-paint spinner, real content available for SEO/metadata.
- Hydrates the client `PlaylistDetailContent` with `initialPlaylist` and `initialClimbs`, and seeds React Query's `useInfiniteQuery` with the SSR climbs.

## What changed since #1794
The reviewer feedback on the original PR identified an infinite re-render loop and a data/query-key mismatch. Both are addressed here:

- **Infinite re-render loop fixed.** `playlist` is no longer in the `fetchPlaylist` `useCallback` deps; a `hasPlaylistDataRef` ref now drives the "only spinner when we have no data yet" guard. Subsequent refetches no longer recreate the callback.
- **`initialData` no longer immediately stale.** Added `initialDataUpdatedAt` (frozen on mount via ref) so React Query honours the 5-minute `staleTime` and skips the redundant first-paint refetch.
- **No spinner while `tokenLoading` if SSR data is present.** Gate changed to `loading || (tokenLoading && !playlist)`.
- **Board-scoped query-key / data mismatch resolved.** On `/b/.../playlists/[uuid]` the SSR climbs call now passes the full filter tuple (`sizeId`/`setIds`/`angle`), and `initialClimbs` is only seeded when `findMatchingBoard(initialMyBoards, boardSlug)` resolves — so the client's first query key (`selectedBoard.uuid`) matches the SSR payload exactly.
- **Silent error swallowing removed.** `console.error(...)` before each `return null` in `serverPlaylist` / `serverPlaylistClimbs` (plus `serverMyBoards` / `serverUserPlaylists` for consistency).
- **Dynamic operation imports converted to static** top-level imports in `server-graphql.ts`.

## Test plan
- [ ] Hard-reload `/playlists/[uuid]` for a playlist with climbs — hero + first ~20 climbs visible on first paint, no full-page spinner flash, no `GetPlaylist` refetch loop in Network.
- [ ] Hard-reload `/b/<slug>/40/playlists/[uuid]` while signed in with a matching user board — board-filtered climbs visible on first paint; first `GetPlaylistClimbs` request `input` includes `boardName`, `layoutId`, `sizeId`, `setIds`, `angle`.
- [ ] Same board-scoped route while signed out (no `initialMyBoards`) — playlist details still SSR'd, climbs list shows its own loading state (no big page spinner).
- [ ] `/playlists/00000000-0000-0000-0000-000000000000` — "not found" empty state, no crash, no spinner.
- [ ] Pin/unpin and follow/unfollow on the detail page still work.
- [ ] Legacy `/[board]/[layout]/[size]/[setIds]/[angle]/playlists/[uuid]` route still renders (no SSR climbs there — expected).
- [ ] Server logs surface `serverPlaylist failed: …` / `serverPlaylistClimbs failed: …` instead of swallowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)