### PR TITLE
perf(list): trim SSR initial climb count on page=0

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
@@ -8,7 +8,7 @@ import BoardPageClimbsList from '@/app/components/board-page/board-page-climbs-l
 import { cachedSearchClimbs } from '@/app/lib/db/queries/climbs/search-climbs';
 import { hasUserSpecificFilters } from '@/app/lib/list-page-cache';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
-import { MAX_PAGE_SIZE } from '@/app/components/board-page/constants';
+import { MAX_PAGE_SIZE, SSR_INITIAL_PAGE_SIZE } from '@/app/components/board-page/constants';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/lib/auth/auth-options';
 import { scheduleOverlayWarming } from '@/app/lib/warm-overlay-cache';
@@ -56,13 +56,17 @@ export default async function DynamicResultsPage(props: {
 
   const searchParamsObject: SearchRequestPagination = parsedRouteSearchParamsToSearchParams(searchParams);
 
-  // For the SSR version we increase the pageSize so it also gets whatever page number
-  // is in the search params. Without this, it would load the SSR version of the page on page 2
-  // which would then flicker once SWR runs on the client.
-  const requestedPageSize = (Number(searchParamsObject.page) + 1) * Number(searchParamsObject.pageSize);
-
-  // Enforce max page size to prevent excessive database queries
-  searchParamsObject.pageSize = Math.min(requestedPageSize, MAX_PAGE_SIZE);
+  const requestedPage = Number(searchParamsObject.page);
+  if (requestedPage === 0) {
+    // First-viewport SSR: ship a small initial batch and let SWR fetch the rest.
+    searchParamsObject.pageSize = SSR_INITIAL_PAGE_SIZE;
+  } else {
+    // page>0 (deep-link): aggregate pages 0..N so SSR matches what SWR will
+    // fetch, preventing a flicker as cached pages backfill. Enforce max page
+    // size to prevent excessive database queries.
+    const requestedPageSize = (requestedPage + 1) * Number(searchParamsObject.pageSize);
+    searchParamsObject.pageSize = Math.min(requestedPageSize, MAX_PAGE_SIZE);
+  }
   searchParamsObject.page = 0;
 
   const hasProgressFilters = hasUserSpecificFilters(searchParamsObject);

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
@@ -8,7 +8,7 @@ import BoardPageClimbsList from '@/app/components/board-page/board-page-climbs-l
 import { cachedSearchClimbs } from '@/app/lib/db/queries/climbs/search-climbs';
 import { hasUserSpecificFilters } from '@/app/lib/list-page-cache';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
-import { MAX_PAGE_SIZE, SSR_INITIAL_PAGE_SIZE } from '@/app/components/board-page/constants';
+import { resolveSsrInitialPageSize } from '@/app/components/board-page/constants';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/lib/auth/auth-options';
 import { scheduleOverlayWarming } from '@/app/lib/warm-overlay-cache';
@@ -56,17 +56,10 @@ export default async function DynamicResultsPage(props: {
 
   const searchParamsObject: SearchRequestPagination = parsedRouteSearchParamsToSearchParams(searchParams);
 
-  const requestedPage = Number(searchParamsObject.page);
-  if (requestedPage === 0) {
-    // First-viewport SSR: ship a small initial batch and let SWR fetch the rest.
-    searchParamsObject.pageSize = SSR_INITIAL_PAGE_SIZE;
-  } else {
-    // page>0 (deep-link): aggregate pages 0..N so SSR matches what SWR will
-    // fetch, preventing a flicker as cached pages backfill. Enforce max page
-    // size to prevent excessive database queries.
-    const requestedPageSize = (requestedPage + 1) * Number(searchParamsObject.pageSize);
-    searchParamsObject.pageSize = Math.min(requestedPageSize, MAX_PAGE_SIZE);
-  }
+  searchParamsObject.pageSize = resolveSsrInitialPageSize(
+    Number(searchParamsObject.page),
+    Number(searchParamsObject.pageSize),
+  );
   searchParamsObject.page = 0;
 
   const hasProgressFilters = hasUserSpecificFilters(searchParamsObject);
@@ -127,7 +120,12 @@ export default async function DynamicResultsPage(props: {
   return (
     <>
       {preloadUrl && <link rel="preload" as="image" href={preloadUrl} fetchPriority="high" />}
-      <BoardPageClimbsList {...parsedParams} boardDetails={boardDetails} initialClimbs={searchResponse.climbs} />
+      <BoardPageClimbsList
+        {...parsedParams}
+        boardDetails={boardDetails}
+        initialClimbs={searchResponse.climbs}
+        initialHasMore={searchResponse.hasMore}
+      />
     </>
   );
 }

--- a/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
@@ -8,7 +8,7 @@ import BoardPageClimbsList from '@/app/components/board-page/board-page-climbs-l
 import { cachedSearchClimbs } from '@/app/lib/db/queries/climbs/search-climbs';
 import { hasUserSpecificFilters } from '@/app/lib/list-page-cache';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
-import { MAX_PAGE_SIZE, SSR_INITIAL_PAGE_SIZE } from '@/app/components/board-page/constants';
+import { resolveSsrInitialPageSize } from '@/app/components/board-page/constants';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/lib/auth/auth-options';
 import { scheduleOverlayWarming } from '@/app/lib/warm-overlay-cache';
@@ -65,16 +65,10 @@ export default async function BoardSlugListPage(props: BoardSlugListPageProps) {
   const parsedParams = boardToRouteParams(board, Number(params.angle));
   const searchParamsObject: SearchRequestPagination = parsedRouteSearchParamsToSearchParams(searchParams);
 
-  const requestedPage = Number(searchParamsObject.page);
-  if (requestedPage === 0) {
-    // First-viewport SSR: ship a small initial batch and let SWR fetch the rest.
-    searchParamsObject.pageSize = SSR_INITIAL_PAGE_SIZE;
-  } else {
-    // page>0 (deep-link): aggregate pages 0..N so SSR matches what SWR will
-    // fetch, preventing a flicker as cached pages backfill.
-    const requestedPageSize = (requestedPage + 1) * Number(searchParamsObject.pageSize);
-    searchParamsObject.pageSize = Math.min(requestedPageSize, MAX_PAGE_SIZE);
-  }
+  searchParamsObject.pageSize = resolveSsrInitialPageSize(
+    Number(searchParamsObject.page),
+    Number(searchParamsObject.pageSize),
+  );
   searchParamsObject.page = 0;
 
   const hasProgressFilters = hasUserSpecificFilters(searchParamsObject);
@@ -126,7 +120,12 @@ export default async function BoardSlugListPage(props: BoardSlugListPageProps) {
   return (
     <>
       {preloadUrl && <link rel="preload" as="image" href={preloadUrl} fetchPriority="high" />}
-      <BoardPageClimbsList {...parsedParams} boardDetails={boardDetails} initialClimbs={searchResponse.climbs} />
+      <BoardPageClimbsList
+        {...parsedParams}
+        boardDetails={boardDetails}
+        initialClimbs={searchResponse.climbs}
+        initialHasMore={searchResponse.hasMore}
+      />
     </>
   );
 }

--- a/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
@@ -8,7 +8,7 @@ import BoardPageClimbsList from '@/app/components/board-page/board-page-climbs-l
 import { cachedSearchClimbs } from '@/app/lib/db/queries/climbs/search-climbs';
 import { hasUserSpecificFilters } from '@/app/lib/list-page-cache';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
-import { MAX_PAGE_SIZE } from '@/app/components/board-page/constants';
+import { MAX_PAGE_SIZE, SSR_INITIAL_PAGE_SIZE } from '@/app/components/board-page/constants';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/lib/auth/auth-options';
 import { scheduleOverlayWarming } from '@/app/lib/warm-overlay-cache';
@@ -65,8 +65,16 @@ export default async function BoardSlugListPage(props: BoardSlugListPageProps) {
   const parsedParams = boardToRouteParams(board, Number(params.angle));
   const searchParamsObject: SearchRequestPagination = parsedRouteSearchParamsToSearchParams(searchParams);
 
-  const requestedPageSize = (Number(searchParamsObject.page) + 1) * Number(searchParamsObject.pageSize);
-  searchParamsObject.pageSize = Math.min(requestedPageSize, MAX_PAGE_SIZE);
+  const requestedPage = Number(searchParamsObject.page);
+  if (requestedPage === 0) {
+    // First-viewport SSR: ship a small initial batch and let SWR fetch the rest.
+    searchParamsObject.pageSize = SSR_INITIAL_PAGE_SIZE;
+  } else {
+    // page>0 (deep-link): aggregate pages 0..N so SSR matches what SWR will
+    // fetch, preventing a flicker as cached pages backfill.
+    const requestedPageSize = (requestedPage + 1) * Number(searchParamsObject.pageSize);
+    searchParamsObject.pageSize = Math.min(requestedPageSize, MAX_PAGE_SIZE);
+  }
   searchParamsObject.page = 0;
 
   const hasProgressFilters = hasUserSpecificFilters(searchParamsObject);

--- a/packages/web/app/components/board-page/__tests__/ssr-initial-page-size.test.ts
+++ b/packages/web/app/components/board-page/__tests__/ssr-initial-page-size.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { MAX_PAGE_SIZE, SSR_INITIAL_PAGE_SIZE, resolveSsrInitialPageSize } from '../constants';
+
+describe('resolveSsrInitialPageSize', () => {
+  it('returns the small initial batch on page=0 with a default page size', () => {
+    expect(resolveSsrInitialPageSize(0, 20)).toBe(SSR_INITIAL_PAGE_SIZE);
+  });
+
+  it('caps page=0 to SSR_INITIAL_PAGE_SIZE even if a larger page size is requested', () => {
+    expect(resolveSsrInitialPageSize(0, 50)).toBe(SSR_INITIAL_PAGE_SIZE);
+  });
+
+  it('aggregates pages 0..N for page>0 (deep-link)', () => {
+    expect(resolveSsrInitialPageSize(1, 20)).toBe(40);
+  });
+
+  it('caps the aggregated size at MAX_PAGE_SIZE when the request would exceed it', () => {
+    // (3 + 1) * 30 = 120 > MAX_PAGE_SIZE (100)
+    expect(resolveSsrInitialPageSize(3, 30)).toBe(MAX_PAGE_SIZE);
+  });
+
+  it('returns the exact aggregated size when under MAX_PAGE_SIZE', () => {
+    // (2 + 1) * 10 = 30
+    expect(resolveSsrInitialPageSize(2, 10)).toBe(30);
+  });
+});

--- a/packages/web/app/components/board-page/board-page-climbs-list.tsx
+++ b/packages/web/app/components/board-page/board-page-climbs-list.tsx
@@ -10,11 +10,13 @@ import AngleSelector from './angle-selector';
 type BoardPageClimbsListProps = ParsedBoardRouteParameters & {
   boardDetails: BoardDetails;
   initialClimbs: Climb[];
+  initialHasMore?: boolean;
 };
 
 const BoardPageClimbsList = ({
   boardDetails,
   initialClimbs,
+  initialHasMore = false,
   board_name,
   layout_id: _layout_id,
   size_id: _size_id,
@@ -70,7 +72,7 @@ const BoardPageClimbsList = ({
       climbs={climbs}
       selectedClimbUuid={currentClimb?.uuid}
       isFetching={isFetchingClimbs}
-      hasMore={hasMoreResults}
+      hasMore={!hasDoneFirstFetch ? initialHasMore : hasMoreResults}
       onClimbSelect={setCurrentClimb}
       addToQueue={addToQueue}
       onLoadMore={fetchMoreClimbs}

--- a/packages/web/app/components/board-page/constants.ts
+++ b/packages/web/app/components/board-page/constants.ts
@@ -1,6 +1,15 @@
 export const PAGE_LIMIT = 20;
 export const MAX_PAGE_SIZE = 100; // Maximum page size to prevent excessive database queries
 
+/**
+ * On page=0 SSR (the default landing case), we only need enough climbs to
+ * fill the first viewport — SWR fetches the rest after hydration. Shipping
+ * fewer climbs in the SSR HTML/RSC payload speeds up mobile parse time.
+ * Roughly one viewport of cards: keep it small but big enough that a fast
+ * mobile scroll doesn't outrun SWR's first fetch.
+ */
+export const SSR_INITIAL_PAGE_SIZE = 10;
+
 // Threshold for proactive fetching of suggestions
 // When suggestedClimbs falls below this, we fetch more automatically
 // Set to 10 to keep a healthy buffer of suggestions available

--- a/packages/web/app/components/board-page/constants.ts
+++ b/packages/web/app/components/board-page/constants.ts
@@ -10,6 +10,23 @@ export const MAX_PAGE_SIZE = 100; // Maximum page size to prevent excessive data
  */
 export const SSR_INITIAL_PAGE_SIZE = 10;
 
+/**
+ * Resolves the SSR pageSize for the climb list pages.
+ *
+ * On page=0 (the default landing case) we ship a small initial batch
+ * (SSR_INITIAL_PAGE_SIZE) so the HTML/RSC payload stays light — SWR fetches
+ * the rest after hydration.
+ *
+ * On page>0 (deep-link to a paginated result) we aggregate pages 0..N into a
+ * single SSR fetch so the rendered list matches what SWR will reconstruct
+ * client-side, preventing a flicker as cached pages backfill. We cap the
+ * aggregated size at MAX_PAGE_SIZE to prevent excessive database queries.
+ */
+export function resolveSsrInitialPageSize(requestedPage: number, requestedPageSize: number): number {
+  if (requestedPage === 0) return SSR_INITIAL_PAGE_SIZE;
+  return Math.min((requestedPage + 1) * requestedPageSize, MAX_PAGE_SIZE);
+}
+
 // Threshold for proactive fetching of suggestions
 // When suggestedClimbs falls below this, we fetch more automatically
 // Set to 10 to keep a healthy buffer of suggestions available


### PR DESCRIPTION
## Summary

The list page SSRs `(page + 1) * pageSize` climbs to prevent flicker on deep-linked `page=N` loads. For the common `page=0` case (where SWR starts at page 0 anyway), that ships up to 20 climbs of RSC payload to mobile — far more than the ~5 cards that fit in the first viewport.

Cap SSR to `SSR_INITIAL_PAGE_SIZE = 10` on `page=0`; keep the existing aggregation for `page>0` so deep-linked loads still avoid the flicker.

Expected impact: ~30-40% smaller RSC payload on the common case, faster mobile parse.

## Test plan

- [ ] `vp check` clean
- [ ] `vp run typecheck:web` clean
- [ ] `vp test --project web` passes
- [ ] On preview: `/[board]/.../list` SSRs 10 climbs (count `data-testid="climb-thumbnail"` in source); SWR backfills page 1 within ~1s
- [ ] On preview: `/[board]/.../list?page=2` still SSRs 60 climbs (existing aggregation behavior)
- [ ] No visible flicker on either path