### PR TITLE
fix(live-activities): point iOS registration at the backend host

### DIFF
--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -352,13 +352,13 @@ APNs env vars are not set in `packages/backend/.env.local`. Double-check all fiv
 
 ### "No registered Live Activity tokens"
 
-The APNs hook fired for a queue change, but `activity_push_tokens` has no rows for that session:
+The APNs hook fired for a queue change, but `activity_push_tokens` has no rows for that session. The log lives at `debug` level (because most party sessions don't have an iOS device watching, and at `info` the channel would be unreadable):
 
 ```
 [APNs] No registered Live Activity tokens for session ...; skipping update
 ```
 
-This usually means ActivityKit emitted a push token but native registration failed before the backend stored it. Check iOS console logs for keychain write failures, missing auth-token warnings, GraphQL registration errors, or backend reachability errors.
+For a session you *expect* to have an iOS device, this means ActivityKit emitted a push token but native registration failed before the backend stored it. Check iOS console logs for keychain write failures, missing auth-token warnings, GraphQL registration errors, or backend reachability errors. A common past failure mode: the plugin was POSTing the mutation to the web origin (`https://www.boardsesh.com/graphql`) instead of the backend host (`https://ws.boardsesh.com/graphql`) — every request 404'd silently. Verify `graphqlUrl` is passed in to `startSession` from JS and stored in `_currentGraphqlUrl`.
 
 ### "BadDeviceToken" in APNs results
 
@@ -372,7 +372,7 @@ The .p8 key JWT has expired (tokens are valid for 1 hour). The `@parse/node-apn`
 
 ### Widget buttons don't send HTTP request
 
-- Check that `serverUrl` is stored in SharedDefaults. The `LiveActivityPlugin.startSession()` stores it — verify by checking Xcode console logs during session start.
+- Check that `bs_widget_navigate_url` (constant: `SharedConstants.widgetNavigateUrlKey`) is stored in SharedDefaults. `LiveActivityPlugin.startSession()` derives it from `graphqlUrl` (e.g. `https://ws.boardsesh.com/api/widget/navigate`) and writes it — verify in the Xcode console during session start. The widget reads this exact URL via `WidgetNetworking.sendNavigation`; if the key is missing the call silently no-ops. Earlier builds derived the URL from `bs_server_url` (the web origin), which is wrong because `/api/widget/navigate` is a backend route, not a Next.js route — if you're seeing the old key in SharedDefaults, the user is on a stale build.
 - The widget extension must have the App Group entitlement to read SharedDefaults.
 - Check backend logs for incoming requests to `/api/widget/navigate`.
 

--- a/mobile/ios/App/App/LiveActivityPlugin.swift
+++ b/mobile/ios/App/App/LiveActivityPlugin.swift
@@ -25,6 +25,10 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     private let tokenQueue = DispatchQueue(label: "com.boardsesh.LiveActivityPlugin.token")
     private var _currentPushToken: String?
     private var _currentServerUrl: String?
+    /// HTTP GraphQL endpoint on the backend (e.g. https://ws.boardsesh.com/graphql).
+    /// Distinct from _currentServerUrl, which is the web origin
+    /// (https://www.boardsesh.com) — the backend lives on a different host.
+    private var _currentGraphqlUrl: String?
     private var _currentSessionId: String?
 
     /// Monotonically increments every time `registerPushTokenWithBackend` is
@@ -123,8 +127,8 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     private func handlePushRegistrationStale() {
-        let (token, sessionId, serverUrl) = tokenQueue.sync {
-            (_currentPushToken, _currentSessionId, _currentServerUrl)
+        let (token, sessionId, serverUrl, graphqlUrl) = tokenQueue.sync {
+            (_currentPushToken, _currentSessionId, _currentServerUrl, _currentGraphqlUrl)
         }
         // Leave `livePushTokenKey` in the keychain so the widget keeps sending
         // the same Bearer while we re-register. Once the backend rebinds the
@@ -134,9 +138,9 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         // retry window, which doesn't trigger the Darwin notification
         // fallback — so the widget would silently fail buttons until the
         // foreground observer eventually runs.
-        if let token, let sessionId, let serverUrl {
+        if let token, let sessionId, let serverUrl, let graphqlUrl {
             logger.info("Re-registering push token after widget 410")
-            registerPushTokenWithBackend(token: token, sessionId: sessionId, serverUrl: serverUrl)
+            registerPushTokenWithBackend(token: token, sessionId: sessionId, serverUrl: serverUrl, graphqlUrl: graphqlUrl)
         } else {
             logger.warning("Push registration stale notification received but no current session/token to re-register")
         }
@@ -202,11 +206,12 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
 
     /// Persist a pending-registration record to the shared keychain so that a
     /// crash, app relaunch, or backgrounded retry path can pick it up later.
-    private func writePendingRegistration(token: String, sessionId: String, serverUrl: String) {
+    private func writePendingRegistration(token: String, sessionId: String, serverUrl: String, graphqlUrl: String) {
         let payload: [String: String] = [
             "token": token,
             "sessionId": sessionId,
             "serverUrl": serverUrl,
+            "graphqlUrl": graphqlUrl,
         ]
         guard let data = try? JSONSerialization.data(withJSONObject: payload),
               let json = String(data: data, encoding: .utf8) else { return }
@@ -233,15 +238,22 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         SharedKeychain.remove(SharedKeychain.pendingPushRegistrationKey)
     }
 
-    private func readPendingRegistration() -> (token: String, sessionId: String, serverUrl: String)? {
+    private func readPendingRegistration() -> (token: String, sessionId: String, serverUrl: String, graphqlUrl: String)? {
         guard let json = SharedKeychain.get(SharedKeychain.pendingPushRegistrationKey),
               let data = json.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: String],
               let token = obj["token"], !token.isEmpty,
               let sessionId = obj["sessionId"], !sessionId.isEmpty,
-              let serverUrl = obj["serverUrl"], !serverUrl.isEmpty
+              let serverUrl = obj["serverUrl"], !serverUrl.isEmpty,
+              // graphqlUrl was added in the same release that fixed the
+              // wrong-host registration bug. Records written by earlier builds
+              // lack it; discard them so we don't retry against a stale URL.
+              // ActivityKit will deliver a fresh push token shortly after
+              // foregrounding, which kicks off a new registration with the
+              // correct URL.
+              let graphqlUrl = obj["graphqlUrl"], !graphqlUrl.isEmpty
         else { return nil }
-        return (token: token, sessionId: sessionId, serverUrl: serverUrl)
+        return (token: token, sessionId: sessionId, serverUrl: serverUrl, graphqlUrl: graphqlUrl)
     }
 
     /// Kick off a push-token registration with exponential retries.
@@ -250,20 +262,20 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     /// from a previous call aborts on its next tick. Persists a pending record
     /// to the shared keychain so foreground / WS-reconnect hooks can retry
     /// later. Safe to call from any thread.
-    private func registerPushTokenWithBackend(token: String, sessionId: String, serverUrl: String) {
+    private func registerPushTokenWithBackend(token: String, sessionId: String, serverUrl: String, graphqlUrl: String) {
         let generation = tokenQueue.sync { () -> UInt64 in
             _activeRegistrationGeneration += 1
             return _activeRegistrationGeneration
         }
-        writePendingRegistration(token: token, sessionId: sessionId, serverUrl: serverUrl)
+        writePendingRegistration(token: token, sessionId: sessionId, serverUrl: serverUrl, graphqlUrl: graphqlUrl)
         scheduleRegistrationAttempt(
-            token: token, sessionId: sessionId, serverUrl: serverUrl,
+            token: token, sessionId: sessionId, serverUrl: serverUrl, graphqlUrl: graphqlUrl,
             attemptIndex: 0, generation: generation
         )
     }
 
     private func scheduleRegistrationAttempt(
-        token: String, sessionId: String, serverUrl: String,
+        token: String, sessionId: String, serverUrl: String, graphqlUrl: String,
         attemptIndex: Int, generation: UInt64
     ) {
         guard attemptIndex < pushRegistrationRetryDelays.count else {
@@ -275,7 +287,7 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         let delay = pushRegistrationRetryDelays[attemptIndex]
         let work: () -> Void = { [weak self] in
             self?.attemptRegistration(
-                token: token, sessionId: sessionId, serverUrl: serverUrl,
+                token: token, sessionId: sessionId, serverUrl: serverUrl, graphqlUrl: graphqlUrl,
                 attemptIndex: attemptIndex, generation: generation
             )
         }
@@ -287,7 +299,7 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     private func attemptRegistration(
-        token: String, sessionId: String, serverUrl: String,
+        token: String, sessionId: String, serverUrl: String, graphqlUrl: String,
         attemptIndex: Int, generation: UInt64
     ) {
         // Treat both a session-mismatch AND a nil active session as "abort":
@@ -334,7 +346,7 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             "query": query,
             "variables": ["sessionId": sessionId, "token": token]
         ]
-        guard let url = URL(string: "\(serverUrl)/graphql"),
+        guard let url = URL(string: graphqlUrl),
               let jsonData = try? JSONSerialization.data(withJSONObject: body) else { return }
 
         var request = URLRequest(url: url)
@@ -364,7 +376,7 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
                         "Push token registration attempt \(attemptIndex + 1, privacy: .public) failed (\(failureReason, privacy: .public)); retrying in \(self.pushRegistrationRetryDelays[nextAttemptIndex], privacy: .public)s"
                     )
                     self.scheduleRegistrationAttempt(
-                        token: token, sessionId: sessionId, serverUrl: serverUrl,
+                        token: token, sessionId: sessionId, serverUrl: serverUrl, graphqlUrl: graphqlUrl,
                         attemptIndex: nextAttemptIndex, generation: generation
                     )
                 } else {
@@ -409,11 +421,12 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         registerPushTokenWithBackend(
             token: pending.token,
             sessionId: pending.sessionId,
-            serverUrl: pending.serverUrl
+            serverUrl: pending.serverUrl,
+            graphqlUrl: pending.graphqlUrl
         )
     }
 
-    private func unregisterPushTokenFromBackend(token: String, sessionId: String, serverUrl: String) {
+    private func unregisterPushTokenFromBackend(token: String, sessionId: String, graphqlUrl: String) {
         // The backend resolver authenticates via ConnectionContext, so we MUST
         // attach the user's app auth token. Without it the resolver rejects.
         guard let authToken = SharedKeychain.get(SharedKeychain.authTokenKey),
@@ -432,7 +445,7 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             "query": query,
             "variables": ["sessionId": sessionId, "token": token]
         ]
-        guard let url = URL(string: "\(serverUrl)/graphql"),
+        guard let url = URL(string: graphqlUrl),
               let jsonData = try? JSONSerialization.data(withJSONObject: body) else { return }
 
         var request = URLRequest(url: url)
@@ -510,12 +523,28 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         let setIds = call.getString("setIds") ?? ""
         let authToken = call.getString("authToken")
         let wsUrl = call.getString("wsUrl")
+        // Backend GraphQL endpoint. The web origin (`serverUrl`) does not
+        // serve `/graphql` — that route is on the backend host (e.g.
+        // ws.boardsesh.com). Without this, registerActivityPushToken hits
+        // the web origin and 404s silently.
+        let graphqlUrl = call.getString("graphqlUrl")
 
         // Store session details for push token registration.
         tokenQueue.sync {
             _currentServerUrl = serverUrl
+            _currentGraphqlUrl = graphqlUrl
             _currentSessionId = sessionId
         }
+
+        // Derive the widget navigate URL from the backend GraphQL URL —
+        // they share host + scheme, just different paths.
+        let widgetNavigateUrl: String? = {
+            guard let graphqlUrl, var components = URLComponents(string: graphqlUrl) else { return nil }
+            components.path = "/api/widget/navigate"
+            components.query = nil
+            components.fragment = nil
+            return components.url?.absoluteString
+        }()
 
         // Store board details in shared UserDefaults for App Intents
         // and thumbnail URL construction. Auth + push tokens go through
@@ -524,6 +553,9 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         if let defaults = SharedConstants.sharedDefaults {
             defaults.set(sessionId, forKey: SharedConstants.sessionIdKey)
             defaults.set(serverUrl, forKey: SharedConstants.serverUrlKey)
+            if let widgetNavigateUrl {
+                defaults.set(widgetNavigateUrl, forKey: SharedConstants.widgetNavigateUrlKey)
+            }
             defaults.set(boardName, forKey: SharedConstants.boardNameKey)
             defaults.set(layoutId, forKey: SharedConstants.layoutIdKey)
             defaults.set(sizeId, forKey: SharedConstants.sizeIdKey)
@@ -597,14 +629,14 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         // silently drop it.
         let pushTokenHandler: @Sendable (String) -> Void = { [weak self] token in
             guard let self else { return }
-            // Single sync block: write the token and read sessionId/serverUrl
-            // in one critical section. Two separate tokenQueue.sync calls
-            // would deadlock if ActivityKit ever delivers the token on a
+            // Single sync block: write the token and read sessionId/serverUrl/
+            // graphqlUrl in one critical section. Two separate tokenQueue.sync
+            // calls would deadlock if ActivityKit ever delivers the token on a
             // thread already holding the queue (Swift serial DispatchQueues
             // are not reentrant).
-            let (sid, surl) = self.tokenQueue.sync { () -> (String?, String?) in
+            let (sid, surl, gurl) = self.tokenQueue.sync { () -> (String?, String?, String?) in
                 self._currentPushToken = token
-                return (self._currentSessionId, self._currentServerUrl)
+                return (self._currentSessionId, self._currentServerUrl, self._currentGraphqlUrl)
             }
             // Write the APNs push token to the shared keychain so the
             // widget extension can attach it as a Bearer header on
@@ -612,8 +644,12 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             if !SharedKeychain.set(token, for: SharedKeychain.livePushTokenKey) {
                 self.logger.error("Failed to write Live Activity push token to shared keychain")
             }
-            if let sessionId = sid, let serverUrl = surl {
-                self.registerPushTokenWithBackend(token: token, sessionId: sessionId, serverUrl: serverUrl)
+            if let sessionId = sid, let serverUrl = surl, let graphqlUrl = gurl {
+                self.registerPushTokenWithBackend(token: token, sessionId: sessionId, serverUrl: serverUrl, graphqlUrl: graphqlUrl)
+            } else {
+                self.logger.warning(
+                    "Received push token but cannot register (sessionId=\(sid ?? "nil", privacy: .public), serverUrl=\(surl ?? "nil", privacy: .public), graphqlUrl=\(gurl ?? "nil", privacy: .public))"
+                )
             }
         }
 
@@ -642,15 +678,16 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         stopForegroundObservation()
 
         // Unregister the push token from the backend before tearing down.
-        let (token, sessionId, serverUrl) = tokenQueue.sync {
-            (_currentPushToken, _currentSessionId, _currentServerUrl)
+        let (token, sessionId, graphqlUrl) = tokenQueue.sync {
+            (_currentPushToken, _currentSessionId, _currentGraphqlUrl)
         }
-        if let token, let sessionId, let serverUrl {
-            unregisterPushTokenFromBackend(token: token, sessionId: sessionId, serverUrl: serverUrl)
+        if let token, let sessionId, let graphqlUrl {
+            unregisterPushTokenFromBackend(token: token, sessionId: sessionId, graphqlUrl: graphqlUrl)
         }
         tokenQueue.sync {
             _currentPushToken = nil
             _currentServerUrl = nil
+            _currentGraphqlUrl = nil
             _currentSessionId = nil
         }
         // Drop any in-flight pending registration so a stale retry can't
@@ -668,6 +705,7 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             defaults.removeObject(forKey: SharedConstants.currentIndexKey)
             defaults.removeObject(forKey: SharedConstants.sessionIdKey)
             defaults.removeObject(forKey: SharedConstants.pendingActionKey)
+            defaults.removeObject(forKey: SharedConstants.widgetNavigateUrlKey)
             // Cover earlier builds that wrote tokens to UserDefaults so
             // we don't leave plaintext credentials behind after upgrade.
             defaults.removeObject(forKey: SharedConstants.authTokenKey)

--- a/mobile/ios/App/App/SharedConstants.swift
+++ b/mobile/ios/App/App/SharedConstants.swift
@@ -10,7 +10,14 @@ enum SharedConstants {
     static let queueItemsKey = "bs_queue_items"
     static let currentIndexKey = "bs_current_index"
     static let sessionIdKey = "bs_session_id"
+    /// Web origin (e.g. https://www.boardsesh.com). Used by the widget for
+    /// Next.js-hosted routes like `/api/internal/board-render`.
     static let serverUrlKey = "bs_server_url"
+    /// Fully-qualified backend `/api/widget/navigate` URL (e.g.
+    /// https://ws.boardsesh.com/api/widget/navigate). The widget POSTs button
+    /// taps here. Distinct from `serverUrlKey` because the backend lives on a
+    /// different host than the web app.
+    static let widgetNavigateUrlKey = "bs_widget_navigate_url"
     static let boardNameKey = "bs_board_name"
     static let layoutIdKey = "bs_layout_id"
     static let sizeIdKey = "bs_size_id"

--- a/mobile/ios/App/BoardseshWidgets/WidgetNetworking.swift
+++ b/mobile/ios/App/BoardseshWidgets/WidgetNetworking.swift
@@ -6,11 +6,11 @@ enum WidgetNetworking {
     @discardableResult
     static func sendNavigation(action: String, currentIndex: Int) async -> Bool {
         guard let defaults = SharedConstants.sharedDefaults,
-              let serverUrl = defaults.string(forKey: SharedConstants.serverUrlKey),
+              let widgetNavigateUrl = defaults.string(forKey: SharedConstants.widgetNavigateUrlKey),
               let sessionId = defaults.string(forKey: SharedConstants.sessionIdKey)
         else { return false }
 
-        guard let url = URL(string: "\(serverUrl)/api/widget/navigate") else { return false }
+        guard let url = URL(string: widgetNavigateUrl) else { return false }
 
         let body: [String: Any] = [
             "sessionId": sessionId,

--- a/mobile/ios/App/BoardseshWidgets/WidgetNetworking.swift
+++ b/mobile/ios/App/BoardseshWidgets/WidgetNetworking.swift
@@ -5,6 +5,14 @@ enum WidgetNetworking {
     /// Returns `true` if the request succeeded (HTTP 200), `false` otherwise.
     @discardableResult
     static func sendNavigation(action: String, currentIndex: Int) async -> Bool {
+        // `widgetNavigateUrlKey` is written by `LiveActivityPlugin.startSession`.
+        // If the user upgrades the app mid-session without re-running
+        // `startSession` (e.g. they had a Live Activity running, installed the
+        // new build, didn't relaunch the main app), the key won't be in
+        // UserDefaults and the widget will silently no-op. Acceptable: the
+        // pre-fix build already had broken widget navigation, and the user
+        // gets recovery as soon as they open the main app and start a new
+        // session. The optimistic UI update in the widget intent still fires.
         guard let defaults = SharedConstants.sharedDefaults,
               let widgetNavigateUrl = defaults.string(forKey: SharedConstants.widgetNavigateUrlKey),
               let sessionId = defaults.string(forKey: SharedConstants.sessionIdKey)

--- a/packages/backend/src/services/apns/index.ts
+++ b/packages/backend/src/services/apns/index.ts
@@ -342,7 +342,10 @@ async function executeDebouncedSend(sessionId: string): Promise<void> {
   const source = entry.source;
   pendingSends.delete(sessionId);
   if (tokens.length === 0) {
-    console.info(`[APNs] No registered Live Activity tokens for session ${sessionId}; skipping update`);
+    // Demoted to debug because every queue event on a party session without an
+    // iOS Live Activity device produces one of these. Multiplied by N backend
+    // instances and M queue events/min, the info-level version was unreadable.
+    console.debug(`[APNs] No registered Live Activity tokens for session ${sessionId}; skipping update`);
     return;
   }
 
@@ -434,7 +437,7 @@ export async function endLiveActivity(sessionId: string): Promise<void> {
   if (tokens.length > 0) {
     await sendNotification(sessionId, tokens, 'end');
   } else {
-    console.info(`[APNs] No registered Live Activity tokens for session ${sessionId}; skipping end`);
+    console.debug(`[APNs] No registered Live Activity tokens for session ${sessionId}; skipping end`);
   }
 
   await cleanupTokensForSession(sessionId);

--- a/packages/web/app/lib/live-activity/__tests__/use-live-activity.test.ts
+++ b/packages/web/app/lib/live-activity/__tests__/use-live-activity.test.ts
@@ -45,6 +45,7 @@ vi.mock('../live-activity-plugin', () => ({
 
 vi.mock('../../backend-url', () => ({
   getBackendWsUrl: () => 'ws://localhost:8080/graphql',
+  getGraphQLHttpUrl: () => 'http://localhost:8080/graphql',
 }));
 
 vi.mock('@/app/hooks/use-ws-auth-token', () => ({
@@ -249,6 +250,11 @@ describe('useLiveActivity', () => {
         authToken: 'test-auth-token',
         layoutId: 1,
         sizeId: 1,
+        // The HTTP graphql URL must be derived from the WS URL so the iOS
+        // plugin posts registerActivityPushToken at the backend host, not
+        // the web origin. Regressing this re-creates the 404-loop bug.
+        wsUrl: 'ws://localhost:8080/graphql',
+        graphqlUrl: 'http://localhost:8080/graphql',
       }),
     );
 

--- a/packages/web/app/lib/live-activity/live-activity-plugin.ts
+++ b/packages/web/app/lib/live-activity/live-activity-plugin.ts
@@ -4,6 +4,14 @@ type LiveActivityStartOptions = {
   sessionId: string;
   serverUrl: string;
   wsUrl?: string;
+  /**
+   * Fully-qualified HTTP GraphQL endpoint on the backend (e.g.
+   * `https://ws.boardsesh.com/graphql`). The native plugin POSTs the
+   * `registerActivityPushToken` mutation here. We pass an explicit URL because
+   * `serverUrl` is the web origin (`https://www.boardsesh.com`), which has no
+   * `/graphql` route and would 404.
+   */
+  graphqlUrl?: string;
   authToken?: string;
   boardName: string;
   layoutId: number;

--- a/packages/web/app/lib/live-activity/use-live-activity.ts
+++ b/packages/web/app/lib/live-activity/use-live-activity.ts
@@ -103,10 +103,18 @@ export function useLiveActivity({
       isActiveRef.current = true;
       const startGeneration = ++generationRef.current;
 
+      const wsUrl = getBackendWsUrl();
+      // Backend GraphQL is hosted on a different domain than the web app (e.g.
+      // ws.boardsesh.com vs www.boardsesh.com). The native plugin can't derive
+      // the right host from `serverUrl`, so pass the HTTP form of wsUrl
+      // explicitly. Without this, registerActivityPushToken hits 404.
+      const graphqlUrl = wsUrl ? wsUrl.replace(/^ws(s?):\/\//, 'http$1://') : undefined;
+
       void startLiveActivitySession({
         sessionId: sessionIdRef.current ?? `local-${Date.now()}`,
         serverUrl,
-        wsUrl: getBackendWsUrl() ?? undefined,
+        wsUrl: wsUrl ?? undefined,
+        graphqlUrl,
         authToken: authTokenRef.current ?? undefined,
         boardName: stableBoardDetails.board_name,
         layoutId: stableBoardDetails.layout_id,

--- a/packages/web/app/lib/live-activity/use-live-activity.ts
+++ b/packages/web/app/lib/live-activity/use-live-activity.ts
@@ -10,7 +10,7 @@ import {
   isLiveActivityAvailable,
 } from './live-activity-plugin';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
-import { getBackendWsUrl } from '../backend-url';
+import { getBackendWsUrl, getGraphQLHttpUrl } from '../backend-url';
 import type { ClimbQueueItem } from '@/app/components/queue-control/types';
 import type { BoardDetails } from '../types';
 
@@ -108,7 +108,15 @@ export function useLiveActivity({
       // ws.boardsesh.com vs www.boardsesh.com). The native plugin can't derive
       // the right host from `serverUrl`, so pass the HTTP form of wsUrl
       // explicitly. Without this, registerActivityPushToken hits 404.
-      const graphqlUrl = wsUrl ? wsUrl.replace(/^ws(s?):\/\//, 'http$1://') : undefined;
+      // `getGraphQLHttpUrl` throws when no backend URL is configured — fall
+      // back to undefined so iOS still gets the foreground-only Live Activity
+      // (WebSocket path works without a registered token).
+      let graphqlUrl: string | undefined;
+      try {
+        graphqlUrl = getGraphQLHttpUrl();
+      } catch {
+        graphqlUrl = undefined;
+      }
 
       void startLiveActivitySession({
         sessionId: sessionIdRef.current ?? `local-${Date.now()}`,


### PR DESCRIPTION
## Summary

- iOS push-token registration was POSTing the `registerActivityPushToken` mutation to `\(serverUrl)/graphql`, where `serverUrl` is the web origin (`https://www.boardsesh.com`). The backend GraphQL endpoint lives on a different host (`https://ws.boardsesh.com/graphql`) — Next.js has no `/graphql` route — so every request 404'd silently and **no tokens ever reached the backend**. That's exactly what the user observed: zero "Registered Live Activity token" logs and no Live Activity push updates on their phone.
- The lock-screen widget had the same bug for `\(serverUrl)/api/widget/navigate` (also a backend route).
- The "No registered Live Activity tokens for session …; skipping update" log fires on every queue event for any party session without an iOS device watching. At `console.info` level across N backend instances + M queue events/min, it drowned out everything else.

## What changed

- `useLiveActivity` derives `graphqlUrl` from `getBackendWsUrl()` (`ws://` → `http://`) and passes it through `startLiveActivitySession`.
- `LiveActivityPlugin.swift` reads `graphqlUrl`, stores it in `_currentGraphqlUrl`, and uses it in both register and unregister calls. The pending-registration keychain record now carries `graphqlUrl` too, so foreground / WS-reconnect retries hit the right host. Old records without `graphqlUrl` are discarded — ActivityKit redelivers a fresh push token on the next foreground, kicking off a new registration with the correct URL.
- `LiveActivityPlugin.swift` also writes a derived `widgetNavigateUrl` into App Group UserDefaults (path-swapped from `graphqlUrl`) and `WidgetNetworking.swift` reads it directly instead of constructing from the web `serverUrl`.
- Demoted the no-tokens log to `console.debug` in both the update and end paths.

## Test plan

- [x] `vp run typecheck:web` clean
- [x] `vp run typecheck:backend` clean
- [x] `vp test --project web` — 4432/4432 passing (includes `use-live-activity.test.ts`)
- [x] `vp test --project backend` for `push-tokens.test.ts`, `apns-cleanup.test.ts`, `apns-heartbeat.test.ts` — all green (28 tests)
- [x] `vp check` — 0 errors; no new warnings in the touched files
- [ ] Ship a TestFlight build with the iOS changes, start a session, confirm `[APNs] Registered Live Activity token for session <X>: <prefix>…` appears in the backend logs and the lock-screen widget receives push updates while the phone is backgrounded
- [ ] Tap Next/Previous on the lock-screen widget while backgrounded, confirm the request reaches the backend (not 404 on the web)

https://claude.ai/code/session_0122E7zVroZdyp42uBR38yq3

---
_Generated by [Claude Code](https://claude.ai/code/session_0122E7zVroZdyp42uBR38yq3)_