### PR TITLE
refactor(beta-videos): dedup constant, tighten test mock, add section tests

### DIFF
--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -24,27 +24,34 @@ const {
 
 vi.mock('../db/client', () => ({
   db: {
-    select: (selection?: unknown) => {
-      // `betaLinks` runs `db.select().from(...).where(...)`; `recentBetaLinks`
-      // runs `db.select({ ... }).from(...).leftJoin(...).where(...).orderBy(...).limit(...)`.
-      // Branch on whether a projection is passed so each test mock returns
-      // the right shape.
-      const isProjected = selection !== undefined;
-      if (!isProjected) {
+    select: (selection?: Record<string, unknown>) => {
+      // Route by the shape of the projection so a future query that doesn't
+      // match either known path fails loudly instead of resolving via the
+      // wrong mock.
+      // - `betaLinks` calls `db.select()` with no projection, then
+      //   `.from(...).where(...)`.
+      // - `recentBetaLinks` calls `db.select({ ..., climbName, ... })` then
+      //   `.from(...).leftJoin(...).where(...).orderBy(...).limit(...)`.
+      if (selection === undefined) {
         return {
           from: () => ({
             where: () => Promise.resolve(selectMock()),
           }),
         };
       }
-      const chain = {
-        from: () => chain,
-        leftJoin: () => chain,
-        where: () => chain,
-        orderBy: () => chain,
-        limit: () => Promise.resolve(recentSelectMock()),
-      };
-      return chain;
+      if ('climbName' in selection) {
+        const chain = {
+          from: () => chain,
+          leftJoin: () => chain,
+          where: () => chain,
+          orderBy: () => chain,
+          limit: () => Promise.resolve(recentSelectMock()),
+        };
+        return chain;
+      }
+      throw new Error(
+        `Unhandled db.select() projection in beta-link-queries test mock: ${JSON.stringify(Object.keys(selection))}`,
+      );
     },
     update: () => ({
       set: () => ({

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -9,6 +9,7 @@ import {
   getDevProxyThumbnailUrl,
   isOurS3Url,
   isS3Configured,
+  STATIC_THUMBNAIL_PREFIX,
 } from '../../../lib/beta-link-thumbnails';
 
 type BetaLinkResult = {
@@ -27,11 +28,6 @@ type RecentBetaLinkResult = {
   boardType: string;
 };
 
-// Mirrors STATIC_THUMBNAIL_PREFIX in ../../../lib/beta-link-thumbnails. Keep
-// the two in sync — the recentBetaLinks query uses a SQL LIKE filter to
-// pre-trim to rows that already have a cached S3 thumbnail, so the prefix
-// must match what isOurS3Url's static-prefix branch accepts.
-const STATIC_THUMBNAIL_PREFIX = '/static/beta-link-thumbnails/';
 const RECENT_BETA_LINKS_MAX_LIMIT = 50;
 const RECENT_BETA_LINKS_DEFAULT_LIMIT = 20;
 

--- a/packages/backend/src/lib/beta-link-thumbnails.ts
+++ b/packages/backend/src/lib/beta-link-thumbnails.ts
@@ -9,10 +9,7 @@ export { isS3Configured };
 // not bytes, so this is the byte-level back-stop.
 const MAX_THUMBNAIL_BYTES = 5 * 1024 * 1024;
 
-// Keep in sync with STATIC_THUMBNAIL_PREFIX in
-// ../graphql/resolvers/beta-videos/queries.ts — the recentBetaLinks SQL
-// LIKE filter relies on the same prefix to pre-trim to cached rows.
-const STATIC_THUMBNAIL_PREFIX = '/static/beta-link-thumbnails/';
+export const STATIC_THUMBNAIL_PREFIX = '/static/beta-link-thumbnails/';
 
 /**
  * URL we surface to clients for a cached thumbnail. Mirrors the avatar

--- a/packages/web/app/components/beta-videos/__tests__/home-recent-beta-section.test.tsx
+++ b/packages/web/app/components/beta-videos/__tests__/home-recent-beta-section.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import type { RecentBetaLinkRow } from '@/app/lib/server-recent-beta-links';
+import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
+
+const mockRequest = vi.fn();
+const boardseshBetaListSpy = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@/app/lib/graphql/operations/beta-links', () => ({
+  GET_RECENT_BETA_LINKS: 'GET_RECENT_BETA_LINKS',
+}));
+
+vi.mock('@/app/lib/beta-video-url', () => ({
+  mapBetaLinkRow: (row: { link: string; climbUuid: string }) =>
+    ({
+      link: row.link,
+      climb_uuid: row.climbUuid,
+      foreign_username: null,
+      angle: null,
+      thumbnail: null,
+      is_listed: false,
+      created_at: '',
+    }) as BetaLink,
+}));
+
+vi.mock('../boardsesh-beta-list', () => ({
+  default: (props: {
+    links: BetaLink[];
+    isLoading: boolean;
+    source: string;
+    getClimbName?: (link: BetaLink) => string | null | undefined;
+  }) => {
+    boardseshBetaListSpy(props);
+    return (
+      <div data-testid="boardsesh-beta-list">
+        {props.links.map((link) => (
+          <div key={link.link} data-testid="beta-list-item">
+            {link.link}::{props.getClimbName?.(link) ?? 'no-name'}
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+import HomeRecentBetaSection from '../home-recent-beta-section';
+
+function makeRow(overrides: { link: string; climbUuid?: string; climbName?: string | null }): RecentBetaLinkRow {
+  return {
+    climbName: overrides.climbName ?? null,
+    boardType: 'kilter',
+    betaLink: {
+      climbUuid: overrides.climbUuid ?? 'climb-uuid-1',
+      link: overrides.link,
+      foreignUsername: null,
+      angle: null,
+      thumbnail: null,
+      isListed: true,
+      createdAt: null,
+    },
+  };
+}
+
+function renderSection(initialRecentBeta: RecentBetaLinkRow[]) {
+  const client = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <HomeRecentBetaSection initialRecentBeta={initialRecentBeta} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockRequest.mockReset();
+  boardseshBetaListSpy.mockReset();
+});
+
+describe('HomeRecentBetaSection', () => {
+  it('renders nothing when there are no beta rows', () => {
+    const { container } = renderSection([]);
+    expect(container.firstChild).toBeNull();
+    expect(boardseshBetaListSpy).not.toHaveBeenCalled();
+  });
+
+  it('maps rows into BetaLink shapes and passes climbName via getClimbName', () => {
+    const rows = [
+      makeRow({ link: 'https://instagram.com/p/aaa', climbUuid: 'c1', climbName: 'Cut to the Chase' }),
+      makeRow({ link: 'https://www.tiktok.com/@u/video/123', climbUuid: 'c2', climbName: null }),
+    ];
+
+    renderSection(rows);
+
+    expect(boardseshBetaListSpy).toHaveBeenCalledTimes(1);
+    const props = boardseshBetaListSpy.mock.calls[0][0] as {
+      links: BetaLink[];
+      isLoading: boolean;
+      source: string;
+      getClimbName?: (link: BetaLink) => string | null | undefined;
+    };
+    expect(props.links).toHaveLength(2);
+    expect(props.links[0].link).toBe('https://instagram.com/p/aaa');
+    expect(props.links[1].link).toBe('https://www.tiktok.com/@u/video/123');
+    expect(props.isLoading).toBe(false);
+    expect(props.source).toBe('home');
+    expect(props.getClimbName?.(props.links[0])).toBe('Cut to the Chase');
+    expect(props.getClimbName?.(props.links[1])).toBeNull();
+    expect(props.getClimbName?.({ ...props.links[0], link: 'https://nope.example/x' })).toBeUndefined();
+  });
+
+  it('uses initialData without firing a GraphQL request on first render', async () => {
+    renderSection([makeRow({ link: 'https://instagram.com/p/aaa', climbName: 'Boulder X' })]);
+
+    // Wait one tick to make sure no background fetch sneaks in.
+    await waitFor(() => {
+      expect(screen.getByTestId('boardsesh-beta-list')).toBeTruthy();
+    });
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/beta-videos/home-recent-beta-section.tsx
+++ b/packages/web/app/components/beta-videos/home-recent-beta-section.tsx
@@ -28,7 +28,7 @@ export default function HomeRecentBetaSection({ initialRecentBeta }: HomeRecentB
   const { t } = useTranslation('marketing');
 
   const { data: rows = [] } = useQuery<RecentBetaLinkRow[]>({
-    queryKey: ['recentBetaLinks', null],
+    queryKey: ['recentBetaLinks'],
     queryFn: async () => {
       const client = createGraphQLHttpClient();
       const result = await client.request<RecentBetaResponse>(GET_RECENT_BETA_LINKS, { limit: RECENT_BETA_LIMIT });


### PR DESCRIPTION
## Summary

Four small follow-ups on the recent beta-videos work — none are bugs in
the running product, but each is a small footgun for the next person
touching this code.

- **Single source of truth for `STATIC_THUMBNAIL_PREFIX`.** Exported
  from `packages/backend/src/lib/beta-link-thumbnails.ts` and imported
  by the `recentBetaLinks` resolver. The two "keep in sync" comments
  are now unnecessary and have been deleted.
- **Tighten the backend db mock router.** `beta-link-queries.test.ts`
  previously routed on `selection !== undefined`, which would silently
  resolve a future projected query through the wrong mock if it didn't
  end at `.limit()`. The mock now routes by the presence of `climbName`
  in the projection and throws an explicit error on any unknown shape.
- **Add unit tests for `HomeRecentBetaSection`.** Covers the empty-state
  guard, the row → `BetaLink` mapping (including `getClimbName` lookup
  by URL), and verifies the component uses `initialData` without firing
  a refetch on first render. Previously only mocked out as `() => null`
  in the home-page test.
- **Clean up the React Query key.** `['recentBetaLinks', null]` →
  `['recentBetaLinks']`. `boardType` is never threaded into this
  component, so the `null` placeholder was unexplained.

## Test plan

- [x] `vp test run --project backend beta-link-queries` — 14/14 pass
- [x] `vp test run --project web home-recent-beta-section` — 3/3 pass
- [x] `vp run typecheck:backend`
- [x] `vp run typecheck:web`
- [x] `vp lint` on changed files (no new warnings introduced)
- [x] `vp fmt --check` on changed files

https://claude.ai/code/session_01UwpZEpSdXh8fRHPV8Nh5Jv

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwpZEpSdXh8fRHPV8Nh5Jv)_