### PR TITLE
feat(beta-videos): copy & open Instagram from Add Beta Link form

### DIFF
--- a/packages/web/app/components/beta-videos/attach-beta-link-dialog.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-dialog.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
-import AttachBetaLinkForm from './attach-beta-link-form';
+import AttachBetaLinkForm, { type AttachBetaLinkSurface } from './attach-beta-link-form';
 
 type AttachBetaLinkDialogProps = {
   open: boolean;
@@ -14,6 +14,10 @@ type AttachBetaLinkDialogProps = {
   climbUuid: string;
   climbName?: string;
   angle?: number | null;
+  grade?: string | null;
+  setter?: string | null;
+  layoutId?: number | null;
+  surface?: AttachBetaLinkSurface;
 };
 
 const AttachBetaLinkDialog: React.FC<AttachBetaLinkDialogProps> = ({
@@ -23,6 +27,10 @@ const AttachBetaLinkDialog: React.FC<AttachBetaLinkDialogProps> = ({
   climbUuid,
   climbName,
   angle,
+  grade,
+  setter,
+  layoutId,
+  surface = 'logbook',
 }) => {
   const { t } = useTranslation('feed');
   return (
@@ -36,6 +44,10 @@ const AttachBetaLinkDialog: React.FC<AttachBetaLinkDialogProps> = ({
           climbUuid={climbUuid}
           climbName={climbName}
           angle={angle}
+          grade={grade}
+          setter={setter}
+          layoutId={layoutId}
+          surface={surface}
           resetTrigger={open}
           submitLabel={t('betaVideos.shareBeta')}
           helperText={t('betaVideos.dialogHelper')}

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -153,8 +153,19 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
     if (!instagramCaption || isLaunchingInstagram) return;
     track('Beta Caption Copy Clicked', { boardType, climbUuid, surface });
     setIsLaunchingInstagram(true);
-    const result = await copyAndOpenInstagram(instagramCaption);
-    setIsLaunchingInstagram(false);
+    let result: { copied: boolean; opened: boolean };
+    try {
+      result = await copyAndOpenInstagram(instagramCaption);
+    } catch {
+      // Defensive: copyAndOpenInstagram catches its own errors but a thrown
+      // navigation/clipboard exception from a restricted browser context
+      // would otherwise leave the button stuck in the launching state.
+      track('Beta Caption Copy Failed', { boardType, climbUuid, surface, reason: 'copyFailed' });
+      showMessage(t('betaVideos.instagramCopyFailed'), 'error');
+      return;
+    } finally {
+      setIsLaunchingInstagram(false);
+    }
 
     if (!result.copied) {
       track('Beta Caption Copy Failed', { boardType, climbUuid, surface, reason: 'copyFailed' });

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Box from '@mui/material/Box';
+import InstagramIcon from '@mui/icons-material/Instagram';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { track } from '@/app/lib/analytics';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -22,6 +23,7 @@ import {
   BETA_VIDEO_URL_VALIDATION_MESSAGE,
 } from '@/app/lib/beta-video-url';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { buildInstagramCaption, copyAndOpenInstagram } from '@/app/lib/instagram-posting';
 
 // graphql-request throws ClientError-shaped errors with a `response.errors[]`
 // array. We trust those messages because they come from our own resolvers
@@ -41,11 +43,17 @@ export function extractGraphQLErrorMessage(error: unknown): string | null {
   return typeof message === 'string' && message.length > 0 ? message : null;
 }
 
+export type AttachBetaLinkSurface = 'play-view' | 'logbook' | 'instagram-dialog' | 'unknown';
+
 type AttachBetaLinkFormProps = {
   boardType: string;
   climbUuid: string;
   climbName?: string;
   angle?: number | null;
+  grade?: string | null;
+  setter?: string | null;
+  layoutId?: number | null;
+  surface?: AttachBetaLinkSurface;
   resetTrigger?: unknown;
   submitLabel?: string;
   helperText?: string;
@@ -61,6 +69,10 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
   climbUuid,
   climbName,
   angle,
+  grade,
+  setter,
+  layoutId,
+  surface = 'unknown',
   resetTrigger,
   submitLabel,
   helperText,
@@ -73,9 +85,22 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
   const { t } = useTranslation('feed');
   const resolvedSubmitLabel = submitLabel ?? t('betaVideos.shareBeta');
   const [url, setUrl] = useState('');
+  const [isLaunchingInstagram, setIsLaunchingInstagram] = useState(false);
   const { token } = useWsAuthToken();
   const queryClient = useQueryClient();
   const { showMessage } = useSnackbar();
+
+  const instagramCaption = useMemo(() => {
+    if (!climbName || angle == null) return '';
+    return buildInstagramCaption({
+      climbName,
+      angle,
+      boardType,
+      grade,
+      setter,
+      layoutId,
+    });
+  }, [climbName, angle, boardType, grade, setter, layoutId]);
 
   useEffect(() => {
     setUrl('');
@@ -124,6 +149,30 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
 
   const canSubmit = !!trimmed && !validationError && !mutation.isPending;
 
+  const handleCopyAndOpenInstagram = async () => {
+    if (!instagramCaption || isLaunchingInstagram) return;
+    track('Beta Caption Copy Clicked', { boardType, climbUuid, surface });
+    setIsLaunchingInstagram(true);
+    const result = await copyAndOpenInstagram(instagramCaption);
+    setIsLaunchingInstagram(false);
+
+    if (!result.copied) {
+      track('Beta Caption Copy Failed', { boardType, climbUuid, surface, reason: 'copyFailed' });
+      showMessage(t('betaVideos.instagramCopyFailed'), 'error');
+      return;
+    }
+
+    track('Beta Caption Copied', { boardType, climbUuid, surface, opened: result.opened });
+
+    if (!result.opened) {
+      // Copy succeeded — let the user paste manually wherever they want.
+      showMessage(t('betaVideos.instagramCopiedOnly'), 'success');
+      return;
+    }
+
+    showMessage(t('betaVideos.instagramCopiedAndOpened'), 'success');
+  };
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: compact ? 1.25 : 1.5 }}>
       <TextField
@@ -143,7 +192,18 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
         }}
       />
 
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, flexWrap: 'wrap' }}>
+        {instagramCaption && (
+          <Button
+            variant="outlined"
+            onClick={handleCopyAndOpenInstagram}
+            disabled={isLaunchingInstagram || mutation.isPending}
+            startIcon={isLaunchingInstagram ? <CircularProgress size={16} /> : <InstagramIcon />}
+            sx={{ mr: 'auto' }}
+          >
+            {t('betaVideos.copyAndOpenInstagram')}
+          </Button>
+        )}
         {showCancel && onCancel && (
           <Button onClick={onCancel} disabled={mutation.isPending}>
             {t('betaVideos.cancel')}

--- a/packages/web/app/components/beta-videos/boardsesh-beta-add-panel.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-add-panel.tsx
@@ -8,6 +8,10 @@ type BoardseshBetaAddPanelProps = {
   boardType: string;
   climbUuid: string;
   angle: number;
+  climbName?: string;
+  grade?: string | null;
+  setter?: string | null;
+  layoutId?: number | null;
   onCancel: () => void;
   onSuccess: () => void;
 };
@@ -21,6 +25,10 @@ const BoardseshBetaAddPanel: React.FC<BoardseshBetaAddPanelProps> = ({
   boardType,
   climbUuid,
   angle,
+  climbName,
+  grade,
+  setter,
+  layoutId,
   onCancel,
   onSuccess,
 }) => {
@@ -55,7 +63,12 @@ const BoardseshBetaAddPanel: React.FC<BoardseshBetaAddPanelProps> = ({
       <AttachBetaLinkForm
         boardType={boardType}
         climbUuid={climbUuid}
+        climbName={climbName}
         angle={angle}
+        grade={grade}
+        setter={setter}
+        layoutId={layoutId}
+        surface="play-view"
         autoFocus
         compact
         submitLabel="Add"

--- a/packages/web/app/components/beta-videos/boardsesh-beta-add-panel.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-add-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import AttachBetaLinkForm from './attach-beta-link-form';
 
@@ -32,6 +33,7 @@ const BoardseshBetaAddPanel: React.FC<BoardseshBetaAddPanelProps> = ({
   onCancel,
   onSuccess,
 }) => {
+  const { t } = useTranslation('feed');
   // Reset add-mode in the parent only when the panel unmounts via an
   // unhandled path (section collapse via lazy: true). When the user
   // explicitly cancels or successfully submits, the parent already flipped
@@ -71,7 +73,7 @@ const BoardseshBetaAddPanel: React.FC<BoardseshBetaAddPanelProps> = ({
         surface="play-view"
         autoFocus
         compact
-        submitLabel="Add"
+        submitLabel={t('betaVideos.addSubmit')}
         showCancel
         onCancel={handleCancel}
         onSuccess={handleSuccess}

--- a/packages/web/app/components/climb-actions/actions/instagram-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/instagram-action.tsx
@@ -53,8 +53,11 @@ export function InstagramAction({
       climbUuid: climb.uuid,
       climbName: climb.name,
       angle,
+      grade: climb.difficulty,
+      setter: climb.setter_username,
+      layoutId: climb.layoutId,
     }),
-    [boardDetails.board_name, climb.uuid, climb.name, angle],
+    [boardDetails.board_name, climb.uuid, climb.name, angle, climb.difficulty, climb.setter_username, climb.layoutId],
   );
 
   const extraContent = (

--- a/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
+++ b/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
@@ -107,7 +107,11 @@ export function useBuildClimbDetailSections({
             <BoardseshBetaAddPanel
               boardType={boardType}
               climbUuid={climbUuid}
+              climbName={climb.name}
               angle={angle}
+              grade={climb.difficulty}
+              setter={climb.setter_username}
+              layoutId={climb.layoutId}
               onCancel={() => setIsAddingBeta(false)}
               onSuccess={() => setIsAddingBeta(false)}
             />

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -935,6 +935,10 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
             climbUuid={item.climbUuid}
             climbName={item.climbName}
             angle={item.angle}
+            grade={item.difficultyName}
+            setter={item.setterUsername}
+            layoutId={item.layoutId}
+            surface="logbook"
           />
         )}
       </>

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -922,6 +922,9 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
                     climbUuid: item.climbUuid,
                     climbName: item.climbName,
                     angle: item.angle,
+                    grade: item.difficultyName,
+                    setter: item.setterUsername,
+                    layoutId: item.layoutId,
                   }
                 : null
             }

--- a/packages/web/app/components/library/post-to-instagram-dialog.tsx
+++ b/packages/web/app/components/library/post-to-instagram-dialog.tsx
@@ -332,6 +332,7 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
               climbUuid={item.climbUuid}
               climbName={item.climbName}
               angle={item.angle}
+              surface="instagram-dialog"
               resetTrigger={open}
               submitLabel={t('logbook.instagram.addLinkSubmit')}
               helperText={t('logbook.instagram.pasteLinkHelper')}

--- a/packages/web/app/components/library/post-to-instagram-dialog.tsx
+++ b/packages/web/app/components/library/post-to-instagram-dialog.tsx
@@ -29,6 +29,9 @@ export type InstagramPostingTarget = {
   climbUuid: string;
   climbName: string;
   angle: number;
+  grade?: string | null;
+  setter?: string | null;
+  layoutId?: number | null;
 };
 
 type PostToInstagramDialogProps = {
@@ -77,6 +80,9 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
       climbName: item.climbName,
       angle: item.angle,
       boardType: item.boardType,
+      grade: item.grade,
+      setter: item.setter,
+      layoutId: item.layoutId,
     });
   }, [item]);
 
@@ -332,6 +338,9 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
               climbUuid={item.climbUuid}
               climbName={item.climbName}
               angle={item.angle}
+              grade={item.grade}
+              setter={item.setter}
+              layoutId={item.layoutId}
               surface="instagram-dialog"
               resetTrigger={open}
               submitLabel={t('logbook.instagram.addLinkSubmit')}

--- a/packages/web/app/lib/__tests__/instagram-posting.test.ts
+++ b/packages/web/app/lib/__tests__/instagram-posting.test.ts
@@ -106,9 +106,14 @@ describe('instagram-posting', () => {
     );
   });
 
-  it('builds the caption for Decoy with a Tension-style fallback', () => {
-    expect(buildInstagramCaption({ climbName: 'Sandbag', angle: 30, boardType: 'decoy' })).toBe(
-      `"Sandbag" @ 30° on the Decoy Board. #climbing #bouldering @boardsesh #boardsesh`,
+  it.each([
+    ['decoy', 'Decoy Board'],
+    ['touchstone', 'Touchstone Board'],
+    ['grasshopper', 'Grasshopper Board'],
+    ['soill', 'So iLL Board'],
+  ])('builds a Tension-style caption for the %s board', (boardType, boardName) => {
+    expect(buildInstagramCaption({ climbName: 'Sandbag', angle: 30, boardType })).toBe(
+      `"Sandbag" @ 30° on the ${boardName}. #climbing #bouldering @boardsesh #boardsesh`,
     );
   });
 
@@ -193,5 +198,24 @@ describe('instagram-posting', () => {
     expect(global.document.execCommand).toHaveBeenCalledWith('copy'); // eslint-disable-line @typescript-eslint/unbound-method -- vi.fn() mock, no `this` concern
     expect(result).toEqual({ copied: true, opened: true });
     expect(global.window.location.href).toBe('instagram://camera');
+  });
+
+  it('reports copied: false and does not launch Instagram when both copy paths fail', async () => {
+    Object.defineProperty(global, 'navigator', {
+      configurable: true,
+      value: {
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)',
+        clipboard: {
+          writeText: vi.fn(() => Promise.reject(new Error('clipboard blocked'))),
+        },
+      },
+    });
+    global.document.execCommand = vi.fn(() => false);
+    global.window.location.href = '';
+
+    const result = await copyAndOpenInstagram('whatever caption');
+
+    expect(result).toEqual({ copied: false, opened: false });
+    expect(global.window.location.href).toBe('');
   });
 });

--- a/packages/web/app/lib/__tests__/instagram-posting.test.ts
+++ b/packages/web/app/lib/__tests__/instagram-posting.test.ts
@@ -90,31 +90,52 @@ describe('instagram-posting', () => {
 
   it('builds the Kilter caption when boardType is omitted', () => {
     expect(buildInstagramCaption({ climbName: 'Texas Sun', angle: 35 })).toBe(
-      `"Texas Sun" @ 35° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips`,
+      `"Texas Sun" @ 35° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips @boardsesh #boardsesh`,
     );
   });
 
   it('builds the Kilter caption when boardType is kilter', () => {
     expect(buildInstagramCaption({ climbName: 'Texas Sun', angle: 35, boardType: 'kilter' })).toBe(
-      `"Texas Sun" @ 35° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips`,
+      `"Texas Sun" @ 35° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips @boardsesh #boardsesh`,
     );
   });
 
   it('builds the caption for Tension', () => {
     expect(buildInstagramCaption({ climbName: 'High Hopes', angle: 40, boardType: 'tension' })).toBe(
-      `"High Hopes" @ 40° on the Tension Board.\n@tensionclimbing #tensionboard`,
+      `"High Hopes" @ 40° on the Tension Board. @tensionclimbing #tensionboard #climbing #bouldering @boardsesh #boardsesh`,
     );
   });
 
-  it('builds the caption for MoonBoard', () => {
-    expect(buildInstagramCaption({ climbName: 'Wheel of Fortune', angle: 40, boardType: 'moonboard' })).toBe(
-      `"Wheel of Fortune" @ 40° on the MoonBoard.\n@moon_climbing #moonboard`,
+  it('builds the caption for Decoy with a Tension-style fallback', () => {
+    expect(buildInstagramCaption({ climbName: 'Sandbag', angle: 30, boardType: 'decoy' })).toBe(
+      `"Sandbag" @ 30° on the Decoy Board. #climbing #bouldering @boardsesh #boardsesh`,
+    );
+  });
+
+  it('builds the full MoonBoard caption with grade, layout, and setter', () => {
+    expect(
+      buildInstagramCaption({
+        climbName: 'Wheel of Fortune',
+        angle: 40,
+        boardType: 'moonboard',
+        grade: 'V7',
+        setter: 'Dana Rader',
+        layoutId: 3,
+      }),
+    ).toBe(
+      `Wheel of Fortune, V7, 40° MoonBoard, MoonBoard 2024 setup, set by Dana Rader. - @moonclimbing #moonboard #moonclimbing #moonboardchallenge #trainhardclimbharder @boardsesh #boardsesh`,
+    );
+  });
+
+  it('builds a degraded MoonBoard caption when grade, setter, and layoutId are missing', () => {
+    expect(buildInstagramCaption({ climbName: 'Mystery Route', angle: 40, boardType: 'moonboard' })).toBe(
+      `Mystery Route, 40° MoonBoard. - @moonclimbing #moonboard #moonclimbing #moonboardchallenge #trainhardclimbharder @boardsesh #boardsesh`,
     );
   });
 
   it('falls back to Kilter caption for an unknown boardType', () => {
     expect(buildInstagramCaption({ climbName: 'Mystery Route', angle: 50, boardType: 'unknownboard' })).toBe(
-      `"Mystery Route" @ 50° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips`,
+      `"Mystery Route" @ 50° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips @boardsesh #boardsesh`,
     );
   });
 

--- a/packages/web/app/lib/instagram-posting.ts
+++ b/packages/web/app/lib/instagram-posting.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { getPlatform, isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import { MOONBOARD_LAYOUTS } from '@/app/lib/moonboard-config';
 
 export type InstagramPostingPlatform = 'ios' | 'android' | 'unsupported';
 
@@ -8,26 +9,96 @@ export type InstagramCaptionInput = {
   climbName: string;
   angle: number;
   boardType?: string;
+  grade?: string | null;
+  setter?: string | null;
+  layoutId?: number | null;
 };
 
-const BOARD_CAPTION_CONFIG: Record<string, { name: string; displayName: string; handle: string; hashtags: string }> = {
+const BOARDSESH_TAG = '@boardsesh #boardsesh';
+
+type SimpleBoardCaptionConfig = {
+  kind: 'simple';
+  name: string;
+  displayName: string;
+  handle?: string;
+  hashtags: string;
+  separator: '\n' | ' ';
+};
+
+type CustomBoardCaptionConfig = {
+  kind: 'custom';
+  displayName: string;
+  format: (input: InstagramCaptionInput) => string;
+};
+
+type BoardCaptionConfig = SimpleBoardCaptionConfig | CustomBoardCaptionConfig;
+
+function findMoonBoardLayoutName(layoutId: number | null | undefined): string | null {
+  if (layoutId == null) return null;
+  const match = Object.values(MOONBOARD_LAYOUTS).find((layout) => layout.id === layoutId);
+  return match?.name ?? null;
+}
+
+function buildMoonBoardCaption({ climbName, angle, grade, setter, layoutId }: InstagramCaptionInput): string {
+  const layoutName = findMoonBoardLayoutName(layoutId);
+  const segments: string[] = [climbName];
+  if (grade) segments.push(grade);
+  segments.push(`${angle}° MoonBoard`);
+  if (layoutName) segments.push(`${layoutName} setup`);
+  let prefix = segments.join(', ');
+  if (setter) prefix += `, set by ${setter}`;
+  return `${prefix}. - @moonclimbing #moonboard #moonclimbing #moonboardchallenge #trainhardclimbharder ${BOARDSESH_TAG}`;
+}
+
+const BOARD_CAPTION_CONFIG: Record<string, BoardCaptionConfig> = {
   kilter: {
+    kind: 'simple',
     name: 'Kilter Board',
     displayName: 'Kilter',
     handle: '@kilterboard',
     hashtags: '#kilterboard #kiltergrips',
+    separator: '\n',
   },
   tension: {
+    kind: 'simple',
     name: 'Tension Board',
     displayName: 'Tension',
     handle: '@tensionclimbing',
-    hashtags: '#tensionboard',
+    hashtags: '#tensionboard #climbing #bouldering',
+    separator: ' ',
+  },
+  decoy: {
+    kind: 'simple',
+    name: 'Decoy Board',
+    displayName: 'Decoy',
+    hashtags: '#climbing #bouldering',
+    separator: ' ',
+  },
+  touchstone: {
+    kind: 'simple',
+    name: 'Touchstone Board',
+    displayName: 'Touchstone',
+    hashtags: '#climbing #bouldering',
+    separator: ' ',
+  },
+  grasshopper: {
+    kind: 'simple',
+    name: 'Grasshopper Board',
+    displayName: 'Grasshopper',
+    hashtags: '#climbing #bouldering',
+    separator: ' ',
+  },
+  soill: {
+    kind: 'simple',
+    name: 'So iLL Board',
+    displayName: 'So iLL',
+    hashtags: '#climbing #bouldering',
+    separator: ' ',
   },
   moonboard: {
-    name: 'MoonBoard',
+    kind: 'custom',
     displayName: 'MoonBoard',
-    handle: '@moon_climbing',
-    hashtags: '#moonboard',
+    format: buildMoonBoardCaption,
   },
 };
 
@@ -150,9 +221,19 @@ export function getBoardDisplayName(boardType: string): string {
   return boardType.charAt(0).toUpperCase() + boardType.slice(1);
 }
 
-export function buildInstagramCaption({ climbName, angle, boardType = 'kilter' }: InstagramCaptionInput): string {
+function formatSimpleCaption(config: SimpleBoardCaptionConfig, input: InstagramCaptionInput): string {
+  const { climbName, angle } = input;
+  const social = config.handle
+    ? `${config.handle} ${config.hashtags} ${BOARDSESH_TAG}`
+    : `${config.hashtags} ${BOARDSESH_TAG}`;
+  return `"${climbName}" @ ${angle}\u00b0 on the ${config.name}.${config.separator}${social}`;
+}
+
+export function buildInstagramCaption(input: InstagramCaptionInput): string {
+  const boardType = input.boardType ?? 'kilter';
   const config = BOARD_CAPTION_CONFIG[boardType] ?? BOARD_CAPTION_CONFIG.kilter;
-  return `"${climbName}" @ ${angle}\u00b0 on the ${config.name}.\n${config.handle} ${config.hashtags}`;
+  if (config.kind === 'custom') return config.format(input);
+  return formatSimpleCaption(config, input);
 }
 
 function getInstagramLaunchUrl(platform: InstagramPostingPlatform): string | null {

--- a/packages/web/app/lib/instagram-posting.ts
+++ b/packages/web/app/lib/instagram-posting.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { getPlatform, isNativeApp } from '@/app/lib/ble/capacitor-utils';
-import { MOONBOARD_LAYOUTS } from '@/app/lib/moonboard-config';
+import { getLayoutById } from '@/app/lib/moonboard-config';
 
 export type InstagramPostingPlatform = 'ios' | 'android' | 'unsupported';
 
@@ -35,8 +35,7 @@ type BoardCaptionConfig = SimpleBoardCaptionConfig | CustomBoardCaptionConfig;
 
 function findMoonBoardLayoutName(layoutId: number | null | undefined): string | null {
   if (layoutId == null) return null;
-  const match = Object.values(MOONBOARD_LAYOUTS).find((layout) => layout.id === layoutId);
-  return match?.name ?? null;
+  return getLayoutById(layoutId)?.[1]?.name ?? null;
 }
 
 function buildMoonBoardCaption({ climbName, angle, grade, setter, layoutId }: InstagramCaptionInput): string {
@@ -107,8 +106,7 @@ export type CopyAndOpenInstagramResult = {
   opened: boolean;
 };
 
-const IOS_INSTAGRAM_CREATE_URL = 'instagram://camera';
-const ANDROID_INSTAGRAM_OPEN_URL = 'instagram://camera';
+const INSTAGRAM_CAMERA_URL = 'instagram://camera';
 
 const CLIPBOARD_SETTLE_DELAY_MS = 180;
 
@@ -237,14 +235,8 @@ export function buildInstagramCaption(input: InstagramCaptionInput): string {
 }
 
 function getInstagramLaunchUrl(platform: InstagramPostingPlatform): string | null {
-  switch (platform) {
-    case 'ios':
-      return IOS_INSTAGRAM_CREATE_URL;
-    case 'android':
-      return ANDROID_INSTAGRAM_OPEN_URL;
-    default:
-      return null;
-  }
+  if (platform === 'ios' || platform === 'android') return INSTAGRAM_CAMERA_URL;
+  return null;
 }
 
 function attemptInstagramLaunch(platform: InstagramPostingPlatform): Promise<boolean> {

--- a/packages/web/i18n/locales/en-US/feed.json
+++ b/packages/web/i18n/locales/en-US/feed.json
@@ -31,7 +31,11 @@
     "urlLabel": "Beta video URL",
     "urlLabelForClimb": "Beta video URL for {{name}}",
     "defaultHelper": "Paste a public Instagram reel/post or TikTok URL so others can see your beta.",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "copyAndOpenInstagram": "Copy & open Instagram",
+    "instagramCopyFailed": "Couldn't copy the caption. Try again.",
+    "instagramCopiedAndOpened": "Caption copied — paste it into Instagram.",
+    "instagramCopiedOnly": "Caption copied to clipboard."
   },
   "commentFeed": {
     "empty": "No comments yet",

--- a/packages/web/i18n/locales/en-US/feed.json
+++ b/packages/web/i18n/locales/en-US/feed.json
@@ -35,7 +35,8 @@
     "copyAndOpenInstagram": "Copy & open Instagram",
     "instagramCopyFailed": "Couldn't copy the caption. Try again.",
     "instagramCopiedAndOpened": "Caption copied — paste it into Instagram.",
-    "instagramCopiedOnly": "Caption copied to clipboard."
+    "instagramCopiedOnly": "Caption copied to clipboard.",
+    "addSubmit": "Add"
   },
   "commentFeed": {
     "empty": "No comments yet",


### PR DESCRIPTION
## Summary

- Adds a **Copy & open Instagram** button inside the Add Beta Link form, so it appears in both surfaces that wrap that form: the play-view drawer's inline add panel (`BoardseshBetaAddPanel`) and the logbook 3-dot menu's dialog (`AttachBetaLinkDialog`). The button copies a board-specific caption to the clipboard and launches the Instagram camera (`instagram://camera`), mirroring the existing `copyAndOpenInstagram` flow.
- Refreshes the caption templates in `instagram-posting.ts`:
  - **Kilter** — appends `@boardsesh #boardsesh`.
  - **Tension** — expands to `#tensionboard #climbing #bouldering @boardsesh #boardsesh`.
  - **MoonBoard** — switches to the longer template `<name>, <grade>, <angle>° MoonBoard, <layoutName> setup, set by <setter>. - @moonclimbing #moonboard #moonclimbing #moonboardchallenge #trainhardclimbharder @boardsesh #boardsesh`. `<layoutName>` is resolved from `layoutId` via `MOONBOARD_LAYOUTS` (e.g. `3 → MoonBoard 2024`). Each variable segment drops out cleanly when missing.
  - **Other Aurora** (decoy, touchstone, grasshopper, soill) — Tension-style fallback with the board name swapped and only `@boardsesh` tagged.
- Threads `climbName`, `grade`, `setter`, `layoutId`, and a `surface` analytics tag through `AttachBetaLinkDialog`, `BoardseshBetaAddPanel`, `build-climb-detail-sections`, `logbook-feed-item`, and `post-to-instagram-dialog`.
- Emits three analytics events from the form: `Beta Caption Copy Clicked`, `Beta Caption Copied` (with `opened` boolean), and `Beta Caption Copy Failed`. Each carries `boardType`, `climbUuid`, and `surface ∈ {play-view, logbook, instagram-dialog, unknown}` so funnel stages are distinguishable.
- New i18n keys under `feed.betaVideos`: `copyAndOpenInstagram`, `instagramCopyFailed`, `instagramCopiedAndOpened`, `instagramCopiedOnly`.

## Test plan

- [ ] **Kilter** — Play-view → Beta section → "+" → click **Copy & open Instagram** → caption matches `"<name>" @ <angle>° on the Kilter Board.\n@kilterboard #kilterboard #kiltergrips @boardsesh #boardsesh`.
- [ ] **Tension** — Same flow → caption matches `"<name>" @ <angle>° on the Tension Board. @tensionclimbing #tensionboard #climbing #bouldering @boardsesh #boardsesh`.
- [ ] **MoonBoard with grade/setter/layout** — caption matches `<name>, <grade>, <angle>° MoonBoard, MoonBoard 2024 setup, set by <setter>. - @moonclimbing #moonboard #moonclimbing #moonboardchallenge #trainhardclimbharder @boardsesh #boardsesh`.
- [ ] **MoonBoard with missing fields** — confirm grade/layout/setter segments drop without leaving extra commas.
- [ ] **Decoy / other Aurora board** — caption uses Tension-style fallback with the board name and `#climbing #bouldering @boardsesh #boardsesh`.
- [ ] **Logbook** — 3-dot menu → **Link Instagram Post** → button appears in the dialog with same per-board caption.
- [ ] **Desktop browser** — copy succeeds, Instagram launch returns false; snackbar reads "Caption copied to clipboard."
- [ ] **Mobile UA / device** — Instagram opens after copy; snackbar reads "Caption copied — paste it into Instagram."
- [ ] `vp check` (lint + format), `vp run typecheck:web`, `vp test run` for `instagram-posting`, `vp run check:i18n` and `vp run check:i18n:orphans` — all pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk1qs9rARggN8f4AvCYWez)_