### PR TITLE
Drive BLE writes from Live Activity intents in main app process

### DIFF
--- a/docs/live-activity-board-control.md
+++ b/docs/live-activity-board-control.md
@@ -18,34 +18,43 @@ Control the climbing board from the lock screen while the app is backgrounded. T
 **What's still missing for full lock-screen board control:**
 
 1. Widget can only do prev/next -- no add, remove, reorder, or mirror mutations from lock screen
-2. Widget extension runs in a separate process with no direct access to the main app's BLE connection; it only signals the main app process
-3. Rust board renderer has no Swift/iOS bindings -- only targets WASM today
-4. MoonBoard remains on the existing Capacitor BLE path; the native background BLE path currently targets Aurora boards only
+2. Rust board renderer has no Swift/iOS bindings -- only targets WASM today
+3. MoonBoard remains on the existing Capacitor BLE path; the native background BLE path currently targets Aurora boards only
+4. Cross-device repaint when *another* user navigates: if your phone is suspended, your board stays stale until you unlock the phone. Tracked in issue #2174 (presence/ack design) and ultimately solved by the planned WS-enabled board controller.
 
 ## Architecture Decision: Where Does BLE Live?
 
 The widget extension **cannot** hold a CoreBluetooth connection (extensions have strict memory/runtime limits and Apple kills them after ~30s). The main app process must own the BLE connection.
 
+`LiveActivityIntent` is the iOS 17+ mechanism that lets us drive the main app from a Live Activity button tap. When the intent type is compiled into **both** targets (widget extension + main app) and the user taps a button on the Live Activity, iOS performs the intent in the main app's process — background-launching the app if it was suspended or terminated. The widget acts as the UI host; the actual work runs where the BLE connection lives.
+
 The flow for lock-screen LED control:
 
 ```
 Widget (Next/Previous tap)
-  │ posts Darwin notification
+  │ system invokes LiveActivityIntent
   ▼
-Main app process (even if backgrounded)
-  │ LiveActivityPlugin receives Darwin notification
-  │ repaints the connected board from optimistic App Group queue state
-  │ sends setCurrentClimb via widget HTTP or native WS fallback
-  │ repaints again when CurrentClimbChanged confirms server state
-  ▼
-Native BLE manager (CoreBluetooth, main app process)
-  │ looks up hold positions for the new current climb
-  │ writes UART LED packet to the board
+Main app process (background-launched if needed)
+  │ LiveActivityIntent.perform() runs here, not in the widget
+  │ saves new currentIndex to App Group UserDefaults
+  │ optimistically updates ActivityKit content state
+  │ ┌─────────────────────────────────────────────────┐
+  │ │ BoardBleManager.displayCurrentItemAwaitingReady │
+  │ │   awaits CoreBluetooth state restoration        │
+  │ │   issues UART write inside beginBackgroundTask  │
+  │ │   awaits write-queue drain                      │
+  │ └─────────────────────────────────────────────────┘
+  │ POSTs to /api/widget/navigate so backend / other party clients see the change
   ▼
 Physical board LEDs update
 ```
 
-The main app process can maintain a CoreBluetooth connection in the background if it declares the `bluetooth-central` background mode. This is the critical enabler.
+Two critical enablers in `mobile/ios/App/App.xcodeproj/project.pbxproj`:
+
+- `NextClimbIntent.swift`, `PreviousClimbIntent.swift`, and `WidgetNetworking.swift` are members of **both** the `App` and `BoardseshWidgets` targets. Without `App`-target membership the intent type is not registered in the main app's `AppIntents` package and iOS has no candidate process to background-launch.
+- The widget target sets `OTHER_SWIFT_FLAGS = "$(inherited) -D WIDGET_EXTENSION"`. The intent files gate the main-app-only paths (BLE writes, `UIApplication.beginBackgroundTask`) behind `#if !WIDGET_EXTENSION` so the widget-extension compile excludes symbols it cannot link.
+
+The main app process can maintain a CoreBluetooth connection in the background if it declares the `bluetooth-central` background mode (already done in `Info.plist`). State restoration via `CBCentralManagerOptionRestoreIdentifierKey` makes the peripheral connection survive a process restart — but for the restore callback to actually fire, `CBCentralManager` must be constructed **during launch**, before the run loop services other events. `AppDelegate.didFinishLaunchingWithOptions` eagerly accesses `BoardBleManager.shared` whenever there's a saved BLE board configuration in the App Group, gated to avoid an early Bluetooth permission prompt on fresh installs.
 
 ## Phases
 
@@ -152,7 +161,7 @@ The workout state lives server-side and arrives via the same WebSocket subscript
 **Design constraints:**
 
 - iOS widget interaction is buttons only, no complex input
-- Each action follows the same pattern: optimistic App Group update → Darwin notification → main app sends mutation → server confirms → all clients update
+- Each action follows the same pattern: optimistic App Group update → `LiveActivityIntent.perform()` in main app → BLE write (if owner) + HTTP POST to backend → server confirms → all clients update
 - Lock Screen expanded view has ~160pt height -- plan layouts for queue mode and workout mode
 
 ### Phase 5: Android Parity (Future)
@@ -229,7 +238,7 @@ The board BLE communication uses a UART service. Key characteristics:
 iOS gives backgrounded apps limited execution time. For our use case:
 
 - **CoreBluetooth background mode**: unlimited for maintaining connections and responding to peripheral events
-- **Darwin notification handling**: runs briefly in the main app process, enough to send a WS mutation and a BLE write
+- **`LiveActivityIntent.perform()`**: iOS gives the intent a few seconds of background runtime to complete. `BoardBleManager.displayCurrentItemAwaitingReady` wraps the BLE write in `UIApplication.beginBackgroundTask` to extend that window through state restoration + UART chunk flushing
 - **URLSessionWebSocketTask**: continues receiving messages in the background for a limited time, then iOS may suspend it. The `isDisconnectedCallback` and reconnection logic handle this gracefully
 
 ### State Synchronization

--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -46,16 +46,32 @@ Device-to-server (widget buttons):
 
   User taps Next/Previous on lock screen
        |
-  NextClimbIntent / PreviousClimbIntent (widget extension process)
+  iOS performs the LiveActivityIntent in the MAIN APP process
+  (the intent type is registered in both the App and BoardseshWidgets
+   targets, so iOS background-launches the app when it's suspended
+   instead of running the intent in the widget extension)
        |
-  1. Optimistic: update Live Activity locally (instant)
-  2. HTTP POST /api/widget/navigate (background-safe)
-  3. Darwin notification (secondary, if main app is awake)
+  1. Save new currentIndex to App Group UserDefaults
+  2. Optimistically update Live Activity content state
+  3. In parallel (async let), both run concurrently:
+     a. BoardBleManager.displayCurrentItemAwaitingReady
+          - awaits CoreBluetooth state restoration
+            (peripheral + write characteristic discovered)
+          - issues the UART display write
+          - all inside a UIApplication beginBackgroundTask window
+            with an expiration handler
+     b. HTTP POST /api/widget/navigate
+          - propagates the new index to the backend so other party
+            clients see it via WebSocket / APNs broadcast
        |
   Backend publishes CurrentClimbChanged
        |
