### PR TITLE
fix(persistent-session): stabilize setActiveSession + document lock-key range

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -427,6 +427,8 @@ When a session ends via `endSession`:
 
 `RoomManager.initialize()` starts a background interval (`INACTIVITY_SWEEP_INTERVAL_MS`, currently 1 minute) that calls `endStaleInactiveSessions(INACTIVITY_THRESHOLD_MS)` from `session-discovery.ts`. The sweep marks every session where `status='active' AND isPermanent=false AND lastActivity < NOW() - 1 hour` as `status='ended'` and stamps `endedAt`. Permanent sessions are exempt. The sweep does no Redis or `WriteScheduler` cleanup — by definition no clients are connected (otherwise `lastActivity` would have been refreshed via the debounced queue-write path), so there's no hot state to evict.
 
+In multi-instance deploys the sweep wraps its `UPDATE` in a Postgres transaction-scoped advisory lock (`pg_try_advisory_xact_lock`) so only one instance runs the work per tick — losers see `locked=false` and return 0. The lock is a fan-out optimisation, not a correctness requirement (the `UPDATE` predicate is idempotent). Lock-key numbering convention: app-level advisory locks in the backend live in the reserved range `19550000–19559999` (seeded from issue #1955); `INACTIVITY_SWEEP_LOCK_KEY = 19551850` is the only slot in use today. New advisory locks should pick another unused integer in that range and document what they're for next to the constant.
+
 Because the sweep mutates rows asynchronously to any connected clients, no `SessionEnded` broadcast is emitted. Instead, the client surfaces it lazily on the next app open:
 
 1. `useQueueStorage.restoreState` waits for `useWsAuthToken` to resolve, then runs a pre-flight `GET_SESSION_SUMMARY` query against the persisted session.

--- a/packages/backend/src/services/room-manager/session-discovery.ts
+++ b/packages/backend/src/services/room-manager/session-discovery.ts
@@ -227,9 +227,14 @@ export async function endSession(
   console.info(`[RoomManager] Session ${sessionId} explicitly ended`);
 }
 
-// Advisory lock slot for the inactivity sweep (issue #1955). Postgres accepts
-// a bigint; this slot just needs to be distinct from any other advisory lock
-// keys we add later.
+// Advisory lock slot for the inactivity sweep (derived from issue #1955).
+// Postgres accepts a bigint; this slot just needs to be distinct from any
+// other advisory lock keys we add later.
+//
+// Reserved range for app-level advisory locks in this package: 19550000 –
+// 19559999 (i.e. ~10k slots seeded from issue #1955). New advisory locks
+// should pick another unused integer in that range and add a comment here
+// describing what they're for, so collisions stay greppable.
 const INACTIVITY_SWEEP_LOCK_KEY = 19551850;
 
 /**

--- a/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
@@ -386,6 +386,49 @@ describe('PersistentSessionProvider auto-restore on mount', () => {
     expect(stored).toBeNull();
   });
 
+  it('runs the auto-finished pre-flight exactly once across rapid re-renders after auth resolves', async () => {
+    // Regression guard: previously the inline arrow passed as `setActiveSession`
+    // to `useQueueStorage` was reborn each render. The restore effect listed
+    // that callback in its deps, so rapid re-renders between `isAuthLoading`
+    // flipping false and `hasRunPreflightRef` being set could fire multiple
+    // concurrent `restoreState()` calls (one pre-flight per render).
+    mockWsAuth.token = null;
+    mockWsAuth.isLoading = true;
+    mockHttpRequest.mockResolvedValue({ sessionSummary: buildSessionSummary() });
+
+    const sessionInfo = {
+      sessionId: 'session-race-guard',
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails: createTestBoardDetails(),
+      parsedParams: {
+        board_name: 'kilter' as const,
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1, 2],
+        angle: 40,
+      },
+    };
+    await setPreference(ACTIVE_SESSION_KEY, sessionInfo);
+
+    const { result, rerender } = renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
+
+    // Auth resolves; force several synchronous re-renders before the
+    // pre-flight promise resolves to maximise the window in which a fresh
+    // `setActiveSession` reference could re-fire the restore effect.
+    mockWsAuth.token = 'test-token';
+    mockWsAuth.isLoading = false;
+    rerender();
+    rerender();
+    rerender();
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.activeSession).toEqual(sessionInfo);
+    });
+
+    expect(mockHttpRequest).toHaveBeenCalledTimes(1);
+  });
+
   it('re-checks staleness on visibilitychange and surfaces the auto-finished dialog', async () => {
     const sessionInfo = {
       sessionId: 'session-stale-on-return',

--- a/packages/web/app/components/persistent-session/hooks/use-queue-storage.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-queue-storage.ts
@@ -9,7 +9,7 @@ import { type ActiveSessionInfo, ACTIVE_SESSION_KEY, DEBUG } from '../types';
 
 type UseQueueStorageArgs = {
   activeSession: ActiveSessionInfo | null;
-  setActiveSession: (val: ActiveSessionInfo | null) => void;
+  setActiveSession: (val: ActiveSessionInfo) => void;
   /** Called when a restored session was already auto-finished by the backend */
   onSessionAutoFinished: (summary: SessionSummary, boardType: string | null) => void;
   wsAuthToken: string | null;

--- a/packages/web/app/components/persistent-session/persistent-session-context.tsx
+++ b/packages/web/app/components/persistent-session/persistent-session-context.tsx
@@ -127,8 +127,8 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
   // open a race window between `isAuthLoading` flipping false and
   // `hasRunPreflightRef` being set.
   const handleQueueStorageSetActiveSession = useCallback(
-    (val: ActiveSessionInfo | null) => {
-      if (val) lifecycle.activateSession(val);
+    (val: ActiveSessionInfo) => {
+      lifecycle.activateSession(val);
     },
     [lifecycle.activateSession],
   );

--- a/packages/web/app/components/persistent-session/persistent-session-context.tsx
+++ b/packages/web/app/components/persistent-session/persistent-session-context.tsx
@@ -122,12 +122,21 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
     refs,
   });
 
