### PR TITLE
[codex] Attribute live activity delivery analytics

### DIFF
--- a/docs/live-activity-board-control.md
+++ b/docs/live-activity-board-control.md
@@ -20,7 +20,7 @@ Control the climbing board from the lock screen while the app is backgrounded. T
 1. Widget can only do prev/next -- no add, remove, reorder, or mirror mutations from lock screen
 2. Rust board renderer has no Swift/iOS bindings -- only targets WASM today
 3. MoonBoard remains on the existing Capacitor BLE path; the native background BLE path currently targets Aurora boards only
-4. Cross-device repaint when *another* user navigates: if your phone is suspended, your board stays stale until you unlock the phone. Tracked in issue #2174 (presence/ack design) and ultimately solved by the planned WS-enabled board controller.
+4. Cross-device repaint when _another_ user navigates: if your phone is suspended, your board stays stale until you unlock the phone. Tracked in issue #2174 (presence/ack design) and ultimately solved by the planned WS-enabled board controller.
 
 ## Architecture Decision: Where Does BLE Live?
 

--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -71,7 +71,7 @@ Device-to-server (widget buttons):
 
 Latency on the BLE side from a suspended-app cold-launch is ~1.5–2.5 s: background-launch (~0.5–1 s) + CoreBluetooth state restoration (~0.5–1 s) + UART chunk flush (~0.2–0.5 s). Subsequent taps inside the same wake window are faster because the peripheral stays connected.
 
-Cross-device limitation: when *another* user navigates and your phone is suspended, your board does **not** repaint — the WS connection is dead and the APNs Live Activity push reaches the widget extension, which can't open the CoreBluetooth connection. Tracked in issue #2174; ultimately solved by the planned WS-enabled board controller.
+Cross-device limitation: when _another_ user navigates and your phone is suspended, your board does **not** repaint — the WS connection is dead and the APNs Live Activity push reaches the widget extension, which can't open the CoreBluetooth connection. Tracked in issue #2174; ultimately solved by the planned WS-enabled board controller.
 
 ## Prerequisites
 

--- a/packages/backend/src/__tests__/apns-analytics.test.ts
+++ b/packages/backend/src/__tests__/apns-analytics.test.ts
@@ -14,6 +14,7 @@ const dbMocks = vi.hoisted(() => ({
 
 const analyticsMocks = vi.hoisted(() => ({
   trackLiveActivityEnded: vi.fn(),
+  trackLiveActivityEndedAttributionGap: vi.fn(),
   trackLiveActivityPushDelivery: vi.fn(),
   trackLiveActivityPushDeliveryAttributionGap: vi.fn(),
 }));
@@ -252,6 +253,11 @@ describe('APNs analytics instrumentation', () => {
       sessionId: SESSION_ID,
       reason: 'session-ended',
       tokenCount: 2,
+    });
+    expect(analyticsMocks.trackLiveActivityEndedAttributionGap).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      reason: 'missing_user_id',
+      tokenCount: 1,
     });
     expect(analyticsMocks.trackLiveActivityEnded).toHaveBeenCalledTimes(1);
   });

