### PR TITLE
perf: roll out IDB-persisted React Query cache across the web UI

### DIFF
--- a/packages/web/app/components/activity-feed/activity-feed.tsx
+++ b/packages/web/app/components/activity-feed/activity-feed.tsx
@@ -9,6 +9,7 @@ import PersonSearchOutlined from '@mui/icons-material/PersonSearchOutlined';
 import PublicOutlined from '@mui/icons-material/PublicOutlined';
 import ErrorOutline from '@mui/icons-material/ErrorOutline';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { persistUser } from '@/app/lib/react-query-persist-meta';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -69,7 +70,12 @@ export default function ActivityFeed({
       return lastPage.cursor ?? undefined;
     },
     enabled: isAuthenticated ? !!token : true,
-    staleTime: isAuthenticated ? 60 * 1000 : 24 * 60 * 60 * 1000,
+    staleTime: isAuthenticated ? 5 * 60 * 1000 : 24 * 60 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    // Only persist the signed-in viewer's feed; public reads can vary by viewer
+    // identity (block lists etc.) and aren't worth bothering with IDB for.
+    meta: isAuthenticated ? persistUser : undefined,
     ...(hasInitialData
       ? {
           initialData: {

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -17,6 +17,7 @@ import { PersonFallingIcon } from '@/app/components/icons/person-falling-icon';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { persistUser } from '@/app/lib/react-query-persist-meta';
 import type { TFunction } from 'i18next';
 import { formatTickRelativeTime, tickTimeMs } from '@/app/lib/format-tick-time';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -279,7 +280,10 @@ export const AscentsFeed: React.FC<AscentsFeedProps> = ({ userId, pageSize = 10,
       if (!lastPage.hasMore) return undefined;
       return lastPageParam + lastPage.groups.length;
     },
-    staleTime: 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistUser,
   });
 
   const groups: GroupedAscentFeedItem[] = useMemo(() => data?.pages.flatMap((p) => p.groups) ?? [], [data]);

--- a/packages/web/app/components/activity-feed/comment-feed.tsx
+++ b/packages/web/app/components/activity-feed/comment-feed.tsx
@@ -16,6 +16,7 @@ import LocaleLink from '@/app/components/i18n/locale-link';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { persistShared } from '@/app/lib/react-query-persist-meta';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -74,7 +75,10 @@ export default function CommentFeed({ isAuthenticated, boardUuid }: CommentFeedP
       return lastPage.cursor ?? undefined;
     },
     enabled: isAuthenticated ? !!token : true,
-    staleTime: 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistShared,
   });
 
   const comments: CommentType[] = useMemo(() => data?.pages.flatMap((p) => p.comments) ?? [], [data]);

--- a/packages/web/app/components/activity-feed/comment-feed.tsx
+++ b/packages/web/app/components/activity-feed/comment-feed.tsx
@@ -16,7 +16,7 @@ import LocaleLink from '@/app/components/i18n/locale-link';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { persistShared } from '@/app/lib/react-query-persist-meta';
+import { persistUser } from '@/app/lib/react-query-persist-meta';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -78,7 +78,10 @@ export default function CommentFeed({ isAuthenticated, boardUuid }: CommentFeedP
     staleTime: 5 * 60 * 1000,
     gcTime: 24 * 60 * 60 * 1000,
     refetchOnMount: 'always',
-    meta: persistShared,
+    // Per-row userVote is viewer-specific, so persist per-user (the shared
+    // store is not wiped on account switch and would leak vote state across
+    // identities for the restored frame).
+    meta: persistUser,
   });
 
   const comments: CommentType[] = useMemo(() => data?.pages.flatMap((p) => p.comments) ?? [], [data]);

--- a/packages/web/app/components/board-page/angle-selector.tsx
+++ b/packages/web/app/components/board-page/angle-selector.tsx
@@ -17,6 +17,7 @@ import type { BoardName, BoardDetails, Climb } from '@/app/lib/types';
 import type { ClimbStatsForAngle } from '@/app/lib/data/queries';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
+import { persistShared } from '@/app/lib/react-query-persist-meta';
 import DrawerClimbHeader from '../climb-card/drawer-climb-header';
 import { useTranslation } from 'react-i18next';
 import styles from './angle-selector.module.css';
@@ -51,6 +52,9 @@ export default function AngleSelector({
     queryFn: () => fetch(`/api/v1/${boardName}/climb-stats/${currentClimb!.uuid}`).then((res) => res.json()),
     enabled: !!currentClimb && isDrawerOpen,
     staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistShared,
   });
 
   // Create a map for easy lookup of stats by angle

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import BottomNavigation from '@mui/material/BottomNavigation';
 import BottomNavigationAction from '@mui/material/BottomNavigationAction';
@@ -28,6 +28,7 @@ import { useColorMode } from '@/app/hooks/use-color-mode';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { usePersistentSessionState } from '../persistent-session';
 import { getLastUsedBoard } from '@/app/lib/last-used-board-db';
+import { getPreference } from '@/app/lib/user-preferences-db';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import BoardDiscoveryScroll from '../board-scroll/board-discovery-scroll';
 import BoardSelectorDrawer from '../board-selector-drawer/board-selector-drawer';
@@ -112,6 +113,21 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
 
   // Determine active tab from pathname
   const activeTab = getActiveTab(pathname);
+
+  // Resume the user on whichever /you sub-tab they had open last time. While on
+  // a /you path we use that path directly so re-tapping the icon is a no-op
+  // navigation; otherwise we fall back to the persisted preference. The IDB
+  // read is fast but async, so the link briefly points at /you on first paint
+  // before settling on the resumed sub-tab — acceptable since the icon and
+  // label don't change.
+  const [resumedYouHref, setResumedYouHref] = useState('/you');
+  useEffect(() => {
+    if (pathname.startsWith('/you')) return;
+    void getPreference('youLastTab').then((tab) => {
+      setResumedYouHref(tab === 'logbook' || tab === 'sessions' ? `/you/${tab}` : '/you');
+    });
+  }, [pathname]);
+  const youHref = pathname.startsWith('/you') ? pathname : resumedYouHref;
 
   // Build URLs using effective board details
   // If we're on a /b/ slug route, preserve the slug URL format
@@ -373,7 +389,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           icon={<PersonOutlined sx={{ fontSize: 20 }} />}
           value="you"
           component={LocaleLink}
-          href="/you"
+          href={youHref}
           onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
             // During the session-loading window we don't yet know whether the
             // user is signed in. Let Next.js navigate to /you; the layout
@@ -384,7 +400,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
                 title: t('bottomTabBar.youSignInTitle'),
                 description: t('bottomTabBar.youSignInDescription'),
                 onSuccess: () => {
-                  router.push('/you');
+                  router.push(youHref);
                 },
               });
               return;

--- a/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
+++ b/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
+import { persistShared } from '@/app/lib/react-query-persist-meta';
 import VideocamOutlined from '@mui/icons-material/VideocamOutlined';
 import Box from '@mui/material/Box';
 import type { CollapsibleSectionConfig } from '@/app/components/collapsible-section/collapsible-section';
@@ -83,6 +84,9 @@ export function useBuildClimbDetailSections({
     },
     enabled: enabledProp && !!climbUuid,
     staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistShared,
   });
   const dedupedBetaLinks = useMemo(() => dedupeBetaLinks(betaLinks), [betaLinks]);
   const betaCount = dedupedBetaLinks.length;

--- a/packages/web/app/components/create-climb/drafts-drawer.tsx
+++ b/packages/web/app/components/create-climb/drafts-drawer.tsx
@@ -9,6 +9,7 @@ import IconButton from '@mui/material/IconButton';
 import MuiTooltip from '@mui/material/Tooltip';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { persistUser } from '@/app/lib/react-query-persist-meta';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import ClimbListItem from '../climb-card/climb-list-item';
