### PR TITLE
Add backend PostHog analytics logs

### DIFF
--- a/packages/backend/src/__tests__/analytics-posthog.test.ts
+++ b/packages/backend/src/__tests__/analytics-posthog.test.ts
@@ -7,6 +7,7 @@ const posthogMocks = vi.hoisted(() => ({
   shutdown: vi.fn(),
 }));
 const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
   warn: vi.fn(),
 }));
 
@@ -51,6 +52,9 @@ describe('backend PostHog analytics helper', () => {
     expect(captured).toBe(false);
     expect(posthogMocks.PostHog).not.toHaveBeenCalled();
     expect(posthogMocks.capture).not.toHaveBeenCalled();
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      '[PostHog] POSTHOG_PROJECT_KEY is not set; backend analytics disabled',
+    );
   });
 
   it('captures sanitized events with backend metadata', async () => {
@@ -87,6 +91,12 @@ describe('backend PostHog analytics helper', () => {
         environment: 'production',
       },
     });
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      '[PostHog] Backend analytics initialized (host=https://posthog.example, environment=production)',
+    );
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      '[PostHog] Queued backend analytics event: Live Activity Widget Navigation',
+    );
   });
 
   it('can initialize if the project key appears after an earlier no-op capture', async () => {

--- a/packages/backend/src/services/analytics/posthog.ts
+++ b/packages/backend/src/services/analytics/posthog.ts
@@ -23,6 +23,8 @@ const POSTHOG_FLUSH_INTERVAL_MS = 10_000;
 
 let posthogClient: PostHog | null = null;
 let initAttempted = false;
+let missingProjectKeyLogged = false;
+const loggedQueuedEvents = new Set<BackendAnalyticsEvent>();
 
 function sanitizeProperties(properties: AnalyticsProperties | undefined): SanitizedAnalyticsProperties {
   const sanitized: SanitizedAnalyticsProperties = {};
@@ -41,7 +43,13 @@ function getPosthogClient(): PostHog | null {
   if (posthogClient) return posthogClient;
 
   const projectKey = process.env.POSTHOG_PROJECT_KEY;
-  if (!projectKey) return null;
+  if (!projectKey) {
+    if (!missingProjectKeyLogged) {
+      missingProjectKeyLogged = true;
+      logger.warn('[PostHog] POSTHOG_PROJECT_KEY is not set; backend analytics disabled');
+    }
+    return null;
+  }
   if (initAttempted) return null;
   initAttempted = true;
 
@@ -58,6 +66,7 @@ function getPosthogClient(): PostHog | null {
   });
 
   posthogClient = client;
+  logger.info(`[PostHog] Backend analytics initialized (host=${host}, environment=${getAnalyticsEnvironment()})`);
   return client;
 }
 
@@ -82,6 +91,10 @@ export function captureBackendEvent(eventName: BackendAnalyticsEvent, options: C
       event: eventName,
       properties,
     });
+    if (!loggedQueuedEvents.has(eventName)) {
+      loggedQueuedEvents.add(eventName);
+      logger.info(`[PostHog] Queued backend analytics event: ${eventName}`);
+    }
     return true;
   } catch (error) {
     logger.warn('[PostHog] Capture failed:', error);
@@ -95,6 +108,8 @@ export async function shutdownPosthog(): Promise<void> {
 
   posthogClient = null;
   initAttempted = false;
+  missingProjectKeyLogged = false;
+  loggedQueuedEvents.clear();
 
   try {
     await posthog.shutdown();


### PR DESCRIPTION
## Summary
- Log once when backend PostHog analytics initializes, including host and environment but no secrets
- Warn once when POSTHOG_PROJECT_KEY is missing so disabled backend analytics is visible
- Log once per backend analytics event name when capture is queued

## Validation
- vp test run packages/backend/src/__tests__/analytics-posthog.test.ts
- vp check --fix packages/backend/src/services/analytics/posthog.ts packages/backend/src/__tests__/analytics-posthog.test.ts
- vp run typecheck:backend
- vp staged