### PR TITLE
[codex] Tighten live activity diagnostics

### DIFF
--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -347,7 +347,8 @@ APNs env vars are not set in `packages/backend/.env.local`. Double-check all fiv
 - The token may take a few seconds to arrive after `Activity.request()`
 - Check the Xcode console for "Push token updated" log
 - Check for "Failed to register push token" errors — the backend may not be reachable from the iPhone
-- If you see "Skipping push token registration: no auth token in keychain", the web app did not pass the backend auth token into `LiveActivityPlugin.startSession()`. Confirm `/api/internal/ws-auth` returns a token in the native webview before the Live Activity starts.
+- If you see "Skipping shared keychain auth token write: authToken was empty" or "Skipping shared keychain auth token write: authToken was not provided", the web app did not pass a usable backend auth token into `LiveActivityPlugin.startSession()`. Confirm `/api/internal/ws-auth` returns a token in the native webview before the Live Activity starts.
+- If you see "Skipping push token registration: no auth token in keychain", the ActivityKit push token arrived, but the native plugin could not read a stored auth token when registering it. Check for the shared keychain auth-token write logs immediately before this message.
 
 ### "No registered Live Activity tokens"
 

--- a/mobile/ios/App/App/LiveActivityPlugin.swift
+++ b/mobile/ios/App/App/LiveActivityPlugin.swift
@@ -253,10 +253,14 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             defaults.set(sizeId, forKey: SharedConstants.sizeIdKey)
             defaults.set(setIds, forKey: SharedConstants.setIdsKey)
         }
