### PR TITLE
fix(auto-finish): use last_activity as session stop time

### DIFF
--- a/packages/backend/src/__tests__/end-stale-inactive-sessions.test.ts
+++ b/packages/backend/src/__tests__/end-stale-inactive-sessions.test.ts
@@ -14,20 +14,43 @@ function minutesAgo(minutes: number): Date {
 describe('endStaleInactiveSessions', () => {
   it('ends active, non-permanent sessions whose lastActivity is older than the threshold', async () => {
     const sessionId = uuidv4();
+    const lastActivity = minutesAgo(90);
     await db.insert(sessions).values({
       id: sessionId,
       boardPath: '/kilter/1/2/3/40',
       status: 'active',
       isPermanent: false,
-      lastActivity: minutesAgo(90),
+      lastActivity,
     });
 
     await endStaleInactiveSessions(ONE_HOUR_MS);
 
     const [row] = await db.select().from(sessions).where(eq(sessions.id, sessionId)).limit(1);
     expect(row?.status).toBe('ended');
-    expect(row?.endedAt).not.toBeNull();
-    expect(row?.lastActivity.getTime()).toBeGreaterThan(minutesAgo(1).getTime());
+    // endedAt mirrors the pre-sweep lastActivity so duration reflects when the
+    // user actually stopped, not when the sweep ran.
+    expect(row?.endedAt?.getTime()).toBe(lastActivity.getTime());
+    // lastActivity itself is not touched by the sweep.
+    expect(row?.lastActivity.getTime()).toBe(lastActivity.getTime());
+  });
+
+  it('uses the original lastActivity as endedAt even for sessions stale by hours', async () => {
+    const sessionId = uuidv4();
+    const lastActivity = minutesAgo(180);
+    await db.insert(sessions).values({
+      id: sessionId,
+      boardPath: '/kilter/1/2/3/40',
+      status: 'active',
+      isPermanent: false,
+      lastActivity,
+    });
+
+    await endStaleInactiveSessions(ONE_HOUR_MS);
+
+    const [row] = await db.select().from(sessions).where(eq(sessions.id, sessionId)).limit(1);
+    expect(row?.status).toBe('ended');
+    expect(row?.endedAt?.getTime()).toBe(lastActivity.getTime());
+    expect(row?.lastActivity.getTime()).toBe(lastActivity.getTime());
   });
 
   it('leaves permanent sessions untouched regardless of lastActivity', async () => {

--- a/packages/backend/src/services/room-manager/session-discovery.ts
+++ b/packages/backend/src/services/room-manager/session-discovery.ts
@@ -255,10 +255,12 @@ export async function endStaleInactiveSessions(thresholdMs: number): Promise<num
     }
 
     const cutoff = new Date(Date.now() - thresholdMs);
-    const now = new Date();
+    // endedAt mirrors the existing lastActivity so session duration reflects
+    // when the user actually stopped, not when the sweep ran. lastActivity is
+    // left untouched so the column keeps recording last-evidence going forward.
     const result = await tx
       .update(sessions)
-      .set({ status: 'ended', endedAt: now, lastActivity: now })
+      .set({ status: 'ended', endedAt: sql`${sessions.lastActivity}` })
       .where(and(eq(sessions.status, 'active'), eq(sessions.isPermanent, false), lt(sessions.lastActivity, cutoff)))
       .returning({ id: sessions.id });
     if (result.length > 0) {

--- a/packages/db/drizzle/0091_backfill_session_ended_at.sql
+++ b/packages/db/drizzle/0091_backfill_session_ended_at.sql
@@ -1,0 +1,46 @@
+-- Migration: Backfill board_sessions.ended_at from tick evidence.
+--
+-- Context:
+--   The auto-finish sweep (PR #1955) and the manual endSession() path both
+--   wrote ended_at = NOW() at the moment they ran. For auto-finished rows
+--   that's up to ~1 hour after the user actually stopped, so the
+--   session-summary duration (ended_at - started_at) is inflated. The
+--   forward fix uses last_activity as the new stop time, but past rows had
+--   last_activity clobbered to the same NOW() value, so we recover from
+--   MAX(boardsesh_ticks.climbed_at) instead.
+--
+-- What this does:
+--   For each status='ended' session with non-null ended_at, compute the
+--   greatest of (last climb time, started_at) and overwrite ended_at with
+--   that value when it's earlier than the currently-stored ended_at.
+--
+-- Safety / idempotency:
+--   - Skips rows where there is no evidence (no ticks AND null started_at).
+--   - Only writes when evidence_at < current ended_at, so re-running the
+--     migration is a no-op.
+--   - Clamps to started_at so ended_at can never be set before the session
+--     began.
+--   - Touches ended_at only; last_activity stays as-is.
+
+DO $$
+DECLARE
+  updated_count integer;
+BEGIN
+  UPDATE board_sessions b
+  SET ended_at = sub.evidence_at
+  FROM (
+    SELECT b2.id,
+           GREATEST(MAX(t.climbed_at)::timestamp, b2.started_at) AS evidence_at
+    FROM board_sessions b2
+    LEFT JOIN boardsesh_ticks t ON t.session_id = b2.id
+    WHERE b2.status = 'ended'
+      AND b2.ended_at IS NOT NULL
+    GROUP BY b2.id, b2.started_at
+  ) sub
+  WHERE b.id = sub.id
+    AND sub.evidence_at IS NOT NULL
+    AND sub.evidence_at < b.ended_at;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RAISE NOTICE 'Backfilled ended_at for % board_sessions rows', updated_count;
+END $$;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -638,6 +638,13 @@
       "when": 1778544098841,
       "tag": "0090_partial_shortcode_idx",
       "breakpoints": true
+    },
+    {
+      "idx": 91,
+      "version": "7",
+      "when": 1778976000000,
+      "tag": "0091_backfill_session_ended_at",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Auto-finish sweep was stamping `ended_at = NOW()` at sweep time, inflating `session-summary` durations by up to the 1h inactivity threshold. Mirror `ended_at` off the existing `last_activity` column instead and leave `last_activity` alone so it keeps recording last-evidence going forward.
- Migration `0091_backfill_session_ended_at.sql` corrects historical rows: for each `status='ended'` session it sets `ended_at = GREATEST(MAX(boardsesh_ticks.climbed_at), started_at)` when that's earlier than the currently-stored `ended_at`. `last_activity` on past rows was already clobbered to `NOW()` by the same write, so ticks are the strongest available evidence.

The manual `endSession()` path is untouched — when the user clicks "end", `NOW()` is the correct stop time.

## Test plan

- [x] `vp test --project backend run packages/backend/src/__tests__/end-stale-inactive-sessions.test.ts` — 6/6 passing, including a new case that verifies `ended_at` tracks the original `last_activity` for sessions stale by hours.
- [x] `vp run typecheck:backend` — clean.
- [x] `vp lint` + `vp fmt --check` on the touched files — clean.
- [x] Migration applied locally against the dev DB: `NOTICE: Backfilled ended_at for 10 board_sessions rows`. Re-running is a no-op (`Backfilled ended_at for 0`).
- [ ] Spot-check `sessionSummary.durationMinutes` for a known auto-finished session post-deploy — should reflect activity span, not start-to-sweep-time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)