-  APNs push sent to all session tokens
+  APNs push sent to all session tokens (other devices)
 ```
+
+Latency on the BLE side from a suspended-app cold-launch is ~1.5–2.5 s: background-launch (~0.5–1 s) + CoreBluetooth state restoration (~0.5–1 s) + UART chunk flush (~0.2–0.5 s). Subsequent taps inside the same wake window are faster because the peripheral stays connected.
+
+Cross-device limitation: when *another* user navigates and your phone is suspended, your board does **not** repaint — the WS connection is dead and the APNs Live Activity push reaches the widget extension, which can't open the CoreBluetooth connection. Tracked in issue #2174; ultimately solved by the planned WS-enabled board controller.
 
 ## Prerequisites
 
@@ -241,11 +257,14 @@ Lock your iPhone. The Live Activity widget should update within a few seconds sh
 
 ### Test with App Suspended
 
-1. Lock your iPhone
-2. Wait 30+ seconds for iOS to suspend the app
-3. Tap Next/Previous on the widget
-4. The widget should still update (optimistic + HTTP fallback)
-5. Check backend logs for the POST request
+1. Connect to a board (so there's a saved BLE config — required for the eager `CBCentralManager` init that makes state restoration work)
+2. Lock your iPhone
+3. Wait 30+ seconds for iOS to suspend the app
+4. Tap Next/Previous on the widget
+5. The widget UI updates optimistically (instant)
+6. The board LEDs update within ~2–3 s — iOS background-launches the app, the intent runs in the main app process, BLE state restoration completes, and `BoardBleManager.displayCurrentItemAwaitingReady` issues the write
+7. The HTTP POST to `/api/widget/navigate` should appear in backend logs (independent of the BLE write — they run in parallel)
+8. Filter Console.app by subsystem `com.boardsesh.app`, category `LiveActivityIntent` to confirm the intent ran in the App process (DEBUG builds only)
 
 ### Test with App Force-Killed
 
@@ -254,6 +273,7 @@ Lock your iPhone. The Live Activity widget should update within a few seconds sh
 3. Tap Next/Previous — the widget updates optimistically
 4. The HTTP request to `/api/widget/navigate` should appear in backend logs
 5. Other connected clients should see the queue change
+6. **The board will NOT repaint in this case.** iOS does not background-launch a user-killed app for `LiveActivityIntent`, so the intent falls back to the widget extension process, which cannot reach `BoardBleManager`. Re-opening the app on this device will re-sync the board via the foreground WS path.
 
 ## Testing Background Updates
 

--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		LA100012 /* NextClimbIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200012 /* NextClimbIntent.swift */; };
 		LA100013 /* PreviousClimbIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200013 /* PreviousClimbIntent.swift */; };
 		LA100070 /* WidgetNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200070 /* WidgetNetworking.swift */; };
+		LA100090 /* NextClimbIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200012 /* NextClimbIntent.swift */; };
+		LA100091 /* PreviousClimbIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200013 /* PreviousClimbIntent.swift */; };
+		LA100092 /* WidgetNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200070 /* WidgetNetworking.swift */; };
 		LA100020 /* SharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200001 /* SharedConstants.swift */; };
 		LA100021 /* ClimbSessionAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200002 /* ClimbSessionAttributes.swift */; };
 		LA100080 /* SharedKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200080 /* SharedKeychain.swift */; };
@@ -477,6 +480,9 @@
 				LA100009 /* HealthKitPlugin.m in Sources */,
 				LA100050 /* DevUrlPlugin.swift in Sources */,
 				LA100051 /* DevUrlPlugin.m in Sources */,
+				LA100090 /* NextClimbIntent.swift in Sources */,
+				LA100091 /* PreviousClimbIntent.swift in Sources */,
+				LA100092 /* WidgetNetworking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -743,6 +749,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 1.2;
+				OTHER_SWIFT_FLAGS = "$(inherited) -D WIDGET_EXTENSION";
 				PRODUCT_BUNDLE_IDENTIFIER = com.boardsesh.app.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -764,6 +771,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 1.2;
+				OTHER_SWIFT_FLAGS = "$(inherited) -D WIDGET_EXTENSION";
 				PRODUCT_BUNDLE_IDENTIFIER = com.boardsesh.app.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		LA100090 /* NextClimbIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200012 /* NextClimbIntent.swift */; };
 		LA100091 /* PreviousClimbIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200013 /* PreviousClimbIntent.swift */; };
 		LA100092 /* WidgetNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200070 /* WidgetNetworking.swift */; };
+		LA100100 /* LiveActivityBleBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200100 /* LiveActivityBleBridge.swift */; };
 		LA100020 /* SharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200001 /* SharedConstants.swift */; };
 		LA100021 /* ClimbSessionAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200002 /* ClimbSessionAttributes.swift */; };
 		LA100080 /* SharedKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200080 /* SharedKeychain.swift */; };
@@ -125,6 +126,7 @@
 		LA200013 /* PreviousClimbIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviousClimbIntent.swift; sourceTree = "<group>"; };
 		LA200070 /* WidgetNetworking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetNetworking.swift; sourceTree = "<group>"; };
 		LA200080 /* SharedKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedKeychain.swift; sourceTree = "<group>"; };
+		LA200100 /* LiveActivityBleBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityBleBridge.swift; sourceTree = "<group>"; };
 		LA200014 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		LA200015 /* BoardseshWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BoardseshWidgets.entitlements; sourceTree = "<group>"; };
 		LA200030 /* SessionWebSocketManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionWebSocketManagerTests.swift; sourceTree = "<group>"; };
@@ -203,6 +205,7 @@
 				C1A2B3D4E5F60719 /* BoardseshViewController.swift */,
 				LA200001 /* SharedConstants.swift */,
 				LA200080 /* SharedKeychain.swift */,
+				LA200100 /* LiveActivityBleBridge.swift */,
 				BB200001 /* BoardPlacementData.swift */,
 				BB200002 /* BoardBleEncoding.swift */,
 				BB200003 /* BoardBleManager.swift */,
@@ -483,6 +486,7 @@
 				LA100090 /* NextClimbIntent.swift in Sources */,
 				LA100091 /* PreviousClimbIntent.swift in Sources */,
 				LA100092 /* WidgetNetworking.swift in Sources */,
+				LA100100 /* LiveActivityBleBridge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		LA100091 /* PreviousClimbIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200013 /* PreviousClimbIntent.swift */; };
 		LA100092 /* WidgetNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200070 /* WidgetNetworking.swift */; };
 		LA100100 /* LiveActivityBleBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200100 /* LiveActivityBleBridge.swift */; };
+		LA100110 /* WaiterPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200110 /* WaiterPool.swift */; };
+		LA100111 /* WaiterPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200111 /* WaiterPoolTests.swift */; };
 		LA100020 /* SharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200001 /* SharedConstants.swift */; };
 		LA100021 /* ClimbSessionAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200002 /* ClimbSessionAttributes.swift */; };
 		LA100080 /* SharedKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200080 /* SharedKeychain.swift */; };
@@ -127,6 +129,8 @@
 		LA200070 /* WidgetNetworking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetNetworking.swift; sourceTree = "<group>"; };
 		LA200080 /* SharedKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedKeychain.swift; sourceTree = "<group>"; };
 		LA200100 /* LiveActivityBleBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityBleBridge.swift; sourceTree = "<group>"; };
+		LA200110 /* WaiterPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaiterPool.swift; sourceTree = "<group>"; };
+		LA200111 /* WaiterPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaiterPoolTests.swift; sourceTree = "<group>"; };
 		LA200014 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		LA200015 /* BoardseshWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BoardseshWidgets.entitlements; sourceTree = "<group>"; };
 		LA200030 /* SessionWebSocketManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionWebSocketManagerTests.swift; sourceTree = "<group>"; };
@@ -206,6 +210,7 @@
 				LA200001 /* SharedConstants.swift */,
 				LA200080 /* SharedKeychain.swift */,
 				LA200100 /* LiveActivityBleBridge.swift */,
+				LA200110 /* WaiterPool.swift */,
 				BB200001 /* BoardPlacementData.swift */,
 				BB200002 /* BoardBleEncoding.swift */,
 				BB200003 /* BoardBleManager.swift */,
@@ -249,6 +254,7 @@
 				LA200032 /* LiveActivityManagerTests.swift */,
 				LA200033 /* AppIntentNavigationTests.swift */,
 				LA200034 /* VGradeFormatterTests.swift */,
+				LA200111 /* WaiterPoolTests.swift */,
 				BB200030 /* BoardBleEncodingTests.swift */,
 			);
 			path = AppTests;
@@ -487,6 +493,7 @@
 				LA100091 /* PreviousClimbIntent.swift in Sources */,
 				LA100092 /* WidgetNetworking.swift in Sources */,
 				LA100100 /* LiveActivityBleBridge.swift in Sources */,
+				LA100110 /* WaiterPool.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -499,6 +506,7 @@
 				LA100032 /* LiveActivityManagerTests.swift in Sources */,
 				LA100033 /* AppIntentNavigationTests.swift in Sources */,
 				LA100034 /* VGradeFormatterTests.swift in Sources */,
+				LA100111 /* WaiterPoolTests.swift in Sources */,
 				BB100030 /* BoardBleEncodingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		LA100100 /* LiveActivityBleBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200100 /* LiveActivityBleBridge.swift */; };
 		LA100110 /* WaiterPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200110 /* WaiterPool.swift */; };
 		LA100111 /* WaiterPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200111 /* WaiterPoolTests.swift */; };
+		LA100120 /* ClimbNavigationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200120 /* ClimbNavigationIntent.swift */; };
+		LA100121 /* ClimbNavigationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200120 /* ClimbNavigationIntent.swift */; };
 		LA100020 /* SharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200001 /* SharedConstants.swift */; };
 		LA100021 /* ClimbSessionAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200002 /* ClimbSessionAttributes.swift */; };
 		LA100080 /* SharedKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = LA200080 /* SharedKeychain.swift */; };
@@ -131,6 +133,7 @@
 		LA200100 /* LiveActivityBleBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityBleBridge.swift; sourceTree = "<group>"; };
 		LA200110 /* WaiterPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaiterPool.swift; sourceTree = "<group>"; };
 		LA200111 /* WaiterPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaiterPoolTests.swift; sourceTree = "<group>"; };
+		LA200120 /* ClimbNavigationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClimbNavigationIntent.swift; sourceTree = "<group>"; };
 		LA200014 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		LA200015 /* BoardseshWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BoardseshWidgets.entitlements; sourceTree = "<group>"; };
 		LA200030 /* SessionWebSocketManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionWebSocketManagerTests.swift; sourceTree = "<group>"; };
@@ -267,6 +270,7 @@
 				LA200011 /* ClimbSessionLiveActivity.swift */,
 				LA200012 /* NextClimbIntent.swift */,
 				LA200013 /* PreviousClimbIntent.swift */,
+				LA200120 /* ClimbNavigationIntent.swift */,
 				LA200070 /* WidgetNetworking.swift */,
 				LA200014 /* Info.plist */,
 				LA200015 /* BoardseshWidgets.entitlements */,
@@ -491,6 +495,7 @@
 				LA100051 /* DevUrlPlugin.m in Sources */,
 				LA100090 /* NextClimbIntent.swift in Sources */,
 				LA100091 /* PreviousClimbIntent.swift in Sources */,
+				LA100120 /* ClimbNavigationIntent.swift in Sources */,
 				LA100092 /* WidgetNetworking.swift in Sources */,
 				LA100100 /* LiveActivityBleBridge.swift in Sources */,
 				LA100110 /* WaiterPool.swift in Sources */,
@@ -519,6 +524,7 @@
 				LA100011 /* ClimbSessionLiveActivity.swift in Sources */,
 				LA100012 /* NextClimbIntent.swift in Sources */,
 				LA100013 /* PreviousClimbIntent.swift in Sources */,
+				LA100121 /* ClimbNavigationIntent.swift in Sources */,
 				LA100070 /* WidgetNetworking.swift in Sources */,
 				LA100020 /* SharedConstants.swift in Sources */,
 				LA100081 /* SharedKeychain.swift in Sources */,

--- a/mobile/ios/App/App/AppDelegate.swift
+++ b/mobile/ios/App/App/AppDelegate.swift
@@ -5,9 +5,11 @@ import Capacitor
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        if launchOptions?[.bluetoothCentrals] != nil {
-            _ = BoardBleManager.shared
-        }
+        // Initialize unconditionally so CoreBluetooth state restoration can
+        // deliver willRestoreState during this launch — required when iOS
+        // background-launches us for a Live Activity intent (the
+        // `.bluetoothCentrals` launch option is not set in that case).
+        _ = BoardBleManager.shared
         return true
     }
 

--- a/mobile/ios/App/App/AppDelegate.swift
+++ b/mobile/ios/App/App/AppDelegate.swift
@@ -5,11 +5,19 @@ import Capacitor
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Initialize unconditionally so CoreBluetooth state restoration can
-        // deliver willRestoreState during this launch — required when iOS
-        // background-launches us for a Live Activity intent (the
-        // `.bluetoothCentrals` launch option is not set in that case).
-        _ = BoardBleManager.shared
+        // Initialize during launch so CoreBluetooth state restoration can
+        // deliver willRestoreState — it only fires if CBCentralManager is
+        // constructed before the run loop services other events. Required
+        // when iOS background-launches us for a Live Activity intent.
+        //
+        // Gated on a saved BLE board config so fresh installs (no prior
+        // connection) don't see a Bluetooth permission prompt at first
+        // launch. If there's nothing to restore, the manager is created
+        // lazily later when the user explicitly connects.
+        let hasSavedBleConfig = SharedConstants.sharedDefaults?.data(forKey: SharedConstants.bleBoardConfigKey) != nil
+        if launchOptions?[.bluetoothCentrals] != nil || hasSavedBleConfig {
+            _ = BoardBleManager.shared
+        }
         return true
     }
 

--- a/mobile/ios/App/App/BoardBleManager.swift
+++ b/mobile/ios/App/App/BoardBleManager.swift
@@ -85,12 +85,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var isWriting = false
     private var pendingWriteResume: (() -> Void)?
     private var configuration: BoardBleConfiguration?
-    private var pendingReadyWaiters: [ReadyWaiter] = []
+    private var pendingReadyWaiters: [Waiter] = []
+    private var pendingDrainWaiters: [Waiter] = []
 
     private var onScanResult: ((BoardBleScanResult) -> Void)?
     private var onDisconnect: ((String) -> Void)?
 
-    private struct ReadyWaiter {
+    /// Reused for both `waitUntilReady` and `waitForWriteDrain`: each waiter
+    /// owns a continuation and a per-waiter timeout `DispatchWorkItem`,
+    /// identified by a unique id so the resolve path can find and remove it.
+    private struct Waiter {
         let id: UUID
         let continuation: CheckedContinuation<Void, Never>
         let timeoutWorkItem: DispatchWorkItem
@@ -631,7 +635,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                     }
                 }
                 self.pendingReadyWaiters.append(
-                    ReadyWaiter(id: waiterId, continuation: continuation, timeoutWorkItem: workItem)
+                    Waiter(id: waiterId, continuation: continuation, timeoutWorkItem: workItem)
                 )
                 self.bleQueue.asyncAfter(deadline: .now() + timeout, execute: workItem)
             }
@@ -648,19 +652,43 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     private func waitForWriteDrain(timeout: TimeInterval) async {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            let drained = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-                runOnBleQueue { [weak self] in
-                    guard let self else {
-                        continuation.resume(returning: true)
-                        return
-                    }
-                    continuation.resume(returning: self.writeQueue.isEmpty && !self.isWriting)
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            runOnBleQueue { [weak self] in
+                guard let self else {
+                    continuation.resume()
+                    return
                 }
+                if self.writeQueue.isEmpty, !self.isWriting {
+                    continuation.resume()
+                    return
+                }
+                let waiterId = UUID()
+                let workItem = DispatchWorkItem { [weak self] in
+                    guard let self else { return }
+                    if let index = self.pendingDrainWaiters.firstIndex(where: { $0.id == waiterId }) {
+                        let waiter = self.pendingDrainWaiters.remove(at: index)
+                        waiter.continuation.resume()
+                    }
+                }
+                self.pendingDrainWaiters.append(
+                    Waiter(id: waiterId, continuation: continuation, timeoutWorkItem: workItem)
+                )
+                self.bleQueue.asyncAfter(deadline: .now() + timeout, execute: workItem)
             }
-            if drained { return }
-            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+
+    /// Called from `processWriteQueue` and `failQueuedWrites` whenever the
+    /// write queue could plausibly have become empty. The `Waiter` pattern
+    /// mirrors `resumePendingReadyWaitersOnBleQueue` — see that helper for
+    /// the resume contract.
+    private func notifyDrainWaitersIfDrainedOnBleQueue() {
+        guard writeQueue.isEmpty, !isWriting else { return }
+        let waiters = pendingDrainWaiters
+        pendingDrainWaiters = []
+        for waiter in waiters {
+            waiter.timeoutWorkItem.cancel()
+            waiter.continuation.resume()
         }
     }
 
@@ -701,7 +729,13 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     private func processWriteQueue() {
-        guard !isWriting, !writeQueue.isEmpty else { return }
+        guard !isWriting, !writeQueue.isEmpty else {
+            // Drained (or already mid-write). Notify any drain waiters — the
+            // helper double-checks `writeQueue.isEmpty && !isWriting`, so a
+            // call while we're still writing is a no-op.
+            notifyDrainWaitersIfDrainedOnBleQueue()
+            return
+        }
         isWriting = true
         let request = writeQueue[0]
         writeChunk(
@@ -718,13 +752,27 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         connectionGeneration: UInt64,
         writeGeneration: UInt64
     ) {
-        guard connectionGeneration == self.connectionGeneration, writeGeneration == self.writeGeneration else { return }
+        guard connectionGeneration == self.connectionGeneration, writeGeneration == self.writeGeneration else {
+            // The connection or write generation flipped under us (disconnect,
+            // reconnect, state restoration, or write cancellation). Bail out
+            // and re-arm so `isWriting` can't get stranded `true` — without
+            // this, the next time processWriteQueue is called from outside
+            // the write loop, the guard at its top would short-circuit.
+            isWriting = false
+            processWriteQueue()
+            return
+        }
         guard requestIndex < writeQueue.count else {
             isWriting = false
+            processWriteQueue()
             return
         }
         let request = writeQueue[requestIndex]
-        guard request.connectionGeneration == connectionGeneration, request.writeGeneration == writeGeneration else { return }
+        guard request.connectionGeneration == connectionGeneration, request.writeGeneration == writeGeneration else {
+            isWriting = false
+            processWriteQueue()
+            return
+        }
 
         guard let peripheral = connectedPeripheral, let characteristic = writeCharacteristic else {
             let request = writeQueue.removeFirst()
@@ -774,6 +822,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         for request in queuedWrites {
             request.completion(error)
         }
+        notifyDrainWaitersIfDrainedOnBleQueue()
     }
 
     private func readConfiguration() -> BoardBleConfiguration? {

--- a/mobile/ios/App/App/BoardBleManager.swift
+++ b/mobile/ios/App/App/BoardBleManager.swift
@@ -85,23 +85,24 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var isWriting = false
     private var pendingWriteResume: (() -> Void)?
     private var configuration: BoardBleConfiguration?
-    private var observingBoardBleDisplayNotification = false
+    private var pendingReadyWaiters: [ReadyWaiter] = []
 
     private var onScanResult: ((BoardBleScanResult) -> Void)?
     private var onDisconnect: ((String) -> Void)?
+
+    private struct ReadyWaiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Never>
+        let timeoutWorkItem: DispatchWorkItem
+    }
 
     override private init() {
         super.init()
         bleQueue.setSpecific(key: bleQueueKey, value: ())
         runOnBleQueueSync {
             configuration = readConfiguration()
-            startBoardBleDisplayObservation()
             _ = centralManager
         }
-    }
-
-    deinit {
-        stopBoardBleDisplayObservation()
     }
 
     var isAvailable: Bool {
@@ -185,12 +186,6 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
     }
 
-    func displaySharedCurrentItem() {
-        runOnBleQueue { [weak self] in
-            self?.displaySharedCurrentItemOnBleQueue()
-        }
-    }
-
     func displayCurrentItem(items: [SharedQueueItem], currentIndex: Int) {
         runOnBleQueue { [weak self] in
             self?.displayCurrentItemOnBleQueue(items: items, currentIndex: currentIndex)
@@ -201,6 +196,22 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         runOnBleQueue { [weak self] in
             self?.displayItemOnBleQueue(item)
         }
+    }
+
+    /// Awaits BLE readiness (peripheral + write characteristic discovered) up to
+    /// `timeout` seconds, then enqueues the display write and waits for the
+    /// write queue to drain. Designed for Live Activity intents that wake the
+    /// main app in the background: CoreBluetooth state restoration is
+    /// asynchronous, so a write issued immediately after wake would silently
+    /// no-op against the `connectedPeripheral == nil` guard. If the timeout
+    /// elapses before readiness, the write is still attempted; the existing
+    /// `notConnected` guard in `writeOnBleQueue` will no-op cleanly.
+    func displayCurrentItemAwaitingReady(
+        items: [SharedQueueItem], currentIndex: Int, timeout: TimeInterval
+    ) async {
+        await waitUntilReady(timeout: timeout)
+        displayCurrentItem(items: items, currentIndex: currentIndex)
+        await waitForWriteDrain(timeout: 1.5)
     }
 
     private var isAvailableOnBleQueue: Bool {
@@ -554,7 +565,15 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         writeCharacteristic = characteristic
         completePendingConnect(.success(()))
         logger.info("Connected to board BLE peripheral \(peripheral.identifier.uuidString, privacy: .public)")
-        displaySharedCurrentItemOnBleQueue()
+        let hadPendingReadyWaiters = !pendingReadyWaiters.isEmpty
+        resumePendingReadyWaitersOnBleQueue()
+        // Skip the implicit shared-state write when an intent is waiting on
+        // readiness — the intent's awaited code will issue its own
+        // displayCurrentItem with the same shared state, and we'd otherwise
+        // write the identical packet twice.
+        if !hadPendingReadyWaiters {
+            displaySharedCurrentItemOnBleQueue()
+        }
     }
 
     func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
@@ -582,26 +601,63 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         return bleQueue.sync(execute: operation)
     }
 
-    private func startBoardBleDisplayObservation() {
-        guard !observingBoardBleDisplayNotification else { return }
-        observingBoardBleDisplayNotification = true
+    private var isReadyForWrite: Bool {
+        centralManager.state == .poweredOn
+            && connectedPeripheral != nil
+            && writeCharacteristic != nil
+    }
 
-        let center = CFNotificationCenterGetDarwinNotifyCenter()
-        let name = CFNotificationName(SharedConstants.boardBleDisplayNotification as CFString)
-        let observer = Unmanaged.passUnretained(self).toOpaque()
+    private func waitUntilReady(timeout: TimeInterval) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            runOnBleQueue { [weak self] in
+                guard let self else {
+                    continuation.resume()
+                    return
+                }
+                if self.isReadyForWrite {
+                    continuation.resume()
+                    return
+                }
+                let waiterId = UUID()
+                let workItem = DispatchWorkItem { [weak self] in
+                    guard let self else { return }
+                    if let index = self.pendingReadyWaiters.firstIndex(where: { $0.id == waiterId }) {
+                        let waiter = self.pendingReadyWaiters.remove(at: index)
+                        waiter.continuation.resume()
+                    }
+                }
+                self.pendingReadyWaiters.append(
+                    ReadyWaiter(id: waiterId, continuation: continuation, timeoutWorkItem: workItem)
+                )
+                self.bleQueue.asyncAfter(deadline: .now() + timeout, execute: workItem)
+            }
+        }
+    }
 
-        CFNotificationCenterAddObserver(
-            center,
-            observer,
-            { (_, observer, _, _, _) in
-                guard let observer = observer else { return }
-                let manager = Unmanaged<BoardBleManager>.fromOpaque(observer).takeUnretainedValue()
-                manager.displaySharedCurrentItem()
-            },
-            name.rawValue,
-            nil,
-            .deliverImmediately
-        )
+    private func resumePendingReadyWaitersOnBleQueue() {
+        let waiters = pendingReadyWaiters
+        pendingReadyWaiters = []
+        for waiter in waiters {
+            waiter.timeoutWorkItem.cancel()
+            waiter.continuation.resume()
+        }
+    }
+
+    private func waitForWriteDrain(timeout: TimeInterval) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let drained = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+                runOnBleQueue { [weak self] in
+                    guard let self else {
+                        continuation.resume(returning: true)
+                        return
+                    }
+                    continuation.resume(returning: self.writeQueue.isEmpty && !self.isWriting)
+                }
+            }
+            if drained { return }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
     }
 
     private func apiLevelOnBleQueue(configuration: BoardBleConfiguration) -> Int {
@@ -614,16 +670,6 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         return configuration.apiLevel ?? BoardBleEncoding.parseApiLevel(
             deviceName: connectedDeviceName ?? configuration.deviceName
         )
-    }
-
-    private func stopBoardBleDisplayObservation() {
-        guard observingBoardBleDisplayNotification else { return }
-        observingBoardBleDisplayNotification = false
-
-        let center = CFNotificationCenterGetDarwinNotifyCenter()
-        let observer = Unmanaged.passUnretained(self).toOpaque()
-        let name = CFNotificationName(SharedConstants.boardBleDisplayNotification as CFString)
-        CFNotificationCenterRemoveObserver(center, observer, name, nil)
     }
 
     private func completePendingConnect(_ result: Result<Void, Error>) {

--- a/mobile/ios/App/App/BoardBleManager.swift
+++ b/mobile/ios/App/App/BoardBleManager.swift
@@ -85,20 +85,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var isWriting = false
     private var pendingWriteResume: (() -> Void)?
     private var configuration: BoardBleConfiguration?
-    private var pendingReadyWaiters: [Waiter] = []
-    private var pendingDrainWaiters: [Waiter] = []
+    private lazy var readyWaiters = WaiterPool(queue: bleQueue)
+    private lazy var drainWaiters = WaiterPool(queue: bleQueue)
 
     private var onScanResult: ((BoardBleScanResult) -> Void)?
     private var onDisconnect: ((String) -> Void)?
-
-    /// Reused for both `waitUntilReady` and `waitForWriteDrain`: each waiter
-    /// owns a continuation and a per-waiter timeout `DispatchWorkItem`,
-    /// identified by a unique id so the resolve path can find and remove it.
-    private struct Waiter {
-        let id: UUID
-        let continuation: CheckedContinuation<Void, Never>
-        let timeoutWorkItem: DispatchWorkItem
-    }
 
     override private init() {
         super.init()
@@ -573,8 +564,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         writeCharacteristic = characteristic
         completePendingConnect(.success(()))
         logger.info("Connected to board BLE peripheral \(peripheral.identifier.uuidString, privacy: .public)")
-        let hadPendingReadyWaiters = !pendingReadyWaiters.isEmpty
-        resumePendingReadyWaitersOnBleQueue()
+        let hadPendingReadyWaiters = readyWaiters.hasPendingWaiters
+        readyWaiters.signalAll()
         // Skip the implicit shared-state write when an intent is waiting on
         // readiness — the intent's awaited code will issue its own
         // displayCurrentItem with the same shared state, and we'd otherwise
@@ -616,80 +607,24 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     private func waitUntilReady(timeout: TimeInterval) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            runOnBleQueue { [weak self] in
-                guard let self else {
-                    continuation.resume()
-                    return
-                }
-                if self.isReadyForWrite {
-                    continuation.resume()
-                    return
-                }
-                let waiterId = UUID()
-                let workItem = DispatchWorkItem { [weak self] in
-                    guard let self else { return }
-                    if let index = self.pendingReadyWaiters.firstIndex(where: { $0.id == waiterId }) {
-                        let waiter = self.pendingReadyWaiters.remove(at: index)
-                        waiter.continuation.resume()
-                    }
-                }
-                self.pendingReadyWaiters.append(
-                    Waiter(id: waiterId, continuation: continuation, timeoutWorkItem: workItem)
-                )
-                self.bleQueue.asyncAfter(deadline: .now() + timeout, execute: workItem)
-            }
-        }
-    }
-
-    private func resumePendingReadyWaitersOnBleQueue() {
-        let waiters = pendingReadyWaiters
-        pendingReadyWaiters = []
-        for waiter in waiters {
-            waiter.timeoutWorkItem.cancel()
-            waiter.continuation.resume()
+        await readyWaiters.wait(timeout: timeout) { [weak self] in
+            self?.isReadyForWrite ?? true
         }
     }
 
     private func waitForWriteDrain(timeout: TimeInterval) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            runOnBleQueue { [weak self] in
-                guard let self else {
-                    continuation.resume()
-                    return
-                }
-                if self.writeQueue.isEmpty, !self.isWriting {
-                    continuation.resume()
-                    return
-                }
-                let waiterId = UUID()
-                let workItem = DispatchWorkItem { [weak self] in
-                    guard let self else { return }
-                    if let index = self.pendingDrainWaiters.firstIndex(where: { $0.id == waiterId }) {
-                        let waiter = self.pendingDrainWaiters.remove(at: index)
-                        waiter.continuation.resume()
-                    }
-                }
-                self.pendingDrainWaiters.append(
-                    Waiter(id: waiterId, continuation: continuation, timeoutWorkItem: workItem)
-                )
-                self.bleQueue.asyncAfter(deadline: .now() + timeout, execute: workItem)
-            }
+        await drainWaiters.wait(timeout: timeout) { [weak self] in
+            guard let self else { return true }
+            return self.writeQueue.isEmpty && !self.isWriting
         }
     }
 
-    /// Called from `processWriteQueue` and `failQueuedWrites` whenever the
-    /// write queue could plausibly have become empty. The `Waiter` pattern
-    /// mirrors `resumePendingReadyWaitersOnBleQueue` — see that helper for
-    /// the resume contract.
+    /// Resume any drain waiters now that the write queue may have emptied.
+    /// Called from `processWriteQueue` (when its top-of-function guard
+    /// indicates we're drained) and `failQueuedWrites`.
     private func notifyDrainWaitersIfDrainedOnBleQueue() {
         guard writeQueue.isEmpty, !isWriting else { return }
-        let waiters = pendingDrainWaiters
-        pendingDrainWaiters = []
-        for waiter in waiters {
-            waiter.timeoutWorkItem.cancel()
-            waiter.continuation.resume()
-        }
+        drainWaiters.signalAll()
     }
 
     private func apiLevelOnBleQueue(configuration: BoardBleConfiguration) -> Int {
@@ -729,10 +664,13 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     private func processWriteQueue() {
-        guard !isWriting, !writeQueue.isEmpty else {
-            // Drained (or already mid-write). Notify any drain waiters — the
-            // helper double-checks `writeQueue.isEmpty && !isWriting`, so a
-            // call while we're still writing is a no-op.
+        if isWriting {
+            // A chunk is already in flight; the post-chunk path will call us
+            // again. Nothing to do here.
+            return
+        }
+        if writeQueue.isEmpty {
+            // Drained. Resume any tasks awaiting `waitForWriteDrain`.
             notifyDrainWaitersIfDrainedOnBleQueue()
             return
         }

--- a/mobile/ios/App/App/BoardBleManager.swift
+++ b/mobile/ios/App/App/BoardBleManager.swift
@@ -693,22 +693,24 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         guard connectionGeneration == self.connectionGeneration, writeGeneration == self.writeGeneration else {
             // The connection or write generation flipped under us (disconnect,
             // reconnect, state restoration, or write cancellation). Bail out
-            // and re-arm so `isWriting` can't get stranded `true` — without
-            // this, the next time processWriteQueue is called from outside
-            // the write loop, the guard at its top would short-circuit.
+            // and re-arm so `isWriting` can't get stranded `true`. Dispatched
+            // back through `bleQueue` rather than tail-called so the stack
+            // stays bounded even if the queue contains many stale-generation
+            // requests in a row (current code paths clear the queue on
+            // generation bumps so this is defensive).
             isWriting = false
-            processWriteQueue()
+            bleQueue.async { [weak self] in self?.processWriteQueue() }
             return
         }
         guard requestIndex < writeQueue.count else {
             isWriting = false
-            processWriteQueue()
+            bleQueue.async { [weak self] in self?.processWriteQueue() }
             return
         }
         let request = writeQueue[requestIndex]
         guard request.connectionGeneration == connectionGeneration, request.writeGeneration == writeGeneration else {
             isWriting = false
-            processWriteQueue()
+            bleQueue.async { [weak self] in self?.processWriteQueue() }
             return
         }
 

--- a/mobile/ios/App/App/BoardBleManager.swift
+++ b/mobile/ios/App/App/BoardBleManager.swift
@@ -199,19 +199,23 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     /// Awaits BLE readiness (peripheral + write characteristic discovered) up to
-    /// `timeout` seconds, then enqueues the display write and waits for the
-    /// write queue to drain. Designed for Live Activity intents that wake the
-    /// main app in the background: CoreBluetooth state restoration is
-    /// asynchronous, so a write issued immediately after wake would silently
-    /// no-op against the `connectedPeripheral == nil` guard. If the timeout
-    /// elapses before readiness, the write is still attempted; the existing
-    /// `notConnected` guard in `writeOnBleQueue` will no-op cleanly.
+    /// `readyTimeout`, enqueues the display write, then waits up to
+    /// `drainTimeout` for the UART chunks to flush. Designed for Live Activity
+    /// intents that wake the main app in the background: CoreBluetooth state
+    /// restoration is asynchronous, so a write issued immediately after wake
+    /// would silently no-op against the `connectedPeripheral == nil` guard.
+    /// If `readyTimeout` elapses before readiness, the write is still
+    /// attempted; the existing `notConnected` guard in `writeOnBleQueue` will
+    /// no-op cleanly.
     func displayCurrentItemAwaitingReady(
-        items: [SharedQueueItem], currentIndex: Int, timeout: TimeInterval
+        items: [SharedQueueItem],
+        currentIndex: Int,
+        readyTimeout: TimeInterval,
+        drainTimeout: TimeInterval = 1.5
     ) async {
-        await waitUntilReady(timeout: timeout)
+        await waitUntilReady(timeout: readyTimeout)
         displayCurrentItem(items: items, currentIndex: currentIndex)
-        await waitForWriteDrain(timeout: 1.5)
+        await waitForWriteDrain(timeout: drainTimeout)
     }
 
     private var isAvailableOnBleQueue: Bool {

--- a/mobile/ios/App/App/LiveActivityBleBridge.swift
+++ b/mobile/ios/App/App/LiveActivityBleBridge.swift
@@ -1,0 +1,26 @@
+import Foundation
+import UIKit
+
+/// Shared bridge invoked from `LiveActivityIntent.perform()` when it runs in
+/// the main app process. Only compiled into the `App` target — the widget
+/// extension cannot link `BoardBleManager` or call `UIApplication`, and the
+/// intent files gate the call site behind `#if !WIDGET_EXTENSION`.
+@available(iOS 17.0, *)
+enum LiveActivityBleBridge {
+    /// Awaits BLE readiness and issues a board display write inside a
+    /// `beginBackgroundTask` window so iOS does not suspend the app between
+    /// state restoration and the final UART chunk flush.
+    static func writeBoardForIntent(items: [SharedQueueItem], currentIndex: Int) async {
+        let task = await MainActor.run {
+            UIApplication.shared.beginBackgroundTask(withName: "ble-display-intent")
+        }
+        await BoardBleManager.shared.displayCurrentItemAwaitingReady(
+            items: items,
+            currentIndex: currentIndex,
+            readyTimeout: 3.0
+        )
+        await MainActor.run {
+            UIApplication.shared.endBackgroundTask(task)
+        }
+    }
+}

