### PR TITLE
fix(party-session): reland #2128 with ClimbMirrored.uuid alias + subscription backoff

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -144,8 +144,8 @@ sequenceDiagram
     WS->>C: ConnectionAck
 
     C->>WS: Execute joinSession mutation
-    Note over C,WS: With optional initialQueue & initialCurrentClimb
-    WS->>RM: joinSession(connectionId, sessionId, boardPath, initialQueue?)
+    Note over C,WS: With stable participantId and optional initialQueue/current climb
+    WS->>RM: joinSession(connectionId, sessionId, boardPath, participantId, initialQueue?)
 
     alt Session exists in memory
         RM->>RM: Add client to session
@@ -192,7 +192,8 @@ sequenceDiagram
 2. **Authentication**: Optional auth token passed in `connectionParams`
 3. **Eager Subscription**: Queue subscription starts BEFORE fetching state to prevent race conditions
 4. **Session Restoration**: Sessions can be restored from Redis (warm cache) or PostgreSQL (dormant durable state)
-5. **Initial Queue Seeding**: When creating a new session, clients can provide `initialQueue` and `initialCurrentClimb` to seed the session with an existing local queue (e.g., when starting party mode with climbs already queued)
+5. **Stable Participant Identity**: Anonymous clients persist a `participantId` in `ACTIVE_SESSION_KEY`; authenticated clients use their `userId`. Reconnects therefore update the same participant instead of creating a new user row for every socket.
+6. **Initial Queue Seeding**: When creating a new session, clients can provide `initialQueue` and `initialCurrentClimb` to seed the session with an existing local queue (e.g., when starting party mode with climbs already queued)
 
 ### Initial Queue Seeding
 
@@ -206,6 +207,7 @@ mutation JoinSession(
   $boardPath: String!
   $username: String
   $avatarUrl: String
+  $participantId: ID                       # Optional: stable anonymous participant identity
   $initialQueue: [ClimbQueueItemInput!]    # Optional: existing queue items
   $initialCurrentClimb: ClimbQueueItemInput # Optional: current climb
   $sessionName: String                      # Optional: display name for the session
@@ -215,6 +217,7 @@ mutation JoinSession(
     boardPath: $boardPath
     username: $username
     avatarUrl: $avatarUrl
+    participantId: $participantId
     initialQueue: $initialQueue
     initialCurrentClimb: $initialCurrentClimb
     sessionName: $sessionName
@@ -226,6 +229,7 @@ mutation JoinSession(
 
 - `initialQueue`, `initialCurrentClimb`, and `sessionName` are **only applied when creating a new session**
 - If joining an existing session (active, warm, or dormant), these values are ignored and the existing session state is used
+- `participantId` is optional for backward compatibility, but current clients always send it for anonymous sessions so reconnects preserve identity
 - The queue is persisted immediately to Postgres (not debounced) to ensure durability for new sessions
 - All users who join after the initial seed will receive the seeded queue state
 
@@ -358,7 +362,8 @@ The main Traefik instance routes `*.preview.boardsesh.com` and `*.ws.preview.boa
     │  - Redis cache hot                           │
     │  - In-memory session state                   │
     └──────┬───────────────────────┬───────────────┘
-           │ Last user leaves      │ Leader calls endSession
+           │ Last participant      │ Participant calls endSession
+           │ leaves/expires        │
            ▼                       ▼
     ┌──────────────────────────┐   ┌──────────────────────────────┐
     │   GRACE PERIOD (60s)     │   │     ENDED (explicit)         │
@@ -397,7 +402,9 @@ The main Traefik instance routes `*.preview.boardsesh.com` and `*.ws.preview.boa
     └────────────────────┘
 ```
 
-**Grace Period:** When the last user disconnects from this backend instance, the session enters a 60-second grace period where in-memory state is preserved. If a client reconnects within this window (common during network flaps or page refreshes), the session is instantly available without the expensive lock + Redis/Postgres restoration cycle. The grace period duration is controlled by `SESSION_GRACE_PERIOD_MS` in `RoomManager`.
+**Grace Period:** When the last socket on a backend instance drops unexpectedly, the instance enters a 60-second grace period where in-memory state and pending queue writes are preserved. The participant is marked `RECONNECTING`, not removed. If a client reconnects within this window (common during network flaps or page refreshes), the same `participantId` is marked `CONNECTED` and the session is instantly available without the expensive lock + Redis/Postgres restoration cycle. The grace period duration is controlled by `SESSION_GRACE_PERIOD_MS` in `RoomManager`.
+
+Explicit UI actions still leave or end sessions immediately: `leaveSession` removes the participant and emits `UserLeft`; `endSession` is restricted to the session creator or current leader. Passive WebSocket disconnects emit `UserPresenceChanged` first and only emit `UserLeft` if the reconnect timer expires.
 
 If the grace period expires, the session is evicted from memory but remains restorable from Redis until the 4-hour TTL expires. After Redis TTL expiry, the session is still not ended; the next join restores it from Postgres as long as the durable row has not been explicitly marked `ended`.
 
@@ -457,6 +464,8 @@ Sessions can be linked to multiple boards within the same gym via the `sessionBo
 
 ### Leader Election
 
+Leader state is retained for compatibility and UI flags, and it is an authorization boundary for ending sessions over WebSocket: `endSession` requires the caller to be the session creator or the current leader. HTTP callers must be the authenticated session creator.
+
 Leader election uses Redis-backed atomic operations for consistency across instances:
 
 **Single Instance Mode:**
@@ -481,15 +490,15 @@ sequenceDiagram
 
     Note over U1,PS: User 1 is current leader
 
-    U1->>RM: disconnect()
-    RM->>DS: leaveSession(connectionId, sessionId)
+    U1->>RM: passive disconnect()
+    RM->>DS: removeConnection(connectionId, electNewLeader=true)
     DS->>R: Execute ELECT_NEW_LEADER Lua script
     R->>R: Find earliest connected member
     R->>R: SET leader key atomically
-    R-->>DS: newLeaderId = U2
-    DS-->>RM: {newLeaderId: U2}
+    R-->>DS: newLeaderId = U2 connection ID
+    DS-->>RM: {newLeaderId, newLeaderParticipantId}
     RM->>PS: publishSessionEvent(LeaderChanged)
-    PS->>U2: LeaderChanged{leaderId: U2}
+    PS->>U2: LeaderChanged{leaderId: U2 participant ID, leaderConnectionId: U2 connection ID}
 
     Note over U2: User 2 is now leader (on Instance 2)
 ```
@@ -507,13 +516,14 @@ sequenceDiagram
 
 `sessionUpdates(sessionId)` emits membership/lifecycle events and live stats updates.
 
-| Event                 | When emitted                                | Key fields                                                                                                                                                        |
-| --------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `UserJoined`          | A client joins the session                  | `user`                                                                                                                                                            |
-| `UserLeft`            | A client disconnects/leaves                 | `userId`                                                                                                                                                          |
-| `LeaderChanged`       | Leader election selects a new leader        | `leaderId`                                                                                                                                                        |
-| `SessionEnded`        | Session is ended explicitly or by cleanup   | `reason`, `newPath`                                                                                                                                               |
-| `SessionStatsUpdated` | A tick is saved for an active party session | `totalSends`, `totalFlashes`, `totalAttempts`, `tickCount`, `participants`, `gradeDistribution`, `boardTypes`, `hardestGrade`, `durationMinutes`, `goal`, `ticks` |
+| Event                 | When emitted                                                                                           | Key fields                                                                                                                                                        |
+| --------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `UserJoined`          | A new participant joins the session                                                                    | `user` with `connectionState`                                                                                                                                     |
+| `UserPresenceChanged` | A known participant reconnects or drops                                                                | `user` with `connectionState` (`CONNECTED` or `RECONNECTING`)                                                                                                     |
+| `UserLeft`            | A participant explicitly leaves or expires                                                             | `userId`                                                                                                                                                          |
+| `LeaderChanged`       | Leader election selects a new leader after explicit leave, passive disconnect, or stale-member cleanup | `leaderId` is the stable `SessionUser.id`; `leaderConnectionId` is present for current-client connection checks                                                   |
+| `SessionEnded`        | Session is ended explicitly                                                                            | `reason`, `newPath`                                                                                                                                               |
+| `SessionStatsUpdated` | A tick is saved for an active party session                                                            | `totalSends`, `totalFlashes`, `totalAttempts`, `tickCount`, `participants`, `gradeDistribution`, `boardTypes`, `hardestGrade`, `durationMinutes`, `goal`, `ticks` |
 
 `SessionStatsUpdated` payloads include full `ticks` rows so clients can update charts and climbs/attempt lists without issuing an extra session detail refetch. On the client, `useEventProcessor` patches the `SESSION_DETAIL_QUERY_KEY(sessionId)` React Query cache entry directly with the new stats and ticks — there is no separate `liveSessionStats` merge layer, so any component subscribed via `useSessionDetail` re-renders from the updated cache automatically.
 
@@ -527,27 +537,29 @@ sequenceDiagram
 
 ### Event Types
 
-| Event                 | Description             | Fields                                          |
-| --------------------- | ----------------------- | ----------------------------------------------- |
-| `FullSync`            | Complete state snapshot | `sequence`, `state` (queue + currentClimb)      |
-| `QueueItemAdded`      | Item added to queue     | `sequence`, `item`, `position`                  |
-| `QueueItemRemoved`    | Item removed from queue | `sequence`, `uuid`                              |
-| `QueueReordered`      | Item moved in queue     | `sequence`, `uuid`, `oldIndex`, `newIndex`      |
-| `CurrentClimbChanged` | Active climb changed    | `sequence`, `item`, `clientId`, `correlationId` |
-| `ClimbMirrored`       | Mirror state toggled    | `sequence`, `mirrored`                          |
+| Event                 | Description             | Fields                                                       |
+| --------------------- | ----------------------- | ------------------------------------------------------------ |
+| `FullSync`            | Complete state snapshot | `sequence`, `state` (queue + currentClimb + `stateHash`)     |
+| `QueueItemAdded`      | Item added to queue     | `sequence`, `stateHash`, `item`, `position`                  |
+| `QueueItemRemoved`    | Item removed from queue | `sequence`, `stateHash`, `uuid`                              |
+| `QueueReordered`      | Item moved in queue     | `sequence`, `stateHash`, `uuid`, `oldIndex`, `newIndex`      |
+| `CurrentClimbChanged` | Active climb changed    | `sequence`, `stateHash`, `item`, `clientId`, `correlationId` |
+| `ClimbMirrored`       | Mirror state toggled    | `sequence`, `stateHash`, `uuid`, `mirrored`                  |
+
+Every delta event carries the post-event `stateHash`. Clients must store that hash after accepting the matching `sequence`; the periodic hash watchdog compares the local queue hash against this last accepted server hash. Updating the hash only on `FullSync` is incorrect and can create a resync loop after ordinary delta traffic.
 
 ### Queue Mutations
 
-| Mutation                   | Event emitted                            | Notes                                                                                                                                                                                                                                                                                                                           |
-| -------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `addQueueItem`             | `QueueItemAdded`                         | Appends to queue or inserts at `position`. Idempotent on `item.uuid` — duplicate adds are collapsed server-side during offline reconciliation.                                                                                                                                                                                  |
-| `removeQueueItem`          | `QueueItemRemoved`                       | Removes by queue-item uuid.                                                                                                                                                                                                                                                                                                     |
-| `reorderQueue`             | `QueueReordered`                         | Moves a queue item to a new index.                                                                                                                                                                                                                                                                                              |
-| `setCurrentClimbQueueItem` | `CurrentClimbChanged`                    | Activates an existing queue item by uuid.                                                                                                                                                                                                                                                                                       |
-| `setCurrentClimb`          | `CurrentClimbChanged` + `QueueItemAdded` | Adds the climb to the queue (if not already present) and activates it.                                                                                                                                                                                                                                                          |
-| `replaceQueueItem`         | `FullSync`                               | Replaces the climb inside an existing queue slot in place, preserving position and the queue-item uuid. Used by the create-climb form to push saves of the currently-authored climb to peers without reshuffling the queue. Emits `FullSync` rather than a narrow delta because replace is infrequent and simpler to reconcile. |
-| `mirrorCurrentClimb`       | `ClimbMirrored`                          | Flips the mirror flag on the current climb.                                                                                                                                                                                                                                                                                     |
-| `setQueue`                 | `FullSync`                               | Bulk replaces queue + current climb. Used for offline → online reconciliation.                                                                                                                                                                                                                                                  |
+| Mutation                   | Event emitted                       | Notes                                                                                                                                                                                                                                                                                                                           |
+| -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `addQueueItem`             | `QueueItemAdded`                    | Appends to queue or inserts at `position`. Idempotent on `item.uuid` — duplicate adds are collapsed server-side during offline reconciliation.                                                                                                                                                                                  |
+| `removeQueueItem`          | `QueueItemRemoved`                  | Removes by queue-item uuid and clears current climb if it removed the active item.                                                                                                                                                                                                                                              |
+| `reorderQueue`             | `QueueReordered`                    | Moves a queue item to a new index.                                                                                                                                                                                                                                                                                              |
+| `setCurrentClimbQueueItem` | `CurrentClimbChanged`               | Activates an existing queue item by uuid.                                                                                                                                                                                                                                                                                       |
+| `setCurrentClimb`          | `CurrentClimbChanged` or `FullSync` | Emits `CurrentClimbChanged` when only the active climb changes. Emits `FullSync` when `shouldAddToQueue` adds a new queue item and activates it in the same mutation, because one sequence now represents both queue membership and current-climb state.                                                                        |
+| `replaceQueueItem`         | `FullSync`                          | Replaces the climb inside an existing queue slot in place, preserving position and the queue-item uuid. Used by the create-climb form to push saves of the currently-authored climb to peers without reshuffling the queue. Emits `FullSync` rather than a narrow delta because replace is infrequent and simpler to reconcile. |
+| `mirrorCurrentClimb`       | `ClimbMirrored`                     | Flips the mirror flag on the current climb and the matching queue item.                                                                                                                                                                                                                                                         |
+| `setQueue`                 | `FullSync`                          | Bulk replaces queue + current climb. Used for offline → online reconciliation.                                                                                                                                                                                                                                                  |
 
 ### Tick Mode and Queue Bar Freeze
 
@@ -713,6 +725,10 @@ boardsesh:session:{sessionId}:events
 └── Oldest event (max 100 events, 5 min TTL)
 ```
 
+On reconnect, the web client calls `eventsReplay(sessionId, sinceSequence)` when the sequence gap is between 1 and 100 events. Replay is accepted only when the returned events cover every sequence from `sinceSequence + 1` through `currentSequence`, except that a `FullSync` event covers all earlier missing sequence numbers up to its own sequence. Empty or partial replay responses fall back to a fresh `FullSync`.
+
+The `EVENTS_REPLAY` query uses the same GraphQL aliases as `queueUpdates` (`addedItem: item`, `currentItem: item`) so the event processor can apply live and replayed events through the same code path.
+
 ---
 
 ## Failure States and Recovery
@@ -750,9 +766,10 @@ sequenceDiagram
 
 - Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s (max)
 - Up to 10 retry attempts
-- On reconnection: re-join session and sync state
-- Delta sync attempted if gap ≤ 100 events
-- Falls back to full sync if gap too large
+- On reconnection: re-join session with the same `participantId` and sync state
+- Delta sync attempted if gap ≤ 100 events and the replay buffer has contiguous coverage
+- Falls back to full sync if the gap is too large, replay is incomplete, or the local hash disagrees despite no sequence gap
+- Queue and session subscription `error`/`complete` callbacks schedule a reconnect/resubscribe pass, so a completed subscription does not leave the client silently joined but deaf to future events
 - Client-side supervisor detects stale connections and triggers reconnect (see [Client-Side Connection Supervisor](#client-side-connection-supervisor))
 
 **Offline queue support:**
@@ -1029,7 +1046,7 @@ graphql-ws Client(s)
 A 1-second interval (`HEALTH_CHECK_INTERVAL_MS`) monitors each registered client:
 
 1. If `document.visibilityState !== 'visible'`, skip (avoid terminating background tabs).
-2. If `Date.now() - lastActivity > STALE_GRACE_MS` (10s, or 2x the server keep-alive interval), mark the client as `reconnecting` and call `client.terminate()` to force a fresh connection.
+2. If `Date.now() - lastActivity > STALE_GRACE_MS` (25s), mark the client as `reconnecting` and call `client.terminate()` to force a fresh connection.
 
 This catches silent connection deaths that are common on iOS Safari when the app is backgrounded and the OS kills the socket without a close frame.
 
@@ -1114,10 +1131,10 @@ When Redis is unavailable, RoomManager falls back to **Postgres-only mode**:
 
 Session participation is tracked in two layers:
 
-| Layer                     | Table / Key                      | Granularity            | Lifetime           |
-| ------------------------- | -------------------------------- | ---------------------- | ------------------ |
-| **Real-time** (Redis)     | `boardsesh:session:{id}:members` | Per connection ID      | Ephemeral (4h TTL) |
-| **Historical** (Postgres) | `board_session_participants`     | Per authenticated user | Permanent          |
+| Layer                     | Table / Key                           | Granularity               | Lifetime           |
+| ------------------------- | ------------------------------------- | ------------------------- | ------------------ |
+| **Real-time** (Redis)     | `boardsesh:session:{id}:participants` | Per stable participant ID | Ephemeral (4h TTL) |
+| **Historical** (Postgres) | `board_session_participants`          | Per authenticated user    | Permanent          |
 
 **`board_session_participants`** records one row per (session_id, user_id) with a `joined_at` timestamp. It is upserted (`ON CONFLICT DO NOTHING`) when an authenticated user joins a session. Rows are never deleted on disconnect — they serve as a permanent historical record of who participated.
 
@@ -1141,6 +1158,9 @@ boardsesh:lock:session:restore:{id} # String - distributed lock (10s TTL)
 ```
 boardsesh:conn:{connectionId}       # Hash - connection data (1h TTL, refreshed on activity)
 boardsesh:session:{id}:members      # Set - connection IDs in session (4h TTL)
+boardsesh:session:{id}:participants # Set - stable participant IDs in session (4h TTL)
+boardsesh:participant:{id}:{pid}    # Hash - participant presence data and connectionState
+boardsesh:participant:{id}:{pid}:connections # Set - live connection IDs for one participant
 boardsesh:session:{id}:leader       # String - leader connection ID (4h TTL)
 boardsesh:instance:{id}:conns       # Set - connections owned by instance (2h TTL, refreshed on heartbeat)
 boardsesh:instance:{id}:heartbeat   # String - instance heartbeat timestamp (60s TTL, refreshed every 30s)

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -192,7 +192,7 @@ sequenceDiagram
 2. **Authentication**: Optional auth token passed in `connectionParams`
 3. **Eager Subscription**: Queue subscription starts BEFORE fetching state to prevent race conditions
 4. **Session Restoration**: Sessions can be restored from Redis (warm cache) or PostgreSQL (dormant durable state)
-5. **Stable Participant Identity**: Anonymous clients persist a `participantId` in `ACTIVE_SESSION_KEY`; authenticated clients use their `userId`. Reconnects therefore update the same participant instead of creating a new user row for every socket.
+5. **Stable Participant Identity (authenticated only)**: Authenticated clients bind `participantId` to their verified `userId`, so reconnects across socket drops update the same participant row (peers see `UserPresenceChanged`, not `UserLeft` + `UserJoined`). Anonymous clients bind `participantId` to their `connectionId` instead — a client-supplied participantId is intentionally rejected on the server (it would let any session member impersonate any other participant, since `SessionUser.id` is broadcast to peers). Each anonymous WebSocket drop therefore appears as a fresh participant.
 6. **Initial Queue Seeding**: When creating a new session, clients can provide `initialQueue` and `initialCurrentClimb` to seed the session with an existing local queue (e.g., when starting party mode with climbs already queued)
 
 ### Initial Queue Seeding

--- a/embedded/scripts/generate-graphql-types.test.mjs
+++ b/embedded/scripts/generate-graphql-types.test.mjs
@@ -5,7 +5,7 @@
  * Run with: node --test embedded/scripts/generate-graphql-types.test.mjs
  */
 
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/embedded/scripts/generate-graphql-types.test.mjs
+++ b/embedded/scripts/generate-graphql-types.test.mjs
@@ -16,7 +16,6 @@ import {
   parseGraphQLSchema,
   graphqlTypeToCpp,
   generateCppStruct,
-  generateHeader,
   TYPE_MAP,
   FIELD_TYPE_OVERRIDES,
   CONTROLLER_TYPES,

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -153,27 +153,14 @@ The `backendUrl` is configured via the `NEXT_PUBLIC_WS_URL` environment variable
 
 ## API
 
-The backend uses WebSocket with JSON messages. See `src/types/messages.ts` for the full protocol definition.
+The backend exposes GraphQL over HTTP and WebSocket at `/graphql`. Party mode uses the `graphql-ws` protocol so session mutations and subscriptions share one connection context.
 
-### Client -> Backend Messages
+Primary WebSocket operations:
 
-- `join-session`: Join a session room
-- `leave-session`: Leave current session
-- `update-username`: Update display name
-- `add-queue-item`: Add climb to queue
-- `remove-queue-item`: Remove climb from queue
-- `update-queue`: Full queue replacement
-- `update-current-climb`: Set current climb
-- `mirror-current-climb`: Toggle climb mirroring
-- `heartbeat`: Keep-alive ping
+- `joinSession(sessionId, boardPath, participantId, ...)`: joins or restores a party session. `participantId` is a stable anonymous participant ID; authenticated clients use their user ID.
+- `leaveSession`: explicit UI leave. Passive WebSocket disconnects do not call this path.
+- `endSession`: explicit finish. WebSocket callers must be the session creator or current leader; HTTP callers must be the authenticated session creator.
+- Queue mutations: `addQueueItem`, `removeQueueItem`, `setQueue`, `setCurrentClimb`, `mirrorCurrentClimb`.
+- Subscriptions: `queueUpdates(sessionId)` and `sessionUpdates(sessionId)`.
 
-### Backend -> Client Messages
-
-- `session-joined`: Confirmation with session state
-- `user-joined`: New user notification
-- `user-left`: User left notification
-- `leader-changed`: Leader change notification
-- `heartbeat-response`: Heartbeat response
-- `error`: Error message
-
-Queue operation messages are relayed to all session members.
+Passive disconnects mark participants `RECONNECTING`, elect a new leader immediately when needed, and keep the session recoverable during the reconnect grace period. See [docs/websocket-implementation.md](../../docs/websocket-implementation.md) for the current protocol and failure-recovery details.

--- a/packages/backend/src/__tests__/create-session-auth.test.ts
+++ b/packages/backend/src/__tests__/create-session-auth.test.ts
@@ -62,6 +62,7 @@ vi.mock('./session-summary', () => ({
 function makeAuthenticatedCtx(userId = 'user-1'): ConnectionContext {
   return {
     connectionId: `http-${userId}`,
+    transport: 'http',
     sessionId: undefined,
     userId,
     isAuthenticated: true,
@@ -71,6 +72,7 @@ function makeAuthenticatedCtx(userId = 'user-1'): ConnectionContext {
 function makeAnonymousCtx(clientIp?: string): ConnectionContext {
   return {
     connectionId: `http-anonymous-${Math.random()}`,
+    transport: 'http',
     sessionId: undefined,
     userId: undefined,
     isAuthenticated: false,

--- a/packages/backend/src/__tests__/distributed-state.test.ts
+++ b/packages/backend/src/__tests__/distributed-state.test.ts
@@ -273,6 +273,25 @@ describe.skipIf(!redisAvailable)('DistributedStateManager', () => {
       const members = await manager.getSessionMembers('non-existent-session');
       expect(members).toEqual([]);
     });
+
+    it('should preserve leader status when marking participant presence', async () => {
+      await manager.registerConnection('leader-presence-conn', 'LeaderPresence');
+      await manager.joinSession('leader-presence-conn', 'presence-session');
+
+      const presenceUser = await manager.markParticipantPresence(
+        'presence-session',
+        'leader-presence-conn',
+        'RECONNECTING',
+      );
+
+      expect(presenceUser).toEqual(
+        expect.objectContaining({
+          id: 'leader-presence-conn',
+          isLeader: true,
+          connectionState: 'RECONNECTING',
+        }),
+      );
+    });
   });
 
   describe('Connection Validation', () => {

--- a/packages/backend/src/__tests__/helpers/mock-redis.ts
+++ b/packages/backend/src/__tests__/helpers/mock-redis.ts
@@ -110,12 +110,17 @@ export const createMockRedis = (): MockRedis => {
       const set = sets.get(key);
       return set ? set.size : 0;
     }),
-    hset: vi.fn(async (key: string, field: string, value: string) => {
+    hset: vi.fn(async (key: string, ...fieldsAndValues: string[]) => {
       if (!hashes.has(key)) hashes.set(key, {});
       const hash = hashes.get(key)!;
-      const isNew = !(field in hash);
-      hash[field] = value;
-      return isNew ? 1 : 0;
+      let newCount = 0;
+      for (let i = 0; i < fieldsAndValues.length; i += 2) {
+        const field = fieldsAndValues[i];
+        const value = fieldsAndValues[i + 1] ?? '';
+        if (!(field in hash)) newCount++;
+        hash[field] = value;
+      }
+      return newCount;
     }),
     setex: vi.fn(async (key: string, _seconds: number, value: string) => {
       store.set(key, value);
@@ -128,6 +133,10 @@ export const createMockRedis = (): MockRedis => {
       const chainable = {
         hmset: (key: string, obj: Record<string, string>) => {
           commands.push(() => mockRedis.hmset(key, obj));
+          return chainable;
+        },
+        hset: (key: string, ...fieldsAndValues: string[]) => {
+          commands.push(() => mockRedis.hset(key, ...fieldsAndValues));
           return chainable;
         },
         expire: (_key: string, _seconds: number) => {
@@ -178,6 +187,17 @@ export const createMockRedis = (): MockRedis => {
           commands.push(async () => {
             return hashes.get(key) || {};
           });
+          return chainable;
+        },
+        smembers: (key: string) => {
+          commands.push(async () => {
+            const set = sets.get(key);
+            return set ? Array.from(set) : [];
+          });
+          return chainable;
+        },
+        srem: (key: string, ...members: string[]) => {
+          commands.push(() => mockRedis.srem(key, ...members));
           return chainable;
         },
         exists: (key: string) => {

--- a/packages/backend/src/__tests__/integration.test.ts
+++ b/packages/backend/src/__tests__/integration.test.ts
@@ -32,7 +32,7 @@ type MirrorCurrentClimbResult = {
 
 type SessionQueryResult = {
   queueState: { queue: Array<{ uuid: string }>; currentClimbQueueItem: { uuid: string } | null };
-  users: Array<{ id: string }>;
+  users: Array<{ id: string; connectionState?: string }>;
 };
 
 type QueueEvent =
@@ -48,8 +48,9 @@ type QueueEvent =
 
 type SessionEvent =
   | { __typename: 'UserJoined'; user: { id: string; username: string } }
+  | { __typename: 'UserPresenceChanged'; user: { id: string; username?: string; connectionState: string } }
   | { __typename: 'UserLeft'; userId: string }
-  | { __typename: 'LeaderChanged'; leaderId: string }
+  | { __typename: 'LeaderChanged'; leaderId: string; leaderConnectionId?: string | null }
   | { __typename: 'SessionEnded'; reason: string };
 
 // Test fixtures
@@ -600,7 +601,7 @@ describe('Daemon Integration Tests', () => {
       // Client 2 subscribes to session updates
       const eventPromise = waitForEvent<QueueEvent | SessionEvent>(
         client2,
-        `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on LeaderChanged { leaderId } ... on UserLeft { userId } } }`,
+        `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on LeaderChanged { leaderId leaderConnectionId } ... on UserPresenceChanged { user { id connectionState } } } }`,
         (e) => e.__typename === 'LeaderChanged',
       );
 
@@ -614,6 +615,7 @@ describe('Daemon Integration Tests', () => {
 
       expectTypename(event, 'LeaderChanged');
       expect(event.leaderId).toBe(result2.joinSession.clientId);
+      expect(event.leaderConnectionId).toBe(result2.joinSession.clientId);
     });
 
     it('should maintain leader when non-leader disconnects', async () => {
@@ -632,11 +634,11 @@ describe('Daemon Integration Tests', () => {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}", username: "Follower") { isLeader } }`,
       });
 
-      // Client 1 subscribes to session updates to detect UserLeft
+      // Client 1 subscribes to session updates to detect passive presence changes
       const eventPromise = waitForEvent<QueueEvent | SessionEvent>(
         client1,
-        `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on UserLeft { userId } ... on LeaderChanged { leaderId } } }`,
-        (e) => e.__typename === 'UserLeft',
+        `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on UserPresenceChanged { user { id connectionState } } ... on LeaderChanged { leaderId leaderConnectionId } } }`,
+        (e) => e.__typename === 'UserPresenceChanged',
       );
 
       // Client 2 disconnects
@@ -646,8 +648,9 @@ describe('Daemon Integration Tests', () => {
 
       const event = await eventPromise;
 
-      // Should only get UserLeft, not LeaderChanged (leader is still client1)
-      expect(event.__typename).toBe('UserLeft');
+      // Should only get UserPresenceChanged, not LeaderChanged (leader is still client1)
+      expectTypename(event, 'UserPresenceChanged');
+      expect(event.user.connectionState).toBe('RECONNECTING');
     });
   });
 
@@ -681,7 +684,7 @@ describe('Daemon Integration Tests', () => {
       expect(event.user.username).toBe('Second');
     });
 
