### PR TITLE
Drive party-session recovery after onDisconnect teardown

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -779,6 +779,8 @@ sequenceDiagram
 - Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s (max)
 - Up to 10 retry attempts
 - On `closed`: the lifecycle hook unsubscribes both queue and session subscriptions before graphql-ws begins reconnecting. Without this, graphql-ws would auto-replay the old subscriptions on the new socket before `joinSession` registers the new `connectionId`, and the backend `requireSessionMember` check would fail with `Unauthorized: not in any session`.
+- Tearing down all subscriptions drops graphql-ws's internal `locks` count to zero, which makes its retry loop deny the next connect with `"All Subscriptions Gone"` (verified against `graphql-ws/dist/client.js` retry guard). The lifecycle hook therefore drives recovery itself by calling `scheduleSubscriptionRecovery` from `handleDisconnect` — `handleReconnect` runs `joinSession`, which registers a fresh subscription via `execute` and triggers a new WS connection on the now-registered `connectionId`.
+- If `joinSession` returns no payload (transient mutation failure), `handleReconnect` schedules another recovery attempt instead of bailing silently. Without this, a single transient failure on the rejoin would leave the user stuck showing the offline banner until a manual refresh, even after the network came back.
 - On reconnection: re-join session with the same `participantId`, then create fresh subscriptions on the now-registered connection
 - Delta sync attempted if gap ≤ 100 events and the replay buffer has contiguous coverage
 - Falls back to full sync if the gap is too large, replay is incomplete, or the local hash disagrees despite no sequence gap

--- a/packages/web/app/components/persistent-session/__tests__/session-lifecycle-disconnect.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/session-lifecycle-disconnect.test.tsx
@@ -150,6 +150,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -188,4 +189,114 @@ describe('useSessionLifecycle onDisconnect teardown', () => {
     expect(queueUnsubscribe).toHaveBeenCalledTimes(1);
     expect(sessionUnsubscribe).toHaveBeenCalledTimes(1);
   });
