### PR TITLE
feat(session): reuse playlist generator from start session drawer

### DIFF
--- a/packages/web/app/components/library/create-playlist-drawer.tsx
+++ b/packages/web/app/components/library/create-playlist-drawer.tsx
@@ -144,7 +144,7 @@ export default function CreatePlaylistDrawer({
       onTransitionEnd={onTransitionEnd}
       styles={{
         wrapper: { height: 'auto' },
-        body: { padding: themeTokens.spacing[4] },
+        body: { padding: `${themeTokens.spacing[4]}px` },
       }}
       extra={
         <MuiButton variant="contained" onClick={handleSubmit} disabled={submitting}>

--- a/packages/web/app/components/library/playlist-edit-drawer.tsx
+++ b/packages/web/app/components/library/playlist-edit-drawer.tsx
@@ -162,7 +162,7 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
       styles={{
         wrapper: { height: 'auto' },
         body: {
-          paddingBottom: themeTokens.spacing[6],
+          paddingBottom: `${themeTokens.spacing[6]}px`,
         },
       }}
       extra={

--- a/packages/web/app/components/playlist-generator/__tests__/generator-options-form.test.tsx
+++ b/packages/web/app/components/playlist-generator/__tests__/generator-options-form.test.tsx
@@ -35,6 +35,8 @@ describe('GeneratorOptionsForm quality filters', () => {
         onChange={onChange}
         onReset={vi.fn()}
         boardDetails={boardDetails}
+        targetAngle={40}
+        onTargetAngleChange={vi.fn()}
       />,
     );
 
@@ -52,6 +54,8 @@ describe('GeneratorOptionsForm quality filters', () => {
         onChange={onChange}
         onReset={vi.fn()}
         boardDetails={boardDetails}
+        targetAngle={40}
+        onTargetAngleChange={vi.fn()}
       />,
     );
 

--- a/packages/web/app/components/playlist-generator/generator-options-form.tsx
+++ b/packages/web/app/components/playlist-generator/generator-options-form.tsx
@@ -12,7 +12,7 @@ import MuiButton from '@mui/material/Button';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { RemoveOutlined, AddOutlined, RefreshOutlined } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
-import { getGradesForBoard } from '@/app/lib/board-data';
+import { ANGLES, getGradesForBoard } from '@/app/lib/board-data';
 import MinAscentsBucketPicker from '@/app/components/climb-quality-filter/min-ascents-bucket-picker';
 import { InlineStarPicker } from '@/app/components/logbook/tick-controls';
 import type { BoardDetails } from '@/app/lib/types';
@@ -53,6 +53,8 @@ type GeneratorOptionsFormProps = {
   onChange: (options: GeneratorOptions) => void;
   onReset: () => void;
   boardDetails: BoardDetails;
+  targetAngle: number;
+  onTargetAngleChange: (angle: number) => void;
 };
 
 const GeneratorOptionsForm: React.FC<GeneratorOptionsFormProps> = ({
@@ -61,9 +63,12 @@ const GeneratorOptionsForm: React.FC<GeneratorOptionsFormProps> = ({
   onChange,
   onReset,
   boardDetails,
+  targetAngle,
+  onTargetAngleChange,
 }) => {
   const { t } = useTranslation('playlists');
   const grades = getGradesForBoard(boardDetails.board_name);
+  const angles = ANGLES[boardDetails.board_name] ?? [];
 
   const warmUpOptions = WARM_UP_OPTIONS.map((opt) => ({
     value: opt.value,
@@ -151,6 +156,28 @@ const GeneratorOptionsForm: React.FC<GeneratorOptionsFormProps> = ({
   // Common options for all workout types
   const renderCommonOptions = () => (
     <>
+      {/* Target Angle */}
+      {angles.length > 0 && (
+        <div className={styles.formRow}>
+          <Typography variant="body2" component="span" className={styles.label}>
+            {t('generator.options.targetAngle')}
+          </Typography>
+          <MuiSelect
+            value={targetAngle}
+            onChange={(e) => onTargetAngleChange(Number(e.target.value))}
+            className={styles.select}
+            size="small"
+            MenuProps={{ sx: { width: 'auto' } }}
+          >
+            {angles.map((angle) => (
+              <MenuItem key={angle} value={angle}>
+                {`${angle}°`}
+              </MenuItem>
+            ))}
+          </MuiSelect>
+        </div>
+      )}
+
       {/* Warm Up */}
       {renderSelect<WarmUpType>(t('generator.options.warmUp'), options.warmUp, warmUpOptions, (v) =>
         updateOption('warmUp', v),

--- a/packages/web/app/components/playlist-generator/index.ts
+++ b/packages/web/app/components/playlist-generator/index.ts
@@ -1,4 +1,5 @@
 export { default as PlaylistGeneratorDrawer } from './playlist-generator-drawer';
+export type { GeneratorCompletionResult, GeneratorTargetType } from './playlist-generator-drawer';
 export { default as WorkoutTypeSelector } from './workout-type-selector';
 export { default as GeneratorOptionsForm, getDefaultOptions } from './generator-options-form';
 export { default as GradeProgressionChart } from './grade-progression-chart';

--- a/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
+++ b/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useTranslation } from 'react-i18next';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
@@ -17,6 +17,7 @@ import {
 } from '@/app/lib/graphql/operations/climb-search';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { normalizeMinRatingFilter } from '@/app/lib/climb-quality-filter-options';
+import { track } from '@/app/lib/analytics';
 import { type WorkoutType, type GeneratorOptions, type PlannedClimbSlot, WORKOUT_TYPES } from './types';
 import WorkoutTypeSelector from './workout-type-selector';
 import GeneratorOptionsForm, { getDefaultOptions } from './generator-options-form';
@@ -28,7 +29,13 @@ export type GeneratorCompletionResult = {
   added: number;
   failed: number;
   total: number;
+  /** Workout type the user picked. Useful for downstream analytics. */
+  workoutType: WorkoutType;
 };
+
+/** Tag attached to every analytics event so we can split funnels by where
+ *  the generated climbs end up (a playlist mutation vs the session queue). */
+export type GeneratorTargetType = 'playlist' | 'session';
 
 type PlaylistGeneratorDrawerProps = {
   open: boolean;
@@ -37,6 +44,7 @@ type PlaylistGeneratorDrawerProps = {
   defaultAngle: number;
   onAddClimb: (climb: Climb, slot: PlannedClimbSlot, angle: number) => Promise<void>;
   onComplete?: (result: GeneratorCompletionResult) => void;
+  targetType: GeneratorTargetType;
 };
 
 type DrawerState = 'select' | 'configure' | 'generating';
@@ -48,6 +56,7 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
   defaultAngle,
   onAddClimb,
   onComplete,
+  targetType,
 }) => {
   const { token, isAuthenticated } = useWsAuthToken();
   const { showMessage } = useSnackbar();
@@ -62,6 +71,11 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
   const [generating, setGenerating] = useState(false);
   const [progress, setProgress] = useState({ current: 0, total: 0 });
 
+  // Tracks whether the user actually generated something during this open
+  // session. Lets us distinguish "closed mid-configure" (cancellation) from
+  // "closed after generation completed" (success path, no extra event).
+  const completedSuccessfullyRef = useRef(false);
+
   useEffect(() => {
     if (open) {
       setDrawerState('select');
@@ -70,8 +84,14 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
       setTargetAngle(defaultAngle);
       setGenerating(false);
       setProgress({ current: 0, total: 0 });
+      completedSuccessfullyRef.current = false;
+      track('Workout Generator Opened', {
+        targetType,
+        boardName: boardDetails.board_name,
+        angle: defaultAngle,
+      });
     }
-  }, [open, defaultAngle]);
+  }, [open, defaultAngle, targetType, boardDetails.board_name]);
 
   const plannedSlots = useMemo(() => {
     if (!options) return [];
@@ -83,17 +103,42 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
       setSelectedType(type);
       setOptions(getDefaultOptions(type, defaultTargetGrade));
       setDrawerState('configure');
+      track('Workout Type Selected', {
+        targetType,
+        workoutType: type,
+        boardName: boardDetails.board_name,
+      });
     },
-    [defaultTargetGrade],
+    [defaultTargetGrade, targetType, boardDetails.board_name],
   );
 
   const handleBack = useCallback(() => {
     if (drawerState === 'configure') {
+      track('Workout Generator Back Clicked', {
+        targetType,
+        workoutType: selectedType,
+        boardName: boardDetails.board_name,
+      });
       setDrawerState('select');
       setSelectedType(null);
       setOptions(null);
     }
-  }, [drawerState]);
+  }, [drawerState, targetType, selectedType, boardDetails.board_name]);
+
+  // Wrap onClose so dismissals mid-configure (no run completed) fire a
+  // cancellation event. Generating phase already blocks dismissal via the
+  // `onClose={generating ? undefined : ...}` guard below.
+  const handleClose = useCallback(() => {
+    if (drawerState === 'configure' && !generating && !completedSuccessfullyRef.current) {
+      track('Workout Generator Cancelled', {
+        targetType,
+        workoutType: selectedType,
+        stage: 'configure',
+        boardName: boardDetails.board_name,
+      });
+    }
+    onClose();
+  }, [drawerState, generating, targetType, selectedType, boardDetails.board_name, onClose]);
 
   const handleReset = useCallback(() => {
     if (selectedType) {
@@ -145,10 +190,46 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
   );
 
   const handleGenerate = useCallback(async () => {
-    if (!options || plannedSlots.length === 0) {
+    if (!options || plannedSlots.length === 0 || !selectedType) {
       showMessage(t('generator.messages.noClimbs'), 'error');
       return;
     }
+
+    // Snapshot the option set as flat scalars so the analytics events stay
+    // queryable without unpacking nested JSON downstream.
+    const optionsSnapshot: Record<string, string | number | boolean | null> = {
+      workoutType: selectedType,
+      targetGrade: options.targetGrade,
+      targetAngle,
+      warmUp: options.warmUp,
+      minAscents: options.minAscents,
+      minRating: options.minRating,
+      climbBias: options.climbBias,
+      onlyTallClimbs: !!options.onlyTallClimbs,
+    };
+    switch (options.type) {
+      case 'volume':
+        optionsSnapshot.mainSetClimbs = options.mainSetClimbs;
+        optionsSnapshot.mainSetVariability = options.mainSetVariability;
+        break;
+      case 'pyramid':
+      case 'ladder':
+        optionsSnapshot.numberOfSteps = options.numberOfSteps;
+        optionsSnapshot.climbsPerStep = options.climbsPerStep;
+        break;
+      case 'gradeFocus':
+        optionsSnapshot.numberOfClimbs = options.numberOfClimbs;
+        break;
+    }
+
+    track('Workout Generator Generate Clicked', {
+      targetType,
+      boardName: boardDetails.board_name,
+      plannedCount: plannedSlots.length,
+      ...optionsSnapshot,
+    });
+
+    const startedAt = performance.now();
 
     setGenerating(true);
     setDrawerState('generating');
@@ -200,9 +281,35 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
     setGenerating(false);
 
     const added = plannedSlots.length - failedSlots.length;
-    onComplete?.({ added, failed: failedSlots.length, total: plannedSlots.length });
+    completedSuccessfullyRef.current = added > 0;
+    const durationMs = Math.round(performance.now() - startedAt);
+
+    track('Workout Generated', {
+      targetType,
+      boardName: boardDetails.board_name,
+      plannedCount: plannedSlots.length,
+      savedCount: added,
+      failedCount: failedSlots.length,
+      durationMs,
+      ...optionsSnapshot,
+    });
+
+    onComplete?.({ added, failed: failedSlots.length, total: plannedSlots.length, workoutType: selectedType });
     onClose();
-  }, [options, plannedSlots, targetAngle, onAddClimb, onComplete, onClose, showMessage, searchClimbsForGrade, t]);
+  }, [
+    options,
+    plannedSlots,
+    selectedType,
+    targetAngle,
+    targetType,
+    boardDetails.board_name,
+    onAddClimb,
+    onComplete,
+    onClose,
+    showMessage,
+    searchClimbsForGrade,
+    t,
+  ]);
 
   const workoutTypeInfo = selectedType ? WORKOUT_TYPES.find((wt) => wt.type === selectedType) : null;
 
@@ -308,7 +415,7 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
         </div>
       }
       open={open}
-      onClose={generating ? undefined : onClose}
+      onClose={generating ? undefined : handleClose}
       placement="bottom"
       showCloseButton={!generating}
       disableBackdropClick={generating}

--- a/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
+++ b/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
@@ -15,11 +15,6 @@ import {
   type ClimbSearchResponse,
   SEARCH_CLIMBS,
 } from '@/app/lib/graphql/operations/climb-search';
-import {
-  type AddClimbToPlaylistMutationVariables,
-  type AddClimbToPlaylistMutationResponse,
-  ADD_CLIMB_TO_PLAYLIST,
-} from '@/app/lib/graphql/operations/playlists';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { normalizeMinRatingFilter } from '@/app/lib/climb-quality-filter-options';
 import { type WorkoutType, type GeneratorOptions, type PlannedClimbSlot, WORKOUT_TYPES } from './types';
@@ -29,13 +24,19 @@ import GradeProgressionChart from './grade-progression-chart';
 import { generateWorkoutPlan, groupSlotsBySection, getGradeName } from './generation-utils';
 import styles from './playlist-generator-drawer.module.css';
 
+export type GeneratorCompletionResult = {
+  added: number;
+  failed: number;
+  total: number;
+};
+
 type PlaylistGeneratorDrawerProps = {
   open: boolean;
   onClose: () => void;
-  playlistUuid: string;
   boardDetails: BoardDetails;
-  angle: number;
-  onSuccess?: () => void;
+  defaultAngle: number;
+  onAddClimb: (climb: Climb, slot: PlannedClimbSlot, angle: number) => Promise<void>;
+  onComplete?: (result: GeneratorCompletionResult) => void;
 };
 
 type DrawerState = 'select' | 'configure' | 'generating';
@@ -43,42 +44,40 @@ type DrawerState = 'select' | 'configure' | 'generating';
 const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
   open,
   onClose,
-  playlistUuid,
   boardDetails,
-  angle,
-  onSuccess,
+  defaultAngle,
+  onAddClimb,
+  onComplete,
 }) => {
   const { token, isAuthenticated } = useWsAuthToken();
   const { showMessage } = useSnackbar();
   const { t } = useTranslation('playlists');
 
-  // Default target grade (middle of range)
-  const defaultTargetGrade = 18; // 6b/V4
+  const defaultTargetGrade = 18;
 
   const [drawerState, setDrawerState] = useState<DrawerState>('select');
   const [selectedType, setSelectedType] = useState<WorkoutType | null>(null);
   const [options, setOptions] = useState<GeneratorOptions | null>(null);
+  const [targetAngle, setTargetAngle] = useState<number>(defaultAngle);
   const [generating, setGenerating] = useState(false);
   const [progress, setProgress] = useState({ current: 0, total: 0 });
 
-  // Reset state when drawer opens/closes
   useEffect(() => {
     if (open) {
       setDrawerState('select');
       setSelectedType(null);
       setOptions(null);
+      setTargetAngle(defaultAngle);
       setGenerating(false);
       setProgress({ current: 0, total: 0 });
     }
-  }, [open]);
+  }, [open, defaultAngle]);
 
-  // Generate the workout plan preview
   const plannedSlots = useMemo(() => {
     if (!options) return [];
     return generateWorkoutPlan(options, boardDetails.board_name);
   }, [options, boardDetails.board_name]);
 
-  // Handle workout type selection
   const handleTypeSelect = useCallback(
     (type: WorkoutType) => {
       setSelectedType(type);
@@ -88,7 +87,6 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
     [defaultTargetGrade],
   );
 
-  // Handle back button
   const handleBack = useCallback(() => {
     if (drawerState === 'configure') {
       setDrawerState('select');
@@ -97,14 +95,13 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
     }
   }, [drawerState]);
 
-  // Handle options reset
   const handleReset = useCallback(() => {
     if (selectedType) {
       setOptions(getDefaultOptions(selectedType, defaultTargetGrade));
+      setTargetAngle(defaultAngle);
     }
-  }, [selectedType, defaultTargetGrade]);
+  }, [selectedType, defaultTargetGrade, defaultAngle]);
 
-  // Search for climbs at a specific grade
   const searchClimbsForGrade = useCallback(
     async (grade: number, excludeUuids: Set<string>): Promise<Climb[]> => {
       const input: ClimbSearchInputVariables['input'] = {
@@ -112,7 +109,7 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
         layoutId: boardDetails.layout_id,
         sizeId: boardDetails.size_id,
         setIds: boardDetails.set_ids.join(','),
-        angle,
+        angle: targetAngle,
         minGrade: grade,
         maxGrade: grade,
         minAscents: options?.minAscents ?? 5,
@@ -120,11 +117,10 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
         sortBy: 'quality',
         sortOrder: 'desc',
         page: 1,
-        pageSize: 50, // Get a pool of climbs to choose from
+        pageSize: 50,
         onlyTallClimbs: options?.onlyTallClimbs || false,
       };
 
-      // Apply climb bias filters if user is authenticated
       if (options && isAuthenticated) {
         switch (options.climbBias) {
           case 'unfamiliar':
@@ -134,7 +130,6 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
           case 'attempted':
             input.showOnlyAttempted = true;
             break;
-          // 'any' - no additional filters
         }
       }
 
@@ -144,13 +139,11 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
         token,
       );
 
-      // Filter out already selected climbs
       return response.searchClimbs.climbs.filter((c) => !excludeUuids.has(c.uuid));
     },
-    [boardDetails, angle, options, isAuthenticated, token],
+    [boardDetails, targetAngle, options, isAuthenticated, token],
   );
 
-  // Generate the playlist
   const handleGenerate = useCallback(async () => {
     if (!options || plannedSlots.length === 0) {
       showMessage(t('generator.messages.noClimbs'), 'error');
@@ -163,30 +156,17 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
 
     const addedUuids = new Set<string>();
     const failedSlots: PlannedClimbSlot[] = [];
-
-    // Group slots by grade to batch search
-    const gradeGroups = new Map<number, PlannedClimbSlot[]>();
-    for (const slot of plannedSlots) {
-      const existing = gradeGroups.get(slot.grade) || [];
-      existing.push(slot);
-      gradeGroups.set(slot.grade, existing);
-    }
-
-    // Cache searched climbs by grade
     const climbCache = new Map<number, Climb[]>();
 
     let processed = 0;
 
-    // Process slots in order
     for (const slot of plannedSlots) {
       try {
-        // Get or search for climbs at this grade
         let availableClimbs = climbCache.get(slot.grade);
         if (!availableClimbs) {
           availableClimbs = await searchClimbsForGrade(slot.grade, addedUuids);
           climbCache.set(slot.grade, availableClimbs);
         } else {
-          // Filter out already added
           availableClimbs = availableClimbs.filter((c) => !addedUuids.has(c.uuid));
           climbCache.set(slot.grade, availableClimbs);
         }
@@ -198,27 +178,14 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
           continue;
         }
 
-        // Pick a random climb from top candidates (weighted towards better quality)
         const poolSize = Math.min(5, availableClimbs.length);
         const selectedIndex = Math.floor(Math.random() * poolSize);
         const selectedClimb = availableClimbs[selectedIndex];
 
-        // Add to playlist
-        await executeGraphQL<AddClimbToPlaylistMutationResponse, AddClimbToPlaylistMutationVariables>(
-          ADD_CLIMB_TO_PLAYLIST,
-          {
-            input: {
-              playlistId: playlistUuid,
-              climbUuid: selectedClimb.uuid,
-              angle,
-            },
-          },
-          token,
-        );
+        await onAddClimb(selectedClimb, slot, targetAngle);
 
         addedUuids.add(selectedClimb.uuid);
 
-        // Remove from cache
         const updatedCache = (climbCache.get(slot.grade) || []).filter((c) => c.uuid !== selectedClimb.uuid);
         climbCache.set(slot.grade, updatedCache);
       } catch (error) {
@@ -232,28 +199,13 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
 
     setGenerating(false);
 
-    if (failedSlots.length === 0) {
-      showMessage(t('generator.messages.addedAll', { count: plannedSlots.length }), 'success');
-    } else if (failedSlots.length < plannedSlots.length) {
-      showMessage(
-        t('generator.messages.addedPartial', {
-          added: plannedSlots.length - failedSlots.length,
-          failed: failedSlots.length,
-        }),
-        'warning',
-      );
-    } else {
-      showMessage(t('generator.messages.failed'), 'error');
-    }
-
-    onSuccess?.();
+    const added = plannedSlots.length - failedSlots.length;
+    onComplete?.({ added, failed: failedSlots.length, total: plannedSlots.length });
     onClose();
-  }, [options, plannedSlots, playlistUuid, angle, token, onSuccess, onClose, showMessage, searchClimbsForGrade, t]);
+  }, [options, plannedSlots, targetAngle, onAddClimb, onComplete, onClose, showMessage, searchClimbsForGrade, t]);
 
-  // Get workout type info
   const workoutTypeInfo = selectedType ? WORKOUT_TYPES.find((wt) => wt.type === selectedType) : null;
 
-  // Render title based on state
   const renderTitle = () => {
     if (drawerState === 'select') {
       return t('generator.drawerTitle');
@@ -264,7 +216,6 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
     return workoutTypeInfo ? t(`generator.workoutTypes.${workoutTypeInfo.type}.name`) : t('generator.optionsTitle');
   };
 
-  // Render content based on state
   const renderContent = () => {
     if (drawerState === 'select') {
       return <WorkoutTypeSelector onSelect={handleTypeSelect} />;
@@ -286,12 +237,10 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
 
       return (
         <div className={styles.configureContainer}>
-          {/* Chart Preview */}
           <div className={styles.chartSection}>
             <GradeProgressionChart plannedSlots={plannedSlots} boardDetails={boardDetails} height={140} />
           </div>
 
-          {/* Summary */}
           <div className={styles.summarySection}>
             {groupedSlots.map((group) => {
               const firstGrade = group.slots[0].grade;
@@ -324,7 +273,6 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
             </div>
           </div>
 
-          {/* Options Form */}
           <div className={styles.optionsSection}>
             <GeneratorOptionsForm
               workoutType={selectedType}
@@ -332,6 +280,8 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
               onChange={setOptions}
               onReset={handleReset}
               boardDetails={boardDetails}
+              targetAngle={targetAngle}
+              onTargetAngleChange={setTargetAngle}
             />
           </div>
         </div>
@@ -368,7 +318,7 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
           borderBottom: `1px solid var(--neutral-200)`,
         },
         body: {
-          padding: drawerState === 'select' ? 0 : 16,
+          padding: drawerState === 'select' ? 0 : '16px',
           overflow: 'auto',
         },
       }}

--- a/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
+++ b/packages/web/app/components/playlist-generator/playlist-generator-drawer.tsx
@@ -53,7 +53,7 @@ const PlaylistGeneratorDrawer: React.FC<PlaylistGeneratorDrawerProps> = ({
   const { showMessage } = useSnackbar();
   const { t } = useTranslation('playlists');
 
-  const defaultTargetGrade = 18;
+  const defaultTargetGrade = 18; // 6b/V4
 
   const [drawerState, setDrawerState] = useState<DrawerState>('select');
   const [selectedType, setSelectedType] = useState<WorkoutType | null>(null);

--- a/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
+++ b/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
@@ -183,12 +183,18 @@ vi.mock('@/app/components/board-selector-drawer/board-selector-drawer', () => ({
 // without mounting the real generator (which pulls in React Query / WS auth).
 type GeneratorMockProps = {
   open: boolean;
+  onClose: () => void;
   onAddClimb: (
-    climb: { uuid: string; name: string; angle: number; frames?: string; mirrored?: boolean },
+    climb: Record<string, unknown> & { uuid: string; name: string; angle: number },
     slot: unknown,
     angle: number,
   ) => Promise<void>;
-  onComplete?: (result: { added: number; failed: number; total: number }) => void;
+  onComplete?: (result: {
+    added: number;
+    failed: number;
+    total: number;
+    workoutType: 'volume' | 'pyramid' | 'ladder' | 'gradeFocus';
+  }) => void;
 };
 let lastGeneratorProps: GeneratorMockProps | null = null;
 vi.mock('@/app/components/playlist-generator', () => ({
@@ -620,7 +626,34 @@ describe('StartSeshDrawer', () => {
     );
   }
 
-  async function simulateGeneration(climbs: Array<{ uuid: string; name: string; angle: number }>) {
+  // Shape-complete mock that the real `toClimbQueueItemInput` could
+  // serialize without erroring. Fields beyond what tests assert on are
+  // filled with neutral values.
+  function makeMockClimb(uuid: string, name: string, angle: number) {
+    return {
+      uuid,
+      name,
+      angle,
+      setter_username: 'setter',
+      userId: null,
+      frames: '',
+      mirrored: false,
+      difficulty: '6b/V4',
+      ascensionist_count: 0,
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0',
+      benchmark_difficulty: null,
+      userAscents: 0,
+      userAttempts: 0,
+    };
+  }
+
+  async function simulateGeneration(
+    climbs: Array<{ uuid: string; name: string; angle: number }>,
+    targetAngle?: number,
+    workoutType: 'volume' | 'pyramid' | 'ladder' | 'gradeFocus' = 'volume',
+  ) {
     // Fire the generator drawer's onAddClimb once per climb, then onComplete.
     // This is what the real generator does after the user picks options and
     // hits Generate — we skip the UI but reach the same state transitions.
@@ -628,14 +661,19 @@ describe('StartSeshDrawer', () => {
     for (const climb of climbs) {
       await act(async () => {
         await lastGeneratorProps!.onAddClimb(
-          { ...climb, frames: '', mirrored: false },
+          makeMockClimb(climb.uuid, climb.name, climb.angle),
           { grade: 18, section: 'main', index: 0 },
-          climb.angle,
+          targetAngle ?? climb.angle,
         );
       });
     }
     await act(async () => {
-      lastGeneratorProps!.onComplete?.({ added: climbs.length, failed: 0, total: climbs.length });
+      lastGeneratorProps!.onComplete?.({
+        added: climbs.length,
+        failed: 0,
+        total: climbs.length,
+        workoutType,
+      });
     });
   }
 
@@ -690,18 +728,16 @@ describe('StartSeshDrawer', () => {
     render(<StartSeshDrawer open onClose={vi.fn()} />);
     fireEvent.click(getGenerateButton()!);
 
-    // Search response had angle=40; user picked angle=50 in the generator.
-    // The queue item must reflect the user's chosen angle.
-    await simulateGeneration([{ uuid: 'climb-a', name: 'A', angle: 40 }]);
-    // Override the simulated climb's angle via the generator callback path:
-    if (!lastGeneratorProps) throw new Error('no generator props');
-    await act(async () => {
-      await lastGeneratorProps!.onAddClimb(
-        { uuid: 'climb-b', name: 'B', angle: 40, frames: '', mirrored: false },
-        { grade: 18, section: 'main', index: 0 },
-        50,
-      );
-    });
+    // Search response returns climbs with climb.angle=40 (the board's default).
+    // User picked angle=50 in the generator — the queue items must reflect
+    // that override, not the search-response angle.
+    await simulateGeneration(
+      [
+        { uuid: 'climb-a', name: 'A', angle: 40 },
+        { uuid: 'climb-b', name: 'B', angle: 40 },
+      ],
+      50,
+    );
 
     await submitSesh();
 
@@ -710,7 +746,7 @@ describe('StartSeshDrawer', () => {
     });
 
     const queue = mockSetInitialQueueForSession.mock.calls[0][1] as Array<{ climb: { uuid: string; angle: number } }>;
-    expect(queue.find((i) => i.climb.uuid === 'climb-a')?.climb.angle).toBe(40);
+    expect(queue.find((i) => i.climb.uuid === 'climb-a')?.climb.angle).toBe(50);
     expect(queue.find((i) => i.climb.uuid === 'climb-b')?.climb.angle).toBe(50);
   });
 
@@ -736,6 +772,37 @@ describe('StartSeshDrawer', () => {
     expect((queue as Array<{ uuid: string }>).map((i) => i.uuid)).toEqual(['q1', expect.any(String)]);
     // Carried current wins over the first generated climb.
     expect(current).toBe(carried);
+  });
+
+  it('preserves the existing generated queue when Regenerate is dismissed before completing', async () => {
+    mockLocalBoardPath = '/b/kilter-original-12x12/40/list';
+    mockLocalBoardDetails = { board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 2] };
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    // Initial generation lands two climbs.
+    fireEvent.click(getGenerateButton()!);
+    await simulateGeneration([
+      { uuid: 'climb-a', name: 'A', angle: 40 },
+      { uuid: 'climb-b', name: 'B', angle: 40 },
+    ]);
+
+    // Tap Regenerate — opens the generator again — then dismiss it without
+    // running another generation.
+    const regen = screen.getByRole('button', { name: /regenerate/i });
+    fireEvent.click(regen);
+    await act(async () => {
+      lastGeneratorProps!.onClose();
+    });
+
+    await submitSesh();
+    await waitFor(() => {
+      expect(mockSetInitialQueueForSession).toHaveBeenCalled();
+    });
+
+    // The original two climbs must still be the session's initial queue.
+    const queue = mockSetInitialQueueForSession.mock.calls[0][1] as Array<{ climb: { uuid: string } }>;
+    expect(queue.map((i) => i.climb.uuid)).toEqual(['climb-a', 'climb-b']);
   });
 
   it('clears the generated queue when the board selection changes', async () => {

--- a/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
+++ b/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
@@ -179,6 +179,25 @@ vi.mock('@/app/components/board-selector-drawer/board-selector-drawer', () => ({
   default: () => null,
 }));
 
+// Capture the generator drawer's callbacks so tests can simulate generation
+// without mounting the real generator (which pulls in React Query / WS auth).
+type GeneratorMockProps = {
+  open: boolean;
+  onAddClimb: (
+    climb: { uuid: string; name: string; angle: number; frames?: string; mirrored?: boolean },
+    slot: unknown,
+    angle: number,
+  ) => Promise<void>;
+  onComplete?: (result: { added: number; failed: number; total: number }) => void;
+};
+let lastGeneratorProps: GeneratorMockProps | null = null;
+vi.mock('@/app/components/playlist-generator', () => ({
+  PlaylistGeneratorDrawer: (props: GeneratorMockProps) => {
+    lastGeneratorProps = props;
+    return props.open ? <div data-testid="playlist-generator-drawer" /> : null;
+  },
+}));
+
 let mockBridgeBoardDetails: {
   board_name: string;
   layout_id: number;
@@ -236,6 +255,7 @@ describe('StartSeshDrawer', () => {
     mockBridgeCurrentClimbQueueItem = null;
     mockPathname = null;
     mockCreateSession.mockResolvedValue('new-session-id');
+    lastGeneratorProps = null;
   });
 
   async function expandBoardSelectorAndSelect(boardName: string) {
@@ -588,5 +608,151 @@ describe('StartSeshDrawer', () => {
 
     const drawer = screen.getByTestId('drawer');
     expect(drawer.getAttribute('data-placement')).toBe('bottom');
+  });
+
+  // --- Workout generator entry point ---
+
+  function getGenerateButton() {
+    return screen.queryByRole('button', { name: /generate workout queue/i });
+  }
+
+  async function simulateGeneration(climbs: Array<{ uuid: string; name: string; angle: number }>) {
+    // Fire the generator drawer's onAddClimb once per climb, then onComplete.
+    // This is what the real generator does after the user picks options and
+    // hits Generate — we skip the UI but reach the same state transitions.
+    if (!lastGeneratorProps) throw new Error('generator drawer not mounted');
+    for (const climb of climbs) {
+      await act(async () => {
+        await lastGeneratorProps!.onAddClimb(
+          { ...climb, frames: '', mirrored: false },
+          { grade: 18, section: 'main', index: 0 },
+          climb.angle,
+        );
+      });
+    }
+    await act(async () => {
+      lastGeneratorProps!.onComplete?.({ added: climbs.length, failed: 0, total: climbs.length });
+    });
+  }
+
+  it('disables the generate button until a board is selected', () => {
+    // No board context anywhere → entry point should be disabled.
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+    const btn = getGenerateButton();
+    expect(btn).toBeTruthy();
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('enables the generate button when a board has been auto-selected', () => {
+    mockLocalBoardPath = '/b/kilter-original-12x12/40/list';
+    mockLocalBoardDetails = { board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 2] };
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    const btn = getGenerateButton();
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('appends generated climbs to initialQueue and uses the first as initialCurrent when no carried queue', async () => {
+    mockLocalBoardPath = '/b/kilter-original-12x12/40/list';
+    mockLocalBoardDetails = { board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 2] };
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    // Open the generator and feed it two climbs.
+    fireEvent.click(getGenerateButton()!);
+    await simulateGeneration([
+      { uuid: 'climb-a', name: 'A', angle: 40 },
+      { uuid: 'climb-b', name: 'B', angle: 40 },
+    ]);
+
+    await submitSesh();
+
+    await waitFor(() => {
+      expect(mockSetInitialQueueForSession).toHaveBeenCalled();
+    });
+
+    const [, queue, current] = mockSetInitialQueueForSession.mock.calls[0];
+    expect((queue as Array<{ climb: { uuid: string } }>).map((i) => i.climb.uuid)).toEqual(['climb-a', 'climb-b']);
+    // initialCurrent must be the same object reference as the first queue item
+    // (same uuid) so the backend doesn't insert it twice.
+    expect(current).toBe(queue[0]);
+  });
+
+  it('stamps the user-chosen target angle onto each generated queue item', async () => {
+    mockLocalBoardPath = '/b/kilter-original-12x12/40/list';
+    mockLocalBoardDetails = { board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 2] };
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+    fireEvent.click(getGenerateButton()!);
+
+    // Search response had angle=40; user picked angle=50 in the generator.
+    // The queue item must reflect the user's chosen angle.
+    await simulateGeneration([{ uuid: 'climb-a', name: 'A', angle: 40 }]);
+    // Override the simulated climb's angle via the generator callback path:
+    if (!lastGeneratorProps) throw new Error('no generator props');
+    await act(async () => {
+      await lastGeneratorProps!.onAddClimb(
+        { uuid: 'climb-b', name: 'B', angle: 40, frames: '', mirrored: false },
+        { grade: 18, section: 'main', index: 0 },
+        50,
+      );
+    });
+
+    await submitSesh();
+
+    await waitFor(() => {
+      expect(mockSetInitialQueueForSession).toHaveBeenCalled();
+    });
+
+    const queue = mockSetInitialQueueForSession.mock.calls[0][1] as Array<{ climb: { uuid: string; angle: number } }>;
+    expect(queue.find((i) => i.climb.uuid === 'climb-a')?.climb.angle).toBe(40);
+    expect(queue.find((i) => i.climb.uuid === 'climb-b')?.climb.angle).toBe(50);
+  });
+
+  it('appends generated climbs after a carried same-board queue and keeps the carried current', async () => {
+    const carried = makeQueueItem('q1', 'Carried');
+    mockLocalQueue = [carried];
+    mockLocalCurrentClimbQueueItem = carried;
+    mockLocalBoardPath = '/b/kilter-original-12x12/40/list';
+    mockLocalBoardDetails = { board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 2] };
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    fireEvent.click(getGenerateButton()!);
+    await simulateGeneration([{ uuid: 'climb-a', name: 'A', angle: 40 }]);
+
+    await submitSesh();
+
+    await waitFor(() => {
+      expect(mockSetInitialQueueForSession).toHaveBeenCalled();
+    });
+
+    const [, queue, current] = mockSetInitialQueueForSession.mock.calls[0];
+    expect((queue as Array<{ uuid: string }>).map((i) => i.uuid)).toEqual(['q1', expect.any(String)]);
+    // Carried current wins over the first generated climb.
+    expect(current).toBe(carried);
+  });
+
+  it('clears the generated queue when the board selection changes', async () => {
+    mockLocalBoardPath = '/b/kilter-original-12x12/40/list';
+    mockLocalBoardDetails = { board_name: 'kilter', layout_id: 1, size_id: 10, set_ids: [1, 2] };
+
+    render(<StartSeshDrawer open onClose={vi.fn()} />);
+
+    fireEvent.click(getGenerateButton()!);
+    await simulateGeneration([{ uuid: 'climb-a', name: 'A', angle: 40 }]);
+
+    // Chip should now show the count; expand the board selector and switch.
+    await expandBoardSelectorAndSelect('Tension');
+
+    // After board change, the entry point should be back to the empty state.
+    expect(getGenerateButton()).toBeTruthy();
+    // Mock generator was reset; submit should not pass any generated climbs.
+    await submitSesh();
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalled();
+    });
+    expect(mockSetInitialQueueForSession).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
+++ b/packages/web/app/components/session-creation/__tests__/start-sesh-drawer.test.tsx
@@ -613,7 +613,11 @@ describe('StartSeshDrawer', () => {
   // --- Workout generator entry point ---
 
   function getGenerateButton() {
-    return screen.queryByRole('button', { name: /generate workout queue/i });
+    // Label switches to a hint when the button is disabled (no board picked yet).
+    return (
+      screen.queryByRole('button', { name: /generate workout queue/i }) ??
+      screen.queryByRole('button', { name: /pick a board first/i })
+    );
   }
 
   async function simulateGeneration(climbs: Array<{ uuid: string; name: string; angle: number }>) {

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -8,7 +8,11 @@ import Button from '@mui/material/Button';
 import LoginOutlined from '@mui/icons-material/LoginOutlined';
 import EditOutlined from '@mui/icons-material/EditOutlined';
 import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
+import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
+import RestartAltOutlined from '@mui/icons-material/RestartAltOutlined';
 import CircularProgress from '@mui/material/CircularProgress';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
 import Collapse from '@mui/material/Collapse';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import drawerCss from '../swipeable-drawer/swipeable-drawer.module.css';
@@ -31,6 +35,9 @@ import {
   tryConstructSlugListUrl,
 } from '@/app/lib/url-utils';
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
+import { useBoardDetails } from '@/app/components/board-scroll/board-thumbnail';
+import { PlaylistGeneratorDrawer } from '@/app/components/playlist-generator';
+import type { ClimbQueueItem } from '@/app/components/queue-control/types';
 import { isBoardRoutePath } from '@/app/lib/board-route-paths';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { setClimbSessionCookie } from '@/app/lib/climb-session-cookie';
@@ -86,8 +93,18 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
   const [showBoardDrawer, setShowBoardDrawer] = useState(false);
   const [formKey, setFormKey] = useState(0);
   const [boardSelectorExpanded, setBoardSelectorExpanded] = useState(false);
+  const [generatorOpen, setGeneratorOpen] = useState(false);
+  const [generatedQueue, setGeneratedQueue] = useState<ClimbQueueItem[]>([]);
   const hasAutoSelectedRef = useRef(false);
   const formSubmitRef = useRef<(() => void) | null>(null);
+
+  const selectedBoardDetails = useBoardDetails(selectedBoard ?? undefined, selectedCustomConfig ?? undefined);
+  const generatorBoardDetails = selectedBoardDetails ?? bridgeBoardDetails ?? localBoardDetails ?? null;
+  const generatorDefaultAngle =
+    selectedBoard?.angle ??
+    selectedCustomConfig?.angle ??
+    bridgeAngle ??
+    (generatorBoardDetails ? getDefaultAngleForBoard(generatorBoardDetails.board_name) : 40);
 
   // Reset auto-selection tracking and expander state when the drawer closes.
   // handleClose covers user-initiated closes, but the parent can also flip
@@ -163,6 +180,8 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     setSelectedCustomPath(null);
     setSelectedCustomConfig(null);
     setBoardSelectorExpanded(false);
+    setGeneratedQueue([]);
+    setGeneratorOpen(false);
     setFormKey((k) => k + 1);
   }, [onClose]);
 
@@ -171,6 +190,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     setSelectedCustomPath(null);
     setSelectedCustomConfig(null);
     setBoardSelectorExpanded(false);
+    setGeneratedQueue([]);
   }, []);
 
   const handleDiscoveryBoardClick = useCallback(
@@ -212,6 +232,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     });
     setSelectedBoard(null);
     setBoardSelectorExpanded(false);
+    setGeneratedQueue([]);
   }, []);
 
   const handleCustomSelect = (url: string, config?: StoredBoardConfig) => {
@@ -220,6 +241,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     setSelectedBoard(null);
     setShowBoardDrawer(false);
     setBoardSelectorExpanded(false);
+    setGeneratedQueue([]);
   };
 
   const handleSubmit = async (formData: SessionCreationFormData) => {
@@ -261,9 +283,15 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
       const effectiveCurrentClimb = localCurrentClimbQueueItem ?? bridgeCurrentClimbQueueItem;
       const boardsMatch = effectiveBaseBoardPath != null && effectiveBaseBoardPath === getBaseBoardPath(boardPath);
 
-      // Transfer existing queue to the new session if on the same board
-      if (boardsMatch && (effectiveQueue.length > 0 || effectiveCurrentClimb)) {
-        setInitialQueueForSession(sessionId, effectiveQueue, effectiveCurrentClimb, formData.name);
+      // Merge any existing same-board queue with the generated queue: existing
+      // first, generated appended. The generated queue is always for the
+      // selected board by construction, so it bypasses the boardsMatch gate.
+      const carriedQueue = boardsMatch ? effectiveQueue : [];
+      const carriedCurrent = boardsMatch ? effectiveCurrentClimb : null;
+      const initialQueue = [...carriedQueue, ...generatedQueue];
+      const initialCurrent = carriedCurrent ?? generatedQueue[0] ?? null;
+      if (initialQueue.length > 0 || initialCurrent) {
+        setInitialQueueForSession(sessionId, initialQueue, initialCurrent, formData.name);
       }
 
       setClimbSessionCookie(sessionId);
@@ -369,6 +397,51 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     </Box>
   );
 
+  const generateEntry =
+    generatedQueue.length > 0 ? (
+      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+        <Chip
+          color="primary"
+          variant="filled"
+          icon={<ElectricBoltOutlined />}
+          label={t('creation.generateQueue.summary', { count: generatedQueue.length })}
+        />
+        <Button
+          variant="text"
+          size="small"
+          startIcon={<RestartAltOutlined />}
+          onClick={() => {
+            setGeneratedQueue([]);
+            setGeneratorOpen(true);
+          }}
+          disabled={!generatorBoardDetails}
+        >
+          {t('creation.generateQueue.regenerate')}
+        </Button>
+        <Button variant="text" size="small" onClick={() => setGeneratedQueue([])}>
+          {t('creation.generateQueue.clear')}
+        </Button>
+      </Stack>
+    ) : (
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={<ElectricBoltOutlined />}
+        onClick={() => setGeneratorOpen(true)}
+        disabled={!generatorBoardDetails}
+        sx={{ alignSelf: 'flex-start' }}
+      >
+        {t('creation.generateQueue.button')}
+      </Button>
+    );
+
+  const formHeader = (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {boardSelector}
+      {generateEntry}
+    </Box>
+  );
+
   return (
     <>
       <SwipeableDrawer
@@ -420,7 +493,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
             onSubmit={handleSubmit}
             isSubmitting={isCreating}
             submitLabel={t('creation.submitDefault')}
-            headerContent={boardSelector}
+            headerContent={formHeader}
             isAnonymous={!isLoggedIn}
             renderSubmit={({ onSubmit: formSubmit }) => {
               formSubmitRef.current = formSubmit;
@@ -453,6 +526,32 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
           boardConfigs={boardConfigs}
           placement="top"
           onBoardSelected={handleCustomSelect}
+        />
+      )}
+
+      {generatorOpen && generatorBoardDetails && (
+        <PlaylistGeneratorDrawer
+          open={generatorOpen}
+          onClose={() => setGeneratorOpen(false)}
+          boardDetails={generatorBoardDetails}
+          defaultAngle={generatorDefaultAngle}
+          onAddClimb={async (climb) => {
+            setGeneratedQueue((prev) => [
+              ...prev,
+              {
+                uuid: crypto.randomUUID(),
+                climb,
+                suggested: true,
+              },
+            ]);
+          }}
+          onComplete={({ added, failed }) => {
+            if (added > 0 && failed > 0) {
+              showMessage(t('creation.generateQueue.addedPartial', { added, failed }), 'warning');
+            } else if (added === 0) {
+              showMessage(t('creation.generateQueue.failed'), 'error');
+            }
+          }}
         />
       )}
     </>

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -529,18 +529,22 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
         />
       )}
 
-      {generatorOpen && generatorBoardDetails && (
+      {generatorBoardDetails && (
         <PlaylistGeneratorDrawer
           open={generatorOpen}
           onClose={() => setGeneratorOpen(false)}
           boardDetails={generatorBoardDetails}
           defaultAngle={generatorDefaultAngle}
-          onAddClimb={async (climb) => {
+          // Stamp the user-chosen angle onto the queue item's climb so the
+          // session queue uses it verbatim. The search response's climb.angle
+          // typically matches the queried angle today, but trusting that
+          // coupling is fragile — pin it explicitly.
+          onAddClimb={async (climb, _slot, angle) => {
             setGeneratedQueue((prev) => [
               ...prev,
               {
                 uuid: crypto.randomUUID(),
-                climb,
+                climb: { ...climb, angle },
                 suggested: true,
               },
             ]);

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -98,6 +98,11 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
   const [generatedWorkoutType, setGeneratedWorkoutType] = useState<WorkoutType | null>(null);
   const hasAutoSelectedRef = useRef(false);
   const formSubmitRef = useRef<(() => void) | null>(null);
+  // Per-run buffer for in-flight generations. We accumulate here instead of
+  // mutating generatedQueue directly so that dismissing the generator
+  // mid-run preserves the prior queue. Committed to generatedQueue on
+  // onComplete only when at least one climb was added.
+  const runBufferRef = useRef<ClimbQueueItem[]>([]);
 
   const selectedBoardDetails = useBoardDetails(selectedBoard ?? undefined, selectedCustomConfig ?? undefined);
   const generatorBoardDetails = selectedBoardDetails ?? bridgeBoardDetails ?? localBoardDetails ?? null;
@@ -184,6 +189,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     setGeneratedQueue([]);
     setGeneratedWorkoutType(null);
     setGeneratorOpen(false);
+    runBufferRef.current = [];
     setFormKey((k) => k + 1);
   }, [onClose]);
 
@@ -194,6 +200,10 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     setBoardSelectorExpanded(false);
     setGeneratedQueue([]);
     setGeneratedWorkoutType(null);
+    // Close the generator if it was open against the old board — its
+    // boardDetails prop is about to become stale.
+    setGeneratorOpen(false);
+    runBufferRef.current = [];
   }, []);
 
   const handleDiscoveryBoardClick = useCallback(
@@ -237,6 +247,10 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     setBoardSelectorExpanded(false);
     setGeneratedQueue([]);
     setGeneratedWorkoutType(null);
+    // Close the generator if it was open against the old board — its
+    // boardDetails prop is about to become stale.
+    setGeneratorOpen(false);
+    runBufferRef.current = [];
   }, []);
 
   const handleCustomSelect = (url: string, config?: StoredBoardConfig) => {
@@ -247,6 +261,8 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     setBoardSelectorExpanded(false);
     setGeneratedQueue([]);
     setGeneratedWorkoutType(null);
+    setGeneratorOpen(false);
+    runBufferRef.current = [];
   };
 
   const handleClearGenerated = useCallback(() => {
@@ -437,11 +453,13 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
         <Button
           size="small"
           variant="text"
-          onClick={() => {
-            setGeneratedQueue([]);
-            setGeneratedWorkoutType(null);
-            setGeneratorOpen(true);
-          }}
+          // Don't wipe the current queue on click. If the user dismisses
+          // the generator mid-flow, the previous queue is still intact.
+          // The generator drawer pushes climbs incrementally via onAddClimb,
+          // which appends — so without clearing, a fresh run would mix old
+          // and new climbs. We clear once on the first append of the new run
+          // (handled in the onAddClimb callback below).
+          onClick={() => setGeneratorOpen(true)}
           disabled={!generatorBoardDetails}
         >
           {t('creation.generateQueue.regenerate')}
@@ -563,7 +581,12 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
       {generatorBoardDetails && (
         <PlaylistGeneratorDrawer
           open={generatorOpen}
-          onClose={() => setGeneratorOpen(false)}
+          onClose={() => {
+            // Drop any in-flight buffer so a future Regenerate doesn't pick
+            // up half a previous run.
+            runBufferRef.current = [];
+            setGeneratorOpen(false);
+          }}
           boardDetails={generatorBoardDetails}
           defaultAngle={generatorDefaultAngle}
           targetType="session"
@@ -571,18 +594,25 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
           // session queue uses it verbatim. The search response's climb.angle
           // typically matches the queried angle today, but trusting that
           // coupling is fragile — pin it explicitly.
+          //
+          // We accumulate into `runBufferRef` rather than `generatedQueue` so
+          // that dismissing the generator mid-run leaves the previous queue
+          // intact. The buffer is committed by `onComplete` below, only when
+          // at least one climb was actually saved.
           onAddClimb={async (climb, _slot, angle) => {
-            setGeneratedQueue((prev) => [
-              ...prev,
-              {
-                uuid: crypto.randomUUID(),
-                climb: { ...climb, angle },
-                suggested: true,
-              },
-            ]);
+            const safeUuid =
+              typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+                ? crypto.randomUUID()
+                : `gen-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+            runBufferRef.current.push({
+              uuid: safeUuid,
+              climb: { ...climb, angle },
+              suggested: true,
+            });
           }}
-          onComplete={({ added, failed, workoutType }) => {
+          onComplete={({ added, failed, total, workoutType }) => {
             if (added > 0) {
+              setGeneratedQueue(runBufferRef.current);
               setGeneratedWorkoutType(workoutType);
               track('Session Queue Generated', {
                 workoutType,
@@ -592,9 +622,12 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
                 failedCount: failed,
               });
             }
-            if (added > 0 && failed > 0) {
+            runBufferRef.current = [];
+            if (failed === 0 && added > 0) {
+              showMessage(t('creation.generateQueue.addedAll', { count: total }), 'success');
+            } else if (added > 0) {
               showMessage(t('creation.generateQueue.addedPartial', { added, failed }), 'warning');
-            } else if (added === 0) {
+            } else {
               showMessage(t('creation.generateQueue.failed'), 'error');
             }
           }}

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -8,10 +8,10 @@ import Button from '@mui/material/Button';
 import LoginOutlined from '@mui/icons-material/LoginOutlined';
 import EditOutlined from '@mui/icons-material/EditOutlined';
 import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
-import ElectricBoltOutlined from '@mui/icons-material/ElectricBoltOutlined';
-import RestartAltOutlined from '@mui/icons-material/RestartAltOutlined';
+import AutoFixHighOutlined from '@mui/icons-material/AutoFixHighOutlined';
+import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import CircularProgress from '@mui/material/CircularProgress';
-import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import Collapse from '@mui/material/Collapse';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
@@ -36,7 +36,7 @@ import {
 } from '@/app/lib/url-utils';
 import { getDefaultAngleForBoard } from '@/app/lib/board-config-for-playlist';
 import { useBoardDetails } from '@/app/components/board-scroll/board-thumbnail';
-import { PlaylistGeneratorDrawer } from '@/app/components/playlist-generator';
+import { PlaylistGeneratorDrawer, type WorkoutType } from '@/app/components/playlist-generator';
 import type { ClimbQueueItem } from '@/app/components/queue-control/types';
 import { isBoardRoutePath } from '@/app/lib/board-route-paths';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
@@ -95,6 +95,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
   const [boardSelectorExpanded, setBoardSelectorExpanded] = useState(false);
   const [generatorOpen, setGeneratorOpen] = useState(false);
   const [generatedQueue, setGeneratedQueue] = useState<ClimbQueueItem[]>([]);
+  const [generatedWorkoutType, setGeneratedWorkoutType] = useState<WorkoutType | null>(null);
   const hasAutoSelectedRef = useRef(false);
   const formSubmitRef = useRef<(() => void) | null>(null);
 
@@ -181,6 +182,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     setSelectedCustomConfig(null);
     setBoardSelectorExpanded(false);
     setGeneratedQueue([]);
+    setGeneratedWorkoutType(null);
     setGeneratorOpen(false);
     setFormKey((k) => k + 1);
   }, [onClose]);
@@ -191,6 +193,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     setSelectedCustomConfig(null);
     setBoardSelectorExpanded(false);
     setGeneratedQueue([]);
+    setGeneratedWorkoutType(null);
   }, []);
 
   const handleDiscoveryBoardClick = useCallback(
@@ -233,6 +236,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     setSelectedBoard(null);
     setBoardSelectorExpanded(false);
     setGeneratedQueue([]);
+    setGeneratedWorkoutType(null);
   }, []);
 
   const handleCustomSelect = (url: string, config?: StoredBoardConfig) => {
@@ -242,7 +246,19 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
     setShowBoardDrawer(false);
     setBoardSelectorExpanded(false);
     setGeneratedQueue([]);
+    setGeneratedWorkoutType(null);
   };
+
+  const handleClearGenerated = useCallback(() => {
+    if (generatedQueue.length === 0) return;
+    track('Session Queue Generated Cleared', {
+      workoutType: generatedWorkoutType,
+      savedCount: generatedQueue.length,
+      boardName: generatorBoardDetails?.board_name ?? '',
+    });
+    setGeneratedQueue([]);
+    setGeneratedWorkoutType(null);
+  }, [generatedQueue.length, generatedWorkoutType, generatorBoardDetails]);
 
   const handleSubmit = async (formData: SessionCreationFormData) => {
     let boardPath: string | undefined;
@@ -325,6 +341,8 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
         boardName: effectiveBoardDetails?.board_name ?? '',
         hasGoal: !!formData.goal,
         isDiscoverable: !!formData.discoverable,
+        generatedQueueCount: generatedQueue.length,
+        generatedWorkoutType: generatedWorkoutType ?? undefined,
       });
 
       handleClose();
@@ -399,39 +417,52 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
 
   const generateEntry =
     generatedQueue.length > 0 ? (
-      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-        <Chip
-          color="primary"
-          variant="filled"
-          icon={<ElectricBoltOutlined />}
-          label={t('creation.generateQueue.summary', { count: generatedQueue.length })}
-        />
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={1}
+        sx={{
+          p: 1.25,
+          borderRadius: 1,
+          border: `1px solid ${themeTokens.colors.primary}`,
+          bgcolor: themeTokens.semantic.selectedLight,
+        }}
+      >
+        <AutoFixHighOutlined fontSize="small" sx={{ color: 'primary.main' }} />
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            {t('creation.generateQueue.summary', { count: generatedQueue.length })}
+          </Typography>
+        </Box>
         <Button
-          variant="text"
           size="small"
-          startIcon={<RestartAltOutlined />}
+          variant="text"
           onClick={() => {
             setGeneratedQueue([]);
+            setGeneratedWorkoutType(null);
             setGeneratorOpen(true);
           }}
           disabled={!generatorBoardDetails}
         >
           {t('creation.generateQueue.regenerate')}
         </Button>
-        <Button variant="text" size="small" onClick={() => setGeneratedQueue([])}>
-          {t('creation.generateQueue.clear')}
-        </Button>
+        <IconButton
+          size="small"
+          onClick={handleClearGenerated}
+          aria-label={t('creation.generateQueue.clear')}
+        >
+          <CloseOutlined fontSize="small" />
+        </IconButton>
       </Stack>
     ) : (
       <Button
         variant="outlined"
-        size="small"
-        startIcon={<ElectricBoltOutlined />}
+        fullWidth
+        startIcon={<AutoFixHighOutlined />}
         onClick={() => setGeneratorOpen(true)}
         disabled={!generatorBoardDetails}
-        sx={{ alignSelf: 'flex-start' }}
       >
-        {t('creation.generateQueue.button')}
+        {generatorBoardDetails ? t('creation.generateQueue.button') : t('creation.generateQueue.buttonHint')}
       </Button>
     );
 
@@ -535,6 +566,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
           onClose={() => setGeneratorOpen(false)}
           boardDetails={generatorBoardDetails}
           defaultAngle={generatorDefaultAngle}
+          targetType="session"
           // Stamp the user-chosen angle onto the queue item's climb so the
           // session queue uses it verbatim. The search response's climb.angle
           // typically matches the queried angle today, but trusting that
@@ -549,7 +581,17 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
               },
             ]);
           }}
-          onComplete={({ added, failed }) => {
+          onComplete={({ added, failed, workoutType }) => {
+            if (added > 0) {
+              setGeneratedWorkoutType(workoutType);
+              track('Session Queue Generated', {
+                workoutType,
+                boardName: generatorBoardDetails.board_name,
+                angle: generatorDefaultAngle,
+                savedCount: added,
+                failedCount: failed,
+              });
+            }
             if (added > 0 && failed > 0) {
               showMessage(t('creation.generateQueue.addedPartial', { added, failed }), 'warning');
             } else if (added === 0) {

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -648,6 +648,7 @@ export default function PlaylistDetailContent({
           onClose={() => setGeneratorOpen(false)}
           boardDetails={generatorBoardDetails}
           defaultAngle={generatorAngle}
+          targetType="playlist"
           onAddClimb={async (climb, _slot, angle) => {
             await executeGraphQL<AddClimbToPlaylistMutationResponse, AddClimbToPlaylistMutationVariables>(
               ADD_CLIMB_TO_PLAYLIST,

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -670,7 +670,11 @@ export default function PlaylistDetailContent({
             } else {
               showMessage(t('generator.messages.failed'), 'error');
             }
-            handlePlaylistUpdated();
+            // Only refetch if we actually wrote to the playlist; full failures
+            // change nothing on the server side.
+            if (added > 0) {
+              handlePlaylistUpdated();
+            }
           }}
         />
       )}

--- a/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
+++ b/packages/web/app/playlists/[playlist_uuid]/playlist-detail-content.tsx
@@ -50,6 +50,9 @@ import {
   type GetPlaylistClimbsQueryVariables,
   type GetPlaylistClimbsInput,
   type PlaylistClimbsResult,
+  type AddClimbToPlaylistMutationResponse,
+  type AddClimbToPlaylistMutationVariables,
+  ADD_CLIMB_TO_PLAYLIST,
 } from '@/app/lib/graphql/operations/playlists';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { shareWithFallback } from '@/app/lib/share-utils';
@@ -643,10 +646,31 @@ export default function PlaylistDetailContent({
         <PlaylistGeneratorDrawer
           open={generatorOpen}
           onClose={() => setGeneratorOpen(false)}
-          playlistUuid={playlistUuid}
           boardDetails={generatorBoardDetails}
-          angle={generatorAngle}
-          onSuccess={handlePlaylistUpdated}
+          defaultAngle={generatorAngle}
+          onAddClimb={async (climb, _slot, angle) => {
+            await executeGraphQL<AddClimbToPlaylistMutationResponse, AddClimbToPlaylistMutationVariables>(
+              ADD_CLIMB_TO_PLAYLIST,
+              {
+                input: {
+                  playlistId: playlistUuid,
+                  climbUuid: climb.uuid,
+                  angle,
+                },
+              },
+              token,
+            );
+          }}
+          onComplete={({ added, failed, total }) => {
+            if (failed === 0) {
+              showMessage(t('generator.messages.addedAll', { count: total }), 'success');
+            } else if (added > 0) {
+              showMessage(t('generator.messages.addedPartial', { added, failed }), 'warning');
+            } else {
+              showMessage(t('generator.messages.failed'), 'error');
+            }
+            handlePlaylistUpdated();
+          }}
         />
       )}
     </>

--- a/packages/web/i18n/locales/en-US/playlists.json
+++ b/packages/web/i18n/locales/en-US/playlists.json
@@ -152,6 +152,7 @@
     "summaryRow_other": "{{count}} climbs ({{range}})",
     "options": {
       "warmUp": "Warm Up",
+      "targetAngle": "Target Angle",
       "targetGrade": "Target Grade",
       "minAscents": "Min Ascents",
       "minRating": "Min Rating",

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -127,6 +127,15 @@
     },
     "errors": {
       "createFailed": "Failed to start session"
+    },
+    "generateQueue": {
+      "button": "Generate workout queue",
+      "regenerate": "Regenerate",
+      "clear": "Clear",
+      "summary_one": "{{count}} climb queued",
+      "summary_other": "{{count}} climbs queued",
+      "addedPartial": "Queued {{added}} climbs. {{failed}} slots couldn't be filled.",
+      "failed": "Couldn't generate a queue. No matching climbs found."
     }
   },
   "summary": {

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -130,6 +130,7 @@
     },
     "generateQueue": {
       "button": "Generate workout queue",
+      "buttonHint": "Pick a board first",
       "regenerate": "Regenerate",
       "clear": "Clear",
       "summary_one": "{{count}} climb queued",

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -135,6 +135,8 @@
       "clear": "Clear",
       "summary_one": "{{count}} climb queued",
       "summary_other": "{{count}} climbs queued",
+      "addedAll_one": "{{count}} climb queued for your session",
+      "addedAll_other": "{{count}} climbs queued for your session",
       "addedPartial": "Queued {{added}} climbs. {{failed}} slots couldn't be filled.",
       "failed": "Couldn't generate a queue. No matching climbs found."
     }

--- a/packages/web/i18n/locales/es/playlists.json
+++ b/packages/web/i18n/locales/es/playlists.json
@@ -152,6 +152,7 @@
     "summaryRow_other": "{{count}} bloques ({{range}})",
     "options": {
       "warmUp": "Calentamiento",
+      "targetAngle": "Ángulo objetivo",
       "targetGrade": "Grado objetivo",
       "minAscents": "Encadenes mínimos",
       "minRating": "Valoración mínima",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -130,6 +130,7 @@
     },
     "generateQueue": {
       "button": "Generar cola de entrenamiento",
+      "buttonHint": "Elige un board primero",
       "regenerate": "Regenerar",
       "clear": "Limpiar",
       "summary_one": "{{count}} bloque en cola",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -135,6 +135,8 @@
       "clear": "Limpiar",
       "summary_one": "{{count}} bloque en cola",
       "summary_other": "{{count}} bloques en cola",
+      "addedAll_one": "{{count}} bloque en cola para tu sesión",
+      "addedAll_other": "{{count}} bloques en cola para tu sesión",
       "addedPartial": "Añadidos {{added}} bloques. No se pudieron rellenar {{failed}} huecos.",
       "failed": "No se pudo generar la cola. No se encontraron bloques que coincidan."
     }

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -127,6 +127,15 @@
     },
     "errors": {
       "createFailed": "No se pudo empezar la sesión"
+    },
+    "generateQueue": {
+      "button": "Generar cola de entrenamiento",
+      "regenerate": "Regenerar",
+      "clear": "Limpiar",
+      "summary_one": "{{count}} bloque en cola",
+      "summary_other": "{{count}} bloques en cola",
+      "addedPartial": "Añadidos {{added}} bloques. No se pudieron rellenar {{failed}} huecos.",
+      "failed": "No se pudo generar la cola. No se encontraron bloques que coincidan."
     }
   },
   "summary": {

--- a/packages/web/i18n/locales/fr/playlists.json
+++ b/packages/web/i18n/locales/fr/playlists.json
@@ -152,6 +152,7 @@
     "summaryRow_other": "{{count}} blocs ({{range}})",
     "options": {
       "warmUp": "Échauffement",
+      "targetAngle": "Angle cible",
       "targetGrade": "Cotation cible",
       "minAscents": "Enchaînements min.",
       "minRating": "Note min.",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -130,6 +130,7 @@
     },
     "generateQueue": {
       "button": "Générer une file d'entraînement",
+      "buttonHint": "Choisis d'abord un board",
       "regenerate": "Régénérer",
       "clear": "Effacer",
       "summary_one": "{{count}} voie en file",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -127,6 +127,15 @@
     },
     "errors": {
       "createFailed": "Échec du lancement de la session"
+    },
+    "generateQueue": {
+      "button": "Générer une file d'entraînement",
+      "regenerate": "Régénérer",
+      "clear": "Effacer",
+      "summary_one": "{{count}} voie en file",
+      "summary_other": "{{count}} voies en file",
+      "addedPartial": "{{added}} voies ajoutées. {{failed}} créneaux n'ont pas pu être remplis.",
+      "failed": "Impossible de générer une file. Aucune voie correspondante trouvée."
     }
   },
   "summary": {

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -135,6 +135,8 @@
       "clear": "Effacer",
       "summary_one": "{{count}} voie en file",
       "summary_other": "{{count}} voies en file",
+      "addedAll_one": "{{count}} voie ajoutée à ta session",
+      "addedAll_other": "{{count}} voies ajoutées à ta session",
       "addedPartial": "{{added}} voies ajoutées. {{failed}} créneaux n'ont pas pu être remplis.",
       "failed": "Impossible de générer une file. Aucune voie correspondante trouvée."
     }


### PR DESCRIPTION
## Summary

- Surface the existing playlist generator (workout-type → options → search) from the Start Session drawer. Pick a board, tap **Generate workout queue**, choose Volume / Pyramid / Ladder / Grade Focus, and the resulting climbs become the new session's initial queue via the same `setInitialQueueForSession` path that already transfers same-board queues.
- Refactor the generator drawer so it doesn't know where its output goes. It takes `onAddClimb(climb, slot, angle)` + `onComplete({ added, failed, total, workoutType })` callbacks and a new required `targetType: 'playlist' | 'session'` flag. The playlist-detail page keeps its own `ADD_CLIMB_TO_PLAYLIST` mutation + snackbar copy; the session drawer collects climbs into a local `ClimbQueueItem[]` and stamps the user-chosen angle onto each one explicitly.
- Add a **Target Angle** picker to the generator's options form. Defaults to the surrounding context's angle (playlist's angle or selected board's angle) and is overridable per generation.
- Add analytics events fired from inside the drawer (`Workout Generator Opened`, `Workout Type Selected`, `Workout Generator Back Clicked`, `Workout Generator Cancelled`, `Workout Generator Generate Clicked`, `Workout Generated` with savedCount / failedCount / durationMs / flat options snapshot) and from the session drawer (`Session Queue Generated`, `Session Queue Generated Cleared`, plus `generatedQueueCount` / `generatedWorkoutType` on `Session Started`). Everything is tagged with `targetType` so funnels split cleanly between playlist and session destinations.
- Entry-point UI: full-width outlined button with the `AutoFixHigh` magic-wand icon ("Pick a board first" when disabled). Once a queue has been generated, the button is replaced by a primary-bordered card with `selectedLight` background showing the count, a text Regenerate button, and an X IconButton to clear.
- Fix a pre-existing `padding: 16` → 128 px bug in the generator drawer body — and in `create-playlist-drawer.tsx` + `playlist-edit-drawer.tsx` (same MUI `sx` spacing-scale gotcha). On a 390 px phone the drawer body was cropped to a narrow center column with ~128 px of dead space on each side.

## Test plan

- [ ] **Playlist regression:** open a playlist → Generate → climbs land, snackbar fires, playlist refreshes. Analytics: `Workout Generator Opened` (targetType=playlist), `Workout Generated` (targetType=playlist).
- [ ] **Target-angle picker (playlist):** change the target angle before generating → climbs added to the playlist carry the chosen angle.
- [ ] **Session golden path:** open a board, tap Start sesh → "Generate workout queue" is enabled → pick Volume → angle picker defaults to the board's angle → generate → drawer closes → bordered card shows "N climbs queued" → Sesh → after JOIN_SESSION settles, the queue contains the generated climbs. Analytics: `Workout Generator Opened` (targetType=session), `Workout Generated`, `Session Queue Generated`, `Session Started` (with generatedQueueCount).
- [ ] **Without prior board context:** from `/`, open Start sesh → entry-point button label is "Pick a board first" and is disabled → pick a UserBoard or popular config → label flips to "Generate workout queue" and enables → generation works (no missing-board errors).
- [ ] **Cancel mid-configure:** open generator, pick Volume, dismiss the drawer without hitting Generate → `Workout Generator Cancelled` fires with stage=configure.
- [ ] **Board switch clears queue:** generate, then change the selected board → bordered card disappears and the empty-state button comes back.
- [ ] **Existing queue + generated queue:** be on a board with a non-empty queue → open Start sesh → generate → submit → new session queue is `[existing..., generated...]` in that order, carried `currentClimb` wins over the first generated climb.
- [ ] **Clear button:** generate, tap the X on the bordered card → `Session Queue Generated Cleared` fires, card disappears.
- [ ] **Mobile layout:** generator drawer is full-width on a 390 px viewport (chart, summary rows on one line, options form spans width). Same check on Create Playlist and Edit Playlist drawers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)