### PR TITLE
feat(logging): trace tick mutations + climb-stats recompute via winston

### DIFF
--- a/packages/backend/src/__tests__/debounced-climb-stats-publisher.test.ts
+++ b/packages/backend/src/__tests__/debounced-climb-stats-publisher.test.ts
@@ -156,6 +156,26 @@ describe('queueClimbStatsRecompute', () => {
     expect(recomputeClimbStatsMock).toHaveBeenCalledWith('kilter', 'CLIMB-1', 40);
   });
 
+  it('logs [debouncedClimbStats] queued ... at queue time', async () => {
+    const loggerSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+
+    queueClimbStatsRecompute('kilter', 'CLIMB-1', 40);
+
+    expect(loggerSpy).toHaveBeenCalledWith(`[debouncedClimbStats] queued ${KEY}`);
+    loggerSpy.mockRestore();
+  });
+
+  it('logs [debouncedClimbStats] firing ... when the timer fires', async () => {
+    const loggerSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    redisGetMock.mockImplementation(async () => redisSetMock.mock.calls[0]?.[1] ?? null);
+
+    queueClimbStatsRecompute('kilter', 'CLIMB-1', 40);
+    await vi.advanceTimersByTimeAsync(2100);
+
+    expect(loggerSpy).toHaveBeenCalledWith(`[debouncedClimbStats] firing ${KEY}`);
+    loggerSpy.mockRestore();
+  });
+
   it('logs an error when the recompute throws', async () => {
     const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
     recomputeClimbStatsMock.mockRejectedValue(new Error('DB write failed'));

--- a/packages/backend/src/__tests__/recompute-climb-stats.test.ts
+++ b/packages/backend/src/__tests__/recompute-climb-stats.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { logger } from '../utils/logger';
 
 // Captured SQL fragments per call to tx.execute.
 const executedSql: string[] = [];
@@ -195,5 +196,88 @@ describe('recomputeClimbStats', () => {
     expect(sql).toMatch(/quality_average\s*=\s*CASE[\s\S]+?agg\.avg_quality[\s\S]+?s\.quality_average/);
     expect(sql).toMatch(/difficulty_average\s*=\s*CASE[\s\S]+?agg\.avg_difficulty[\s\S]+?s\.difficulty_average/);
     expect(sql).toMatch(/display_difficulty\s*=\s*CASE[\s\S]+?agg\.avg_difficulty[\s\S]+?s\.display_difficulty/);
+  });
+
+  it('emits a [recomputeClimbStats] info log line with prev/new diff when a row was updated', async () => {
+    const loggerSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
+      const tx = {
+        insert: vi.fn(() => ({
+          values: vi.fn(() => ({ onConflictDoNothing: vi.fn() })),
+        })),
+        // The combined WITH … RETURNING query returns one diff row.
+        execute: vi.fn(async () => [
+          {
+            prev_bs: 0,
+            prev_total: 3,
+            prev_fa: null,
+            new_bs: 1,
+            new_total: 4,
+            new_fa: 'Alice',
+          },
+        ]),
+      };
+      await callback(tx);
+    });
+
+    await recomputeClimbStats('kilter', 'D15DDE9F3F72410F', 40);
+
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('[recomputeClimbStats]'));
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('kilter/D15DDE9F/40'));
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('boardsesh=1'));
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('total=4'));
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('delta=+1'));
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('fa=set:Alice'));
+    loggerSpy.mockRestore();
+  });
+
+  it('does not log when the UPDATE matched no row (defensive)', async () => {
+    const loggerSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
+      const tx = {
+        insert: vi.fn(() => ({
+          values: vi.fn(() => ({ onConflictDoNothing: vi.fn() })),
+        })),
+        execute: vi.fn(async () => []),
+      };
+      await callback(tx);
+    });
+
+    await recomputeClimbStats('kilter', 'D15DDE9F3F72410F', 40);
+
+    const recomputeCalls = (loggerSpy.mock.calls as unknown as unknown[][]).filter(
+      (call) => typeof call[0] === 'string' && call[0].includes('[recomputeClimbStats]'),
+    );
+    expect(recomputeCalls).toHaveLength(0);
+    loggerSpy.mockRestore();
+  });
+
+  it('classifies fa changes (unchanged, set, cleared, changed)', async () => {
+    const cases: Array<{ prev: string | null; next: string | null; expected: string }> = [
+      { prev: 'Alice', next: 'Alice', expected: 'fa=unchanged' },
+      { prev: null, next: 'Alice', expected: 'fa=set:Alice' },
+      { prev: 'Alice', next: null, expected: 'fa=cleared' },
+      { prev: 'Alice', next: 'Bob', expected: 'fa=changed:Alice→Bob' },
+    ];
+
+    for (const { prev, next, expected } of cases) {
+      const loggerSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+      mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
+        const tx = {
+          insert: vi.fn(() => ({
+            values: vi.fn(() => ({ onConflictDoNothing: vi.fn() })),
+          })),
+          execute: vi.fn(async () => [
+            { prev_bs: 0, prev_total: 0, prev_fa: prev, new_bs: 0, new_total: 0, new_fa: next },
+          ]),
+        };
+        await callback(tx);
+      });
+
+      await recomputeClimbStats('kilter', 'CLIMB-1', 40);
+
+      expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining(expected));
+      loggerSpy.mockRestore();
+    }
   });
 });

