### PR TITLE
perf(list): stabilize --bottom-bar-height to cut CLS

### DIFF
--- a/packages/web/app/components/index.css
+++ b/packages/web/app/components/index.css
@@ -117,10 +117,16 @@
 
   /* Layout */
   --global-header-height: calc(max(8dvh, 48px) + var(--safe-area-inset-top));
-  /* Matches the SSR-rendered bottom-bar wrapper height on board routes:
-     queue-control shell (~85px: session header strip + main row) + tab bar (~60px).
-     JS in persistent-session-wrapper measures the actual height post-hydration. */
-  --bottom-bar-height: calc(145px + var(--safe-area-inset-bottom));
+  /* Reserved height for the fixed bottom bar (queue control + tab bar).
+     Layouts pad pages by this much so content isn't occluded.
+     The default reserves space matching the queue-shell + tab-bar render;
+     JS in persistent-session-wrapper publishes a measured value into
+     --bottom-bar-height-measured. CSS max() picks whichever is larger,
+     so the reserved height never *shrinks* after hydration (the dominant
+     CLS source on mobile p75). */
+  --bottom-bar-height-default: calc(145px + var(--safe-area-inset-bottom));
+  --bottom-bar-height-measured: 0px;
+  --bottom-bar-height: max(var(--bottom-bar-height-default), var(--bottom-bar-height-measured));
 
   /* Tap highlight (Android/mobile browsers) */
   --tap-highlight: transparent;

