### PR TITLE
fix(live-activities): tighten registration + add server heartbeat

### DIFF
--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -33,7 +33,7 @@ Server-to-device (push updates):
        |
   roomManager.getQueueState() --> build ContentState
        |
-  apnsService.sendLiveActivityUpdate() (5s debounce)
+  apnsService.sendLiveActivityUpdate() (1s debounce)
        |
   Apple Push Notification Service (production)
        |

--- a/mobile/ios/App/App/LiveActivityManager.swift
+++ b/mobile/ios/App/App/LiveActivityManager.swift
@@ -31,11 +31,14 @@ actor LiveActivityManager {
     /// Timestamp of the last ActivityKit update, used for deduplication.
     private var lastUpdateTime: Date?
 
-    /// How far in the future the stale date is set. The ping timeout timer
-    /// refreshes this every 60s, so 3 minutes gives a comfortable 2× margin
-    /// during normal operation. After a force-quit the activity goes stale
-    /// in 3 minutes instead of lingering for 30.
-    private let staleInterval: TimeInterval = 3 * 60
+    /// How far in the future the stale date is set. The server-side APNs
+    /// heartbeat (`packages/backend/src/services/apns/heartbeat.ts`) re-sends
+    /// the latest content state every 90 s while at least one push token is
+    /// registered for the session, so a 10-minute stale interval gives ~6×
+    /// headroom against missed pushes (network blip, APNs latency, server
+    /// restart). After a force-quit with no server keepalive the activity
+    /// goes stale in 10 minutes instead of lingering indefinitely.
+    private let staleInterval: TimeInterval = 10 * 60
 
     // MARK: - Init
 

--- a/mobile/ios/App/App/LiveActivityPlugin.swift
+++ b/mobile/ios/App/App/LiveActivityPlugin.swift
@@ -1,5 +1,6 @@
 import Capacitor
 import ActivityKit
+import UIKit
 import os.log
 
 @objc(LiveActivityPlugin)
@@ -16,6 +17,8 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityPlugin")
     private var observingDarwinNotification = false
+    private var observingPushRegistrationStale = false
+    private var observingForegroundNotification = false
 
     /// Serial queue protecting push token state accessed from both the Capacitor
     /// thread and the LiveActivityManager push token callback.
@@ -23,6 +26,11 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     private var _currentPushToken: String?
     private var _currentServerUrl: String?
     private var _currentSessionId: String?
+
+    /// Retry schedule for push-token registration when the initial HTTP attempt
+    /// fails (network blip on the just-locked phone is the common case). Five
+    /// attempts spread across ~50 seconds, all in-process and non-blocking.
+    private let pushRegistrationRetryDelays: [TimeInterval] = [0, 2, 5, 15, 30]
 
     // MARK: - Darwin Notification (Widget → JS bridge)
 
@@ -53,6 +61,8 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
 
     deinit {
         stopDarwinObservation()
+        stopPushRegistrationStaleObservation()
+        stopForegroundObservation()
     }
 
     private func stopDarwinObservation() {
@@ -62,6 +72,86 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         let center = CFNotificationCenterGetDarwinNotifyCenter()
         let observer = Unmanaged.passUnretained(self).toOpaque()
         CFNotificationCenterRemoveObserver(center, observer, nil, nil)
+    }
+
+    // MARK: - Push registration stale (widget 410)
+
+    /// Observe the Darwin notification fired by the widget when
+    /// `/api/widget/navigate` responds 410 Gone — the cached push token is
+    /// bound to a different session. We respond by re-registering.
+    private func startPushRegistrationStaleObservation() {
+        guard !observingPushRegistrationStale else { return }
+        observingPushRegistrationStale = true
+
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        let name = CFNotificationName(SharedConstants.pushRegistrationStaleNotification as CFString)
+        let observer = Unmanaged.passUnretained(self).toOpaque()
+
+        CFNotificationCenterAddObserver(
+            center,
+            observer,
+            { (_, observer, _, _, _) in
+                guard let observer = observer else { return }
+                let plugin = Unmanaged<LiveActivityPlugin>.fromOpaque(observer).takeUnretainedValue()
+                plugin.handlePushRegistrationStale()
+            },
+            name.rawValue,
+            nil,
+            .deliverImmediately
+        )
+    }
+
+    private func stopPushRegistrationStaleObservation() {
+        guard observingPushRegistrationStale else { return }
+        observingPushRegistrationStale = false
+
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        let observer = Unmanaged.passUnretained(self).toOpaque()
+        CFNotificationCenterRemoveObserver(center, observer, nil, nil)
+    }
+
+    private func handlePushRegistrationStale() {
+        let (token, sessionId, serverUrl) = tokenQueue.sync {
+            (_currentPushToken, _currentSessionId, _currentServerUrl)
+        }
+        // Clear the widget-readable copy so the widget reverts to an
+        // un-authenticated request (which the backend handles by simply
+        // returning 401 → Darwin notification fallback) until we get a fresh
+        // token registration in.
+        SharedKeychain.remove(SharedKeychain.livePushTokenKey)
+        if let token, let sessionId, let serverUrl {
+            logger.info("Re-registering push token after widget 410")
+            registerPushTokenWithBackend(token: token, sessionId: sessionId, serverUrl: serverUrl)
+        } else {
+            logger.warning("Push registration stale notification received but no current session/token to re-register")
+        }
+    }
+
+    // MARK: - App foreground
+
+    private func startForegroundObservation() {
+        guard !observingForegroundNotification else { return }
+        observingForegroundNotification = true
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+    }
+
+    private func stopForegroundObservation() {
+        guard observingForegroundNotification else { return }
+        observingForegroundNotification = false
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleAppWillEnterForeground() {
+        retryPendingRegistrationIfNeeded(trigger: "foreground")
     }
 
     private func handleQueueNavigateFromWidget() {
@@ -95,13 +185,85 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
 
     // MARK: - Push Token Registration
 
+    /// Persist a pending-registration record to the shared keychain so that a
+    /// crash, app relaunch, or backgrounded retry path can pick it up later.
+    private func writePendingRegistration(token: String, sessionId: String, serverUrl: String) {
+        let payload: [String: String] = [
+            "token": token,
+            "sessionId": sessionId,
+            "serverUrl": serverUrl,
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8) else { return }
+        if !SharedKeychain.set(json, for: SharedKeychain.pendingPushRegistrationKey) {
+            logger.error("Failed to persist pending push registration")
+        }
+    }
+
+    private func clearPendingRegistration() {
+        SharedKeychain.remove(SharedKeychain.pendingPushRegistrationKey)
+    }
+
+    private func readPendingRegistration() -> (token: String, sessionId: String, serverUrl: String)? {
+        guard let json = SharedKeychain.get(SharedKeychain.pendingPushRegistrationKey),
+              let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: String],
+              let token = obj["token"], !token.isEmpty,
+              let sessionId = obj["sessionId"], !sessionId.isEmpty,
+              let serverUrl = obj["serverUrl"], !serverUrl.isEmpty
+        else { return nil }
+        return (token: token, sessionId: sessionId, serverUrl: serverUrl)
+    }
+
+    /// Kick off a push-token registration with exponential retries. Persists a
+    /// pending-record to the shared keychain on first attempt; the record is
+    /// cleared on success or on `endSession`. Safe to call from any thread.
     private func registerPushTokenWithBackend(token: String, sessionId: String, serverUrl: String) {
+        writePendingRegistration(token: token, sessionId: sessionId, serverUrl: serverUrl)
+        scheduleRegistrationAttempt(token: token, sessionId: sessionId, serverUrl: serverUrl, attemptIndex: 0)
+    }
+
+    private func scheduleRegistrationAttempt(token: String, sessionId: String, serverUrl: String, attemptIndex: Int) {
+        guard attemptIndex < pushRegistrationRetryDelays.count else {
+            logger.error(
+                "Push token registration exhausted retries (\(self.pushRegistrationRetryDelays.count, privacy: .public)); leaving pending record for later retry"
+            )
+            return
+        }
+        let delay = pushRegistrationRetryDelays[attemptIndex]
+        let work: () -> Void = { [weak self] in
+            self?.attemptRegistration(token: token, sessionId: sessionId, serverUrl: serverUrl, attemptIndex: attemptIndex)
+        }
+        if delay == 0 {
+            DispatchQueue.global(qos: .utility).async(execute: work)
+        } else {
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay, execute: work)
+        }
+    }
+
+    private func attemptRegistration(token: String, sessionId: String, serverUrl: String, attemptIndex: Int) {
+        // Bail if the session changed mid-flight. A stale retry from a
+        // previously active session must not be allowed to clobber the current
+        // session's registration.
+        let activeSessionId = tokenQueue.sync { _currentSessionId }
+        if let activeSessionId, activeSessionId != sessionId {
+            logger.info(
+                "Aborting stale push token registration: active session is \(activeSessionId, privacy: .public), retry was for \(sessionId, privacy: .public)"
+            )
+            return
+        }
+
         // The backend resolver authenticates via ConnectionContext, so we MUST
         // attach the user's app auth token. Without it the resolver rejects.
         guard let authToken = SharedKeychain.get(SharedKeychain.authTokenKey),
               !authToken.isEmpty
         else {
-            logger.warning("Skipping push token registration: no auth token in keychain")
+            logger.warning(
+                "Skipping push token registration (attempt \(attemptIndex + 1, privacy: .public)): no auth token in keychain"
+            )
+            // Without an auth token, retrying immediately won't help. Leave
+            // the pending record in place — the foreground / WS-connected
+            // hook will pick it up once the user is signed in again.
             return
         }
 
@@ -121,20 +283,61 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 15
         request.httpBody = jsonData
 
         URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            guard let self else { return }
+
+            // Treat network errors, non-2xx HTTP, and GraphQL errors as failures.
+            var failureReason: String?
             if let error = error {
-                self?.logger.error("Failed to register push token: \(error.localizedDescription, privacy: .public)")
+                failureReason = error.localizedDescription
             } else if let httpResponse = response as? HTTPURLResponse,
                       !(200...299).contains(httpResponse.statusCode) {
-                self?.logger.error("Failed to register push token: HTTP \(httpResponse.statusCode, privacy: .public)")
+                failureReason = "HTTP \(httpResponse.statusCode)"
             } else if let graphQLError = Self.graphQLErrorMessage(from: data) {
-                self?.logger.error("Failed to register push token: \(graphQLError, privacy: .public)")
-            } else {
-                self?.logger.info("Push token registered with backend")
+                failureReason = graphQLError
             }
+
+            if let failureReason {
+                let nextAttemptIndex = attemptIndex + 1
+                if nextAttemptIndex < self.pushRegistrationRetryDelays.count {
+                    self.logger.warning(
+                        "Push token registration attempt \(attemptIndex + 1, privacy: .public) failed (\(failureReason, privacy: .public)); retrying in \(self.pushRegistrationRetryDelays[nextAttemptIndex], privacy: .public)s"
+                    )
+                    self.scheduleRegistrationAttempt(token: token, sessionId: sessionId, serverUrl: serverUrl, attemptIndex: nextAttemptIndex)
+                } else {
+                    self.logger.error(
+                        "Push token registration failed after \(self.pushRegistrationRetryDelays.count, privacy: .public) attempts (\(failureReason, privacy: .public)); pending record retained for foreground retry"
+                    )
+                }
+                return
+            }
+
+            self.clearPendingRegistration()
+            self.logger.info("Push token registered with backend (attempt \(attemptIndex + 1, privacy: .public))")
         }.resume()
+    }
+
+    /// Trigger another registration attempt from any persisted pending record.
+    /// Called on app foreground and on WebSocket reconnect.
+    private func retryPendingRegistrationIfNeeded(trigger: String) {
+        guard let pending = readPendingRegistration() else { return }
+        let activeSessionId = tokenQueue.sync { _currentSessionId }
+        if let activeSessionId, activeSessionId != pending.sessionId {
+            logger.info(
+                "Skipping pending push registration (\(trigger, privacy: .public)): active session \(activeSessionId, privacy: .public) ≠ pending \(pending.sessionId, privacy: .public)"
+            )
+            return
+        }
+        logger.info("Retrying pending push token registration (\(trigger, privacy: .public))")
+        scheduleRegistrationAttempt(
+            token: pending.token,
+            sessionId: pending.sessionId,
+            serverUrl: pending.serverUrl,
+            attemptIndex: 0
+        )
     }
 
     private func unregisterPushTokenFromBackend(token: String, sessionId: String, serverUrl: String) {
@@ -284,11 +487,24 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             }
         }
 
+        // On reconnect (initial or recovery), retry any pending push-token
+        // registration that previously failed. The first WS connection often
+        // beats the ActivityKit push-token callback, so the foreground/Darwin
+        // observers below also cover the case where there's nothing pending
+        // until ActivityKit emits.
+        wsManager.onConnected = { [weak self] in
+            self?.retryPendingRegistrationIfNeeded(trigger: "ws-connect")
+        }
+
         // Connect after callback is set to ensure no events are missed.
         wsManager.connect(serverUrl: serverUrl, sessionId: sessionId, authToken: authToken, wsUrl: wsUrl)
 
         // Observe widget navigation intents and forward to JS.
         startDarwinObservation()
+        // Observe widget 410 hints and app foreground transitions so we can
+        // retry push-token registration in both directions.
+        startPushRegistrationStaleObservation()
+        startForegroundObservation()
 
         // Start the Live Activity with an initial "Loading..." state.
         let initialState = ClimbSessionAttributes.ContentState(
@@ -349,6 +565,8 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func endSession(_ call: CAPPluginCall) {
         stopDarwinObservation()
+        stopPushRegistrationStaleObservation()
+        stopForegroundObservation()
 
         // Unregister the push token from the backend before tearing down.
         let (token, sessionId, serverUrl) = tokenQueue.sync {
@@ -362,9 +580,13 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             _currentServerUrl = nil
             _currentSessionId = nil
         }
+        // Drop any in-flight pending registration so a stale retry can't
+        // resurrect the token after the session ended.
+        clearPendingRegistration()
 
         let wsManager = SessionWebSocketManager.shared
         wsManager.onQueueStateChanged = nil
+        wsManager.onConnected = nil
         wsManager.disconnect()
 
         // Clear shared UserDefaults queue state.

--- a/mobile/ios/App/App/LiveActivityPlugin.swift
+++ b/mobile/ios/App/App/LiveActivityPlugin.swift
@@ -27,6 +27,13 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     private var _currentServerUrl: String?
     private var _currentSessionId: String?
 
+    /// Monotonically increments every time `registerPushTokenWithBackend` is
+    /// called. A retry chain captures its generation and aborts as soon as the
+    /// counter advances — so a second entry point (foreground, WS reconnect,
+    /// widget 410, fresh ActivityKit token) supersedes any in-flight chain
+    /// rather than running in parallel with it.
+    private var _activeRegistrationGeneration: UInt64 = 0
+
     /// Retry schedule for push-token registration when the initial HTTP attempt
     /// fails (network blip on the just-locked phone is the common case). Five
     /// attempts spread across ~50 seconds, all in-process and non-blocking.
@@ -69,9 +76,13 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         guard observingDarwinNotification else { return }
         observingDarwinNotification = false
 
+        // Pass the specific name; CFNotificationCenterRemoveObserver with
+        // nil-name would clobber every Darwin observer registered against
+        // `self`, not just this one.
         let center = CFNotificationCenterGetDarwinNotifyCenter()
         let observer = Unmanaged.passUnretained(self).toOpaque()
-        CFNotificationCenterRemoveObserver(center, observer, nil, nil)
+        let name = CFNotificationName(SharedConstants.queueNavigateNotification as CFString)
+        CFNotificationCenterRemoveObserver(center, observer, name, nil)
     }
 
     // MARK: - Push registration stale (widget 410)
@@ -107,7 +118,8 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
 
         let center = CFNotificationCenterGetDarwinNotifyCenter()
         let observer = Unmanaged.passUnretained(self).toOpaque()
-        CFNotificationCenterRemoveObserver(center, observer, nil, nil)
+        let name = CFNotificationName(SharedConstants.pushRegistrationStaleNotification as CFString)
+        CFNotificationCenterRemoveObserver(center, observer, name, nil)
     }
 
     private func handlePushRegistrationStale() {
@@ -200,7 +212,21 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    /// Remove the pending-registration record unconditionally. Used by
+    /// `endSession`; callers in the success path should prefer
+    /// `clearPendingRegistrationIfMatches` to avoid wiping a record written
+    /// for a fresher (token, sessionId) by a later `startSession`.
     private func clearPendingRegistration() {
+        SharedKeychain.remove(SharedKeychain.pendingPushRegistrationKey)
+    }
+
+    /// Remove the pending record only if it still describes the same
+    /// (token, sessionId) we just registered. Protects against a late-arriving
+    /// URLSession completion clobbering a record that a new session wrote in
+    /// the meantime.
+    private func clearPendingRegistrationIfMatches(token: String, sessionId: String) {
+        guard let pending = readPendingRegistration() else { return }
+        guard pending.token == token, pending.sessionId == sessionId else { return }
         SharedKeychain.remove(SharedKeychain.pendingPushRegistrationKey)
     }
 
@@ -215,15 +241,28 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         return (token: token, sessionId: sessionId, serverUrl: serverUrl)
     }
 
-    /// Kick off a push-token registration with exponential retries. Persists a
-    /// pending-record to the shared keychain on first attempt; the record is
-    /// cleared on success or on `endSession`. Safe to call from any thread.
+    /// Kick off a push-token registration with exponential retries.
+    ///
+    /// Bumps the active registration generation, so any in-flight retry chain
+    /// from a previous call aborts on its next tick. Persists a pending record
+    /// to the shared keychain so foreground / WS-reconnect hooks can retry
+    /// later. Safe to call from any thread.
     private func registerPushTokenWithBackend(token: String, sessionId: String, serverUrl: String) {
+        let generation = tokenQueue.sync { () -> UInt64 in
+            _activeRegistrationGeneration += 1
+            return _activeRegistrationGeneration
+        }
         writePendingRegistration(token: token, sessionId: sessionId, serverUrl: serverUrl)
-        scheduleRegistrationAttempt(token: token, sessionId: sessionId, serverUrl: serverUrl, attemptIndex: 0)
+        scheduleRegistrationAttempt(
+            token: token, sessionId: sessionId, serverUrl: serverUrl,
+            attemptIndex: 0, generation: generation
+        )
     }
 
