### PR TITLE
Tear down WS subscriptions on disconnect to fix session-member race

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -747,21 +747,26 @@ sequenceDiagram
     participant C as Client
     participant WS as WebSocket
     participant G as graphql-ws Client
+    participant L as useSessionLifecycle
 
-    Note over C,G: Connection Lost
+    Note over C,L: Connection Lost
 
     WS--xC: Connection closed
-    G->>G: Detect disconnection
+    G->>G: Fire `closed` event
+    G->>L: onDisconnect callback
+    L->>L: Unsubscribe queueUpdates + sessionUpdates, clear refs
+    Note over L: graphql-ws now has no live subscriptions to auto-replay
     G->>G: Start retry (attempt 1)
     G->>G: Wait 1s (exponential backoff)
     G->>WS: Reconnect attempt
 
     alt Reconnect succeeds
-        WS->>G: Connected
-        G->>G: Call onReconnect callback
-        G->>WS: joinSession mutation
-        WS-->>G: Session state
-        G->>G: Delta sync or full sync
+        WS->>G: Connected (new connectionId assigned server-side)
+        G->>L: onReconnect callback
+        L->>WS: joinSession mutation
+        WS-->>L: Session state, new connectionId now a session member
+        L->>WS: Resubscribe queueUpdates + sessionUpdates
+        L->>L: Delta sync or full sync
     else Reconnect fails
         G->>G: Retry with backoff
         Note over G: 1s → 2s → 4s → 8s → ... → 30s max
@@ -773,7 +778,8 @@ sequenceDiagram
 
 - Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s (max)
 - Up to 10 retry attempts
-- On reconnection: re-join session with the same `participantId` and sync state
+- On `closed`: the lifecycle hook unsubscribes both queue and session subscriptions before graphql-ws begins reconnecting. Without this, graphql-ws would auto-replay the old subscriptions on the new socket before `joinSession` registers the new `connectionId`, and the backend `requireSessionMember` check would fail with `Unauthorized: not in any session`.
+- On reconnection: re-join session with the same `participantId`, then create fresh subscriptions on the now-registered connection
 - Delta sync attempted if gap ≤ 100 events and the replay buffer has contiguous coverage
 - Falls back to full sync if the gap is too large, replay is incomplete, or the local hash disagrees despite no sequence gap
 - Queue and session subscription `error`/`complete` callbacks schedule a reconnect/resubscribe pass, so a completed subscription does not leave the client silently joined but deaf to future events

