### PR TITLE
fix(db): drop 0091 journal when below 0092 to keep monotonicity

### DIFF
--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -642,7 +642,7 @@
     {
       "idx": 91,
       "version": "7",
-      "when": 1778976000000,
+      "when": 1778632284838,
       "tag": "0091_backfill_session_ended_at",
       "breakpoints": true
     },


### PR DESCRIPTION
## Summary

Follow-up to #2159. Drops idx 91's journal \`when\` from \`1778976000000\` to \`1778632284838\` (one below 0092's \`1778632284839\`) so the tail of the journal is monotonic and the next migration generated by \`drizzle-kit generate\` actually runs.

## Why this isn't covered by #2159

#2159 fixed 0093/0094 (the hand-bumped \`when\` values from the \`replay\` commit). It didn't touch 0091, but 0091 sat at \`when = 1778976000000\` — higher than 0092-0097.

That wasn't the bug we were chasing (the prod tracker had \`MAX(created_at) = 1779000100000\` from 0094), but it became the bug as soon as we fixed 0094: max(journal_when) dropped to 1778976000000 (0091), still above the current \`Date.now()\` (~1778889600000 on 2026-05-15).

Concretely: \`pg-core/dialect.js:56-62\` queries \`lastDbMigration\` **once** before the loop. On a fresh DB build, it's \`undefined\`, so every migration runs regardless of \`when\` — but the tracker rows that get inserted carry \`created_at = journal_when\`. So after a fresh dev DB image rebuild (which happens automatically when migration files change), \`max(created_at)\` = max(journal_when) = 1778976000000, and any migration generated via \`drizzle-kit generate\` over the next ~24 hours would silently skip on every dev DB rebuilt from the new image.

Dropping idx 91's \`when\` brings max(journal_when) down to 0097's \`1778796374020\`, well below current \`Date.now()\`. Future \`drizzle-kit generate\` runs produce monotonic timestamps from here on.

## Why no prod tracker SQL

The 0091 row in the prod tracker was already updated to \`created_at = 1778632284838\` as part of the manual SQL after #2159. Journal and tracker are now consistent.

## Test plan

- [ ] \`vp run typecheck\` clean.
- [ ] \`docker compose down -v && vp run db:up\` produces a tracker where 0091 has \`created_at = 1778632284838\` and 0095/0096/0097 are present.
- [ ] Confirm \`max(created_at)\` in a fresh dev tracker is \`1778796374020\` (0097's \`when\`), not 1778976000000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)