### PR TITLE
Write board_climb_stats for user-created climbs

### DIFF
--- a/packages/backend/src/__tests__/climb-mutations.test.ts
+++ b/packages/backend/src/__tests__/climb-mutations.test.ts
@@ -264,6 +264,79 @@ describe('climb mutations', () => {
     expect(statsInsert?.values).not.toHaveProperty('difficultyAverage');
   });
 
+  it('skips the stats seed for draft MoonBoard climbs without a grade', async () => {
+    mockDb.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([{ name: 'Bob', displayName: 'Bob Setter', image: null, avatarUrl: null }]),
+    );
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.saveMoonBoardClimb(
+      {},
+      {
+        input: {
+          boardType: 'moonboard',
+          layoutId: 3,
+          name: 'Draft No-grade MoonBoard',
+          description: '',
+          holds: { start: ['A1'], hand: ['B2'], finish: ['C3'] },
+          angle: 40,
+          isDraft: true,
+        },
+      },
+      makeCtx(),
+    );
+
+    // climb_holds rows are still inserted, but no board_climb_stats row should appear.
+    const statsInsert = insertCalls.find(
+      (call) => typeof call.values === 'object' && call.values !== null && 'ascensionistCount' in call.values,
+    );
+    expect(statsInsert).toBeUndefined();
+  });
+
+  it('seeds a stats row with the grade for draft MoonBoard climbs that supplied one', async () => {
+    mockDb.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockDb.select
+      .mockReturnValueOnce(createMockChain([{ name: 'Bob', displayName: 'Bob Setter', image: null, avatarUrl: null }]))
+      .mockReturnValueOnce(createMockChain([{ difficulty: 17 }]));
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.saveMoonBoardClimb(
+      {},
+      {
+        input: {
+          boardType: 'moonboard',
+          layoutId: 3,
+          name: 'Draft Graded MoonBoard',
+          description: '',
+          holds: { start: ['A1'], hand: ['B2'], finish: ['C3'] },
+          angle: 40,
+          isDraft: true,
+          userGrade: '6A+',
+          isBenchmark: false,
+        },
+      },
+      makeCtx(),
+    );
+
+    // We preserve the grade for draft MoonBoard climbs even though the search
+    // filter masks the draft. Otherwise the user's grade would be lost on
+    // publish (updateClimb has no userGrade source to reconstruct it from).
+    const statsInsert = insertCalls.find(
+      (call) => typeof call.values === 'object' && call.values !== null && 'displayDifficulty' in call.values,
+    );
+    expect(statsInsert?.values).toMatchObject({
+      boardType: 'moonboard',
+      angle: 40,
+      displayDifficulty: 17,
+      difficultyAverage: 17,
+    });
+  });
+
   it('seeds a stats row on draft → publish transition in updateClimb', async () => {
     mockDb.select
       .mockReturnValueOnce(
@@ -348,6 +421,10 @@ describe('climb mutations', () => {
       ),
     ).rejects.toThrow('Cannot publish climb without an angle');
 
+    // The throw must fire BEFORE the board_climbs update — otherwise the caller
+    // sees a 500 but the row is left in a half-published state (isDraft = false,
+    // publishedAt = now, no stats row), which is the bug this PR is fixing.
+    expect(mockDb.update).not.toHaveBeenCalled();
     expect(insertCalls).toHaveLength(0);
   });
 

--- a/packages/backend/src/__tests__/climb-mutations.test.ts
+++ b/packages/backend/src/__tests__/climb-mutations.test.ts
@@ -121,6 +121,37 @@ describe('climb mutations', () => {
     });
   });
 
+  it('skips the stats seed for draft Aurora climbs', async () => {
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([{ name: 'Alice', displayName: 'Alice Setter', image: null, avatarUrl: null }]),
+    );
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.saveClimb(
+      {},
+      {
+        input: {
+          boardType: 'kilter',
+          layoutId: 1,
+          name: 'Draft Aurora Climb',
+          description: '',
+          isDraft: true,
+          frames: 'p1r43',
+          angle: 40,
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0].values).toMatchObject({
+      isDraft: true,
+      isListed: false,
+    });
+  });
+
   it('stores non-draft MoonBoard climbs as listed', async () => {
     mockDb.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
     mockDb.select
@@ -243,6 +274,7 @@ describe('climb mutations', () => {
             publishedAt: null,
             createdAt: '2026-05-14T20:00:00.000Z',
             angle: 35,
+            setterUsername: 'Alice Setter',
           },
         ]),
       )
@@ -272,6 +304,7 @@ describe('climb mutations', () => {
       climbUuid: 'climb-1',
       angle: 35,
       ascensionistCount: 0,
+      faUsername: 'Alice Setter',
     });
   });
 
@@ -286,6 +319,7 @@ describe('climb mutations', () => {
           publishedAt,
           createdAt: publishedAt,
           angle: 35,
+          setterUsername: 'Bob Setter',
         },
       ]),
     );
@@ -312,6 +346,7 @@ describe('climb mutations', () => {
       climbUuid: 'climb-2',
       angle: 40,
       ascensionistCount: 0,
+      faUsername: 'Bob Setter',
     });
   });
 
@@ -326,6 +361,7 @@ describe('climb mutations', () => {
           publishedAt,
           createdAt: publishedAt,
           angle: 35,
+          setterUsername: 'Carol Setter',
         },
       ]),
     );

