### PR TITLE
fix: log/Sentry nits — debug prefix, comma-op split, resync fingerprint

### DIFF
--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -70,7 +70,7 @@ function installInstanceLogTag(): void {
   const instanceTag = `[i:${instanceId.slice(0, 8)}] `;
   const trimmedTag = instanceTag.trim();
 
-  for (const method of ['info', 'warn', 'error', 'log'] as const) {
+  for (const method of ['debug', 'info', 'warn', 'error', 'log'] as const) {
     const original = console[method].bind(console);
     console[method] = (...args: unknown[]) => {
       if (args.length === 0) {

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -230,9 +230,11 @@ export async function leaveSession(
   const wasLeader = client.isLeader;
 
   const sessionClientIds = sessionsMap.get(sessionId);
-  const wentLocallyEmpty = sessionClientIds
-    ? (sessionClientIds.delete(connectionId), sessionClientIds.size === 0)
-    : false;
+  let wentLocallyEmpty = false;
+  if (sessionClientIds) {
+    sessionClientIds.delete(connectionId);
+    wentLocallyEmpty = sessionClientIds.size === 0;
+  }
 
   if (wentLocallyEmpty) {
     const existingGraceTimer = sessionGraceTimers.get(sessionId);

--- a/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
@@ -140,11 +140,12 @@ export function useSessionSubscriptions({
         ) {
           sentryReportedHashRef.current = lastReceivedStateHash;
           console.error(
-            `[PersistentSession] Resync loop detected: ${consecutiveResyncCountRef.current} consecutive resyncs for server hash ${lastReceivedStateHash} (local hash ${localHash}). Filing Sentry breadcrumb.`,
+            `[PersistentSession] Resync loop detected: ${consecutiveResyncCountRef.current} consecutive resyncs for server hash ${lastReceivedStateHash} (local hash ${localHash}). Capturing Sentry message.`,
           );
           Sentry.captureMessage('Resync loop: client keeps disagreeing with server hash', {
             level: 'warning',
             tags: { feature: 'party-session', issue: 'hash-resync-loop' },
+            fingerprint: ['party-session', 'hash-resync-loop'],
             extra: {
               sessionId: session.id,
               serverHash: lastReceivedStateHash,


### PR DESCRIPTION
## Summary

Three small review nits in one commit:

- **`packages/backend/src/server.ts`** — `installInstanceLogTag()` now also wraps `console.debug`, so debug-level lines carry the `[i:xxxxxxxx]` pubsub-instance prefix and can be attributed to their emitting instance in multi-instance Railway logs (previously the loop only covered `info`/`warn`/`error`/`log`).
- **`packages/backend/src/services/room-manager/client-lifecycle.ts`** — Replaced the `(sessionClientIds.delete(connectionId), sessionClientIds.size === 0)` comma expression with two explicit statements. Behaviour is identical; the destructive `Set.delete` is no longer hidden inside a value expression (clears `no-sequences`).
- **`packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts`** — The log line said "Filing Sentry breadcrumb" but the call is `Sentry.captureMessage`, which opens an issue. Fixed the log copy, and added `fingerprint: ['party-session', 'hash-resync-loop']` to the `captureMessage` options so every resync-loop capture groups under a single Sentry issue rather than one fresh issue per drifting server hash every 3 min × N tabs.

## Test plan

- [x] `vp lint` on the three changed files — 0 warnings, 0 errors
- [x] `vp fmt --check` on the three changed files — all formatted
- [x] `vp run typecheck:backend` — passes
- [x] `vp run typecheck:web` — passes
- [ ] Manual: confirm in dev logs that a `console.debug` line emits with the `[i:xxxxxxxx]` prefix once Redis is configured
- [ ] Manual: join and leave a party session across two tabs; leader re-election still works (covers the `client-lifecycle` refactor)

https://claude.ai/code/session_018tabQDCG9YXhE63F9a5ZQj

---
_Generated by [Claude Code](https://claude.ai/code/session_018tabQDCG9YXhE63F9a5ZQj)_