### PR TITLE
fix(pickers): visible selected chip on grade/star/tries pickers in light mode

### DIFF
--- a/packages/web/app/components/grade-picker/inline-grade-picker.module.css
+++ b/packages/web/app/components/grade-picker/inline-grade-picker.module.css
@@ -82,18 +82,18 @@
 @media (hover: hover) {
   .pickerItem:hover {
     opacity: 1;
-    background-color: rgba(128, 128, 128, 0.12);
+    background-color: rgba(140, 74, 82, 0.1);
   }
 }
 
 .pickerItem:focus-visible {
   opacity: 1;
-  background-color: rgba(128, 128, 128, 0.12);
+  background-color: rgba(140, 74, 82, 0.1);
 }
 
 .pickerItemSelected {
   opacity: 1;
-  background-color: rgba(128, 128, 128, 0.18);
+  background-color: rgba(140, 74, 82, 0.18);
 }
 
 .pickerItemFocused {

--- a/packages/web/app/components/logbook/tick-controls.module.css
+++ b/packages/web/app/components/logbook/tick-controls.module.css
@@ -240,18 +240,18 @@
 @media (hover: hover) {
   .pickerItem:hover {
     opacity: 1;
-    background-color: rgba(128, 128, 128, 0.12);
+    background-color: rgba(140, 74, 82, 0.1);
   }
 }
 
 .pickerItem:focus-visible {
   opacity: 1;
-  background-color: rgba(128, 128, 128, 0.12);
+  background-color: rgba(140, 74, 82, 0.1);
 }
 
 .pickerItemSelected {
   opacity: 1;
-  background-color: rgba(128, 128, 128, 0.18);
+  background-color: rgba(140, 74, 82, 0.18);
 }
 
 .pickerItemFocused {


### PR DESCRIPTION
## Summary

- The horizontal grade/star/tries pickers (`InlineGradePicker`, `InlineStarPicker`, `InlineTriesPicker`) used `rgba(128,128,128,0.18)` for the selected chip — a mid-gray at 18% opacity that all but disappears against the near-white drawer surface in light mode.
- Swap the selected background to the brand primary tint `rgba(140,74,82,0.18)` so the active state is visible in light mode. Hover + focus-visible move to the matching 10% rose tint so the hover → selected progression stays in the same colour family.
- Dark-mode overrides (`rgba(255,255,255,0.15)`) are untouched and continue to win via the existing `:global(html[data-theme='dark'])` selectors.
- Touches two duplicated CSS modules — `inline-grade-picker.module.css` and `tick-controls.module.css` — that share the `.pickerItem*` class names. The duplication predates this change and is out of scope for this fix.

## Audit notes

- The MUI `<Slider>` in the Library filter drawer (Wall Angle Range) was also audited per the request to "fix the active mode for all form sliders". It uses the default theme primary (`#8C4A52`) for both track and thumb, which is already visible in light mode — no change needed.
- `MinAscentsBucketPicker` (`ToggleButtonGroup`) is a different component family and not affected by these CSS classes.

## Test plan

- [ ] In light mode, open Library → filter drawer → Min/Max Grade pickers. Tap a grade chip and confirm the rose-tinted selection is clearly visible.
- [ ] Drag the Wall Angle Range MUI slider in the same drawer — confirm the active track + thumb read well in light mode.
- [ ] Open the Playlist Generator → Target Grade picker — selected chip should be visibly tinted.
- [ ] Open the Accordion search form (climb list filter) → grade pickers — same check.
- [ ] Open the tick flow → expand Stars / Grade / Tries one at a time — selected chip should be visibly tinted in each.
- [ ] Toggle to dark mode and spot-check one picker — appearance should be unchanged from before this PR.
- [ ] `vp check`, `vp run typecheck`, and the existing tests for `quick-tick-bar` and `logbook-search-form` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyzSrHYT4jBiXDsDMDzqzt)_