### PR TITLE
fix(android): stop safe-area plugin keyboard padding from collapsing dvh layout

### DIFF
--- a/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
+++ b/mobile/android/app/src/main/java/com/boardsesh/app/MainActivity.java
@@ -19,6 +19,9 @@ import android.webkit.WebView;
 
 import androidx.activity.EdgeToEdge;
 import androidx.annotation.NonNull;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import com.boardsesh.app.plugins.DevUrlPlugin;
 import com.getcapacitor.Bridge;
@@ -55,6 +58,34 @@ public class MainActivity extends BridgeActivity {
         // any other App Link) never lands. Mirror SceneDelegate.swift on iOS by
         // forwarding the intent URL into the WebView ourselves.
         loadDeepLinkIfPresent(getIntent(), webView);
+
+        // The safe-area plugin (8.0.x) pads the DecorView by imeInsets.bottom on
+        // Chrome >= 140, which physically shrinks window.innerHeight when the keyboard
+        // opens. This overrides interactiveWidget: 'resizes-visual' (set in the
+        // viewport meta) because the browser treats it as a physical window resize,
+        // not a virtual keyboard event — collapsing all dvh-based layouts.
+        // Chrome 140+ handles keyboard insets natively via interactiveWidget, so the
+        // physical padding is not needed. Override the listener here (after super.onCreate
+        // which loads plugins) to pass system bar insets through — preserving
+        // env(safe-area-inset-*) — without applying keyboard padding.
+        disableSafeAreaKeyboardPadding();
+    }
+
+    private void disableSafeAreaKeyboardPadding() {
+        android.view.View decorView = getWindow().getDecorView();
+        ViewCompat.setOnApplyWindowInsetsListener(decorView, (v, windowInsets) -> {
+            Insets systemBarsInsets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout()
+            );
+            v.setPadding(0, 0, 0, 0);
+            return new WindowInsetsCompat.Builder(windowInsets)
+                .setInsets(
+                    WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(),
+                    Insets.of(systemBarsInsets.left, systemBarsInsets.top,
+                              systemBarsInsets.right, systemBarsInsets.bottom)
+                )
+                .build();
+        });
     }
 
     @Override


### PR DESCRIPTION
## Summary

- The \`@capacitor-community/safe-area\` plugin (v8.0.x) sets a physical bottom padding on the \`DecorView\` equal to \`imeInsets.bottom\` for Chrome >= 140
- Chrome treats this as a physical window resize, so \`interactiveWidget: 'resizes-visual'\` (set in the viewport meta) has no effect — \`window.innerHeight\` drops from ~986px to ~243px when the keyboard opens, collapsing every \`dvh\`-based layout
- Fix: override the \`DecorView\`'s \`OnApplyWindowInsetsListener\` in \`onCreate()\` after \`super.onCreate()\` (which loads plugins) to pass system bar insets through unchanged while zeroing physical padding — Chrome 140+ handles keyboard insets natively

## Context

Issue #1808 was correctly fixed by removing \`@capacitor/keyboard\` + \`adjustResize\`. That commit's explanation stated the safe-area plugin's DecorView padding would work correctly alongside \`interactiveWidget: 'resizes-visual'\`. In practice it does not: the physical padding causes Chrome to fire a window resize event (not a virtual keyboard event), bypassing \`interactiveWidget\` entirely. Tested on a Pixel 10 Pro XL with Chrome 148 — \`window.innerHeight\` 986px → 243px without this fix, ~986px → ~600px (correct overlay behavior) with it.

## Test plan

- [ ] Build debug APK: \`./gradlew assembleDebug\` from \`mobile/android/\`
- [ ] Install on Android device (Chrome 140+)
- [ ] Tap a text field — layout should stay full height, keyboard overlays
- [ ] Verify \`window.innerHeight\` stays ~986px via \`chrome://inspect/#devices\` Console (was 243px before this fix)
- [ ] Verify \`env(safe-area-inset-top/bottom)\` still reflects status bar / nav bar heights
- [ ] Verify bottom tab bar stays fixed at bottom when keyboard is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)