### PR TITLE
test(create-climb-form): fix MoonBoard duplicate test Save climb query

### DIFF
--- a/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
@@ -288,7 +288,9 @@ describe('CreateClimbForm', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText<HTMLButtonElement>('Save climb').disabled).toBe(true);
+      const saveButton = getSaveButton();
+      expect(saveButton).toBeTruthy();
+      expect(saveButton?.disabled).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- Restores the `getSaveButton()` helper in the MoonBoard duplicate-error test.
- Main has been red on every `Web Tests` run since #1487 merged.

## Why

#1487 added the test suite; #12bf93e83 (follow-up "test: simplify Save climb button query in duplicate-hold test") replaced `getSaveButton()` with `screen.getByLabelText<HTMLButtonElement>('Save climb')` in this one assertion. The rendered DOM has **two** elements labeled "Save climb" — the tooltip wrapper and the actual button — so the simpler query throws `Found multiple elements with the text of: Save climb`. The other tests in this file use the `getSaveButton()` helper (which filters `tagName === 'BUTTON'`) and pass.

This was caught while validating PR #1995, but my fix didn't make it into that PR before merge.

## Test plan

- [x] `vp test run --project web packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx` — 51/51 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)