--- a/mobile/ios/App/App/LiveActivityBleBridge.swift
+++ b/mobile/ios/App/App/LiveActivityBleBridge.swift
@@ -8,19 +8,50 @@ import UIKit
 @available(iOS 17.0, *)
 enum LiveActivityBleBridge {
     /// Awaits BLE readiness and issues a board display write inside a
-    /// `beginBackgroundTask` window so iOS does not suspend the app between
-    /// state restoration and the final UART chunk flush.
+    /// `beginBackgroundTask` window. The window carries its own expiration
+    /// handler that cleanly releases the task identifier if iOS reclaims
+    /// background budget before the write completes — without that handler
+    /// the system terminates the app on expiry instead of giving us a chance
+    /// to release the identifier ourselves.
     static func writeBoardForIntent(items: [SharedQueueItem], currentIndex: Int) async {
-        let task = await MainActor.run {
-            UIApplication.shared.beginBackgroundTask(withName: "ble-display-intent")
-        }
+        let task = BleIntentBackgroundTask()
+        task.begin(name: "ble-display-intent")
+        defer { task.end() }
         await BoardBleManager.shared.displayCurrentItemAwaitingReady(
             items: items,
             currentIndex: currentIndex,
             readyTimeout: 3.0
         )
-        await MainActor.run {
-            UIApplication.shared.endBackgroundTask(task)
+    }
+}
+
+/// Owns a single `UIBackgroundTaskIdentifier`. Begin and end are atomic and
+/// idempotent so the expiration handler, the `defer` cleanup, and (in pathological
+/// double-tap scenarios) a deinit can all race without crashing or leaking the
+/// identifier. `UIApplication.beginBackgroundTask` / `endBackgroundTask` are
+/// documented to be safe from any thread, so we don't hop to MainActor.
+private final class BleIntentBackgroundTask: @unchecked Sendable {
+    private let lock = NSLock()
+    private var taskId: UIBackgroundTaskIdentifier = .invalid
+
+    func begin(name: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard taskId == .invalid else { return }
+        taskId = UIApplication.shared.beginBackgroundTask(withName: name) { [weak self] in
+            self?.end()
         }
+    }
+
+    func end() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard taskId != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(taskId)
+        taskId = .invalid
+    }
+
+    deinit {
+        end()
     }
 }

