### PR TITLE
Open play drawer on full climb-list row tap

### DIFF
--- a/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/climbs-list-virtualization.test.tsx
@@ -311,13 +311,13 @@ describe('ClimbsList virtualization', () => {
   });
 });
 
-describe('ClimbsList thumbnail vs row click', () => {
+describe('ClimbsList thumbnail and row click both open the play drawer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     lastVirtualizerOpts = null;
   });
 
-  it('row click activates the climb but does NOT open the play drawer', () => {
+  it('row click activates the climb AND opens the play drawer', () => {
     const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
     const onClimbSelect = vi.fn();
     render(
@@ -337,7 +337,7 @@ describe('ClimbsList thumbnail vs row click', () => {
     const dispatched = dispatchSpy.mock.calls.some(
       ([event]) => event instanceof CustomEvent && event.type === 'boardsesh:open-play-drawer',
     );
-    expect(dispatched).toBe(false);
+    expect(dispatched).toBe(true);
     dispatchSpy.mockRestore();
   });
 

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -416,7 +416,7 @@ const ClimbsList = ({
         } else {
           dispatchOpenPlayDrawer();
         }
-        track('Climb List Cover Clicked', { climbUuid: climb.uuid });
+        track('Climb List Row Clicked', { climbUuid: climb.uuid });
       }
     },
     [climbs],

--- a/packages/web/app/components/board-page/climbs-list.tsx
+++ b/packages/web/app/components/board-page/climbs-list.tsx
@@ -402,27 +402,7 @@ const ClimbsList = ({
     isFetching,
   });
 
-  // Row click: activates the climb but does NOT open the play drawer.
-  // Only the thumbnail (list mode) or card cover (grid mode) opens the drawer.
-  const handleClimbClickByIndex = useCallback(
-    (index: number) => {
-      const climb = climbs[index];
-      if (climb) {
-        onClimbSelectRef.current?.(climb);
-        // Explicit user-pick signal for the onboarding tour. Fires only while
-        // the tour is on the climb-list step so it can advance without
-        // relying on a currentClimb-change observer (which async queue
-        // hydration can trip).
-        if (tourStepRef.current === 'climb-list') {
-          dispatchTourClimbListPick();
-        }
-        track('Climb List Row Clicked', { climbUuid: climb.uuid });
-      }
-    },
-    [climbs],
-  );
-
-  // Thumbnail / card-cover click: activates the climb and opens the play drawer.
+  // Row / thumbnail / card-cover click: activates the climb and opens the play drawer.
   const handleClimbThumbnailClickByIndex = useCallback(
     (index: number) => {
       const climb = climbs[index];
@@ -680,7 +660,7 @@ const ClimbsList = ({
                           isDark={isDark}
                           preferImageLayers={index < initialImageCount}
                           fetchPriority={index === 0 ? 'high' : undefined}
-                          onSelect={() => handleClimbClickByIndex(index)}
+                          onSelect={() => handleClimbThumbnailClickByIndex(index)}
                           onThumbnailClick={() => handleClimbThumbnailClickByIndex(index)}
                           unsupported={unsupportedClimbs?.has(climb.uuid)}
                           needsBiggerBoard={upsizedClimbs?.has(climb.uuid)}


### PR DESCRIPTION
## Summary

- Tapping a climb-list row now matches the thumbnail: it activates the climb **and** opens the play drawer.
- Previously, only the thumbnail opened the drawer; the rest of the row only set the climb active, which made most of the tap target effectively dead.
- Implementation: drop the row-only `handleClimbClickByIndex` callback and point the row's `onSelect` at the existing `handleClimbThumbnailClickByIndex`, which already handles the onboarding-tour case correctly. Grid mode already routed clicks through this handler — list mode now matches.

## Test plan

- [ ] List view: tap a row **outside** the thumbnail → climb activates and play drawer opens.
- [ ] List view: tap a row's thumbnail → climb activates and play drawer opens (unchanged baseline; `e.stopPropagation` prevents double-fire).
- [ ] Grid view: tap a card → drawer opens (unchanged).
- [ ] Onboarding tour: on the climb-list step, tapping a row advances the tour (`dispatchTourClimbListPick`) without falling into the play drawer.
- [ ] `vp run test:e2e` — `layout-screenshots` spec taps the thumbnail explicitly and waits for the drawer; should still pass.

https://claude.ai/code/session_01WK9HcMW9a4ncTDWh4QMr8b

---
_Generated by [Claude Code](https://claude.ai/code/session_01WK9HcMW9a4ncTDWh4QMr8b)_