### PR TITLE
fix(admin-retention): use classic Dn semantics, not first-N-days funnel

### DIFF
--- a/packages/web/app/admin/retention/page.tsx
+++ b/packages/web/app/admin/retention/page.tsx
@@ -49,20 +49,24 @@ type RawRetentionRow = {
 
 async function fetchRetention(): Promise<RetentionRow[]> {
   // Cohort = week-of-signup (UTC, Monday-anchored). The d1/d3/d7/d30 columns
-  // here are an *early-activation funnel* — "did the user do action X within
-  // the first N days of signup?" — not classic Dn retention. By construction
-  // d1 ⊆ d3 ⊆ d7 ⊆ d30. Two parallel definitions of "active":
+  // are *classic Dn retention*: a user counts toward Dn if they had activity
+  // in the 24-hour window [signup + N days, signup + (N+1) days). This is
+  // the Amplitude / Mixpanel / GA definition — "active on day N", not
+  // "active anytime in the first N days". Day-0 (the signup day itself) is
+  // not counted toward D1; that's intentional and standard for retention
+  // triangles. Two parallel definitions of "active":
   //   1. Tick activity: at least one boardsesh tick (aurora_id IS NULL —
   //      not synced in from Aurora). This is the original metric.
   //   2. Any activity: a UNION ALL of every user-attributable timestamp
   //      we record — ticks, party sessions, favorites/playlists/pins/follows,
   //      gym/board follows, controller/serial setup, comments/votes/
   //      proposals/feedback. Captures returners who don't tick.
-  // Each Dn % is NULL'd until *every* user in the cohort has had a full N days
-  // to be active (cohort_week + N + 7, since the cohort spans Mon–Sun). The
-  // 211-day prefilter on UNION branches is 180-day cohort window + 30-day Dn
-  // window + 1-day slack; it lets the planner skip very old rows without
-  // changing semantics. Today timestamps are read in UTC to match the cohort.
+  // Each Dn % is NULL'd until *every* user in the cohort has had time to
+  // complete day N (cohort_week + 7 + N + 1 days, since the cohort spans
+  // Mon–Sun and we need the latest signup to reach day N+1). The 211-day
+  // prefilter on UNION branches is 180-day cohort window + 30-day Dn window
+  // + 1-day slack; it lets the planner skip very old rows without changing
+  // semantics. Today timestamps are read in UTC to match the cohort.
   const rows = await executeRows<RawRetentionRow>(
     dbz,
     sql`
@@ -80,10 +84,14 @@ async function fetchRetention(): Promise<RetentionRow[]> {
       ticks_by_user AS (
         SELECT
           sc.user_id,
-          BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '1 day')  AS active_d1,
-          BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '3 days') AS active_d3,
-          BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '7 days') AS active_d7,
-          BOOL_OR(t.climbed_at <= sc.created_at + INTERVAL '30 days') AS active_d30
+          BOOL_OR(t.climbed_at >= sc.created_at + INTERVAL '1 day'
+              AND t.climbed_at <  sc.created_at + INTERVAL '2 days')  AS active_d1,
+          BOOL_OR(t.climbed_at >= sc.created_at + INTERVAL '3 days'
+              AND t.climbed_at <  sc.created_at + INTERVAL '4 days')  AS active_d3,
+          BOOL_OR(t.climbed_at >= sc.created_at + INTERVAL '7 days'
+              AND t.climbed_at <  sc.created_at + INTERVAL '8 days')  AS active_d7,
+          BOOL_OR(t.climbed_at >= sc.created_at + INTERVAL '30 days'
+              AND t.climbed_at <  sc.created_at + INTERVAL '31 days') AS active_d30
         FROM signup_cohorts sc
         JOIN boardsesh_ticks t
           ON t.user_id = sc.user_id
@@ -155,10 +163,14 @@ async function fetchRetention(): Promise<RetentionRow[]> {
       activity_by_user AS (
         SELECT
           sc.user_id,
-          BOOL_OR(ae.ts <= sc.created_at + INTERVAL '1 day')  AS active_d1,
-          BOOL_OR(ae.ts <= sc.created_at + INTERVAL '3 days') AS active_d3,
-          BOOL_OR(ae.ts <= sc.created_at + INTERVAL '7 days') AS active_d7,
-          BOOL_OR(ae.ts <= sc.created_at + INTERVAL '30 days') AS active_d30
+          BOOL_OR(ae.ts >= sc.created_at + INTERVAL '1 day'
+              AND ae.ts <  sc.created_at + INTERVAL '2 days')  AS active_d1,
+          BOOL_OR(ae.ts >= sc.created_at + INTERVAL '3 days'
+              AND ae.ts <  sc.created_at + INTERVAL '4 days')  AS active_d3,
+          BOOL_OR(ae.ts >= sc.created_at + INTERVAL '7 days'
+              AND ae.ts <  sc.created_at + INTERVAL '8 days')  AS active_d7,
+          BOOL_OR(ae.ts >= sc.created_at + INTERVAL '30 days'
+              AND ae.ts <  sc.created_at + INTERVAL '31 days') AS active_d30
         FROM signup_cohorts sc
         JOIN activity_events ae
           ON ae.user_id = sc.user_id
@@ -192,13 +204,13 @@ async function fetchRetention(): Promise<RetentionRow[]> {
         cr.d7_count,
         cr.d30_count,
         cr.activated_count,
-        CASE WHEN cr.cohort_week + INTERVAL '8 days'  <= today_utc.d
+        CASE WHEN cr.cohort_week + INTERVAL '9 days'  <= today_utc.d
              THEN ROUND(100.0 * cr.d1_count  / NULLIF(cr.signups, 0), 1) END AS d1_pct,
-        CASE WHEN cr.cohort_week + INTERVAL '10 days' <= today_utc.d
+        CASE WHEN cr.cohort_week + INTERVAL '11 days' <= today_utc.d
              THEN ROUND(100.0 * cr.d3_count  / NULLIF(cr.signups, 0), 1) END AS d3_pct,
-        CASE WHEN cr.cohort_week + INTERVAL '14 days' <= today_utc.d
+        CASE WHEN cr.cohort_week + INTERVAL '15 days' <= today_utc.d
              THEN ROUND(100.0 * cr.d7_count  / NULLIF(cr.signups, 0), 1) END AS d7_pct,
-        CASE WHEN cr.cohort_week + INTERVAL '37 days' <= today_utc.d
+        CASE WHEN cr.cohort_week + INTERVAL '38 days' <= today_utc.d
              THEN ROUND(100.0 * cr.d30_count / NULLIF(cr.signups, 0), 1) END AS d30_pct,
         ROUND(100.0 * cr.activated_count / NULLIF(cr.signups, 0), 1) AS activation_pct,
         cr.d1_any_count,
@@ -206,13 +218,13 @@ async function fetchRetention(): Promise<RetentionRow[]> {
         cr.d7_any_count,
         cr.d30_any_count,
         cr.activated_any_count,
-        CASE WHEN cr.cohort_week + INTERVAL '8 days'  <= today_utc.d
+        CASE WHEN cr.cohort_week + INTERVAL '9 days'  <= today_utc.d
              THEN ROUND(100.0 * cr.d1_any_count  / NULLIF(cr.signups, 0), 1) END AS d1_any_pct,
-        CASE WHEN cr.cohort_week + INTERVAL '10 days' <= today_utc.d
+        CASE WHEN cr.cohort_week + INTERVAL '11 days' <= today_utc.d
              THEN ROUND(100.0 * cr.d3_any_count  / NULLIF(cr.signups, 0), 1) END AS d3_any_pct,
-        CASE WHEN cr.cohort_week + INTERVAL '14 days' <= today_utc.d
+        CASE WHEN cr.cohort_week + INTERVAL '15 days' <= today_utc.d
              THEN ROUND(100.0 * cr.d7_any_count  / NULLIF(cr.signups, 0), 1) END AS d7_any_pct,
-        CASE WHEN cr.cohort_week + INTERVAL '37 days' <= today_utc.d
+        CASE WHEN cr.cohort_week + INTERVAL '38 days' <= today_utc.d
              THEN ROUND(100.0 * cr.d30_any_count / NULLIF(cr.signups, 0), 1) END AS d30_any_pct,
         ROUND(100.0 * cr.activated_any_count / NULLIF(cr.signups, 0), 1) AS activation_any_pct
       FROM cohort_rollup cr

--- a/packages/web/i18n/locales/en-US/admin.json
+++ b/packages/web/i18n/locales/en-US/admin.json
@@ -23,8 +23,8 @@
   },
   "retention": {
     "heading": "User retention",
-    "subheading": "Of users who signed up in week W, how many came back within N days — both as ticks (climbs logged) and as any in-app activity.",
-    "definitions": "Cohort = signup week (UTC). Ticks = at least one climb logged in Boardsesh (Aurora-imported ticks excluded). Any activity = a tick, party-session host or join, favorite, playlist (created or pinned), follow (user, setter, or playlist), new-climb subscription, comment, vote, proposal vote, or feedback submission. D7 = active within 7 days of signup. Cohorts younger than the window show —.",
+    "subheading": "Of users who signed up in week W, what share were active on day N — classic Dn retention. Computed for both ticks (climbs logged) and any in-app activity.",
+    "definitions": "Cohort = signup week (UTC). Dn counts a user if they had activity in the 24-hour window starting N days after signup (so D7 = active exactly on day 7, not anytime in the first 7 days). Ticks = at least one climb logged in Boardsesh (Aurora-imported ticks excluded). Any activity = a tick, party-session host or join, favorite, playlist (created or pinned), follow (user, setter, or playlist), new-climb subscription, comment, vote, proposal vote, or feedback submission. Cohorts younger than the window show —.",
     "back": "Back to admin",
     "table": {
       "cohortWeek": "Cohort week",


### PR DESCRIPTION
## Summary

The admin retention dashboard at `/admin/retention` showed columns labelled D1/D3/D7/D30 but the underlying SQL computed `BOOL_OR(ts <= signup + INTERVAL 'N days')` — "was the user active anytime in the first N days post-signup?" By construction D1 ⊆ D3 ⊆ D7 ⊆ D30, so the D30 number was always the highest, the opposite of how retention should read. A code comment even acknowledged it was an "early-activation funnel — not classic Dn retention."

Switch the predicate to classic industry-standard Dn retention: a user counts toward Dn if they had activity in the 24-hour window `[signup + N days, signup + (N+1) days)`. This is what Amplitude, Mixpanel, and GA call "Day N retention" and what users expect when they read "D7" / "D30". Earlier-day numbers are now generally higher than later-day numbers, as expected.

Applied to both the ticks block and the any-activity block. No type changes — `RawRetentionRow` / `RetentionRow` shapes are unchanged.

## Changes

- **SQL predicate** in `ticks_by_user` and `activity_by_user` (`packages/web/app/admin/retention/page.tsx`): replace `BOOL_OR(ts <= signup + N days)` with `BOOL_OR(ts >= signup + N days AND ts < signup + (N+1) days)` for each of D1/D3/D7/D30.
- **Visibility gates** (8 occurrences in the final SELECT) move +1 day so the latest cohort member has time to *complete* day N before the metric appears: D1: +8→+9, D3: +10→+11, D7: +14→+15, D30: +37→+38.
- **Top-of-query comment** rewritten to describe Dn semantics instead of the funnel.
- **i18n strings** `retention.subheading` and `retention.definitions` (`packages/web/i18n/locales/en-US/admin.json`) updated to describe classic Dn ("active on day 7, not anytime in the first 7 days"). The chart title "D7 retention by cohort week" stays — already accurate under the new definition.

## Test plan

- [ ] Visit `/admin/retention` as an admin in `vp run dev`.
- [ ] Sanity check: D1 column is generally the highest, D30 the lowest for cohorts old enough to qualify (the bug-confirmation case).
- [ ] Newest cohorts may show `—` for D30 where they previously showed a number (gate moved from +37 to +38 days); same +1 day shift for D1/D3/D7.
- [ ] Subheading and definitions text reflect Dn semantics on the page.
- [ ] Confirm no count exceeds `signups` for any cohort.
- [ ] SQL spot-check:
      ```sql
      SELECT cohort_week, signups, d1_count, d3_count, d7_count, d30_count
      FROM (... full retention CTE ...)
      WHERE cohort_week + INTERVAL '38 days' <= (NOW() AT TIME ZONE 'UTC')::date
      ORDER BY cohort_week DESC LIMIT 12;
      ```
- [ ] `vp run typecheck` passes (verified locally).
- [ ] `vp check` on the staged files passes (verified locally; one pre-existing format issue in an unrelated file is not introduced by this PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkB8nhSoD6JbSsBPZp7Bnr)_