--- a/mobile/ios/App/App/SharedConstants.swift
+++ b/mobile/ios/App/App/SharedConstants.swift
@@ -37,11 +37,6 @@ enum SharedConstants {
 
     static let queueNavigateNotification = "com.boardsesh.app.queueNavigate"
 
-    /// Fired by the widget after an optimistic current-index update so the
-    /// backgrounded main app can repaint the connected board without sending a
-    /// duplicate queue mutation.
-    static let boardBleDisplayNotification = "com.boardsesh.app.boardBleDisplay"
-
     /// Fired by the widget extension when `/api/widget/navigate` responds 410
     /// Gone, signaling that the cached APNs push token is bound to a different
     /// session and the main app should re-register.

--- a/mobile/ios/App/App/WaiterPool.swift
+++ b/mobile/ios/App/App/WaiterPool.swift
@@ -10,7 +10,11 @@ import Foundation
 ///
 /// Extracted from `BoardBleManager` so the waiter timing logic can be unit
 /// tested without standing up a real `CBCentralManager`.
-final class WaiterPool {
+///
+/// `@unchecked Sendable`: every mutation of `waiters` happens on `queue`,
+/// which is a serial `DispatchQueue`. There's no shared concurrent access
+/// to the array, but the compiler can't see that — hence unchecked.
+final class WaiterPool: @unchecked Sendable {
     private struct Waiter {
         let id: UUID
         let continuation: CheckedContinuation<Void, Never>

--- a/mobile/ios/App/App/WaiterPool.swift
+++ b/mobile/ios/App/App/WaiterPool.swift
@@ -44,11 +44,25 @@ final class WaiterPool: @unchecked Sendable {
                 }
                 let waiterId = UUID()
                 let workItem = DispatchWorkItem { [weak self] in
-                    guard let self else { return }
+                    guard let self else {
+                        // Pool was deallocated between wait() enqueueing the
+                        // waiter and the timeout firing. The Waiter struct
+                        // (along with its continuation reference inside the
+                        // pool's array) is gone, so resume the captured
+                        // continuation directly — leaking a CheckedContinuation
+                        // traps in debug builds and hangs the awaiting Task.
+                        // In practice unreachable while BoardBleManager.shared
+                        // owns the pool, but the contract has to hold.
+                        continuation.resume()
+                        return
+                    }
                     if let index = self.waiters.firstIndex(where: { $0.id == waiterId }) {
                         let waiter = self.waiters.remove(at: index)
                         waiter.continuation.resume()
                     }
+                    // If no matching waiter is found, signalAll already
+                    // resumed this continuation and removed the entry — do
+                    // nothing (double-resume would trap).
                 }
                 self.waiters.append(
                     Waiter(id: waiterId, continuation: continuation, timeoutWorkItem: workItem)

--- a/mobile/ios/App/App/WaiterPool.swift
+++ b/mobile/ios/App/App/WaiterPool.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Generic async-waiter pool. Each `wait(timeout:isReady:)` call suspends
+/// until either `signalAll()` resumes pending waiters or the per-waiter
+/// timeout elapses, whichever comes first.
+///
+/// All state mutation runs on the pool's serial `queue`, so the pool inherits
+/// the queue's serial ordering — there's no internal locking. Callers must
+/// invoke `signalAll()` and read `hasPendingWaiters` from that queue too.
+///
+/// Extracted from `BoardBleManager` so the waiter timing logic can be unit
+/// tested without standing up a real `CBCentralManager`.
+final class WaiterPool {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Never>
+        let timeoutWorkItem: DispatchWorkItem
+    }
+
+    private let queue: DispatchQueue
+    private var waiters: [Waiter] = []
+
+    init(queue: DispatchQueue) {
+        self.queue = queue
+    }
+
+    /// Returns immediately if `isReady()` is true when evaluated on the pool's
+    /// queue; otherwise suspends until `signalAll()` is called or `timeout`
+    /// elapses.
+    func wait(timeout: TimeInterval, isReady: @escaping () -> Bool) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            queue.async { [weak self] in
+                guard let self else {
+                    continuation.resume()
+                    return
+                }
+                if isReady() {
+                    continuation.resume()
+                    return
+                }
+                let waiterId = UUID()
+                let workItem = DispatchWorkItem { [weak self] in
+                    guard let self else { return }
+                    if let index = self.waiters.firstIndex(where: { $0.id == waiterId }) {
+                        let waiter = self.waiters.remove(at: index)
+                        waiter.continuation.resume()
+                    }
+                }
+                self.waiters.append(
+                    Waiter(id: waiterId, continuation: continuation, timeoutWorkItem: workItem)
+                )
+                self.queue.asyncAfter(deadline: .now() + timeout, execute: workItem)
+            }
+        }
+    }
+
+    /// Resumes every currently pending waiter and cancels their pending
+    /// timeout work items. Must be invoked from the pool's queue.
+    func signalAll() {
+        let snapshot = waiters
+        waiters = []
+        for waiter in snapshot {
+            waiter.timeoutWorkItem.cancel()
+            waiter.continuation.resume()
+        }
+    }
+
+    /// `true` while at least one continuation is suspended. Must be read on
+    /// the pool's queue.
+    var hasPendingWaiters: Bool {
+        !waiters.isEmpty
+    }
+}

--- a/mobile/ios/App/AppTests/WaiterPoolTests.swift
+++ b/mobile/ios/App/AppTests/WaiterPoolTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import App
+
+final class WaiterPoolTests: XCTestCase {
+    private var queue: DispatchQueue!
+    private var pool: WaiterPool!
+
+    override func setUp() {
+        super.setUp()
+        queue = DispatchQueue(label: "test.waiter-pool.\(UUID().uuidString)")
+        pool = WaiterPool(queue: queue)
+    }
+
+    override func tearDown() {
+        pool = nil
+        queue = nil
+        super.tearDown()
+    }
+
+    // MARK: - Immediate resume
+
+    func testWaitReturnsImmediatelyWhenIsReadyIsTrue() async {
+        let start = Date()
+        await pool.wait(timeout: 5.0) { true }
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertLessThan(elapsed, 0.1, "Expected near-immediate return, took \(elapsed)s")
+    }
+
+    // MARK: - Signal-based resume
+
+    func testWaitResumesWhenSignalAllCalled() async {
+        let signalAfter: TimeInterval = 0.05
+        let start = Date()
+
+        // Fire signalAll asynchronously while wait is suspended.
+        queue.asyncAfter(deadline: .now() + signalAfter) { [weak self] in
+            self?.pool.signalAll()
+        }
+
+        await pool.wait(timeout: 5.0) { false }
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertGreaterThan(elapsed, signalAfter * 0.5, "Resumed too quickly (\(elapsed)s) — should have suspended until signalAll")
+        XCTAssertLessThan(elapsed, 1.0, "Resumed too slowly (\(elapsed)s) — expected signalAll to drive resume")
+    }
+
+    // MARK: - Timeout
+
+    func testWaitResumesViaTimeoutWhenSignalNeverCalled() async {
+        let timeout: TimeInterval = 0.15
+        let start = Date()
+        await pool.wait(timeout: timeout) { false }
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertGreaterThanOrEqual(elapsed, timeout * 0.8, "Resumed before timeout (\(elapsed)s, expected ~\(timeout)s)")
+        XCTAssertLessThan(elapsed, timeout + 0.3, "Resumed long after timeout (\(elapsed)s, expected ~\(timeout)s)")
+    }
+
+    // MARK: - Concurrent waiters
+
+    func testMultipleConcurrentWaitersAllResumeOnSignalAll() async {
+        let waiterCount = 5
+        let signalAfter: TimeInterval = 0.05
+
+        queue.asyncAfter(deadline: .now() + signalAfter) { [weak self] in
+            self?.pool.signalAll()
+        }
+
+        let start = Date()
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<waiterCount {
+                group.addTask { [pool] in
+                    await pool!.wait(timeout: 5.0) { false }
+                }
+            }
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertLessThan(elapsed, 1.0, "All waiters should have resumed via signalAll within 1s, took \(elapsed)s")
+    }
+
+    func testMixedSignalAndTimeoutInterleaving() async {
+        // Three waiters with 1s timeout. Signal at 0.1s — all three should
+        // resume via signal, not timeout. Verifies signal cancels the
+        // per-waiter DispatchWorkItem cleanly without double-resume.
+        let signalAfter: TimeInterval = 0.1
+
+        queue.asyncAfter(deadline: .now() + signalAfter) { [weak self] in
+            self?.pool.signalAll()
+        }
+
+        let start = Date()
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<3 {
+                group.addTask { [pool] in
+                    await pool!.wait(timeout: 1.0) { false }
+                }
+            }
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertLessThan(elapsed, 0.5, "Expected signal-driven resume (~0.1s), got \(elapsed)s — possibly timed out instead")
+    }
+
+    // MARK: - hasPendingWaiters
+
+    func testHasPendingWaitersReflectsState() async {
+        let isPendingBefore = await readHasPendingWaiters()
+        XCTAssertFalse(isPendingBefore, "Pool should start empty")
+
+        let waitTask = Task { [pool] in
+            await pool!.wait(timeout: 2.0) { false }
+        }
+
+        // Give the wait a moment to enqueue on the pool's queue.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        let isPendingDuring = await readHasPendingWaiters()
+        XCTAssertTrue(isPendingDuring, "Pool should report a pending waiter while a wait is suspended")
+
+        await runOnQueue { [pool] in
+            pool!.signalAll()
+        }
+
+        await waitTask.value
+
+        let isPendingAfter = await readHasPendingWaiters()
+        XCTAssertFalse(isPendingAfter, "Pool should be empty after signalAll")
+    }
+
+    func testSignalAllOnEmptyPoolIsNoop() async {
+        await runOnQueue { [pool] in
+            pool!.signalAll()
+            pool!.signalAll()
+            pool!.signalAll()
+        }
+        // If signalAll on empty pool double-resumed anything we'd already
+        // have trapped on a CheckedContinuation. Reaching here is success.
+        XCTAssertFalse(await readHasPendingWaiters())
+    }
+
+    // MARK: - Helpers
+
+    private func readHasPendingWaiters() async -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            queue.async { [pool] in
+                continuation.resume(returning: pool!.hasPendingWaiters)
+            }
+        }
+    }
+
+    private func runOnQueue(_ block: @escaping () -> Void) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            queue.async {
+                block()
+                continuation.resume()
+            }
+        }
+    }
+}

