### PR TITLE
Handle GraphQL rate-limit errors gracefully on reconnect

### DIFF
--- a/packages/backend/src/__tests__/rate-limiter.test.ts
+++ b/packages/backend/src/__tests__/rate-limiter.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { GraphQLError } from 'graphql';
 import { checkRateLimit, cleanupRateLimit, getRateLimitStatus } from '../utils/rate-limiter';
+import { wrapDatabaseOperation } from '../utils/error-handler';
+import { createRateLimitError, RATE_LIMIT_ERROR_CODE } from '../utils/rate-limit-error';
 
 describe('In-memory rate limiter', () => {
   beforeEach(() => {
@@ -45,6 +48,22 @@ describe('In-memory rate limiter', () => {
         expect.fail('should have thrown');
       } catch (err) {
         expect((err as Error).message).toMatch(/Try again in \d+ seconds/);
+      }
+    });
+
+    it('throws a GraphQLError with RATE_LIMITED extension code', () => {
+      for (let i = 0; i < 5; i++) {
+        checkRateLimit('test-conn', 5, 60_000);
+      }
+      try {
+        checkRateLimit('test-conn', 5, 60_000);
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(GraphQLError);
+        const gqlErr = err as GraphQLError;
+        expect(gqlErr.extensions?.code).toBe(RATE_LIMIT_ERROR_CODE);
+        expect(typeof gqlErr.extensions?.retryAfterSeconds).toBe('number');
+        expect(gqlErr.extensions?.retryAfterSeconds as number).toBeGreaterThan(0);
       }
     });
 
@@ -99,6 +118,24 @@ describe('In-memory rate limiter', () => {
 
     it('is safe to call for non-existent connections', () => {
       expect(() => cleanupRateLimit('nonexistent')).not.toThrow();
+    });
+  });
+
+  describe('wrapDatabaseOperation rate-limit passthrough', () => {
+    it('passes GraphQLError instances through unchanged', async () => {
+      const original = createRateLimitError(7);
+      let caught: unknown;
+      try {
+        await wrapDatabaseOperation(async () => {
+          throw original;
+        }, 'test');
+        expect.fail('should have thrown');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBe(original);
+      expect((caught as GraphQLError).extensions?.code).toBe(RATE_LIMIT_ERROR_CODE);
+      expect((caught as GraphQLError).extensions?.retryAfterSeconds).toBe(7);
     });
   });
 

--- a/packages/backend/src/__tests__/redis-rate-limiter.test.ts
+++ b/packages/backend/src/__tests__/redis-rate-limiter.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { GraphQLError } from 'graphql';
 import { checkRateLimitRedis } from '../utils/redis-rate-limiter';
+import { RATE_LIMIT_ERROR_CODE } from '../utils/rate-limit-error';
 
 // Use vi.hoisted() so mock variables are available when vi.mock factories run
 const { mockEval, mockIsRedisConnected, mockCheckRateLimit } = vi.hoisted(() => ({
@@ -66,6 +68,20 @@ describe('checkRateLimitRedis', () => {
       mockEval.mockResolvedValue(31); // over limit of 30
 
       await expect(checkRateLimitRedis('user-1', 'vote', 30, 60_000)).rejects.toThrow('Rate limit exceeded');
+    });
+
+    it('throws a GraphQLError with RATE_LIMITED extension when exceeded', async () => {
+      mockEval.mockResolvedValue(31);
+
+      try {
+        await checkRateLimitRedis('user-1', 'vote', 30, 60_000);
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(GraphQLError);
+        const gqlErr = err as GraphQLError;
+        expect(gqlErr.extensions?.code).toBe(RATE_LIMIT_ERROR_CODE);
+        expect(typeof gqlErr.extensions?.retryAfterSeconds).toBe('number');
+      }
     });
 
     it('uses correct window bucket based on current time', async () => {

--- a/packages/backend/src/utils/error-handler.ts
+++ b/packages/backend/src/utils/error-handler.ts
@@ -1,3 +1,4 @@
+import { GraphQLError } from 'graphql';
 import { logger } from './logger';
 /**
  * Error handling utilities for preventing information disclosure.
@@ -18,6 +19,12 @@ export async function wrapDatabaseOperation<T>(operation: () => Promise<T>, cont
   } catch (error) {
     // Log the full error internally for debugging
     logger.error(`[${context}] Database operation failed:`, error);
+
+    // Pass through structured GraphQL errors (rate limits, etc.) so client-side
+    // handling can inspect extensions.code instead of regex-parsing the message.
+    if (error instanceof GraphQLError) {
+      throw error;
+    }
 
     // Check for specific error types we want to handle specially
     if (error instanceof Error) {

--- a/packages/backend/src/utils/rate-limit-error.ts
+++ b/packages/backend/src/utils/rate-limit-error.ts
@@ -1,0 +1,12 @@
+import { GraphQLError } from 'graphql';
+
+export const RATE_LIMIT_ERROR_CODE = 'RATE_LIMITED';
+
+export function createRateLimitError(retryAfterSeconds: number): GraphQLError {
+  return new GraphQLError(`Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`, {
+    extensions: {
+      code: RATE_LIMIT_ERROR_CODE,
+      retryAfterSeconds,
+    },
+  });
+}

--- a/packages/backend/src/utils/rate-limiter.ts
+++ b/packages/backend/src/utils/rate-limiter.ts
@@ -3,6 +3,8 @@
  * Uses a sliding window algorithm with per-connection tracking.
  */
 
+import { createRateLimitError } from './rate-limit-error';
+
 type RateLimitEntry = {
   count: number;
   resetAt: number;
@@ -42,7 +44,7 @@ export function checkRateLimit(
   // Check if limit exceeded
   if (entry.count >= maxRequests) {
     const retryAfterSeconds = Math.ceil((entry.resetAt - now) / 1000);
-    throw new Error(`Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`);
+    throw createRateLimitError(retryAfterSeconds);
   }
 
   // Increment counter

--- a/packages/backend/src/utils/redis-rate-limiter.ts
+++ b/packages/backend/src/utils/redis-rate-limiter.ts
@@ -1,5 +1,7 @@
+import { GraphQLError } from 'graphql';
 import { redisClientManager } from '../redis/client';
 import { checkRateLimit } from './rate-limiter';
+import { createRateLimitError, RATE_LIMIT_ERROR_CODE } from './rate-limit-error';
 import { logger } from './logger';
 
 /**
@@ -51,10 +53,13 @@ export async function checkRateLimitRedis(
 
     if (count > maxRequests) {
       const retryAfterSeconds = Math.ceil((windowMs - (Date.now() % windowMs)) / 1000);
-      throw new Error(`Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`);
+      throw createRateLimitError(retryAfterSeconds);
     }
   } catch (err) {
     // If the error is our rate limit error, re-throw it
+    if (err instanceof GraphQLError && err.extensions?.code === RATE_LIMIT_ERROR_CODE) {
+      throw err;
+    }
     if (err instanceof Error && err.message.startsWith('Rate limit exceeded')) {
       throw err;
     }

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -19,6 +19,7 @@ import { useSnackbar } from '../providers/snackbar-provider';
 import SessionSummaryDialog from '../session-summary/session-summary-dialog';
 import { trackQueueOperation, trackQueueOperationError, type QueueOperationMode } from '@/app/lib/queue-metrics';
 
+import { onRateLimited } from './rate-limit-error';
 import { useSessionIdManagement } from './hooks/use-session-id-management';
 import { useQueueRestoration } from './hooks/use-queue-restoration';
 import { useQueueEventSubscription } from './hooks/use-queue-event-subscription';
@@ -171,6 +172,22 @@ export const GraphQLQueueProvider = ({
       showMessage(t('queueProvider.offlineLimitReached'), 'warning');
     }
   }, [rawOfflineBuffer.isBufferFull, showMessage, t]);
+
+  // Surface a calmer toast when a mutation hits the rate limit and is being
+  // retried. Stay silent on the first retry (most reconciliation hiccups
+  // recover in one round); only toast if a *second* retry is needed. Debounce
+  // so a flurry of rate-limited mutations doesn't spam the snackbar.
+  const lastRateLimitToastRef = useRef(0);
+  useEffect(() => {
+    const RATE_LIMIT_TOAST_DEBOUNCE_MS = 3000;
+    return onRateLimited((_err, attempt) => {
+      if (attempt < 2) return;
+      const now = Date.now();
+      if (now - lastRateLimitToastRef.current < RATE_LIMIT_TOAST_DEBOUNCE_MS) return;
+      lastRateLimitToastRef.current = now;
+      showMessage(t('queueProvider.rateLimitCatchUp'), 'info');
+    });
+  }, [showMessage, t]);
 
   // --- Offline reconciliation (push buffered additions on reconnect) ---
   useOfflineReconciliation({

--- a/packages/web/app/components/graphql-queue/__tests__/graphql-client.rate-limit.test.ts
+++ b/packages/web/app/components/graphql-queue/__tests__/graphql-client.rate-limit.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+type SubscribeSink = {
+  next: (data: { data?: unknown; errors?: Array<{ message: string; extensions?: Record<string, unknown> }> }) => void;
+  error: (err: unknown) => void;
+  complete: () => void;
+};
+
+const { mockGraphQLWsClient } = vi.hoisted(() => ({
+  mockGraphQLWsClient: {
+    subscribe: vi.fn(),
+    dispose: vi.fn(),
+    iterate: vi.fn(),
+    terminate: vi.fn(),
+    on: vi.fn(),
+  },
+}));
+
+vi.mock('graphql-ws', () => ({
+  createClient: vi.fn(() => mockGraphQLWsClient),
+}));
+
+vi.mock('../../connection-manager/websocket-connection-manager', () => ({
+  connectionManager: { registerClient: vi.fn(() => vi.fn()) },
+  KEEP_ALIVE_MS: 30_000,
+}));
+
+import { execute } from '../graphql-client';
+import { RateLimitError, onRateLimited } from '../rate-limit-error';
+
+const QUERY = 'mutation Test { test }';
+
+beforeEach(() => {
+  mockGraphQLWsClient.subscribe.mockReset();
+});
+
+function setupSubscribeSequence(responders: Array<(sink: SubscribeSink) => void>) {
+  let call = 0;
+  mockGraphQLWsClient.subscribe.mockImplementation((_payload: unknown, sink: SubscribeSink) => {
+    const respond = responders[call++];
+    if (!respond) throw new Error('Unexpected extra subscribe call');
+    // Defer so the caller can return the unsubscribe function before sink fires.
+    queueMicrotask(() => respond(sink));
+    return () => {};
+  });
+}
+
+describe('execute() rate-limit retry', () => {
+  it('retries after a RATE_LIMITED error with extensions and resolves', async () => {
+    setupSubscribeSequence([
+      (sink) => {
+        sink.next({
+          errors: [
+            {
+              message: 'Rate limit exceeded. Try again in 0 seconds.',
+              extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 0 },
+            },
+          ],
+        });
+      },
+      (sink) => {
+        sink.next({ data: { test: 'ok' } });
+        sink.complete();
+      },
+    ]);
+
+    const result = await execute(mockGraphQLWsClient as never, { query: QUERY });
+    expect(result).toEqual({ test: 'ok' });
+    expect(mockGraphQLWsClient.subscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to message regex when extensions are missing', async () => {
+    setupSubscribeSequence([
+      (sink) => {
+        sink.next({ errors: [{ message: 'Rate limit exceeded. Try again in 0 seconds.' }] });
+      },
+      (sink) => {
+        sink.next({ data: { test: 'legacy' } });
+        sink.complete();
+      },
+    ]);
+
+    const result = await execute(mockGraphQLWsClient as never, { query: QUERY });
+    expect(result).toEqual({ test: 'legacy' });
+    expect(mockGraphQLWsClient.subscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects with RateLimitError after exhausting retries', async () => {
+    setupSubscribeSequence([
+      (sink) =>
+        sink.next({
+          errors: [
+            {
+              message: 'Rate limit exceeded. Try again in 0 seconds.',
+              extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 0 },
+            },
+          ],
+        }),
+      (sink) =>
+        sink.next({
+          errors: [
+            {
+              message: 'Rate limit exceeded. Try again in 0 seconds.',
+              extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 0 },
+            },
+          ],
+        }),
+      (sink) =>
+        sink.next({
+          errors: [
+            {
+              message: 'Rate limit exceeded. Try again in 0 seconds.',
+              extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 0 },
+            },
+          ],
+        }),
+    ]);
+
+    await expect(execute(mockGraphQLWsClient as never, { query: QUERY })).rejects.toBeInstanceOf(RateLimitError);
+    expect(mockGraphQLWsClient.subscribe).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry non-rate-limit GraphQL errors', async () => {
+    setupSubscribeSequence([(sink) => sink.next({ errors: [{ message: 'Validation failed' }] })]);
+
+    await expect(execute(mockGraphQLWsClient as never, { query: QUERY })).rejects.toThrow('Validation failed');
+    expect(mockGraphQLWsClient.subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits onRateLimited for each retry attempt', async () => {
+    setupSubscribeSequence([
+      (sink) =>
+        sink.next({
+          errors: [
+            {
+              message: 'Rate limit exceeded. Try again in 0 seconds.',
+              extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 0 },
+            },
+          ],
+        }),
+      (sink) => {
+        sink.next({ data: { test: 'ok' } });
+        sink.complete();
+      },
+    ]);
+
+    const events: Array<{ attempt: number; retryAfter: number }> = [];
+    const unsubscribe = onRateLimited((err, attempt) => {
+      events.push({ attempt, retryAfter: err.retryAfterSeconds });
+    });
+
+    try {
+      await execute(mockGraphQLWsClient as never, { query: QUERY });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(events).toEqual([{ attempt: 1, retryAfter: 0 }]);
+  });
+});

--- a/packages/web/app/components/graphql-queue/graphql-client.ts
+++ b/packages/web/app/components/graphql-queue/graphql-client.ts
@@ -1,6 +1,13 @@
 import { type Client, type Sink, createClient } from 'graphql-ws';
 import { connectionManager, KEEP_ALIVE_MS } from '../connection-manager/websocket-connection-manager';
 import { INITIAL_RETRY_DELAY_MS, MAX_RETRY_DELAY_MS, BACKOFF_MULTIPLIER } from './retry-constants';
+import {
+  parseRateLimitError,
+  emitRateLimited,
+  MAX_RATE_LIMIT_RETRIES,
+  MAX_RATE_LIMIT_WAIT_MS,
+  RateLimitError,
+} from './rate-limit-error';
 
 export type { Client };
 
@@ -143,19 +150,12 @@ export function createGraphQLClient(
   return client;
 }
 
-/**
- * Execute a GraphQL mutation and return the result as a promise
- * Includes automatic cleanup and timeout handling
- */
-export function execute<TData = unknown, TVariables = Record<string, unknown>>(
+function executeOnce<TData, TVariables>(
   client: Client,
   operation: { query: string; variables?: TVariables },
-  timeoutMs: number = MUTATION_TIMEOUT_MS,
+  opName: string,
+  timeoutMs: number,
 ): Promise<TData> {
-  const opName = getOperationName(operation, 'mutation');
-
-  if (DEBUG) console.info(`[GraphQL] execute START: ${opName}`);
-
   const executionPromise = new Promise<TData>((resolve, reject) => {
     let result: TData | undefined;
     let hasResolved = false;
@@ -178,6 +178,11 @@ export function execute<TData = unknown, TVariables = Record<string, unknown>>(
             if (!hasResolved) {
               hasResolved = true;
               unsubscribe();
+              const rateLimitError = parseRateLimitError(data.errors);
+              if (rateLimitError) {
+                reject(rateLimitError);
+                return;
+              }
               reject(new Error(data.errors.map((e) => e.message).join(', ')));
             }
           }
@@ -211,14 +216,59 @@ export function execute<TData = unknown, TVariables = Record<string, unknown>>(
     );
   });
 
-  // Add timeout to prevent mutations from hanging forever
+  // Per-attempt timeout: reset on each retry so a rate-limit wait can't trip the
+  // mutation timeout. Otherwise a 30s wait + 5s execution would exceed a single
+  // outer 30s timeout.
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => {
+    timeoutHandle = setTimeout(() => {
       reject(new Error(`GraphQL mutation '${opName}' timed out after ${timeoutMs}ms`));
     }, timeoutMs);
   });
 
-  return Promise.race([executionPromise, timeoutPromise]);
+  return Promise.race([executionPromise, timeoutPromise]).finally(() => {
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+  });
+}
+
+/**
+ * Execute a GraphQL mutation and return the result as a promise.
+ * Retries automatically on rate-limit errors (RateLimitError) up to
+ * MAX_RATE_LIMIT_RETRIES, waiting `retryAfterSeconds` between attempts.
+ */
+export function execute<TData = unknown, TVariables = Record<string, unknown>>(
+  client: Client,
+  operation: { query: string; variables?: TVariables },
+  timeoutMs: number = MUTATION_TIMEOUT_MS,
+): Promise<TData> {
+  const opName = getOperationName(operation, 'mutation');
+
+  if (DEBUG) console.info(`[GraphQL] execute START: ${opName}`);
+
+  return executeWithRateLimitRetry<TData, TVariables>(client, operation, opName, timeoutMs);
+}
+
+async function executeWithRateLimitRetry<TData, TVariables>(
+  client: Client,
+  operation: { query: string; variables?: TVariables },
+  opName: string,
+  timeoutMs: number,
+): Promise<TData> {
+  let attempt = 0;
+  while (true) {
+    try {
+      return await executeOnce<TData, TVariables>(client, operation, opName, timeoutMs);
+    } catch (err) {
+      if (!(err instanceof RateLimitError) || attempt >= MAX_RATE_LIMIT_RETRIES) {
+        throw err;
+      }
+      attempt++;
+      emitRateLimited(err, attempt);
+      const waitMs = Math.min(err.retryAfterSeconds * 1000, MAX_RATE_LIMIT_WAIT_MS) + Math.floor(Math.random() * 250);
+      if (DEBUG) console.info(`[GraphQL] execute RATE_LIMITED ${opName}, retry #${attempt} in ${waitMs}ms`);
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+    }
+  }
 }
 
 /**
@@ -243,7 +293,8 @@ export function subscribe<TData = unknown, TVariables = Record<string, unknown>>
           sink.next?.(data.data);
         }
         if (data.errors) {
-          sink.error?.(new Error(data.errors.map((e) => e.message).join(', ')));
+          const rateLimitError = parseRateLimitError(data.errors);
+          sink.error?.(rateLimitError ?? new Error(data.errors.map((e) => e.message).join(', ')));
         }
       },
       error: (error) => {

--- a/packages/web/app/components/graphql-queue/hooks/__tests__/use-offline-reconciliation.test.ts
+++ b/packages/web/app/components/graphql-queue/hooks/__tests__/use-offline-reconciliation.test.ts
@@ -195,6 +195,8 @@ describe('useOfflineReconciliation', () => {
             sequence: 10,
           },
         });
+        // Flush inter-op pacing delays (75ms each between buffered ops).
+        await vi.advanceTimersByTimeAsync(1000);
       });
 
       // Should use individual addQueueItem, NOT setQueue
@@ -252,6 +254,7 @@ describe('useOfflineReconciliation', () => {
             sequence: 10,
           },
         });
+        await vi.advanceTimersByTimeAsync(1000);
       });
 
       expect(mockAddQueueItem).toHaveBeenCalledTimes(3);
@@ -311,6 +314,7 @@ describe('useOfflineReconciliation', () => {
             sequence: 10,
           },
         });
+        await vi.advanceTimersByTimeAsync(1000);
       });
 
       // Should use setQueue (full replace), NOT individual addQueueItem

--- a/packages/web/app/components/graphql-queue/hooks/use-offline-reconciliation.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-offline-reconciliation.ts
@@ -3,6 +3,14 @@ import type { SubscriptionQueueEvent, SessionUser } from '@boardsesh/shared-sche
 import type { ClimbQueueItem } from '../../queue-control/types';
 
 const RECONCILIATION_TIMEOUT_MS = 15000;
+// Space replayed mutations so a backlog of buffered additions can't trip the
+// per-user rate limit (60/min default, 30/min for some operations) the instant
+// the WebSocket reconnects. 75ms = ~13 ops/sec, well under any per-minute cap.
+const RECONCILIATION_INTER_OP_DELAY_MS = 75;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export type UseOfflineReconciliationParams = {
   offlineBuffer: {
@@ -111,6 +119,8 @@ export function useOfflineReconciliation({
         if (isSuperseded()) return;
         await persistentSession.setQueue(localQueue, localCurrentClimb);
         if (localCurrentClimb && !isSuperseded()) {
+          await sleep(RECONCILIATION_INTER_OP_DELAY_MS);
+          if (isSuperseded()) return;
           await persistentSession.setCurrentClimb(localCurrentClimb, false);
         }
       } catch (error) {
@@ -125,11 +135,17 @@ export function useOfflineReconciliation({
       const pending = offlineBuffer.getBufferedAdditions();
       const serverUuids = new Set(serverQueue.map((item) => item.uuid));
 
+      let sentCount = 0;
       for (const item of pending) {
         if (isSuperseded()) return;
         if (serverUuids.has(item.uuid)) continue;
+        if (sentCount > 0) {
+          await sleep(RECONCILIATION_INTER_OP_DELAY_MS);
+          if (isSuperseded()) return;
+        }
         try {
           await persistentSession.addQueueItem(item);
+          sentCount++;
         } catch (error) {
           console.error('[OfflineReconciliation] Failed to add buffered item:', item.climb?.name, error);
         }

--- a/packages/web/app/components/graphql-queue/index.ts
+++ b/packages/web/app/components/graphql-queue/index.ts
@@ -1,6 +1,7 @@
 // GraphQL Queue - New graphql-ws based queue management
 export { createGraphQLClient, execute, subscribe } from './graphql-client';
 export type { Client } from './graphql-client';
+export { RateLimitError, onRateLimited } from './rate-limit-error';
 
 export {
   GraphQLQueueProvider,

--- a/packages/web/app/components/graphql-queue/rate-limit-error.ts
+++ b/packages/web/app/components/graphql-queue/rate-limit-error.ts
@@ -1,0 +1,66 @@
+import type { GraphQLFormattedError } from 'graphql';
+
+export const RATE_LIMIT_ERROR_CODE = 'RATE_LIMITED';
+
+export const MAX_RATE_LIMIT_RETRIES = 2;
+export const MAX_RATE_LIMIT_WAIT_MS = 30_000;
+const DEFAULT_RETRY_AFTER_SECONDS = 5;
+
+export class RateLimitError extends Error {
+  readonly name = 'RateLimitError';
+  readonly retryAfterSeconds: number;
+
+  constructor(retryAfterSeconds: number, message?: string) {
+    super(message ?? `Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`);
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+// Modern backends attach { code: 'RATE_LIMITED', retryAfterSeconds } in extensions.
+// Older deployments only return the human-readable message — fall back to regex.
+const MESSAGE_PATTERN = /Try again in (\d+)\s*seconds?/i;
+
+export function parseRateLimitError(errors: readonly GraphQLFormattedError[] | undefined): RateLimitError | null {
+  if (!errors?.length) return null;
+
+  for (const err of errors) {
+    const code = err.extensions?.code;
+    if (code === RATE_LIMIT_ERROR_CODE) {
+      const retryAfter = err.extensions?.retryAfterSeconds;
+      const seconds = typeof retryAfter === 'number' && retryAfter >= 0 ? retryAfter : DEFAULT_RETRY_AFTER_SECONDS;
+      return new RateLimitError(seconds, err.message);
+    }
+  }
+
+  for (const err of errors) {
+    if (!err.message?.startsWith('Rate limit exceeded')) continue;
+    const match = err.message.match(MESSAGE_PATTERN);
+    const seconds = match ? Number(match[1]) : DEFAULT_RETRY_AFTER_SECONDS;
+    return new RateLimitError(seconds, err.message);
+  }
+
+  return null;
+}
+
+// Module-level pub/sub so the QueueContext can surface a toast on retry without
+// threading a callback through 4 layers (QueueContext → persistent-session →
+// useQueueMutations → execute). execute() emits, listeners subscribe.
+type RateLimitListener = (err: RateLimitError, attempt: number) => void;
+const listeners = new Set<RateLimitListener>();
+
+export function onRateLimited(listener: RateLimitListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function emitRateLimited(err: RateLimitError, attempt: number): void {
+  for (const listener of listeners) {
+    try {
+      listener(err, attempt);
+    } catch {
+      // Listener failures must not interfere with retry logic.
+    }
+  }
+}

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -208,7 +208,8 @@
     "endMessage": "That's all for now"
   },
   "queueProvider": {
-    "offlineLimitReached": "You've hit the offline queue limit. Reconnect to sync your climbs."
+    "offlineLimitReached": "You've hit the offline queue limit. Reconnect to sync your climbs.",
+    "rateLimitCatchUp": "Slow down — catching up…"
   },
   "playView": {
     "yourAscents_one": "Your Ascent ({{count}})",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -208,7 +208,8 @@
     "endMessage": "C'est tout pour l'instant"
   },
   "queueProvider": {
-    "offlineLimitReached": "Tu as atteint la limite hors ligne de la file d'attente. Reconnecte-toi pour synchroniser tes blocs."
+    "offlineLimitReached": "Tu as atteint la limite hors ligne de la file d'attente. Reconnecte-toi pour synchroniser tes blocs.",
+    "rateLimitCatchUp": "Doucement — on rattrape…"
   },
   "playView": {
     "yourAscents_one": "Ton ascension ({{count}})",


### PR DESCRIPTION
## Summary

After a brief network outage, the WebSocket reconnects and the offline-reconciliation flow can fire enough buffered mutations to trip the per-user rate limit on the backend. Today that surfaces as a raw `Rate limit exceeded. Try again in 4 seconds.` error to the user. This change handles the round trip quietly.

- **Backend** throws a structured `GraphQLError` with `extensions: { code: 'RATE_LIMITED', retryAfterSeconds }` from both the in-memory limiter (`rate-limiter.ts`) and the Redis limiter (`redis-rate-limiter.ts`). Shared helper in new `rate-limit-error.ts`. `error-handler.ts` explicitly passes `GraphQLError` instances through. Message stays human-readable for legacy clients.
- **Frontend** `execute()` detects rate-limit errors (prefers `extensions.code === 'RATE_LIMITED'`, falls back to regex on the message for backends not yet redeployed) and retries up to 2 times, waiting `retryAfterSeconds` (capped at 30s, plus small jitter) between attempts. Subscriptions surface a typed `RateLimitError` but aren't retried (graphql-ws handles subscription reconnection).
- **Offline reconciliation** (`use-offline-reconciliation.ts`) now spaces replayed mutations 75ms apart, so a buffered batch can't blow the per-minute budget the instant the socket reconnects.
- **UX**: a debounced `"Slow down — catching up…"` snackbar surfaces only on the second retry; single-retry recoveries stay silent. Wired via a tiny module-level pub/sub in `rate-limit-error.ts` so the toast doesn't require threading a callback through 4 layers.

## Test plan

- [x] `vp run typecheck` — clean across all packages.
- [x] `vp check` — clean (no lint/format diff on files I touched).
- [x] Backend unit tests — `rate-limiter.test.ts` and `redis-rate-limiter.test.ts` assert the thrown error is a `GraphQLError` with the `RATE_LIMITED` extension code and a positive `retryAfterSeconds`. `wrapDatabaseOperation` passes the structured error through unchanged.
- [x] Frontend unit tests — new `graphql-client.rate-limit.test.ts` covers: retry with extensions, retry via legacy message regex, exhaustion → `RateLimitError`, no retry on non-rate-limit errors, and the `onRateLimited` listener fires per attempt.
- [x] Existing `use-offline-reconciliation.test.ts` updated to flush the new inter-op timer with `vi.advanceTimersByTimeAsync(1000)` after FullSync.
- [x] `vp run check:i18n` and `vp run check:i18n:orphans` pass. New `queueProvider.rateLimitCatchUp` key added to `en-US` and `fr` catalogs (community-maintained `es` left to fall back).
- [ ] Manual outage simulation in DevTools (offline 30s with buffered queue ops, then back online): no rate-limit error visible. See `.boardsesh/qa-notes.md` for the full walkthrough — Docker isn't available in this remote environment, so the dev server wasn't run here.
- [ ] Manual forced rate-limit (lower a mutation limit, temporarily disable the dev-mode early-return in `helpers.ts`, hammer the endpoint): silent first retry, then the "Slow down — catching up…" toast appears once.

Closes the rate-limit-on-reconnect issue the user reported.

---
_Generated by [Claude Code](https://claude.ai/code/session_019En5888bRJAfYJ6UvLf5gX)_