-    it('should emit UserLeft when client disconnects', async () => {
+    it('should emit UserPresenceChanged when client passively disconnects', async () => {
       const sessionId = createTestSessionId();
       const client1 = createTestClient();
       const client2 = createTestClient();
@@ -697,8 +700,8 @@ describe('Daemon Integration Tests', () => {
       // Client 1 subscribes to session updates
       const eventPromise = waitForEvent<QueueEvent | SessionEvent>(
         client1,
-        `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on UserLeft { userId } } }`,
-        (e) => e.__typename === 'UserLeft',
+        `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on UserPresenceChanged { user { id connectionState } } } }`,
+        (e) => e.__typename === 'UserPresenceChanged',
       );
 
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -710,8 +713,9 @@ describe('Daemon Integration Tests', () => {
 
       const event = await eventPromise;
 
-      expectTypename(event, 'UserLeft');
-      expect(event.userId).toBe(result2.joinSession.clientId);
+      expectTypename(event, 'UserPresenceChanged');
+      expect(event.user.id).toBe(result2.joinSession.clientId);
+      expect(event.user.connectionState).toBe('RECONNECTING');
     });
 
     it('should emit LeaderChanged when leader leaves', async () => {
@@ -732,8 +736,8 @@ describe('Daemon Integration Tests', () => {
       // Client 2 subscribes to session updates
       const eventPromise = collectEvents<SessionEvent>(
         client2,
-        `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on UserLeft { userId } ... on LeaderChanged { leaderId } } }`,
-        2, // UserLeft + LeaderChanged
+        `subscription { sessionUpdates(sessionId: "${sessionId}") { __typename ... on UserPresenceChanged { user { id connectionState } } ... on LeaderChanged { leaderId leaderConnectionId } } }`,
+        2, // UserPresenceChanged + LeaderChanged
       );
 
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -745,21 +749,23 @@ describe('Daemon Integration Tests', () => {
 
       const events = await eventPromise;
 
-      // Should get both UserLeft and LeaderChanged
-      const userLeftEvent = events.find((e) => e.__typename === 'UserLeft');
+      // Should get both UserPresenceChanged and LeaderChanged
+      const userPresenceEvent = events.find((e) => e.__typename === 'UserPresenceChanged');
       const leaderChangedEvent = events.find((e) => e.__typename === 'LeaderChanged');
 
-      expect(userLeftEvent).toBeDefined();
+      expect(userPresenceEvent).toBeDefined();
       expect(leaderChangedEvent).toBeDefined();
-      expectTypename(userLeftEvent!, 'UserLeft');
+      expectTypename(userPresenceEvent!, 'UserPresenceChanged');
       expectTypename(leaderChangedEvent!, 'LeaderChanged');
-      expect(userLeftEvent.userId).toBe(result1.joinSession.clientId);
+      expect(userPresenceEvent.user.id).toBe(result1.joinSession.clientId);
+      expect(userPresenceEvent.user.connectionState).toBe('RECONNECTING');
       expect(leaderChangedEvent.leaderId).toBe(result2.joinSession.clientId);
+      expect(leaderChangedEvent.leaderConnectionId).toBe(result2.joinSession.clientId);
     });
   });
 
   describe('Disconnect Handling', () => {
-    it('should cleanup session when all clients disconnect', async () => {
+    it('should preserve recoverable session state when all clients passively disconnect', async () => {
       const sessionId = createTestSessionId();
       const client1 = createTestClient();
 
@@ -780,16 +786,16 @@ describe('Daemon Integration Tests', () => {
       // Wait for cleanup
       await new Promise((resolve) => setTimeout(resolve, 200));
 
-      // New client joins same session - should get empty state (session was cleaned up)
+      // New client joins same session during the reconnect grace window.
       const client2 = createTestClient();
       const result = await execute<{ joinSession: JoinSessionResult }>(client2, {
         query: `mutation { joinSession(sessionId: "${sessionId}", boardPath: "${TEST_BOARD_PATH}") { isLeader users { id } queueState { queue { uuid } } } }`,
       });
 
-      // New client should be leader (first in fresh session)
+      // New client should be leader, and the queue should remain recoverable.
       expect(result.joinSession.isLeader).toBe(true);
-      // Should be only user
-      expect(result.joinSession.users).toHaveLength(1);
+      expect(result.joinSession.queueState.queue).toHaveLength(1);
+      expect(result.joinSession.users).toHaveLength(2);
     });
 
     it('should continue session when one of multiple clients disconnects', async () => {
@@ -820,12 +826,12 @@ describe('Daemon Integration Tests', () => {
 
       // Client 2 should still see the queue item (query session state)
       const result = await execute<{ session: SessionQueryResult }>(client2, {
-        query: `query { session(sessionId: "${sessionId}") { queueState { queue { uuid } } users { id } } }`,
+        query: `query { session(sessionId: "${sessionId}") { queueState { queue { uuid } } users { id connectionState } } }`,
       });
 
       expect(result.session.queueState.queue).toHaveLength(1);
       expect(result.session.queueState.queue[0].uuid).toBe(getTestClimbUuid('persist-test'));
-      expect(result.session.users).toHaveLength(1); // Only client2 remains
+      expect(result.session.users).toHaveLength(2); // client1 is reconnecting, client2 is connected
     });
   });
 

--- a/packages/backend/src/__tests__/leave-session-multi-instance.test.ts
+++ b/packages/backend/src/__tests__/leave-session-multi-instance.test.ts
@@ -27,7 +27,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { leaveSession } from '../services/room-manager/client-lifecycle';
-import type { ConnectedClient } from '../services/room-manager/types';
+import type { ConnectedClient, LocalSessionParticipant } from '../services/room-manager/types';
 import type { RedisSessionStore } from '../services/redis-session-store';
 import type { DistributedStateManager } from '../services/distributed-state';
 import type { WriteScheduler } from '../services/room-manager/write-scheduler';
@@ -36,7 +36,8 @@ const GRACE_PERIOD_MS = 60_000;
 
 type MockedRedisStore = Pick<RedisSessionStore, 'markInactive' | 'saveUsers'>;
 type MockedWriteScheduler = Pick<WriteScheduler, 'cancelPendingWrites'>;
-type MockedDistState = Pick<DistributedStateManager, 'leaveSession' | 'getSessionMembers'>;
+type MockedDistState = Pick<DistributedStateManager, 'leaveSession' | 'getSessionMembers' | 'removeParticipant'> &
+  Partial<Pick<DistributedStateManager, 'getConnection'>>;
 
 function makeRedisStore(): MockedRedisStore {
   return {
@@ -55,6 +56,7 @@ function makeClient(connectionId: string, sessionId: string | null): ConnectedCl
   return {
     connectionId,
     sessionId,
+    participantId: connectionId,
     userId: 'user-1',
     username: 'test',
     isLeader: false,
@@ -66,6 +68,7 @@ function makeClient(connectionId: string, sessionId: string | null): ConnectedCl
 describe('leaveSession multi-instance markInactive race', () => {
   let clients: Map<string, ConnectedClient>;
   let sessionsMap: Map<string, Set<string>>;
+  let sessionParticipants: Map<string, Map<string, LocalSessionParticipant>>;
   let sessionGraceTimers: Map<string, NodeJS.Timeout>;
   let pendingJoinPersists: Map<string, Promise<void>>;
   let redisStore: MockedRedisStore;
@@ -78,6 +81,7 @@ describe('leaveSession multi-instance markInactive race', () => {
   beforeEach(() => {
     clients = new Map();
     sessionsMap = new Map();
+    sessionParticipants = new Map();
     sessionGraceTimers = new Map();
     pendingJoinPersists = new Map();
     redisStore = makeRedisStore();
@@ -85,6 +89,23 @@ describe('leaveSession multi-instance markInactive race', () => {
 
     clients.set(LOCAL_CONN, makeClient(LOCAL_CONN, SESSION_ID));
     sessionsMap.set(SESSION_ID, new Set([LOCAL_CONN]));
+    sessionParticipants.set(
+      SESSION_ID,
+      new Map([
+        [
+          LOCAL_CONN,
+          {
+            id: LOCAL_CONN,
+            username: 'test',
+            userId: 'user-1',
+            avatarUrl: undefined,
+            isLeader: false,
+            connectionState: 'CONNECTED',
+            connectionIds: new Set([LOCAL_CONN]),
+          },
+        ],
+      ]),
+    );
   });
 
   it('skips markInactive and keeps pending writes when other instances still have members', async () => {
@@ -92,13 +113,26 @@ describe('leaveSession multi-instance markInactive race', () => {
     // connection is still in the membership set.
     const distributedState: MockedDistState = {
       leaveSession: vi.fn().mockResolvedValue({ newLeaderId: REMOTE_CONN }),
+      getConnection: vi.fn().mockResolvedValue({
+        connectionId: REMOTE_CONN,
+        instanceId: 'remote-instance',
+        sessionId: SESSION_ID,
+        participantId: 'remote-participant',
+        userId: null,
+        username: 'b',
+        avatarUrl: null,
+        isLeader: true,
+        connectedAt: Date.now(),
+      }),
       getSessionMembers: vi.fn().mockResolvedValue([{ id: REMOTE_CONN, username: 'b', isLeader: true }]),
+      removeParticipant: vi.fn().mockResolvedValue(undefined),
     };
 
     const result = await leaveSession(
       LOCAL_CONN,
       clients,
       sessionsMap,
+      sessionParticipants,
       redisStore as unknown as RedisSessionStore,
       distributedState as unknown as DistributedStateManager,
       writeScheduler as unknown as WriteScheduler,
@@ -109,6 +143,7 @@ describe('leaveSession multi-instance markInactive race', () => {
 
     expect(result?.sessionId).toBe(SESSION_ID);
     expect(result?.newLeaderId).toBe(REMOTE_CONN);
+    expect(result?.newLeaderParticipantId).toBe('remote-participant');
 
     // The dangerous side-effects must be skipped because another instance
     // still has members.
@@ -126,12 +161,14 @@ describe('leaveSession multi-instance markInactive race', () => {
     const distributedState: MockedDistState = {
       leaveSession: vi.fn().mockResolvedValue({ newLeaderId: null }),
       getSessionMembers: vi.fn().mockResolvedValue([]),
+      removeParticipant: vi.fn().mockResolvedValue(undefined),
     };
 
     const result = await leaveSession(
       LOCAL_CONN,
       clients,
       sessionsMap,
+      sessionParticipants,
       redisStore as unknown as RedisSessionStore,
       distributedState as unknown as DistributedStateManager,
       writeScheduler as unknown as WriteScheduler,
@@ -165,12 +202,14 @@ describe('leaveSession multi-instance markInactive race', () => {
         callOrder.push('getSessionMembers');
         return [];
       }),
+      removeParticipant: vi.fn().mockResolvedValue(undefined),
     };
 
     await leaveSession(
       LOCAL_CONN,
       clients,
       sessionsMap,
+      sessionParticipants,
       redisStore as unknown as RedisSessionStore,
       distributedState as unknown as DistributedStateManager,
       writeScheduler as unknown as WriteScheduler,
@@ -190,6 +229,7 @@ describe('leaveSession multi-instance markInactive race', () => {
       LOCAL_CONN,
       clients,
       sessionsMap,
+      sessionParticipants,
       redisStore as unknown as RedisSessionStore,
       null, // no distributed state
       writeScheduler as unknown as WriteScheduler,
@@ -213,6 +253,7 @@ describe('leaveSession multi-instance markInactive race', () => {
     const distributedState: MockedDistState = {
       leaveSession: vi.fn().mockResolvedValue({ newLeaderId: null }),
       getSessionMembers: vi.fn().mockRejectedValue(new Error('redis down')),
+      removeParticipant: vi.fn().mockResolvedValue(undefined),
     };
 
     // Silence the expected console.error from the catch branch.
@@ -222,6 +263,7 @@ describe('leaveSession multi-instance markInactive race', () => {
       LOCAL_CONN,
       clients,
       sessionsMap,
+      sessionParticipants,
       redisStore as unknown as RedisSessionStore,
       distributedState as unknown as DistributedStateManager,
       writeScheduler as unknown as WriteScheduler,

--- a/packages/backend/src/__tests__/operations-schema-validation.test.ts
+++ b/packages/backend/src/__tests__/operations-schema-validation.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { buildSchema, parse, validate, type DocumentNode, type GraphQLSchema } from 'graphql';
+import { typeDefs } from '@boardsesh/shared-schema';
+import * as operations from '@boardsesh/shared-schema/operations';
+
+// Build a fresh schema from the raw typeDefs inside this test's `graphql`
+// instance. Importing the backend's `schema` object crosses the boundary
+// between two installed `graphql` modules (the backend builds with one,
+// `validate()` uses another), which graphql-js rejects with "Cannot use
+// GraphQLSchema ...". Building locally keeps everything in one module.
+let schema: GraphQLSchema;
+try {
+  schema = buildSchema(typeDefs.join('\n\n'));
+} catch (error) {
+  throw new Error(`Failed to build schema from shared-schema typeDefs: ${(error as Error).message}`);
+}
+
+/**
+ * Guard against the OverlappingFieldsCanBeMergedRule (and any other) GraphQL
+ * validation regression that broke production twice:
+ *   1. PR #2128 added `uuid: ID` to `ClimbMirrored` while sibling union arms
+ *      declared `uuid: ID!`. Every party-session join failed validation, the
+ *      client tight-looped reconnects, and the PR had to be reverted.
+ *   2. The reland reintroduced the same hazard at first and would have hit
+ *      prod again without manual catching.
+ *
+ * The graphql-js validator catches both classes of bug deterministically when
+ * run against the schema. Run every exported `*_OPERATION` string in
+ * `operations.ts` through `parse()` + `validate(schema, doc)` and assert no
+ * errors. One ~10ms unit test is cheap insurance.
+ */
+describe('shared-schema operations validate against the executable schema', () => {
+  // Pull every exported value that looks like a GraphQL operation string.
+  // operations.ts uses plain template-literal strings (not gql tags), so we
+  // duck-type by checking it starts with `mutation`/`query`/`subscription`
+  // after optional whitespace.
+  const operationEntries = Object.entries(operations).filter(([, value]): value is string => {
+    if (typeof value !== 'string') return false;
+    return /^\s*(query|mutation|subscription)\b/i.test(value);
+  });
+
+  it('found at least one exported operation to validate', () => {
+    expect(operationEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [name, source] of operationEntries) {
+    it(`${name} parses and validates against the schema`, () => {
+      let document: DocumentNode;
+      try {
+        document = parse(source);
+      } catch (error) {
+        throw new Error(`Operation ${name} failed to parse: ${(error as Error).message}`);
+      }
+
+      const errors = validate(schema, document);
+      if (errors.length > 0) {
+        const detail = errors.map((e, i) => `  ${i + 1}. ${e.message}`).join('\n');
+        throw new Error(`Operation ${name} has GraphQL validation errors:\n${detail}`);
+      }
+    });
+  }
+});

--- a/packages/backend/src/__tests__/operations-schema-validation.test.ts
+++ b/packages/backend/src/__tests__/operations-schema-validation.test.ts
@@ -34,10 +34,12 @@ describe('shared-schema operations validate against the executable schema', () =
   // operations.ts uses plain template-literal strings (not gql tags), so we
   // duck-type by checking it starts with `mutation`/`query`/`subscription`
   // after optional whitespace.
-  const operationEntries = Object.entries(operations).filter(([, value]): value is string => {
-    if (typeof value !== 'string') return false;
-    return /^\s*(query|mutation|subscription)\b/i.test(value);
-  });
+  const operationEntries: Array<[string, string]> = [];
+  for (const [name, value] of Object.entries(operations)) {
+    if (typeof value !== 'string') continue;
+    if (!/^\s*(query|mutation|subscription)\b/i.test(value)) continue;
+    operationEntries.push([name, value]);
+  }
 
   it('found at least one exported operation to validate', () => {
     expect(operationEntries.length).toBeGreaterThan(0);

--- a/packages/backend/src/__tests__/queue-sync-fixes.test.ts
+++ b/packages/backend/src/__tests__/queue-sync-fixes.test.ts
@@ -520,3 +520,77 @@ describe('reorderQueueItem - Return type handling', () => {
     );
   });
 });
+
+describe('setCurrentClimb - combined queue/current state publishing', () => {
+  let mockRedis: MockRedis;
+  let publishSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    mockRedis = createMockRedis();
+    roomManager.reset();
+    await roomManager.initialize(mockRedis);
+    publishSpy = vi.spyOn(pubsub, 'publishQueueEvent').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('publishes FullSync when shouldAddToQueue adds and activates in one mutation', async () => {
+    const sessionId = uuidv4();
+    const boardPath = '/kilter/1/2/3/40';
+    await registerAndJoinSession('client-1', sessionId, boardPath, 'User1');
+
+    const climb = createTestClimb();
+    const ctx = {
+      connectionId: 'client-1',
+      sessionId,
+      rateLimitTokens: 60,
+      rateLimitLastReset: Date.now(),
+    };
+
+    await queueMutations.setCurrentClimb({}, { item: climb, shouldAddToQueue: true }, ctx);
+
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledWith(
+      sessionId,
+      expect.objectContaining({
+        __typename: 'FullSync',
+        state: expect.objectContaining({
+          stateHash: expect.any(String),
+          queue: [climb],
+          currentClimbQueueItem: climb,
+        }),
+      }),
+    );
+  });
+
+  it('publishes CurrentClimbChanged with stateHash when activating an existing queue item', async () => {
+    const sessionId = uuidv4();
+    const boardPath = '/kilter/1/2/3/40';
+    await registerAndJoinSession('client-1', sessionId, boardPath, 'User1');
+
+    const climb = createTestClimb();
+    const state = await roomManager.getQueueState(sessionId);
+    await roomManager.updateQueueState(sessionId, [climb], null, state.version);
+    publishSpy.mockClear();
+
+    const ctx = {
+      connectionId: 'client-1',
+      sessionId,
+      rateLimitTokens: 60,
+      rateLimitLastReset: Date.now(),
+    };
+
+    await queueMutations.setCurrentClimb({}, { item: climb, shouldAddToQueue: true }, ctx);
+
+    expect(publishSpy).toHaveBeenCalledWith(
+      sessionId,
+      expect.objectContaining({
+        __typename: 'CurrentClimbChanged',
+        stateHash: expect.any(String),
+        item: climb,
+      }),
+    );
+  });
+});

--- a/packages/backend/src/__tests__/redis-pubsub.test.ts
+++ b/packages/backend/src/__tests__/redis-pubsub.test.ts
@@ -60,6 +60,7 @@ describe('Redis PubSub Adapter', () => {
       const event: QueueEvent = {
         __typename: 'QueueItemAdded',
         sequence: 1,
+        stateHash: 'hash-1',
         item: {
           uuid: 'test-uuid',
           climb: {
@@ -121,6 +122,7 @@ describe('Redis PubSub Adapter', () => {
           username: 'TestUser',
           isLeader: true,
           avatarUrl: undefined,
+          connectionState: 'CONNECTED',
         },
       };
 
@@ -157,6 +159,7 @@ describe('Redis PubSub Adapter', () => {
       const event: QueueEvent = {
         __typename: 'QueueItemRemoved',
         sequence: 1,
+        stateHash: 'hash-1',
         uuid: 'removed-uuid',
       };
 
@@ -224,6 +227,8 @@ describe('Redis PubSub Adapter - Unit Tests (mocked)', () => {
     const event: QueueEvent = {
       __typename: 'ClimbMirrored',
       sequence: 1,
+      stateHash: 'hash-1',
+      uuid: 'queue-item-1',
       mirrored: true,
     };
 

--- a/packages/backend/src/__tests__/session-context.test.ts
+++ b/packages/backend/src/__tests__/session-context.test.ts
@@ -37,6 +37,11 @@ vi.mock('../services/room-manager', () => ({
       sessionId: 'session-aaaa-bbbb-cccc-dddd',
       participantId: 'stable-participant-123',
       newLeaderId: undefined,
+      // Default to a full departure so the UserLeft broadcast path is
+      // exercised by tests that don't override with `mockResolvedValueOnce`.
+      // The per-tab leave case (`participantFullyLeft: false`) is covered by
+      // its own explicit override elsewhere.
+      participantFullyLeft: true,
     }),
     createDiscoverableSession: vi.fn().mockResolvedValue({}),
     getSessionById: vi.fn().mockResolvedValue(null),

--- a/packages/backend/src/__tests__/session-context.test.ts
+++ b/packages/backend/src/__tests__/session-context.test.ts
@@ -170,6 +170,10 @@ describe('leaveSession publishes UserLeft with the stable participant ID', () =>
       sessionId: 'session-aaaa-bbbb-cccc-dddd',
       participantId: realUserId,
       newLeaderId: undefined,
+      // participant had only this connection; UserLeft should fire. (When
+      // false — e.g. a sibling tab still in the session — the resolver
+      // intentionally suppresses the broadcast.)
+      participantFullyLeft: true,
     });
     const ctx: ConnectionContext = {
       connectionId: 'ws-conn-abc-123',
@@ -206,6 +210,7 @@ describe('leaveSession publishes UserLeft with the stable participant ID', () =>
       sessionId: 'session-zzzz',
       participantId: 'anon-stable-participant',
       newLeaderId: undefined,
+      participantFullyLeft: true,
     });
     const ctx: ConnectionContext = {
       connectionId: 'ws-conn-anon-456',

--- a/packages/backend/src/__tests__/session-context.test.ts
+++ b/packages/backend/src/__tests__/session-context.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { sessionMutations } from '../graphql/resolvers/sessions/mutations';
+import { roomManager } from '../services/room-manager';
 import { updateContext } from '../graphql/context';
 import { pubsub } from '../pubsub/index';
 
@@ -28,9 +29,13 @@ vi.mock('../services/room-manager', () => ({
       sequence: 0,
       stateHash: 'hash',
       sessionName: null,
+      participantId: 'stable-participant-123',
+      participantWasKnown: false,
+      participantWasReconnecting: false,
     }),
     leaveSession: vi.fn().mockResolvedValue({
       sessionId: 'session-aaaa-bbbb-cccc-dddd',
+      participantId: 'stable-participant-123',
       newLeaderId: undefined,
     }),
     createDiscoverableSession: vi.fn().mockResolvedValue({}),
@@ -82,7 +87,7 @@ describe('joinSession does not clobber ctx.userId', () => {
     vi.clearAllMocks();
   });
 
-  it('passes only { sessionId } to updateContext, preserving the authenticated user UUID', async () => {
+  it('passes sessionId and participantId to updateContext without clobbering the authenticated user UUID', async () => {
     const realUserId = '8a68ddc8-8da0-47e2-a968-1029b6fb4bb3';
     const ctx = makeWsAuthenticatedCtx(realUserId);
 
@@ -98,7 +103,10 @@ describe('joinSession does not clobber ctx.userId', () => {
     expect(updateContext).toHaveBeenCalledOnce();
     const [calledConnectionId, calledUpdates] = vi.mocked(updateContext).mock.calls[0];
     expect(calledConnectionId).toBe('ws-conn-abc-123');
-    expect(calledUpdates).toEqual({ sessionId: 'session-aaaa-bbbb-cccc-dddd' });
+    expect(calledUpdates).toEqual({
+      sessionId: 'session-aaaa-bbbb-cccc-dddd',
+      participantId: 'stable-participant-123',
+    });
     expect(calledUpdates).not.toHaveProperty('userId');
   });
 });
@@ -108,7 +116,7 @@ describe('createSession does not clobber ctx.userId', () => {
     vi.clearAllMocks();
   });
 
-  it('passes only { sessionId } to updateContext on the WebSocket path', async () => {
+  it('passes sessionId and participantId to updateContext on the WebSocket path', async () => {
     const realUserId = '8a68ddc8-8da0-47e2-a968-1029b6fb4bb3';
     const ctx = makeWsAuthenticatedCtx(realUserId);
 
@@ -128,34 +136,41 @@ describe('createSession does not clobber ctx.userId', () => {
 
     expect(updateContext).toHaveBeenCalledOnce();
     const [, calledUpdates] = vi.mocked(updateContext).mock.calls[0];
-    expect(calledUpdates).toEqual({ sessionId: 'test-session-uuid' });
+    expect(calledUpdates).toEqual({
+      sessionId: 'test-session-uuid',
+      participantId: 'stable-participant-123',
+    });
     expect(calledUpdates).not.toHaveProperty('userId');
   });
 });
 
-describe('leaveSession publishes UserLeft with the connection ID', () => {
+describe('leaveSession publishes UserLeft with the stable participant ID', () => {
   // Background: the disconnect handler in websocket/setup.ts and the
   // explicit `leaveSession` mutation both emit a `UserLeft` event so
   // peers can drop the departing user from their participant list. The
-  // GraphQL schema names the payload field `userId` but the *contract*
-  // with the client is that it carries the connection ID — clients
-  // populate their participant list from `UserJoined.user.id`, which is
-  // `result.clientId` (the connection ID), and filter by
-  // `u.id !== event.userId`. The two events must agree.
+  // GraphQL schema names the payload field `userId` but the current contract
+  // with the client is that it carries the stable participant ID. Clients
+  // populate their participant list from `UserJoined.user.id` and filter by
+  // `u.id !== event.userId`, so joined and left events must agree.
   //
   // Earlier commits in this PR stopped clobbering `ctx.userId` with the
   // connection ID. The leaveSession mutation was previously guarded by
   // `if (userId)` and only fired because of that clobber, so it would
   // have silently stopped emitting UserLeft for unauthenticated clients
   // (and for authenticated clients would have emitted the real user
-  // UUID — wrong shape, fails the client filter). This test pins the
-  // correct behaviour.
+  // UUID when the participant ID differs from the user ID. These tests pin the
+  // current behaviour.
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('emits UserLeft with userId === ctx.connectionId for authenticated clients', async () => {
+  it('emits UserLeft with the returned participantId for authenticated clients', async () => {
     const realUserId = '8a68ddc8-8da0-47e2-a968-1029b6fb4bb3';
+    vi.mocked(roomManager.leaveSession).mockResolvedValueOnce({
+      sessionId: 'session-aaaa-bbbb-cccc-dddd',
+      participantId: realUserId,
+      newLeaderId: undefined,
+    });
     const ctx: ConnectionContext = {
       connectionId: 'ws-conn-abc-123',
       sessionId: 'session-aaaa-bbbb-cccc-dddd',
@@ -174,23 +189,24 @@ describe('leaveSession publishes UserLeft with the connection ID', () => {
     );
     expect(userLeftCall).toBeDefined();
     expect(userLeftCall![0]).toBe('session-aaaa-bbbb-cccc-dddd');
-    expect(userLeftCall![1].userId).toBe('ws-conn-abc-123');
-    // It must NOT be the auth user UUID — clients filter participants
-    // by connection ID and would fail to remove the user otherwise.
-    expect(userLeftCall![1].userId).not.toBe(realUserId);
+    expect(userLeftCall![1].userId).toBe(realUserId);
+    expect(userLeftCall![1].userId).not.toBe('ws-conn-abc-123');
 
-    // updateContext must clear ONLY sessionId; userId must be preserved
-    // for downstream resolvers on this same connection (queries, social
-    // actions, etc.). An earlier version of this resolver wrote
-    // `{ sessionId: undefined, userId: undefined }`, which looked like
-    // it was deliberately wiping the auth UUID.
+    // updateContext must clear ONLY session/participant state; userId must be
+    // preserved for downstream resolvers on this same connection (queries,
+    // social actions, etc.).
     expect(updateContext).toHaveBeenCalledOnce();
     const [, calledUpdates] = vi.mocked(updateContext).mock.calls[0];
-    expect(calledUpdates).toEqual({ sessionId: undefined });
+    expect(calledUpdates).toEqual({ sessionId: undefined, participantId: undefined });
     expect(calledUpdates).not.toHaveProperty('userId');
   });
 
   it('emits UserLeft for unauthenticated clients (which previously had no userId on ctx)', async () => {
+    vi.mocked(roomManager.leaveSession).mockResolvedValueOnce({
+      sessionId: 'session-zzzz',
+      participantId: 'anon-stable-participant',
+      newLeaderId: undefined,
+    });
     const ctx: ConnectionContext = {
       connectionId: 'ws-conn-anon-456',
       sessionId: 'session-zzzz',
@@ -208,6 +224,6 @@ describe('leaveSession publishes UserLeft with the connection ID', () => {
         (call[1] as { __typename?: string }).__typename === 'UserLeft',
     );
     expect(userLeftCall).toBeDefined();
-    expect(userLeftCall![1].userId).toBe('ws-conn-anon-456');
+    expect(userLeftCall![1].userId).toBe('anon-stable-participant');
   });
 });

--- a/packages/backend/src/__tests__/session-persistence.test.ts
+++ b/packages/backend/src/__tests__/session-persistence.test.ts
@@ -48,6 +48,7 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
   });
 
   afterEach(() => {
+    roomManager.reset();
     vi.clearAllTimers();
   });
 
@@ -170,6 +171,166 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
       expect(results).toHaveLength(3);
       const users = await roomManager.getSessionUsers(sessionId);
       expect(users).toHaveLength(3);
+    });
+  });
+
+  describe('Reconnect Lifecycle', () => {
+    it('marks a passively disconnected participant as reconnecting and restores them on reconnect', async () => {
+      const sessionId = uuidv4();
+      const boardPath = '/kilter/1/2/3/40';
+
+      const joined = await registerAndJoinSession('client-1', sessionId, boardPath, 'User1');
+
+      const disconnectResult = await roomManager.disconnectClient('client-1');
+      expect(disconnectResult?.presenceUser).toEqual(
+        expect.objectContaining({
+          id: joined.participantId,
+          username: 'User1',
+          connectionState: 'RECONNECTING',
+        }),
+      );
+
+      const reconnectingUsers = await roomManager.getSessionUsers(sessionId);
+      expect(reconnectingUsers).toContainEqual(
+        expect.objectContaining({
+          id: joined.participantId,
+          connectionState: 'RECONNECTING',
+        }),
+      );
+
+      await roomManager.registerClient('client-1b');
+      const rejoined = await roomManager.joinSession(
+        'client-1b',
+        sessionId,
+        boardPath,
+        'User1',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        joined.participantId,
+      );
+
+      expect(rejoined.participantWasReconnecting).toBe(true);
+      expect(rejoined.participantId).toBe(joined.participantId);
+      expect(rejoined.users).toContainEqual(
+        expect.objectContaining({
+          id: joined.participantId,
+          connectionState: 'CONNECTED',
+        }),
+      );
+    });
+
+    it('elects a new leader on passive leader disconnect while the old leader is reconnecting', async () => {
+      const sessionId = uuidv4();
+      const boardPath = '/kilter/1/2/3/40';
+
+      const leader = await registerAndJoinSession('leader-client', sessionId, boardPath, 'Leader');
+      const member = await registerAndJoinSession('member-client', sessionId, boardPath, 'Member');
+
+      expect(leader.isLeader).toBe(true);
+      expect(member.isLeader).toBe(false);
+
+      const disconnectResult = await roomManager.disconnectClient('leader-client');
+
+      expect(disconnectResult?.newLeaderId).toBe('member-client');
+      expect(disconnectResult?.newLeaderParticipantId).toBe(member.participantId);
+      expect(disconnectResult?.presenceUser).toEqual(
+        expect.objectContaining({
+          id: leader.participantId,
+          isLeader: false,
+          connectionState: 'RECONNECTING',
+        }),
+      );
+
+      const users = await roomManager.getSessionUsers(sessionId);
+      expect(users).toContainEqual(
+        expect.objectContaining({
+          id: member.participantId,
+          isLeader: true,
+          connectionState: 'CONNECTED',
+        }),
+      );
+      expect(users).toContainEqual(
+        expect.objectContaining({
+          id: leader.participantId,
+          isLeader: false,
+          connectionState: 'RECONNECTING',
+        }),
+      );
+    });
+
+    it('returns stable participant leader IDs separately from connection IDs on passive disconnect', async () => {
+      const sessionId = uuidv4();
+      const boardPath = '/kilter/1/2/3/40';
+
+      await roomManager.registerClient('leader-conn', 'Leader');
+      const leader = await roomManager.joinSession(
+        'leader-conn',
+        sessionId,
+        boardPath,
+        'Leader',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'leader-participant-id',
+      );
+      await roomManager.registerClient('member-conn', 'Member');
+      const member = await roomManager.joinSession(
+        'member-conn',
+        sessionId,
+        boardPath,
+        'Member',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'member-participant-id',
+      );
+
+      expect(leader.participantId).toBe('leader-participant-id');
+      expect(member.participantId).toBe('member-participant-id');
+
+      const disconnectResult = await roomManager.disconnectClient('leader-conn');
+
+      expect(disconnectResult?.newLeaderId).toBe('member-conn');
+      expect(disconnectResult?.newLeaderParticipantId).toBe('member-participant-id');
+    });
+
+    it('returns stable participant leader IDs when a leader explicitly leaves', async () => {
+      const sessionId = uuidv4();
+      const boardPath = '/kilter/1/2/3/40';
+
+      await roomManager.registerClient('leader-conn', 'Leader');
+      await roomManager.joinSession(
+        'leader-conn',
+        sessionId,
+        boardPath,
+        'Leader',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'leader-participant-id',
+      );
+      await roomManager.registerClient('member-conn', 'Member');
+      await roomManager.joinSession(
+        'member-conn',
+        sessionId,
+        boardPath,
+        'Member',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'member-participant-id',
+      );
+
+      const leaveResult = await roomManager.leaveSession('leader-conn');
+
+      expect(leaveResult?.newLeaderId).toBe('member-conn');
+      expect(leaveResult?.newLeaderParticipantId).toBe('member-participant-id');
     });
   });
 

--- a/packages/backend/src/__tests__/session-persistence.test.ts
+++ b/packages/backend/src/__tests__/session-persistence.test.ts
@@ -208,6 +208,43 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
       }
     });
 
+    it('treats an anonymous reconnect as a fresh participant (no client-supplied participantId trust)', async () => {
+      // P1 security guarantee: client-supplied participantId is ignored for
+      // anonymous users so a malicious member cannot grab another peer's
+      // SessionUser.id and impersonate them. The trade-off: an anonymous
+      // user that drops the WebSocket and reconnects gets a new
+      // participantId, and peers see UserLeft + UserJoined instead of
+      // UserPresenceChanged. This test pins that intentional UX in place.
+      const sessionId = uuidv4();
+      const boardPath = '/kilter/1/2/3/40';
+
+      // First anonymous connection joins.
+      const original = await registerAndJoinSession('anon-conn-1', sessionId, boardPath, 'Anon');
+      expect(original.participantId).toBe('anon-conn-1');
+
+      await roomManager.disconnectClient('anon-conn-1');
+
+      // Reconnect from a NEW anonymous connection. Even if the client tries
+      // to replay the previous participantId, the server must reject it.
+      await roomManager.registerClient('anon-conn-2');
+      const rejoined = await roomManager.joinSession(
+        'anon-conn-2',
+        sessionId,
+        boardPath,
+        'Anon',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        original.participantId, // attacker-controlled value — must be ignored
+      );
+
+      expect(rejoined.participantId).toBe('anon-conn-2');
+      expect(rejoined.participantId).not.toBe(original.participantId);
+      expect(rejoined.participantWasReconnecting).toBe(false);
+      expect(rejoined.participantWasKnown).toBe(false);
+    });
+
     it('marks a passively disconnected participant as reconnecting and restores them on reconnect', async () => {
       const sessionId = uuidv4();
       const boardPath = '/kilter/1/2/3/40';

--- a/packages/backend/src/__tests__/session-persistence.test.ts
+++ b/packages/backend/src/__tests__/session-persistence.test.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { roomManager } from '../services/room-manager';
 import { db } from '../db/client';
 import { sessions, sessionQueues, boardSessionParticipants } from '../db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import type { ClimbQueueItem } from '@boardsesh/shared-schema';
 import { createMockRedis, type MockRedis } from './helpers/mock-redis';
 
@@ -29,9 +29,18 @@ const createTestClimb = (): ClimbQueueItem => ({
   suggested: false,
 });
 
-// Helper function to register a client before joining
-const registerAndJoinSession = async (clientId: string, sessionId: string, boardPath: string, username?: string) => {
-  await roomManager.registerClient(clientId);
+// Helper function to register a client before joining.
+// Pass `userId` to simulate an authenticated user — that's the only path that
+// produces a stable participantId across reconnects (anonymous reconnects
+// intentionally yield a fresh participantId, per the join-side security fix).
+const registerAndJoinSession = async (
+  clientId: string,
+  sessionId: string,
+  boardPath: string,
+  username?: string,
+  userId?: string,
+) => {
+  await roomManager.registerClient(clientId, username, userId);
   return roomManager.joinSession(clientId, sessionId, boardPath, username);
 };
 
@@ -175,11 +184,38 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
   });
 
   describe('Reconnect Lifecycle', () => {
+    // Stable participantId across reconnects only works for authenticated
+    // users (the P1 fix removed trust in client-supplied participantId). The
+    // tests below pass userIds that are written to board_sessions.created_by_user_id;
+    // those values need to exist in the users table (FK constraint).
+    const RECONNECT_TEST_USERS = ['user-A', 'leader-participant-id', 'member-participant-id'];
+
+    beforeEach(async () => {
+      for (const userId of RECONNECT_TEST_USERS) {
+        await db.execute(sql`
+          INSERT INTO users (id, email, name, created_at, updated_at)
+          VALUES (${userId}, ${userId + '@reconnect.test'}, ${userId}, now(), now())
+          ON CONFLICT (id) DO NOTHING
+        `);
+      }
+    });
+
+    afterEach(async () => {
+      // Sessions FK-cascade onto board_sessions; clean up users we inserted.
+      for (const userId of RECONNECT_TEST_USERS) {
+        await db.execute(sql`DELETE FROM board_sessions WHERE created_by_user_id = ${userId}`);
+        await db.execute(sql`DELETE FROM users WHERE id = ${userId}`);
+      }
+    });
+
     it('marks a passively disconnected participant as reconnecting and restores them on reconnect', async () => {
       const sessionId = uuidv4();
       const boardPath = '/kilter/1/2/3/40';
 
-      const joined = await registerAndJoinSession('client-1', sessionId, boardPath, 'User1');
+      // Authenticated user: stable participantId == userId across reconnects.
+      // Anonymous users intentionally don't share continuity here; that's the
+      // P1 security fix on the join side.
+      const joined = await registerAndJoinSession('client-1', sessionId, boardPath, 'User1', 'user-A');
 
       const disconnectResult = await roomManager.disconnectClient('client-1');
       expect(disconnectResult?.presenceUser).toEqual(
@@ -198,18 +234,10 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
         }),
       );
 
-      await roomManager.registerClient('client-1b');
-      const rejoined = await roomManager.joinSession(
-        'client-1b',
-        sessionId,
-        boardPath,
-        'User1',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        joined.participantId,
-      );
+      // Reconnect: a NEW connection authenticated as the same userId resolves
+      // to the same participantId server-side.
+      await roomManager.registerClient('client-1b', 'User1', 'user-A');
+      const rejoined = await roomManager.joinSession('client-1b', sessionId, boardPath, 'User1');
 
       expect(rejoined.participantWasReconnecting).toBe(true);
       expect(rejoined.participantId).toBe(joined.participantId);
@@ -264,30 +292,12 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
       const sessionId = uuidv4();
       const boardPath = '/kilter/1/2/3/40';
 
-      await roomManager.registerClient('leader-conn', 'Leader');
-      const leader = await roomManager.joinSession(
-        'leader-conn',
-        sessionId,
-        boardPath,
-        'Leader',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        'leader-participant-id',
-      );
-      await roomManager.registerClient('member-conn', 'Member');
-      const member = await roomManager.joinSession(
-        'member-conn',
-        sessionId,
-        boardPath,
-        'Member',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        'member-participant-id',
-      );
+      // Authenticated users: participantId is bound to userId server-side.
+      // Client-supplied participantId is ignored (P1 security fix).
+      await roomManager.registerClient('leader-conn', 'Leader', 'leader-participant-id');
+      const leader = await roomManager.joinSession('leader-conn', sessionId, boardPath, 'Leader');
+      await roomManager.registerClient('member-conn', 'Member', 'member-participant-id');
+      const member = await roomManager.joinSession('member-conn', sessionId, boardPath, 'Member');
 
       expect(leader.participantId).toBe('leader-participant-id');
       expect(member.participantId).toBe('member-participant-id');
@@ -302,30 +312,10 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
       const sessionId = uuidv4();
       const boardPath = '/kilter/1/2/3/40';
 
-      await roomManager.registerClient('leader-conn', 'Leader');
-      await roomManager.joinSession(
-        'leader-conn',
-        sessionId,
-        boardPath,
-        'Leader',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        'leader-participant-id',
-      );
-      await roomManager.registerClient('member-conn', 'Member');
-      await roomManager.joinSession(
-        'member-conn',
-        sessionId,
-        boardPath,
-        'Member',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        'member-participant-id',
-      );
+      await roomManager.registerClient('leader-conn', 'Leader', 'leader-participant-id');
+      await roomManager.joinSession('leader-conn', sessionId, boardPath, 'Leader');
+      await roomManager.registerClient('member-conn', 'Member', 'member-participant-id');
+      await roomManager.joinSession('member-conn', sessionId, boardPath, 'Member');
 
       const leaveResult = await roomManager.leaveSession('leader-conn');
 

--- a/packages/backend/src/__tests__/tiktok-meta.test.ts
+++ b/packages/backend/src/__tests__/tiktok-meta.test.ts
@@ -241,7 +241,7 @@ describe('fetchTikTokMeta', () => {
     const dateSpy = vi.spyOn(Date, 'now');
     dateSpy.mockReturnValue(0);
 
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     for (let i = 0; i < 10; i++) {
       const url = `https://www.tiktok.com/@user/video/${String(i).padStart(19, '0')}`;

--- a/packages/backend/src/graphql/context.ts
+++ b/packages/backend/src/graphql/context.ts
@@ -25,6 +25,7 @@ export function createContext(
   const id = connectionId || uuidv4();
   const context: ConnectionContext = {
     connectionId: id,
+    transport: 'ws',
     sessionId: undefined,
     userId: userId,
     isAuthenticated: isAuthenticated || false,

--- a/packages/backend/src/graphql/context.ts
+++ b/packages/backend/src/graphql/context.ts
@@ -64,17 +64,20 @@ export function updateContext(connectionId: string, updates: Partial<Omit<Connec
 
   if (DEBUG) {
     console.info(
-      `[Context] updateContext: ${connectionId} -> sessionId=${updates.sessionId}, userId=${updates.userId}`,
+      `[Context] updateContext: ${connectionId} -> sessionId=${updates.sessionId}, participantId=${updates.participantId}, userId=${updates.userId}`,
     );
   }
 
-  if (updates.sessionId !== undefined) {
+  if (Object.prototype.hasOwnProperty.call(updates, 'sessionId')) {
     context.sessionId = updates.sessionId;
   }
-  if (updates.userId !== undefined) {
+  if (Object.prototype.hasOwnProperty.call(updates, 'participantId')) {
+    context.participantId = updates.participantId;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'userId')) {
     context.userId = updates.userId;
   }
-  if (updates.isAuthenticated !== undefined) {
+  if (Object.prototype.hasOwnProperty.call(updates, 'isAuthenticated')) {
     context.isAuthenticated = updates.isAuthenticated;
   }
 }

--- a/packages/backend/src/graphql/resolvers/controller/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/controller/mutations.ts
@@ -190,6 +190,7 @@ export const controllerMutations = {
       pubsub.publishQueueEvent(sessionId, {
         __typename: 'CurrentClimbChanged',
         sequence: currentState.sequence,
+        stateHash: currentState.stateHash,
         item: null, // No queue item for unknown climb
         clientId: clientIdForEvent, // ESP32 compares this with its MAC
         correlationId: null,
@@ -238,17 +239,20 @@ export const controllerMutations = {
         ? [...currentState.queue, queueItem]
         : [...currentState.queue.slice(0, currentIndex + 1), queueItem, ...currentState.queue.slice(currentIndex + 1)];
 
-    // Calculate the position where the item was inserted
-    const insertPosition = currentIndex === -1 ? currentState.queue.length : currentIndex + 1;
+    const { sequence, stateHash } = await roomManager.updateQueueState(sessionId, updatedQueue, queueItem);
 
-    const { sequence } = await roomManager.updateQueueState(sessionId, updatedQueue, queueItem);
-
-    // Publish QueueItemAdded event for the new item
+    // Publish a FullSync for clients because one mutation changed both queue
+    // membership and current climb. The controller-specific CurrentClimbChanged
+    // follows so ESP32 clients still receive the originating clientId.
     pubsub.publishQueueEvent(sessionId, {
-      __typename: 'QueueItemAdded',
+      __typename: 'FullSync',
       sequence,
-      item: queueItem,
-      position: insertPosition,
+      state: {
+        sequence,
+        stateHash,
+        queue: updatedQueue,
+        currentClimbQueueItem: queueItem,
+      },
     });
 
     // Publish CurrentClimbChanged event with controllerMac as clientId
@@ -258,6 +262,7 @@ export const controllerMutations = {
     pubsub.publishQueueEvent(sessionId, {
       __typename: 'CurrentClimbChanged',
       sequence,
+      stateHash,
       item: queueItem,
       clientId: matchClientId,
       correlationId: null,
@@ -382,12 +387,13 @@ export const controllerMutations = {
         );
 
         // Update queue state
-        const { sequence } = await roomManager.updateQueueState(sessionId, queue, newCurrentClimb);
+        const { sequence, stateHash } = await roomManager.updateQueueState(sessionId, queue, newCurrentClimb);
 
         // Publish CurrentClimbChanged event
         pubsub.publishQueueEvent(sessionId, {
           __typename: 'CurrentClimbChanged',
           sequence,
+          stateHash,
           item: newCurrentClimb,
           clientId: null,
           correlationId: null,
@@ -446,7 +452,7 @@ export const controllerMutations = {
     console.info(`[Controller] Queue has ${queue.length} items, updating current to index ${targetIndex}`);
 
     // Update queue state (keep the same queue, just change current climb)
-    const { sequence } = await roomManager.updateQueueState(sessionId, queue, newCurrentClimb);
+    const { sequence, stateHash } = await roomManager.updateQueueState(sessionId, queue, newCurrentClimb);
 
     // Publish CurrentClimbChanged event WITHOUT clientId
     // Unlike setClimbFromLedPositions (where we skip because ESP32 already has LEDs from BLE),
@@ -454,6 +460,7 @@ export const controllerMutations = {
     pubsub.publishQueueEvent(sessionId, {
       __typename: 'CurrentClimbChanged',
       sequence,
+      stateHash,
       item: newCurrentClimb,
       clientId: null, // Don't skip - ESP32 needs the new climb data
       correlationId: null,

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -47,6 +47,7 @@ export const queueMutations = {
     let originalQueueLength = 0;
     let itemWasAdded = false;
     let resultSequence = 0;
+    let resultStateHash = '';
 
     // Retry loop for optimistic locking
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
@@ -80,6 +81,7 @@ export const queueMutations = {
         const result = await roomManager.updateQueueOnly(sessionId, queue, currentState.version);
         itemWasAdded = true;
         resultSequence = result.sequence;
+        resultStateHash = result.stateHash;
         break; // Success, exit retry loop
       } catch (error) {
         if (error instanceof VersionConflictError && attempt < MAX_RETRIES - 1) {
@@ -101,6 +103,7 @@ export const queueMutations = {
       pubsub.publishQueueEvent(sessionId, {
         __typename: 'QueueItemAdded',
         sequence: resultSequence,
+        stateHash: resultStateHash,
         item: item,
         position: actualPosition,
       });
@@ -133,11 +136,12 @@ export const queueMutations = {
       currentClimb = null;
     }
 
-    const { sequence } = await roomManager.updateQueueState(sessionId, queue, currentClimb);
+    const { sequence, stateHash } = await roomManager.updateQueueState(sessionId, queue, currentClimb);
 
     pubsub.publishQueueEvent(sessionId, {
       __typename: 'QueueItemRemoved',
       sequence,
+      stateHash,
       uuid,
     });
 
@@ -171,6 +175,7 @@ export const queueMutations = {
     }
 
     let resultSequence = currentState.sequence;
+    let resultStateHash = currentState.stateHash;
 
     if (oldIndex >= 0 && oldIndex < queue.length && newIndex >= 0 && newIndex < queue.length) {
       const [movedItem] = queue.splice(oldIndex, 1);
@@ -178,11 +183,13 @@ export const queueMutations = {
       // Use updateQueueOnly to avoid overwriting currentClimbQueueItem
       const result = await roomManager.updateQueueOnly(sessionId, queue);
       resultSequence = result.sequence;
+      resultStateHash = result.stateHash;
     }
 
     pubsub.publishQueueEvent(sessionId, {
       __typename: 'QueueReordered',
       sequence: resultSequence,
+      stateHash: resultStateHash,
       uuid,
       oldIndex,
       newIndex,
@@ -238,18 +245,26 @@ export const queueMutations = {
 
     // Retry loop for optimistic locking
     let sequence = 0;
+    let stateHash = '';
+    let addedToQueue = false;
+    let updatedQueue: ClimbQueueItem[] = [];
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
       const currentState = await roomManager.getQueueState(sessionId);
       let queue = currentState.queue;
+      let addedInThisAttempt = false;
 
       // Optionally add to queue if not already present
       if (shouldAddToQueue && item && !queue.some((i) => i.uuid === item.uuid)) {
         queue = [...queue, item];
+        addedInThisAttempt = true;
       }
 
       try {
         const result = await roomManager.updateQueueState(sessionId, queue, item, currentState.version);
         sequence = result.sequence;
+        stateHash = result.stateHash;
+        updatedQueue = queue;
+        addedToQueue = addedInThisAttempt;
         break; // Success, exit retry loop
       } catch (error) {
         if (error instanceof VersionConflictError && attempt < MAX_RETRIES - 1) {
@@ -261,13 +276,27 @@ export const queueMutations = {
       }
     }
 
-    pubsub.publishQueueEvent(sessionId, {
-      __typename: 'CurrentClimbChanged',
-      sequence,
-      item: item,
-      clientId: ctx.connectionId || null,
-      correlationId: correlationId || null,
-    });
+    if (addedToQueue) {
+      pubsub.publishQueueEvent(sessionId, {
+        __typename: 'FullSync',
+        sequence,
+        state: {
+          sequence,
+          stateHash,
+          queue: updatedQueue,
+          currentClimbQueueItem: item,
+        },
+      });
+    } else {
+      pubsub.publishQueueEvent(sessionId, {
+        __typename: 'CurrentClimbChanged',
+        sequence,
+        stateHash,
+        item: item,
+        clientId: ctx.connectionId || null,
+        correlationId: correlationId || null,
+      });
+    }
 
     logMutationMetrics('setCurrentClimb', performance.now() - startTime, sessionId, {
       shouldAddToQueue: !!shouldAddToQueue,
@@ -287,6 +316,8 @@ export const queueMutations = {
     const currentState = await roomManager.getQueueState(sessionId);
     let currentClimb = currentState.currentClimbQueueItem;
     let sequence = currentState.sequence;
+    let stateHash = currentState.stateHash;
+    const mirroredUuid = currentClimb?.uuid ?? null;
 
     if (currentClimb) {
       // Update the mirrored state
@@ -302,11 +333,14 @@ export const queueMutations = {
 
       const result = await roomManager.updateQueueState(sessionId, queue, currentClimb);
       sequence = result.sequence;
+      stateHash = result.stateHash;
     }
 
     pubsub.publishQueueEvent(sessionId, {
       __typename: 'ClimbMirrored',
       sequence,
+      stateHash,
+      uuid: mirroredUuid,
       mirrored,
     });
 

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -362,6 +362,14 @@ export const sessionMutations = {
   endSession: async (_: unknown, { sessionId }: { sessionId: string }, ctx: ConnectionContext) => {
     await applyRateLimit(ctx, 5);
     validateInput(SessionIdSchema, sessionId, 'sessionId');
+    // Ending a session is destructive (terminates every subscriber, generates
+    // a summary row, marks the session ended in Postgres). The pre-#2128 code
+    // required authentication unconditionally; the reland accidentally
+    // narrowed the auth check to the HTTP branch only, which would let an
+    // anonymous WS member who is the current leader destroy the session.
+    // Restore the unconditional requirement so the WS branch's
+    // membership-and-leadership check is gated on an authenticated principal.
+    requireAuthenticated(ctx);
 
     const sessionData = await roomManager.getSessionById(sessionId);
     if (!sessionData) {
@@ -369,7 +377,6 @@ export const sessionMutations = {
     }
 
     if (ctx.transport === 'http') {
-      requireAuthenticated(ctx);
       if (!sessionData.createdByUserId || sessionData.createdByUserId !== ctx.userId) {
         throw new Error('Only the session creator can end this session over HTTP');
       }

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -234,7 +234,7 @@ export const sessionMutations = {
 
     // For HTTP requests (stateless), skip joining the session in-memory.
     // The creator will join via WebSocket when they navigate to the board page.
-    const isHttpRequest = ctx.connectionId.startsWith('http-');
+    const isHttpRequest = ctx.transport === 'http';
 
     if (!isHttpRequest) {
       // WebSocket path: join the session as the creator.
@@ -361,7 +361,7 @@ export const sessionMutations = {
       throw new Error('Session not found');
     }
 
-    if (ctx.connectionId.startsWith('http-')) {
+    if (ctx.transport === 'http') {
       requireAuthenticated(ctx);
       if (!sessionData.createdByUserId || sessionData.createdByUserId !== ctx.userId) {
         throw new Error('Only the session creator can end this session over HTTP');
@@ -369,12 +369,20 @@ export const sessionMutations = {
     } else {
       await requireSessionMember(ctx, sessionId);
       const sessionUsers = await roomManager.getSessionUsers(sessionId);
+      // Prefer authenticated identity for actor lookup. ctx.connectionId is a
+      // last-ditch fallback only — it will never match SessionUser.id since
+      // those are participantIds — so when actor ends up undefined here, log
+      // the inputs we tried so the misleading "Only the session creator or
+      // current leader" error has a paper trail to debug.
       const actorId = ctx.participantId || ctx.userId || ctx.connectionId;
       const actor = sessionUsers.find(
         (user) => user.id === actorId || (ctx.userId ? user.userId === ctx.userId : false),
       );
       const isCreator = !!ctx.userId && sessionData.createdByUserId === ctx.userId;
       if (!isCreator && !actor?.isLeader) {
+        console.warn(
+          `[endSession] actor lookup failed for session ${sessionId.slice(0, 8)}: connectionId=${ctx.connectionId.slice(0, 8)}, participantId=${ctx.participantId?.slice(0, 8) ?? 'none'}, userId=${ctx.userId?.slice(0, 8) ?? 'none'}, isAuthenticated=${ctx.isAuthenticated}, members=${sessionUsers.length}`,
+        );
         throw new Error('Only the session creator or current leader can end this session');
       }
     }

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -3,9 +3,10 @@ import type { ConnectionContext, SessionEvent, ClimbQueueItem } from '@boardsesh
 import { roomManager } from '../../../services/room-manager';
 import { pubsub } from '../../../pubsub/index';
 import { updateContext } from '../../context';
-import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
+import { requireAuthenticated, requireSessionMember, applyRateLimit, validateInput } from '../shared/helpers';
 import {
   SessionIdSchema,
+  ParticipantIdSchema,
   BoardPathSchema,
   UsernameSchema,
   AvatarUrlSchema,
@@ -59,6 +60,7 @@ export const sessionMutations = {
       boardPath,
       username,
       avatarUrl,
+      participantId,
       initialQueue,
       initialCurrentClimb,
       sessionName,
@@ -67,6 +69,7 @@ export const sessionMutations = {
       boardPath: string;
       username?: string;
       avatarUrl?: string;
+      participantId?: string;
       initialQueue?: ClimbQueueItem[];
       initialCurrentClimb?: ClimbQueueItem;
       sessionName?: string;
@@ -85,6 +88,7 @@ export const sessionMutations = {
     validateInput(BoardPathSchema, boardPath, 'boardPath');
     if (username) validateInput(UsernameSchema, username, 'username');
     if (avatarUrl) validateInput(AvatarUrlSchema, avatarUrl, 'avatarUrl');
+    if (participantId) validateInput(ParticipantIdSchema, participantId, 'participantId');
     if (sessionName) validateInput(SessionNameSchema, sessionName, 'sessionName');
     if (initialQueue) validateInput(QueueArraySchema, initialQueue, 'initialQueue');
     if (initialCurrentClimb) validateInput(ClimbQueueItemSchema, initialCurrentClimb, 'initialCurrentClimb');
@@ -98,6 +102,7 @@ export const sessionMutations = {
       initialQueue,
       initialCurrentClimb || null,
       sessionName || undefined,
+      participantId || undefined,
     );
     if (DEBUG)
       console.info(
@@ -112,7 +117,7 @@ export const sessionMutations = {
     // clobber the real UUID for every downstream resolver on this connection
     // (ESP32 auto-authorize, tick inserts, climb ownership, etc.).
     if (DEBUG) console.info(`[joinSession] Before updateContext - ctx.sessionId: ${ctx.sessionId}`);
-    updateContext(ctx.connectionId, { sessionId });
+    updateContext(ctx.connectionId, { sessionId, participantId: result.participantId });
     if (DEBUG) console.info(`[joinSession] After updateContext - ctx.sessionId: ${ctx.sessionId}`);
 
     // Auto-authorize user's ESP32 controllers for this session (if authenticated)
@@ -126,17 +131,19 @@ export const sessionMutations = {
       });
     }
 
-    // Notify session about new user
-    const userJoinedEvent: SessionEvent = {
-      __typename: 'UserJoined',
-      user: {
-        id: result.clientId,
-        username: username || `User-${result.clientId.substring(0, 6)}`,
-        isLeader: result.isLeader,
-        avatarUrl: avatarUrl,
-      },
+    // Notify session about new or reconnected participant
+    const sessionUser = result.users.find((user) => user.id === result.participantId) ?? {
+      id: result.participantId,
+      username: username || `User-${result.participantId.substring(0, 6)}`,
+      isLeader: result.isLeader,
+      avatarUrl: avatarUrl,
+      userId: ctx.isAuthenticated ? ctx.userId : null,
+      connectionState: 'CONNECTED' as const,
     };
-    pubsub.publishSessionEvent(sessionId, userJoinedEvent);
+    const sessionEvent: SessionEvent = result.participantWasReconnecting
+      ? { __typename: 'UserPresenceChanged', user: sessionUser }
+      : { __typename: 'UserJoined', user: sessionUser };
+    pubsub.publishSessionEvent(sessionId, sessionEvent);
 
     // Fetch session data for new fields
     const sessionData = await roomManager.getSessionById(sessionId);
@@ -246,7 +253,7 @@ export const sessionMutations = {
       if (DEBUG)
         console.info(`[createSession] Joined session - clientId: ${result.clientId}, isLeader: ${result.isLeader}`);
 
-      updateContext(ctx.connectionId, { sessionId });
+      updateContext(ctx.connectionId, { sessionId, participantId: result.participantId });
 
       // Adopt recent solo ticks now that the session row exists in board_sessions
       // (boardsesh_ticks.session_id is a FK to board_sessions.id)
@@ -310,31 +317,31 @@ export const sessionMutations = {
     if (!ctx.sessionId) return false;
 
     const sessionId = ctx.sessionId;
+    const participantId = ctx.participantId;
     const result = await roomManager.leaveSession(ctx.connectionId);
 
     if (result) {
-      // Notify session about user leaving. UserLeft.userId is the
-      // connection ID (matching UserJoined.user.id = result.clientId).
-      // See websocket/setup.ts onDisconnect for the same pattern.
+      // Notify session about the stable participant leaving. The schema field
+      // is named `userId` for historical reasons, but current clients compare
+      // it with `SessionUser.id`, which is the stable participant ID.
       pubsub.publishSessionEvent(sessionId, {
         __typename: 'UserLeft',
-        userId: ctx.connectionId,
+        userId: result.participantId || participantId || ctx.connectionId,
       });
 
       // Notify about new leader if changed
       if (result.newLeaderId) {
         pubsub.publishSessionEvent(sessionId, {
           __typename: 'LeaderChanged',
-          leaderId: result.newLeaderId,
+          leaderId: result.newLeaderParticipantId || result.newLeaderId,
+          leaderConnectionId: result.newLeaderId,
         });
       }
 
-      // Only clear sessionId — leave userId alone. Auth set it to the
-      // real user UUID at connection time and downstream resolvers on
-      // this same WebSocket (queries from other tabs, social actions,
-      // etc.) still need it. Mirrors the joinSession / createSession fix
-      // earlier in this file.
-      updateContext(ctx.connectionId, { sessionId: undefined });
+      // Only clear session/participant state. Auth set userId to the real
+      // UUID at connection time and downstream resolvers on this same
+      // WebSocket still need it.
+      updateContext(ctx.connectionId, { sessionId: undefined, participantId: undefined });
     }
 
     return true;
@@ -342,26 +349,34 @@ export const sessionMutations = {
 
   /**
    * End a session explicitly.
-   * Validates the caller is the session creator or leader.
+   * Validates the caller is the creator or current leader.
    * Returns a session summary with stats, or null if no ticks.
    */
   endSession: async (_: unknown, { sessionId }: { sessionId: string }, ctx: ConnectionContext) => {
     await applyRateLimit(ctx, 5);
-    requireAuthenticated(ctx);
     validateInput(SessionIdSchema, sessionId, 'sessionId');
 
-    // Verify caller is session creator or leader
     const sessionData = await roomManager.getSessionById(sessionId);
     if (!sessionData) {
       throw new Error('Session not found');
     }
 
-    const isCreator = sessionData.createdByUserId === ctx.userId;
-    const client = roomManager.getClient(ctx.connectionId);
-    const isLeader = client?.isLeader ?? false;
-
-    if (!isCreator && !isLeader) {
-      throw new Error('Only the session creator or leader can end a session');
+    if (ctx.connectionId.startsWith('http-')) {
+      requireAuthenticated(ctx);
+      if (!sessionData.createdByUserId || sessionData.createdByUserId !== ctx.userId) {
+        throw new Error('Only the session creator can end this session over HTTP');
+      }
+    } else {
+      await requireSessionMember(ctx, sessionId);
+      const sessionUsers = await roomManager.getSessionUsers(sessionId);
+      const actorId = ctx.participantId || ctx.userId || ctx.connectionId;
+      const actor = sessionUsers.find(
+        (user) => user.id === actorId || (ctx.userId ? user.userId === ctx.userId : false),
+      );
+      const isCreator = !!ctx.userId && sessionData.createdByUserId === ctx.userId;
+      if (!isCreator && !actor?.isLeader) {
+        throw new Error('Only the session creator or current leader can end this session');
+      }
     }
 
     // End the session via room manager
@@ -370,7 +385,7 @@ export const sessionMutations = {
     // Publish SessionEnded event so all connected clients are notified
     const sessionEndedEvent: SessionEvent = {
       __typename: 'SessionEnded',
-      reason: 'Session ended by leader',
+      reason: 'Session ended by participant',
     };
     pubsub.publishSessionEvent(sessionId, sessionEndedEvent);
 
@@ -401,10 +416,12 @@ export const sessionMutations = {
         pubsub.publishSessionEvent(ctx.sessionId, {
           __typename: 'UserJoined',
           user: {
-            id: client.connectionId,
+            id: client.participantId || client.connectionId,
             username,
             isLeader: client.isLeader,
             avatarUrl: client.avatarUrl,
+            userId: client.userId,
+            connectionState: 'CONNECTED',
           },
         });
       }

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -324,10 +324,17 @@ export const sessionMutations = {
       // Notify session about the stable participant leaving. The schema field
       // is named `userId` for historical reasons, but current clients compare
       // it with `SessionUser.id`, which is the stable participant ID.
-      pubsub.publishSessionEvent(sessionId, {
-        __typename: 'UserLeft',
-        userId: result.participantId || participantId || ctx.connectionId,
-      });
+      //
+      // Only fire UserLeft when the participant's last connection just left.
+      // If the user has another tab open in the same session (authenticated
+      // users share one participantId across tabs), suppress the broadcast —
+      // peers should keep seeing the participant.
+      if (result.participantFullyLeft) {
+        pubsub.publishSessionEvent(sessionId, {
+          __typename: 'UserLeft',
+          userId: result.participantId || participantId || ctx.connectionId,
+        });
+      }
 
       // Notify about new leader if changed
       if (result.newLeaderId) {

--- a/packages/backend/src/graphql/yoga.ts
+++ b/packages/backend/src/graphql/yoga.ts
@@ -40,6 +40,7 @@ export function createYogaInstance() {
         if (authResult) {
           return {
             connectionId: `http-${uuidv4()}`,
+            transport: 'http' as const,
             sessionId: undefined,
             userId: authResult.userId,
             isAuthenticated: true,
@@ -50,6 +51,7 @@ export function createYogaInstance() {
 
       return {
         connectionId: `http-${uuidv4()}`,
+        transport: 'http' as const,
         sessionId: undefined,
         userId: undefined,
         isAuthenticated: false,

--- a/packages/backend/src/services/distributed-state/connection-ops.ts
+++ b/packages/backend/src/services/distributed-state/connection-ops.ts
@@ -131,7 +131,11 @@ export async function removeConnection(
   return { sessionId, participantId, wasLeader, newLeaderId, remainingParticipantConnections };
 }
 
-async function countLiveParticipantConnections(redis: Redis, sessionId: string, participantId: string): Promise<number> {
+async function countLiveParticipantConnections(
+  redis: Redis,
+  sessionId: string,
+  participantId: string,
+): Promise<number> {
   const key = KEYS.participantConnections(sessionId, participantId);
   const connectionIds = await redis.smembers(key);
   if (connectionIds.length === 0) {

--- a/packages/backend/src/services/distributed-state/connection-ops.ts
+++ b/packages/backend/src/services/distributed-state/connection-ops.ts
@@ -26,6 +26,7 @@ export async function registerConnection(
     connectionId,
     instanceId,
     sessionId: null,
+    participantId: null,
     userId: userId || null,
     username,
     avatarUrl: avatarUrl || null,
@@ -71,16 +72,29 @@ export async function removeConnection(
   instanceId: string,
   connectionId: string,
   electNewLeader: boolean = true,
-): Promise<{ sessionId: string | null; wasLeader: boolean; newLeaderId: string | null }> {
+): Promise<{
+  sessionId: string | null;
+  participantId: string | null;
+  wasLeader: boolean;
+  newLeaderId: string | null;
+  remainingParticipantConnections: number | null;
+}> {
   validateConnectionId(connectionId);
 
   // Get current connection state
   const connection = await getConnection(redis, connectionId);
   if (!connection) {
-    return { sessionId: null, wasLeader: false, newLeaderId: null };
+    return {
+      sessionId: null,
+      participantId: null,
+      wasLeader: false,
+      newLeaderId: null,
+      remainingParticipantConnections: null,
+    };
   }
 
   const sessionId = connection.sessionId;
+  const participantId = connection.participantId;
   const wasLeader = connection.isLeader;
 
   const multi = redis.multi();
@@ -95,10 +109,18 @@ export async function removeConnection(
   if (sessionId) {
     multi.srem(KEYS.sessionMembers(sessionId), connectionId);
   }
+  if (sessionId && participantId) {
+    multi.srem(KEYS.participantConnections(sessionId, participantId), connectionId);
+  }
 
   await multi.exec();
 
   console.info(`[DistributedState] Removed connection: ${connectionId.slice(0, 8)}`);
+
+  let remainingParticipantConnections: number | null = null;
+  if (sessionId && participantId) {
+    remainingParticipantConnections = await countLiveParticipantConnections(redis, sessionId, participantId);
+  }
 
   // Automatically elect new leader if was leader and requested
   let newLeaderId: string | null = null;
@@ -106,7 +128,40 @@ export async function removeConnection(
     newLeaderId = await electLeaderAfterRemoval(redis, sessionId, connectionId);
   }
 
-  return { sessionId, wasLeader, newLeaderId };
+  return { sessionId, participantId, wasLeader, newLeaderId, remainingParticipantConnections };
+}
+
+async function countLiveParticipantConnections(redis: Redis, sessionId: string, participantId: string): Promise<number> {
+  const key = KEYS.participantConnections(sessionId, participantId);
+  const connectionIds = await redis.smembers(key);
+  if (connectionIds.length === 0) {
+    return 0;
+  }
+
+  const pipeline = redis.pipeline();
+  for (const id of connectionIds) {
+    pipeline.exists(KEYS.connection(id));
+  }
+  const results = await pipeline.exec();
+
+  let live = 0;
+  const staleIds: string[] = [];
+  if (results) {
+    for (let i = 0; i < results.length; i++) {
+      const [err, exists] = results[i] as [Error | null, number];
+      if (!err && exists === 1) {
+        live++;
+      } else if (!err) {
+        staleIds.push(connectionIds[i]);
+      }
+    }
+  }
+
+  if (staleIds.length > 0) {
+    await redis.srem(key, ...staleIds).catch(() => {});
+  }
+
+  return live;
 }
 
 /**

--- a/packages/backend/src/services/distributed-state/constants.ts
+++ b/packages/backend/src/services/distributed-state/constants.ts
@@ -5,11 +5,22 @@ export type DistributedConnection = {
   connectionId: string;
   instanceId: string;
   sessionId: string | null;
+  participantId: string | null;
   userId: string | null;
   username: string;
   avatarUrl: string | null;
   isLeader: boolean;
   connectedAt: number; // Unix timestamp ms
+};
+
+export type DistributedParticipant = {
+  participantId: string;
+  sessionId: string;
+  userId: string | null;
+  username: string;
+  avatarUrl: string | null;
+  connectionState: 'CONNECTED' | 'RECONNECTING';
+  lastSeenAt: number;
 };
 
 /**
@@ -20,6 +31,13 @@ export const KEYS = {
   connection: (connectionId: string) => `boardsesh:conn:${connectionId}`,
   // Set: sessionId -> set of connectionIds
   sessionMembers: (sessionId: string) => `boardsesh:session:${sessionId}:members`,
+  // Set: sessionId -> set of stable participantIds
+  sessionParticipants: (sessionId: string) => `boardsesh:session:${sessionId}:participants`,
+  // Hash: sessionId + participantId -> participant presence data
+  participant: (sessionId: string, participantId: string) => `boardsesh:participant:${sessionId}:${participantId}`,
+  // Set: sessionId + participantId -> live connectionIds for that participant
+  participantConnections: (sessionId: string, participantId: string) =>
+    `boardsesh:participant:${sessionId}:${participantId}:connections`,
   // String: sessionId -> connectionId of leader
   sessionLeader: (sessionId: string) => `boardsesh:session:${sessionId}:leader`,
   // Set: instanceId -> set of connectionIds owned by this instance
@@ -61,6 +79,12 @@ export function validateSessionId(sessionId: string): void {
   }
 }
 
+export function validateParticipantId(participantId: string): void {
+  if (!participantId || participantId.length > 128 || !/^[a-zA-Z0-9_-]+$/.test(participantId)) {
+    throw new Error(`Invalid participantId format: ${participantId.slice(0, 20)}`);
+  }
+}
+
 /**
  * Convert connection object to Redis hash fields.
  */
@@ -69,6 +93,7 @@ export function connectionToHash(conn: DistributedConnection): Record<string, st
     connectionId: conn.connectionId,
     instanceId: conn.instanceId,
     sessionId: conn.sessionId || '',
+    participantId: conn.participantId || '',
     userId: conn.userId || '',
     username: conn.username,
     avatarUrl: conn.avatarUrl || '',
@@ -86,6 +111,7 @@ export function hashToConnection(hash: Record<string, string>): DistributedConne
   // Empty string in Redis means "not set" - convert to null for consistency
   // This matches the pattern: null -> '' (storage) -> null (retrieval)
   const sessionId = hash.sessionId && hash.sessionId !== '' ? hash.sessionId : null;
+  const participantId = hash.participantId && hash.participantId !== '' ? hash.participantId : null;
   const userId = hash.userId && hash.userId !== '' ? hash.userId : null;
   const avatarUrl = hash.avatarUrl && hash.avatarUrl !== '' ? hash.avatarUrl : null;
 
@@ -102,6 +128,7 @@ export function hashToConnection(hash: Record<string, string>): DistributedConne
     connectionId: hash.connectionId,
     instanceId: hash.instanceId,
     sessionId,
+    participantId,
     userId,
     username: hash.username,
     avatarUrl,

--- a/packages/backend/src/services/distributed-state/distributed-state.ts
+++ b/packages/backend/src/services/distributed-state/distributed-state.ts
@@ -15,6 +15,8 @@ import {
   hasSessionMembers,
   cleanupStaleSessionMembers,
   cleanupEmptySession,
+  markParticipantPresence,
+  removeParticipant,
 } from './session-ops';
 import {
   updateHeartbeat,
@@ -112,7 +114,13 @@ export class DistributedStateManager {
   async removeConnection(
     connectionId: string,
     electNewLeader: boolean = true,
-  ): Promise<{ sessionId: string | null; wasLeader: boolean; newLeaderId: string | null }> {
+  ): Promise<{
+    sessionId: string | null;
+    participantId: string | null;
+    wasLeader: boolean;
+    newLeaderId: string | null;
+    remainingParticipantConnections: number | null;
+  }> {
     return removeConnection(this.redis, this.instanceId, connectionId, electNewLeader);
   }
 
@@ -132,8 +140,9 @@ export class DistributedStateManager {
     sessionId: string,
     username?: string,
     avatarUrl?: string | null,
+    participantId?: string | null,
   ): Promise<{ isLeader: boolean }> {
-    return joinSession(this.redis, connectionId, sessionId, username, avatarUrl);
+    return joinSession(this.redis, connectionId, sessionId, username, avatarUrl, participantId);
   }
 
   /** Leave a session. Handles leader election if leaving member was leader. */
@@ -198,6 +207,20 @@ export class DistributedStateManager {
   /** Clean up session state when it becomes empty. */
   async cleanupEmptySession(sessionId: string): Promise<void> {
     return cleanupEmptySession(this.redis, sessionId);
+  }
+
+  /** Mark a stable participant as connected/reconnecting. */
+  async markParticipantPresence(
+    sessionId: string,
+    participantId: string,
+    connectionState: 'CONNECTED' | 'RECONNECTING',
+  ): Promise<SessionUser | null> {
+    return markParticipantPresence(this.redis, sessionId, participantId, connectionState);
+  }
+
+  /** Remove a stable participant from a session. */
+  async removeParticipant(sessionId: string, participantId: string): Promise<void> {
+    return removeParticipant(this.redis, sessionId, participantId);
   }
 
   /**

--- a/packages/backend/src/services/distributed-state/distributed-state.ts
+++ b/packages/backend/src/services/distributed-state/distributed-state.ts
@@ -17,6 +17,7 @@ import {
   cleanupEmptySession,
   markParticipantPresence,
   removeParticipant,
+  removeParticipantConnection,
 } from './session-ops';
 import {
   updateHeartbeat,
@@ -221,6 +222,16 @@ export class DistributedStateManager {
   /** Remove a stable participant from a session. */
   async removeParticipant(sessionId: string, participantId: string): Promise<void> {
     return removeParticipant(this.redis, sessionId, participantId);
+  }
+
+  /**
+   * Remove a single connection from a participant's connection set. If that was
+   * the participant's last connection, atomically tear down the participant
+   * entry. Used by explicit-leave: clicking "Leave" on one tab must not wipe
+   * the user's other tabs that are still in the session.
+   */
+  async removeParticipantConnection(sessionId: string, participantId: string, connectionId: string): Promise<void> {
+    return removeParticipantConnection(this.redis, sessionId, participantId, connectionId);
   }
 
   /**

--- a/packages/backend/src/services/distributed-state/lua-scripts.ts
+++ b/packages/backend/src/services/distributed-state/lua-scripts.ts
@@ -106,8 +106,14 @@ export const LEAVE_SESSION_SCRIPT = `
   local currentLeader = redis.call('GET', leaderKey)
   local wasLeader = (currentLeader == connectionId)
 
-  -- Update connection state
-  redis.call('HMSET', connKey, 'sessionId', '', 'participantId', '', 'isLeader', 'false')
+  -- Update connection state, but only if the hash still exists. An
+  -- unconditional HMSET would resurrect a deleted connection hash with no
+  -- TTL and no connectionId field, leaving a zombie key that leaks forever.
+  -- A concurrent removeConnection on another instance (e.g. WS disconnect
+  -- racing this leave) may already have deleted it.
+  if redis.call('EXISTS', connKey) == 1 then
+    redis.call('HMSET', connKey, 'sessionId', '', 'participantId', '', 'isLeader', 'false')
+  end
 
   -- Remove from session members
   redis.call('SREM', sessionMembersKey, connectionId)
@@ -175,6 +181,15 @@ export const JOIN_SESSION_SCRIPT = `
   local username = ARGV[5]
   local avatarUrl = ARGV[6]
   local UNSET = '__UNSET__'
+
+  -- Refuse to join if the connection hash has been reaped (TTL, manual DEL,
+  -- or instance cleanup). HSETs on a missing key would resurrect it as a
+  -- partial hash without connectionId / instanceId / connectedAt and (after
+  -- the EXPIRE) with a fresh TTL. Better to fail fast and let the caller
+  -- re-register.
+  if redis.call('EXISTS', connKey) == 0 then
+    return -1
+  end
 
   -- Update connection with session info
   redis.call('HSET', connKey, 'sessionId', sessionId)

--- a/packages/backend/src/services/distributed-state/lua-scripts.ts
+++ b/packages/backend/src/services/distributed-state/lua-scripts.ts
@@ -243,6 +243,39 @@ export const REFRESH_TTL_SCRIPT = `
 `;
 
 /**
+ * Lua script for atomic participant-connection removal.
+ * SREM the connection from the participant's connection set, then either return
+ * the remaining count (if > 0) or atomically clean up the participant record
+ * and remove from session participants. Closing the read-then-delete race in
+ * the prior multi() implementation: a concurrent re-join that re-adds to the
+ * connection set between our SREM and DEL would otherwise be wiped out.
+ * KEYS[1] = participantConnections set key
+ * KEYS[2] = sessionParticipants set key
+ * KEYS[3] = participant hash key
+ * ARGV[1] = connectionId being removed
+ * ARGV[2] = participantId being removed
+ * Returns: remaining connection count after removal (0 means participant cleaned up)
+ */
+export const REMOVE_PARTICIPANT_CONNECTION_SCRIPT = `
+  local participantConnectionsKey = KEYS[1]
+  local sessionParticipantsKey = KEYS[2]
+  local participantKey = KEYS[3]
+  local connectionId = ARGV[1]
+  local participantId = ARGV[2]
+
+  redis.call('SREM', participantConnectionsKey, connectionId)
+  local remaining = redis.call('SCARD', participantConnectionsKey)
+  if remaining > 0 then
+    return remaining
+  end
+
+  redis.call('SREM', sessionParticipantsKey, participantId)
+  redis.call('DEL', participantKey)
+  redis.call('DEL', participantConnectionsKey)
+  return 0
+`;
+
+/**
  * Lua script to prune stale members from a session.
  * For each member in the session set, checks if the connection hash still exists.
  * Removes stale entries, re-elects leader if needed, and cleans up empty sessions.

--- a/packages/backend/src/services/distributed-state/lua-scripts.ts
+++ b/packages/backend/src/services/distributed-state/lua-scripts.ts
@@ -107,7 +107,7 @@ export const LEAVE_SESSION_SCRIPT = `
   local wasLeader = (currentLeader == connectionId)
 
   -- Update connection state
-  redis.call('HMSET', connKey, 'sessionId', '', 'isLeader', 'false')
+  redis.call('HMSET', connKey, 'sessionId', '', 'participantId', '', 'isLeader', 'false')
 
   -- Remove from session members
   redis.call('SREM', sessionMembersKey, connectionId)
@@ -227,6 +227,16 @@ export const REFRESH_TTL_SCRIPT = `
   if sessionId and sessionId ~= '' then
     local sessionMembersKey = 'boardsesh:session:' .. sessionId .. ':members'
     redis.call('EXPIRE', sessionMembersKey, sessionTTL)
+
+    local participantId = redis.call('HGET', connKey, 'participantId')
+    if participantId and participantId ~= '' then
+      local sessionParticipantsKey = 'boardsesh:session:' .. sessionId .. ':participants'
+      local participantKey = 'boardsesh:participant:' .. sessionId .. ':' .. participantId
+      local participantConnectionsKey = 'boardsesh:participant:' .. sessionId .. ':' .. participantId .. ':connections'
+      redis.call('EXPIRE', sessionParticipantsKey, sessionTTL)
+      redis.call('EXPIRE', participantKey, sessionTTL)
+      redis.call('EXPIRE', participantConnectionsKey, sessionTTL)
+    end
   end
 
   return 1

--- a/packages/backend/src/services/distributed-state/lua-scripts.ts
+++ b/packages/backend/src/services/distributed-state/lua-scripts.ts
@@ -258,6 +258,46 @@ export const REFRESH_TTL_SCRIPT = `
 `;
 
 /**
+ * Lua script for atomic full-participant eviction.
+ * Reads the participant's connection set inside the script, then SREMs the
+ * participant from sessionParticipants, deletes the participant + connection
+ * set, and for every connectionId in the snapshot SREMs it from sessionMembers
+ * and clears its connection hash. All in one round-trip, so a concurrent join
+ * adding a fresh connection to participantConnections cannot have its work
+ * silently wiped between our read and our writes.
+ *
+ * The sibling KEYS.connection() keys are still computed inside the script via
+ * string concatenation; this keeps consistency with the rest of the file but
+ * is documented as a Redis-cluster portability concern in issue #2143.
+ * KEYS[1] = sessionParticipants set key
+ * KEYS[2] = participant hash key
+ * KEYS[3] = participantConnections set key
+ * KEYS[4] = sessionMembers set key
+ * ARGV[1] = participantId being evicted
+ * Returns: number of connection slots cleaned up
+ */
+export const REMOVE_PARTICIPANT_SCRIPT = `
+  local sessionParticipantsKey = KEYS[1]
+  local participantKey = KEYS[2]
+  local participantConnectionsKey = KEYS[3]
+  local sessionMembersKey = KEYS[4]
+  local participantId = ARGV[1]
+
+  local connectionIds = redis.call('SMEMBERS', participantConnectionsKey)
+  redis.call('SREM', sessionParticipantsKey, participantId)
+  redis.call('DEL', participantKey)
+  redis.call('DEL', participantConnectionsKey)
+  for _, connectionId in ipairs(connectionIds) do
+    redis.call('SREM', sessionMembersKey, connectionId)
+    local connKey = 'boardsesh:conn:' .. connectionId
+    if redis.call('EXISTS', connKey) == 1 then
+      redis.call('HMSET', connKey, 'sessionId', '', 'participantId', '', 'isLeader', 'false')
+    end
+  end
+  return #connectionIds
+`;
+
+/**
  * Lua script for atomic participant-connection removal.
  * SREM the connection from the participant's connection set, then either return
  * the remaining count (if > 0) or atomically clean up the participant record

--- a/packages/backend/src/services/distributed-state/session-ops.ts
+++ b/packages/backend/src/services/distributed-state/session-ops.ts
@@ -16,6 +16,7 @@ import {
   REFRESH_TTL_SCRIPT,
   PRUNE_STALE_SESSION_MEMBERS_SCRIPT,
   REMOVE_PARTICIPANT_CONNECTION_SCRIPT,
+  REMOVE_PARTICIPANT_SCRIPT,
 } from './lua-scripts';
 
 /**
@@ -466,15 +467,6 @@ export async function markParticipantPresence(
   };
 }
 
-async function getConnectionForParticipantCleanup(
-  redis: Redis,
-  connectionId: string,
-): Promise<ReturnType<typeof hashToConnection> | null> {
-  const data = await redis.hgetall(KEYS.connection(connectionId));
-  if (!data?.connectionId) return null;
-  return hashToConnection(data);
-}
-
 export async function removeParticipantConnection(
   redis: Redis,
   sessionId: string,
@@ -500,16 +492,20 @@ export async function removeParticipantConnection(
 export async function removeParticipant(redis: Redis, sessionId: string, participantId: string): Promise<void> {
   validateSessionId(sessionId);
   validateParticipantId(participantId);
-  const connectionIds = await redis.smembers(KEYS.participantConnections(sessionId, participantId));
-  const multi = redis.multi();
-  multi.srem(KEYS.sessionParticipants(sessionId), participantId);
-  multi.del(KEYS.participant(sessionId, participantId));
-  multi.del(KEYS.participantConnections(sessionId, participantId));
-  for (const connectionId of connectionIds) {
-    multi.srem(KEYS.sessionMembers(sessionId), connectionId);
-    multi.hset(KEYS.connection(connectionId), 'sessionId', '', 'participantId', '', 'isLeader', 'false');
-  }
-  await multi.exec();
+  // Atomic via Lua. The prior `smembers` -> `multi().exec()` sequence had a
+  // race window where a concurrent join (cross-instance, e.g. another tab
+  // reconnecting in the grace window) could insert a fresh connection into
+  // participantConnections between the snapshot and the multi's `del`, and
+  // its participant hash would be wiped after this multi ran.
+  await redis.eval(
+    REMOVE_PARTICIPANT_SCRIPT,
+    4,
+    KEYS.sessionParticipants(sessionId),
+    KEYS.participant(sessionId, participantId),
+    KEYS.participantConnections(sessionId, participantId),
+    KEYS.sessionMembers(sessionId),
+    participantId,
+  );
 }
 
 /**

--- a/packages/backend/src/services/distributed-state/session-ops.ts
+++ b/packages/backend/src/services/distributed-state/session-ops.ts
@@ -15,6 +15,7 @@ import {
   ELECT_NEW_LEADER_SCRIPT,
   REFRESH_TTL_SCRIPT,
   PRUNE_STALE_SESSION_MEMBERS_SCRIPT,
+  REMOVE_PARTICIPANT_CONNECTION_SCRIPT,
 } from './lua-scripts';
 
 /**
@@ -467,18 +468,20 @@ async function removeParticipantConnection(
   participantId: string,
   connectionId: string,
 ): Promise<void> {
-  await redis.srem(KEYS.participantConnections(sessionId, participantId), connectionId);
-  const remainingIds = await redis.smembers(KEYS.participantConnections(sessionId, participantId));
-  if (remainingIds.length > 0) {
-    return;
-  }
-
-  await redis
-    .multi()
-    .srem(KEYS.sessionParticipants(sessionId), participantId)
-    .del(KEYS.participant(sessionId, participantId))
-    .del(KEYS.participantConnections(sessionId, participantId))
-    .exec();
+  // Atomic SREM-then-conditional-cleanup. The previous srem -> smembers ->
+  // multi().exec() sequence had a window where a concurrent re-join could add
+  // a new connection to the set after our smembers read 0, then the multi
+  // would wipe out that fresh participant. The Lua script collapses the read
+  // and delete into a single atomic operation.
+  await redis.eval(
+    REMOVE_PARTICIPANT_CONNECTION_SCRIPT,
+    3,
+    KEYS.participantConnections(sessionId, participantId),
+    KEYS.sessionParticipants(sessionId),
+    KEYS.participant(sessionId, participantId),
+    connectionId,
+    participantId,
+  );
 }
 
 export async function removeParticipant(redis: Redis, sessionId: string, participantId: string): Promise<void> {

--- a/packages/backend/src/services/distributed-state/session-ops.ts
+++ b/packages/backend/src/services/distributed-state/session-ops.ts
@@ -52,6 +52,16 @@ export async function joinSession(
     avatarUrl !== undefined ? avatarUrl || '' : UNSET_SENTINEL,
   )) as number;
 
+  // -1 means the connection hash was reaped between registerClient and join
+  // (TTL expiry, manual cleanup, etc.). The caller has to re-register first;
+  // surfacing a typed error lets graphql-yoga return a transient-join error
+  // that the client's lifecycle hook already knows how to recover from.
+  if (becameLeader === -1) {
+    throw new Error(
+      `[DistributedState] joinSession refused for ${connectionId.slice(0, 8)}: connection hash missing (reaped). Re-register and retry.`,
+    );
+  }
+
   if (becameLeader === 1) {
     console.info(
       `[DistributedState] Connection ${connectionId.slice(0, 8)} became leader of session ${sessionId.slice(0, 8)}`,
@@ -152,8 +162,13 @@ async function leaveSessionFallback(
       const currentLeader = await redis.get(KEYS.sessionLeader(sessionId));
       const wasLeader = currentLeader === connectionId;
 
+      // Mirror the Lua-side guard: only touch the connection hash if it still
+      // exists, otherwise the HMSET would resurrect a zombie key without TTL.
+      const connectionExists = (await redis.exists(KEYS.connection(connectionId))) === 1;
       const multi = redis.multi();
-      multi.hmset(KEYS.connection(connectionId), { sessionId: '', participantId: '', isLeader: 'false' });
+      if (connectionExists) {
+        multi.hmset(KEYS.connection(connectionId), { sessionId: '', participantId: '', isLeader: 'false' });
+      }
       multi.srem(KEYS.sessionMembers(sessionId), connectionId);
       const execResult = await multi.exec();
 
@@ -460,7 +475,7 @@ async function getConnectionForParticipantCleanup(
   return hashToConnection(data);
 }
 
-async function removeParticipantConnection(
+export async function removeParticipantConnection(
   redis: Redis,
   sessionId: string,
   participantId: string,

--- a/packages/backend/src/services/distributed-state/session-ops.ts
+++ b/packages/backend/src/services/distributed-state/session-ops.ts
@@ -98,7 +98,6 @@ export async function leaveSession(
 ): Promise<{ newLeaderId: string | null }> {
   validateConnectionId(connectionId);
   validateSessionId(sessionId);
-  const connection = await getConnectionForParticipantCleanup(redis, connectionId);
 
   try {
     const result = (await redis.eval(
@@ -112,9 +111,12 @@ export async function leaveSession(
       TTL.sessionMembership.toString(),
     )) as string | null;
 
-    if (connection?.participantId) {
-      await removeParticipantConnection(redis, sessionId, connection.participantId, connectionId);
-    }
+    // Participant cleanup intentionally not done here. The explicit-leave
+    // caller in `client-lifecycle.ts` follows this call with
+    // `removeParticipant`, which evicts the whole participant entry
+    // (correct semantics for "user clicked leave" even when they have other
+    // tabs open). Doing connection-level cleanup here too would be redundant
+    // double-work on every explicit leave.
 
     // Result: null = wasn't leader, '' = was leader but no new leader, otherwise = new leader ID
     if (result === null) {
@@ -143,7 +145,6 @@ async function leaveSessionFallback(
   connectionId: string,
   sessionId: string,
 ): Promise<{ newLeaderId: string | null }> {
-  const connection = await getConnectionForParticipantCleanup(redis, connectionId);
   try {
     await redis.watch(KEYS.sessionLeader(sessionId));
 
@@ -191,11 +192,8 @@ async function leaveSessionFallback(
     }
   } catch {
     // Ignore fallback error - self-healing via next join
-  } finally {
-    if (connection?.participantId) {
-      await removeParticipantConnection(redis, sessionId, connection.participantId, connectionId).catch(() => {});
-    }
   }
+  // Participant cleanup intentionally not done here; see leaveSession above.
   return { newLeaderId: null };
 }
 

--- a/packages/backend/src/services/distributed-state/session-ops.ts
+++ b/packages/backend/src/services/distributed-state/session-ops.ts
@@ -1,6 +1,14 @@
 import type Redis from 'ioredis';
-import type { SessionUser } from '@boardsesh/shared-schema';
-import { KEYS, TTL, UNSET_SENTINEL, validateConnectionId, validateSessionId, hashToConnection } from './constants';
+import type { SessionConnectionState, SessionUser } from '@boardsesh/shared-schema';
+import {
+  KEYS,
+  TTL,
+  UNSET_SENTINEL,
+  validateConnectionId,
+  validateParticipantId,
+  validateSessionId,
+  hashToConnection,
+} from './constants';
 import {
   JOIN_SESSION_SCRIPT,
   LEAVE_SESSION_SCRIPT,
@@ -20,9 +28,12 @@ export async function joinSession(
   sessionId: string,
   username?: string,
   avatarUrl?: string | null,
+  participantId?: string | null,
 ): Promise<{ isLeader: boolean }> {
   validateConnectionId(connectionId);
   validateSessionId(sessionId);
+  const resolvedParticipantId = participantId || connectionId;
+  validateParticipantId(resolvedParticipantId);
 
   const becameLeader = (await redis.eval(
     JOIN_SESSION_SCRIPT,
@@ -46,6 +57,31 @@ export async function joinSession(
     );
   }
 
+  const connection = hashToConnection(await redis.hgetall(KEYS.connection(connectionId)));
+  const resolvedUsername = username || connection.username;
+  const resolvedAvatarUrl = avatarUrl !== undefined ? avatarUrl || null : connection.avatarUrl;
+  const now = Date.now().toString();
+
+  const participantKey = KEYS.participant(sessionId, resolvedParticipantId);
+  const participantConnectionsKey = KEYS.participantConnections(sessionId, resolvedParticipantId);
+  const multi = redis.multi();
+  multi.hset(KEYS.connection(connectionId), 'participantId', resolvedParticipantId);
+  multi.sadd(KEYS.sessionParticipants(sessionId), resolvedParticipantId);
+  multi.expire(KEYS.sessionParticipants(sessionId), TTL.sessionMembership);
+  multi.hmset(participantKey, {
+    participantId: resolvedParticipantId,
+    sessionId,
+    userId: connection.userId || '',
+    username: resolvedUsername,
+    avatarUrl: resolvedAvatarUrl || '',
+    connectionState: 'CONNECTED',
+    lastSeenAt: now,
+  });
+  multi.expire(participantKey, TTL.sessionMembership);
+  multi.sadd(participantConnectionsKey, connectionId);
+  multi.expire(participantConnectionsKey, TTL.sessionMembership);
+  await multi.exec();
+
   return { isLeader: becameLeader === 1 };
 }
 
@@ -61,6 +97,7 @@ export async function leaveSession(
 ): Promise<{ newLeaderId: string | null }> {
   validateConnectionId(connectionId);
   validateSessionId(sessionId);
+  const connection = await getConnectionForParticipantCleanup(redis, connectionId);
 
   try {
     const result = (await redis.eval(
@@ -73,6 +110,10 @@ export async function leaveSession(
       TTL.sessionMembership.toString(),
       TTL.sessionMembership.toString(),
     )) as string | null;
+
+    if (connection?.participantId) {
+      await removeParticipantConnection(redis, sessionId, connection.participantId, connectionId);
+    }
 
     // Result: null = wasn't leader, '' = was leader but no new leader, otherwise = new leader ID
     if (result === null) {
@@ -101,6 +142,7 @@ async function leaveSessionFallback(
   connectionId: string,
   sessionId: string,
 ): Promise<{ newLeaderId: string | null }> {
+  const connection = await getConnectionForParticipantCleanup(redis, connectionId);
   try {
     await redis.watch(KEYS.sessionLeader(sessionId));
 
@@ -109,7 +151,7 @@ async function leaveSessionFallback(
       const wasLeader = currentLeader === connectionId;
 
       const multi = redis.multi();
-      multi.hmset(KEYS.connection(connectionId), { sessionId: '', isLeader: 'false' });
+      multi.hmset(KEYS.connection(connectionId), { sessionId: '', participantId: '', isLeader: 'false' });
       multi.srem(KEYS.sessionMembers(sessionId), connectionId);
       const execResult = await multi.exec();
 
@@ -148,6 +190,10 @@ async function leaveSessionFallback(
     }
   } catch {
     // Ignore fallback error - self-healing via next join
+  } finally {
+    if (connection?.participantId) {
+      await removeParticipantConnection(redis, sessionId, connection.participantId, connectionId).catch(() => {});
+    }
   }
   return { newLeaderId: null };
 }
@@ -157,6 +203,17 @@ async function leaveSessionFallback(
  */
 export async function getSessionMembers(redis: Redis, sessionId: string): Promise<SessionUser[]> {
   validateSessionId(sessionId);
+  const memberCleanup = cleanupStaleSessionMembers(redis, sessionId).catch((err) => {
+    console.error(`[DistributedState] Failed to prune stale session members for ${sessionId.slice(0, 8)}:`, err);
+  });
+
+  const participantIds = await redis.smembers(KEYS.sessionParticipants(sessionId));
+  if (participantIds.length > 0) {
+    const users = await getSessionParticipants(redis, sessionId, participantIds);
+    await memberCleanup;
+    return users;
+  }
+
   const memberIds = await redis.smembers(KEYS.sessionMembers(sessionId));
 
   if (memberIds.length === 0) {
@@ -183,6 +240,7 @@ export async function getSessionMembers(redis: Redis, sessionId: string): Promis
           isLeader: connection.isLeader,
           avatarUrl: connection.avatarUrl || undefined,
           userId: connection.userId,
+          connectionState: 'CONNECTED',
         });
       } else if (!err) {
         // Connection hash expired — mark for removal from the session set
@@ -206,6 +264,232 @@ export async function getSessionMembers(redis: Redis, sessionId: string): Promis
   }
 
   return users;
+}
+
+async function getSessionParticipants(redis: Redis, sessionId: string, participantIds: string[]): Promise<SessionUser[]> {
+  const pipeline = redis.pipeline();
+  for (const participantId of participantIds) {
+    pipeline.hgetall(KEYS.participant(sessionId, participantId));
+  }
+  const results = await pipeline.exec();
+
+  const leaderParticipantId = await getLeaderParticipantId(redis, sessionId);
+  const participantConnectionIds = await getParticipantConnectionIds(redis, sessionId, participantIds);
+  const connectionData = await getParticipantConnectionData(redis, participantConnectionIds);
+
+  const users: SessionUser[] = [];
+  const staleParticipantIds: string[] = [];
+  const staleConnectionsByParticipant = new Map<string, string[]>();
+
+  if (results) {
+    for (let i = 0; i < results.length; i++) {
+      const [err, data] = results[i] as [Error | null, Record<string, string>];
+      const participantId = participantIds[i];
+      if (err || !data || !data.participantId) {
+        if (!err) staleParticipantIds.push(participantId);
+        continue;
+      }
+
+      const liveConnections = getLiveConnectionsForParticipant(
+        sessionId,
+        participantId,
+        participantConnectionIds.get(participantId) ?? [],
+        connectionData,
+        staleConnectionsByParticipant,
+      );
+
+      if (data.connectionState !== 'RECONNECTING' && liveConnections.length === 0) {
+        staleParticipantIds.push(participantId);
+        continue;
+      }
+
+      const connectionState =
+        data.connectionState === 'RECONNECTING' && liveConnections.length === 0
+          ? ('RECONNECTING' as const)
+          : ('CONNECTED' as const);
+
+      users.push({
+        id: data.participantId,
+        username: data.username || `User-${data.participantId.slice(0, 6)}`,
+        isLeader: leaderParticipantId === data.participantId,
+        avatarUrl: data.avatarUrl || undefined,
+        userId: data.userId || null,
+        connectionState,
+      });
+    }
+  }
+
+  if (staleParticipantIds.length > 0) {
+    const cleanup = redis.multi();
+    cleanup.srem(KEYS.sessionParticipants(sessionId), ...staleParticipantIds);
+    for (const participantId of staleParticipantIds) {
+      cleanup.del(KEYS.participant(sessionId, participantId));
+      cleanup.del(KEYS.participantConnections(sessionId, participantId));
+    }
+    cleanup.exec().catch(() => {});
+  }
+
+  if (staleConnectionsByParticipant.size > 0) {
+    const cleanup = redis.multi();
+    for (const [participantId, connectionIds] of staleConnectionsByParticipant) {
+      cleanup.srem(KEYS.participantConnections(sessionId, participantId), ...connectionIds);
+    }
+    cleanup.exec().catch(() => {});
+  }
+
+  return users;
+}
+
+async function getParticipantConnectionIds(
+  redis: Redis,
+  sessionId: string,
+  participantIds: string[],
+): Promise<Map<string, string[]>> {
+  const pipeline = redis.pipeline();
+  for (const participantId of participantIds) {
+    pipeline.smembers(KEYS.participantConnections(sessionId, participantId));
+  }
+  const results = await pipeline.exec();
+  const connectionIdsByParticipant = new Map<string, string[]>();
+
+  if (results) {
+    for (let i = 0; i < results.length; i++) {
+      const [err, connectionIds] = results[i] as [Error | null, string[]];
+      connectionIdsByParticipant.set(participantIds[i], err || !connectionIds ? [] : connectionIds);
+    }
+  }
+  return connectionIdsByParticipant;
+}
+
+async function getParticipantConnectionData(
+  redis: Redis,
+  connectionIdsByParticipant: Map<string, string[]>,
+): Promise<Map<string, ReturnType<typeof hashToConnection> | null>> {
+  const uniqueConnectionIds = Array.from(new Set(Array.from(connectionIdsByParticipant.values()).flat()));
+  const connectionData = new Map<string, ReturnType<typeof hashToConnection> | null>();
+  if (uniqueConnectionIds.length === 0) {
+    return connectionData;
+  }
+
+  const pipeline = redis.pipeline();
+  for (const id of uniqueConnectionIds) {
+    pipeline.hgetall(KEYS.connection(id));
+  }
+  const results = await pipeline.exec();
+  if (results) {
+    for (let i = 0; i < results.length; i++) {
+      const [err, data] = results[i] as [Error | null, Record<string, string>];
+      connectionData.set(uniqueConnectionIds[i], !err && data?.connectionId ? hashToConnection(data) : null);
+    }
+  }
+  return connectionData;
+}
+
+function getLiveConnectionsForParticipant(
+  sessionId: string,
+  participantId: string,
+  connectionIds: string[],
+  connectionData: Map<string, ReturnType<typeof hashToConnection> | null>,
+  staleConnectionsByParticipant: Map<string, string[]>,
+): string[] {
+  const liveConnectionIds: string[] = [];
+
+  for (const connectionId of connectionIds) {
+    const connection = connectionData.get(connectionId) ?? null;
+    if (connection?.sessionId === sessionId && connection.participantId === participantId) {
+      liveConnectionIds.push(connectionId);
+    } else {
+      const stale = staleConnectionsByParticipant.get(participantId) ?? [];
+      stale.push(connectionId);
+      staleConnectionsByParticipant.set(participantId, stale);
+    }
+  }
+  return liveConnectionIds;
+}
+
+async function getLeaderParticipantId(redis: Redis, sessionId: string): Promise<string | null> {
+  const leaderConnectionId = await getSessionLeader(redis, sessionId);
+  if (!leaderConnectionId) return null;
+  const leaderData = await redis.hgetall(KEYS.connection(leaderConnectionId));
+  if (!leaderData?.connectionId) return null;
+  return hashToConnection(leaderData).participantId;
+}
+
+export async function markParticipantPresence(
+  redis: Redis,
+  sessionId: string,
+  participantId: string,
+  connectionState: SessionConnectionState,
+): Promise<SessionUser | null> {
+  validateSessionId(sessionId);
+  validateParticipantId(participantId);
+  const key = KEYS.participant(sessionId, participantId);
+  const data = await redis.hgetall(key);
+  if (!data || !data.participantId) {
+    return null;
+  }
+
+  await redis
+    .multi()
+    .hset(key, 'connectionState', connectionState, 'lastSeenAt', Date.now().toString())
+    .expire(key, TTL.sessionMembership)
+    .expire(KEYS.sessionParticipants(sessionId), TTL.sessionMembership)
+    .exec();
+
+  const leaderParticipantId = await getLeaderParticipantId(redis, sessionId);
+
+  return {
+    id: data.participantId,
+    username: data.username || `User-${data.participantId.slice(0, 6)}`,
+    isLeader: leaderParticipantId === data.participantId,
+    avatarUrl: data.avatarUrl || undefined,
+    userId: data.userId || null,
+    connectionState,
+  };
+}
+
+async function getConnectionForParticipantCleanup(
+  redis: Redis,
+  connectionId: string,
+): Promise<ReturnType<typeof hashToConnection> | null> {
+  const data = await redis.hgetall(KEYS.connection(connectionId));
+  if (!data?.connectionId) return null;
+  return hashToConnection(data);
+}
+
+async function removeParticipantConnection(
+  redis: Redis,
+  sessionId: string,
+  participantId: string,
+  connectionId: string,
+): Promise<void> {
+  await redis.srem(KEYS.participantConnections(sessionId, participantId), connectionId);
+  const remainingIds = await redis.smembers(KEYS.participantConnections(sessionId, participantId));
+  if (remainingIds.length > 0) {
+    return;
+  }
+
+  await redis
+    .multi()
+    .srem(KEYS.sessionParticipants(sessionId), participantId)
+    .del(KEYS.participant(sessionId, participantId))
+    .del(KEYS.participantConnections(sessionId, participantId))
+    .exec();
+}
+
+export async function removeParticipant(redis: Redis, sessionId: string, participantId: string): Promise<void> {
+  validateSessionId(sessionId);
+  validateParticipantId(participantId);
+  const connectionIds = await redis.smembers(KEYS.participantConnections(sessionId, participantId));
+  const multi = redis.multi();
+  multi.srem(KEYS.sessionParticipants(sessionId), participantId);
+  multi.del(KEYS.participant(sessionId, participantId));
+  multi.del(KEYS.participantConnections(sessionId, participantId));
+  for (const connectionId of connectionIds) {
+    multi.srem(KEYS.sessionMembers(sessionId), connectionId);
+    multi.hset(KEYS.connection(connectionId), 'sessionId', '', 'participantId', '', 'isLeader', 'false');
+  }
+  await multi.exec();
 }
 
 /**

--- a/packages/backend/src/services/distributed-state/session-ops.ts
+++ b/packages/backend/src/services/distributed-state/session-ops.ts
@@ -266,7 +266,11 @@ export async function getSessionMembers(redis: Redis, sessionId: string): Promis
   return users;
 }
 
-async function getSessionParticipants(redis: Redis, sessionId: string, participantIds: string[]): Promise<SessionUser[]> {
+async function getSessionParticipants(
+  redis: Redis,
+  sessionId: string,
+  participantIds: string[],
+): Promise<SessionUser[]> {
   const pipeline = redis.pipeline();
   for (const participantId of participantIds) {
     pipeline.hgetall(KEYS.participant(sessionId, participantId));

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -3,7 +3,7 @@ import { db } from '../../db/client';
 import { sessions, type Session } from '../../db/schema';
 import type { RedisSessionStore } from '../redis-session-store';
 import type { DistributedStateManager } from '../distributed-state';
-import type { ConnectedClient } from './types';
+import type { ConnectedClient, LocalSessionParticipant } from './types';
 import { restoreSessionWithLock } from './session-restoration';
 import type { WriteScheduler } from './write-scheduler';
 
@@ -22,6 +22,7 @@ export async function registerClient(
   clients.set(connectionId, {
     connectionId,
     sessionId: null,
+    participantId: null,
     userId: userId || null,
     username: defaultUsername,
     isLeader: false,
@@ -52,6 +53,7 @@ export async function joinSession(
   boardPath: string,
   clients: Map<string, ConnectedClient>,
   sessionsMap: Map<string, Set<string>>,
+  sessionParticipants: Map<string, Map<string, LocalSessionParticipant>>,
   redisStore: RedisSessionStore | null,
   distributedState: DistributedStateManager | null,
   writeScheduler: WriteScheduler,
@@ -73,12 +75,13 @@ export async function joinSession(
     currentClimbQueueItem: ClimbQueueItem | null,
     expectedVersion?: number,
   ) => Promise<number>,
-  leaveSessionFn: (connectionId: string) => Promise<{ sessionId: string; newLeaderId?: string } | null>,
+  leaveSessionFn: (connectionId: string) => Promise<SessionLeaveResult | null>,
   username?: string,
   avatarUrl?: string,
   initialQueue?: ClimbQueueItem[],
   initialCurrentClimb?: ClimbQueueItem | null,
   sessionName?: string,
+  participantId?: string | null,
 ): Promise<{
   clientId: string;
   users: SessionUser[];
@@ -88,11 +91,15 @@ export async function joinSession(
   stateHash: string;
   isLeader: boolean;
   sessionName: string | null;
+  participantId: string;
+  participantWasKnown: boolean;
+  participantWasReconnecting: boolean;
 }> {
   const client = clients.get(connectionId);
   if (!client) {
     throw new Error('Client not registered');
   }
+  const resolvedParticipantId = client.userId || participantId || connectionId;
 
   // Leave current session if in one
   if (client.sessionId) {
@@ -101,6 +108,7 @@ export async function joinSession(
 
   // Update client info
   client.sessionId = sessionId;
+  client.participantId = resolvedParticipantId;
   if (username) {
     client.username = username;
   }
@@ -146,7 +154,13 @@ export async function joinSession(
   let isLeader: boolean;
 
   if (distributedState) {
-    const result = await distributedState.joinSession(connectionId, sessionId, client.username, client.avatarUrl);
+    const result = await distributedState.joinSession(
+      connectionId,
+      sessionId,
+      client.username,
+      client.avatarUrl,
+      resolvedParticipantId,
+    );
     isLeader = result.isLeader;
   } else {
     isLeader = sessionClientIds.size === 0;
@@ -154,6 +168,13 @@ export async function joinSession(
 
   client.isLeader = isLeader;
   sessionClientIds.add(connectionId);
+  const participantStatus = upsertLocalParticipant(
+    sessionId,
+    resolvedParticipantId,
+    client,
+    isLeader,
+    sessionParticipants,
+  );
 
   // Ensure new sessions exist in Postgres before any queue state persists.
   // Existing sessions stay Redis-only for join/leave activity.
@@ -204,6 +225,9 @@ export async function joinSession(
     stateHash: queueState.stateHash,
     isLeader,
     sessionName: resolvedSessionName,
+    participantId: resolvedParticipantId,
+    participantWasKnown: participantStatus.wasKnown,
+    participantWasReconnecting: participantStatus.wasReconnecting,
   };
 }
 
@@ -214,19 +238,21 @@ export async function leaveSession(
   connectionId: string,
   clients: Map<string, ConnectedClient>,
   sessionsMap: Map<string, Set<string>>,
+  sessionParticipants: Map<string, Map<string, LocalSessionParticipant>>,
   redisStore: RedisSessionStore | null,
   distributedState: DistributedStateManager | null,
   writeScheduler: WriteScheduler,
   sessionGraceTimers: Map<string, NodeJS.Timeout>,
   pendingJoinPersists: Map<string, Promise<void>>,
   SESSION_GRACE_PERIOD_MS: number,
-): Promise<{ sessionId: string; newLeaderId?: string } | null> {
+): Promise<SessionLeaveResult | null> {
   const client = clients.get(connectionId);
   if (!client || !client.sessionId) {
     return null;
   }
 
   const sessionId = client.sessionId;
+  const participantId = client.participantId || connectionId;
   const wasLeader = client.isLeader;
 
   const sessionClientIds = sessionsMap.get(sessionId);
@@ -253,22 +279,37 @@ export async function leaveSession(
 
   // Reset client state
   client.sessionId = null;
+  client.participantId = null;
   client.isLeader = false;
 
   // Elect new leader. This also atomically removes our connection from
   // distributed state, so the post-leave membership re-check below sees
   // an accurate global view.
+  const participants = sessionParticipants.get(sessionId);
+  const participant = participants?.get(participantId);
+  if (participant) {
+    if (participant.reconnectTimer) {
+      clearTimeout(participant.reconnectTimer);
+    }
+    participants?.delete(participantId);
+    if (participants?.size === 0) {
+      sessionParticipants.delete(sessionId);
+    }
+  }
   let newLeaderId: string | undefined;
+  let newLeaderParticipantId: string | undefined;
 
   if (distributedState) {
     const result = await distributedState.leaveSession(connectionId, sessionId);
     if (result.newLeaderId) {
       newLeaderId = result.newLeaderId;
+      newLeaderParticipantId = await resolveLeaderParticipantId(newLeaderId, clients, distributedState);
       const localNewLeader = clients.get(newLeaderId);
       if (localNewLeader) {
         localNewLeader.isLeader = true;
       }
     }
+    await distributedState.removeParticipant(sessionId, participantId);
   } else if (wasLeader && sessionClientIds && sessionClientIds.size > 0) {
     const clientsArray = Array.from(sessionClientIds)
       .map((id) => clients.get(id))
@@ -279,6 +320,16 @@ export async function leaveSession(
       const newLeader = clientsArray[0];
       newLeader.isLeader = true;
       newLeaderId = newLeader.connectionId;
+      newLeaderParticipantId = newLeader.participantId || newLeader.connectionId;
+    }
+  }
+
+  if (newLeaderId) {
+    const newLeader = clients.get(newLeaderId);
+    newLeaderParticipantId = newLeaderParticipantId || newLeader?.participantId || newLeaderId;
+    const newLeaderParticipant = participants?.get(newLeaderParticipantId);
+    if (newLeaderParticipant) {
+      newLeaderParticipant.isLeader = true;
     }
   }
 
@@ -292,14 +343,9 @@ export async function leaveSession(
   // membership) collapses both branches of that race into "the last
   // instance to leave wins and runs the cleanup".
   //
-  // INVARIANT: `member.id` returned by `getSessionMembers` is the connection
-  // ID, set in `services/distributed-state/session-ops.ts:181`:
-  //   `id: connection.connectionId`
-  // The empty-check below relies on that — if the field ever switches to a
-  // user UUID, the leaving connection would no longer be subtracted by
-  // `distributedState.leaveSession` from the same membership view, and the
-  // emptiness signal would diverge from reality. The tests in
-  // `__tests__/leave-session-multi-instance.test.ts` pin this contract.
+  // INVARIANT: `getSessionMembers` returns active stable participants. The
+  // explicit leave path removes the leaving participant before this check, so
+  // a non-empty result means another participant is still active globally.
   if (wentLocallyEmpty) {
     let globallyEmpty = true;
     if (distributedState) {
@@ -332,7 +378,233 @@ export async function leaveSession(
     }
   }
 
-  return { sessionId, newLeaderId };
+  return { sessionId, participantId, newLeaderId, newLeaderParticipantId };
+}
+
+/**
+ * Handle an unintentional WebSocket disconnect without treating the participant
+ * as having explicitly left the session.
+ */
+export async function disconnectClient(
+  connectionId: string,
+  clients: Map<string, ConnectedClient>,
+  sessionsMap: Map<string, Set<string>>,
+  sessionParticipants: Map<string, Map<string, LocalSessionParticipant>>,
+  redisStore: RedisSessionStore | null,
+  distributedState: DistributedStateManager | null,
+  writeScheduler: WriteScheduler,
+  sessionGraceTimers: Map<string, NodeJS.Timeout>,
+  pendingJoinPersists: Map<string, Promise<void>>,
+  SESSION_GRACE_PERIOD_MS: number,
+  onParticipantExpired?: (sessionId: string, participantId: string) => void,
+): Promise<SessionDisconnectResult | null> {
+  const client = clients.get(connectionId);
+  if (!client) {
+    return null;
+  }
+
+  const sessionId = client.sessionId;
+  const participantId = client.participantId || connectionId;
+  const wasLeader = client.isLeader;
+
+  if (!sessionId) {
+    clients.delete(connectionId);
+    if (distributedState) {
+      await distributedState.removeConnection(connectionId, false).catch(() => {});
+    }
+    return null;
+  }
+
+  const sessionClientIds = sessionsMap.get(sessionId);
+  const wentLocallyEmpty = sessionClientIds
+    ? (sessionClientIds.delete(connectionId), sessionClientIds.size === 0)
+    : false;
+
+  if (wentLocallyEmpty) {
+    const existingGraceTimer = sessionGraceTimers.get(sessionId);
+    if (existingGraceTimer) clearTimeout(existingGraceTimer);
+
+    const timer = setTimeout(() => {
+      const currentClients = sessionsMap.get(sessionId);
+      if (currentClients && currentClients.size === 0) {
+        sessionsMap.delete(sessionId);
+        writeScheduler.cancelPendingWrites(sessionId);
+        console.info(`[RoomManager] Session ${sessionId} removed from memory after grace period`);
+      }
+      sessionGraceTimers.delete(sessionId);
+    }, SESSION_GRACE_PERIOD_MS);
+    sessionGraceTimers.set(sessionId, timer);
+  }
+
+  let remainingConnections = 0;
+  let newLeaderId: string | undefined;
+  let newLeaderParticipantId: string | undefined;
+  if (distributedState) {
+    const result = await distributedState.removeConnection(connectionId, true);
+    remainingConnections = result.remainingParticipantConnections ?? 0;
+    newLeaderId = result.newLeaderId || undefined;
+    if (newLeaderId) {
+      newLeaderParticipantId = await resolveLeaderParticipantId(newLeaderId, clients, distributedState);
+    }
+  }
+
+  if (wentLocallyEmpty) {
+    let globallyNoLiveConnections = true;
+    if (distributedState) {
+      try {
+        globallyNoLiveConnections = (await distributedState.getSessionMemberCount(sessionId)) === 0;
+      } catch (error) {
+        // If Redis cannot answer, keep the legacy conservative behaviour:
+        // mark inactive rather than leave hot session state indefinitely.
+        console.error(
+          `[RoomManager] Failed to query distributed member count for ${sessionId} during disconnectClient:`,
+          error,
+        );
+      }
+    }
+
+    if (globallyNoLiveConnections && redisStore) {
+      await redisStore.markInactive(sessionId);
+      console.info(`[RoomManager] Session ${sessionId} marked inactive - grace period started (60s)`);
+    }
+
+    const pending = pendingJoinPersists.get(sessionId);
+    if (pending) {
+      await pending;
+    }
+  }
+
+  const participants = getOrCreateParticipantMap(sessionId, sessionParticipants);
+  let participant = participants.get(participantId);
+  if (!participant) {
+    participant = {
+      id: participantId,
+      username: client.username,
+      userId: client.userId,
+      avatarUrl: client.avatarUrl,
+      isLeader: false,
+      connectionState: 'CONNECTED',
+      connectionIds: new Set(),
+    };
+    participants.set(participantId, participant);
+  }
+
+  participant.connectionIds.delete(connectionId);
+  if (!distributedState) {
+    remainingConnections = participant.connectionIds.size;
+    if (wasLeader && sessionClientIds && sessionClientIds.size > 0) {
+      const clientsArray = Array.from(sessionClientIds)
+        .map((id) => clients.get(id))
+        .filter((c): c is ConnectedClient => c !== undefined)
+        .sort((a, b) => a.connectedAt.getTime() - b.connectedAt.getTime());
+
+      const newLeader = clientsArray[0];
+      if (newLeader) {
+        newLeader.isLeader = true;
+        newLeaderId = newLeader.connectionId;
+        newLeaderParticipantId = newLeader.participantId || newLeader.connectionId;
+      }
+    }
+  }
+
+  client.sessionId = null;
+  client.participantId = null;
+  client.isLeader = false;
+  clients.delete(connectionId);
+
+  if (wasLeader) {
+    participant.isLeader = false;
+  }
+  if (newLeaderId) {
+    const newLeader = clients.get(newLeaderId);
+    newLeaderParticipantId = newLeaderParticipantId || newLeader?.participantId || newLeaderId;
+    const newLeaderParticipant = participants.get(newLeaderParticipantId);
+    if (newLeaderParticipant) {
+      newLeaderParticipant.isLeader = true;
+    }
+  }
+
+  if (remainingConnections > 0) {
+    return { sessionId, participantId, newLeaderId, newLeaderParticipantId };
+  }
+
+  participant.connectionState = 'RECONNECTING';
+  const presenceUser =
+    (distributedState
+      ? await distributedState.markParticipantPresence(sessionId, participantId, 'RECONNECTING')
+      : localParticipantToSessionUser(participant)) || localParticipantToSessionUser(participant);
+
+  if (participant.reconnectTimer) {
+    clearTimeout(participant.reconnectTimer);
+  }
+  participant.reconnectTimer = setTimeout(() => {
+    void (async () => {
+      if (distributedState) {
+        const users = await distributedState.getSessionMembers(sessionId).catch(() => []);
+        const currentUser = users.find((user) => user.id === participantId);
+        if (currentUser?.connectionState === 'CONNECTED') {
+          return;
+        }
+        await distributedState.removeParticipant(sessionId, participantId).catch((err) => {
+          console.error(`[RoomManager] Failed to expire participant ${participantId.slice(0, 8)}:`, err);
+        });
+      }
+
+      const currentParticipants = sessionParticipants.get(sessionId);
+      const currentParticipant = currentParticipants?.get(participantId);
+      if (currentParticipant && currentParticipant.connectionIds.size === 0) {
+        currentParticipants?.delete(participantId);
+        if (currentParticipants?.size === 0) {
+          sessionParticipants.delete(sessionId);
+        }
+        onParticipantExpired?.(sessionId, participantId);
+      }
+    })();
+  }, SESSION_GRACE_PERIOD_MS);
+
+  return { sessionId, participantId, presenceUser, newLeaderId, newLeaderParticipantId };
+}
+
+export type SessionLeaveResult = {
+  sessionId: string;
+  participantId?: string;
+  newLeaderId?: string;
+  newLeaderParticipantId?: string;
+};
+
+export type SessionDisconnectResult = {
+  sessionId: string;
+  participantId: string;
+  presenceUser?: SessionUser;
+  newLeaderId?: string;
+  newLeaderParticipantId?: string;
+};
+
+async function resolveLeaderParticipantId(
+  leaderConnectionId: string,
+  clients: Map<string, ConnectedClient>,
+  distributedState: DistributedStateManager | null,
+): Promise<string> {
+  const localLeader = clients.get(leaderConnectionId);
+  if (localLeader?.participantId) {
+    return localLeader.participantId;
+  }
+
+  if (distributedState) {
+    try {
+      const distributedLeader = await distributedState.getConnection(leaderConnectionId);
+      if (distributedLeader?.participantId) {
+        return distributedLeader.participantId;
+      }
+    } catch (error) {
+      console.error(
+        `[RoomManager] Failed to resolve leader participant for ${leaderConnectionId.slice(0, 8)}:`,
+        error,
+      );
+    }
+  }
+
+  return leaderConnectionId;
 }
 
 /**
@@ -374,6 +646,64 @@ export async function removeClient(
   clients.delete(connectionId);
 
   return { distributedStateCleanedUp };
+}
+
+function upsertLocalParticipant(
+  sessionId: string,
+  participantId: string,
+  client: ConnectedClient,
+  isLeader: boolean,
+  sessionParticipants: Map<string, Map<string, LocalSessionParticipant>>,
+): { wasKnown: boolean; wasReconnecting: boolean } {
+  let participants = sessionParticipants.get(sessionId);
+  if (!participants) {
+    participants = new Map();
+    sessionParticipants.set(sessionId, participants);
+  }
+
+  const existing = participants.get(participantId);
+  const wasKnown = !!existing;
+  const wasReconnecting = existing?.connectionState === 'RECONNECTING';
+
+  if (existing?.reconnectTimer) {
+    clearTimeout(existing.reconnectTimer);
+    existing.reconnectTimer = undefined;
+  }
+
+  participants.set(participantId, {
+    id: participantId,
+    username: client.username,
+    userId: client.userId,
+    avatarUrl: client.avatarUrl,
+    isLeader: existing?.isLeader || isLeader,
+    connectionState: 'CONNECTED',
+    connectionIds: new Set([...(existing?.connectionIds ?? []), client.connectionId]),
+  });
+
+  return { wasKnown, wasReconnecting };
+}
+
+function getOrCreateParticipantMap(
+  sessionId: string,
+  sessionParticipants: Map<string, Map<string, LocalSessionParticipant>>,
+): Map<string, LocalSessionParticipant> {
+  let participants = sessionParticipants.get(sessionId);
+  if (!participants) {
+    participants = new Map();
+    sessionParticipants.set(sessionId, participants);
+  }
+  return participants;
+}
+
+function localParticipantToSessionUser(participant: LocalSessionParticipant): SessionUser {
+  return {
+    id: participant.id,
+    username: participant.username,
+    isLeader: participant.isLeader,
+    avatarUrl: participant.avatarUrl,
+    userId: participant.userId,
+    connectionState: participant.connectionState,
+  };
 }
 
 /**

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -99,7 +99,18 @@ export async function joinSession(
   if (!client) {
     throw new Error('Client not registered');
   }
-  const resolvedParticipantId = client.userId || participantId || connectionId;
+  // SECURITY: Never trust a client-supplied participantId. SessionUser.id is
+  // broadcast to every peer in the session, so accepting an arbitrary
+  // participantId here lets any member impersonate any other participant
+  // (including the leader, since leadership checks key off participant
+  // identity). For authenticated users we bind to their verified userId. For
+  // anonymous users we use the connectionId; reconnection across WebSocket
+  // drops then appears as a fresh participant (UserLeft + UserJoined) — that's
+  // the correct trade-off because anonymous reconnects have no proof of
+  // identity. The `participantId` parameter is accepted for API stability but
+  // intentionally ignored.
+  void participantId;
+  const resolvedParticipantId = client.userId || connectionId;
 
   // Leave current session if in one
   if (client.sessionId) {
@@ -343,6 +354,13 @@ export async function leaveSession(
   // membership) collapses both branches of that race into "the last
   // instance to leave wins and runs the cleanup".
   //
+  // It's still possible for two instances to both observe `globallyEmpty`
+  // when they leave simultaneously and both run `markInactive` /
+  // `cancelPendingWrites`. Both operations are idempotent:
+  // `markInactive` is `SREM` on the active set, `cancelPendingWrites` is
+  // a no-op when there are no pending writes for this session. Last writer
+  // wins; double-calls are safe.
+  //
   // INVARIANT: `getSessionMembers` returns active stable participants. The
   // explicit leave path removes the leaving participant before this check, so
   // a non-empty result means another participant is still active globally.
@@ -529,6 +547,12 @@ export async function disconnectClient(
   }
 
   participant.connectionState = 'RECONNECTING';
+  // markParticipantPresence returns null when the Redis participant hash has
+  // already expired (TTL elapsed before the disconnect cleanup ran). Fall
+  // back to the local participant snapshot so peers always see a
+  // UserPresenceChanged event during the grace window — without this
+  // fallback the only signal they'd get is the eventual UserLeft, with no
+  // RECONNECTING state in between.
   const presenceUser =
     (distributedState
       ? await distributedState.markParticipantPresence(sessionId, participantId, 'RECONNECTING')
@@ -540,7 +564,21 @@ export async function disconnectClient(
   participant.reconnectTimer = setTimeout(() => {
     void (async () => {
       if (distributedState) {
-        const users = await distributedState.getSessionMembers(sessionId).catch(() => []);
+        // Do NOT swallow Redis errors here. A failed getSessionMembers
+        // previously returned [], the participant looked absent, and we
+        // expelled them — the exact opposite of what the grace period is
+        // for. On infra failure, keep the participant alive and let the
+        // next reconnect run the grace logic again.
+        let users;
+        try {
+          users = await distributedState.getSessionMembers(sessionId);
+        } catch (err) {
+          console.error(
+            `[RoomManager] Grace timer failed to query session ${sessionId.slice(0, 8)} members; keeping participant ${participantId.slice(0, 8)} alive:`,
+            err,
+          );
+          return;
+        }
         const currentUser = users.find((user) => user.id === participantId);
         if (currentUser?.connectionState === 'CONNECTED') {
           return;

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -597,10 +597,7 @@ async function resolveLeaderParticipantId(
         return distributedLeader.participantId;
       }
     } catch (error) {
-      console.error(
-        `[RoomManager] Failed to resolve leader participant for ${leaderConnectionId.slice(0, 8)}:`,
-        error,
-      );
+      console.error(`[RoomManager] Failed to resolve leader participant for ${leaderConnectionId.slice(0, 8)}:`, error);
     }
   }
 

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -296,16 +296,31 @@ export async function leaveSession(
   // Elect new leader. This also atomically removes our connection from
   // distributed state, so the post-leave membership re-check below sees
   // an accurate global view.
+  //
+  // Multi-tab handling: an authenticated user opening the same session in
+  // two tabs shares one `participantId` (their userId). Clicking "Leave" on
+  // one tab must NOT wipe the other tab's participant entry. We drop only
+  // this connection from the participant and let the entry persist if any
+  // sibling connection remains. The participant is fully torn down only
+  // when its connection set hits zero.
   const participants = sessionParticipants.get(sessionId);
   const participant = participants?.get(participantId);
+  let participantBecameEmpty = false;
   if (participant) {
-    if (participant.reconnectTimer) {
-      clearTimeout(participant.reconnectTimer);
+    participant.connectionIds.delete(connectionId);
+    if (participant.connectionIds.size === 0) {
+      if (participant.reconnectTimer) {
+        clearTimeout(participant.reconnectTimer);
+      }
+      participants?.delete(participantId);
+      if (participants?.size === 0) {
+        sessionParticipants.delete(sessionId);
+      }
+      participantBecameEmpty = true;
     }
-    participants?.delete(participantId);
-    if (participants?.size === 0) {
-      sessionParticipants.delete(sessionId);
-    }
+  } else {
+    // Local view doesn't know this participant; treat as drained.
+    participantBecameEmpty = true;
   }
   let newLeaderId: string | undefined;
   let newLeaderParticipantId: string | undefined;
@@ -320,7 +335,17 @@ export async function leaveSession(
         localNewLeader.isLeader = true;
       }
     }
-    await distributedState.removeParticipant(sessionId, participantId);
+    if (participantBecameEmpty) {
+      // No more connections for this participant — tear down the participant
+      // entry and broadcast UserLeft to peers.
+      await distributedState.removeParticipant(sessionId, participantId);
+    } else {
+      // Sibling tab still in the session — only detach this connection.
+      // `removeParticipantConnection` is atomic via Lua: SREM the connection
+      // from the participant's set; if the set just hit zero, delete the
+      // participant entry.
+      await distributedState.removeParticipantConnection(sessionId, participantId, connectionId);
+    }
   } else if (wasLeader && sessionClientIds && sessionClientIds.size > 0) {
     const clientsArray = Array.from(sessionClientIds)
       .map((id) => clients.get(id))
@@ -396,7 +421,13 @@ export async function leaveSession(
     }
   }
 
-  return { sessionId, participantId, newLeaderId, newLeaderParticipantId };
+  return {
+    sessionId,
+    participantId,
+    newLeaderId,
+    newLeaderParticipantId,
+    participantFullyLeft: participantBecameEmpty,
+  };
 }
 
 /**
@@ -608,6 +639,14 @@ export type SessionLeaveResult = {
   participantId?: string;
   newLeaderId?: string;
   newLeaderParticipantId?: string;
+  /**
+   * True when this leave drained the last connection for the participant —
+   * peers should see a `UserLeft` event. False when the participant still has
+   * sibling connections (e.g. another tab open as the same authenticated
+   * user); in that case the leave is per-tab and peers should not be told
+   * the user departed.
+   */
+  participantFullyLeft: boolean;
 };
 
 export type SessionDisconnectResult = {

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -8,7 +8,7 @@ import {
   shutdownDistributedState,
   forceResetDistributedState,
 } from '../distributed-state';
-import type { ConnectedClient, DiscoverableSession, QueueState } from './types';
+import type { ConnectedClient, DiscoverableSession, LocalSessionParticipant, QueueState } from './types';
 import { WriteScheduler } from './write-scheduler';
 import {
   updateQueueState as updateQueueStateFn,
@@ -20,8 +20,12 @@ import {
   registerClient as registerClientFn,
   joinSession as joinSessionFn,
   leaveSession as leaveSessionFn,
+  disconnectClient as disconnectClientFn,
   removeClient as removeClientFn,
+  type SessionDisconnectResult,
+  type SessionLeaveResult,
 } from './client-lifecycle';
+import { pubsub } from '../../pubsub/index';
 import {
   getSessionById as getSessionByIdFn,
   createDiscoverableSession as createDiscoverableSessionFn,
@@ -37,6 +41,7 @@ const INACTIVITY_SWEEP_INTERVAL_MS = 60 * 1000;
 class RoomManager {
   private clients = new Map<string, ConnectedClient>();
   private sessions = new Map<string, Set<string>>();
+  private sessionParticipants = new Map<string, Map<string, LocalSessionParticipant>>();
   private redisStore: RedisSessionStore | null = null;
   private distributedState: DistributedStateManager | null = null;
   private sessionGraceTimers = new Map<string, NodeJS.Timeout>();
@@ -49,8 +54,17 @@ class RoomManager {
    * Reset all state (for testing purposes)
    */
   reset(): void {
+    for (const participants of this.sessionParticipants.values()) {
+      for (const participant of participants.values()) {
+        if (participant.reconnectTimer) {
+          clearTimeout(participant.reconnectTimer);
+        }
+      }
+    }
+
     this.clients.clear();
     this.sessions.clear();
+    this.sessionParticipants.clear();
     this.redisStore = null;
     this.distributedState = null;
 
@@ -144,6 +158,7 @@ class RoomManager {
     initialQueue?: ClimbQueueItem[],
     initialCurrentClimb?: ClimbQueueItem | null,
     sessionName?: string,
+    participantId?: string | null,
   ): Promise<{
     clientId: string;
     users: SessionUser[];
@@ -153,6 +168,9 @@ class RoomManager {
     stateHash: string;
     isLeader: boolean;
     sessionName: string | null;
+    participantId: string;
+    participantWasKnown: boolean;
+    participantWasReconnecting: boolean;
   }> {
     return joinSessionFn(
       connectionId,
@@ -160,6 +178,7 @@ class RoomManager {
       boardPath,
       this.clients,
       this.sessions,
+      this.sessionParticipants,
       this.redisStore,
       this.distributedState,
       this.writeScheduler,
@@ -176,20 +195,43 @@ class RoomManager {
       initialQueue,
       initialCurrentClimb,
       sessionName,
+      participantId,
     );
   }
 
-  async leaveSession(connectionId: string): Promise<{ sessionId: string; newLeaderId?: string } | null> {
+  async leaveSession(connectionId: string): Promise<SessionLeaveResult | null> {
     return leaveSessionFn(
       connectionId,
       this.clients,
       this.sessions,
+      this.sessionParticipants,
       this.redisStore,
       this.distributedState,
       this.writeScheduler,
       this.sessionGraceTimers,
       this.pendingJoinPersists,
       this.SESSION_GRACE_PERIOD_MS,
+    );
+  }
+
+  async disconnectClient(connectionId: string): Promise<SessionDisconnectResult | null> {
+    return disconnectClientFn(
+      connectionId,
+      this.clients,
+      this.sessions,
+      this.sessionParticipants,
+      this.redisStore,
+      this.distributedState,
+      this.writeScheduler,
+      this.sessionGraceTimers,
+      this.pendingJoinPersists,
+      this.SESSION_GRACE_PERIOD_MS,
+      (sessionId, participantId) => {
+        pubsub.publishSessionEvent(sessionId, {
+          __typename: 'UserLeft',
+          userId: participantId,
+        });
+      },
     );
   }
 
@@ -211,19 +253,31 @@ class RoomManager {
    * Get session users from local instance only.
    */
   getSessionUsersLocal(sessionId: string): SessionUser[] {
+    const participants = this.sessionParticipants.get(sessionId);
+    if (participants && participants.size > 0) {
+      return Array.from(participants.values()).map((participant) => ({
+        id: participant.id,
+        username: participant.username,
+        isLeader: participant.isLeader,
+        avatarUrl: participant.avatarUrl,
+        userId: participant.userId,
+        connectionState: participant.connectionState,
+      }));
+    }
+
     const sessionClientIds = this.sessions.get(sessionId);
     if (!sessionClientIds) return [];
-
     const users: SessionUser[] = [];
     for (const clientId of sessionClientIds) {
       const client = this.clients.get(clientId);
       if (client) {
         users.push({
-          id: client.connectionId,
+          id: client.participantId || client.connectionId,
           username: client.username,
           isLeader: client.isLeader,
           avatarUrl: client.avatarUrl,
           userId: client.userId,
+          connectionState: 'CONNECTED',
         });
       }
     }

--- a/packages/backend/src/services/room-manager/types.ts
+++ b/packages/backend/src/services/room-manager/types.ts
@@ -13,11 +13,23 @@ export class VersionConflictError extends Error {
 export type ConnectedClient = {
   connectionId: string;
   sessionId: string | null;
+  participantId: string | null;
   userId: string | null;
   username: string;
   avatarUrl?: string;
   isLeader: boolean;
   connectedAt: Date;
+};
+
+export type LocalSessionParticipant = {
+  id: string;
+  username: string;
+  userId: string | null;
+  avatarUrl?: string;
+  isLeader: boolean;
+  connectionState: 'CONNECTED' | 'RECONNECTING';
+  connectionIds: Set<string>;
+  reconnectTimer?: NodeJS.Timeout;
 };
 
 export type DiscoverableSession = {

--- a/packages/backend/src/validation/schemas/primitives.ts
+++ b/packages/backend/src/validation/schemas/primitives.ts
@@ -21,6 +21,12 @@ export const SessionIdSchema = z
   .max(100, 'Session ID too long')
   .regex(/^[a-zA-Z0-9-]+$/, 'Session ID must be alphanumeric with hyphens only');
 
+export const ParticipantIdSchema = z
+  .string()
+  .min(1, 'Participant ID cannot be empty')
+  .max(128, 'Participant ID too long')
+  .regex(/^[a-zA-Z0-9_-]+$/, 'Participant ID must be alphanumeric with hyphens or underscores only');
+
 /**
  * GPS coordinate validation schemas
  */

--- a/packages/backend/src/websocket/setup.ts
+++ b/packages/backend/src/websocket/setup.ts
@@ -172,31 +172,24 @@ export function setupWebSocketServer(httpServer: HttpServer): {
 
           // Handle session cleanup
           if (latestContext?.sessionId) {
-            const result = await roomManager.leaveSession(context.connectionId);
+            const result = await roomManager.disconnectClient(context.connectionId);
 
-            if (result) {
-              // Notify session about user leaving. The `userId` field name
-              // in the GraphQL schema is a misnomer — it's the connection
-              // ID, matching the `id` field that UserJoined emits via
-              // `user.id = result.clientId` in joinSession (which is the
-              // connection ID). Clients filter their participant list by
-              // `u.id !== event.userId`, so the two events must agree.
+            if (result?.presenceUser) {
               pubsub.publishSessionEvent(result.sessionId, {
-                __typename: 'UserLeft',
-                userId: context.connectionId,
+                __typename: 'UserPresenceChanged',
+                user: result.presenceUser,
               });
-
-              // Notify about new leader if changed
-              if (result.newLeaderId) {
-                pubsub.publishSessionEvent(result.sessionId, {
-                  __typename: 'LeaderChanged',
-                  leaderId: result.newLeaderId,
-                });
-              }
             }
+            if (result?.newLeaderId) {
+              pubsub.publishSessionEvent(result.sessionId, {
+                __typename: 'LeaderChanged',
+                leaderId: result.newLeaderParticipantId || result.newLeaderId,
+                leaderConnectionId: result.newLeaderId,
+              });
+            }
+          } else {
+            await roomManager.removeClient(context.connectionId);
           }
-
-          await roomManager.removeClient(context.connectionId);
           removeContext(context.connectionId);
         }
       },

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -253,19 +253,29 @@ type EventsReplayResponse {
 }
 
 """
+Current realtime connection state for a session participant.
+"""
+enum SessionConnectionState {
+  CONNECTED
+  RECONNECTING
+}
+
+"""
 A user participating in a climbing session.
 """
 type SessionUser {
-  "Unique user identifier"
+  "Stable participant identifier within this session"
   id: ID!
   "Display name"
   username: String!
-  "Whether this user is the session leader (controls the queue)"
+  "Whether this user is the session leader (presentation/backward compatibility only)"
   isLeader: Boolean!
   "URL to user's avatar image"
   avatarUrl: String
   "Stable database user UUID (null for unauthenticated connections)"
   userId: ID
+  "Realtime connection state for this participant"
+  connectionState: SessionConnectionState!
 }
 
 """
@@ -282,7 +292,7 @@ type Session {
   users: [SessionUser!]!
   "Current queue state"
   queueState: QueueState!
-  "Whether the current client is the session leader"
+  "Whether the current client is the session leader (presentation/backward compatibility only)"
   isLeader: Boolean!
   "Unique identifier for this client's connection"
   clientId: ID!
@@ -3914,6 +3924,7 @@ type Mutation {
     boardPath: String!
     username: String
     avatarUrl: String
+    participantId: ID
     initialQueue: [ClimbQueueItemInput!]
     initialCurrentClimb: ClimbQueueItemInput
     sessionName: String
@@ -3930,7 +3941,7 @@ type Mutation {
   leaveSession: Boolean!
 
   """
-  End a session (leader only).
+  End a session (active participant only).
   """
   endSession(sessionId: ID!): SessionSummary
 
@@ -4432,7 +4443,7 @@ type Subscription {
 """
 Union of possible session events.
 """
-union SessionEvent = UserJoined | UserLeft | LeaderChanged | SessionEnded | SessionStatsUpdated
+union SessionEvent = UserJoined | UserLeft | UserPresenceChanged | LeaderChanged | SessionEnded | SessionStatsUpdated
 
 """
 Event when a user joins the session.
@@ -4451,11 +4462,21 @@ type UserLeft {
 }
 
 """
+Event when a participant's realtime presence state changes.
+"""
+type UserPresenceChanged {
+  "The participant whose presence changed"
+  user: SessionUser!
+}
+
+"""
 Event when session leadership changes.
 """
 type LeaderChanged {
-  "ID of the new leader"
+  "Stable participant ID of the new leader"
   leaderId: ID!
+  "Connection ID of the new leader, for current-client leadership checks"
+  leaderConnectionId: ID
 }
 
 """
@@ -4520,6 +4541,8 @@ Event when an item is added to the queue.
 type QueueItemAdded {
   "Sequence number of this event"
   sequence: Int!
+  "Queue state hash after this event is applied"
+  stateHash: String!
   "The added item"
   item: ClimbQueueItem!
   "Position where item was inserted (null = end)"
@@ -4532,6 +4555,8 @@ Event when an item is removed from the queue.
 type QueueItemRemoved {
   "Sequence number of this event"
   sequence: Int!
+  "Queue state hash after this event is applied"
+  stateHash: String!
   "UUID of the removed item"
   uuid: ID!
 }
@@ -4542,6 +4567,8 @@ Event when queue order changes.
 type QueueReordered {
   "Sequence number of this event"
   sequence: Int!
+  "Queue state hash after this event is applied"
+  stateHash: String!
   "UUID of the moved item"
   uuid: ID!
   "Previous position"
@@ -4556,6 +4583,8 @@ Event when the current climb changes.
 type CurrentClimbChanged {
   "Sequence number of this event"
   sequence: Int!
+  "Queue state hash after this event is applied"
+  stateHash: String!
   "New current climb (null to clear)"
   item: ClimbQueueItem
   "ID of the client that made this change"
@@ -4570,6 +4599,10 @@ Event when the current climb's mirror state changes.
 type ClimbMirrored {
   "Sequence number of this event"
   sequence: Int!
+  "Queue state hash after this event is applied"
+  stateHash: String!
+  "UUID of the mirrored queue item, when a current climb exists"
+  uuid: ID
   "New mirror state"
   mirrored: Boolean!
 }

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -540,6 +540,10 @@ export type ClimbMirrored = {
   mirrored: Scalars['Boolean']['output'];
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
+  /** Queue state hash after this event is applied */
+  stateHash: Scalars['String']['output'];
+  /** UUID of the mirrored queue item, when a current climb exists */
+  uuid?: Maybe<Scalars['ID']['output']>;
 };
 
 /** Playlist membership for a single climb in a batch query. */
@@ -963,6 +967,8 @@ export type CurrentClimbChanged = {
   item?: Maybe<ClimbQueueItem>;
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
+  /** Queue state hash after this event is applied */
+  stateHash: Scalars['String']['output'];
 };
 
 /** Information needed before account deletion. */
@@ -1668,7 +1674,9 @@ export type LayoutStats = {
 /** Event when session leadership changes. */
 export type LeaderChanged = {
   __typename?: 'LeaderChanged';
-  /** ID of the new leader */
+  /** Connection ID of the new leader, for current-client leadership checks */
+  leaderConnectionId?: Maybe<Scalars['ID']['output']>;
+  /** Stable participant ID of the new leader */
   leaderId: Scalars['ID']['output'];
 };
 
@@ -1799,7 +1807,7 @@ export type Mutation = {
   deleteProposal: Scalars['Boolean']['output'];
   /** Delete a tick (climb attempt record). Only the owner can delete. */
   deleteTick: Scalars['Boolean']['output'];
-  /** End a session (leader only). */
+  /** End a session (active participant only). */
   endSession?: Maybe<SessionSummary>;
   /** Follow a board. */
   followBoard: Scalars['Boolean']['output'];
@@ -2123,6 +2131,7 @@ export type MutationJoinSessionArgs = {
   boardPath: Scalars['String']['input'];
   initialCurrentClimb?: InputMaybe<ClimbQueueItemInput>;
   initialQueue?: InputMaybe<Array<ClimbQueueItemInput>>;
+  participantId?: InputMaybe<Scalars['ID']['input']>;
   sessionId: Scalars['ID']['input'];
   sessionName?: InputMaybe<Scalars['String']['input']>;
   username?: InputMaybe<Scalars['String']['input']>;
@@ -3492,6 +3501,8 @@ export type QueueItemAdded = {
   position?: Maybe<Scalars['Int']['output']>;
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
+  /** Queue state hash after this event is applied */
+  stateHash: Scalars['String']['output'];
 };
 
 /** Event when an item is removed from the queue. */
@@ -3499,6 +3510,8 @@ export type QueueItemRemoved = {
   __typename?: 'QueueItemRemoved';
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
+  /** Queue state hash after this event is applied */
+  stateHash: Scalars['String']['output'];
   /** UUID of the removed item */
   uuid: Scalars['ID']['output'];
 };
@@ -3549,6 +3562,8 @@ export type QueueReordered = {
   oldIndex: Scalars['Int']['output'];
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
+  /** Queue state hash after this event is applied */
+  stateHash: Scalars['String']['output'];
   /** UUID of the moved item */
   uuid: Scalars['ID']['output'];
 };
@@ -3799,7 +3814,7 @@ export type Session = {
   goal?: Maybe<Scalars['String']['output']>;
   /** Unique session identifier */
   id: Scalars['ID']['output'];
-  /** Whether the current client is the session leader */
+  /** Whether the current client is the session leader (presentation/backward compatibility only) */
   isLeader: Scalars['Boolean']['output'];
   /** Whether session is exempt from auto-end */
   isPermanent: Scalars['Boolean']['output'];
@@ -3814,6 +3829,9 @@ export type Session = {
   /** Users currently in the session */
   users: Array<SessionUser>;
 };
+
+/** Current realtime connection state for a session participant. */
+export type SessionConnectionState = 'CONNECTED' | 'RECONNECTING';
 
 /** Full detail for a single session, including all ticks. */
 export type SessionDetail = {
@@ -3879,7 +3897,13 @@ export type SessionEnded = {
 };
 
 /** Union of possible session events. */
-export type SessionEvent = LeaderChanged | SessionEnded | SessionStatsUpdated | UserJoined | UserLeft;
+export type SessionEvent =
+  | LeaderChanged
+  | SessionEnded
+  | SessionStatsUpdated
+  | UserJoined
+  | UserLeft
+  | UserPresenceChanged;
 
 /** A session feed card representing a group of ticks from a climbing session. */
 export type SessionFeedItem = {
@@ -4028,9 +4052,11 @@ export type SessionUser = {
   __typename?: 'SessionUser';
   /** URL to user's avatar image */
   avatarUrl?: Maybe<Scalars['String']['output']>;
-  /** Unique user identifier */
+  /** Realtime connection state for this participant */
+  connectionState: SessionConnectionState;
+  /** Stable participant identifier within this session */
   id: Scalars['ID']['output'];
-  /** Whether this user is the session leader (controls the queue) */
+  /** Whether this user is the session leader (presentation/backward compatibility only) */
   isLeader: Scalars['Boolean']['output'];
   /** Stable database user UUID (null for unauthenticated connections) */
   userId?: Maybe<Scalars['ID']['output']>;
@@ -4685,6 +4711,13 @@ export type UserLeft = {
   userId: Scalars['ID']['output'];
 };
 
+/** Event when a participant's realtime presence state changes. */
+export type UserPresenceChanged = {
+  __typename?: 'UserPresenceChanged';
+  /** The participant whose presence changed */
+  user: SessionUser;
+};
+
 /** User profile information. */
 export type UserProfile = {
   __typename?: 'UserProfile';
@@ -4846,7 +4879,7 @@ export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = Reso
   CommentEvent: CommentAdded | CommentDeleted | CommentUpdated;
   ControllerEvent: ControllerPing | ControllerQueueSync | LedUpdate;
   QueueEvent: ClimbMirrored | CurrentClimbChanged | FullSync | QueueItemAdded | QueueItemRemoved | QueueReordered;
-  SessionEvent: LeaderChanged | SessionEnded | SessionStatsUpdated | UserJoined | UserLeft;
+  SessionEvent: LeaderChanged | SessionEnded | SessionStatsUpdated | UserJoined | UserLeft | UserPresenceChanged;
 }>;
 
 /** Mapping between all available schema types and the resolvers types */
@@ -5035,6 +5068,7 @@ export type ResolversTypes = ResolversObject<{
   SendDeviceLogsInput: SendDeviceLogsInput;
   SendDeviceLogsResponse: ResolverTypeWrapper<SendDeviceLogsResponse>;
   Session: ResolverTypeWrapper<Session>;
+  SessionConnectionState: SessionConnectionState;
   SessionDetail: ResolverTypeWrapper<SessionDetail>;
   SessionDetailTick: ResolverTypeWrapper<SessionDetailTick>;
   SessionEnded: ResolverTypeWrapper<SessionEnded>;
@@ -5089,6 +5123,7 @@ export type ResolversTypes = ResolversObject<{
   UserClimbsInput: UserClimbsInput;
   UserJoined: ResolverTypeWrapper<UserJoined>;
   UserLeft: ResolverTypeWrapper<UserLeft>;
+  UserPresenceChanged: ResolverTypeWrapper<UserPresenceChanged>;
   UserProfile: ResolverTypeWrapper<UserProfile>;
   UserSearchConnection: ResolverTypeWrapper<UserSearchConnection>;
   UserSearchResult: ResolverTypeWrapper<UserSearchResult>;
@@ -5325,6 +5360,7 @@ export type ResolversParentTypes = ResolversObject<{
   UserClimbsInput: UserClimbsInput;
   UserJoined: UserJoined;
   UserLeft: UserLeft;
+  UserPresenceChanged: UserPresenceChanged;
   UserProfile: UserProfile;
   UserSearchConnection: UserSearchConnection;
   UserSearchResult: UserSearchResult;
@@ -5590,6 +5626,8 @@ export type ClimbMirroredResolvers<
 > = ResolversObject<{
   mirrored?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  uuid?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -5805,6 +5843,7 @@ export type CurrentClimbChangedResolvers<
   correlationId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   item?: Resolver<Maybe<ResolversTypes['ClimbQueueItem']>, ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -6134,6 +6173,7 @@ export type LeaderChangedResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['LeaderChanged'] = ResolversParentTypes['LeaderChanged'],
 > = ResolversObject<{
+  leaderConnectionId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   leaderId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -7383,6 +7423,7 @@ export type QueueItemAddedResolvers<
   item?: Resolver<ResolversTypes['ClimbQueueItem'], ParentType, ContextType>;
   position?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -7391,6 +7432,7 @@ export type QueueItemRemovedResolvers<
   ParentType extends ResolversParentTypes['QueueItemRemoved'] = ResolversParentTypes['QueueItemRemoved'],
 > = ResolversObject<{
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   uuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -7433,6 +7475,7 @@ export type QueueReorderedResolvers<
   newIndex?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   oldIndex?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   uuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -7579,7 +7622,7 @@ export type SessionEventResolvers<
   ParentType extends ResolversParentTypes['SessionEvent'] = ResolversParentTypes['SessionEvent'],
 > = ResolversObject<{
   __resolveType: TypeResolveFn<
-    'LeaderChanged' | 'SessionEnded' | 'SessionStatsUpdated' | 'UserJoined' | 'UserLeft',
+    'LeaderChanged' | 'SessionEnded' | 'SessionStatsUpdated' | 'UserJoined' | 'UserLeft' | 'UserPresenceChanged',
     ParentType,
     ContextType
   >;
@@ -7719,6 +7762,7 @@ export type SessionUserResolvers<
   ParentType extends ResolversParentTypes['SessionUser'] = ResolversParentTypes['SessionUser'],
 > = ResolversObject<{
   avatarUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  connectionState?: Resolver<ResolversTypes['SessionConnectionState'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   isLeader?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   userId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
@@ -8006,6 +8050,14 @@ export type UserLeftResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type UserPresenceChangedResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['UserPresenceChanged'] = ResolversParentTypes['UserPresenceChanged'],
+> = ResolversObject<{
+  user?: Resolver<ResolversTypes['SessionUser'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type UserProfileResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['UserProfile'] = ResolversParentTypes['UserProfile'],
@@ -8181,6 +8233,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   UserClimbPercentile?: UserClimbPercentileResolvers<ContextType>;
   UserJoined?: UserJoinedResolvers<ContextType>;
   UserLeft?: UserLeftResolvers<ContextType>;
+  UserPresenceChanged?: UserPresenceChangedResolvers<ContextType>;
   UserProfile?: UserProfileResolvers<ContextType>;
   UserSearchConnection?: UserSearchConnectionResolvers<ContextType>;
   UserSearchResult?: UserSearchResultResolvers<ContextType>;

--- a/packages/shared-schema/src/operations.ts
+++ b/packages/shared-schema/src/operations.ts
@@ -344,7 +344,7 @@ export const EVENTS_REPLAY = `
         ... on ClimbMirrored {
           sequence
           stateHash
-          uuid
+          mirroredUuid: uuid
           mirrored
         }
       }
@@ -401,7 +401,7 @@ export const QUEUE_UPDATES = `
       ... on ClimbMirrored {
         sequence
         stateHash
-        uuid
+        mirroredUuid: uuid
         mirrored
       }
     }

--- a/packages/shared-schema/src/operations.ts
+++ b/packages/shared-schema/src/operations.ts
@@ -39,8 +39,8 @@ const QUEUE_ITEM_FIELDS = `
 
 // Mutations
 export const JOIN_SESSION = `
-  mutation JoinSession($sessionId: ID!, $boardPath: String!, $username: String, $avatarUrl: String, $initialQueue: [ClimbQueueItemInput!], $initialCurrentClimb: ClimbQueueItemInput, $sessionName: String) {
-    joinSession(sessionId: $sessionId, boardPath: $boardPath, username: $username, avatarUrl: $avatarUrl, initialQueue: $initialQueue, initialCurrentClimb: $initialCurrentClimb, sessionName: $sessionName) {
+  mutation JoinSession($sessionId: ID!, $boardPath: String!, $username: String, $avatarUrl: String, $participantId: ID, $initialQueue: [ClimbQueueItemInput!], $initialCurrentClimb: ClimbQueueItemInput, $sessionName: String) {
+    joinSession(sessionId: $sessionId, boardPath: $boardPath, username: $username, avatarUrl: $avatarUrl, participantId: $participantId, initialQueue: $initialQueue, initialCurrentClimb: $initialCurrentClimb, sessionName: $sessionName) {
       id
       name
       boardPath
@@ -58,6 +58,7 @@ export const JOIN_SESSION = `
         isLeader
         avatarUrl
         userId
+        connectionState
       }
       queueState {
         sequence
@@ -188,6 +189,7 @@ export const CREATE_SESSION = `
         isLeader
         avatarUrl
         userId
+        connectionState
       }
       queueState {
         sequence
@@ -215,13 +217,25 @@ export const SESSION_UPDATES = `
           isLeader
           avatarUrl
           userId
+          connectionState
         }
       }
       ... on UserLeft {
         userId
       }
+      ... on UserPresenceChanged {
+        user {
+          id
+          username
+          isLeader
+          avatarUrl
+          userId
+          connectionState
+        }
+      }
       ... on LeaderChanged {
         leaderId
+        leaderConnectionId
       }
       ... on SessionEnded {
         reason
@@ -300,6 +314,7 @@ export const EVENTS_REPLAY = `
         }
         ... on QueueItemAdded {
           sequence
+          stateHash
           addedItem: item {
             ${QUEUE_ITEM_FIELDS}
           }
@@ -307,16 +322,19 @@ export const EVENTS_REPLAY = `
         }
         ... on QueueItemRemoved {
           sequence
+          stateHash
           uuid
         }
         ... on QueueReordered {
           sequence
+          stateHash
           uuid
           oldIndex
           newIndex
         }
         ... on CurrentClimbChanged {
           sequence
+          stateHash
           currentItem: item {
             ${QUEUE_ITEM_FIELDS}
           }
@@ -325,6 +343,8 @@ export const EVENTS_REPLAY = `
         }
         ... on ClimbMirrored {
           sequence
+          stateHash
+          uuid
           mirrored
         }
       }
@@ -351,6 +371,7 @@ export const QUEUE_UPDATES = `
       }
       ... on QueueItemAdded {
         sequence
+        stateHash
         addedItem: item {
           ${QUEUE_ITEM_FIELDS}
         }
@@ -358,16 +379,19 @@ export const QUEUE_UPDATES = `
       }
       ... on QueueItemRemoved {
         sequence
+        stateHash
         uuid
       }
       ... on QueueReordered {
         sequence
+        stateHash
         uuid
         oldIndex
         newIndex
       }
       ... on CurrentClimbChanged {
         sequence
+        stateHash
         currentItem: item {
           ${QUEUE_ITEM_FIELDS}
         }
@@ -376,6 +400,8 @@ export const QUEUE_UPDATES = `
       }
       ... on ClimbMirrored {
         sequence
+        stateHash
+        uuid
         mirrored
       }
     }

--- a/packages/shared-schema/src/schema/events.ts
+++ b/packages/shared-schema/src/schema/events.ts
@@ -2,7 +2,7 @@ export const eventsTypeDefs = /* GraphQL */ `
   """
   Union of possible session events.
   """
-  union SessionEvent = UserJoined | UserLeft | LeaderChanged | SessionEnded | SessionStatsUpdated
+  union SessionEvent = UserJoined | UserLeft | UserPresenceChanged | LeaderChanged | SessionEnded | SessionStatsUpdated
 
   """
   Event when a user joins the session.
@@ -21,11 +21,21 @@ export const eventsTypeDefs = /* GraphQL */ `
   }
 
   """
+  Event when a participant's realtime presence state changes.
+  """
+  type UserPresenceChanged {
+    "The participant whose presence changed"
+    user: SessionUser!
+  }
+
+  """
   Event when session leadership changes.
   """
   type LeaderChanged {
-    "ID of the new leader"
+    "Stable participant ID of the new leader"
     leaderId: ID!
+    "Connection ID of the new leader, for current-client leadership checks"
+    leaderConnectionId: ID
   }
 
   """
@@ -90,6 +100,8 @@ export const eventsTypeDefs = /* GraphQL */ `
   type QueueItemAdded {
     "Sequence number of this event"
     sequence: Int!
+    "Queue state hash after this event is applied"
+    stateHash: String!
     "The added item"
     item: ClimbQueueItem!
     "Position where item was inserted (null = end)"
@@ -102,6 +114,8 @@ export const eventsTypeDefs = /* GraphQL */ `
   type QueueItemRemoved {
     "Sequence number of this event"
     sequence: Int!
+    "Queue state hash after this event is applied"
+    stateHash: String!
     "UUID of the removed item"
     uuid: ID!
   }
@@ -112,6 +126,8 @@ export const eventsTypeDefs = /* GraphQL */ `
   type QueueReordered {
     "Sequence number of this event"
     sequence: Int!
+    "Queue state hash after this event is applied"
+    stateHash: String!
     "UUID of the moved item"
     uuid: ID!
     "Previous position"
@@ -126,6 +142,8 @@ export const eventsTypeDefs = /* GraphQL */ `
   type CurrentClimbChanged {
     "Sequence number of this event"
     sequence: Int!
+    "Queue state hash after this event is applied"
+    stateHash: String!
     "New current climb (null to clear)"
     item: ClimbQueueItem
     "ID of the client that made this change"
@@ -140,6 +158,10 @@ export const eventsTypeDefs = /* GraphQL */ `
   type ClimbMirrored {
     "Sequence number of this event"
     sequence: Int!
+    "Queue state hash after this event is applied"
+    stateHash: String!
+    "UUID of the mirrored queue item, when a current climb exists"
+    uuid: ID
     "New mirror state"
     mirrored: Boolean!
   }

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -12,6 +12,7 @@ export const mutationsTypeDefs = /* GraphQL */ `
       boardPath: String!
       username: String
       avatarUrl: String
+      participantId: ID
       initialQueue: [ClimbQueueItemInput!]
       initialCurrentClimb: ClimbQueueItemInput
       sessionName: String
@@ -28,7 +29,7 @@ export const mutationsTypeDefs = /* GraphQL */ `
     leaveSession: Boolean!
 
     """
-    End a session (leader only).
+    End a session (active participant only).
     """
     endSession(sessionId: ID!): SessionSummary
 

--- a/packages/shared-schema/src/schema/session.ts
+++ b/packages/shared-schema/src/schema/session.ts
@@ -1,18 +1,28 @@
 export const sessionTypeDefs = /* GraphQL */ `
   """
+  Current realtime connection state for a session participant.
+  """
+  enum SessionConnectionState {
+    CONNECTED
+    RECONNECTING
+  }
+
+  """
   A user participating in a climbing session.
   """
   type SessionUser {
-    "Unique user identifier"
+    "Stable participant identifier within this session"
     id: ID!
     "Display name"
     username: String!
-    "Whether this user is the session leader (controls the queue)"
+    "Whether this user is the session leader (presentation/backward compatibility only)"
     isLeader: Boolean!
     "URL to user's avatar image"
     avatarUrl: String
     "Stable database user UUID (null for unauthenticated connections)"
     userId: ID
+    "Realtime connection state for this participant"
+    connectionState: SessionConnectionState!
   }
 
   """
@@ -29,7 +39,7 @@ export const sessionTypeDefs = /* GraphQL */ `
     users: [SessionUser!]!
     "Current queue state"
     queueState: QueueState!
-    "Whether the current client is the session leader"
+    "Whether the current client is the session leader (presentation/backward compatibility only)"
     isLeader: Boolean!
     "Unique identifier for this client's connection"
     clientId: ID!

--- a/packages/shared-schema/src/types/events.ts
+++ b/packages/shared-schema/src/types/events.ts
@@ -84,7 +84,13 @@ export type SubscriptionQueueEvent =
       clientId: string | null;
       correlationId: string | null;
     }
-  | { __typename: 'ClimbMirrored'; sequence: number; stateHash: string; uuid?: string | null; mirrored: boolean };
+  | {
+      __typename: 'ClimbMirrored';
+      sequence: number;
+      stateHash: string;
+      mirroredUuid?: string | null;
+      mirrored: boolean;
+    };
 
 export type SessionEvent =
   | { __typename: 'UserJoined'; user: SessionUser }

--- a/packages/shared-schema/src/types/events.ts
+++ b/packages/shared-schema/src/types/events.ts
@@ -18,21 +18,31 @@ import type { ClimbQueueItem, QueueState } from './queue';
 import type { SessionUser } from './session';
 import type { SessionFeedParticipant, SessionGradeDistributionItem, SessionDetailTick } from './activity-feed';
 
-// Response for delta sync event replay (Phase 2)
-// Uses QueueEvent since this is a query returning buffered events with standard field names
+// Response for delta sync event replay (Phase 2). Backend resolvers publish
+// QueueEvent objects, while GraphQL clients receive aliased subscription-shaped
+// payloads from the EVENTS_REPLAY operation.
 export type EventsReplayResponse = {
-  events: QueueEvent[];
+  events: ReplayQueueEvent[];
   currentSequence: number;
 };
+
+export type ReplayQueueEvent = QueueEvent | SubscriptionQueueEvent;
 
 // Server-side event type - uses actual GraphQL field names
 export type QueueEvent =
   | { __typename: 'FullSync'; sequence: number; state: QueueState }
-  | { __typename: 'QueueItemAdded'; sequence: number; item: ClimbQueueItem; position?: number }
-  | { __typename: 'QueueItemRemoved'; sequence: number; uuid: string }
+  | {
+      __typename: 'QueueItemAdded';
+      sequence: number;
+      stateHash: string;
+      item: ClimbQueueItem;
+      position?: number | null;
+    }
+  | { __typename: 'QueueItemRemoved'; sequence: number; stateHash: string; uuid: string }
   | {
       __typename: 'QueueReordered';
       sequence: number;
+      stateHash: string;
       uuid: string;
       oldIndex: number;
       newIndex: number;
@@ -40,20 +50,28 @@ export type QueueEvent =
   | {
       __typename: 'CurrentClimbChanged';
       sequence: number;
+      stateHash: string;
       item: ClimbQueueItem | null;
       clientId: string | null;
       correlationId: string | null;
     }
-  | { __typename: 'ClimbMirrored'; sequence: number; mirrored: boolean };
+  | { __typename: 'ClimbMirrored'; sequence: number; stateHash: string; uuid?: string | null; mirrored: boolean };
 
 // Client-side subscription event type - uses aliased field names to avoid GraphQL union conflicts
 export type SubscriptionQueueEvent =
   | { __typename: 'FullSync'; sequence: number; state: QueueState }
-  | { __typename: 'QueueItemAdded'; sequence: number; addedItem: ClimbQueueItem; position?: number }
-  | { __typename: 'QueueItemRemoved'; sequence: number; uuid: string }
+  | {
+      __typename: 'QueueItemAdded';
+      sequence: number;
+      stateHash: string;
+      addedItem: ClimbQueueItem;
+      position?: number | null;
+    }
+  | { __typename: 'QueueItemRemoved'; sequence: number; stateHash: string; uuid: string }
   | {
       __typename: 'QueueReordered';
       sequence: number;
+      stateHash: string;
       uuid: string;
       oldIndex: number;
       newIndex: number;
@@ -61,16 +79,18 @@ export type SubscriptionQueueEvent =
   | {
       __typename: 'CurrentClimbChanged';
       sequence: number;
+      stateHash: string;
       currentItem: ClimbQueueItem | null;
       clientId: string | null;
       correlationId: string | null;
     }
-  | { __typename: 'ClimbMirrored'; sequence: number; mirrored: boolean };
+  | { __typename: 'ClimbMirrored'; sequence: number; stateHash: string; uuid?: string | null; mirrored: boolean };
 
 export type SessionEvent =
   | { __typename: 'UserJoined'; user: SessionUser }
   | { __typename: 'UserLeft'; userId: string }
-  | { __typename: 'LeaderChanged'; leaderId: string }
+  | { __typename: 'UserPresenceChanged'; user: SessionUser }
+  | { __typename: 'LeaderChanged'; leaderId: string; leaderConnectionId?: string | null }
   | { __typename: 'SessionEnded'; reason: string; newPath?: string }
   | {
       __typename: 'SessionStatsUpdated';
@@ -91,6 +111,7 @@ export type SessionEvent =
 export type ConnectionContext = {
   connectionId: string;
   sessionId?: string;
+  participantId?: string;
   userId?: string;
   isAuthenticated?: boolean;
   // Client IP for rate limiting anonymous HTTP requests

--- a/packages/shared-schema/src/types/events.ts
+++ b/packages/shared-schema/src/types/events.ts
@@ -116,6 +116,11 @@ export type SessionEvent =
 
 export type ConnectionContext = {
   connectionId: string;
+  // Transport that produced this context. Resolvers branch on this for
+  // HTTP-vs-WebSocket behaviour; avoid grepping `connectionId.startsWith(...)`
+  // which is fragile to id-format changes. Optional for test contexts that
+  // don't care which transport they emulate; production paths always set it.
+  transport?: 'http' | 'ws';
   sessionId?: string;
   participantId?: string;
   userId?: string;

--- a/packages/shared-schema/src/types/session.ts
+++ b/packages/shared-schema/src/types/session.ts
@@ -1,5 +1,7 @@
 // Session types
 
+export type SessionConnectionState = 'CONNECTED' | 'RECONNECTING';
+
 export type SessionUser = {
   id: string;
   username: string;
@@ -7,6 +9,7 @@ export type SessionUser = {
   avatarUrl?: string;
   /** Stable database user UUID (null for unauthenticated connections) */
   userId?: string | null;
+  connectionState: SessionConnectionState;
 };
 
 export type SessionGradeCount = {

--- a/packages/web/app/components/connection-manager/websocket-connection-manager.ts
+++ b/packages/web/app/components/connection-manager/websocket-connection-manager.ts
@@ -20,7 +20,7 @@ type RegisteredClient = {
 };
 
 const KEEP_ALIVE_MS = 5000;
-const STALE_GRACE_MS = 10_000;
+const STALE_GRACE_MS = 25_000;
 const HEALTH_CHECK_INTERVAL_MS = 1000;
 
 class WebSocketConnectionManager {

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -204,6 +204,7 @@ export const GraphQLQueueProvider = ({
     isPersistentSessionActive,
     pendingCurrentClimbUpdates: state.pendingCurrentClimbUpdates,
     dispatch,
+    onStalePendingUpdates: persistentSession.triggerResync,
   });
 
   // --- Current user info ---

--- a/packages/web/app/components/graphql-queue/hooks/use-pending-update-cleanup.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-pending-update-cleanup.ts
@@ -5,6 +5,7 @@ type UsePendingUpdateCleanupParams = {
   isPersistentSessionActive: boolean;
   pendingCurrentClimbUpdates: string[];
   dispatch: Dispatch<QueueAction>;
+  onStalePendingUpdates?: () => void;
 };
 
 /**
@@ -18,6 +19,7 @@ export function usePendingUpdateCleanup({
   isPersistentSessionActive,
   pendingCurrentClimbUpdates,
   dispatch,
+  onStalePendingUpdates,
 }: UsePendingUpdateCleanupParams) {
   const pendingTimestampsRef = useRef(new Map<string, number>());
 
@@ -55,6 +57,7 @@ export function usePendingUpdateCleanup({
 
       if (staleIds.length > 0) {
         console.warn('[QueueContext] Cleaning up orphaned pending updates:', staleIds);
+        onStalePendingUpdates?.();
         dispatch({
           type: 'CLEANUP_PENDING_UPDATES_BATCH',
           payload: { correlationIds: staleIds },
@@ -66,5 +69,5 @@ export function usePendingUpdateCleanup({
     return () => {
       clearInterval(cleanupTimer);
     };
-  }, [isPersistentSessionActive, pendingCurrentClimbUpdates, dispatch]);
+  }, [isPersistentSessionActive, pendingCurrentClimbUpdates, dispatch, onStalePendingUpdates]);
 }

--- a/packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts
@@ -44,7 +44,7 @@ export function useQueueEventSubscription({
             type: 'DELTA_ADD_QUEUE_ITEM',
             payload: {
               item: event.addedItem as ClimbQueueItem,
-              position: event.position,
+              position: event.position ?? undefined,
             },
           });
           break;

--- a/packages/web/app/components/graphql-queue/hooks/use-session-id-management.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-session-id-management.ts
@@ -141,7 +141,7 @@ export function useSessionIdManagement({
 
   const endSession = useCallback(() => {
     const endingSessionId = activeSessionId;
-    persistentSession.deactivateSession();
+    persistentSession.deactivateSession({ notifyServer: false });
     clearClimbSessionCookie();
     setActiveSessionId(null);
 

--- a/packages/web/app/components/persistent-session/__tests__/event-processor-offline.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-processor-offline.test.ts
@@ -162,6 +162,7 @@ describe('useEventProcessor - offline FullSync merge', () => {
       result.current.handleQueueEvent({
         __typename: 'QueueItemAdded',
         sequence: 5,
+        stateHash: 'hash-2',
         addedItem,
         position: undefined,
       } as SubscriptionQueueEvent);
@@ -169,5 +170,66 @@ describe('useEventProcessor - offline FullSync merge', () => {
 
     expect(result.current.queue).toHaveLength(1);
     expect(result.current.queue[0]).toEqual(addedItem);
+    expect(result.current.lastReceivedStateHash).toBe('hash-2');
+  });
+
+  it('QueueItemRemoved clears current climb and advances state hash', () => {
+    const refs = createRefs([]);
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const removedItem = createItem('removed-1');
+    const keptItem = createItem('kept-1');
+
+    act(() => {
+      result.current.handleQueueEvent({
+        __typename: 'FullSync',
+        sequence: 5,
+        state: {
+          queue: [removedItem as never, keptItem as never],
+          currentClimbQueueItem: removedItem as never,
+          stateHash: 'hash-1',
+          sequence: 5,
+        },
+      });
+      result.current.handleQueueEvent({
+        __typename: 'QueueItemRemoved',
+        sequence: 6,
+        stateHash: 'hash-2',
+        uuid: removedItem.uuid,
+      });
+    });
+
+    expect(result.current.queue).toEqual([keptItem]);
+    expect(result.current.currentClimbQueueItem).toBeNull();
+    expect(result.current.lastReceivedStateHash).toBe('hash-2');
+  });
+
+  it('ClimbMirrored updates both queue item and current climb', () => {
+    const refs = createRefs([]);
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const item = createItem('mirror-1');
+
+    act(() => {
+      result.current.handleQueueEvent({
+        __typename: 'FullSync',
+        sequence: 5,
+        state: {
+          queue: [item as never],
+          currentClimbQueueItem: item as never,
+          stateHash: 'hash-1',
+          sequence: 5,
+        },
+      });
+      result.current.handleQueueEvent({
+        __typename: 'ClimbMirrored',
+        sequence: 6,
+        stateHash: 'hash-2',
+        uuid: item.uuid,
+        mirrored: true,
+      });
+    });
+
+    expect(result.current.queue[0]?.climb.mirrored).toBe(true);
+    expect(result.current.currentClimbQueueItem?.climb.mirrored).toBe(true);
+    expect(result.current.lastReceivedStateHash).toBe('hash-2');
   });
 });

--- a/packages/web/app/components/persistent-session/__tests__/event-processor-offline.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-processor-offline.test.ts
@@ -223,7 +223,7 @@ describe('useEventProcessor - offline FullSync merge', () => {
         __typename: 'ClimbMirrored',
         sequence: 6,
         stateHash: 'hash-2',
-        uuid: item.uuid,
+        mirroredUuid: item.uuid,
         mirrored: true,
       });
     });

--- a/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
@@ -281,7 +281,7 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     act(() => {
       result.current.handleSessionEvent({
         __typename: 'UserJoined',
-        user: { id: 'user-1', username: 'test', isLeader: false },
+        user: { id: 'user-1', username: 'test', isLeader: false, connectionState: 'CONNECTED' },
       });
     });
 

--- a/packages/web/app/components/persistent-session/__tests__/event-utils.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-utils.test.ts
@@ -9,6 +9,7 @@ describe('persistent session event utils', () => {
       username: 'User A',
       isLeader: false,
       avatarUrl: undefined,
+      connectionState: 'CONNECTED',
     };
 
     it('adds a new user when id does not exist', () => {

--- a/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
@@ -113,6 +113,11 @@ function createTestBoardDetails(overrides?: Partial<BoardDetails>): BoardDetails
   } as BoardDetails;
 }
 
+const expectSessionWithParticipant = (actual: unknown, expected: object) => {
+  expect(actual).toMatchObject(expected);
+  expect(actual).toEqual(expect.objectContaining({ participantId: expect.any(String) }));
+};
+
 function createWrapper() {
   // Fresh QueryClient per test so cached session-detail entries don't leak
   // across cases. PersistentSessionProvider's useEventProcessor calls
@@ -231,7 +236,7 @@ describe('PersistentSessionProvider auto-restore on mount', () => {
     });
 
     // Party session should be active
-    expect(result.current.activeSession).toEqual(sessionInfo);
+    expectSessionWithParticipant(result.current.activeSession, sessionInfo);
     // Local queue should be empty (no IndexedDB persistence)
     expect(result.current.localQueue).toEqual([]);
   });
@@ -263,7 +268,7 @@ describe('PersistentSessionProvider auto-restore on mount', () => {
     // Wait for the async persistence to complete
     await waitFor(async () => {
       const stored = await getPreference(ACTIVE_SESSION_KEY);
-      expect(stored).toEqual(sessionInfo);
+      expectSessionWithParticipant(stored, sessionInfo);
     });
   });
 
@@ -332,14 +337,14 @@ describe('PersistentSessionProvider auto-restore on mount', () => {
     const { result } = renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
 
     await waitFor(() => {
-      expect(result.current.activeSession).toEqual(sessionInfo);
+      expectSessionWithParticipant(result.current.activeSession, sessionInfo);
     });
 
     expect(result.current.sessionSummaryAutoFinished).toBe(false);
     expect(result.current.sessionSummary).toBeNull();
 
     const stored = await getPreference(ACTIVE_SESSION_KEY);
-    expect(stored).toEqual(sessionInfo);
+    expectSessionWithParticipant(stored, sessionInfo);
   });
 
   it('waits for auth to load before running mount pre-flight', async () => {
@@ -423,7 +428,7 @@ describe('PersistentSessionProvider auto-restore on mount', () => {
     rerender();
 
     await waitFor(() => {
-      expect(result.current.activeSession).toEqual(sessionInfo);
+      expectSessionWithParticipant(result.current.activeSession, sessionInfo);
     });
 
     expect(mockHttpRequest).toHaveBeenCalledTimes(1);
@@ -448,7 +453,7 @@ describe('PersistentSessionProvider auto-restore on mount', () => {
 
     // First mount: pre-flight says still-active, session is restored.
     await waitFor(() => {
-      expect(result.current.activeSession).toEqual(sessionInfo);
+      expectSessionWithParticipant(result.current.activeSession, sessionInfo);
     });
     expect(result.current.sessionSummaryAutoFinished).toBe(false);
 
@@ -493,7 +498,7 @@ describe('PersistentSessionProvider auto-restore on mount', () => {
     const { result } = renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
 
     await waitFor(() => {
-      expect(result.current.activeSession).toEqual(sessionInfo);
+      expectSessionWithParticipant(result.current.activeSession, sessionInfo);
     });
 
     act(() => {

--- a/packages/web/app/components/persistent-session/__tests__/session-lifecycle-replay.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/session-lifecycle-replay.test.ts
@@ -55,6 +55,24 @@ describe('session lifecycle replay helpers', () => {
     });
   });
 
+  it('maps unaliased ClimbMirrored replay events to subscription shape', () => {
+    const event: QueueEvent = {
+      __typename: 'ClimbMirrored',
+      sequence: 7,
+      stateHash: 'hash-7',
+      uuid: 'queue-item-1',
+      mirrored: true,
+    };
+
+    expect(transformToSubscriptionEvent(event)).toEqual({
+      __typename: 'ClimbMirrored',
+      sequence: 7,
+      stateHash: 'hash-7',
+      mirroredUuid: 'queue-item-1',
+      mirrored: true,
+    });
+  });
+
   it('rejects replay coverage with a missing sequence', () => {
     const events: SubscriptionQueueEvent[] = [
       {

--- a/packages/web/app/components/persistent-session/__tests__/session-lifecycle-replay.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/session-lifecycle-replay.test.ts
@@ -118,4 +118,32 @@ describe('session lifecycle replay helpers', () => {
 
     expect(hasContiguousReplayCoverage(events, 5, 8)).toBe(true);
   });
+
+  it('handles reverse-order FullSync + same-sequence delta from the backend', () => {
+    // Verifies the explicit tie-breaker: even when the backend returns the
+    // delta before its co-sequenced FullSync, the sort prioritises FullSync
+    // so the contiguity check still passes.
+    const events: SubscriptionQueueEvent[] = [
+      {
+        __typename: 'CurrentClimbChanged',
+        sequence: 8,
+        stateHash: 'hash-8',
+        currentItem: queueItem,
+        clientId: 'controller-1',
+        correlationId: null,
+      },
+      {
+        __typename: 'FullSync',
+        sequence: 8,
+        state: {
+          sequence: 8,
+          stateHash: 'hash-8',
+          queue: [queueItem],
+          currentClimbQueueItem: queueItem,
+        },
+      },
+    ];
+
+    expect(hasContiguousReplayCoverage(events, 5, 8)).toBe(true);
+  });
 });

--- a/packages/web/app/components/persistent-session/__tests__/session-lifecycle-replay.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/session-lifecycle-replay.test.ts
@@ -146,4 +146,31 @@ describe('session lifecycle replay helpers', () => {
 
     expect(hasContiguousReplayCoverage(events, 5, 8)).toBe(true);
   });
+
+  it('handles QueueItemAdded co-sequenced with a FullSync (delta arrives first)', () => {
+    // Same tie-break invariant as the CurrentClimbChanged case but with a
+    // QueueItemAdded delta. The sort puts FullSync first so the contiguity
+    // check still passes regardless of arrival order.
+    const events: SubscriptionQueueEvent[] = [
+      {
+        __typename: 'QueueItemAdded',
+        sequence: 8,
+        stateHash: 'hash-8',
+        addedItem: queueItem,
+        position: null,
+      },
+      {
+        __typename: 'FullSync',
+        sequence: 8,
+        state: {
+          sequence: 8,
+          stateHash: 'hash-8',
+          queue: [queueItem],
+          currentClimbQueueItem: queueItem,
+        },
+      },
+    ];
+
+    expect(hasContiguousReplayCoverage(events, 5, 8)).toBe(true);
+  });
 });

--- a/packages/web/app/components/persistent-session/__tests__/session-lifecycle-replay.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/session-lifecycle-replay.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vite-plus/test';
+import type { QueueEvent, SubscriptionQueueEvent } from '@boardsesh/shared-schema';
+import { hasContiguousReplayCoverage, transformToSubscriptionEvent } from '../hooks/use-session-lifecycle';
+
+const queueItem = {
+  uuid: 'queue-item-1',
+  climb: {
+    uuid: 'climb-1',
+    setter_username: 'setter',
+    name: 'Test Climb',
+    description: '',
+    frames: '',
+    angle: 40,
+    ascensionist_count: 0,
+    difficulty: '6A',
+    quality_average: '3.5',
+    stars: 3.5,
+    difficulty_error: '0.5',
+    mirrored: false,
+    benchmark_difficulty: null,
+  },
+  suggested: false,
+};
+
+describe('session lifecycle replay helpers', () => {
+  it('preserves aliased QueueItemAdded replay events', () => {
+    const event: SubscriptionQueueEvent = {
+      __typename: 'QueueItemAdded',
+      sequence: 6,
+      stateHash: 'hash-6',
+      addedItem: queueItem,
+      position: null,
+    };
+
+    expect(transformToSubscriptionEvent(event)).toEqual(event);
+  });
+
+  it('maps unaliased CurrentClimbChanged replay events to subscription shape', () => {
+    const event: QueueEvent = {
+      __typename: 'CurrentClimbChanged',
+      sequence: 6,
+      stateHash: 'hash-6',
+      item: queueItem,
+      clientId: 'client-1',
+      correlationId: 'correlation-1',
+    };
+
+    expect(transformToSubscriptionEvent(event)).toEqual({
+      __typename: 'CurrentClimbChanged',
+      sequence: 6,
+      stateHash: 'hash-6',
+      currentItem: queueItem,
+      clientId: 'client-1',
+      correlationId: 'correlation-1',
+    });
+  });
+
+  it('rejects replay coverage with a missing sequence', () => {
+    const events: SubscriptionQueueEvent[] = [
+      {
+        __typename: 'QueueItemAdded',
+        sequence: 6,
+        stateHash: 'hash-6',
+        addedItem: queueItem,
+      },
+      {
+        __typename: 'CurrentClimbChanged',
+        sequence: 8,
+        stateHash: 'hash-8',
+        currentItem: queueItem,
+        clientId: null,
+        correlationId: null,
+      },
+    ];
+
+    expect(hasContiguousReplayCoverage(events, 5, 8)).toBe(false);
+  });
+
+  it('allows FullSync to cover earlier missing sequences and same-sequence controller events', () => {
+    const events: SubscriptionQueueEvent[] = [
+      {
+        __typename: 'FullSync',
+        sequence: 8,
+        state: {
+          sequence: 8,
+          stateHash: 'hash-8',
+          queue: [queueItem],
+          currentClimbQueueItem: queueItem,
+        },
+      },
+      {
+        __typename: 'CurrentClimbChanged',
+        sequence: 8,
+        stateHash: 'hash-8',
+        currentItem: queueItem,
+        clientId: 'controller-1',
+        correlationId: null,
+      },
+    ];
+
+    expect(hasContiguousReplayCoverage(events, 5, 8)).toBe(true);
+  });
+});

--- a/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
@@ -30,6 +30,7 @@ export type EventProcessorActions = {
   handleSessionEvent: (event: SessionEvent) => void;
   setQueueState: Dispatch<SetStateAction<LocalClimbQueueItem[]>>;
   setCurrentClimbQueueItem: Dispatch<SetStateAction<LocalClimbQueueItem | null>>;
+  setLastReceivedStateHash: Dispatch<SetStateAction<string | null>>;
   notifyQueueSubscribers: (event: SubscriptionQueueEvent) => void;
   notifySessionSubscribers: (event: SessionEvent) => void;
 };
@@ -128,34 +129,55 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
         case 'QueueItemAdded':
           if (event.addedItem == null) {
             console.error('[PersistentSession] Received QueueItemAdded with null/undefined item, skipping');
-            updateLastReceivedSequence(event.sequence);
             break;
           }
           setQueueState((prev) => {
-            return insertQueueItemIdempotent(prev, event.addedItem as LocalClimbQueueItem, event.position);
+            return insertQueueItemIdempotent(prev, event.addedItem as LocalClimbQueueItem, event.position ?? undefined);
           });
-          updateLastReceivedSequence(event.sequence);
           break;
         case 'QueueItemRemoved':
           setQueueState((prev) => prev.filter((item) => item.uuid !== event.uuid));
-          updateLastReceivedSequence(event.sequence);
+          setCurrentClimbQueueItem((prev) => (prev?.uuid === event.uuid ? null : prev));
           break;
         case 'QueueReordered':
           setQueueState((prev) => {
+            const sourceIndex = prev.findIndex((item) => item.uuid === event.uuid);
+            const oldIndex = sourceIndex >= 0 ? sourceIndex : event.oldIndex;
+            if (oldIndex < 0 || oldIndex >= prev.length) {
+              console.warn(
+                `[PersistentSession] Received QueueReordered for missing item ${event.uuid}; waiting for hash watchdog resync`,
+              );
+              return prev;
+            }
             const newQueue = [...prev];
-            const [item] = newQueue.splice(event.oldIndex, 1);
-            newQueue.splice(event.newIndex, 0, item);
+            const [item] = newQueue.splice(oldIndex, 1);
+            const newIndex = Math.max(0, Math.min(event.newIndex, newQueue.length));
+            newQueue.splice(newIndex, 0, item);
             return newQueue;
           });
-          updateLastReceivedSequence(event.sequence);
           break;
         case 'CurrentClimbChanged':
           setCurrentClimbQueueItem(event.currentItem as LocalClimbQueueItem | null);
-          updateLastReceivedSequence(event.sequence);
           break;
         case 'ClimbMirrored':
+          if (event.uuid) {
+            setQueueState((prev) =>
+              prev.map((item) =>
+                item.uuid === event.uuid
+                  ? {
+                      ...item,
+                      climb: {
+                        ...item.climb,
+                        mirrored: event.mirrored,
+                      },
+                    }
+                  : item,
+              ),
+            );
+          }
           setCurrentClimbQueueItem((prev) => {
             if (!prev) return prev;
+            if (event.uuid && prev.uuid !== event.uuid) return prev;
             return {
               ...prev,
               climb: {
@@ -164,8 +186,12 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
               },
             };
           });
-          updateLastReceivedSequence(event.sequence);
           break;
+      }
+
+      if (event.__typename !== 'FullSync') {
+        updateLastReceivedSequence(event.sequence);
+        setLastReceivedStateHash(event.stateHash);
       }
 
       // Notify external subscribers
@@ -222,6 +248,7 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
     handleSessionEvent,
     setQueueState,
     setCurrentClimbQueueItem,
+    setLastReceivedStateHash,
     notifyQueueSubscribers,
     notifySessionSubscribers,
   };

--- a/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
@@ -160,10 +160,10 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
           setCurrentClimbQueueItem(event.currentItem as LocalClimbQueueItem | null);
           break;
         case 'ClimbMirrored':
-          if (event.uuid) {
+          if (event.mirroredUuid) {
             setQueueState((prev) =>
               prev.map((item) =>
-                item.uuid === event.uuid
+                item.uuid === event.mirroredUuid
                   ? {
                       ...item,
                       climb: {
@@ -177,7 +177,7 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
           }
           setCurrentClimbQueueItem((prev) => {
             if (!prev) return prev;
-            if (event.uuid && prev.uuid !== event.uuid) return prev;
+            if (event.mirroredUuid && prev.uuid !== event.mirroredUuid) return prev;
             return {
               ...prev,
               climb: {

--- a/packages/web/app/components/persistent-session/hooks/use-queue-storage.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-queue-storage.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import type { SessionSummary } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
 import type { BoardDetails } from '@/app/lib/types';
-import { getPreference, removePreference } from '@/app/lib/user-preferences-db';
+import { getPreference, removePreference, setPreference } from '@/app/lib/user-preferences-db';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { GET_SESSION_SUMMARY, type GetSessionSummaryResponse } from '@/app/lib/graphql/operations/sessions';
 import { type ActiveSessionInfo, ACTIVE_SESSION_KEY, DEBUG } from '../types';
@@ -11,10 +11,19 @@ type UseQueueStorageArgs = {
   activeSession: ActiveSessionInfo | null;
   setActiveSession: (val: ActiveSessionInfo) => void;
   /** Called when a restored session was already auto-finished by the backend */
-  onSessionAutoFinished: (summary: SessionSummary, boardType: string | null) => void;
-  wsAuthToken: string | null;
-  isAuthLoading: boolean;
+  onSessionAutoFinished?: (summary: SessionSummary, boardType: string | null) => void;
+  wsAuthToken?: string | null;
+  isAuthLoading?: boolean;
 };
+
+function ensureParticipantId(info: ActiveSessionInfo): ActiveSessionInfo {
+  if (info.participantId) return info;
+  const participantId =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `participant-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  return { ...info, participantId };
+}
 
 export type QueueStorageState = {
   localQueue: LocalClimbQueueItem[];
@@ -37,9 +46,9 @@ export type QueueStorageActions = {
 export function useQueueStorage({
   activeSession,
   setActiveSession,
-  onSessionAutoFinished,
-  wsAuthToken,
-  isAuthLoading,
+  onSessionAutoFinished = () => {},
+  wsAuthToken = null,
+  isAuthLoading = false,
 }: UseQueueStorageArgs): QueueStorageState & QueueStorageActions {
   const [localQueue, setLocalQueue] = useState<LocalClimbQueueItem[]>([]);
   const [localCurrentClimbQueueItem, setLocalCurrentClimbQueueItem] = useState<LocalClimbQueueItem | null>(null);
@@ -90,7 +99,11 @@ export function useQueueStorage({
       try {
         const persisted = await getPreference<ActiveSessionInfo>(ACTIVE_SESSION_KEY);
         if (persisted && persisted.sessionId && persisted.boardPath && persisted.boardDetails) {
-          if (DEBUG) console.info('[PersistentSession] Restoring persisted session:', persisted.sessionId);
+          const restored = ensureParticipantId(persisted);
+          if (restored !== persisted) {
+            await setPreference(ACTIVE_SESSION_KEY, restored);
+          }
+          if (DEBUG) console.info('[PersistentSession] Restoring persisted session:', restored.sessionId);
 
           if (!wsAuthToken) {
             console.info(
@@ -98,13 +111,13 @@ export function useQueueStorage({
             );
             if (!hasActivatedRef.current) {
               hasActivatedRef.current = true;
-              setActiveSession(persisted);
+              setActiveSession(restored);
             }
             setIsLocalQueueLoaded(true);
             return;
           }
 
-          const autoFinished = await fetchAutoFinishedSummary(persisted, wsAuthToken);
+          const autoFinished = await fetchAutoFinishedSummary(restored, wsAuthToken);
           hasRunPreflightRef.current = true;
           if (autoFinished) {
             if (DEBUG) console.info('[PersistentSession] Session was auto-finished, showing summary');
@@ -116,7 +129,7 @@ export function useQueueStorage({
 
           if (!hasActivatedRef.current) {
             hasActivatedRef.current = true;
-            setActiveSession(persisted);
+            setActiveSession(restored);
           }
           setIsLocalQueueLoaded(true);
           return;

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -63,6 +63,18 @@ export function transformToSubscriptionEvent(event: QueueEvent | SubscriptionQue
         correlationId: event.correlationId,
       };
     }
+    case 'ClimbMirrored': {
+      // Wire shape exposes `uuid`; aliased subscription shape uses `mirroredUuid`. Read both.
+      const climbMirroredCandidate = event as { uuid?: string | null; mirroredUuid?: string | null };
+      const mirroredUuid = climbMirroredCandidate.mirroredUuid ?? climbMirroredCandidate.uuid ?? null;
+      return {
+        __typename: 'ClimbMirrored',
+        sequence: event.sequence,
+        stateHash: event.stateHash,
+        mirroredUuid,
+        mirrored: event.mirrored,
+      };
+    }
     default:
       return event as SubscriptionQueueEvent;
   }
@@ -393,6 +405,7 @@ export function useSessionLifecycle({
     let retryConnectTimeout: ReturnType<typeof setTimeout> | null = null;
     let subscriptionRestartTimeout: ReturnType<typeof setTimeout> | null = null;
     let transientRetryCount = 0;
+    let subscriptionRetryCount = 0;
     let isCleaningUp = false;
 
     async function joinSession(clientToUse: Client): Promise<Session | null> {
@@ -549,13 +562,31 @@ export function useSessionLifecycle({
       if (connectionGenerationRef.current !== connectionGeneration) return;
       if (subscriptionRestartTimeout) return;
 
-      if (DEBUG) console.info(`[PersistentSession] Scheduling subscription recovery: ${reason}`);
+      subscriptionRetryCount++;
+      if (subscriptionRetryCount > MAX_TRANSIENT_RETRIES) {
+        console.warn(`[PersistentSession] Exhausted ${MAX_TRANSIENT_RETRIES} subscription retries, clearing session`);
+        subscriptionRetryCount = 0;
+        removePreference(ACTIVE_SESSION_KEY).catch(() => {});
+        if (mountedRef.current) {
+          setActiveSession(null);
+        }
+        return;
+      }
+
+      const delay = Math.min(
+        INITIAL_RETRY_DELAY_MS * Math.pow(BACKOFF_MULTIPLIER, subscriptionRetryCount - 1),
+        MAX_RETRY_DELAY_MS,
+      );
+      if (DEBUG)
+        console.info(
+          `[PersistentSession] Scheduling subscription recovery (${subscriptionRetryCount}/${MAX_TRANSIENT_RETRIES}) in ${delay}ms: ${reason}`,
+        );
       subscriptionRestartTimeout = setTimeout(() => {
         subscriptionRestartTimeout = null;
         if (isCleaningUp || !mountedRef.current) return;
         if (connectionGenerationRef.current !== connectionGeneration) return;
         void handleReconnect();
-      }, INITIAL_RETRY_DELAY_MS);
+      }, delay);
     }
 
     function startSubscriptions(clientToUse: Client) {
@@ -569,6 +600,7 @@ export function useSessionLifecycle({
           {
             next: (data) => {
               if (data.queueUpdates) {
+                subscriptionRetryCount = 0;
                 handleQueueEvent(data.queueUpdates);
               }
             },
@@ -596,6 +628,7 @@ export function useSessionLifecycle({
           {
             next: (data) => {
               if (data.sessionUpdates) {
+                subscriptionRetryCount = 0;
                 // Handle UserJoined/UserLeft/LeaderChanged/SessionEnded in session state
                 const event = data.sessionUpdates;
                 if (event.__typename !== 'SessionStatsUpdated') {
@@ -692,6 +725,7 @@ export function useSessionLifecycle({
         if (DEBUG) console.info('[PersistentSession] Joined session, clientId:', sessionData.clientId);
 
         transientRetryCount = 0;
+        subscriptionRetryCount = 0;
         setSession(sessionData);
         setHasConnected(true);
         setIsConnecting(false);

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -90,7 +90,20 @@ export function hasContiguousReplayCoverage(
   }
 
   let expectedSequence = sinceSequence + 1;
-  const sortedEvents = [...events].sort((a, b) => a.sequence - b.sequence);
+  // FullSync and CurrentClimbChanged can share a sequence number when a
+  // controller-issued climb change races with a snapshot. Process FullSync
+  // first within a tie so the snapshot establishes the new expected sequence
+  // before the same-sequence delta is checked — otherwise the delta would
+  // fail the `event.sequence !== expectedSequence` invariant and we'd
+  // wrongly report a gap. We can't rely on sort stability for this — even
+  // with ECMAScript 2019's stable sort, the assertion still depends on the
+  // caller's insertion order, which is not contractual.
+  const sortedEvents = [...events].sort((a, b) => {
+    if (a.sequence !== b.sequence) return a.sequence - b.sequence;
+    if (a.__typename === 'FullSync' && b.__typename !== 'FullSync') return -1;
+    if (b.__typename === 'FullSync' && a.__typename !== 'FullSync') return 1;
+    return 0;
+  });
 
   for (const event of sortedEvents) {
     if (event.sequence < expectedSequence) {

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -40,32 +40,71 @@ import {
 /**
  * Transform QueueEvent (from eventsReplay) to SubscriptionQueueEvent format.
  */
-function transformToSubscriptionEvent(event: QueueEvent): SubscriptionQueueEvent {
+export function transformToSubscriptionEvent(event: QueueEvent | SubscriptionQueueEvent): SubscriptionQueueEvent {
   switch (event.__typename) {
-    case 'QueueItemAdded':
+    case 'QueueItemAdded': {
+      const addedItem = 'addedItem' in event ? event.addedItem : event.item;
       return {
         __typename: 'QueueItemAdded',
         sequence: event.sequence,
-        addedItem: event.item,
+        stateHash: event.stateHash,
+        addedItem,
         position: event.position,
       };
-    case 'CurrentClimbChanged':
+    }
+    case 'CurrentClimbChanged': {
+      const currentItem = 'currentItem' in event ? event.currentItem : event.item;
       return {
         __typename: 'CurrentClimbChanged',
         sequence: event.sequence,
-        currentItem: event.item,
+        stateHash: event.stateHash,
+        currentItem,
         clientId: event.clientId,
         correlationId: event.correlationId,
       };
+    }
     default:
       return event as SubscriptionQueueEvent;
   }
+}
+
+export function hasContiguousReplayCoverage(
+  events: SubscriptionQueueEvent[],
+  sinceSequence: number,
+  currentSequence: number,
+): boolean {
+  if (currentSequence <= sinceSequence) {
+    return true;
+  }
+
+  let expectedSequence = sinceSequence + 1;
+  const sortedEvents = [...events].sort((a, b) => a.sequence - b.sequence);
+
+  for (const event of sortedEvents) {
+    if (event.sequence < expectedSequence) {
+      continue;
+    }
+
+    if (event.__typename === 'FullSync') {
+      expectedSequence = event.sequence + 1;
+      continue;
+    }
+
+    if (event.sequence !== expectedSequence) {
+      return false;
+    }
+
+    expectedSequence++;
+  }
+
+  return expectedSequence > currentSequence;
 }
 
 type UseSessionLifecycleArgs = {
   isAuthLoading: boolean;
   handleQueueEvent: (event: SubscriptionQueueEvent) => void;
   handleSessionEvent: (event: SessionEvent) => void;
+  setLastReceivedStateHash: Dispatch<SetStateAction<string | null>>;
   setSession: Dispatch<SetStateAction<Session | null>>;
   refs: Pick<
     SharedRefs,
@@ -87,6 +126,13 @@ type UseSessionLifecycleArgs = {
   >;
 };
 
+function createParticipantId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `participant-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 export type SessionLifecycleState = {
   activeSession: ActiveSessionInfo | null;
   client: Client | null;
@@ -102,7 +148,7 @@ export type SessionLifecycleState = {
 
 export type SessionLifecycleActions = {
   activateSession: (info: ActiveSessionInfo) => void;
-  deactivateSession: () => void;
+  deactivateSession: (options?: { notifyServer?: boolean }) => void;
   setInitialQueueForSession: (
     sessionId: string,
     queue: LocalClimbQueueItem[],
@@ -119,6 +165,7 @@ export function useSessionLifecycle({
   isAuthLoading,
   handleQueueEvent,
   handleSessionEvent,
+  setLastReceivedStateHash,
   setSession: setSessionExternal,
   refs,
 }: UseSessionLifecycleArgs): SessionLifecycleState & SessionLifecycleActions {
@@ -150,9 +197,12 @@ export function useSessionLifecycle({
   const [sessionSummaryBoardType, setSessionSummaryBoardType] = useState<string | null>(null);
   const [sessionSummaryHealthKitWorkoutId, setSessionSummaryHealthKitWorkoutId] = useState<string | null>(null);
   const [sessionSummaryAutoFinished, setSessionSummaryAutoFinished] = useState(false);
+  const sendLeaveOnCleanupRef = useRef(false);
 
-  // Pending initial queue for new sessions
-  const [pendingInitialQueue, setPendingInitialQueue] = useState<PendingInitialQueue | null>(null);
+  // Pending initial queue for new sessions. This intentionally lives in a ref
+  // so session activation and queue seeding can happen in either order without
+  // the WebSocket effect capturing a stale null value.
+  const pendingInitialQueueRef = useRef<PendingInitialQueue | null>(null);
 
   // Combined setter that updates both local and external state
   const setSession = useCallback(
@@ -177,18 +227,32 @@ export function useSessionLifecycle({
   const activateSession = useCallback((info: ActiveSessionInfo) => {
     setActiveSession((prev) => {
       if (prev?.sessionId === info.sessionId && prev?.boardPath === info.boardPath) {
+        if (!prev.participantId) {
+          const nextInfo = { ...prev, participantId: createParticipantId() };
+          setPreference(ACTIVE_SESSION_KEY, nextInfo).catch((err) =>
+            console.error('[PersistentSession] Failed to persist session:', err),
+          );
+          return nextInfo;
+        }
         return prev;
       }
+      if (prev) {
+        sendLeaveOnCleanupRef.current = true;
+      }
+      const nextInfo = { ...info, participantId: info.participantId || createParticipantId() };
       if (DEBUG) console.info('[PersistentSession] Activating session:', info.sessionId);
-      setPreference(ACTIVE_SESSION_KEY, info).catch((err) =>
+      setPreference(ACTIVE_SESSION_KEY, nextInfo).catch((err) =>
         console.error('[PersistentSession] Failed to persist session:', err),
       );
-      return info;
+      return nextInfo;
     });
   }, []);
 
-  const deactivateSession = useCallback(() => {
+  const deactivateSession = useCallback((options?: { notifyServer?: boolean }) => {
     if (DEBUG) console.info('[PersistentSession] Deactivating session');
+    if (options?.notifyServer !== false) {
+      sendLeaveOnCleanupRef.current = true;
+    }
     setActiveSession(null);
     removePreference(ACTIVE_SESSION_KEY).catch((err) =>
       console.error('[PersistentSession] Failed to clear persisted session:', err),
@@ -209,7 +273,7 @@ export function useSessionLifecycle({
           'items',
           sessionName ? `name: ${sessionName}` : '',
         );
-      setPendingInitialQueue({ sessionId, queue, currentClimb, sessionName });
+      pendingInitialQueueRef.current = { sessionId, queue, currentClimb, sessionName };
     },
     [],
   );
@@ -233,7 +297,7 @@ export function useSessionLifecycle({
     const boardType = activeSessionRef.current?.parsedParams.board_name ?? null;
     const token = wsAuthTokenRef.current;
 
-    deactivateSession();
+    deactivateSession({ notifyServer: false });
 
     if (endingSessionId && token) {
       const httpClient = createGraphQLHttpClient(token);
@@ -268,7 +332,7 @@ export function useSessionLifecycle({
         const result = await fetchAutoFinishedSummary(active, wsAuthTokenRef.current);
         if (!result) return;
         if (activeSessionRef.current?.sessionId !== active.sessionId) return;
-        deactivateSession();
+        deactivateSession({ notifyServer: false });
         setAutoFinishedSummary(result.summary, result.boardType);
       } finally {
         visibilityCheckInFlightRef.current = false;
@@ -327,12 +391,15 @@ export function useSessionLifecycle({
     const connectionGeneration = ++connectionGenerationRef.current;
     let graphqlClient: Client | null = null;
     let retryConnectTimeout: ReturnType<typeof setTimeout> | null = null;
+    let subscriptionRestartTimeout: ReturnType<typeof setTimeout> | null = null;
     let transientRetryCount = 0;
+    let isCleaningUp = false;
 
     async function joinSession(clientToUse: Client): Promise<Session | null> {
       if (DEBUG) console.info('[PersistentSession] Calling joinSession mutation...');
       try {
-        const initialQueueData = pendingInitialQueue?.sessionId === sessionId ? pendingInitialQueue : null;
+        const initialQueueData =
+          pendingInitialQueueRef.current?.sessionId === sessionId ? pendingInitialQueueRef.current : null;
 
         if (DEBUG && initialQueueData) {
           console.info('[PersistentSession] Sending initial queue with', initialQueueData.queue.length, 'items');
@@ -344,6 +411,7 @@ export function useSessionLifecycle({
           boardPath,
           username: usernameRef.current,
           avatarUrl: avatarUrlRef.current,
+          participantId: activeSessionRef.current?.participantId,
           ...(initialQueueData && {
             initialQueue: initialQueueData.queue.map(toClimbQueueItemInput),
             initialCurrentClimb: initialQueueData.currentClimb
@@ -365,7 +433,7 @@ export function useSessionLifecycle({
         }
 
         if (initialQueueData) {
-          setPendingInitialQueue(null);
+          pendingInitialQueueRef.current = null;
         }
 
         return joinedSession;
@@ -376,7 +444,8 @@ export function useSessionLifecycle({
     }
 
     async function handleReconnect() {
-      if (!mountedRef.current || !graphqlClient) return;
+      const clientForReconnect = graphqlClient;
+      if (!mountedRef.current || !clientForReconnect) return;
       if (connectionGenerationRef.current !== connectionGeneration) return;
       if (isReconnectingRef.current) {
         if (DEBUG) console.info('[PersistentSession] Reconnection already in progress');
@@ -388,7 +457,7 @@ export function useSessionLifecycle({
         if (DEBUG) console.info('[PersistentSession] Reconnecting...');
 
         const lastSeq = lastReceivedSequenceRef.current;
-        const sessionData = await joinSession(graphqlClient);
+        const sessionData = await joinSession(clientForReconnect);
         if (!sessionData || !mountedRef.current) return;
 
         const currentSeq = sessionData.queueState.sequence;
@@ -403,7 +472,7 @@ export function useSessionLifecycle({
           try {
             if (DEBUG) console.info(`[PersistentSession] Attempting delta sync for ${gap} missed events...`);
 
-            const response = await execute<{ eventsReplay: EventsReplayResponse }>(graphqlClient, {
+            const response = await execute<{ eventsReplay: EventsReplayResponse }>(clientForReconnect, {
               query: EVENTS_REPLAY,
               variables: { sessionId, sinceSequence: lastSeq },
             });
@@ -413,10 +482,22 @@ export function useSessionLifecycle({
               throw new Error('eventsReplay payload missing');
             }
 
-            if (replay.events.length > 0) {
-              if (DEBUG) console.info(`[PersistentSession] Replaying ${replay.events.length} events`);
-              replay.events.forEach((event) => {
-                handleQueueEvent(transformToSubscriptionEvent(event));
+            const replayEvents = replay.events.map(transformToSubscriptionEvent);
+            if (replay.currentSequence < currentSeq) {
+              throw new Error(
+                `eventsReplay currentSequence ${replay.currentSequence} is behind joined sequence ${currentSeq}`,
+              );
+            }
+            if (!hasContiguousReplayCoverage(replayEvents, lastSeq, replay.currentSequence)) {
+              throw new Error(
+                `eventsReplay returned non-contiguous coverage from ${lastSeq} to ${replay.currentSequence}`,
+              );
+            }
+
+            if (replayEvents.length > 0) {
+              if (DEBUG) console.info(`[PersistentSession] Replaying ${replayEvents.length} events`);
+              replayEvents.forEach((event) => {
+                handleQueueEvent(event);
               });
               if (DEBUG) console.info('[PersistentSession] Delta sync completed successfully');
             } else {
@@ -438,11 +519,13 @@ export function useSessionLifecycle({
             if (DEBUG) console.info('[PersistentSession] Hash mismatch on reconnect despite gap=0, applying full sync');
             applyFullSync(sessionData);
           } else {
+            setLastReceivedStateHash(sessionData.queueState.stateHash);
             if (DEBUG) console.info('[PersistentSession] No missed events, already in sync');
           }
         }
 
         setSession(sessionData);
+        startSubscriptions(clientForReconnect);
         if (DEBUG) console.info('[PersistentSession] Reconnection complete, clientId:', sessionData.clientId);
       } finally {
         isReconnectingRef.current = false;
@@ -458,6 +541,108 @@ export function useSessionLifecycle({
           sequence: sessionData.queueState.sequence,
           state: sessionData.queueState,
         });
+      }
+    }
+
+    function scheduleSubscriptionRecovery(reason: string) {
+      if (isCleaningUp || !mountedRef.current) return;
+      if (connectionGenerationRef.current !== connectionGeneration) return;
+      if (subscriptionRestartTimeout) return;
+
+      if (DEBUG) console.info(`[PersistentSession] Scheduling subscription recovery: ${reason}`);
+      subscriptionRestartTimeout = setTimeout(() => {
+        subscriptionRestartTimeout = null;
+        if (isCleaningUp || !mountedRef.current) return;
+        if (connectionGenerationRef.current !== connectionGeneration) return;
+        void handleReconnect();
+      }, INITIAL_RETRY_DELAY_MS);
+    }
+
+    function startSubscriptions(clientToUse: Client) {
+      if (isCleaningUp || !mountedRef.current) return;
+      if (connectionGenerationRef.current !== connectionGeneration) return;
+
+      if (!queueUnsubscribeRef.current) {
+        queueUnsubscribeRef.current = subscribe<{ queueUpdates: SubscriptionQueueEvent }>(
+          clientToUse,
+          { query: QUEUE_UPDATES, variables: { sessionId } },
+          {
+            next: (data) => {
+              if (data.queueUpdates) {
+                handleQueueEvent(data.queueUpdates);
+              }
+            },
+            error: (err) => {
+              console.error('[PersistentSession] Queue subscription error:', err);
+              queueUnsubscribeRef.current = null;
+              if (mountedRef.current) {
+                setError(err instanceof Error ? err : new Error(String(err)));
+              }
+              scheduleSubscriptionRecovery('queue subscription error');
+            },
+            complete: () => {
+              if (DEBUG) console.info('[PersistentSession] Queue subscription completed');
+              queueUnsubscribeRef.current = null;
+              scheduleSubscriptionRecovery('queue subscription completed');
+            },
+          },
+        );
+      }
+
+      if (!sessionUnsubscribeRef.current) {
+        sessionUnsubscribeRef.current = subscribe<{ sessionUpdates: SessionEvent }>(
+          clientToUse,
+          { query: SESSION_UPDATES, variables: { sessionId } },
+          {
+            next: (data) => {
+              if (data.sessionUpdates) {
+                // Handle UserJoined/UserLeft/LeaderChanged/SessionEnded in session state
+                const event = data.sessionUpdates;
+                if (event.__typename !== 'SessionStatsUpdated') {
+                  setSession((prev) => {
+                    if (!prev) return prev;
+                    switch (event.__typename) {
+                      case 'UserJoined':
+                        return { ...prev, users: upsertSessionUser(prev.users, event.user) };
+                      case 'UserPresenceChanged':
+                        return { ...prev, users: upsertSessionUser(prev.users, event.user) };
+                      case 'UserLeft':
+                        return { ...prev, users: prev.users.filter((u) => u.id !== event.userId) };
+                      case 'LeaderChanged': {
+                        const leaderConnectionId = event.leaderConnectionId || event.leaderId;
+                        return {
+                          ...prev,
+                          isLeader: leaderConnectionId === prev.clientId,
+                          users: prev.users.map((u) => ({
+                            ...u,
+                            isLeader: u.id === event.leaderId,
+                          })),
+                        };
+                      }
+                      case 'SessionEnded':
+                        if (DEBUG) console.info('[PersistentSession] Session ended:', event.reason);
+                        removePreference(ACTIVE_SESSION_KEY).catch(() => {});
+                        return prev;
+                      default:
+                        return prev;
+                    }
+                  });
+                }
+                handleSessionEvent(event);
+              }
+            },
+            error: (err) => {
+              console.error('[PersistentSession] Session subscription error:', err);
+              sessionUnsubscribeRef.current = null;
+              scheduleSubscriptionRecovery('session subscription error');
+            },
+            complete: () => {
+              if (DEBUG) console.info('[PersistentSession] Session subscription completed');
+              sessionUnsubscribeRef.current = null;
+              scheduleSubscriptionRecovery('session subscription completed');
+            },
+          },
+        );
       }
     }
 
@@ -519,78 +704,7 @@ export function useSessionLifecycle({
           });
         }
 
-        // Subscribe to queue updates
-        queueUnsubscribeRef.current = subscribe<{ queueUpdates: SubscriptionQueueEvent }>(
-          graphqlClient,
-          { query: QUEUE_UPDATES, variables: { sessionId } },
-          {
-            next: (data) => {
-              if (data.queueUpdates) {
-                handleQueueEvent(data.queueUpdates);
-              }
-            },
-            error: (err) => {
-              console.error('[PersistentSession] Queue subscription error:', err);
-              queueUnsubscribeRef.current = null;
-              if (mountedRef.current) {
-                setError(err instanceof Error ? err : new Error(String(err)));
-              }
-            },
-            complete: () => {
-              if (DEBUG) console.info('[PersistentSession] Queue subscription completed');
-              queueUnsubscribeRef.current = null;
-            },
-          },
-        );
-
-        // Subscribe to session updates
-        sessionUnsubscribeRef.current = subscribe<{ sessionUpdates: SessionEvent }>(
-          graphqlClient,
-          { query: SESSION_UPDATES, variables: { sessionId } },
-          {
-            next: (data) => {
-              if (data.sessionUpdates) {
-                // Handle UserJoined/UserLeft/LeaderChanged/SessionEnded in session state
-                const event = data.sessionUpdates;
-                if (event.__typename !== 'SessionStatsUpdated') {
-                  setSession((prev) => {
-                    if (!prev) return prev;
-                    switch (event.__typename) {
-                      case 'UserJoined':
-                        return { ...prev, users: upsertSessionUser(prev.users, event.user) };
-                      case 'UserLeft':
-                        return { ...prev, users: prev.users.filter((u) => u.id !== event.userId) };
-                      case 'LeaderChanged':
-                        return {
-                          ...prev,
-                          isLeader: event.leaderId === prev.clientId,
-                          users: prev.users.map((u) => ({
-                            ...u,
-                            isLeader: u.id === event.leaderId,
-                          })),
-                        };
-                      case 'SessionEnded':
-                        if (DEBUG) console.info('[PersistentSession] Session ended:', event.reason);
-                        removePreference(ACTIVE_SESSION_KEY).catch(() => {});
-                        return prev;
-                      default:
-                        return prev;
-                    }
-                  });
-                }
-                handleSessionEvent(event);
-              }
-            },
-            error: (err) => {
-              console.error('[PersistentSession] Session subscription error:', err);
-              sessionUnsubscribeRef.current = null;
-            },
-            complete: () => {
-              if (DEBUG) console.info('[PersistentSession] Session subscription completed');
-              sessionUnsubscribeRef.current = null;
-            },
-          },
-        );
+        startSubscriptions(graphqlClient);
 
         isConnectingRef.current = false;
       } catch (err) {
@@ -645,8 +759,11 @@ export function useSessionLifecycle({
 
     return () => {
       if (DEBUG) console.info('[PersistentSession] Cleaning up connection');
+      isCleaningUp = true;
       mountedRef.current = false;
       isConnectingRef.current = false;
+      const shouldSendLeave = sendLeaveOnCleanupRef.current;
+      sendLeaveOnCleanupRef.current = false;
 
       const clientToCleanup = graphqlClient;
       graphqlClient = null;
@@ -659,10 +776,14 @@ export function useSessionLifecycle({
       if (clientToCleanup) {
         void Promise.resolve()
           .then(async () => {
-            if (sessionRef.current) {
-              await execute(clientToCleanup, { query: LEAVE_SESSION }).catch(() => {});
+            if (shouldSendLeave) {
+              try {
+                await execute(clientToCleanup, { query: LEAVE_SESSION }, 5000);
+              } catch (err) {
+                if (DEBUG) console.info('[PersistentSession] Explicit leave failed during cleanup:', err);
+              }
             }
-            void clientToCleanup.dispose();
+            await clientToCleanup.dispose();
           })
           .catch((err) => {
             // Swallow errors during cleanup — the WebSocket is being torn down
@@ -677,9 +798,12 @@ export function useSessionLifecycle({
       if (retryConnectTimeout) {
         clearTimeout(retryConnectTimeout);
       }
+      if (subscriptionRestartTimeout) {
+        clearTimeout(subscriptionRestartTimeout);
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- refs are stable, only .current changes; intentional dep list
-  }, [activeSession, isAuthLoading, handleQueueEvent, handleSessionEvent, setSession, pendingInitialQueue]);
+  }, [activeSession, isAuthLoading, handleQueueEvent, handleSessionEvent, setLastReceivedStateHash, setSession]);
 
   return {
     activeSession,

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -486,6 +486,17 @@ export function useSessionLifecycle({
         const sessionData = await joinSession(clientForReconnect);
         if (!sessionData || !mountedRef.current) return;
 
+        // Match the initial `connect()` success path: reset both retry
+        // counters now that we know the rejoin succeeded. Otherwise a
+        // low-traffic session where every reconnect succeeds but no event
+        // arrives before the next disconnect accumulates strikes across
+        // recovery cycles and silently force-clears the session after
+        // MAX_TRANSIENT_RETRIES, even though every individual join was
+        // healthy. The next-handler reset only fires when an event arrives,
+        // which isn't guaranteed during a quiet window.
+        transientRetryCount = 0;
+        subscriptionRetryCount = 0;
+
         const currentSeq = sessionData.queueState.sequence;
         const gap = lastSeq !== null ? currentSeq - lastSeq : 0;
 

--- a/packages/web/app/components/persistent-session/persistent-session-context.tsx
+++ b/packages/web/app/components/persistent-session/persistent-session-context.tsx
@@ -118,6 +118,7 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
     isAuthLoading,
     handleQueueEvent: eventProcessor.handleQueueEvent,
     handleSessionEvent: eventProcessor.handleSessionEvent,
+    setLastReceivedStateHash: eventProcessor.setLastReceivedStateHash,
     setSession: noopSetSession, // Session is managed internally by lifecycle
     refs,
   });

--- a/packages/web/app/components/persistent-session/types.ts
+++ b/packages/web/app/components/persistent-session/types.ts
@@ -32,6 +32,7 @@ export type Session = {
 // Active session info stored at root level
 export type ActiveSessionInfo = {
   sessionId: string;
+  participantId?: string;
   sessionName?: string;
   boardPath: string;
   boardDetails: BoardDetails;
@@ -55,7 +56,7 @@ export type PersistentSessionActionsType = {
 
   // Session lifecycle
   activateSession: (info: ActiveSessionInfo) => void;
-  deactivateSession: () => void;
+  deactivateSession: (options?: { notifyServer?: boolean }) => void;
   setInitialQueueForSession: (
     sessionId: string,
     queue: LocalClimbQueueItem[],

--- a/packages/web/app/components/session-creation/start-sesh-drawer.tsx
+++ b/packages/web/app/components/session-creation/start-sesh-drawer.tsx
@@ -464,11 +464,7 @@ export default function StartSeshDrawer({ open, onClose, onTransitionEnd, boardC
         >
           {t('creation.generateQueue.regenerate')}
         </Button>
-        <IconButton
-          size="small"
-          onClick={handleClearGenerated}
-          aria-label={t('creation.generateQueue.clear')}
-        >
+        <IconButton size="small" onClick={handleClearGenerated} aria-label={t('creation.generateQueue.clear')}>
           <CloseOutlined fontSize="small" />
         </IconButton>
       </Stack>

--- a/packages/web/app/docs/docs-client.tsx
+++ b/packages/web/app/docs/docs-client.tsx
@@ -182,15 +182,18 @@ const unsubscribe = client.subscribe(
         queueUpdates(sessionId: $sessionId) {
           ... on QueueItemAdded {
             sequence
-            item { uuid climb { name difficulty } }
+            stateHash
+            addedItem: item { uuid climb { name difficulty } }
           }
           ... on QueueItemRemoved {
             sequence
+            stateHash
             uuid
           }
           ... on CurrentClimbChanged {
             sequence
-            item { climb { name } }
+            stateHash
+            currentItem: item { climb { name } }
           }
         }
       }
@@ -258,8 +261,20 @@ const { eventsReplay } = await client.query({
   query: \`
     query EventsReplay($sessionId: ID!, $sinceSequence: Int!) {
       eventsReplay(sessionId: $sessionId, sinceSequence: $sinceSequence) {
-        events { ... }
         currentSequence
+        events {
+          __typename
+          ... on QueueItemAdded {
+            sequence
+            stateHash
+            addedItem: item { uuid climb { name difficulty } }
+          }
+          ... on CurrentClimbChanged {
+            sequence
+            stateHash
+            currentItem: item { uuid climb { name difficulty } }
+          }
+        }
       }
     }
   \`,

--- a/packages/web/app/lib/graphql/generated/graphql.ts
+++ b/packages/web/app/lib/graphql/generated/graphql.ts
@@ -537,6 +537,10 @@ export type ClimbMirrored = {
   mirrored: Scalars['Boolean']['output'];
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
+  /** Queue state hash after this event is applied */
+  stateHash: Scalars['String']['output'];
+  /** UUID of the mirrored queue item, when a current climb exists */
+  uuid?: Maybe<Scalars['ID']['output']>;
 };
 
 /** Playlist membership for a single climb in a batch query. */
@@ -960,6 +964,8 @@ export type CurrentClimbChanged = {
   item?: Maybe<ClimbQueueItem>;
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
+  /** Queue state hash after this event is applied */
+  stateHash: Scalars['String']['output'];
 };
 
 /** Information needed before account deletion. */
@@ -1665,7 +1671,9 @@ export type LayoutStats = {
 /** Event when session leadership changes. */
 export type LeaderChanged = {
   __typename?: 'LeaderChanged';
-  /** ID of the new leader */
+  /** Connection ID of the new leader, for current-client leadership checks */
+  leaderConnectionId?: Maybe<Scalars['ID']['output']>;
+  /** Stable participant ID of the new leader */
   leaderId: Scalars['ID']['output'];
 };
 
@@ -1796,7 +1804,7 @@ export type Mutation = {
   deleteProposal: Scalars['Boolean']['output'];
   /** Delete a tick (climb attempt record). Only the owner can delete. */
   deleteTick: Scalars['Boolean']['output'];
-  /** End a session (leader only). */
+  /** End a session (active participant only). */
   endSession?: Maybe<SessionSummary>;
   /** Follow a board. */
   followBoard: Scalars['Boolean']['output'];
@@ -2120,6 +2128,7 @@ export type MutationJoinSessionArgs = {
   boardPath: Scalars['String']['input'];
   initialCurrentClimb?: InputMaybe<ClimbQueueItemInput>;
   initialQueue?: InputMaybe<Array<ClimbQueueItemInput>>;
+  participantId?: InputMaybe<Scalars['ID']['input']>;
   sessionId: Scalars['ID']['input'];
   sessionName?: InputMaybe<Scalars['String']['input']>;
   username?: InputMaybe<Scalars['String']['input']>;
@@ -3489,6 +3498,8 @@ export type QueueItemAdded = {
   position?: Maybe<Scalars['Int']['output']>;
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
+  /** Queue state hash after this event is applied */
+  stateHash: Scalars['String']['output'];
 };
 
 /** Event when an item is removed from the queue. */
@@ -3496,6 +3507,8 @@ export type QueueItemRemoved = {
   __typename?: 'QueueItemRemoved';
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
+  /** Queue state hash after this event is applied */
+  stateHash: Scalars['String']['output'];
   /** UUID of the removed item */
   uuid: Scalars['ID']['output'];
 };
@@ -3546,6 +3559,8 @@ export type QueueReordered = {
   oldIndex: Scalars['Int']['output'];
   /** Sequence number of this event */
   sequence: Scalars['Int']['output'];
+  /** Queue state hash after this event is applied */
+  stateHash: Scalars['String']['output'];
   /** UUID of the moved item */
   uuid: Scalars['ID']['output'];
 };
@@ -3796,7 +3811,7 @@ export type Session = {
   goal?: Maybe<Scalars['String']['output']>;
   /** Unique session identifier */
   id: Scalars['ID']['output'];
-  /** Whether the current client is the session leader */
+  /** Whether the current client is the session leader (presentation/backward compatibility only) */
   isLeader: Scalars['Boolean']['output'];
   /** Whether session is exempt from auto-end */
   isPermanent: Scalars['Boolean']['output'];
@@ -3811,6 +3826,9 @@ export type Session = {
   /** Users currently in the session */
   users: Array<SessionUser>;
 };
+
+/** Current realtime connection state for a session participant. */
+export type SessionConnectionState = 'CONNECTED' | 'RECONNECTING';
 
 /** Full detail for a single session, including all ticks. */
 export type SessionDetail = {
@@ -3876,7 +3894,13 @@ export type SessionEnded = {
 };
 
 /** Union of possible session events. */
-export type SessionEvent = LeaderChanged | SessionEnded | SessionStatsUpdated | UserJoined | UserLeft;
+export type SessionEvent =
+  | LeaderChanged
+  | SessionEnded
+  | SessionStatsUpdated
+  | UserJoined
+  | UserLeft
+  | UserPresenceChanged;
 
 /** A session feed card representing a group of ticks from a climbing session. */
 export type SessionFeedItem = {
@@ -4025,9 +4049,11 @@ export type SessionUser = {
   __typename?: 'SessionUser';
   /** URL to user's avatar image */
   avatarUrl?: Maybe<Scalars['String']['output']>;
-  /** Unique user identifier */
+  /** Realtime connection state for this participant */
+  connectionState: SessionConnectionState;
+  /** Stable participant identifier within this session */
   id: Scalars['ID']['output'];
-  /** Whether this user is the session leader (controls the queue) */
+  /** Whether this user is the session leader (presentation/backward compatibility only) */
   isLeader: Scalars['Boolean']['output'];
   /** Stable database user UUID (null for unauthenticated connections) */
   userId?: Maybe<Scalars['ID']['output']>;
@@ -4680,6 +4706,13 @@ export type UserLeft = {
   __typename?: 'UserLeft';
   /** ID of the user who left */
   userId: Scalars['ID']['output'];
+};
+
+/** Event when a participant's realtime presence state changes. */
+export type UserPresenceChanged = {
+  __typename?: 'UserPresenceChanged';
+  /** The participant whose presence changed */
+  user: SessionUser;
 };
 
 /** User profile information. */


### PR DESCRIPTION
## Summary

- Relands PR #2128 (which was reverted in PR #2137 to stop the bleeding) and fixes the GraphQL validation bug that broke party-session joins in prod.
- Aliases `uuid` to `mirroredUuid` on the `ClimbMirrored` selection in `QUEUE_UPDATES` and `EVENTS_REPLAY` — the `OverlappingFieldsCanBeMergedRule` was rejecting every join because `ClimbMirrored.uuid` is nullable `ID` while `QueueItemRemoved.uuid` / `QueueReordered.uuid` are `ID!`.
- Replaces the flat 1 s subscription-recovery delay with exponential backoff (1, 2, 4, 8, 16 s, capped, gives up after `MAX_TRANSIENT_RETRIES`) so we don't tight-loop reconnects again if a future schema regression slips through.

## Context

Production server log (link in chat): 48 `Fields "uuid" conflict` validation errors on every join attempt for session `0f44bc70-13cc-44e7-9c1e-3bba7d9f480c`, with the client reconnecting every 3-50 ms because `scheduleSubscriptionRecovery` retried at a flat 1 s. Two symptoms followed:

1. **Queue updates never sync** — both `queueUpdates` subscription and `eventsReplay` query failed validation.
2. **Joining takes forever** — every join failed, the client hammered reconnects, and the server kept tearing down + recreating the room.

PR #2128 (`5c7fcd523 Fix websocket queue replay hashes`) introduced the bug when it added `uuid: ID` to `ClimbMirrored`. The schema is correct — the resolver legitimately publishes `ClimbMirrored` with `uuid: null` when there is no current climb (`mutations.ts:320`: `const mirroredUuid = currentClimb?.uuid ?? null`) — so we alias on the client side instead of flipping the schema to `ID!`.

## What's in this PR

1. `82b8385a` — `git revert dad2e2d37`, reapplying PR #2128 wholesale (`connectionState`, `UserPresenceChanged`, `leaderConnectionId`, `stateHash` propagation, backend resilience improvements, and the buggy `ClimbMirrored.uuid` selection).
2. `ab394315` — fix commit:
   - `packages/shared-schema/src/operations.ts` — `mirroredUuid: uuid` aliases on `ClimbMirrored` in both `EVENTS_REPLAY` and `QUEUE_UPDATES`.
   - `packages/shared-schema/src/types/events.ts` — `SubscriptionQueueEvent.ClimbMirrored` now uses `mirroredUuid?: string | null`. Server-side `QueueEvent` keeps `uuid` (wire shape unchanged).
   - `packages/web/app/components/persistent-session/hooks/use-event-processor.ts` — reads `event.mirroredUuid`.
   - `packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts` — explicit `ClimbMirrored` arm in `transformToSubscriptionEvent` (handles both wire and aliased shapes) + exponential backoff with counter reset on successful event / successful join.
   - Tests updated; `session-lifecycle-replay.test.ts` gains a `ClimbMirrored` transform test.
   - Folds in oxfmt cleanup of files that came back with stale formatting via the revert reapply.

## Test plan

- [x] `vp check` — clean for files I touched (one pre-existing repo-wide lint warning in `packages/backend/src/graphql/resolvers/playlists/queries/user-playlists.ts` predates this PR).
- [x] `vp run typecheck` — exit 0.
- [x] `vp test --project web` — 4377 pass; one pre-existing failure in `i18n-catalog-completeness` (`fr/feed.json` drift, unrelated).
- [x] `vp test --project backend` — 937 pass.
- [ ] Manual QA in the running dev server (see `.boardsesh/qa-notes.md`):
  - Two-tab join: tab B's queue list populates within ~1 s.
  - Live add / remove / reorder / current-climb-change from tab A appears in tab B within ~200 ms.
  - **Mirror-toggle the current climb in tab A** — the specific event that was broken — reaches tab B without error.
  - Reload tab B mid-session; replay restores state.
  - No `GraphQLError: Fields "uuid" conflict` in `vp run dev` output during any of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)