### PR TITLE
i18n: backfill es + fr to full parity with en-US, enforce in CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ Boardsesh ships English (`en-US`) at root paths and Spanish (`es`) at `/es/*`. T
 
 **Adding new copy**
 
-- Add the key to the matching English catalog only: `packages/web/i18n/locales/en-US/<namespace>.json`. Spanish catalogs are filled by community contributors. Missing Spanish keys fall back to English automatically (i18next `fallbackLng`).
+- Add the key to **every** supported locale catalog: `packages/web/i18n/locales/<locale>/<namespace>.json` for each entry in `SUPPORTED_LOCALES` (currently `en-US`, `es`, `fr`). Catalogs must stay at full parity — missing keys would fall back to English at runtime via i18next's `fallbackLng`, but they show up as warnings in Sentry and ship silently-English copy to non-English users. `packages/web/app/__tests__/i18n-catalog-completeness.test.ts` enforces parity per namespace for every supported locale and will fail the build if you add an English key without its `es` and `fr` translations.
 - Pick the right namespace. Currently `common` (shared chrome) and `marketing` (about/help/docs/legal/privacy/home). Add a new namespace by adding it to `SEED_NAMESPACES` in `packages/web/app/lib/i18n/config.ts` and creating `<lang>/<namespace>.json` files for each supported locale.
 - Use ICU-style placeholders for interpolation: `"greeting": "Hello {{name}}"`.
 

--- a/packages/web/app/__tests__/i18n-catalog-completeness.test.ts
+++ b/packages/web/app/__tests__/i18n-catalog-completeness.test.ts
@@ -6,11 +6,11 @@ import { DEFAULT_LOCALE } from '@/app/lib/i18n/config';
 
 const LOCALES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'i18n', 'locales');
 
-// Locales we ship and own end-to-end. Community-maintained locales (e.g. `es`)
-// are intentionally allowed to have gaps — i18next falls back to English. New
-// owned locales must stay at full parity so a missing key surfaces here, not
-// in production as silently-English copy.
-const STRICTLY_ENFORCED_LOCALES = ['fr'] as const;
+// Every supported locale (except the source `en-US`) must stay at full parity
+// with the English catalog. Missing keys silently fall back to English at
+// runtime, ship untranslated copy to users, and spam Sentry with missing-key
+// warnings — fail the build here instead.
+const STRICTLY_ENFORCED_LOCALES = ['es', 'fr'] as const;
 
 type Catalog = Record<string, unknown>;
 

--- a/packages/web/i18n/locales/es/admin.json
+++ b/packages/web/i18n/locales/es/admin.json
@@ -3,6 +3,10 @@
     "admin": {
       "title": "Panel de admin",
       "description": "Panel de admin de Boardsesh"
+    },
+    "retention": {
+      "title": "Retención",
+      "description": "Panel de retención por cohortes"
     }
   },
   "title": "Panel de admin",
@@ -109,6 +113,33 @@
       "saved_one": "Se guardó {{count}} ajuste",
       "saved_other": "Se guardaron {{count}} ajustes",
       "saveFailed": "No se pudieron guardar los ajustes"
+    }
+  },
+  "nav": {
+    "retention": "Panel de retención"
+  },
+  "retention": {
+    "heading": "Retención de usuarios",
+    "subheading": "De los usuarios que se registraron en la semana W, qué porcentaje estuvo activo el día N — retención Dn clásica. Calculada tanto para marcas (bloques registrados) como para cualquier actividad en la app.",
+    "definitions": "Cohorte = semana de registro (UTC). Dn cuenta a un usuario si tuvo actividad en la ventana de 24 horas que empieza N días después del registro (así D7 = activo exactamente el día 7, no en cualquier momento de los primeros 7 días). Marcas = al menos un bloque registrado en Boardsesh (las marcas importadas de Aurora no se cuentan). Cualquier actividad = una marca, anfitrión o participación en una sesión de fiesta, favorito, playlist (creada o fijada), seguimiento (de usuario, setter o playlist), suscripción a nuevos bloques, comentario, voto, voto en propuesta o envío de comentarios. Las cohortes más recientes que la ventana muestran —.",
+    "back": "Volver al panel de admin",
+    "table": {
+      "cohortWeek": "Semana de cohorte",
+      "signups": "Registros",
+      "groupTicks": "Marcas",
+      "groupAny": "Cualquier actividad",
+      "activated": "Activados",
+      "d1": "D1",
+      "d3": "D3",
+      "d7": "D7",
+      "d30": "D30",
+      "notReady": "—",
+      "empty": "Aún no hay datos de cohortes."
+    },
+    "chart": {
+      "title": "Retención D7 por semana de cohorte",
+      "label": "Marcas",
+      "labelAny": "Cualquier actividad"
     }
   }
 }

--- a/packages/web/i18n/locales/es/climbs.json
+++ b/packages/web/i18n/locales/es/climbs.json
@@ -105,7 +105,10 @@
       "somewhatAccurate": "Algo precisa (<0.2)",
       "veryAccurate": "Muy precisa (<0.1)",
       "extremelyAccurate": "Extremadamente precisa (<0.05)",
-      "classicsOnly": "Solo clásicos"
+      "classicsOnly": "Solo clásicos",
+      "minAscentsOption": "{{value}}+",
+      "minRatingOption_one": "{{count}} estrella o más",
+      "minRatingOption_other": "{{count}} estrellas o más"
     },
     "panels": {
       "quality": "Calidad",
@@ -292,6 +295,12 @@
         "updateFailed": "No se pudo actualizar el favorito. Inténtalo de nuevo.",
         "saveFailed": "No se pudo guardar el favorito. Inténtalo de nuevo."
       }
