### PR TITLE
fix(pickers): selected ring + dark frosted scroll arrows + similar-climbs hydration

### DIFF
--- a/packages/web/app/components/grade-picker/inline-grade-picker.module.css
+++ b/packages/web/app/components/grade-picker/inline-grade-picker.module.css
@@ -62,6 +62,18 @@
   -webkit-mask-image: linear-gradient(to left, black 60%, transparent);
 }
 
+/* Dark mode: the medium-grey (--neutral-400) gradient base reads as a *light*
+   frost against the dark drawer surface — exactly the wrong direction. Swap
+   to a translucent black so the blur fades darker into the surface, giving a
+   "dark frosted glass" look instead of a "white glass" look. */
+:global(html[data-theme='dark']) .scrollIndicatorLeft {
+  background: linear-gradient(to right, rgba(0, 0, 0, 0.55) 0%, transparent 100%);
+}
+
+:global(html[data-theme='dark']) .scrollIndicatorRight {
+  background: linear-gradient(to left, rgba(0, 0, 0, 0.55) 0%, transparent 100%);
+}
+
 .pickerItem {
   display: inline-flex;
   align-items: center;

--- a/packages/web/app/components/grade-picker/inline-grade-picker.module.css
+++ b/packages/web/app/components/grade-picker/inline-grade-picker.module.css
@@ -91,12 +91,15 @@
   background-color: rgba(175, 45, 60, 0.14);
 }
 
-/* Brand-rose tint + solid ring so selection reads even against vivid grade-text colors */
+/* Brand-rose tint + solid ring so selection reads even against vivid grade-text colors.
+   Uses inset box-shadow (not outline) so the ring honours border-radius and can't be
+   killed by upstream `outline: 0` resets — the prior outline-based version rendered
+   too faintly in light mode against the pale fill. */
 .pickerItemSelected {
   opacity: 1;
-  background-color: rgba(175, 45, 60, 0.28);
-  outline: 1.5px solid #8c4a52;
-  outline-offset: -1.5px;
+  background-color: rgba(175, 45, 60, 0.32);
+  box-shadow: inset 0 0 0 2px #8c4a52;
+  font-weight: 700;
 }
 
 .pickerItemFocused {
@@ -115,10 +118,9 @@
   background-color: rgba(255, 255, 255, 0.1);
 }
 
-/* Dark mode: white-tint surface treatment already reads; drop the rose ring to avoid clashing */
+/* Dark mode: keep the rose ring on top of the white-tint fill for consistency with light mode */
 :global(html[data-theme='dark']) .pickerItemSelected {
   background-color: rgba(255, 255, 255, 0.15);
-  outline: none;
 }
 
 .pickerClear {

--- a/packages/web/app/components/logbook/tick-controls.module.css
+++ b/packages/web/app/components/logbook/tick-controls.module.css
@@ -219,6 +219,18 @@
   -webkit-mask-image: linear-gradient(to left, black 60%, transparent);
 }
 
+/* Dark mode: the medium-grey (--neutral-400) gradient base reads as a *light*
+   frost against the dark drawer surface — exactly the wrong direction. Swap
+   to a translucent black so the blur fades darker into the surface, giving a
+   "dark frosted glass" look instead of a "white glass" look. */
+:global(html[data-theme='dark']) .scrollIndicatorLeft {
+  background: linear-gradient(to right, rgba(0, 0, 0, 0.55) 0%, transparent 100%);
+}
+
+:global(html[data-theme='dark']) .scrollIndicatorRight {
+  background: linear-gradient(to left, rgba(0, 0, 0, 0.55) 0%, transparent 100%);
+}
+
 .pickerItem {
   display: inline-flex;
   align-items: center;

--- a/packages/web/app/components/logbook/tick-controls.module.css
+++ b/packages/web/app/components/logbook/tick-controls.module.css
@@ -249,12 +249,15 @@
   background-color: rgba(175, 45, 60, 0.14);
 }
 