--- a/packages/backend/src/__tests__/climb-mutations.test.ts
+++ b/packages/backend/src/__tests__/climb-mutations.test.ts
@@ -8,6 +8,7 @@ const { mockDb, mockPublishSocialEvent, insertCalls } = vi.hoisted(() => {
   const mockDb = {
     select: vi.fn(),
     insert: vi.fn(),
+    update: vi.fn(),
     delete: vi.fn(),
     transaction: vi.fn(),
     execute: vi.fn(),
@@ -306,6 +307,48 @@ describe('climb mutations', () => {
       ascensionistCount: 0,
       faUsername: 'Alice Setter',
     });
+    // Prove the full publish path ran past the stats insert — getUserProfile is
+    // called inside the `transitioningToPublished` block and feeds the social
+    // event payload, so a successful publish event call means both the second
+    // select mock was consumed and publishSocialEvent received it.
+    expect(mockPublishSocialEvent).toHaveBeenCalledTimes(1);
+    expect(mockPublishSocialEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'climb.created',
+        entityId: 'climb-1',
+        metadata: expect.objectContaining({ setterDisplayName: 'Alice Setter' }),
+      }),
+    );
+  });
+
+  it('throws when publishing a draft without an angle', async () => {
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([
+        {
+          uuid: 'climb-no-angle',
+          userId: 'user-123',
+          isDraft: true,
+          publishedAt: null,
+          createdAt: '2026-05-14T20:00:00.000Z',
+          angle: null,
+          setterUsername: null,
+        },
+      ]),
+    );
+    mockDb.update = vi.fn().mockReturnValue(createMockChain(undefined));
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await expect(
+      climbMutations.updateClimb(
+        {},
+        { input: { boardType: 'kilter', uuid: 'climb-no-angle', isDraft: false } },
+        makeCtx(),
+      ),
+    ).rejects.toThrow('Cannot publish climb without an angle');
+
+    expect(insertCalls).toHaveLength(0);
   });
 
   it('seeds a stats row on angle change for a published climb in updateClimb', async () => {

--- a/packages/backend/src/__tests__/climb-mutations.test.ts
+++ b/packages/backend/src/__tests__/climb-mutations.test.ts
@@ -108,10 +108,15 @@ describe('climb mutations', () => {
       makeCtx(),
     );
 
-    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls).toHaveLength(2);
     expect(insertCalls[0].values).toMatchObject({
       isDraft: false,
       isListed: true,
+    });
+    expect(insertCalls[1].values).toMatchObject({
+      boardType: 'kilter',
+      angle: 40,
+      ascensionistCount: 0,
     });
   });
 