+    },
+    "sendToBoard": {
+      "label": "Enviar al board",
+      "active": "En el muro",
+      "tooltip": "Enviar al board",
+      "activeTooltip": "Ahora en el muro"
     }
   },
   "card": {
@@ -310,7 +319,9 @@
   },
   "detail": {
     "sections": {
-      "beta": "Beta"
+      "beta": "Beta",
+      "similarClimbs": "Bloques similares",
+      "similarClimbsSummary": "Bloques que comparten el 50%+ de estas presas"
     }
   },
   "multiboardList": {
@@ -331,7 +342,9 @@
       "gradeOverride": "Grado personalizado",
       "clearGradeOverride": "Borrar grado personalizado",
       "consensusSuffix": "consenso",
-      "attemptCount": "Número de intentos"
+      "attemptCount": "Número de intentos",
+      "starOption_one": "{{count}} estrella",
+      "starOption_other": "{{count}} estrellas"
     },
     "bar": {
       "logAscent": "Registrar encadene",
@@ -369,7 +382,12 @@
     "alerts": {
       "importFailed": "Importación fallida: {{error}}",
       "importWarnings": "Avisos de importación:",
-      "checkingMoonBoardDuplicate": "Comprobando si este bloque de MoonBoard ya existe..."
+      "checkingMoonBoardDuplicate": "Comprobando si este bloque de MoonBoard ya existe...",
+      "publishDuplicateNamed": "Este patrón de presas coincide con \"{{name}}\". Activa Borrador para guardarlo sin publicar, o cambia una presa.",
+      "publishDuplicateUnnamed": "Este patrón de presas coincide con un bloque existente. Activa Borrador para guardarlo sin publicar, o cambia una presa.",
+      "viewMatchingClimb": "Ver bloque coincidente",
+      "identicalClimbDrawerTitle": "Bloque idéntico",
+      "saveFailedFallback": "No se pudo guardar el bloque. Inténtalo de nuevo."
     },
     "settings": {
       "tooltip": "Ajustes del bloque",
@@ -403,6 +421,14 @@
     "empty": {
       "title": "Aún no hay borradores",
       "subtitle": "Guarda un bloque como borrador para retomarlo más tarde."
+    },
+    "delete": {
+      "tooltip": "Eliminar borrador",
+      "title": "¿Eliminar este borrador?",
+      "description": "Esto elimina el borrador guardado. Los bloques publicados no se ven afectados.",
+      "confirm": "Eliminar",
+      "success": "Borrador eliminado.",
+      "error": "No se pudo eliminar ese borrador. Inténtalo de nuevo."
     }
   },
   "holdTypePicker": {
@@ -488,5 +514,14 @@
     "grade": "Grado: {{grade}}",
     "angle": "Ángulo: {{angle}}°",
     "unknown": "Desconocido"
+  },
+  "similarClimbs": {
+    "loadError": "No se pudieron cargar los bloques similares.",
+    "emptyDefault": "Aún no hay bloques similares.",
+    "emptyOnLayout": "No hay bloques similares en este layout.",
+    "emptyIdentical": "Ahora mismo no se encontraron bloques idénticos.",
+    "untitledClimb": "Bloque sin título",
+    "openActions": "Más acciones",
+    "actionsUnavailable": "No se pueden abrir acciones para este bloque — configuración de la tabla no disponible."
   }
 }

--- a/packages/web/i18n/locales/es/common.json
+++ b/packages/web/i18n/locales/es/common.json
@@ -74,7 +74,11 @@
     "about": "Sobre",
     "rateBoardsesh": "Valorar Boardsesh",
     "reportBug": "Reportar un bug",
-    "logout": "Cerrar sesión"
+    "logout": "Cerrar sesión",
+    "devBuild": "Build de dev",
+    "branch": "Rama",
+    "qaNotes": "Notas de QA",
+    "qaNotesEmpty": "Sin archivo de notas de QA"
   },
   "loading": {
     "messages": [
@@ -195,5 +199,40 @@
   },
   "board": {
     "resetZoom": "Restablecer zoom"
+  },
+  "lightControl": {
+    "title": "Luces",
+    "turnOffAll": "Apagar todas las luces",
+    "partyMode": "Modo fiesta",
+    "stopParty": "Parar fiesta",
+    "partyUnsupported": "El modo fiesta no está disponible en esta tabla",
+    "discoMode": "Modo disco",
+    "stopDisco": "Parar disco",
+    "discoNeedsClimb": "Carga un bloque para empezar el disco",
+    "clearFailed": "No se pudo limpiar la tabla",
+    "customizeColors": "Personalizar colores",
+    "customizeColorsUnsupported": "Los colores personalizados no están disponibles en esta tabla",
+    "customizeColorsTitle": "Colores de los LED",
+    "customizeColorsHelp": "Elige los colores con los que tu tabla ilumina las manos, los pies y la presa final. Las presas de inicio mantienen su verde por defecto.",
+    "resetColors": "Restablecer",
+    "disconnect": "Desconectar tabla",
+    "role": {
+      "HAND": "Manos",
+      "FOOT": "Pies",
+      "FINISH": "Final"
+    }
+  },
+  "ascents": {
+    "deleteTitle": "Eliminar encadene",
+    "deleteDescription": "¿Seguro? No se puede deshacer.",
+    "statusFlash": "flash",
+    "statusSend": "encadene",
+    "statusAttempt": "intento",
+    "flashed_one": "Flash",
+    "flashed_other": "{{count}} flashes",
+    "sent_one": "Encadenado",
+    "sent_other": "{{count}} encadenes",
+    "attempts_one": "1 intento",
+    "attempts_other": "{{count}} intentos"
   }
 }

--- a/packages/web/i18n/locales/es/feed.json
+++ b/packages/web/i18n/locales/es/feed.json
@@ -37,7 +37,12 @@
       "step1Title": "Abre Instagram y copia tu descripción",
       "step2Title": "Desde tu publicación, copia el enlace para compartir",
       "step3Title": "Pega el enlace abajo"