+
+  it('schedules a fresh joinSession after handleDisconnect tears down subscriptions', async () => {
+    // Regression test for the offline-error bug: tearing down both
+    // subscriptions leaves graphql-ws with zero "locks", so it refuses to
+    // auto-reconnect ("All Subscriptions Gone"). Without an explicit
+    // recovery trigger from handleDisconnect, the session is stranded
+    // showing the offline banner until the user refreshes.
+    await setPreference(ACTIVE_SESSION_KEY, {
+      sessionId: 'session-disconnect-test',
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails: createTestBoardDetails(),
+      parsedParams: {
+        board_name: 'kilter' as const,
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1, 2],
+        angle: 40,
+      },
+    });
+
+    renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
+
+    // Initial connect: joinSession mutation + queue/session subscriptions.
+    await waitFor(() => {
+      expect(subscribeSpy).toHaveBeenCalledTimes(2);
+    });
+    const joinCallsBeforeDisconnect = executeSpy.mock.calls.length;
+
+    // Hand out fresh unsubscribe spies for the post-recovery resubscribe
+    // BEFORE driving the disconnect — the recovery path runs on the next
+    // microtask after `onDisconnect` schedules its timer.
+    const queueUnsubscribeAfterRecovery = vi.fn();
+    const sessionUnsubscribeAfterRecovery = vi.fn();
+    subscribeSpy
+      .mockReturnValueOnce(queueUnsubscribeAfterRecovery)
+      .mockReturnValueOnce(sessionUnsubscribeAfterRecovery);
+
+    // Simulate graphql-ws firing `closed`.
+    capturedOptions.current?.onDisconnect?.();
+
+    // handleDisconnect schedules scheduleSubscriptionRecovery, which fires
+    // handleReconnect after INITIAL_RETRY_DELAY_MS (1000ms). Wait long
+    // enough for that to land + the joinSession mutation to resolve.
+    await waitFor(
+      () => {
+        expect(executeSpy.mock.calls.length).toBeGreaterThan(joinCallsBeforeDisconnect);
+      },
+      { timeout: 4000 },
+    );
+
+    // ...and re-created both subscriptions on the recovered connection.
+    await waitFor(() => {
+      expect(subscribeSpy).toHaveBeenCalledTimes(4);
+    });
+  }, 10_000);
+
+  it('schedules another recovery attempt when joinSession fails during reconnect', async () => {
+    // Without this, a single transient joinSession failure (network blip,
+    // 5xx, mutation timeout) silently strands the session: handleReconnect
+    // returns and nothing else triggers another attempt.
+    await setPreference(ACTIVE_SESSION_KEY, {
+      sessionId: 'session-disconnect-test',
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails: createTestBoardDetails(),
+      parsedParams: {
+        board_name: 'kilter' as const,
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1, 2],
+        angle: 40,
+      },
+    });
+
+    renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(subscribeSpy).toHaveBeenCalledTimes(2);
+    });
+    const joinCallsBeforeDisconnect = executeSpy.mock.calls.length;
+
+    // Make the FIRST recovery joinSession fail (transient failure — null payload).
+    // The next call falls through to the default beforeEach mock (success).
+    executeSpy.mockResolvedValueOnce({ joinSession: null });
+
+    capturedOptions.current?.onDisconnect?.();
+
+    // First handleReconnect attempt — joinSession returns null payload.
+    await waitFor(
+      () => {
+        expect(executeSpy.mock.calls.length).toBeGreaterThan(joinCallsBeforeDisconnect);
+      },
+      { timeout: 4000 },
+    );
+    const callsAfterFirstAttempt = executeSpy.mock.calls.length;
+
+    // Hand out fresh unsubscribe spies for the eventual successful resubscribe.
+    const queueUnsubscribeAfterRecovery = vi.fn();
+    const sessionUnsubscribeAfterRecovery = vi.fn();
+    subscribeSpy
+      .mockReturnValueOnce(queueUnsubscribeAfterRecovery)
+      .mockReturnValueOnce(sessionUnsubscribeAfterRecovery);
+
+    // Second attempt has 2x backoff (subscriptionRetryCount=2 → 2000ms).
+    await waitFor(
+      () => {
+        expect(executeSpy.mock.calls.length).toBeGreaterThan(callsAfterFirstAttempt);
+      },
+      { timeout: 6000 },
+    );
+  }, 15_000);
 });

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -484,7 +484,17 @@ export function useSessionLifecycle({
 
         const lastSeq = lastReceivedSequenceRef.current;
         const sessionData = await joinSession(clientForReconnect);
-        if (!sessionData || !mountedRef.current) return;
+        if (!mountedRef.current) return;
+        if (!sessionData) {
+          // joinSession failed (network hiccup, server down, mutation rejected).
+          // Don't bail silently — schedule another attempt so the user isn't
+          // stranded "Offline" until they refresh. The recovery counter caps
+          // total retries, so we won't loop forever on a permanent failure.
+          // The finally block resets isReconnectingRef so the scheduled
+          // handleReconnect can run.
+          scheduleSubscriptionRecovery('joinSession returned no session payload');
+          return;
+        }
 
         // Match the initial `connect()` success path: reset both retry
         // counters now that we know the rejoin succeeded. Otherwise a
@@ -583,6 +593,17 @@ export function useSessionLifecycle({
         queueUnsubscribeRef.current = null;
         sessionUnsubscribeRef.current?.();
         sessionUnsubscribeRef.current = null;
+        // Tearing down all subs leaves graphql-ws with zero "locks", which
+        // makes its retry loop deny the next reconnect attempt with
+        // "All Subscriptions Gone". Without an active operation, graphql-ws
+        // will not re-open the WebSocket on its own, so the `connected`
+        // event that normally drives `handleReconnect` never fires and the
+        // user is stranded showing the offline banner.
+        // Schedule recovery ourselves: handleReconnect will call joinSession
+        // (which adds a fresh subscription via execute → triggers a new WS
+        // connection) and then resubscribe to queue + session updates on the
+        // now-registered connectionId.
+        scheduleSubscriptionRecovery('socket closed');
       }
     }
 


### PR DESCRIPTION
## Summary

After PR #2180 ("Tear down WS subscriptions on disconnect to fix session-member race"), a transient WebSocket close inside a party session would frequently leave the user stranded showing the **Offline** banner — sometimes indefinitely until a manual refresh.

## Why the previous fix stalled recovery

The teardown is correct in spirit: it stops graphql-ws from auto-replaying old subscriptions on the new socket before `joinSession` registers the new `connectionId`. But dropping both subscriptions takes graphql-ws's internal `locks` count to zero. With no active operations, graphql-ws denies the next reconnect with `{ code: 1000, reason: "All Subscriptions Gone" }` (verified in `node_modules/graphql-ws/dist/client.js` lines 124-131):

```js
if (retrying) {
  await retryWait(retries);
  if (!locks) {
    connecting = void 0;
    return denied({ code: 1e3, reason: "All Subscriptions Gone" });
  }
  ...
}
```

So the `connected` event that normally drives `handleReconnect` never fires. Recovery then depended entirely on the indirect chain: subscribe loop catches → denied → `sink.complete()` → our complete handler → `scheduleSubscriptionRecovery`. That path:
1. Added ~1s of `retryWait` delay before recovery even started, and
2. If `joinSession` inside `handleReconnect` returned no payload (transient network blip, 5xx, mutation timeout), `handleReconnect` returned silently with **no further retries** — the user was stuck "Offline" until refresh.

## What changed

`packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts`:

- `handleDisconnect` now calls `scheduleSubscriptionRecovery('socket closed')` immediately after tearing down the subscriptions. Recovery starts on the first retry tick instead of waiting for the indirect denial → complete callback path.
- `handleReconnect` schedules another recovery attempt when `joinSession` returns no session payload, instead of bailing silently. `MAX_TRANSIENT_RETRIES = 5` still caps total attempts so we don't loop forever on a permanent failure.

`docs/websocket-implementation.md` updated to explain the new recovery wiring.

Two regression tests in `session-lifecycle-disconnect.test.tsx` cover:
- The post-disconnect joinSession + resubscribe cycle
- The retry-on-failure path when joinSession returns null

Both tests fail against the pre-fix code (verified by stashing the fix and re-running).

## Test plan

- [x] `bun x vp test run --reporter=agent packages/web/app/components/persistent-session/__tests__/` — 46/46 pass (was 44 + 2 new)
- [x] `bun x vp test run --reporter=agent packages/web/app/components/graphql-queue packages/web/app/components/persistent-session packages/web/app/components/queue-control packages/web/app/components/connection-manager` — 336/336 pass
- [x] `bun x vp run typecheck:web` — clean
- [ ] Manual QA in dev: join a party session, toggle network offline → online in dev tools, confirm offline banner clears within a few seconds and the session syncs again (see `.boardsesh/qa-notes.md`)
- [ ] Multi-client smoke: two clients in the same session, cycle one offline, confirm the surviving client keeps seeing live updates and both reconcile on recovery


---
_Generated by [Claude Code](https://claude.ai/code/session_013gDKJdopdZcNbV1Yct7u1t)_