### PR TITLE
docs(lint): explain backend no-console override

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
       typeCheck: true,
     },
     overrides: [
+      // Backend uses the winston logger at packages/backend/src/utils/logger.ts.
+      // Block all console.* in production code; allow warn/error/info in tests
+      // (test infra emits orchestration noise via console).
+      // See docs/logging.md and commit f91697a.
       {
         files: ['packages/backend/src/**/*.ts'],
         rules: {


### PR DESCRIPTION
## Summary

The lint rule that blocks `console.*` in the backend already exists — it landed in commit f91697a alongside the move to winston. A recent review still surfaced a `console.error` comment, suggesting the rule isn't discoverable from the file it lives in (`vite.config.ts`, mixed in with task definitions). Add a four-line comment above the override so the next reader doesn't have to spelunk git history.

No rule changes. Verified the rule still fires by dropping `console.error('canary')` / `console.log('canary')` into `packages/backend/src/utils/logger.ts` and running `vp lint` — both flagged as `eslint(no-console)`.

### Why not a package-local `.oxlintrc.json`?

Tried it first (mirroring `packages/web/.oxlintrc.json`). Raw `oxlint` honors nested config discovery, but `vp lint` generates its oxlint invocation from `vite.config.ts` + root `.oxlintrc.json` only — 108 rules under `vp lint` vs 189 under raw `oxlint`. So nested package configs are silently ignored by the canonical `vp check` / pre-commit path. `vite.config.ts` `lint.overrides` is the only mechanism that actually fires.

## Test plan

- [ ] `vp lint packages/backend` passes (0 errors, pre-existing 29 warnings).
- [ ] Temporarily add `console.error('x')` to any non-test file under `packages/backend/src/**` — `vp lint` reports `eslint(no-console): Unexpected console statement`.
- [ ] Temporarily add `console.log('x')` to a test file under `packages/backend/src/__tests__/**` — also flagged (only warn/error/info are allowed in tests).

https://claude.ai/code/session_019Wtdyc63H36XBwjqUJVvLa

---
_Generated by [Claude Code](https://claude.ai/code/session_019Wtdyc63H36XBwjqUJVvLa)_