-    }
+    },
+    "copyAndOpenInstagram": "Copiar y abrir Instagram",
+    "instagramCopyFailed": "No se pudo copiar la descripción. Inténtalo de nuevo.",
+    "instagramCopiedAndOpened": "Descripción copiada — pégala en Instagram.",
+    "instagramCopiedOnly": "Descripción copiada al portapapeles.",
+    "addSubmit": "Añadir"
   },
   "commentFeed": {
     "empty": "Sin comentarios todavía",

--- a/packages/web/i18n/locales/es/marketing.json
+++ b/packages/web/i18n/locales/es/marketing.json
@@ -113,7 +113,9 @@
       "activityLabel": "Actividad de escalada.",
       "activityBody": "Cuando registras un envío o un intento guardamos los detalles del problema, el grado, la fecha y las notas que añadas. Esto alimenta tu logbook y el seguimiento de progresión.",
       "locationLabel": "Ubicación.",
-      "locationBody": "Si concedes permiso de ubicación, usamos tu ubicación aproximada para ayudarte a descubrir sesiones de Modo Fiesta cercanas. No rastreamos tu ubicación en segundo plano ni guardamos historial."
+      "locationBody": "Si concedes permiso de ubicación, usamos tu ubicación aproximada para ayudarte a descubrir sesiones de Modo Fiesta cercanas. No rastreamos tu ubicación en segundo plano ni guardamos historial.",
+      "productAnalyticsLabel": "Analítica de producto.",
+      "productAnalyticsBody": "Usamos PostHog y Vercel Analytics para entender el uso de las funciones, las visitas a páginas, el rendimiento y dónde se atasca la app. Algunos eventos de producto registrados con la sesión iniciada se asocian a tu cuenta de Boardsesh para entender qué funciones resultan útiles. No usamos estos datos para publicidad."
     },
     "bluetooth": {
       "title": "Bluetooth",
@@ -132,11 +134,15 @@
       "auroraLabel": "API de Aurora Climbing.",
       "auroraBody": "Si vinculas tu cuenta de Aurora Climbing (usada por las tablas Kilter y Tension), sincronizamos tus datos de escalada con los servidores de Aurora para que tu logbook sea coherente entre apps. Esta sincronización solo ocurre cuando tú la inicias. Consulta ",
       "auroraLink": "Aurora Climbing",
-      "auroraBodyEnd": " para sus prácticas de datos."
+      "auroraBodyEnd": " para sus prácticas de datos.",
+      "posthogLabel": "PostHog.",
+      "posthogBody": "Usamos PostHog para analítica de producto, incluidos eventos del lado del servidor para funciones nativas como las Live Activities de iOS. Consulta ",
+      "posthogLink": "la política de privacidad de PostHog"
     },
     "sharing": {
       "title": "Compartir de datos",
-      "body2": "Otros usuarios de Boardsesh pueden ver tu nombre de usuario, tu perfil y tus problemas registrados si participas en funciones sociales como el Modo Fiesta. Esto se ve en la app y forma parte de cómo funciona el producto."
+      "body2": "Otros usuarios de Boardsesh pueden ver tu nombre de usuario, tu perfil y tus problemas registrados si participas en funciones sociales como el Modo Fiesta. Esto se ve en la app y forma parte de cómo funciona el producto.",
+      "body1ProductAnalytics": "No vendemos tus datos. No mostramos anuncios. No compartimos tu información con anunciantes ni con brokers de datos. Los únicos datos que se comparten externamente son los descritos arriba (alojamiento y analítica de Vercel, analítica de producto de PostHog y sincronización con Aurora Climbing cuando lo activas tú)."
     },
     "retention": {
       "title": "Retención de datos",
@@ -169,6 +175,387 @@
       "body2Start": "Boardsesh es código abierto. Puedes ver exactamente qué datos recoge la app y cómo se procesan leyendo el código fuente en ",
       "body2Link": "GitHub",
       "body2End": "."
+    },
+    "lastUpdatedProductAnalytics": "Última actualización: mayo de 2026",
+    "intro2ProductAnalytics": "Resumen rápido: solo recogemos lo necesario para que la app funcione. No vendemos tus datos, no mostramos anuncios y no compartimos datos con anunciantes ni con brokers de datos."
+  },
+  "legal": {
+    "headerTitle": "Legal",
+    "intro": {
+      "title": "Política Legal y de Propiedad Intelectual",
+      "p1": "Boardsesh es una alternativa gratuita, de código abierto y construida por la comunidad para navegar e interactuar con tablas de entrenamiento de escalada con LEDs estandarizadas (Kilter Board, Tension Board, MoonBoard y otras). No tiene fines comerciales y está mantenida íntegramente por voluntarios.",
+      "p2": "Creemos que los escaladores deben tener la libertad de elegir cómo interactúan con el hardware que han comprado y que los datos creados por la comunidad deben seguir siendo accesibles para la comunidad."
+    },
+    "climbData": {
+      "title": "Nuestra Posición sobre los Datos de los Bloques",
+      "facts": {
+        "title": "Los bloques son datos factuales",
+        "p1": "Un bloque en una tabla estandarizada es una lista de posiciones de presas sobre un layout fijo y estandarizado (por ejemplo, «empieza en A5, usa B12, C3, D18, termina en K11»), combinada con un grado y un ángulo del muro. Esto es información factual y funcional —comparable a una posición de ajedrez, un conjunto de coordenadas GPS o un número de teléfono— y no una obra creativa de autoría.",
+        "p2": "Según la ley de derechos de autor de EE. UU., los hechos no son protegibles por copyright (<em>Feist Publications, Inc. v. Rural Telephone Service Co.</em>, 499 U.S. 340 (1991)). Una tabla estandarizada con un número finito de presas (normalmente 200–500) produce definiciones de bloques que son intrínsecamente limitadas, factuales y funcionales."
+      },
+      "community": {
+        "title": "La base de datos la crea la comunidad",
+        "p1": "Las bases de datos de bloques de estas tablas son casi en su totalidad contenido generado por los usuarios. Cada escalador crea y envía bloques. Los fabricantes de las tablas no son los autores de este contenido: solo proporcionan una plataforma para enviarlo y mostrarlo.",
+        "p2": "La situación de licencia varía según el fabricante, pero en ningún caso un fabricante es dueño de los datos de bloques de la comunidad:",
+        "aurora": "<strong>Aurora Climbing</strong> (Kilter Board, Tension Board y otras): los Términos de Uso de Aurora les otorgan una «licencia perpetua, sin restricciones, ilimitada, no exclusiva e irrevocable» sobre el contenido enviado por los usuarios. Lo importante es que esta licencia es <strong>no exclusiva</strong>: no transfiere la propiedad a Aurora ni impide que el creador original (o terceros) usen, recopilen o presenten de forma independiente los mismos datos factuales.",
+        "moonLabel": "Moon Climbing (MoonBoard):",
+        "moonBody": "En la última revisión de los documentos legales públicos de Moon Climbing (febrero de 2026), Moon Climbing no tiene unos Términos de Servicio específicos para la app, ni un Acuerdo de Licencia de Usuario Final, ni una licencia sobre el contenido aportado que regule la app de MoonBoard o su base de datos de bloques. A falta de cualquier acuerdo de este tipo, Moon Climbing no tiene ninguna reclamación contractual sobre los bloques creados y enviados por sus usuarios."
+      },
+      "compilation": {
+        "title": "Las bases de datos exhaustivas tienen una protección débil como compilación",
+        "body": "Incluso cuando la disposición de una base de datos pudiera optar a una protección de copyright limitada como compilación, el Tribunal Supremo de EE. UU. ha establecido que la protección se extiende únicamente a la selección o disposición creativa, no a los hechos subyacentes. Una base de datos que recoge de forma exhaustiva todos los envíos de usuarios sin curación editorial (como hacen estas plataformas) es análoga a un directorio telefónico ordenado alfabéticamente, que el Tribunal consideró no protegible en <em>Feist</em>."
+      }
+    },
+    "attribution": {
+      "title": "Atribución y Respeto a los Creadores",
+      "intro": "Respetamos a la comunidad escaladora y a quienes crean los bloques.",
+      "item1": "Cuando hay información del creador del bloque disponible, atribuimos el bloque a su nombre de usuario.",
+      "item2": "No nos atribuimos la autoría de bloques que no hemos creado.",
+      "item3Start": "Si eres el creador de un bloque y te gustaría que lo retirásemos, por favor",
+      "item3Link": "abre un issue",
+      "item3End": "o contáctanos y atenderemos tu solicitud con rapidez."
+    },
+    "interop": {
+      "title": "Interoperabilidad y Compatibilidad de Hardware",
+      "intro": "Este proyecto ofrece software y diseños de hardware compatibles con tablas de escalada estandarizadas. Los escaladores que han comprado estas tablas tienen derecho a usar software y controladores de terceros con su propio hardware.",
+      "software": {
+        "title": "Interoperabilidad de software",
+        "body": "Nuestra app se comunica con los controladores de las tablas mediante protocolos Bluetooth estándar. El protocolo de comunicación Bluetooth que usan estas tablas no está cifrado y se basa en hardware de consumo (LEDs direccionables WS2812B controlados por controladores Bluetooth estándar). Implementar una interfaz Bluetooth compatible con fines de interoperabilidad está reconocido como lícito tanto en el derecho de EE. UU. como en el de la UE (<em>Sega Enterprises Ltd. v. Accolade, Inc.</em>, 977 F.2d 1510 (9th Cir. 1992); Directiva 2009/24/CE de la UE, artículo 6)."
+      },
+      "controller": {
+        "title": "Controlador de código abierto",
+        "p1": "Este proyecto también ofrece diseños de hardware y firmware de controlador en código abierto. El controlador es una implementación independiente y original que se comunica usando el mismo protocolo Bluetooth que los controladores oficiales. Está construido sobre componentes de consumo (microcontroladores estándar y LEDs WS2812B) y no incorpora ningún firmware, código o diseño de hardware propietario de ningún fabricante de tablas. No se conoce la existencia de patentes que cubran los sistemas de controlador LED utilizados por ningún fabricante de tablas actual.",
+        "p2": "Nuestro controlador está diseñado para ser interoperable tanto con el software de este proyecto como, a discreción del usuario, con las apps oficiales del fabricante. Cualquier interoperabilidad de este tipo la inicia el usuario final con su propio hardware."
+      }
+    },
+    "trademark": {
+      "title": "Uso de Marcas Registradas",
+      "body": "Usamos los nombres de tablas y productos (por ejemplo, «Kilter Board», «MoonBoard», «Tension Board») únicamente para describir la compatibilidad e interoperabilidad de hardware. Estos nombres son marcas registradas de sus respectivos propietarios. Este proyecto no está afiliado, respaldado ni patrocinado por Aurora Climbing, Moon Climbing ni ningún fabricante de tablas."
+    },
+    "dmca": {
+      "title": "DMCA y Solicitudes de Retirada",
+      "intro": "Nos tomamos en serio las cuestiones de propiedad intelectual. Si crees que algún material de este proyecto infringe tus derechos de autor, por favor contáctanos con la siguiente información:",
+      "item1": "Identificación de la obra protegida por derechos de autor que crees que se está infringiendo.",
+      "item2": "Identificación del material que crees que está infringiendo, con suficiente detalle para que podamos localizarlo.",
+      "item3": "Tu información de contacto (nombre, dirección, correo electrónico, teléfono).",
+      "item4": "Una declaración de que crees de buena fe que el uso no está autorizado por el titular de los derechos de autor, su agente o la ley.",
+      "item5": "Una declaración, bajo pena de perjurio, de que la información de tu notificación es exacta y de que eres el titular de los derechos de autor o estás autorizado a actuar en su nombre.",
+      "review1": "Revisaremos todas las solicitudes válidas con rapidez y de buena fe. También podemos presentar una contranotificación cuando consideremos que una solicitud de retirada se basa en una identificación errónea del material o en una mala interpretación de la ley.",
+      "contactLabel": "Contacto:"
+    },
+    "community": {
+      "title": "Una Nota para la Comunidad",
+      "p1": "La comunidad escaladora tiene una larga tradición de compartir beta abiertamente. Este proyecto existe con ese espíritu. No tratamos de perjudicar a ninguna empresa: solo intentamos dar a los escaladores mejores herramientas para interactuar con el hardware que ya poseen y con los datos que han ayudado a crear.",
+      "p2": "Los fabricantes siguen beneficiándose de este ecosistema. Nuestro proyecto genera demanda para sus productos físicos (presas, tablas, paneles), donde sí aportan un valor real. Simplemente creemos que los escaladores merecen poder elegir cómo interactúan con su hardware.",
+      "p3": "Si eres un fabricante de tablas y te gustaría hablar de colaborar o tienes alguna preocupación, estamos abiertos al diálogo. Escríbenos."
+    },
+    "thirdParty": {
+      "title": "Avisos de Terceros",
+      "iconLabel": "Icono de Person Falling",
+      "iconFrom": "de",
+      "fontAwesomeLink": "Font Awesome Free 6.7.2",
+      "byAuthor": "por @fontawesome.",
+      "licenseLabel": "Licencia:",
+      "licenseLink": "CC BY 4.0",
+      "copyright": ". Copyright 2024 Fonticons, Inc."
+    },
+    "footer": "Este documento se proporciona con fines informativos y no constituye asesoramiento legal. Última actualización: 08-02-2026"
+  },
+  "help": {
+    "headerTitle": "Ayuda",
+    "hero": {
+      "title": "¿En qué te podemos ayudar?",
+      "subtitle": "Conoce las funciones de Boardsesh y saca el máximo partido a tus sesiones de escalada"
+    },
+    "sections": {
+      "visualization": {
+        "label": "Visualización y análisis"
+      },
+      "collaboration": {
+        "label": "Sesión y colaboración"
+      },
+      "training": {
+        "label": "Entrenamiento"
+      },
+      "search": {
+        "label": "Búsqueda y descubrimiento"
+      },
+      "connectivity": {
+        "label": "Sincronización y conectividad"
+      }
+    },
+    "heatmap": {
+      "q": "¿Cómo uso el mapa de calor?",
+      "imgAlt": "Visualización del mapa de calor",
+      "intro": "El mapa de calor muestra patrones de uso de las presas en todos los bloques, lo que te ayuda a identificar presas populares y oportunidades de entrenamiento.",
+      "accessLabel": "Para acceder al mapa de calor:",
+      "access1": "Abre el panel de búsqueda y despliega la sección «Presas»",
+      "access2": "Pulsa el botón «Mostrar mapa de calor»",
+      "access3": "La tabla mostrará una capa de color que va de verde (poco uso) a rojo (mucho uso)",
+      "modesLabel": "Modos de color disponibles:",
+      "modes": {
+        "ascentsLabel": "Encadenes:",
+        "ascentsBody": "Popularidad general basada en el total de encadenes",
+        "startLabel": "Presas de salida:",
+        "startBody": "Posiciones habituales de inicio",
+        "handFootLabel": "Presas de mano/pie:",
+        "handFootBody": "Uso por tipo de extremidad",
+        "finishLabel": "Presas de top:",
+        "finishBody": "Posiciones habituales de top out"
+      },
+      "outro": "Usa los interruptores para mostrar/ocultar los números de presa e incluir/excluir las presas de pie."
+    },
+    "holdClassification": {
+      "q": "¿Cómo clasifico las presas de mi tabla?",
+      "imgAlt": "Asistente de clasificación de presas",
+      "intro": "La clasificación de presas te permite crear valoraciones personales para cada presa de tu tabla, ayudándote a entender tus puntos fuertes y a encontrar bloques que te encajen.",
+      "attrsLabel": "Atributos de clasificación:",
+      "attrs": {
+        "holdTypeLabel": "Tipo de presa:",
+        "holdTypeBody": "Jug, sloper, pinza, regleta o agujero",
+        "handRatingLabel": "Valoración de mano:",
+        "handRatingBody": "Escala de dificultad 1-5 para el uso con la mano",
+        "footRatingLabel": "Valoración de pie:",
+        "footRatingBody": "Escala de dificultad 1-5 para el uso con el pie",
+        "pullDirectionLabel": "Dirección de tracción:",
+        "pullDirectionBody": "Ángulo óptimo de tracción de 0 a 360"
+      },
+      "outro": "Las clasificaciones son personales y se guardan en tu cuenta, así puedes ir construyendo con el tiempo una comprensión a medida de tu tabla."
+    },
+    "partyMode": {
+      "q": "¿Cómo empiezo una sesión colaborativa?",
+      "imgAlt": "Sesión del Modo Fiesta activa",
+      "intro": "El Modo Fiesta permite que varios escaladores compartan una cola y se vayan turnando en la tabla en tiempo real.",
+      "startLabel": "Para empezar una sesión:",
+      "start1": "Toca el icono de la bombilla en la barra de la cola, abajo",
+      "start2": "Ve a la pestaña «Empezar sesión» e inicia sesión si aún no lo has hecho",
+      "start3": "Pulsa «Empezar Modo Fiesta» para crear una nueva sesión",
+      "start4": "Comparte la sesión con tus amigos mediante código QR o enlace",
+      "joinLabel": "Para unirte a una sesión:",
+      "join": {
+        "qrLabel": "Escanear código QR:",
+        "qrBody": "El anfitrión de la sesión puede mostrar un código QR para que los demás lo escaneen con la cámara del móvil",
+        "shareLabel": "Compartir enlace:",
+        "shareBody": "Copia y comparte la URL de la sesión: cualquiera con el enlace puede unirse",
+        "idLabel": "Introducir ID de sesión:",
+        "idBody": "Ve a la pestaña «Unirse a sesión» y pega la URL completa o solo el ID de sesión"
+      },
+      "featuresLabel": "Funciones de la sesión:",
+      "feature1": "Sincronización de la cola en tiempo real en todos los dispositivos",
+      "feature2": "Varios usuarios pueden añadir/quitar bloques",
+      "feature3": "El líder de la sesión controla lo que se muestra en la tabla",
+      "feature4": "Traspaso automático del liderazgo si el líder actual se desconecta",
+      "feature5": "La sesión se mantiene tras recargar la página y reconexiones"
+    },
+    "queueManagement": {
+      "q": "¿Cómo gestiono la cola de bloques?",
+      "imgAlt": "Gestión de la cola",
+      "intro": "La cola te permite organizar los bloques para tu sesión, ya escales solo o con otros.",
+      "actionsLabel": "Acciones de la cola:",
+      "actions": {
+        "addLabel": "Añadir bloques:",
+        "addBody": "Toca dos veces cualquier bloque de la lista para añadirlo a tu cola",
+        "reorderLabel": "Reordenar:",
+        "reorderBody": "Arrastra y suelta los bloques para cambiar el orden",
+        "currentLabel": "Marcar actual:",
+        "currentBody": "Pulsa un bloque para convertirlo en el bloque activo",
+        "removeLabel": "Quitar:",
+        "removeBody": "Pulsa la X de cualquier bloque en cola",
+        "mirrorLabel": "Espejo:",
+        "mirrorBody": "Activa el modo espejo para entrenamiento bilateral"
+      },
+      "outro": "La cola se sincroniza automáticamente con los miembros del grupo y se mantiene offline para que tu sesión no se corte."
+    },
+    "playlistGenerator": {
+      "q": "¿Cómo genero una playlist de entrenamiento?",
+      "intro": "El Generador de Playlists crea entrenamientos estructurados a la medida de tus objetivos.",
+      "typesLabel": "Tipos de entrenamiento:",
+      "types": {
+        "volumeLabel": "Volumen:",
+        "volumeBody": "Muchas repeticiones a un grado constante para resistencia",
+        "pyramidLabel": "Pirámide:",
+        "pyramidBody": "Sube hasta un grado tope y luego baja",
+        "ladderLabel": "Escalera:",
+        "ladderBody": "Progresión por escalones subiendo grados",
+        "gradeFocusLabel": "Foco en grado:",
+        "gradeFocusBody": "Trabajo concentrado en un único grado objetivo"
+      },
+      "optionsLabel": "Opciones de configuración:",
+      "option1": "Estilo de calentamiento (estándar, extendido o ninguno)",
+      "option2": "Selección del grado objetivo",
+      "option3": "Sesgo de bloques (desconocidos, intentados o cualquiera)",
+      "option4": "Filtros de encadenes/valoración mínima",
+      "option5": "Número de bloques por sección"
+    },
+    "mirroring": {
+      "q": "¿Cómo hago un bloque en espejo?",
+      "intro": "El espejo de bloques invierte todas las presas al lado opuesto de la tabla, perfecto para entrenamiento de fuerza bilateral.",
+      "howLabel": "Para hacer un bloque en espejo:",
+      "step1": "Busca el bloque que quieres invertir",
+      "step2": "Busca el icono de espejo en las acciones del bloque",
+      "step3": "Actívalo para invertir el bloque horizontalmente",
+      "outro": "Cuando estés conectado por Bluetooth, la tabla con LEDs mostrará automáticamente el patrón invertido. Esta función está disponible en tablas compatibles como la Kilter Homewall."
+    },
+    "searchFilters": {
+      "q": "¿Qué filtros de búsqueda hay disponibles?",
+      "imgAlt": "Filtros de búsqueda",
+      "basicLabel": "Filtros de búsqueda básicos:",
+      "basic": {
+        "nameLabel": "Nombre del bloque:",
+        "nameBody": "Busca por el título del bloque",
+        "gradeLabel": "Rango de grado:",
+        "gradeBody": "Define grado mínimo y máximo",
+        "setterLabel": "Setter:",
+        "setterBody": "Filtra por el creador del bloque",
+        "minAscentsLabel": "Encadenes mín.:",
+        "minAscentsBody": "Muestra solo bloques populares",
+        "minRatingLabel": "Valoración mín.:",
+        "minRatingBody": "Filtra por valoración de calidad",
+        "classicsLabel": "Solo clásicos:",
+        "classicsBody": "Muestra solo bloques marcados como clásicos"
+      },
+      "personalLabel": "Filtros de progreso personal",
+      "personalRequires": "(requiere iniciar sesión):",
+      "personalImgAlt": "Filtros de progreso personal",
+      "personal1": "Ocultar bloques encadenados",
+      "personal2": "Ocultar bloques intentados",
+      "personal3": "Mostrar solo bloques intentados",
+      "personal4": "Mostrar solo bloques encadenados"
+    },
+    "searchByHold": {
+      "q": "¿Cómo busco por presas concretas?",
+      "imgAlt": "Buscar por presa",
+      "intro": "Buscar por Presa te permite encontrar bloques que usen (o eviten) presas concretas de la tabla.",
+      "howLabel": "Para buscar por presas:",
+      "step1": "Abre el panel de búsqueda y despliega la sección «Presas»",
+      "step2": "Elige el modo «Incluir» o «Excluir» en el desplegable",
+      "step3": "Toca las presas de la tabla para seleccionarlas",
+      "step4": "Los resultados se actualizan automáticamente conforme seleccionas presas",
+      "includeLabel": "Modo incluir:",
+      "includeBody": "Los bloques deben usar las presas seleccionadas",
+      "excludeLabel": "Modo excluir:",
+      "excludeBody": "Los bloques no deben usar las presas seleccionadas"
+    },
+    "bluetooth": {
+      "q": "¿Cómo conecto los LEDs de mi tabla?",
+      "intro": "Boardsesh usa Web Bluetooth para controlar el sistema de LEDs de tu tabla directamente desde el navegador.",
+      "requirementsLabel": "Requisitos:",
+      "req1": "Navegador Chrome (recomendado) u otro navegador compatible con Web Bluetooth",
+      "req2": "Usuarios de iOS: usa la app de Boardsesh (Safari no soporta Web Bluetooth)",
+      "req3": "Bluetooth activado en tu dispositivo",
+      "req4": "Tabla encendida y al alcance",
+      "connectLabel": "Para conectar:",
+      "connect1": "Toca el icono de la bombilla en la barra de la cola",
+      "connect2": "Selecciona tu tabla en la lista de dispositivos",
+      "connect3": "Una vez conectada, los LEDs muestran automáticamente el bloque actual",
+      "outro": "La conexión admite patrones en espejo y se actualizará automáticamente cuando cambies de bloque."
+    },
+    "userSync": {
+      "q": "¿Cómo sincronizo con mi cuenta de Kilter/Tension?",
+      "imgAlt": "Ajustes de la cuenta de Aurora",
+      "intro": "Vincula tu cuenta de Aurora (Kilter o Tension) para sincronizar tu historial de escalada y tu progreso.",
+      "linkLabel": "Para vincular tu cuenta:",
+      "link1": "Abre el menú (toca tu avatar) y ve a Ajustes",
+      "link2": "Busca la sección «Cuentas de Aurora»",
+      "link3": "Introduce tus credenciales de Kilter o Tension",
+      "link4": "Pulsa «Vincular cuenta»",
+      "syncsLabel": "Qué se sincroniza:",
+      "syncs1": "Historial de encadenes (bloques completados)",
+      "syncs2": "Intentos",
+      "syncs3": "Circuitos/playlists",
+      "outro": "Los cambios se sincronizan en ambos sentidos, así que los encadenes registrados en Boardsesh aparecerán también en las apps oficiales."
+    },
+    "logbook": {
+      "q": "¿Cómo registro mis bloques?",
+      "imgAlt": "Detalle del bloque con acciones",
+      "intro": "Sigue tu progreso registrando encadenes e intentos.",
+      "fromLabel": "Desde cualquier bloque:",
+      "actions": {
+        "tickLabel": "Marcar:",
+        "tickBody": "Registra un intento en el bloque",
+        "logLabel": "Registrar encadene:",
+        "logBody": "Marca el bloque como completado (encadene)",
+        "favoriteLabel": "Favorito:",
+        "favoriteBody": "Guarda bloques para acceder rápido"
+      },
+      "outro": "Tu logbook se sincroniza con las cuentas de Aurora vinculadas y puedes filtrarlo en los resultados de búsqueda para encontrar retos nuevos o retomar viejos proyectos."
+    },
+    "offline": {
+      "q": "¿Funciona Boardsesh sin conexión?",
+      "intro": "¡Sí! Boardsesh está diseñado para funcionar de forma fiable incluso con conexión intermitente.",
+      "worksLabel": "Qué funciona sin conexión:",
+      "works1": "Tu cola se guarda en local mediante IndexedDB",
+      "works2": "Los tokens de sesión se cachean para reconectar rápido",
+      "works3": "Los datos del perfil se guardan en local",
+      "works4": "El control de los LEDs por Bluetooth funciona de forma independiente",
+      "outro": "Cuando se restablece la conexión, los cambios pendientes se sincronizan automáticamente en segundo plano."
+    }
+  },
+  "docs": {
+    "loading": "Cargando documentación...",
+    "headerTitle": "Documentación de la API",
+    "headerSubtitle": "Referencia completa de las APIs REST y WebSocket de Boardsesh",
+    "tabs": {
+      "overview": "Resumen",
+      "rest": "API REST",
+      "graphql": "Esquema GraphQL",
+      "websocket": "Guía de WebSocket"
+    },
+    "overview": {
+      "title": "Resumen de la API de Boardsesh",
+      "intro": "Boardsesh ofrece dos APIs complementarias para interactuar con tablas de entrenamiento de escalada interactivas (Kilter, Tension):",
+      "rest": {
+        "title": "API REST",
+        "intro": "Usa la API REST para operaciones sin estado, como buscar bloques, obtener la configuración de la tabla o autenticar usuarios. La API REST es ideal para:",
+        "feature1": "Obtener datos y estadísticas de bloques",
+        "feature2": "Registro y autenticación de usuarios",
+        "feature3": "Gestión de perfil",
+        "feature4": "Integración con la plataforma Aurora",
+        "baseUrlLabel": "URL base:"
+      },
+      "ws": {
+        "title": "API GraphQL por WebSocket",
+        "intro": "Usa la API por WebSocket para funciones en tiempo real, como sesiones de fiesta y sincronización de la cola. La API GraphQL ofrece:",
+        "feature1": "Actualizaciones de la cola en tiempo real mediante suscripciones",
+        "feature2": "Gestión de sesiones (crear, unirse, salir)",
+        "feature3": "Colaboración multiusuario",
+        "feature4": "Toda la funcionalidad de la API REST mediante queries/mutations",
+        "endpointLabel": "Endpoint:",
+        "endpointSuffix": "(mediante el protocolo graphql-ws)"
+      },
+      "auth": {
+        "title": "Autenticación",
+        "restLabel": "API REST:",
+        "restBody": "Usa cookies de sesión de NextAuth. Autentícate mediante los endpoints",
+        "restBodyEnd": ".",
+        "wsLabel": "API por WebSocket:",
+        "wsBody": "Obtén un token JWT desde",
+        "wsBodyEnd": "e inclúyelo en los parámetros de conexión:"
+      },
+      "rateLimit": {
+        "title": "Límite de solicitudes",
+        "body": "Los endpoints de autenticación tienen límite de solicitudes para evitar abusos. Las respuestas incluyen cabeceras con la información del límite. Los endpoints públicos de lectura tienen límites generosos."
+      }
+    },
+    "ws": {
+      "title": "Guía de conexión por WebSocket",
+      "introStart": "La API por WebSocket de Boardsesh usa el protocolo",
+      "introEnd": "para suscripciones GraphQL en tiempo real.",
+      "connection": {
+        "title": "Configuración de la conexión"
+      },
+      "session": {
+        "title": "Gestión de sesiones",
+        "body": "Las sesiones son la unidad básica de colaboración. Los usuarios se unen a sesiones para compartir una cola de bloques."
+      },
+      "delta": {
+        "title": "Sincronización delta",
+        "body": "Al reconectar, usa la sincronización delta para ponerte al día sin transferir el estado completo:"
+      },
+      "connectionHandling": {
+        "title": "Gestión de la conexión",
+        "body": "La conexión WebSocket puede interrumpirse por cambios de red. Implementa la lógica de reconexión con las opciones de reintento de graphql-ws y usa la sincronización delta para mantener la coherencia del estado."
+      }
     }
   }
 }

