### PR TITLE
feat(home): add recent beta videos slider

### DIFF
--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
 
 const {
   selectMock,
+  recentSelectMock,
   updateMock,
   fetchInstagramMetaMock,
   fetchTikTokMetaMock,
@@ -11,6 +12,7 @@ const {
   getPublicUrlMock,
 } = vi.hoisted(() => ({
   selectMock: vi.fn(),
+  recentSelectMock: vi.fn(),
   updateMock: vi.fn(),
   fetchInstagramMetaMock: vi.fn(),
   fetchTikTokMetaMock: vi.fn(),
@@ -22,11 +24,28 @@ const {
 
 vi.mock('../db/client', () => ({
   db: {
-    select: () => ({
-      from: () => ({
-        where: () => Promise.resolve(selectMock()),
-      }),
-    }),
+    select: (selection?: unknown) => {
+      // `betaLinks` runs `db.select().from(...).where(...)`; `recentBetaLinks`
+      // runs `db.select({ ... }).from(...).leftJoin(...).where(...).orderBy(...).limit(...)`.
+      // Branch on whether a projection is passed so each test mock returns
+      // the right shape.
+      const isProjected = selection !== undefined;
+      if (!isProjected) {
+        return {
+          from: () => ({
+            where: () => Promise.resolve(selectMock()),
+          }),
+        };
+      }
+      const chain = {
+        from: () => chain,
+        leftJoin: () => chain,
+        where: () => chain,
+        orderBy: () => chain,
+        limit: () => Promise.resolve(recentSelectMock()),
+      };
+      return chain;
+    },
     update: () => ({
       set: () => ({
         where: (...args: unknown[]) => {
@@ -228,5 +247,91 @@ describe('betaLinks resolver', () => {
       'https://p16-common-sign.tiktokcdn.com/x.jpg?x-expires=1',
     );
     expect(fetchInstagramMetaMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('recentBetaLinks resolver', () => {
+  beforeEach(() => {
+    recentSelectMock.mockReset();
+    fetchInstagramMetaMock.mockReset();
+    fetchTikTokMetaMock.mockReset();
+  });
+
+  function joinedRow(overrides: Partial<Row> = {}, climbName: string | null = 'Test Climb') {
+    return {
+      betaLink: row({
+        thumbnail: '/static/beta-link-thumbnails/instagram/ABC.jpg',
+        ...overrides,
+      }),
+      climbName,
+    };
+  }
+
+  it('returns wrapped rows with the joined climb name and source boardType', async () => {
+    recentSelectMock.mockReturnValueOnce([
+      joinedRow({ link: 'https://www.instagram.com/p/A/' }, 'Crimpy Mantle'),
+      joinedRow({ link: 'https://www.instagram.com/p/B/', boardType: 'tension' }, 'Steep Compression'),
+    ]);
+
+    const result = await betaLinkQueries.recentBetaLinks(undefined, { limit: 20 });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      climbName: 'Crimpy Mantle',
+      boardType: 'kilter',
+      betaLink: { link: 'https://www.instagram.com/p/A/' },
+    });
+    expect(result[1]).toMatchObject({ climbName: 'Steep Compression', boardType: 'tension' });
+  });
+
+  it('drops KayaClimb URLs', async () => {
+    recentSelectMock.mockReturnValueOnce([
+      joinedRow({ link: 'https://app.kayaclimb.com/share/post?id=1' }),
+      joinedRow({ link: 'https://www.instagram.com/p/A/' }, 'Project'),
+    ]);
+
+    const result = await betaLinkQueries.recentBetaLinks(undefined, { limit: 20 });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.climbName).toBe('Project');
+  });
+
+  it('tolerates a null climbName (beta link arrived before the climb synced)', async () => {
+    recentSelectMock.mockReturnValueOnce([joinedRow({}, null)]);
+
+    const result = await betaLinkQueries.recentBetaLinks(undefined, { limit: 20 });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.climbName).toBeNull();
+  });
+
+  it('passes thumbnails through unchanged when they are already on our static prefix', async () => {
+    const ourThumb = '/static/beta-link-thumbnails/instagram/ABC.jpg';
+    recentSelectMock.mockReturnValueOnce([joinedRow({ thumbnail: ourThumb })]);
+
+    const result = await betaLinkQueries.recentBetaLinks(undefined, { limit: 20 });
+
+    expect(result[0]?.betaLink.thumbnail).toBe(ourThumb);
+  });
+
+  it('never enriches via the live IG/TikTok APIs', async () => {
+    recentSelectMock.mockReturnValueOnce([
+      joinedRow({ link: 'https://www.instagram.com/p/A/' }),
+      joinedRow({ link: 'https://www.tiktok.com/@u/video/1' }),
+    ]);
+
+    await betaLinkQueries.recentBetaLinks(undefined, { limit: 20 });
+
+    expect(fetchInstagramMetaMock).not.toHaveBeenCalled();
+    expect(fetchTikTokMetaMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts the boardType filter without throwing', async () => {
+    recentSelectMock.mockReturnValueOnce([joinedRow({ boardType: 'kilter' })]);
+
+    const result = await betaLinkQueries.recentBetaLinks(undefined, { limit: 20, boardType: 'kilter' });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.boardType).toBe('kilter');
   });
 });

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -1,6 +1,6 @@
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, desc, isNotNull, like } from 'drizzle-orm';
 import { fetchInstagramMeta, getInstagramMediaId, isInstagramUrl } from '../../../lib/instagram-meta';
 import { fetchTikTokMeta, getTikTokCacheId, isTikTokUrl } from '../../../lib/tiktok-meta';
 import {
@@ -20,6 +20,20 @@ type BetaLinkResult = {
   isListed: boolean | null;
   createdAt: string | null;
 };
+
+type RecentBetaLinkResult = {
+  betaLink: BetaLinkResult;
+  climbName: string | null;
+  boardType: string;
+};
+
+// Mirrors STATIC_THUMBNAIL_PREFIX in ../../../lib/beta-link-thumbnails. Keep
+// the two in sync — the recentBetaLinks query uses a SQL LIKE filter to
+// pre-trim to rows that already have a cached S3 thumbnail, so the prefix
+// must match what isOurS3Url's static-prefix branch accepts.
+const STATIC_THUMBNAIL_PREFIX = '/static/beta-link-thumbnails/';
+const RECENT_BETA_LINKS_MAX_LIMIT = 50;
+const RECENT_BETA_LINKS_DEFAULT_LIMIT = 20;
 
 // We never surface KayaClimb beta links — we don't want to drive traffic to a
 // competing climbing app from our slider. Filter them out at the resolver.
@@ -221,5 +235,47 @@ export const betaLinkQueries = {
     const enriched = await Promise.all(rows.map((row) => limit(() => enrichRowSafe(row))));
 
     return enriched.filter((r): r is BetaLinkResult => r !== null);
+  },
+
+  // Powers the home-screen "Fresh beta" slider. We deliberately read only
+  // pre-cached rows here — fanning out the live IG/TikTok enrichment in
+  // `betaLinks` across the whole table is the failure mode this resolver
+  // exists to avoid.
+  recentBetaLinks: async (
+    _: unknown,
+    { limit, boardType }: { limit?: number | null; boardType?: string | null },
+  ): Promise<RecentBetaLinkResult[]> => {
+    const cappedLimit = Math.min(Math.max(limit ?? RECENT_BETA_LINKS_DEFAULT_LIMIT, 1), RECENT_BETA_LINKS_MAX_LIMIT);
+
+    // LEFT JOIN: beta links can land before their climb during sync, and we
+    // still want them in the slider — UI tolerates a null climbName.
+    const rows = await db
+      .select({ betaLink: dbSchema.boardBetaLinks, climbName: dbSchema.boardClimbs.name })
+      .from(dbSchema.boardBetaLinks)
+      .leftJoin(
+        dbSchema.boardClimbs,
+        and(
+          eq(dbSchema.boardBetaLinks.boardType, dbSchema.boardClimbs.boardType),
+          eq(dbSchema.boardBetaLinks.climbUuid, dbSchema.boardClimbs.uuid),
+        ),
+      )
+      .where(
+        and(
+          eq(dbSchema.boardBetaLinks.isListed, true),
+          isNotNull(dbSchema.boardBetaLinks.thumbnail),
+          like(dbSchema.boardBetaLinks.thumbnail, `${STATIC_THUMBNAIL_PREFIX}%`),
+          boardType ? eq(dbSchema.boardBetaLinks.boardType, boardType) : undefined,
+        ),
+      )
+      .orderBy(desc(dbSchema.boardBetaLinks.createdAt))
+      .limit(cappedLimit);
+
+    return rows
+      .filter((r) => !isKayaClimbUrl(r.betaLink.link))
+      .map((r) => ({
+        betaLink: passthroughResult(r.betaLink),
+        climbName: r.climbName,
+        boardType: r.betaLink.boardType,
+      }));
   },
 };

--- a/packages/backend/src/lib/beta-link-thumbnails.ts
+++ b/packages/backend/src/lib/beta-link-thumbnails.ts
@@ -9,6 +9,9 @@ export { isS3Configured };
 // not bytes, so this is the byte-level back-stop.
 const MAX_THUMBNAIL_BYTES = 5 * 1024 * 1024;
 
+// Keep in sync with STATIC_THUMBNAIL_PREFIX in
+// ../graphql/resolvers/beta-videos/queries.ts — the recentBetaLinks SQL
+// LIKE filter relies on the same prefix to pre-trim to cached rows.
 const STATIC_THUMBNAIL_PREFIX = '/static/beta-link-thumbnails/';
 
 /**

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -3336,6 +3336,16 @@ type BetaLink {
 }
 
 """
+A recent beta link enriched with the parent climb's display name. Used
+by the home-page slider where multiple climbs are aggregated together.
+"""
+type RecentBetaLink {
+  betaLink: BetaLink!
+  climbName: String
+  boardType: String!
+}
+
+"""
 Root query type for all read operations.
 """
 type Query {
@@ -3883,6 +3893,12 @@ type Query {
   Caches thumbnails to our S3 bucket on first read.
   """
   betaLinks(boardType: String!, climbUuid: String!): [BetaLink!]!
+
+  """
+  Most recent beta videos across all climbs. Returns only rows whose
+  thumbnails are already cached in our S3; no live IG/TikTok enrichment.
+  """
+  recentBetaLinks(limit: Int = 20, boardType: String): [RecentBetaLink!]!
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2959,6 +2959,11 @@ export type Query = {
   profile?: Maybe<UserProfile>;
   /** Get a public user profile by ID. */
   publicProfile?: Maybe<PublicUserProfile>;
+  /**
+   * Most recent beta videos across all climbs. Returns only rows whose
+   * thumbnails are already cached in our S3; no live IG/TikTok enrichment.
+   */
+  recentBetaLinks: Array<RecentBetaLink>;
   /** Search public boards. */
   searchBoards: UserBoardConnection;
   /**
@@ -3335,6 +3340,12 @@ export type QueryPublicProfileArgs = {
 };
 
 /** Root query type for all read operations. */
+export type QueryRecentBetaLinksArgs = {
+  boardType?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** Root query type for all read operations. */
 export type QuerySearchBoardsArgs = {
   input: SearchBoardsInput;
 };
@@ -3556,6 +3567,17 @@ export type QueueState = {
   sequence: Scalars['Int']['output'];
   /** Hash of the current state for consistency checking */
   stateHash: Scalars['String']['output'];
+};
+
+/**
+ * A recent beta link enriched with the parent climb's display name. Used
+ * by the home-page slider where multiple climbs are aggregated together.
+ */
+export type RecentBetaLink = {
+  __typename?: 'RecentBetaLink';
+  betaLink: BetaLink;
+  boardType: Scalars['String']['output'];
+  climbName?: Maybe<Scalars['String']['output']>;
 };
 
 export type RegisterControllerInput = {
@@ -4993,6 +5015,7 @@ export type ResolversTypes = ResolversObject<{
   QueueNavigationItem: ResolverTypeWrapper<QueueNavigationItem>;
   QueueReordered: ResolverTypeWrapper<QueueReordered>;
   QueueState: ResolverTypeWrapper<QueueState>;
+  RecentBetaLink: ResolverTypeWrapper<RecentBetaLink>;
   RegisterControllerInput: RegisterControllerInput;
   RemoveClimbFromPlaylistInput: RemoveClimbFromPlaylistInput;
   RemoveGymMemberInput: RemoveGymMemberInput;
@@ -5233,6 +5256,7 @@ export type ResolversParentTypes = ResolversObject<{
   QueueNavigationItem: QueueNavigationItem;
   QueueReordered: QueueReordered;
   QueueState: QueueState;
+  RecentBetaLink: RecentBetaLink;
   RegisterControllerInput: RegisterControllerInput;
   RemoveClimbFromPlaylistInput: RemoveClimbFromPlaylistInput;
   RemoveGymMemberInput: RemoveGymMemberInput;
@@ -7185,6 +7209,12 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QueryPublicProfileArgs, 'userId'>
   >;
+  recentBetaLinks?: Resolver<
+    Array<ResolversTypes['RecentBetaLink']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryRecentBetaLinksArgs, 'limit'>
+  >;
   searchBoards?: Resolver<
     ResolversTypes['UserBoardConnection'],
     ParentType,
@@ -7415,6 +7445,16 @@ export type QueueStateResolvers<
   queue?: Resolver<Array<ResolversTypes['ClimbQueueItem']>, ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RecentBetaLinkResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['RecentBetaLink'] = ResolversParentTypes['RecentBetaLink'],
+> = ResolversObject<{
+  betaLink?: Resolver<ResolversTypes['BetaLink'], ParentType, ContextType>;
+  boardType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  climbName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -8104,6 +8144,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   QueueNavigationItem?: QueueNavigationItemResolvers<ContextType>;
   QueueReordered?: QueueReorderedResolvers<ContextType>;
   QueueState?: QueueStateResolvers<ContextType>;
+  RecentBetaLink?: RecentBetaLinkResolvers<ContextType>;
   SaveClimbResult?: SaveClimbResultResolvers<ContextType>;
   SearchPlaylistsResult?: SearchPlaylistsResultResolvers<ContextType>;
   SendDeviceLogsResponse?: SendDeviceLogsResponseResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/beta-links.ts
+++ b/packages/shared-schema/src/schema/beta-links.ts
@@ -12,4 +12,14 @@ export const betaLinksTypeDefs = /* GraphQL */ `
     isListed: Boolean
     createdAt: String
   }
+
+  """
+  A recent beta link enriched with the parent climb's display name. Used
+  by the home-page slider where multiple climbs are aggregated together.
+  """
+  type RecentBetaLink {
+    betaLink: BetaLink!
+    climbName: String
+    boardType: String!
+  }
 `;

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -547,5 +547,11 @@ export const queriesTypeDefs = /* GraphQL */ `
     Caches thumbnails to our S3 bucket on first read.
     """
     betaLinks(boardType: String!, climbUuid: String!): [BetaLink!]!
+
+    """
+    Most recent beta videos across all climbs. Returns only rows whose
+    thumbnails are already cached in our S3; no live IG/TikTok enrichment.
+    """
+    recentBetaLinks(limit: Int = 20, boardType: String): [RecentBetaLink!]!
   }
 `;

--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -79,6 +79,10 @@ vi.mock('@/app/components/board-scroll/board-discovery-scroll', () => ({
   default: () => null,
 }));
 
+vi.mock('@/app/components/beta-videos/home-recent-beta-section', () => ({
+  default: () => null,
+}));
+
 // --- Helpers ---
 
 function makeActiveSession(overrides: Partial<ActiveSessionInfo> = {}): ActiveSessionInfo {

--- a/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
@@ -8,11 +8,24 @@ import { isInstagramUrl, isTikTokUrl } from '@/app/lib/beta-video-url';
 import TikTokIcon from './tiktok-icon';
 import styles from './boardsesh-beta.module.css';
 
+type BoardseshBetaCardSource = 'home' | 'drawer';
+
 type BoardseshBetaCardProps = {
   link: BetaLink;
+  /**
+   * Optional climb label rendered as a top-anchored chip. Only the
+   * home-screen slider passes this — the per-climb drawer slider omits it
+   * because every card belongs to the same climb.
+   */
+  climbName?: string | null;
+  /**
+   * Surfaces where this card appears. Tagged on the analytics event so we
+   * can measure CTR per placement.
+   */
+  source?: BoardseshBetaCardSource;
 };
 
-const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link }) => {
+const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link, climbName, source = 'drawer' }) => {
   const [thumbnailFailed, setThumbnailFailed] = useState(false);
   const thumbnailSrc = !thumbnailFailed ? link.thumbnail : null;
   const isTikTok = isTikTokUrl(link.link);
@@ -26,17 +39,24 @@ const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link }) => {
     analyticsPlatform = 'Instagram';
   }
 
+  const climbLabel = climbName?.trim() ? climbName : null;
+  const ariaLabel =
+    `Open beta on ${displayPlatform}` +
+    (link.foreign_username ? ` by ${link.foreign_username}` : '') +
+    (climbLabel ? ` for ${climbLabel}` : '');
+
   return (
     <a
       href={link.link}
       target="_blank"
       rel="noopener noreferrer"
       className={styles.card}
-      aria-label={`Open beta on ${displayPlatform}${link.foreign_username ? ` by ${link.foreign_username}` : ''}`}
+      aria-label={ariaLabel}
       onClick={() =>
         track('Beta Video Link Clicked', {
           platform: analyticsPlatform,
           climbUuid: link.climb_uuid,
+          source,
           ...(link.foreign_username ? { foreignUsername: link.foreign_username } : {}),
         })
       }
@@ -59,6 +79,7 @@ const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link }) => {
         <span className={styles.platformBadge} aria-label={`From ${displayPlatform}`}>
           <PlatformIcon sx={{ fontSize: 12 }} />
         </span>
+        {climbLabel && <span className={styles.climbChip}>{climbLabel}</span>}
         {link.foreign_username && <span className={styles.userChip}>@{link.foreign_username}</span>}
       </div>
     </a>

--- a/packages/web/app/components/beta-videos/boardsesh-beta-list.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-list.tsx
@@ -7,12 +7,21 @@ import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 import BoardseshBetaCard from './boardsesh-beta-card';
 import styles from './boardsesh-beta.module.css';
 
+type BoardseshBetaListSource = 'home' | 'drawer';
+
 type BoardseshBetaListProps = {
   links: BetaLink[];
   isLoading: boolean;
+  /**
+   * When set, each card renders a top-anchored climb-name chip resolved
+   * from this function. Used by the home-screen slider where the cards
+   * come from many different climbs.
+   */
+  getClimbName?: (link: BetaLink) => string | null | undefined;
+  source?: BoardseshBetaListSource;
 };
 
-const BoardseshBetaList: React.FC<BoardseshBetaListProps> = ({ links, isLoading }) => {
+const BoardseshBetaList: React.FC<BoardseshBetaListProps> = ({ links, isLoading, getClimbName, source = 'drawer' }) => {
   const { t } = useTranslation('common');
   return (
     <div className={styles.section}>
@@ -28,7 +37,7 @@ const BoardseshBetaList: React.FC<BoardseshBetaListProps> = ({ links, isLoading 
         ) : (
           <>
             {links.map((link) => (
-              <BoardseshBetaCard key={link.link} link={link} />
+              <BoardseshBetaCard key={link.link} link={link} climbName={getClimbName?.(link) ?? null} source={source} />
             ))}
             {links.length === 0 && <span className={styles.emptyText}>{t('betaVideos.empty')}</span>}
           </>

--- a/packages/web/app/components/beta-videos/boardsesh-beta.module.css
+++ b/packages/web/app/components/beta-videos/boardsesh-beta.module.css
@@ -72,6 +72,22 @@
   line-height: 1.4;
 }
 
+.climbChip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: var(--overlay-dark);
+  color: white;
+  font-size: 11px;
+  padding: 2px 6px;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
 .platformBadge {
   position: absolute;
   top: 6px;

--- a/packages/web/app/components/beta-videos/home-recent-beta-section.tsx
+++ b/packages/web/app/components/beta-videos/home-recent-beta-section.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { themeTokens } from '@/app/theme/theme-config';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { GET_RECENT_BETA_LINKS } from '@/app/lib/graphql/operations/beta-links';
+import { mapBetaLinkRow } from '@/app/lib/beta-video-url';
+import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
+import type { RecentBetaLinkRow } from '@/app/lib/server-recent-beta-links';
+import BoardseshBetaList from './boardsesh-beta-list';
+
+type HomeRecentBetaSectionProps = {
+  initialRecentBeta: RecentBetaLinkRow[];
+};
+
+const RECENT_BETA_LIMIT = 20;
+const RECENT_BETA_STALE_TIME_MS = 5 * 60 * 1000;
+
+type RecentBetaResponse = {
+  recentBetaLinks: RecentBetaLinkRow[];
+};
+
+export default function HomeRecentBetaSection({ initialRecentBeta }: HomeRecentBetaSectionProps) {
+  const { t } = useTranslation('marketing');
+
+  const { data: rows = [] } = useQuery<RecentBetaLinkRow[]>({
+    queryKey: ['recentBetaLinks', null],
+    queryFn: async () => {
+      const client = createGraphQLHttpClient();
+      const result = await client.request<RecentBetaResponse>(GET_RECENT_BETA_LINKS, { limit: RECENT_BETA_LIMIT });
+      return result.recentBetaLinks;
+    },
+    initialData: initialRecentBeta,
+    staleTime: RECENT_BETA_STALE_TIME_MS,
+  });
+
+  const { links, climbNameByLink } = useMemo(() => {
+    const mapped: BetaLink[] = [];
+    const nameByLink = new Map<string, string | null>();
+    for (const row of rows) {
+      const link = mapBetaLinkRow(row.betaLink);
+      mapped.push(link);
+      nameByLink.set(link.link, row.climbName);
+    }
+    return { links: mapped, climbNameByLink: nameByLink };
+  }, [rows]);
+
+  if (links.length === 0) return null;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, width: '100%' }}>
+      <Typography
+        variant="body2"
+        fontWeight={themeTokens.typography.fontWeight.semibold}
+        sx={{
+          color: 'var(--neutral-400)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+          fontSize: themeTokens.typography.fontSize.xs,
+          px: 0.5,
+        }}
+      >
+        {t('home.recentBeta.title')}
+      </Typography>
+      <BoardseshBetaList
+        links={links}
+        isLoading={false}
+        source="home"
+        getClimbName={(link) => climbNameByLink.get(link.link)}
+      />
+    </Box>
+  );
+}

--- a/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
+++ b/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
@@ -291,10 +291,7 @@ describe('StartSeshDrawer', () => {
     await submitSesh();
 
     await waitFor(() => {
-      expect(mockCreateSession).toHaveBeenCalledWith(
-        expect.anything(),
-        '/kilter/original/12x12/screw_bolt/40/list',
-      );
+      expect(mockCreateSession).toHaveBeenCalledWith(expect.anything(), '/kilter/original/12x12/screw_bolt/40/list');
     });
     expect(mockRouterPush).toHaveBeenCalled();
   });
@@ -316,10 +313,7 @@ describe('StartSeshDrawer', () => {
     });
     // boardPath should reflect the CURRENT (bridge) route, not the stale
     // localBoardPath — i.e. auto-select picked the bridge-side custom config.
-    expect(mockCreateSession).toHaveBeenCalledWith(
-      expect.anything(),
-      '/kilter/original/12x12/screw_bolt/40/list',
-    );
+    expect(mockCreateSession).toHaveBeenCalledWith(expect.anything(), '/kilter/original/12x12/screw_bolt/40/list');
   });
 
   it('shows collapsed card when board is auto-selected', async () => {

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -30,6 +30,8 @@ import { constructBoardSlugListUrl, constructClimbListWithSlugs, tryConstructSlu
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
+import type { RecentBetaLinkRow } from '@/app/lib/server-recent-beta-links';
+import HomeRecentBetaSection from '@/app/components/beta-videos/home-recent-beta-section';
 import { track } from '@/app/lib/analytics';
 import { setClimbSessionCookie } from '@/app/lib/climb-session-cookie';
 import { useOnboardingTourOptional } from '@/app/components/onboarding/onboarding-tour-provider';
@@ -48,6 +50,7 @@ const BoardSelectorDrawer = dynamic(() => import('@/app/components/board-selecto
 type HomePageContentProps = {
   boardConfigs: BoardConfigData;
   initialPopularConfigs?: PopularBoardConfig[];
+  initialRecentBeta?: RecentBetaLinkRow[];
 };
 
 type OnboardingCardAccent = 'action' | 'social' | 'help' | 'v11' | 'v12' | 'v13' | 'none';
@@ -231,7 +234,11 @@ function InstallAppCard({ platform }: { platform: InstallPlatform }) {
   );
 }
 
-export default function HomePageContent({ boardConfigs, initialPopularConfigs }: HomePageContentProps) {
+export default function HomePageContent({
+  boardConfigs,
+  initialPopularConfigs,
+  initialRecentBeta = [],
+}: HomePageContentProps) {
   const { t } = useTranslation('marketing');
   const { status } = useSession();
   const router = useLocaleRouter();
@@ -537,6 +544,9 @@ export default function HomePageContent({ boardConfigs, initialPopularConfigs }:
             onClick={() => window.open('https://discord.gg/YXA8GsXfQK', '_blank', 'noopener,noreferrer')}
           />
         </Box>
+
+        {/* Recent beta videos from across the community */}
+        <HomeRecentBetaSection initialRecentBeta={initialRecentBeta} />
 
         {/* Authenticated users: nudge to feed */}
         {isAuthenticated && (

--- a/packages/web/app/lib/beta-video-url.ts
+++ b/packages/web/app/lib/beta-video-url.ts
@@ -75,7 +75,7 @@ export function dedupeBetaLinks(betaLinks: BetaLink[]): BetaLink[] {
  * the rest of the web app. Used by both `BoardseshBetaList` and the IG
  * post dialog.
  */
-type BetaLinksGqlRow = {
+export type BetaLinksGqlRow = {
   climbUuid: string;
   link: string;
   foreignUsername: string | null;
@@ -85,14 +85,18 @@ type BetaLinksGqlRow = {
   createdAt: string | null;
 };
 
+export function mapBetaLinkRow(row: BetaLinksGqlRow): BetaLink {
+  return {
+    climb_uuid: row.climbUuid,
+    link: row.link,
+    foreign_username: row.foreignUsername,
+    angle: row.angle,
+    thumbnail: absolutizeThumbnail(row.thumbnail),
+    is_listed: row.isListed ?? false,
+    created_at: row.createdAt ?? '',
+  };
+}
+
 export function mapBetaLinksResponse(rows: BetaLinksGqlRow[]): BetaLink[] {
-  return rows.map((b) => ({
-    climb_uuid: b.climbUuid,
-    link: b.link,
-    foreign_username: b.foreignUsername,
-    angle: b.angle,
-    thumbnail: absolutizeThumbnail(b.thumbnail),
-    is_listed: b.isListed ?? false,
-    created_at: b.createdAt ?? '',
-  }));
+  return rows.map(mapBetaLinkRow);
 }

--- a/packages/web/app/lib/graphql/__tests__/server-graphql.test.ts
+++ b/packages/web/app/lib/graphql/__tests__/server-graphql.test.ts
@@ -132,7 +132,12 @@ describe('server-graphql helpers', () => {
       };
       requestMock.mockResolvedValueOnce({ smartPlaylist: payload });
 
-      const result = await serverSmartPlaylist('auth-token', { type: 'FIVE_STARS', userId: 'u1', page: 0, pageSize: 20 });
+      const result = await serverSmartPlaylist('auth-token', {
+        type: 'FIVE_STARS',
+        userId: 'u1',
+        page: 0,
+        pageSize: 20,
+      });
 
       expect(result).toEqual(payload);
     });

--- a/packages/web/app/lib/graphql/__tests__/ssr-query-seed.test.ts
+++ b/packages/web/app/lib/graphql/__tests__/ssr-query-seed.test.ts
@@ -4,9 +4,9 @@ import { ssrSeedMatchesQueryKey } from '../ssr-query-seed';
 
 describe('ssrSeedMatchesQueryKey', () => {
   it('returns false when no SSR payload is present, even if keys match', () => {
-    expect(
-      ssrSeedMatchesQueryKey(false, { boardUuid: null, refreshKey: 0 }, { boardUuid: null, refreshKey: 0 }),
-    ).toBe(false);
+    expect(ssrSeedMatchesQueryKey(false, { boardUuid: null, refreshKey: 0 }, { boardUuid: null, refreshKey: 0 })).toBe(
+      false,
+    );
   });
 
   it('returns true when the live key tuple matches the snapshot exactly', () => {
@@ -33,8 +33,8 @@ describe('ssrSeedMatchesQueryKey', () => {
 
   it('compares every snapshot key, not just the first', () => {
     // boardUuid matches but refreshKey diverges — must still be rejected.
-    expect(
-      ssrSeedMatchesQueryKey(true, { boardUuid: 'b', refreshKey: 0 }, { boardUuid: 'b', refreshKey: 7 }),
-    ).toBe(false);
+    expect(ssrSeedMatchesQueryKey(true, { boardUuid: 'b', refreshKey: 0 }, { boardUuid: 'b', refreshKey: 7 })).toBe(
+      false,
+    );
   });
 });

--- a/packages/web/app/lib/graphql/generated/gql.ts
+++ b/packages/web/app/lib/graphql/generated/gql.ts
@@ -17,6 +17,7 @@ type Documents = {
   '\n  query GetDeleteAccountInfo {\n    deleteAccountInfo {\n      publishedClimbCount\n    }\n  }\n': typeof types.GetDeleteAccountInfoDocument;
   '\n  mutation DeleteAccount($input: DeleteAccountInput!) {\n    deleteAccount(input: $input)\n  }\n': typeof types.DeleteAccountDocument;
   '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n    }\n  }\n': typeof types.GetBetaLinksDocument;
+  '\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n': typeof types.GetRecentBetaLinksDocument;
   '\n  query ClimbStatsHistory($boardName: String!, $climbUuid: ID!) {\n    climbStatsHistory(boardName: $boardName, climbUuid: $climbUuid) {\n      angle\n      ascensionistCount\n      qualityAverage\n      difficultyAverage\n      displayDifficulty\n      createdAt\n    }\n  }\n': typeof types.ClimbStatsHistoryDocument;
   '\n  query GetGlobalCommentFeed($input: GlobalCommentFeedInput) {\n    globalCommentFeed(input: $input) {\n      comments {\n        uuid\n        userId\n        userDisplayName\n        userAvatarUrl\n        entityType\n        entityId\n        parentCommentUuid\n        body\n        isDeleted\n        replyCount\n        upvotes\n        downvotes\n        voteScore\n        userVote\n        createdAt\n        updatedAt\n      }\n      totalCount\n      hasMore\n      cursor\n    }\n  }\n': typeof types.GetGlobalCommentFeedDocument;
   '\n  query GetComments($input: CommentsInput!) {\n    comments(input: $input) {\n      comments {\n        uuid\n        userId\n        userDisplayName\n        userAvatarUrl\n        entityType\n        entityId\n        parentCommentUuid\n        body\n        isDeleted\n        replyCount\n        upvotes\n        downvotes\n        voteScore\n        userVote\n        createdAt\n        updatedAt\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.GetCommentsDocument;
@@ -126,6 +127,8 @@ const documents: Documents = {
     types.DeleteAccountDocument,
   '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n    }\n  }\n':
     types.GetBetaLinksDocument,
+  '\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n':
+    types.GetRecentBetaLinksDocument,
   '\n  query ClimbStatsHistory($boardName: String!, $climbUuid: ID!) {\n    climbStatsHistory(boardName: $boardName, climbUuid: $climbUuid) {\n      angle\n      ascensionistCount\n      qualityAverage\n      difficultyAverage\n      displayDifficulty\n      createdAt\n    }\n  }\n':
     types.ClimbStatsHistoryDocument,
   '\n  query GetGlobalCommentFeed($input: GlobalCommentFeedInput) {\n    globalCommentFeed(input: $input) {\n      comments {\n        uuid\n        userId\n        userDisplayName\n        userAvatarUrl\n        entityType\n        entityId\n        parentCommentUuid\n        body\n        isDeleted\n        replyCount\n        upvotes\n        downvotes\n        voteScore\n        userVote\n        createdAt\n        updatedAt\n      }\n      totalCount\n      hasMore\n      cursor\n    }\n  }\n':
@@ -357,6 +360,12 @@ export function graphql(
 export function graphql(
   source: '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n    }\n  }\n',
 ): (typeof documents)['\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n    }\n  }\n'];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n',
+): (typeof documents)['\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/web/app/lib/graphql/generated/graphql.ts
+++ b/packages/web/app/lib/graphql/generated/graphql.ts
@@ -2956,6 +2956,11 @@ export type Query = {
   profile?: Maybe<UserProfile>;
   /** Get a public user profile by ID. */
   publicProfile?: Maybe<PublicUserProfile>;
+  /**
+   * Most recent beta videos across all climbs. Returns only rows whose
+   * thumbnails are already cached in our S3; no live IG/TikTok enrichment.
+   */
+  recentBetaLinks: Array<RecentBetaLink>;
   /** Search public boards. */
   searchBoards: UserBoardConnection;
   /**
@@ -3332,6 +3337,12 @@ export type QueryPublicProfileArgs = {
 };
 
 /** Root query type for all read operations. */
+export type QueryRecentBetaLinksArgs = {
+  boardType?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** Root query type for all read operations. */
 export type QuerySearchBoardsArgs = {
   input: SearchBoardsInput;
 };
@@ -3553,6 +3564,17 @@ export type QueueState = {
   sequence: Scalars['Int']['output'];
   /** Hash of the current state for consistency checking */
   stateHash: Scalars['String']['output'];
+};
+
+/**
+ * A recent beta link enriched with the parent climb's display name. Used
+ * by the home-page slider where multiple climbs are aggregated together.
+ */
+export type RecentBetaLink = {
+  __typename?: 'RecentBetaLink';
+  betaLink: BetaLink;
+  boardType: Scalars['String']['output'];
+  climbName?: Maybe<Scalars['String']['output']>;
 };
 
 export type RegisterControllerInput = {
@@ -4772,6 +4794,30 @@ export type GetBetaLinksQuery = {
     thumbnail?: string | null;
     isListed?: boolean | null;
     createdAt?: string | null;
+  }>;
+};
+
+export type GetRecentBetaLinksQueryVariables = Exact<{
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  boardType?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+export type GetRecentBetaLinksQuery = {
+  __typename?: 'Query';
+  recentBetaLinks: Array<{
+    __typename?: 'RecentBetaLink';
+    climbName?: string | null;
+    boardType: string;
+    betaLink: {
+      __typename?: 'BetaLink';
+      climbUuid: string;
+      link: string;
+      foreignUsername?: string | null;
+      angle?: number | null;
+      thumbnail?: string | null;
+      isListed?: boolean | null;
+      createdAt?: string | null;
+    };
   }>;
 };
 
@@ -6946,6 +6992,72 @@ export const GetBetaLinksDocument = {
     },
   ],
 } as unknown as DocumentNode<GetBetaLinksQuery, GetBetaLinksQueryVariables>;
+export const GetRecentBetaLinksDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'GetRecentBetaLinks' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'limit' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'boardType' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'recentBetaLinks' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'limit' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'limit' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'boardType' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'boardType' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'climbName' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'boardType' } },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'betaLink' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'climbUuid' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'link' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'foreignUsername' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'angle' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'thumbnail' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'isListed' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetRecentBetaLinksQuery, GetRecentBetaLinksQueryVariables>;
 export const ClimbStatsHistoryDocument = {
   kind: 'Document',
   definitions: [

--- a/packages/web/app/lib/graphql/operations/beta-links.ts
+++ b/packages/web/app/lib/graphql/operations/beta-links.ts
@@ -13,3 +13,21 @@ export const GET_BETA_LINKS = gql`
     }
   }
 `;
+
+export const GET_RECENT_BETA_LINKS = gql`
+  query GetRecentBetaLinks($limit: Int, $boardType: String) {
+    recentBetaLinks(limit: $limit, boardType: $boardType) {
+      climbName
+      boardType
+      betaLink {
+        climbUuid
+        link
+        foreignUsername
+        angle
+        thumbnail
+        isListed
+        createdAt
+      }
+    }
+  }
+`;

--- a/packages/web/app/lib/server-recent-beta-links.ts
+++ b/packages/web/app/lib/server-recent-beta-links.ts
@@ -1,0 +1,46 @@
+import React from 'react';
+import 'server-only';
+import { GraphQLClient } from 'graphql-request';
+import { getGraphQLHttpUrl } from '@/app/lib/graphql/client';
+import { GET_RECENT_BETA_LINKS } from '@/app/lib/graphql/operations/beta-links';
+import type { BetaLinksGqlRow } from '@/app/lib/beta-video-url';
+
+export type RecentBetaLinkRow = {
+  climbName: string | null;
+  boardType: string;
+  betaLink: BetaLinksGqlRow;
+};
+
+type RecentBetaLinksResponse = {
+  recentBetaLinks: RecentBetaLinkRow[];
+};
+
+/**
+ * Fetches the latest cross-climb beta videos for the home-screen slider.
+ * Mirrors `server-popular-configs.ts`: React.cache for request dedupe, a
+ * 1s timeout, and a silent fall back to `[]` so a backend hiccup doesn't
+ * fail the page render — the client section will retry on mount.
+ */
+export const getRecentBetaLinks = React.cache(async (limit = 20): Promise<RecentBetaLinkRow[]> => {
+  let url: string;
+  try {
+    url = getGraphQLHttpUrl();
+  } catch {
+    return [];
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1000);
+  try {
+    const client = new GraphQLClient(url, {
+      headers: { 'Content-Type': 'application/json' },
+      signal: controller.signal,
+    });
+    const result = await client.request<RecentBetaLinksResponse>(GET_RECENT_BETA_LINKS, { limit });
+    return result.recentBetaLinks;
+  } catch {
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+});

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -5,6 +5,7 @@ import { getLocale } from '@/app/lib/i18n/get-locale';
 import I18nProvider from '@/app/components/providers/i18n-provider';
 import { getAllBoardConfigs } from './lib/server-board-configs';
 import { getPopularBoardConfigs } from './lib/server-popular-configs';
+import { getRecentBetaLinks } from './lib/server-recent-beta-links';
 import { buildPopularLcpImageUrl } from './lib/popular-lcp-preload';
 import HomePageContent from './home-page-content';
 
@@ -20,9 +21,10 @@ export async function generateMetadata() {
 }
 
 export default async function Home() {
-  const [boardConfigs, popularConfigs, locale] = await Promise.all([
+  const [boardConfigs, popularConfigs, recentBeta, locale] = await Promise.all([
     getAllBoardConfigs(),
     getPopularBoardConfigs(),
+    getRecentBetaLinks(),
     getLocale(),
   ]);
   const lcpPreloadUrl = buildPopularLcpImageUrl(popularConfigs);
@@ -30,7 +32,11 @@ export default async function Home() {
   return (
     <I18nProvider locale={locale} namespaces={['marketing', 'boards', 'climbs', 'profile', 'feed']}>
       {lcpPreloadUrl && <link rel="preload" as="image" href={lcpPreloadUrl} fetchPriority="high" />}
-      <HomePageContent boardConfigs={boardConfigs} initialPopularConfigs={popularConfigs} />
+      <HomePageContent
+        boardConfigs={boardConfigs}
+        initialPopularConfigs={popularConfigs}
+        initialRecentBeta={recentBeta}
+      />
     </I18nProvider>
   );
 }

--- a/packages/web/i18n/locales/en-US/marketing.json
+++ b/packages/web/i18n/locales/en-US/marketing.json
@@ -57,6 +57,9 @@
     "feed": {
       "callout": "Your friends are climbing.",
       "cta": "See the feed"
+    },
+    "recentBeta": {
+      "title": "Fresh beta"
     }
   },
   "about": {

--- a/packages/web/i18n/locales/es/marketing.json
+++ b/packages/web/i18n/locales/es/marketing.json
@@ -57,6 +57,9 @@
     "feed": {
       "callout": "Tus amigos están escalando.",
       "cta": "Ver el feed"
+    },
+    "recentBeta": {
+      "title": "Beta fresca"
     }
   },
   "about": {

--- a/packages/web/i18n/locales/fr/marketing.json
+++ b/packages/web/i18n/locales/fr/marketing.json
@@ -57,6 +57,9 @@
     "feed": {
       "callout": "Vos potes sont en train de grimper.",
       "cta": "Voir le feed"
+    },
+    "recentBeta": {
+      "title": "Beta fraîche"
     }
   },
   "about": {


### PR DESCRIPTION
## Summary
- Adds a horizontal **Fresh beta** slider on the home page that surfaces the most recently added beta videos across all climbs.
- New `recentBetaLinks(limit, boardType)` GraphQL query reads only rows whose thumbnails are already cached to our S3 — never fans out the live IG/TikTok enrichment that the per-climb resolver does.
- Reuses the existing `BoardseshBetaList` / `BoardseshBetaCard`; cards in the new slider gain a top-anchored climb-name chip (drawer call-sites unchanged).

## Implementation notes
- **Backend resolver** filters on `is_listed = true` + `thumbnail LIKE '/static/beta-link-thumbnails/%'`, caps `limit` at 50, LEFT-JOINs `boardClimbs` (beta links can land before their climb syncs — UI tolerates a null climbName), and reuses `passthroughResult` + `isKayaClimbUrl` from the existing resolver for parity.
- **Schema** introduces a `RecentBetaLink` wrapper type so the embedded `BetaLink` shape stays unchanged for every existing consumer.
- **Home page** server-fetches the initial 20 rows in parallel with `popularConfigs` (1 s timeout, swallow-and-fallback-to-empty pattern from `server-popular-configs.ts`). The new client section uses `useQuery` with `initialData` and renders nothing on empty so the section never shows an empty pill.
- **Analytics** events now carry `source: 'home' | 'drawer'` so we can measure CTR per placement.
- **i18n** key added to `en-US`, `es`, `fr` (fr is parity-enforced).

## Test plan
- [ ] Open `/` — "FRESH BETA" section appears between the onboarding card stack and the auth-feed nudge.
- [ ] Cards show climb name (top chip), `@username` (bottom chip), and an Instagram/TikTok platform badge.
- [ ] Tapping a card opens the external video in a new tab; analytics event carries `source: 'home'`.
- [ ] Open any climb's play-view drawer — beta section visually unchanged (no climb chip; cards tagged `source: 'drawer'`).
- [ ] Open `/es/` — section title reads "Beta fresca". Open `/fr/` — "Beta fraîche".
- [ ] Open `/graphql` and run `{ recentBetaLinks(limit: 20) { climbName boardType betaLink { link thumbnail } } }` — every thumbnail starts with `/static/beta-link-thumbnails/`; no KayaClimb URLs.
- [ ] DB has no qualifying rows → section disappears entirely (no header, no empty pill).
- [ ] `vp check`, `vp run typecheck`, `vp run check:i18n`, `vp run check:i18n:orphans`, `vp test` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)