--- a/mobile/ios/App/AppTests/WaiterPoolTests.swift
+++ b/mobile/ios/App/AppTests/WaiterPoolTests.swift
@@ -101,11 +101,13 @@ final class WaiterPoolTests: XCTestCase {
             await pool.wait(timeout: 2.0) { false }
         }
 
-        // Give the wait a moment to enqueue on the pool's queue.
-        try? await Task.sleep(nanoseconds: 50_000_000)
-
-        let isPendingDuring = await Self.readHasPendingWaiters(pool: pool, queue: queue)
-        XCTAssertTrue(isPendingDuring, "Pool should report a pending waiter while a wait is suspended")
+        // Poll until the waiter is observed enqueued on the pool's queue.
+        // A fixed sleep would race on a slow CI runner where the new Task
+        // hasn't been scheduled yet.
+        let pendingObserved = await Self.pollUntil(timeout: 2.0) {
+            await Self.readHasPendingWaiters(pool: pool, queue: queue)
+        }
+        XCTAssertTrue(pendingObserved, "Pool should report a pending waiter within 2s")
 
         await Self.runOnQueue(queue) {
             pool.signalAll()
@@ -115,6 +117,47 @@ final class WaiterPoolTests: XCTestCase {
 
         let isPendingAfter = await Self.readHasPendingWaiters(pool: pool, queue: queue)
         XCTAssertFalse(isPendingAfter, "Pool should be empty after signalAll")
+    }
+
+    // MARK: - Signal-cancels-timeout race
+
+    func testSignalAllRacingWithTimeoutDoesNotDoubleResume() async {
+        // signalAll is scheduled to fire ~25 ms after the wait starts; the
+        // wait's own timeout is 50 ms. The work item is queued at +50 ms but
+        // signalAll's `cancel()` at +25 ms removes it from the queue before
+        // it can run. If signalAll AND the timeout both managed to resume
+        // the same continuation, CheckedContinuation would trap. Reaching
+        // the end of the test without trapping locks the invariant in.
+        let (pool, queue) = makePoolAndQueue()
+
+        queue.asyncAfter(deadline: .now() + 0.025) {
+            pool.signalAll()
+        }
+
+        await pool.wait(timeout: 0.05) { false }
+
+        // Give any (cancelled) work item a chance to fire — it should not.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let isPending = await Self.readHasPendingWaiters(pool: pool, queue: queue)
+        XCTAssertFalse(isPending, "Pool should be empty after signalAll cancelled the timeout")
+    }
+
+    func testTimeoutFiringFirstSkipsLaterSignalAll() async {
+        // The opposite ordering: let the timeout resume the continuation
+        // first, then call signalAll. The timeout's work item removes the
+        // waiter from the pool's array, so signalAll sees an empty array
+        // and does nothing. Locks in the remove-by-id semantics.
+        let (pool, queue) = makePoolAndQueue()
+
+        await pool.wait(timeout: 0.05) { false }
+
+        await Self.runOnQueue(queue) {
+            pool.signalAll()
+        }
+
+        let isPending = await Self.readHasPendingWaiters(pool: pool, queue: queue)
+        XCTAssertFalse(isPending, "Pool should be empty after timeout-then-signalAll")
     }
 
     func testSignalAllOnEmptyPoolIsNoop() async {
@@ -163,5 +206,20 @@ final class WaiterPoolTests: XCTestCase {
                 continuation.resume()
             }
         }
+    }
+
+    /// Polls `predicate` every 50ms for up to `timeout` seconds. Returns
+    /// `true` as soon as the predicate returns `true`; returns `false` if
+    /// the timeout elapses first. Replaces fixed-duration sleeps that race
+    /// on heavily loaded CI runners.
+    private static func pollUntil(timeout: TimeInterval, _ predicate: @Sendable () async -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await predicate() {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return false
     }
 }

