### PR TITLE
Phase 2 PR2: drawer lightbulb + non-driver swipe walks suggestions only

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -679,19 +679,31 @@ export const GraphQLQueueProvider = ({
     latestRef.current.fetchMoreClimbs();
   }, []);
 
-  const getNextClimbQueueItem = useCallback((options?: { from?: ClimbQueueItem | null }) => {
+  const getNextClimbQueueItem = useCallback((options?: { from?: ClimbQueueItem | null; suggestionsOnly?: boolean }) => {
     const r = latestRef.current;
     // `from` lets the drawer walk preview navigation from its locally-
     // displayed climb without first writing to state.currentClimbQueueItem.
     // Default anchor is the current wall climb, preserving existing callers.
+    //
+    // `suggestionsOnly` (queue-control-bar pivot, rule 5) is the non-driver
+    // swipe path: skip the shared queue entirely and walk only the
+    // suggested-climbs feed. The shared queue represents "climbs the driver
+    // is committed to," so a non-driver browsing it would scrub through
+    // someone else's plan; suggestedClimbs is the catalogue the user is
+    // already looking at and is the cleaner preview surface.
     const anchorUuid = options?.from ? options.from.uuid : r.state.currentClimbQueueItem?.uuid;
+    const anchorClimbUuid = options?.from ? options.from.climb?.uuid : r.state.currentClimbQueueItem?.climb?.uuid;
+    if (options?.suggestionsOnly) {
+      if (!r.suggestedClimbs || r.suggestedClimbs.length === 0) return null;
+      const nextClimb = r.suggestedClimbs.find((climb: Climb) => climb.uuid !== anchorClimbUuid);
+      return nextClimb ? createClimbQueueItem(nextClimb, r.clientId, r.currentUserInfo, true) : null;
+    }
     const queueItemIndex = r.state.queue.findIndex((queueItem: ClimbQueueItem) => queueItem.uuid === anchorUuid);
     if (
       (r.state.queue.length === 0 || r.state.queue.length <= queueItemIndex + 1) &&
       r.climbSearchResults &&
       r.climbSearchResults.length > 0
     ) {
-      const anchorClimbUuid = options?.from ? options.from.climb?.uuid : r.state.currentClimbQueueItem?.climb?.uuid;
       const nextClimb = r.suggestedClimbs.find(
         (climb: Climb) =>
           climb.uuid !== anchorClimbUuid &&
@@ -702,12 +714,28 @@ export const GraphQLQueueProvider = ({
     return queueItemIndex >= r.state.queue.length - 1 ? null : r.state.queue[queueItemIndex + 1];
   }, []);
 
-  const getPreviousClimbQueueItem = useCallback((options?: { from?: ClimbQueueItem | null }) => {
-    const r = latestRef.current;
-    const anchorUuid = options?.from ? options.from.uuid : r.state.currentClimbQueueItem?.uuid;
-    const queueItemIndex = r.state.queue.findIndex((queueItem: ClimbQueueItem) => queueItem.uuid === anchorUuid);
-    return queueItemIndex > 0 ? r.state.queue[queueItemIndex - 1] : null;
-  }, []);
+  const getPreviousClimbQueueItem = useCallback(
+    (options?: { from?: ClimbQueueItem | null; suggestionsOnly?: boolean }) => {
+      const r = latestRef.current;
+      const anchorUuid = options?.from ? options.from.uuid : r.state.currentClimbQueueItem?.uuid;
+      const anchorClimbUuid = options?.from ? options.from.climb?.uuid : r.state.currentClimbQueueItem?.climb?.uuid;
+      if (options?.suggestionsOnly) {
+        // Non-driver previous: walk the suggestedClimbs array backwards.
+        // No fall-through into the queue — that would let a non-driver scrub
+        // backwards through someone else's committed plan.
+        if (!r.suggestedClimbs || r.suggestedClimbs.length === 0) return null;
+        const anchorIdx = r.suggestedClimbs.findIndex((climb: Climb) => climb.uuid === anchorClimbUuid);
+        // If the anchor isn't in suggestedClimbs (e.g. anchor is a queue
+        // item, not a suggestion), there's no meaningful "previous suggestion."
+        if (anchorIdx <= 0) return null;
+        const prevClimb = r.suggestedClimbs[anchorIdx - 1];
+        return prevClimb ? createClimbQueueItem(prevClimb, r.clientId, r.currentUserInfo, true) : null;
+      }
+      const queueItemIndex = r.state.queue.findIndex((queueItem: ClimbQueueItem) => queueItem.uuid === anchorUuid);
+      return queueItemIndex > 0 ? r.state.queue[queueItemIndex - 1] : null;
+    },
+    [],
+  );
 
   // Optimistic dispatch for widget navigation (Next/Previous from Live Activity).
   // The native WebSocket already sent the server mutation, so we only need to

--- a/packages/web/app/components/play-view/__tests__/play-view-action-bar.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/play-view-action-bar.test.tsx
@@ -70,6 +70,9 @@ function buildProps(
     onToggleFavorite: vi.fn(),
     onOpenActions: vi.fn(),
     onOpenQueue: vi.fn(),
+    isDriver: true,
+    displayedClimbName: 'Test Climb',
+    onLightbulb: vi.fn(),
     ...overrides,
   };
 }

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -12,6 +12,8 @@ import FavoriteBorderOutlined from '@mui/icons-material/FavoriteBorderOutlined';
 import Favorite from '@mui/icons-material/Favorite';
 import SkipPreviousOutlined from '@mui/icons-material/SkipPreviousOutlined';
 import SkipNextOutlined from '@mui/icons-material/SkipNextOutlined';
+import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
+import Lightbulb from '@mui/icons-material/Lightbulb';
 import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import KeyboardArrowUpOutlined from '@mui/icons-material/KeyboardArrowUpOutlined';
@@ -103,6 +105,19 @@ type PlayViewActionBarProps = {
   onToggleFavorite: () => void;
   onOpenActions: () => void;
   onOpenQueue: () => void;
+  /** Whether the local user currently drives the wall. Drives the lightbulb
+   *  visual (filled vs outlined). True in solo regardless. Prev/next stay
+   *  visible to everyone in the drawer — Phase 1 already makes them
+   *  preview-only in party (drawer-local state, no broadcast), so non-drivers
+   *  can still scrub through nearby climbs without yanking the wall. */
+  isDriver: boolean;
+  /** Name of the currently displayed climb. Used in the lightbulb's aria
+   *  label so screen-reader users hear what they're sending. */
+  displayedClimbName: string | null;
+  /** Pivot's lightbulb gesture: in solo it sends the climb to the wall via
+   *  the existing BLE auto-sender path; in party it claims driver and
+   *  broadcasts the climb. */
+  onLightbulb: () => void;
   angleSelector?: React.ReactNode;
 };
 
@@ -119,9 +134,21 @@ export const PlayViewActionBar = React.memo(function PlayViewActionBar({
   onToggleFavorite,
   onOpenActions,
   onOpenQueue,
+  isDriver,
+  displayedClimbName,
+  onLightbulb,
   angleSelector,
 }: PlayViewActionBarProps) {
   const { t } = useTranslation('session');
+  // Lightbulb aria label per spec — driver vs non-driver framing makes the
+  // action's destructive-vs-additive nature explicit for screen readers.
+  const lightbulbLabel = displayedClimbName
+    ? isDriver
+      ? `Send '${displayedClimbName}' to the wall`
+      : `Take wall control and send '${displayedClimbName}'`
+    : isDriver
+      ? 'Send to the wall'
+      : 'Take wall control';
   return (
     <div className={styles.actionBar}>
       <IconButton disabled={!canSwipePrevious} onClick={onPrevClick}>
@@ -147,6 +174,12 @@ export const PlayViewActionBar = React.memo(function PlayViewActionBar({
       )}
       <IconButton onClick={onToggleFavorite}>
         {isFavorited ? <Favorite sx={{ color: themeTokens.colors.error }} /> : <FavoriteBorderOutlined />}
+      </IconButton>
+      {/* Lightbulb: the queue-control-bar pivot's primary "send/take" gesture.
+          Filled when the local user is driving (in solo this is always true);
+          outlined when someone else holds the wall (party non-driver). */}
+      <IconButton onClick={onLightbulb} aria-label={lightbulbLabel} color={isDriver ? 'primary' : 'default'}>
+        {isDriver ? <Lightbulb /> : <LightbulbOutlined />}
       </IconButton>
       <ShareBoardButton />
       {angleSelector}
@@ -494,8 +527,9 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
 
   const { currentClimbQueueItem } = isOpen ? currentClimbData : deferredCurrentClimb;
   const { queue } = isOpen ? queueListData : deferredQueue;
-  const { viewOnlyMode, isPersistentSessionActive } = isOpen ? sessionData : deferredSession;
-  const { mirrorClimb, getNextClimbQueueItem, getPreviousClimbQueueItem, setCurrentClimbQueueItem } = useQueueActions();
+  const { viewOnlyMode, isPersistentSessionActive, isDriver } = isOpen ? sessionData : deferredSession;
+  const { mirrorClimb, getNextClimbQueueItem, getPreviousClimbQueueItem, setCurrentClimbQueueItem, takeControl } =
+    useQueueActions();
 
   // In a party session, the drawer-local `drawerDisplayedItem` (set by browse
   // callers via the open-drawer event payload) takes precedence over the wall
@@ -560,9 +594,16 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   // Card-swipe navigation. In an active party session, prev/next walks the
   // drawer-local preview state without broadcasting (browse-doesn't-yank). In
   // solo, it mutates the wall climb like today so BLE keeps sending.
+  //
+  // Non-driver swipe (party + isDriver===false): walks the suggested-climbs
+  // feed only — skip the shared queue, which is "the climbs the driver
+  // committed to" and not a non-driver's preview surface (pivot rule 5).
+  // Drivers (and solo, where isDriver is always true) get the existing
+  // queue → suggestions fall-through.
   const navigateFromItem = effectiveItem ?? null;
-  const nextItem = getNextClimbQueueItem({ from: navigateFromItem });
-  const prevItem = getPreviousClimbQueueItem({ from: navigateFromItem });
+  const swipeSuggestionsOnly = isPersistentSessionActive && !isDriver;
+  const nextItem = getNextClimbQueueItem({ from: navigateFromItem, suggestionsOnly: swipeSuggestionsOnly });
+  const prevItem = getPreviousClimbQueueItem({ from: navigateFromItem, suggestionsOnly: swipeSuggestionsOnly });
 
   const advanceTo = useCallback(
     (item: ClimbQueueItem, method: string, direction: 'next' | 'previous') => {
@@ -578,16 +619,16 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   );
 
   const handleSwipeNext = useCallback(() => {
-    const next = getNextClimbQueueItem({ from: navigateFromItem });
+    const next = getNextClimbQueueItem({ from: navigateFromItem, suggestionsOnly: swipeSuggestionsOnly });
     if (!next || viewOnlyMode) return;
     advanceTo(next, 'swipePlayViewDrawer', 'next');
-  }, [getNextClimbQueueItem, navigateFromItem, viewOnlyMode, advanceTo]);
+  }, [getNextClimbQueueItem, navigateFromItem, swipeSuggestionsOnly, viewOnlyMode, advanceTo]);
 
   const handleSwipePrevious = useCallback(() => {
-    const prev = getPreviousClimbQueueItem({ from: navigateFromItem });
+    const prev = getPreviousClimbQueueItem({ from: navigateFromItem, suggestionsOnly: swipeSuggestionsOnly });
     if (!prev || viewOnlyMode) return;
     advanceTo(prev, 'swipePlayViewDrawer', 'previous');
-  }, [getPreviousClimbQueueItem, navigateFromItem, viewOnlyMode, advanceTo]);
+  }, [getPreviousClimbQueueItem, navigateFromItem, swipeSuggestionsOnly, viewOnlyMode, advanceTo]);
 
   const canSwipeNext = !viewOnlyMode && !!nextItem;
   const canSwipePrevious = !viewOnlyMode && !!prevItem;
@@ -612,15 +653,36 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   }, [showMessage, t]);
 
   const handlePrevNavClick = useCallback(() => {
-    const prev = getPreviousClimbQueueItem({ from: navigateFromItem });
+    const prev = getPreviousClimbQueueItem({ from: navigateFromItem, suggestionsOnly: swipeSuggestionsOnly });
     if (!prev) return;
     advanceTo(prev, 'playViewDrawer', 'previous');
-  }, [getPreviousClimbQueueItem, navigateFromItem, advanceTo]);
+  }, [getPreviousClimbQueueItem, navigateFromItem, swipeSuggestionsOnly, advanceTo]);
+  /**
+   * Lightbulb press: the queue-control-bar pivot's primary "send/take" gesture.
+   * Routes through `queueActions.takeControl(climb)`, which:
+   *  - In solo: degrades to the existing setCurrentClimb path (the BLE
+   *    auto-sender picks up the climb-change and sends frames).
+   *  - In party + non-driver: claims driver via the new takeControl mutation
+   *    AND broadcasts the climb as the new wall climb. Yanks any prior driver.
+   *  - In party + driver: re-broadcasts the climb (the resolver's atomic-swap
+   *    suppresses the redundant DriverChanged event; CurrentClimbChanged still
+   *    fires so peers see the new wall climb).
+   */
+  const handleLightbulbClick = useCallback(() => {
+    if (!currentClimb) return;
+    void takeControl(currentClimb);
+    track('Wall Control Taken', {
+      source: 'lightbulb_drawer',
+      previousDriver: isDriver ? 'self' : 'other',
+      mode: isPersistentSessionActive ? 'party' : 'solo',
+      climbUuid: currentClimb.uuid,
+    });
+  }, [currentClimb, takeControl, isDriver, isPersistentSessionActive]);
   const handleNextNavClick = useCallback(() => {
-    const next = getNextClimbQueueItem({ from: navigateFromItem });
+    const next = getNextClimbQueueItem({ from: navigateFromItem, suggestionsOnly: swipeSuggestionsOnly });
     if (!next) return;
     advanceTo(next, 'playViewDrawer', 'next');
-  }, [getNextClimbQueueItem, navigateFromItem, advanceTo]);
+  }, [getNextClimbQueueItem, navigateFromItem, swipeSuggestionsOnly, advanceTo]);
   const handleOpenActionsMenu = useCallback(() => {
     setIsQueueOpen(false);
     setIsPlaylistSelectorOpen(false);
@@ -881,6 +943,9 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
             onToggleFavorite={toggleFavorite}
             onOpenActions={handleOpenActionsMenu}
             onOpenQueue={handleOpenQueueDrawer}
+            isDriver={isDriver}
+            displayedClimbName={currentClimb?.name ?? null}
+            onLightbulb={handleLightbulbClick}
             angleSelector={
               <AngleSelector
                 boardName={boardDetails.board_name}
@@ -921,6 +986,8 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     toggleFavorite,
     handleOpenActionsMenu,
     handleOpenQueueDrawer,
+    isDriver,
+    handleLightbulbClick,
     angle,
     handleTickBarClose,
     handleTickBarError,

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -205,19 +205,30 @@ function usePersistentSessionQueueAdapter(): {
     return false;
   }, []);
 
-  const getNextClimbQueueItem = useCallback((options?: { from?: ClimbQueueItem | null }): ClimbQueueItem | null => {
-    const { queue, currentClimbQueueItem: current } = latestRef.current;
-    const anchorUuid = options?.from ? options.from.uuid : current?.uuid;
-    const idx = queue.findIndex(({ uuid }) => uuid === anchorUuid);
-    return idx >= 0 && idx < queue.length - 1 ? queue[idx + 1] : null;
-  }, []);
+  // Bridge-mode nav is queue-only (no search results plumbed through here),
+  // so suggestionsOnly is a no-op in this adapter — return null instead of
+  // a queue item. The drawer is the only caller passing suggestionsOnly today.
+  const getNextClimbQueueItem = useCallback(
+    (options?: { from?: ClimbQueueItem | null; suggestionsOnly?: boolean }): ClimbQueueItem | null => {
+      if (options?.suggestionsOnly) return null;
+      const { queue, currentClimbQueueItem: current } = latestRef.current;
+      const anchorUuid = options?.from ? options.from.uuid : current?.uuid;
+      const idx = queue.findIndex(({ uuid }) => uuid === anchorUuid);
+      return idx >= 0 && idx < queue.length - 1 ? queue[idx + 1] : null;
+    },
+    [],
+  );
 
-  const getPreviousClimbQueueItem = useCallback((options?: { from?: ClimbQueueItem | null }): ClimbQueueItem | null => {
-    const { queue, currentClimbQueueItem: current } = latestRef.current;
-    const anchorUuid = options?.from ? options.from.uuid : current?.uuid;
-    const idx = queue.findIndex(({ uuid }) => uuid === anchorUuid);
-    return idx > 0 ? queue[idx - 1] : null;
-  }, []);
+  const getPreviousClimbQueueItem = useCallback(
+    (options?: { from?: ClimbQueueItem | null; suggestionsOnly?: boolean }): ClimbQueueItem | null => {
+      if (options?.suggestionsOnly) return null;
+      const { queue, currentClimbQueueItem: current } = latestRef.current;
+      const anchorUuid = options?.from ? options.from.uuid : current?.uuid;
+      const idx = queue.findIndex(({ uuid }) => uuid === anchorUuid);
+      return idx > 0 ? queue[idx - 1] : null;
+    },
+    [],
+  );
 
   const setCurrentClimbQueueItem = useCallback((item: ClimbQueueItem) => {
     const { queue, currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;

--- a/packages/web/app/components/queue-control/types.ts
+++ b/packages/web/app/components/queue-control/types.ts
@@ -108,11 +108,24 @@ export type QueueActionsType = {
   fetchMoreClimbs: () => void;
   /** Returns the next ClimbQueueItem after `from` (defaults to the current
    *  wall climb). Walks the shared queue first, then falls through to
-   *  suggested climbs once the queue is exhausted. */
-  getNextClimbQueueItem: (options?: { from?: ClimbQueueItem | null }) => ClimbQueueItem | null;
+   *  suggested climbs once the queue is exhausted.
+   *
+   *  Pass `suggestionsOnly: true` to skip the shared queue entirely and walk
+   *  only the suggested-climbs feed — the non-driver swipe path in party
+   *  (the shared queue is "what the driver committed to," not a non-driver's
+   *  browsing surface). */
+  getNextClimbQueueItem: (options?: {
+    from?: ClimbQueueItem | null;
+    suggestionsOnly?: boolean;
+  }) => ClimbQueueItem | null;
   /** Returns the previous ClimbQueueItem before `from` (defaults to the
-   *  current wall climb). Does not walk into suggestions. */
-  getPreviousClimbQueueItem: (options?: { from?: ClimbQueueItem | null }) => ClimbQueueItem | null;
+   *  current wall climb). Default walks the queue only (no suggestions
+   *  fall-through). With `suggestionsOnly: true`, walks `suggestedClimbs`
+   *  backwards instead — used by the non-driver swipe-back path. */
+  getPreviousClimbQueueItem: (options?: {
+    from?: ClimbQueueItem | null;
+    suggestionsOnly?: boolean;
+  }) => ClimbQueueItem | null;
   setQueue: (queue: ClimbQueueItem[]) => void;
   disconnect?: () => void;
   /** Dispatch an optimistic current-climb update from a native widget navigation.


### PR DESCRIPTION
## Summary

PR 2 of 3 in the queue-control-bar pivot. Wires up the user-facing **lightbulb gesture** in the Play View Drawer and splits the drawer's swipe surface for **non-drivers in party** so they preview the catalogue through `suggestedClimbs` instead of scrubbing through the shared queue.

Targets PR #2195 (driver state foundation). PR 3 (bar lightbulb + 3s hold-to-confirm + wall-view drawer + renames) follows on top of this branch.

## Lightbulb in the drawer's action bar

- **Filled** (`color=primary`) when local user is driving (in solo, `isDriver` is always true); **outlined** when someone else holds.
- `onClick` → `queueActions.takeControl(currentClimb)`.
  - **Solo**: degrades to the existing `setCurrentClimb` path; BLE auto-sender picks up the climb-change and sends frames.
  - **Party + non-driver**: claims driver and broadcasts the climb in one round trip via PR 1's `takeControl` mutation.
  - **Party + driver**: broadcasts the climb. The resolver's atomic swap suppresses the redundant `DriverChanged` event; `CurrentClimbChanged` still fires so peers see the new wall climb.
- a11y label varies by driver state per spec: `"Send '{climb}' to the wall"` vs `"Take wall control and send '{climb}'"`.

## Non-driver drawer swipe + prev/next walk `suggestedClimbs` only

Pivot rule 5: the shared queue is "the climbs the driver committed to," not a non-driver's preview surface. Drivers (and solo, where `isDriver` is always true) keep the existing queue → suggestions fall-through.

- `getNextClimbQueueItem` / `getPreviousClimbQueueItem` gain a `suggestionsOnly` option that walks `suggestedClimbs` only (no queue, no fall-through).
- Drawer's swipe + prev/next handlers pass `suggestionsOnly: true` when in party + `!isDriver`. Phase 1's preview-vs-broadcast fork in `advanceTo` is unchanged.

Drawer prev/next stays visible to everyone — Phase 1 already makes the click preview-only in party, so non-drivers scrubbing through suggestions doesn't yank the wall.

## What's NOT in this PR

PR 3 lands the bar-side work:
- Bar lightbulb visual + driver-first AvatarGroup + lightbulb badge on driver
- 3-second press-and-hold on bar prev/next for non-drivers with snackbar countdown
- Wall-view drawer mode (tap the bar body)
- `Set Active Climb` → "Send to board" rename (extract hardcoded labels to i18n)
- `Queue` → "Up next" rename across en-US i18n keys
- Delete the play-view drawer bounce hint + `swipeHint:playViewSeen` preference
- First-run lightbulb coachmark + `swipeHint:lightbulbSeen` preference

## Test plan

- [x] Typecheck clean
- [ ] Manual: solo, BLE connected — open drawer on a climb, press lightbulb → wall lights up. Identical to today's "Set Active Climb" flow.
- [ ] Manual: party, not driving — open drawer, swipe left/right → preview walks `suggestedClimbs` only (does NOT touch the shared queue, does NOT broadcast). Other phones see nothing.
- [ ] Manual: party, not driving — press lightbulb in drawer → wall changes to that climb on all phones, you become the driver, other phones see `DriverChanged` event.
- [ ] Manual: party, driving — press lightbulb on a different climb → wall changes, you stay driver (no redundant `DriverChanged`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)