+  // Stable wrapper: the queue-storage restore effect lists this in its dep
+  // array, so a fresh inline arrow each render would re-fire the effect and
+  // open a race window between `isAuthLoading` flipping false and
+  // `hasRunPreflightRef` being set.
+  const handleQueueStorageSetActiveSession = useCallback(
+    (val: ActiveSessionInfo | null) => {
+      if (val) lifecycle.activateSession(val);
+    },
+    [lifecycle.activateSession],
+  );
+
   // 3. Queue storage: in-memory local queue state
   const queueStorage = useQueueStorage({
     activeSession: lifecycle.activeSession,
-    setActiveSession: (val) => {
-      if (val) lifecycle.activateSession(val);
-    },
+    setActiveSession: handleQueueStorageSetActiveSession,
     onSessionAutoFinished: lifecycle.setAutoFinishedSummary,
     wsAuthToken,
     isAuthLoading,


### PR DESCRIPTION
## Summary

Two small follow-ups from review feedback:

- **`persistent-session-context.tsx`**: The arrow passed as `setActiveSession` to `useQueueStorage` created a new reference on every render, which destabilized the restore effect's dep array in `use-queue-storage.ts:85`. Between `isAuthLoading` flipping false and `hasRunPreflightRef.current` being set, concurrent `restoreState` calls could race past the existing guards. Wrap it in `useCallback` (keyed on `lifecycle.activateSession`, which is already memoized) to close that window.
- **`session-discovery.ts`**: Expand the comment above `INACTIVITY_SWEEP_LOCK_KEY = 19551850` to document a reserved range (`19550000–19559999`, derived from issue #1955) so any future advisory locks added to the backend have a documented place to land without accidental collisions.

No behavior change beyond removing the race window; the lock-key change is comment-only.

## Test plan

- [ ] `vp check` passes
- [ ] `vp run typecheck` passes
- [ ] Manually verify: app load with a persisted active-session restores correctly (auth resolved → token present)
- [ ] Manually verify: app load while signed-out then signing in still triggers the auto-finished pre-flight exactly once

https://claude.ai/code/session_01UdNCnQEvaqbHNNHg1iHNc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdNCnQEvaqbHNNHg1iHNc9)_