--- a/mobile/ios/App/AppTests/WaiterPoolTests.swift
+++ b/mobile/ios/App/AppTests/WaiterPoolTests.swift
@@ -2,24 +2,11 @@ import XCTest
 @testable import App
 
 final class WaiterPoolTests: XCTestCase {
-    private var queue: DispatchQueue!
-    private var pool: WaiterPool!
-
-    override func setUp() {
-        super.setUp()
-        queue = DispatchQueue(label: "test.waiter-pool.\(UUID().uuidString)")
-        pool = WaiterPool(queue: queue)
-    }
-
-    override func tearDown() {
-        pool = nil
-        queue = nil
-        super.tearDown()
-    }
 
     // MARK: - Immediate resume
 
     func testWaitReturnsImmediatelyWhenIsReadyIsTrue() async {
+        let pool = makePool()
         let start = Date()
         await pool.wait(timeout: 5.0) { true }
         let elapsed = Date().timeIntervalSince(start)
@@ -29,12 +16,13 @@ final class WaiterPoolTests: XCTestCase {
     // MARK: - Signal-based resume
 
     func testWaitResumesWhenSignalAllCalled() async {
+        let (pool, queue) = makePoolAndQueue()
         let signalAfter: TimeInterval = 0.05
         let start = Date()
 
         // Fire signalAll asynchronously while wait is suspended.
-        queue.asyncAfter(deadline: .now() + signalAfter) { [weak self] in
-            self?.pool.signalAll()
+        queue.asyncAfter(deadline: .now() + signalAfter) {
+            pool.signalAll()
         }
 
         await pool.wait(timeout: 5.0) { false }
@@ -46,6 +34,7 @@ final class WaiterPoolTests: XCTestCase {
     // MARK: - Timeout
 
     func testWaitResumesViaTimeoutWhenSignalNeverCalled() async {
+        let pool = makePool()
         let timeout: TimeInterval = 0.15
         let start = Date()
         await pool.wait(timeout: timeout) { false }
@@ -57,18 +46,19 @@ final class WaiterPoolTests: XCTestCase {
     // MARK: - Concurrent waiters
 
     func testMultipleConcurrentWaitersAllResumeOnSignalAll() async {
+        let (pool, queue) = makePoolAndQueue()
         let waiterCount = 5
         let signalAfter: TimeInterval = 0.05
 
-        queue.asyncAfter(deadline: .now() + signalAfter) { [weak self] in
-            self?.pool.signalAll()
+        queue.asyncAfter(deadline: .now() + signalAfter) {
+            pool.signalAll()
         }
 
         let start = Date()
         await withTaskGroup(of: Void.self) { group in
             for _ in 0..<waiterCount {
-                group.addTask { [pool] in
-                    await pool!.wait(timeout: 5.0) { false }
+                group.addTask {
+                    await pool.wait(timeout: 5.0) { false }
                 }
             }
         }
@@ -80,17 +70,18 @@ final class WaiterPoolTests: XCTestCase {
         // Three waiters with 1s timeout. Signal at 0.1s — all three should
         // resume via signal, not timeout. Verifies signal cancels the
         // per-waiter DispatchWorkItem cleanly without double-resume.
+        let (pool, queue) = makePoolAndQueue()
         let signalAfter: TimeInterval = 0.1
 
-        queue.asyncAfter(deadline: .now() + signalAfter) { [weak self] in
-            self?.pool.signalAll()
+        queue.asyncAfter(deadline: .now() + signalAfter) {
+            pool.signalAll()
         }
 
         let start = Date()
         await withTaskGroup(of: Void.self) { group in
             for _ in 0..<3 {
-                group.addTask { [pool] in
-                    await pool!.wait(timeout: 1.0) { false }
+                group.addTask {
+                    await pool.wait(timeout: 1.0) { false }
                 }
             }
         }
@@ -101,51 +92,71 @@ final class WaiterPoolTests: XCTestCase {
     // MARK: - hasPendingWaiters
 
     func testHasPendingWaitersReflectsState() async {
-        let isPendingBefore = await readHasPendingWaiters()
+        let (pool, queue) = makePoolAndQueue()
+
+        let isPendingBefore = await Self.readHasPendingWaiters(pool: pool, queue: queue)
         XCTAssertFalse(isPendingBefore, "Pool should start empty")
 
-        let waitTask = Task { [pool] in
-            await pool!.wait(timeout: 2.0) { false }
+        let waitTask = Task {
+            await pool.wait(timeout: 2.0) { false }
         }
 
         // Give the wait a moment to enqueue on the pool's queue.
         try? await Task.sleep(nanoseconds: 50_000_000)
 
-        let isPendingDuring = await readHasPendingWaiters()
+        let isPendingDuring = await Self.readHasPendingWaiters(pool: pool, queue: queue)
         XCTAssertTrue(isPendingDuring, "Pool should report a pending waiter while a wait is suspended")
 
-        await runOnQueue { [pool] in
-            pool!.signalAll()
+        await Self.runOnQueue(queue) {
+            pool.signalAll()
         }
 
         await waitTask.value
 
-        let isPendingAfter = await readHasPendingWaiters()
+        let isPendingAfter = await Self.readHasPendingWaiters(pool: pool, queue: queue)
         XCTAssertFalse(isPendingAfter, "Pool should be empty after signalAll")
     }
 
     func testSignalAllOnEmptyPoolIsNoop() async {
-        await runOnQueue { [pool] in
-            pool!.signalAll()
-            pool!.signalAll()
-            pool!.signalAll()
+        let (pool, queue) = makePoolAndQueue()
+
+        await Self.runOnQueue(queue) {
+            pool.signalAll()
+            pool.signalAll()
+            pool.signalAll()
         }
+
         // If signalAll on empty pool double-resumed anything we'd already
         // have trapped on a CheckedContinuation. Reaching here is success.
-        XCTAssertFalse(await readHasPendingWaiters())
+        let isPending = await Self.readHasPendingWaiters(pool: pool, queue: queue)
+        XCTAssertFalse(isPending)
     }
 
     // MARK: - Helpers
 
-    private func readHasPendingWaiters() async -> Bool {
+    private func makePool() -> WaiterPool {
+        makePoolAndQueue().0
+    }
+
+    private func makePoolAndQueue() -> (WaiterPool, DispatchQueue) {
+        let queue = DispatchQueue(label: "test.waiter-pool.\(UUID().uuidString)")
+        let pool = WaiterPool(queue: queue)
+        return (pool, queue)
+    }
+
+    /// Static so the closure passed to `withCheckedContinuation` doesn't
+    /// capture `self` — XCTestCase isn't `Sendable`, and DispatchQueue's
+    /// `async` closure is `@Sendable`. Capturing `pool` and `queue` by
+    /// value (both `Sendable`) keeps strict-concurrency happy.
+    private static func readHasPendingWaiters(pool: WaiterPool, queue: DispatchQueue) async -> Bool {
         await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            queue.async { [pool] in
-                continuation.resume(returning: pool!.hasPendingWaiters)
+            queue.async {
+                continuation.resume(returning: pool.hasPendingWaiters)
             }
         }
     }
 
-    private func runOnQueue(_ block: @escaping () -> Void) async {
+    private static func runOnQueue(_ queue: DispatchQueue, _ block: @escaping @Sendable () -> Void) async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             queue.async {
                 block()

--- a/mobile/ios/App/BoardseshWidgets/ClimbNavigationIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/ClimbNavigationIntent.swift
@@ -1,0 +1,94 @@
+import ActivityKit
+import AppIntents
+import os.log
+
+@available(iOS 17.0, *)
+enum ClimbNavigationDirection: String {
+    case next
+    case previous
+
+    /// Returns the new queue index, or nil if navigation is out of bounds.
+    func newIndex(from currentIndex: Int, count: Int) -> Int? {
+        switch self {
+        case .next:
+            let candidate = currentIndex + 1
+            return candidate < count ? candidate : nil
+        case .previous:
+            let candidate = currentIndex - 1
+            return (candidate >= 0 && candidate < count) ? candidate : nil
+        }
+    }
+}
+
+/// Shared body for `NextClimbIntent.perform()` and
+/// `PreviousClimbIntent.perform()`. Compiled into both the `App` and
+/// `BoardseshWidgets` targets so the same code runs whether iOS routes the
+/// intent to the main app process (the desired path) or to the widget
+/// extension as a fallback.
+@available(iOS 17.0, *)
+enum ClimbNavigationIntent {
+    private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
+
+    static func perform(direction: ClimbNavigationDirection, label: String) async {
+        #if DEBUG
+        // Lets us confirm in Console.app which process iOS chose to perform
+        // the intent in. Kept under DEBUG so production builds don't log on
+        // every tap, but dev builds surface immediately if Apple ever
+        // changes the routing.
+        logger.debug("\(label).perform() running in bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public)")
+        #endif
+
+        guard let defaults = SharedConstants.sharedDefaults else { return }
+
+        let (items, currentIndex) = SharedQueueState.load(from: defaults)
+        guard let newIndex = direction.newIndex(from: currentIndex, count: items.count) else {
+            return
+        }
+
+        SharedQueueState.saveCurrentIndex(newIndex, to: defaults)
+
+        let newItem = items[newIndex]
+        let newState = ClimbSessionAttributes.ContentState(
+            climbName: newItem.climbName,
+            climbDifficulty: VGradeFormatter.formatVGrade(newItem.difficulty),
+            angle: newItem.angle,
+            currentIndex: newIndex,
+            totalClimbs: items.count,
+            hasNext: newIndex < items.count - 1,
+            hasPrevious: newIndex > 0,
+            climbUuid: newItem.climbUuid
+        )
+
+        for activity in Activity<ClimbSessionAttributes>.activities {
+            guard activity.activityState == .active else { continue }
+            let content = ActivityContent(state: newState, staleDate: Date().addingTimeInterval(180))
+            await activity.update(content)
+        }
+
+        // BLE write (main app process only) and HTTP POST to the backend run
+        // concurrently so a slow CoreBluetooth state restoration doesn't
+        // delay backend propagation to other party clients.
+        #if !WIDGET_EXTENSION
+        async let bleWrite: Void = LiveActivityBleBridge.writeBoardForIntent(items: items, currentIndex: newIndex)
+        #endif
+
+        let httpSuccess = await WidgetNetworking.sendNavigation(action: direction.rawValue, currentIndex: newIndex)
+        if !httpSuccess {
+            defaults.set(direction.rawValue, forKey: SharedConstants.pendingActionKey)
+            postQueueNavigateDarwinNotification()
+        }
+
+        #if !WIDGET_EXTENSION
+        await bleWrite
+        #endif
+    }
+
+    private static func postQueueNavigateDarwinNotification() {
+        let name = SharedConstants.queueNavigateNotification as CFString
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(name),
+            nil, nil, true
+        )
+    }
+}

--- a/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
@@ -1,5 +1,6 @@
 import ActivityKit
 import AppIntents
+import os.log
 
 #if !WIDGET_EXTENSION
 import UIKit
@@ -10,7 +11,16 @@ struct NextClimbIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Next Climb"
     static var description = IntentDescription("Navigate to the next climb in the queue")
 
+    private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
+
     func perform() async throws -> some IntentResult {
+        // Logged so we can confirm in Console.app which process iOS chose to
+        // perform the intent in. If this logs from `BoardseshWidgets` while
+        // the app is suspended, the main-app-only BLE path below is dead and
+        // we need a different architecture. If it logs from `App`, the fix
+        // is working as designed.
+        Self.logger.info("NextClimbIntent.perform() running in bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public)")
+
         guard let defaults = SharedConstants.sharedDefaults else {
             return .result()
         }

--- a/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
@@ -2,10 +2,6 @@ import ActivityKit
 import AppIntents
 import os.log
 
-#if !WIDGET_EXTENSION
-import UIKit
-#endif
-
 @available(iOS 17.0, *)
 struct NextClimbIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Next Climb"
@@ -54,14 +50,11 @@ struct NextClimbIntent: LiveActivityIntent {
 
         #if !WIDGET_EXTENSION
         // Running in the main app process — write directly to the connected
-        // board. iOS launches the app in the background to perform the intent
-        // when the intent type is registered in the main-app target, even when
-        // the app was suspended. CoreBluetooth state restoration is
-        // asynchronous, so we await readiness (peripheral + write
-        // characteristic discovered) up to 3s before issuing the write, and
-        // wrap the whole thing in a background task so the OS doesn't suspend
-        // us mid-write.
-        await writeBoardOnMainApp(items: items, currentIndex: nextIndex)
+        // board. iOS background-launches the app to perform the intent when
+        // the intent type is registered in the main-app target, even when
+        // the app was suspended. See `LiveActivityBleBridge` for the
+        // readiness wait + background-task wrapping.
+        await LiveActivityBleBridge.writeBoardForIntent(items: items, currentIndex: nextIndex)
         #endif
 
         let httpSuccess = await WidgetNetworking.sendNavigation(action: "next", currentIndex: nextIndex)
@@ -82,18 +75,3 @@ struct NextClimbIntent: LiveActivityIntent {
         )
     }
 }
-
-#if !WIDGET_EXTENSION
-@available(iOS 17.0, *)
-private func writeBoardOnMainApp(items: [SharedQueueItem], currentIndex: Int) async {
-    let task = await MainActor.run {
-        UIApplication.shared.beginBackgroundTask(withName: "ble-display-intent")
-    }
-    await BoardBleManager.shared.displayCurrentItemAwaitingReady(
-        items: items, currentIndex: currentIndex, timeout: 3.0
-    )
-    await MainActor.run {
-        UIApplication.shared.endBackgroundTask(task)
-    }
-}
-#endif

--- a/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
@@ -1,6 +1,10 @@
 import ActivityKit
 import AppIntents
 
+#if !WIDGET_EXTENSION
+import UIKit
+#endif
+
 @available(iOS 17.0, *)
 struct NextClimbIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Next Climb"
@@ -18,10 +22,8 @@ struct NextClimbIntent: LiveActivityIntent {
             return .result()
         }
 
-        // Persist the new index so the main app picks it up.
         SharedQueueState.saveCurrentIndex(nextIndex, to: defaults)
 
-        // Optimistically update every active Live Activity.
         let nextItem = items[nextIndex]
         let newState = ClimbSessionAttributes.ContentState(
             climbName: nextItem.climbName,
@@ -35,30 +37,33 @@ struct NextClimbIntent: LiveActivityIntent {
         )
 
         for activity in Activity<ClimbSessionAttributes>.activities {
-            // ActivityKit's update() is non-throwing, but only update active
-            // activities — calling update on ended/dismissed activities is a no-op
-            // but logs warnings in the system.
             guard activity.activityState == .active else { continue }
             let content = ActivityContent(state: newState, staleDate: Date().addingTimeInterval(180))
             await activity.update(content)
         }
 
-        postBoardBleDisplayNotification()
+        #if !WIDGET_EXTENSION
+        // Running in the main app process — write directly to the connected
+        // board. iOS launches the app in the background to perform the intent
+        // when the intent type is registered in the main-app target, even when
+        // the app was suspended. CoreBluetooth state restoration is
+        // asynchronous, so we await readiness (peripheral + write
+        // characteristic discovered) up to 3s before issuing the write, and
+        // wrap the whole thing in a background task so the OS doesn't suspend
+        // us mid-write.
+        await writeBoardOnMainApp(items: items, currentIndex: nextIndex)
+        #endif
 
-        // Send navigation to the backend directly via HTTP. This works even
-        // when the main app is suspended. Only fall back to the Darwin
-        // notification path (which wakes the main app to send a WS mutation)
-        // if the HTTP request fails.
         let httpSuccess = await WidgetNetworking.sendNavigation(action: "next", currentIndex: nextIndex)
         if !httpSuccess {
             defaults.set("next", forKey: SharedConstants.pendingActionKey)
-            postDarwinNotification()
+            postQueueNavigateDarwinNotification()
         }
 
         return .result()
     }
 
-    private func postDarwinNotification() {
+    private func postQueueNavigateDarwinNotification() {
         let name = SharedConstants.queueNavigateNotification as CFString
         CFNotificationCenterPostNotification(
             CFNotificationCenterGetDarwinNotifyCenter(),
@@ -66,13 +71,19 @@ struct NextClimbIntent: LiveActivityIntent {
             nil, nil, true
         )
     }
+}
 
-    private func postBoardBleDisplayNotification() {
-        let name = SharedConstants.boardBleDisplayNotification as CFString
-        CFNotificationCenterPostNotification(
-            CFNotificationCenterGetDarwinNotifyCenter(),
-            CFNotificationName(name),
-            nil, nil, true
-        )
+#if !WIDGET_EXTENSION
+@available(iOS 17.0, *)
+private func writeBoardOnMainApp(items: [SharedQueueItem], currentIndex: Int) async {
+    let task = await MainActor.run {
+        UIApplication.shared.beginBackgroundTask(withName: "ble-display-intent")
+    }
+    await BoardBleManager.shared.displayCurrentItemAwaitingReady(
+        items: items, currentIndex: currentIndex, timeout: 3.0
+    )
+    await MainActor.run {
+        UIApplication.shared.endBackgroundTask(task)
     }
 }
+#endif

--- a/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
@@ -48,13 +48,11 @@ struct NextClimbIntent: LiveActivityIntent {
             await activity.update(content)
         }
 
+        // BLE write (main app process only) and HTTP POST to the backend are
+        // independent — run them concurrently so a slow CoreBluetooth state
+        // restoration doesn't delay the backend / other party clients.
         #if !WIDGET_EXTENSION
-        // Running in the main app process — write directly to the connected
-        // board. iOS background-launches the app to perform the intent when
-        // the intent type is registered in the main-app target, even when
-        // the app was suspended. See `LiveActivityBleBridge` for the
-        // readiness wait + background-task wrapping.
-        await LiveActivityBleBridge.writeBoardForIntent(items: items, currentIndex: nextIndex)
+        async let bleWrite: Void = LiveActivityBleBridge.writeBoardForIntent(items: items, currentIndex: nextIndex)
         #endif
 
         let httpSuccess = await WidgetNetworking.sendNavigation(action: "next", currentIndex: nextIndex)
@@ -62,6 +60,10 @@ struct NextClimbIntent: LiveActivityIntent {
             defaults.set("next", forKey: SharedConstants.pendingActionKey)
             postQueueNavigateDarwinNotification()
         }
+
+        #if !WIDGET_EXTENSION
+        await bleWrite
+        #endif
 
         return .result()
     }

--- a/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
@@ -1,81 +1,12 @@
-import ActivityKit
 import AppIntents
-import os.log
 
 @available(iOS 17.0, *)
 struct NextClimbIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Next Climb"
     static var description = IntentDescription("Navigate to the next climb in the queue")
 
-    private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
-
     func perform() async throws -> some IntentResult {
-        #if DEBUG
-        // Lets us confirm in Console.app which process iOS chose to perform
-        // the intent in. Empirically verified that iOS routes to the `App`
-        // process when the intent is registered there (see commit history);
-        // kept under DEBUG so production builds don't log on every tap, but
-        // dev builds surface immediately if Apple ever changes the routing.
-        Self.logger.debug("NextClimbIntent.perform() running in bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public)")
-        #endif
-
-        guard let defaults = SharedConstants.sharedDefaults else {
-            return .result()
-        }
-
-        let (items, currentIndex) = SharedQueueState.load(from: defaults)
-
-        let nextIndex = currentIndex + 1
-        guard nextIndex < items.count else {
-            return .result()
-        }
-
-        SharedQueueState.saveCurrentIndex(nextIndex, to: defaults)
-
-        let nextItem = items[nextIndex]
-        let newState = ClimbSessionAttributes.ContentState(
-            climbName: nextItem.climbName,
-            climbDifficulty: VGradeFormatter.formatVGrade(nextItem.difficulty),
-            angle: nextItem.angle,
-            currentIndex: nextIndex,
-            totalClimbs: items.count,
-            hasNext: nextIndex < items.count - 1,
-            hasPrevious: nextIndex > 0,
-            climbUuid: nextItem.climbUuid
-        )
-
-        for activity in Activity<ClimbSessionAttributes>.activities {
-            guard activity.activityState == .active else { continue }
-            let content = ActivityContent(state: newState, staleDate: Date().addingTimeInterval(180))
-            await activity.update(content)
-        }
-
-        // BLE write (main app process only) and HTTP POST to the backend are
-        // independent — run them concurrently so a slow CoreBluetooth state
-        // restoration doesn't delay the backend / other party clients.
-        #if !WIDGET_EXTENSION
-        async let bleWrite: Void = LiveActivityBleBridge.writeBoardForIntent(items: items, currentIndex: nextIndex)
-        #endif
-
-        let httpSuccess = await WidgetNetworking.sendNavigation(action: "next", currentIndex: nextIndex)
-        if !httpSuccess {
-            defaults.set("next", forKey: SharedConstants.pendingActionKey)
-            postQueueNavigateDarwinNotification()
-        }
-
-        #if !WIDGET_EXTENSION
-        await bleWrite
-        #endif
-
+        await ClimbNavigationIntent.perform(direction: .next, label: "NextClimbIntent")
         return .result()
-    }
-
-    private func postQueueNavigateDarwinNotification() {
-        let name = SharedConstants.queueNavigateNotification as CFString
-        CFNotificationCenterPostNotification(
-            CFNotificationCenterGetDarwinNotifyCenter(),
-            CFNotificationName(name),
-            nil, nil, true
-        )
     }
 }

--- a/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/NextClimbIntent.swift
@@ -10,12 +10,14 @@ struct NextClimbIntent: LiveActivityIntent {
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 
     func perform() async throws -> some IntentResult {
-        // Logged so we can confirm in Console.app which process iOS chose to
-        // perform the intent in. If this logs from `BoardseshWidgets` while
-        // the app is suspended, the main-app-only BLE path below is dead and
-        // we need a different architecture. If it logs from `App`, the fix
-        // is working as designed.
-        Self.logger.info("NextClimbIntent.perform() running in bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public)")
+        #if DEBUG
+        // Lets us confirm in Console.app which process iOS chose to perform
+        // the intent in. Empirically verified that iOS routes to the `App`
+        // process when the intent is registered there (see commit history);
+        // kept under DEBUG so production builds don't log on every tap, but
+        // dev builds surface immediately if Apple ever changes the routing.
+        Self.logger.debug("NextClimbIntent.perform() running in bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public)")
+        #endif
 
         guard let defaults = SharedConstants.sharedDefaults else {
             return .result()

--- a/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
@@ -2,10 +2,6 @@ import ActivityKit
 import AppIntents
 import os.log
 
-#if !WIDGET_EXTENSION
-import UIKit
-#endif
-
 @available(iOS 17.0, *)
 struct PreviousClimbIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Previous Climb"
@@ -52,10 +48,10 @@ struct PreviousClimbIntent: LiveActivityIntent {
 
         #if !WIDGET_EXTENSION
         // See NextClimbIntent for the rationale: when this intent runs in the
-        // main app's background process, drive the BLE write directly through
-        // the singleton, awaiting state restoration with a short timeout and
-        // a background task so the write actually flushes.
-        await writePreviousBoardOnMainApp(items: items, currentIndex: prevIndex)
+        // main app's background process, drive the BLE write through the
+        // shared bridge so the readiness wait + background-task wrapping
+        // stay in one place.
+        await LiveActivityBleBridge.writeBoardForIntent(items: items, currentIndex: prevIndex)
         #endif
 
         let httpSuccess = await WidgetNetworking.sendNavigation(action: "previous", currentIndex: prevIndex)
@@ -76,18 +72,3 @@ struct PreviousClimbIntent: LiveActivityIntent {
         )
     }
 }
-
-#if !WIDGET_EXTENSION
-@available(iOS 17.0, *)
-private func writePreviousBoardOnMainApp(items: [SharedQueueItem], currentIndex: Int) async {
-    let task = await MainActor.run {
-        UIApplication.shared.beginBackgroundTask(withName: "ble-display-intent")
-    }
-    await BoardBleManager.shared.displayCurrentItemAwaitingReady(
-        items: items, currentIndex: currentIndex, timeout: 3.0
-    )
-    await MainActor.run {
-        UIApplication.shared.endBackgroundTask(task)
-    }
-}
-#endif

--- a/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
@@ -1,76 +1,12 @@
-import ActivityKit
 import AppIntents
-import os.log
 
 @available(iOS 17.0, *)
 struct PreviousClimbIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Previous Climb"
     static var description = IntentDescription("Navigate to the previous climb in the queue")
 
-    private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
-
     func perform() async throws -> some IntentResult {
-        #if DEBUG
-        // See NextClimbIntent: kept under DEBUG so production builds don't
-        // log on every tap, but dev builds still surface the routing fact.
-        Self.logger.debug("PreviousClimbIntent.perform() running in bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public)")
-        #endif
-
-        guard let defaults = SharedConstants.sharedDefaults else {
-            return .result()
-        }
-
-        let (items, currentIndex) = SharedQueueState.load(from: defaults)
-
-        let prevIndex = currentIndex - 1
-        guard prevIndex >= 0, prevIndex < items.count else {
-            return .result()
-        }
-
-        SharedQueueState.saveCurrentIndex(prevIndex, to: defaults)
-
-        let prevItem = items[prevIndex]
-        let newState = ClimbSessionAttributes.ContentState(
-            climbName: prevItem.climbName,
-            climbDifficulty: VGradeFormatter.formatVGrade(prevItem.difficulty),
-            angle: prevItem.angle,
-            currentIndex: prevIndex,
-            totalClimbs: items.count,
-            hasNext: prevIndex < items.count - 1,
-            hasPrevious: prevIndex > 0,
-            climbUuid: prevItem.climbUuid
-        )
-
-        for activity in Activity<ClimbSessionAttributes>.activities {
-            guard activity.activityState == .active else { continue }
-            let content = ActivityContent(state: newState, staleDate: Date().addingTimeInterval(180))
-            await activity.update(content)
-        }
-
-        // See NextClimbIntent: BLE write and HTTP POST run concurrently.
-        #if !WIDGET_EXTENSION
-        async let bleWrite: Void = LiveActivityBleBridge.writeBoardForIntent(items: items, currentIndex: prevIndex)
-        #endif
-
-        let httpSuccess = await WidgetNetworking.sendNavigation(action: "previous", currentIndex: prevIndex)
-        if !httpSuccess {
-            defaults.set("previous", forKey: SharedConstants.pendingActionKey)
-            postQueueNavigateDarwinNotification()
-        }
-
-        #if !WIDGET_EXTENSION
-        await bleWrite
-        #endif
-
+        await ClimbNavigationIntent.perform(direction: .previous, label: "PreviousClimbIntent")
         return .result()
-    }
-
-    private func postQueueNavigateDarwinNotification() {
-        let name = SharedConstants.queueNavigateNotification as CFString
-        CFNotificationCenterPostNotification(
-            CFNotificationCenterGetDarwinNotifyCenter(),
-            CFNotificationName(name),
-            nil, nil, true
-        )
     }
 }

--- a/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
@@ -46,12 +46,9 @@ struct PreviousClimbIntent: LiveActivityIntent {
             await activity.update(content)
         }
 
+        // See NextClimbIntent: BLE write and HTTP POST run concurrently.
         #if !WIDGET_EXTENSION
-        // See NextClimbIntent for the rationale: when this intent runs in the
-        // main app's background process, drive the BLE write through the
-        // shared bridge so the readiness wait + background-task wrapping
-        // stay in one place.
-        await LiveActivityBleBridge.writeBoardForIntent(items: items, currentIndex: prevIndex)
+        async let bleWrite: Void = LiveActivityBleBridge.writeBoardForIntent(items: items, currentIndex: prevIndex)
         #endif
 
         let httpSuccess = await WidgetNetworking.sendNavigation(action: "previous", currentIndex: prevIndex)
@@ -59,6 +56,10 @@ struct PreviousClimbIntent: LiveActivityIntent {
             defaults.set("previous", forKey: SharedConstants.pendingActionKey)
             postQueueNavigateDarwinNotification()
         }
+
+        #if !WIDGET_EXTENSION
+        await bleWrite
+        #endif
 
         return .result()
     }

--- a/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
@@ -1,6 +1,10 @@
 import ActivityKit
 import AppIntents
 
+#if !WIDGET_EXTENSION
+import UIKit
+#endif
+
 @available(iOS 17.0, *)
 struct PreviousClimbIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Previous Climb"
@@ -18,10 +22,8 @@ struct PreviousClimbIntent: LiveActivityIntent {
             return .result()
         }
 
-        // Persist the new index so the main app picks it up.
         SharedQueueState.saveCurrentIndex(prevIndex, to: defaults)
 
-        // Optimistically update every active Live Activity.
         let prevItem = items[prevIndex]
         let newState = ClimbSessionAttributes.ContentState(
             climbName: prevItem.climbName,
@@ -35,30 +37,29 @@ struct PreviousClimbIntent: LiveActivityIntent {
         )
 
         for activity in Activity<ClimbSessionAttributes>.activities {
-            // ActivityKit's update() is non-throwing, but only update active
-            // activities — calling update on ended/dismissed activities is a no-op
-            // but logs warnings in the system.
             guard activity.activityState == .active else { continue }
             let content = ActivityContent(state: newState, staleDate: Date().addingTimeInterval(180))
             await activity.update(content)
         }
 
-        postBoardBleDisplayNotification()
+        #if !WIDGET_EXTENSION
+        // See NextClimbIntent for the rationale: when this intent runs in the
+        // main app's background process, drive the BLE write directly through
+        // the singleton, awaiting state restoration with a short timeout and
+        // a background task so the write actually flushes.
+        await writePreviousBoardOnMainApp(items: items, currentIndex: prevIndex)
+        #endif
 
-        // Send navigation to the backend directly via HTTP. This works even
-        // when the main app is suspended. Only fall back to the Darwin
-        // notification path (which wakes the main app to send a WS mutation)
-        // if the HTTP request fails.
         let httpSuccess = await WidgetNetworking.sendNavigation(action: "previous", currentIndex: prevIndex)
         if !httpSuccess {
             defaults.set("previous", forKey: SharedConstants.pendingActionKey)
-            postDarwinNotification()
+            postQueueNavigateDarwinNotification()
         }
 
         return .result()
     }
 
-    private func postDarwinNotification() {
+    private func postQueueNavigateDarwinNotification() {
         let name = SharedConstants.queueNavigateNotification as CFString
         CFNotificationCenterPostNotification(
             CFNotificationCenterGetDarwinNotifyCenter(),
@@ -66,13 +67,19 @@ struct PreviousClimbIntent: LiveActivityIntent {
             nil, nil, true
         )
     }
+}
 
-    private func postBoardBleDisplayNotification() {
-        let name = SharedConstants.boardBleDisplayNotification as CFString
-        CFNotificationCenterPostNotification(
-            CFNotificationCenterGetDarwinNotifyCenter(),
-            CFNotificationName(name),
-            nil, nil, true
-        )
+#if !WIDGET_EXTENSION
+@available(iOS 17.0, *)
+private func writePreviousBoardOnMainApp(items: [SharedQueueItem], currentIndex: Int) async {
+    let task = await MainActor.run {
+        UIApplication.shared.beginBackgroundTask(withName: "ble-display-intent")
+    }
+    await BoardBleManager.shared.displayCurrentItemAwaitingReady(
+        items: items, currentIndex: currentIndex, timeout: 3.0
+    )
+    await MainActor.run {
+        UIApplication.shared.endBackgroundTask(task)
     }
 }
+#endif

--- a/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
@@ -10,10 +10,11 @@ struct PreviousClimbIntent: LiveActivityIntent {
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 
     func perform() async throws -> some IntentResult {
-        // See NextClimbIntent: this log line lets us verify whether iOS runs
-        // the intent in the App process (fix works) or the BoardseshWidgets
-        // extension (fix dead, need different architecture).
-        Self.logger.info("PreviousClimbIntent.perform() running in bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public)")
+        #if DEBUG
+        // See NextClimbIntent: kept under DEBUG so production builds don't
+        // log on every tap, but dev builds still surface the routing fact.
+        Self.logger.debug("PreviousClimbIntent.perform() running in bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public)")
+        #endif
 
         guard let defaults = SharedConstants.sharedDefaults else {
             return .result()

--- a/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/PreviousClimbIntent.swift
@@ -1,5 +1,6 @@
 import ActivityKit
 import AppIntents
+import os.log
 
 #if !WIDGET_EXTENSION
 import UIKit
@@ -10,7 +11,14 @@ struct PreviousClimbIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Previous Climb"
     static var description = IntentDescription("Navigate to the previous climb in the queue")
 
+    private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
+
     func perform() async throws -> some IntentResult {
+        // See NextClimbIntent: this log line lets us verify whether iOS runs
+        // the intent in the App process (fix works) or the BoardseshWidgets
+        // extension (fix dead, need different architecture).
+        Self.logger.info("PreviousClimbIntent.perform() running in bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public)")
+
         guard let defaults = SharedConstants.sharedDefaults else {
             return .result()
         }


### PR DESCRIPTION
## Summary

- When iOS suspends the main app, tapping Next/Previous in the Live Activity advanced the UI but never repainted the connected board. Re-opening the app showed the correct climb, but the press itself was a no-op for BLE.
- The intent files lived only in the widget extension target, so the system ran `LiveActivityIntent.perform()` in the widget process. `BoardBleManager.shared` is not linked there, and the Darwin notification fallback can't wake a suspended app.
- This change adds the intent files to the **App target** as well. iOS now background-launches the main app to perform the intent, where it can call `BoardBleManager.shared` directly. The main-app-only path is gated behind a new `WIDGET_EXTENSION` compile flag set on the widget target.
- New `BoardBleManager.displayCurrentItemAwaitingReady(...)` awaits CoreBluetooth state restoration (peripheral + write characteristic discovered) up to a timeout, issues the write, then drains the write queue. A `UIApplication.beginBackgroundTask` wraps the call so iOS does not suspend mid-write.
- The Darwin observer in `BoardBleManager` (`startBoardBleDisplayObservation`, `displaySharedCurrentItem`, the `boardBleDisplayNotification` constant) is deleted — it was load-bearing only for the foreground case the new direct path already covers, and was broken in the suspended case anyway.
- HTTP POST to `/api/widget/navigate` is unchanged so other party clients still see the navigation.

## Test plan

This is iOS native; needs a physical iPhone + a real connected board (simulator has no BLE).

- [ ] Build both schemes in Xcode (`App`, `BoardseshWidgets`) — verify no compile errors, especially that the widget target build excludes the `BoardBleManager`/`UIApplication` paths via `#if !WIDGET_EXTENSION`.
- [ ] Launch app, connect to a board, start a session with ≥3 climbs queued. Lock the device and wait ~30s so iOS suspends the app.
- [ ] Tap **Next** on the lock-screen Live Activity. Expect the board LEDs to update within ~2–3 s.
- [ ] Tap **Previous**. Same expectation.
- [ ] Tap **Next** 3× rapidly — the board should end up displaying the final climb (intermediate flashes acceptable).
- [ ] Park the phone ~10 min so iOS terminates the app. Tap **Next** — the system should background-launch the app, restore the BLE peripheral via the existing `CBCentralManagerOptionRestoreIdentifierKey` path, and update the board within ~3–5 s.
- [ ] With the app in foreground, tap Next from the Dynamic Island — confirm no regression.
- [ ] Confirm backend propagation: from a second client (web), join the same party session and tap Next on the phone — web client's queue index advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)