--- a/packages/backend/src/__tests__/apns-analytics.test.ts
+++ b/packages/backend/src/__tests__/apns-analytics.test.ts
@@ -15,6 +15,7 @@ const dbMocks = vi.hoisted(() => ({
 const analyticsMocks = vi.hoisted(() => ({
   trackLiveActivityEnded: vi.fn(),
   trackLiveActivityPushDelivery: vi.fn(),
+  trackLiveActivityPushDeliveryAttributionGap: vi.fn(),
 }));
 
 vi.mock('@parse/node-apn', () => ({
@@ -61,6 +62,7 @@ describe('APNs analytics instrumentation', () => {
   const TOKEN_ONE = 'a'.repeat(64);
   const TOKEN_TWO = 'b'.repeat(64);
   const TOKEN_THREE = 'c'.repeat(64);
+  const TOKEN_FOUR = 'd'.repeat(64);
   const SESSION_ID = 'session-apns-analytics';
 
   beforeEach(() => {
@@ -79,14 +81,14 @@ describe('APNs analytics instrumentation', () => {
     dbMocks.tokenRows.mockReturnValue([]);
   });
 
-  it('tracks aggregate delivery for immediate Live Activity updates', async () => {
+  it('tracks per-user delivery for immediate Live Activity updates', async () => {
     stubApnsEnv();
     const { initializeApns, sendLiveActivityUpdateToTokens } = await loadApnsModule();
     initializeApns();
 
     await sendLiveActivityUpdateToTokens(
       SESSION_ID,
-      [TOKEN_ONE],
+      [{ token: TOKEN_ONE, userId: 'user-1' }],
       {
         climbName: 'Hidden from analytics',
         climbDifficulty: 'V5',
@@ -101,12 +103,81 @@ describe('APNs analytics instrumentation', () => {
     );
 
     expect(analyticsMocks.trackLiveActivityPushDelivery).toHaveBeenCalledWith({
+      userId: 'user-1',
       sessionId: SESSION_ID,
       event: 'update',
       source: 'registration',
       tokenCount: 1,
       sentCount: 1,
       failedCount: 0,
+      staleCount: 0,
+      elapsedMs: expect.any(Number),
+    });
+  });
+
+  it('tracks delivery counts separately by recipient user', async () => {
+    stubApnsEnv();
+    apnsMocks.send.mockResolvedValue({
+      sent: [{ device: TOKEN_ONE }, { device: TOKEN_THREE }],
+      failed: [
+        { device: TOKEN_TWO, status: 410, response: { reason: 'Unregistered' } },
+        { device: TOKEN_FOUR, status: 500, response: { reason: 'InternalServerError' } },
+      ],
+    });
+    const { initializeApns, sendLiveActivityUpdateToTokens } = await loadApnsModule();
+    initializeApns();
+
+    await sendLiveActivityUpdateToTokens(
+      SESSION_ID,
+      [
+        { token: TOKEN_ONE, userId: 'user-1' },
+        { token: TOKEN_TWO, userId: 'user-1' },
+        { token: TOKEN_THREE, userId: 'user-2' },
+        { token: TOKEN_FOUR, userId: null },
+      ],
+      {
+        climbName: 'Hidden from analytics',
+        climbDifficulty: 'V5',
+        angle: 40,
+        currentIndex: 0,
+        totalClimbs: 1,
+        hasNext: false,
+        hasPrevious: false,
+        climbUuid: 'climb-1',
+      },
+      { source: 'registration' },
+    );
+
+    expect(analyticsMocks.trackLiveActivityPushDelivery).toHaveBeenCalledWith({
+      userId: 'user-1',
+      sessionId: SESSION_ID,
+      event: 'update',
+      source: 'registration',
+      tokenCount: 2,
+      sentCount: 1,
+      failedCount: 1,
+      staleCount: 1,
+      elapsedMs: expect.any(Number),
+    });
+    expect(analyticsMocks.trackLiveActivityPushDelivery).toHaveBeenCalledWith({
+      userId: 'user-2',
+      sessionId: SESSION_ID,
+      event: 'update',
+      source: 'registration',
+      tokenCount: 1,
+      sentCount: 1,
+      failedCount: 0,
+      staleCount: 0,
+      elapsedMs: expect.any(Number),
+    });
+    expect(analyticsMocks.trackLiveActivityPushDeliveryAttributionGap).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      event: 'update',
+      source: 'registration',
+      reason: 'missing_user_id',
+      tokenCount: 1,
+      sentCount: 0,
+      failedCount: 1,
       staleCount: 0,
       elapsedMs: expect.any(Number),
     });
@@ -135,6 +206,7 @@ describe('APNs analytics instrumentation', () => {
 
     expect(apnsMocks.send).not.toHaveBeenCalled();
     expect(analyticsMocks.trackLiveActivityPushDelivery).not.toHaveBeenCalled();
+    expect(analyticsMocks.trackLiveActivityPushDeliveryAttributionGap).not.toHaveBeenCalled();
   });
 
   it('tracks one session-ended event per attributed user when ending Live Activities', async () => {
@@ -155,11 +227,23 @@ describe('APNs analytics instrumentation', () => {
 
     expect(analyticsMocks.trackLiveActivityPushDelivery).toHaveBeenCalledWith(
       expect.objectContaining({
+        userId: 'user-1',
         sessionId: SESSION_ID,
         event: 'end',
         source: 'event',
-        tokenCount: 3,
-        sentCount: 3,
+        tokenCount: 2,
+        sentCount: 2,
+        failedCount: 0,
+      }),
+    );
+    expect(analyticsMocks.trackLiveActivityPushDeliveryAttributionGap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: SESSION_ID,
+        event: 'end',
+        source: 'event',
+        reason: 'missing_user_id',
+        tokenCount: 1,
+        sentCount: 1,
         failedCount: 0,
       }),
     );

--- a/packages/backend/src/__tests__/push-tokens.test.ts
+++ b/packages/backend/src/__tests__/push-tokens.test.ts
@@ -360,7 +360,7 @@ describe('registerActivityPushToken', () => {
     await new Promise((resolve) => setImmediate(resolve));
     expect(sendLiveActivityUpdateToTokensMock).toHaveBeenCalledWith(
       SESSION_ID,
-      [VALID_TOKEN],
+      [{ token: VALID_TOKEN, userId: USER_ID }],
       expect.objectContaining({ climbUuid: 'c1' }),
       { source: 'registration' },
     );

--- a/packages/backend/src/graphql/resolvers/sessions/push-tokens.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/push-tokens.ts
@@ -174,6 +174,7 @@ export const pushTokenMutations = {
       );
       throw new Error('Authentication required to perform this operation');
     }
+    const userId = ctx.userId;
 
     if (!sessionId || !token) {
       logger.warn(
@@ -189,16 +190,16 @@ export const pushTokenMutations = {
       throw new Error('Invalid APNs token format');
     }
 
-    if (!checkTokenMutationRateLimit(ctx.userId, sessionId)) {
+    if (!checkTokenMutationRateLimit(userId, sessionId)) {
       logger.warn(
-        `[APNs] Rejected Live Activity token registration for session ${sessionId}: rate limited user ${ctx.userId}`,
+        `[APNs] Rejected Live Activity token registration for session ${sessionId}: rate limited user ${userId}`,
       );
       throw new Error('Too many push-token requests, please retry later');
     }
 
-    if (!(await isParticipant(ctx.userId, sessionId))) {
+    if (!(await isParticipant(userId, sessionId))) {
       logger.warn(
-        `[APNs] Rejected Live Activity token registration for session ${sessionId}: user ${ctx.userId} is not a participant`,
+        `[APNs] Rejected Live Activity token registration for session ${sessionId}: user ${userId} is not a participant`,
       );
       throw new Error('Unauthorized: not a participant in this session');
     }
@@ -229,7 +230,7 @@ export const pushTokenMutations = {
         if (previousTokenSessionId && previousTokenSessionId !== sessionId) {
           incrementApnsMetric('tokensRebound');
           logger.warn(
-            `[APNs] Rebound token ${describeTokenForLog(token)} from session ${previousTokenSessionId} → ${sessionId} (user ${ctx.userId})`,
+            `[APNs] Rebound token ${describeTokenForLog(token)} from session ${previousTokenSessionId} → ${sessionId} (user ${userId})`,
           );
         }
 
@@ -276,13 +277,13 @@ export const pushTokenMutations = {
           .values({
             token,
             sessionId,
-            userId: ctx.userId,
+            userId,
           })
           .onConflictDoUpdate({
             target: activityPushTokens.token,
             set: {
               sessionId,
-              userId: ctx.userId,
+              userId,
               updatedAt: new Date(),
             },
           });
@@ -298,7 +299,7 @@ export const pushTokenMutations = {
     incrementApnsMetric('tokensRegistered');
     logger.info(`[APNs] Registered Live Activity token for session ${sessionId}: ${describeTokenForLog(token)}`);
     trackLiveActivityStarted({
-      userId: ctx.userId,
+      userId,
       sessionId,
       tokenLength: token.length,
       apnsConfigured: isApnsConfigured(),
@@ -315,7 +316,9 @@ export const pushTokenMutations = {
         const state = await buildContentStateForSession(sessionId);
         if (!state) return;
         try {
-          await sendLiveActivityUpdateToTokens(sessionId, [token], state, { source: 'registration' });
+          await sendLiveActivityUpdateToTokens(sessionId, [{ token, userId }], state, {
+            source: 'registration',
+          });
         } catch (error) {
           logger.warn(
             `[APNs] Failed initial Live Activity send for session ${sessionId} (${describeTokenForLog(token)}):`,

--- a/packages/backend/src/graphql/resolvers/sessions/push-tokens.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/push-tokens.ts
@@ -174,7 +174,6 @@ export const pushTokenMutations = {
       );
       throw new Error('Authentication required to perform this operation');
     }
-    const userId = ctx.userId;
 
     if (!sessionId || !token) {
       logger.warn(
@@ -190,16 +189,16 @@ export const pushTokenMutations = {
       throw new Error('Invalid APNs token format');
     }
 
-    if (!checkTokenMutationRateLimit(userId, sessionId)) {
+    if (!checkTokenMutationRateLimit(ctx.userId, sessionId)) {
       logger.warn(
-        `[APNs] Rejected Live Activity token registration for session ${sessionId}: rate limited user ${userId}`,
+        `[APNs] Rejected Live Activity token registration for session ${sessionId}: rate limited user ${ctx.userId}`,
       );
       throw new Error('Too many push-token requests, please retry later');
     }
 
-    if (!(await isParticipant(userId, sessionId))) {
+    if (!(await isParticipant(ctx.userId, sessionId))) {
       logger.warn(
-        `[APNs] Rejected Live Activity token registration for session ${sessionId}: user ${userId} is not a participant`,
+        `[APNs] Rejected Live Activity token registration for session ${sessionId}: user ${ctx.userId} is not a participant`,
       );
       throw new Error('Unauthorized: not a participant in this session');
     }
@@ -230,7 +229,7 @@ export const pushTokenMutations = {
         if (previousTokenSessionId && previousTokenSessionId !== sessionId) {
           incrementApnsMetric('tokensRebound');
           logger.warn(
-            `[APNs] Rebound token ${describeTokenForLog(token)} from session ${previousTokenSessionId} → ${sessionId} (user ${userId})`,
+            `[APNs] Rebound token ${describeTokenForLog(token)} from session ${previousTokenSessionId} → ${sessionId} (user ${ctx.userId})`,
           );
         }
 
@@ -277,13 +276,13 @@ export const pushTokenMutations = {
           .values({
             token,
             sessionId,
-            userId,
+            userId: ctx.userId,
           })
           .onConflictDoUpdate({
             target: activityPushTokens.token,
             set: {
               sessionId,
-              userId,
+              userId: ctx.userId,
               updatedAt: new Date(),
             },
           });
@@ -299,7 +298,7 @@ export const pushTokenMutations = {
     incrementApnsMetric('tokensRegistered');
     logger.info(`[APNs] Registered Live Activity token for session ${sessionId}: ${describeTokenForLog(token)}`);
     trackLiveActivityStarted({
-      userId,
+      userId: ctx.userId,
       sessionId,
       tokenLength: token.length,
       apnsConfigured: isApnsConfigured(),
@@ -316,7 +315,7 @@ export const pushTokenMutations = {
         const state = await buildContentStateForSession(sessionId);
         if (!state) return;
         try {
-          await sendLiveActivityUpdateToTokens(sessionId, [{ token, userId }], state, {
+          await sendLiveActivityUpdateToTokens(sessionId, [{ token, userId: ctx.userId ?? null }], state, {
             source: 'registration',
           });
         } catch (error) {

--- a/packages/backend/src/services/analytics/live-activity.ts
+++ b/packages/backend/src/services/analytics/live-activity.ts
@@ -24,6 +24,12 @@ interface LiveActivityEndEvent {
   tokenCount?: number;
 }
 
+interface LiveActivityEndAttributionGapEvent {
+  sessionId: string;
+  reason: 'missing_user_id';
+  tokenCount: number;
+}
+
 interface LiveActivityWidgetNavigationEvent {
   userId: string;
   sessionId: string;
@@ -91,6 +97,18 @@ export function trackLiveActivityEnded(event: LiveActivityEndEvent): void {
     distinctId: event.userId,
     properties: {
       userId: event.userId,
+      sessionId: event.sessionId,
+      reason: event.reason,
+      tokenCount: event.tokenCount,
+    },
+  });
+}
+
+export function trackLiveActivityEndedAttributionGap(event: LiveActivityEndAttributionGapEvent): void {
+  captureBackendEvent('Live Activity Ended Attribution Gap', {
+    distinctId: `live-activity-session:${event.sessionId}`,
+    processPersonProfile: false,
+    properties: {
       sessionId: event.sessionId,
       reason: event.reason,
       tokenCount: event.tokenCount,

--- a/packages/backend/src/services/analytics/live-activity.ts
+++ b/packages/backend/src/services/analytics/live-activity.ts
@@ -49,9 +49,22 @@ interface LiveActivityWidgetNavigationAttributionGapEvent {
 }
 
 interface LiveActivityPushDeliveryEvent {
+  userId: string;
   sessionId: string;
   event: 'update' | 'end';
   source: 'event' | 'heartbeat' | 'registration';
+  tokenCount: number;
+  sentCount: number;
+  failedCount: number;
+  staleCount: number;
+  elapsedMs: number;
+}
+
+interface LiveActivityPushDeliveryAttributionGapEvent {
+  sessionId: string;
+  event: 'update' | 'end';
+  source: 'event' | 'heartbeat' | 'registration';
+  reason: 'missing_user_id';
   tokenCount: number;
   sentCount: number;
   failedCount: number;
@@ -63,6 +76,7 @@ export function trackLiveActivityStarted(event: LiveActivityRegistrationEvent): 
   captureBackendEvent('Live Activity Started', {
     distinctId: event.userId,
     properties: {
+      userId: event.userId,
       sessionId: event.sessionId,
       tokenLength: event.tokenLength,
       apnsConfigured: event.apnsConfigured,
@@ -76,6 +90,7 @@ export function trackLiveActivityEnded(event: LiveActivityEndEvent): void {
   captureBackendEvent('Live Activity Ended', {
     distinctId: event.userId,
     properties: {
+      userId: event.userId,
       sessionId: event.sessionId,
       reason: event.reason,
       tokenCount: event.tokenCount,
@@ -87,6 +102,7 @@ export function trackLiveActivityWidgetNavigation(event: LiveActivityWidgetNavig
   captureBackendEvent('Live Activity Widget Navigation', {
     distinctId: event.userId,
     properties: {
+      userId: event.userId,
       sessionId: event.sessionId,
       action: event.action,
       outcome: event.outcome,
@@ -121,12 +137,30 @@ export function trackLiveActivityWidgetNavigationAttributionGap(
 
 export function trackLiveActivityPushDelivery(event: LiveActivityPushDeliveryEvent): void {
   captureBackendEvent('Live Activity Push Delivery', {
+    distinctId: event.userId,
+    properties: {
+      userId: event.userId,
+      sessionId: event.sessionId,
+      event: event.event,
+      source: event.source,
+      tokenCount: event.tokenCount,
+      sentCount: event.sentCount,
+      failedCount: event.failedCount,
+      staleCount: event.staleCount,
+      elapsedMs: event.elapsedMs,
+    },
+  });
+}
+
+export function trackLiveActivityPushDeliveryAttributionGap(event: LiveActivityPushDeliveryAttributionGapEvent): void {
+  captureBackendEvent('Live Activity Push Delivery Attribution Gap', {
     distinctId: `live-activity-session:${event.sessionId}`,
     processPersonProfile: false,
     properties: {
       sessionId: event.sessionId,
       event: event.event,
       source: event.source,
+      reason: event.reason,
       tokenCount: event.tokenCount,
       sentCount: event.sentCount,
       failedCount: event.failedCount,

--- a/packages/backend/src/services/analytics/posthog.ts
+++ b/packages/backend/src/services/analytics/posthog.ts
@@ -7,6 +7,7 @@ type SanitizedAnalyticsProperties = Record<string, string | number | boolean | n
 export type BackendAnalyticsEvent =
   | 'Live Activity Ended'
   | 'Live Activity Push Delivery'
+  | 'Live Activity Push Delivery Attribution Gap'
   | 'Live Activity Started'
   | 'Live Activity Widget Navigation'
   | 'Live Activity Widget Navigation Attribution Gap';

--- a/packages/backend/src/services/analytics/posthog.ts
+++ b/packages/backend/src/services/analytics/posthog.ts
@@ -6,6 +6,7 @@ type AnalyticsProperties = Record<string, AnalyticsPropertyValue>;
 type SanitizedAnalyticsProperties = Record<string, string | number | boolean | null>;
 export type BackendAnalyticsEvent =
   | 'Live Activity Ended'
+  | 'Live Activity Ended Attribution Gap'
   | 'Live Activity Push Delivery'
   | 'Live Activity Push Delivery Attribution Gap'
   | 'Live Activity Started'

--- a/packages/backend/src/services/apns/index.ts
+++ b/packages/backend/src/services/apns/index.ts
@@ -14,6 +14,7 @@ import { activityPushTokens } from '@boardsesh/db/schema/app';
 import { db } from '../../db/client';
 import {
   trackLiveActivityEnded,
+  trackLiveActivityEndedAttributionGap,
   trackLiveActivityPushDelivery,
   trackLiveActivityPushDeliveryAttributionGap,
 } from '../analytics/live-activity';
@@ -435,8 +436,13 @@ async function sendNotification(
 
 function trackSessionEndedForRegistrations(sessionId: string, registrations: LiveActivityTokenRegistration[]): void {
   const tokenCountsByUserId = new Map<string, number>();
+  let unattributedTokenCount = 0;
+
   for (const registration of registrations) {
-    if (!registration.userId) continue;
+    if (!registration.userId) {
+      unattributedTokenCount++;
+      continue;
+    }
     tokenCountsByUserId.set(registration.userId, (tokenCountsByUserId.get(registration.userId) ?? 0) + 1);
   }
 
@@ -446,6 +452,14 @@ function trackSessionEndedForRegistrations(sessionId: string, registrations: Liv
       sessionId,
       reason: 'session-ended',
       tokenCount,
+    });
+  }
+
+  if (unattributedTokenCount > 0) {
+    trackLiveActivityEndedAttributionGap({
+      sessionId,
+      reason: 'missing_user_id',
+      tokenCount: unattributedTokenCount,
     });
   }
 }

--- a/packages/backend/src/services/apns/index.ts
+++ b/packages/backend/src/services/apns/index.ts
@@ -12,7 +12,11 @@ import apn from '@parse/node-apn';
 import { eq } from 'drizzle-orm';
 import { activityPushTokens } from '@boardsesh/db/schema/app';
 import { db } from '../../db/client';
-import { trackLiveActivityEnded, trackLiveActivityPushDelivery } from '../analytics/live-activity';
+import {
+  trackLiveActivityEnded,
+  trackLiveActivityPushDelivery,
+  trackLiveActivityPushDeliveryAttributionGap,
+} from '../analytics/live-activity';
 import { logger } from '../../utils/logger';
 
 // ---------------------------------------------------------------------------
@@ -43,9 +47,27 @@ interface DebouncedEntry {
   source: SendSource;
 }
 
-interface TokenRegistration {
+export interface LiveActivityTokenRegistration {
   token: string;
   userId: string | null;
+}
+
+interface DeliveryCounts {
+  tokenCount: number;
+  sentCount: number;
+  failedCount: number;
+  staleCount: number;
+}
+
+interface DeliveryTrackingInput {
+  sessionId: string;
+  event: 'update' | 'end';
+  source: SendSource;
+  registrations: LiveActivityTokenRegistration[];
+  sentDevices: string[];
+  failedDevices: string[];
+  staleDevices: ReadonlySet<string>;
+  elapsedMs: number;
 }
 
 // Exponential-ish backoff schedule for transient DB lookup failures.
@@ -196,7 +218,7 @@ export async function shutdownApns(): Promise<void> {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-async function getTokenRegistrationsForSession(sessionId: string): Promise<TokenRegistration[]> {
+async function getTokenRegistrationsForSession(sessionId: string): Promise<LiveActivityTokenRegistration[]> {
   const rows = await db
     .select({ token: activityPushTokens.token, userId: activityPushTokens.userId })
     .from(activityPushTokens)
@@ -223,15 +245,107 @@ interface SendOptions {
   source?: SendSource;
 }
 
+function createDeliveryCounts(): DeliveryCounts {
+  return {
+    tokenCount: 0,
+    sentCount: 0,
+    failedCount: 0,
+    staleCount: 0,
+  };
+}
+
+function getDeliveryCountsForRegistration(
+  registration: LiveActivityTokenRegistration,
+  deliveryCountsByUserId: Map<string, DeliveryCounts>,
+  unattributedDeliveryCounts: DeliveryCounts,
+): DeliveryCounts {
+  if (!registration.userId) return unattributedDeliveryCounts;
+
+  const existingCounts = deliveryCountsByUserId.get(registration.userId);
+  if (existingCounts) return existingCounts;
+
+  const createdCounts = createDeliveryCounts();
+  deliveryCountsByUserId.set(registration.userId, createdCounts);
+  return createdCounts;
+}
+
+function trackPushDeliveryForRegistrations({
+  sessionId,
+  event,
+  source,
+  registrations,
+  sentDevices,
+  failedDevices,
+  staleDevices,
+  elapsedMs,
+}: DeliveryTrackingInput): void {
+  const registrationByToken = new Map(registrations.map((registration) => [registration.token, registration]));
+  const deliveryCountsByUserId = new Map<string, DeliveryCounts>();
+  const unattributedDeliveryCounts = createDeliveryCounts();
+
+  for (const registration of registrations) {
+    getDeliveryCountsForRegistration(registration, deliveryCountsByUserId, unattributedDeliveryCounts).tokenCount++;
+  }
+
+  for (const sentDevice of sentDevices) {
+    const registration = registrationByToken.get(sentDevice);
+    if (!registration) continue;
+    getDeliveryCountsForRegistration(registration, deliveryCountsByUserId, unattributedDeliveryCounts).sentCount++;
+  }
+
+  for (const failedDevice of failedDevices) {
+    const registration = registrationByToken.get(failedDevice);
+    if (!registration) continue;
+    const deliveryCounts = getDeliveryCountsForRegistration(
+      registration,
+      deliveryCountsByUserId,
+      unattributedDeliveryCounts,
+    );
+    deliveryCounts.failedCount++;
+    if (staleDevices.has(failedDevice)) {
+      deliveryCounts.staleCount++;
+    }
+  }
+
+  for (const [userId, deliveryCounts] of deliveryCountsByUserId.entries()) {
+    trackLiveActivityPushDelivery({
+      userId,
+      sessionId,
+      event,
+      source,
+      tokenCount: deliveryCounts.tokenCount,
+      sentCount: deliveryCounts.sentCount,
+      failedCount: deliveryCounts.failedCount,
+      staleCount: deliveryCounts.staleCount,
+      elapsedMs,
+    });
+  }
+
+  if (unattributedDeliveryCounts.tokenCount > 0) {
+    trackLiveActivityPushDeliveryAttributionGap({
+      sessionId,
+      event,
+      source,
+      reason: 'missing_user_id',
+      tokenCount: unattributedDeliveryCounts.tokenCount,
+      sentCount: unattributedDeliveryCounts.sentCount,
+      failedCount: unattributedDeliveryCounts.failedCount,
+      staleCount: unattributedDeliveryCounts.staleCount,
+      elapsedMs,
+    });
+  }
+}
+
 async function sendNotification(
   sessionId: string,
-  tokens: string[],
+  registrations: LiveActivityTokenRegistration[],
   event: 'update' | 'end',
   contentState?: LiveActivityContentState,
   options: SendOptions = {},
 ): Promise<{ sent: number; failed: number; stale: number }> {
-  if (!provider || tokens.length === 0) return { sent: 0, failed: 0, stale: 0 };
+  if (!provider || registrations.length === 0) return { sent: 0, failed: 0, stale: 0 };
 
+  const tokens = registrations.map((registration) => registration.token);
   metrics.sendsAttempted += tokens.length;
 
   const notification = new apn.Notification();
@@ -252,6 +366,7 @@ async function sendNotification(
 
   const startedAt = Date.now();
   let stale = 0;
+  const staleDevices = new Set<string>();
 
   try {
     const result = await provider.send(notification, tokens);
@@ -269,6 +384,7 @@ async function sendNotification(
 
         if (status === 410 || reason === 'BadDeviceToken' || reason === 'Unregistered' || reason === 'ExpiredToken') {
           stale++;
+          staleDevices.add(failure.device);
           staleTokenDeletions.push(deleteStaleToken(failure.device));
         } else {
           logger.error(
@@ -288,14 +404,14 @@ async function sendNotification(
         `tokens=${String(tokens.length)} sent=${String(sent)} failed=${String(failed)} stale=${String(stale)} ` +
         `elapsedMs=${String(Date.now() - startedAt)}`,
     );
-    trackLiveActivityPushDelivery({
+    trackPushDeliveryForRegistrations({
       sessionId,
       event,
       source: options.source ?? 'event',
-      tokenCount: tokens.length,
-      sentCount: sent,
-      failedCount: failed,
-      staleCount: stale,
+      registrations,
+      sentDevices: result.sent.map((sentDevice) => sentDevice.device),
+      failedDevices: result.failed.map((failedDevice) => failedDevice.device),
+      staleDevices,
       elapsedMs: Date.now() - startedAt,
     });
 
@@ -303,21 +419,21 @@ async function sendNotification(
   } catch (error) {
     metrics.sendsFailed += tokens.length;
     logger.error(`[APNs] Send error for session ${sessionId}:`, error);
-    trackLiveActivityPushDelivery({
+    trackPushDeliveryForRegistrations({
       sessionId,
       event,
       source: options.source ?? 'event',
-      tokenCount: tokens.length,
-      sentCount: 0,
-      failedCount: tokens.length,
-      staleCount: 0,
+      registrations,
+      sentDevices: [],
+      failedDevices: tokens,
+      staleDevices: new Set<string>(),
       elapsedMs: Date.now() - startedAt,
     });
     return { sent: 0, failed: tokens.length, stale: 0 };
   }
 }
 
-function trackSessionEndedForRegistrations(sessionId: string, registrations: TokenRegistration[]): void {
+function trackSessionEndedForRegistrations(sessionId: string, registrations: LiveActivityTokenRegistration[]): void {
   const tokenCountsByUserId = new Map<string, number>();
   for (const registration of registrations) {
     if (!registration.userId) continue;
@@ -350,7 +466,7 @@ async function executeDebouncedSend(sessionId: string): Promise<void> {
   const entry = pendingSends.get(sessionId);
   if (!entry) return;
 
-  let registrations: TokenRegistration[];
+  let registrations: LiveActivityTokenRegistration[];
   try {
     registrations = await getTokenRegistrationsForSession(sessionId);
   } catch (error) {
@@ -388,8 +504,7 @@ async function executeDebouncedSend(sessionId: string): Promise<void> {
 
   const source = entry.source;
   pendingSends.delete(sessionId);
-  const tokens = registrations.map((registration) => registration.token);
-  if (tokens.length === 0) {
+  if (registrations.length === 0) {
     // Demoted to debug because every queue event on a party session without an
     // iOS Live Activity device produces one of these. Multiplied by N backend
     // instances and M queue events/min, the info-level version was unreadable.
@@ -397,7 +512,7 @@ async function executeDebouncedSend(sessionId: string): Promise<void> {
     return;
   }
 
-  await sendNotification(sessionId, tokens, 'update', entry.latestState, { source });
+  await sendNotification(sessionId, registrations, 'update', entry.latestState, { source });
 }
 
 // ---------------------------------------------------------------------------
@@ -442,7 +557,7 @@ export function sendLiveActivityUpdate(
 }
 
 /**
- * Send an immediate Live Activity update to a specific set of tokens,
+ * Send an immediate Live Activity update to a specific set of token registrations,
  * bypassing the per-session debounce. Used right after a device registers a
  * push token so the lock-screen widget exits "Loading…" without waiting for
  * the next organic queue event.
@@ -452,13 +567,15 @@ export function sendLiveActivityUpdate(
  */
 export async function sendLiveActivityUpdateToTokens(
   sessionId: string,
-  tokens: string[],
+  registrations: LiveActivityTokenRegistration[],
   contentState: LiveActivityContentState,
   options: { source?: 'registration' | 'heartbeat' } = {},
 ): Promise<void> {
   if (!configured) return;
-  if (tokens.length === 0) return;
-  await sendNotification(sessionId, tokens, 'update', contentState, { source: options.source ?? 'registration' });
+  if (registrations.length === 0) return;
+  await sendNotification(sessionId, registrations, 'update', contentState, {
+    source: options.source ?? 'registration',
+  });
 }
 
 /**
@@ -475,16 +592,14 @@ export async function endLiveActivity(sessionId: string): Promise<void> {
     pendingSends.delete(sessionId);
   }
 
-  let registrations: TokenRegistration[] = [];
+  let registrations: LiveActivityTokenRegistration[] = [];
   try {
     registrations = await getTokenRegistrationsForSession(sessionId);
   } catch (error) {
     logger.error(`[APNs] endLiveActivity: token lookup failed for session ${sessionId}:`, error);
   }
-  const tokens = registrations.map((registration) => registration.token);
-
-  if (tokens.length > 0) {
-    await sendNotification(sessionId, tokens, 'end');
+  if (registrations.length > 0) {
+    await sendNotification(sessionId, registrations, 'end');
     trackSessionEndedForRegistrations(sessionId, registrations);
   } else {
     logger.debug(`[APNs] No registered Live Activity tokens for session ${sessionId}; skipping end`);

--- a/packages/web/e2e/app-store-screenshots.spec.ts
+++ b/packages/web/e2e/app-store-screenshots.spec.ts
@@ -22,9 +22,16 @@
  *   - 6.9" (iPhone 16 Pro Max): 1320x2868 -- App Store Connect accepts 6.5" for this slot
  *   - 12.9" iPad: 2048x2732 -- optional, not covered here
  */
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import path from 'path';
-import { drawer, waitForBoardListReady, waitForDrawerOpen, waitForSkeletonsGone } from './helpers/waits';
+import {
+  clickWithDomFallback,
+  clickUntilVisible,
+  drawer,
+  waitForBoardListReady,
+  waitForDrawerOpen,
+  waitForSkeletonsGone,
+} from './helpers/waits';
 
 const SCREENSHOT_DIR = path.resolve(__dirname, '../../../mobile/screenshots');
 const boardUrl = '/kilter/original/12x12-square/screw_bolt/40/list';
@@ -88,9 +95,11 @@ test.describe('App Store Screenshots', () => {
     // right state on both desktop and mobile without relying on dblclick.
     const thumbnail = page.locator('#onboarding-climb-card [data-testid="climb-thumbnail"]');
     await thumbnail.waitFor({ state: 'visible', timeout: 15_000 });
-    await thumbnail.click();
-
-    await waitForDrawerOpen(page, 0, 15_000);
+    await clickUntilVisible(page, thumbnail, drawer(page), {
+      clickTimeout: 3_000,
+      waitTimeout: 3_000,
+      maxAttempts: 6,
+    });
     // Board renderer fetches the layout SVG + hold images asynchronously after
     // the drawer animates in. Wait for the in-drawer skeletons to clear, then
     // a brief settle for SVG paint.
@@ -111,22 +120,25 @@ test.describe('App Store Screenshots', () => {
     await secondRow.waitFor({ state: 'visible', timeout: 15_000 });
 
     const queueBar = page.locator('[data-testid="queue-control-bar"]');
-    await firstRow.click();
-    await expect(queueBar).toBeVisible({ timeout: 10_000 });
-    await secondRow.click();
+    const selectedQueueClimb = queueBar.locator('#onboarding-queue-toggle').filter({ hasNotText: 'No climb selected' });
+    await clickUntilVisible(page, firstRow, selectedQueueClimb, { waitTimeout: 3_000 });
+    await clickWithDomFallback(page, secondRow);
     // Brief settle so the queue reducer applies the second add before the
     // third click — there's no per-add DOM signal that's safe to assert on
     // without depending on the climb name (varies per seed).
     await page.waitForTimeout(150);
-    await firstRow.click();
+    await clickWithDomFallback(page, firstRow);
     await page.waitForTimeout(150);
 
     // Open the play drawer (tap the thumbnail), then press the in-drawer
     // queue button so the screenshot shows the actual queue list, not the
     // climb browser with the queue bar at the bottom.
     const thumbnail = firstRow.locator('[data-testid="climb-thumbnail"]');
-    await thumbnail.click();
-    await waitForDrawerOpen(page, 0, 15_000);
+    await clickUntilVisible(page, thumbnail, drawer(page), {
+      clickTimeout: 3_000,
+      waitTimeout: 3_000,
+      maxAttempts: 6,
+    });
 
     await page.getByRole('button', { name: 'Open queue' }).click();
     // The queue drawer is the second swipeable drawer (stacked above play).

--- a/packages/web/e2e/help-screenshots.spec.ts
+++ b/packages/web/e2e/help-screenshots.spec.ts
@@ -19,7 +19,7 @@
  */
 import { test, expect } from '@playwright/test';
 import { openDummySesh } from './helpers/dummy-sesh';
-import { waitForBoardListReady, waitForDrawerOpen } from './helpers/waits';
+import { clickUntilVisible, drawer, waitForBoardListReady, waitForDrawerOpen } from './helpers/waits';
 
 const SCREENSHOT_DIR = 'public/help';
 const boardUrl = '/kilter/original/12x12-square/screw_bolt/40/list';
@@ -79,8 +79,11 @@ test.describe('Help Page Screenshots', () => {
     // the open-play-drawer event, so the play view shows climb details.
     const thumbnail = page.locator('#onboarding-climb-card [data-testid="climb-thumbnail"]');
     await thumbnail.waitFor({ state: 'visible', timeout: 15_000 });
-    await thumbnail.click();
-    await waitForDrawerOpen(page, 0, 15_000);
+    await clickUntilVisible(page, thumbnail, drawer(page), {
+      clickTimeout: 3_000,
+      waitTimeout: 3_000,
+      maxAttempts: 6,
+    });
     await page.screenshot({ path: `${SCREENSHOT_DIR}/climb-detail.png` });
   });
 
@@ -91,24 +94,27 @@ test.describe('Help Page Screenshots', () => {
     // container's dead space and often missed the onClick handler.
     const row = page.locator('#onboarding-climb-card');
     await row.waitFor({ state: 'visible', timeout: 15_000 });
-    await row.click();
 
     const queueBar = page.locator('[data-testid="queue-control-bar"]');
-    await expect(queueBar).toBeVisible({ timeout: 10_000 });
+    const selectedQueueClimb = queueBar.locator('#onboarding-queue-toggle').filter({ hasNotText: 'No climb selected' });
+    await clickUntilVisible(page, row, selectedQueueClimb, { waitTimeout: 3_000 });
 
-    await queueBar.getByText('Start sesh').click();
-    await waitForDrawerOpen(page);
+    const startSeshButton = queueBar.locator('[role="button"]').filter({ hasText: 'Start sesh' }).first();
+    await clickUntilVisible(page, startSeshButton, drawer(page), {
+      clickTimeout: 3_000,
+      waitTimeout: 3_000,
+    });
     await page.screenshot({ path: `${SCREENSHOT_DIR}/party-mode.png` });
   });
 
   test('login modal', async ({ page }) => {
     // Open user drawer → Sign in → auth modal with email/password form.
     const userMenu = page.getByLabel('User menu');
+    const signInButton = page.getByRole('button', { name: 'Sign in' });
+    const loginEmailInput = page.locator('input#login_email');
     await userMenu.waitFor({ state: 'visible', timeout: 15_000 });
-    await userMenu.click();
-    await page.getByRole('button', { name: 'Sign in' }).waitFor({ state: 'visible', timeout: 15_000 });
-    await page.getByRole('button', { name: 'Sign in' }).click();
-    await page.waitForSelector('input#login_email', { state: 'visible' });
+    await clickUntilVisible(page, userMenu, signInButton);
+    await clickUntilVisible(page, signInButton, loginEmailInput);
     await page.screenshot({ path: `${SCREENSHOT_DIR}/login-modal.png` });
   });
 });
@@ -133,13 +139,13 @@ test.describe('Help Page Screenshots - Authenticated', () => {
     // before this click; without it, the click can fire before the
     // header's onClick handler is mounted.
     const userMenu = page.getByLabel('User menu');
+    const signInButton = page.getByRole('button', { name: 'Sign in' });
+    const loginEmailInput = page.locator('input#login_email');
     await userMenu.waitFor({ state: 'visible', timeout: 15_000 });
-    await userMenu.click();
-    await page.getByRole('button', { name: 'Sign in' }).waitFor({ state: 'visible', timeout: 15_000 });
-    await page.getByRole('button', { name: 'Sign in' }).click();
-    await page.waitForSelector('input#login_email', { state: 'visible' });
+    await clickUntilVisible(page, userMenu, signInButton);
+    await clickUntilVisible(page, signInButton, loginEmailInput);
 
-    await page.locator('input#login_email').fill(testEmail);
+    await loginEmailInput.fill(testEmail);
     await page.locator('input#login_password').fill(testPassword);
     await page.locator('button[type="submit"]').filter({ hasText: 'Login' }).click();
 

--- a/packages/web/e2e/helpers/waits.ts
+++ b/packages/web/e2e/helpers/waits.ts
@@ -31,6 +31,89 @@ export async function waitForDrawerOpen(page: Page, index = 0, timeout = 10_000)
   await drawer(page, index).waitFor({ timeout });
 }
 
+export async function clickWithDomFallback(
+  page: Page,
+  trigger: Locator,
+  options: {
+    maxAttempts?: number;
+    clickTimeout?: number;
+    interAttemptMs?: number;
+  } = {},
+): Promise<void> {
+  const maxAttempts = options.maxAttempts ?? 4;
+  const clickTimeout = options.clickTimeout ?? 5_000;
+  const interAttemptMs = options.interAttemptMs ?? 250;
+  let lastFailure: unknown;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      await trigger.click({ timeout: clickTimeout });
+      return;
+    } catch (clickError) {
+      lastFailure = clickError;
+      try {
+        await trigger.evaluate((element: Element) => {
+          if (element instanceof HTMLElement) {
+            element.click();
+            return;
+          }
+          element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        });
+        return;
+      } catch (fallbackError) {
+        lastFailure = fallbackError;
+        if (attempt < maxAttempts - 1) {
+          await page.waitForTimeout(interAttemptMs);
+        }
+      }
+    }
+  }
+
+  if (lastFailure instanceof Error) {
+    throw lastFailure;
+  }
+  throw new Error('Click did not complete after repeated attempts');
+}
+
+export async function clickUntilVisible(
+  page: Page,
+  trigger: Locator,
+  target: Locator,
+  options: {
+    maxAttempts?: number;
+    clickTimeout?: number;
+    waitTimeout?: number;
+    interAttemptMs?: number;
+  } = {},
+): Promise<void> {
+  const maxAttempts = options.maxAttempts ?? 4;
+  const clickTimeout = options.clickTimeout ?? 5_000;
+  const waitTimeout = options.waitTimeout ?? 5_000;
+  const interAttemptMs = options.interAttemptMs ?? 250;
+  let lastFailure: unknown;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      await clickWithDomFallback(page, trigger, {
+        clickTimeout,
+        maxAttempts: 1,
+      });
+      await target.waitFor({ state: 'visible', timeout: waitTimeout });
+      return;
+    } catch (error) {
+      lastFailure = error;
+      if (attempt < maxAttempts - 1) {
+        await page.waitForTimeout(interAttemptMs);
+      }
+    }
+  }
+
+  if (lastFailure instanceof Error) {
+    throw lastFailure;
+  }
+  throw new Error('Target did not become visible after repeated clicks');
+}
+
 // Soft wait: if skeletons never fully unmount within the timeout, resolve
 // rather than throw. Boardsesh renders MUI Skeletons in two patterns:
 //   1. "page is loading data" — these unmount once the data arrives.


### PR DESCRIPTION
## Summary

- Attribute backend Live Activity push-delivery analytics to recipient users instead of the session aggregate.
- Carry `{ token, userId }` through immediate and debounced APNs sends so delivery counts can be grouped by owner.
- Add a Live Activity push-delivery attribution-gap event for token rows without a user id.

## Impact

PostHog `Live Activity Push Delivery` events now use the recipient `userId` as `distinctId` and include `userId` in properties. Multi-device or multi-user sends remain batched at APNs, but analytics are emitted once per recipient user with that user's token/sent/failed/stale counts.

## Validation

- `vp test run packages/backend/src/__tests__/apns-analytics.test.ts packages/backend/src/__tests__/push-tokens.test.ts packages/backend/src/__tests__/widget-navigate.test.ts`
- `vp run typecheck:backend`
- `vp check packages/backend/src/services/apns/index.ts packages/backend/src/services/analytics/live-activity.ts packages/backend/src/services/analytics/posthog.ts packages/backend/src/graphql/resolvers/sessions/push-tokens.ts packages/backend/src/__tests__/apns-analytics.test.ts packages/backend/src/__tests__/push-tokens.test.ts`

Full `vp check` is currently blocked by formatting issues in unmodified docs files: `docs/live-activity-board-control.md` and `docs/live-activity-push-testing.md`.