### PR TITLE
fix(party-session): preserve userId, fix markInactive race, add diagn…

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -397,9 +397,11 @@ The main Traefik instance routes `*.preview.boardsesh.com` and `*.ws.preview.boa
     └────────────────────┘
 ```
 
-**Grace Period:** When the last user disconnects, the session enters a 60-second grace period where in-memory state is preserved. If a client reconnects within this window (common during network flaps or page refreshes), the session is instantly available without the expensive lock + Redis/Postgres restoration cycle. The grace period duration is controlled by `SESSION_GRACE_PERIOD_MS` in `RoomManager`.
+**Grace Period:** When the last user disconnects from this backend instance, the session enters a 60-second grace period where in-memory state is preserved. If a client reconnects within this window (common during network flaps or page refreshes), the session is instantly available without the expensive lock + Redis/Postgres restoration cycle. The grace period duration is controlled by `SESSION_GRACE_PERIOD_MS` in `RoomManager`.
 
 If the grace period expires, the session is evicted from memory but remains restorable from Redis until the 4-hour TTL expires. After Redis TTL expiry, the session is still not ended; the next join restores it from Postgres as long as the durable row has not been explicitly marked `ended`.
+
+**Multi-instance grace handling:** Because each instance tracks its own local clients, "the last user disconnected" is a per-instance event — another instance may still host active members. Before tearing down session state (cancelling pending Postgres writes, marking the session inactive in Redis), `leaveSession` in `room-manager/client-lifecycle.ts` queries `distributedState.getSessionMembers(sessionId)` and filters out the leaving connection. The dangerous side-effects (`writeScheduler.cancelPendingWrites`, `redisStore.markInactive`) only fire when no other instance has members. The local grace timer (memory cleanup for this instance's `sessionsMap`) still runs regardless. The filter relies on the invariant that `SessionUser.id` returned by `getSessionMembers` is the connection ID (see `distributed-state/session-ops.ts:181`); the regression test `leave-session-multi-instance.test.ts` pins this.
 
 ### Session Properties
 
@@ -514,6 +516,10 @@ sequenceDiagram
 | `SessionStatsUpdated` | A tick is saved for an active party session | `totalSends`, `totalFlashes`, `totalAttempts`, `tickCount`, `participants`, `gradeDistribution`, `boardTypes`, `hardestGrade`, `durationMinutes`, `goal`, `ticks` |
 
 `SessionStatsUpdated` payloads include full `ticks` rows so clients can update charts and climbs/attempt lists without issuing an extra session detail refetch. On the client, `useEventProcessor` patches the `SESSION_DETAIL_QUERY_KEY(sessionId)` React Query cache entry directly with the new stats and ticks — there is no separate `liveSessionStats` merge layer, so any component subscribed via `useSessionDetail` re-renders from the updated cache automatically.
+
+**UserJoined / UserLeft identifier contract:** The `user.id` field in `UserJoined` and the `userId` field in `UserLeft` both carry the **WebSocket connection ID**, not the stable database user UUID. The schema-field name `userId` predates the distinction and is a misnomer — renaming it is a breaking change for clients and out of scope. The web client populates its participant list from `UserJoined.user.id` and filters on disconnect with `u.id !== event.userId` (`use-session-lifecycle.ts:562`), so the two events must agree on shape. If you need the stable user UUID downstream (auth checks, tick attribution), use `ctx.userId` on the backend — which auth middleware sets and resolvers must not overwrite — or include `SessionUser.userId` in the payload explicitly (it is a separate field).
+
+**`ctx.userId` lifecycle:** Auth middleware sets `ctx.userId` once at connection time to the stable database user UUID (or `undefined` for unauthenticated clients). Session-related resolvers (`joinSession`, `createSession`) must not overwrite this field — they only update `ctx.sessionId`. An earlier bug clobbered `ctx.userId` with the connection ID inside `joinSession`, breaking every downstream resolver that read `ctx.userId` (ESP32 auto-authorize, climb / tick mutations, controller queries). The regression test `session-context.test.ts` pins the correct behaviour.
 
 ---
 

--- a/packages/backend/src/__tests__/leave-session-multi-instance.test.ts
+++ b/packages/backend/src/__tests__/leave-session-multi-instance.test.ts
@@ -1,19 +1,29 @@
 /**
- * Regression test for the multi-instance markInactive race in
+ * Regression tests for the multi-instance `markInactive` cleanup in
  * `leaveSession`.
  *
- * Before this fix: when the local sessionsMap entry for a session emptied,
- * the instance unconditionally called `redisStore.markInactive(sessionId)`,
+ * Before any of these fixes: when the local sessionsMap entry for a
+ * session emptied, the instance unconditionally called
+ * `redisStore.markInactive(sessionId)`,
  * `writeScheduler.cancelPendingWrites(sessionId)`, and logged
- * "Session ... marked inactive - grace period started (60s)" — even though
- * other backend instances might still have active members. The cancelled
- * pending Postgres writes are the dangerous side-effect: a queue mutation
- * made just before the local instance emptied could be lost from durable
- * storage.
+ * "Session ... marked inactive - grace period started (60s)" — even
+ * though other backend instances might still have active members. The
+ * cancelled pending Postgres writes are the dangerous side-effect: a
+ * queue mutation made just before the local instance emptied could be
+ * lost from durable storage.
  *
- * After this fix: the side-effects are skipped when distributed state
- * still lists members on other instances. The local grace timer still runs
- * (it only manages this instance's memory).
+ * After the fix in this PR:
+ * - We only mark inactive when the session is globally empty.
+ * - The global-emptiness check runs AFTER `distributedState.leaveSession`
+ *   so the two-instance concurrent-leave race can't leak — when both
+ *   instances see [other] in a pre-leave snapshot, both leave, then both
+ *   re-check post-leave and both see [] → both call markInactive
+ *   idempotently. (`SREM` on the `boardsesh:session:active` set is a
+ *   no-op the second time.) The single-instance-with-friend-on-other-
+ *   instance case still works because the friend hasn't left yet, so
+ *   the post-leave query returns `[friend]` not `[]`.
+ * - The local grace timer still runs unconditionally (per-instance
+ *   memory cleanup is independent of global session state).
  */
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { leaveSession } from '../services/room-manager/client-lifecycle';
@@ -78,12 +88,11 @@ describe('leaveSession multi-instance markInactive race', () => {
   });
 
   it('skips markInactive and keeps pending writes when other instances still have members', async () => {
+    // Post-leave query: we already left, but the other instance's
+    // connection is still in the membership set.
     const distributedState: MockedDistState = {
       leaveSession: vi.fn().mockResolvedValue({ newLeaderId: REMOTE_CONN }),
-      getSessionMembers: vi.fn().mockResolvedValue([
-        { id: LOCAL_CONN, username: 'a', isLeader: false },
-        { id: REMOTE_CONN, username: 'b', isLeader: true },
-      ]),
+      getSessionMembers: vi.fn().mockResolvedValue([{ id: REMOTE_CONN, username: 'b', isLeader: true }]),
     };
 
     const result = await leaveSession(
@@ -112,12 +121,11 @@ describe('leaveSession multi-instance markInactive race', () => {
   });
 
   it('still calls markInactive and cancels pending writes when no other instances have members', async () => {
+    // Post-leave query returns empty because we were the only member
+    // globally.
     const distributedState: MockedDistState = {
       leaveSession: vi.fn().mockResolvedValue({ newLeaderId: null }),
-      getSessionMembers: vi.fn().mockResolvedValue([
-        // Only the leaving connection remains; nothing else globally.
-        { id: LOCAL_CONN, username: 'a', isLeader: true },
-      ]),
+      getSessionMembers: vi.fn().mockResolvedValue([]),
     };
 
     const result = await leaveSession(
@@ -140,15 +148,23 @@ describe('leaveSession multi-instance markInactive race', () => {
     clearTimeout(sessionGraceTimers.get(SESSION_ID)!);
   });
 
-  it('still calls markInactive when getSessionMembers returns an empty array (session already evicted)', async () => {
-    // This documents the desired fallback when distributed state has
-    // already pruned the leaving connection (e.g. TTL expired between
-    // `leaveSession`'s callsite and the membership query). The race
-    // result is that `members` is empty, which we treat the same as
-    // "no other members" — mark inactive, cancel pending writes.
+  it('queries getSessionMembers AFTER distributedState.leaveSession so the post-leave view collapses the concurrent-leave race', async () => {
+    // Two-instance concurrent-leave race: both instances see [other] in
+    // a *pre*-leave snapshot, both decide to skip markInactive, both
+    // distributedState.leaveSession runs, then both re-check post-leave
+    // and see []. With the call order baked in here, the cleanup fires
+    // idempotently — `SREM boardsesh:session:active` is a no-op the
+    // second time, so both instances calling markInactive is fine.
+    const callOrder: string[] = [];
     const distributedState: MockedDistState = {
-      leaveSession: vi.fn().mockResolvedValue({ newLeaderId: null }),
-      getSessionMembers: vi.fn().mockResolvedValue([]),
+      leaveSession: vi.fn().mockImplementation(async () => {
+        callOrder.push('leaveSession');
+        return { newLeaderId: null };
+      }),
+      getSessionMembers: vi.fn().mockImplementation(async () => {
+        callOrder.push('getSessionMembers');
+        return [];
+      }),
     };
 
     await leaveSession(
@@ -163,9 +179,8 @@ describe('leaveSession multi-instance markInactive race', () => {
       GRACE_PERIOD_MS,
     );
 
-    expect(distributedState.getSessionMembers).toHaveBeenCalledWith(SESSION_ID);
+    expect(callOrder).toEqual(['leaveSession', 'getSessionMembers']);
     expect(redisStore.markInactive).toHaveBeenCalledWith(SESSION_ID);
-    expect(writeScheduler.cancelPendingWrites).toHaveBeenCalledWith(SESSION_ID);
 
     clearTimeout(sessionGraceTimers.get(SESSION_ID)!);
   });

--- a/packages/backend/src/__tests__/leave-session-multi-instance.test.ts
+++ b/packages/backend/src/__tests__/leave-session-multi-instance.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression test for the multi-instance markInactive race in
+ * `leaveSession`.
+ *
+ * Before this fix: when the local sessionsMap entry for a session emptied,
+ * the instance unconditionally called `redisStore.markInactive(sessionId)`,
+ * `writeScheduler.cancelPendingWrites(sessionId)`, and logged
+ * "Session ... marked inactive - grace period started (60s)" — even though
+ * other backend instances might still have active members. The cancelled
+ * pending Postgres writes are the dangerous side-effect: a queue mutation
+ * made just before the local instance emptied could be lost from durable
+ * storage.
+ *
+ * After this fix: the side-effects are skipped when distributed state
+ * still lists members on other instances. The local grace timer still runs
+ * (it only manages this instance's memory).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { leaveSession } from '../services/room-manager/client-lifecycle';
+import type { ConnectedClient } from '../services/room-manager/types';
+import type { RedisSessionStore } from '../services/redis-session-store';
+import type { DistributedStateManager } from '../services/distributed-state';
+import type { WriteScheduler } from '../services/room-manager/write-scheduler';
+
+const GRACE_PERIOD_MS = 60_000;
+
+type MockedRedisStore = Pick<RedisSessionStore, 'markInactive' | 'saveUsers'>;
+type MockedWriteScheduler = Pick<WriteScheduler, 'cancelPendingWrites'>;
+type MockedDistState = Pick<DistributedStateManager, 'leaveSession' | 'getSessionMembers'>;
+
+function makeRedisStore(): MockedRedisStore {
+  return {
+    markInactive: vi.fn().mockResolvedValue(undefined),
+    saveUsers: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeWriteScheduler(): MockedWriteScheduler {
+  return {
+    cancelPendingWrites: vi.fn(),
+  };
+}
+
+function makeClient(connectionId: string, sessionId: string | null): ConnectedClient {
+  return {
+    connectionId,
+    sessionId,
+    userId: 'user-1',
+    username: 'test',
+    isLeader: false,
+    connectedAt: new Date(),
+    avatarUrl: undefined,
+  };
+}
+
+describe('leaveSession multi-instance markInactive race', () => {
+  let clients: Map<string, ConnectedClient>;
+  let sessionsMap: Map<string, Set<string>>;
+  let sessionGraceTimers: Map<string, NodeJS.Timeout>;
+  let pendingJoinPersists: Map<string, Promise<void>>;
+  let redisStore: MockedRedisStore;
+  let writeScheduler: MockedWriteScheduler;
+
+  const SESSION_ID = 'session-multi-instance';
+  const LOCAL_CONN = 'conn-local';
+  const REMOTE_CONN = 'conn-on-other-instance';
+
+  beforeEach(() => {
+    clients = new Map();
+    sessionsMap = new Map();
+    sessionGraceTimers = new Map();
+    pendingJoinPersists = new Map();
+    redisStore = makeRedisStore();
+    writeScheduler = makeWriteScheduler();
+
+    clients.set(LOCAL_CONN, makeClient(LOCAL_CONN, SESSION_ID));
+    sessionsMap.set(SESSION_ID, new Set([LOCAL_CONN]));
+  });
+
+  it('skips markInactive and keeps pending writes when other instances still have members', async () => {
+    const distributedState: MockedDistState = {
+      leaveSession: vi.fn().mockResolvedValue({ newLeaderId: REMOTE_CONN }),
+      getSessionMembers: vi.fn().mockResolvedValue([
+        { id: LOCAL_CONN, username: 'a', isLeader: false },
+        { id: REMOTE_CONN, username: 'b', isLeader: true },
+      ]),
+    };
+
+    const result = await leaveSession(
+      LOCAL_CONN,
+      clients,
+      sessionsMap,
+      redisStore as unknown as RedisSessionStore,
+      distributedState as unknown as DistributedStateManager,
+      writeScheduler as unknown as WriteScheduler,
+      sessionGraceTimers,
+      pendingJoinPersists,
+      GRACE_PERIOD_MS,
+    );
+
+    expect(result?.sessionId).toBe(SESSION_ID);
+    expect(result?.newLeaderId).toBe(REMOTE_CONN);
+
+    // The dangerous side-effects must be skipped because another instance
+    // still has members.
+    expect(writeScheduler.cancelPendingWrites).not.toHaveBeenCalled();
+    expect(redisStore.markInactive).not.toHaveBeenCalled();
+
+    // Local grace timer still runs (per-instance memory cleanup).
+    expect(sessionGraceTimers.has(SESSION_ID)).toBe(true);
+    clearTimeout(sessionGraceTimers.get(SESSION_ID)!);
+  });
+
+  it('still calls markInactive and cancels pending writes when no other instances have members', async () => {
+    const distributedState: MockedDistState = {
+      leaveSession: vi.fn().mockResolvedValue({ newLeaderId: null }),
+      getSessionMembers: vi.fn().mockResolvedValue([
+        // Only the leaving connection remains; nothing else globally.
+        { id: LOCAL_CONN, username: 'a', isLeader: true },
+      ]),
+    };
+
+    const result = await leaveSession(
+      LOCAL_CONN,
+      clients,
+      sessionsMap,
+      redisStore as unknown as RedisSessionStore,
+      distributedState as unknown as DistributedStateManager,
+      writeScheduler as unknown as WriteScheduler,
+      sessionGraceTimers,
+      pendingJoinPersists,
+      GRACE_PERIOD_MS,
+    );
+
+    expect(result?.sessionId).toBe(SESSION_ID);
+    expect(writeScheduler.cancelPendingWrites).toHaveBeenCalledWith(SESSION_ID);
+    expect(redisStore.markInactive).toHaveBeenCalledWith(SESSION_ID);
+
+    expect(sessionGraceTimers.has(SESSION_ID)).toBe(true);
+    clearTimeout(sessionGraceTimers.get(SESSION_ID)!);
+  });
+
+  it('falls back to markInactive when distributedState is unavailable (single-instance dev mode)', async () => {
+    const result = await leaveSession(
+      LOCAL_CONN,
+      clients,
+      sessionsMap,
+      redisStore as unknown as RedisSessionStore,
+      null, // no distributed state
+      writeScheduler as unknown as WriteScheduler,
+      sessionGraceTimers,
+      pendingJoinPersists,
+      GRACE_PERIOD_MS,
+    );
+
+    expect(result?.sessionId).toBe(SESSION_ID);
+
+    // Without distributed state we cannot check global membership, so the
+    // legacy behaviour (mark inactive immediately) must remain.
+    expect(redisStore.markInactive).toHaveBeenCalledWith(SESSION_ID);
+    expect(writeScheduler.cancelPendingWrites).toHaveBeenCalledWith(SESSION_ID);
+    expect(redisStore.saveUsers).toHaveBeenCalledWith(SESSION_ID, []);
+
+    clearTimeout(sessionGraceTimers.get(SESSION_ID)!);
+  });
+
+  it('treats a failing distributed members query as "no other members" to avoid leaked sessions', async () => {
+    const distributedState: MockedDistState = {
+      leaveSession: vi.fn().mockResolvedValue({ newLeaderId: null }),
+      getSessionMembers: vi.fn().mockRejectedValue(new Error('redis down')),
+    };
+
+    // Silence the expected console.error from the catch branch.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await leaveSession(
+      LOCAL_CONN,
+      clients,
+      sessionsMap,
+      redisStore as unknown as RedisSessionStore,
+      distributedState as unknown as DistributedStateManager,
+      writeScheduler as unknown as WriteScheduler,
+      sessionGraceTimers,
+      pendingJoinPersists,
+      GRACE_PERIOD_MS,
+    );
+
+    expect(redisStore.markInactive).toHaveBeenCalledWith(SESSION_ID);
+    expect(writeScheduler.cancelPendingWrites).toHaveBeenCalledWith(SESSION_ID);
+
+    clearTimeout(sessionGraceTimers.get(SESSION_ID)!);
+    errSpy.mockRestore();
+  });
+});

--- a/packages/backend/src/__tests__/leave-session-multi-instance.test.ts
+++ b/packages/backend/src/__tests__/leave-session-multi-instance.test.ts
@@ -140,6 +140,36 @@ describe('leaveSession multi-instance markInactive race', () => {
     clearTimeout(sessionGraceTimers.get(SESSION_ID)!);
   });
 
+  it('still calls markInactive when getSessionMembers returns an empty array (session already evicted)', async () => {
+    // This documents the desired fallback when distributed state has
+    // already pruned the leaving connection (e.g. TTL expired between
+    // `leaveSession`'s callsite and the membership query). The race
+    // result is that `members` is empty, which we treat the same as
+    // "no other members" — mark inactive, cancel pending writes.
+    const distributedState: MockedDistState = {
+      leaveSession: vi.fn().mockResolvedValue({ newLeaderId: null }),
+      getSessionMembers: vi.fn().mockResolvedValue([]),
+    };
+
+    await leaveSession(
+      LOCAL_CONN,
+      clients,
+      sessionsMap,
+      redisStore as unknown as RedisSessionStore,
+      distributedState as unknown as DistributedStateManager,
+      writeScheduler as unknown as WriteScheduler,
+      sessionGraceTimers,
+      pendingJoinPersists,
+      GRACE_PERIOD_MS,
+    );
+
+    expect(distributedState.getSessionMembers).toHaveBeenCalledWith(SESSION_ID);
+    expect(redisStore.markInactive).toHaveBeenCalledWith(SESSION_ID);
+    expect(writeScheduler.cancelPendingWrites).toHaveBeenCalledWith(SESSION_ID);
+
+    clearTimeout(sessionGraceTimers.get(SESSION_ID)!);
+  });
+
   it('falls back to markInactive when distributedState is unavailable (single-instance dev mode)', async () => {
     const result = await leaveSession(
       LOCAL_CONN,

--- a/packages/backend/src/__tests__/session-context.test.ts
+++ b/packages/backend/src/__tests__/session-context.test.ts
@@ -178,6 +178,16 @@ describe('leaveSession publishes UserLeft with the connection ID', () => {
     // It must NOT be the auth user UUID — clients filter participants
     // by connection ID and would fail to remove the user otherwise.
     expect(userLeftCall![1].userId).not.toBe(realUserId);
+
+    // updateContext must clear ONLY sessionId; userId must be preserved
+    // for downstream resolvers on this same connection (queries, social
+    // actions, etc.). An earlier version of this resolver wrote
+    // `{ sessionId: undefined, userId: undefined }`, which looked like
+    // it was deliberately wiping the auth UUID.
+    expect(updateContext).toHaveBeenCalledOnce();
+    const [, calledUpdates] = vi.mocked(updateContext).mock.calls[0];
+    expect(calledUpdates).toEqual({ sessionId: undefined });
+    expect(calledUpdates).not.toHaveProperty('userId');
   });
 
   it('emits UserLeft for unauthenticated clients (which previously had no userId on ctx)', async () => {

--- a/packages/backend/src/__tests__/session-context.test.ts
+++ b/packages/backend/src/__tests__/session-context.test.ts
@@ -15,6 +15,7 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { sessionMutations } from '../graphql/resolvers/sessions/mutations';
 import { updateContext } from '../graphql/context';
+import { pubsub } from '../pubsub/index';
 
 vi.mock('../services/room-manager', () => ({
   roomManager: {
@@ -27,6 +28,10 @@ vi.mock('../services/room-manager', () => ({
       sequence: 0,
       stateHash: 'hash',
       sessionName: null,
+    }),
+    leaveSession: vi.fn().mockResolvedValue({
+      sessionId: 'session-aaaa-bbbb-cccc-dddd',
+      newLeaderId: undefined,
     }),
     createDiscoverableSession: vi.fn().mockResolvedValue({}),
     getSessionById: vi.fn().mockResolvedValue(null),
@@ -125,5 +130,74 @@ describe('createSession does not clobber ctx.userId', () => {
     const [, calledUpdates] = vi.mocked(updateContext).mock.calls[0];
     expect(calledUpdates).toEqual({ sessionId: 'test-session-uuid' });
     expect(calledUpdates).not.toHaveProperty('userId');
+  });
+});
+
+describe('leaveSession publishes UserLeft with the connection ID', () => {
+  // Background: the disconnect handler in websocket/setup.ts and the
+  // explicit `leaveSession` mutation both emit a `UserLeft` event so
+  // peers can drop the departing user from their participant list. The
+  // GraphQL schema names the payload field `userId` but the *contract*
+  // with the client is that it carries the connection ID — clients
+  // populate their participant list from `UserJoined.user.id`, which is
+  // `result.clientId` (the connection ID), and filter by
+  // `u.id !== event.userId`. The two events must agree.
+  //
+  // Earlier commits in this PR stopped clobbering `ctx.userId` with the
+  // connection ID. The leaveSession mutation was previously guarded by
+  // `if (userId)` and only fired because of that clobber, so it would
+  // have silently stopped emitting UserLeft for unauthenticated clients
+  // (and for authenticated clients would have emitted the real user
+  // UUID — wrong shape, fails the client filter). This test pins the
+  // correct behaviour.
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('emits UserLeft with userId === ctx.connectionId for authenticated clients', async () => {
+    const realUserId = '8a68ddc8-8da0-47e2-a968-1029b6fb4bb3';
+    const ctx: ConnectionContext = {
+      connectionId: 'ws-conn-abc-123',
+      sessionId: 'session-aaaa-bbbb-cccc-dddd',
+      userId: realUserId,
+      isAuthenticated: true,
+    };
+
+    await sessionMutations.leaveSession(undefined, undefined, ctx);
+
+    const calls = vi.mocked(pubsub.publishSessionEvent).mock.calls;
+    const userLeftCall = calls.find(
+      (call): call is [string, { __typename: 'UserLeft'; userId: string }] =>
+        typeof call[1] === 'object' &&
+        call[1] !== null &&
+        (call[1] as { __typename?: string }).__typename === 'UserLeft',
+    );
+    expect(userLeftCall).toBeDefined();
+    expect(userLeftCall![0]).toBe('session-aaaa-bbbb-cccc-dddd');
+    expect(userLeftCall![1].userId).toBe('ws-conn-abc-123');
+    // It must NOT be the auth user UUID — clients filter participants
+    // by connection ID and would fail to remove the user otherwise.
+    expect(userLeftCall![1].userId).not.toBe(realUserId);
+  });
+
+  it('emits UserLeft for unauthenticated clients (which previously had no userId on ctx)', async () => {
+    const ctx: ConnectionContext = {
+      connectionId: 'ws-conn-anon-456',
+      sessionId: 'session-zzzz',
+      userId: undefined,
+      isAuthenticated: false,
+    };
+
+    await sessionMutations.leaveSession(undefined, undefined, ctx);
+
+    const calls = vi.mocked(pubsub.publishSessionEvent).mock.calls;
+    const userLeftCall = calls.find(
+      (call): call is [string, { __typename: 'UserLeft'; userId: string }] =>
+        typeof call[1] === 'object' &&
+        call[1] !== null &&
+        (call[1] as { __typename?: string }).__typename === 'UserLeft',
+    );
+    expect(userLeftCall).toBeDefined();
+    expect(userLeftCall![1].userId).toBe('ws-conn-anon-456');
   });
 });

--- a/packages/backend/src/__tests__/session-context.test.ts
+++ b/packages/backend/src/__tests__/session-context.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for the joinSession / createSession context-update flow.
+ *
+ * Background: `roomManager.joinSession` returns `clientId: connectionId` (the
+ * WebSocket connection ID). For a long time the resolvers passed that value
+ * into `updateContext` as `userId`, clobbering the real authenticated user
+ * UUID set by auth middleware. Downstream resolvers (climb mutations, ESP32
+ * auto-authorize, tick adoption) then queried using the connection ID and
+ * either matched zero rows or wrote records under the wrong owner.
+ *
+ * These tests pin the contract: `updateContext` must never receive a
+ * `userId` field from joinSession / createSession — auth already set it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { sessionMutations } from '../graphql/resolvers/sessions/mutations';
+import { updateContext } from '../graphql/context';
+
+vi.mock('../services/room-manager', () => ({
+  roomManager: {
+    joinSession: vi.fn().mockResolvedValue({
+      clientId: 'ws-conn-abc-123',
+      isLeader: true,
+      users: [],
+      queue: [],
+      currentClimbQueueItem: null,
+      sequence: 0,
+      stateHash: 'hash',
+      sessionName: null,
+    }),
+    createDiscoverableSession: vi.fn().mockResolvedValue({}),
+    getSessionById: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock('../pubsub/index', () => ({
+  pubsub: { publishSessionEvent: vi.fn() },
+}));
+
+vi.mock('../graphql/context', () => ({
+  updateContext: vi.fn(),
+}));
+
+vi.mock('uuid', () => ({
+  v4: () => 'test-session-uuid',
+}));
+
+vi.mock('../db/client', () => ({
+  db: {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue([]),
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+  },
+}));
+
+vi.mock('../jobs/inferred-session-builder', () => ({
+  adoptRecentTicksForSession: vi.fn().mockResolvedValue(undefined),
+  extractBoardType: vi.fn().mockReturnValue('kilter'),
+}));
+
+function makeWsAuthenticatedCtx(userId: string): ConnectionContext {
+  return {
+    connectionId: 'ws-conn-abc-123',
+    sessionId: undefined,
+    userId,
+    isAuthenticated: true,
+  };
+}
+
+describe('joinSession does not clobber ctx.userId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes only { sessionId } to updateContext, preserving the authenticated user UUID', async () => {
+    const realUserId = '8a68ddc8-8da0-47e2-a968-1029b6fb4bb3';
+    const ctx = makeWsAuthenticatedCtx(realUserId);
+
+    await sessionMutations.joinSession(
+      undefined,
+      {
+        sessionId: 'session-aaaa-bbbb-cccc-dddd',
+        boardPath: '/kilter/1/2/3/40',
+      },
+      ctx,
+    );
+
+    expect(updateContext).toHaveBeenCalledOnce();
+    const [calledConnectionId, calledUpdates] = vi.mocked(updateContext).mock.calls[0];
+    expect(calledConnectionId).toBe('ws-conn-abc-123');
+    expect(calledUpdates).toEqual({ sessionId: 'session-aaaa-bbbb-cccc-dddd' });
+    expect(calledUpdates).not.toHaveProperty('userId');
+  });
+});
+
+describe('createSession does not clobber ctx.userId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes only { sessionId } to updateContext on the WebSocket path', async () => {
+    const realUserId = '8a68ddc8-8da0-47e2-a968-1029b6fb4bb3';
+    const ctx = makeWsAuthenticatedCtx(realUserId);
+
+    await sessionMutations.createSession(
+      undefined,
+      {
+        input: {
+          boardPath: '/kilter/1/2/3/40',
+          latitude: 0,
+          longitude: 0,
+          discoverable: false,
+          name: 'Test',
+        },
+      },
+      ctx,
+    );
+
+    expect(updateContext).toHaveBeenCalledOnce();
+    const [, calledUpdates] = vi.mocked(updateContext).mock.calls[0];
+    expect(calledUpdates).toEqual({ sessionId: 'test-session-uuid' });
+    expect(calledUpdates).not.toHaveProperty('userId');
+  });
+});

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -372,19 +372,22 @@ export const queueMutations = {
       validateInput(ClimbQueueItemSchema, currentClimbQueueItem, 'currentClimbQueueItem');
     }
 
-    // Capture the previous state hash so we can flag no-op resyncs. The
-    // client's 60s state-hash watchdog (see
+    // updateQueueState returns `previousStateHash` from the same Redis
+    // read it already does internally, so this no-op check costs nothing
+    // extra. The client's 60s state-hash watchdog (see
     // packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts)
-    // triggers setQueue when it thinks local and server state have diverged.
-    // If the resulting hash matches what the server already had, the client
-    // was wrong about the drift — usually a bug in the local hash
-    // computation or event processor — and the loop will fire again next
-    // minute. This warn surfaces those loops.
-    const previousHash = (await roomManager.getQueueState(sessionId)).stateHash;
+    // triggers setQueue when it thinks local and server state have
+    // diverged. If the resulting hash matches what the server already
+    // had, the client was wrong about the drift — usually a bug in the
+    // local hash computation or event processor — and the loop will fire
+    // again next minute. The warn surfaces those loops.
+    const { sequence, stateHash, previousStateHash } = await roomManager.updateQueueState(
+      sessionId,
+      queue,
+      currentClimbQueueItem || null,
+    );
 
-    const { sequence, stateHash } = await roomManager.updateQueueState(sessionId, queue, currentClimbQueueItem || null);
-
-    if (previousHash === stateHash) {
+    if (previousStateHash !== null && previousStateHash === stateHash) {
       console.warn(
         `[setQueue] No-op resync for session ${sessionId} (hash=${stateHash}, queueSize=${queue.length}). Client state already matched server — investigate hash-drift on the publisher.`,
       );

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -372,7 +372,23 @@ export const queueMutations = {
       validateInput(ClimbQueueItemSchema, currentClimbQueueItem, 'currentClimbQueueItem');
     }
 
+    // Capture the previous state hash so we can flag no-op resyncs. The
+    // client's 60s state-hash watchdog (see
+    // packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts)
+    // triggers setQueue when it thinks local and server state have diverged.
+    // If the resulting hash matches what the server already had, the client
+    // was wrong about the drift — usually a bug in the local hash
+    // computation or event processor — and the loop will fire again next
+    // minute. This warn surfaces those loops.
+    const previousHash = (await roomManager.getQueueState(sessionId)).stateHash;
+
     const { sequence, stateHash } = await roomManager.updateQueueState(sessionId, queue, currentClimbQueueItem || null);
+
+    if (previousHash === stateHash) {
+      console.warn(
+        `[setQueue] No-op resync for session ${sessionId} (hash=${stateHash}, queueSize=${queue.length}). Client state already matched server — investigate hash-drift on the publisher.`,
+      );
+    }
 
     const state: QueueState = {
       sequence,

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -104,9 +104,15 @@ export const sessionMutations = {
         `[joinSession] roomManager.joinSession completed - clientId: ${result.clientId}, isLeader: ${result.isLeader}`,
       );
 
-    // Update context with session info
+    // Update context with session info. Do NOT touch userId here — auth
+    // middleware set it to the real authenticated user UUID when the WS
+    // connected. `result.clientId` is the connection ID (see
+    // services/room-manager/client-lifecycle.ts:199 which returns
+    // `clientId: connectionId`), and writing it to `ctx.userId` would
+    // clobber the real UUID for every downstream resolver on this connection
+    // (ESP32 auto-authorize, tick inserts, climb ownership, etc.).
     if (DEBUG) console.info(`[joinSession] Before updateContext - ctx.sessionId: ${ctx.sessionId}`);
-    updateContext(ctx.connectionId, { sessionId, userId: result.clientId });
+    updateContext(ctx.connectionId, { sessionId });
     if (DEBUG) console.info(`[joinSession] After updateContext - ctx.sessionId: ${ctx.sessionId}`);
 
     // Auto-authorize user's ESP32 controllers for this session (if authenticated)
@@ -240,7 +246,7 @@ export const sessionMutations = {
       if (DEBUG)
         console.info(`[createSession] Joined session - clientId: ${result.clientId}, isLeader: ${result.isLeader}`);
 
-      updateContext(ctx.connectionId, { sessionId, userId: result.clientId });
+      updateContext(ctx.connectionId, { sessionId });
 
       // Adopt recent solo ticks now that the session row exists in board_sessions
       // (boardsesh_ticks.session_id is a FK to board_sessions.id)

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -329,7 +329,12 @@ export const sessionMutations = {
         });
       }
 
-      updateContext(ctx.connectionId, { sessionId: undefined, userId: undefined });
+      // Only clear sessionId — leave userId alone. Auth set it to the
+      // real user UUID at connection time and downstream resolvers on
+      // this same WebSocket (queries from other tabs, social actions,
+      // etc.) still need it. Mirrors the joinSession / createSession fix
+      // earlier in this file.
+      updateContext(ctx.connectionId, { sessionId: undefined });
     }
 
     return true;

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -310,17 +310,16 @@ export const sessionMutations = {
     if (!ctx.sessionId) return false;
 
     const sessionId = ctx.sessionId;
-    const userId = ctx.userId;
     const result = await roomManager.leaveSession(ctx.connectionId);
 
     if (result) {
-      // Notify session about user leaving
-      if (userId) {
-        pubsub.publishSessionEvent(sessionId, {
-          __typename: 'UserLeft',
-          userId,
-        });
-      }
+      // Notify session about user leaving. UserLeft.userId is the
+      // connection ID (matching UserJoined.user.id = result.clientId).
+      // See websocket/setup.ts onDisconnect for the same pattern.
+      pubsub.publishSessionEvent(sessionId, {
+        __typename: 'UserLeft',
+        userId: ctx.connectionId,
+      });
 
       // Notify about new leader if changed
       if (result.newLeaderId) {

--- a/packages/backend/src/pubsub/index.ts
+++ b/packages/backend/src/pubsub/index.ts
@@ -87,6 +87,15 @@ class PubSub {
     return this.redisRequired;
   }
 
+  /**
+   * Get the unique ID assigned to this backend instance, or null when
+   * running in local-only mode. Used to tag logs and correlate cross-instance
+   * events.
+   */
+  getInstanceId(): string | null {
+    return this.redisAdapter?.getInstanceId() ?? null;
+  }
+
   private setupRedisMessageHandlers(): void {
     if (!this.redisAdapter) return;
 

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -43,18 +43,33 @@ export async function startServer(): Promise<ServerResources> {
   // requires triangulating via connection-registration logs to figure out
   // which instance emitted any given line — see
   // gist.github.com/marcodejongh/90a125720ad48bf0355ec176f9ebc0df for an
-  // example session where this cost hours of analysis time. When Redis is
-  // not configured the instance ID is omitted and the patch is a no-op.
+  // example session where this cost hours of analysis time.
+  //
+  // TRADE-OFFS:
+  // - This patches the GLOBAL `console.*`, so any third-party library that
+  //   logs to console also picks up the prefix. That's fine today: we
+  //   don't use a structured logger (Pino/Winston) anywhere — every log
+  //   is raw `console.*` and is consumed by Railway as plain text. If we
+  //   move to a structured logger later, swap this for a logger wrapper
+  //   and remove the patch.
+  // - When the first arg is non-string (e.g. `console.error(err)`), we
+  //   pass the tag as a separate leading arg so util.format / inspect()
+  //   on the trailing arg is preserved. Output stays one line per call.
+  // - When Redis is not configured the instance ID is null and we skip
+  //   the patch entirely (local-only dev mode — no need to disambiguate).
   const instanceId = pubsub.getInstanceId();
   const instanceTag = instanceId ? `[i:${instanceId.slice(0, 8)}] ` : '';
   if (instanceTag) {
+    const trimmedTag = instanceTag.trim();
     for (const method of ['info', 'warn', 'error', 'log'] as const) {
       const original = console[method].bind(console);
       console[method] = (...args: unknown[]) => {
-        if (args.length > 0 && typeof args[0] === 'string') {
+        if (args.length === 0) {
+          original(trimmedTag);
+        } else if (typeof args[0] === 'string') {
           original(`${instanceTag}${args[0]}`, ...args.slice(1));
         } else {
-          original(instanceTag.trim(), ...args);
+          original(trimmedTag, ...args);
         }
       };
     }

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -38,6 +38,28 @@ export async function startServer(): Promise<ServerResources> {
   // This must happen before we start accepting connections
   await pubsub.initialize();
 
+  // Prefix every console line with the pubsub instance ID so multi-instance
+  // logs can be untangled. Without this, debugging cross-instance pub/sub
+  // requires triangulating via connection-registration logs to figure out
+  // which instance emitted any given line — see
+  // gist.github.com/marcodejongh/90a125720ad48bf0355ec176f9ebc0df for an
+  // example session where this cost hours of analysis time. When Redis is
+  // not configured the instance ID is omitted and the patch is a no-op.
+  const instanceId = pubsub.getInstanceId();
+  const instanceTag = instanceId ? `[i:${instanceId.slice(0, 8)}] ` : '';
+  if (instanceTag) {
+    for (const method of ['info', 'warn', 'error', 'log'] as const) {
+      const original = console[method].bind(console);
+      console[method] = (...args: unknown[]) => {
+        if (args.length > 0 && typeof args[0] === 'string') {
+          original(`${instanceTag}${args[0]}`, ...args.slice(1));
+        } else {
+          original(instanceTag.trim(), ...args);
+        }
+      };
+    }
+  }
+
   // Initialize RoomManager with Redis for session persistence
   if (redisClientManager.isRedisConfigured() && redisClientManager.isRedisConnected()) {
     const { publisher, streamConsumer } = redisClientManager.getClients();

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -33,47 +33,65 @@ export type ServerResources = {
   shutdownServices: () => Promise<void>;
 };
 
+// Idempotency guard: re-running `startServer()` (which tests do) must not
+// stack the console wrapper — otherwise each call prepends another copy
+// of the instance tag and we get `[i:abc] [i:abc] message`.
+let instanceLogTagInstalled = false;
+
+/**
+ * Prefix every console line with the pubsub instance ID so multi-instance
+ * logs can be untangled. Without this, debugging cross-instance pub/sub
+ * requires triangulating via connection-registration logs to figure out
+ * which instance emitted any given line — see
+ * gist.github.com/marcodejongh/90a125720ad48bf0355ec176f9ebc0df for an
+ * example session where this cost hours of analysis time.
+ *
+ * TRADE-OFFS:
+ * - This patches the GLOBAL `console.*`, so any third-party library that
+ *   logs to console also picks up the prefix. That's fine today: we
+ *   don't use a structured logger (Pino/Winston) anywhere — every log
+ *   is raw `console.*` and is consumed by Railway as plain text. If we
+ *   move to a structured logger later, swap this for a logger wrapper
+ *   and remove the patch.
+ * - When the first arg is non-string (e.g. `console.error(err)`), we
+ *   pass the tag as a separate leading arg so util.format / inspect()
+ *   on the trailing arg is preserved. Output stays one line per call.
+ * - When Redis is not configured the instance ID is null and we skip
+ *   the patch entirely (local-only dev mode — no need to disambiguate).
+ * - Module-level `instanceLogTagInstalled` flag prevents double-wrapping
+ *   if `startServer()` is invoked more than once (e.g. in tests).
+ */
+function installInstanceLogTag(): void {
+  if (instanceLogTagInstalled) return;
+
+  const instanceId = pubsub.getInstanceId();
+  if (!instanceId) return;
+
+  const instanceTag = `[i:${instanceId.slice(0, 8)}] `;
+  const trimmedTag = instanceTag.trim();
+
+  for (const method of ['info', 'warn', 'error', 'log'] as const) {
+    const original = console[method].bind(console);
+    console[method] = (...args: unknown[]) => {
+      if (args.length === 0) {
+        original(trimmedTag);
+      } else if (typeof args[0] === 'string') {
+        original(`${instanceTag}${args[0]}`, ...args.slice(1));
+      } else {
+        original(trimmedTag, ...args);
+      }
+    };
+  }
+
+  instanceLogTagInstalled = true;
+}
+
 export async function startServer(): Promise<ServerResources> {
   // Initialize PubSub (connects to Redis if configured)
   // This must happen before we start accepting connections
   await pubsub.initialize();
 
-  // Prefix every console line with the pubsub instance ID so multi-instance
-  // logs can be untangled. Without this, debugging cross-instance pub/sub
-  // requires triangulating via connection-registration logs to figure out
-  // which instance emitted any given line — see
-  // gist.github.com/marcodejongh/90a125720ad48bf0355ec176f9ebc0df for an
-  // example session where this cost hours of analysis time.
-  //
-  // TRADE-OFFS:
-  // - This patches the GLOBAL `console.*`, so any third-party library that
-  //   logs to console also picks up the prefix. That's fine today: we
-  //   don't use a structured logger (Pino/Winston) anywhere — every log
-  //   is raw `console.*` and is consumed by Railway as plain text. If we
-  //   move to a structured logger later, swap this for a logger wrapper
-  //   and remove the patch.
-  // - When the first arg is non-string (e.g. `console.error(err)`), we
-  //   pass the tag as a separate leading arg so util.format / inspect()
-  //   on the trailing arg is preserved. Output stays one line per call.
-  // - When Redis is not configured the instance ID is null and we skip
-  //   the patch entirely (local-only dev mode — no need to disambiguate).
-  const instanceId = pubsub.getInstanceId();
-  const instanceTag = instanceId ? `[i:${instanceId.slice(0, 8)}] ` : '';
-  if (instanceTag) {
-    const trimmedTag = instanceTag.trim();
-    for (const method of ['info', 'warn', 'error', 'log'] as const) {
-      const original = console[method].bind(console);
-      console[method] = (...args: unknown[]) => {
-        if (args.length === 0) {
-          original(trimmedTag);
-        } else if (typeof args[0] === 'string') {
-          original(`${instanceTag}${args[0]}`, ...args.slice(1));
-        } else {
-          original(trimmedTag, ...args);
-        }
-      };
-    }
-  }
+  installInstanceLogTag();
 
   // Initialize RoomManager with Redis for session persistence
   if (redisClientManager.isRedisConfigured() && redisClientManager.isRedisConnected()) {

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -230,83 +230,32 @@ export async function leaveSession(
   const wasLeader = client.isLeader;
 
   const sessionClientIds = sessionsMap.get(sessionId);
-  if (sessionClientIds) {
-    sessionClientIds.delete(connectionId);
+  const wentLocallyEmpty = sessionClientIds
+    ? (sessionClientIds.delete(connectionId), sessionClientIds.size === 0)
+    : false;
 
-    if (sessionClientIds.size === 0) {
-      const existingGraceTimer = sessionGraceTimers.get(sessionId);
-      if (existingGraceTimer) clearTimeout(existingGraceTimer);
+  if (wentLocallyEmpty) {
+    const existingGraceTimer = sessionGraceTimers.get(sessionId);
+    if (existingGraceTimer) clearTimeout(existingGraceTimer);
 
-      const timer = setTimeout(() => {
-        const currentClients = sessionsMap.get(sessionId);
-        if (currentClients && currentClients.size === 0) {
-          sessionsMap.delete(sessionId);
-          console.info(`[RoomManager] Session ${sessionId} removed from memory after grace period`);
-        }
-        sessionGraceTimers.delete(sessionId);
-      }, SESSION_GRACE_PERIOD_MS);
-      sessionGraceTimers.set(sessionId, timer);
-
-      // Cancelling pending Postgres writes and marking the session inactive is
-      // only safe when no OTHER backend instance still has members for this
-      // session. The local sessionsMap is per-instance — being empty here only
-      // means this instance has no active clients, not that the session is
-      // globally idle.
-      //
-      // INVARIANT: `member.id` returned by `getSessionMembers` is the
-      // CONNECTION ID, not the stable user UUID. This is set in
-      // `services/distributed-state/session-ops.ts:181`:
-      //   `id: connection.connectionId`
-      // The filter below relies on that — if the field ever switches to
-      // user UUID, this race-protection regresses silently (we'd filter
-      // by the wrong identifier and the leaving connection would never
-      // be subtracted). The two tests in
-      // `__tests__/leave-session-multi-instance.test.ts` pin this
-      // contract; update them in lockstep if the invariant changes.
-      //
-      // We query before `distributedState.leaveSession` runs below, so
-      // this connection is still listed in distributed state and must
-      // be filtered out.
-      let otherInstanceHasMembers = false;
-      if (distributedState) {
-        try {
-          const members = await distributedState.getSessionMembers(sessionId);
-          otherInstanceHasMembers = members.some((member) => member.id !== connectionId);
-        } catch (error) {
-          // If the distributed check fails, default to the legacy behaviour
-          // (mark inactive) rather than risk a leaked session.
-          console.error(
-            `[RoomManager] Failed to query distributed members for ${sessionId} during leaveSession:`,
-            error,
-          );
-        }
+    const timer = setTimeout(() => {
+      const currentClients = sessionsMap.get(sessionId);
+      if (currentClients && currentClients.size === 0) {
+        sessionsMap.delete(sessionId);
+        console.info(`[RoomManager] Session ${sessionId} removed from memory after grace period`);
       }
-
-      if (!otherInstanceHasMembers) {
-        writeScheduler.cancelPendingWrites(sessionId);
-
-        if (redisStore) {
-          await redisStore.markInactive(sessionId);
-          if (!distributedState) {
-            await redisStore.saveUsers(sessionId, []);
-          }
-          console.info(`[RoomManager] Session ${sessionId} marked inactive - grace period started (60s)`);
-        }
-      }
-
-      // Await pending session insert for brand-new sessions.
-      const pending = pendingJoinPersists.get(sessionId);
-      if (pending) {
-        await pending;
-      }
-    }
+      sessionGraceTimers.delete(sessionId);
+    }, SESSION_GRACE_PERIOD_MS);
+    sessionGraceTimers.set(sessionId, timer);
   }
 
   // Reset client state
   client.sessionId = null;
   client.isLeader = false;
 
-  // Elect new leader
+  // Elect new leader. This also atomically removes our connection from
+  // distributed state, so the post-leave membership re-check below sees
+  // an accurate global view.
   let newLeaderId: string | undefined;
 
   if (distributedState) {
@@ -328,6 +277,56 @@ export async function leaveSession(
       const newLeader = clientsArray[0];
       newLeader.isLeader = true;
       newLeaderId = newLeader.connectionId;
+    }
+  }
+
+  // Decide whether to mark the session globally inactive and cancel pending
+  // Postgres writes. The check must run AFTER `distributedState.leaveSession`
+  // — querying members beforehand opens a TOCTOU race where two instances
+  // concurrently see each other in the membership snapshot, both decide to
+  // skip the inactive path, then both leave the session globally empty
+  // without anyone calling `markInactive` or `cancelPendingWrites`. Running
+  // the check after our own leave (and against the post-leave Redis set
+  // membership) collapses both branches of that race into "the last
+  // instance to leave wins and runs the cleanup".
+  //
+  // INVARIANT: `member.id` returned by `getSessionMembers` is the connection
+  // ID, set in `services/distributed-state/session-ops.ts:181`:
+  //   `id: connection.connectionId`
+  // The empty-check below relies on that — if the field ever switches to a
+  // user UUID, the leaving connection would no longer be subtracted by
+  // `distributedState.leaveSession` from the same membership view, and the
+  // emptiness signal would diverge from reality. The tests in
+  // `__tests__/leave-session-multi-instance.test.ts` pin this contract.
+  if (wentLocallyEmpty) {
+    let globallyEmpty = true;
+    if (distributedState) {
+      try {
+        const members = await distributedState.getSessionMembers(sessionId);
+        globallyEmpty = members.length === 0;
+      } catch (error) {
+        // If the distributed check fails, default to the legacy behaviour
+        // (mark inactive) rather than risk a leaked session.
+        console.error(`[RoomManager] Failed to query distributed members for ${sessionId} during leaveSession:`, error);
+      }
+    }
+
+    if (globallyEmpty) {
+      writeScheduler.cancelPendingWrites(sessionId);
+
+      if (redisStore) {
+        await redisStore.markInactive(sessionId);
+        if (!distributedState) {
+          await redisStore.saveUsers(sessionId, []);
+        }
+        console.info(`[RoomManager] Session ${sessionId} marked inactive - grace period started (60s)`);
+      }
+    }
+
+    // Await pending session insert for brand-new sessions.
+    const pending = pendingJoinPersists.get(sessionId);
+    if (pending) {
+      await pending;
     }
   }
 

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -251,10 +251,22 @@ export async function leaveSession(
       // only safe when no OTHER backend instance still has members for this
       // session. The local sessionsMap is per-instance — being empty here only
       // means this instance has no active clients, not that the session is
-      // globally idle. We check distributed state (filtering out this leaving
-      // connection, which is still listed until distributedState.leaveSession
-      // runs below) and skip the inactive-marking when others are still
-      // connected.
+      // globally idle.
+      //
+      // INVARIANT: `member.id` returned by `getSessionMembers` is the
+      // CONNECTION ID, not the stable user UUID. This is set in
+      // `services/distributed-state/session-ops.ts:181`:
+      //   `id: connection.connectionId`
+      // The filter below relies on that — if the field ever switches to
+      // user UUID, this race-protection regresses silently (we'd filter
+      // by the wrong identifier and the leaving connection would never
+      // be subtracted). The two tests in
+      // `__tests__/leave-session-multi-instance.test.ts` pin this
+      // contract; update them in lockstep if the invariant changes.
+      //
+      // We query before `distributedState.leaveSession` runs below, so
+      // this connection is still listed in distributed state and must
+      // be filtered out.
       let otherInstanceHasMembers = false;
       if (distributedState) {
         try {

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -247,14 +247,39 @@ export async function leaveSession(
       }, SESSION_GRACE_PERIOD_MS);
       sessionGraceTimers.set(sessionId, timer);
 
-      writeScheduler.cancelPendingWrites(sessionId);
-
-      if (redisStore) {
-        await redisStore.markInactive(sessionId);
-        if (!distributedState) {
-          await redisStore.saveUsers(sessionId, []);
+      // Cancelling pending Postgres writes and marking the session inactive is
+      // only safe when no OTHER backend instance still has members for this
+      // session. The local sessionsMap is per-instance — being empty here only
+      // means this instance has no active clients, not that the session is
+      // globally idle. We check distributed state (filtering out this leaving
+      // connection, which is still listed until distributedState.leaveSession
+      // runs below) and skip the inactive-marking when others are still
+      // connected.
+      let otherInstanceHasMembers = false;
+      if (distributedState) {
+        try {
+          const members = await distributedState.getSessionMembers(sessionId);
+          otherInstanceHasMembers = members.some((member) => member.id !== connectionId);
+        } catch (error) {
+          // If the distributed check fails, default to the legacy behaviour
+          // (mark inactive) rather than risk a leaked session.
+          console.error(
+            `[RoomManager] Failed to query distributed members for ${sessionId} during leaveSession:`,
+            error,
+          );
         }
-        console.info(`[RoomManager] Session ${sessionId} marked inactive - grace period started (60s)`);
+      }
+
+      if (!otherInstanceHasMembers) {
+        writeScheduler.cancelPendingWrites(sessionId);
+
+        if (redisStore) {
+          await redisStore.markInactive(sessionId);
+          if (!distributedState) {
+            await redisStore.saveUsers(sessionId, []);
+          }
+          console.info(`[RoomManager] Session ${sessionId} marked inactive - grace period started (60s)`);
+        }
       }
 
       // Await pending session insert for brand-new sessions.

--- a/packages/backend/src/services/room-manager/queue-state.ts
+++ b/packages/backend/src/services/room-manager/queue-state.ts
@@ -19,31 +19,39 @@ export async function updateQueueState(
   redisStore: RedisSessionStore | null,
   writeScheduler: WriteScheduler,
   distributedState: DistributedStateManager | null,
-): Promise<{ version: number; sequence: number; stateHash: string }> {
-  // Get current version and sequence from Redis if available, otherwise from Postgres
+): Promise<{ version: number; sequence: number; stateHash: string; previousStateHash: string | null }> {
+  // Get current version, sequence, and prior state hash from Redis if
+  // available, otherwise from Postgres. The prior hash is returned so
+  // callers (currently setQueue) can detect no-op resyncs without a
+  // second round-trip.
   let currentVersion = expectedVersion;
   let currentSequence = 0;
+  let previousStateHash: string | null = null;
 
   if (currentVersion === undefined) {
     if (redisStore) {
       const redisSession = await redisStore.getSession(sessionId);
       currentVersion = redisSession?.version ?? 0;
       currentSequence = redisSession?.sequence ?? 0;
+      previousStateHash = redisSession?.stateHash ?? null;
     }
     if (currentVersion === undefined || currentVersion === 0) {
       const pgState = await getQueueState(sessionId, redisStore);
       currentVersion = pgState.version;
       currentSequence = pgState.sequence;
+      previousStateHash ??= pgState.stateHash;
     }
   } else {
-    // If version is provided, get sequence from Redis or Postgres
+    // If version is provided, get sequence and prior hash from Redis or Postgres
     if (redisStore) {
       const redisSession = await redisStore.getSession(sessionId);
       currentSequence = redisSession?.sequence ?? 0;
+      previousStateHash = redisSession?.stateHash ?? null;
     }
     if (currentSequence === 0) {
       const pgState = await getQueueState(sessionId, redisStore);
       currentSequence = pgState.sequence;
+      previousStateHash ??= pgState.stateHash;
     }
   }
 
@@ -72,7 +80,7 @@ export async function updateQueueState(
     );
   }
 
-  return { version: newVersion, sequence: newSequence, stateHash };
+  return { version: newVersion, sequence: newSequence, stateHash, previousStateHash };
 }
 
 /**

--- a/packages/backend/src/services/room-manager/queue-state.ts
+++ b/packages/backend/src/services/room-manager/queue-state.ts
@@ -24,6 +24,18 @@ export async function updateQueueState(
   // available, otherwise from Postgres. The prior hash is returned so
   // callers (currently setQueue) can detect no-op resyncs without a
   // second round-trip.
+  //
+  // We coerce empty-string hashes to null. Legacy session rows in Redis
+  // or Postgres can have `stateHash = ''` (the hash field was added
+  // mid-development and older rows never recorded one). `computeQueueStateHash`
+  // always returns a non-empty 8-character hex string, so an empty stored
+  // hash means "we don't know the previous state" — semantically the
+  // same as null. Callers compare with `=== stateHash`, which would
+  // silently never match for legacy sessions even when the resync *was*
+  // a no-op, suppressing the diagnostic. Normalising here makes
+  // null-vs-empty a non-issue at the consumer.
+  const normalizeHash = (h: string | undefined | null): string | null => (h ? h : null);
+
   let currentVersion = expectedVersion;
   let currentSequence = 0;
   let previousStateHash: string | null = null;
@@ -33,25 +45,25 @@ export async function updateQueueState(
       const redisSession = await redisStore.getSession(sessionId);
       currentVersion = redisSession?.version ?? 0;
       currentSequence = redisSession?.sequence ?? 0;
-      previousStateHash = redisSession?.stateHash ?? null;
+      previousStateHash = normalizeHash(redisSession?.stateHash);
     }
     if (currentVersion === undefined || currentVersion === 0) {
       const pgState = await getQueueState(sessionId, redisStore);
       currentVersion = pgState.version;
       currentSequence = pgState.sequence;
-      previousStateHash ??= pgState.stateHash;
+      previousStateHash ??= normalizeHash(pgState.stateHash);
     }
   } else {
     // If version is provided, get sequence and prior hash from Redis or Postgres
     if (redisStore) {
       const redisSession = await redisStore.getSession(sessionId);
       currentSequence = redisSession?.sequence ?? 0;
-      previousStateHash = redisSession?.stateHash ?? null;
+      previousStateHash = normalizeHash(redisSession?.stateHash);
     }
     if (currentSequence === 0) {
       const pgState = await getQueueState(sessionId, redisStore);
       currentSequence = pgState.sequence;
-      previousStateHash ??= pgState.stateHash;
+      previousStateHash ??= normalizeHash(pgState.stateHash);
     }
   }
 

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -276,7 +276,7 @@ class RoomManager {
     queue: ClimbQueueItem[],
     currentClimbQueueItem: ClimbQueueItem | null,
     expectedVersion?: number,
-  ): Promise<{ version: number; sequence: number; stateHash: string }> {
+  ): Promise<{ version: number; sequence: number; stateHash: string; previousStateHash: string | null }> {
     return updateQueueStateFn(
       sessionId,
       queue,

--- a/packages/backend/src/websocket/setup.ts
+++ b/packages/backend/src/websocket/setup.ts
@@ -175,13 +175,16 @@ export function setupWebSocketServer(httpServer: HttpServer): {
             const result = await roomManager.leaveSession(context.connectionId);
 
             if (result) {
-              // Notify session about user leaving
-              if (latestContext.userId) {
-                pubsub.publishSessionEvent(result.sessionId, {
-                  __typename: 'UserLeft',
-                  userId: latestContext.userId,
-                });
-              }
+              // Notify session about user leaving. The `userId` field name
+              // in the GraphQL schema is a misnomer — it's the connection
+              // ID, matching the `id` field that UserJoined emits via
+              // `user.id = result.clientId` in joinSession (which is the
+              // connection ID). Clients filter their participant list by
+              // `u.id !== event.userId`, so the two events must agree.
+              pubsub.publishSessionEvent(result.sessionId, {
+                __typename: 'UserLeft',
+                userId: context.connectionId,
+              });
 
               // Notify about new leader if changed
               if (result.newLeaderId) {

--- a/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
@@ -100,6 +100,17 @@ export function useSessionSubscriptions({
   const consecutiveResyncCountRef = useRef(0);
   const sentryReportedHashRef = useRef<string | null>(null);
 
+  // Reset the resync-loop trackers whenever the active session changes.
+  // Otherwise a hash that triggered N resyncs in session A would carry
+  // forward into session B and either over-count or suppress the Sentry
+  // breadcrumb that should fire fresh per session.
+  const sessionIdForReset = session?.id ?? null;
+  useEffect(() => {
+    lastResyncHashRef.current = null;
+    consecutiveResyncCountRef.current = 0;
+    sentryReportedHashRef.current = null;
+  }, [sessionIdForReset]);
+
   useEffect(() => {
     if (!session || !lastReceivedStateHash || queue.length === 0) {
       return;

--- a/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
@@ -1,8 +1,16 @@
-import { useCallback, useEffect, type Dispatch, type SetStateAction } from 'react';
+import { useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
+import * as Sentry from '@sentry/nextjs';
 import type { SubscriptionQueueEvent, SessionEvent } from '@boardsesh/shared-schema';
 import { computeQueueStateHash } from '@/app/utils/hash';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
 import { type Session, type SharedRefs, CORRUPTION_RESYNC_COOLDOWN_MS, DEBUG } from '../types';
+
+// When the 60s hash watchdog triggers resync for the *same* server hash this
+// many times in a row, the underlying drift isn't getting fixed — the client
+// and server agree on the hash but the client's local computation keeps
+// disagreeing with itself. Surface it to Sentry so we have something to
+// investigate instead of an invisible per-minute resync loop.
+const RESYNC_LOOP_THRESHOLD = 3;
 
 type UseSessionSubscriptionsArgs = {
   session: Session | null;
@@ -88,6 +96,10 @@ export function useSessionSubscriptions({
   ]);
 
   // Periodic state hash verification (every 60 seconds)
+  const lastResyncHashRef = useRef<string | null>(null);
+  const consecutiveResyncCountRef = useRef(0);
+  const sentryReportedHashRef = useRef<string | null>(null);
+
   useEffect(() => {
     if (!session || !lastReceivedStateHash || queue.length === 0) {
       return;
@@ -102,10 +114,45 @@ export function useSessionSubscriptions({
           `Local: ${localHash}, Server: ${lastReceivedStateHash}`,
           'Triggering automatic resync...',
         );
+
+        if (lastResyncHashRef.current === lastReceivedStateHash) {
+          consecutiveResyncCountRef.current += 1;
+        } else {
+          lastResyncHashRef.current = lastReceivedStateHash;
+          consecutiveResyncCountRef.current = 1;
+          sentryReportedHashRef.current = null;
+        }
+
+        if (
+          consecutiveResyncCountRef.current >= RESYNC_LOOP_THRESHOLD &&
+          sentryReportedHashRef.current !== lastReceivedStateHash
+        ) {
+          sentryReportedHashRef.current = lastReceivedStateHash;
+          console.error(
+            `[PersistentSession] Resync loop detected: ${consecutiveResyncCountRef.current} consecutive resyncs for server hash ${lastReceivedStateHash} (local hash ${localHash}). Filing Sentry breadcrumb.`,
+          );
+          Sentry.captureMessage('Resync loop: client keeps disagreeing with server hash', {
+            level: 'warning',
+            tags: { feature: 'party-session', issue: 'hash-resync-loop' },
+            extra: {
+              sessionId: session.id,
+              serverHash: lastReceivedStateHash,
+              localHash,
+              consecutiveResyncs: consecutiveResyncCountRef.current,
+              queueLength: queue.length,
+              currentClimbUuid: currentClimbQueueItem?.uuid ?? null,
+            },
+          });
+        }
+
         if (triggerResyncRef.current) {
           triggerResyncRef.current();
         }
       } else {
+        // Hash matches — reset the loop counter so future drift starts fresh.
+        consecutiveResyncCountRef.current = 0;
+        lastResyncHashRef.current = null;
+        sentryReportedHashRef.current = null;
         if (DEBUG) console.info('[PersistentSession] State hash verification passed');
       }
     }, 60000);


### PR DESCRIPTION
…ostics

Investigation of a sync failure in a morning party session (gist: github.com/marcodejongh/90a125720ad48bf0355ec176f9ebc0df) surfaced three backend bugs and a logging gap that made the gist hard to triage. Fix all four together so the next incident is debuggable.

1. Stop clobbering `ctx.userId` with the connection ID. The joinSession and createSession resolvers were passing `result.clientId` (which is the connection ID per room-manager/client-lifecycle.ts:199) into `updateContext` as `userId`. That silently broke every downstream resolver that reads `ctx.userId` — ESP32 auto-authorize, climb ownership, tick attribution, controller queries — and made the `[Session] Auto-authorized user X's controllers` log misleading.

2. Don't markInactive when other instances still have members. In multi-instance deploys, a backend whose local sessionsMap empties was calling `redisStore.markInactive` and `cancelPendingWrites` without asking `DistributedStateManager` whether other instances still hosted members. The cancelled pending writes are the dangerous part — a queue mutation made just before the local instance emptied could be lost.

3. Surface the FullSync resync loop. The client's 60s state-hash watchdog was firing every minute on a stable session in the incident logs, which means it's not a one-off. Add a server-side warn when setQueue produces a no-op (new hash == previous hash) and a client-side Sentry breadcrumb when three consecutive resyncs fire for the same server hash, so the underlying drift is visible next time.

4. Prefix every backend log line with the pubsub instance ID. Without this, cross-instance pub/sub had to be reconstructed from "Subscribed" logs (which only fire on the first local subscriber per instance) and connection-registration lines — costing hours per gist.

Tests cover the userId-preservation contract and the four branches of the markInactive logic (other-instance has members, no others, no distributed state, distributed query fails). Pre-existing failures in integration.test.ts are unrelated and present on origin/main.