--- a/packages/web/i18n/locales/es/playlists.json
+++ b/packages/web/i18n/locales/es/playlists.json
@@ -163,7 +163,11 @@
       "mainSetVariability": "Variabilidad de la serie principal",
       "numberOfSteps": "Número de pasos",
       "climbsPerStep": "Bloques por paso",
-      "numberOfClimbs": "Número de bloques"
+      "numberOfClimbs": "Número de bloques",
+      "any": "Cualquiera",
+      "minAscentsOption": "{{value}}+",
+      "minRatingOption_one": "{{count}} estrella o más",
+      "minRatingOption_other": "{{count}} estrellas o más"
     },
     "warmUpOptions": {
       "standard": "Estándar",

--- a/packages/web/i18n/locales/fr/climbs.json
+++ b/packages/web/i18n/locales/fr/climbs.json
@@ -246,6 +246,12 @@
         "submit": "Créer"
       }
     },
+    "sendToBoard": {
+      "label": "Envoyer au board",
+      "active": "Sur le mur",
+      "tooltip": "Envoyer au board",
+      "activeTooltip": "Actuellement sur le mur"
+    },
     "tick": {
       "drawer": {
         "signInRequired": "Connexion requise",

--- a/packages/web/i18n/locales/fr/common.json
+++ b/packages/web/i18n/locales/fr/common.json
@@ -17,6 +17,7 @@
     "customizeColorsTitle": "Couleurs des LED",
     "customizeColorsHelp": "Choisissez les couleurs des prises pour les mains, les pieds et l'arrivée. Les prises de départ gardent leur vert par défaut.",
     "resetColors": "Réinitialiser",
+    "disconnect": "Déconnecter le board",
     "role": {
       "HAND": "Mains",
       "FOOT": "Pieds",


### PR DESCRIPTION
## Summary

Sentry was flooded with `Missing i18n key: …` warnings from Spanish users (BOARDSESH-67, -68, -6D, -6E, -6F, -6G, and more). The reporter was working correctly — the catalog was just incomplete. The old CLAUDE.md guidance treated `es` as a "community-maintained" locale that could legitimately fall back to English, but that ships silently-English copy to Spanish users and keeps Sentry noisy on every new feature.

- **CLAUDE.md**: rewrite the i18n catalog rule — every supported locale must stay at full parity with `en-US`. No more carve-out for `es`.
- **i18n-catalog-completeness.test.ts**: add `es` to `STRICTLY_ENFORCED_LOCALES` alongside `fr` so missing keys fail the build instead of leaking to prod.
- **es/\*.json**: translate **373 missing keys** across `admin`, `climbs`, `common`, `feed`, `marketing`, `playlists`. Matches the existing Spain-Spanish voice (bloque, encadene, presa, `tú`-form). Brand names + ICU placeholders preserved. Largest chunk is `marketing.json` (legal disclaimers, help center, DMCA wording) — native-speaker polish welcome later, but every key is now translated.
- **fr/climbs.json + fr/common.json**: backfill 5 keys that had drifted (`sendToBoard.*`, `lightControl.disconnect`) so the French parity test passes again — `main` was already failing this test before my changes.

## Test plan
- [x] `vp test run --project web i18n-catalog-completeness` — 28/28 pass (14 ns × 2 strict locales)
- [x] `vp test run --project web missing-key-reporter` — 5/5 pass
- [x] `vp run typecheck:web` — clean
- [x] `vp run check:i18n` — clean
- [x] `vp run check:i18n:orphans` — clean (2159 keys, all referenced)
- [ ] Manual spot-check in the dev server at `/es/*` to confirm Spanish copy renders naturally
- [ ] Native Spanish speaker passes over `marketing.json` for polish (especially legal/DMCA wording)

https://claude.ai/code/session_01HxJzkAeGoabExfWWarDDzN

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxJzkAeGoabExfWWarDDzN)_