### PR TITLE
fix(db): restore migration journal monotonicity + idempotent 0095/0096

### DIFF
--- a/packages/db/drizzle/0095_activity_push_tokens.sql
+++ b/packages/db/drizzle/0095_activity_push_tokens.sql
@@ -1,9 +1,16 @@
-CREATE TABLE "activity_push_tokens" (
+CREATE TABLE IF NOT EXISTS "activity_push_tokens" (
 	"token" text PRIMARY KEY NOT NULL,
 	"session_id" text NOT NULL,
 	"created_at" timestamp DEFAULT now() NOT NULL,
 	"updated_at" timestamp DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "activity_push_tokens" ADD CONSTRAINT "activity_push_tokens_session_id_board_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."board_sessions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "activity_push_tokens_session_idx" ON "activity_push_tokens" USING btree ("session_id");
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint WHERE conname = 'activity_push_tokens_session_id_board_sessions_id_fk'
+	) THEN
+		ALTER TABLE "activity_push_tokens" ADD CONSTRAINT "activity_push_tokens_session_id_board_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."board_sessions"("id") ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "activity_push_tokens_session_idx" ON "activity_push_tokens" USING btree ("session_id");

--- a/packages/db/drizzle/0096_abnormal_korg.sql
+++ b/packages/db/drizzle/0096_abnormal_korg.sql
@@ -1,1 +1,1 @@
-CREATE INDEX "activity_push_tokens_updated_at_idx" ON "activity_push_tokens" USING btree ("updated_at");
+CREATE INDEX IF NOT EXISTS "activity_push_tokens_updated_at_idx" ON "activity_push_tokens" USING btree ("updated_at");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -656,14 +656,14 @@
     {
       "idx": 93,
       "version": "7",
-      "when": 1779000000000,
+      "when": 1778632284840,
       "tag": "0093_amused_loners",
       "breakpoints": true
     },
     {
       "idx": 94,
       "version": "7",
-      "when": 1779000100000,
+      "when": 1778632284841,
       "tag": "0094_replay_board_placements_idx",
       "breakpoints": true
     },


### PR DESCRIPTION
## Summary

- Drops 0093/0094's hand-bumped \`when\` values back into monotonic order so drizzle stops silently skipping 0095/0096/0097.
- Makes 0095 and 0096 idempotent (\`CREATE TABLE IF NOT EXISTS\`, \`CREATE INDEX IF NOT EXISTS\`, FK guarded by \`pg_constraint\` lookup) so re-running them is safe where parts were applied by hand. 0097 was already idempotent by design.

## Why

Drizzle's pg migrator (\`node_modules/drizzle-orm/pg-core/dialect.js:62\`) compares each journal entry's \`when\` against \`MAX(created_at)\` from \`drizzle.__drizzle_migrations\`. Anything with a lower \`when\` is treated as already-applied — no error, no warning. 0094 set \`when = 1779000100000\` (∼2026-05-17) to dodge an orphan tracker row, which silently disqualified 0095/0096/0097 (all generated with normal \"now\" timestamps in the 1778-range).

Symptoms in prod (\`tramway.proxy.rlwy.net:45638/railway\`):
- \`drizzle.__drizzle_migrations\` has 91 rows; journal has 98 entries.
- Max \`created_at\` = 1779000100000 (= 0094's bumped \`when\`).
- 0095/0096/0097 hashes are absent from the tracker.

Same skip would have hit every fresh pre-built dev DB build, so dev environments are also missing the \`activity_push_tokens\` table and the climb stats backfill.

## What changes

| File | Change |
|------|--------|
| \`packages/db/drizzle/meta/_journal.json\` | 0093 \`when\`: \`1779000000000\` → \`1778632284840\`; 0094 \`when\`: \`1779000100000\` → \`1778632284841\` (both immediately after 0092's \`1778632284839\`). |
| \`packages/db/drizzle/0095_activity_push_tokens.sql\` | \`CREATE TABLE IF NOT EXISTS\`, FK wrapped in \`DO $$ ... IF NOT EXISTS (SELECT FROM pg_constraint) ...\`, \`CREATE INDEX IF NOT EXISTS\`. |
| \`packages/db/drizzle/0096_abnormal_korg.sql\` | \`CREATE INDEX IF NOT EXISTS\`. |

0097 left untouched — it's already idempotent (NULL guards + \`ON CONFLICT DO NOTHING\`).

## Production tracker repair (run out of band, NOT in this PR)

After merge, before the next deploy that runs migrations, run this on prod to drop the artificially-high \`created_at\` values on the 0093/0094 tracker rows so drizzle sees 0095/0096/0097 as unapplied:

\`\`\`sql
UPDATE drizzle.__drizzle_migrations
SET created_at = 1778632284840
WHERE hash = '57364d9a45aa651f92d944765544c6bb8c47845f0ac07f374f4b1f420cc76cb0'; -- 0093_amused_loners

UPDATE drizzle.__drizzle_migrations
SET created_at = 1778632284841
WHERE hash = '0583053dd6adbec101cd72efea4f1813b11161fbea37cad9608aa7ef97220260'; -- 0094_replay_board_placements_idx
\`\`\`

The next deploy then runs 0095/0096/0097 cleanly. Because all three are idempotent now, the hand-applied rows from the manual rollout will be no-ops, and any unapplied state gets filled in.

## Test plan

- [ ] \`vp run typecheck\` clean.
- [ ] Pull \`docker compose down -v && vp run db:up\` and confirm \`activity_push_tokens\` exists with the expected FK + indexes.
- [ ] On a copy of prod (or a throwaway DB with the prod tracker state replicated), run the SQL above, then \`vp run db:migrate\`, and confirm 0095/0096/0097 hashes land in \`drizzle.__drizzle_migrations\`.
- [ ] Confirm 0097 step 1 (\`INSERT ... ON CONFLICT DO NOTHING\`) inserts the remaining rows without duplicating the user's manual backfill of ~25 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)