### PR TITLE
fix(stats): fall back to consensus grade for ungraded ticks

### DIFF
--- a/docs/ascents-and-attempts.md
+++ b/docs/ascents-and-attempts.md
@@ -111,17 +111,33 @@ Option 2 is the common case. `QuickTickBar` initializes `difficulty` state to `u
 
 ### The consequence: read paths must fall back to consensus
 
-Any aggregation or display that groups by grade **must** COALESCE `boardsesh_ticks.difficulty` with the climb's consensus difficulty from `board_climb_stats`. Otherwise ungraded ticks silently disappear from charts.
+Any aggregation, display, or filter that touches grade **must** COALESCE `boardsesh_ticks.difficulty` with the climb's consensus difficulty from `board_climb_stats`. Otherwise ungraded ticks silently disappear from charts or fall outside grade-range filters.
 
-Two backend resolvers already implement this (`packages/backend/src/graphql/resolvers/ticks/queries.ts`):
+The pattern (`packages/backend/src/graphql/resolvers/ticks/queries.ts`):
 
 ```ts
 COALESCE(boardseshTicks.difficulty, consensusDifficultyExpr);
 ```
 
-where `consensusDifficultyExpr = ROUND(boardClimbStats.displayDifficulty)`, defined in `packages/backend/src/graphql/resolvers/shared/sql-expressions.ts`.
+where `consensusDifficultyExpr = ROUND(boardClimbStats.displayDifficulty)`, defined in `packages/backend/src/graphql/resolvers/shared/sql-expressions.ts`. Reusing this expression in any new tick-aggregation query also keeps the `board_climb_stats` join shape consistent — it's joined on `(climbUuid, boardType, angle)` (its primary key, so the join doesn't multiply rows).
 
-The `userTicks` and `userProfileStats` resolvers LEFT JOIN `board_climb_stats` on `(climbUuid, boardType, angle)` (its primary key — fast) and return the coalesced value as `difficulty`. The client side then receives an effective difficulty that respects the user's override when set and the consensus otherwise. **Reuse this pattern** for any new tick-aggregation query.
+### `difficulty` and `effectiveDifficulty` — two separate GraphQL fields
+
+The `Tick` GraphQL type exposes both:
+
+- `difficulty: Int` — the **raw** stored value. NULL when the user didn't attach a personal override. Use this when you care about the user's intent (e.g. an "edit my grade" UI, or an Aurora sync write-back).
+- `effectiveDifficulty: Int` — the COALESCE'd value. Use this for charts, leaderboards, filters, and any per-grade bucketing. Still nullable when neither the tick nor the climb has a grade yet.
+
+Splitting them prevents an optimistic write (`useSaveTick` puts the raw user input on a temp row) from flickering when the server hydration comes back: optimistic and server `difficulty` agree (both null for ungraded), and `effectiveDifficulty` simply fills in once the server knows the consensus.
+
+### Resolvers that fall back to consensus
+
+| Resolver                                                      | Surface                                            | How                                                                                                                                                                      |
+| ------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `userTicks` (`queries.ts:126`)                                | profile stats charts, hardest send/flash, V-points | LEFT JOIN `board_climb_stats`, expose both `difficulty` and `effectiveDifficulty`                                                                                        |
+| `userProfileStats` (`queries.ts:773`)                         | per-layout grade buckets, layout %s                | Same JOIN, `groupBy(layoutId, COALESCE(...))`, plus a separate per-layout distinct sub-query so `distinctClimbCount` is correct when a climb appears in multiple buckets |
+| `userAscentsFeed` (`queries.ts:176`)                          | activity feed                                      | `minDifficulty` / `maxDifficulty` filter on `COALESCE(...)` so ungraded ticks whose consensus is in range still appear                                                   |
+| `followingLeaderboard.hardestGrade` (`social/boards.ts:1035`) | follow-leaderboard                                 | `MAX(COALESCE(...))` so ungraded sends still raise a user's hardest grade                                                                                                |
 
 If neither the tick nor `board_climb_stats` has a difficulty (e.g. a brand-new unrated climb), the effective difficulty remains `null` and the row is excluded from grade buckets but still counts toward total ascent counts. That's the correct behavior — there's no way to bucket it.
 

--- a/docs/ascents-and-attempts.md
+++ b/docs/ascents-and-attempts.md
@@ -1,0 +1,217 @@
+# Ascents and Attempts
+
+This document describes how Boardsesh models a user's interactions with a climb — the per-tick "I tried this" and "I sent this" records — across schema, write paths, read paths, Aurora sync, and stats aggregation. Read this before touching any code that creates, queries, or aggregates `boardsesh_ticks`.
+
+## Table of Contents
+
+1. [Mental Model](#mental-model)
+2. [The Single Table: `boardsesh_ticks`](#the-single-table-boardsesh_ticks)
+3. [Status Taxonomy](#status-taxonomy)
+4. [`difficulty` Is Nullable — and That's Intentional](#difficulty-is-nullable--and-thats-intentional)
+5. [Quality Is Nullable Too](#quality-is-nullable-too)
+6. [Write Paths](#write-paths)
+7. [Read Paths and the Consensus Fallback](#read-paths-and-the-consensus-fallback)
+8. [Aurora Sync Mapping](#aurora-sync-mapping)
+9. [Sessions](#sessions)
+10. [Rules for Future Code](#rules-for-future-code)
+
+---
+
+## Mental Model
+
+A **tick** is a single row in `boardsesh_ticks`. It records that a user did *something* on a climb at a specific angle at a specific time. There are exactly three things a tick can represent:
+
+- **flash** — user completed the climb on the first attempt
+- **send** — user completed the climb after one or more failed attempts
+- **attempt** — user tried and did *not* complete the climb (a "bid")
+
+A flash and a send are collectively "ascents". Attempts are "bids". The same user can log many ticks against the same climb at the same angle over time — ticks are not deduplicated; their natural key is `(uuid)` (a Boardsesh-generated UUID), with `aurora_id` as the cross-system anchor when the tick has been synced.
+
+Everything about ascents is single-table: one PostgreSQL table (`boardsesh_ticks`), one TypeScript type (`BoardseshTick`), one GraphQL type (`Tick`).
+
+---
+
+## The Single Table: `boardsesh_ticks`
+
+Schema lives at `packages/db/src/schema/app/ascents.ts`. Key fields:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `uuid` | `text` (unique) | Boardsesh-generated UUID, the stable identifier we expose externally |
+| `user_id` | `text` → `users.id` | Owner of this tick; cascades on user delete |
+| `board_type` | `text` | `'kilter'`, `'tension'`, or `'moonboard'` |
+| `climb_uuid` | `text` | References `board_climbs.uuid` (logically — there's intentionally no FK; see schema comments) |
+| `angle` | `int` | Wall angle at climb time, in degrees |
+| `is_mirror` | `bool` | Whether the user climbed the mirrored variant |
+| `status` | `tick_status` enum | `'flash'` / `'send'` / `'attempt'` |
+| `attempt_count` | `int` | Number of attempts for this entry. **Always `1` for flash.** For sends and attempts, it's the count the user reported |
+| `quality` | `int?` | 1–5 user star rating. **Null for attempts**, optionally null for ascents |
+| `difficulty` | `int?` | User's personal grade override (a `difficulty_id`, not a name). **Null means "use the climb's consensus grade"** — see below |
+| `is_benchmark` | `bool` | Whether the user marked the climb as a benchmark |
+| `comment` | `text` | Free-form note |
+| `climbed_at` | `timestamp` | When the climb happened (user-supplied, not server-time) |
+| `created_at` / `updated_at` | `timestamp` | Row audit |
+| `session_id` | `text?` → `board_sessions.id` | If logged inside a party-mode session |
+| `inferred_session_id` | `text?` → `inferred_sessions.id` | Auto-assigned grouping; see [Inferred Sessions](inferred-sessions.md) |
+| `board_id` | `bigint?` → `user_boards.id` | The physical board the tick was recorded on, when known |
+| `aurora_type` | `aurora_table_type?` enum | `'ascents'` / `'bids'`; null until synced to Aurora |
+| `aurora_id` | `text?` | Aurora's UUID once synced (uniquely indexed) |
+| `aurora_synced_at` | `timestamp?` | When the sync succeeded |
+| `aurora_sync_error` | `text?` | Last sync error if a sync attempt failed |
+
+The `tick_status` and `aurora_table_type` enums are defined alongside the table. Don't introduce new enum values without coordinating with the Aurora API mapping in `packages/aurora-sync/src/sync/user-sync.ts`.
+
+---
+
+## Status Taxonomy
+
+```
+                    completed?
+                       │
+              ┌────────┴────────┐
+              │                 │
+             yes                no
+              │                 │
+        attempt_count?      'attempt'
+        ┌────┴────┐         (Aurora: bids)
+        │         │
+        1     >1
+        │         │
+     'flash'   'send'
+            (Aurora: ascents)
+```
+
+Two write paths derive status differently:
+
+- **QuickTickBar** (compact in-app tick bar — `packages/web/app/components/logbook/quick-tick-bar.tsx`) derives status from `(hasPriorHistory, attemptCount)`:
+  - If `attemptCount === 1` *and* the user has no prior logbook entry for this climb → `flash`
+  - Otherwise an ascent → `send`
+  - Explicit attempt button → `attempt`
+- **LogAscentForm** (the full form — `packages/web/app/components/logbook/logascent-form.tsx`) uses the simpler `getAscentStatus(attempts) = attempts === 1 ? 'flash' : 'send'` plus an explicit `LogType` toggle for attempts.
+
+These rules can diverge — keep them in mind when adding a new save UI. The status field is the source of truth; don't re-derive it on the read side.
+
+> **Legacy heuristic:** `chart-data-builders.buildFlashRedpointBars` still falls back to `attempts === 1 ? flash : send` when `status` is null. That's only for very old pre-status rows; new code must set `status` explicitly.
+
+---
+
+## `difficulty` Is Nullable — and That's Intentional
+
+`boardsesh_ticks.difficulty` is the user's *personal* grade for this ascent. It is **not** the climb's consensus grade.
+
+A user logging a tick may:
+
+1. **Manually pick a grade** in the picker → `difficulty = the picked difficulty_id`
+2. **Tap "tick" without opening the grade picker** → `difficulty = null`
+3. **Log a `attempt`** → `difficulty = null` (by convention; attempts don't carry a grade)
+
+Option 2 is the common case. `QuickTickBar` initializes `difficulty` state to `undefined` and only sets it if the user explicitly picks one. The consensus grade is offered as a *focus hint* in the picker (`focusGradeId={consensusGradeId}`) but is intentionally **not** baked into the saved row. This keeps the stored data honest: `null` means "use whatever the current consensus is", so the tick's effective grade tracks the climb's consensus over time even if it gets re-graded later.
+
+**Aurora imports are also allowed to be null.** `packages/aurora-sync/src/sync/user-sync.ts:176` does `item.difficulty ? Number(item.difficulty) : null` — if Aurora doesn't send a difficulty (e.g. some older rows), we store null and lean on the read-side fallback.
+
+### The consequence: read paths must fall back to consensus
+
+Any aggregation or display that groups by grade **must** COALESCE `boardsesh_ticks.difficulty` with the climb's consensus difficulty from `board_climb_stats`. Otherwise ungraded ticks silently disappear from charts.
+
+Two backend resolvers already implement this (`packages/backend/src/graphql/resolvers/ticks/queries.ts`):
+
+```ts
+COALESCE(boardseshTicks.difficulty, consensusDifficultyExpr)
+```
+
+where `consensusDifficultyExpr = ROUND(boardClimbStats.displayDifficulty)`, defined in `packages/backend/src/graphql/resolvers/shared/sql-expressions.ts`.
+
+The `userTicks` and `userProfileStats` resolvers LEFT JOIN `board_climb_stats` on `(climbUuid, boardType, angle)` (its primary key — fast) and return the coalesced value as `difficulty`. The client side then receives an effective difficulty that respects the user's override when set and the consensus otherwise. **Reuse this pattern** for any new tick-aggregation query.
+
+If neither the tick nor `board_climb_stats` has a difficulty (e.g. a brand-new unrated climb), the effective difficulty remains `null` and the row is excluded from grade buckets but still counts toward total ascent counts. That's the correct behavior — there's no way to bucket it.
+
+---
+
+## Quality Is Nullable Too
+
+Same rules as difficulty, with one simplification: there's no community-wide "consensus star rating" to fall back to (`board_climb_stats.qualityAverage` exists but isn't used as a substitute for the user's rating). A null quality on an ascent simply means "user didn't rate this one". Attempts always have null quality by convention.
+
+---
+
+## Write Paths
+
+There are exactly three production code paths that insert into `boardsesh_ticks`:
+
+### 1. `saveTick` GraphQL mutation
+
+`packages/backend/src/graphql/resolvers/ticks/mutations.ts:276`. Inserts one row.
+
+- `difficulty: validatedInput.difficulty ?? null` — undefined → null
+- `quality: validatedInput.quality ?? null`
+- Aurora fields all set to `null`; they get populated later by the periodic sync daemon.
+- Fires `assignInferredSession` (fire-and-forget) for non-party ticks.
+- Publishes `ascent.logged` event for the feed (only for `flash`/`send`, not `attempt`).
+- If `videoUrl` was attached, also inserts a `board_beta_links` row.
+
+Two client hooks call it:
+
+- `useSaveTick` (`packages/web/app/hooks/use-save-tick.ts`) — low-level React Query mutation; optimistically updates the logbook cache.
+- `useTickSave` (`packages/web/app/hooks/use-tick-save.ts`) — higher-level wrapper used by `QuickTickBar` and `InlineListTickBar`; handles status derivation, confetti, and IndexedDB drafts for offline retry.
+
+### 2. Aurora sync — ascents
+
+`packages/aurora-sync/src/sync/user-sync.ts:162`. Bulk inserts (upserts on `aurora_id`) from Aurora's `ascents` table. Maps `attempt_id === 1 → flash`, else → `send`. Preserves Aurora's `difficulty` if present, otherwise null.
+
+### 3. Aurora sync — bids
+
+`packages/aurora-sync/src/sync/user-sync.ts:214`. Bulk inserts attempts. Status is hardcoded to `'attempt'`. Quality and difficulty are always null.
+
+**No other code path may insert into `boardsesh_ticks`.** If you need to bulk-create ticks (a test, an import script), route through the same code or write a script in `packages/aurora-sync` that mirrors this shape.
+
+---
+
+## Read Paths and the Consensus Fallback
+
+| Surface | Resolver / fetch | Joins `board_climb_stats`? |
+|---|---|---|
+| Profile stats (per-grade chart, hardest send/flash, V-points) | `userTicks` (`queries.ts:126`) | ✅ uses consensus fallback |
+| Profile stats summary (layout %, grade buckets) | `userProfileStats` (`queries.ts:773`) | ✅ uses consensus fallback |
+| Profile activity feed | `userAscentsFeed` (`queries.ts:176`) | ✅ joins `board_climb_stats` — exposes both `tick.difficulty` (raw) and `consensusDifficulty` (rounded) for the UI to choose |
+| Logbook (`/you/logbook`) | `userAscentsFeed` via React Query | Inherits from feed resolver |
+| Climb pages (counters per-user) | various climb queries | n/a — they count rows, not grades |
+| Percentile ranking | `userClimbPercentile` (`queries.ts`) | Doesn't need it — counts distinct climbs, not grade buckets |
+
+When you add a new chart, leaderboard, or stat that groups ticks by grade, follow the join-and-coalesce pattern. Don't query `boardsesh_ticks.difficulty` directly.
+
+### Client-side filtering
+
+Once the resolver provides the effective difficulty, client code (e.g. `packages/web/app/profile/[user_id]/utils/chart-data-builders.ts`) still includes a defensive `if (entry.difficulty === null) return` guard. That guard is intentional — it handles the case where neither the user nor the consensus has a grade (new climbs, no `board_climb_stats` row yet) — but it should rarely fire in practice. **Do not pre-filter in the resolver** to "save bytes": the client guard is the right place.
+
+---
+
+## Aurora Sync Mapping
+
+```
+Aurora `ascents` table  ───►  boardsesh_ticks.status ∈ {'flash','send'}
+                              boardsesh_ticks.aurora_type = 'ascents'
+
+Aurora `bids` table      ───►  boardsesh_ticks.status = 'attempt'
+                              boardsesh_ticks.aurora_type = 'bids'
+```
+
+`aurora_id` is the cross-system anchor. It's unique (Postgres allows multiple nulls), so the periodic sync daemon can upsert without dup-key risk. Reverse direction (Boardsesh → Aurora) is the responsibility of a separate sync job that picks up rows with `aurora_id IS NULL` and posts them to Aurora. After success, `aurora_id`, `aurora_type`, and `aurora_synced_at` are written back to the row. See [`aurora-sync.md`](aurora-sync.md) for the full sync architecture.
+
+---
+
+## Sessions
+
+Every tick belongs to exactly one session — either an explicit party-mode `board_sessions` row (via `session_id`) or an auto-grouped `inferred_sessions` row (via `inferred_session_id`). See [`inferred-sessions.md`](inferred-sessions.md). The session attribution is independent of `status`, `difficulty`, or anything else discussed here.
+
+---
+
+## Rules for Future Code
+
+1. **Don't treat `tick.difficulty` as required.** If you see a non-null assertion, a Zod schema marking it required, or a `.filter(t => t.difficulty != null)` that's being used to *exclude* ascents from a count, that's a bug.
+2. **Don't pre-bake the consensus grade into the saved row.** The whole point of the nullable column is that it tracks consensus changes over time. If a user genuinely meant to override, they would have picked a grade.
+3. **Always join `board_climb_stats` and COALESCE** when grouping ticks by grade. Reuse `consensusDifficultyExpr` from `packages/backend/src/graphql/resolvers/shared/sql-expressions.ts`.
+4. **Status is the source of truth, not `attempt_count`.** New code must check `status === 'flash'` / `'send'` / `'attempt'`, not infer from attempt counts. The attempt-count heuristic in `buildFlashRedpointBars` is a legacy fallback for pre-status rows only.
+5. **All inserts go through `saveTick` or the Aurora sync.** Don't write ad-hoc inserts elsewhere; you'll skip inferred-session assignment, the `ascent.logged` event, beta-link attach, and the IndexedDB draft cleanup.
+6. **Aurora fields are owned by the sync daemon.** Don't set `aurora_id`, `aurora_type`, or `aurora_synced_at` from a write path other than the sync job.
+7. **Attempts never carry a `quality` or `difficulty`.** If you add an "attempt with grade override" UX, document it here first — every aggregation in this doc assumes the convention.
+
+If you change any of these invariants, update this document in the same PR.

--- a/docs/ascents-and-attempts.md
+++ b/docs/ascents-and-attempts.md
@@ -19,11 +19,11 @@ This document describes how Boardsesh models a user's interactions with a climb 
 
 ## Mental Model
 
-A **tick** is a single row in `boardsesh_ticks`. It records that a user did *something* on a climb at a specific angle at a specific time. There are exactly three things a tick can represent:
+A **tick** is a single row in `boardsesh_ticks`. It records that a user did _something_ on a climb at a specific angle at a specific time. There are exactly three things a tick can represent:
 
 - **flash** — user completed the climb on the first attempt
 - **send** — user completed the climb after one or more failed attempts
-- **attempt** — user tried and did *not* complete the climb (a "bid")
+- **attempt** — user tried and did _not_ complete the climb (a "bid")
 
 A flash and a send are collectively "ascents". Attempts are "bids". The same user can log many ticks against the same climb at the same angle over time — ticks are not deduplicated; their natural key is `(uuid)` (a Boardsesh-generated UUID), with `aurora_id` as the cross-system anchor when the tick has been synced.
 
@@ -35,29 +35,29 @@ Everything about ascents is single-table: one PostgreSQL table (`boardsesh_ticks
 
 Schema lives at `packages/db/src/schema/app/ascents.ts`. Key fields:
 
