### PR TITLE
feat(logbook): let signed-out users log ticks locally (Phase 1)

### DIFF
--- a/packages/web/app/components/climb-actions/__tests__/tick-action.test.tsx
+++ b/packages/web/app/components/climb-actions/__tests__/tick-action.test.tsx
@@ -368,7 +368,7 @@ describe('TickAction', () => {
       expect(screen.getByTestId('log-ascent-drawer')).toBeTruthy();
     });
 
-    it('shows sign-in prompt when not authenticated and drawer is opened', async () => {
+    it('opens the log ascent drawer for signed-out users (local IndexedDB save)', async () => {
       setupMocks({ hasBoardProvider: true, isAuthenticated: false });
       render(<TestTickAction {...defaultProps} />);
 
@@ -376,9 +376,8 @@ describe('TickAction', () => {
         screen.getByRole('button', { name: /log ascent/i }).click();
       });
 
-      const drawer = screen.getByTestId('swipeable-drawer');
-      expect(drawer.getAttribute('data-title')).toBe('Sign in required');
-      expect(screen.getByText('Sign in to record ticks')).toBeTruthy();
+      expect(screen.queryByText('Sign in to record ticks')).toBeNull();
+      expect(screen.getByTestId('log-ascent-drawer')).toBeTruthy();
     });
 
     it('does not show board selector', async () => {
@@ -636,7 +635,7 @@ describe('TickAction', () => {
   });
 
   describe('without BoardProvider, not authenticated', () => {
-    it('shows sign-in prompt', async () => {
+    it('opens the log ascent form (signed-out users save locally)', async () => {
       setupMocks({ isAuthenticated: false });
       render(<TestTickAction {...defaultProps} />);
 
@@ -644,9 +643,8 @@ describe('TickAction', () => {
         screen.getByRole('button', { name: /log ascent/i }).click();
       });
 
-      const drawer = screen.getByTestId('swipeable-drawer');
-      expect(drawer.getAttribute('data-title')).toBe('Sign in required');
-      expect(screen.getByText('Sign in to record ticks')).toBeTruthy();
+      expect(screen.queryByText('Sign in to record ticks')).toBeNull();
+      expect(screen.getByTestId('log-ascent-form')).toBeTruthy();
     });
 
     it('does not fetch user boards', () => {
@@ -657,7 +655,7 @@ describe('TickAction', () => {
       expect(mockUseMyBoards).toHaveBeenCalledWith(false);
     });
 
-    it('does not show board selector or LogAscentForm', async () => {
+    it('skips the board selector for signed-out users', async () => {
       setupMocks({ isAuthenticated: false });
       render(<TestTickAction {...defaultProps} />);
 
@@ -666,7 +664,6 @@ describe('TickAction', () => {
       });
 
       expect(screen.queryByText('Which board did you climb on?')).toBeNull();
-      expect(screen.queryByTestId('log-ascent-form')).toBeNull();
     });
   });
 

--- a/packages/web/app/components/climb-actions/actions/tick-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/tick-action.tsx
@@ -9,11 +9,8 @@ import Box from '@mui/material/Box';
 import SwipeableDrawer from '../../swipeable-drawer/swipeable-drawer';
 import { ActionTooltip } from '../action-tooltip';
 import CheckOutlined from '@mui/icons-material/CheckOutlined';
-import LoginOutlined from '@mui/icons-material/LoginOutlined';
-import AppsOutlined from '@mui/icons-material/AppsOutlined';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { useOptionalBoardProvider, BoardProvider } from '../../board-provider/board-provider-context';
-import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { LogAscentForm } from '../../logbook/logascent-form';
 import { track } from '@/app/lib/analytics';
 import { constructClimbInfoUrl } from '@/app/lib/url-utils';
@@ -52,7 +49,6 @@ export function TickAction({
   const { t } = useTranslation('climbs');
   const [drawerVisible, setDrawerVisible] = useState(false);
   const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(null);
-  const { openAuthModal } = useAuthModal();
 
   // Use optional board provider - allows TickAction to work outside board routes
   const boardProvider = useOptionalBoardProvider();
@@ -79,7 +75,7 @@ export function TickAction({
     [myBoards, boardDetails.board_name],
   );
 
-  const { alwaysUseApp, loaded, enableAlwaysUseApp } = useAlwaysTickInApp();
+  const { alwaysUseApp, loaded } = useAlwaysTickInApp();
 
   // Find ascent entries for this climb
   const filteredLogbook = useMemo(() => {
@@ -124,60 +120,6 @@ export function TickAction({
     setSelectedBoard(null);
     onComplete?.();
   }, [onComplete]);
-
-  // URL for opening in the Aurora app (null for Kilter as app URL is no longer accessible)
-  const openInAppUrl = useMemo(() => constructClimbInfoUrl(boardDetails, climb.uuid), [boardDetails, climb.uuid]);
-
-  const handleOpenInApp = useCallback(() => {
-    if (!openInAppUrl) return;
-    openExternalUrl(openInAppUrl);
-    closeDrawer();
-  }, [openInAppUrl, closeDrawer]);
-
-  const renderSignInPrompt = () => (
-    <Stack spacing={3} sx={{ width: '100%', textAlign: 'center', padding: '24px 0' }}>
-      <Typography variant="body2" component="span" fontWeight={600} sx={{ fontSize: 16 }}>
-        {t('actions.tick.drawer.signInToRecord')}
-      </Typography>
-      <Typography variant="body1" component="p" color="text.secondary">
-        {t('actions.tick.drawer.createAccountBlurb')}
-      </Typography>
-      <MuiButton
-        variant="contained"
-        startIcon={<LoginOutlined />}
-        onClick={() =>
-          openAuthModal({
-            title: t('actions.tick.drawer.authModalTitle'),
-            description: t('actions.tick.drawer.authModalDescription'),
-          })
-        }
-        fullWidth
-      >
-        {t('actions.tick.drawer.signIn')}
-      </MuiButton>
-      {openInAppUrl && (
-        <>
-          <Typography variant="body1" component="p" color="text.secondary">
-            {t('actions.tick.drawer.orLogInOfficialApp')}
-          </Typography>
-          <MuiButton variant="outlined" startIcon={<AppsOutlined />} onClick={handleOpenInApp} fullWidth>
-            {t('actions.tick.drawer.openInApp')}
-          </MuiButton>
-          <MuiButton
-            variant="text"
-            size="small"
-            color="secondary"
-            onClick={async () => {
-              await enableAlwaysUseApp();
-              handleOpenInApp();
-            }}
-          >
-            {t('actions.tick.drawer.alwaysOpenInApp')}
-          </MuiButton>
-        </>
-      )}
-    </Stack>
-  );
 
   const label = t('actions.tick.drawer.logAscent');
   const shouldShowLabel = showLabel ?? (viewMode === 'button' || viewMode === 'dropdown');
@@ -255,31 +197,15 @@ export function TickAction({
 
   const renderDrawers = () => {
     if (boardProvider) {
-      // Inside a board route - existing flow unchanged
-      if (isAuthenticated) {
-        return (
-          <LogAscentDrawer
-            open={drawerVisible}
-            onClose={closeDrawer}
-            currentClimb={climb}
-            boardDetails={boardDetails}
-          />
-        );
-      }
+      // Inside a board route — works for signed-in (server save) and signed-out (local IndexedDB save).
       return (
-        <SwipeableDrawer
-          title={t('actions.tick.drawer.signInRequired')}
-          placement="bottom"
-          onClose={closeDrawer}
-          open={drawerVisible}
-          styles={{ wrapper: { height: '60%' } }}
-        >
-          {renderSignInPrompt()}
-        </SwipeableDrawer>
+        <LogAscentDrawer open={drawerVisible} onClose={closeDrawer} currentClimb={climb} boardDetails={boardDetails} />
       );
     }
+    // Outside a board route. Authenticated users get the board selector (their linked
+    // Aurora boards); signed-out users skip the selector and log against the boardDetails
+    // we already have (the local-tick path doesn't need user-specific board metadata).
     if (isAuthenticated) {
-      // Outside board route, authenticated - board selector + log form
       return (
         <SwipeableDrawer
           title={showBoardSelector ? t('actions.tick.drawer.selectBoard') : t('actions.tick.drawer.logAscent')}
@@ -300,16 +226,16 @@ export function TickAction({
         </SwipeableDrawer>
       );
     }
-    // Outside board route, not authenticated - sign-in prompt
     return (
       <SwipeableDrawer
-        title={t('actions.tick.drawer.signInRequired')}
+        title={t('actions.tick.drawer.logAscent')}
         placement="bottom"
         onClose={closeDrawer}
         open={drawerVisible}
-        styles={{ wrapper: { height: '60%' } }}
+        fullHeight
+        styles={{ wrapper: { height: '100%' } }}
       >
-        {renderSignInPrompt()}
+        <BoardProvider boardName={resolvedBoardName}>{renderLogAscentForm()}</BoardProvider>
       </SwipeableDrawer>
     );
   };

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -59,7 +59,7 @@ type LogAscentFormProps = {
 export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boardDetails, onClose }) => {
   const { t } = useTranslation('climbs');
   const { t: tProfile } = useTranslation('profile');
-  const { saveTick, isAuthenticated } = useBoardProvider();
+  const { saveTick } = useBoardProvider();
   const grades = useMemo(() => getGradesForBoard(boardDetails.board_name), [boardDetails.board_name]);
   const angleOptions = ANGLES[boardDetails.board_name];
 
@@ -127,7 +127,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
   };
 
   const handleSubmit = async (values: LogAscentFormValues) => {
-    if (!currentClimb?.uuid || !isAuthenticated) {
+    if (!currentClimb?.uuid) {
       return;
     }
 

--- a/packages/web/app/components/logbook/tick-button.tsx
+++ b/packages/web/app/components/logbook/tick-button.tsx
@@ -1,21 +1,13 @@
 'use client';
 
 import React, { useState, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 import type { Angle, Climb, BoardDetails } from '@/app/lib/types';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import MuiBadge from '@mui/material/Badge';
-import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import type { SxProps, Theme } from '@mui/material/styles';
-import Stack from '@mui/material/Stack';
-import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
-import LoginOutlined from '@mui/icons-material/LoginOutlined';
-import AppsOutlined from '@mui/icons-material/AppsOutlined';
 import { track } from '@/app/lib/analytics';
 import { LogAscentDrawer } from './log-ascent-drawer';
-import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { constructClimbInfoUrl } from '@/app/lib/url-utils';
 import { openExternalUrl } from '@/app/lib/open-external-url';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -47,11 +39,9 @@ export const TickButton: React.FC<TickButtonProps> = ({
   isFlash,
   ascentType,
 }) => {
-  const { t } = useTranslation('climbs');
   const { logbook, isAuthenticated } = useBoardProvider();
   const [drawerVisible, setDrawerVisible] = useState(false);
-  const { openAuthModal } = useAuthModal();
-  const { alwaysUseApp, loaded, enableAlwaysUseApp } = useAlwaysTickInApp();
+  const { alwaysUseApp, loaded } = useAlwaysTickInApp();
 
   // URL for opening in the Aurora app (null for Kilter as app URL is no longer accessible)
   const openInAppUrl = useMemo(
@@ -76,8 +66,8 @@ export const TickButton: React.FC<TickButtonProps> = ({
       return;
     }
 
-    // Use inline tick bar when available and authenticated
-    if (isAuthenticated && onActivateTickBar) {
+    // Use inline tick bar when available — works for signed-in and signed-out users.
+    if (onActivateTickBar) {
       onActivateTickBar();
       return;
     }
@@ -85,12 +75,6 @@ export const TickButton: React.FC<TickButtonProps> = ({
     setDrawerVisible(true);
   };
   const closeDrawer = () => setDrawerVisible(false);
-
-  const handleOpenInApp = () => {
-    if (!openInAppUrl) return;
-    openExternalUrl(openInAppUrl);
-    closeDrawer();
-  };
 
   const filteredLogbook = useMemo(
     () => logbook.filter((asc) => asc.climb_uuid === currentClimb?.uuid && Number(asc.angle) === angle),
@@ -165,65 +149,12 @@ export const TickButton: React.FC<TickButtonProps> = ({
     <>
       {tickBarActive ? <TickButtonWithLabel label={tickLabel}>{badge}</TickButtonWithLabel> : badge}
 
-      {isAuthenticated ? (
-        <LogAscentDrawer
-          open={drawerVisible}
-          onClose={closeDrawer}
-          currentClimb={currentClimb}
-          boardDetails={boardDetails}
-        />
-      ) : (
-        <SwipeableDrawer
-          title={t('actions.tick.drawer.signInRequired')}
-          placement="bottom"
-          onClose={closeDrawer}
-          open={drawerVisible}
-          styles={{ wrapper: { height: '60%' } }}
-        >
-          <Stack spacing={3} sx={{ width: '100%', textAlign: 'center', padding: '24px 0' }}>
-            <Typography variant="body2" component="span" fontWeight={600} sx={{ fontSize: 16 }}>
-              {t('actions.tick.drawer.signInToRecord')}
-            </Typography>
-            <Typography variant="body1" component="p" color="text.secondary">
-              {t('actions.tick.drawer.createAccountBlurb')}
-            </Typography>
-            <Button
-              variant="contained"
-              startIcon={<LoginOutlined />}
-              onClick={() =>
-                openAuthModal({
-                  title: t('actions.tick.drawer.authModalTitle'),
-                  description: t('actions.tick.drawer.authModalDescription'),
-                })
-              }
-              fullWidth
-            >
-              {t('actions.tick.drawer.signIn')}
-            </Button>
-            {openInAppUrl && (
-              <>
-                <Typography variant="body1" component="p" color="text.secondary">
-                  {t('actions.tick.drawer.orLogInOfficialApp')}
-                </Typography>
-                <Button variant="outlined" startIcon={<AppsOutlined />} onClick={handleOpenInApp} fullWidth>
-                  {t('actions.tick.drawer.openInApp')}
-                </Button>
-                <Button
-                  variant="text"
-                  size="small"
-                  color="secondary"
-                  onClick={async () => {
-                    await enableAlwaysUseApp();
-                    handleOpenInApp();
-                  }}
-                >
-                  {t('actions.tick.drawer.alwaysOpenInApp')}
-                </Button>
-              </>
-            )}
-          </Stack>
-        </SwipeableDrawer>
-      )}
+      <LogAscentDrawer
+        open={drawerVisible}
+        onClose={closeDrawer}
+        currentClimb={currentClimb}
+        boardDetails={boardDetails}
+      />
     </>
   );
 };

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -9,7 +9,6 @@ import Stack from '@mui/material/Stack';
 import MuiDivider from '@mui/material/Divider';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import drawerCss from '../swipeable-drawer/swipeable-drawer.module.css';
-import LoginOutlined from '@mui/icons-material/LoginOutlined';
 import { useQueueActions, useCurrentClimbUuid, useQueueList, useSearchData, useSessionData } from '../graphql-queue';
 import type { Climb, BoardDetails } from '@/app/lib/types';
 import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
@@ -28,9 +27,7 @@ import { ClimbActions } from '../climb-actions';
 import PlaylistSelectionContent from '../climb-actions/playlist-selection-content';
 import { getExcludedClimbActions } from '@/app/lib/climb-action-utils';
 import { themeTokens } from '@/app/theme/theme-config';
-import { useOptionalBoardProvider } from '../board-provider/board-provider-context';
 import { LogAscentDrawer } from '../logbook/log-ascent-drawer';
-import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import type { ClimbQueueItem } from './types';
 import { isClimbEditable } from './is-climb-editable';
 import styles from './queue-list.module.css';
@@ -106,12 +103,9 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
       [router, boardSlug, angleParam],
     );
 
-    const isAuthenticated = useOptionalBoardProvider()?.isAuthenticated ?? false;
-
     // Tick drawer state
     const [tickDrawerVisible, setTickDrawerVisible] = useState(false);
     const [tickClimb, setTickClimb] = useState<Climb | null>(null);
-    const { openAuthModal } = useAuthModal();
 
     // Shared drawer state — one actions drawer and one playlist drawer for all items.
     // This replaces the per-ClimbListItem drawers (previously 100+ drawer trees).
@@ -497,50 +491,13 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
           })}
         </div>
 
-        {/* Tick drawer - now works with just NextAuth authentication */}
-        {isAuthenticated ? (
-          <LogAscentDrawer
-            open={tickDrawerVisible}
-            onClose={closeTickDrawer}
-            currentClimb={tickClimb}
-            boardDetails={boardDetails}
-          />
-        ) : (
-          <SwipeableDrawer
-            title={t('actions.tick.drawer.signInRequired')}
-            placement="bottom"
-            onClose={closeTickDrawer}
-            open={tickDrawerVisible}
-            styles={{ wrapper: { height: '50%' } }}
-          >
-            <Stack spacing={3} sx={{ width: '100%', textAlign: 'center', padding: `${themeTokens.spacing[6]}px 0` }}>
-              <Typography
-                variant="body2"
-                component="span"
-                fontWeight={600}
-                sx={{ fontSize: themeTokens.typography.fontSize.base }}
-              >
-                {t('actions.tick.drawer.signInToRecord')}
-              </Typography>
-              <Typography variant="body1" component="p" color="text.secondary">
-                {t('actions.tick.drawer.createAccountBlurb')}
-              </Typography>
-              <Button
-                variant="contained"
-                startIcon={<LoginOutlined />}
-                onClick={() =>
-                  openAuthModal({
-                    title: t('actions.tick.drawer.authModalTitle'),
-                    description: t('actions.tick.drawer.authModalDescription'),
-                  })
-                }
-                fullWidth
-              >
-                {t('actions.tick.drawer.signIn')}
-              </Button>
-            </Stack>
-          </SwipeableDrawer>
-        )}
+        {/* Tick drawer — works for signed-in users (server save) and signed-out users (local IndexedDB save). */}
+        <LogAscentDrawer
+          open={tickDrawerVisible}
+          onClose={closeTickDrawer}
+          currentClimb={tickClimb}
+          boardDetails={boardDetails}
+        />
 
         {/* Shared actions drawer — only mount when a climb's actions are open */}
         {actionsClimb && (

--- a/packages/web/app/hooks/__tests__/use-save-tick.test.ts
+++ b/packages/web/app/hooks/__tests__/use-save-tick.test.ts
@@ -30,6 +30,11 @@ vi.mock('@/app/lib/graphql/operations', () => ({
   SAVE_TICK: 'SAVE_TICK_MUTATION',
 }));
 
+const mockSaveLocalTick = vi.fn();
+vi.mock('@/app/lib/local-ticks-db', () => ({
+  saveLocalTick: (...args: unknown[]) => mockSaveLocalTick(...args),
+}));
+
 const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
 const mockUseSession = vi.mocked(useSession);
 
@@ -75,6 +80,7 @@ describe('useSaveTick', () => {
     vi.clearAllMocks();
     mockRequest.mockReset();
     mockShowMessage.mockReset();
+    mockSaveLocalTick.mockReset();
     mockUseWsAuthToken.mockReturnValue({
       token: 'test-token',
       isAuthenticated: true,
@@ -88,15 +94,32 @@ describe('useSaveTick', () => {
     });
   });
 
-  it('throws when not authenticated', async () => {
+  it('saves locally when not authenticated', async () => {
     mockUseSession.mockReturnValue({
       status: 'unauthenticated',
       data: null,
       update: vi.fn(),
     });
+    mockSaveLocalTick.mockResolvedValue({
+      uuid: 'local-uuid-1',
+      climbUuid: 'climb-1',
+      angle: 40,
+      isMirror: false,
+      status: 'send',
+      attemptCount: 3,
+      quality: null,
+      difficulty: null,
+      comment: 'Great climb',
+      climbedAt: '2024-01-01',
+      videoUrl: null,
+      boardName: 'kilter',
+      layoutId: null,
+      sizeId: null,
+      setIds: null,
+      localSessionId: 'session-1',
+    });
 
     const { wrapper } = createTestWrapper();
-
     const { result } = renderHook(() => useSaveTick('kilter'), { wrapper });
 
     await act(async () => {
@@ -104,22 +127,71 @@ describe('useSaveTick', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.isError).toBe(true);
+      expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(result.current.error?.message).toBe('Not authenticated');
+    expect(mockSaveLocalTick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        climbUuid: 'climb-1',
+        angle: 40,
+        status: 'send',
+        attemptCount: 3,
+        boardName: 'kilter',
+      }),
+    );
+    expect(mockRequest).not.toHaveBeenCalled();
   });
 
-  it('throws when no token', async () => {
+  it('saves locally when no token is available', async () => {
     mockUseWsAuthToken.mockReturnValue({
       token: null,
       isAuthenticated: false,
       isLoading: false,
       error: null,
     });
+    mockSaveLocalTick.mockResolvedValue({
+      uuid: 'local-uuid-2',
+      climbUuid: 'climb-1',
+      angle: 40,
+      isMirror: false,
+      status: 'send',
+      attemptCount: 3,
+      quality: null,
+      difficulty: null,
+      comment: 'Great climb',
+      climbedAt: '2024-01-01',
+      videoUrl: null,
+      boardName: 'kilter',
+      layoutId: null,
+      sizeId: null,
+      setIds: null,
+      localSessionId: 'session-2',
+    });
 
     const { wrapper } = createTestWrapper();
+    const { result } = renderHook(() => useSaveTick('kilter'), { wrapper });
 
+    await act(async () => {
+      result.current.mutate(createTickOptions());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockSaveLocalTick).toHaveBeenCalled();
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a local-storage error when IndexedDB is unavailable', async () => {
+    mockUseSession.mockReturnValue({
+      status: 'unauthenticated',
+      data: null,
+      update: vi.fn(),
+    });
+    mockSaveLocalTick.mockResolvedValue(null);
+
+    const { wrapper } = createTestWrapper();
     const { result } = renderHook(() => useSaveTick('kilter'), { wrapper });
 
     await act(async () => {
@@ -130,7 +202,7 @@ describe('useSaveTick', () => {
       expect(result.current.isError).toBe(true);
     });
 
-    expect(result.current.error?.message).toBe('Auth token not available');
+    expect(result.current.error?.message).toBe('Local storage unavailable');
   });
 
   it('calls GraphQL mutation with correct variables', async () => {

--- a/packages/web/app/hooks/use-logbook.ts
+++ b/packages/web/app/hooks/use-logbook.ts
@@ -7,6 +7,7 @@ import { useSession } from 'next-auth/react';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { GET_TICKS, type GetTicksQueryVariables, type GetTicksQueryResponse } from '@/app/lib/graphql/operations';
 import type { BoardName, ClimbUuid } from '@/app/lib/types';
+import { listAllLocalTicks, type LocalTick } from '@/app/lib/local-ticks-db';
 
 // Tick status type matching the database enum
 export type TickStatus = 'flash' | 'send' | 'attempt';
@@ -68,6 +69,21 @@ function transformTicks(ticks: GetTicksQueryResponse['ticks']): LogbookEntry[] {
   return ticks.map(toLogbookEntry);
 }
 
+function localTickToLogbookEntry(tick: LocalTick): LogbookEntry {
+  return toLogbookEntry({
+    uuid: tick.uuid,
+    climbUuid: tick.climbUuid,
+    angle: tick.angle,
+    isMirror: tick.isMirror,
+    status: tick.status,
+    attemptCount: tick.attemptCount,
+    quality: tick.quality,
+    difficulty: tick.difficulty,
+    comment: tick.comment,
+    climbedAt: tick.climbedAt,
+  });
+}
+
 export function mergeLogbookEntries(existing: LogbookEntry[], incoming: LogbookEntry[]): LogbookEntry[] {
   if (incoming.length === 0) return existing;
 
@@ -119,6 +135,8 @@ export function useLogbook(boardName: BoardName, climbUuids: ClimbUuid[]) {
   const [invalidationCount, setInvalidationCount] = useState(0);
 
   const isEnabled = sessionStatus === 'authenticated' && !!token;
+  // Signed-out → hydrate from local IndexedDB. Token isn't required for local mode.
+  const isLocalMode = sessionStatus === 'unauthenticated';
 
   const accumulatedQuery = useQuery<LogbookEntry[]>({
     queryKey: accumulatedKey,
@@ -207,6 +225,29 @@ export function useLogbook(boardName: BoardName, climbUuids: ClimbUuid[]) {
       queryClient.removeQueries({ queryKey: ['logbook', boardName] });
     }
   }, [isEnabled, boardName, queryClient]);
+
+  // Hydrate the accumulated cache from IndexedDB whenever we're in local mode.
+  // Runs after the reset above so it survives the logout-clear and re-runs if
+  // the cache subscription bumps invalidationCount. Subsequent local saves are
+  // merged optimistically via useSaveTick.onMutate, so this is one-shot per
+  // session-status transition.
+  useEffect(() => {
+    if (!isLocalMode) return;
+    let cancelled = false;
+    void (async () => {
+      const localTicks = await listAllLocalTicks();
+      if (cancelled) return;
+      const forBoard = localTicks.filter((tick) => tick.boardName === boardName);
+      if (forBoard.length === 0) return;
+      const entries = forBoard.map(localTickToLogbookEntry);
+      queryClient.setQueryData<LogbookEntry[]>(accumulatedKey, (existing = []) =>
+        mergeLogbookEntries(existing, entries),
+      );
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isLocalMode, accumulatedKey, queryClient, invalidationCount, boardName]);
 
   return {
     logbook,

--- a/packages/web/app/hooks/use-save-tick.ts
+++ b/packages/web/app/hooks/use-save-tick.ts
@@ -14,6 +14,7 @@ import {
   type LogbookEntry,
 } from './use-logbook';
 import { clearTickDraft } from '@/app/lib/tick-draft-db';
+import { saveLocalTick } from '@/app/lib/local-ticks-db';
 
 // Options for saving a tick (local storage, no Aurora required)
 export type SaveTickOptions = {
@@ -46,11 +47,45 @@ export function useSaveTick(boardName: BoardName) {
 
   return useMutation({
     mutationFn: async (options: SaveTickOptions) => {
-      if (sessionStatus !== 'authenticated') {
-        throw new Error('Not authenticated');
-      }
-      if (!token) {
-        throw new Error('Auth token not available');
+      // Signed-out users: persist locally instead of hitting the server.
+      // The optimistic merge handles UI updates; we return a tick-shaped object
+      // so the rest of the lifecycle treats this just like a server save.
+      if (sessionStatus !== 'authenticated' || !token) {
+        const setIdsForLocal =
+          options.setIds === undefined || options.setIds === null || options.setIds === ''
+            ? null
+            : String(options.setIds);
+        const tick = await saveLocalTick({
+          climbUuid: options.climbUuid,
+          angle: options.angle,
+          isMirror: options.isMirror,
+          status: options.status,
+          attemptCount: options.attemptCount,
+          quality: options.quality ?? null,
+          difficulty: options.difficulty ?? null,
+          comment: options.comment,
+          climbedAt: options.climbedAt,
+          videoUrl: options.videoUrl ?? null,
+          boardName,
+          layoutId: options.layoutId ?? null,
+          sizeId: options.sizeId ?? null,
+          setIds: setIdsForLocal,
+        });
+        if (!tick) {
+          throw new Error('Local storage unavailable');
+        }
+        return {
+          uuid: tick.uuid,
+          climbUuid: tick.climbUuid,
+          angle: tick.angle,
+          isMirror: tick.isMirror,
+          status: tick.status,
+          attemptCount: tick.attemptCount,
+          quality: tick.quality,
+          difficulty: tick.difficulty,
+          comment: tick.comment,
+          climbedAt: tick.climbedAt,
+        };
       }
 
       const client = createGraphQLHttpClient(token);

--- a/packages/web/app/lib/local-installation-db.ts
+++ b/packages/web/app/lib/local-installation-db.ts
@@ -1,0 +1,39 @@
+import { createIndexedDBStore } from './idb-helper';
+
+const STORE_NAME = 'installation';
+const INSTALLATION_ID_KEY = 'installation-id';
+
+const getDB = createIndexedDBStore('boardsesh-local-installation', STORE_NAME);
+
+function randomUuid(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID (very old Safari).
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
+}
+
+let cachedInstallationId: string | null = null;
+
+export async function getInstallationId(): Promise<string | null> {
+  if (cachedInstallationId) return cachedInstallationId;
+
+  const db = await getDB();
+  if (!db) return null;
+
+  const existing = (await db.get(STORE_NAME, INSTALLATION_ID_KEY)) as string | undefined;
+  if (existing) {
+    cachedInstallationId = existing;
+    return existing;
+  }
+
+  const fresh = randomUuid();
+  await db.put(STORE_NAME, fresh, INSTALLATION_ID_KEY);
+  cachedInstallationId = fresh;
+  return fresh;
+}

--- a/packages/web/app/lib/local-sessions-db.ts
+++ b/packages/web/app/lib/local-sessions-db.ts
@@ -1,0 +1,171 @@
+import { v5 as uuidv5 } from 'uuid';
+import type { BoardName } from '@/app/lib/types';
+import { createIndexedDBStore } from './idb-helper';
+import { getInstallationId } from './local-installation-db';
+
+const STORE_NAME = 'local-sessions';
+const SESSION_GAP_MS = 4 * 60 * 60 * 1000;
+
+// Same namespace the server-side inferred-session builder uses
+// (packages/web/app/lib/data-sync/aurora/inferred-session-builder.ts). Keeping it
+// identical means an account-upgrade migration can replay local ticks and end
+// up with stable session IDs that match the server's own grouping rules.
+const INFERRED_SESSION_NAMESPACE = '6ba7b812-9dad-11d1-80b4-00c04fd430c8';
+
+export type LocalSession = {
+  id: string;
+  firstTickAt: string;
+  lastTickAt: string;
+  endedAt: string | null;
+  totalSends: number;
+  totalFlashes: number;
+  totalAttempts: number;
+  tickCount: number;
+  boardName: BoardName;
+  layoutId: number | null;
+  sizeId: number | null;
+  setIds: string | null;
+  defaultAngle: number | null;
+  healthKitWorkoutId?: string | null;
+  healthConnectRecordId?: string | null;
+};
+
+const getDB = createIndexedDBStore('boardsesh-local-sessions', STORE_NAME);
+
+function generateLocalSessionId(installationId: string, firstTickAt: string): string {
+  return uuidv5(`${installationId}:${firstTickAt}`, INFERRED_SESSION_NAMESPACE);
+}
+
+export async function listLocalSessions(): Promise<LocalSession[]> {
+  const db = await getDB();
+  if (!db) return [];
+  const all = (await db.getAll(STORE_NAME)) as LocalSession[];
+  return all.sort((a, b) => new Date(b.firstTickAt).getTime() - new Date(a.firstTickAt).getTime());
+}
+
+export async function getLocalSession(sessionId: string): Promise<LocalSession | null> {
+  const db = await getDB();
+  if (!db) return null;
+  const session = (await db.get(STORE_NAME, sessionId)) as LocalSession | undefined;
+  return session ?? null;
+}
+
+type AssignSessionInput = {
+  climbedAt: string;
+  boardName: BoardName;
+  layoutId: number | null;
+  sizeId: number | null;
+  setIds: string | null;
+  defaultAngle: number | null;
+};
+
+export type AssignSessionResult = {
+  sessionId: string;
+};
+
+/**
+ * Assign a tick to a local session using the same 4-hour-gap rule the server
+ * uses for inferred sessions. Creates a new session if none is open within
+ * the gap, otherwise extends the existing one. Caller is responsible for
+ * persisting the tick itself and then calling `recalculateLocalSessionStats`.
+ */
+export async function assignLocalSession(input: AssignSessionInput): Promise<AssignSessionResult | null> {
+  const installationId = await getInstallationId();
+  if (!installationId) return null;
+
+  const db = await getDB();
+  if (!db) return null;
+
+  const climbedAtMs = new Date(input.climbedAt).getTime();
+  const all = (await db.getAll(STORE_NAME)) as LocalSession[];
+
+  // Find an open session within the 4-hour gap that matches this board config.
+  // We scope grouping to a specific board configuration so that switching gyms
+  // mid-day starts a new session rather than fusing them.
+  const candidate = all
+    .filter(
+      (s) =>
+        s.endedAt === null &&
+        s.boardName === input.boardName &&
+        s.layoutId === input.layoutId &&
+        s.sizeId === input.sizeId &&
+        s.setIds === input.setIds,
+    )
+    .sort((a, b) => new Date(b.lastTickAt).getTime() - new Date(a.lastTickAt).getTime())[0];
+
+  if (candidate) {
+    const lastTickMs = new Date(candidate.lastTickAt).getTime();
+    const firstTickMs = new Date(candidate.firstTickAt).getTime();
+    if (Math.abs(climbedAtMs - lastTickMs) <= SESSION_GAP_MS || Math.abs(climbedAtMs - firstTickMs) <= SESSION_GAP_MS) {
+      const updated: LocalSession = {
+        ...candidate,
+        firstTickAt: climbedAtMs < firstTickMs ? input.climbedAt : candidate.firstTickAt,
+        lastTickAt: climbedAtMs > lastTickMs ? input.climbedAt : candidate.lastTickAt,
+      };
+      await db.put(STORE_NAME, updated, updated.id);
+      return { sessionId: updated.id };
+    }
+  }
+
+  const sessionId = generateLocalSessionId(installationId, input.climbedAt);
+  const existing = (await db.get(STORE_NAME, sessionId)) as LocalSession | undefined;
+  if (existing) {
+    return { sessionId };
+  }
+
+  const fresh: LocalSession = {
+    id: sessionId,
+    firstTickAt: input.climbedAt,
+    lastTickAt: input.climbedAt,
+    endedAt: null,
+    totalSends: 0,
+    totalFlashes: 0,
+    totalAttempts: 0,
+    tickCount: 0,
+    boardName: input.boardName,
+    layoutId: input.layoutId,
+    sizeId: input.sizeId,
+    setIds: input.setIds,
+    defaultAngle: input.defaultAngle,
+    healthKitWorkoutId: null,
+    healthConnectRecordId: null,
+  };
+  await db.put(STORE_NAME, fresh, sessionId);
+  return { sessionId };
+}
+
+export type SessionStatsDelta = {
+  sendsDelta: number;
+  flashesDelta: number;
+  attemptsDelta: number;
+  tickCountDelta: number;
+  climbedAt: string;
+};
+
+export async function applySessionStatsDelta(sessionId: string, delta: SessionStatsDelta): Promise<void> {
+  const db = await getDB();
+  if (!db) return;
+  const session = (await db.get(STORE_NAME, sessionId)) as LocalSession | undefined;
+  if (!session) return;
+
+  const ts = new Date(delta.climbedAt).getTime();
+  const firstMs = new Date(session.firstTickAt).getTime();
+  const lastMs = new Date(session.lastTickAt).getTime();
+
+  const updated: LocalSession = {
+    ...session,
+    totalSends: Math.max(0, session.totalSends + delta.sendsDelta),
+    totalFlashes: Math.max(0, session.totalFlashes + delta.flashesDelta),
+    totalAttempts: Math.max(0, session.totalAttempts + delta.attemptsDelta),
+    tickCount: Math.max(0, session.tickCount + delta.tickCountDelta),
+    firstTickAt: ts < firstMs ? delta.climbedAt : session.firstTickAt,
+    lastTickAt: ts > lastMs ? delta.climbedAt : session.lastTickAt,
+  };
+  await db.put(STORE_NAME, updated, sessionId);
+}
+
+export async function clearAllLocalSessions(): Promise<void> {
+  const db = await getDB();
+  if (!db) return;
+  await db.clear(STORE_NAME);
+}

--- a/packages/web/app/lib/local-ticks-db.ts
+++ b/packages/web/app/lib/local-ticks-db.ts
@@ -1,0 +1,150 @@
+import type { BoardName } from '@/app/lib/types';
+import type { TickStatus } from '@/app/hooks/use-logbook';
+import { createIndexedDBStore } from './idb-helper';
+import { assignLocalSession, applySessionStatsDelta, type SessionStatsDelta } from './local-sessions-db';
+
+const STORE_NAME = 'local-ticks';
+
+export type LocalTick = {
+  uuid: string;
+  climbUuid: string;
+  angle: number;
+  isMirror: boolean;
+  status: TickStatus;
+  attemptCount: number;
+  quality: number | null;
+  difficulty: number | null;
+  comment: string;
+  climbedAt: string;
+  videoUrl: string | null;
+  boardName: BoardName;
+  layoutId: number | null;
+  sizeId: number | null;
+  setIds: string | null;
+  localSessionId: string;
+};
+
+const getDB = createIndexedDBStore('boardsesh-local-ticks', STORE_NAME, 1, (db) => {
+  if (!db.objectStoreNames.contains(STORE_NAME)) {
+    const store = db.createObjectStore(STORE_NAME, { keyPath: 'uuid' });
+    store.createIndex('climbUuid', 'climbUuid');
+    store.createIndex('climbedAt', 'climbedAt');
+    store.createIndex('localSessionId', 'localSessionId');
+  }
+});
+
+function randomUuid(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'));
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
+}
+
+function deltaForStatus(status: TickStatus, climbedAt: string): SessionStatsDelta {
+  let sends = 0;
+  let flashes = 0;
+  let attempts = 0;
+  if (status === 'flash') {
+    sends = 1;
+    flashes = 1;
+  } else if (status === 'send') {
+    sends = 1;
+  } else {
+    attempts = 1;
+  }
+  return {
+    sendsDelta: sends,
+    flashesDelta: flashes,
+    attemptsDelta: attempts,
+    tickCountDelta: 1,
+    climbedAt,
+  };
+}
+
+export type SaveLocalTickInput = Omit<LocalTick, 'uuid' | 'localSessionId'>;
+
+let persistRequested = false;
+
+async function requestPersistentStorage(): Promise<void> {
+  if (persistRequested) return;
+  persistRequested = true;
+  if (typeof navigator === 'undefined' || !navigator.storage?.persist) return;
+  try {
+    await navigator.storage.persist();
+  } catch {
+    // Best-effort — browser may decline. The data is still in IndexedDB.
+  }
+}
+
+export async function saveLocalTick(input: SaveLocalTickInput): Promise<LocalTick | null> {
+  const db = await getDB();
+  if (!db) return null;
+
+  // Ask the browser to mark our storage as persistent so it doesn't get
+  // evicted under pressure. Safe to call repeatedly — we no-op after first try.
+  void requestPersistentStorage();
+
+  const assignment = await assignLocalSession({
+    climbedAt: input.climbedAt,
+    boardName: input.boardName,
+    layoutId: input.layoutId,
+    sizeId: input.sizeId,
+    setIds: input.setIds,
+    defaultAngle: input.angle,
+  });
+  if (!assignment) return null;
+
+  const tick: LocalTick = {
+    ...input,
+    uuid: randomUuid(),
+    localSessionId: assignment.sessionId,
+  };
+  await db.put(STORE_NAME, tick);
+  await applySessionStatsDelta(assignment.sessionId, deltaForStatus(input.status, input.climbedAt));
+  return tick;
+}
+
+export async function listAllLocalTicks(): Promise<LocalTick[]> {
+  const db = await getDB();
+  if (!db) return [];
+  return (await db.getAll(STORE_NAME)) as LocalTick[];
+}
+
+export async function listLocalTicksForClimbs(climbUuids: readonly string[]): Promise<LocalTick[]> {
+  if (climbUuids.length === 0) return [];
+  const db = await getDB();
+  if (!db) return [];
+  const tx = db.transaction(STORE_NAME, 'readonly');
+  const index = tx.store.index('climbUuid');
+  const lookups = await Promise.all(climbUuids.map((uuid) => index.getAll(uuid)));
+  await tx.done;
+  return lookups.flat() as LocalTick[];
+}
+
+export async function deleteLocalTick(uuid: string): Promise<LocalTick | null> {
+  const db = await getDB();
+  if (!db) return null;
+  const tick = (await db.get(STORE_NAME, uuid)) as LocalTick | undefined;
+  if (!tick) return null;
+  await db.delete(STORE_NAME, uuid);
+  const reverseDelta = deltaForStatus(tick.status, tick.climbedAt);
+  await applySessionStatsDelta(tick.localSessionId, {
+    sendsDelta: -reverseDelta.sendsDelta,
+    flashesDelta: -reverseDelta.flashesDelta,
+    attemptsDelta: -reverseDelta.attemptsDelta,
+    tickCountDelta: -reverseDelta.tickCountDelta,
+    climbedAt: tick.climbedAt,
+  });
+  return tick;
+}
+
+export async function clearAllLocalTicks(): Promise<void> {
+  const db = await getDB();
+  if (!db) return;
+  await db.clear(STORE_NAME);
+}


### PR DESCRIPTION
## Why

> _"I downloaded this because I don't need my ticks published or anything. I like that I can use the board at all, but dislike that it refuses to log data locally."_

Today logging a tick requires a Boardsesh account — `use-save-tick.ts` hard-fails on `sessionStatus !== 'authenticated'` and every tick UI shows a sign-in drawer. This PR lets signed-out users log ticks straight into IndexedDB on the device. No account, no server roundtrip, fully private.

This is **Phase 1 of a multi-phase plan**. The plan file is at `/root/.claude/plans/i-downloaded-this-because-harmonic-lerdorf.md`. Phase 2 mirrors local sessions to Apple HealthKit, Phase 3 adds a Google Health Connect Capacitor plugin, Phase 4 adds JSON export + account-upgrade migration.

## What this PR does

- **New IndexedDB stores** under `packages/web/app/lib/`:
  - `local-installation-db.ts` — per-device UUID (namespace for session IDs).
  - `local-sessions-db.ts` — client-side session records, grouped by the same 4-hour-gap UUIDv5 rule the server uses for inferred sessions (`inferred-session-builder.ts:139-144`). Same algorithm = same IDs after account upgrade = no duplicates on replay.
  - `local-ticks-db.ts` — per-tick records, indexed on `climbUuid`, `climbedAt`, and `localSessionId`. Calls `navigator.storage.persist()` on first write so the browser doesn't evict the store.
- **`use-save-tick.ts`** — when `sessionStatus !== 'authenticated'` or there's no token, write to local IndexedDB instead of GraphQL and return a tick-shaped object so the existing optimistic-update lifecycle keeps working.
- **`use-logbook.ts`** — on signed-out mode, hydrate the accumulated cache from `listAllLocalTicks()`, filtered by `boardName`. Runs after the existing "reset on auth lost" effect so it survives the logout clear; re-runs on `invalidationCount` so cache subscriptions don't strand the data.
- **UI unlocks** — dropped the sign-in-required drawer in `tick-button.tsx`, `tick-action.tsx`, and `queue-list.tsx`. Removed the `!isAuthenticated` early-return in `logascent-form.tsx`. All four tick entry points now open the regular log-ascent drawer/form for signed-out users.

## What this PR does NOT do (later phases)

- No HealthKit / Health Connect persistence yet — Phase 2 / Phase 3.
- No "Export my ticks" JSON download — Phase 4.
- No account-upgrade migration prompt yet — Phase 4.
- No signed-out variant of `/you/logbook` (the page still redirects to `/`).

## Test plan

- [ ] Sign out. Open any climb. Log a flash/send/attempt. Reload the page → tick still appears on the climb (IndexedDB persisted).
- [ ] Sign out. Log ticks on two different climbs across a >4h gap (use system clock tricks if needed) → second batch starts a new local session (`localSessionId` differs).
- [ ] Sign out. Switch between Kilter and Tension boards → only ticks for the current board appear in the logbook badge counts.
- [ ] Open dev tools → Application → IndexedDB → confirm `boardsesh-local-ticks`, `boardsesh-local-sessions`, `boardsesh-local-installation` databases exist with expected records.
- [ ] Sign in as an existing user → server-fetched ticks appear; local ticks are not merged in (intentional — that's the Phase 4 migration prompt).
- [ ] Sign out from a signed-in session → server data clears, local data (if any) appears.
- [ ] CI: `vp check` + `vp run typecheck` + all touched test files (use-save-tick, use-logbook, tick-button, tick-action, queue-control/*) green locally.

## Files changed at a glance

- New: `packages/web/app/lib/local-{installation,sessions,ticks}-db.ts`
- Hooks: `use-save-tick.ts`, `use-logbook.ts` (+ tests)
- UI: `tick-button.tsx`, `tick-action.tsx`, `queue-list.tsx`, `logascent-form.tsx`

https://claude.ai/code/session_01SSgzcaAp7Xh9Q1fMN29trp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSgzcaAp7Xh9Q1fMN29trp)_