### PR TITLE
default BOARDSESH_WEB_URL to production

### DIFF
--- a/packages/backend/src/lib/web-revalidate.ts
+++ b/packages/backend/src/lib/web-revalidate.ts
@@ -11,17 +11,17 @@
  * call.
  */
 
-const WEB_URL = process.env.BOARDSESH_WEB_URL;
+const WEB_URL = process.env.BOARDSESH_WEB_URL ?? 'https://www.boardsesh.com';
 const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET;
 const REQUEST_TIMEOUT_MS = 5000;
 
 let warned = false;
 
 export async function notifyClimbRevalidated(climbUuid: string): Promise<void> {
-  if (!WEB_URL || !REVALIDATE_SECRET) {
+  if (!REVALIDATE_SECRET) {
     if (!warned) {
       console.warn(
-        '[web-revalidate] BOARDSESH_WEB_URL or REVALIDATE_SECRET not set; climb-cache invalidation disabled. Cached climb pages will refresh on the configured TTL.',
+        '[web-revalidate] REVALIDATE_SECRET not set; climb-cache invalidation disabled. Cached climb pages will refresh on the configured TTL.',
       );
       warned = true;
     }


### PR DESCRIPTION
## Context

Investigated a batch of Railway server logs the user flagged as `[err]`. Triage:

- **`checkpoint starting/complete` lines** — `LOG:` severity, not errors. Postgres routes LOG messages to stderr, Railway tags everything on stderr `[err]`. Frequency matches default `checkpoint_timeout = 5min`. No action.
- **`could not receive data from client: Connection reset by peer` bursts** — also `LOG:` severity. Bursts of 5–10 PIDs at a time match a single Node process exiting without `pool.end()` (Railway recycling a web container, serverless invocation ending). Backend already has a SIGTERM `closePool()`; web is Next.js-managed. No action.
- **`GraphQL error: write EPIPE`** — single occurrence, already caught by the existing `onError` handler in `packages/backend/src/websocket/setup.ts`. Race window between WS client teardown and the next 30s ping; unavoidable for mobile WS clients. No action.
- **`[web-revalidate] BOARDSESH_WEB_URL or REVALIDATE_SECRET not set`** — real config gap. The backend → web `unstable_cache` invalidation for climb pages is silently disabled, so cached climb pages stay stale until TTL.

## Summary

- Default `BOARDSESH_WEB_URL` to `https://www.boardsesh.com` so the production case doesn't need an explicit env var. Override stays available for preview/staging.
- Drop `BOARDSESH_WEB_URL` from the missing-env-var warning since it's no longer required; the warning now points only at the secret that still needs to be configured per-deployment.

## Follow-up (config, not code)

`REVALIDATE_SECRET` still needs to be set on the Railway backend service to whatever value the web service already uses. Restart the backend after setting it; the warning should stop appearing on startup.

## Test plan

- [ ] CI lint + typecheck pass
- [ ] After `REVALIDATE_SECRET` is set on the backend Railway service, no `[web-revalidate] ... not set` warning on startup
- [ ] Mutating a climb (e.g. comment / community status change) does not surface a `[web-revalidate] climb-cache invalidation failed` follow-up line
- [ ] The mutated climb's public page reflects the change without waiting for the 1h TTL

https://claude.ai/code/session_01EnihFaWS7QQrvKbAT88xgb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnihFaWS7QQrvKbAT88xgb)_