### PR TITLE
[codex] Enable tall climbs filter on 8x12 Kilter Homewall

### DIFF
--- a/packages/board-constants/src/__tests__/product-sizes.test.ts
+++ b/packages/board-constants/src/__tests__/product-sizes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { isKilterHomewallTallSizeId, isKilterHomewallWideSizeId } from '../product-sizes';
+
+describe('Kilter Homewall size filter capabilities', () => {
+  it('marks 8x12 and 10x12 Homewall sizes as tall-capable', () => {
+    for (const sizeId of [23, 24, 25, 26]) {
+      expect(isKilterHomewallTallSizeId(sizeId)).toBe(true);
+    }
+  });
+
+  it('does not mark 10-high Homewall sizes as tall-capable', () => {
+    for (const sizeId of [17, 18, 21, 22, 29]) {
+      expect(isKilterHomewallTallSizeId(sizeId)).toBe(false);
+    }
+  });
+
+  it('keeps 8x12 Homewall sizes out of the wide-climbs filter', () => {
+    for (const sizeId of [23, 24]) {
+      expect(isKilterHomewallWideSizeId(sizeId)).toBe(false);
+    }
+  });
+});

--- a/packages/board-constants/src/product-sizes.ts
+++ b/packages/board-constants/src/product-sizes.ts
@@ -24,8 +24,8 @@ export const PRODUCT_SIZES: Record<BoardName, Record<number, ProductSizeData>> =
 
 export { LAYOUTS, SETS, IMAGE_FILENAMES, HOLE_PLACEMENTS };
 
-// 25/26 are 10x12 Full Ride/Mainline.
-const KILTER_HOMEWALL_TALL_SIZE_ID_SET: ReadonlySet<number> = new Set([25, 26]);
+// 23/24 are 8x12 Full Ride/Mainline, 25/26 are 10x12 Full Ride/Mainline.
+const KILTER_HOMEWALL_TALL_SIZE_ID_SET: ReadonlySet<number> = new Set([23, 24, 25, 26]);
 
 // 21/22 are 10x10 Full Ride/Mainline, 25/26 are 10x12 Full Ride/Mainline,
 // and 29 is the 10x10 Auxiliary LED Kit.

--- a/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
@@ -219,6 +219,15 @@ void describe('createClimbFilters: tall climbs', () => {
     assert.match(rendered, /product_id/);
   });
 