-/* Brand-rose tint + solid ring so selection reads even against vivid grade-text colors */
+/* Brand-rose tint + solid ring so selection reads even against vivid grade-text colors.
+   Uses inset box-shadow (not outline) so the ring honours border-radius and can't be
+   killed by upstream `outline: 0` resets — the prior outline-based version rendered
+   too faintly in light mode against the pale fill. */
 .pickerItemSelected {
   opacity: 1;
-  background-color: rgba(175, 45, 60, 0.28);
-  outline: 1.5px solid #8c4a52;
-  outline-offset: -1.5px;
+  background-color: rgba(175, 45, 60, 0.32);
+  box-shadow: inset 0 0 0 2px #8c4a52;
+  font-weight: 700;
 }
 
 .pickerItemFocused {
@@ -273,10 +276,9 @@
   background-color: rgba(255, 255, 255, 0.1);
 }
 
-/* Dark mode: white-tint surface treatment already reads; drop the rose ring to avoid clashing */
+/* Dark mode: keep the rose ring on top of the white-tint fill for consistency with light mode */
 :global(html[data-theme='dark']) .pickerItemSelected {
   background-color: rgba(255, 255, 255, 0.15);
-  outline: none;
 }
 
 .pickerClear {

--- a/packages/web/app/components/similar-climbs/similar-climbs-list.module.css
+++ b/packages/web/app/components/similar-climbs/similar-climbs-list.module.css
@@ -11,11 +11,22 @@
   display: none;
 }
 
