### PR TITLE
fix(backend): address APNs Live Activity review feedback

### DIFF
--- a/packages/backend/src/__tests__/apns.test.ts
+++ b/packages/backend/src/__tests__/apns.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { eq, inArray } from 'drizzle-orm';
+import { activityPushTokens, boardSessions } from '@boardsesh/db/schema/app';
+import { db } from '../db/client';
+import type { LiveActivityContentState } from '../services/apns';
+
+interface MockSendResult {
+  sent: unknown[];
+  failed: unknown[];
+}
+
+type MockSend = (notification: Record<string, unknown>, tokens: string[]) => Promise<MockSendResult>;
+
+const { mockSend, mockShutdown, ProviderCtor, NotificationCtor } = vi.hoisted(() => {
+  const mockSend = vi.fn<MockSend>(async () => ({ sent: [], failed: [] }));
+  const mockShutdown = vi.fn(async () => undefined);
+  // Arrow-function implementations can't be invoked with `new`. The SUT does
+  // `new apn.Provider(...)` / `new apn.Notification()`, so the mock impls must
+  // be `function` expressions that populate `this`.
+  const ProviderCtor = vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.send = mockSend;
+    this.shutdown = mockShutdown;
+  });
+  const NotificationCtor = vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.aps = {};
+  });
+  return { mockSend, mockShutdown, ProviderCtor, NotificationCtor };
+});
+
+vi.mock('@parse/node-apn', () => ({
+  default: { Provider: ProviderCtor, Notification: NotificationCtor },
+  Provider: ProviderCtor,
+  Notification: NotificationCtor,
+}));
+
+const APNS_ENV_KEYS = [
+  'APNS_KEY_ID',
+  'APNS_TEAM_ID',
+  'APNS_KEY_CONTENTS',
+  'APNS_BUNDLE_ID',
+  'APNS_PRODUCTION',
+] as const;
+
+function snapshotEnv(): Record<string, string | undefined> {
+  const snap: Record<string, string | undefined> = {};
+  for (const key of APNS_ENV_KEYS) snap[key] = process.env[key];
+  return snap;
+}
+
+function restoreEnv(snap: Record<string, string | undefined>): void {
+  for (const key of APNS_ENV_KEYS) {
+    if (snap[key] === undefined) delete process.env[key];
+    else process.env[key] = snap[key];
+  }
+}
+
+function setApnsEnv(overrides: Partial<Record<(typeof APNS_ENV_KEYS)[number], string | undefined>> = {}): void {
+  const defaults: Record<(typeof APNS_ENV_KEYS)[number], string> = {
+    APNS_KEY_ID: 'TEST_KEY_ID',
+    APNS_TEAM_ID: 'TEST_TEAM_ID',
+    APNS_KEY_CONTENTS: 'a'.repeat(40),
+    APNS_BUNDLE_ID: 'com.boardsesh.test',
+    APNS_PRODUCTION: 'false',
+  };
+  for (const key of APNS_ENV_KEYS) {
+    // `key in overrides` distinguishes "caller explicitly passed undefined"
+    // (unset the env var) from "caller didn't mention this key" (use default).
+    const value = key in overrides ? overrides[key] : defaults[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+interface ApnsModule {
+  initializeApns: () => void;
+  shutdownApns: () => Promise<void>;
+  __resetApnsForTests: () => void;
+  __setApnsTimingForTests: (opts: { debounceMs?: number; dbRetryDelaysMs?: readonly number[] }) => void;
+  isApnsConfigured: () => boolean;
+  hasPendingSend: (sessionId: string) => boolean;
+  sendLiveActivityUpdate: (sessionId: string, contentState: LiveActivityContentState) => void;
+  endLiveActivity: (sessionId: string) => Promise<void>;
+}
+
+async function loadApns(): Promise<ApnsModule> {
+  return (await import('../services/apns')) as unknown as ApnsModule;
+}
+
+async function insertSession(sessionId: string): Promise<void> {
+  await db.insert(boardSessions).values({
+    id: sessionId,
+    boardPath: 'kilter',
+    status: 'active',
+  });
+}
+
+async function insertTokens(sessionId: string, tokens: string[]): Promise<void> {
+  if (tokens.length === 0) return;
+  await db.insert(activityPushTokens).values(
+    tokens.map((token) => ({
+      token,
+      sessionId,
+    })),
+  );
+}
+
+async function tokensForSession(sessionId: string): Promise<string[]> {
+  const rows = await db
+    .select({ token: activityPushTokens.token })
+    .from(activityPushTokens)
+    .where(eq(activityPushTokens.sessionId, sessionId));
+  return rows.map((r) => r.token).sort();
+}
+
+// Tiny test-only debounce/retry windows. Real production values are 1_000 ms
+// debounce + [1_000, 3_000, 8_000] ms retry array — we shrink them via
+// __setApnsTimingForTests so we can use real timers instead of fake timers
+// (faking setTimeout would deadlock postgres-js's connection pool).
+const TEST_DEBOUNCE_MS = 25;
+const TEST_DB_RETRY_DELAYS_MS = [10] as const;
+// Generous slack on top of debounce + retry windows so parallel DB deletes
+// (Promise.all over up to 6 staleTokenDeletions) all finish before assertions.
+const SETTLE_SLACK_MS = 300;
+
+function waitForSettle(extraMs = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, SETTLE_SLACK_MS + extraMs));
+}
+
+const sampleContentState: LiveActivityContentState = {
+  climbName: 'Test Climb',
+  climbDifficulty: 'V5',
+  angle: 40,
+  currentIndex: 0,
+  totalClimbs: 5,
+  hasNext: true,
+  hasPrevious: false,
+  climbUuid: 'climb-uuid-1',
+};
+
+describe('APNs Live Activity service', () => {
+  let envSnapshot: Record<string, string | undefined>;
+  let apns: ApnsModule;
+
+  beforeAll(async () => {
+    // Reset modules once so the dynamic import below resolves
+    // `import apn from '@parse/node-apn'` through the vi.mock factory above.
+    // The mocked module is cached for the rest of the file; subsequent tests
+    // share the same SUT instance and rely on __resetApnsForTests for cleanup.
+    vi.resetModules();
+    apns = await loadApns();
+  });
+
+  beforeEach(() => {
+    envSnapshot = snapshotEnv();
+    apns.__resetApnsForTests();
+    apns.__setApnsTimingForTests({ debounceMs: TEST_DEBOUNCE_MS, dbRetryDelaysMs: TEST_DB_RETRY_DELAYS_MS });
+    vi.clearAllMocks();
+    mockSend.mockImplementation(async () => ({ sent: [], failed: [] }));
+  });
+
+  afterEach(async () => {
+    await apns.shutdownApns();
+    apns.__resetApnsForTests();
+    restoreEnv(envSnapshot);
+  });
+
+  describe('initializeApns', () => {
+    it('returns disabled when APNS_BUNDLE_ID is missing', () => {
+      setApnsEnv({ APNS_BUNDLE_ID: undefined });
+      apns.initializeApns();
+      expect(apns.isApnsConfigured()).toBe(false);
+      expect(ProviderCtor).not.toHaveBeenCalled();
+    });
+
+    it('initializes the provider when every required env var is set', () => {
+      setApnsEnv();
+      apns.initializeApns();
+      expect(apns.isApnsConfigured()).toBe(true);
+      expect(ProviderCtor).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sendLiveActivityUpdate', () => {
+    it('is a no-op when APNs is not configured', async () => {
+      apns.sendLiveActivityUpdate('session-noconfig', sampleContentState);
+      await waitForSettle();
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('debounces multiple calls within DEBOUNCE_MS to a single send with the latest state', async () => {
+      const sessionId = 'session-debounce';
+      setApnsEnv();
+      apns.initializeApns();
+      await insertSession(sessionId);
+      await insertTokens(sessionId, ['debounce-token-1', 'debounce-token-2']);
+
+      apns.sendLiveActivityUpdate(sessionId, { ...sampleContentState, currentIndex: 0 });
+      apns.sendLiveActivityUpdate(sessionId, { ...sampleContentState, currentIndex: 1 });
+      apns.sendLiveActivityUpdate(sessionId, { ...sampleContentState, currentIndex: 2 });
+
+      await waitForSettle();
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const [notification, tokens] = mockSend.mock.calls[0];
+      const aps = notification.aps as { 'content-state'?: LiveActivityContentState; event?: string };
+      expect(aps['content-state']?.currentIndex).toBe(2);
+      expect(aps.event).toBe('update');
+      expect([...tokens].sort()).toEqual(['debounce-token-1', 'debounce-token-2']);
+    });
+  });
+
+  describe('executeDebouncedSend retry', () => {
+    it('retries on transient DB failure then sends successfully', async () => {
+      const sessionId = 'session-retry-succeed';
+      setApnsEnv();
+      apns.initializeApns();
+      await insertSession(sessionId);
+      await insertTokens(sessionId, ['retry-token']);
+
+      const selectSpy = vi.spyOn(db, 'select').mockImplementationOnce(() => {
+        throw new Error('transient DB failure');
+      });
+
+      try {
+        apns.sendLiveActivityUpdate(sessionId, sampleContentState);
+        // Wait long enough for debounce + every retry-delay slot to elapse.
+        const retryBudget = TEST_DB_RETRY_DELAYS_MS.reduce((sum, ms) => sum + ms, 0);
+        await waitForSettle(TEST_DEBOUNCE_MS + retryBudget);
+
+        expect(mockSend).toHaveBeenCalledTimes(1);
+        const [, tokens] = mockSend.mock.calls[0];
+        expect(tokens).toEqual(['retry-token']);
+      } finally {
+        selectSpy.mockRestore();
+      }
+    });
+
+    it('requeues with a fresh retry counter after exhausting the retry schedule', async () => {
+      // After the SUT walks the whole DB_RETRY_DELAYS_MS schedule with every
+      // attempt still failing, it requeues the latest state instead of
+      // dropping the update outright. That bounds the user-visible regression
+      // to one more debounce window rather than waiting for the 90 s heartbeat.
+      const sessionId = 'session-retry-requeue';
+      setApnsEnv();
+      apns.initializeApns();
+      await insertSession(sessionId);
+      await insertTokens(sessionId, ['requeue-token']);
+
+      const selectSpy = vi.spyOn(db, 'select').mockImplementation(() => {
+        throw new Error('DB unavailable');
+      });
+
+      try {
+        apns.sendLiveActivityUpdate(sessionId, sampleContentState);
+        // Wait long enough for one full debounce → all retries → give-up cycle.
+        const retryBudget = TEST_DB_RETRY_DELAYS_MS.reduce((sum, ms) => sum + ms, 0);
+        await waitForSettle(TEST_DEBOUNCE_MS + retryBudget);
+
+        expect(mockSend).not.toHaveBeenCalled();
+        // SUT requeued — a new debounce window is in flight for this session.
+        expect(apns.hasPendingSend(sessionId)).toBe(true);
+        // Halt the requeue loop *before* restoring the spy so the next cycle
+        // doesn't race the test teardown by succeeding against a real DB call.
+        apns.__resetApnsForTests();
+      } finally {
+        selectSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('stale token cleanup', () => {
+    it('deletes tokens for 410 / BadDeviceToken / Unregistered / ExpiredToken; leaves others intact', async () => {
+      const sessionId = 'session-stale';
+      setApnsEnv();
+      apns.initializeApns();
+      await insertSession(sessionId);
+      const seeded = [
+        'stale-status-410',
+        'stale-bad-device',
+        'stale-unregistered',
+        'stale-expired',
+        'live-token-500',
+        'live-token-sent',
+      ];
+      await insertTokens(sessionId, seeded);
+
+      mockSend.mockImplementationOnce(async () => ({
+        sent: [{ device: 'live-token-sent' }],
+        failed: [
+          { device: 'stale-status-410', status: 410, response: { reason: undefined } },
+          { device: 'stale-bad-device', status: 400, response: { reason: 'BadDeviceToken' } },
+          { device: 'stale-unregistered', status: 410, response: { reason: 'Unregistered' } },
+          { device: 'stale-expired', status: 410, response: { reason: 'ExpiredToken' } },
+          { device: 'live-token-500', status: 500, response: { reason: 'InternalServerError' } },
+        ],
+      }));
+
+      apns.sendLiveActivityUpdate(sessionId, sampleContentState);
+      await waitForSettle();
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const remaining = await tokensForSession(sessionId);
+      expect(remaining).toEqual(['live-token-500', 'live-token-sent'].sort());
+    });
+  });
+
+  describe('endLiveActivity', () => {
+    it('cancels a pending debounce so no update is sent, only the end event', async () => {
+      const sessionId = 'session-end-cancels';
+      setApnsEnv();
+      apns.initializeApns();
+      await insertSession(sessionId);
+      await insertTokens(sessionId, ['end-cancel-token']);
+
+      apns.sendLiveActivityUpdate(sessionId, sampleContentState);
+      await apns.endLiveActivity(sessionId);
+
+      // Wait past the debounce window — if cancellation failed, a second
+      // (`update`) send would fire here.
+      await waitForSettle();
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const [notification] = mockSend.mock.calls[0];
+      const aps = notification.aps as { event?: string };
+      expect(aps.event).toBe('end');
+    });
+
+    it('cleans up all push tokens for the session after the end push', async () => {
+      const sessionId = 'session-end-cleanup';
+      setApnsEnv();
+      apns.initializeApns();
+      await insertSession(sessionId);
+      await insertTokens(sessionId, ['cleanup-token-a', 'cleanup-token-b']);
+
+      await apns.endLiveActivity(sessionId);
+      const remaining = await tokensForSession(sessionId);
+      expect(remaining).toEqual([]);
+    });
+  });
+
+  describe('cleanupTokensForSession (via endLiveActivity)', () => {
+    it('only deletes tokens for the given session', async () => {
+      const sessionA = 'session-isolation-A';
+      const sessionB = 'session-isolation-B';
+      setApnsEnv();
+      apns.initializeApns();
+      await insertSession(sessionA);
+      await insertSession(sessionB);
+      await insertTokens(sessionA, ['iso-token-A1', 'iso-token-A2']);
+      await insertTokens(sessionB, ['iso-token-B1']);
+
+      await apns.endLiveActivity(sessionA);
+
+      const rowsB = await tokensForSession(sessionB);
+      expect(rowsB).toEqual(['iso-token-B1']);
+
+      const remainingA = await db
+        .select({ token: activityPushTokens.token })
+        .from(activityPushTokens)
+        .where(inArray(activityPushTokens.token, ['iso-token-A1', 'iso-token-A2']));
+      expect(remainingA).toEqual([]);
+    });
+  });
+});

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -75,6 +75,18 @@ export const schemaSQL = `
     "updated_at" timestamp DEFAULT now() NOT NULL
   );
 
+  DROP TABLE IF EXISTS "activity_push_tokens" CASCADE;
+  CREATE TABLE IF NOT EXISTS "activity_push_tokens" (
+    "token" text PRIMARY KEY NOT NULL,
+    "session_id" text NOT NULL REFERENCES "board_sessions"("id") ON DELETE CASCADE,
+    "user_id" text REFERENCES "users"("id") ON DELETE SET NULL,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS "activity_push_tokens_session_idx" ON "activity_push_tokens" ("session_id");
+  CREATE INDEX IF NOT EXISTS "activity_push_tokens_user_idx" ON "activity_push_tokens" ("user_id");
+  CREATE INDEX IF NOT EXISTS "activity_push_tokens_updated_at_idx" ON "activity_push_tokens" ("updated_at");
+
   CREATE INDEX IF NOT EXISTS "board_sessions_location_idx" ON "board_sessions" ("latitude", "longitude");
   CREATE INDEX IF NOT EXISTS "board_sessions_discoverable_idx" ON "board_sessions" ("discoverable");
   CREATE INDEX IF NOT EXISTS "board_sessions_user_idx" ON "board_sessions" ("created_by_user_id");

--- a/packages/backend/src/__tests__/setup.ts
+++ b/packages/backend/src/__tests__/setup.ts
@@ -19,6 +19,7 @@ let dbAvailable = false;
 // Tables the per-file beforeAll resets so each file starts on a clean slate.
 // Order doesn't matter — TRUNCATE ... CASCADE handles FK edges.
 const TABLES_TO_RESET = [
+  'activity_push_tokens',
   'board_session_queues',
   'board_session_clients',
   'board_session_participants',

--- a/packages/backend/src/__tests__/widget-navigate.test.ts
+++ b/packages/backend/src/__tests__/widget-navigate.test.ts
@@ -411,7 +411,10 @@ describe('handleWidgetNavigate', () => {
     expect(res.statusCode).toBe(500);
     const parsed = JSON.parse(res.body) as { success: boolean; error: string };
     expect(parsed.success).toBe(false);
-    expect(parsed.error).toBe('navigation exploded');
+    // Error detail stays in server logs; the 500 body returns a generic
+    // message so internal state (DB strings, schema hints) can't leak to the
+    // iOS widget. See handlers/widget-navigate.ts catch block.
+    expect(parsed.error).toBe('Internal server error');
     expect(trackLiveActivityWidgetNavigationMock).toHaveBeenCalledWith({
       userId: USER_ID,
       sessionId: SESSION_ID,

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -427,9 +427,11 @@ export const sessionMutations = {
     // Send APNs `end` push to dismiss every device's Live Activity. Without
     // this, other participants' lock-screen tiles linger with stale data
     // until ActivityKit's stale date elapses.
-    endLiveActivity(sessionId).catch((err) => {
+    try {
+      await endLiveActivity(sessionId);
+    } catch (err) {
       logger.error(`[APNs] endLiveActivity failed for session ${sessionId}:`, err);
-    });
+    }
 
     // Generate and return summary
     const summary = await generateSessionSummary(sessionId);

--- a/packages/backend/src/handlers/widget-navigate.ts
+++ b/packages/backend/src/handlers/widget-navigate.ts
@@ -18,6 +18,18 @@ interface WidgetNavigateBody {
   currentIndex: number;
 }
 
+/**
+ * Validate the widget request body.
+ *
+ * `currentIndex` is required and shape-checked but the handler does not use
+ * its value — once the request passes auth + rate-limit, the server resolves
+ * the authoritative index from `roomManager.getQueueState` (see the call site
+ * around the `_ignoredClientIndex` destructuring below for the full rationale).
+ * The field is still validated here so malformed payloads from a future widget
+ * regression get rejected at the door rather than coercing into a no-op.
+ * Dropping the field from the schema would break wire-compat with the already-
+ * shipped iOS widget, which always sends it.
+ */
 function isValidBody(body: unknown): body is WidgetNavigateBody {
   if (typeof body !== 'object' || body === null) return false;
   const candidate = body as Record<string, unknown>;
@@ -224,6 +236,10 @@ export async function handleWidgetNavigate(req: IncomingMessage, res: ServerResp
     return;
   }
 
+  // currentIndex is intentionally aliased to `_ignoredClientIndex` — see the
+  // server-authoritative index lookup further down and the doc comment on
+  // `isValidBody` above. The widget sends it, we validate it, but we never use
+  // its value.
   const { sessionId, action, currentIndex: _ignoredClientIndex } = body;
 
   // Auth: bearer token must be registered to this sessionId
@@ -357,6 +373,9 @@ export async function handleWidgetNavigate(req: IncomingMessage, res: ServerResp
       res.end(JSON.stringify({ success: false, error: 'Target index out of bounds' }));
     }
   } catch (error) {
+    // Detail (DB connection strings, stack traces, schema hints) stays in
+    // server logs; the iOS widget receives only a generic message so we don't
+    // leak internals to a remote client.
     logger.error('[WidgetNavigate] Error:', error);
     trackWidgetNavigation(authResult.userId, {
       sessionId,
@@ -365,12 +384,7 @@ export async function handleWidgetNavigate(req: IncomingMessage, res: ServerResp
       statusCode: 500,
     });
     res.writeHead(500, { 'Content-Type': 'application/json' });
-    res.end(
-      JSON.stringify({
-        success: false,
-        error: error instanceof Error ? error.message : 'Internal server error',
-      }),
-    );
+    res.end(JSON.stringify({ success: false, error: 'Internal server error' }));
   }
 }
 

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -42,6 +42,19 @@ export type ServerResources = {
   shutdownServices: () => Promise<void>;
 };
 
+/**
+ * Build a Live Activity content snapshot from current room state and dispatch
+ * a debounced APNs push. Pulled out of the queue-event hook so the call site
+ * is a single promise chain whose rejections are explicitly swallowed at the
+ * top — easier to grep, easier to attach a real observability sink to later.
+ */
+async function dispatchLiveActivityForSession(sessionId: string): Promise<void> {
+  const queueState = await roomManager.getQueueState(sessionId);
+  const contentState = buildContentStateFromQueueState(queueState);
+  if (!contentState) return;
+  sendLiveActivityUpdate(sessionId, contentState);
+}
+
 export async function startServer(): Promise<ServerResources> {
   // Initialize PubSub (connects to Redis if configured)
   // This must happen before we start accepting connections
@@ -200,17 +213,16 @@ export async function startServer(): Promise<ServerResources> {
     // mutation when env vars aren't configured.
     if (!isApnsConfigured()) return;
 
-    // Async work wrapped in a void IIFE — never awaited, never throws
-    void (async () => {
-      try {
-        const queueState = await roomManager.getQueueState(sessionId);
-        const contentState = buildContentStateFromQueueState(queueState);
-        if (!contentState) return;
-        sendLiveActivityUpdate(sessionId, contentState);
-      } catch (error) {
-        logger.error(`[APNs Hook] Failed to send Live Activity update for session ${sessionId}:`, error);
-      }
-    })();
+    // Errors are intentionally swallowed: a failed Live Activity dispatch must
+    // not crash the queue-event consumer or surface to the originating GraphQL
+    // request. Stack + sessionId go to the structured logger so a search on
+    // "dispatchLiveActivityForSession failed" surfaces the failure mode.
+    dispatchLiveActivityForSession(sessionId).catch((error: unknown) => {
+      logger.error(
+        `[APNs Hook] dispatchLiveActivityForSession failed for session ${sessionId}:`,
+        error instanceof Error ? (error.stack ?? error.message) : error,
+      );
+    });
   });
 
   const PORT = parseInt(process.env.PORT || '8080', 10);

--- a/packages/backend/src/services/apns/index.ts
+++ b/packages/backend/src/services/apns/index.ts
@@ -52,15 +52,29 @@ interface TokenRegistration {
 // 3 retries with growing delays gives ~14 s of total wait before giving up,
 // which is enough to ride out a brief connection-pool blip or Postgres
 // failover without dropping the update.
-const DB_RETRY_DELAYS_MS = [1_000, 3_000, 8_000];
+const DEFAULT_DB_RETRY_DELAYS_MS = [1_000, 3_000, 8_000];
+
+// 1 s debounce. Climb navigation needs to feel responsive on the lock screen;
+// a 5 s window made tapping Next visibly laggy. 1 s still absorbs the most
+// common burst (QueueItemAdded + CurrentClimbChanged emitted back-to-back when
+// a climb is queued). A restart inside this 1 s window can drop the pending
+// update; the heartbeat loop catches up within 90 s.
+const DEFAULT_DEBOUNCE_MS = 1_000;
 
 // ---------------------------------------------------------------------------
 // Module state
 // ---------------------------------------------------------------------------
 
 let provider: apn.Provider | null = null;
-let bundleId: string = 'com.boardsesh.app';
+let bundleId: string = '';
 let configured = false;
+
+// Mutable so tests can shrink the windows to milliseconds rather than awaiting
+// the production-grade 1 s debounce + multi-second retry delays against real
+// timers (faking setTimeout deadlocks postgres-js's connection pool). In prod
+// these stay at DEFAULT_* and are reset by __resetApnsForTests.
+let DEBOUNCE_MS = DEFAULT_DEBOUNCE_MS;
+let DB_RETRY_DELAYS_MS: readonly number[] = DEFAULT_DB_RETRY_DELAYS_MS;
 
 /** Returns true if APNs env vars were present and the provider initialized. */
 export function isApnsConfigured(): boolean {
@@ -69,13 +83,6 @@ export function isApnsConfigured(): boolean {
 
 /** Debounce map: sessionId -> pending send state */
 const pendingSends = new Map<string, DebouncedEntry>();
-
-// 1 s debounce. Climb navigation needs to feel responsive on the lock screen;
-// a 5 s window made tapping Next visibly laggy. 1 s still absorbs the most
-// common burst (QueueItemAdded + CurrentClimbChanged emitted back-to-back when
-// a climb is queued). A restart inside this 1 s window can drop the pending
-// update; the heartbeat loop catches up within 90 s.
-const DEBOUNCE_MS = 1_000;
 
 /** Whether a session currently has a pending debounced send in flight. */
 export function hasPendingSend(sessionId: string): boolean {
@@ -144,17 +151,15 @@ export function initializeApns(): void {
   const envBundleId = process.env.APNS_BUNDLE_ID;
   const production = process.env.APNS_PRODUCTION === 'true';
 
-  if (!keyId || !teamId || !keyContentsBase64) {
+  if (!keyId || !teamId || !keyContentsBase64 || !envBundleId) {
     logger.warn(
-      '[APNs] Missing one or more required env vars (APNS_KEY_ID, APNS_TEAM_ID, APNS_KEY_CONTENTS). ' +
+      '[APNs] Missing one or more required env vars (APNS_KEY_ID, APNS_TEAM_ID, APNS_KEY_CONTENTS, APNS_BUNDLE_ID). ' +
         'Live Activity push notifications are disabled.',
     );
     return;
   }
 
-  if (envBundleId) {
-    bundleId = envBundleId;
-  }
+  bundleId = envBundleId;
 
   const keyContents = Buffer.from(keyContentsBase64, 'base64').toString('utf-8');
 
@@ -511,4 +516,33 @@ export function __resetApnsStateForTests(): void {
   for (const key of Object.keys(metrics) as (keyof ApnsMetrics)[]) {
     metrics[key] = 0;
   }
+}
+
+/**
+ * Test-only utility for fully clearing module state between tests. Matches
+ * the `__reset*ForTests` pattern used by widget-navigate and push-tokens.
+ * Strictly stronger than `__resetApnsStateForTests`: also nulls the provider,
+ * clears bundleId/configured, and restores DEBOUNCE_MS / DB_RETRY_DELAYS_MS
+ * to their production defaults. Tests that call `initializeApns()` should
+ * use this so the next test starts on a clean slate.
+ */
+export function __resetApnsForTests(): void {
+  __resetApnsStateForTests();
+  provider = null;
+  bundleId = '';
+  configured = false;
+  DEBOUNCE_MS = DEFAULT_DEBOUNCE_MS;
+  DB_RETRY_DELAYS_MS = DEFAULT_DB_RETRY_DELAYS_MS;
+}
+
+/**
+ * Test-only override for the debounce and DB-retry windows. Used by
+ * `apns.test.ts` to collapse the 1 s debounce + multi-second retry delays
+ * into a few ms so we don't have to combine fake timers with the real
+ * postgres-js pool (the pool's own setTimeout-based idle/keepalive logic
+ * deadlocks under faked timers). Reset by `__resetApnsForTests`.
+ */
+export function __setApnsTimingForTests(opts: { debounceMs?: number; dbRetryDelaysMs?: readonly number[] }): void {
+  if (opts.debounceMs !== undefined) DEBOUNCE_MS = opts.debounceMs;
+  if (opts.dbRetryDelaysMs !== undefined) DB_RETRY_DELAYS_MS = opts.dbRetryDelaysMs;
 }


### PR DESCRIPTION
## Summary

Follow-up to the Live Activity backend work merged in #1791 (`packages/backend/`). Addresses seven review-feedback items left open after the original PR landed.

### Changes per feedback item

1. **APNS_BUNDLE_ID is now required** (`packages/backend/src/services/apns/index.ts`). The previous init guard only checked the three credential vars; missing `APNS_BUNDLE_ID` silently fell back to the hardcoded `com.boardsesh.app`, which would have manifested as `BadDeviceToken` rejections in production with no obvious log hint. Hardcoded fallback removed; init now refuses to configure without the bundle id and warns explicitly.

2. **Single-instance rate-limit scope** — already addressed in #1791 (`widget-navigate.ts:62-64`, `push-tokens.ts:29-30`). No code change needed; flagged here so the reviewer can confirm.

3. **APNs service test coverage** — new `packages/backend/src/__tests__/apns.test.ts` covers init guard, debounce collapse, DB retry + give-up, stale-token deletion (status 410 / `BadDeviceToken` / `Unregistered` / `ExpiredToken`), end-cancels-pending-update, and per-session cleanup isolation. To support real-timer testing without fighting postgres-js's internal `setTimeout`s, the SUT exposes two test-only hooks: `__resetApnsForTests` (matches the existing `__reset*ForTests` pattern) and `__setApnsTimingForTests` (collapses the 5 s / 2 s windows to milliseconds for tests only — reset by `__resetApnsForTests`).

4. **Awaited `endLiveActivity`** (`mutations.ts:429`). Was fire-and-forget; now awaited so the mutation cannot return before token cleanup completes. Errors stay caught and logged so the mutation doesn't fail if APNs cleanup hits a transient issue.

5. **Named dispatch + explicit swallow** (`server.ts:162`). Replaced the `void (async () => { try {...} catch {...} })()` IIFE with a named `dispatchLiveActivityForSession` + `.catch()` that logs the stack and sessionId. There's no observability stack to surface to (backend logs go to plain stderr), so the realistic improvement is making the failure mode greppable and explicit.

6. **Generic widget error response** (`widget-navigate.ts:278`). The 500 body previously returned `error.message`, which can leak DB connection strings, query text, or schema hints. Now returns `{ error: 'Internal server error' }`; detail stays in server logs.

7. **`currentIndex` documented** (`widget-navigate.ts`). Added a doc comment to `isValidBody` and an inline comment on the `_ignoredClientIndex` destructuring explaining that the field is validated as defense-in-depth but the server uses its own authoritative index from `roomManager.getQueueState`. Dropping the field would break wire-compat with shipped iOS widgets.

## Test plan

- [x] `vp check` — 0 errors (125 pre-existing warnings)
- [x] `vp run typecheck:backend` — clean
- [x] `vp test --project backend --run --reporter=agent` — **1002/1002 tests pass** including the new 10 in `apns.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)