--- a/packages/backend/src/graphql/resolvers/ticks/debounced-climb-stats-publisher.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/debounced-climb-stats-publisher.ts
@@ -47,10 +47,13 @@ export function queueClimbStatsRecompute(boardType: string, climbUuid: string, a
     });
   }
 
+  logger.info(`[debouncedClimbStats] queued ${key}`);
+
   pending.set(
     key,
     setTimeout(async () => {
       pending.delete(key);
+      logger.info(`[debouncedClimbStats] firing ${key}`);
 
       // Best-effort multi-instance dedup: if we can confirm via Redis that
       // we still own the latest nonce, clean up the key. If GET throws, the

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -236,6 +236,10 @@ export const tickMutations = {
       throw new Error('You can only delete your own ticks');
     }
 
+    logger.info(
+      `[deleteTick] user=${userId} tick=${uuid} ${tick.boardType}/${tick.climbUuid.slice(0, 8)}/${tick.angle}`,
+    );
+
     await db.transaction(async (tx) => {
       // Collect comment IDs on this tick so we can clean up their notifications
       const tickComments = await tx
@@ -277,6 +281,8 @@ export const tickMutations = {
     // inflated or the FA pinned to a now-vanished tick.
     queueClimbStatsRecompute(tick.boardType, tick.climbUuid, tick.angle);
 
+    logger.info(`[deleteTick] deleted tick=${uuid} user=${userId}`);
+
     return true;
   },
 
@@ -290,6 +296,11 @@ export const tickMutations = {
     const validatedInput = validateInput(SaveTickInputSchema, input, 'input');
 
     const userId = ctx.userId!;
+    logger.info(
+      `[saveTick] user=${userId} ${validatedInput.boardType}/${validatedInput.climbUuid.slice(0, 8)}/${validatedInput.angle} ` +
+        `status=${validatedInput.status}` +
+        (validatedInput.sessionId ? ` session=${validatedInput.sessionId}` : ''),
+    );
     const uuid = uuidv4();
     const now = new Date().toISOString();
     const climbedAt = new Date(validatedInput.climbedAt).toISOString();
@@ -451,6 +462,11 @@ export const tickMutations = {
     // on the same climb collapses into one recompute.
     queueClimbStatsRecompute(tick.boardType, tick.climbUuid, tick.angle);
 
+    logger.info(
+      `[saveTick] saved tick=${tick.uuid} user=${userId} ` +
+        `${tick.boardType}/${tick.climbUuid.slice(0, 8)}/${tick.angle} status=${tick.status}`,
+    );
+
     return result;
   },
 
@@ -547,6 +563,9 @@ export const tickMutations = {
       throw new Error('Not authorized to update this tick');
     }
 
+    const changedFields = Object.keys(validatedInput);
+    logger.info(`[updateTick] user=${userId} tick=${uuid} fields=[${changedFields.join(',')}]`);
+
     const updates: Record<string, unknown> = {
       updatedAt: new Date().toISOString(),
     };
@@ -568,6 +587,11 @@ export const tickMutations = {
     // toward ascensionist_count, and a quality/difficulty/comment edit can
     // also change downstream derived stats once we aggregate those. Recompute.
     queueClimbStatsRecompute(updated.boardType, updated.climbUuid, updated.angle);
+
+    logger.info(
+      `[updateTick] updated tick=${updated.uuid} user=${userId} ` +
+        `${updated.boardType}/${updated.climbUuid.slice(0, 8)}/${updated.angle} status=${updated.status}`,
+    );
 
     return {
       uuid: updated.uuid,

--- a/packages/backend/src/graphql/resolvers/ticks/recompute-climb-stats.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/recompute-climb-stats.ts
@@ -1,6 +1,7 @@
 import { sql } from 'drizzle-orm';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
+import { logger } from '../../../utils/logger';
 
 /**
  * Recompute board_climb_stats for a single (boardType, climbUuid, angle)
@@ -52,8 +53,36 @@ import * as dbSchema from '@boardsesh/db/schema';
  * happen after the saveClimb stats seed, but ticks can theoretically arrive at
  * angles the seed didn't cover), insert a minimal row first so the subsequent
  * UPDATE has something to touch.
+ *
+ * After the UPDATE commits, emits a single `[recomputeClimbStats]` info log
+ * that captures the prev → new diff (Boardsesh count, total, FA status). The
+ * diff comes from a `WITH before AS (SELECT …), updated AS (UPDATE … RETURNING …)`
+ * round-trip so we don't need an extra SELECT before the write.
  */
+
+type DiffRow = {
+  prev_bs: number | string | null;
+  prev_total: number | string | null;
+  prev_fa: string | null;
+  new_bs: number | string | null;
+  new_total: number | string | null;
+  new_fa: string | null;
+};
+
+function shortUuid(uuid: string): string {
+  return uuid.length > 8 ? uuid.slice(0, 8) : uuid;
+}
+
+function faStatusFor(prev: string | null, next: string | null): string {
+  if (prev === next) return 'unchanged';
+  if (prev === null && next !== null) return `set:${next}`;
+  if (prev !== null && next === null) return 'cleared';
+  return `changed:${prev}→${next}`;
+}
+
 export async function recomputeClimbStats(boardType: string, climbUuid: string, angle: number): Promise<void> {
+  let diff: DiffRow | undefined;
+
   await db.transaction(async (tx) => {
     // Defensive seed: set aurora_/kilter_ascensionist_count to 0 explicitly so
     // the subsequent recompute (COALESCE(kilter, aurora, 0) + boardsesh) and any
@@ -78,8 +107,17 @@ export async function recomputeClimbStats(boardType: string, climbUuid: string, 
         ],
       });
 
-    await tx.execute(sql`
-      WITH agg AS (
+    const result = await tx.execute(sql`
+      WITH before AS (
+        SELECT boardsesh_ascensionist_count AS prev_bs,
+               ascensionist_count           AS prev_total,
+               fa_username                  AS prev_fa
+          FROM board_climb_stats
+         WHERE board_type = ${boardType}
+           AND climb_uuid = ${climbUuid}
+           AND angle      = ${angle}
+      ),
+      agg AS (
         SELECT
           COUNT(DISTINCT bt.user_id) AS distinct_senders,
           MIN(bt.climbed_at)         AS first_at,
@@ -106,48 +144,74 @@ export async function recomputeClimbStats(boardType: string, climbUuid: string, 
           FROM board_climbs bc
          WHERE bc.board_type = ${boardType}
            AND bc.uuid       = ${climbUuid}
+      ),
+      updated AS (
+        UPDATE board_climb_stats s
+           SET boardsesh_ascensionist_count = COALESCE(agg.distinct_senders, 0),
+               ascensionist_count           = COALESCE(s.kilter_ascensionist_count, s.aurora_ascensionist_count, 0)
+                                            + COALESCE(agg.distinct_senders, 0),
+               fa_username = CASE
+                 WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)
+                   THEN agg.first_user
+                 ELSE COALESCE(s.fa_username, agg.first_user)
+               END,
+               fa_at = CASE
+                 WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)
+                   THEN agg.first_at
+                 ELSE COALESCE(s.fa_at, agg.first_at)
+               END,
+               quality_average = CASE
+                 WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)
+                   THEN agg.avg_quality
+                 ELSE s.quality_average
+               END,
+               -- Boardsesh-owned climbs derive quality from boardsesh_ticks, which
+               -- are already on the 1-5 scale, so the row is normalized. For
+               -- Aurora-synced climbs leave the flag as-is (its own sync sets it).
+               quality_normalized = CASE
+                 WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)
+                   THEN TRUE
+                 ELSE s.quality_normalized
+               END,
+               difficulty_average = CASE
+                 WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)
+                   THEN agg.avg_difficulty
+                 ELSE s.difficulty_average
+               END,
+               display_difficulty = CASE
+                 WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)
+                   THEN agg.avg_difficulty
+                 ELSE s.display_difficulty
+               END
+          FROM agg
+         WHERE s.board_type = ${boardType}
+           AND s.climb_uuid = ${climbUuid}
+           AND s.angle      = ${angle}
+        RETURNING boardsesh_ascensionist_count AS new_bs,
+                  ascensionist_count           AS new_total,
+                  fa_username                  AS new_fa
       )
-      UPDATE board_climb_stats s
-         SET boardsesh_ascensionist_count = COALESCE(agg.distinct_senders, 0),
-             ascensionist_count           = COALESCE(s.kilter_ascensionist_count, s.aurora_ascensionist_count, 0)
-                                          + COALESCE(agg.distinct_senders, 0),
-             fa_username = CASE
-               WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)
-                 THEN agg.first_user
-               ELSE COALESCE(s.fa_username, agg.first_user)
-             END,
-             fa_at = CASE
-               WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)
-                 THEN agg.first_at
-               ELSE COALESCE(s.fa_at, agg.first_at)
-             END,
-             quality_average = CASE
-               WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)
-                 THEN agg.avg_quality
-               ELSE s.quality_average
-             END,
-             -- Boardsesh-owned climbs derive quality from boardsesh_ticks, which
-             -- are already on the 1-5 scale, so the row is normalized. For
-             -- Aurora-synced climbs leave the flag as-is (its own sync sets it).
-             quality_normalized = CASE
-               WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)
-                 THEN TRUE
-               ELSE s.quality_normalized
-             END,
-             difficulty_average = CASE
-               WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)
-                 THEN agg.avg_difficulty
-               ELSE s.difficulty_average
-             END,
-             display_difficulty = CASE
-               WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)
-                 THEN agg.avg_difficulty
-               ELSE s.display_difficulty
-             END
-        FROM agg
-       WHERE s.board_type = ${boardType}
-         AND s.climb_uuid = ${climbUuid}
-         AND s.angle      = ${angle};
+      SELECT before.prev_bs, before.prev_total, before.prev_fa,
+             updated.new_bs, updated.new_total, updated.new_fa
+        FROM before, updated;
     `);
+
+    const rows = Array.isArray(result) ? (result as unknown as DiffRow[]) : [];
+    if (rows.length > 0) {
+      diff = rows[0];
+    }
   });
+
+  if (diff) {
+    const prevTotal = Number(diff.prev_total ?? 0);
+    const newTotal = Number(diff.new_total ?? 0);
+    const delta = newTotal - prevTotal;
+    const deltaStr = delta >= 0 ? `+${delta}` : `${delta}`;
+    const faStatus = faStatusFor(diff.prev_fa, diff.new_fa);
+    logger.info(
+      `[recomputeClimbStats] ${boardType}/${shortUuid(climbUuid)}/${angle} ` +
+        `boardsesh=${Number(diff.new_bs ?? 0)} total=${newTotal} delta=${deltaStr} ` +
+        `fa=${faStatus}`,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to the merged tick-stats wiring (PR #2171). When a tick lands and the climb's stats don't move, there's nothing in production logs to confirm:

1. The mutation actually ran for this user.
2. The recompute fired (vs coalesced or dropped by debounce).
3. What the resulting count + FA are after the recompute.

This PR adds info-level winston logs at every step so an operator can grep the full trip:

\`\`\`
[saveTick] user=… kilter/D15D…/40 status=send
[saveTick] saved tick=… user=… kilter/D15D…/40 status=send
[debouncedClimbStats] queued kilter|D15D…|40
[debouncedClimbStats] firing kilter|D15D…|40
[recomputeClimbStats] kilter/D15D…/40 boardsesh=1 total=1 delta=+1 fa=set:Test User
\`\`\`

### Conventions chosen

- **Level**: info (always emit, no \`LOG_LEVEL=debug\` opt-in required). Volume cost accepted — saveTick is bounded by real user activity.
- **Shape**: string interpolation with the existing \`[FeatureName]\` prefix. No structured-metadata objects; matches every other backend log line.

### Implementation notes

- \`recomputeClimbStats\` now does its UPDATE inside a \`WITH before / agg / owner / updated AS (… RETURNING …) SELECT\` round-trip so the log line carries the prev → new diff in a single statement (no extra SELECT). Behavior of the UPDATE itself is unchanged.
- \`fa=<status>\` is derived from prev/new FA: \`unchanged\`, \`set:<user>\`, \`cleared\`, or \`changed:<prev>→<new>\`.
- When the UPDATE matches no row (defensive insert raced or the stats row vanished), the log is skipped — the existing error path in the publisher still catches recompute throws.
- Existing \`logger.error\` calls in all three files are left verbatim.

## Files

- \`packages/backend/src/graphql/resolvers/ticks/recompute-climb-stats.ts\` — diff-capturing CTE + info log
- \`packages/backend/src/graphql/resolvers/ticks/debounced-climb-stats-publisher.ts\` — queued / firing info logs
- \`packages/backend/src/graphql/resolvers/ticks/mutations.ts\` — entry + exit info logs in saveTick, updateTick, deleteTick
- \`packages/backend/src/__tests__/recompute-climb-stats.test.ts\` — 4 new test cases (happy-path diff, no-log on empty UPDATE, 4 fa-status branches)
- \`packages/backend/src/__tests__/debounced-climb-stats-publisher.test.ts\` — 2 new test cases (queued at enqueue, firing at timer wake)

## Test plan

- [x] \`vp run typecheck:backend\` passes
- [x] \`SKIP_TEST_INFRA=1 vp test run packages/backend/src/__tests__/recompute-climb-stats.test.ts packages/backend/src/__tests__/debounced-climb-stats-publisher.test.ts\` — 18 / 18 pass (was 13)
- [x] \`SKIP_TEST_INFRA=1 vp test run packages/backend/src/__tests__/climb-mutations.test.ts\` — 14 / 14, unrelated tests still green
- [ ] Reviewer: on dev server, submit a \`send\` tick on a Kilter climb and grep the backend log for the five expected lines above. Submit two more ticks in quick succession; the \`queued\` line should appear three times but \`firing\` / \`[recomputeClimbStats]\` only once (debounce coalesces). Delete the FA's tick; verify a new \`[recomputeClimbStats]\` line shows \`delta=-1\` and either \`fa=cleared\` or \`fa=changed:User1→User2\`.

## Out of scope

- Structured-metadata objects on log calls. The current convention is string interpolation everywhere; this PR doesn't introduce a parallel pattern.
- Logging in other backend mutations. Scoped strictly to the tick → recompute chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)