-    private func scheduleRegistrationAttempt(token: String, sessionId: String, serverUrl: String, attemptIndex: Int) {
+    private func scheduleRegistrationAttempt(
+        token: String, sessionId: String, serverUrl: String,
+        attemptIndex: Int, generation: UInt64
+    ) {
         guard attemptIndex < pushRegistrationRetryDelays.count else {
             logger.error(
                 "Push token registration exhausted retries (\(self.pushRegistrationRetryDelays.count, privacy: .public)); leaving pending record for later retry"
@@ -232,7 +271,10 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         }
         let delay = pushRegistrationRetryDelays[attemptIndex]
         let work: () -> Void = { [weak self] in
-            self?.attemptRegistration(token: token, sessionId: sessionId, serverUrl: serverUrl, attemptIndex: attemptIndex)
+            self?.attemptRegistration(
+                token: token, sessionId: sessionId, serverUrl: serverUrl,
+                attemptIndex: attemptIndex, generation: generation
+            )
         }
         if delay == 0 {
             DispatchQueue.global(qos: .utility).async(execute: work)
@@ -241,14 +283,27 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
-    private func attemptRegistration(token: String, sessionId: String, serverUrl: String, attemptIndex: Int) {
-        // Bail if the session changed mid-flight. A stale retry from a
-        // previously active session must not be allowed to clobber the current
-        // session's registration.
-        let activeSessionId = tokenQueue.sync { _currentSessionId }
-        if let activeSessionId, activeSessionId != sessionId {
+    private func attemptRegistration(
+        token: String, sessionId: String, serverUrl: String,
+        attemptIndex: Int, generation: UInt64
+    ) {
+        // Treat both a session-mismatch AND a nil active session as "abort":
+        // nil means `endSession` has already cleared module state, so an
+        // in-flight retry must not re-register a token for a session the user
+        // has just left. A superseding `registerPushTokenWithBackend` call
+        // also aborts us via the generation counter.
+        let (activeSessionId, activeGeneration) = tokenQueue.sync {
+            (_currentSessionId, _activeRegistrationGeneration)
+        }
+        guard activeSessionId == sessionId else {
             logger.info(
-                "Aborting stale push token registration: active session is \(activeSessionId, privacy: .public), retry was for \(sessionId, privacy: .public)"
+                "Aborting stale push token registration: active session is \(activeSessionId ?? "nil", privacy: .public), retry was for \(sessionId, privacy: .public)"
+            )
+            return
+        }
+        guard activeGeneration == generation else {
+            logger.info(
+                "Aborting superseded push token registration (generation \(generation, privacy: .public) < \(activeGeneration, privacy: .public))"
             )
             return
         }
@@ -289,7 +344,6 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
             guard let self else { return }
 
-            // Treat network errors, non-2xx HTTP, and GraphQL errors as failures.
             var failureReason: String?
             if let error = error {
                 failureReason = error.localizedDescription
@@ -306,7 +360,10 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
                     self.logger.warning(
                         "Push token registration attempt \(attemptIndex + 1, privacy: .public) failed (\(failureReason, privacy: .public)); retrying in \(self.pushRegistrationRetryDelays[nextAttemptIndex], privacy: .public)s"
                     )
-                    self.scheduleRegistrationAttempt(token: token, sessionId: sessionId, serverUrl: serverUrl, attemptIndex: nextAttemptIndex)
+                    self.scheduleRegistrationAttempt(
+                        token: token, sessionId: sessionId, serverUrl: serverUrl,
+                        attemptIndex: nextAttemptIndex, generation: generation
+                    )
                 } else {
                     self.logger.error(
                         "Push token registration failed after \(self.pushRegistrationRetryDelays.count, privacy: .public) attempts (\(failureReason, privacy: .public)); pending record retained for foreground retry"
@@ -315,28 +372,41 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
                 return
             }
 
-            self.clearPendingRegistration()
+            // Only clear the pending record if it still describes this
+            // (token, sessionId). A later startSession may have already
+            // written a fresh record we mustn't wipe.
+            self.clearPendingRegistrationIfMatches(token: token, sessionId: sessionId)
             self.logger.info("Push token registered with backend (attempt \(attemptIndex + 1, privacy: .public))")
         }.resume()
     }
 
     /// Trigger another registration attempt from any persisted pending record.
     /// Called on app foreground and on WebSocket reconnect.
+    ///
+    /// If the pending record is for a different session than the currently
+    /// active one (force-quit during session A, started session B), drop the
+    /// orphan rather than letting it accumulate in the keychain across
+    /// installs.
     private func retryPendingRegistrationIfNeeded(trigger: String) {
         guard let pending = readPendingRegistration() else { return }
         let activeSessionId = tokenQueue.sync { _currentSessionId }
         if let activeSessionId, activeSessionId != pending.sessionId {
             logger.info(
-                "Skipping pending push registration (\(trigger, privacy: .public)): active session \(activeSessionId, privacy: .public) ≠ pending \(pending.sessionId, privacy: .public)"
+                "Discarding orphan pending push registration (\(trigger, privacy: .public)): active session \(activeSessionId, privacy: .public) ≠ pending \(pending.sessionId, privacy: .public)"
             )
+            clearPendingRegistration()
+            return
+        }
+        if activeSessionId == nil {
+            // No session is active — nothing to register against. Wait for
+            // the next startSession to either re-register or clear.
             return
         }
         logger.info("Retrying pending push token registration (\(trigger, privacy: .public))")
-        scheduleRegistrationAttempt(
+        registerPushTokenWithBackend(
             token: pending.token,
             sessionId: pending.sessionId,
-            serverUrl: pending.serverUrl,
-            attemptIndex: 0
+            serverUrl: pending.serverUrl
         )
     }
 

--- a/mobile/ios/App/App/LiveActivityPlugin.swift
+++ b/mobile/ios/App/App/LiveActivityPlugin.swift
@@ -126,11 +126,14 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         let (token, sessionId, serverUrl) = tokenQueue.sync {
             (_currentPushToken, _currentSessionId, _currentServerUrl)
         }
-        // Clear the widget-readable copy so the widget reverts to an
-        // un-authenticated request (which the backend handles by simply
-        // returning 401 → Darwin notification fallback) until we get a fresh
-        // token registration in.
-        SharedKeychain.remove(SharedKeychain.livePushTokenKey)
+        // Leave `livePushTokenKey` in the keychain so the widget keeps sending
+        // the same Bearer while we re-register. Once the backend rebinds the
+        // token to the current session, the widget's next call returns 200
+        // without needing a new token. Wiping the keychain here would make
+        // widget requests authenticate as 401 (not 410) during the ~50s
+        // retry window, which doesn't trigger the Darwin notification
+        // fallback — so the widget would silently fail buttons until the
+        // foreground observer eventually runs.
         if let token, let sessionId, let serverUrl {
             logger.info("Re-registering push token after widget 410")
             registerPushTokenWithBackend(token: token, sessionId: sessionId, serverUrl: serverUrl)

--- a/mobile/ios/App/App/SessionWebSocketManager.swift
+++ b/mobile/ios/App/App/SessionWebSocketManager.swift
@@ -201,6 +201,16 @@ final class SessionWebSocketManager {
         set { stateQueue.sync { _onQueueStateChanged = newValue } }
     }
 
+    /// Fires every time the WebSocket transitions to the connected state
+    /// (initial connect AND reconnects). Used by `LiveActivityPlugin` to retry
+    /// pending push-token registrations that failed while we were offline.
+    private var _onConnected: (() -> Void)?
+
+    var onConnected: (() -> Void)? {
+        get { stateQueue.sync { _onConnected } }
+        set { stateQueue.sync { _onConnected = newValue } }
+    }
+
     // MARK: - Configuration
 
     private(set) var sessionId: String?
@@ -547,6 +557,13 @@ final class SessionWebSocketManager {
                 self.reconnectAttempt = 0
                 self.sendJoinSession()
                 self.sendSubscription()
+                // Fire after join/subscribe so observers can rely on the
+                // session being usable when they're invoked.
+                if let onConnected = self._onConnected {
+                    DispatchQueue.main.async {
+                        onConnected()
+                    }
+                }
             }
             startPingTimeoutTimer()
 

--- a/mobile/ios/App/App/SharedConstants.swift
+++ b/mobile/ios/App/App/SharedConstants.swift
@@ -29,6 +29,11 @@ enum SharedConstants {
 
     static let queueNavigateNotification = "com.boardsesh.app.queueNavigate"
 
+    /// Fired by the widget extension when `/api/widget/navigate` responds 410
+    /// Gone, signaling that the cached APNs push token is bound to a different
+    /// session and the main app should re-register.
+    static let pushRegistrationStaleNotification = "com.boardsesh.app.pushRegistrationStale"
+
     // MARK: Live Activity
 
     /// Minimum seconds between consecutive ActivityKit pushes.

--- a/mobile/ios/App/App/SharedKeychain.swift
+++ b/mobile/ios/App/App/SharedKeychain.swift
@@ -54,6 +54,11 @@ enum SharedKeychain {
 
     static let authTokenKey = "bs_auth_token"
     static let livePushTokenKey = "bs_live_push_token"
+    /// Persisted record describing a push-token registration that didn't make
+    /// it through to the backend yet. Stored as JSON. Cleared on success and
+    /// on session end. Schema:
+    /// `{"token": "...", "sessionId": "...", "serverUrl": "https://..."}`
+    static let pendingPushRegistrationKey = "bs_pending_push_registration"
 
     // MARK: - Public API
 

--- a/mobile/ios/App/BoardseshWidgets/WidgetNetworking.swift
+++ b/mobile/ios/App/BoardseshWidgets/WidgetNetworking.swift
@@ -48,11 +48,13 @@ enum WidgetNetworking {
             if statusCode == 410 {
                 // The push token was rebound to a different session (the main
                 // app joined another session on the same device). Post the
-                // Darwin notification BEFORE the keychain delete — iOS can
-                // suspend the widget extension at any point once URLSession
-                // returns, and we'd rather the main app get the re-register
-                // signal than wake up to a wiped widget token with no hint
-                // about why it's gone.
+                // Darwin notification so the main app re-registers; do NOT
+                // clear the keychain entry. The Bearer is still the right
+                // APNs token — the backend just needs to update its
+                // (token, sessionId) mapping. Wiping the keychain here would
+                // turn subsequent widget calls into 401s (no Bearer), which
+                // do NOT trigger the Darwin notification, so the widget
+                // would silently fail until the foreground observer runs.
                 print("[Widget] Navigation request received 410; signaling re-registration")
                 let name = CFNotificationName(SharedConstants.pushRegistrationStaleNotification as CFString)
                 CFNotificationCenterPostNotification(
@@ -62,7 +64,6 @@ enum WidgetNetworking {
                     nil,
                     true
                 )
-                SharedKeychain.remove(SharedKeychain.livePushTokenKey)
                 return false
             }
             print("[Widget] Navigation request failed with status \(statusCode)")

--- a/mobile/ios/App/BoardseshWidgets/WidgetNetworking.swift
+++ b/mobile/ios/App/BoardseshWidgets/WidgetNetworking.swift
@@ -41,10 +41,29 @@ enum WidgetNetworking {
 
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
-            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            if statusCode == 200 {
                 return true
             }
-            print("[Widget] Navigation request failed with status \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+            if statusCode == 410 {
+                // The push token was rebound to a different session (the main
+                // app joined another session on the same device). Drop the
+                // cached widget token so we stop sending an authoritative-
+                // looking Bearer with stale binding, and ping the main app
+                // via Darwin notification so it can re-register.
+                print("[Widget] Navigation request received 410; signaling re-registration")
+                SharedKeychain.remove(SharedKeychain.livePushTokenKey)
+                let name = CFNotificationName(SharedConstants.pushRegistrationStaleNotification as CFString)
+                CFNotificationCenterPostNotification(
+                    CFNotificationCenterGetDarwinNotifyCenter(),
+                    name,
+                    nil,
+                    nil,
+                    true
+                )
+                return false
+            }
+            print("[Widget] Navigation request failed with status \(statusCode)")
             return false
         } catch {
             print("[Widget] Navigation request failed: \(error.localizedDescription)")

--- a/mobile/ios/App/BoardseshWidgets/WidgetNetworking.swift
+++ b/mobile/ios/App/BoardseshWidgets/WidgetNetworking.swift
@@ -47,12 +47,13 @@ enum WidgetNetworking {
             }
             if statusCode == 410 {
                 // The push token was rebound to a different session (the main
-                // app joined another session on the same device). Drop the
-                // cached widget token so we stop sending an authoritative-
-                // looking Bearer with stale binding, and ping the main app
-                // via Darwin notification so it can re-register.
+                // app joined another session on the same device). Post the
+                // Darwin notification BEFORE the keychain delete — iOS can
+                // suspend the widget extension at any point once URLSession
+                // returns, and we'd rather the main app get the re-register
+                // signal than wake up to a wiped widget token with no hint
+                // about why it's gone.
                 print("[Widget] Navigation request received 410; signaling re-registration")
-                SharedKeychain.remove(SharedKeychain.livePushTokenKey)
                 let name = CFNotificationName(SharedConstants.pushRegistrationStaleNotification as CFString)
                 CFNotificationCenterPostNotification(
                     CFNotificationCenterGetDarwinNotifyCenter(),
@@ -61,6 +62,7 @@ enum WidgetNetworking {
                     nil,
                     true
                 )
+                SharedKeychain.remove(SharedKeychain.livePushTokenKey)
                 return false
             }
             print("[Widget] Navigation request failed with status \(statusCode)")

--- a/packages/backend/src/__tests__/apns-cleanup.test.ts
+++ b/packages/backend/src/__tests__/apns-cleanup.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for the APNs stale-token cleanup sweep.
+ *
+ * Verifies:
+ * - Skips when APNs is not configured.
+ * - Issues a DELETE filtered by `updated_at < cutoff`.
+ * - Increments tokensSweptStale by the number of deleted rows.
+ * - Skips the metric increment when nothing was deleted.
+ * - Logs and swallows DB errors without throwing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vite-plus/test';
+
+const deleteReturningMock = vi.fn<() => Promise<Array<{ token: string }>>>(async () => []);
+const deleteWhereMock = vi.fn(() => ({ returning: deleteReturningMock }));
+
+vi.mock('../db/client', () => ({
+  db: {
+    delete: vi.fn(() => ({ where: deleteWhereMock })),
+  },
+}));
+
+const isApnsConfiguredMock = vi.fn<() => boolean>(() => true);
+const incrementApnsMetricMock = vi.fn<(key: string, delta?: number) => void>();
+
+vi.mock('../services/apns', () => ({
+  isApnsConfigured: () => isApnsConfiguredMock(),
+  incrementApnsMetric: (key: string, delta?: number) => incrementApnsMetricMock(key, delta),
+}));
+
+const { __runCleanupTickForTests } = await import('../services/apns/cleanup');
+
+const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+afterAll(() => {
+  consoleInfoSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+});
+
+describe('runCleanupTick', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isApnsConfiguredMock.mockReturnValue(true);
+    deleteReturningMock.mockResolvedValue([]);
+  });
+
+  it('skips entirely when APNs is not configured', async () => {
+    isApnsConfiguredMock.mockReturnValue(false);
+
+    await __runCleanupTickForTests();
+
+    expect(deleteWhereMock).not.toHaveBeenCalled();
+    expect(incrementApnsMetricMock).not.toHaveBeenCalled();
+  });
+
+  it('issues the delete and does not bump the metric when nothing was stale', async () => {
+    deleteReturningMock.mockResolvedValue([]);
+
+    await __runCleanupTickForTests();
+
+    expect(deleteWhereMock).toHaveBeenCalledTimes(1);
+    expect(incrementApnsMetricMock).not.toHaveBeenCalled();
+  });
+
+  it('increments the metric by the number of deleted rows', async () => {
+    deleteReturningMock.mockResolvedValue([
+      { token: 'a'.repeat(64) },
+      { token: 'b'.repeat(64) },
+      { token: 'c'.repeat(64) },
+    ]);
+
+    await __runCleanupTickForTests();
+
+    expect(incrementApnsMetricMock).toHaveBeenCalledWith('tokensSweptStale', 3);
+    expect(consoleInfoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[APNs Cleanup] Removed 3 push token(s) untouched since'),
+    );
+  });
+
+  it('swallows DB errors without throwing', async () => {
+    const boom = new Error('connection refused');
+    deleteReturningMock.mockRejectedValue(boom);
+
+    await expect(__runCleanupTickForTests()).resolves.toBeUndefined();
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[APNs Cleanup] Failed to remove stale tokens:', boom);
+    expect(incrementApnsMetricMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/apns-heartbeat.test.ts
+++ b/packages/backend/src/__tests__/apns-heartbeat.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the APNs Live Activity heartbeat.
+ *
+ * Verifies:
+ * - Skips when APNs is not configured.
+ * - Acquires the cluster lock; bails when another instance holds it.
+ * - Calls sendLiveActivityUpdate for every session with a registered token.
+ * - Skips sessions where buildContentStateFromQueueState returns null.
+ * - Skips sessions that already have a pending debounced send.
+ * - Increments the heartbeatsSent metric per dispatched session.
+ * - Survives a thrown error in one session without blocking the others.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vite-plus/test';
+import type { QueueState } from '../services/room-manager';
+
+// ---------------------------------------------------------------------------
+// Mocks (hoisted before importing the heartbeat module)
+// ---------------------------------------------------------------------------
+
+const distinctSessionsRows = vi.fn<() => Array<{ sessionId: string }>>(() => []);
+
+vi.mock('../db/client', () => {
+  function makeSelectDistinctChain() {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(async () => distinctSessionsRows());
+    return chain;
+  }
+  return {
+    db: {
+      selectDistinct: vi.fn(() => makeSelectDistinctChain()),
+    },
+  };
+});
+
+const isApnsConfiguredMock = vi.fn<() => boolean>(() => true);
+const hasPendingSendMock = vi.fn<(sessionId: string) => boolean>(() => false);
+const sendLiveActivityUpdateMock = vi.fn<(sessionId: string, state: unknown) => void>();
+const incrementApnsMetricMock = vi.fn<(key: string) => void>();
+
+vi.mock('../services/apns', () => ({
+  isApnsConfigured: () => isApnsConfiguredMock(),
+  hasPendingSend: (sessionId: string) => hasPendingSendMock(sessionId),
+  sendLiveActivityUpdate: (sessionId: string, state: unknown) => sendLiveActivityUpdateMock(sessionId, state),
+  incrementApnsMetric: (key: string) => incrementApnsMetricMock(key),
+}));
+
+const redisIsConnectedMock = vi.fn<() => boolean>(() => true);
+const redisSetMock = vi.fn<(...args: unknown[]) => Promise<string | null>>(async () => 'OK');
+
+vi.mock('../redis/client', () => ({
+  redisClientManager: {
+    isRedisConnected: () => redisIsConnectedMock(),
+    getClients: () => ({
+      publisher: {
+        set: redisSetMock,
+      },
+    }),
+  },
+}));
+
+const { __runHeartbeatTickForTests } = await import('../services/apns/heartbeat');
+
+const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+afterAll(() => {
+  consoleWarnSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeQueueState(sessionLabel: string): QueueState {
+  const item = {
+    uuid: `q-${sessionLabel}`,
+    climb: {
+      uuid: `c-${sessionLabel}`,
+      name: `Test ${sessionLabel}`,
+      difficulty: 'V5',
+      angle: 40,
+    },
+  };
+  return {
+    queue: [item],
+    currentClimbQueueItem: item,
+  } as unknown as QueueState;
+}
+
+function makeRoomManager(stateMap: Record<string, QueueState | Error | null>) {
+  return {
+    getQueueState: vi.fn(async (sessionId: string) => {
+      const entry = stateMap[sessionId];
+      if (entry instanceof Error) throw entry;
+      if (entry === null) {
+        return { queue: [], currentClimbQueueItem: null } as unknown as QueueState;
+      }
+      if (!entry) throw new Error(`unexpected sessionId ${sessionId}`);
+      return entry;
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('runHeartbeatTick', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isApnsConfiguredMock.mockReturnValue(true);
+    hasPendingSendMock.mockReturnValue(false);
+    redisIsConnectedMock.mockReturnValue(true);
+    redisSetMock.mockResolvedValue('OK');
+    distinctSessionsRows.mockReturnValue([]);
+  });
+
+  it('skips entirely when APNs is not configured', async () => {
+    isApnsConfiguredMock.mockReturnValue(false);
+    distinctSessionsRows.mockReturnValue([{ sessionId: 'a' }]);
+    const roomManager = makeRoomManager({ a: makeQueueState('a') });
+
+    await __runHeartbeatTickForTests(roomManager);
+
+    expect(roomManager.getQueueState).not.toHaveBeenCalled();
+    expect(sendLiveActivityUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the tick when another instance holds the lock', async () => {
+    redisSetMock.mockResolvedValue(null); // NX rejected
+    distinctSessionsRows.mockReturnValue([{ sessionId: 'a' }]);
+    const roomManager = makeRoomManager({ a: makeQueueState('a') });
+
+    await __runHeartbeatTickForTests(roomManager);
+
+    expect(roomManager.getQueueState).not.toHaveBeenCalled();
+    expect(sendLiveActivityUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('dispatches one send per session and increments the metric', async () => {
+    distinctSessionsRows.mockReturnValue([{ sessionId: 'a' }, { sessionId: 'b' }]);
+    const roomManager = makeRoomManager({
+      a: makeQueueState('a'),
+      b: makeQueueState('b'),
+    });
+
+    await __runHeartbeatTickForTests(roomManager);
+
+    expect(sendLiveActivityUpdateMock).toHaveBeenCalledTimes(2);
+    expect(sendLiveActivityUpdateMock).toHaveBeenCalledWith('a', expect.objectContaining({ climbUuid: 'c-a' }));
+    expect(sendLiveActivityUpdateMock).toHaveBeenCalledWith('b', expect.objectContaining({ climbUuid: 'c-b' }));
+    expect(incrementApnsMetricMock).toHaveBeenCalledTimes(2);
+    expect(incrementApnsMetricMock).toHaveBeenCalledWith('heartbeatsSent');
+  });
+
+  it('skips sessions whose queue state yields no current item', async () => {
+    distinctSessionsRows.mockReturnValue([{ sessionId: 'a' }, { sessionId: 'b' }]);
+    const roomManager = makeRoomManager({
+      a: null, // no currentClimbQueueItem → builder returns null → skip
+      b: makeQueueState('b'),
+    });
+
+    await __runHeartbeatTickForTests(roomManager);
+
+    expect(sendLiveActivityUpdateMock).toHaveBeenCalledTimes(1);
+    expect(sendLiveActivityUpdateMock).toHaveBeenCalledWith('b', expect.objectContaining({ climbUuid: 'c-b' }));
+  });
+
+  it('skips sessions that already have a pending debounced send', async () => {
+    distinctSessionsRows.mockReturnValue([{ sessionId: 'a' }, { sessionId: 'b' }]);
+    hasPendingSendMock.mockImplementation((sessionId: string) => sessionId === 'a');
+    const roomManager = makeRoomManager({
+      a: makeQueueState('a'),
+      b: makeQueueState('b'),
+    });
+
+    await __runHeartbeatTickForTests(roomManager);
+
+    expect(sendLiveActivityUpdateMock).toHaveBeenCalledTimes(1);
+    expect(sendLiveActivityUpdateMock).toHaveBeenCalledWith('b', expect.anything());
+  });
+
+  it('does not block other sessions when one throws', async () => {
+    distinctSessionsRows.mockReturnValue([{ sessionId: 'a' }, { sessionId: 'b' }]);
+    const roomManager = makeRoomManager({
+      a: new Error('boom'),
+      b: makeQueueState('b'),
+    });
+
+    await __runHeartbeatTickForTests(roomManager);
+
+    expect(sendLiveActivityUpdateMock).toHaveBeenCalledTimes(1);
+    expect(sendLiveActivityUpdateMock).toHaveBeenCalledWith('b', expect.anything());
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[APNs Heartbeat] Failed to build heartbeat state for session a:'),
+      expect.any(Error),
+    );
+  });
+});

--- a/packages/backend/src/__tests__/push-tokens.test.ts
+++ b/packages/backend/src/__tests__/push-tokens.test.ts
@@ -7,16 +7,22 @@
  * - Bad token format is rejected.
  * - Authenticated participant + good token succeeds.
  * - The unregister DELETE is scoped by both token AND sessionId.
+ * - Token rebind is detected and logged.
+ * - Eviction respects the 1-hour freshness window.
+ * - An immediate APNs push is fired for the just-registered token.
  */
 
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vite-plus/test';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { activityPushTokens } from '@boardsesh/db/schema/app';
+import { boardSessionParticipants } from '../db/schema';
 
 // ---------------------------------------------------------------------------
 // Mocks — exercised before the resolver is imported.
 // ---------------------------------------------------------------------------
 
 const participantRows = vi.fn<() => Array<{ sessionId: string }>>(() => []);
+const existingTokenRows = vi.fn<() => Array<{ sessionId: string }>>(() => []);
 const countRows = vi.fn<() => Array<{ value: number }>>(() => [{ value: 0 }]);
 const oldestTokenRows = vi.fn<() => Array<{ token: string }>>(() => []);
 const oldestLimit = vi.fn<(_n: number) => Promise<Array<{ token: string }>>>(async (_n) => oldestTokenRows());
@@ -27,18 +33,28 @@ const insertValuesReturn = { onConflictDoUpdate: insertOnConflictDoUpdate };
 const insertReturn = { values: vi.fn(() => insertValuesReturn) };
 
 vi.mock('../db/client', () => {
-  const limit = vi.fn(async (_n: number) => participantRows());
-
-  // Drizzle-style chain: select().from().where().limit() OR
-  //                     select({...count}).from().where()
+  // Drizzle-style chain: select().from(table).where().limit() OR
+  //                     select(...).from(table).where()   (thenable for count)
+  //                     select(...).from(table).where().orderBy(...).limit() (oldest)
+  //
+  // The chain remembers which table was passed to from(...) so .limit(1) can
+  // dispatch to the right mocked row source: `boardSessionParticipants` →
+  // participantRows (the participant lookup), `activityPushTokens` →
+  // existingTokenRows (the rebind lookup inside the transaction).
   function makeSelectChain() {
+    let currentTable: unknown = null;
     const chain: Record<string, unknown> = {};
-    chain.from = vi.fn(() => chain);
+    chain.from = vi.fn((table: unknown) => {
+      currentTable = table;
+      return chain;
+    });
     chain.where = vi.fn(() => {
-      // For count(): the `where()` is awaited directly. We hand back a thenable.
-      // For participant: a `.limit()` call is appended.
       const result: Record<string, unknown> = {};
-      result.limit = limit;
+      result.limit = vi.fn(async (_n: number) => {
+        if (currentTable === activityPushTokens) return existingTokenRows();
+        if (currentTable === boardSessionParticipants) return participantRows();
+        return [];
+      });
       result.orderBy = vi.fn(() => ({
         limit: oldestLimit,
       }));
@@ -54,11 +70,12 @@ vi.mock('../db/client', () => {
     select: vi.fn(() => makeSelectChain()),
     insert: vi.fn(() => insertReturn),
     delete: vi.fn(() => ({ where: deleteWhere })),
-    // The resolver runs count + delete + insert inside `db.transaction(...)`
-    // under a Postgres advisory lock. The mock transaction just exposes the
-    // same surface and invokes the callback synchronously — `execute` is a
-    // no-op here because the tests don't care about the lock SQL itself,
-    // only about the chained select/delete/insert calls.
+    // The resolver runs the rebind lookup, count, optional eviction and the
+    // insert inside `db.transaction(...)` under a Postgres advisory lock. The
+    // mock transaction just exposes the same surface and invokes the callback
+    // synchronously — `execute` is a no-op here because the tests don't care
+    // about the lock SQL itself, only about the chained select/delete/insert
+    // calls.
     transaction: vi.fn(
       async <T>(callback: (tx: typeof db & { execute: (q: unknown) => Promise<void> }) => Promise<T>): Promise<T> => {
         const tx = {
@@ -72,6 +89,27 @@ vi.mock('../db/client', () => {
 
   return { db };
 });
+
+// Stub the APNs service so the resolver's immediate-send-on-register branch
+// can be observed without touching real APNs state.
+const sendLiveActivityUpdateToTokensMock = vi.fn(async () => undefined);
+const isApnsConfiguredMock = vi.fn(() => false);
+const incrementApnsMetricMock = vi.fn();
+
+vi.mock('../services/apns', () => ({
+  isApnsConfigured: () => isApnsConfiguredMock(),
+  sendLiveActivityUpdateToTokens: sendLiveActivityUpdateToTokensMock,
+  incrementApnsMetric: incrementApnsMetricMock,
+}));
+
+vi.mock('../services/room-manager', () => ({
+  roomManager: {
+    getQueueState: vi.fn(async () => ({
+      queue: [{ uuid: 'q1', climb: { uuid: 'c1', name: 'Test', difficulty: 'V5', angle: 40 } }],
+      currentClimbQueueItem: { uuid: 'q1', climb: { uuid: 'c1', name: 'Test', difficulty: 'V5', angle: 40 } },
+    })),
+  },
+}));
 
 const { pushTokenMutations, __resetPushTokenRateLimitForTests } =
   await import('../graphql/resolvers/sessions/push-tokens');
@@ -87,6 +125,7 @@ const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => unde
 const VALID_TOKEN = 'a'.repeat(64); // 64 hex chars
 const INVALID_TOKEN = 'not-a-real-hex-token';
 const SESSION_ID = 'session-test-1';
+const OTHER_SESSION_ID = 'session-test-2';
 const USER_ID = 'user-test-1';
 
 function authedCtx(userId = USER_ID): ConnectionContext {
@@ -107,6 +146,16 @@ function anonCtx(): ConnectionContext {
   };
 }
 
+function resetAllMocks(): void {
+  vi.clearAllMocks();
+  __resetPushTokenRateLimitForTests();
+  participantRows.mockReturnValue([{ sessionId: SESSION_ID }]);
+  existingTokenRows.mockReturnValue([]);
+  countRows.mockReturnValue([{ value: 0 }]);
+  oldestTokenRows.mockReturnValue([]);
+  isApnsConfiguredMock.mockReturnValue(false);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -119,11 +168,7 @@ afterAll(() => {
 
 describe('registerActivityPushToken', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    __resetPushTokenRateLimitForTests();
-    participantRows.mockReturnValue([{ sessionId: SESSION_ID }]);
-    countRows.mockReturnValue([{ value: 0 }]);
-    oldestTokenRows.mockReturnValue([]);
+    resetAllMocks();
   });
 
   it('rejects unauthenticated callers', async () => {
@@ -173,7 +218,40 @@ describe('registerActivityPushToken', () => {
     );
   });
 
-  it('evicts oldest tokens when the per-session cap is reached', async () => {
+  it('logs a rebind warning when an existing token moves between sessions', async () => {
+    existingTokenRows.mockReturnValue([{ sessionId: OTHER_SESSION_ID }]);
+
+    const result = await pushTokenMutations.registerActivityPushToken(
+      undefined,
+      { sessionId: SESSION_ID, token: VALID_TOKEN },
+      authedCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      `[APNs] Rebound token ${VALID_TOKEN.slice(0, 8)}... from session ${OTHER_SESSION_ID} → ${SESSION_ID} (user ${USER_ID})`,
+    );
+    expect(incrementApnsMetricMock).toHaveBeenCalledWith('tokensRebound');
+  });
+
+  it('does not evict when at cap but oldest token is fresh (within 1h)', async () => {
+    // Cap is 8; we report a count of 9 (over cap) but the freshness-filtered
+    // SELECT returns no eviction candidates because every token was updated
+    // in the last hour. The resolver should refuse instead of evicting.
+    countRows.mockReturnValue([{ value: 9 }]);
+    oldestTokenRows.mockReturnValue([]); // no stale candidates
+
+    await expect(
+      pushTokenMutations.registerActivityPushToken(
+        undefined,
+        { sessionId: SESSION_ID, token: VALID_TOKEN },
+        authedCtx(),
+      ),
+    ).rejects.toThrow('Too many active devices');
+    expect(insertReturn.values).not.toHaveBeenCalled();
+  });
+
+  it('evicts oldest tokens when the per-session cap is reached and they are stale', async () => {
     const oldestTokens = [{ token: 'b'.repeat(64) }, { token: 'c'.repeat(64) }];
     countRows.mockReturnValue([{ value: 9 }]);
     oldestTokenRows.mockReturnValue(oldestTokens);
@@ -191,6 +269,46 @@ describe('registerActivityPushToken', () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       `[APNs] Evicting 2 old Live Activity token(s) for session ${SESSION_ID}; cap is 8`,
     );
+    expect(incrementApnsMetricMock).toHaveBeenCalledWith('tokensEvicted');
+  });
+
+  it('does not enforce the cap when upserting an existing token in the same session', async () => {
+    // Rebind for the same session = no row growth = cap shouldn't apply even
+    // if we're already at 9.
+    existingTokenRows.mockReturnValue([{ sessionId: SESSION_ID }]);
+    countRows.mockReturnValue([{ value: 9 }]);
+    oldestTokenRows.mockReturnValue([]);
+
+    const result = await pushTokenMutations.registerActivityPushToken(
+      undefined,
+      { sessionId: SESSION_ID, token: VALID_TOKEN },
+      authedCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(insertOnConflictDoUpdate).toHaveBeenCalled();
+  });
+
+  it('triggers an immediate APNs send when APNs is configured', async () => {
+    isApnsConfiguredMock.mockReturnValue(true);
+    sendLiveActivityUpdateToTokensMock.mockResolvedValue(undefined);
+
+    const result = await pushTokenMutations.registerActivityPushToken(
+      undefined,
+      { sessionId: SESSION_ID, token: VALID_TOKEN },
+      authedCtx(),
+    );
+
+    expect(result).toBe(true);
+    // The immediate send is fire-and-forget; flush microtasks so the test
+    // observes the call.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(sendLiveActivityUpdateToTokensMock).toHaveBeenCalledWith(
+      SESSION_ID,
+      [VALID_TOKEN],
+      expect.objectContaining({ climbUuid: 'c1' }),
+      { source: 'registration' },
+    );
   });
 
   it('rejects empty sessionId or token', async () => {
@@ -205,9 +323,7 @@ describe('registerActivityPushToken', () => {
 
 describe('unregisterActivityPushToken', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    __resetPushTokenRateLimitForTests();
-    participantRows.mockReturnValue([{ sessionId: SESSION_ID }]);
+    resetAllMocks();
   });
 
   it('rejects unauthenticated callers', async () => {
@@ -260,11 +376,7 @@ describe('unregisterActivityPushToken', () => {
 
 describe('rate limiting', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    __resetPushTokenRateLimitForTests();
-    participantRows.mockReturnValue([{ sessionId: SESSION_ID }]);
-    countRows.mockReturnValue([{ value: 0 }]);
-    oldestTokenRows.mockReturnValue([]);
+    resetAllMocks();
     deleteWhere.mockResolvedValue(undefined);
   });
 

--- a/packages/backend/src/__tests__/push-tokens.test.ts
+++ b/packages/backend/src/__tests__/push-tokens.test.ts
@@ -218,6 +218,22 @@ describe('registerActivityPushToken', () => {
     );
   });
 
+  it('does NOT fire an immediate APNs send when APNs is not configured', async () => {
+    // Default mock returns false; this test makes that contract explicit so a
+    // regression in the `isApnsConfigured()` guard would fail loudly.
+    isApnsConfiguredMock.mockReturnValue(false);
+
+    const result = await pushTokenMutations.registerActivityPushToken(
+      undefined,
+      { sessionId: SESSION_ID, token: VALID_TOKEN },
+      authedCtx(),
+    );
+
+    expect(result).toBe(true);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(sendLiveActivityUpdateToTokensMock).not.toHaveBeenCalled();
+  });
+
   it('logs a rebind warning when an existing token moves between sessions', async () => {
     existingTokenRows.mockReturnValue([{ sessionId: OTHER_SESSION_ID }]);
 

--- a/packages/backend/src/__tests__/widget-navigate.test.ts
+++ b/packages/backend/src/__tests__/widget-navigate.test.ts
@@ -16,7 +16,11 @@ import { EventEmitter } from 'node:events';
 // Mocks (must be hoisted before importing the handler)
 // ---------------------------------------------------------------------------
 
-const tokenLookupRows = vi.fn<() => Array<{ token: string }>>(() => []);
+// The handler now looks up `(token,)` (not `(token, sessionId)`) so the
+// returned row's `sessionId` can distinguish "no row at all → 401" from
+// "row exists but bound to a different session → 410". The mock returns
+// `{sessionId}` rows accordingly.
+const tokenLookupRows = vi.fn<() => Array<{ sessionId: string }>>(() => []);
 
 vi.mock('../db/client', () => {
   function makeChain() {
@@ -159,7 +163,7 @@ describe('handleWidgetNavigate', () => {
     expect(parsed.success).toBe(false);
   });
 
-  it('returns 401 when bearer token is not registered for sessionId', async () => {
+  it('returns 401 when bearer token is not in the table at all', async () => {
     tokenLookupRows.mockReturnValue([]); // no matching row
     const req = makeRequest({
       method: 'POST',
@@ -172,8 +176,27 @@ describe('handleWidgetNavigate', () => {
     expect(res.statusCode).toBe(401);
   });
 
+  it('returns 410 when bearer token is bound to a different sessionId', async () => {
+    // Token exists in the DB but is bound to a different session — signal
+    // the widget to re-register rather than silently 401.
+    tokenLookupRows.mockReturnValue([{ sessionId: 'session-other' }]);
+    const req = makeRequest({
+      method: 'POST',
+      authHeader: `Bearer ${REGISTERED_TOKEN}`,
+      body: { sessionId: SESSION_ID, action: 'next', currentIndex: 0 },
+    });
+    const res = makeResponse();
+    await handleWidgetNavigate(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+
+    expect(res.statusCode).toBe(410);
+    const parsed = JSON.parse(res.body) as { success: boolean; error: string };
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain('re-register');
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('returns 200 when bearer token is registered for sessionId', async () => {
-    tokenLookupRows.mockReturnValue([{ token: REGISTERED_TOKEN }]);
+    tokenLookupRows.mockReturnValue([{ sessionId: SESSION_ID }]);
     const req = makeRequest({
       method: 'POST',
       authHeader: `Bearer ${REGISTERED_TOKEN}`,
@@ -189,7 +212,7 @@ describe('handleWidgetNavigate', () => {
   });
 
   it('returns 429 once the per-session token bucket is exhausted', async () => {
-    tokenLookupRows.mockReturnValue([{ token: REGISTERED_TOKEN }]);
+    tokenLookupRows.mockReturnValue([{ sessionId: SESSION_ID }]);
 
     // Bucket capacity is 2 — first two requests allowed, third returns 429.
     for (let i = 0; i < 2; i++) {

--- a/packages/backend/src/graphql/resolvers/sessions/push-tokens.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/push-tokens.ts
@@ -1,8 +1,15 @@
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { activityPushTokens } from '@boardsesh/db/schema/app';
 import { boardSessionParticipants } from '../../../db/schema';
-import { and, count, eq, sql } from 'drizzle-orm';
+import { and, count, eq, lt, sql } from 'drizzle-orm';
 import { db } from '../../../db/client';
+import {
+  incrementApnsMetric,
+  isApnsConfigured,
+  sendLiveActivityUpdateToTokens,
+  type LiveActivityContentState,
+} from '../../../services/apns';
+import { roomManager } from '../../../services/room-manager';
 
 /**
  * APNs ActivityKit device tokens are 32-byte values rendered as hex strings,
@@ -15,6 +22,16 @@ const APNS_TOKEN_PATTERN = /^[0-9a-fA-F]{32,128}$/;
 /** Per-session cap on registered push tokens. Bounds blast radius if a single
  *  session somehow accumulates many tokens (e.g. user reinstalls repeatedly). */
 const MAX_TOKENS_PER_SESSION = 8;
+
+/**
+ * Eviction freshness window. When the cap is hit we only evict tokens that
+ * haven't been touched in over an hour, so a burst of fresh registrations
+ * cannot wipe an active device's still-valid token. If every slot is
+ * fresh-but-saturated (8 distinct active devices in one session), the new
+ * registration is rejected with a clear error and iOS retries later via the
+ * pending-registration flow in `LiveActivityPlugin.swift`.
+ */
+const EVICTION_FRESHNESS_WINDOW_MS = 60 * 60 * 1000;
 
 /**
  * Per-(userId, sessionId) token bucket protecting the push-token mutations
@@ -112,11 +129,46 @@ function describeSessionForLog(sessionId: string | null | undefined): string {
   return sessionId || '<missing>';
 }
 
+/**
+ * Build a Live Activity content state from the current queue state for a
+ * session, or null if the queue is empty / has no current item.
+ *
+ * Shared with the queue-event hook in server.ts; kept here as a small helper
+ * so the resolver doesn't grow a manual dependency on roomManager internals.
+ */
+async function buildContentStateForSession(sessionId: string): Promise<LiveActivityContentState | null> {
+  try {
+    const queueState = await roomManager.getQueueState(sessionId);
+    const currentItem = queueState.currentClimbQueueItem;
+    if (!currentItem) return null;
+
+    const currentIndex = queueState.queue.findIndex((item) => item.uuid === currentItem.uuid);
+
+    return {
+      climbName: currentItem.climb.name,
+      climbDifficulty: currentItem.climb.difficulty,
+      angle: currentItem.climb.angle,
+      currentIndex: currentIndex >= 0 ? currentIndex : 0,
+      totalClimbs: queueState.queue.length,
+      hasNext: currentIndex >= 0 && currentIndex < queueState.queue.length - 1,
+      hasPrevious: currentIndex > 0,
+      climbUuid: currentItem.climb.uuid,
+    };
+  } catch (error) {
+    console.warn(`[APNs] Failed to build content state for session ${sessionId} during token registration:`, error);
+    return null;
+  }
+}
+
 export const pushTokenMutations = {
   /**
    * Register (upsert) an APNs device token for Live Activity push updates.
    * Requires authentication and that the caller is a participant in the session.
    * If the token already exists, updates the associated sessionId and updatedAt.
+   *
+   * On success, immediately dispatches a single APNs push to the newly
+   * registered token so the lock-screen widget shows real content instead of
+   * "Loading…" without waiting for the next organic queue event.
    */
   registerActivityPushToken: async (
     _: unknown,
@@ -158,12 +210,12 @@ export const pushTokenMutations = {
       throw new Error('Unauthorized: not a participant in this session');
     }
 
-    // Bound the number of tokens per session.
+    // Bound the number of tokens per session and detect rebinding.
     //
-    // Run count + delete + insert inside one transaction with a per-session
-    // Postgres advisory lock so concurrent registrations against the same
-    // session serialize at the lock. Without this, two requests could both
-    // observe currentCount = cap - 1, both skip the eviction, and both
+    // Run lookup + (optional) eviction + insert inside one transaction with a
+    // per-session Postgres advisory lock so concurrent registrations against
+    // the same session serialize at the lock. Without this, two requests could
+    // both observe currentCount = cap - 1, both skip the eviction, and both
     // insert, ending up at cap + 1. The advisory lock auto-releases at
     // transaction end (`_xact_` variant) so we don't have to clean up on
     // error paths.
@@ -171,28 +223,56 @@ export const pushTokenMutations = {
       await db.transaction(async (tx) => {
         await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${sessionId}))`);
 
+        // F4: detect token rebinding. Reading the existing row inside the
+        // lock means we get a consistent before/after view in the same txn.
+        const existingRows = await tx
+          .select({ sessionId: activityPushTokens.sessionId })
+          .from(activityPushTokens)
+          .where(eq(activityPushTokens.token, token))
+          .limit(1);
+        const previousSessionId = existingRows[0]?.sessionId ?? null;
+        if (previousSessionId && previousSessionId !== sessionId) {
+          incrementApnsMetric('tokensRebound');
+          console.warn(
+            `[APNs] Rebound token ${describeTokenForLog(token)} from session ${previousSessionId} → ${sessionId} (user ${ctx.userId})`,
+          );
+        }
+
         const [{ value: currentCount } = { value: 0 }] = await tx
           .select({ value: count() })
           .from(activityPushTokens)
           .where(eq(activityPushTokens.sessionId, sessionId));
 
-        if (currentCount >= MAX_TOKENS_PER_SESSION) {
+        // Only enforce the cap if this is a *new* registration for the
+        // session. A rebind/upsert of an existing token doesn't grow the row
+        // count, so it should never be blocked by the cap.
+        const isNewRegistration = previousSessionId !== sessionId;
+        if (isNewRegistration && currentCount >= MAX_TOKENS_PER_SESSION) {
           const evictionCount = currentCount - MAX_TOKENS_PER_SESSION + 1;
+          const freshnessCutoff = new Date(Date.now() - EVICTION_FRESHNESS_WINDOW_MS);
           const oldest = await tx
             .select({ token: activityPushTokens.token })
             .from(activityPushTokens)
-            .where(eq(activityPushTokens.sessionId, sessionId))
+            .where(and(eq(activityPushTokens.sessionId, sessionId), lt(activityPushTokens.updatedAt, freshnessCutoff)))
             .orderBy(activityPushTokens.updatedAt)
             .limit(evictionCount);
 
-          if (oldest.length > 0) {
+          if (oldest.length < evictionCount) {
+            // Every slot is occupied by a fresh registration. Refuse rather
+            // than evict a still-valid token. iOS will retry later.
             console.warn(
-              `[APNs] Evicting ${String(oldest.length)} old Live Activity token(s) for session ${sessionId}; cap is ${String(MAX_TOKENS_PER_SESSION)}`,
+              `[APNs] Refusing Live Activity token registration for session ${sessionId}: ` +
+                `all ${String(MAX_TOKENS_PER_SESSION)} slots used by tokens registered within the last hour`,
             );
+            throw new Error('Too many active devices for this session right now; please retry shortly');
           }
 
+          console.warn(
+            `[APNs] Evicting ${String(oldest.length)} old Live Activity token(s) for session ${sessionId}; cap is ${String(MAX_TOKENS_PER_SESSION)}`,
+          );
           for (const row of oldest) {
             await tx.delete(activityPushTokens).where(eq(activityPushTokens.token, row.token));
+            incrementApnsMetric('tokensEvicted');
           }
         }
 
@@ -218,7 +298,27 @@ export const pushTokenMutations = {
       throw error;
     }
 
+    incrementApnsMetric('tokensRegistered');
     console.info(`[APNs] Registered Live Activity token for session ${sessionId}: ${describeTokenForLog(token)}`);
+
+    // F3: fire a single, debounce-bypassing APNs push to the newly registered
+    // token so the widget exits "Loading…" right away. Fire-and-forget — the
+    // resolver still returns `true` even if the immediate send fails, because
+    // the next queue event or the heartbeat loop will pick up the slack.
+    if (isApnsConfigured()) {
+      void (async () => {
+        const state = await buildContentStateForSession(sessionId);
+        if (!state) return;
+        try {
+          await sendLiveActivityUpdateToTokens(sessionId, [token], state, { source: 'registration' });
+        } catch (error) {
+          console.warn(
+            `[APNs] Failed initial Live Activity send for session ${sessionId} (${describeTokenForLog(token)}):`,
+            error,
+          );
+        }
+      })();
+    }
 
     return true;
   },

--- a/packages/backend/src/graphql/resolvers/sessions/push-tokens.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/push-tokens.ts
@@ -9,6 +9,7 @@ import {
   sendLiveActivityUpdateToTokens,
   type LiveActivityContentState,
 } from '../../../services/apns';
+import { buildContentStateFromQueueState } from '../../../services/apns/content-state';
 import { roomManager } from '../../../services/room-manager';
 
 /**
@@ -22,6 +23,15 @@ const APNS_TOKEN_PATTERN = /^[0-9a-fA-F]{32,128}$/;
 /** Per-session cap on registered push tokens. Bounds blast radius if a single
  *  session somehow accumulates many tokens (e.g. user reinstalls repeatedly). */
 const MAX_TOKENS_PER_SESSION = 8;
+
+/**
+ * Advisory-lock namespace for push-token operations. `pg_advisory_xact_lock`
+ * uses a global lock space, so two unrelated callers that hash to the same
+ * 32-bit key contend on the same lock. The two-int form namespaces the lock
+ * by an arbitrary first arg — `0x70757368` is ASCII "push". Any other
+ * advisory-lock user in this codebase should pick a distinct namespace.
+ */
+const PUSH_TOKEN_LOCK_NAMESPACE = 0x70757368;
 
 /**
  * Eviction freshness window. When the cap is hit we only evict tokens that
@@ -129,31 +139,10 @@ function describeSessionForLog(sessionId: string | null | undefined): string {
   return sessionId || '<missing>';
 }
 
-/**
- * Build a Live Activity content state from the current queue state for a
- * session, or null if the queue is empty / has no current item.
- *
- * Shared with the queue-event hook in server.ts; kept here as a small helper
- * so the resolver doesn't grow a manual dependency on roomManager internals.
- */
 async function buildContentStateForSession(sessionId: string): Promise<LiveActivityContentState | null> {
   try {
     const queueState = await roomManager.getQueueState(sessionId);
-    const currentItem = queueState.currentClimbQueueItem;
-    if (!currentItem) return null;
-
-    const currentIndex = queueState.queue.findIndex((item) => item.uuid === currentItem.uuid);
-
-    return {
-      climbName: currentItem.climb.name,
-      climbDifficulty: currentItem.climb.difficulty,
-      angle: currentItem.climb.angle,
-      currentIndex: currentIndex >= 0 ? currentIndex : 0,
-      totalClimbs: queueState.queue.length,
-      hasNext: currentIndex >= 0 && currentIndex < queueState.queue.length - 1,
-      hasPrevious: currentIndex > 0,
-      climbUuid: currentItem.climb.uuid,
-    };
+    return buildContentStateFromQueueState(queueState);
   } catch (error) {
     console.warn(`[APNs] Failed to build content state for session ${sessionId} during token registration:`, error);
     return null;
@@ -221,7 +210,7 @@ export const pushTokenMutations = {
     // error paths.
     try {
       await db.transaction(async (tx) => {
-        await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${sessionId}))`);
+        await tx.execute(sql`SELECT pg_advisory_xact_lock(${PUSH_TOKEN_LOCK_NAMESPACE}, hashtext(${sessionId}))`);
 
         // F4: detect token rebinding. Reading the existing row inside the
         // lock means we get a consistent before/after view in the same txn.

--- a/packages/backend/src/handlers/apns-stats.ts
+++ b/packages/backend/src/handlers/apns-stats.ts
@@ -4,6 +4,11 @@ import { getApnsMetrics } from '../services/apns';
 
 const APNS_STATS_SECRET = process.env.APNS_STATS_SECRET;
 
+// The same identifier convention used by `server.ts` for the multi-instance
+// config marker. Including it in the response makes the endpoint useful in a
+// multi-instance deploy — without it you can't tell which node responded.
+const INSTANCE_ID = process.env.HOSTNAME || process.env.FLY_MACHINE_ID || 'local';
+
 /**
  * GET /api/internal/apns-stats
  *
@@ -15,12 +20,6 @@ const APNS_STATS_SECRET = process.env.APNS_STATS_SECRET;
  */
 export async function handleApnsStats(req: IncomingMessage, res: ServerResponse): Promise<void> {
   if (!applyCorsHeaders(req, res)) return;
-
-  if (req.method === 'OPTIONS') {
-    res.writeHead(200);
-    res.end();
-    return;
-  }
 
   if (req.method !== 'GET') {
     res.writeHead(405, { 'Content-Type': 'application/json' });
@@ -43,5 +42,5 @@ export async function handleApnsStats(req: IncomingMessage, res: ServerResponse)
   }
 
   res.writeHead(200, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify(getApnsMetrics()));
+  res.end(JSON.stringify({ instanceId: INSTANCE_ID, ...getApnsMetrics() }));
 }

--- a/packages/backend/src/handlers/apns-stats.ts
+++ b/packages/backend/src/handlers/apns-stats.ts
@@ -1,0 +1,47 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+import { applyCorsHeaders } from './cors';
+import { getApnsMetrics } from '../services/apns';
+
+const APNS_STATS_SECRET = process.env.APNS_STATS_SECRET;
+
+/**
+ * GET /api/internal/apns-stats
+ *
+ * Returns the in-memory APNs metrics counters for the current process. Counters
+ * reset on restart — this is a debugging aid, not a long-term metrics store.
+ *
+ * Gated on the optional `APNS_STATS_SECRET` env var, matching the pattern used
+ * by `/sync-cron`. If the env var is unset the endpoint is disabled.
+ */
+export async function handleApnsStats(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (!applyCorsHeaders(req, res)) return;
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(200);
+    res.end();
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.writeHead(405, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Method not allowed' }));
+    return;
+  }
+
+  if (!APNS_STATS_SECRET) {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+    return;
+  }
+
+  const authHeader = req.headers['authorization'];
+  const authValue = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+  if (authValue !== `Bearer ${APNS_STATS_SECRET}`) {
+    res.writeHead(401, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Unauthorized' }));
+    return;
+  }
+
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(getApnsMetrics()));
+}

--- a/packages/backend/src/handlers/widget-navigate.ts
+++ b/packages/backend/src/handlers/widget-navigate.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'http';
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { activityPushTokens } from '@boardsesh/db/schema/app';
 import { db } from '../db/client';
 import { applyCorsHeaders } from './cors';
@@ -115,24 +115,37 @@ function ensurePrunerRunning(): void {
   if (typeof pruneIntervalHandle.unref === 'function') pruneIntervalHandle.unref();
 }
 
+type AuthResult =
+  | { kind: 'ok' }
+  | { kind: 'missing' } // No bearer at all → 401
+  | { kind: 'unknown' } // Bearer present but no row matches the token → 401
+  | { kind: 'wrong-session'; boundSessionId: string }; // Token exists but bound to a different session → 410
+
 /**
  * Verify that the bearer token in the Authorization header is registered to
  * `sessionId` in `activity_push_tokens`. This is the auth contract the iOS
  * widget honors: the widget reads its APNs Live Activity push token (already
  * registered via `registerActivityPushToken`) and sends it as a Bearer header.
+ *
+ * Distinguishes "token unknown" (genuinely bogus → 401) from "token bound to
+ * a different session" (need to re-register → 410). iOS uses the 410 hint to
+ * fire a fresh `registerActivityPushToken` mutation.
  */
-async function authenticateWidget(authHeader: string | undefined, sessionId: string): Promise<boolean> {
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return false;
+async function authenticateWidget(authHeader: string | undefined, sessionId: string): Promise<AuthResult> {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return { kind: 'missing' };
   const bearer = authHeader.slice(7).trim();
-  if (!bearer) return false;
+  if (!bearer) return { kind: 'missing' };
 
   const rows = await db
-    .select({ token: activityPushTokens.token })
+    .select({ sessionId: activityPushTokens.sessionId })
     .from(activityPushTokens)
-    .where(and(eq(activityPushTokens.token, bearer), eq(activityPushTokens.sessionId, sessionId)))
+    .where(eq(activityPushTokens.token, bearer))
     .limit(1);
 
-  return rows.length > 0;
+  if (rows.length === 0) return { kind: 'unknown' };
+  const boundSessionId = rows[0].sessionId;
+  if (boundSessionId !== sessionId) return { kind: 'wrong-session', boundSessionId };
+  return { kind: 'ok' };
 }
 
 /**
@@ -201,9 +214,9 @@ export async function handleWidgetNavigate(req: IncomingMessage, res: ServerResp
   const authHeader = req.headers['authorization'];
   const authHeaderValue = Array.isArray(authHeader) ? authHeader[0] : authHeader;
 
-  let authorized: boolean;
+  let authResult: AuthResult;
   try {
-    authorized = await authenticateWidget(authHeaderValue, sessionId);
+    authResult = await authenticateWidget(authHeaderValue, sessionId);
   } catch (error) {
     console.error('[WidgetNavigate] Auth lookup failed:', error);
     res.writeHead(500, { 'Content-Type': 'application/json' });
@@ -211,7 +224,18 @@ export async function handleWidgetNavigate(req: IncomingMessage, res: ServerResp
     return;
   }
 
-  if (!authorized) {
+  if (authResult.kind !== 'ok') {
+    if (authResult.kind === 'wrong-session') {
+      // Token is known but bound to a different session. Returning 410 Gone
+      // signals the widget to clear its cached push token and trigger a
+      // re-registration via the main app.
+      console.info(
+        `[WidgetNavigate] Token bound to session ${authResult.boundSessionId}, request was for ${sessionId}; signaling re-register`,
+      );
+      res.writeHead(410, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: false, error: 'Token bound to a different session; re-register' }));
+      return;
+    }
     res.writeHead(401, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ success: false, error: 'Unauthorized' }));
     return;

--- a/packages/backend/src/handlers/widget-navigate.ts
+++ b/packages/backend/src/handlers/widget-navigate.ts
@@ -171,15 +171,10 @@ async function authenticateWidget(authHeader: string | undefined, sessionId: str
 export async function handleWidgetNavigate(req: IncomingMessage, res: ServerResponse): Promise<void> {
   ensurePrunerRunning();
 
-  // CORS headers (allow the widget's URLSession to call this)
+  // CORS headers (allow the widget's URLSession to call this).
+  // applyCorsHeaders already replies 200 for OPTIONS preflight and returns
+  // false, so we short-circuit on that path.
   if (!applyCorsHeaders(req, res)) return;
-
-  // Handle preflight
-  if (req.method === 'OPTIONS') {
-    res.writeHead(200);
-    res.end();
-    return;
-  }
 
   if (req.method !== 'POST') {
     res.writeHead(405, { 'Content-Type': 'application/json' });

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -16,11 +16,14 @@ import { handleOcrTestDataUpload } from './handlers/ocr-test-data';
 import { handlePosthogProxy } from './handlers/posthog';
 import { handleUserDataExport, handleUserDataExportDownload } from './handlers/user-data-export';
 import { handleWidgetNavigate } from './handlers/widget-navigate';
+import { handleApnsStats } from './handlers/apns-stats';
 import { createYogaInstance } from './graphql/yoga';
 import { setupWebSocketServer } from './websocket/setup';
 import { warmPopularConfigsCache } from './graphql/resolvers/social/boards';
 import { warmRecentBetaLinksCache } from './graphql/resolvers/beta-videos/queries';
 import { initializeApns, shutdownApns, sendLiveActivityUpdate, isApnsConfigured } from './services/apns';
+import { startApnsHeartbeat, stopApnsHeartbeat } from './services/apns/heartbeat';
+import { startApnsStaleTokenCleanup, stopApnsStaleTokenCleanup } from './services/apns/cleanup';
 import type { QueueEvent } from '@boardsesh/shared-schema';
 import type { LiveActivityContentState } from './services/apns';
 
@@ -117,6 +120,11 @@ export async function startServer(): Promise<ServerResources> {
     console.info('[Server] No Redis - EventBroker disabled, inline notification fallback active');
   }
 
+  // Holds the F10 multi-instance APNs config marker interval. Set when Redis
+  // is configured (see below); cleared by `shutdownServices` so the timer
+  // doesn't outlive the process during tests.
+  let apnsInstanceConfigInterval: ReturnType<typeof setInterval> | null = null;
+
   // Initialize APNs for iOS Live Activity push notifications
   initializeApns();
 
@@ -129,6 +137,13 @@ export async function startServer(): Promise<ServerResources> {
   const instanceId = process.env.HOSTNAME || process.env.FLY_MACHINE_ID || 'local';
   if (isApnsConfigured()) {
     console.info(`[Server] APNs configured for instance ${instanceId}`);
+    // Heartbeat keeps the lock-screen Live Activity alive during long idle
+    // periods. The 90-s tick re-sends the latest content state for every
+    // session with at least one registered push token.
+    startApnsHeartbeat(roomManager);
+    // Periodic cleanup of week-old push tokens that never had a chance to
+    // bounce back as stale via a real send.
+    startApnsStaleTokenCleanup();
   } else {
     console.warn(
       `[Server] APNs NOT configured on instance ${instanceId}. ` +
@@ -136,6 +151,71 @@ export async function startServer(): Promise<ServerResources> {
         'events that originate on this instance. Set APNS_KEY_ID, APNS_TEAM_ID, ' +
         'and APNS_KEY_CONTENTS on every backend node that handles queue mutations.',
     );
+  }
+
+  // F10: multi-instance APNs configuration sanity check. Each instance writes
+  // its own configured/unconfigured marker to Redis with a 60-s TTL refresh.
+  // If any peer is configured but we are not (or vice-versa) we escalate the
+  // log to ERROR so a half-rolled-out deploy doesn't silently lose pushes.
+  if (redisClientManager.isRedisConfigured()) {
+    const APNS_INSTANCE_KEY_PREFIX = 'boardsesh:apns:instance-config:';
+    const APNS_INSTANCE_TTL_SEC = 60;
+    const APNS_INSTANCE_REFRESH_MS = 30 * 1000;
+
+    async function refreshApnsInstanceConfigMarker(): Promise<void> {
+      if (!redisClientManager.isRedisConnected()) return;
+      try {
+        const { publisher } = redisClientManager.getClients();
+        const key = `${APNS_INSTANCE_KEY_PREFIX}${instanceId}`;
+        await publisher.set(key, isApnsConfigured() ? '1' : '0', 'EX', APNS_INSTANCE_TTL_SEC);
+
+        // Scan peers and detect mixed configuration.
+        let cursor = '0';
+        let configuredPeers = 0;
+        let unconfiguredPeers = 0;
+        do {
+          const [next, keys] = await publisher.scan(cursor, 'MATCH', `${APNS_INSTANCE_KEY_PREFIX}*`, 'COUNT', 100);
+          cursor = next;
+          for (const peerKey of keys) {
+            if (peerKey === key) continue;
+            const value = await publisher.get(peerKey);
+            if (value === '1') configuredPeers++;
+            else if (value === '0') unconfiguredPeers++;
+          }
+        } while (cursor !== '0');
+
+        if (isApnsConfigured() && unconfiguredPeers > 0) {
+          console.error(
+            `[APNs] Mixed cluster configuration detected: ${String(unconfiguredPeers)} peer(s) lack APNs env vars. ` +
+              'Queue events originating on those instances will silently skip Live Activity pushes.',
+          );
+        } else if (!isApnsConfigured() && configuredPeers > 0) {
+          console.error(
+            `[APNs] This instance (${instanceId}) is missing APNs env vars while ${String(configuredPeers)} peer(s) ` +
+              'are configured. Push notifications will be silently dropped for queue events originating here.',
+          );
+        }
+      } catch (error) {
+        console.warn('[APNs] Failed to refresh multi-instance config marker:', error);
+      }
+    }
+
+    // Fire once shortly after startup, then on the refresh interval. The
+    // initial delay lets other instances boot and write their markers so the
+    // first check sees a stable picture.
+    const initialApnsConfigDelay = setTimeout(() => {
+      refreshApnsInstanceConfigMarker().catch((err) => {
+        console.warn('[APNs] Initial config marker refresh failed:', err);
+      });
+    }, 5_000);
+    if (typeof initialApnsConfigDelay.unref === 'function') initialApnsConfigDelay.unref();
+
+    apnsInstanceConfigInterval = setInterval(() => {
+      refreshApnsInstanceConfigMarker().catch((err) => {
+        console.warn('[APNs] Config marker refresh failed:', err);
+      });
+    }, APNS_INSTANCE_REFRESH_MS);
+    if (typeof apnsInstanceConfigInterval.unref === 'function') apnsInstanceConfigInterval.unref();
   }
 
   // Wire PubSub queue events to APNs Live Activity updates.
@@ -281,6 +361,12 @@ export async function startServer(): Promise<ServerResources> {
         return;
       }
 
+      // APNs metrics (debugging aid, gated on APNS_STATS_SECRET)
+      if (pathname === '/api/internal/apns-stats' && (req.method === 'GET' || req.method === 'OPTIONS')) {
+        await handleApnsStats(req, res);
+        return;
+      }
+
       // Sync cron endpoint (triggered by external cron service)
       if (pathname === '/sync-cron' && (req.method === 'POST' || req.method === 'OPTIONS')) {
         await handleSyncCron(req, res);
@@ -380,6 +466,23 @@ export async function startServer(): Promise<ServerResources> {
    */
   async function shutdownServices(): Promise<void> {
     eventBroker.shutdown();
+
+    if (apnsInstanceConfigInterval !== null) {
+      clearInterval(apnsInstanceConfigInterval);
+      apnsInstanceConfigInterval = null;
+    }
+
+    try {
+      stopApnsHeartbeat();
+    } catch (error) {
+      console.error('[Server] Error stopping APNs heartbeat:', error);
+    }
+
+    try {
+      stopApnsStaleTokenCleanup();
+    } catch (error) {
+      console.error('[Server] Error stopping APNs cleanup:', error);
+    }
 
     try {
       await shutdownApns();

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -24,8 +24,8 @@ import { warmRecentBetaLinksCache } from './graphql/resolvers/beta-videos/querie
 import { initializeApns, shutdownApns, sendLiveActivityUpdate, isApnsConfigured } from './services/apns';
 import { startApnsHeartbeat, stopApnsHeartbeat } from './services/apns/heartbeat';
 import { startApnsStaleTokenCleanup, stopApnsStaleTokenCleanup } from './services/apns/cleanup';
+import { buildContentStateFromQueueState } from './services/apns/content-state';
 import type { QueueEvent } from '@boardsesh/shared-schema';
-import type { LiveActivityContentState } from './services/apns';
 
 /**
  * Start the Boardsesh Backend server
@@ -139,8 +139,9 @@ export async function startServer(): Promise<ServerResources> {
     console.info(`[Server] APNs configured for instance ${instanceId}`);
     // Heartbeat keeps the lock-screen Live Activity alive during long idle
     // periods. The 90-s tick re-sends the latest content state for every
-    // session with at least one registered push token.
-    startApnsHeartbeat(roomManager);
+    // session with at least one registered push token. Only one instance in
+    // the cluster runs the sweep on any given tick (Redis lock).
+    startApnsHeartbeat(roomManager, instanceId);
     // Periodic cleanup of week-old push tokens that never had a chance to
     // bounce back as stale via a real send.
     startApnsStaleTokenCleanup();
@@ -153,36 +154,48 @@ export async function startServer(): Promise<ServerResources> {
     );
   }
 
-  // F10: multi-instance APNs configuration sanity check. Each instance writes
-  // its own configured/unconfigured marker to Redis with a 60-s TTL refresh.
-  // If any peer is configured but we are not (or vice-versa) we escalate the
-  // log to ERROR so a half-rolled-out deploy doesn't silently lose pushes.
+  // Multi-instance APNs configuration sanity check. Each instance writes its
+  // own configured/unconfigured marker to a shared Redis hash. If any peer is
+  // configured but we are not (or vice-versa), escalate to ERROR so a
+  // half-rolled-out deploy doesn't silently lose pushes. Stored as a single
+  // hash with HSET + HGETALL so reads are O(1) round-trips regardless of
+  // cluster size, and stale entries time out via per-field expiry simulation
+  // (instance writes its own value every 30 s; markers older than 60 s are
+  // ignored by the freshness check below).
   if (redisClientManager.isRedisConfigured()) {
-    const APNS_INSTANCE_KEY_PREFIX = 'boardsesh:apns:instance-config:';
-    const APNS_INSTANCE_TTL_SEC = 60;
+    const APNS_INSTANCE_HASH_KEY = 'boardsesh:apns:instance-config';
+    const APNS_INSTANCE_STALE_MS = 60 * 1000;
     const APNS_INSTANCE_REFRESH_MS = 30 * 1000;
 
     async function refreshApnsInstanceConfigMarker(): Promise<void> {
       if (!redisClientManager.isRedisConnected()) return;
       try {
         const { publisher } = redisClientManager.getClients();
-        const key = `${APNS_INSTANCE_KEY_PREFIX}${instanceId}`;
-        await publisher.set(key, isApnsConfigured() ? '1' : '0', 'EX', APNS_INSTANCE_TTL_SEC);
+        const now = Date.now();
+        const value = JSON.stringify({ configured: isApnsConfigured(), ts: now });
+        await publisher.hset(APNS_INSTANCE_HASH_KEY, instanceId, value);
 
-        // Scan peers and detect mixed configuration.
-        let cursor = '0';
+        const all = await publisher.hgetall(APNS_INSTANCE_HASH_KEY);
         let configuredPeers = 0;
         let unconfiguredPeers = 0;
-        do {
-          const [next, keys] = await publisher.scan(cursor, 'MATCH', `${APNS_INSTANCE_KEY_PREFIX}*`, 'COUNT', 100);
-          cursor = next;
-          for (const peerKey of keys) {
-            if (peerKey === key) continue;
-            const value = await publisher.get(peerKey);
-            if (value === '1') configuredPeers++;
-            else if (value === '0') unconfiguredPeers++;
+        const stalePeers: string[] = [];
+        for (const [peerId, raw] of Object.entries(all)) {
+          if (peerId === instanceId) continue;
+          try {
+            const parsed = JSON.parse(raw) as { configured: boolean; ts: number };
+            if (now - parsed.ts > APNS_INSTANCE_STALE_MS) {
+              stalePeers.push(peerId);
+              continue;
+            }
+            if (parsed.configured) configuredPeers++;
+            else unconfiguredPeers++;
+          } catch {
+            stalePeers.push(peerId);
           }
-        } while (cursor !== '0');
+        }
+        if (stalePeers.length > 0) {
+          await publisher.hdel(APNS_INSTANCE_HASH_KEY, ...stalePeers);
+        }
 
         if (isApnsConfigured() && unconfiguredPeers > 0) {
           console.error(
@@ -200,9 +213,6 @@ export async function startServer(): Promise<ServerResources> {
       }
     }
 
-    // Fire once shortly after startup, then on the refresh interval. The
-    // initial delay lets other instances boot and write their markers so the
-    // first check sees a stable picture.
     const initialApnsConfigDelay = setTimeout(() => {
       refreshApnsInstanceConfigMarker().catch((err) => {
         console.warn('[APNs] Initial config marker refresh failed:', err);
@@ -242,23 +252,8 @@ export async function startServer(): Promise<ServerResources> {
     void (async () => {
       try {
         const queueState = await roomManager.getQueueState(sessionId);
-        const { queue, currentClimbQueueItem } = queueState;
-
-        if (!currentClimbQueueItem) return;
-
-        const currentIndex = queue.findIndex((item) => item.uuid === currentClimbQueueItem.uuid);
-
-        const contentState: LiveActivityContentState = {
-          climbName: currentClimbQueueItem.climb.name,
-          climbDifficulty: currentClimbQueueItem.climb.difficulty,
-          angle: currentClimbQueueItem.climb.angle,
-          currentIndex: currentIndex >= 0 ? currentIndex : 0,
-          totalClimbs: queue.length,
-          hasNext: currentIndex < queue.length - 1,
-          hasPrevious: currentIndex > 0,
-          climbUuid: currentClimbQueueItem.climb.uuid,
-        };
-
+        const contentState = buildContentStateFromQueueState(queueState);
+        if (!contentState) return;
         sendLiveActivityUpdate(sessionId, contentState);
       } catch (error) {
         console.error(`[APNs Hook] Failed to send Live Activity update for session ${sessionId}:`, error);

--- a/packages/backend/src/services/apns/cleanup.ts
+++ b/packages/backend/src/services/apns/cleanup.ts
@@ -30,7 +30,7 @@ async function runCleanupTick(): Promise<void> {
       .where(lt(activityPushTokens.updatedAt, cutoff))
       .returning({ token: activityPushTokens.token });
     if (result.length > 0) {
-      incrementApnsMetric('tokensCleanedUpStale', result.length);
+      incrementApnsMetric('tokensSweptStale', result.length);
       console.info(
         `[APNs Cleanup] Removed ${String(result.length)} push token(s) untouched since ${cutoff.toISOString()}`,
       );

--- a/packages/backend/src/services/apns/cleanup.ts
+++ b/packages/backend/src/services/apns/cleanup.ts
@@ -1,0 +1,80 @@
+/**
+ * Background cleanup of stale APNs Live Activity tokens.
+ *
+ * Tokens accumulate when iOS devices stop calling the unregister path (app
+ * force-killed, OS reinstall, user removed the Activity manually). Until now
+ * those rows were only cleared as a side-effect of an APNs send returning
+ * 410/BadDeviceToken, which doesn't happen for sessions that have gone idle.
+ *
+ * A week of `updated_at` staleness is a strong signal the device is gone —
+ * every legitimate device re-registers on app foreground / Activity start, and
+ * those paths bump `updated_at` via the UPSERT.
+ */
+
+import { lt } from 'drizzle-orm';
+import { activityPushTokens } from '@boardsesh/db/schema/app';
+import { db } from '../../db/client';
+import { incrementApnsMetric, isApnsConfigured } from './index';
+
+const STALE_TOKEN_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+let cleanupHandle: ReturnType<typeof setInterval> | null = null;
+
+async function runCleanupTick(): Promise<void> {
+  if (!isApnsConfigured()) return;
+  const cutoff = new Date(Date.now() - STALE_TOKEN_AGE_MS);
+  try {
+    const result = await db
+      .delete(activityPushTokens)
+      .where(lt(activityPushTokens.updatedAt, cutoff))
+      .returning({ token: activityPushTokens.token });
+    if (result.length > 0) {
+      incrementApnsMetric('tokensCleanedUpStale', result.length);
+      console.info(
+        `[APNs Cleanup] Removed ${String(result.length)} push token(s) untouched since ${cutoff.toISOString()}`,
+      );
+    }
+  } catch (error) {
+    console.error('[APNs Cleanup] Failed to remove stale tokens:', error);
+  }
+}
+
+/** Start the periodic stale-token cleanup loop. */
+export function startApnsStaleTokenCleanup(): void {
+  if (cleanupHandle !== null) return;
+  console.info(
+    `[APNs Cleanup] Started (interval=${String(CLEANUP_INTERVAL_MS)}ms, ` +
+      `staleAfter=${String(STALE_TOKEN_AGE_MS / (24 * 60 * 60 * 1000))}d)`,
+  );
+
+  // Run once shortly after startup so a fresh deploy benefits immediately,
+  // then on the regular interval. A small delay avoids piling work onto the
+  // process boot.
+  const initialDelay = setTimeout(() => {
+    runCleanupTick().catch((error) => {
+      console.error('[APNs Cleanup] Initial tick failed:', error);
+    });
+  }, 60 * 1000);
+  if (typeof initialDelay.unref === 'function') initialDelay.unref();
+
+  cleanupHandle = setInterval(() => {
+    runCleanupTick().catch((error) => {
+      console.error('[APNs Cleanup] Tick failed:', error);
+    });
+  }, CLEANUP_INTERVAL_MS);
+
+  if (typeof cleanupHandle.unref === 'function') cleanupHandle.unref();
+}
+
+export function stopApnsStaleTokenCleanup(): void {
+  if (cleanupHandle === null) return;
+  clearInterval(cleanupHandle);
+  cleanupHandle = null;
+  console.info('[APNs Cleanup] Stopped');
+}
+
+/** Test-only utility. */
+export async function __runCleanupTickForTests(): Promise<void> {
+  await runCleanupTick();
+}

--- a/packages/backend/src/services/apns/content-state.ts
+++ b/packages/backend/src/services/apns/content-state.ts
@@ -1,0 +1,35 @@
+/**
+ * Single source of truth for building a `LiveActivityContentState` from a
+ * `QueueState`. Called by the queue-event hook, the heartbeat, and the
+ * push-token registration resolver.
+ *
+ * Returns `null` when the session has no current climb (paused / empty queue)
+ * or when the current item's uuid isn't present in the queue array (a
+ * transient drift state that would otherwise produce an incorrect `hasNext`
+ * value with `currentIndex = -1`).
+ */
+
+import type { QueueState } from '../room-manager';
+import type { LiveActivityContentState } from './index';
+
+export function buildContentStateFromQueueState(queueState: QueueState): LiveActivityContentState | null {
+  const currentItem = queueState.currentClimbQueueItem;
+  if (!currentItem) return null;
+
+  const currentIndex = queueState.queue.findIndex((item) => item.uuid === currentItem.uuid);
+  // currentIndex === -1 means the current item is not in the queue array
+  // (transient drift between Postgres and Redis state). Bail rather than
+  // emit a `hasNext: true` push the widget would render incorrectly.
+  if (currentIndex < 0) return null;
+
+  return {
+    climbName: currentItem.climb.name,
+    climbDifficulty: currentItem.climb.difficulty,
+    angle: currentItem.climb.angle,
+    currentIndex,
+    totalClimbs: queueState.queue.length,
+    hasNext: currentIndex < queueState.queue.length - 1,
+    hasPrevious: currentIndex > 0,
+    climbUuid: currentItem.climb.uuid,
+  };
+}

--- a/packages/backend/src/services/apns/heartbeat.ts
+++ b/packages/backend/src/services/apns/heartbeat.ts
@@ -78,6 +78,13 @@ async function acquireHeartbeatLock(instanceId: string): Promise<boolean> {
   }
 }
 
+/**
+ * Run `worker` against each item in `items` with at most `limit` items in
+ * flight at once. Relies on Node.js single-threading: the `const index =
+ * cursor++` claim happens synchronously and is the only mutation point — no
+ * `await` falls between the read and the increment, so two workers cannot
+ * claim the same index. Don't insert an await above the increment.
+ */
 async function processWithConcurrency<T>(items: T[], limit: number, worker: (item: T) => Promise<void>): Promise<void> {
   let cursor = 0;
   async function nextBatch(): Promise<void> {
@@ -111,7 +118,9 @@ async function runHeartbeatTick(roomManager: RoomManagerLike, instanceId: string
     try {
       const state = await buildHeartbeatStateFor(sessionId, roomManager);
       if (!state) return;
-      sendLiveActivityUpdate(sessionId, state);
+      // Pass source so the structured per-send log line attributes the push to
+      // the heartbeat, not a real queue event.
+      sendLiveActivityUpdate(sessionId, state, { source: 'heartbeat' });
       incrementApnsMetric('heartbeatsSent');
     } catch (error) {
       console.warn(`[APNs Heartbeat] Failed to build heartbeat state for session ${sessionId}:`, error);

--- a/packages/backend/src/services/apns/heartbeat.ts
+++ b/packages/backend/src/services/apns/heartbeat.ts
@@ -1,0 +1,124 @@
+/**
+ * APNs Live Activity heartbeat.
+ *
+ * Backgrounded iOS apps lose the native WebSocket, so the only way to keep the
+ * lock-screen Live Activity from going stale (`staleDate = now + 10min` on the
+ * device) is for the server to push an APNs update. Real queue events do that
+ * naturally, but when a session is idle for several minutes the activity would
+ * tip over into "Session ended" before any new event arrives.
+ *
+ * This module runs a periodic sweep every 90 s that re-sends the current
+ * content state for every session with at least one registered push token. It
+ * piggybacks on the existing debounce path, so if a real queue event was
+ * already coalesced into the pending window the heartbeat just gets dropped
+ * harmlessly.
+ */
+
+import { sql } from 'drizzle-orm';
+import { activityPushTokens } from '@boardsesh/db/schema/app';
+import { db } from '../../db/client';
+import { type LiveActivityContentState, incrementApnsMetric, isApnsConfigured, sendLiveActivityUpdate } from './index';
+import type { roomManager as RoomManagerType } from '../room-manager';
+
+/**
+ * 90 s gives 6× headroom against the 10-minute iOS staleInterval. We need to
+ * stay well below the staleInterval so a single dropped APNs (network blip,
+ * APNs latency spike, server restart) doesn't tip the activity into stale.
+ */
+const HEARTBEAT_INTERVAL_MS = 90 * 1000;
+
+let heartbeatHandle: ReturnType<typeof setInterval> | null = null;
+
+type RoomManager = Pick<typeof RoomManagerType, 'getQueueState'>;
+
+/**
+ * Distinct session_ids that currently have at least one registered push token.
+ * Bounded by the total number of active iOS Live Activities in the cluster,
+ * which is small enough that a SELECT DISTINCT every 90 s is fine.
+ */
+async function getSessionsWithRegisteredTokens(): Promise<string[]> {
+  const rows = await db.execute<{ session_id: string }>(sql`SELECT DISTINCT session_id FROM ${activityPushTokens}`);
+  // drizzle's execute returns either { rows: [...] } or the raw array depending
+  // on the dialect/driver. Normalize.
+  const data =
+    (rows as unknown as { rows?: { session_id: string }[] }).rows ?? (rows as unknown as { session_id: string }[]);
+  return data.map((r) => r.session_id);
+}
+
+async function buildContentStateForSession(
+  sessionId: string,
+  roomManager: RoomManager,
+): Promise<LiveActivityContentState | null> {
+  const queueState = await roomManager.getQueueState(sessionId);
+  const currentItem = queueState.currentClimbQueueItem;
+  if (!currentItem) return null;
+
+  const currentIndex = queueState.queue.findIndex((item) => item.uuid === currentItem.uuid);
+
+  return {
+    climbName: currentItem.climb.name,
+    climbDifficulty: currentItem.climb.difficulty,
+    angle: currentItem.climb.angle,
+    currentIndex: currentIndex >= 0 ? currentIndex : 0,
+    totalClimbs: queueState.queue.length,
+    hasNext: currentIndex >= 0 && currentIndex < queueState.queue.length - 1,
+    hasPrevious: currentIndex > 0,
+    climbUuid: currentItem.climb.uuid,
+  };
+}
+
+async function runHeartbeatTick(roomManager: RoomManager): Promise<void> {
+  if (!isApnsConfigured()) return;
+
+  let sessions: string[];
+  try {
+    sessions = await getSessionsWithRegisteredTokens();
+  } catch (error) {
+    console.error('[APNs Heartbeat] Failed to list sessions with registered tokens:', error);
+    return;
+  }
+
+  if (sessions.length === 0) return;
+
+  for (const sessionId of sessions) {
+    try {
+      const state = await buildContentStateForSession(sessionId, roomManager);
+      if (!state) continue;
+      sendLiveActivityUpdate(sessionId, state);
+      incrementApnsMetric('heartbeatsSent');
+    } catch (error) {
+      console.warn(`[APNs Heartbeat] Failed to build heartbeat state for session ${sessionId}:`, error);
+    }
+  }
+}
+
+/**
+ * Start the periodic heartbeat loop. Safe to call multiple times; subsequent
+ * calls are no-ops until `stopApnsHeartbeat()` is called.
+ */
+export function startApnsHeartbeat(roomManager: RoomManager): void {
+  if (heartbeatHandle !== null) return;
+  if (!isApnsConfigured()) return;
+
+  console.info(`[APNs Heartbeat] Started (interval=${String(HEARTBEAT_INTERVAL_MS)}ms)`);
+
+  heartbeatHandle = setInterval(() => {
+    runHeartbeatTick(roomManager).catch((error) => {
+      console.error('[APNs Heartbeat] Tick failed:', error);
+    });
+  }, HEARTBEAT_INTERVAL_MS);
+
+  if (typeof heartbeatHandle.unref === 'function') heartbeatHandle.unref();
+}
+
+export function stopApnsHeartbeat(): void {
+  if (heartbeatHandle === null) return;
+  clearInterval(heartbeatHandle);
+  heartbeatHandle = null;
+  console.info('[APNs Heartbeat] Stopped');
+}
+
+/** Test-only utility. */
+export async function __runHeartbeatTickForTests(roomManager: RoomManager): Promise<void> {
+  await runHeartbeatTick(roomManager);
+}

--- a/packages/backend/src/services/apns/heartbeat.ts
+++ b/packages/backend/src/services/apns/heartbeat.ts
@@ -8,67 +8,91 @@
  * tip over into "Session ended" before any new event arrives.
  *
  * This module runs a periodic sweep every 90 s that re-sends the current
- * content state for every session with at least one registered push token. It
- * piggybacks on the existing debounce path, so if a real queue event was
- * already coalesced into the pending window the heartbeat just gets dropped
- * harmlessly.
+ * content state for every session with at least one registered push token.
+ *
+ * Multi-instance safety: each tick acquires a cluster-wide Redis lock so that
+ * only one instance in the cluster does the sweep on any given tick. Without
+ * the lock, N instances would each push N times for every session, eating
+ * into APNs' per-activity rate budget. Same pattern as
+ * `warmPopularConfigsCache` in social/boards.ts.
  */
 
-import { sql } from 'drizzle-orm';
 import { activityPushTokens } from '@boardsesh/db/schema/app';
 import { db } from '../../db/client';
-import { type LiveActivityContentState, incrementApnsMetric, isApnsConfigured, sendLiveActivityUpdate } from './index';
-import type { roomManager as RoomManagerType } from '../room-manager';
+import { redisClientManager } from '../../redis/client';
+import {
+  type LiveActivityContentState,
+  hasPendingSend,
+  incrementApnsMetric,
+  isApnsConfigured,
+  sendLiveActivityUpdate,
+} from './index';
+import { buildContentStateFromQueueState } from './content-state';
+import type { QueueState } from '../room-manager';
 
-/**
- * 90 s gives 6× headroom against the 10-minute iOS staleInterval. We need to
- * stay well below the staleInterval so a single dropped APNs (network blip,
- * APNs latency spike, server restart) doesn't tip the activity into stale.
- */
 const HEARTBEAT_INTERVAL_MS = 90 * 1000;
+
+// Lock TTL is twice the tick interval so a slow/crashing leader doesn't lock
+// the cluster out indefinitely.
+const HEARTBEAT_LOCK_KEY = 'boardsesh:apns:heartbeat-lock';
+const HEARTBEAT_LOCK_TTL_SEC = 180;
+
+// Process at most this many sessions in parallel per tick so a slow Redis or
+// roomManager doesn't serialize the whole sweep.
+const HEARTBEAT_CONCURRENCY = 10;
 
 let heartbeatHandle: ReturnType<typeof setInterval> | null = null;
 
-type RoomManager = Pick<typeof RoomManagerType, 'getQueueState'>;
-
-/**
- * Distinct session_ids that currently have at least one registered push token.
- * Bounded by the total number of active iOS Live Activities in the cluster,
- * which is small enough that a SELECT DISTINCT every 90 s is fine.
- */
-async function getSessionsWithRegisteredTokens(): Promise<string[]> {
-  const rows = await db.execute<{ session_id: string }>(sql`SELECT DISTINCT session_id FROM ${activityPushTokens}`);
-  // drizzle's execute returns either { rows: [...] } or the raw array depending
-  // on the dialect/driver. Normalize.
-  const data =
-    (rows as unknown as { rows?: { session_id: string }[] }).rows ?? (rows as unknown as { session_id: string }[]);
-  return data.map((r) => r.session_id);
+interface RoomManagerLike {
+  getQueueState(sessionId: string): Promise<QueueState>;
 }
 
-async function buildContentStateForSession(
+async function getSessionsWithRegisteredTokens(): Promise<string[]> {
+  const rows = await db.selectDistinct({ sessionId: activityPushTokens.sessionId }).from(activityPushTokens);
+  return rows.map((r) => r.sessionId);
+}
+
+async function buildHeartbeatStateFor(
   sessionId: string,
-  roomManager: RoomManager,
+  roomManager: RoomManagerLike,
 ): Promise<LiveActivityContentState | null> {
   const queueState = await roomManager.getQueueState(sessionId);
-  const currentItem = queueState.currentClimbQueueItem;
-  if (!currentItem) return null;
-
-  const currentIndex = queueState.queue.findIndex((item) => item.uuid === currentItem.uuid);
-
-  return {
-    climbName: currentItem.climb.name,
-    climbDifficulty: currentItem.climb.difficulty,
-    angle: currentItem.climb.angle,
-    currentIndex: currentIndex >= 0 ? currentIndex : 0,
-    totalClimbs: queueState.queue.length,
-    hasNext: currentIndex >= 0 && currentIndex < queueState.queue.length - 1,
-    hasPrevious: currentIndex > 0,
-    climbUuid: currentItem.climb.uuid,
-  };
+  return buildContentStateFromQueueState(queueState);
 }
 
-async function runHeartbeatTick(roomManager: RoomManager): Promise<void> {
+/**
+ * Try to acquire the cluster-wide heartbeat lock. Returns true if this
+ * instance won. If Redis isn't connected, returns true so single-instance dev
+ * still works — the lock is purely a multi-instance dedupe, not a correctness
+ * primitive.
+ */
+async function acquireHeartbeatLock(instanceId: string): Promise<boolean> {
+  if (!redisClientManager.isRedisConnected()) return true;
+  try {
+    const { publisher } = redisClientManager.getClients();
+    const result = await publisher.set(HEARTBEAT_LOCK_KEY, instanceId, 'EX', HEARTBEAT_LOCK_TTL_SEC, 'NX');
+    return result === 'OK';
+  } catch (error) {
+    console.warn('[APNs Heartbeat] Failed to acquire lock; skipping tick:', error);
+    return false;
+  }
+}
+
+async function processWithConcurrency<T>(items: T[], limit: number, worker: (item: T) => Promise<void>): Promise<void> {
+  let cursor = 0;
+  async function nextBatch(): Promise<void> {
+    while (cursor < items.length) {
+      const index = cursor++;
+      await worker(items[index]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => nextBatch()));
+}
+
+async function runHeartbeatTick(roomManager: RoomManagerLike, instanceId: string): Promise<void> {
   if (!isApnsConfigured()) return;
+
+  if (!(await acquireHeartbeatLock(instanceId))) return;
 
   let sessions: string[];
   try {
@@ -80,30 +104,33 @@ async function runHeartbeatTick(roomManager: RoomManager): Promise<void> {
 
   if (sessions.length === 0) return;
 
-  for (const sessionId of sessions) {
+  await processWithConcurrency(sessions, HEARTBEAT_CONCURRENCY, async (sessionId) => {
+    // Skip sessions where a real queue event already has a debounce timer in
+    // flight — the heartbeat is a backstop, not a primary update path.
+    if (hasPendingSend(sessionId)) return;
     try {
-      const state = await buildContentStateForSession(sessionId, roomManager);
-      if (!state) continue;
+      const state = await buildHeartbeatStateFor(sessionId, roomManager);
+      if (!state) return;
       sendLiveActivityUpdate(sessionId, state);
       incrementApnsMetric('heartbeatsSent');
     } catch (error) {
       console.warn(`[APNs Heartbeat] Failed to build heartbeat state for session ${sessionId}:`, error);
     }
-  }
+  });
 }
 
 /**
  * Start the periodic heartbeat loop. Safe to call multiple times; subsequent
  * calls are no-ops until `stopApnsHeartbeat()` is called.
  */
-export function startApnsHeartbeat(roomManager: RoomManager): void {
+export function startApnsHeartbeat(roomManager: RoomManagerLike, instanceId: string): void {
   if (heartbeatHandle !== null) return;
   if (!isApnsConfigured()) return;
 
-  console.info(`[APNs Heartbeat] Started (interval=${String(HEARTBEAT_INTERVAL_MS)}ms)`);
+  console.info(`[APNs Heartbeat] Started (interval=${String(HEARTBEAT_INTERVAL_MS)}ms, instance=${instanceId})`);
 
   heartbeatHandle = setInterval(() => {
-    runHeartbeatTick(roomManager).catch((error) => {
+    runHeartbeatTick(roomManager, instanceId).catch((error) => {
       console.error('[APNs Heartbeat] Tick failed:', error);
     });
   }, HEARTBEAT_INTERVAL_MS);
@@ -119,6 +146,6 @@ export function stopApnsHeartbeat(): void {
 }
 
 /** Test-only utility. */
-export async function __runHeartbeatTickForTests(roomManager: RoomManager): Promise<void> {
-  await runHeartbeatTick(roomManager);
+export async function __runHeartbeatTickForTests(roomManager: RoomManagerLike, instanceId = 'test'): Promise<void> {
+  await runHeartbeatTick(roomManager, instanceId);
 }

--- a/packages/backend/src/services/apns/index.ts
+++ b/packages/backend/src/services/apns/index.ts
@@ -12,6 +12,7 @@ import apn from '@parse/node-apn';
 import { eq } from 'drizzle-orm';
 import { activityPushTokens } from '@boardsesh/db/schema/app';
 import { db } from '../../db/client';
+import { redisClientManager } from '../../redis/client';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -31,12 +32,15 @@ export interface LiveActivityContentState {
 interface DebouncedEntry {
   timeout: ReturnType<typeof setTimeout>;
   latestState: LiveActivityContentState;
-  /** Number of times we've retried after a transient DB error. Capped at 1. */
-  dbRetryCount: number;
+  /** Index into DB_RETRY_DELAYS_MS for the next retry. */
+  dbRetryAttempt: number;
 }
 
-const MAX_DB_RETRIES = 1;
-const DB_RETRY_DELAY_MS = 2_000;
+// Exponential-ish backoff schedule for transient DB lookup failures.
+// 3 retries with growing delays gives ~14 s of total wait before giving up,
+// which is enough to ride out a brief connection-pool blip or Postgres
+// failover without dropping the update.
+const DB_RETRY_DELAYS_MS = [1_000, 3_000, 8_000];
 
 // ---------------------------------------------------------------------------
 // Module state
@@ -54,7 +58,60 @@ export function isApnsConfigured(): boolean {
 /** Debounce map: sessionId -> pending send state */
 const pendingSends = new Map<string, DebouncedEntry>();
 
-const DEBOUNCE_MS = 5_000;
+// 1 s debounce. Climb navigation needs to feel responsive on the lock screen;
+// a 5 s window made tapping Next visibly laggy. 1 s still absorbs the most
+// common burst (QueueItemAdded + CurrentClimbChanged emitted back-to-back when
+// a climb is queued).
+const DEBOUNCE_MS = 1_000;
+
+const REDIS_PENDING_KEY_PREFIX = 'boardsesh:apns:pending:';
+// TTL slightly longer than the debounce so a restart within the window can
+// still recover the latest pending state on next startup.
+const REDIS_PENDING_TTL_SEC = 30;
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+interface ApnsMetrics {
+  tokensRegistered: number;
+  tokensEvicted: number;
+  tokensRebound: number;
+  tokensCleanedUpStale: number;
+  sendsAttempted: number;
+  sendsSucceeded: number;
+  sendsFailed: number;
+  sendsCoalesced: number;
+  heartbeatsSent: number;
+  dbRetriesUsed: number;
+  pendingRecovered: number;
+}
+
+const metrics: ApnsMetrics = {
+  tokensRegistered: 0,
+  tokensEvicted: 0,
+  tokensRebound: 0,
+  tokensCleanedUpStale: 0,
+  sendsAttempted: 0,
+  sendsSucceeded: 0,
+  sendsFailed: 0,
+  sendsCoalesced: 0,
+  heartbeatsSent: 0,
+  dbRetriesUsed: 0,
+  pendingRecovered: 0,
+};
+
+export function getApnsMetrics(): Readonly<ApnsMetrics> & { configured: boolean; pendingSendsInFlight: number } {
+  return {
+    ...metrics,
+    configured,
+    pendingSendsInFlight: pendingSends.size,
+  };
+}
+
+export function incrementApnsMetric(key: keyof ApnsMetrics, delta = 1): void {
+  metrics[key] += delta;
+}
 
 // ---------------------------------------------------------------------------
 // Initialization
@@ -97,13 +154,21 @@ export function initializeApns(): void {
 
   configured = true;
   console.log(`[APNs] Initialized (production=${String(production)}, bundleId=${bundleId})`);
+
+  // Best-effort: recover any debounced sends that were pending in Redis when
+  // the previous process exited (or that another instance enqueued but never
+  // got to flush). Failures are logged and ignored — the next queue event or
+  // the heartbeat loop will catch up.
+  void recoverPendingSendsFromRedis();
 }
 
 /**
  * Shutdown the APNs provider. Call during graceful server shutdown.
  */
 export async function shutdownApns(): Promise<void> {
-  // Clear all pending debounce timers
+  // Clear all pending debounce timers. The latest state is already persisted
+  // in Redis (see sendLiveActivityUpdate), so recoverPendingSendsFromRedis on
+  // the next process will pick them up.
   for (const [, entry] of pendingSends) {
     clearTimeout(entry.timeout);
   }
@@ -114,6 +179,74 @@ export async function shutdownApns(): Promise<void> {
     provider = null;
     configured = false;
     console.log('[APNs] Provider shut down');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Redis-backed pending-send persistence
+// ---------------------------------------------------------------------------
+
+function redisPendingKey(sessionId: string): string {
+  return `${REDIS_PENDING_KEY_PREFIX}${sessionId}`;
+}
+
+async function writePendingToRedis(sessionId: string, state: LiveActivityContentState): Promise<void> {
+  if (!redisClientManager.isRedisConnected()) return;
+  try {
+    const { publisher } = redisClientManager.getClients();
+    await publisher.set(redisPendingKey(sessionId), JSON.stringify(state), 'EX', REDIS_PENDING_TTL_SEC);
+  } catch (error) {
+    // Persistence is best-effort; in-memory pendingSends is still the source
+    // of truth for the active process.
+    console.warn(`[APNs] Failed to persist pending send for session ${sessionId} to Redis:`, error);
+  }
+}
+
+async function deletePendingFromRedis(sessionId: string): Promise<void> {
+  if (!redisClientManager.isRedisConnected()) return;
+  try {
+    const { publisher } = redisClientManager.getClients();
+    await publisher.del(redisPendingKey(sessionId));
+  } catch (error) {
+    console.warn(`[APNs] Failed to delete persisted pending send for session ${sessionId} from Redis:`, error);
+  }
+}
+
+async function recoverPendingSendsFromRedis(): Promise<void> {
+  if (!redisClientManager.isRedisConnected()) return;
+  try {
+    const { publisher } = redisClientManager.getClients();
+    // SCAN is cheap at this volume (one key per active session at most) and
+    // avoids the latency-spike risk of KEYS.
+    let cursor = '0';
+    const recovered: { sessionId: string; state: LiveActivityContentState }[] = [];
+    do {
+      const [nextCursor, keys] = await publisher.scan(cursor, 'MATCH', `${REDIS_PENDING_KEY_PREFIX}*`, 'COUNT', 100);
+      cursor = nextCursor;
+      for (const key of keys) {
+        // GETDEL is atomic so two recovering instances don't race on the same
+        // pending send. Available since Redis 6.2.
+        const value = await publisher.call('GETDEL', key);
+        if (typeof value !== 'string') continue;
+        const sessionId = key.slice(REDIS_PENDING_KEY_PREFIX.length);
+        try {
+          const state = JSON.parse(value) as LiveActivityContentState;
+          recovered.push({ sessionId, state });
+        } catch (parseError) {
+          console.warn(`[APNs] Skipping malformed pending-send record for session ${sessionId}:`, parseError);
+        }
+      }
+    } while (cursor !== '0');
+
+    if (recovered.length === 0) return;
+
+    console.info(`[APNs] Recovering ${String(recovered.length)} pending Live Activity send(s) from Redis`);
+    for (const { sessionId, state } of recovered) {
+      metrics.pendingRecovered++;
+      sendLiveActivityUpdate(sessionId, state);
+    }
+  } catch (error) {
+    console.warn('[APNs] Failed to recover pending sends from Redis:', error);
   }
 }
 
@@ -139,24 +272,32 @@ async function getTokensForSession(sessionId: string): Promise<string[]> {
 async function deleteStaleToken(token: string): Promise<void> {
   try {
     await db.delete(activityPushTokens).where(eq(activityPushTokens.token, token));
+    metrics.tokensCleanedUpStale++;
     console.log(`[APNs] Deleted stale token ${token.slice(0, 8)}...`);
   } catch (error) {
     console.error('[APNs] Failed to delete stale token:', error);
   }
 }
 
+interface SendOptions {
+  /** If set, used in the structured log line to indicate the trigger. */
+  source?: 'event' | 'heartbeat' | 'registration';
+}
+
 /**
  * Build and send an APNs Live Activity notification to the given tokens.
+ * Returns the number of successful sends.
  */
 async function sendNotification(
   sessionId: string,
   tokens: string[],
   event: 'update' | 'end',
   contentState?: LiveActivityContentState,
-): Promise<void> {
-  if (!provider || tokens.length === 0) return;
+  options: SendOptions = {},
+): Promise<{ sent: number; failed: number; stale: number }> {
+  if (!provider || tokens.length === 0) return { sent: 0, failed: 0, stale: 0 };
 
-  console.log(`[APNs] Sending Live Activity ${event} for session ${sessionId} to ${String(tokens.length)} device(s)`);
+  metrics.sendsAttempted += tokens.length;
 
   const notification = new apn.Notification();
   notification.topic = `${bundleId}.push-type.liveactivity`;
@@ -175,15 +316,17 @@ async function sendNotification(
   // Expire update notifications after 5 minutes, end notifications after 1 minute
   notification.expiry = Math.floor(Date.now() / 1000) + (event === 'end' ? 60 : 300);
 
+  const startedAt = Date.now();
+  let stale = 0;
+
   try {
     const result = await provider.send(notification, tokens);
-    console.log(
-      `[APNs] Results for session ${sessionId}: ${String(result.sent.length)} sent, ` +
-        `${String(result.failed.length)} failed`,
-    );
+    const sent = result.sent.length;
+    const failed = result.failed.length;
+    metrics.sendsSucceeded += sent;
+    metrics.sendsFailed += failed;
 
-    if (result.failed.length > 0) {
-      // Handle stale tokens (410 Gone / BadDeviceToken / Unregistered)
+    if (failed > 0) {
       const staleTokenDeletions: Promise<void>[] = [];
 
       for (const failure of result.failed) {
@@ -191,10 +334,7 @@ async function sendNotification(
         const status = failure.status;
 
         if (status === 410 || reason === 'BadDeviceToken' || reason === 'Unregistered' || reason === 'ExpiredToken') {
-          console.log(
-            `[APNs] Stale token for session ${sessionId} (${reason ?? `status ${String(status)}`}): ` +
-              `${failure.device.slice(0, 8)}...`,
-          );
+          stale++;
           staleTokenDeletions.push(deleteStaleToken(failure.device));
         } else {
           console.error(
@@ -208,18 +348,27 @@ async function sendNotification(
         await Promise.all(staleTokenDeletions);
       }
     }
+
+    console.info(
+      `[APNs] session=${sessionId} event=${event} source=${options.source ?? 'event'} ` +
+        `tokens=${String(tokens.length)} sent=${String(sent)} failed=${String(failed)} stale=${String(stale)} ` +
+        `elapsedMs=${String(Date.now() - startedAt)}`,
+    );
+
+    return { sent, failed, stale };
   } catch (error) {
-    console.error('[APNs] Send error:', error);
+    metrics.sendsFailed += tokens.length;
+    console.error(`[APNs] Send error for session ${sessionId}:`, error);
+    return { sent: 0, failed: tokens.length, stale: 0 };
   }
 }
 
 /**
  * Execute debounced send: looks up tokens and delivers the notification.
  *
- * If the DB lookup fails (transient connection error, timeout) and we
- * haven't already retried, re-arm the debounce timer once after a short
- * delay rather than silently dropping the update. The cap of MAX_DB_RETRIES
- * prevents unbounded loops if the DB is genuinely down.
+ * On transient DB failure, re-arms the debounce timer with an exponential
+ * backoff schedule (1s, 3s, 8s). The pendingSends entry is preserved across
+ * the retry so the latest coalesced state is still sent when the DB recovers.
  */
 async function executeDebouncedSend(sessionId: string): Promise<void> {
   const entry = pendingSends.get(sessionId);
@@ -229,26 +378,34 @@ async function executeDebouncedSend(sessionId: string): Promise<void> {
   try {
     tokens = await getTokensForSession(sessionId);
   } catch (error) {
-    if (entry.dbRetryCount < MAX_DB_RETRIES) {
+    if (entry.dbRetryAttempt < DB_RETRY_DELAYS_MS.length) {
+      const delay = DB_RETRY_DELAYS_MS[entry.dbRetryAttempt];
       console.error(
-        `[APNs] getTokensForSession failed for session ${sessionId} (retry ${String(entry.dbRetryCount + 1)}/${String(MAX_DB_RETRIES)}):`,
+        `[APNs] getTokensForSession failed for session ${sessionId} ` +
+          `(retry ${String(entry.dbRetryAttempt + 1)}/${String(DB_RETRY_DELAYS_MS.length)} in ${String(delay)}ms):`,
         error,
       );
-      entry.dbRetryCount++;
+      entry.dbRetryAttempt++;
+      metrics.dbRetriesUsed++;
       entry.timeout = setTimeout(() => {
         executeDebouncedSend(sessionId).catch((retryError) => {
           console.error(`[APNs] Retried debounced send failed for session ${sessionId}:`, retryError);
         });
-      }, DB_RETRY_DELAY_MS);
+      }, delay);
       return;
     }
-    console.error(`[APNs] Giving up on session ${sessionId} after ${String(MAX_DB_RETRIES)} DB retry(ies):`, error);
+    console.error(
+      `[APNs] Giving up on session ${sessionId} after ${String(DB_RETRY_DELAYS_MS.length)} DB retry(ies):`,
+      error,
+    );
     pendingSends.delete(sessionId);
+    void deletePendingFromRedis(sessionId);
     return;
   }
 
   // Successful lookup — clear the entry and send.
   pendingSends.delete(sessionId);
+  void deletePendingFromRedis(sessionId);
   if (tokens.length === 0) {
     console.info(`[APNs] No registered Live Activity tokens for session ${sessionId}; skipping update`);
     return;
@@ -264,23 +421,25 @@ async function executeDebouncedSend(sessionId: string): Promise<void> {
 /**
  * Send a debounced Live Activity update for a session.
  *
- * If called multiple times within the debounce window (5 s), only the
- * latest state is sent. This respects APNs rate limits for Live Activity
- * updates (roughly 1 per second sustained, with budgets).
+ * If called multiple times within the debounce window, only the latest state
+ * is sent. This respects APNs rate limits for Live Activity updates while
+ * still feeling responsive for back-to-back queue mutations.
  */
 export function sendLiveActivityUpdate(sessionId: string, contentState: LiveActivityContentState): void {
   if (!configured) return;
+
+  // Persist the latest state to Redis so a restart inside the debounce window
+  // can recover it. Failure to persist is non-fatal.
+  void writePendingToRedis(sessionId, contentState);
 
   const existing = pendingSends.get(sessionId);
 
   if (existing) {
     // Replace the pending state but keep the existing timer
     existing.latestState = contentState;
-    console.info(`[APNs] Coalesced Live Activity update for session ${sessionId} into pending debounce`);
+    metrics.sendsCoalesced++;
     return;
   }
-
-  console.info(`[APNs] Queued Live Activity update for session ${sessionId}; waiting for debounce`);
 
   // Schedule a new send after the debounce window
   const timeout = setTimeout(() => {
@@ -289,7 +448,27 @@ export function sendLiveActivityUpdate(sessionId: string, contentState: LiveActi
     });
   }, DEBOUNCE_MS);
 
-  pendingSends.set(sessionId, { timeout, latestState: contentState, dbRetryCount: 0 });
+  pendingSends.set(sessionId, { timeout, latestState: contentState, dbRetryAttempt: 0 });
+}
+
+/**
+ * Send an immediate Live Activity update to a specific set of tokens,
+ * bypassing the per-session debounce. Used right after a device registers a
+ * push token so the lock-screen widget exits "Loading…" without waiting for
+ * the next organic queue event.
+ *
+ * Failures are logged but never thrown — this is a best-effort optimisation,
+ * not a correctness guarantee.
+ */
+export async function sendLiveActivityUpdateToTokens(
+  sessionId: string,
+  tokens: string[],
+  contentState: LiveActivityContentState,
+  options: { source?: 'registration' | 'heartbeat' } = {},
+): Promise<void> {
+  if (!configured) return;
+  if (tokens.length === 0) return;
+  await sendNotification(sessionId, tokens, 'update', contentState, { source: options.source ?? 'registration' });
 }
 
 /**
@@ -306,6 +485,7 @@ export async function endLiveActivity(sessionId: string): Promise<void> {
     clearTimeout(pending.timeout);
     pendingSends.delete(sessionId);
   }
+  void deletePendingFromRedis(sessionId);
 
   // Best-effort lookup — log and continue if the DB is unavailable.
   let tokens: string[] = [];
@@ -335,4 +515,12 @@ export async function cleanupTokensForSession(sessionId: string): Promise<void> 
   } catch (error) {
     console.error(`[APNs] Failed to clean up tokens for session ${sessionId}:`, error);
   }
+}
+
+/** Test-only utility for clearing pendingSends between tests. */
+export function __resetApnsPendingForTests(): void {
+  for (const [, entry] of pendingSends) {
+    clearTimeout(entry.timeout);
+  }
+  pendingSends.clear();
 }

--- a/packages/backend/src/services/apns/index.ts
+++ b/packages/backend/src/services/apns/index.ts
@@ -12,7 +12,6 @@ import apn from '@parse/node-apn';
 import { eq } from 'drizzle-orm';
 import { activityPushTokens } from '@boardsesh/db/schema/app';
 import { db } from '../../db/client';
-import { redisClientManager } from '../../redis/client';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -61,13 +60,14 @@ const pendingSends = new Map<string, DebouncedEntry>();
 // 1 s debounce. Climb navigation needs to feel responsive on the lock screen;
 // a 5 s window made tapping Next visibly laggy. 1 s still absorbs the most
 // common burst (QueueItemAdded + CurrentClimbChanged emitted back-to-back when
-// a climb is queued).
+// a climb is queued). A restart inside this 1 s window can drop the pending
+// update; the heartbeat loop catches up within 90 s.
 const DEBOUNCE_MS = 1_000;
 
-const REDIS_PENDING_KEY_PREFIX = 'boardsesh:apns:pending:';
-// TTL slightly longer than the debounce so a restart within the window can
-// still recover the latest pending state on next startup.
-const REDIS_PENDING_TTL_SEC = 30;
+/** Whether a session currently has a pending debounced send in flight. */
+export function hasPendingSend(sessionId: string): boolean {
+  return pendingSends.has(sessionId);
+}
 
 // ---------------------------------------------------------------------------
 // Metrics
@@ -84,7 +84,6 @@ interface ApnsMetrics {
   sendsCoalesced: number;
   heartbeatsSent: number;
   dbRetriesUsed: number;
-  pendingRecovered: number;
 }
 
 const metrics: ApnsMetrics = {
@@ -98,10 +97,9 @@ const metrics: ApnsMetrics = {
   sendsCoalesced: 0,
   heartbeatsSent: 0,
   dbRetriesUsed: 0,
-  pendingRecovered: 0,
 };
 
-export function getApnsMetrics(): Readonly<ApnsMetrics> & { configured: boolean; pendingSendsInFlight: number } {
+export function getApnsMetrics(): ApnsMetrics & { configured: boolean; pendingSendsInFlight: number } {
   return {
     ...metrics,
     configured,
@@ -154,21 +152,16 @@ export function initializeApns(): void {
 
   configured = true;
   console.log(`[APNs] Initialized (production=${String(production)}, bundleId=${bundleId})`);
-
-  // Best-effort: recover any debounced sends that were pending in Redis when
-  // the previous process exited (or that another instance enqueued but never
-  // got to flush). Failures are logged and ignored — the next queue event or
-  // the heartbeat loop will catch up.
-  void recoverPendingSendsFromRedis();
 }
 
 /**
  * Shutdown the APNs provider. Call during graceful server shutdown.
+ *
+ * Pending debounce timers are cleared. A pending update that hasn't fired by
+ * shutdown is lost; the next queue event or heartbeat tick after the new
+ * process boots will produce a fresh send.
  */
 export async function shutdownApns(): Promise<void> {
-  // Clear all pending debounce timers. The latest state is already persisted
-  // in Redis (see sendLiveActivityUpdate), so recoverPendingSendsFromRedis on
-  // the next process will pick them up.
   for (const [, entry] of pendingSends) {
     clearTimeout(entry.timeout);
   }
@@ -183,80 +176,9 @@ export async function shutdownApns(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Redis-backed pending-send persistence
-// ---------------------------------------------------------------------------
-
-function redisPendingKey(sessionId: string): string {
-  return `${REDIS_PENDING_KEY_PREFIX}${sessionId}`;
-}
-
-async function writePendingToRedis(sessionId: string, state: LiveActivityContentState): Promise<void> {
-  if (!redisClientManager.isRedisConnected()) return;
-  try {
-    const { publisher } = redisClientManager.getClients();
-    await publisher.set(redisPendingKey(sessionId), JSON.stringify(state), 'EX', REDIS_PENDING_TTL_SEC);
-  } catch (error) {
-    // Persistence is best-effort; in-memory pendingSends is still the source
-    // of truth for the active process.
-    console.warn(`[APNs] Failed to persist pending send for session ${sessionId} to Redis:`, error);
-  }
-}
-
-async function deletePendingFromRedis(sessionId: string): Promise<void> {
-  if (!redisClientManager.isRedisConnected()) return;
-  try {
-    const { publisher } = redisClientManager.getClients();
-    await publisher.del(redisPendingKey(sessionId));
-  } catch (error) {
-    console.warn(`[APNs] Failed to delete persisted pending send for session ${sessionId} from Redis:`, error);
-  }
-}
-
-async function recoverPendingSendsFromRedis(): Promise<void> {
-  if (!redisClientManager.isRedisConnected()) return;
-  try {
-    const { publisher } = redisClientManager.getClients();
-    // SCAN is cheap at this volume (one key per active session at most) and
-    // avoids the latency-spike risk of KEYS.
-    let cursor = '0';
-    const recovered: { sessionId: string; state: LiveActivityContentState }[] = [];
-    do {
-      const [nextCursor, keys] = await publisher.scan(cursor, 'MATCH', `${REDIS_PENDING_KEY_PREFIX}*`, 'COUNT', 100);
-      cursor = nextCursor;
-      for (const key of keys) {
-        // GETDEL is atomic so two recovering instances don't race on the same
-        // pending send. Available since Redis 6.2.
-        const value = await publisher.call('GETDEL', key);
-        if (typeof value !== 'string') continue;
-        const sessionId = key.slice(REDIS_PENDING_KEY_PREFIX.length);
-        try {
-          const state = JSON.parse(value) as LiveActivityContentState;
-          recovered.push({ sessionId, state });
-        } catch (parseError) {
-          console.warn(`[APNs] Skipping malformed pending-send record for session ${sessionId}:`, parseError);
-        }
-      }
-    } while (cursor !== '0');
-
-    if (recovered.length === 0) return;
-
-    console.info(`[APNs] Recovering ${String(recovered.length)} pending Live Activity send(s) from Redis`);
-    for (const { sessionId, state } of recovered) {
-      metrics.pendingRecovered++;
-      sendLiveActivityUpdate(sessionId, state);
-    }
-  } catch (error) {
-    console.warn('[APNs] Failed to recover pending sends from Redis:', error);
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Fetch all APNs device tokens for a given session from the database.
- */
 async function getTokensForSession(sessionId: string): Promise<string[]> {
   const rows = await db
     .select({ token: activityPushTokens.token })
@@ -266,9 +188,6 @@ async function getTokensForSession(sessionId: string): Promise<string[]> {
   return rows.map((r) => r.token);
 }
 
-/**
- * Delete a single stale device token from the database.
- */
 async function deleteStaleToken(token: string): Promise<void> {
   try {
     await db.delete(activityPushTokens).where(eq(activityPushTokens.token, token));
@@ -284,10 +203,6 @@ interface SendOptions {
   source?: 'event' | 'heartbeat' | 'registration';
 }
 
-/**
- * Build and send an APNs Live Activity notification to the given tokens.
- * Returns the number of successful sends.
- */
 async function sendNotification(
   sessionId: string,
   tokens: string[],
@@ -313,7 +228,6 @@ async function sendNotification(
     notification.aps['content-state'] = contentState;
   }
 
-  // Expire update notifications after 5 minutes, end notifications after 1 minute
   notification.expiry = Math.floor(Date.now() / 1000) + (event === 'end' ? 60 : 300);
 
   const startedAt = Date.now();
@@ -367,8 +281,13 @@ async function sendNotification(
  * Execute debounced send: looks up tokens and delivers the notification.
  *
  * On transient DB failure, re-arms the debounce timer with an exponential
- * backoff schedule (1s, 3s, 8s). The pendingSends entry is preserved across
- * the retry so the latest coalesced state is still sent when the DB recovers.
+ * backoff schedule. The pendingSends entry is preserved across the retry so
+ * the latest coalesced state is still sent when the DB recovers.
+ *
+ * On retry exhaustion, requeue the latest state with a fresh retry counter so
+ * a transient outage doesn't permanently drop the update — the next attempt
+ * starts at debounce 0 with the same `latestState` (which may have been
+ * mutated by intervening `sendLiveActivityUpdate` calls).
  */
 async function executeDebouncedSend(sessionId: string): Promise<void> {
   const entry = pendingSends.get(sessionId);
@@ -398,14 +317,15 @@ async function executeDebouncedSend(sessionId: string): Promise<void> {
       `[APNs] Giving up on session ${sessionId} after ${String(DB_RETRY_DELAYS_MS.length)} DB retry(ies):`,
       error,
     );
+    const lastState = entry.latestState;
     pendingSends.delete(sessionId);
-    void deletePendingFromRedis(sessionId);
+    // Requeue with a fresh retry counter so the user-visible regression is
+    // bounded by one more debounce window rather than 90 s of heartbeat lag.
+    sendLiveActivityUpdate(sessionId, lastState);
     return;
   }
 
-  // Successful lookup — clear the entry and send.
   pendingSends.delete(sessionId);
-  void deletePendingFromRedis(sessionId);
   if (tokens.length === 0) {
     console.info(`[APNs] No registered Live Activity tokens for session ${sessionId}; skipping update`);
     return;
@@ -428,20 +348,14 @@ async function executeDebouncedSend(sessionId: string): Promise<void> {
 export function sendLiveActivityUpdate(sessionId: string, contentState: LiveActivityContentState): void {
   if (!configured) return;
 
-  // Persist the latest state to Redis so a restart inside the debounce window
-  // can recover it. Failure to persist is non-fatal.
-  void writePendingToRedis(sessionId, contentState);
-
   const existing = pendingSends.get(sessionId);
 
   if (existing) {
-    // Replace the pending state but keep the existing timer
     existing.latestState = contentState;
     metrics.sendsCoalesced++;
     return;
   }
 
-  // Schedule a new send after the debounce window
   const timeout = setTimeout(() => {
     executeDebouncedSend(sessionId).catch((error) => {
       console.error(`[APNs] Debounced send failed for session ${sessionId}:`, error);
@@ -479,15 +393,12 @@ export async function sendLiveActivityUpdateToTokens(
 export async function endLiveActivity(sessionId: string): Promise<void> {
   if (!configured) return;
 
-  // Cancel any pending debounced update
   const pending = pendingSends.get(sessionId);
   if (pending) {
     clearTimeout(pending.timeout);
     pendingSends.delete(sessionId);
   }
-  void deletePendingFromRedis(sessionId);
 
-  // Best-effort lookup — log and continue if the DB is unavailable.
   let tokens: string[] = [];
   try {
     tokens = await getTokensForSession(sessionId);
@@ -501,13 +412,9 @@ export async function endLiveActivity(sessionId: string): Promise<void> {
     console.info(`[APNs] No registered Live Activity tokens for session ${sessionId}; skipping end`);
   }
 
-  // Clean up tokens after ending (already wrapped in try/catch internally)
   await cleanupTokensForSession(sessionId);
 }
 
-/**
- * Delete all APNs device tokens for a session from the database.
- */
 export async function cleanupTokensForSession(sessionId: string): Promise<void> {
   try {
     await db.delete(activityPushTokens).where(eq(activityPushTokens.sessionId, sessionId));
@@ -517,10 +424,13 @@ export async function cleanupTokensForSession(sessionId: string): Promise<void> 
   }
 }
 
-/** Test-only utility for clearing pendingSends between tests. */
-export function __resetApnsPendingForTests(): void {
+/** Test-only utility: clears pendingSends timers and resets counters. */
+export function __resetApnsStateForTests(): void {
   for (const [, entry] of pendingSends) {
     clearTimeout(entry.timeout);
   }
   pendingSends.clear();
+  for (const key of Object.keys(metrics) as (keyof ApnsMetrics)[]) {
+    metrics[key] = 0;
+  }
 }

--- a/packages/backend/src/services/apns/index.ts
+++ b/packages/backend/src/services/apns/index.ts
@@ -28,11 +28,17 @@ export interface LiveActivityContentState {
   climbUuid: string;
 }
 
+/** Source attribution for the structured per-send log line. */
+type SendSource = 'event' | 'heartbeat' | 'registration';
+
 interface DebouncedEntry {
   timeout: ReturnType<typeof setTimeout>;
   latestState: LiveActivityContentState;
   /** Index into DB_RETRY_DELAYS_MS for the next retry. */
   dbRetryAttempt: number;
+  /** Last `source` passed to `sendLiveActivityUpdate` for this entry. The
+   *  latest call wins on coalesce — same convention as `latestState`. */
+  source: SendSource;
 }
 
 // Exponential-ish backoff schedule for transient DB lookup failures.
@@ -77,7 +83,10 @@ interface ApnsMetrics {
   tokensRegistered: number;
   tokensEvicted: number;
   tokensRebound: number;
-  tokensCleanedUpStale: number;
+  /** Stale tokens removed via the live-send 410 / BadDeviceToken path. */
+  tokensRemovedOn410: number;
+  /** Stale tokens removed via the scheduled `apns/cleanup.ts` daily sweep. */
+  tokensSweptStale: number;
   sendsAttempted: number;
   sendsSucceeded: number;
   sendsFailed: number;
@@ -90,7 +99,8 @@ const metrics: ApnsMetrics = {
   tokensRegistered: 0,
   tokensEvicted: 0,
   tokensRebound: 0,
-  tokensCleanedUpStale: 0,
+  tokensRemovedOn410: 0,
+  tokensSweptStale: 0,
   sendsAttempted: 0,
   sendsSucceeded: 0,
   sendsFailed: 0,
@@ -191,7 +201,7 @@ async function getTokensForSession(sessionId: string): Promise<string[]> {
 async function deleteStaleToken(token: string): Promise<void> {
   try {
     await db.delete(activityPushTokens).where(eq(activityPushTokens.token, token));
-    metrics.tokensCleanedUpStale++;
+    metrics.tokensRemovedOn410++;
     console.log(`[APNs] Deleted stale token ${token.slice(0, 8)}...`);
   } catch (error) {
     console.error('[APNs] Failed to delete stale token:', error);
@@ -200,7 +210,7 @@ async function deleteStaleToken(token: string): Promise<void> {
 
 interface SendOptions {
   /** If set, used in the structured log line to indicate the trigger. */
-  source?: 'event' | 'heartbeat' | 'registration';
+  source?: SendSource;
 }
 
 async function sendNotification(
@@ -318,20 +328,25 @@ async function executeDebouncedSend(sessionId: string): Promise<void> {
       error,
     );
     const lastState = entry.latestState;
+    const lastSource = entry.source;
     pendingSends.delete(sessionId);
     // Requeue with a fresh retry counter so the user-visible regression is
     // bounded by one more debounce window rather than 90 s of heartbeat lag.
-    sendLiveActivityUpdate(sessionId, lastState);
+    // Synchronous delete + synchronous sendLiveActivityUpdate run on the same
+    // event-loop task — Node.js single-threading means no foreign callback
+    // can interleave between these two lines.
+    sendLiveActivityUpdate(sessionId, lastState, { source: lastSource });
     return;
   }
 
+  const source = entry.source;
   pendingSends.delete(sessionId);
   if (tokens.length === 0) {
     console.info(`[APNs] No registered Live Activity tokens for session ${sessionId}; skipping update`);
     return;
   }
 
-  await sendNotification(sessionId, tokens, 'update', entry.latestState);
+  await sendNotification(sessionId, tokens, 'update', entry.latestState, { source });
 }
 
 // ---------------------------------------------------------------------------
@@ -344,14 +359,24 @@ async function executeDebouncedSend(sessionId: string): Promise<void> {
  * If called multiple times within the debounce window, only the latest state
  * is sent. This respects APNs rate limits for Live Activity updates while
  * still feeling responsive for back-to-back queue mutations.
+ *
+ * `options.source` flows into the structured per-send log line so heartbeat
+ * sends, queue events, and registration kicks are distinguishable in logs.
+ * Latest call wins on coalesce.
  */
-export function sendLiveActivityUpdate(sessionId: string, contentState: LiveActivityContentState): void {
+export function sendLiveActivityUpdate(
+  sessionId: string,
+  contentState: LiveActivityContentState,
+  options: { source?: SendSource } = {},
+): void {
   if (!configured) return;
 
+  const source = options.source ?? 'event';
   const existing = pendingSends.get(sessionId);
 
   if (existing) {
     existing.latestState = contentState;
+    existing.source = source;
     metrics.sendsCoalesced++;
     return;
   }
@@ -362,7 +387,7 @@ export function sendLiveActivityUpdate(sessionId: string, contentState: LiveActi
     });
   }, DEBOUNCE_MS);
 
-  pendingSends.set(sessionId, { timeout, latestState: contentState, dbRetryAttempt: 0 });
+  pendingSends.set(sessionId, { timeout, latestState: contentState, dbRetryAttempt: 0, source });
 }
 
 /**

--- a/packages/db/drizzle/0096_abnormal_korg.sql
+++ b/packages/db/drizzle/0096_abnormal_korg.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "activity_push_tokens_updated_at_idx" ON "activity_push_tokens" USING btree ("updated_at");

--- a/packages/db/drizzle/meta/0096_snapshot.json
+++ b/packages/db/drizzle/meta/0096_snapshot.json
@@ -1,0 +1,8154 @@
+{
+  "id": "3d03ebd1-ac9e-4ec2-a03f-a6e747a6b7f9",
+  "prevId": "cc82e724-7230-47d2-9150-2c722327fe91",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.board_attempts": {
+      "name": "board_attempts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_attempts_board_type_id_pk": {
+          "name": "board_attempts_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_beta_links": {
+      "name": "board_beta_links",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shortcode": {
+          "name": "shortcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_beta_links_shortcode_idx": {
+          "name": "board_beta_links_shortcode_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shortcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"shortcode\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_created_by_idx": {
+          "name": "board_beta_links_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"created_by_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_beta_links_board_type_climb_uuid_link_pk": {
+          "name": "board_beta_links_board_type_climb_uuid_link_pk",
+          "columns": ["board_type", "climb_uuid", "link"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits": {
+      "name": "board_circuits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_user_fk": {
+          "name": "board_circuits_user_fk",
+          "tableFrom": "board_circuits",
+          "tableTo": "board_users",
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_board_type_uuid_pk": {
+          "name": "board_circuits_board_type_uuid_pk",
+          "columns": ["board_type", "uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits_climbs": {
+      "name": "board_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_climbs_circuit_fk": {
+          "name": "board_circuits_climbs_circuit_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_circuits",
+          "columnsFrom": ["board_type", "circuit_uuid"],
+          "columnsTo": ["board_type", "uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_circuits_climbs_climb_fk": {
+          "name": "board_circuits_climbs_climb_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_climbs",
+          "columnsFrom": ["climb_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
+          "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
+          "columns": ["board_type", "circuit_uuid", "climb_uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_holds": {
+      "name": "board_climb_holds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_holds_search_idx": {
+          "name": "board_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_holds_climb_fk": {
+          "name": "board_climb_holds_climb_fk",
+          "tableFrom": "board_climb_holds",
+          "tableTo": "board_climbs",
+          "columnsFrom": ["climb_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
+          "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
+          "columns": ["board_type", "climb_uuid", "hold_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats": {
+      "name": "board_climb_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_stats_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
+          "columns": ["board_type", "climb_uuid", "angle"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats_history": {
+      "name": "board_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_stats_history_lookup_idx": {
+          "name": "board_climb_stats_history_lookup_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climbs": {
+      "name": "board_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_set_ids": {
+          "name": "required_set_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compatible_size_ids": {
+          "name": "compatible_size_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_climbs_board_type_idx": {
+          "name": "board_climbs_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_search_filter_idx": {
+          "name": "board_climbs_search_filter_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_setter_username_idx": {
+          "name": "board_climbs_setter_username_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_user_id_idx": {
+          "name": "board_climbs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_climbs\".\"user_id\" IS NOT NULL AND \"board_climbs\".\"is_draft\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_name_idx": {
+          "name": "board_climbs_name_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climbs_user_id_users_id_fk": {
+          "name": "board_climbs_user_id_users_id_fk",
+          "tableFrom": "board_climbs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_difficulty_grades": {
+      "name": "board_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_difficulty_grades_board_type_difficulty_pk": {
+          "name": "board_difficulty_grades_board_type_difficulty_pk",
+          "columns": ["board_type", "difficulty"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_holes": {
+      "name": "board_holes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_holes_product_fk": {
+          "name": "board_holes_product_fk",
+          "tableFrom": "board_holes",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_holes_board_type_id_pk": {
+          "name": "board_holes_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_kits": {
+      "name": "board_kits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_autoconnect": {
+          "name": "is_autoconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_kits_board_type_serial_number_pk": {
+          "name": "board_kits_board_type_serial_number_pk",
+          "columns": ["board_type", "serial_number"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_layouts": {
+      "name": "board_layouts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_layouts_product_fk": {
+          "name": "board_layouts_product_fk",
+          "tableFrom": "board_layouts",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layouts_board_type_id_pk": {
+          "name": "board_layouts_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_leds": {
+      "name": "board_leds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_leds_product_size_fk": {
+          "name": "board_leds_product_size_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_leds_hole_fk": {
+          "name": "board_leds_hole_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_holes",
+          "columnsFrom": ["board_type", "hole_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_leds_board_type_id_pk": {
+          "name": "board_leds_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placement_roles": {
+      "name": "board_placement_roles",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_placement_roles_product_fk": {
+          "name": "board_placement_roles_product_fk",
+          "tableFrom": "board_placement_roles",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placement_roles_board_type_id_pk": {
+          "name": "board_placement_roles_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placements": {
+      "name": "board_placements",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_placements_board_type_layout_id_set_hole_idx": {
+          "name": "board_placements_board_type_layout_id_set_hole_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hole_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_placements_layout_fk": {
+          "name": "board_placements_layout_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_hole_fk": {
+          "name": "board_placements_hole_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_holes",
+          "columnsFrom": ["board_type", "hole_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_set_fk": {
+          "name": "board_placements_set_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_sets",
+          "columnsFrom": ["board_type", "set_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_role_fk": {
+          "name": "board_placements_role_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_placement_roles",
+          "columnsFrom": ["board_type", "default_placement_role_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placements_board_type_id_pk": {
+          "name": "board_placements_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes": {
+      "name": "board_product_sizes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_product_sizes_product_fk": {
+          "name": "board_product_sizes_product_fk",
+          "tableFrom": "board_product_sizes",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_board_type_id_pk": {
+          "name": "board_product_sizes_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes_layouts_sets": {
+      "name": "board_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_psls_product_size_fk": {
+          "name": "board_psls_product_size_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_layout_fk": {
+          "name": "board_psls_layout_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_set_fk": {
+          "name": "board_psls_set_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_sets",
+          "columnsFrom": ["board_type", "set_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_layouts_sets_board_type_id_pk": {
+          "name": "board_product_sizes_layouts_sets_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_products": {
+      "name": "board_products",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_products_board_type_id_pk": {
+          "name": "board_products_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sets": {
+      "name": "board_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_sets_board_type_id_pk": {
+          "name": "board_sets_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_shared_syncs": {
+      "name": "board_shared_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_shared_syncs_board_type_table_name_pk": {
+          "name": "board_shared_syncs_board_type_table_name_pk",
+          "columns": ["board_type", "table_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_tags": {
+      "name": "board_tags",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_tags_board_type_entity_uuid_user_id_name_pk": {
+          "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
+          "columns": ["board_type", "entity_uuid", "user_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_user_syncs": {
+      "name": "board_user_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_user_syncs_user_fk": {
+          "name": "board_user_syncs_user_fk",
+          "tableFrom": "board_user_syncs",
+          "tableTo": "board_users",
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_user_syncs_board_type_user_id_table_name_pk": {
+          "name": "board_user_syncs_board_type_user_id_table_name_pk",
+          "columns": ["board_type", "user_id", "table_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_users": {
+      "name": "board_users",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_users_board_type_id_pk": {
+          "name": "board_users_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_walls": {
+      "name": "board_walls",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_walls_user_fk": {
+          "name": "board_walls_user_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_users",
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_fk": {
+          "name": "board_walls_product_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_layout_fk": {
+          "name": "board_walls_layout_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_size_fk": {
+          "name": "board_walls_product_size_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_walls_board_type_uuid_pk": {
+          "name": "board_walls_board_type_uuid_pk",
+          "columns": ["board_type", "uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": ["provider", "providerAccountId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationTokens": {
+      "name": "verificationTokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationTokens_identifier_token_pk": {
+          "name": "verificationTokens_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_credentials": {
+      "name": "user_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aurora_credentials": {
+      "name": "aurora_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_username": {
+          "name": "encrypted_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aurora_user_id": {
+          "name": "aurora_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_token": {
+          "name": "aurora_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_credential": {
+          "name": "unique_user_board_credential",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_user_idx": {
+          "name": "aurora_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "aurora_credentials_user_id_users_id_fk": {
+          "name": "aurora_credentials_user_id_users_id_fk",
+          "tableFrom": "aurora_credentials",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_mappings": {
+      "name": "user_board_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_user_id": {
+          "name": "board_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_username": {
+          "name": "board_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_mapping": {
+          "name": "unique_user_board_mapping",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_idx": {
+          "name": "board_user_mapping_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_mappings_user_id_users_id_fk": {
+          "name": "user_board_mappings_user_id_users_id_fk",
+          "tableFrom": "user_board_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_follows": {
+      "name": "gym_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_follows_unique_gym_user": {
+          "name": "gym_follows_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_follows_gym_id_gyms_id_fk": {
+          "name": "gym_follows_gym_id_gyms_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "gyms",
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_follows_user_id_users_id_fk": {
+          "name": "gym_follows_user_id_users_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_members": {
+      "name": "gym_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "gym_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_members_unique_gym_user": {
+          "name": "gym_members_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_members_gym_id_gyms_id_fk": {
+          "name": "gym_members_gym_id_gyms_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "gyms",
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_members_user_id_users_id_fk": {
+          "name": "gym_members_user_id_users_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gyms": {
+      "name": "gyms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gyms_unique_slug": {
+          "name": "gyms_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_uuid_idx": {
+          "name": "gyms_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_owner_idx": {
+          "name": "gyms_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_public_idx": {
+          "name": "gyms_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gyms_owner_id_users_id_fk": {
+          "name": "gyms_owner_id_users_id_fk",
+          "tableFrom": "gyms",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gyms_uuid_unique": {
+          "name": "gyms_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_follows": {
+      "name": "board_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_follows_unique_user_board": {
+          "name": "board_follows_unique_user_board",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_user_idx": {
+          "name": "board_follows_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_board_uuid_idx": {
+          "name": "board_follows_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_follows_user_id_users_id_fk": {
+          "name": "board_follows_user_id_users_id_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_follows_board_uuid_user_boards_uuid_fk": {
+          "name": "board_follows_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_boards": {
+      "name": "user_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_unlisted": {
+          "name": "is_unlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_location": {
+          "name": "hide_location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_owned": {
+          "name": "is_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "is_angle_adjustable": {
+          "name": "is_angle_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_boards_gym_idx": {
+          "name": "user_boards_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_owner_config": {
+          "name": "user_boards_unique_owner_config",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL AND \"user_boards\".\"owner_id\" != '00000000-0000-0000-0000-000000000000'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_owner_owned_idx": {
+          "name": "user_boards_owner_owned_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_owned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_public_idx": {
+          "name": "user_boards_public_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_slug": {
+          "name": "user_boards_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_uuid_idx": {
+          "name": "user_boards_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_boards_owner_id_users_id_fk": {
+          "name": "user_boards_owner_id_users_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_boards_gym_id_gyms_id_fk": {
+          "name": "user_boards_gym_id_gyms_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "gyms",
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_boards_uuid_unique": {
+          "name": "user_boards_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_serials": {
+      "name": "user_board_serials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_board_serials_unique_user_serial": {
+          "name": "user_board_serials_unique_user_serial",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_serials_serial_idx": {
+          "name": "user_board_serials_serial_idx",
+          "columns": [
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_serials_board_uuid_idx": {
+          "name": "user_board_serials_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_serials_user_id_users_id_fk": {
+          "name": "user_board_serials_user_id_users_id_fk",
+          "tableFrom": "user_board_serials",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_board_serials_board_uuid_user_boards_uuid_fk": {
+          "name": "user_board_serials_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "user_board_serials",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_clients": {
+      "name": "board_session_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_leader": {
+          "name": "is_leader",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_clients_session_id_board_sessions_id_fk": {
+          "name": "board_session_clients_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_clients",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_queues": {
+      "name": "board_session_queues",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "current_climb_queue_item": {
+          "name": "current_climb_queue_item",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_queues_session_id_board_sessions_id_fk": {
+          "name": "board_session_queues_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_queues",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sessions": {
+      "name": "board_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_path": {
+          "name": "board_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_permanent": {
+          "name": "is_permanent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_kit_workout_id": {
+          "name": "health_kit_workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_sessions_location_idx": {
+          "name": "board_sessions_location_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discoverable_idx": {
+          "name": "board_sessions_discoverable_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_user_idx": {
+          "name": "board_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_status_idx": {
+          "name": "board_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_last_activity_idx": {
+          "name": "board_sessions_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discovery_idx": {
+          "name": "board_sessions_discovery_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_sessions_created_by_user_id_users_id_fk": {
+          "name": "board_sessions_created_by_user_id_users_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_sessions_board_id_user_boards_id_fk": {
+          "name": "board_sessions_board_id_user_boards_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_boards": {
+      "name": "session_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_boards_session_board_idx": {
+          "name": "session_boards_session_board_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_session_idx": {
+          "name": "session_boards_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_board_idx": {
+          "name": "session_boards_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_boards_session_id_board_sessions_id_fk": {
+          "name": "session_boards_session_id_board_sessions_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_boards_board_id_user_boards_id_fk": {
+          "name": "session_boards_board_id_user_boards_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_favorite": {
+          "name": "unique_user_favorite",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_idx": {
+          "name": "user_favorites_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_climb_idx": {
+          "name": "user_favorites_climb_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inferred_sessions": {
+      "name": "inferred_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_tick_at": {
+          "name": "first_tick_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_tick_at": {
+          "name": "last_tick_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sends": {
+          "name": "total_sends",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_attempts": {
+          "name": "total_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_flashes": {
+          "name": "total_flashes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tick_count": {
+          "name": "tick_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_kit_workout_id": {
+          "name": "health_kit_workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inferred_sessions_user_idx": {
+          "name": "inferred_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inferred_sessions_user_last_tick_idx": {
+          "name": "inferred_sessions_user_last_tick_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_tick_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inferred_sessions_last_tick_idx": {
+          "name": "inferred_sessions_last_tick_idx",
+          "columns": [
+            {
+              "expression": "last_tick_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inferred_sessions_user_id_users_id_fk": {
+          "name": "inferred_sessions_user_id_users_id_fk",
+          "tableFrom": "inferred_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_member_overrides": {
+      "name": "session_member_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_user_id": {
+          "name": "added_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_member_overrides_session_idx": {
+          "name": "session_member_overrides_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_member_overrides_user_idx": {
+          "name": "session_member_overrides_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_member_overrides_session_id_inferred_sessions_id_fk": {
+          "name": "session_member_overrides_session_id_inferred_sessions_id_fk",
+          "tableFrom": "session_member_overrides",
+          "tableTo": "inferred_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_member_overrides_user_id_users_id_fk": {
+          "name": "session_member_overrides_user_id_users_id_fk",
+          "tableFrom": "session_member_overrides",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_member_overrides_added_by_user_id_users_id_fk": {
+          "name": "session_member_overrides_added_by_user_id_users_id_fk",
+          "tableFrom": "session_member_overrides",
+          "tableTo": "users",
+          "columnsFrom": ["added_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_member_overrides_session_user_unique": {
+          "name": "session_member_overrides_session_user_unique",
+          "nullsNotDistinct": false,
+          "columns": ["session_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boardsesh_ticks": {
+      "name": "boardsesh_ticks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tick_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inferred_session_id": {
+          "name": "inferred_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_inferred_session_id": {
+          "name": "previous_inferred_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "aurora_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_sync_error": {
+          "name": "aurora_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boardsesh_ticks_user_board_idx": {
+          "name": "boardsesh_ticks_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climb_idx": {
+          "name": "boardsesh_ticks_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_aurora_id_unique": {
+          "name": "boardsesh_ticks_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_sync_pending_idx": {
+          "name": "boardsesh_ticks_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_session_idx": {
+          "name": "boardsesh_ticks_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_inferred_session_idx": {
+          "name": "boardsesh_ticks_inferred_session_idx",
+          "columns": [
+            {
+              "expression": "inferred_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climbed_at_idx": {
+          "name": "boardsesh_ticks_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climbed_at_idx": {
+          "name": "boardsesh_ticks_user_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_climbed_at_idx": {
+          "name": "boardsesh_ticks_board_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_user_idx": {
+          "name": "boardsesh_ticks_board_user_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climb_lookup_idx": {
+          "name": "boardsesh_ticks_user_climb_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boardsesh_ticks_user_id_users_id_fk": {
+          "name": "boardsesh_ticks_user_id_users_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_session_id_board_sessions_id_fk": {
+          "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk": {
+          "name": "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "inferred_sessions",
+          "columnsFrom": ["inferred_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk": {
+          "name": "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "inferred_sessions",
+          "columnsFrom": ["previous_inferred_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_board_id_user_boards_id_fk": {
+          "name": "boardsesh_ticks_board_id_user_boards_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boardsesh_ticks_uuid_unique": {
+          "name": "boardsesh_ticks_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_climbs": {
+      "name": "playlist_climbs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_climb": {
+          "name": "unique_playlist_climb",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_climb_idx": {
+          "name": "playlist_climbs_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_position_idx": {
+          "name": "playlist_climbs_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_climbs_playlist_id_playlists_id_fk": {
+          "name": "playlist_climbs_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_climbs",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_ownership": {
+      "name": "playlist_ownership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_ownership": {
+          "name": "unique_playlist_ownership",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_ownership_user_idx": {
+          "name": "playlist_ownership_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_ownership_playlist_id_playlists_id_fk": {
+          "name": "playlist_ownership_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_ownership_user_id_users_id_fk": {
+          "name": "playlist_ownership_user_id_users_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlists": {
+      "name": "playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "playlists_board_layout_idx": {
+          "name": "playlists_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_uuid_idx": {
+          "name": "playlists_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_updated_at_idx": {
+          "name": "playlists_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_last_accessed_at_idx": {
+          "name": "playlists_last_accessed_at_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_aurora_id_idx": {
+          "name": "playlists_aurora_id_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlists_uuid_unique": {
+          "name": "playlists_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlist_pins": {
+      "name": "user_playlist_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_playlist_pin": {
+          "name": "unique_user_playlist_pin",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlist_pins_user_idx": {
+          "name": "user_playlist_pins_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlist_pins_playlist_idx": {
+          "name": "user_playlist_pins_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_playlist_pins_user_id_users_id_fk": {
+          "name": "user_playlist_pins_user_id_users_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_playlist_pins_playlist_id_playlists_id_fk": {
+          "name": "user_playlist_pins_playlist_id_playlists_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hold_classifications": {
+      "name": "user_hold_classifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_type": {
+          "name": "hold_type",
+          "type": "hold_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_rating": {
+          "name": "hand_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foot_rating": {
+          "name": "foot_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_direction": {
+          "name": "pull_direction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hold_classifications_user_board_idx": {
+          "name": "user_hold_classifications_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_unique_idx": {
+          "name": "user_hold_classifications_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_hold_idx": {
+          "name": "user_hold_classifications_hold_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hold_classifications_user_id_users_id_fk": {
+          "name": "user_hold_classifications_user_id_users_id_fk",
+          "tableFrom": "user_hold_classifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esp32_controllers": {
+      "name": "esp32_controllers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_session_id": {
+          "name": "authorized_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "esp32_controllers_user_idx": {
+          "name": "esp32_controllers_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_api_key_idx": {
+          "name": "esp32_controllers_api_key_idx",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_session_idx": {
+          "name": "esp32_controllers_session_idx",
+          "columns": [
+            {
+              "expression": "authorized_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esp32_controllers_user_id_users_id_fk": {
+          "name": "esp32_controllers_user_id_users_id_fk",
+          "tableFrom": "esp32_controllers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "esp32_controllers_api_key_unique": {
+          "name": "esp32_controllers_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["api_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_follows": {
+      "name": "playlist_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_uuid": {
+          "name": "playlist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_follow": {
+          "name": "unique_playlist_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_follower_idx": {
+          "name": "playlist_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_playlist_idx": {
+          "name": "playlist_follows_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_follows_follower_id_users_id_fk": {
+          "name": "playlist_follows_follower_id_users_id_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "users",
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_follows_playlist_uuid_playlists_uuid_fk": {
+          "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setter_follows": {
+      "name": "setter_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_setter_follow": {
+          "name": "unique_setter_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_follower_idx": {
+          "name": "setter_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_setter_idx": {
+          "name": "setter_follows_setter_idx",
+          "columns": [
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setter_follows_follower_id_users_id_fk": {
+          "name": "setter_follows_follower_id_users_id_fk",
+          "tableFrom": "setter_follows",
+          "tableTo": "users",
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_follow": {
+          "name": "unique_user_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_following_idx": {
+          "name": "user_follows_following_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": ["following_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_follow": {
+          "name": "no_self_follow",
+          "value": "\"user_follows\".\"follower_id\" != \"user_follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_entity_created_at_idx": {
+          "name": "comments_entity_created_at_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_user_created_at_idx": {
+          "name": "comments_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_parent_comment_idx": {
+          "name": "comments_parent_comment_idx",
+          "columns": [
+            {
+              "expression": "parent_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comments_uuid_unique": {
+          "name": "comments_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_unique_user_entity": {
+          "name": "votes_unique_user_entity",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_entity_idx": {
+          "name": "votes_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_user_idx": {
+          "name": "votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vote_value_check": {
+          "name": "vote_value_check",
+          "value": "\"votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_created_at_idx": {
+          "name": "notifications_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_dedup_idx": {
+          "name": "notifications_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipient_id_users_id_fk": {
+          "name": "notifications_recipient_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_comments_id_fk": {
+          "name": "notifications_comment_id_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_uuid_unique": {
+          "name": "notifications_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "feed_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_recipient_created_at_idx": {
+          "name": "feed_items_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_recipient_board_created_at_idx": {
+          "name": "feed_items_recipient_board_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_actor_created_at_idx": {
+          "name": "feed_items_actor_created_at_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_created_at_idx": {
+          "name": "feed_items_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_entity_type_entity_id_idx": {
+          "name": "feed_items_entity_type_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_recipient_id_users_id_fk": {
+          "name": "feed_items_recipient_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feed_items_actor_id_users_id_fk": {
+          "name": "feed_items_actor_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_classic_status": {
+      "name": "climb_classic_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_classic": {
+          "name": "is_classic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_classic_status_unique_idx": {
+          "name": "climb_classic_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_classic_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_classic_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": ["last_proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_community_status": {
+      "name": "climb_community_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_grade": {
+          "name": "community_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_community_status_unique_idx": {
+          "name": "climb_community_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_community_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_community_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": ["last_proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_proposals": {
+      "name": "climb_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "climb_proposals_climb_angle_type_idx": {
+          "name": "climb_proposals_climb_angle_type_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_status_idx": {
+          "name": "climb_proposals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_proposer_idx": {
+          "name": "climb_proposals_proposer_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_board_type_idx": {
+          "name": "climb_proposals_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_created_at_idx": {
+          "name": "climb_proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_proposals_proposer_id_users_id_fk": {
+          "name": "climb_proposals_proposer_id_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": ["proposer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "climb_proposals_resolved_by_users_id_fk": {
+          "name": "climb_proposals_resolved_by_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "climb_proposals_uuid_unique": {
+          "name": "climb_proposals_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_roles": {
+      "name": "community_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_roles_board_type_idx": {
+          "name": "community_roles_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_roles_user_id_users_id_fk": {
+          "name": "community_roles_user_id_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_roles_granted_by_users_id_fk": {
+          "name": "community_roles_granted_by_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": ["granted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_roles_user_role_board_idx": {
+          "name": "community_roles_user_role_board_idx",
+          "nullsNotDistinct": true,
+          "columns": ["user_id", "role", "board_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_by": {
+          "name": "set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_settings_scope_key_idx": {
+          "name": "community_settings_scope_key_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_settings_set_by_users_id_fk": {
+          "name": "community_settings_set_by_users_id_fk",
+          "tableFrom": "community_settings",
+          "tableTo": "users",
+          "columnsFrom": ["set_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_votes_unique_user_proposal": {
+          "name": "proposal_votes_unique_user_proposal",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_proposal_idx": {
+          "name": "proposal_votes_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_climb_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "climb_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_user_id_users_id_fk": {
+          "name": "proposal_votes_user_id_users_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_vote_value_check": {
+          "name": "proposal_vote_value_check",
+          "value": "\"proposal_votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.new_climb_subscriptions": {
+      "name": "new_climb_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "new_climb_subscriptions_unique_user_board_layout": {
+          "name": "new_climb_subscriptions_unique_user_board_layout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_user_idx": {
+          "name": "new_climb_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_board_layout_idx": {
+          "name": "new_climb_subscriptions_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_climb_subscriptions_user_id_users_id_fk": {
+          "name": "new_climb_subscriptions_user_id_users_id_fk",
+          "tableFrom": "new_climb_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_counts": {
+      "name": "vote_counts",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vote_counts_score_idx": {
+          "name": "vote_counts_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_counts_hot_score_idx": {
+          "name": "vote_counts_hot_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hot_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "vote_counts_entity_type_entity_id_pk": {
+          "name": "vote_counts_entity_type_entity_id_pk",
+          "columns": ["entity_type", "entity_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_participants": {
+      "name": "board_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_session_participants_session_idx": {
+          "name": "board_session_participants_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_session_participants_user_idx": {
+          "name": "board_session_participants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_session_participants_session_id_board_sessions_id_fk": {
+          "name": "board_session_participants_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_session_participants_user_id_users_id_fk": {
+          "name": "board_session_participants_user_id_users_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_session_participants_session_id_user_id_pk": {
+          "name": "board_session_participants_session_id_user_id_pk",
+          "columns": ["session_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_feedback": {
+      "name": "app_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_feedback_created_at_idx": {
+          "name": "app_feedback_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_user_idx": {
+          "name": "app_feedback_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_board_idx": {
+          "name": "app_feedback_board_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_feedback_user_id_users_id_fk": {
+          "name": "app_feedback_user_id_users_id_fk",
+          "tableFrom": "app_feedback",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_climb_percentiles": {
+      "name": "user_climb_percentiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_distinct_climbs": {
+          "name": "total_distinct_climbs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "percentile": {
+          "name": "percentile",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_active_users": {
+          "name": "total_active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_climb_percentiles_user_id_users_id_fk": {
+          "name": "user_climb_percentiles_user_id_users_id_fk",
+          "tableFrom": "user_climb_percentiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_push_tokens": {
+      "name": "activity_push_tokens",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_push_tokens_session_idx": {
+          "name": "activity_push_tokens_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_push_tokens_updated_at_idx": {
+          "name": "activity_push_tokens_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_push_tokens_session_id_board_sessions_id_fk": {
+          "name": "activity_push_tokens_session_id_board_sessions_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.gym_member_role": {
+      "name": "gym_member_role",
+      "schema": "public",
+      "values": ["admin", "member"]
+    },
+    "public.aurora_table_type": {
+      "name": "aurora_table_type",
+      "schema": "public",
+      "values": ["ascents", "bids"]
+    },
+    "public.tick_status": {
+      "name": "tick_status",
+      "schema": "public",
+      "values": ["flash", "send", "attempt"]
+    },
+    "public.hold_type": {
+      "name": "hold_type",
+      "schema": "public",
+      "values": ["jug", "sloper", "pinch", "crimp", "pocket"]
+    },
+    "public.social_entity_type": {
+      "name": "social_entity_type",
+      "schema": "public",
+      "values": ["playlist_climb", "climb", "tick", "comment", "proposal", "board", "gym", "session"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "new_follower",
+        "comment_reply",
+        "comment_on_tick",
+        "comment_on_climb",
+        "vote_on_tick",
+        "vote_on_comment",
+        "new_climb",
+        "new_climb_global",
+        "proposal_approved",
+        "proposal_rejected",
+        "proposal_vote",
+        "proposal_created",
+        "new_climbs_synced"
+      ]
+    },
+    "public.feed_item_type": {
+      "name": "feed_item_type",
+      "schema": "public",
+      "values": ["ascent", "new_climb", "comment", "proposal_approved", "session_summary"]
+    },
+    "public.community_role_type": {
+      "name": "community_role_type",
+      "schema": "public",
+      "values": ["admin", "community_leader"]
+    },
+    "public.proposal_status": {
+      "name": "proposal_status",
+      "schema": "public",
+      "values": ["open", "approved", "rejected", "superseded"]
+    },
+    "public.proposal_type": {
+      "name": "proposal_type",
+      "schema": "public",
+      "values": ["grade", "classic", "benchmark"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -673,6 +673,13 @@
       "when": 1778738922542,
       "tag": "0095_activity_push_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 96,
+      "version": "7",
+      "when": 1778796374010,
+      "tag": "0096_abnormal_korg",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app/activity-push-tokens.ts
+++ b/packages/db/src/schema/app/activity-push-tokens.ts
@@ -14,6 +14,12 @@ export const activityPushTokens = pgTable(
   },
   (table) => ({
     sessionIdx: index('activity_push_tokens_session_idx').on(table.sessionId),
+    // Supports the eviction freshness filter (`WHERE updated_at < cutoff`) in
+    // `registerActivityPushToken` and the periodic stale-token sweep in
+    // `apns/cleanup.ts`. Both queries also filter by session, but a global
+    // index on `updated_at` is cheap and lets the cleanup sweep stay cluster-
+    // wide rather than per-session.
+    updatedAtIdx: index('activity_push_tokens_updated_at_idx').on(table.updatedAt),
   }),
 );
 

--- a/packages/db/src/schema/app/activity-push-tokens.ts
+++ b/packages/db/src/schema/app/activity-push-tokens.ts
@@ -14,11 +14,10 @@ export const activityPushTokens = pgTable(
   },
   (table) => ({
     sessionIdx: index('activity_push_tokens_session_idx').on(table.sessionId),
-    // Supports the eviction freshness filter (`WHERE updated_at < cutoff`) in
-    // `registerActivityPushToken` and the periodic stale-token sweep in
-    // `apns/cleanup.ts`. Both queries also filter by session, but a global
-    // index on `updated_at` is cheap and lets the cleanup sweep stay cluster-
-    // wide rather than per-session.
+    // Supports the cluster-wide stale-token sweep in `apns/cleanup.ts`
+    // (`DELETE WHERE updated_at < cutoff`). The per-session eviction in
+    // `registerActivityPushToken` is served by the existing
+    // (session_id) index at the small row counts involved (≤8 per session).
     updatedAtIdx: index('activity_push_tokens_updated_at_idx').on(table.updatedAt),
   }),
 );


### PR DESCRIPTION
## Summary

iOS Live Activities were flakey because (a) push-token registration was fire-and-forget with no retry — a momentary network blip on a just-locked phone would silently break widget navigation forever — and (b) the only way to refresh the lock-screen widget was for a real queue event to fire, so any session that went idle for >3 min showed "Session ended" until a user touched the queue again.

This change is a comprehensive overhaul covering both symptoms, plus the supporting reliability fixes that surfaced across two rounds of independent code review.

> **Note on commit history.** Three review passes shaped this PR:
> - Initial scope (`ff01dba`): debounce shrink, heartbeat, immediate-send on register, retries, etc.
> - Reviewer-driven Tier 1-3 fixes (`6a20a54`): leader election on heartbeat, content-state dedupe + real `hasNext` bug fix, iOS `endSession`/observer/retry races, F8 drop.
> - Round-2 review fixes (`2ea783c`): heartbeat source attribution, 410 keychain handling, metric split, cleanup tests, doc updates.
> The bullet list below describes the final state, not the per-commit diff.

### Backend

- **F1** 90 s heartbeat keeps the lock-screen Live Activity alive through idle periods (`apns/heartbeat.ts`). Sweeps every session with a registered push token; one cluster-wide Redis leader-lock per tick so N instances don't multiply APNs traffic. Bounded concurrency (10 parallel). Skips sessions that already have a pending debounced send so the backstop doesn't overwrite a fresher in-flight state. **`source: 'heartbeat'`** flows into the per-send log line.
- **F2** APNs debounce 5 s → 1 s. Lock-screen Next/Previous now feels responsive.
- **F3** Token registration triggers an immediate single-token APNs push so the widget exits "Loading…" without waiting for a queue event.
- **F4** Token rebind detection: logs and counts when a token moves between sessions.
- **F5** `/api/widget/navigate` returns **410** (not 401) when a token is bound to a different session; iOS uses the hint to re-register. Note: the widget keeps its cached Bearer through the re-register window — the backend rebinds the same token, so subsequent calls return 200 once rebind completes.
- **F6** Cap eviction respects a 1 h freshness window — bursts of new registrations can't evict a still-valid token. If all 8 slots are fresh, we reject and let iOS retry.
- **F7** DB-retry exhaustion requeues the latest state with a fresh retry counter rather than dropping it; transient outages cost at most one extra debounce window.
- **F9** Daily sweep removes push tokens with `updated_at < now() - 7 days`.
- **F10** Multi-instance APNs configuration check via a Redis hash (HSET / HGETALL) — O(1) round-trips regardless of cluster size — escalates to ERROR when peers are misconfigured.
- **F11** (iOS) `staleInterval` 3 min → 10 min (6× headroom against the 90 s heartbeat).
- **F12** Migration adds `activity_push_tokens_updated_at_idx` for the daily cleanup sweep.
- **F13/F14** (iOS) Push-token registration retries with exponential backoff (0/2/5/15/30 s); pending record persisted to shared keychain; retry on app foreground, WS reconnect, and widget 410.
- **F15** (iOS) Widget posts the re-register Darwin notification on 410.
- **F16** New `/api/internal/apns-stats` returns in-memory counters keyed by `instanceId` for debugging (gated by `APNS_STATS_SECRET`).
- **F17** Single structured per-send log line: `[APNs] session=X event=update source=Y tokens=N sent=N failed=N stale=N elapsedMs=N`.
- **F18** Metric split: `tokensRemovedOn410` (live-send 410/BadDeviceToken path) vs `tokensSweptStale` (daily cleanup sweep) — distinguishes the two cleanup paths.

### iOS

- Push-token registration retries with persistence + foreground/WS-reconnect/widget-410 replay (see F13/F14/F15).
- **Single source of truth**: `CFNotificationCenterRemoveObserver` now passes the specific name (the nil-name form would silently remove *all* observers for `self`).
- `attemptRegistration` treats `nil _currentSessionId` as **abort**, not as fallthrough — closes the race where an in-flight retry from a just-ended session re-registers the old token.
- Retry chains carry a generation counter; a superseded chain aborts on its next tick rather than running in parallel with the new chain.
- `clearPendingRegistrationIfMatches` protects against a late URLSession completion wiping a record a newer `startSession` already wrote.
- Orphan pending records GC'd on session-ID mismatch in `retryPendingRegistrationIfNeeded`.
- Widget 410 path: posts the Darwin notification BEFORE the keychain delete… and now doesn't delete the keychain at all (Bearer stays valid; backend rebinds it).
- `staleInterval` 3 min → 10 min (F11).

### What changed from the original scope

- **F8 (Redis-pending mirror) was dropped** during round-2 review. The mirror was half-built (30 s TTL vs 1 s debounce, no peer-side scanner, races between writes/deletes) and the heartbeat is the real backstop — a restart inside the 1 s debounce window costs at most 90 s of staleness, which is acceptable. Removing it eliminated two race conditions for free.

### Schema

- New migration `0096_abnormal_korg.sql` adds the index on `activity_push_tokens.updated_at` (serves the cluster-wide cleanup sweep; the existing per-session index serves eviction).

### Tests

- `push-tokens.test.ts` (12 tests): rebind logging, eviction freshness, immediate-send-on-register positive AND negative, in-session upsert cap exemption, rate limiting variations.
- `widget-navigate.test.ts` (6 tests): 401 vs 410 split, rate limiting, method validation.
- `apns-heartbeat.test.ts` (6 tests, new): config gating, lock contention, per-session dispatch, null-state skip, pending-send skip, error isolation across sessions.
- `apns-cleanup.test.ts` (4 tests, new): config gating, no-op on empty result, metric increment, DB-error swallowing.
- 34/34 targeted tests pass.

### Validation done locally

- `vp run typecheck` — green across all packages.
- `vp check` — green for changed files.
- `SKIP_TEST_INFRA=1 vp test run packages/backend/src/__tests__/{push-tokens,widget-navigate,apns-heartbeat,apns-cleanup}.test.ts` — 34/34 passing.
- Drizzle migration generated via `bunx drizzle-kit generate`; `_journal.json` updated.

## Test plan

End-to-end verification requires a real iOS build per `docs/live-activity-push-testing.md`. Suggested scenarios:

- [ ] **Heartbeat keeps activity alive.** Start a session, lock 12+ min with no queue activity. Widget stays live. Backend logs show heartbeats ~every 90 s with `source=heartbeat`.
- [ ] **Fresh state within ~1 s of token registration.** New session shows climb name within ~1 s, not "Loading…".
- [ ] **Token registration retries.** Toggle airplane mode at session start; Xcode console shows successful registration on attempt N within 5 s of reconnect.
- [ ] **Rebind logging.** Start session A, then session B on same iPhone. Backend logs `[APNs] Rebound token … from session A → B`.
- [ ] **Widget 410 → re-register.** Manually delete the `activity_push_tokens` row mid-session. Widget Next/Previous refreshes within ~5 s; no silent 401 window.
- [ ] **DB retry survives a Postgres blip.** Brief `docker compose stop postgres` during a queue event; Live Activity updates within 15 s of recovery.
- [ ] **Heartbeat ordering.** With multiple instances configured, only one instance's logs show heartbeat sends per tick.
- [ ] **`apns-stats` metric split.** `tokensRemovedOn410` increments on a forced 410 send; `tokensSweptStale` increments after `UPDATE … SET updated_at = now() - interval '8 days'` and the next cleanup tick.

## Open follow-ups

Tracked in #2155 (Tier 4 deferred items). Includes constant-time secret comparison, jitter on retry delays, consecutive-410 cap, NWPathMonitor watchdog, widget `os.log` Logger, and a few smaller hygiene items.

PR-activity subscription is active for this PR; review comments and CI failures will reach me directly.

https://claude.ai/code/session_0122E7zVroZdyp42uBR38yq3