-        if let authToken = authToken, !authToken.isEmpty {
-            if !SharedKeychain.set(authToken, for: SharedKeychain.authTokenKey) {
+        if let authToken = authToken {
+            if authToken.isEmpty {
+                logger.warning("Skipping shared keychain auth token write: authToken was empty")
+            } else if !SharedKeychain.set(authToken, for: SharedKeychain.authTokenKey) {
                 logger.error("Failed to write auth token to shared keychain")
             }
+        } else {
+            logger.debug("Skipping shared keychain auth token write: authToken was not provided")
         }
 
         // For party mode (real session), connect the WebSocket manager

--- a/mobile/ios/App/App/SharedKeychain.swift
+++ b/mobile/ios/App/App/SharedKeychain.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os.log
 import Security
 
 /// Shared-access-group Keychain helper for credentials that the widget
@@ -22,25 +23,33 @@ import Security
 /// - `ThisDeviceOnly` keeps it out of iCloud Keychain backups, since
 ///   these are short-lived per-session credentials.
 enum SharedKeychain {
+    private static let logger = Logger(subsystem: "com.boardsesh.app", category: "SharedKeychain")
+
     /// Keychain access group suffix declared in both `App.entitlements` and
     /// `BoardseshWidgets.entitlements`.
     private static let accessGroupSuffix = "group.com.boardsesh.app"
-    private static let fallbackAccessGroupPrefix = "9L3HKPZBH3."
 
     /// Resolved keychain access group. Keychain queries need the fully
     /// expanded entitlement value, including the app identifier prefix. The
     /// build setting is expanded into both app and widget Info.plists so this
     /// remains extension-safe.
-    private static let accessGroup: String = {
-        if let plistGroup = Bundle.main.object(forInfoDictionaryKey: "BoardseshKeychainAccessGroup") as? String,
-           !plistGroup.isEmpty,
-           !plistGroup.contains("$(")
-        {
-            return plistGroup
+    private static let accessGroup: String? = {
+        guard let plistGroup = Bundle.main.object(forInfoDictionaryKey: "BoardseshKeychainAccessGroup") as? String else {
+            return unresolvedAccessGroup("missing BoardseshKeychainAccessGroup")
         }
 
-        print("[SharedKeychain] Could not resolve expanded keychain group from Info.plist; falling back to project team")
-        return "\(fallbackAccessGroupPrefix)\(accessGroupSuffix)"
+        let trimmedGroup = plistGroup.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedGroup.isEmpty else {
+            return unresolvedAccessGroup("empty BoardseshKeychainAccessGroup")
+        }
+        guard !trimmedGroup.contains("$(") else {
+            return unresolvedAccessGroup("unexpanded BoardseshKeychainAccessGroup: \(trimmedGroup)")
+        }
+        guard trimmedGroup.hasSuffix(accessGroupSuffix) else {
+            return unresolvedAccessGroup("unexpected BoardseshKeychainAccessGroup suffix: \(trimmedGroup)")
+        }
+
+        return trimmedGroup
     }()
 
     static let authTokenKey = "bs_auth_token"
@@ -53,7 +62,10 @@ enum SharedKeychain {
     @discardableResult
     static func set(_ value: String, for key: String) -> Bool {
         guard let data = value.data(using: .utf8) else { return false }
-        var query = baseQuery(for: key)
+        guard var query = baseQuery(for: key) else {
+            logUnavailable("set", key: key)
+            return false
+        }
         let attributes: [String: Any] = [
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
@@ -82,7 +94,10 @@ enum SharedKeychain {
 
     /// Read a string value from the shared keychain, or `nil` if absent.
     static func get(_ key: String) -> String? {
-        var query = baseQuery(for: key)
+        guard var query = baseQuery(for: key) else {
+            logUnavailable("read", key: key)
+            return nil
+        }
         query[kSecMatchLimit as String] = kSecMatchLimitOne
         query[kSecReturnData as String] = true
 
@@ -99,7 +114,10 @@ enum SharedKeychain {
 
     /// Delete the value associated with `key`. No-op if absent.
     static func remove(_ key: String) {
-        let query = baseQuery(for: key)
+        guard let query = baseQuery(for: key) else {
+            logUnavailable("delete", key: key)
+            return
+        }
         let status = SecItemDelete(query as CFDictionary)
         if status != errSecSuccess && status != errSecItemNotFound {
             logFailure("delete", key: key, status: status)
@@ -108,15 +126,36 @@ enum SharedKeychain {
 
     // MARK: - Internals
 
-    private static func baseQuery(for key: String) -> [String: Any] {
+    private static func baseQuery(for key: String) -> [String: Any]? {
+        guard let resolvedAccessGroup = accessGroup else { return nil }
+
         return [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key,
-            kSecAttrAccessGroup as String: accessGroup,
+            kSecAttrAccessGroup as String: resolvedAccessGroup,
         ]
     }
 
+    private static func unresolvedAccessGroup(_ reason: String) -> String? {
+        let message = "[SharedKeychain] Invalid keychain access group configuration: \(reason). " +
+            "Set BoardseshKeychainAccessGroup in each Info.plist to $(AppIdentifierPrefix)\(accessGroupSuffix)."
+        logger.fault("\(message, privacy: .public)")
+#if DEBUG
+        fatalError(message)
+#else
+        return nil
+#endif
+    }
+
+    private static func logUnavailable(_ operation: String, key: String) {
+        logger.error(
+            "[SharedKeychain] \(operation, privacy: .public) skipped for \(key, privacy: .public): keychain access group unavailable"
+        )
+    }
+
     private static func logFailure(_ operation: String, key: String, status: OSStatus) {
-        print("[SharedKeychain] \(operation) failed for \(key): OSStatus \(status)")
+        logger.error(
+            "[SharedKeychain] \(operation, privacy: .public) failed for \(key, privacy: .public): OSStatus \(String(status), privacy: .public)"
+        )
     }
 }

--- a/packages/backend/src/__tests__/push-tokens.test.ts
+++ b/packages/backend/src/__tests__/push-tokens.test.ts
@@ -9,7 +9,7 @@
  * - The unregister DELETE is scoped by both token AND sessionId.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vite-plus/test';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 
 // ---------------------------------------------------------------------------
@@ -19,6 +19,7 @@ import type { ConnectionContext } from '@boardsesh/shared-schema';
 const participantRows = vi.fn<() => Array<{ sessionId: string }>>(() => []);
 const countRows = vi.fn<() => Array<{ value: number }>>(() => [{ value: 0 }]);
 const oldestTokenRows = vi.fn<() => Array<{ token: string }>>(() => []);
+const oldestLimit = vi.fn<(_n: number) => Promise<Array<{ token: string }>>>(async (_n) => oldestTokenRows());
 
 const insertOnConflictDoUpdate = vi.fn();
 const deleteWhere = vi.fn();
@@ -39,9 +40,10 @@ vi.mock('../db/client', () => {
       const result: Record<string, unknown> = {};
       result.limit = limit;
       result.orderBy = vi.fn(() => ({
-        limit: vi.fn(async (_n: number) => oldestTokenRows()),
+        limit: oldestLimit,
       }));
       // Make this object thenable so `await db.select().from().where()` resolves
+      // eslint-disable-next-line unicorn/no-thenable -- The Drizzle mock must be both awaitable and chainable.
       result.then = (onFulfilled: (rows: Array<{ value: number }>) => unknown) => onFulfilled(countRows());
       return result;
     });
@@ -74,6 +76,10 @@ vi.mock('../db/client', () => {
 const { pushTokenMutations, __resetPushTokenRateLimitForTests } =
   await import('../graphql/resolvers/sessions/push-tokens');
 
+const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -105,6 +111,12 @@ function anonCtx(): ConnectionContext {
 // Tests
 // ---------------------------------------------------------------------------
 
+afterAll(() => {
+  consoleInfoSpy.mockRestore();
+  consoleWarnSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+});
+
 describe('registerActivityPushToken', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -118,6 +130,9 @@ describe('registerActivityPushToken', () => {
     await expect(
       pushTokenMutations.registerActivityPushToken(undefined, { sessionId: SESSION_ID, token: VALID_TOKEN }, anonCtx()),
     ).rejects.toThrow('Authentication required');
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      `[APNs] Rejected Live Activity token registration for session ${SESSION_ID}: unauthenticated`,
+    );
   });
 
   it('rejects authenticated non-participants', async () => {
@@ -153,6 +168,29 @@ describe('registerActivityPushToken', () => {
       expect.objectContaining({ token: VALID_TOKEN, sessionId: SESSION_ID }),
     );
     expect(insertOnConflictDoUpdate).toHaveBeenCalled();
+    expect(consoleInfoSpy).toHaveBeenCalledWith(
+      `[APNs] Registered Live Activity token for session ${SESSION_ID}: ${VALID_TOKEN.slice(0, 8)}...`,
+    );
+  });
+
+  it('evicts oldest tokens when the per-session cap is reached', async () => {
+    const oldestTokens = [{ token: 'b'.repeat(64) }, { token: 'c'.repeat(64) }];
+    countRows.mockReturnValue([{ value: 9 }]);
+    oldestTokenRows.mockReturnValue(oldestTokens);
+    deleteWhere.mockResolvedValue(undefined);
+
+    const result = await pushTokenMutations.registerActivityPushToken(
+      undefined,
+      { sessionId: SESSION_ID, token: VALID_TOKEN },
+      authedCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(oldestLimit).toHaveBeenCalledWith(2);
+    expect(deleteWhere).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      `[APNs] Evicting 2 old Live Activity token(s) for session ${SESSION_ID}; cap is 8`,
+    );
   });
 
   it('rejects empty sessionId or token', async () => {
@@ -214,6 +252,9 @@ describe('unregisterActivityPushToken', () => {
 
     expect(result).toBe(true);
     expect(deleteWhere).toHaveBeenCalledTimes(1);
+    expect(consoleInfoSpy).toHaveBeenCalledWith(
+      `[APNs] Unregistered Live Activity token for session ${SESSION_ID}: ${VALID_TOKEN.slice(0, 8)}...`,
+    );
   });
 });
 

--- a/packages/backend/src/graphql/resolvers/sessions/push-tokens.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/push-tokens.ts
@@ -104,6 +104,14 @@ async function isParticipant(userId: string, sessionId: string): Promise<boolean
   return rows.length > 0;
 }
 
+function describeTokenForLog(token: string): string {
+  return `${token.slice(0, 8)}...`;
+}
+
+function describeSessionForLog(sessionId: string | null | undefined): string {
+  return sessionId || '<missing>';
+}
+
 export const pushTokenMutations = {
   /**
    * Register (upsert) an APNs device token for Live Activity push updates.
@@ -116,22 +124,37 @@ export const pushTokenMutations = {
     ctx: ConnectionContext,
   ) => {
     if (!ctx.isAuthenticated || !ctx.userId) {
+      console.warn(
+        `[APNs] Rejected Live Activity token registration for session ${describeSessionForLog(sessionId)}: unauthenticated`,
+      );
       throw new Error('Authentication required to perform this operation');
     }
 
     if (!sessionId || !token) {
+      console.warn(
+        `[APNs] Rejected Live Activity token registration for session ${describeSessionForLog(sessionId)}: missing sessionId or token`,
+      );
       throw new Error('sessionId and token are required');
     }
 
     if (!APNS_TOKEN_PATTERN.test(token)) {
+      console.warn(
+        `[APNs] Rejected Live Activity token registration for session ${sessionId}: invalid token format (length ${String(token.length)})`,
+      );
       throw new Error('Invalid APNs token format');
     }
 
     if (!checkTokenMutationRateLimit(ctx.userId, sessionId)) {
+      console.warn(
+        `[APNs] Rejected Live Activity token registration for session ${sessionId}: rate limited user ${ctx.userId}`,
+      );
       throw new Error('Too many push-token requests, please retry later');
     }
 
     if (!(await isParticipant(ctx.userId, sessionId))) {
+      console.warn(
+        `[APNs] Rejected Live Activity token registration for session ${sessionId}: user ${ctx.userId} is not a participant`,
+      );
       throw new Error('Unauthorized: not a participant in this session');
     }
 
@@ -144,41 +167,58 @@ export const pushTokenMutations = {
     // insert, ending up at cap + 1. The advisory lock auto-releases at
     // transaction end (`_xact_` variant) so we don't have to clean up on
     // error paths.
-    await db.transaction(async (tx) => {
-      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${sessionId}))`);
+    try {
+      await db.transaction(async (tx) => {
+        await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${sessionId}))`);
 
-      const [{ value: currentCount } = { value: 0 }] = await tx
-        .select({ value: count() })
-        .from(activityPushTokens)
-        .where(eq(activityPushTokens.sessionId, sessionId));
-
-      if (currentCount >= MAX_TOKENS_PER_SESSION) {
-        const oldest = await tx
-          .select({ token: activityPushTokens.token })
+        const [{ value: currentCount } = { value: 0 }] = await tx
+          .select({ value: count() })
           .from(activityPushTokens)
-          .where(eq(activityPushTokens.sessionId, sessionId))
-          .orderBy(activityPushTokens.updatedAt)
-          .limit(currentCount - MAX_TOKENS_PER_SESSION + 1);
+          .where(eq(activityPushTokens.sessionId, sessionId));
 
-        for (const row of oldest) {
-          await tx.delete(activityPushTokens).where(eq(activityPushTokens.token, row.token));
+        if (currentCount >= MAX_TOKENS_PER_SESSION) {
+          const evictionCount = currentCount - MAX_TOKENS_PER_SESSION + 1;
+          const oldest = await tx
+            .select({ token: activityPushTokens.token })
+            .from(activityPushTokens)
+            .where(eq(activityPushTokens.sessionId, sessionId))
+            .orderBy(activityPushTokens.updatedAt)
+            .limit(evictionCount);
+
+          if (oldest.length > 0) {
+            console.warn(
+              `[APNs] Evicting ${String(oldest.length)} old Live Activity token(s) for session ${sessionId}; cap is ${String(MAX_TOKENS_PER_SESSION)}`,
+            );
+          }
+
+          for (const row of oldest) {
+            await tx.delete(activityPushTokens).where(eq(activityPushTokens.token, row.token));
+          }
         }
-      }
 
-      await tx
-        .insert(activityPushTokens)
-        .values({
-          token,
-          sessionId,
-        })
-        .onConflictDoUpdate({
-          target: activityPushTokens.token,
-          set: {
+        await tx
+          .insert(activityPushTokens)
+          .values({
+            token,
             sessionId,
-            updatedAt: new Date(),
-          },
-        });
-    });
+          })
+          .onConflictDoUpdate({
+            target: activityPushTokens.token,
+            set: {
+              sessionId,
+              updatedAt: new Date(),
+            },
+          });
+      });
+    } catch (error) {
+      console.error(
+        `[APNs] Failed to register Live Activity token for session ${sessionId} (${describeTokenForLog(token)}):`,
+        error,
+      );
+      throw error;
+    }
+
+    console.info(`[APNs] Registered Live Activity token for session ${sessionId}: ${describeTokenForLog(token)}`);
 
     return true;
   },
@@ -195,28 +235,53 @@ export const pushTokenMutations = {
     ctx: ConnectionContext,
   ) => {
     if (!ctx.isAuthenticated || !ctx.userId) {
+      console.warn(
+        `[APNs] Rejected Live Activity token unregister for session ${describeSessionForLog(sessionId)}: unauthenticated`,
+      );
       throw new Error('Authentication required to perform this operation');
     }
 
     if (!sessionId || !token) {
+      console.warn(
+        `[APNs] Rejected Live Activity token unregister for session ${describeSessionForLog(sessionId)}: missing sessionId or token`,
+      );
       throw new Error('sessionId and token are required');
     }
 
     if (!APNS_TOKEN_PATTERN.test(token)) {
+      console.warn(
+        `[APNs] Rejected Live Activity token unregister for session ${sessionId}: invalid token format (length ${String(token.length)})`,
+      );
       throw new Error('Invalid APNs token format');
     }
 
     if (!checkTokenMutationRateLimit(ctx.userId, sessionId)) {
+      console.warn(
+        `[APNs] Rejected Live Activity token unregister for session ${sessionId}: rate limited user ${ctx.userId}`,
+      );
       throw new Error('Too many push-token requests, please retry later');
     }
 
     if (!(await isParticipant(ctx.userId, sessionId))) {
+      console.warn(
+        `[APNs] Rejected Live Activity token unregister for session ${sessionId}: user ${ctx.userId} is not a participant`,
+      );
       throw new Error('Unauthorized: not a participant in this session');
     }
 
-    await db
-      .delete(activityPushTokens)
-      .where(and(eq(activityPushTokens.token, token), eq(activityPushTokens.sessionId, sessionId)));
+    try {
+      await db
+        .delete(activityPushTokens)
+        .where(and(eq(activityPushTokens.token, token), eq(activityPushTokens.sessionId, sessionId)));
+    } catch (error) {
+      console.error(
+        `[APNs] Failed to unregister Live Activity token for session ${sessionId} (${describeTokenForLog(token)}):`,
+        error,
+      );
+      throw error;
+    }
+
+    console.info(`[APNs] Unregistered Live Activity token for session ${sessionId}: ${describeTokenForLog(token)}`);
 
     return true;
   },

--- a/packages/backend/src/services/apns/index.ts
+++ b/packages/backend/src/services/apns/index.ts
@@ -156,9 +156,7 @@ async function sendNotification(
 ): Promise<void> {
   if (!provider || tokens.length === 0) return;
 
-  console.log(
-    `[APNs] Sending Live Activity ${event} for session ${sessionId} to ${String(tokens.length)} device(s)`,
-  );
+  console.log(`[APNs] Sending Live Activity ${event} for session ${sessionId} to ${String(tokens.length)} device(s)`);
 
   const notification = new apn.Notification();
   notification.topic = `${bundleId}.push-type.liveactivity`;
@@ -278,10 +276,11 @@ export function sendLiveActivityUpdate(sessionId: string, contentState: LiveActi
   if (existing) {
     // Replace the pending state but keep the existing timer
     existing.latestState = contentState;
+    console.info(`[APNs] Coalesced Live Activity update for session ${sessionId} into pending debounce`);
     return;
   }
 
-  console.info(`[APNs] Scheduled Live Activity update for session ${sessionId}`);
+  console.info(`[APNs] Queued Live Activity update for session ${sessionId}; waiting for debounce`);
 
   // Schedule a new send after the debounce window
   const timeout = setTimeout(() => {


### PR DESCRIPTION
## Summary

Follow-up to the Live Activity push-token fix. This removes the hardcoded keychain Team ID fallback and makes the remaining Live Activity diagnostics clearer when configuration, auth input, token registration, token-cap eviction, or APNs debounce behavior is wrong.

## Changes

- Remove the hardcoded keychain access-group prefix from `SharedKeychain`.
- Treat missing, empty, unexpanded, or unexpected `BoardseshKeychainAccessGroup` values as configuration failures instead of silently selecting the wrong access group.
- Emit structured `SharedKeychain` fault/error logs when release builds cannot resolve the access group or skip keychain operations because it is unavailable.
- Add native logs when `startSession` receives a missing or empty `authToken`, with empty strings logged as warnings.
- Rename the APNs debounce log from scheduled-send language to queue/coalesce language so it does not look like a delivery confirmation before the debounce fires.
- Log Live Activity push-token registration, unregister, rejection, and token-cap eviction paths without printing the full APNs token.
- Update Live Activity troubleshooting docs to match the current native auth-token log messages.

## Validation

- `vp test run packages/backend/src/__tests__/push-tokens.test.ts`
- `vp run typecheck:backend`
- `git diff --check`
- `vp check` confirms formatting is clean, but still exits on existing unrelated lint warnings across the repo.

## Notes

- Local environment is Linux, so the iOS Swift compile is left to the GitHub iOS build.