--- a/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
+++ b/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
@@ -248,7 +248,7 @@ describe('RootBottomBar --bottom-bar-height measurement', () => {
     mockQueueContext = { queue: [], currentClimb: null };
 
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
-    document.documentElement.style.removeProperty('--bottom-bar-height');
+    document.documentElement.style.removeProperty('--bottom-bar-height-measured');
 
     // Stub getBoundingClientRect at the prototype level so the initial
     // measurement on mount is deterministic (jsdom otherwise returns all
@@ -281,15 +281,15 @@ describe('RootBottomBar --bottom-bar-height measurement', () => {
   afterEach(() => {
     globalThis.ResizeObserver = originalResizeObserver;
     HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
-    document.documentElement.style.removeProperty('--bottom-bar-height');
+    document.documentElement.style.removeProperty('--bottom-bar-height-measured');
     vi.restoreAllMocks();
   });
 
-  it('grows --bottom-bar-height when the measured occlusion exceeds the current value', () => {
-    // Seed the CSS default so the layout effect starts from a known baseline.
-    // 145px matches the SSR default in index.css for the no-queue + tab-bar
-    // case; measurements below this should be ignored (grow-only).
-    document.documentElement.style.setProperty('--bottom-bar-height', '145px');
+  it('grows --bottom-bar-height-measured when the measured occlusion exceeds the last published value', () => {
+    // Seed a baseline measured value so the layout effect starts from a known
+    // floor. The CSS default lives separately in --bottom-bar-height-default;
+    // JS now only tracks its own published measurement.
+    document.documentElement.style.setProperty('--bottom-bar-height-measured', '145px');
 
     const { rerender } = render(<RootBottomBar boardConfigs={mockBoardConfigs} />);
 
@@ -298,19 +298,19 @@ describe('RootBottomBar --bottom-bar-height measurement', () => {
     act(() => {
       resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
     });
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height-measured')).toBe('200px');
 
     // Sanity: rerender keeps the value stable.
     rerender(<RootBottomBar boardConfigs={mockBoardConfigs} />);
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height-measured')).toBe('200px');
   });
 
-  it('never shrinks --bottom-bar-height after hydration', () => {
-    // Seed an already-large value (mimicking the CSS default reserving space
-    // for the queue-control bar). The measured occlusion on the no-queue
-    // path is smaller, but we must not shrink — that would shift every
-    // page's padding-bottom and is the dominant CLS source.
-    document.documentElement.style.setProperty('--bottom-bar-height', '200px');
+  it('never shrinks --bottom-bar-height-measured after hydration', () => {
+    // Seed an already-large measured value. The grow-only guard in JS must
+    // ignore smaller occlusion readings — CSS max() with --default handles
+    // the floor independently, but the measured channel itself should also
+    // be monotonic to avoid bouncing under jitter.
+    document.documentElement.style.setProperty('--bottom-bar-height-measured', '200px');
 
     render(<RootBottomBar boardConfigs={mockBoardConfigs} />);
 
@@ -319,25 +319,25 @@ describe('RootBottomBar --bottom-bar-height measurement', () => {
     act(() => {
       resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
     });
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height-measured')).toBe('200px');
 
     // 800 - 650 = 150px, still smaller — ignored.
     setWrapperTop(650);
     act(() => {
       resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
     });
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height-measured')).toBe('200px');
 
     // 800 - 550 = 250px, exceeds 200px — grow.
     setWrapperTop(550);
     act(() => {
       resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
     });
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('250px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height-measured')).toBe('250px');
   });
 
   it('ignores growth within the 2px jitter tolerance', () => {
-    document.documentElement.style.setProperty('--bottom-bar-height', '200px');
+    document.documentElement.style.setProperty('--bottom-bar-height-measured', '200px');
 
     render(<RootBottomBar boardConfigs={mockBoardConfigs} />);
 
@@ -346,7 +346,7 @@ describe('RootBottomBar --bottom-bar-height measurement', () => {
     act(() => {
       resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
     });
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height-measured')).toBe('200px');
 
     // 800 - 598 = 202px — exactly at the tolerance ceiling (currentPx + 2);
     // ignored because the guard requires strictly greater than currentPx + 2.
@@ -354,21 +354,21 @@ describe('RootBottomBar --bottom-bar-height measurement', () => {
     act(() => {
       resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
     });
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height-measured')).toBe('200px');
 
     // 800 - 597 = 203px — exceeds tolerance, grow.
     setWrapperTop(597);
     act(() => {
       resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
     });
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('203px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height-measured')).toBe('203px');
   });
 
-  it('removes --bottom-bar-height and detaches resize listeners on unmount', () => {
+  it('removes --bottom-bar-height-measured and detaches resize listeners on unmount', () => {
     const removeWindowSpy = vi.spyOn(window, 'removeEventListener');
     const removeViewportSpy = window.visualViewport ? vi.spyOn(window.visualViewport, 'removeEventListener') : null;
 
-    document.documentElement.style.setProperty('--bottom-bar-height', '145px');
+    document.documentElement.style.setProperty('--bottom-bar-height-measured', '145px');
 
     const { unmount } = render(<RootBottomBar boardConfigs={mockBoardConfigs} />);
 
@@ -376,11 +376,11 @@ describe('RootBottomBar --bottom-bar-height measurement', () => {
     act(() => {
       resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
     });
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height-measured')).toBe('200px');
 
     unmount();
 
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height-measured')).toBe('');
     expect(removeWindowSpy).toHaveBeenCalledWith('resize', expect.any(Function));
     if (removeViewportSpy) {
       expect(removeViewportSpy).toHaveBeenCalledWith('resize', expect.any(Function));

--- a/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
+++ b/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
@@ -305,6 +305,19 @@ describe('RootBottomBar --bottom-bar-height measurement', () => {
     expect(document.documentElement.style.getPropertyValue('--bottom-bar-height-measured')).toBe('200px');
   });
 
+  it('publishes the first measurement on mount when --bottom-bar-height-measured is unset', () => {
+    // No pre-seed: the inline-style override starts empty, so parseFloat reads
+    // 0. The grow-only guard (px > measured + 2) must still fire on the
+    // initial mount measurement so the first published value reflects the
+    // real occlusion — otherwise the page would render against the CSS
+    // default forever, missing any case where the rendered bar exceeds it.
+    mockedTop = 620; // 800 - 620 = 180px initial occlusion
+
+    render(<RootBottomBar boardConfigs={mockBoardConfigs} />);
+
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height-measured')).toBe('180px');
+  });
+
   it('never shrinks --bottom-bar-height-measured after hydration', () => {
     // Seed an already-large measured value. The grow-only guard in JS must
     // ignore smaller occlusion readings — CSS max() with --default handles

--- a/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
+++ b/packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx
@@ -216,9 +216,12 @@ describe('RootBottomBar', () => {
 
 describe('RootBottomBar --bottom-bar-height measurement', () => {
   let resizeCallbacks: ResizeObserverCallback[] = [];
+  let mockedTop = 0;
   const originalResizeObserver = globalThis.ResizeObserver;
+  const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
 
   const setWrapperTop = (top: number) => {
+    mockedTop = top;
     const wrapper = screen.getByTestId('bottom-bar-wrapper');
     vi.spyOn(wrapper, 'getBoundingClientRect').mockReturnValue({
       top,
@@ -235,6 +238,7 @@ describe('RootBottomBar --bottom-bar-height measurement', () => {
 
   beforeEach(() => {
     resizeCallbacks = [];
+    mockedTop = 800; // Default: wrapper at viewport bottom → px = 0
     mockPathname = '/';
     mockQueueBridgeBoardInfo = {
       boardDetails: null,
@@ -245,6 +249,23 @@ describe('RootBottomBar --bottom-bar-height measurement', () => {
 
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
     document.documentElement.style.removeProperty('--bottom-bar-height');
+
+    // Stub getBoundingClientRect at the prototype level so the initial
+    // measurement on mount is deterministic (jsdom otherwise returns all
+    // zeros, which would compute px = 800 and lock out grow-only updates).
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      return {
+        top: mockedTop,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: mockedTop,
+        toJSON: () => ({}),
+      } as DOMRect;
+    };
 
     class MockResizeObserver {
       constructor(cb: ResizeObserverCallback) {
@@ -259,37 +280,55 @@ describe('RootBottomBar --bottom-bar-height measurement', () => {
 
   afterEach(() => {
     globalThis.ResizeObserver = originalResizeObserver;
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
     document.documentElement.style.removeProperty('--bottom-bar-height');
     vi.restoreAllMocks();
   });
 
-  it('publishes --bottom-bar-height on mount using viewportHeight - rect.top', () => {
+  it('grows --bottom-bar-height when the measured occlusion exceeds the current value', () => {
+    // Seed the CSS default so the layout effect starts from a known baseline.
+    // 145px matches the SSR default in index.css for the no-queue + tab-bar
+    // case; measurements below this should be ignored (grow-only).
+    document.documentElement.style.setProperty('--bottom-bar-height', '145px');
+
     const { rerender } = render(<RootBottomBar boardConfigs={mockBoardConfigs} />);
 
-    // First mount measures whatever jsdom reports for the wrapper rect.
-    // To assert the formula, override and rerender to retrigger the layout effect.
-    setWrapperTop(620);
+    // viewportHeight - rect.top = 800 - 600 = 200px, which exceeds 145px.
+    setWrapperTop(600);
     act(() => {
-      // Trigger the ResizeObserver callback the effect registered on mount.
       resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
     });
-
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('180px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
 
     // Sanity: rerender keeps the value stable.
     rerender(<RootBottomBar boardConfigs={mockBoardConfigs} />);
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('180px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
   });
 
-  it('updates --bottom-bar-height when the wrapper resizes', () => {
+  it('never shrinks --bottom-bar-height after hydration', () => {
+    // Seed an already-large value (mimicking the CSS default reserving space
+    // for the queue-control bar). The measured occlusion on the no-queue
+    // path is smaller, but we must not shrink — that would shift every
+    // page's padding-bottom and is the dominant CLS source.
+    document.documentElement.style.setProperty('--bottom-bar-height', '200px');
+
     render(<RootBottomBar boardConfigs={mockBoardConfigs} />);
 
+    // 800 - 700 = 100px, smaller than the current 200px — ignored.
     setWrapperTop(700);
     act(() => {
       resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
     });
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('100px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
 
+    // 800 - 650 = 150px, still smaller — ignored.
+    setWrapperTop(650);
+    act(() => {
+      resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
+    });
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
+
+    // 800 - 550 = 250px, exceeds 200px — grow.
     setWrapperTop(550);
     act(() => {
       resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
@@ -297,17 +336,47 @@ describe('RootBottomBar --bottom-bar-height measurement', () => {
     expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('250px');
   });
 
+  it('ignores growth within the 2px jitter tolerance', () => {
+    document.documentElement.style.setProperty('--bottom-bar-height', '200px');
+
+    render(<RootBottomBar boardConfigs={mockBoardConfigs} />);
+
+    // 800 - 599 = 201px — only 1px more than current, within tolerance.
+    setWrapperTop(599);
+    act(() => {
+      resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
+    });
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
+
+    // 800 - 598 = 202px — exactly at the tolerance ceiling (currentPx + 2);
+    // ignored because the guard requires strictly greater than currentPx + 2.
+    setWrapperTop(598);
+    act(() => {
+      resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
+    });
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
+
+    // 800 - 597 = 203px — exceeds tolerance, grow.
+    setWrapperTop(597);
+    act(() => {
+      resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
+    });
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('203px');
+  });
+
   it('removes --bottom-bar-height and detaches resize listeners on unmount', () => {
     const removeWindowSpy = vi.spyOn(window, 'removeEventListener');
     const removeViewportSpy = window.visualViewport ? vi.spyOn(window.visualViewport, 'removeEventListener') : null;
 
+    document.documentElement.style.setProperty('--bottom-bar-height', '145px');
+
     const { unmount } = render(<RootBottomBar boardConfigs={mockBoardConfigs} />);
 
-    setWrapperTop(620);
+    setWrapperTop(600);
     act(() => {
       resizeCallbacks.forEach((cb) => cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver));
     });
-    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('180px');
+    expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('200px');
 
     unmount();
 

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -154,11 +154,23 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
   const hideTabBar = HIDE_TAB_BAR_PAGES.some((prefix) => pathname.startsWith(prefix)) && !hasActiveQueue;
   const shouldShowQueueShell = isBoardRoutePath(pathname) && !hasActiveQueue && !boardDetails;
 
-  // Measure the bottom bar's visual occlusion and expose it as --bottom-bar-height.
-  // Use viewportHeight - rect.top (not rect.height) so the iOS `bottom: 2dvh` offset
-  // and the BottomNavigation's negative-margin extension are both included.
-  // Prefer visualViewport.height over innerHeight so iOS keyboard / URL-bar collapse
-  // shrinks the published value as expected.
+  // Measure the bottom bar's visual occlusion and publish it into the
+  // sidecar --bottom-bar-height-measured custom property. The visible
+  // --bottom-bar-height is computed in CSS as
+  //   max(--bottom-bar-height-default, --bottom-bar-height-measured)
+  // so the reserved height never shrinks below the SSR default — CSS
+  // handles the never-shrink guarantee. JS only needs to track its own
+  // last-published measurement (read back via the inline-style override,
+  // which IS resolvable via parseFloat because it only ever contains
+  // `${px}px`; reading the composed --bottom-bar-height via
+  // getComputedStyle would return an unresolved calc()/max() string for
+  // unregistered custom properties).
+  //
+  // Use viewportHeight - rect.top (not rect.height) so the iOS
+  // `bottom: 2dvh` offset and the BottomNavigation's negative-margin
+  // extension are both included. Prefer visualViewport.height over
+  // innerHeight so iOS keyboard / URL-bar collapse shrinks the measured
+  // value as expected (CSS max() with the default still floors it).
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   useIsomorphicLayoutEffect(() => {
     const el = wrapperRef.current;
@@ -168,19 +180,15 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
       const viewportH = window.visualViewport?.height ?? window.innerHeight;
       const px = Math.max(0, viewportH - top);
 
-      // Only grow the reserved bottom-padding, never shrink it. Shrinking
-      // after hydration shifts every page's content downward and is the
-      // dominant CLS source on the list page (the CSS default reserves
-      // space for a queue-control bar; most users land without an active
-      // queue, so the measured occlusion is smaller). A 2px tolerance
-      // avoids ResizeObserver jitter (subpixel rounding from iOS URL bar
-      // / safe-area transitions). Shrinking is deferred to a full unmount
-      // (cleanup below removes the var so a re-mount re-applies the
-      // default).
-      const currentRaw = getComputedStyle(document.documentElement).getPropertyValue('--bottom-bar-height').trim();
-      const currentPx = Number.parseFloat(currentRaw) || 0;
-      if (px > currentPx + 2) {
-        document.documentElement.style.setProperty('--bottom-bar-height', `${px}px`);
+      // Track the largest occlusion we've observed and publish it into
+      // --bottom-bar-height-measured. CSS max(--default, --measured)
+      // ensures the reserved space never shrinks below the default — the
+      // dominant CLS source pre-fix. A 2px tolerance avoids ResizeObserver
+      // jitter that doesn't change visible layout.
+      const measuredRaw = document.documentElement.style.getPropertyValue('--bottom-bar-height-measured');
+      const measuredPx = Number.parseFloat(measuredRaw) || 0;
+      if (px > measuredPx + 2) {
+        document.documentElement.style.setProperty('--bottom-bar-height-measured', `${px}px`);
       }
     };
     update();
@@ -192,7 +200,7 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
       ro?.disconnect();
       window.removeEventListener('resize', update);
       window.visualViewport?.removeEventListener('resize', update);
-      document.documentElement.style.removeProperty('--bottom-bar-height');
+      document.documentElement.style.removeProperty('--bottom-bar-height-measured');
     };
   }, []);
 

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -167,7 +167,21 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
       const top = el.getBoundingClientRect().top;
       const viewportH = window.visualViewport?.height ?? window.innerHeight;
       const px = Math.max(0, viewportH - top);
-      document.documentElement.style.setProperty('--bottom-bar-height', `${px}px`);
+
+      // Only grow the reserved bottom-padding, never shrink it. Shrinking
+      // after hydration shifts every page's content downward and is the
+      // dominant CLS source on the list page (the CSS default reserves
+      // space for a queue-control bar; most users land without an active
+      // queue, so the measured occlusion is smaller). A 2px tolerance
+      // avoids ResizeObserver jitter (subpixel rounding from iOS URL bar
+      // / safe-area transitions). Shrinking is deferred to a full unmount
+      // (cleanup below removes the var so a re-mount re-applies the
+      // default).
+      const currentRaw = getComputedStyle(document.documentElement).getPropertyValue('--bottom-bar-height').trim();
+      const currentPx = Number.parseFloat(currentRaw) || 0;
+      if (px > currentPx + 2) {
+        document.documentElement.style.setProperty('--bottom-bar-height', `${px}px`);
+      }
     };
     update();
     const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(update) : null;


### PR DESCRIPTION
## Summary

Real-user mobile CLS on `/[board]/.../list` is **0.28** (target ≤ 0.1). The dominant culprit is the `--bottom-bar-height` CSS variable: the static CSS default reserves space for a queue-control bar, but most users land without an active queue. After hydration, the `ResizeObserver` in `persistent-session-wrapper.tsx` measures a smaller occlusion and **shrinks** the var, dragging every page's `padding-bottom` down and visibly shifting the climb list.

This PR:
- Makes the `update()` function in `persistent-session-wrapper.tsx` **grow-only** — never shrinks the reserved space after hydration. A 2px tolerance avoids ResizeObserver jitter.
- Leaves the CSS default at `145px + safe-area-inset-bottom` since the in-file comment documents that 145px already matches the SSR no-queue + tab-bar rendering. The grow-only guard alone neutralises the dominant CLS direction; if a measured device renders larger than 145px, the var still grows correctly.

The cleanup still removes the var on unmount, so re-mounting reapplies the default and downstream changes (queue activation mid-session) still get reflected by growing.

The existing layout-effect tests were updated to assert the new contract: growth above the current value is published, shrinkage and sub-3px jitter are ignored, and the var is still cleared on unmount.

## Test plan

- [ ] `vp check` clean (modulo pre-existing embedded/graphql lint+format issues on main, unaffected by this PR)
- [ ] `vp run typecheck:web` clean
- [ ] `vp test --project web -- persistent-session` passes (9/9)
- [ ] On dev: list page mobile (DevTools mobile emulation) — record performance; CLS should drop from ~0.28 to <0.1
- [ ] No regression: activate a queue from the list page → bar appears → `--bottom-bar-height` grows correctly, no content overlap
- [ ] iOS Safari URL-bar collapse / safe-area changes don't cause runaway jitter (2px tolerance absorbs sub-pixel rounding)