-| Field | Type | Purpose |
-|---|---|---|
-| `uuid` | `text` (unique) | Boardsesh-generated UUID, the stable identifier we expose externally |
-| `user_id` | `text` → `users.id` | Owner of this tick; cascades on user delete |
-| `board_type` | `text` | `'kilter'`, `'tension'`, or `'moonboard'` |
-| `climb_uuid` | `text` | References `board_climbs.uuid` (logically — there's intentionally no FK; see schema comments) |
-| `angle` | `int` | Wall angle at climb time, in degrees |
-| `is_mirror` | `bool` | Whether the user climbed the mirrored variant |
-| `status` | `tick_status` enum | `'flash'` / `'send'` / `'attempt'` |
-| `attempt_count` | `int` | Number of attempts for this entry. **Always `1` for flash.** For sends and attempts, it's the count the user reported |
-| `quality` | `int?` | 1–5 user star rating. **Null for attempts**, optionally null for ascents |
-| `difficulty` | `int?` | User's personal grade override (a `difficulty_id`, not a name). **Null means "use the climb's consensus grade"** — see below |
-| `is_benchmark` | `bool` | Whether the user marked the climb as a benchmark |
-| `comment` | `text` | Free-form note |
-| `climbed_at` | `timestamp` | When the climb happened (user-supplied, not server-time) |
-| `created_at` / `updated_at` | `timestamp` | Row audit |
-| `session_id` | `text?` → `board_sessions.id` | If logged inside a party-mode session |
-| `inferred_session_id` | `text?` → `inferred_sessions.id` | Auto-assigned grouping; see [Inferred Sessions](inferred-sessions.md) |
-| `board_id` | `bigint?` → `user_boards.id` | The physical board the tick was recorded on, when known |
-| `aurora_type` | `aurora_table_type?` enum | `'ascents'` / `'bids'`; null until synced to Aurora |
-| `aurora_id` | `text?` | Aurora's UUID once synced (uniquely indexed) |
-| `aurora_synced_at` | `timestamp?` | When the sync succeeded |
-| `aurora_sync_error` | `text?` | Last sync error if a sync attempt failed |
+| Field                       | Type                             | Purpose                                                                                                                      |
+| --------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `uuid`                      | `text` (unique)                  | Boardsesh-generated UUID, the stable identifier we expose externally                                                         |
+| `user_id`                   | `text` → `users.id`              | Owner of this tick; cascades on user delete                                                                                  |
+| `board_type`                | `text`                           | `'kilter'`, `'tension'`, or `'moonboard'`                                                                                    |
+| `climb_uuid`                | `text`                           | References `board_climbs.uuid` (logically — there's intentionally no FK; see schema comments)                                |
+| `angle`                     | `int`                            | Wall angle at climb time, in degrees                                                                                         |
+| `is_mirror`                 | `bool`                           | Whether the user climbed the mirrored variant                                                                                |
+| `status`                    | `tick_status` enum               | `'flash'` / `'send'` / `'attempt'`                                                                                           |
+| `attempt_count`             | `int`                            | Number of attempts for this entry. **Always `1` for flash.** For sends and attempts, it's the count the user reported        |
+| `quality`                   | `int?`                           | 1–5 user star rating. **Null for attempts**, optionally null for ascents                                                     |
+| `difficulty`                | `int?`                           | User's personal grade override (a `difficulty_id`, not a name). **Null means "use the climb's consensus grade"** — see below |
+| `is_benchmark`              | `bool`                           | Whether the user marked the climb as a benchmark                                                                             |
+| `comment`                   | `text`                           | Free-form note                                                                                                               |
+| `climbed_at`                | `timestamp`                      | When the climb happened (user-supplied, not server-time)                                                                     |
+| `created_at` / `updated_at` | `timestamp`                      | Row audit                                                                                                                    |
+| `session_id`                | `text?` → `board_sessions.id`    | If logged inside a party-mode session                                                                                        |
+| `inferred_session_id`       | `text?` → `inferred_sessions.id` | Auto-assigned grouping; see [Inferred Sessions](inferred-sessions.md)                                                        |
+| `board_id`                  | `bigint?` → `user_boards.id`     | The physical board the tick was recorded on, when known                                                                      |
+| `aurora_type`               | `aurora_table_type?` enum        | `'ascents'` / `'bids'`; null until synced to Aurora                                                                          |
+| `aurora_id`                 | `text?`                          | Aurora's UUID once synced (uniquely indexed)                                                                                 |
+| `aurora_synced_at`          | `timestamp?`                     | When the sync succeeded                                                                                                      |
+| `aurora_sync_error`         | `text?`                          | Last sync error if a sync attempt failed                                                                                     |
 
 The `tick_status` and `aurora_table_type` enums are defined alongside the table. Don't introduce new enum values without coordinating with the Aurora API mapping in `packages/aurora-sync/src/sync/user-sync.ts`.
 
@@ -84,7 +84,7 @@ The `tick_status` and `aurora_table_type` enums are defined alongside the table.
 Two write paths derive status differently:
 
 - **QuickTickBar** (compact in-app tick bar — `packages/web/app/components/logbook/quick-tick-bar.tsx`) derives status from `(hasPriorHistory, attemptCount)`:
-  - If `attemptCount === 1` *and* the user has no prior logbook entry for this climb → `flash`
+  - If `attemptCount === 1` _and_ the user has no prior logbook entry for this climb → `flash`
   - Otherwise an ascent → `send`
   - Explicit attempt button → `attempt`
 - **LogAscentForm** (the full form — `packages/web/app/components/logbook/logascent-form.tsx`) uses the simpler `getAscentStatus(attempts) = attempts === 1 ? 'flash' : 'send'` plus an explicit `LogType` toggle for attempts.
@@ -97,7 +97,7 @@ These rules can diverge — keep them in mind when adding a new save UI. The sta
 
 ## `difficulty` Is Nullable — and That's Intentional
 
-`boardsesh_ticks.difficulty` is the user's *personal* grade for this ascent. It is **not** the climb's consensus grade.
+`boardsesh_ticks.difficulty` is the user's _personal_ grade for this ascent. It is **not** the climb's consensus grade.
 
 A user logging a tick may:
 
@@ -105,7 +105,7 @@ A user logging a tick may:
 2. **Tap "tick" without opening the grade picker** → `difficulty = null`
 3. **Log a `attempt`** → `difficulty = null` (by convention; attempts don't carry a grade)
 
-Option 2 is the common case. `QuickTickBar` initializes `difficulty` state to `undefined` and only sets it if the user explicitly picks one. The consensus grade is offered as a *focus hint* in the picker (`focusGradeId={consensusGradeId}`) but is intentionally **not** baked into the saved row. This keeps the stored data honest: `null` means "use whatever the current consensus is", so the tick's effective grade tracks the climb's consensus over time even if it gets re-graded later.
+Option 2 is the common case. `QuickTickBar` initializes `difficulty` state to `undefined` and only sets it if the user explicitly picks one. The consensus grade is offered as a _focus hint_ in the picker (`focusGradeId={consensusGradeId}`) but is intentionally **not** baked into the saved row. This keeps the stored data honest: `null` means "use whatever the current consensus is", so the tick's effective grade tracks the climb's consensus over time even if it gets re-graded later.
 
 **Aurora imports are also allowed to be null.** `packages/aurora-sync/src/sync/user-sync.ts:176` does `item.difficulty ? Number(item.difficulty) : null` — if Aurora doesn't send a difficulty (e.g. some older rows), we store null and lean on the read-side fallback.
 
@@ -116,7 +116,7 @@ Any aggregation or display that groups by grade **must** COALESCE `boardsesh_tic
 Two backend resolvers already implement this (`packages/backend/src/graphql/resolvers/ticks/queries.ts`):
 
 ```ts
-COALESCE(boardseshTicks.difficulty, consensusDifficultyExpr)
+COALESCE(boardseshTicks.difficulty, consensusDifficultyExpr);
 ```
 
 where `consensusDifficultyExpr = ROUND(boardClimbStats.displayDifficulty)`, defined in `packages/backend/src/graphql/resolvers/shared/sql-expressions.ts`.
@@ -167,14 +167,14 @@ Two client hooks call it:
 
 ## Read Paths and the Consensus Fallback
 
-| Surface | Resolver / fetch | Joins `board_climb_stats`? |
-|---|---|---|
-| Profile stats (per-grade chart, hardest send/flash, V-points) | `userTicks` (`queries.ts:126`) | ✅ uses consensus fallback |
-| Profile stats summary (layout %, grade buckets) | `userProfileStats` (`queries.ts:773`) | ✅ uses consensus fallback |
-| Profile activity feed | `userAscentsFeed` (`queries.ts:176`) | ✅ joins `board_climb_stats` — exposes both `tick.difficulty` (raw) and `consensusDifficulty` (rounded) for the UI to choose |
-| Logbook (`/you/logbook`) | `userAscentsFeed` via React Query | Inherits from feed resolver |
-| Climb pages (counters per-user) | various climb queries | n/a — they count rows, not grades |
-| Percentile ranking | `userClimbPercentile` (`queries.ts`) | Doesn't need it — counts distinct climbs, not grade buckets |
+| Surface                                                       | Resolver / fetch                      | Joins `board_climb_stats`?                                                                                                   |
+| ------------------------------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Profile stats (per-grade chart, hardest send/flash, V-points) | `userTicks` (`queries.ts:126`)        | ✅ uses consensus fallback                                                                                                   |
+| Profile stats summary (layout %, grade buckets)               | `userProfileStats` (`queries.ts:773`) | ✅ uses consensus fallback                                                                                                   |
+| Profile activity feed                                         | `userAscentsFeed` (`queries.ts:176`)  | ✅ joins `board_climb_stats` — exposes both `tick.difficulty` (raw) and `consensusDifficulty` (rounded) for the UI to choose |
+| Logbook (`/you/logbook`)                                      | `userAscentsFeed` via React Query     | Inherits from feed resolver                                                                                                  |
+| Climb pages (counters per-user)                               | various climb queries                 | n/a — they count rows, not grades                                                                                            |
+| Percentile ranking                                            | `userClimbPercentile` (`queries.ts`)  | Doesn't need it — counts distinct climbs, not grade buckets                                                                  |
 
 When you add a new chart, leaderboard, or stat that groups ticks by grade, follow the join-and-coalesce pattern. Don't query `boardsesh_ticks.difficulty` directly.
 
@@ -206,7 +206,7 @@ Every tick belongs to exactly one session — either an explicit party-mode `boa
 
 ## Rules for Future Code
 
-1. **Don't treat `tick.difficulty` as required.** If you see a non-null assertion, a Zod schema marking it required, or a `.filter(t => t.difficulty != null)` that's being used to *exclude* ascents from a count, that's a bug.
+1. **Don't treat `tick.difficulty` as required.** If you see a non-null assertion, a Zod schema marking it required, or a `.filter(t => t.difficulty != null)` that's being used to _exclude_ ascents from a count, that's a bug.
 2. **Don't pre-bake the consensus grade into the saved row.** The whole point of the nullable column is that it tracks consensus changes over time. If a user genuinely meant to override, they would have picked a grade.
 3. **Always join `board_climb_stats` and COALESCE** when grouping ticks by grade. Reuse `consensusDifficultyExpr` from `packages/backend/src/graphql/resolvers/shared/sql-expressions.ts`.
 4. **Status is the source of truth, not `attempt_count`.** New code must check `status === 'flash'` / `'send'` / `'attempt'`, not infer from attempt counts. The attempt-count heuristic in `buildFlashRedpointBars` is a legacy fallback for pre-status rows only.

--- a/packages/backend/src/__tests__/tick-queries.test.ts
+++ b/packages/backend/src/__tests__/tick-queries.test.ts
@@ -107,13 +107,30 @@ const insertTick = async (params: {
   attemptCount?: number;
   boardType?: string;
   difficulty?: number;
+  angle?: number;
 }) => {
   const userId = params.userId ?? TEST_USER_ID;
   const attemptCount = params.attemptCount ?? 1;
   const boardType = params.boardType ?? 'kilter';
+  const angle = params.angle ?? 40;
   await db.execute(sql`
     INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, status, attempt_count, difficulty, climbed_at)
-    VALUES (${params.uuid}, ${userId}, ${boardType}, ${params.climbUuid}, 40, ${params.status}, ${attemptCount}, ${params.difficulty ?? null}, ${params.climbedAt})
+    VALUES (${params.uuid}, ${userId}, ${boardType}, ${params.climbUuid}, ${angle}, ${params.status}, ${attemptCount}, ${params.difficulty ?? null}, ${params.climbedAt})
+  `);
+};
+
+const insertBoardClimbStats = async (params: {
+  climbUuid: string;
+  boardType?: string;
+  angle?: number;
+  displayDifficulty: number;
+}) => {
+  const boardType = params.boardType ?? 'kilter';
+  const angle = params.angle ?? 40;
+  await db.execute(sql`
+    INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, ascensionist_count, difficulty_average, quality_average)
+    VALUES (${boardType}, ${params.climbUuid}, ${angle}, ${params.displayDifficulty}, 10, ${params.displayDifficulty}, 4)
+    ON CONFLICT (board_type, climb_uuid, angle) DO UPDATE SET display_difficulty = excluded.display_difficulty
   `);
 };
 
@@ -571,6 +588,115 @@ describe('tickQueries — behavior fixes', () => {
         percentile: 0,
         totalActiveUsers: 88,
       });
+    });
+  });
+
+  // Hard invariant from docs/ascents-and-attempts.md: a tick with
+  // `difficulty IS NULL` must bucket under the climb's consensus grade,
+  // not be silently dropped from per-grade aggregates / range filters.
+  describe('NULL-difficulty ticks fall back to consensus grade', () => {
+    it('userTicks exposes raw difficulty and effectiveDifficulty (consensus fallback)', async () => {
+      const climbUuid = CLIMB_PREFIX + 'null-diff-userticks';
+      await insertClimb(climbUuid, 'Null-diff via userTicks');
+      await insertBoardClimbStats({ climbUuid, displayDifficulty: 22.4 });
+
+      // User-graded tick on the same climb at a different angle
+      await insertTick({
+        uuid: 'tick-null-diff-graded',
+        climbUuid,
+        climbedAt: '2026-04-01 10:00:00',
+        status: 'flash',
+        difficulty: 18,
+        angle: 30,
+      });
+
+      // Ungraded tick — should bucket at consensus (ROUND(22.4) = 22)
+      await insertTick({
+        uuid: 'tick-null-diff-ungraded',
+        climbUuid,
+        climbedAt: '2026-04-02 10:00:00',
+        status: 'send',
+        attemptCount: 2,
+      });
+
+      const ticks = (await tickQueries.userTicks(undefined, {
+        userId: TEST_USER_ID,
+        boardType: 'kilter',
+      })) as Array<{
+        uuid: string;
+        difficulty: number | null;
+        effectiveDifficulty: number | null;
+      }>;
+
+      const graded = ticks.find((t) => t.uuid === 'tick-null-diff-graded');
+      const ungraded = ticks.find((t) => t.uuid === 'tick-null-diff-ungraded');
+
+      // Raw field preserves user-state: null vs. explicit override.
+      expect(graded?.difficulty).toBe(18);
+      expect(ungraded?.difficulty).toBeNull();
+      // Effective field falls back to consensus for the ungraded tick.
+      expect(graded?.effectiveDifficulty).toBe(18);
+      expect(ungraded?.effectiveDifficulty).toBe(22);
+    });
+
+    it('userProfileStats buckets NULL-difficulty ticks under the consensus grade', async () => {
+      const gradedClimb = CLIMB_PREFIX + 'null-diff-stats-graded';
+      const ungradedClimb = CLIMB_PREFIX + 'null-diff-stats-ungraded';
+      await insertClimb(gradedClimb, 'graded climb');
+      await insertClimb(ungradedClimb, 'ungraded climb');
+      await insertBoardClimbStats({ climbUuid: ungradedClimb, displayDifficulty: 19.8 });
+
+      await insertTick({
+        uuid: 'tick-stats-graded',
+        climbUuid: gradedClimb,
+        climbedAt: '2026-04-01 10:00:00',
+        status: 'flash',
+        difficulty: 16,
+      });
+      await insertTick({
+        uuid: 'tick-stats-ungraded',
+        climbUuid: ungradedClimb,
+        climbedAt: '2026-04-02 10:00:00',
+        status: 'flash',
+      });
+
+      const stats = (await tickQueries.userProfileStats(undefined, { userId: TEST_USER_ID })) as {
+        totalDistinctClimbs: number;
+        layoutStats: Array<{
+          layoutKey: string;
+          distinctClimbCount: number;
+          gradeCounts: Array<{ grade: string; count: number }>;
+        }>;
+      };
+
+      const kilter1 = stats.layoutStats.find((l) => l.layoutKey === 'kilter-1');
+      expect(kilter1).toBeDefined();
+      // Both climbs counted distinctly.
+      expect(kilter1?.distinctClimbCount).toBe(2);
+      // Both grades present — the ungraded one bucketed at ROUND(19.8) = 20.
+      const gradeMap = new Map(kilter1?.gradeCounts.map((gc) => [gc.grade, gc.count]) ?? []);
+      expect(gradeMap.get('16')).toBe(1);
+      expect(gradeMap.get('20')).toBe(1);
+    });
+
+    it('userAscentsFeed minDifficulty includes NULL-difficulty ticks whose consensus is in range', async () => {
+      const climbUuid = CLIMB_PREFIX + 'null-diff-feed-filter';
+      await insertClimb(climbUuid, 'feed filter test');
+      await insertBoardClimbStats({ climbUuid, displayDifficulty: 24.1 });
+
+      // Tick has no user grade; consensus rounds to 24
+      await insertTick({
+        uuid: 'tick-feed-ungraded',
+        climbUuid,
+        climbedAt: '2026-04-03 10:00:00',
+        status: 'flash',
+      });
+
+      const inRange = await callUserAscentsFeed(TEST_USER_ID, { minDifficulty: 22, maxDifficulty: 26, limit: 50 });
+      expect(inRange.items.map((i) => i.uuid)).toContain('tick-feed-ungraded');
+
+      const outOfRange = await callUserAscentsFeed(TEST_USER_ID, { minDifficulty: 26, limit: 50 });
+      expect(outOfRange.items.map((i) => i.uuid)).not.toContain('tick-feed-ungraded');
     });
   });
 });

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -5,6 +5,7 @@ import { rowsFromResult } from '@boardsesh/db/client';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
+import { consensusDifficultyExpr } from '../shared/sql-expressions';
 import {
   CreateBoardInputSchema,
   UpdateBoardInputSchema,
@@ -1026,16 +1027,29 @@ export const socialBoardQueries = {
 
     const totalCount = Number(countResult?.count || 0);
 
-    // Get leaderboard entries
+    // Get leaderboard entries. `hardestGrade` falls back to the climb's
+    // consensus grade when the user didn't attach a personal override (NULL
+    // difficulty means "use consensus" — see docs/ascents-and-attempts.md).
+    // board_climb_stats joined on its PK so the join doesn't multiply rows.
     const entries = await db
       .select({
         userId: dbSchema.boardseshTicks.userId,
         totalSends: count(),
         totalFlashes: sql<number>`SUM(CASE WHEN ${dbSchema.boardseshTicks.status} = 'flash' THEN 1 ELSE 0 END)`,
-        hardestGrade: sql<number | null>`MAX(${dbSchema.boardseshTicks.difficulty})`,
+        hardestGrade: sql<
+          number | null
+        >`MAX(COALESCE(${dbSchema.boardseshTicks.difficulty}, ${consensusDifficultyExpr}))`,
         totalSessions: sql<number>`COUNT(DISTINCT DATE(${dbSchema.boardseshTicks.climbedAt}))`,
       })
       .from(dbSchema.boardseshTicks)
+      .leftJoin(
+        dbSchema.boardClimbStats,
+        and(
+          eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbStats.climbUuid),
+          eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbStats.boardType),
+          eq(dbSchema.boardseshTicks.angle, dbSchema.boardClimbStats.angle),
+        ),
+      )
       .where(whereClause)
       .groupBy(dbSchema.boardseshTicks.userId)
       .orderBy(sql`COUNT(*) DESC`)

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, desc, inArray, isNull, sql, count, ilike, gte, lte } from 'drizzle-orm';
+import { eq, ne, and, or, desc, inArray, isNull, sql, count, ilike, gte, lte } from 'drizzle-orm';
 import { type ConnectionContext, type BoardName, SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
@@ -128,10 +128,12 @@ export const tickQueries = {
 
     const conditions = [eq(dbSchema.boardseshTicks.userId, userId), eq(dbSchema.boardseshTicks.boardType, boardType)];
 
-    // Fetch ticks with layoutId from unified board_climbs table.
-    // COALESCE the tick's own difficulty with the climb's consensus difficulty so
-    // ticks logged without a user-picked grade still bucket into the right grade
-    // on profile stats charts (a NULL stored value means "use consensus").
+    // Fetch ticks with layoutId from unified board_climbs table. We surface
+    // `difficulty` as the raw user override (preserving the field's pre-fix
+    // contract so optimistic writes don't flicker), and an additional
+    // `effectiveDifficulty` that COALESCEs with the climb's consensus grade
+    // for chart-bucket / aggregation consumers. NULL difficulty means "use
+    // consensus" — see docs/ascents-and-attempts.md.
     const results = await db
       .select({
         tick: dbSchema.boardseshTicks,
@@ -169,7 +171,8 @@ export const tickQueries = {
       status: tick.status,
       attemptCount: tick.attemptCount,
       quality: tick.quality,
-      difficulty: effectiveDifficulty,
+      difficulty: tick.difficulty,
+      effectiveDifficulty,
       isBenchmark: tick.isBenchmark,
       comment: tick.comment,
       climbedAt: tick.climbedAt,
@@ -256,6 +259,11 @@ export const tickQueries = {
       ELSE false
     END`;
 
+    // Filter on the effective difficulty (user override → consensus fallback) so
+    // a grade-range filter doesn't silently hide ungraded ascents whose consensus
+    // is in range. See docs/ascents-and-attempts.md.
+    const effectiveDifficultyExpr = sql<number>`COALESCE(${dbSchema.boardseshTicks.difficulty}, ${consensusDifficultyExpr})`;
+
     // Build shared WHERE conditions
     const tickConditions = [
       eq(dbSchema.boardseshTicks.userId, userId),
@@ -263,8 +271,8 @@ export const tickQueries = {
       ...(boardTypes && boardTypes.length > 0 && !boardType
         ? [inArray(dbSchema.boardseshTicks.boardType, boardTypes)]
         : []),
-      ...(minDifficulty !== undefined ? [gte(dbSchema.boardseshTicks.difficulty, minDifficulty)] : []),
-      ...(maxDifficulty !== undefined ? [lte(dbSchema.boardseshTicks.difficulty, maxDifficulty)] : []),
+      ...(minDifficulty !== undefined ? [gte(effectiveDifficultyExpr, minDifficulty)] : []),
+      ...(maxDifficulty !== undefined ? [lte(effectiveDifficultyExpr, maxDifficulty)] : []),
       ...(minAngle !== undefined ? [gte(dbSchema.boardseshTicks.angle, minAngle)] : []),
       ...(maxAngle !== undefined ? [lte(dbSchema.boardseshTicks.angle, maxAngle)] : []),
       ...(fromDate ? [gte(dbSchema.boardseshTicks.climbedAt, fromDate)] : []),
@@ -808,6 +816,7 @@ export const tickQueries = {
       {
         boardType: string;
         layoutId: number | null;
+        distinctClimbCount: number;
         gradeCounts: Array<{ grade: string; count: number }>;
       }
     > = {};
@@ -822,9 +831,19 @@ export const tickQueries = {
         number | null
       >`COALESCE(${dbSchema.boardseshTicks.difficulty}, ${consensusDifficultyExpr})`;
 
-      // Run both queries in parallel for this board type
-      const [gradeResults, distinctClimbs] = await Promise.all([
-        // Get distinct climb counts grouped by layoutId and effective difficulty using SQL aggregation
+      const baseConditions = and(
+        eq(dbSchema.boardseshTicks.userId, userId),
+        eq(dbSchema.boardseshTicks.boardType, boardType),
+        ne(dbSchema.boardseshTicks.status, 'attempt'),
+      );
+
+      // Run three queries in parallel for this board type:
+      // - gradeResults: counts per (layout, effective difficulty) for the chart
+      // - distinctByLayout: per-layout distinct climb count (correct even when one
+      //   climb appears across multiple grade buckets — e.g. logged at multiple
+      //   angles whose consensus differs)
+      // - distinctClimbs: global distinct climbs for `totalDistinctClimbs`
+      const [gradeResults, distinctByLayout, distinctClimbs] = await Promise.all([
         db
           .select({
             layoutId: dbSchema.boardClimbs.layoutId,
@@ -847,55 +866,63 @@ export const tickQueries = {
               eq(dbSchema.boardseshTicks.angle, dbSchema.boardClimbStats.angle),
             ),
           )
-          .where(
-            and(
-              eq(dbSchema.boardseshTicks.userId, userId),
-              eq(dbSchema.boardseshTicks.boardType, boardType),
-              sql`${dbSchema.boardseshTicks.status} != 'attempt'`,
-            ),
-          )
+          .where(baseConditions)
           .groupBy(dbSchema.boardClimbs.layoutId, effectiveDifficultyExpr),
 
-        // Get all distinct climbUuids for total count
+        db
+          .select({
+            layoutId: dbSchema.boardClimbs.layoutId,
+            distinctCount: sql<number>`count(distinct ${dbSchema.boardseshTicks.climbUuid})`.as('distinct_count'),
+          })
+          .from(dbSchema.boardseshTicks)
+          .leftJoin(
+            dbSchema.boardClimbs,
+            and(
+              eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbs.uuid),
+              eq(dbSchema.boardClimbs.boardType, boardType),
+            ),
+          )
+          .where(baseConditions)
+          .groupBy(dbSchema.boardClimbs.layoutId),
+
         db
           .selectDistinct({ climbUuid: dbSchema.boardseshTicks.climbUuid })
           .from(dbSchema.boardseshTicks)
-          .where(
-            and(
-              eq(dbSchema.boardseshTicks.userId, userId),
-              eq(dbSchema.boardseshTicks.boardType, boardType),
-              sql`${dbSchema.boardseshTicks.status} != 'attempt'`,
-            ),
-          ),
+          .where(baseConditions),
       ]);
 
-      return { gradeResults, distinctClimbs, boardType };
+      return { gradeResults, distinctByLayout, distinctClimbs, boardType };
     };
 
     // Fetch stats for all board types in parallel
     const boardResults = await Promise.all(boardTypes.map(fetchBoardStats));
 
+    const ensureLayoutEntry = (boardType: string, layoutId: number | null) => {
+      const layoutKey = `${boardType}-${layoutId ?? 'unknown'}`;
+      if (!layoutStatsMap[layoutKey]) {
+        layoutStatsMap[layoutKey] = { boardType, layoutId, distinctClimbCount: 0, gradeCounts: [] };
+      }
+      return layoutStatsMap[layoutKey];
+    };
+
     // Process results from all boards
-    for (const { gradeResults, distinctClimbs, boardType } of boardResults) {
-      // Add to total distinct climbs set
+    for (const { gradeResults, distinctByLayout, distinctClimbs, boardType } of boardResults) {
       for (const row of distinctClimbs) {
         allClimbUuids.add(row.climbUuid);
       }
 
-      // Process grade results into layout stats
+      // Per-layout distinct climb count — separate sub-query so a climb logged at
+      // multiple angles with different consensus grades only counts once.
+      for (const row of distinctByLayout) {
+        const entry = ensureLayoutEntry(boardType, row.layoutId);
+        entry.distinctClimbCount = Number(row.distinctCount);
+      }
+
+      // Per-(layout, effective grade) counts for the chart bucketing.
       for (const row of gradeResults) {
-        const layoutKey = `${boardType}-${row.layoutId ?? 'unknown'}`;
-
-        if (!layoutStatsMap[layoutKey]) {
-          layoutStatsMap[layoutKey] = {
-            boardType,
-            layoutId: row.layoutId,
-            gradeCounts: [],
-          };
-        }
-
+        const entry = ensureLayoutEntry(boardType, row.layoutId);
         if (row.difficulty !== null) {
-          layoutStatsMap[layoutKey].gradeCounts.push({
+          entry.gradeCounts.push({
             grade: String(row.difficulty),
             count: Number(row.distinctCount),
           });
@@ -903,19 +930,13 @@ export const tickQueries = {
       }
     }
 
-    // Convert to response format with sorted grade counts
-    const layoutStats = Object.entries(layoutStatsMap).map(([layoutKey, stats]) => {
-      // Calculate total distinct climbs for this layout by summing grade counts
-      const distinctClimbCount = stats.gradeCounts.reduce((sum, gc) => sum + gc.count, 0);
-
-      return {
-        layoutKey,
-        boardType: stats.boardType,
-        layoutId: stats.layoutId,
-        distinctClimbCount,
-        gradeCounts: stats.gradeCounts.sort((a, b) => parseInt(a.grade) - parseInt(b.grade)),
-      };
-    });
+    const layoutStats = Object.entries(layoutStatsMap).map(([layoutKey, stats]) => ({
+      layoutKey,
+      boardType: stats.boardType,
+      layoutId: stats.layoutId,
+      distinctClimbCount: stats.distinctClimbCount,
+      gradeCounts: stats.gradeCounts.sort((a, b) => parseInt(a.grade) - parseInt(b.grade)),
+    }));
 
     return {
       totalDistinctClimbs: allClimbUuids.size,

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -128,11 +128,17 @@ export const tickQueries = {
 
     const conditions = [eq(dbSchema.boardseshTicks.userId, userId), eq(dbSchema.boardseshTicks.boardType, boardType)];
 
-    // Fetch ticks with layoutId from unified board_climbs table
+    // Fetch ticks with layoutId from unified board_climbs table.
+    // COALESCE the tick's own difficulty with the climb's consensus difficulty so
+    // ticks logged without a user-picked grade still bucket into the right grade
+    // on profile stats charts (a NULL stored value means "use consensus").
     const results = await db
       .select({
         tick: dbSchema.boardseshTicks,
         layoutId: dbSchema.boardClimbs.layoutId,
+        effectiveDifficulty: sql<
+          number | null
+        >`COALESCE(${dbSchema.boardseshTicks.difficulty}, ${consensusDifficultyExpr})`,
       })
       .from(dbSchema.boardseshTicks)
       .leftJoin(
@@ -142,10 +148,18 @@ export const tickQueries = {
           eq(dbSchema.boardClimbs.boardType, boardType),
         ),
       )
+      .leftJoin(
+        dbSchema.boardClimbStats,
+        and(
+          eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbStats.climbUuid),
+          eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbStats.boardType),
+          eq(dbSchema.boardseshTicks.angle, dbSchema.boardClimbStats.angle),
+        ),
+      )
       .where(and(...conditions))
       .orderBy(desc(dbSchema.boardseshTicks.climbedAt));
 
-    return results.map(({ tick, layoutId }) => ({
+    return results.map(({ tick, layoutId, effectiveDifficulty }) => ({
       uuid: tick.uuid,
       userId: tick.userId,
       boardType: tick.boardType,
@@ -155,7 +169,7 @@ export const tickQueries = {
       status: tick.status,
       attemptCount: tick.attemptCount,
       quality: tick.quality,
-      difficulty: tick.difficulty,
+      difficulty: effectiveDifficulty,
       isBenchmark: tick.isBenchmark,
       comment: tick.comment,
       climbedAt: tick.climbedAt,
@@ -801,13 +815,20 @@ export const tickQueries = {
 
     // Helper function to fetch stats for a single board type
     const fetchBoardStats = async (boardType: BoardName) => {
+      // COALESCE the tick's own difficulty with the climb's consensus difficulty so a
+      // tick logged without a user-picked grade still buckets into the consensus grade
+      // (a NULL stored value means "use consensus" — see the matching join in userTicks).
+      const effectiveDifficultyExpr = sql<
+        number | null
+      >`COALESCE(${dbSchema.boardseshTicks.difficulty}, ${consensusDifficultyExpr})`;
+
       // Run both queries in parallel for this board type
       const [gradeResults, distinctClimbs] = await Promise.all([
-        // Get distinct climb counts grouped by layoutId and difficulty using SQL aggregation
+        // Get distinct climb counts grouped by layoutId and effective difficulty using SQL aggregation
         db
           .select({
             layoutId: dbSchema.boardClimbs.layoutId,
-            difficulty: dbSchema.boardseshTicks.difficulty,
+            difficulty: effectiveDifficultyExpr.as('effective_difficulty'),
             distinctCount: sql<number>`count(distinct ${dbSchema.boardseshTicks.climbUuid})`.as('distinct_count'),
           })
           .from(dbSchema.boardseshTicks)
@@ -818,6 +839,14 @@ export const tickQueries = {
               eq(dbSchema.boardClimbs.boardType, boardType),
             ),
           )
+          .leftJoin(
+            dbSchema.boardClimbStats,
+            and(
+              eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbStats.climbUuid),
+              eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbStats.boardType),
+              eq(dbSchema.boardseshTicks.angle, dbSchema.boardClimbStats.angle),
+            ),
+          )
           .where(
             and(
               eq(dbSchema.boardseshTicks.userId, userId),
@@ -825,7 +854,7 @@ export const tickQueries = {
               sql`${dbSchema.boardseshTicks.status} != 'attempt'`,
             ),
           )
-          .groupBy(dbSchema.boardClimbs.layoutId, dbSchema.boardseshTicks.difficulty),
+          .groupBy(dbSchema.boardClimbs.layoutId, effectiveDifficultyExpr),
 
         // Get all distinct climbUuids for total count
         db

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -641,8 +641,10 @@ type Tick {
   attemptCount: Int!
   "User's quality rating (1-5)"
   quality: Int
-  "User's difficulty rating"
+  "User's personal grade override as a difficulty_id. Null means the user did not attach a personal grade — read `effectiveDifficulty` for the value to display (it falls back to the climb's consensus). See docs/ascents-and-attempts.md."
   difficulty: Int
+  "Effective grade for display and aggregation: COALESCE(difficulty, ROUND(consensus_difficulty)). Still nullable when the climb has no consensus yet."
+  effectiveDifficulty: Int
   "Whether this is a benchmark climb"
   isBenchmark: Boolean!
   "User's comment about the climb"

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4398,10 +4398,12 @@ export type Tick = {
   commentCount?: Maybe<Scalars['Int']['output']>;
   /** When this record was created (ISO 8601) */
   createdAt: Scalars['String']['output'];
-  /** User's difficulty rating */
+  /** User's personal grade override as a difficulty_id. Null means the user did not attach a personal grade — read `effectiveDifficulty` for the value to display (it falls back to the climb's consensus). See docs/ascents-and-attempts.md. */
   difficulty?: Maybe<Scalars['Int']['output']>;
   /** Number of downvotes on this tick. Null unless populated by a read query. */
   downvotes?: Maybe<Scalars['Int']['output']>;
+  /** Effective grade for display and aggregation: COALESCE(difficulty, ROUND(consensus_difficulty)). Still nullable when the climb has no consensus yet. */
+  effectiveDifficulty?: Maybe<Scalars['Int']['output']>;
   /** Whether this is a benchmark climb */
   isBenchmark: Scalars['Boolean']['output'];
   /** Whether the climb was mirrored */
@@ -7987,6 +7989,7 @@ export type TickResolvers<
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   difficulty?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   downvotes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  effectiveDifficulty?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isBenchmark?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   isMirror?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   layoutId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/ticks.ts
+++ b/packages/shared-schema/src/schema/ticks.ts
@@ -37,8 +37,10 @@ export const ticksTypeDefs = /* GraphQL */ `
     attemptCount: Int!
     "User's quality rating (1-5)"
     quality: Int
-    "User's difficulty rating"
+    "User's personal grade override as a difficulty_id. Null means the user did not attach a personal grade — read \`effectiveDifficulty\` for the value to display (it falls back to the climb's consensus). See docs/ascents-and-attempts.md."
     difficulty: Int
+    "Effective grade for display and aggregation: COALESCE(difficulty, ROUND(consensus_difficulty)). Still nullable when the climb has no consensus yet."
+    effectiveDifficulty: Int
     "Whether this is a benchmark climb"
     isBenchmark: Boolean!
     "User's comment about the climb"

--- a/packages/shared-schema/src/types/ticks.ts
+++ b/packages/shared-schema/src/types/ticks.ts
@@ -12,7 +12,14 @@ export type Tick = {
   status: TickStatus;
   attemptCount: number;
   quality: number | null;
+  // Raw user grade override; null means "use the climb's consensus grade".
+  // See docs/ascents-and-attempts.md.
   difficulty: number | null;
+  // COALESCE(difficulty, ROUND(consensus_difficulty)) — what charts, leaderboards,
+  // and grade-range filters should bucket on. Null when neither the user nor
+  // the climb has a grade yet. Populated by read queries; mutation responses
+  // (saveTick / updateTick) don't compute it.
+  effectiveDifficulty?: number | null;
   isBenchmark: boolean;
   comment: string;
   climbedAt: string;

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -32,7 +32,9 @@ type LogAscentFormValues = {
   angle: number;
   attempts: number;
   quality: number;
-  difficulty: number;
+  // `undefined` means "no personal grade override; use the climb's consensus".
+  // See docs/ascents-and-attempts.md — never coerce to 0, that's a real grade_id.
+  difficulty: number | undefined;
   notes?: string;
   videoUrl?: string;
 };
@@ -68,7 +70,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
     angle: currentClimb?.angle || 0,
     attempts: 1,
     quality: 0,
-    difficulty: grades.find((grade) => grade.difficulty_name === currentClimb?.difficulty)?.difficulty_id || 0,
+    difficulty: grades.find((grade) => grade.difficulty_name === currentClimb?.difficulty)?.difficulty_id,
   });
 
   const [formValues, setFormValues] = useState<LogAscentFormValues>(getInitialValues);
@@ -85,7 +87,7 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
       date: dayjs(),
       angle: currentClimb?.angle || prev.angle,
       difficulty:
-        grades.find((grade) => grade.difficulty_name === currentClimb?.difficulty)?.difficulty_id || prev.difficulty,
+        grades.find((grade) => grade.difficulty_name === currentClimb?.difficulty)?.difficulty_id ?? prev.difficulty,
       attempts: 1,
     }));
     setIsMirrored(!!currentClimb?.mirrored);
@@ -278,12 +280,21 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
           <Typography sx={{ width: 120, flexShrink: 0 }}>{tProfile('logbook.form.difficulty')}</Typography>
           <Box sx={{ flex: 1 }}>
-            <MuiSelect
-              value={formValues.difficulty}
-              onChange={(e) => setFormValues((prev) => ({ ...prev, difficulty: Number(e.target.value) }))}
+            <MuiSelect<number | ''>
+              value={formValues.difficulty ?? ''}
+              onChange={(e) =>
+                setFormValues((prev) => ({
+                  ...prev,
+                  difficulty: e.target.value === '' ? undefined : Number(e.target.value),
+                }))
+              }
               size="small"
               sx={{ width: 120 }}
+              displayEmpty
             >
+              <MenuItem value="">
+                <em>{tProfile('logbook.form.difficultyNoOverride')}</em>
+              </MenuItem>
               {grades.map((grade) => (
                 <MenuItem key={grade.difficulty_id} value={grade.difficulty_id}>
                   {grade.difficulty_name}

--- a/packages/web/app/lib/api-wrappers/aurora/types.ts
+++ b/packages/web/app/lib/api-wrappers/aurora/types.ts
@@ -135,9 +135,13 @@ export type Ascent = {
   updated_at: string;
 };
 
-export type LogbookEntry = Omit<Ascent, 'bid_count'> & {
+// LogbookEntry covers both ascents and attempts. Difficulty is intentionally
+// nullable — see docs/ascents-and-attempts.md. Attempts never carry a grade,
+// and ascents may be saved without a user override.
+export type LogbookEntry = Omit<Ascent, 'bid_count' | 'difficulty'> & {
   tries: number;
   is_ascent: boolean;
+  difficulty: number | null;
 };
 
 export type ClimbStat = {

--- a/packages/web/app/lib/data/get-logbook.ts
+++ b/packages/web/app/lib/data/get-logbook.ts
@@ -2,7 +2,7 @@ import { dbz } from '@/app/lib/db/db';
 import type { ClimbUuid } from '../types';
 import type { LogbookEntry, AuroraBoardName } from '../api-wrappers/aurora/types';
 import { boardseshTicks } from '@/app/lib/db/schema';
-import { eq, and, inArray, isNotNull, desc } from 'drizzle-orm';
+import { eq, and, inArray, desc } from 'drizzle-orm';
 
 /**
  * Get logbook entries for a user from boardsesh_ticks.
@@ -19,9 +19,6 @@ export async function getLogbook(
 
   if (climbUuids && climbUuids.length > 0) {
     baseConditions.push(inArray(boardseshTicks.climbUuid, climbUuids));
-  } else {
-    // When no specific climbs requested, only return entries with difficulty
-    baseConditions.push(isNotNull(boardseshTicks.difficulty));
   }
 
   const results = await dbz
@@ -50,7 +47,7 @@ export async function getLogbook(
       attempt_id: attemptId,
       tries: tick.attemptCount,
       quality: tick.quality ?? 0,
-      difficulty: tick.difficulty ?? 0,
+      difficulty: tick.difficulty,
       is_benchmark: tick.isBenchmark ?? false,
       is_listed: true,
       comment: tick.comment ?? '',

--- a/packages/web/app/lib/graphql/generated/gql.ts
+++ b/packages/web/app/lib/graphql/generated/gql.ts
@@ -111,7 +111,7 @@ type Documents = {
   '\n  query GetUserClimbs($input: UserClimbsInput!) {\n    userClimbs(input: $input) {\n      climbs {\n        uuid\n        layoutId\n        boardType\n        setter_username\n        name\n        description\n        frames\n        angle\n        ascensionist_count\n        difficulty\n        quality_average\n        stars\n        difficulty_error\n        benchmark_difficulty\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.GetUserClimbsDocument;
   '\n  query SearchUsersAndSetters($input: SearchUsersInput!) {\n    searchUsersAndSetters(input: $input) {\n      results {\n        user {\n          id\n          displayName\n          avatarUrl\n          followerCount\n          followingCount\n          isFollowedByMe\n        }\n        setter {\n          username\n          climbCount\n          boardTypes\n          isFollowedByMe\n        }\n        recentAscentCount\n        matchReason\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.SearchUsersAndSettersDocument;
   '\n  query GetTicks($input: GetTicksInput!) {\n    ticks(input: $input) {\n      uuid\n      climbUuid\n      angle\n      isMirror\n      status\n      attemptCount\n      quality\n      difficulty\n      isBenchmark\n      comment\n      climbedAt\n      upvotes\n      downvotes\n      commentCount\n    }\n  }\n': typeof types.GetTicksDocument;
-  '\n  query GetUserTicks($userId: ID!, $boardType: String!) {\n    userTicks(userId: $userId, boardType: $boardType) {\n      climbUuid\n      angle\n      status\n      attemptCount\n      difficulty\n      climbedAt\n      layoutId\n    }\n  }\n': typeof types.GetUserTicksDocument;
+  '\n  query GetUserTicks($userId: ID!, $boardType: String!) {\n    userTicks(userId: $userId, boardType: $boardType) {\n      climbUuid\n      angle\n      status\n      attemptCount\n      difficulty\n      effectiveDifficulty\n      climbedAt\n      layoutId\n    }\n  }\n': typeof types.GetUserTicksDocument;
   '\n  mutation SaveTick($input: SaveTickInput!) {\n    saveTick(input: $input) {\n      uuid\n      climbUuid\n      angle\n      isMirror\n      status\n      attemptCount\n      quality\n      difficulty\n      comment\n      climbedAt\n    }\n  }\n': typeof types.SaveTickDocument;
   '\n  mutation AttachBetaLink($input: AttachBetaLinkInput!) {\n    attachBetaLink(input: $input)\n  }\n': typeof types.AttachBetaLinkDocument;
   '\n  mutation DeleteTick($uuid: ID!) {\n    deleteTick(uuid: $uuid)\n  }\n': typeof types.DeleteTickDocument;
@@ -312,7 +312,7 @@ const documents: Documents = {
     types.SearchUsersAndSettersDocument,
   '\n  query GetTicks($input: GetTicksInput!) {\n    ticks(input: $input) {\n      uuid\n      climbUuid\n      angle\n      isMirror\n      status\n      attemptCount\n      quality\n      difficulty\n      isBenchmark\n      comment\n      climbedAt\n      upvotes\n      downvotes\n      commentCount\n    }\n  }\n':
     types.GetTicksDocument,
-  '\n  query GetUserTicks($userId: ID!, $boardType: String!) {\n    userTicks(userId: $userId, boardType: $boardType) {\n      climbUuid\n      angle\n      status\n      attemptCount\n      difficulty\n      climbedAt\n      layoutId\n    }\n  }\n':
+  '\n  query GetUserTicks($userId: ID!, $boardType: String!) {\n    userTicks(userId: $userId, boardType: $boardType) {\n      climbUuid\n      angle\n      status\n      attemptCount\n      difficulty\n      effectiveDifficulty\n      climbedAt\n      layoutId\n    }\n  }\n':
     types.GetUserTicksDocument,
   '\n  mutation SaveTick($input: SaveTickInput!) {\n    saveTick(input: $input) {\n      uuid\n      climbUuid\n      angle\n      isMirror\n      status\n      attemptCount\n      quality\n      difficulty\n      comment\n      climbedAt\n    }\n  }\n':
     types.SaveTickDocument,
@@ -931,8 +931,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  query GetUserTicks($userId: ID!, $boardType: String!) {\n    userTicks(userId: $userId, boardType: $boardType) {\n      climbUuid\n      angle\n      status\n      attemptCount\n      difficulty\n      climbedAt\n      layoutId\n    }\n  }\n',
-): (typeof documents)['\n  query GetUserTicks($userId: ID!, $boardType: String!) {\n    userTicks(userId: $userId, boardType: $boardType) {\n      climbUuid\n      angle\n      status\n      attemptCount\n      difficulty\n      climbedAt\n      layoutId\n    }\n  }\n'];
+  source: '\n  query GetUserTicks($userId: ID!, $boardType: String!) {\n    userTicks(userId: $userId, boardType: $boardType) {\n      climbUuid\n      angle\n      status\n      attemptCount\n      difficulty\n      effectiveDifficulty\n      climbedAt\n      layoutId\n    }\n  }\n',
+): (typeof documents)['\n  query GetUserTicks($userId: ID!, $boardType: String!) {\n    userTicks(userId: $userId, boardType: $boardType) {\n      climbUuid\n      angle\n      status\n      attemptCount\n      difficulty\n      effectiveDifficulty\n      climbedAt\n      layoutId\n    }\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/web/app/lib/graphql/generated/graphql.ts
+++ b/packages/web/app/lib/graphql/generated/graphql.ts
@@ -4395,10 +4395,12 @@ export type Tick = {
   commentCount?: Maybe<Scalars['Int']['output']>;
   /** When this record was created (ISO 8601) */
   createdAt: Scalars['String']['output'];
-  /** User's difficulty rating */
+  /** User's personal grade override as a difficulty_id. Null means the user did not attach a personal grade — read `effectiveDifficulty` for the value to display (it falls back to the climb's consensus). See docs/ascents-and-attempts.md. */
   difficulty?: Maybe<Scalars['Int']['output']>;
   /** Number of downvotes on this tick. Null unless populated by a read query. */
   downvotes?: Maybe<Scalars['Int']['output']>;
+  /** Effective grade for display and aggregation: COALESCE(difficulty, ROUND(consensus_difficulty)). Still nullable when the climb has no consensus yet. */
+  effectiveDifficulty?: Maybe<Scalars['Int']['output']>;
   /** Whether this is a benchmark climb */
   isBenchmark: Scalars['Boolean']['output'];
   /** Whether the climb was mirrored */
@@ -6707,6 +6709,7 @@ export type GetUserTicksQuery = {
     status: TickStatus;
     attemptCount: number;
     difficulty?: number | null;
+    effectiveDifficulty?: number | null;
     climbedAt: string;
     layoutId?: number | null;
   }>;
@@ -11924,6 +11927,7 @@ export const GetUserTicksDocument = {
                 { kind: 'Field', name: { kind: 'Name', value: 'status' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'attemptCount' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'difficulty' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'effectiveDifficulty' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'climbedAt' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'layoutId' } },
               ],

--- a/packages/web/app/lib/graphql/operations/ticks.ts
+++ b/packages/web/app/lib/graphql/operations/ticks.ts
@@ -30,6 +30,7 @@ export const GET_USER_TICKS = gql`
       status
       attemptCount
       difficulty
+      effectiveDifficulty
       climbedAt
       layoutId
     }
@@ -73,7 +74,7 @@ type TickFromGetTicks = Pick<
 >;
 type TickFromGetUserTicks = Pick<
   Tick,
-  'climbUuid' | 'angle' | 'status' | 'attemptCount' | 'difficulty' | 'climbedAt' | 'layoutId'
+  'climbUuid' | 'angle' | 'status' | 'attemptCount' | 'difficulty' | 'effectiveDifficulty' | 'climbedAt' | 'layoutId'
 >;
 type TickFromSaveTick = Pick<
   Tick,

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -195,6 +195,23 @@ export async function cachedUserProfileStats(
 }
 
 /**
+ * Uncached server-side fetch of user profile stats. Used by /you (the user's
+ * own dashboard) where freshly-logged ticks must appear immediately rather
+ * than waiting on the cache TTL.
+ */
+export async function serverUserProfileStats(
+  userId: string,
+): Promise<GetUserProfileStatsQueryResponse['userProfileStats'] | null> {
+  const { GET_USER_PROFILE_STATS } = await import('@/app/lib/graphql/operations/ticks');
+  try {
+    const result = await executeGraphQLInternal<GetUserProfileStatsQueryResponse>(GET_USER_PROFILE_STATS, { userId });
+    return result.userProfileStats;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Cached server-side fetch of user climb percentile (public, no auth needed).
  */
 export async function cachedUserClimbPercentile(
@@ -217,6 +234,23 @@ export async function cachedUserClimbPercentile(
 }
 
 /**
+ * Uncached counterpart of {@link cachedUserClimbPercentile} for /you.
+ */
+export async function serverUserClimbPercentile(
+  userId: string,
+): Promise<GetUserClimbPercentileQueryResponse['userClimbPercentile'] | null> {
+  const { GET_USER_CLIMB_PERCENTILE } = await import('@/app/lib/graphql/operations/ticks');
+  try {
+    const result = await executeGraphQLInternal<GetUserClimbPercentileQueryResponse>(GET_USER_CLIMB_PERCENTILE, {
+      userId,
+    });
+    return result.userClimbPercentile;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Cached server-side fetch of user ticks for a specific board type (public, no auth needed).
  */
 export async function cachedUserTicks(
@@ -230,6 +264,23 @@ export async function cachedUserTicks(
     const tag = `user-ticks-${userId}-${boardType}`;
     const query = createCachedGraphQLQuery<Response>(GET_USER_TICKS, tag, 300);
     const result = await query({ userId, boardType });
+    return result.userTicks;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Uncached counterpart of {@link cachedUserTicks} for /you. Logging a tick
+ * must show up on the user's own dashboard immediately.
+ */
+export async function serverUserTicks(
+  userId: string,
+  boardType: string,
+): Promise<GetUserTicksQueryResponse['userTicks'] | null> {
+  const { GET_USER_TICKS } = await import('@/app/lib/graphql/operations/ticks');
+  try {
+    const result = await executeGraphQLInternal<GetUserTicksQueryResponse>(GET_USER_TICKS, { userId, boardType });
     return result.userTicks;
   } catch {
     return null;

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -234,23 +234,6 @@ export async function cachedUserClimbPercentile(
 }
 
 /**
- * Uncached counterpart of {@link cachedUserClimbPercentile} for /you.
- */
-export async function serverUserClimbPercentile(
-  userId: string,
-): Promise<GetUserClimbPercentileQueryResponse['userClimbPercentile'] | null> {
-  const { GET_USER_CLIMB_PERCENTILE } = await import('@/app/lib/graphql/operations/ticks');
-  try {
-    const result = await executeGraphQLInternal<GetUserClimbPercentileQueryResponse>(GET_USER_CLIMB_PERCENTILE, {
-      userId,
-    });
-    return result.userClimbPercentile;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Cached server-side fetch of user ticks for a specific board type (public, no auth needed).
  */
 export async function cachedUserTicks(

--- a/packages/web/app/profile/[user_id]/hooks/use-profile-data.ts
+++ b/packages/web/app/profile/[user_id]/hooks/use-profile-data.ts
@@ -114,6 +114,7 @@ export function useProfileData(userId: string, initialData?: InitialData) {
           results[boardType] = response.userTicks.map((tick) => ({
             climbed_at: tick.climbedAt,
             difficulty: tick.difficulty,
+            effectiveDifficulty: tick.effectiveDifficulty ?? null,
             tries: tick.attemptCount,
             angle: tick.angle,
             status: tick.status,
@@ -223,12 +224,15 @@ export function useProfileData(userId: string, initialData?: InitialData) {
     let maxFlashDifficulty = -1;
 
     for (const tick of allTicks) {
-      if (tick.difficulty == null) continue;
+      // Prefer the server-coalesced consensus value; fall back to the raw
+      // override when absent (test fixtures, transient optimistic writes).
+      const grade = tick.effectiveDifficulty ?? tick.difficulty;
+      if (grade == null) continue;
       if (tick.status === 'send' || tick.status === 'flash') {
-        if (tick.difficulty > maxSendDifficulty) maxSendDifficulty = tick.difficulty;
+        if (grade > maxSendDifficulty) maxSendDifficulty = grade;
       }
       if (tick.status === 'flash') {
-        if (tick.difficulty > maxFlashDifficulty) maxFlashDifficulty = tick.difficulty;
+        if (grade > maxFlashDifficulty) maxFlashDifficulty = grade;
       }
     }
 

--- a/packages/web/app/profile/[user_id]/server-profile-stats.ts
+++ b/packages/web/app/profile/[user_id]/server-profile-stats.ts
@@ -2,7 +2,6 @@ import {
   cachedUserClimbPercentile,
   cachedUserProfileStats,
   cachedUserTicks,
-  serverUserClimbPercentile,
   serverUserProfileStats,
   serverUserTicks,
 } from '@/app/lib/graphql/server-cached-client';
@@ -37,12 +36,13 @@ export async function fetchProfileStatsData(
   options: FetchProfileStatsOptions = {},
 ): Promise<ProfileStatsData> {
   const profileStatsFn = options.skipCache ? serverUserProfileStats : cachedUserProfileStats;
-  const percentileFn = options.skipCache ? serverUserClimbPercentile : cachedUserClimbPercentile;
   const ticksFn = options.skipCache ? serverUserTicks : cachedUserTicks;
 
+  // Percentile is a snapshot of the user's rank in a community-wide leaderboard;
+  // a single new tick doesn't shift it. Always serve from the cache.
   const [initialProfileStats, initialPercentile, ...ticksResults] = await Promise.all([
     profileStatsFn(userId),
-    percentileFn(userId),
+    cachedUserClimbPercentile(userId),
     ...SUPPORTED_BOARDS.map((boardType) => ticksFn(userId, boardType)),
   ]);
 
@@ -53,6 +53,7 @@ export async function fetchProfileStatsData(
       ? ticks.map((tick) => ({
           climbed_at: tick.climbedAt,
           difficulty: tick.difficulty,
+          effectiveDifficulty: tick.effectiveDifficulty ?? null,
           tries: tick.attemptCount,
           angle: tick.angle,
           status: tick.status as LogbookEntry['status'],

--- a/packages/web/app/profile/[user_id]/server-profile-stats.ts
+++ b/packages/web/app/profile/[user_id]/server-profile-stats.ts
@@ -2,6 +2,9 @@ import {
   cachedUserClimbPercentile,
   cachedUserProfileStats,
   cachedUserTicks,
+  serverUserClimbPercentile,
+  serverUserProfileStats,
+  serverUserTicks,
 } from '@/app/lib/graphql/server-cached-client';
 import { SUPPORTED_BOARDS } from '@/app/lib/board-data';
 import type { LogbookEntry } from './utils/profile-constants';
@@ -17,15 +20,30 @@ export type ProfileStatsData = {
   initialLogbook: LogbookEntry[];
 };
 
+export type FetchProfileStatsOptions = {
+  /**
+   * Skip the SSR data cache. Used by /you so the dashboard reflects a
+   * just-logged tick immediately instead of waiting on the unstable_cache TTL.
+   */
+  skipCache?: boolean;
+};
+
 /**
  * Fetches profile stats and tick data for a user across all boards.
  * Shared between /you, /profile/[user_id], and /profile/[user_id]/statistics pages.
  */
-export async function fetchProfileStatsData(userId: string): Promise<ProfileStatsData> {
+export async function fetchProfileStatsData(
+  userId: string,
+  options: FetchProfileStatsOptions = {},
+): Promise<ProfileStatsData> {
+  const profileStatsFn = options.skipCache ? serverUserProfileStats : cachedUserProfileStats;
+  const percentileFn = options.skipCache ? serverUserClimbPercentile : cachedUserClimbPercentile;
+  const ticksFn = options.skipCache ? serverUserTicks : cachedUserTicks;
+
   const [initialProfileStats, initialPercentile, ...ticksResults] = await Promise.all([
-    cachedUserProfileStats(userId),
-    cachedUserClimbPercentile(userId),
-    ...SUPPORTED_BOARDS.map((boardType) => cachedUserTicks(userId, boardType)),
+    profileStatsFn(userId),
+    percentileFn(userId),
+    ...SUPPORTED_BOARDS.map((boardType) => ticksFn(userId, boardType)),
   ]);
 
   const initialAllBoardsTicks: Record<string, LogbookEntry[]> = {};

--- a/packages/web/app/profile/[user_id]/utils/chart-data-builders.ts
+++ b/packages/web/app/profile/[user_id]/utils/chart-data-builders.ts
@@ -24,6 +24,16 @@ import {
 const FLASH_COLOR = `${themeTokens.colors.success}99`; // 60% opacity hex
 const REDPOINT_COLOR = `${themeTokens.colors.error}99`;
 
+/**
+ * Grade id to use for chart bucketing: prefer the server-supplied
+ * `effectiveDifficulty` (COALESCE of user override + climb consensus) and
+ * fall back to the raw `difficulty` when absent. See
+ * docs/ascents-and-attempts.md.
+ */
+function gradeIdForEntry(entry: LogbookEntry): number | null {
+  return entry.effectiveDifficulty ?? entry.difficulty ?? null;
+}
+
 dayjs.extend(isoWeek);
 dayjs.extend(isSameOrAfter);
 dayjs.extend(isSameOrBefore);
@@ -115,8 +125,9 @@ export function buildAggregatedStackedBars(
     const filteredTicks = filterByUnifiedTimeframe(ticks, timeframe, fromDate, toDate);
 
     filteredTicks.forEach((entry) => {
-      if (entry.difficulty === null || entry.status === 'attempt' || !entry.climbUuid) return;
-      const grade = mapping[entry.difficulty];
+      const gradeId = gradeIdForEntry(entry);
+      if (gradeId == null || entry.status === 'attempt' || !entry.climbUuid) return;
+      const grade = mapping[gradeId];
       if (grade) {
         const layoutKey = getLayoutKey(boardType, entry.layoutId);
         if (!layoutGradeClimbs[layoutKey]) layoutGradeClimbs[layoutKey] = {};
@@ -217,8 +228,9 @@ export function buildWeeklyBars(
 
   const weeklyData: Record<string, Record<string, number>> = {};
   entries.forEach((entry) => {
-    if (entry.difficulty === null) return;
-    const grade = mapping[entry.difficulty];
+    const gradeId = gradeIdForEntry(entry);
+    if (gradeId == null) return;
+    const grade = mapping[gradeId];
     if (!grade) return;
     const d = parseTickTime(entry.climbed_at);
     const weekKey = `${d.isoWeekYear()}-W${d.isoWeek()}`;
@@ -267,8 +279,9 @@ export function buildFlashRedpointBars(
   const redpoint: Record<string, number> = {};
 
   filteredLogbook.forEach((entry) => {
-    if (entry.difficulty === null) return;
-    const difficulty = mapping[entry.difficulty];
+    const gradeId = gradeIdForEntry(entry);
+    if (gradeId == null) return;
+    const difficulty = mapping[gradeId];
     if (!difficulty) return;
     // Prefer the canonical status field when available. Fall back to the old
     // tries-based heuristic for legacy rows that don't have status set.
@@ -403,8 +416,9 @@ export function buildVPointsTimeline(
   for (const layoutKey of activeLayouts) {
     const weekPoints: Record<string, number> = {};
     for (const entry of entriesByLayout[layoutKey]) {
-      if (entry.difficulty === null) continue;
-      const grade = difficultyMapping[entry.difficulty];
+      const gradeId = gradeIdForEntry(entry);
+      if (gradeId == null) continue;
+      const grade = difficultyMapping[gradeId];
       if (!grade) continue;
       const d = parseTickTime(entry.climbed_at);
       const wk = `${d.isoWeekYear()}-W${d.isoWeek()}`;

--- a/packages/web/app/profile/[user_id]/utils/profile-constants.ts
+++ b/packages/web/app/profile/[user_id]/utils/profile-constants.ts
@@ -26,7 +26,13 @@ export type UserProfile = {
 
 export type LogbookEntry = {
   climbed_at: string;
+  // Raw user override (null when the user did not attach a personal grade).
   difficulty: number | null;
+  // COALESCE(difficulty, climb consensus). Use this for charts and bucketing
+  // so ungraded ticks fall back to the climb's consensus grade rather than
+  // dropping out of every per-grade aggregate. See docs/ascents-and-attempts.md.
+  // Optional so test fixtures can omit it; producers in production always set it.
+  effectiveDifficulty?: number | null;
   tries: number;
   angle: number;
   status?: 'flash' | 'send' | 'attempt';

--- a/packages/web/app/you/logbook/page.tsx
+++ b/packages/web/app/you/logbook/page.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react';
 import { redirect } from 'next/navigation';
 import LogbookFeed from '@/app/components/library/logbook-feed';
 import LogbookLoading from './loading';
-import { cachedUserProfileStats } from '@/app/lib/graphql/server-cached-client';
+import { serverUserProfileStats } from '@/app/lib/graphql/server-cached-client';
 import { getYouSession } from '../you-auth';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import { getServerTranslation } from '@/app/lib/i18n/server';
@@ -23,7 +23,7 @@ export default async function YouLogbookPage() {
     redirect('/');
   }
   const userId = session.user.id;
-  const profileStats = await cachedUserProfileStats(userId);
+  const profileStats = await serverUserProfileStats(userId);
   const layoutStats = profileStats?.layoutStats ?? [];
 
   // Per-element protection for translator-DOM crashes (issue #2064) lives on

--- a/packages/web/app/you/page.tsx
+++ b/packages/web/app/you/page.tsx
@@ -29,7 +29,7 @@ async function YouProgressStreaming({
   userId: string;
   initialProfile: UserProfile | null;
 }) {
-  const statsData = await fetchProfileStatsData(userId);
+  const statsData = await fetchProfileStatsData(userId, { skipCache: true });
   return (
     <YouProgressContent
       userId={userId}

--- a/packages/web/i18n/locales/en-US/profile.json
+++ b/packages/web/i18n/locales/en-US/profile.json
@@ -106,6 +106,7 @@
       "attempts": "Attempts",
       "quality": "Quality",
       "difficulty": "Difficulty",
+      "difficultyNoOverride": "Use consensus grade",
       "notes": "Notes",
       "video": "Video",
       "videoPlaceholder": "Instagram or TikTok URL",

--- a/packages/web/i18n/locales/es/profile.json
+++ b/packages/web/i18n/locales/es/profile.json
@@ -106,6 +106,7 @@
       "attempts": "Intentos",
       "quality": "Calidad",
       "difficulty": "Dificultad",
+      "difficultyNoOverride": "Usar grado de consenso",
       "notes": "Notas",
       "video": "Vídeo",
       "videoPlaceholder": "URL de Instagram o TikTok",

--- a/packages/web/i18n/locales/fr/profile.json
+++ b/packages/web/i18n/locales/fr/profile.json
@@ -106,6 +106,7 @@
       "attempts": "Essais",
       "quality": "Qualité",
       "difficulty": "Difficulté",
+      "difficultyNoOverride": "Utiliser la cotation consensus",
       "notes": "Notes",
       "video": "Vidéo",
       "videoPlaceholder": "Lien Instagram ou TikTok",


### PR DESCRIPTION
## Summary

Profile statistics charts were dropping every ascent logged without a personal grade — for one reporting user, 39 of 45 kilter+moonboard sends had `boardsesh_ticks.difficulty IS NULL` because the iOS QuickTickBar saves with no grade unless the user explicitly opens the picker. NULL difficulty is the intended state (means "use the climb's consensus grade"), but every per-grade aggregation in the codebase was treating it as missing data and silently filtering the rows out.

This PR codifies the invariant, fixes the surfaces that violated it, and adds a design doc so the rule stays visible.

## What's in this PR

### Read-path consensus fallback
- `userTicks` and `userProfileStats` LEFT JOIN `board_climb_stats` on its PK `(boardType, climbUuid, angle)` and surface a new `effectiveDifficulty = COALESCE(difficulty, ROUND(displayDifficulty))` field. The original `difficulty` field keeps its raw-override contract — splitting them prevents optimistic writes (which set the raw value) from flickering when the server hydrates the effective value.
- `userAscentsFeed` `minDifficulty` / `maxDifficulty` filters now apply to `COALESCE(...)` so a "show me V5–V8" filter no longer hides ungraded ascents whose consensus is in range.
- `social/boards.ts` `hardestGrade` leaderboard uses `MAX(COALESCE(...))` so users who never override still appear at their actual hardest grade.
- `userProfileStats.distinctClimbCount` now comes from a dedicated per-layout distinct sub-query instead of summing `gradeCounts` — fixes pre-existing overcount when the same climb is logged at multiple angles with different consensus grades.

### Write-path defaults (preserve NULL as the intentional "use consensus" sentinel)
- `LogAscentForm`: `difficulty` state is now `number | undefined`; the picker exposes a "Use consensus grade" sentinel option so users can deliberately not attach an override. Removes the `|| 0` fallback that silently logged ungraded ascents at the lowest grade.
- `aurora/types.ts` `LogbookEntry.difficulty`: now nullable, matching the DB column.
- `lib/data/get-logbook.ts`: drops the `isNotNull(difficulty)` filter that silently excluded all NULL-difficulty rows from "all logbook" queries, and stops coercing null to 0.

### Cache: dashboards reflect freshly-logged ticks
- `/you` and `/you/logbook` bypass the Next.js `unstable_cache` wrapping `cachedUserTicks` / `cachedUserProfileStats` so a tick logged via QuickTickBar shows up on the dashboard immediately rather than waiting 5 minutes for the cache TTL.
- `/profile/[user_id]` still uses the cache (viewing someone else's profile is far less latency-sensitive).
- Percentile always serves from its 7-day cache; a single logged tick doesn't move the global ranking.
- Adds `serverUser{ProfileStats,Ticks}` uncached counterparts and a `skipCache` option on the shared `fetchProfileStatsData` helper.

### Tests
- Three new integration tests in `packages/backend/src/__tests__/tick-queries.test.ts`:
  - `userTicks` exposes both raw `difficulty` and `effectiveDifficulty` (consensus fallback).
  - `userProfileStats` buckets NULL-difficulty ticks under the consensus grade.
  - `userAscentsFeed minDifficulty` includes NULL-difficulty ticks whose consensus is in range.

### Docs
- New `docs/ascents-and-attempts.md` covering tick taxonomy, the NULL-as-consensus invariant, the four resolvers that COALESCE, the write-path rules (status is the source of truth; all inserts go through `saveTick` or the Aurora sync), and Aurora `ascents` / `bids` mapping. Future contributors get the architectural picture without needing to re-derive it from the code.

### Minor cleanups
- `ne(boardseshTicks.status, 'attempt')` replaces the raw SQL string compare in `userProfileStats`.
- The GraphQL `Tick.difficulty` description now documents the field's semantics and points at the design doc.

## Test plan

- [x] `vp run typecheck` (web + backend + db + shared)
- [x] `vp check` — 0 errors
- [x] `vp run check:i18n` — no hardcoded user-facing strings
- [x] `vp test --project backend` — 19/19 tick-queries pass (including the 3 new ones)
- [x] `vp test --project web` — 4432/4432 pass
- [x] Logged a tick via QuickTickBar without opening the grade picker; confirmed it now appears in the consensus-grade bucket on `/you` and `/profile/<id>/statistics`
- [x] Logged a tick with an explicit grade that differs from consensus; confirmed it appears in the user-picked bucket (COALESCE precedence)
- [ ] Reviewer to verify on production data: per-grade chart for the reporting user (`00f8433a-9d46-4857-ac73-9e73f93a873f`) now sums to 45 sends instead of 6

## Closes

- Closes #2153 (folded into this PR: B1 hardestGrade leaderboard + B2 feed min/max filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)