### PR TITLE
apns: tighten test-reset surface, guard retry test, doc missing-bundle-id behavior

### DIFF
--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -368,6 +368,8 @@ If you have the push token from the database, you can send a test push directly:
 
 APNs env vars are not set in `packages/backend/.env.local`. Double-check all five vars are present.
 
+Specifically, a missing `APNS_BUNDLE_ID` now produces a warn-and-abort at startup — APNs stays disabled, and there is no hardcoded `com.boardsesh.app` fallback. If the `[APNs] Initialized (... bundleId=...)` line is absent from the init log, that is likely the cause.
+
 ### Push token not appearing in database
 
 - Verify the Live Activity started (check for "Started Live Activity" in Xcode console)

--- a/packages/backend/src/__tests__/apns-analytics.test.ts
+++ b/packages/backend/src/__tests__/apns-analytics.test.ts
@@ -47,7 +47,7 @@ vi.mock('../services/analytics/live-activity', () => analyticsMocks);
 async function loadApnsModule(): Promise<typeof import('../services/apns')> {
   vi.resetModules();
   const apnsModule = await import('../services/apns');
-  apnsModule.__resetApnsStateForTests();
+  apnsModule.__resetApnsForTests();
   return apnsModule;
 }
 

--- a/packages/backend/src/__tests__/apns.test.ts
+++ b/packages/backend/src/__tests__/apns.test.ts
@@ -259,10 +259,10 @@ describe('APNs Live Activity service', () => {
         expect(mockSend).not.toHaveBeenCalled();
         // SUT requeued — a new debounce window is in flight for this session.
         expect(apns.hasPendingSend(sessionId)).toBe(true);
+      } finally {
         // Halt the requeue loop *before* restoring the spy so the next cycle
         // doesn't race the test teardown by succeeding against a real DB call.
         apns.__resetApnsForTests();
-      } finally {
         selectSpy.mockRestore();
       }
     });

--- a/packages/backend/src/services/apns/index.ts
+++ b/packages/backend/src/services/apns/index.ts
@@ -636,8 +636,8 @@ export async function cleanupTokensForSession(sessionId: string): Promise<void> 
   }
 }
 
-/** Test-only utility: clears pendingSends timers and resets counters. */
-export function __resetApnsStateForTests(): void {
+/** Internal helper for `__resetApnsForTests`: clears pendingSends timers and resets counters. */
+function __resetApnsStateForTests(): void {
   for (const [, entry] of pendingSends) {
     clearTimeout(entry.timeout);
   }


### PR DESCRIPTION
## Summary

Three small review follow-ups on the APNs test-reset cleanup:

- **Unexport the weaker `__resetApnsStateForTests`.** It only cleared `pendingSends` + metrics. The strictly-stronger `__resetApnsForTests` already calls it internally and additionally nulls `provider` / `bundleId` / `configured` and restores `DEBOUNCE_MS` / `DB_RETRY_DELAYS_MS` defaults. The only external caller (`apns-analytics.test.ts:50`) is swapped to the stronger reset, which is safe — the test loads the module via `vi.resetModules()` + dynamic import and then re-runs `initializeApns()` itself.
- **Move the in-test reset in `apns.test.ts` into `finally`.** The "requeues with a fresh retry counter…" test was calling `apns.__resetApnsForTests()` inside `try`, so a thrown `hasPendingSend` assertion would have left the live requeue loop running against the active `selectSpy` until `afterEach`. The existing comment about "halt the requeue loop *before* restoring the spy" still applies — both calls are in `finally` now in the documented order.
- **Doc note in `live-activity-push-testing.md`.** Added a one-liner under "Missing one or more required env vars" calling out that a missing `APNS_BUNDLE_ID` now produces a warn-and-abort at startup (APNs stays disabled, no hardcoded `com.boardsesh.app` fallback). Helps when the `bundleId=…` line is absent from the init log.

## Test plan

- [x] `vp run typecheck:backend` — clean
- [x] `vp lint` — 0 errors (only pre-existing warnings unrelated to these files)
- [x] `vp test run --project backend src/__tests__/apns-analytics.test.ts` — all 7 tests pass; confirms the swap to `__resetApnsForTests` works
- [ ] `vp test run --project backend src/__tests__/apns.test.ts` — DB-dependent suite; Docker is unavailable in this remote env, so the DB-dependent half of the suite cannot be exercised here. CI must confirm. The structural change is restricted to one `try` → `finally` move (3 lines of comment + reset call).
- [x] `grep -rn "__resetApnsStateForTests" packages/` — only the two in-file references inside `apns/index.ts` remain; no external test references it.

https://claude.ai/code/session_01RuZSd1DfdzE76nXWtDFmiT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuZSd1DfdzE76nXWtDFmiT)_