### PR TITLE
perf(list): lazy-load below-fold climb thumbnails

### DIFF
--- a/packages/web/app/components/board-renderer/__tests__/board-image-layers.test.tsx
+++ b/packages/web/app/components/board-renderer/__tests__/board-image-layers.test.tsx
@@ -143,4 +143,54 @@ describe('BoardImageLayers', () => {
     expect(img.getAttribute('width')).toBe('1080');
     expect(img.getAttribute('height')).toBe('1350');
   });
+
+  describe('loading attribute', () => {
+    it('lazy on thumbnails without fetchPriority=high (climb-list use case)', () => {
+      const { container } = render(
+        <BoardImageLayers boardDetails={mockBoardDetails} frames="p1r42" mirrored={false} thumbnail />,
+      );
+      expect(container.querySelector('img')!.getAttribute('loading')).toBe('lazy');
+    });
+
+    it('eager on thumbnails when fetchPriority=high (LCP thumbnail)', () => {
+      const { container } = render(
+        <BoardImageLayers
+          boardDetails={mockBoardDetails}
+          frames="p1r42"
+          mirrored={false}
+          thumbnail
+          fetchPriority="high"
+        />,
+      );
+      expect(container.querySelector('img')!.getAttribute('loading')).toBeNull();
+    });
+
+    it('eager on non-thumbnail (full-board) renders regardless of fetchPriority', () => {
+      // climb-card-cover and swipe-board-carousel render full-size without
+      // fetchPriority and are typically the in-viewport LCP target.
+      const { container } = render(
+        <BoardImageLayers boardDetails={mockBoardDetails} frames="p1r42" mirrored={false} />,
+      );
+      expect(container.querySelector('img')!.getAttribute('loading')).toBeNull();
+    });
+
+    it('eager on non-thumbnail background-only renders', () => {
+      const { container } = render(<BoardImageLayers boardDetails={mockBoardDetails} mirrored={false} />);
+      container.querySelectorAll('img').forEach((img) => {
+        expect(img.getAttribute('loading')).toBeNull();
+      });
+    });
+
+    it('first background image is eager when thumbnail + fetchPriority=high', () => {
+      const { container } = render(
+        <BoardImageLayers boardDetails={mockBoardDetails} mirrored={false} thumbnail fetchPriority="high" />,
+      );
+      const imgs = container.querySelectorAll('img');
+      expect(imgs[0].getAttribute('loading')).toBeNull();
+      // Subsequent background layers stay lazy.
+      for (let i = 1; i < imgs.length; i++) {
+        expect(imgs[i].getAttribute('loading')).toBe('lazy');
+      }
+    });
+  });
 });

--- a/packages/web/app/components/board-renderer/board-image-layers.tsx
+++ b/packages/web/app/components/board-renderer/board-image-layers.tsx
@@ -95,6 +95,7 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
           height={imgHeight}
           style={imgStyle}
           fetchPriority={fetchPriority}
+          loading={fetchPriority === 'high' ? undefined : 'lazy'}
           onError={handleOverlayError}
         />
       ) : (
@@ -109,6 +110,7 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
             height={imgHeight}
             style={imgStyle}
             fetchPriority={i === 0 ? fetchPriority : undefined}
+            loading={i === 0 && fetchPriority === 'high' ? undefined : 'lazy'}
           />
         ))
       )}

--- a/packages/web/app/components/board-renderer/board-image-layers.tsx
+++ b/packages/web/app/components/board-renderer/board-image-layers.tsx
@@ -95,7 +95,7 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
           height={imgHeight}
           style={imgStyle}
           fetchPriority={fetchPriority}
-          loading={fetchPriority === 'high' ? undefined : 'lazy'}
+          loading={thumbnail && fetchPriority !== 'high' ? 'lazy' : undefined}
           onError={handleOverlayError}
         />
       ) : (
@@ -110,7 +110,7 @@ const BoardImageLayers = React.memo(function BoardImageLayers({
             height={imgHeight}
             style={imgStyle}
             fetchPriority={i === 0 ? fetchPriority : undefined}
-            loading={i === 0 && fetchPriority === 'high' ? undefined : 'lazy'}
+            loading={thumbnail && !(i === 0 && fetchPriority === 'high') ? 'lazy' : undefined}
           />
         ))
       )}


### PR DESCRIPTION
## Summary

Mobile RES on `/[board]/.../list` is 50 (LCP 4.38s p75). Root cause: React 19's float-preload tracking auto-emits `<link rel=preload as=image>` for every `<img>` rendered during SSR. The list ships 18 SSR'd climb thumbnails, so 21 preload links land in `<head>` and compete for HTTP/2 streams on mobile — starving the actual LCP image.

This change marks non-LCP `<img>` as `loading="lazy"`. React skips preload tracking for lazy images, so SSR preload count drops 21 → ~3.

## Test plan

- [ ] `vp check` clean
- [ ] `vp run typecheck:web` clean
- [ ] `vp test --project web -- board-image-layers` passes
- [ ] On dev or preview: view-source on `/list` page → only 2-3 `<link rel="preload">` tags in `<head>`
- [ ] LCP image (first climb card) still loads with high priority — verify in DevTools network panel
- [ ] Visual: scroll the climb list on mobile — below-fold thumbnails load progressively without visible jank