### PR TITLE
[codex] Fix live activity push token registration

### DIFF
--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -287,7 +287,7 @@ All APNs activity is logged with the `[APNs]` prefix:
 [APNs] Initialized (production=false, bundleId=com.boardsesh.app)
 [APNs] Sending Live Activity update for session ... to 2 device(s)
 [APNs] Results for session ...: 2 sent, 0 failed
-[APNs] Removing stale token abc123... (reason: BadDeviceToken)
+[APNs] Stale token for session ... (BadDeviceToken): abc123...
 ```
 
 ### iOS Console Logs
@@ -347,6 +347,17 @@ APNs env vars are not set in `packages/backend/.env.local`. Double-check all fiv
 - The token may take a few seconds to arrive after `Activity.request()`
 - Check the Xcode console for "Push token updated" log
 - Check for "Failed to register push token" errors — the backend may not be reachable from the iPhone
+- If you see "Skipping push token registration: no auth token in keychain", the web app did not pass the backend auth token into `LiveActivityPlugin.startSession()`. Confirm `/api/internal/ws-auth` returns a token in the native webview before the Live Activity starts.
+
+### "No registered Live Activity tokens"
+
+The APNs hook fired for a queue change, but `activity_push_tokens` has no rows for that session:
+
+```
+[APNs] No registered Live Activity tokens for session ...; skipping update
+```
+
+This usually means ActivityKit emitted a push token but native registration failed before the backend stored it. Check iOS console logs for keychain write failures, missing auth-token warnings, GraphQL registration errors, or backend reachability errors.
 
 ### "BadDeviceToken" in APNs results
 

--- a/mobile/ios/App/App/Info.plist
+++ b/mobile/ios/App/App/Info.plist
@@ -6,6 +6,8 @@
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
         <string>Boardsesh</string>
+	<key>BoardseshKeychainAccessGroup</key>
+	<string>$(AppIdentifierPrefix)group.com.boardsesh.app</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/mobile/ios/App/App/LiveActivityPlugin.swift
+++ b/mobile/ios/App/App/LiveActivityPlugin.swift
@@ -123,9 +123,14 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         request.httpBody = jsonData
 
-        URLSession.shared.dataTask(with: request) { [weak self] _, response, error in
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
             if let error = error {
                 self?.logger.error("Failed to register push token: \(error.localizedDescription, privacy: .public)")
+            } else if let httpResponse = response as? HTTPURLResponse,
+                      !(200...299).contains(httpResponse.statusCode) {
+                self?.logger.error("Failed to register push token: HTTP \(httpResponse.statusCode, privacy: .public)")
+            } else if let graphQLError = Self.graphQLErrorMessage(from: data) {
+                self?.logger.error("Failed to register push token: \(graphQLError, privacy: .public)")
             } else {
                 self?.logger.info("Push token registered with backend")
             }
@@ -160,13 +165,34 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         request.httpBody = jsonData
 
-        URLSession.shared.dataTask(with: request) { [weak self] _, response, error in
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
             if let error = error {
                 self?.logger.error("Failed to unregister push token: \(error.localizedDescription, privacy: .public)")
+            } else if let httpResponse = response as? HTTPURLResponse,
+                      !(200...299).contains(httpResponse.statusCode) {
+                self?.logger.error("Failed to unregister push token: HTTP \(httpResponse.statusCode, privacy: .public)")
+            } else if let graphQLError = Self.graphQLErrorMessage(from: data) {
+                self?.logger.error("Failed to unregister push token: \(graphQLError, privacy: .public)")
             } else {
                 self?.logger.info("Push token unregistered from backend")
             }
         }.resume()
+    }
+
+    private static func graphQLErrorMessage(from data: Data?) -> String? {
+        guard let data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let errors = json["errors"] as? [[String: Any]],
+              !errors.isEmpty
+        else {
+            return nil
+        }
+
+        let messages = errors.compactMap { $0["message"] as? String }
+        if messages.isEmpty {
+            return "GraphQL returned errors"
+        }
+        return messages.joined(separator: "; ")
     }
 
     // MARK: - isAvailable
@@ -228,7 +254,9 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             defaults.set(setIds, forKey: SharedConstants.setIdsKey)
         }
         if let authToken = authToken, !authToken.isEmpty {
-            SharedKeychain.set(authToken, for: SharedKeychain.authTokenKey)
+            if !SharedKeychain.set(authToken, for: SharedKeychain.authTokenKey) {
+                logger.error("Failed to write auth token to shared keychain")
+            }
         }
 
         // For party mode (real session), connect the WebSocket manager
@@ -288,7 +316,9 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             // Write the APNs push token to the shared keychain so the
             // widget extension can attach it as a Bearer header on
             // /api/widget/navigate calls.
-            SharedKeychain.set(token, for: SharedKeychain.livePushTokenKey)
+            if !SharedKeychain.set(token, for: SharedKeychain.livePushTokenKey) {
+                self.logger.error("Failed to write Live Activity push token to shared keychain")
+            }
             if let sessionId = sid, let serverUrl = surl {
                 self.registerPushTokenWithBackend(token: token, sessionId: sessionId, serverUrl: serverUrl)
             }

--- a/mobile/ios/App/App/SharedKeychain.swift
+++ b/mobile/ios/App/App/SharedKeychain.swift
@@ -22,11 +22,26 @@ import Security
 /// - `ThisDeviceOnly` keeps it out of iCloud Keychain backups, since
 ///   these are short-lived per-session credentials.
 enum SharedKeychain {
-    /// Keychain access group declared in both `App.entitlements` and
-    /// `BoardseshWidgets.entitlements`. The `$(AppIdentifierPrefix)` is
-    /// resolved at build time to the team identifier; at runtime we pass
-    /// the bare group name and the OS resolves it from the entitlement.
-    private static let accessGroup = "group.com.boardsesh.app"
+    /// Keychain access group suffix declared in both `App.entitlements` and
+    /// `BoardseshWidgets.entitlements`.
+    private static let accessGroupSuffix = "group.com.boardsesh.app"
+    private static let fallbackAccessGroupPrefix = "9L3HKPZBH3."
+
+    /// Resolved keychain access group. Keychain queries need the fully
+    /// expanded entitlement value, including the app identifier prefix. The
+    /// build setting is expanded into both app and widget Info.plists so this
+    /// remains extension-safe.
+    private static let accessGroup: String = {
+        if let plistGroup = Bundle.main.object(forInfoDictionaryKey: "BoardseshKeychainAccessGroup") as? String,
+           !plistGroup.isEmpty,
+           !plistGroup.contains("$(")
+        {
+            return plistGroup
+        }
+
+        print("[SharedKeychain] Could not resolve expanded keychain group from Info.plist; falling back to project team")
+        return "\(fallbackAccessGroupPrefix)\(accessGroupSuffix)"
+    }()
 
     static let authTokenKey = "bs_auth_token"
     static let livePushTokenKey = "bs_live_push_token"
@@ -49,6 +64,7 @@ enum SharedKeychain {
             return true
         }
         if updateStatus != errSecItemNotFound {
+            logFailure("update", key: key, status: updateStatus)
             return false
         }
 
@@ -57,7 +73,11 @@ enum SharedKeychain {
             query[k] = v
         }
         let addStatus = SecItemAdd(query as CFDictionary, nil)
-        return addStatus == errSecSuccess
+        if addStatus != errSecSuccess {
+            logFailure("add", key: key, status: addStatus)
+            return false
+        }
+        return true
     }
 
     /// Read a string value from the shared keychain, or `nil` if absent.
@@ -69,6 +89,9 @@ enum SharedKeychain {
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         guard status == errSecSuccess, let data = result as? Data else {
+            if status != errSecItemNotFound {
+                logFailure("read", key: key, status: status)
+            }
             return nil
         }
         return String(data: data, encoding: .utf8)
@@ -77,7 +100,10 @@ enum SharedKeychain {
     /// Delete the value associated with `key`. No-op if absent.
     static func remove(_ key: String) {
         let query = baseQuery(for: key)
-        SecItemDelete(query as CFDictionary)
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            logFailure("delete", key: key, status: status)
+        }
     }
 
     // MARK: - Internals
@@ -88,5 +114,9 @@ enum SharedKeychain {
             kSecAttrAccount as String: key,
             kSecAttrAccessGroup as String: accessGroup,
         ]
+    }
+
+    private static func logFailure(_ operation: String, key: String, status: OSStatus) {
+        print("[SharedKeychain] \(operation) failed for \(key): OSStatus \(status)")
     }
 }

--- a/mobile/ios/App/BoardseshWidgets/Info.plist
+++ b/mobile/ios/App/BoardseshWidgets/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDisplayName</key>
 	<string>Boardsesh Widgets</string>
+	<key>BoardseshKeychainAccessGroup</key>
+	<string>$(AppIdentifierPrefix)group.com.boardsesh.app</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/packages/backend/src/services/apns/index.ts
+++ b/packages/backend/src/services/apns/index.ts
@@ -149,11 +149,16 @@ async function deleteStaleToken(token: string): Promise<void> {
  * Build and send an APNs Live Activity notification to the given tokens.
  */
 async function sendNotification(
+  sessionId: string,
   tokens: string[],
   event: 'update' | 'end',
   contentState?: LiveActivityContentState,
 ): Promise<void> {
   if (!provider || tokens.length === 0) return;
+
+  console.log(
+    `[APNs] Sending Live Activity ${event} for session ${sessionId} to ${String(tokens.length)} device(s)`,
+  );
 
   const notification = new apn.Notification();
   notification.topic = `${bundleId}.push-type.liveactivity`;
@@ -174,10 +179,10 @@ async function sendNotification(
 
   try {
     const result = await provider.send(notification, tokens);
-
-    if (result.sent.length > 0) {
-      console.log(`[APNs] Sent ${event} to ${String(result.sent.length)} device(s)`);
-    }
+    console.log(
+      `[APNs] Results for session ${sessionId}: ${String(result.sent.length)} sent, ` +
+        `${String(result.failed.length)} failed`,
+    );
 
     if (result.failed.length > 0) {
       // Handle stale tokens (410 Gone / BadDeviceToken / Unregistered)
@@ -188,11 +193,14 @@ async function sendNotification(
         const status = failure.status;
 
         if (status === 410 || reason === 'BadDeviceToken' || reason === 'Unregistered' || reason === 'ExpiredToken') {
-          console.log(`[APNs] Stale token (${reason ?? `status ${String(status)}`}): ${failure.device.slice(0, 8)}...`);
+          console.log(
+            `[APNs] Stale token for session ${sessionId} (${reason ?? `status ${String(status)}`}): ` +
+              `${failure.device.slice(0, 8)}...`,
+          );
           staleTokenDeletions.push(deleteStaleToken(failure.device));
         } else {
           console.error(
-            `[APNs] Send failed for ${failure.device.slice(0, 8)}...: ` +
+            `[APNs] Send failed for session ${sessionId}, token ${failure.device.slice(0, 8)}...: ` +
               `status=${String(status)} reason=${reason ?? 'unknown'}`,
           );
         }
@@ -243,9 +251,12 @@ async function executeDebouncedSend(sessionId: string): Promise<void> {
 
   // Successful lookup — clear the entry and send.
   pendingSends.delete(sessionId);
-  if (tokens.length === 0) return;
+  if (tokens.length === 0) {
+    console.info(`[APNs] No registered Live Activity tokens for session ${sessionId}; skipping update`);
+    return;
+  }
 
-  await sendNotification(tokens, 'update', entry.latestState);
+  await sendNotification(sessionId, tokens, 'update', entry.latestState);
 }
 
 // ---------------------------------------------------------------------------
@@ -269,6 +280,8 @@ export function sendLiveActivityUpdate(sessionId: string, contentState: LiveActi
     existing.latestState = contentState;
     return;
   }
+
+  console.info(`[APNs] Scheduled Live Activity update for session ${sessionId}`);
 
   // Schedule a new send after the debounce window
   const timeout = setTimeout(() => {
@@ -304,7 +317,9 @@ export async function endLiveActivity(sessionId: string): Promise<void> {
   }
 
   if (tokens.length > 0) {
-    await sendNotification(tokens, 'end');
+    await sendNotification(sessionId, tokens, 'end');
+  } else {
+    console.info(`[APNs] No registered Live Activity tokens for session ${sessionId}; skipping end`);
   }
 
   // Clean up tokens after ending (already wrapped in try/catch internally)

--- a/packages/web/app/hooks/__tests__/use-ws-auth-token.test.ts
+++ b/packages/web/app/hooks/__tests__/use-ws-auth-token.test.ts
@@ -151,4 +151,16 @@ describe('useWsAuthToken', () => {
 
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  it('returns idle unauthenticated state and does not fetch when disabled', () => {
+    const { result } = renderHook(() => useWsAuthToken(false), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.token).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
 });

--- a/packages/web/app/hooks/use-ws-auth-token.ts
+++ b/packages/web/app/hooks/use-ws-auth-token.ts
@@ -25,7 +25,7 @@ async function fetchWsAuthToken(): Promise<WsAuthResponse> {
  * Includes the NextAuth session status in the query key so the token
  * is automatically re-fetched when the user logs in or out.
  */
-export function useWsAuthToken() {
+export function useWsAuthToken(enabled = true) {
   const { status } = useSession();
 
   const { data, isLoading, error } = useQuery({
@@ -33,7 +33,7 @@ export function useWsAuthToken() {
     queryFn: fetchWsAuthToken,
     staleTime: Infinity,
     retry: 1,
-    enabled: status !== 'loading',
+    enabled: enabled && status !== 'loading',
   });
 
   let errorMessage: string | null;
@@ -44,9 +44,9 @@ export function useWsAuthToken() {
   }
 
   return {
-    token: data?.token ?? null,
-    isAuthenticated: data?.authenticated ?? false,
-    isLoading: isLoading || status === 'loading',
-    error: errorMessage,
+    token: enabled ? (data?.token ?? null) : null,
+    isAuthenticated: enabled ? (data?.authenticated ?? false) : false,
+    isLoading: enabled && (isLoading || status === 'loading'),
+    error: enabled ? errorMessage : null,
   };
 }

--- a/packages/web/app/lib/live-activity/__tests__/use-live-activity.test.ts
+++ b/packages/web/app/lib/live-activity/__tests__/use-live-activity.test.ts
@@ -21,6 +21,20 @@ const mockEndLiveActivitySession = vi.fn<() => Promise<void>>(() => Promise.reso
 const mockUpdateLiveActivity = vi.fn<() => Promise<void>>(() => Promise.resolve());
 const mockUpdateLiveActivityClimb = vi.fn<() => Promise<void>>(() => Promise.resolve());
 
+type MockWsAuthTokenResult = {
+  token: string | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+};
+
+const mockUseWsAuthToken = vi.fn<() => MockWsAuthTokenResult>(() => ({
+  token: 'test-auth-token',
+  isAuthenticated: true,
+  isLoading: false,
+  error: null,
+}));
+
 vi.mock('../live-activity-plugin', () => ({
   isLiveActivityAvailable: () => mockIsLiveActivityAvailable(),
   startLiveActivitySession: (...args: unknown[]) => mockStartLiveActivitySession(...(args as [])),
@@ -31,6 +45,10 @@ vi.mock('../live-activity-plugin', () => ({
 
 vi.mock('../../backend-url', () => ({
   getBackendWsUrl: () => 'ws://localhost:8080/graphql',
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => mockUseWsAuthToken(),
 }));
 
 // Import after mocks are set up
@@ -149,6 +167,12 @@ describe('useLiveActivity', () => {
     mockIsNativeApp.mockReturnValue(false);
     mockGetPlatform.mockReturnValue('web');
     mockIsLiveActivityAvailable.mockResolvedValue(true);
+    mockUseWsAuthToken.mockReturnValue({
+      token: 'test-auth-token',
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
   });
 
   it('does not call plugin on non-iOS platforms', async () => {
@@ -222,6 +246,7 @@ describe('useLiveActivity', () => {
     expect(mockStartLiveActivitySession).toHaveBeenCalledWith(
       expect.objectContaining({
         boardName: 'kilter',
+        authToken: 'test-auth-token',
         layoutId: 1,
         sizeId: 1,
       }),
@@ -472,6 +497,87 @@ describe('useLiveActivity', () => {
     // Effect 2 must have been suppressed — if effects were declared in reverse order
     // this assertion would fail because Effect 2 would fire before queueSyncedRef is set.
     expect(mockUpdateLiveActivityClimb).not.toHaveBeenCalled();
+
+    await hook.unmount();
+  });
+
+  it('waits for authenticated token resolution before starting Live Activity', async () => {
+    mockIsNativeApp.mockReturnValue(true);
+    mockGetPlatform.mockReturnValue('ios');
+    mockUseWsAuthToken.mockReturnValue({
+      token: null,
+      isAuthenticated: true,
+      isLoading: true,
+      error: null,
+    });
+
+    const item = makeQueueItem('1');
+    const hook = await renderLiveActivityHook({
+      ...defaultProps(),
+      queue: [item],
+      currentClimbQueueItem: item,
+      boardDetails: makeBoardDetails(),
+      isSessionActive: true,
+      sessionId: 'test-session',
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+    expect(mockStartLiveActivitySession).not.toHaveBeenCalled();
+
+    mockUseWsAuthToken.mockReturnValue({
+      token: 'resolved-auth-token',
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
+
+    await hook.rerender({});
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(mockStartLiveActivitySession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authToken: 'resolved-auth-token',
+      }),
+    );
+
+    await hook.unmount();
+  });
+
+  it('starts without authToken after a settled unauthenticated auth-token response', async () => {
+    mockIsNativeApp.mockReturnValue(true);
+    mockGetPlatform.mockReturnValue('ios');
+    mockUseWsAuthToken.mockReturnValue({
+      token: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: 'Failed to fetch auth token',
+    });
+
+    const item = makeQueueItem('1');
+    const hook = await renderLiveActivityHook({
+      ...defaultProps(),
+      queue: [item],
+      currentClimbQueueItem: item,
+      boardDetails: makeBoardDetails(),
+      isSessionActive: true,
+      sessionId: 'test-session',
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(mockStartLiveActivitySession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'test-session',
+        authToken: undefined,
+      }),
+    );
 
     await hook.unmount();
   });

--- a/packages/web/app/lib/live-activity/use-live-activity.ts
+++ b/packages/web/app/lib/live-activity/use-live-activity.ts
@@ -9,6 +9,7 @@ import {
   updateLiveActivityClimb,
   isLiveActivityAvailable,
 } from './live-activity-plugin';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { getBackendWsUrl } from '../backend-url';
 import type { ClimbQueueItem } from '@/app/components/queue-control/types';
 import type { BoardDetails } from '../types';
@@ -31,10 +32,14 @@ export function useLiveActivity({
   const isActiveRef = useRef(false);
   const generationRef = useRef(0);
   const [available, setAvailable] = useState<boolean | null>(null);
+  const shouldFetchAuthToken = isNativeApp() && getPlatform() === 'ios';
+  const { token: authToken, isLoading: authTokenLoading } = useWsAuthToken(shouldFetchAuthToken);
 
   // Keep refs for values the start callback needs without triggering restarts
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
+  const authTokenRef = useRef(authToken);
+  authTokenRef.current = authToken;
   const queueRef = useRef(queue);
   queueRef.current = queue;
   const currentClimbRef = useRef(currentClimbQueueItem);
@@ -80,7 +85,13 @@ export function useLiveActivity({
   // Start/end session — reacts to session activation, content presence, and board config.
   // Does NOT restart when the current climb changes.
   const hasContent = queue.length > 0 || currentClimbQueueItem !== null;
-  const shouldBeActive = isSessionActive && hasContent && stableBoardDetails !== null && available === true;
+  // Wait for the auth query to settle so signed-in native sessions can pass
+  // their token into Swift, but don't permanently block the Live Activity if
+  // the auth endpoint returns a settled no-token response. The native plugin
+  // logs token-registration failures when no auth token reaches the keychain.
+  const authReadyForStart = !authTokenLoading;
+  const shouldBeActive =
+    isSessionActive && hasContent && stableBoardDetails !== null && available === true && authReadyForStart;
 
   useEffect(() => {
     if (!isNativeApp() || getPlatform() !== 'ios') return;
@@ -96,6 +107,7 @@ export function useLiveActivity({
         sessionId: sessionIdRef.current ?? `local-${Date.now()}`,
         serverUrl,
         wsUrl: getBackendWsUrl() ?? undefined,
+        authToken: authTokenRef.current ?? undefined,
         boardName: stableBoardDetails.board_name,
         layoutId: stableBoardDetails.layout_id,
         sizeId: stableBoardDetails.size_id,


### PR DESCRIPTION
## Summary

Fixes the unreliable iOS Live Activity push path by making the web Live Activity bridge pass the authenticated backend token into the native iOS plugin before ActivityKit push-token registration runs.

## Root Cause

The native `LiveActivityPlugin` requires the app auth token in the shared keychain before it can call `registerActivityPushToken`. The web hook started the Live Activity without passing that token, so ActivityKit could create the widget but backend token registration could be skipped. Queue events then fired normally, but APNs had no registered Live Activity tokens to send to.

## Changes

- Thread the web auth token into `startLiveActivitySession` and wait for authenticated token resolution before starting the Live Activity.
- Add a disabled mode to `useWsAuthToken` so non-iOS paths do not fetch the token just because the bridge is mounted.
- Resolve the fully-prefixed iOS keychain access group from entitlements and log keychain failures.
- Parse native GraphQL token-registration failures instead of logging success for every HTTP response.
- Add backend APNs logs for scheduled sends, zero-token sessions, per-session send results, and stale-token failures.

## Validation

- `vp test run packages/web/app/lib/live-activity/__tests__/use-live-activity.test.ts packages/web/app/hooks/__tests__/use-ws-auth-token.test.ts`
- `vp run typecheck:web`
- `vp run typecheck:backend`