@@ -178,6 +179,10 @@ const DraftsDrawer: React.FC<DraftsDrawerProps> = ({
       return result.searchClimbs.climbs;
     },
     refetchOnWindowFocus: false,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistUser,
   });
 
   const deleteDraftMutation = useMutation({

--- a/packages/web/app/components/gym-entity/gym-selector.tsx
+++ b/packages/web/app/components/gym-entity/gym-selector.tsx
@@ -12,6 +12,7 @@ import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { GET_MY_GYMS, type GetMyGymsQueryVariables, type GetMyGymsQueryResponse } from '@/app/lib/graphql/operations';
 import type { Gym } from '@boardsesh/shared-schema';
+import { persistUser } from '@/app/lib/react-query-persist-meta';
 import CreateGymForm from './create-gym-form';
 
 type GymSelectorProps = {
@@ -36,6 +37,9 @@ export default function GymSelector({ selectedGymUuid, onSelect }: GymSelectorPr
     },
     enabled: !!token,
     staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistUser,
   });
 
   const gyms = data ?? [];

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/app/lib/logbook-preferences';
 import { readFiltersFromQuery, readSortFromQuery, filtersToQueryParams } from '@/app/lib/logbook-url-utils';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
+import { persistUser } from '@/app/lib/react-query-persist-meta';
 import { getBackendHttpUrl } from '@/app/lib/backend-url';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
@@ -446,7 +447,10 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
       return lastPageParam + lastPage.items.length;
     },
     enabled: !!userId && !!token && preferencesLoaded && boardsInitialized,
-    staleTime: 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistUser,
   });
 
   const items: AscentFeedItem[] = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data]);

--- a/packages/web/app/components/logbook/crew-logbook-view.tsx
+++ b/packages/web/app/components/logbook/crew-logbook-view.tsx
@@ -8,6 +8,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { persistUser } from '@/app/lib/react-query-persist-meta';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import {
   GET_FOLLOWING_CLIMB_ASCENTS,
@@ -46,7 +47,10 @@ export const CrewLogbookView: React.FC<CrewLogbookViewProps> = ({ currentClimb, 
       return response.followingClimbAscents;
     },
     enabled,
-    staleTime: 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistUser,
   });
 
   const items = useMemo(() => data?.items ?? [], [data]);

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -161,6 +161,10 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
         sizeId: boardDetails.size_id,
         setIds: Array.isArray(boardDetails.set_ids) ? boardDetails.set_ids.join(',') : String(boardDetails.set_ids),
         videoUrl: logType === 'ascent' && trimmedVideoUrl ? trimmedVideoUrl : undefined,
+        // Context for the optimistic logbook-feed row.
+        climbName: currentClimb.name,
+        setterUsername: currentClimb.setter_username ?? null,
+        frames: currentClimb.frames ?? null,
       });
 
       track('Tick Logged', {

--- a/packages/web/app/components/new-climb-feed/new-climb-feed.tsx
+++ b/packages/web/app/components/new-climb-feed/new-climb-feed.tsx
@@ -7,6 +7,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
 import { useInfiniteQuery, useQueryClient, type InfiniteData } from '@tanstack/react-query';
+import { persistShared } from '@/app/lib/react-query-persist-meta';
 import { type Client, createGraphQLClient, subscribe } from '../graphql-queue/graphql-client';
 import { getBackendWsUrl } from '@/app/lib/backend-url';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -75,7 +76,10 @@ export default function NewClimbFeed({
       if (!lastPage.hasMore) return undefined;
       return (lastPageParam as number) + lastPage.items.length;
     },
-    staleTime: 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistShared,
   });
 
   const items: NewClimbFeedItemType[] = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data]);

--- a/packages/web/app/components/providers/query-client-provider.tsx
+++ b/packages/web/app/components/providers/query-client-provider.tsx
@@ -2,9 +2,9 @@
 
 import React, { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { QueryClient, type Query, useQueryClient } from '@tanstack/react-query';
-import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
+import { PersistQueryClientProvider, persistQueryClient } from '@tanstack/react-query-persist-client';
 import { useSession } from 'next-auth/react';
-import { createIdbPersister, PERSIST_MAX_AGE_MS } from '@/app/lib/react-query-idb-persister';
+import { createIdbPersister, createSharedIdbPersister, PERSIST_MAX_AGE_MS } from '@/app/lib/react-query-idb-persister';
 
 type QueryClientProviderProps = {
   children: ReactNode;
@@ -23,7 +23,8 @@ export default function QueryClientProvider({ children }: QueryClientProviderPro
       }),
   );
 
-  const [persister] = useState(() => createIdbPersister());
+  const [userPersister] = useState(() => createIdbPersister());
+  const [sharedPersister] = useState(() => createSharedIdbPersister());
   // Reads useSession(), so this provider must mount inside SessionProviderWrapper.
   // See app/layout.tsx for the nesting order.
   const { data: session } = useSession();
@@ -33,21 +34,39 @@ export default function QueryClientProvider({ children }: QueryClientProviderPro
   // page load (status: loading), so any session-derived buster would discard
   // the persisted cache before the session resolves. Per-user isolation comes
   // from the query keys themselves (['profile', userId], etc.) — a different
-  // user simply misses the cache because their keys don't exist in it.
-  const persistOptions = useMemo(
+  // user simply misses the cache because their keys don't exist in it. The
+  // SessionCacheBuster below still wipes the IDB blob on actual user-change
+  // transitions, belt-and-braces.
+  const userPersistOptions = useMemo(
     () => ({
-      persister,
+      persister: userPersister,
       maxAge: PERSIST_MAX_AGE_MS,
       dehydrateOptions: {
         shouldDehydrateQuery: (query: Query) => query.meta?.persist === true && query.state.status === 'success',
       },
     }),
-    [persister],
+    [userPersister],
   );
 
+  // Shared persister: no buster, lifecycle independent of session. Set up once
+  // on mount via the imperative API since `PersistQueryClientProvider` only
+  // supports a single persister. Queries opt in via `meta.persistShared`.
+  useEffect(() => {
+    const [unsubscribe] = persistQueryClient({
+      queryClient,
+      persister: sharedPersister,
+      maxAge: PERSIST_MAX_AGE_MS,
+      buster: '',
+      dehydrateOptions: {
+        shouldDehydrateQuery: (query: Query) => query.meta?.persistShared === true && query.state.status === 'success',
+      },
+    });
+    return unsubscribe;
+  }, [queryClient, sharedPersister]);
+
   return (
-    <PersistQueryClientProvider client={queryClient} persistOptions={persistOptions}>
-      <SessionCacheBuster persister={persister} sessionUserId={sessionUserId} />
+    <PersistQueryClientProvider client={queryClient} persistOptions={userPersistOptions}>
+      <SessionCacheBuster persister={userPersister} sessionUserId={sessionUserId} />
       {children}
     </PersistQueryClientProvider>
   );
@@ -58,9 +77,11 @@ type SessionCacheBusterProps = {
   sessionUserId: string | null;
 };
 
-// Wipe both the in-memory persisted queries and the IDB blob when the user
-// transitions from one signed-in identity to another, or signs out — so the
-// next render can't show one user a frame of another user's data.
+// Wipe both the in-memory user-scoped queries and the user IDB blob when the
+// user transitions from one signed-in identity to another, or signs out — so
+// the next render can't show one user a frame of another user's data. Shared
+// queries (`meta.persistShared`) are left alone — they're the same payload
+// for every viewer.
 //
 // The ref is seeded `undefined` as a sentinel for "no transition observed
 // yet", which lets us skip two non-transitions that would otherwise wipe a

--- a/packages/web/app/components/search-drawer/setter-name-select.tsx
+++ b/packages/web/app/components/search-drawer/setter-name-select.tsx
@@ -7,6 +7,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { useUISearchParams } from '../queue-control/ui-searchparams-provider';
 import { useSearchData } from '../graphql-queue';
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { persistShared } from '@/app/lib/react-query-persist-meta';
 import { constructSetterStatsUrl } from '@/app/lib/url-utils';
 
 type SetterStat = {
@@ -43,7 +44,10 @@ const SetterNameSelect = () => {
     queryFn: () => fetcher(apiUrl!),
     enabled: !!apiUrl,
     staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
     placeholderData: keepPreviousData,
+    meta: persistShared,
   });
 
   // Map setter stats to Autocomplete options

--- a/packages/web/app/components/social/following-ascents-feed.tsx
+++ b/packages/web/app/components/social/following-ascents-feed.tsx
@@ -7,6 +7,7 @@ import MuiButton from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import PersonSearchOutlined from '@mui/icons-material/PersonSearchOutlined';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { persistUser } from '@/app/lib/react-query-persist-meta';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
@@ -44,7 +45,10 @@ export default function FollowingAscentsFeed({ onFindClimbers }: FollowingAscent
       return lastPageParam + lastPage.items.length;
     },
     enabled: isAuthenticated && !!token,
-    staleTime: 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistUser,
   });
 
   const items: FollowingAscentFeedItem[] = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data]);