-.card {
+/* Wraps the clickable card and the absolute-positioned ellipsis so the
+   IconButton can render as a sibling (not a descendant) of the card's
+   <button>/<a> — nesting a <button> inside a <button>/<a> is invalid HTML
+   and triggers hydration errors. */
+.cardWrapper {
+  position: relative;
   flex-shrink: 0;
   scroll-snap-align: start;
   /* 180px is the canonical board-preview thumbnail size shared with the
      homepage board card; no spacing-token analogue applies. */
+  width: 180px;
+}
+
+.card {
+  flex-shrink: 0;
+  scroll-snap-align: start;
   width: 180px;
   display: flex;
   flex-direction: column;
@@ -121,4 +132,19 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Positioned over the thumbnail top-right. Anchored to .cardWrapper so the
+   ellipsis stays a sibling of the clickable card surface, not a descendant. */
+.ellipsis {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background-color: var(--semantic-surface-overlay);
+  backdrop-filter: blur(4px);
+  z-index: 1;
+}
+
+.ellipsis:hover {
+  background-color: var(--semantic-surface);
 }

--- a/packages/web/app/components/similar-climbs/similar-climbs-list.tsx
+++ b/packages/web/app/components/similar-climbs/similar-climbs-list.tsx
@@ -309,32 +309,9 @@ function SimilarClimbCard({
     void onSetActive(buildClimbStub(climb, boardType));
   }, [onSetActive, climb, boardType]);
 
-  const body = (
+  const cardInner = (
     <>
-      <Box sx={{ position: 'relative' }}>
-        {thumbnail}
-        {/* Skip the ellipsis when we have no boardDetails — the actions
-            drawer needs them to render anything useful, and clicking the
-            button would silently dismiss the drawer on open. Better to
-            hide the affordance than to expose a dead button. */}
-        {boardDetails ? (
-          <IconButton
-            size="small"
-            onClick={handleEllipsisClick}
-            aria-label={t('similarClimbs.openActions')}
-            sx={{
-              position: 'absolute',
-              top: 4,
-              right: 4,
-              backgroundColor: 'var(--semantic-surface-overlay)',
-              backdropFilter: 'blur(4px)',
-              '&:hover': { backgroundColor: 'var(--semantic-surface)' },
-            }}
-          >
-            <MoreVertOutlined fontSize="small" />
-          </IconButton>
-        ) : null}
-      </Box>
+      {thumbnail}
       <div className={`${styles.nameRow}${dimClass}`}>
         <div className={styles.name} title={climb.name || undefined}>
           {climb.name || t('similarClimbs.untitledClimb')}
@@ -355,6 +332,21 @@ function SimilarClimbCard({
     </>
   );
 
+  // The ellipsis is rendered as a sibling of the clickable card surface
+  // (not a descendant), because a <button> can't be nested inside another
+  // <button> or inside an <a> per HTML spec. Skip it when we have no
+  // boardDetails — the actions drawer needs them to render anything useful.
+  const ellipsis = boardDetails ? (
+    <IconButton
+      size="small"
+      onClick={handleEllipsisClick}
+      aria-label={t('similarClimbs.openActions')}
+      className={styles.ellipsis}
+    >
+      <MoreVertOutlined fontSize="small" />
+    </IconButton>
+  ) : null;
+
   // When the queue is available, the card is a button that activates the
   // climb in the play drawer (same drawer the user already has open). When
   // it isn't, fall back to navigating to the climb-view page so the user
@@ -362,21 +354,27 @@ function SimilarClimbCard({
   // duplicate-resolution drawer in create-climb-form).
   if (onSetActive) {
     return (
-      <button type="button" onClick={handleCardClick} className={`${styles.card} ${styles.cardButton}`}>
-        {body}
-      </button>
+      <div className={styles.cardWrapper}>
+        <button type="button" onClick={handleCardClick} className={`${styles.card} ${styles.cardButton}`}>
+          {cardInner}
+        </button>
+        {ellipsis}
+      </div>
     );
   }
 
   if (climbViewPath) {
     return (
-      <LocaleLink href={climbViewPath} className={styles.card}>
-        {body}
-      </LocaleLink>
+      <div className={styles.cardWrapper}>
+        <LocaleLink href={climbViewPath} className={styles.card}>
+          {cardInner}
+        </LocaleLink>
+        {ellipsis}
+      </div>
     );
   }
 
-  return <div className={`${styles.card} ${styles.cardDisabled}`}>{body}</div>;
+  return <div className={`${styles.card} ${styles.cardDisabled}`}>{cardInner}</div>;
 }
 
 type SimilarClimbActionsDrawerProps = {


### PR DESCRIPTION
## Summary

Three small but related UI fixes uncovered while QA'ing the horizontal grade picker.

- **Selected chip in the grade / star / tries pickers** — swap the inset `outline` (which renders inconsistently against rounded chips and can be silently neutralised by upstream `outline: 0` resets) for an inset `box-shadow`, bump the fill from `0.28` → `0.32`, and bold the chip text. Keep the rose ring on top of the white-tint fill in dark mode too for visual consistency.
- **Scroll-direction fade gradients** at the picker edges — overridden in dark mode to a translucent black instead of the medium-grey base, so the `backdrop-filter` blur reads as *darker* frosted glass on the dark drawer instead of *whitening* it. Light mode is unchanged.
- **`SimilarClimbCard` hydration error** — the ellipsis `IconButton` was nested inside the card's `<button>` (or `<a>`), which is invalid HTML and surfaces as a hydration error in dev. Lift it out as a true sibling inside a `.cardWrapper` `<div>` with `position: relative` so the visual stays identical (top-right of the thumbnail) but the DOM is valid.

## Test plan

- [ ] Light mode: open the search drawer → Climbs tab → min/max grade pickers. Selected chip has a clearly visible 2px brand-rose ring and bold grade text.
- [ ] Dark mode: same surface. Selected chip still gets the ring on top of a white-tint fill.
- [ ] Dark mode: scroll either picker — the left/right fade arrows look like a darker frosted glass, no longer "white glass".
- [ ] Light mode: confirm the scroll arrows still use the previous medium-grey frosted look.
- [ ] Logbook tick row (`/library` → expand a logbook entry → tap **Grade**) — same ring/scroll-arrow treatment.
- [ ] Quick-tick bar (board page → FAB → expand grade) — same.
- [ ] Playlist generator (`/playlists/new`) — min/max grade pickers — same.
- [ ] Star + tries picker in the logbook tick row — same ring + dark-arrow treatment.
- [ ] Open the play drawer with similar climbs visible (board page → tap a climb → scroll to "Similar climbs"). No console hydration error. Ellipsis still sits top-right of each thumbnail and opens the actions drawer.
- [ ] Same check inside the duplicate-resolution drawer in create-climb-form (the `<LocaleLink>` variant of the card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)