--- a/packages/web/app/components/graphql-queue/__tests__/graphql-client.test.ts
+++ b/packages/web/app/components/graphql-queue/__tests__/graphql-client.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+
+// Capture the options passed to graphql-ws's createClient so we can drive
+// the `on.closed` handler directly. We don't open a real WebSocket — the
+// behaviour under test is purely the wiring between graphql-ws lifecycle
+// events and the `onDisconnect` callback we expose.
+const { capturedCreateClientOptions, mockGraphQLWsClient } = vi.hoisted(() => ({
+  capturedCreateClientOptions: { current: null as unknown as Parameters<typeof import('graphql-ws').createClient>[0] },
+  mockGraphQLWsClient: { subscribe: vi.fn(), dispose: vi.fn(), iterate: vi.fn(), terminate: vi.fn(), on: vi.fn() },
+}));
+
+vi.mock('graphql-ws', () => ({
+  createClient: vi.fn((options) => {
+    capturedCreateClientOptions.current = options;
+    return mockGraphQLWsClient;
+  }),
+}));
+
+vi.mock('../../connection-manager/websocket-connection-manager', () => ({
+  connectionManager: { registerClient: vi.fn(() => vi.fn()) },
+  KEEP_ALIVE_MS: 30_000,
+}));
+
+import { createGraphQLClient } from '../graphql-client';
+
+beforeEach(() => {
+  capturedCreateClientOptions.current = null as never;
+});
+
+describe('createGraphQLClient onDisconnect wiring', () => {
+  it('invokes onDisconnect when the underlying socket fires `closed`', () => {
+    const onDisconnect = vi.fn();
+    createGraphQLClient({ url: 'ws://test', onDisconnect });
+
+    const closedHandler = capturedCreateClientOptions.current.on?.closed;
+    expect(typeof closedHandler).toBe('function');
+
+    closedHandler?.({ code: 1006, reason: 'abnormal' } as unknown as CloseEvent);
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw if onDisconnect is omitted', () => {
+    createGraphQLClient({ url: 'ws://test' });
+
+    const closedHandler = capturedCreateClientOptions.current.on?.closed;
+    expect(() => closedHandler?.({ code: 1006 } as unknown as CloseEvent)).not.toThrow();
+  });
+
+  it('fires onDisconnect on every close, not just the first', () => {
+    const onDisconnect = vi.fn();
+    createGraphQLClient({ url: 'ws://test', onDisconnect });
+
+    const closedHandler = capturedCreateClientOptions.current.on?.closed;
+    closedHandler?.({ code: 1006 } as unknown as CloseEvent);
+    closedHandler?.({ code: 1006 } as unknown as CloseEvent);
+    closedHandler?.({ code: 1006 } as unknown as CloseEvent);
+    expect(onDisconnect).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/web/app/components/graphql-queue/graphql-client.ts
+++ b/packages/web/app/components/graphql-queue/graphql-client.ts
@@ -31,6 +31,7 @@ export type GraphQLClientOptions = {
   url: string;
   authToken?: string | null;
   onReconnect?: () => void;
+  onDisconnect?: () => void;
   connectionName?: string;
 };
 
@@ -51,7 +52,13 @@ export function createGraphQLClient(
   const options: GraphQLClientOptions =
     typeof urlOrOptions === 'string' ? { url: urlOrOptions, onReconnect } : urlOrOptions;
 
-  const { url, authToken, onReconnect: onReconnectCallback, connectionName } = options;
+  const {
+    url,
+    authToken,
+    onReconnect: onReconnectCallback,
+    onDisconnect: onDisconnectCallback,
+    connectionName,
+  } = options;
   const managerConnectionName = connectionName ?? 'primary';
 
   const clientId = ++clientCounter;
@@ -102,6 +109,9 @@ export function createGraphQLClient(
       },
       closed: (event) => {
         if (DEBUG) console.info(`[GraphQL] Client #${clientId} closed`, event);
+        // Let consumers drop subscription handles before graphql-ws auto-replays
+        // them on the next socket — replay races joinSession on the new connectionId.
+        onDisconnectCallback?.();
       },
       error: (error) => {
         if (DEBUG) console.info(`[GraphQL] Client #${clientId} error`, error);

--- a/packages/web/app/components/persistent-session/__tests__/session-lifecycle-disconnect.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/session-lifecycle-disconnect.test.tsx
@@ -1,0 +1,191 @@
+import 'fake-indexeddb/auto';
+import { openDB } from 'idb';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { setPreference } from '@/app/lib/user-preferences-db';
+import type { BoardDetails } from '@/app/lib/types';
+import { PersistentSessionProvider, usePersistentSession } from '../persistent-session-context';
+
+// ---------------------------------------------------------------------------
+// Mocks — capture the GraphQL client options so we can drive `onDisconnect`
+// from the test, and hand out distinct unsubscribe spies for each subscribe()
+// call so we can assert the queue + session subscriptions are torn down.
+// ---------------------------------------------------------------------------
+
+const { capturedOptions, queueUnsubscribe, sessionUnsubscribe, subscribeSpy, executeSpy } = vi.hoisted(() => ({
+  capturedOptions: { current: null as { onDisconnect?: () => void } | null },
+  queueUnsubscribe: vi.fn(),
+  sessionUnsubscribe: vi.fn(),
+  subscribeSpy: vi.fn(),
+  executeSpy: vi.fn(),
+}));
+
+vi.mock('../../graphql-queue/graphql-client', () => ({
+  createGraphQLClient: vi.fn((options) => {
+    capturedOptions.current = options;
+    return { dispose: vi.fn() };
+  }),
+  execute: executeSpy,
+  subscribe: subscribeSpy,
+}));
+
+const { mockHttpRequest } = vi.hoisted(() => ({ mockHttpRequest: vi.fn() }));
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: vi.fn(() => ({ request: mockHttpRequest })),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isLoading: false }),
+}));
+
+vi.mock('../../party-manager/party-profile-context', () => ({
+  usePartyProfile: () => ({ profile: { id: 'test-user' }, username: 'tester', avatarUrl: null }),
+  PartyProfileProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock('@/app/utils/hash', () => ({
+  computeQueueStateHash: () => 'mock-hash',
+}));
+
+// The lifecycle hook bails out early when DEFAULT_BACKEND_URL is null, which
+// it is under jsdom without NEXT_PUBLIC_WS_URL set. Force a value so the hook
+// actually constructs the GraphQL client (the boundary we need to test).
+vi.mock('@/app/lib/backend-url', () => ({
+  getBackendWsUrl: () => 'ws://localhost/graphql',
+  getGraphQLHttpUrl: () => 'http://localhost/graphql',
+  getBackendHttpUrl: () => 'http://localhost',
+}));
+
+const ACTIVE_SESSION_KEY = 'activeSession';
+const PREFS_DB_NAME = 'boardsesh-user-preferences';
+const PREFS_STORE_NAME = 'preferences';
+
+function createTestBoardDetails(): BoardDetails {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 10,
+    set_ids: '1,2',
+    images_to_holds: {},
+    holdsData: {},
+    edge_left: 0,
+    edge_right: 100,
+    edge_bottom: 0,
+    edge_top: 100,
+    boardHeight: 100,
+    boardWidth: 100,
+    layout_name: 'Original',
+    size_name: '12x12',
+  } as unknown as BoardDetails;
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <PersistentSessionProvider>{children}</PersistentSessionProvider>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(async () => {
+  capturedOptions.current = null;
+  queueUnsubscribe.mockReset();
+  sessionUnsubscribe.mockReset();
+  subscribeSpy.mockReset();
+  // Hand out distinct unsubscribe handles in subscribe call order — the
+  // lifecycle hook subscribes to queueUpdates first, then sessionUpdates.
+  subscribeSpy.mockReturnValueOnce(queueUnsubscribe).mockReturnValueOnce(sessionUnsubscribe);
+
+  executeSpy.mockReset();
+  // joinSession mutation: return a minimal Session payload sufficient for
+  // setSession() + handleQueueEvent({ FullSync }) + startSubscriptions().
+  executeSpy.mockResolvedValue({
+    joinSession: {
+      id: 'session-disconnect-test',
+      name: null,
+      boardPath: '/kilter/1/10/1,2/40/list',
+      users: [],
+      queueState: { queue: [], currentClimb: null, sequence: 0, stateHash: 'mock-hash' },
+      isLeader: true,
+      clientId: 'test-client',
+    },
+  });
+
+  mockHttpRequest.mockReset();
+  mockHttpRequest.mockResolvedValue({
+    sessionSummary: {
+      sessionId: 'session-disconnect-test',
+      endedAt: null,
+      startedAt: null,
+      durationMinutes: 0,
+      totalSends: 0,
+      totalAttempts: 0,
+      gradeDistribution: [],
+      hardestClimb: null,
+      participants: [],
+      goal: null,
+    },
+  });
+
+  try {
+    const prefsDb = await openDB(PREFS_DB_NAME, 1, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(PREFS_STORE_NAME)) db.createObjectStore(PREFS_STORE_NAME);
+      },
+    });
+    await prefsDb.clear(PREFS_STORE_NAME);
+    prefsDb.close();
+  } catch {
+    // DB may not exist yet
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useSessionLifecycle onDisconnect teardown', () => {
+  it('clears queue + session subscription handles when the GraphQL client reports a socket close', async () => {
+    await setPreference(ACTIVE_SESSION_KEY, {
+      sessionId: 'session-disconnect-test',
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails: createTestBoardDetails(),
+      parsedParams: {
+        board_name: 'kilter' as const,
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1, 2],
+        angle: 40,
+      },
+    });
+
+    renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
+
+    // Wait for the lifecycle hook to connect, join, and start both subscriptions.
+    await waitFor(() => {
+      expect(subscribeSpy).toHaveBeenCalledTimes(2);
+    });
+
+    // The lifecycle hook must have wired an onDisconnect callback into the
+    // GraphQL client — that's the bug fix this test is guarding.
+    expect(capturedOptions.current?.onDisconnect).toBeTypeOf('function');
+
+    // Drive the disconnect path the same way graphql-ws would on a socket
+    // close. After this returns, the lifecycle's `handleDisconnect` must
+    // have unsubscribed both queueUpdates and sessionUpdates so graphql-ws
+    // has nothing to auto-replay on the next reconnect.
+    capturedOptions.current?.onDisconnect?.();
+
+    expect(queueUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(sessionUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -571,6 +571,21 @@ export function useSessionLifecycle({
 
     triggerResyncRef.current = handleReconnect;
 
+    function handleDisconnect() {
+      if (isCleaningUp || !mountedRef.current) return;
+      if (connectionGenerationRef.current !== connectionGeneration) return;
+      // Drop subscription handles on socket close so graphql-ws has nothing to
+      // auto-replay on the next connection. handleReconnect will recreate them
+      // after joinSession registers the new connectionId server-side.
+      if (queueUnsubscribeRef.current || sessionUnsubscribeRef.current) {
+        if (DEBUG) console.info('[PersistentSession] Socket closed, tearing down subscriptions');
+        queueUnsubscribeRef.current?.();
+        queueUnsubscribeRef.current = null;
+        sessionUnsubscribeRef.current?.();
+        sessionUnsubscribeRef.current = null;
+      }
+    }
+
     function applyFullSync(sessionData: Session) {
       if (sessionData.queueState) {
         handleQueueEvent({
@@ -746,6 +761,7 @@ export function useSessionLifecycle({
           url: backendUrl!,
           authToken: wsAuthTokenRef.current,
           onReconnect: () => void handleReconnect(),
+          onDisconnect: handleDisconnect,
           connectionName: 'session',
         });
 


### PR DESCRIPTION
## Summary

Fixes the recurring backend error:

```
[Auth] requireSessionMember failed after 8 retries: not in any session.
GraphQL error: Unauthorized: not in any session
```

### Root cause

When the WebSocket drops, `graphql-ws` reconnects and **automatically replays every active subscription on the new socket** before any `connected`/`onReconnect` callback fires. The new socket gets a fresh `connectionId` from the backend, but that connection has no session membership yet — that only happens after `joinSession` runs inside `handleReconnect`.

So the replayed `queueUpdates` / `sessionUpdates` subscription hits `requireSessionMember` (`packages/backend/src/graphql/resolvers/shared/helpers.ts:66-123`) on a connection that's not in any session. The retry loop (8 attempts, exponential backoff, ~6.35s budget) gives up and throws.

Meanwhile in the client, `startSubscriptions` is gated by `if (!queueUnsubscribeRef.current)` — the refs still hold the old (auto-replayed) subscription handles, so it never creates fresh ones either.

### Fix

- Add an `onDisconnect` option to `createGraphQLClient` and invoke it from the existing `on.closed` handler.
- In `use-session-lifecycle.ts`, wire `onDisconnect` to clear `queueUnsubscribeRef` / `sessionUnsubscribeRef` the moment the socket closes.

With nothing for graphql-ws to auto-replay, `handleReconnect` is free to `await joinSession` first and then call `startSubscriptions`, which now creates fresh subscriptions on the now-registered connection. Backend hits `requireSessionMember` on first try.

The backend retry budget is left alone — it's still useful as defensive cover for the genuine cross-instance Redis-replication window, and shouldn't normally fire after this fix.

## Test plan

- [ ] `vp run typecheck:web` — passes
- [ ] `vp check` — passes (0 errors)
- [ ] Manual repro in dev:
  - [ ] `vp run dev` and join a party session in two browser tabs
  - [ ] In one tab, restart the backend (kill + `vp run dev:backend`) to force a reconnect
  - [ ] DEBUG console shows: `Client closed` → `Socket closed, tearing down subscriptions` → `Client connected` → `Reconnecting...` → `Reconnection complete`
  - [ ] Backend logs do **not** include `requireSessionMember failed after 8 retries`
  - [ ] Queue events from the other tab continue arriving after recovery


---
_Generated by [Claude Code](https://claude.ai/code/session_01WEKAByxiSoM8TU2ou83uNK)_