### PR TITLE
Drop queue-bar prev/next buttons on mobile (keep swipe)

### DIFF
--- a/packages/web/app/components/queue-control/queue-control-bar.module.css
+++ b/packages/web/app/components/queue-control/queue-control-bar.module.css
@@ -325,11 +325,17 @@
   will-change: transform;
 }
 
-/* Navigation buttons: visible on every breakpoint. Mobile keeps the swipe
-   gesture as a secondary path, but the buttons are the primary one — non-
-   drivers used to have no bar-side advance affordance at all. */
+/* Navigation buttons: desktop only. On mobile the bar's horizontal swipe
+   gesture is the advance affordance — buttons would crowd the row and
+   compete with the swipe target. */
 .navButtons {
-  display: inline-flex;
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .navButtons {
+    display: inline-flex;
+  }
 }
 
 /* Desktop-only elements (mirror, play link) */


### PR DESCRIPTION
## Summary

- Hide the `‹` / `›` prev/next buttons in the queue control bar on mobile (`<768px`). Keep them on desktop.
- The bar's existing horizontal swipe (`useCardSwipeNavigation`, applied to `.swipeContainer` in `queue-control-bar.tsx:1263`) is already wired to `setCurrentClimbQueueItem` and tracked as `Queue Navigation { method: 'swipeQueueBar' }`. On mobile it now stands alone; on desktop it coexists with the buttons.
- The pivot-bar work added the buttons everywhere because non-drivers previously had no bar-side advance — true, but on mobile the buttons doubled the affordance, ate horizontal space, and sat on top of the swipe target. Desktop has the room and mouse users need a click target.

CSS-only change; no JSX, no reducer, no hook. `QueueNavButton` still imported, still rendered on desktop.

## Test plan

- [ ] Mobile viewport (DevTools, <768px): prev/next icons gone from the right cluster; swipe left/right on the bar advances the active climb and updates the URL; peek text slides correctly.
- [ ] Tick mode still works on mobile (no swipe interference with the tick row's own dismiss swipe).
- [ ] Tap targets unchanged: thumbnail/title → wall-view drawer; tick button → tick bar.
- [ ] Desktop viewport (≥768px): prev/next icons visible and clickable; `Queue Navigation { method: 'button' }` still fires.
- [ ] Resize across 767↔768: buttons flip in/out alongside the existing `desktopOnly` mirror/play icons — no layout jank.
- [ ] `vp run typecheck:web` clean; all 4 `queue-control-bar` unit specs (32 tests) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)