### PR TITLE
fix(pickers): make selected grade chip clearly visible in light mode

### DIFF
--- a/packages/web/app/components/grade-picker/inline-grade-picker.module.css
+++ b/packages/web/app/components/grade-picker/inline-grade-picker.module.css
@@ -82,18 +82,21 @@
 @media (hover: hover) {
   .pickerItem:hover {
     opacity: 1;
-    background-color: rgba(140, 74, 82, 0.1);
+    background-color: rgba(175, 45, 60, 0.14);
   }
 }
 
 .pickerItem:focus-visible {
   opacity: 1;
-  background-color: rgba(140, 74, 82, 0.1);
+  background-color: rgba(175, 45, 60, 0.14);
 }
 
+/* Brand-rose tint + solid ring so selection reads even against vivid grade-text colors */
 .pickerItemSelected {
   opacity: 1;
-  background-color: rgba(140, 74, 82, 0.18);
+  background-color: rgba(175, 45, 60, 0.28);
+  outline: 1.5px solid #8c4a52;
+  outline-offset: -1.5px;
 }
 
 .pickerItemFocused {
@@ -112,8 +115,10 @@
   background-color: rgba(255, 255, 255, 0.1);
 }
 
+/* Dark mode: white-tint surface treatment already reads; drop the rose ring to avoid clashing */
 :global(html[data-theme='dark']) .pickerItemSelected {
   background-color: rgba(255, 255, 255, 0.15);
+  outline: none;
 }
 
 .pickerClear {

--- a/packages/web/app/components/logbook/tick-controls.module.css
+++ b/packages/web/app/components/logbook/tick-controls.module.css
@@ -240,18 +240,21 @@
 @media (hover: hover) {
   .pickerItem:hover {
     opacity: 1;
-    background-color: rgba(140, 74, 82, 0.1);
+    background-color: rgba(175, 45, 60, 0.14);
   }
 }
 
 .pickerItem:focus-visible {
   opacity: 1;
-  background-color: rgba(140, 74, 82, 0.1);
+  background-color: rgba(175, 45, 60, 0.14);
 }
 
+/* Brand-rose tint + solid ring so selection reads even against vivid grade-text colors */
 .pickerItemSelected {
   opacity: 1;
-  background-color: rgba(140, 74, 82, 0.18);
+  background-color: rgba(175, 45, 60, 0.28);
+  outline: 1.5px solid #8c4a52;
+  outline-offset: -1.5px;
 }
 
 .pickerItemFocused {
@@ -270,8 +273,10 @@
   background-color: rgba(255, 255, 255, 0.1);
 }
 
+/* Dark mode: white-tint surface treatment already reads; drop the rose ring to avoid clashing */
 :global(html[data-theme='dark']) .pickerItemSelected {
   background-color: rgba(255, 255, 255, 0.15);
+  outline: none;
 }
 
 .pickerClear {


### PR DESCRIPTION
## Summary

- Bump the selected-chip background tint from `rgba(140, 74, 82, 0.18)` to the design-token `semantic.selected` value (`rgba(175, 45, 60, 0.28)`) and add a 1.5px solid brand-rose ring so selection reads clearly in light mode, even on chips whose grade text is a vivid color (V-grade colors).
- Bump hover/focus-visible tint to a matching `0.14` so the hover → selected progression stays in the same colour family without crowding the selected state.
- Leave dark mode untouched — the existing white-tint treatment already reads, and the rose ring is suppressed there to avoid clashing.

Applied to both shared CSS modules (they share the `.pickerItem*` classes across InlineGradePicker, InlineStarPicker, InlineTriesPicker):

- `packages/web/app/components/grade-picker/inline-grade-picker.module.css`
- `packages/web/app/components/logbook/tick-controls.module.css`

Follow-up to #2208, which moved the chip from gray to rose but kept the same 18% opacity — still too faint against the near-white drawer.

## Test plan

- [ ] Light mode: open the search drawer, pick a min and max grade — selected chips should have a clear rose fill AND a solid rose ring.
- [ ] Light mode: in the search drawer Quality panel, the min-rating star picker selected state should also be clearly visible.
- [ ] Light mode: open the logbook tick controls — star/tries pickers selected states are clearly visible.
- [ ] Dark mode: no regression in any of the above — selected chip still uses the existing white-tint look, no rose ring.
- [ ] Grade chips whose text color is reddish (V-grade colors near red/orange) — selection still unambiguous thanks to the solid ring.
- [ ] Keyboard focus (Tab) on an unselected chip — focus-visible tint reads but is clearly distinct from the selected state.

https://claude.ai/code/session_01Ph6U8ndPv5zcrkyRrXPKnY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ph6U8ndPv5zcrkyRrXPKnY)_