### PR TITLE
fix(analytics): emit batched $web_vitals event in PostHog dashboard shape

### DIFF
--- a/packages/web/app/components/__tests__/analytics-client.test.tsx
+++ b/packages/web/app/components/__tests__/analytics-client.test.tsx
@@ -2,11 +2,20 @@ import { render, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import AnalyticsClient from '../analytics-client';
 
+type VitalMetric = {
+  name: string;
+  value: number;
+  rating: string;
+  delta: number;
+  id: string;
+  navigationType: string | null;
+};
+
 const mocks = vi.hoisted(() => ({
   capturePosthog: vi.fn(),
   pageview: vi.fn(),
   track: vi.fn(),
-  vitalCallbacks: [] as Array<(metric: Record<string, string | number | null>) => void>,
+  vitalCallbacks: [] as Array<(metric: VitalMetric) => void>,
 }));
 let pathname = '/';
 
@@ -25,7 +34,6 @@ vi.mock('web-vitals', () => ({
   onFCP: vi.fn((callback) => mocks.vitalCallbacks.push(callback)),
   onINP: vi.fn((callback) => mocks.vitalCallbacks.push(callback)),
   onLCP: vi.fn((callback) => mocks.vitalCallbacks.push(callback)),
-  onTTFB: vi.fn((callback) => mocks.vitalCallbacks.push(callback)),
 }));
 
 describe('AnalyticsClient', () => {
@@ -35,6 +43,7 @@ describe('AnalyticsClient', () => {
     mocks.pageview.mockClear();
     mocks.track.mockClear();
     mocks.vitalCallbacks.length = 0;
+    vi.useRealTimers();
   });
 
   it('sends path-only PostHog pageviews', async () => {
@@ -57,30 +66,77 @@ describe('AnalyticsClient', () => {
     });
   });
 
-  it('sends web vitals only to PostHog', async () => {
+  it('batches all four web vitals into one PostHog event', async () => {
     render(<AnalyticsClient />);
 
     await waitFor(() => {
       expect(mocks.vitalCallbacks.length).toBeGreaterThan(0);
     });
 
-    mocks.vitalCallbacks[0]({
-      name: 'LCP',
-      value: 123.4,
-      rating: 'good',
-      delta: 12.3,
-      id: 'metric-1',
+    const reportVital = mocks.vitalCallbacks[0];
+    reportVital({ name: 'LCP', value: 123.4, rating: 'good', delta: 12.3, id: 'lcp-1', navigationType: 'navigate' });
+    reportVital({ name: 'CLS', value: 0.05, rating: 'good', delta: 0.05, id: 'cls-1', navigationType: 'navigate' });
+    reportVital({ name: 'FCP', value: 800, rating: 'good', delta: 800, id: 'fcp-1', navigationType: 'navigate' });
+    reportVital({
+      name: 'INP',
+      value: 50,
+      rating: 'needs-improvement',
+      delta: 50,
+      id: 'inp-1',
       navigationType: 'navigate',
     });
 
+    expect(mocks.capturePosthog).toHaveBeenCalledTimes(1);
     expect(mocks.capturePosthog).toHaveBeenCalledWith('$web_vitals', {
-      metric: 'LCP',
-      value: 123.4,
-      rating: 'good',
-      delta: 12.3,
-      id: 'metric-1',
-      navigationType: 'navigate',
+      $current_url: '/',
+      $web_vitals_LCP_value: 123.4,
+      $web_vitals_LCP_rating: 'good',
+      $web_vitals_LCP_delta: 12.3,
+      $web_vitals_LCP_id: 'lcp-1',
+      $web_vitals_LCP_navigation_type: 'navigate',
+      $web_vitals_CLS_value: 0.05,
+      $web_vitals_CLS_rating: 'good',
+      $web_vitals_CLS_delta: 0.05,
+      $web_vitals_CLS_id: 'cls-1',
+      $web_vitals_CLS_navigation_type: 'navigate',
+      $web_vitals_FCP_value: 800,
+      $web_vitals_FCP_rating: 'good',
+      $web_vitals_FCP_delta: 800,
+      $web_vitals_FCP_id: 'fcp-1',
+      $web_vitals_FCP_navigation_type: 'navigate',
+      $web_vitals_INP_value: 50,
+      $web_vitals_INP_rating: 'needs-improvement',
+      $web_vitals_INP_delta: 50,
+      $web_vitals_INP_id: 'inp-1',
+      $web_vitals_INP_navigation_type: 'navigate',
     });
     expect(mocks.track).not.toHaveBeenCalled();
+  });
+
+  it('flushes a partial buffer after the 5s timer elapses', async () => {
+    render(<AnalyticsClient />);
+
+    await waitFor(() => {
+      expect(mocks.vitalCallbacks.length).toBeGreaterThan(0);
+    });
+
+    vi.useFakeTimers();
+    const reportVital = mocks.vitalCallbacks[0];
+    reportVital({ name: 'LCP', value: 200, rating: 'good', delta: 200, id: 'lcp-2', navigationType: 'navigate' });
+
+    expect(mocks.capturePosthog).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(5000);
+
+    expect(mocks.capturePosthog).toHaveBeenCalledTimes(1);
+    expect(mocks.capturePosthog).toHaveBeenCalledWith(
+      '$web_vitals',
+      expect.objectContaining({
+        $current_url: '/',
+        $web_vitals_LCP_value: 200,
+        $web_vitals_LCP_rating: 'good',
+        $web_vitals_LCP_id: 'lcp-2',
+      }),
+    );
   });
 });

--- a/packages/web/app/components/analytics-client.tsx
+++ b/packages/web/app/components/analytics-client.tsx
@@ -2,47 +2,97 @@
 
 import { useEffect, useRef } from 'react';
 import { usePathname } from 'next/navigation';
-import { onCLS, onFCP, onINP, onLCP, onTTFB, type Metric } from 'web-vitals';
+import { onCLS, onFCP, onINP, onLCP, type Metric } from 'web-vitals';
 import { capturePosthog, pageview } from '@/app/lib/analytics';
-import { isAdminAnalyticsUrl } from '@/app/lib/analytics-paths';
+import { analyticsPathname, isAdminAnalyticsUrl } from '@/app/lib/analytics-paths';
+
+// PostHog's Web Vitals dashboard widget surfaces LCP, CLS, FCP, INP and
+// expects a single batched `$web_vitals` event per page with metric-prefixed
+// properties (`$web_vitals_<NAME>_value`, `$web_vitals_<NAME>_rating`, ...).
+// posthog-js-lite has no built-in web vitals capture, so we mirror the shape
+// of the official posthog-js extension. The `_event` object posthog-js also
+// emits is skipped — our analytics helper only forwards primitive property
+// values, and the dashboard renders from `_value` + `_rating`.
+const ALLOWED_METRICS = ['LCP', 'CLS', 'FCP', 'INP'] as const;
+const FLUSH_DELAY_MS = 5000;
+
+type VitalsBuffer = {
+  metrics: Map<string, Metric>;
+  pageUrl: string | null;
+  timerId: ReturnType<typeof setTimeout> | null;
+};
+
+function flushVitalsBuffer(buffer: VitalsBuffer): void {
+  if (buffer.timerId !== null) {
+    clearTimeout(buffer.timerId);
+    buffer.timerId = null;
+  }
+  if (buffer.metrics.size === 0) return;
+
+  const pageUrl = buffer.pageUrl;
+  const metrics = buffer.metrics;
+  buffer.metrics = new Map();
+  buffer.pageUrl = null;
+
+  if (!pageUrl || isAdminAnalyticsUrl(pageUrl)) return;
+
+  const props: Record<string, string | number | boolean | null> = {
+    $current_url: analyticsPathname(pageUrl),
+  };
+  for (const [name, metric] of metrics) {
+    props[`$web_vitals_${name}_value`] = metric.value;
+    props[`$web_vitals_${name}_rating`] = metric.rating;
+    props[`$web_vitals_${name}_delta`] = metric.delta;
+    props[`$web_vitals_${name}_id`] = metric.id;
+    props[`$web_vitals_${name}_navigation_type`] = metric.navigationType ?? null;
+  }
+
+  capturePosthog('$web_vitals', props);
+}
 
 export default function AnalyticsClient() {
   const pathname = usePathname();
-  const pathnameRef = useRef<string | null>(null);
   const vitalsRegistered = useRef(false);
-
-  useEffect(() => {
-    pathnameRef.current = pathname;
-  }, [pathname]);
+  const bufferRef = useRef<VitalsBuffer>({ metrics: new Map(), pageUrl: null, timerId: null });
 
   useEffect(() => {
     if (vitalsRegistered.current) return;
     vitalsRegistered.current = true;
 
     const reportVital = (metric: Metric): void => {
-      const currentPath = pathnameRef.current;
-      if (currentPath && isAdminAnalyticsUrl(currentPath)) return;
-
-      capturePosthog('$web_vitals', {
-        metric: metric.name,
-        value: metric.value,
-        rating: metric.rating,
-        delta: metric.delta,
-        id: metric.id,
-        navigationType: metric.navigationType ?? null,
-      });
+      const buffer = bufferRef.current;
+      if (buffer.metrics.size === 0) {
+        buffer.pageUrl = typeof window === 'undefined' ? null : window.location.href;
+        buffer.timerId = setTimeout(() => flushVitalsBuffer(buffer), FLUSH_DELAY_MS);
+      }
+      buffer.metrics.set(metric.name, metric);
+      if (buffer.metrics.size >= ALLOWED_METRICS.length) flushVitalsBuffer(buffer);
     };
 
     onCLS(reportVital);
     onFCP(reportVital);
     onINP(reportVital);
     onLCP(reportVital);
-    onTTFB(reportVital);
+
+    const onPageHide = (): void => flushVitalsBuffer(bufferRef.current);
+    window.addEventListener('pagehide', onPageHide);
+    return () => {
+      window.removeEventListener('pagehide', onPageHide);
+    };
   }, []);
 
   useEffect(() => {
     if (!pathname) return;
     if (isAdminAnalyticsUrl(pathname)) return;
+
+    // Flush metrics buffered against the previous URL before recording the new
+    // pageview, so each `$web_vitals` event stays bound to the page it
+    // measured.
+    const buffer = bufferRef.current;
+    if (buffer.metrics.size > 0 && buffer.pageUrl && analyticsPathname(buffer.pageUrl) !== pathname) {
+      flushVitalsBuffer(buffer);
+    }
+
     pageview(pathname);
   }, [pathname]);
 

--- a/packages/web/app/components/analytics-client.tsx
+++ b/packages/web/app/components/analytics-client.tsx
@@ -56,6 +56,9 @@ export default function AnalyticsClient() {
   const bufferRef = useRef<VitalsBuffer>({ metrics: new Map(), pageUrl: null, timerId: null });
 
   useEffect(() => {
+    // web-vitals' on* callbacks attach document-lifetime listeners — guard so
+    // StrictMode's effect re-run can't double-register them and double-count
+    // each metric.
     if (vitalsRegistered.current) return;
     vitalsRegistered.current = true;
 
@@ -73,7 +76,11 @@ export default function AnalyticsClient() {
     onFCP(reportVital);
     onINP(reportVital);
     onLCP(reportVital);
+  }, []);
 
+  // Separate effect so StrictMode's cleanup-and-remount in dev re-attaches
+  // the pagehide listener instead of leaving it removed.
+  useEffect(() => {
     const onPageHide = (): void => flushVitalsBuffer(bufferRef.current);
     window.addEventListener('pagehide', onPageHide);
     return () => {


### PR DESCRIPTION
## Summary

- PostHog's Web Vitals widget surfaces nothing because we emit `$web_vitals` events in a shape it can't parse: one event per metric, with generic property names (`metric`, `value`, `rating`).
- The widget expects a **single batched event per page** with metric-prefixed properties (`$web_vitals_LCP_value`, `$web_vitals_LCP_rating`, `$web_vitals_FCP_value`, ...). Confirmed against `posthog-js`'s built-in extension and the public web-vitals docs.
- `posthog-js-lite` (which we use) has no built-in capture, so we mirror the shape by hand in `analytics-client.tsx`.

### Implementation

- Buffer LCP / CLS / FCP / INP in a `Map` keyed by metric name, scoped to the URL the metric was measured on.
- Flush triggers (mirror posthog-js):
  - all four allowed metrics received,
  - 5s timer after the first metric of a page lands,
  - pathname change (so each event stays bound to its measured URL),
  - `pagehide` (best-effort exit flush).
- Event payload: `$current_url` + per-metric `_value`, `_rating`, `_delta`, `_id`, `_navigation_type` (primitives only — our `sanitizeForPosthog` strips non-primitives, and the dashboard renders from `_value` + `_rating`).
- TTFB dropped — PostHog's widget doesn't surface it; matches posthog-js default.

## Test plan

- [x] `vp lint` + `vp fmt` on the changed file clean.
- [x] `vp run typecheck:web` passes.
- [ ] Network-tab verification on a Vercel preview (or `boardsesh.com`): exactly one `POST /api/posthog/capture` per pageview, payload contains `$web_vitals_LCP_value`, `$web_vitals_FCP_value`, etc.
- [ ] PostHog Web Vitals dashboard populates within ~5 min after a few production pageviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)