### PR TITLE
ios(ble-bridge): debug deinit safety net + state-restoration race doc

### DIFF
--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -376,6 +376,8 @@ Lock your iPhone. The Live Activity widget should update within a few seconds sh
 7. The HTTP POST to `/api/widget/navigate` should appear in backend logs (independent of the BLE write — they run in parallel)
 8. Filter Console.app by subsystem `com.boardsesh.app`, category `LiveActivityIntent` to confirm the intent ran in the App process (DEBUG builds only)
 
+> **Note on the state-restoration delegate-ordering race:** When iOS background-launches the app for state restoration, `centralManagerDidUpdateState(.poweredOn)` and per-peripheral `didDiscoverCharacteristicsFor` callbacks can fire in either order — including discovery before the central reports `.poweredOn`. Write paths must therefore wait on a readiness signal that handles both orderings rather than gating on observing `central.state == .poweredOn` first. `BoardBleManager.displayCurrentItemAwaitingReady` is the path that satisfies this requirement.
+
 ### Test with App Force-Killed
 
 1. Force-kill the app from the app switcher

--- a/mobile/ios/App/App/LiveActivityBleBridge.swift
+++ b/mobile/ios/App/App/LiveActivityBleBridge.swift
@@ -74,13 +74,17 @@ final class BleIntentBackgroundTask {
     }
 
     #if DEBUG
-        // Only observes the `Sendable` sentinel — never calls a `@MainActor`
-        // method, which an implicitly-nonisolated deinit cannot reach.
+        // `deinit` is implicitly nonisolated, so reading the `@MainActor`
+        // `taskId` requires the same `assumeIsolated` hop used by the
+        // expiration handler above. Production callers always release the
+        // instance from a `@MainActor` context, so the precondition holds.
         deinit {
-            assert(
-                taskId == .invalid,
-                "BleIntentBackgroundTask deallocated without end() — caller stored it as a property and leaked the UIBackgroundTaskIdentifier. Use defer { task.end() } or call end() explicitly."
-            )
+            MainActor.assumeIsolated {
+                assert(
+                    taskId == .invalid,
+                    "BleIntentBackgroundTask deallocated without end() — caller stored it as a property and leaked the UIBackgroundTaskIdentifier. Use defer { task.end() } or call end() explicitly."
+                )
+            }
         }
     #endif
 }

--- a/mobile/ios/App/App/LiveActivityBleBridge.swift
+++ b/mobile/ios/App/App/LiveActivityBleBridge.swift
@@ -33,13 +33,16 @@ enum LiveActivityBleBridge {
 /// **Designed for short-lived stack use** — pair `begin(name:)` with an
 /// explicit `end()`, typically via `defer { task.end() }` (as
 /// `LiveActivityBleBridge.writeBoardForIntent` does). The class deliberately
-/// has **no `deinit`-based cleanup**: `deinit` can't run `@MainActor` methods
-/// in Swift 5, so a property-stored instance whose owner is released without
-/// calling `end()` will leak the task identifier (the expiration handler
-/// eventually fires and ends it, but iOS may have already begun reclaiming
-/// budget). The type is non-`private` purely so `BleIntentBackgroundTaskTests`
-/// can verify the idempotency contract — production callers should treat it
-/// as an implementation detail of `LiveActivityBleBridge`.
+/// has **no production `deinit`-based cleanup**: `deinit` can't run
+/// `@MainActor` methods in Swift 5/6 (the deinit is implicitly nonisolated),
+/// so a property-stored instance whose owner is released without calling
+/// `end()` will leak the task identifier (the expiration handler eventually
+/// fires and ends it, but iOS may have already begun reclaiming budget).
+/// A `#if DEBUG` deinit asserts `taskId == .invalid` as a development-time
+/// safety net to surface the leak at the point of release. The type is
+/// non-`private` purely so `BleIntentBackgroundTaskTests` can verify the
+/// idempotency contract — production callers should treat it as an
+/// implementation detail of `LiveActivityBleBridge`.
 ///
 /// `@MainActor`-isolated so `UIApplication.shared` (also `@MainActor`-isolated
 /// under Swift 6 strict concurrency) can be accessed without locks. The
@@ -69,4 +72,15 @@ final class BleIntentBackgroundTask {
         taskId = .invalid
         UIApplication.shared.endBackgroundTask(id)
     }
+
+    #if DEBUG
+        // Only observes the `Sendable` sentinel — never calls a `@MainActor`
+        // method, which an implicitly-nonisolated deinit cannot reach.
+        deinit {
+            assert(
+                taskId == .invalid,
+                "BleIntentBackgroundTask deallocated without end() — caller stored it as a property and leaked the UIBackgroundTaskIdentifier. Use defer { task.end() } or call end() explicitly."
+            )
+        }
+    #endif
 }


### PR DESCRIPTION
## Summary

Addresses three follow-ups from the Live Activity BLE bridge review:

1. **Debug-only deinit safety net** — `BleIntentBackgroundTask` previously had no protection against a future caller storing the instance as a property and forgetting to call `end()`. Adds a `#if DEBUG deinit` that asserts `taskId == .invalid`, so a leaked `UIBackgroundTaskIdentifier` traps at the point of release instead of being silently reclaimed by the expiration handler. The deinit only reads the `Sendable` sentinel — it never calls a `@MainActor` method, which an implicitly-nonisolated deinit cannot reach. Production builds are unchanged.
2. **Doc comment refresh** — Updated the class doc to describe the new debug-only safety net while preserving the existing rationale for both the missing production cleanup and the non-`private` visibility (kept module-internal so `BleIntentBackgroundTaskTests` can `@testable import App`).
3. **Docs: state-restoration delegate-ordering race** — Added a callout to `docs/live-activity-push-testing.md` noting that during background-launched state restoration, `centralManagerDidUpdateState(.poweredOn)` and `didDiscoverCharacteristicsFor` callbacks can fire in either order. Write paths must therefore wait on a readiness signal that handles both orderings rather than gating on `central.state == .poweredOn` — the existing `BoardBleManager.displayCurrentItemAwaitingReady` is the path that satisfies this.

The visibility-comment item was left as a no-op because the existing class doc comment (lines 42–45 in the new file) already states why the type is non-`private`. Adding a separate inline comment would duplicate without adding signal.

## Test plan

- [ ] `xcodebuild -workspace mobile/ios/App/App.xcworkspace -scheme App -configuration Debug build` — confirms the new debug deinit compiles. (Cannot run in this Linux container; needs macOS / Xcode.)
- [ ] `xcodebuild ... -configuration Release build` — confirms `#if DEBUG` cleanly excludes the deinit from release.
- [ ] Run `BleIntentBackgroundTaskTests` — the three existing idempotency tests should still pass; they all call `end()` explicitly so the new assertion never fires during the suite.
- [ ] (Optional) In a Debug build, allocate `BleIntentBackgroundTask`, call `begin(name:)`, drop the reference without `end()`, and confirm the assert traps with the documented message.
- [ ] Render `docs/live-activity-push-testing.md` and verify the new callout reads naturally after step 8 of "Test with App Suspended".

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUdui2VBfZkjFiEfuETnaX)_