+  void it('supports tall climbs on 8x12 Kilter Homewall sizes', () => {
+    for (const sizeId of [23, 24]) {
+      const filters = createClimbFilters({ ...homewallTallParams, size_id: sizeId }, { onlyTallClimbs: true });
+      assert.equal(filters.tallClimbsConditions.length, 1);
+      assert.notEqual(sqlToString(filters.tallClimbsConditions[0]), 'false');
+      assert.match(sqlToString(filters.tallClimbsConditions[0]), /edge_bottom/);
+    }
+  });
+
   void it('returns no results for tall climbs requests on unsupported boards or sizes', () => {
     const unsupportedCases = [
       { ...homewallTallParams, size_id: 21 },

--- a/packages/web/app/components/playlist-generator/__tests__/generator-options-form.test.tsx
+++ b/packages/web/app/components/playlist-generator/__tests__/generator-options-form.test.tsx
@@ -63,4 +63,30 @@ describe('GeneratorOptionsForm quality filters', () => {
 
     expect(onChange.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({ minRating: 4 }));
   });
+
+  it('shows tall climbs option for 8x12 Kilter Homewall and updates options', () => {
+    const onChange = vi.fn();
+    render(
+      <GeneratorOptionsForm
+        workoutType="volume"
+        options={getDefaultOptions('volume', 18)}
+        onChange={onChange}
+        onReset={vi.fn()}
+        boardDetails={{
+          ...boardDetails,
+          board_name: 'kilter',
+          layout_id: 8,
+          size_id: 23,
+          size_name: '8x12',
+        }}
+        targetAngle={40}
+        onTargetAngleChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Tall Climbs Only')).toBeDefined();
+    fireEvent.click(screen.getByRole('switch'));
+
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual(expect.objectContaining({ onlyTallClimbs: true }));
+  });
 });

--- a/packages/web/app/components/playlist-generator/generator-options-form.tsx
+++ b/packages/web/app/components/playlist-generator/generator-options-form.tsx
@@ -79,8 +79,7 @@ const GeneratorOptionsForm: React.FC<GeneratorOptionsFormProps> = ({
     label: t(`generator.climbBiasOptions.${opt.value}`),
   }));
 
-  // Check if we should show the tall climbs filter
-  // Only show for Kilter Homewall on the largest size (10x12)
+  // Check if we should show the tall climbs filter.
   const isKilterHomewall = boardDetails.board_name === 'kilter' && boardDetails.layout_id === KILTER_HOMEWALL_LAYOUT_ID;
   const showTallClimbsFilter = isKilterHomewall && isKilterHomewallTallSizeId(boardDetails.size_id);
 
@@ -244,7 +243,7 @@ const GeneratorOptionsForm: React.FC<GeneratorOptionsFormProps> = ({
           updateOption('climbBias', v),
         )}
 
-        {/* Tall Climbs Only - only for Kilter Homewall large size */}
+        {/* Tall Climbs Only */}
         {showTallClimbsFilter && (
           <div className={styles.formRow}>
             <MuiTooltip title={t('generator.options.tallClimbsTooltip')}>

--- a/packages/web/app/components/search-drawer/__tests__/accordion-search-form-handlers.test.tsx
+++ b/packages/web/app/components/search-drawer/__tests__/accordion-search-form-handlers.test.tsx
@@ -189,6 +189,17 @@ describe('AccordionSearchForm — quality filter controls', () => {
     expect(screen.getByText('Wide Climbs Only')).toBeDefined();
   });
 
+  it('shows tall but not wide climbs filter for 8x12 Kilter Homewall', () => {
+    render(
+      <AccordionSearchForm
+        boardDetails={makeBoardDetails({ board_name: 'kilter', layout_id: 8, size_id: 23, size_name: '8x12' })}
+      />,
+    );
+
+    expect(screen.getByText('Tall Climbs Only')).toBeDefined();
+    expect(screen.queryByText('Wide Climbs Only')).toBeNull();
+  });
+
   it('uses the size id, not size name text, for tall-climbs availability', () => {
     render(
       <AccordionSearchForm

--- a/packages/web/i18n/locales/en-US/climbs.json
+++ b/packages/web/i18n/locales/en-US/climbs.json
@@ -112,7 +112,7 @@
       "minRatingOption_one": "{{count}} star and up",
       "minRatingOption_other": "{{count}} stars and up",
       "tallClimbsOnly": "Tall Climbs Only",
-      "tallClimbsTooltip": "Show only climbs that use holds in the bottom 8 rows (only available on 10x12 boards)",
+      "tallClimbsTooltip": "Show only climbs that use holds in the bottom 8 rows (only available on 8x12 and 10x12 boards)",
       "wideClimbsOnly": "Wide Climbs Only",
       "wideClimbsTooltip": "Show only climbs that use the 10x10 side expansion holds",
       "gradeAccuracy": "Grade Accuracy",

--- a/packages/web/i18n/locales/en-US/playlists.json
+++ b/packages/web/i18n/locales/en-US/playlists.json
@@ -162,7 +162,7 @@
       "minRatingOption_other": "{{count}} stars and up",
       "climbBias": "Climb Bias",
       "tallClimbsLabel": "Tall Climbs Only",
-      "tallClimbsTooltip": "Show only climbs that use holds in the bottom 8 rows (only available on 10x12 boards)",
+      "tallClimbsTooltip": "Show only climbs that use holds in the bottom 8 rows (only available on 8x12 and 10x12 boards)",
       "mainSetClimbs": "Main Set Climbs",
       "mainSetVariability": "Main Set Variability",
       "numberOfSteps": "Number of Steps",

--- a/packages/web/i18n/locales/es/climbs.json
+++ b/packages/web/i18n/locales/es/climbs.json
@@ -109,7 +109,7 @@
       "minRating": "Valoración mín.",
       "any": "Cualquiera",
       "tallClimbsOnly": "Solo bloques altos",
-      "tallClimbsTooltip": "Muestra solo bloques que usan presas en las 8 filas inferiores (solo disponible en tablas 10x12)",
+      "tallClimbsTooltip": "Muestra solo bloques que usan presas en las 8 filas inferiores (solo disponible en tableros 8x12 y 10x12)",
       "wideClimbsOnly": "Solo bloques anchos",
       "wideClimbsTooltip": "Muestra solo bloques que usan las presas laterales extra del 10x10",
       "gradeAccuracy": "Precisión del grado",

--- a/packages/web/i18n/locales/es/playlists.json
+++ b/packages/web/i18n/locales/es/playlists.json
@@ -158,7 +158,7 @@
       "minRating": "Valoración mínima",
       "climbBias": "Sesgo de bloques",
       "tallClimbsLabel": "Solo bloques altos",
-      "tallClimbsTooltip": "Muestra solo bloques que usan presas en las 8 filas inferiores (solo disponible en tableros 10x12)",
+      "tallClimbsTooltip": "Muestra solo bloques que usan presas en las 8 filas inferiores (solo disponible en tableros 8x12 y 10x12)",
       "mainSetClimbs": "Bloques de la serie principal",
       "mainSetVariability": "Variabilidad de la serie principal",
       "numberOfSteps": "Número de pasos",

--- a/packages/web/i18n/locales/fr/climbs.json
+++ b/packages/web/i18n/locales/fr/climbs.json
@@ -112,7 +112,7 @@
       "minRatingOption_one": "{{count}} étoile et plus",
       "minRatingOption_other": "{{count}} étoiles et plus",
       "tallClimbsOnly": "Blocs hauts uniquement",
-      "tallClimbsTooltip": "Afficher uniquement les blocs qui utilisent les prises des 8 rangées du bas (disponible sur les boards 10x12 uniquement)",
+      "tallClimbsTooltip": "Afficher uniquement les blocs qui utilisent les prises des 8 rangées du bas (disponible sur les boards 8x12 et 10x12 uniquement)",
       "wideClimbsOnly": "Blocs larges uniquement",
       "wideClimbsTooltip": "Afficher uniquement les blocs qui utilisent les colonnes latérales supplémentaires (disponible sur les boards 10x10 et 10x12)",
       "gradeAccuracy": "Précision de la cotation",

--- a/packages/web/i18n/locales/fr/playlists.json
+++ b/packages/web/i18n/locales/fr/playlists.json
@@ -162,7 +162,7 @@
       "minRatingOption_other": "{{count}} étoiles et plus",
       "climbBias": "Préférence de blocs",
       "tallClimbsLabel": "Blocs hauts uniquement",
-      "tallClimbsTooltip": "Affiche uniquement les blocs qui utilisent les prises des 8 rangées du bas (uniquement sur les boards 10x12)",
+      "tallClimbsTooltip": "Affiche uniquement les blocs qui utilisent les prises des 8 rangées du bas (uniquement sur les boards 8x12 et 10x12)",
       "mainSetClimbs": "Blocs de la série principale",
       "mainSetVariability": "Variabilité de la série principale",
       "numberOfSteps": "Nombre de paliers",


### PR DESCRIPTION
## Summary

Enable the existing Tall Climbs Only filter for Kilter Homewall 8x12 boards, covering both Full Ride and Mainline size IDs.

## Why

The tall-climbs capability only recognized 10x12 Homewall sizes, so users on 8x12 Homewall boards could not see or use the filter even though those boards also have the lower rows that make the filter meaningful.

## What changed

- Added Kilter Homewall 8x12 size IDs 23 and 24 to the tall-climbs capability predicate.
- Kept the wide-climbs predicate unchanged so 8x12 boards do not use the 10-wide side-expansion filter.
- Updated search drawer and playlist generator tests for 8x12 behavior.
- Updated tooltip copy in English, Spanish, and French from 10x12-only to 8x12/10x12.

## Validation

- `vp test run packages/board-constants/src/__tests__/product-sizes.test.ts packages/web/app/components/search-drawer/__tests__/accordion-search-form-handlers.test.tsx packages/web/app/components/playlist-generator/__tests__/generator-options-form.test.tsx`
- `node --import tsx --test packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts`
- `vp check packages/board-constants/src/product-sizes.ts packages/board-constants/src/__tests__/product-sizes.test.ts packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts packages/web/app/components/search-drawer/__tests__/accordion-search-form-handlers.test.tsx packages/web/app/components/playlist-generator/__tests__/generator-options-form.test.tsx packages/web/app/components/playlist-generator/generator-options-form.tsx packages/web/i18n/locales/en-US/climbs.json packages/web/i18n/locales/en-US/playlists.json packages/web/i18n/locales/es/climbs.json packages/web/i18n/locales/es/playlists.json packages/web/i18n/locales/fr/climbs.json packages/web/i18n/locales/fr/playlists.json`
- `vp run typecheck`

Note: full `vp check` is still blocked by existing unrelated repo-wide lint warnings and a Vite+ stdout panic while printing that warning backlog.