--- a/packages/web/app/components/social/global-ascents-feed.tsx
+++ b/packages/web/app/components/social/global-ascents-feed.tsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import PublicOutlined from '@mui/icons-material/PublicOutlined';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { persistShared } from '@/app/lib/react-query-persist-meta';
 import { EmptyState } from '@/app/components/ui/empty-state';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import {
@@ -35,7 +36,10 @@ export default function GlobalAscentsFeed() {
       if (!lastPage.hasMore) return undefined;
       return lastPageParam + lastPage.items.length;
     },
-    staleTime: 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistShared,
   });
 
   const items: FollowingAscentFeedItem[] = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data]);

--- a/packages/web/app/hooks/__tests__/use-delete-tick.test.ts
+++ b/packages/web/app/hooks/__tests__/use-delete-tick.test.ts
@@ -119,15 +119,72 @@ describe('useDeleteTick', () => {
     });
   });
 
-  it('refreshes relevant query caches on success', async () => {
+  it('removes the row from feed caches and refreshes aggregates on success', async () => {
     mockRequest.mockResolvedValue({ deleteTick: true });
 
     const { wrapper, queryClient } = createTestWrapper();
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
     const removeSpy = vi.spyOn(queryClient, 'removeQueries');
 
-    // Seed some cache data
-    queryClient.setQueryData(['ascentsFeed', 'user-1', 10], { pages: [] });
+    const row = {
+      uuid: 'tick-uuid-1',
+      climbUuid: 'climb-1',
+      climbName: 'Test climb',
+      setterUsername: null,
+      boardType: 'kilter',
+      layoutId: 1,
+      angle: 40,
+      isMirror: false,
+      status: 'send' as const,
+      attemptCount: 3,
+      quality: 2,
+      difficulty: 22,
+      difficultyName: null,
+      consensusDifficulty: null,
+      consensusDifficultyName: null,
+      qualityAverage: null,
+      isBenchmark: false,
+      isNoMatch: false,
+      comment: '',
+      climbedAt: '2026-04-16T00:00:00.000Z',
+      frames: null,
+    };
+    queryClient.setQueryData(['logbookFeed', '1', 'all', 'all-layouts', '', '{}', '{}'], {
+      pages: [{ items: [row], totalCount: 1, hasMore: false }],
+      pageParams: [0],
+    });
+    queryClient.setQueryData(['ascentsFeed', 'user-1', 10], {
+      pages: [
+        {
+          groups: [
+            {
+              key: 'g1',
+              climbUuid: 'climb-1',
+              climbName: 'Test climb',
+              setterUsername: null,
+              boardType: 'kilter',
+              layoutId: 1,
+              angle: 40,
+              isMirror: false,
+              frames: null,
+              difficultyName: null,
+              isBenchmark: false,
+              isNoMatch: false,
+              date: '2026-04-16',
+              flashCount: 0,
+              sendCount: 1,
+              attemptCount: 0,
+              bestQuality: null,
+              latestComment: null,
+              items: [row],
+            },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      ],
+      pageParams: [0],
+    });
     queryClient.setQueryData(['logbook', 'kilter', 'accumulated'], []);
     queryClient.setQueryData(['sessionDetail', 'session-1'], {});
 
@@ -141,10 +198,23 @@ describe('useDeleteTick', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
+    const logbookData = queryClient.getQueryData<{
+      pages: { items: (typeof row)[] }[];
+    }>(['logbookFeed', '1', 'all', 'all-layouts', '', '{}', '{}']);
+    expect(logbookData?.pages[0].items).toHaveLength(0);
+
+    // The ascentsFeed group only contained the deleted row, so the whole group
+    // is removed (empty groups are pruned).
+    const ascentsData = queryClient.getQueryData<{
+      pages: { groups: unknown[] }[];
+    }>(['ascentsFeed', 'user-1', 10]);
+    expect(ascentsData?.pages[0].groups).toHaveLength(0);
+
     const invalidatedKeys = invalidateSpy.mock.calls.map((call) => call[0]?.queryKey);
-    expect(invalidatedKeys).toContainEqual(['ascentsFeed']);
     expect(invalidatedKeys).toContainEqual(['sessionDetail']);
     expect(invalidatedKeys).toContainEqual(['userProfileStats']);
+    expect(invalidatedKeys).toContainEqual(['userTicks']);
+    expect(invalidatedKeys).toContainEqual(['userClimbPercentile']);
     expect(removeSpy).toHaveBeenCalledWith({ queryKey: ['logbook'] });
   });
 

--- a/packages/web/app/hooks/__tests__/use-delete-tick.test.ts
+++ b/packages/web/app/hooks/__tests__/use-delete-tick.test.ts
@@ -235,6 +235,112 @@ describe('useDeleteTick', () => {
     expect(mockShowMessage).toHaveBeenCalledWith('Delete failed', 'error');
   });
 
+  it('recomputes group bestQuality + latestComment when deleting from a multi-item group', async () => {
+    mockRequest.mockResolvedValue({ deleteTick: true });
+
+    const { wrapper, queryClient } = createTestWrapper();
+
+    const baseRow = {
+      climbUuid: 'climb-1',
+      climbName: 'Test climb',
+      setterUsername: null,
+      boardType: 'kilter',
+      layoutId: 1,
+      angle: 40,
+      isMirror: false,
+      attemptCount: 1,
+      difficulty: 22,
+      difficultyName: null,
+      consensusDifficulty: null,
+      consensusDifficultyName: null,
+      qualityAverage: null,
+      isBenchmark: false,
+      isNoMatch: false,
+      climbedAt: '2026-04-16T10:00:00.000Z',
+      frames: null,
+    };
+    const toDelete = {
+      ...baseRow,
+      uuid: 'tick-uuid-1',
+      status: 'send' as const,
+      quality: 5, // highest — bestQuality should fall to the surviving row's value
+      comment: 'Best ever',
+      climbedAt: '2026-04-16T15:00:00.000Z', // latest — latestComment should fall to survivor
+    };
+    const survivor = {
+      ...baseRow,
+      uuid: 'tick-uuid-2',
+      status: 'flash' as const,
+      quality: 3,
+      comment: 'Solid',
+      climbedAt: '2026-04-16T09:00:00.000Z',
+    };
+    queryClient.setQueryData(['ascentsFeed', 'user-1', 10], {
+      pages: [
+        {
+          groups: [
+            {
+              key: 'g1',
+              climbUuid: 'climb-1',
+              climbName: 'Test climb',
+              setterUsername: null,
+              boardType: 'kilter',
+              layoutId: 1,
+              angle: 40,
+              isMirror: false,
+              frames: null,
+              difficultyName: null,
+              isBenchmark: false,
+              isNoMatch: false,
+              date: '2026-04-16',
+              flashCount: 1,
+              sendCount: 1,
+              attemptCount: 0,
+              bestQuality: 5,
+              latestComment: 'Best ever',
+              items: [toDelete, survivor],
+            },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      ],
+      pageParams: [0],
+    });
+
+    const { result } = renderHook(() => useDeleteTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate('tick-uuid-1');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const ascentsData = queryClient.getQueryData<{
+      pages: {
+        groups: {
+          items: (typeof survivor)[];
+          flashCount: number;
+          sendCount: number;
+          attemptCount: number;
+          bestQuality: number | null;
+          latestComment: string | null;
+        }[];
+      }[];
+    }>(['ascentsFeed', 'user-1', 10]);
+
+    expect(ascentsData?.pages[0].groups).toHaveLength(1);
+    const group = ascentsData!.pages[0].groups[0];
+    expect(group.items.map((i) => i.uuid)).toEqual(['tick-uuid-2']);
+    expect(group.flashCount).toBe(1);
+    expect(group.sendCount).toBe(0);
+    expect(group.attemptCount).toBe(0);
+    expect(group.bestQuality).toBe(3);
+    expect(group.latestComment).toBe('Solid');
+  });
+
   it('extracts GraphQL error message from response', async () => {
     const graphqlError: Error & { response?: { errors: { message: string }[] } } = new Error('GraphQL error');
     graphqlError.response = {

--- a/packages/web/app/hooks/__tests__/use-update-tick.test.ts
+++ b/packages/web/app/hooks/__tests__/use-update-tick.test.ts
@@ -113,7 +113,7 @@ describe('useUpdateTick', () => {
     });
   });
 
-  it('refreshes related caches and shows a success snackbar on success', async () => {
+  it('merges the edit into the persisted feed caches and refreshes aggregates', async () => {
     mockRequest.mockResolvedValue({
       updateTick: {
         uuid: 'tick-1',
@@ -128,6 +128,69 @@ describe('useUpdateTick', () => {
     });
 
     const { wrapper, queryClient } = createTestWrapper();
+
+    // Seed both feed caches with a row that holds the same tick uuid so we can
+    // assert the edit lands in place (no skeleton flash on edit).
+    const baseRow = {
+      uuid: 'tick-1',
+      climbUuid: 'climb-1',
+      climbName: 'Test climb',
+      setterUsername: null,
+      boardType: 'kilter',
+      layoutId: 1,
+      angle: 40,
+      isMirror: false,
+      status: 'send' as const,
+      attemptCount: 3,
+      quality: 2,
+      difficulty: 22,
+      difficultyName: null,
+      consensusDifficulty: null,
+      consensusDifficultyName: null,
+      qualityAverage: null,
+      isBenchmark: false,
+      isNoMatch: false,
+      comment: 'Stale',
+      climbedAt: '2026-04-16T00:00:00.000Z',
+      frames: null,
+    };
+    queryClient.setQueryData(['logbookFeed', '1', 'all', 'all-layouts', '', '{}', '{}'], {
+      pages: [{ items: [baseRow], totalCount: 1, hasMore: false }],
+      pageParams: [0],
+    });
+    queryClient.setQueryData(['ascentsFeed', '1', 10], {
+      pages: [
+        {
+          groups: [
+            {
+              key: 'g1',
+              climbUuid: 'climb-1',
+              climbName: 'Test climb',
+              setterUsername: null,
+              boardType: 'kilter',
+              layoutId: 1,
+              angle: 40,
+              isMirror: false,
+              frames: null,
+              difficultyName: null,
+              isBenchmark: false,
+              isNoMatch: false,
+              date: '2026-04-16',
+              flashCount: 0,
+              sendCount: 1,
+              attemptCount: 0,
+              bestQuality: null,
+              latestComment: null,
+              items: [baseRow],
+            },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      ],
+      pageParams: [0],
+    });
+
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
     const removeSpy = vi.spyOn(queryClient, 'removeQueries');
 
@@ -144,11 +207,24 @@ describe('useUpdateTick', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
+    const logbookData = queryClient.getQueryData<{
+      pages: { items: (typeof baseRow)[] }[];
+    }>(['logbookFeed', '1', 'all', 'all-layouts', '', '{}', '{}']);
+    expect(logbookData?.pages[0].items[0].status).toBe('flash');
+    expect(logbookData?.pages[0].items[0].attemptCount).toBe(1);
+    expect(logbookData?.pages[0].items[0].comment).toBe('Sent');
+
+    const ascentsData = queryClient.getQueryData<{
+      pages: { groups: { items: (typeof baseRow)[] }[] }[];
+    }>(['ascentsFeed', '1', 10]);
+    expect(ascentsData?.pages[0].groups[0].items[0].status).toBe('flash');
+    expect(ascentsData?.pages[0].groups[0].items[0].comment).toBe('Sent');
+
     const invalidatedKeys = invalidateSpy.mock.calls.map((call) => call[0]?.queryKey);
-    expect(invalidatedKeys).toContainEqual(['logbookFeed']);
-    expect(invalidatedKeys).toContainEqual(['ascentsFeed']);
     expect(invalidatedKeys).toContainEqual(['sessionDetail']);
     expect(invalidatedKeys).toContainEqual(['userProfileStats']);
+    expect(invalidatedKeys).toContainEqual(['userTicks']);
+    expect(invalidatedKeys).toContainEqual(['userClimbPercentile']);
     expect(removeSpy).toHaveBeenCalledWith({ queryKey: ['logbook'] });
     expect(mockShowMessage).toHaveBeenCalledWith('Tick updated', 'success');
   });

--- a/packages/web/app/hooks/__tests__/use-update-tick.test.ts
+++ b/packages/web/app/hooks/__tests__/use-update-tick.test.ts
@@ -215,10 +215,26 @@ describe('useUpdateTick', () => {
     expect(logbookData?.pages[0].items[0].comment).toBe('Sent');
 
     const ascentsData = queryClient.getQueryData<{
-      pages: { groups: { items: (typeof baseRow)[] }[] }[];
+      pages: {
+        groups: {
+          items: (typeof baseRow)[];
+          flashCount: number;
+          sendCount: number;
+          attemptCount: number;
+          bestQuality: number | null;
+          latestComment: string | null;
+        }[];
+      }[];
     }>(['ascentsFeed', '1', 10]);
     expect(ascentsData?.pages[0].groups[0].items[0].status).toBe('flash');
     expect(ascentsData?.pages[0].groups[0].items[0].comment).toBe('Sent');
+    // status flipped send -> flash: group counters must follow, and bestQuality
+    // / latestComment recompute from the new item set.
+    expect(ascentsData?.pages[0].groups[0].flashCount).toBe(1);
+    expect(ascentsData?.pages[0].groups[0].sendCount).toBe(0);
+    expect(ascentsData?.pages[0].groups[0].attemptCount).toBe(0);
+    expect(ascentsData?.pages[0].groups[0].bestQuality).toBe(5);
+    expect(ascentsData?.pages[0].groups[0].latestComment).toBe('Sent');
 
     const invalidatedKeys = invalidateSpy.mock.calls.map((call) => call[0]?.queryKey);
     expect(invalidatedKeys).toContainEqual(['sessionDetail']);

--- a/packages/web/app/hooks/use-delete-tick.ts
+++ b/packages/web/app/hooks/use-delete-tick.ts
@@ -10,6 +10,7 @@ import {
   type DeleteTickMutationVariables,
   type DeleteTickMutationResponse,
 } from '@/app/lib/graphql/operations';
+import { removeFromAscentsFeed, removeFromLogbookFeed } from './use-tick-feed-cache';
 
 /**
  * Hook to delete a tick (logbook entry) via GraphQL mutation.
@@ -35,8 +36,11 @@ export function useDeleteTick() {
       const response = await client.request<DeleteTickMutationResponse>(DELETE_TICK, variables);
       return response.deleteTick;
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['ascentsFeed'] });
+    onSuccess: (_result, uuid) => {
+      // Drop the row from every cached feed (and its containing group, if any).
+      // The persister picks up the new shape on its next throttled dehydrate.
+      removeFromLogbookFeed(queryClient, uuid);
+      removeFromAscentsFeed(queryClient, uuid);
       queryClient.removeQueries({ queryKey: ['logbook'] });
       void queryClient.invalidateQueries({ queryKey: ['sessionDetail'] });
       void queryClient.invalidateQueries({ queryKey: ['userProfileStats'] });

--- a/packages/web/app/hooks/use-grouped-notifications.ts
+++ b/packages/web/app/hooks/use-grouped-notifications.ts
@@ -11,6 +11,7 @@ import {
 } from '@/app/lib/graphql/operations';
 import type { GroupedNotification, GroupedNotificationConnection } from '@boardsesh/shared-schema';
 import { UNREAD_COUNT_QUERY_KEY } from './use-unread-notification-count';
+import { persistUser } from '@/app/lib/react-query-persist-meta';
 
 const PAGE_SIZE = 20;
 
@@ -50,7 +51,10 @@ export function useGroupedNotifications(initialData?: GroupedNotificationConnect
       return lastPageParam + lastPage.groups.length;
     },
     enabled: isAuthenticated && !!token,
-    staleTime: 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistUser,
     ...(initialData
       ? {
           initialData: { pages: [initialData], pageParams: [0] },

--- a/packages/web/app/hooks/use-save-tick.ts
+++ b/packages/web/app/hooks/use-save-tick.ts
@@ -13,6 +13,15 @@ import {
   type TickStatus,
   type LogbookEntry,
 } from './use-logbook';
+import {
+  buildOptimisticAscentItem,
+  cancelTickFeeds,
+  prependToLogbookFeed,
+  removeFromLogbookFeed,
+  restoreTickFeeds,
+  snapshotTickFeeds,
+  type TickFeedSnapshot,
+} from './use-tick-feed-cache';
 import { clearTickDraft } from '@/app/lib/tick-draft-db';
 
 // Options for saving a tick (local storage, no Aurora required)
@@ -32,6 +41,13 @@ export type SaveTickOptions = {
   sizeId?: number;
   setIds?: string;
   videoUrl?: string;
+  // Optional context for optimistic insert into the logbook feed cache.
+  // Populated by callers that already have the climb on hand; the row renders
+  // instantly with these fields and the background refetch fills in the rest.
+  climbName?: string;
+  setterUsername?: string | null;
+  frames?: string | null;
+  difficultyName?: string | null;
 };
 
 /**
@@ -82,8 +98,9 @@ export function useSaveTick(boardName: BoardName) {
       // Cancel outgoing fetch batches so stale responses merge against the
       // latest accumulated cache entry instead of racing the optimistic write.
       await queryClient.cancelQueries({ queryKey: fetchLogbookQueryKeyPrefix(boardName) });
+      // Same idea for the IDB-persisted logbook/ascents feed caches.
+      await cancelTickFeeds(queryClient);
 
-      // Create optimistic entry
       const tempUuid = `temp-${Date.now()}`;
       const optimisticEntry: LogbookEntry = {
         uuid: tempUuid,
@@ -104,7 +121,33 @@ export function useSaveTick(boardName: BoardName) {
 
       queryClient.setQueryData<LogbookEntry[]>(accumulatedKey, (existing = []) => [optimisticEntry, ...existing]);
 
-      return { tempUuid };
+      // Snapshot the persisted feed caches before mutating so we can roll back
+      // on error.
+      const feedSnapshot = snapshotTickFeeds(queryClient);
+      prependToLogbookFeed(
+        queryClient,
+        buildOptimisticAscentItem({
+          tempUuid,
+          climbUuid: options.climbUuid,
+          climbName: options.climbName,
+          setterUsername: options.setterUsername,
+          boardType: boardName,
+          layoutId: options.layoutId,
+          angle: options.angle,
+          isMirror: options.isMirror,
+          status: options.status,
+          attemptCount: options.attemptCount,
+          quality: options.quality,
+          difficulty: options.difficulty,
+          difficultyName: options.difficultyName,
+          isBenchmark: options.isBenchmark,
+          comment: options.comment,
+          climbedAt: options.climbedAt,
+          frames: options.frames,
+        }),
+      );
+
+      return { tempUuid, feedSnapshot };
     },
     onSuccess: (savedTick, options, context) => {
       const savedEntry = toLogbookEntry(savedTick);
@@ -134,6 +177,16 @@ export function useSaveTick(boardName: BoardName) {
       // Clear any IndexedDB draft for this climb (belt-and-suspenders with QuickTickBar's .then)
       void clearTickDraft(options.climbUuid, options.angle);
 
+      // Drop the temp row from the persisted feed caches; the invalidation
+      // below pulls the canonical server row (with the real uuid + full
+      // metadata) into its place. Doing it in this order avoids a transient
+      // "two rows for the same tick" state.
+      if (context?.tempUuid) {
+        removeFromLogbookFeed(queryClient, context.tempUuid);
+      }
+      void queryClient.invalidateQueries({ queryKey: ['logbookFeed'] });
+      void queryClient.invalidateQueries({ queryKey: ['ascentsFeed'] });
+
       // Bust the You-page stats caches so the next visit reflects the new tick.
       // React Query does prefix matching on queryKey arrays — the bare root
       // string invalidates every variant (['userTicks', '<any-userId>']).
@@ -157,6 +210,9 @@ export function useSaveTick(boardName: BoardName) {
         queryClient.setQueriesData<LogbookEntry[]>({ queryKey: accumulatedKey, exact: true }, (existing = []) =>
           existing.filter((entry) => entry.uuid !== context.tempUuid),
         );
+      }
+      if (context?.feedSnapshot) {
+        restoreTickFeeds(queryClient, context.feedSnapshot satisfies TickFeedSnapshot);
       }
     },
   });

--- a/packages/web/app/hooks/use-session-detail.ts
+++ b/packages/web/app/hooks/use-session-detail.ts
@@ -12,6 +12,7 @@ import {
   type GetSessionDetailQueryResponse,
 } from '@/app/lib/graphql/operations/activity-feed';
 import type { SessionDetail } from '@boardsesh/shared-schema';
+import { persistUser } from '@/app/lib/react-query-persist-meta';
 
 export const SESSION_DETAIL_QUERY_KEY = (sessionId: string) => ['sessionDetail', sessionId] as const;
 
@@ -38,10 +39,13 @@ export function useSessionDetail({ sessionId, initialData, enabled = true }: Use
       return data.sessionDetail;
     },
     enabled: enabled && !!sessionId && isAuthenticated && !!token,
-    staleTime: 30_000,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
     // Live updates arrive via SessionStatsUpdated cache patches, so a
     // window-focus refetch would only race the WS feed and reintroduce flicker.
     refetchOnWindowFocus: false,
+    meta: persistUser,
     ...(initialData
       ? {
           initialData,

--- a/packages/web/app/hooks/use-tick-feed-cache.ts
+++ b/packages/web/app/hooks/use-tick-feed-cache.ts
@@ -1,0 +1,210 @@
+import type { QueryClient } from '@tanstack/react-query';
+import type { AscentFeedItem, GroupedAscentFeedItem } from '@/app/lib/graphql/operations/ticks';
+
+// Shared in-place updates for the two React Query infinite-query caches that
+// hold tick rows:
+//   - ['logbookFeed', ...] — flat per-user ascent list (LogbookFeed)
+//   - ['ascentsFeed', ...] — grouped per-user ascent list (AscentsFeed)
+//
+// Used by useSaveTick / useUpdateTick / useDeleteTick to keep the IDB-persisted
+// caches consistent without an extra network round-trip. Each helper walks every
+// cache entry under the matching root key, so it covers all filter/sort variants.
+
+type LogbookFeedPage = {
+  items: AscentFeedItem[];
+  totalCount?: number;
+  hasMore: boolean;
+};
+
+type LogbookFeedData = {
+  pages: LogbookFeedPage[];
+  pageParams: unknown[];
+};
+
+type AscentsFeedPage = {
+  groups: GroupedAscentFeedItem[];
+  totalCount?: number;
+  hasMore: boolean;
+};
+
+type AscentsFeedData = {
+  pages: AscentsFeedPage[];
+  pageParams: unknown[];
+};
+
+const LOGBOOK_FEED_KEY = ['logbookFeed'] as const;
+const ASCENTS_FEED_KEY = ['ascentsFeed'] as const;
+
+export function prependToLogbookFeed(queryClient: QueryClient, item: AscentFeedItem): void {
+  queryClient.setQueriesData<LogbookFeedData>({ queryKey: LOGBOOK_FEED_KEY }, (old) => {
+    if (!old || old.pages.length === 0) return old;
+    return {
+      ...old,
+      pages: old.pages.map((page, i) =>
+        i === 0
+          ? {
+              ...page,
+              items: [item, ...page.items],
+              totalCount: page.totalCount !== undefined ? page.totalCount + 1 : undefined,
+            }
+          : page,
+      ),
+    };
+  });
+}
+
+export function removeFromLogbookFeed(queryClient: QueryClient, uuid: string): void {
+  queryClient.setQueriesData<LogbookFeedData>({ queryKey: LOGBOOK_FEED_KEY }, (old) => {
+    if (!old) return old;
+    return {
+      ...old,
+      pages: old.pages.map((page) => {
+        const items = page.items.filter((i) => i.uuid !== uuid);
+        if (items.length === page.items.length) return page;
+        return {
+          ...page,
+          items,
+          totalCount: page.totalCount !== undefined ? Math.max(0, page.totalCount - 1) : undefined,
+        };
+      }),
+    };
+  });
+}
+
+export function mergeIntoLogbookFeed(queryClient: QueryClient, uuid: string, patch: Partial<AscentFeedItem>): void {
+  queryClient.setQueriesData<LogbookFeedData>({ queryKey: LOGBOOK_FEED_KEY }, (old) => {
+    if (!old) return old;
+    return {
+      ...old,
+      pages: old.pages.map((page) => {
+        let changed = false;
+        const items = page.items.map((item) => {
+          if (item.uuid !== uuid) return item;
+          changed = true;
+          return { ...item, ...patch };
+        });
+        return changed ? { ...page, items } : page;
+      }),
+    };
+  });
+}
+
+export function removeFromAscentsFeed(queryClient: QueryClient, uuid: string): void {
+  queryClient.setQueriesData<AscentsFeedData>({ queryKey: ASCENTS_FEED_KEY }, (old) => {
+    if (!old) return old;
+    return {
+      ...old,
+      pages: old.pages.map((page) => {
+        let groupChanged = false;
+        const groups = page.groups
+          .map((group) => {
+            const removed = group.items.find((i) => i.uuid === uuid);
+            if (!removed) return group;
+            groupChanged = true;
+            const items = group.items.filter((i) => i.uuid !== uuid);
+            const next: GroupedAscentFeedItem = { ...group, items };
+            if (removed.status === 'flash') next.flashCount = Math.max(0, group.flashCount - 1);
+            else if (removed.status === 'send') next.sendCount = Math.max(0, group.sendCount - 1);
+            else next.attemptCount = Math.max(0, group.attemptCount - 1);
+            return next;
+          })
+          .filter((group) => group.items.length > 0);
+        return groupChanged ? { ...page, groups } : page;
+      }),
+    };
+  });
+}
+
+export function mergeIntoAscentsFeed(queryClient: QueryClient, uuid: string, patch: Partial<AscentFeedItem>): void {
+  queryClient.setQueriesData<AscentsFeedData>({ queryKey: ASCENTS_FEED_KEY }, (old) => {
+    if (!old) return old;
+    return {
+      ...old,
+      pages: old.pages.map((page) => {
+        let pageChanged = false;
+        const groups = page.groups.map((group) => {
+          let groupChanged = false;
+          const items = group.items.map((item) => {
+            if (item.uuid !== uuid) return item;
+            groupChanged = true;
+            return { ...item, ...patch };
+          });
+          if (!groupChanged) return group;
+          pageChanged = true;
+          return { ...group, items };
+        });
+        return pageChanged ? { ...page, groups } : page;
+      }),
+    };
+  });
+}
+
+export type TickFeedSnapshot = {
+  logbookFeed: [readonly unknown[], LogbookFeedData | undefined][];
+  ascentsFeed: [readonly unknown[], AscentsFeedData | undefined][];
+};
+
+export function snapshotTickFeeds(queryClient: QueryClient): TickFeedSnapshot {
+  return {
+    logbookFeed: queryClient.getQueriesData<LogbookFeedData>({ queryKey: LOGBOOK_FEED_KEY }),
+    ascentsFeed: queryClient.getQueriesData<AscentsFeedData>({ queryKey: ASCENTS_FEED_KEY }),
+  };
+}
+
+export function restoreTickFeeds(queryClient: QueryClient, snapshot: TickFeedSnapshot): void {
+  snapshot.logbookFeed.forEach(([key, data]) => queryClient.setQueryData(key, data));
+  snapshot.ascentsFeed.forEach(([key, data]) => queryClient.setQueryData(key, data));
+}
+
+export async function cancelTickFeeds(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.cancelQueries({ queryKey: LOGBOOK_FEED_KEY }),
+    queryClient.cancelQueries({ queryKey: ASCENTS_FEED_KEY }),
+  ]);
+}
+
+export type OptimisticAscentInput = {
+  tempUuid: string;
+  climbUuid: string;
+  climbName?: string;
+  setterUsername?: string | null;
+  boardType: string;
+  layoutId?: number | null;
+  angle: number;
+  isMirror: boolean;
+  status: 'flash' | 'send' | 'attempt';
+  attemptCount: number;
+  quality?: number | null;
+  difficulty?: number | null;
+  difficultyName?: string | null;
+  isBenchmark: boolean;
+  comment: string;
+  climbedAt: string;
+  frames?: string | null;
+};
+
+export function buildOptimisticAscentItem(input: OptimisticAscentInput): AscentFeedItem {
+  return {
+    uuid: input.tempUuid,
+    climbUuid: input.climbUuid,
+    climbName: input.climbName ?? '',
+    setterUsername: input.setterUsername ?? null,
+    boardType: input.boardType,
+    layoutId: input.layoutId ?? null,
+    angle: input.angle,
+    isMirror: input.isMirror,
+    status: input.status,
+    attemptCount: input.attemptCount,
+    quality: input.quality ?? null,
+    difficulty: input.difficulty ?? null,
+    difficultyName: input.difficultyName ?? null,
+    consensusDifficulty: null,
+    consensusDifficultyName: null,
+    qualityAverage: null,
+    isBenchmark: input.isBenchmark,
+    isNoMatch: false,
+    comment: input.comment,
+    climbedAt: input.climbedAt,
+    frames: input.frames ?? null,
+  };
+}

--- a/packages/web/app/hooks/use-tick-feed-cache.ts
+++ b/packages/web/app/hooks/use-tick-feed-cache.ts
@@ -89,6 +89,39 @@ export function mergeIntoLogbookFeed(queryClient: QueryClient, uuid: string, pat
   });
 }
 
+// Recompute every group-level aggregate that's derived from `items`. We do
+// this after any in-place mutation (merge or remove) instead of patching
+// individual counters incrementally — an edit can change an item's status
+// (e.g. attempt → flash), which would flip two counters at once; tracking
+// that with delta logic is fragile and easy to leave inconsistent.
+function recomputeGroupAggregates(group: GroupedAscentFeedItem): GroupedAscentFeedItem {
+  let flashCount = 0;
+  let sendCount = 0;
+  let attemptCount = 0;
+  let bestQuality: number | null = null;
+  for (const item of group.items) {
+    if (item.status === 'flash') flashCount++;
+    else if (item.status === 'send') sendCount++;
+    else attemptCount++;
+    if (item.quality !== null && (bestQuality === null || item.quality > bestQuality)) {
+      bestQuality = item.quality;
+    }
+  }
+  // Latest non-empty comment by climbedAt. Items aren't guaranteed sorted in
+  // cache, so do a single pass tracking the most recent timestamp seen.
+  let latestComment: string | null = null;
+  let latestCommentAt = '';
+  for (const item of group.items) {
+    const trimmed = item.comment?.trim();
+    if (!trimmed) continue;
+    if (item.climbedAt > latestCommentAt) {
+      latestCommentAt = item.climbedAt;
+      latestComment = item.comment;
+    }
+  }
+  return { ...group, flashCount, sendCount, attemptCount, bestQuality, latestComment };
+}
+
 export function removeFromAscentsFeed(queryClient: QueryClient, uuid: string): void {
   queryClient.setQueriesData<AscentsFeedData>({ queryKey: ASCENTS_FEED_KEY }, (old) => {
     if (!old) return old;
@@ -98,15 +131,10 @@ export function removeFromAscentsFeed(queryClient: QueryClient, uuid: string): v
         let groupChanged = false;
         const groups = page.groups
           .map((group) => {
-            const removed = group.items.find((i) => i.uuid === uuid);
-            if (!removed) return group;
-            groupChanged = true;
             const items = group.items.filter((i) => i.uuid !== uuid);
-            const next: GroupedAscentFeedItem = { ...group, items };
-            if (removed.status === 'flash') next.flashCount = Math.max(0, group.flashCount - 1);
-            else if (removed.status === 'send') next.sendCount = Math.max(0, group.sendCount - 1);
-            else next.attemptCount = Math.max(0, group.attemptCount - 1);
-            return next;
+            if (items.length === group.items.length) return group;
+            groupChanged = true;
+            return recomputeGroupAggregates({ ...group, items });
           })
           .filter((group) => group.items.length > 0);
         return groupChanged ? { ...page, groups } : page;
@@ -131,7 +159,7 @@ export function mergeIntoAscentsFeed(queryClient: QueryClient, uuid: string, pat
           });
           if (!groupChanged) return group;
           pageChanged = true;
-          return { ...group, items };
+          return recomputeGroupAggregates({ ...group, items });
         });
         return pageChanged ? { ...page, groups } : page;
       }),

--- a/packages/web/app/hooks/use-tick-save.ts
+++ b/packages/web/app/hooks/use-tick-save.ts
@@ -161,6 +161,11 @@ export function useTickSave(options: UseTickSaveOptions): {
         layoutId: targetBoard.layout_id,
         sizeId: targetBoard.size_id,
         setIds: Array.isArray(targetBoard.set_ids) ? targetBoard.set_ids.join(',') : String(targetBoard.set_ids),
+        // Context for the optimistic logbook-feed row so it doesn't render
+        // empty for the ~200ms before the refetch arrives.
+        climbName: climb.name,
+        setterUsername: climb.setter_username ?? null,
+        frames: climb.frames ?? null,
       })
         .then(() => {
           track('Quick Tick Saved', {

--- a/packages/web/app/hooks/use-unread-notification-count.ts
+++ b/packages/web/app/hooks/use-unread-notification-count.ts
@@ -7,6 +7,7 @@ import {
   GET_UNREAD_NOTIFICATION_COUNT,
   type GetUnreadNotificationCountQueryResponse,
 } from '@/app/lib/graphql/operations';
+import { persistUser } from '@/app/lib/react-query-persist-meta';
 
 export const UNREAD_COUNT_QUERY_KEY = ['notifications', 'unreadCount'] as const;
 
@@ -25,7 +26,10 @@ export function useUnreadNotificationCount() {
       return data.unreadNotificationCount;
     },
     enabled: isAuthenticated && !!token,
-    staleTime: 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnMount: 'always',
+    meta: persistUser,
   });
 
   return unreadCount;

--- a/packages/web/app/hooks/use-update-tick.ts
+++ b/packages/web/app/hooks/use-update-tick.ts
@@ -11,6 +11,8 @@ import {
   type UpdateTickVariables,
   type UpdateTickInput,
 } from '@/app/lib/graphql/operations';
+import type { AscentFeedItem } from '@/app/lib/graphql/operations/ticks';
+import { mergeIntoAscentsFeed, mergeIntoLogbookFeed } from './use-tick-feed-cache';
 
 export type UpdateTickOptions = {
   uuid: string;
@@ -41,9 +43,22 @@ export function useUpdateTick() {
       const response = await client.request<UpdateTickResponse, UpdateTickVariables>(UPDATE_TICK, variables);
       return response.updateTick;
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['logbookFeed'] });
-      void queryClient.invalidateQueries({ queryKey: ['ascentsFeed'] });
+    onSuccess: (updatedTick) => {
+      // Merge the edited fields directly into every cached feed row that holds
+      // this tick uuid. The persister picks up the new shape on its next throttled
+      // dehydrate, so the change survives a reload without a refetch.
+      const patch: Partial<AscentFeedItem> = {
+        status: updatedTick.status as AscentFeedItem['status'],
+        attemptCount: updatedTick.attemptCount,
+        quality: updatedTick.quality,
+        difficulty: updatedTick.difficulty,
+        isBenchmark: updatedTick.isBenchmark,
+        comment: updatedTick.comment,
+      };
+      mergeIntoLogbookFeed(queryClient, updatedTick.uuid, patch);
+      mergeIntoAscentsFeed(queryClient, updatedTick.uuid, patch);
+
+      // Aggregates we can't recompute locally — let them refetch.
       void queryClient.invalidateQueries({ queryKey: ['sessionDetail'] });
       void queryClient.invalidateQueries({ queryKey: ['userProfileStats'] });
       void queryClient.invalidateQueries({ queryKey: ['userTicks'] });

--- a/packages/web/app/lib/react-query-idb-persister.ts
+++ b/packages/web/app/lib/react-query-idb-persister.ts
@@ -1,8 +1,10 @@
+import type { IDBPDatabase } from 'idb';
 import type { PersistedClient, Persister } from '@tanstack/react-query-persist-client';
 
 import { createIndexedDBStore } from './idb-helper';
 
-const DB_NAME = 'boardsesh-react-query';
+const USER_DB_NAME = 'boardsesh-react-query';
+const SHARED_DB_NAME = 'boardsesh-react-query-shared';
 const STORE_NAME = 'cache';
 const CLIENT_KEY = 'client';
 
@@ -11,9 +13,10 @@ const CLIENT_KEY = 'client';
 // persister window — see use-profile-data.ts and query-client-provider.tsx.
 export const PERSIST_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
-const getDB = createIndexedDBStore(DB_NAME, STORE_NAME);
+const getUserDB = createIndexedDBStore(USER_DB_NAME, STORE_NAME);
+const getSharedDB = createIndexedDBStore(SHARED_DB_NAME, STORE_NAME);
 
-export function createIdbPersister(): Persister {
+function createPersister(getDB: () => Promise<IDBPDatabase | null>, label: string): Persister {
   return {
     persistClient: async (client: PersistedClient) => {
       const db = await getDB();
@@ -21,7 +24,7 @@ export function createIdbPersister(): Persister {
       try {
         await db.put(STORE_NAME, client, CLIENT_KEY);
       } catch (error) {
-        console.error('Failed to persist react-query cache to IndexedDB:', error);
+        console.error(`Failed to persist react-query ${label} cache to IndexedDB:`, error);
       }
     },
     restoreClient: async () => {
@@ -31,7 +34,7 @@ export function createIdbPersister(): Persister {
         const restored = (await db.get(STORE_NAME, CLIENT_KEY)) as PersistedClient | undefined;
         return restored;
       } catch (error) {
-        console.error('Failed to restore react-query cache from IndexedDB:', error);
+        console.error(`Failed to restore react-query ${label} cache from IndexedDB:`, error);
         return undefined;
       }
     },
@@ -41,8 +44,16 @@ export function createIdbPersister(): Persister {
       try {
         await db.delete(STORE_NAME, CLIENT_KEY);
       } catch (error) {
-        console.error('Failed to remove react-query cache from IndexedDB:', error);
+        console.error(`Failed to remove react-query ${label} cache from IndexedDB:`, error);
       }
     },
   };
+}
+
+export function createIdbPersister(): Persister {
+  return createPersister(getUserDB, 'user');
+}
+
+export function createSharedIdbPersister(): Persister {
+  return createPersister(getSharedDB, 'shared');
 }

--- a/packages/web/app/lib/react-query-persist-meta.ts
+++ b/packages/web/app/lib/react-query-persist-meta.ts
@@ -1,0 +1,12 @@
+// Opt-in flags for the IDB-backed React Query persisters in
+// `query-client-provider.tsx`. Pass one of these as the `meta` field on a
+// `useQuery` / `useInfiniteQuery` to participate.
+//
+// `persistUser`   → user-scoped IDB store (busted on sign-out / user switch).
+// `persistShared` → shared IDB store with no buster (climb stats, beta links,
+//                   global feeds — same payload for every viewer).
+//
+// A query may opt in to only one of the two. Don't combine them.
+
+export const persistUser = { persist: true } as const;
+export const persistShared = { persistShared: true } as const;

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -37,6 +37,7 @@ export type UserPreferenceKeyMap = {
   'shakeToReport:dismissed': boolean;
   esp32Connections: Esp32Connection[];
   lastUsedGrade: number;
+  youLastTab: 'progress' | 'sessions' | 'logbook';
 };
 
 // Map of IDB preference keys to their legacy localStorage keys for one-time migration

--- a/packages/web/app/you/you-tab-bar.tsx
+++ b/packages/web/app/you/you-tab-bar.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import { useTranslation } from 'react-i18next';
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
+import { setPreference } from '@/app/lib/user-preferences-db';
 
 type YouTab = 'progress' | 'sessions' | 'logbook';
 
@@ -21,6 +22,12 @@ export default function YouTabBar() {
   } else {
     activeTab = 'progress';
   }
+
+  // Remember the last /you sub-tab the user was on so the bottom tab bar's
+  // "you" link can resume them where they left off.
+  useEffect(() => {
+    void setPreference('youLastTab', activeTab);
+  }, [activeTab]);
 
   const handleTabChange = useCallback(
     (_: React.SyntheticEvent, value: YouTab) => {


### PR DESCRIPTION
## Summary

Builds on #2201 (`perf/you-page-client-cache`) and extends the IDB-backed React Query persister to ~15 more surfaces. Skeleton-heavy pages render from IDB on revisit; tick writes update the cached feeds directly so logged ticks appear immediately and edits/deletes don't flash a skeleton.

> **Stacking note:** This branch was cut from `perf/you-page-client-cache` but is being opened against `main` since #2201 will merge first. Once #2201 lands, GitHub will collapse this PR's diff to just the rollout changes.

## What's new

### Infrastructure
- `createSharedIdbPersister` adds a second IDB store (`boardsesh-react-query-shared`) for queries that aren't bound to a signed-in user (climb stats, beta links, global / new-climb feeds). Sign-out leaves it alone.
- `SessionCacheBuster` only wipes `meta.persist === true` queries on user switch; `meta.persistShared === true` is left intact.
- New `packages/web/app/lib/react-query-persist-meta.ts` exports `persistUser` / `persistShared` constants so the rollout footprint is grep-able (no ad-hoc `{ persist: true }` literals).

### Logbook — the marquee win
- `LogbookFeed` and `AscentsFeed` opt in with `staleTime: 5min`, `gcTime: 24h`, `refetchOnMount: 'always'`.
- `useSaveTick` `onMutate` now optimistically prepends an `AscentFeedItem` to every cached `['logbookFeed', ...]` entry, using climb context piped through `SaveTickOptions` (`climbName`, `setterUsername`, `frames`). On success, the temp row is swapped out via a feed invalidation that pulls the canonical server row. On error, the snapshot restores.
- `useUpdateTick` switched from `invalidateQueries(['logbookFeed'])` → targeted `setQueryData` that merges the `UPDATE_TICK` response into every matching row across both the flat and grouped feeds. No skeleton flash on edit.
- `useDeleteTick` switched from `invalidateQueries(['ascentsFeed'])` → targeted `setQueryData` that removes the row and prunes empty groups.
- Aggregate invalidations (`userTicks`, `userProfileStats`, `userClimbPercentile`, `sessionDetail`) stay — those can't be recomputed locally.

### Persisted query keys

**Tier 1 — user-scoped**
| Key | File |
|---|---|
| `['notifications', 'unreadCount']` | `hooks/use-unread-notification-count.ts` |
| `['notifications', 'grouped']` | `hooks/use-grouped-notifications.ts` |
| `['myGyms']` | `components/gym-entity/gym-selector.tsx` |
| `['sessionDetail', sessionId]` | `hooks/use-session-detail.ts` |

**Tier 1 — shared**
| Key | File |
|---|---|
| `['climbStats', boardName, climbUuid]` | `components/board-page/angle-selector.tsx` |
| `['betaLinks', boardType, climbUuid]` | `components/climb-detail/build-climb-detail-sections.tsx` |

**Tier 2 — user-scoped**
| Key | File |
|---|---|
| `['sessionFeed', boardUuid, userId]` (signed-in only) | `components/activity-feed/activity-feed.tsx` |
| `['followingAscentsFeed', token]` | `components/social/following-ascents-feed.tsx` |
| `['followingClimbAscents', userId, boardType, climbUuid]` | `components/logbook/crew-logbook-view.tsx` |
| `['climbDrafts', ...]` | `components/create-climb/drafts-drawer.tsx` |
| `['logbookFeed', userId, ...]` | `components/library/logbook-feed.tsx` |
| `['ascentsFeed', userId, pageSize]` | `components/activity-feed/ascents-feed.tsx` |

**Tier 2 — shared**
| Key | File |
|---|---|
| `['globalAscentsFeed']` | `components/social/global-ascents-feed.tsx` |
| `['newClimbFeed', boardType, layoutId]` | `components/new-climb-feed/new-climb-feed.tsx` |
| `['globalCommentFeed', boardUuid]` | `components/activity-feed/comment-feed.tsx` |
| `['setterStats', apiUrl]` | `components/search-drawer/setter-name-select.tsx` |

### Intentionally NOT persisted
- Party-mode queue / WS state — real-time collaborative.
- WS auth token — rotates per session.
- NextAuth session — already excluded by #2201.
- `['logbook', boardName, 'accumulated']` / `'fetch'` — incremental-fetch hook owns its own merge logic; IDB would fight the ref-based dedup.

## Test plan

- [ ] Cold-load `/you/logbook` in incognito → skeleton once, then GraphQL feed page fires. DevTools → IDB → `boardsesh-react-query` → `cache` → `client` contains `['logbookFeed', userId, ...]`.
- [ ] Soft nav to `/you/logbook` after a previous visit → **no skeleton**, background refetch visible.
- [ ] Hard reload `/you/logbook` → at most one frame of skeleton (the `useIsRestoring` window), then renders from IDB.
- [ ] Log a tick → new row appears at top of `/you/logbook` **before** the network response. Reload — row persists.
- [ ] Edit a tick → updates in place, no skeleton flash.
- [ ] Delete a tick → row disappears immediately, persists across reload.
- [ ] Sign out → sign in as different user → first `/you/logbook` visit is a cold load; no leakage from previous identity. `boardsesh-react-query-shared` IDB blob still present.
- [ ] Notifications badge renders from cache before network resolves; marking all read clears optimistically.
- [ ] Climb detail beta-videos + crew sections render from IDB on second visit; no spinners.
- [ ] Angle-selector drawer renders climb stats from IDB on second open.
- [ ] Party-mode queue keys are NOT present in either IDB store.

## Validation

- `vp check`: passes.
- `vp run typecheck:web`: passes.
- `vp test run --project web`: 4465 pass / 4 pre-existing flakes (i18n catalog drift, create-climb-form, quick-tick-bar, start-sesh-drawer) — all pass in isolation, none introduced by this PR. Updated `use-update-tick.test.ts` and `use-delete-tick.test.ts` to cover the new targeted `setQueryData` behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)