--- a/packages/backend/src/__tests__/climb-mutations.test.ts
+++ b/packages/backend/src/__tests__/climb-mutations.test.ts
@@ -56,6 +56,7 @@ function createMockChain(resolveValue: unknown = [], onValues?: (values: unknown
     'orderBy',
     'limit',
     'values',
+    'set',
     'returning',
     'onConflictDoNothing',
     'onConflictDoUpdate',
@@ -184,6 +185,168 @@ describe('climb mutations', () => {
       benchmarkDifficulty: null,
       difficultyAverage: 17,
     });
+  });
+
+  it('seeds a stats row for MoonBoard climbs saved without a grade', async () => {
+    mockDb.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([{ name: 'Bob', displayName: 'Bob Setter', image: null, avatarUrl: null }]),
+    );
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.saveMoonBoardClimb(
+      {},
+      {
+        input: {
+          boardType: 'moonboard',
+          layoutId: 3,
+          name: 'No-grade MoonBoard',
+          description: '',
+          holds: {
+            start: ['A1'],
+            hand: ['B2'],
+            finish: ['C3'],
+          },
+          angle: 40,
+          isDraft: false,
+        },
+      },
+      makeCtx(),
+    );
+
+    const statsInsert = insertCalls.find(
+      (call) =>
+        typeof call.values === 'object' &&
+        call.values !== null &&
+        'ascensionistCount' in call.values &&
+        'angle' in call.values,
+    );
+    expect(statsInsert?.values).toMatchObject({
+      boardType: 'moonboard',
+      angle: 40,
+      ascensionistCount: 0,
+    });
+    expect(statsInsert?.values).not.toHaveProperty('displayDifficulty');
+    expect(statsInsert?.values).not.toHaveProperty('difficultyAverage');
+  });
+
+  it('seeds a stats row on draft → publish transition in updateClimb', async () => {
+    mockDb.select
+      .mockReturnValueOnce(
+        createMockChain([
+          {
+            uuid: 'climb-1',
+            userId: 'user-123',
+            isDraft: true,
+            publishedAt: null,
+            createdAt: '2026-05-14T20:00:00.000Z',
+            angle: 35,
+          },
+        ]),
+      )
+      .mockReturnValueOnce(
+        createMockChain([{ name: 'Alice', displayName: 'Alice Setter', image: null, avatarUrl: null }]),
+      );
+    mockDb.update = vi.fn().mockReturnValue(createMockChain(undefined));
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.updateClimb(
+      {},
+      {
+        input: {
+          boardType: 'kilter',
+          uuid: 'climb-1',
+          isDraft: false,
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0].values).toMatchObject({
+      boardType: 'kilter',
+      climbUuid: 'climb-1',
+      angle: 35,
+      ascensionistCount: 0,
+    });
+  });
+
+  it('seeds a stats row on angle change for a published climb in updateClimb', async () => {
+    const publishedAt = new Date(Date.now() - 60 * 1000).toISOString();
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([
+        {
+          uuid: 'climb-2',
+          userId: 'user-123',
+          isDraft: false,
+          publishedAt,
+          createdAt: publishedAt,
+          angle: 35,
+        },
+      ]),
+    );
+    mockDb.update = vi.fn().mockReturnValue(createMockChain(undefined));
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.updateClimb(
+      {},
+      {
+        input: {
+          boardType: 'kilter',
+          uuid: 'climb-2',
+          angle: 40,
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0].values).toMatchObject({
+      boardType: 'kilter',
+      climbUuid: 'climb-2',
+      angle: 40,
+      ascensionistCount: 0,
+    });
+  });
+
+  it('does not re-seed stats on a no-op publish/angle update', async () => {
+    const publishedAt = new Date(Date.now() - 60 * 1000).toISOString();
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([
+        {
+          uuid: 'climb-3',
+          userId: 'user-123',
+          isDraft: false,
+          publishedAt,
+          createdAt: publishedAt,
+          angle: 35,
+        },
+      ]),
+    );
+    mockDb.update = vi.fn().mockReturnValue(createMockChain(undefined));
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.updateClimb(
+      {},
+      {
+        input: {
+          boardType: 'kilter',
+          uuid: 'climb-3',
+          name: 'Renamed',
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(insertCalls).toHaveLength(0);
   });
 
   it('rejects duplicate MoonBoard climbs before inserting', async () => {

--- a/packages/backend/src/graphql/resolvers/climbs/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/mutations.ts
@@ -143,6 +143,7 @@ export const climbMutations = {
         climbUuid: uuid,
         angle: validated.angle,
         ascensionistCount: 0,
+        faUsername: preferredSetter,
       })
       .onConflictDoNothing({
         target: [

--- a/packages/backend/src/graphql/resolvers/climbs/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/mutations.ts
@@ -423,7 +423,16 @@ export const climbMutations = {
     // because search filters by exact angle, and removing it would race with concurrent ticks.
     const resolvedAngle = validated.angle ?? existing.angle;
     const angleChanged = validated.angle !== undefined && validated.angle !== existing.angle;
-    if (resolvedAngle !== null && !nextIsDraft && (transitioningToPublished || angleChanged)) {
+    if (!nextIsDraft && (transitioningToPublished || angleChanged)) {
+      if (resolvedAngle === null) {
+        // board_climbs.angle is nullable in the schema but board_climb_stats.angle
+        // is NOT NULL, so a null angle here would either crash the insert or, with
+        // the `null` short-circuit we used to have, silently leave the climb out
+        // of the INNER-JOIN search forever. Surface the malformed state instead.
+        // angleChanged can't reach this — validated.angle would be set; this only
+        // fires on publish of a draft created without an angle.
+        throw new Error('Cannot publish climb without an angle');
+      }
       await db
         .insert(dbSchema.boardClimbStats)
         .values({

--- a/packages/backend/src/graphql/resolvers/climbs/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/mutations.ts
@@ -131,6 +131,27 @@ export const climbMutations = {
     // Populate denormalized required_set_ids and compatible_size_ids
     await populateDenormalizedColumns(db, validated.boardType, [uuid]);
 
+    // Stats rows used to come exclusively from the Aurora sync pipeline, so
+    // Boardsesh-originated climbs had none. The hot search path INNER JOINs
+    // board_climb_stats (search-climbs.ts:statsDrivenSearch), which hid these
+    // climbs from search until someone synced them. Seed a row at the chosen
+    // angle so the climb is discoverable immediately.
+    await db
+      .insert(dbSchema.boardClimbStats)
+      .values({
+        boardType: validated.boardType,
+        climbUuid: uuid,
+        angle: validated.angle,
+        ascensionistCount: 0,
+      })
+      .onConflictDoNothing({
+        target: [
+          dbSchema.boardClimbStats.boardType,
+          dbSchema.boardClimbStats.climbUuid,
+          dbSchema.boardClimbStats.angle,
+        ],
+      });
+
     await publishSocialEvent({
       type: 'climb.created',
       actorId: ctx.userId!,
@@ -211,7 +232,9 @@ export const climbMutations = {
       await db.insert(dbSchema.boardClimbHolds).values(holdRows).onConflictDoNothing();
     }
 
-    // Optional grade stats
+    // Always seed a stats row so the climb is visible to the global search,
+    // which uses an INNER JOIN against board_climb_stats. When the user
+    // supplied a grade we can resolve, fill in difficulty fields too.
     const difficultyId = await resolveDifficultyId(validated.boardType, validated.userGrade);
     if (difficultyId !== null) {
       await db
@@ -239,6 +262,23 @@ export const climbMutations = {
             benchmarkDifficulty: validated.isBenchmark ? difficultyId : null,
             difficultyAverage: difficultyId,
           },
+        });
+    } else {
+      await db
+        .insert(dbSchema.boardClimbStats)
+        .values({
+          boardType: validated.boardType,
+          climbUuid: uuid,
+          angle: validated.angle,
+          ascensionistCount: 0,
+          faUsername: validated.setter || null,
+        })
+        .onConflictDoNothing({
+          target: [
+            dbSchema.boardClimbStats.boardType,
+            dbSchema.boardClimbStats.climbUuid,
+            dbSchema.boardClimbStats.angle,
+          ],
         });
     }
 
@@ -296,6 +336,7 @@ export const climbMutations = {
         isDraft: dbSchema.boardClimbs.isDraft,
         publishedAt: dbSchema.boardClimbs.publishedAt,
         createdAt: dbSchema.boardClimbs.createdAt,
+        angle: dbSchema.boardClimbs.angle,
       })
       .from(dbSchema.boardClimbs)
       .where(
@@ -364,6 +405,30 @@ export const climbMutations = {
     // so search filters still match.
     if (validated.frames !== undefined) {
       await populateDenormalizedColumns(db, validated.boardType, [validated.uuid]);
+    }
+
+    // The search hot path INNER JOINs board_climb_stats by (boardType, climbUuid, angle).
+    // Make sure a row exists at the resolved angle whenever the climb is, or just became,
+    // searchable. The old row at the previous angle is left in place — it's harmless
+    // because search filters by exact angle, and removing it would race with concurrent ticks.
+    const resolvedAngle = validated.angle ?? existing.angle;
+    const angleChanged = validated.angle !== undefined && validated.angle !== existing.angle;
+    if (resolvedAngle !== null && !nextIsDraft && (transitioningToPublished || angleChanged)) {
+      await db
+        .insert(dbSchema.boardClimbStats)
+        .values({
+          boardType: validated.boardType,
+          climbUuid: validated.uuid,
+          angle: resolvedAngle,
+          ascensionistCount: 0,
+        })
+        .onConflictDoNothing({
+          target: [
+            dbSchema.boardClimbStats.boardType,
+            dbSchema.boardClimbStats.climbUuid,
+            dbSchema.boardClimbStats.angle,
+          ],
+        });
     }
 
     // Tell the web app to drop the cached climb-view render so the edit

--- a/packages/backend/src/graphql/resolvers/climbs/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/mutations.ts
@@ -136,22 +136,30 @@ export const climbMutations = {
     // board_climb_stats (search-climbs.ts:statsDrivenSearch), which hid these
     // climbs from search until someone synced them. Seed a row at the chosen
     // angle so the climb is discoverable immediately.
-    await db
-      .insert(dbSchema.boardClimbStats)
-      .values({
-        boardType: validated.boardType,
-        climbUuid: uuid,
-        angle: validated.angle,
-        ascensionistCount: 0,
-        faUsername: preferredSetter,
-      })
-      .onConflictDoNothing({
-        target: [
-          dbSchema.boardClimbStats.boardType,
-          dbSchema.boardClimbStats.climbUuid,
-          dbSchema.boardClimbStats.angle,
-        ],
-      });
+    //
+    // Skip drafts: search uses LEFT JOIN for drafts and a stats row there would
+    // expose the climb to the listed/INNER-JOIN path the moment is_listed flips,
+    // before any other write occurs. Matches migration 0096 Step 1, which only
+    // backfills rows where is_draft = FALSE, and updateClimb (below) which seeds
+    // on draft → publish transition.
+    if (!validated.isDraft) {
+      await db
+        .insert(dbSchema.boardClimbStats)
+        .values({
+          boardType: validated.boardType,
+          climbUuid: uuid,
+          angle: validated.angle,
+          ascensionistCount: 0,
+          faUsername: preferredSetter,
+        })
+        .onConflictDoNothing({
+          target: [
+            dbSchema.boardClimbStats.boardType,
+            dbSchema.boardClimbStats.climbUuid,
+            dbSchema.boardClimbStats.angle,
+          ],
+        });
+    }
 
     await publishSocialEvent({
       type: 'climb.created',
@@ -338,6 +346,7 @@ export const climbMutations = {
         publishedAt: dbSchema.boardClimbs.publishedAt,
         createdAt: dbSchema.boardClimbs.createdAt,
         angle: dbSchema.boardClimbs.angle,
+        setterUsername: dbSchema.boardClimbs.setterUsername,
       })
       .from(dbSchema.boardClimbs)
       .where(
@@ -422,6 +431,7 @@ export const climbMutations = {
           climbUuid: validated.uuid,
           angle: resolvedAngle,
           ascensionistCount: 0,
+          faUsername: existing.setterUsername,
         })
         .onConflictDoNothing({
           target: [

--- a/packages/backend/src/graphql/resolvers/climbs/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/mutations.ts
@@ -241,9 +241,22 @@ export const climbMutations = {
       await db.insert(dbSchema.boardClimbHolds).values(holdRows).onConflictDoNothing();
     }
 
-    // Always seed a stats row so the climb is visible to the global search,
-    // which uses an INNER JOIN against board_climb_stats. When the user
-    // supplied a grade we can resolve, fill in difficulty fields too.
+    // Seed a stats row so the climb is visible to the global search, which
+    // uses an INNER JOIN against board_climb_stats.
+    //
+    // Drafts: search already filters by `is_draft = false` (create-climb-filters
+    // baseConditions), so a stats row on a draft is not directly search-visible.
+    // The seed is still important when the user supplied a grade — board_climb_stats
+    // is the only place we persist the resolved difficulty, and skipping the row
+    // would lose the grade through draft → publish (updateClimb's stats seed has
+    // no grade source to reconstruct it from). So:
+    //   - draft + grade  → seed the row (preserves grade; search filter masks the draft)
+    //   - draft + no grade → skip the seed (matches saveClimb's gate; updateClimb
+    //                        will create a barebones row at publish time)
+    //   - non-draft + grade → seed with grade (current behaviour)
+    //   - non-draft + no grade → seed barebones (current behaviour)
+    // The uuid is freshly generated per call, so the inserts can never conflict —
+    // both branches use `onConflictDoNothing` for consistency with saveClimb.
     const difficultyId = await resolveDifficultyId(validated.boardType, validated.userGrade);
     if (difficultyId !== null) {
       await db
@@ -260,19 +273,14 @@ export const climbMutations = {
           faUsername: validated.setter || null,
           faAt: null,
         })
-        .onConflictDoUpdate({
+        .onConflictDoNothing({
           target: [
             dbSchema.boardClimbStats.boardType,
             dbSchema.boardClimbStats.climbUuid,
             dbSchema.boardClimbStats.angle,
           ],
-          set: {
-            displayDifficulty: difficultyId,
-            benchmarkDifficulty: validated.isBenchmark ? difficultyId : null,
-            difficultyAverage: difficultyId,
-          },
         });
-    } else {
+    } else if (!isDraft) {
       await db
         .insert(dbSchema.boardClimbStats)
         .values({
@@ -391,6 +399,22 @@ export const climbMutations = {
     const now = new Date().toISOString();
     const nextPublishedAt = transitioningToPublished ? now : existing.publishedAt;
 
+    // Decide whether this update needs to seed a board_climb_stats row at the
+    // climb's resolved angle, and validate the angle up front. Doing this
+    // BEFORE the board_climbs UPDATE means a malformed-publish attempt fails
+    // cleanly — without it, we'd flip isDraft=false / publishedAt=now and
+    // then throw, leaving a published climb with no stats row (exactly the
+    // broken state this PR is fixing).
+    const resolvedAngle = validated.angle ?? existing.angle;
+    const angleChanged = validated.angle !== undefined && validated.angle !== existing.angle;
+    const shouldSeedStats = !nextIsDraft && (transitioningToPublished || angleChanged);
+    if (shouldSeedStats && resolvedAngle === null) {
+      // board_climbs.angle is nullable in the schema but board_climb_stats.angle
+      // is NOT NULL. angleChanged can't reach this — validated.angle would be
+      // set; this only fires on publish of a draft created without an angle.
+      throw new Error('Cannot publish climb without an angle');
+    }
+
     // Build the update set from provided fields only.
     const updateSet: Record<string, unknown> = {
       isDraft: nextIsDraft,
@@ -421,18 +445,9 @@ export const climbMutations = {
     // Make sure a row exists at the resolved angle whenever the climb is, or just became,
     // searchable. The old row at the previous angle is left in place — it's harmless
     // because search filters by exact angle, and removing it would race with concurrent ticks.
-    const resolvedAngle = validated.angle ?? existing.angle;
-    const angleChanged = validated.angle !== undefined && validated.angle !== existing.angle;
-    if (!nextIsDraft && (transitioningToPublished || angleChanged)) {
-      if (resolvedAngle === null) {
-        // board_climbs.angle is nullable in the schema but board_climb_stats.angle
-        // is NOT NULL, so a null angle here would either crash the insert or, with
-        // the `null` short-circuit we used to have, silently leave the climb out
-        // of the INNER-JOIN search forever. Surface the malformed state instead.
-        // angleChanged can't reach this — validated.angle would be set; this only
-        // fires on publish of a draft created without an angle.
-        throw new Error('Cannot publish climb without an angle');
-      }
+    // The combined check also re-narrows `resolvedAngle` to non-null for TS — we threw
+    // above on (shouldSeedStats && null) so the second clause is the only path through.
+    if (shouldSeedStats && resolvedAngle !== null) {
       await db
         .insert(dbSchema.boardClimbStats)
         .values({

--- a/packages/db/drizzle/0097_backfill_user_climb_stats.sql
+++ b/packages/db/drizzle/0097_backfill_user_climb_stats.sql
@@ -1,30 +1,35 @@
--- Migration: Backfill board_climb_stats for Boardsesh-originated climbs.
+-- Migration: Backfill stats + denormalized columns for Boardsesh-originated climbs.
 --
 -- Context:
---   The global climbs search hot path INNER JOINs board_climb_stats
---   (see search-climbs.ts:statsDrivenSearch). Historically every row in
---   board_climb_stats came from the Aurora sync pipeline, so climbs
---   originated by Boardsesh users (via the saveClimb GraphQL mutation
---   on Kilter/Tension, or saveMoonBoardClimb without a user grade) had
---   no stats row and were silently excluded from search — even though
---   they showed up on the setter's profile, which uses a LEFT JOIN.
+--   Two compounding bugs hid every user-created Boardsesh climb from the
+--   global climbs search:
 --
---   The application code now seeds a stats row at climb-create time, so
---   only the historical backlog needs cleaning up. This migration handles
---   that one-time fix.
+--   1. The search hot path INNER JOINs board_climb_stats. Stats rows came
+--      exclusively from the Aurora sync pipeline, so saveClimb / grade-less
+--      saveMoonBoardClimb saves left climbs with no stats row at all.
 --
--- What this does:
---   For every published (is_listed=TRUE, is_draft=FALSE), user-originated
---   (user_id IS NOT NULL) climb that has no matching board_climb_stats row
---   at its angle, insert a minimal stats row with ascensionist_count=0 and
---   NULL difficulty/quality fields.
+--   2. populateDenormalizedColumns extracts hold IDs from the `frames` text
+--      using the POSIX regex `p(\d+)r`. The TypeScript source wrote the
+--      literal `'p(\d+)r'`, but a JS string literal silently drops the
+--      backslash before `\d` (unrecognized escape), so PostgreSQL received
+--      `'p(d+)r'` — which matches `pd+r` literally and finds no hold IDs.
+--      Result: every user-created Kilter/Tension climb had NULL edge_left,
+--      required_set_ids, and compatible_size_ids. The search filter requires
+--      compatible_size_ids to contain the user's selected size, so the climb
+--      was filtered out at the SQL level even when the name matched.
+--
+--   Application code now (a) seeds a stats row at climb-create time, and
+--   (b) uses the correctly-escaped regex in populateDenormalizedColumns.
+--   This migration patches the historical data.
 --
 -- Safety / idempotency:
---   - Drafts are deliberately skipped — they're routed to standardSearch
---     (LEFT JOIN) and would just bloat the table.
---   - ON CONFLICT DO NOTHING means re-running is a no-op.
---   - Only inserts; never updates an existing row.
+--   - Drafts are deliberately skipped — search uses LEFT JOIN for drafts
+--     and the denormalized columns are only consulted on the listed path.
+--   - Step 1 (stats backfill): ON CONFLICT DO NOTHING, idempotent.
+--   - Steps 2-4 (denormalization): WHERE clauses guard each update so a
+--     re-run only touches rows that still need work.
 
+-- Step 1: insert missing stats rows so listed user climbs are JOIN-visible.
 INSERT INTO board_climb_stats (
   board_type,
   climb_uuid,
@@ -59,3 +64,74 @@ WHERE bc.is_listed    = TRUE
   AND bc.angle        IS NOT NULL
   AND bcs.climb_uuid  IS NULL
 ON CONFLICT (board_type, climb_uuid, angle) DO NOTHING;
+
+-- Step 2: derive edge_left/right/bottom/top from hold positions for any
+-- Kilter/Tension user climb that's missing them. Mirrors the SQL in
+-- packages/db/src/queries/climbs/populate-denormalized-columns.ts.
+UPDATE board_climbs c
+SET edge_left   = sub.min_x,
+    edge_right  = sub.max_x,
+    edge_bottom = sub.min_y,
+    edge_top    = sub.max_y
+FROM (
+  SELECT c2.uuid, c2.board_type,
+    MIN(bh.x) AS min_x, MAX(bh.x) AS max_x,
+    MIN(bh.y) AS min_y, MAX(bh.y) AS max_y
+  FROM board_climbs c2
+  CROSS JOIN LATERAL regexp_matches(c2.frames, 'p(\d+)r', 'g') AS m(hold_id_arr)
+  JOIN board_placements bp
+    ON bp.id        = (m.hold_id_arr[1])::int
+   AND bp.board_type = c2.board_type
+   AND bp.layout_id  = c2.layout_id
+  JOIN board_holes bh
+    ON bh.id        = bp.hole_id
+   AND bh.board_type = c2.board_type
+  WHERE c2.board_type IN ('kilter', 'tension')
+    AND c2.user_id    IS NOT NULL
+    AND c2.edge_left  IS NULL
+    AND c2.frames     IS NOT NULL
+  GROUP BY c2.uuid, c2.board_type
+) sub
+WHERE c.uuid = sub.uuid AND c.board_type = sub.board_type;
+
+-- Step 3: populate required_set_ids from the same hold-ID extraction.
+UPDATE board_climbs c
+SET required_set_ids = sub.sets
+FROM (
+  SELECT c2.uuid, c2.board_type,
+    ARRAY_AGG(DISTINCT bp.set_id ORDER BY bp.set_id) AS sets
+  FROM board_climbs c2
+  CROSS JOIN LATERAL regexp_matches(c2.frames, 'p(\d+)r', 'g') AS m(hold_id_arr)
+  JOIN board_placements bp
+    ON bp.id        = (m.hold_id_arr[1])::int
+   AND bp.board_type = c2.board_type
+   AND bp.layout_id  = c2.layout_id
+  WHERE c2.board_type        IN ('kilter', 'tension')
+    AND c2.user_id           IS NOT NULL
+    AND c2.required_set_ids  IS NULL
+    AND c2.frames            IS NOT NULL
+  GROUP BY c2.uuid, c2.board_type
+) sub
+WHERE c.uuid = sub.uuid AND c.board_type = sub.board_type;
+
+-- Step 4: populate compatible_size_ids by comparing each climb's bounding box
+-- against the available board product sizes.
+UPDATE board_climbs c
+SET compatible_size_ids = sub.size_ids
+FROM (
+  SELECT c2.uuid, c2.board_type,
+    ARRAY_AGG(ps.id ORDER BY ps.id) AS size_ids
+  FROM board_climbs c2
+  JOIN board_product_sizes ps
+    ON ps.board_type   = c2.board_type
+   AND c2.edge_left    > ps.edge_left
+   AND c2.edge_right   < ps.edge_right
+   AND c2.edge_bottom  > ps.edge_bottom
+   AND c2.edge_top     < ps.edge_top
+  WHERE c2.board_type            IN ('kilter', 'tension')
+    AND c2.user_id               IS NOT NULL
+    AND c2.compatible_size_ids   IS NULL
+    AND c2.edge_left             IS NOT NULL
+  GROUP BY c2.uuid, c2.board_type
+) sub
+WHERE c.uuid = sub.uuid AND c.board_type = sub.board_type;

--- a/packages/db/drizzle/0097_backfill_user_climb_stats.sql
+++ b/packages/db/drizzle/0097_backfill_user_climb_stats.sql
@@ -23,11 +23,18 @@
 --   This migration patches the historical data.
 --
 -- Safety / idempotency:
---   - Drafts are deliberately skipped — search uses LEFT JOIN for drafts
---     and the denormalized columns are only consulted on the listed path.
---   - Step 1 (stats backfill): ON CONFLICT DO NOTHING, idempotent.
---   - Steps 2-4 (denormalization): WHERE clauses guard each update so a
---     re-run only touches rows that still need work.
+--   - Step 1 (stats backfill) skips drafts — search uses an INNER JOIN
+--     against board_climb_stats only for listed climbs, and seeding a row
+--     on a draft would prematurely expose it the moment is_listed flips.
+--     ON CONFLICT DO NOTHING makes it idempotent.
+--   - Steps 2-4 (denormalization) intentionally include drafts. saveClimb
+--     calls populateDenormalizedColumns unconditionally on every climb, so
+--     this matches runtime behavior. The columns are unused while is_draft
+--     is true, but pre-populating them means a future draft → publish that
+--     doesn't touch frames (updateClimb only re-runs populateDenormalized
+--     Columns on a frames change) is search-ready immediately. Each step's
+--     WHERE clause guards by NULL so a re-run only touches rows that still
+--     need work.
 
 -- Step 1: insert missing stats rows so listed user climbs are JOIN-visible.
 INSERT INTO board_climb_stats (

--- a/packages/db/drizzle/0097_backfill_user_climb_stats.sql
+++ b/packages/db/drizzle/0097_backfill_user_climb_stats.sql
@@ -1,0 +1,61 @@
+-- Migration: Backfill board_climb_stats for Boardsesh-originated climbs.
+--
+-- Context:
+--   The global climbs search hot path INNER JOINs board_climb_stats
+--   (see search-climbs.ts:statsDrivenSearch). Historically every row in
+--   board_climb_stats came from the Aurora sync pipeline, so climbs
+--   originated by Boardsesh users (via the saveClimb GraphQL mutation
+--   on Kilter/Tension, or saveMoonBoardClimb without a user grade) had
+--   no stats row and were silently excluded from search — even though
+--   they showed up on the setter's profile, which uses a LEFT JOIN.
+--
+--   The application code now seeds a stats row at climb-create time, so
+--   only the historical backlog needs cleaning up. This migration handles
+--   that one-time fix.
+--
+-- What this does:
+--   For every published (is_listed=TRUE, is_draft=FALSE), user-originated
+--   (user_id IS NOT NULL) climb that has no matching board_climb_stats row
+--   at its angle, insert a minimal stats row with ascensionist_count=0 and
+--   NULL difficulty/quality fields.
+--
+-- Safety / idempotency:
+--   - Drafts are deliberately skipped — they're routed to standardSearch
+--     (LEFT JOIN) and would just bloat the table.
+--   - ON CONFLICT DO NOTHING means re-running is a no-op.
+--   - Only inserts; never updates an existing row.
+
+INSERT INTO board_climb_stats (
+  board_type,
+  climb_uuid,
+  angle,
+  ascensionist_count,
+  display_difficulty,
+  benchmark_difficulty,
+  difficulty_average,
+  quality_average,
+  fa_username,
+  fa_at
+)
+SELECT
+  bc.board_type,
+  bc.uuid,
+  bc.angle,
+  0,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL
+FROM board_climbs bc
+LEFT JOIN board_climb_stats bcs
+  ON bcs.board_type = bc.board_type
+ AND bcs.climb_uuid = bc.uuid
+ AND bcs.angle      = bc.angle
+WHERE bc.is_listed    = TRUE
+  AND bc.is_draft     = FALSE
+  AND bc.user_id      IS NOT NULL
+  AND bc.angle        IS NOT NULL
+  AND bcs.climb_uuid  IS NULL
+ON CONFLICT (board_type, climb_uuid, angle) DO NOTHING;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -680,6 +680,13 @@
       "when": 1778796374010,
       "tag": "0096_abnormal_korg",
       "breakpoints": true
+    },
+    {
+      "idx": 97,
+      "version": "7",
+      "when": 1778796374020,
+      "tag": "0097_backfill_user_climb_stats",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/queries/climbs/populate-denormalized-columns.ts
+++ b/packages/db/src/queries/climbs/populate-denormalized-columns.ts
@@ -44,6 +44,13 @@ export async function populateDenormalizedColumns(
     sql`, `,
   )}]::text[]`;
 
+  // The regex 'p(\d+)r' must be written with a doubled backslash in source.
+  // A JS string literal silently drops the backslash before unrecognized
+  // escapes, so `'p(\d+)r'` becomes `'p(d+)r'` at runtime and matches `pd+r`
+  // literally — that's why user-created climbs never got their edges or
+  // required_set_ids populated. Doubling it gives PG the expected `p(\d+)r`.
+  const holdIdRegex = 'p(\\d+)r';
+
   // Step 1: Compute missing edge values from hold positions.
   // Locally created climbs don't have edges set, but we can derive them from
   // the hold IDs in the frames string -> placements -> holes (x, y).
@@ -58,7 +65,7 @@ export async function populateDenormalizedColumns(
         MIN(bh.x) as min_x, MAX(bh.x) as max_x,
         MIN(bh.y) as min_y, MAX(bh.y) as max_y
       FROM board_climbs c2
-      CROSS JOIN LATERAL regexp_matches(c2.frames, 'p(\d+)r', 'g') AS m(hold_id_arr)
+      CROSS JOIN LATERAL regexp_matches(c2.frames, ${holdIdRegex}, 'g') AS m(hold_id_arr)
       JOIN board_placements bp
         ON bp.id = (m.hold_id_arr[1])::int
         AND bp.board_type = c2.board_type
@@ -85,7 +92,7 @@ export async function populateDenormalizedColumns(
       SELECT c2.uuid,
         ARRAY_AGG(DISTINCT bp.set_id ORDER BY bp.set_id) as sets
       FROM board_climbs c2
-      CROSS JOIN LATERAL regexp_matches(c2.frames, 'p(\d+)r', 'g') AS m(hold_id_arr)
+      CROSS JOIN LATERAL regexp_matches(c2.frames, ${holdIdRegex}, 'g') AS m(hold_id_arr)
       JOIN board_placements bp
         ON bp.id = (m.hold_id_arr[1])::int
         AND bp.board_type = c2.board_type


### PR DESCRIPTION
## Summary

Two compounding bugs made user-created climbs invisible in global search. Marco surfaced this on his profile (`Setty set`, `Ready… Tall boys version`, `Fossil Fuel`) — visible at `/profile/3fa79140-…` but missing from Kilter search.

### Bug 1: no `board_climb_stats` row

`saveClimb` for Aurora boards (and `saveMoonBoardClimb` without a grade) never wrote a row into `board_climb_stats`. The search hot path uses an `INNER JOIN` against that table for its index-driven `ascensionist_count DESC` plan (see `search-climbs.ts:152-208`), so those climbs were excluded at the join. They still showed on the setter's profile (LEFT JOIN), which is why the bug stayed silent. 1,852 published climbs across 104 users since 2020-09 were affected.

Fix: write a minimal stats row at climb-create time in `saveClimb`, on draft→publish in `updateClimb`, and on angle changes. Backfill the historical gap in migration 0096.

### Bug 2: silent regex escape in `populateDenormalizedColumns`

While QA-testing bug 1, "Nailssss" was published and still didn't appear in search by name. Investigation found a second, older bug: `populateDenormalizedColumns` extracts hold IDs from the `frames` text using `regexp_matches(frames, 'p(\d+)r', 'g')`, but the regex was written as a JS string literal — and JS silently drops the backslash before unrecognized escapes, so PG received `'p(d+)r'` and matched zero holds.

The fallout: every user-created Kilter/Tension climb went through `saveClimb` with NULL `edge_left/right/bottom/top`, NULL `required_set_ids`, and NULL `compatible_size_ids`. The search filter requires `compatible_size_ids` to contain the user's selected size, so the climb was filtered out at the SQL level even when the name and stats row matched. This explains why Marco's three climbs have all denormalized columns NULL in production.

Fix: write the regex with a doubled `\\d` so PG sees the intended `\d`. Extended migration 0096 with three additional UPDATEs that backfill edges, required sets, and compatible sizes for affected historical climbs.

### Why search-side wasn't changed

The comment block in `search-climbs.ts:152-160` calls out that the index-driven plan needs `FROM board_climb_stats` first. Switching the INNER JOIN to LEFT JOIN would regress the performance work tracked in PR #1969. Fix belongs on the write side.

## Out of scope (followup — #2151)

Boardsesh ticks (`saveTick`) don't yet increment `ascensionist_count`, so new climbs all show 0 ascents in search until that's wired up. Filed as #2151 — "boardsesh should start generating its own climb stats" end to end.

## Test plan

- [x] `vp run typecheck:backend` and `vp run typecheck:db` pass.
- [x] `vp test --project backend` passes — `climb-mutations.test.ts` updated to assert the new stats insert.
- [x] Local dev DB: backfill SQL applied, recount of stats-less listed user climbs drops from 1,852 to 0.
- [x] Local dev DB: "Nailssss" QA climb now has populated `edge_left/right/bottom/top`, `required_set_ids = {27}`, `compatible_size_ids = {7,10,15,…}`.
- [ ] Reviewer: create a new Kilter climb at 35° on the dev server, publish, verify it appears in search by name and at the chosen size. Edit angle within the 24h window; verify it appears at the new angle.
- [ ] After deploy: spot-check Marco's three Kilter climbs in production search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)