### PR TITLE
Fix Live Activity Next/Prev → wall: always notify JS bridge

### DIFF
--- a/mobile/ios/App/App/BoardBleManager.swift
+++ b/mobile/ios/App/App/BoardBleManager.swift
@@ -201,7 +201,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// would silently no-op against the `connectedPeripheral == nil` guard.
     /// If `readyTimeout` elapses before readiness, the write is still
     /// attempted; the existing `notConnected` guard in `writeOnBleQueue` will
-    /// no-op cleanly.
+    /// no-op cleanly. The not-ready case is logged at `error` level so a
+    /// "widget UI moved but wall didn't" report can be diagnosed from
+    /// Console.app without recompiling under DEBUG.
     func displayCurrentItemAwaitingReady(
         items: [SharedQueueItem],
         currentIndex: Int,
@@ -209,6 +211,15 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         drainTimeout: TimeInterval = 1.5
     ) async {
         await waitUntilReady(timeout: readyTimeout)
+        let ready = runOnBleQueueSync { isReadyForWrite }
+        if !ready {
+            let state = runOnBleQueueSync { (
+                centralState: centralManager.state.rawValue,
+                hasPeripheral: connectedPeripheral != nil,
+                hasWriteChar: writeCharacteristic != nil
+            ) }
+            logger.error("displayCurrentItemAwaitingReady: not ready after \(readyTimeout, privacy: .public)s — centralState=\(state.centralState, privacy: .public) peripheral=\(state.hasPeripheral, privacy: .public) writeChar=\(state.hasWriteChar, privacy: .public); BLE write will no-op until the JS layer's BluetoothAutoSender re-fires")
+        }
         displayCurrentItem(items: items, currentIndex: currentIndex)
         await waitForWriteDrain(timeout: drainTimeout)
     }

--- a/mobile/ios/App/App/LiveActivityPlugin.swift
+++ b/mobile/ios/App/App/LiveActivityPlugin.swift
@@ -175,26 +175,69 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func handleQueueNavigateFromWidget() {
         guard let defaults = SharedConstants.sharedDefaults else { return }
-        guard let action = defaults.string(forKey: SharedConstants.pendingActionKey) else { return }
+
+        // The intent always writes widgetNavigateActionKey; pendingActionKey
+        // is only present when the HTTP path failed and we need to send a
+        // WebSocket mutation as a fallback.
+        guard let action = defaults.string(forKey: SharedConstants.widgetNavigateActionKey) else {
+            // Backwards compatible path for pre-update intents that still only
+            // set pendingActionKey. Falls back to the old behaviour: fallback
+            // mutation + notify JS.
+            if let legacyAction = defaults.string(forKey: SharedConstants.pendingActionKey) {
+                handleLegacyMutationFallback(defaults: defaults, action: legacyAction)
+            }
+            return
+        }
+        defaults.removeObject(forKey: SharedConstants.widgetNavigateActionKey)
+
+        let needsMutationFallback = defaults.string(forKey: SharedConstants.pendingActionKey) != nil
         defaults.removeObject(forKey: SharedConstants.pendingActionKey)
 
         // Read the updated queue state that the widget intent already saved.
         let (items, currentIndex) = SharedQueueState.load(from: defaults)
 
-        // Generate a shared correlationId so the JS side can register the
-        // optimistic update and suppress the server echo when it arrives.
+        // CorrelationId resolution:
+        //   - HTTP success path: intent stored `'widget-navigate'` (matches the
+        //     constant the backend's `/api/widget/navigate` handler echoes
+        //     back), and the WebSocket mutation is skipped.
+        //   - HTTP failure path: no correlationId was stored; we generate a
+        //     fresh UUID here and use it for both the WebSocket mutation we
+        //     send and the JS notify, so the reducer's pending-update tracker
+        //     can match the server echo.
+        let storedCorrelationId = defaults.string(forKey: SharedConstants.widgetNavigateCorrelationIdKey)
+        defaults.removeObject(forKey: SharedConstants.widgetNavigateCorrelationIdKey)
+        let correlationId = storedCorrelationId ?? UUID().uuidString
+
+        if needsMutationFallback, !items.isEmpty, currentIndex >= 0, currentIndex < items.count {
+            let item = items[currentIndex]
+            SessionWebSocketManager.shared.navigateToItem(item, at: currentIndex, totalItems: items, correlationId: correlationId)
+        }
+
+        // Always notify JS so the bridge dispatches the optimistic reducer
+        // update. retainUntilConsumed ensures the event is queued if no
+        // listener is attached yet (e.g. app was on the lock screen).
+        notifyListeners("queueNavigate", data: [
+            "action": action,
+            "currentIndex": currentIndex,
+            "correlationId": correlationId,
+        ], retainUntilConsumed: true)
+    }
+
+    /// Legacy path for older intent builds (pre-widgetNavigateActionKey) that
+    /// only ever wrote pendingActionKey. New installs never hit this branch;
+    /// it stays so a TestFlight build with the old intent + new plugin still
+    /// behaves the same as before.
+    private func handleLegacyMutationFallback(defaults: UserDefaults, action: String) {
+        defaults.removeObject(forKey: SharedConstants.pendingActionKey)
+
+        let (items, currentIndex) = SharedQueueState.load(from: defaults)
         let correlationId = UUID().uuidString
 
-        // Send the server mutation via the native WebSocket.
-        // This works even from the lock screen (no web view needed).
         if !items.isEmpty, currentIndex >= 0, currentIndex < items.count {
             let item = items[currentIndex]
             SessionWebSocketManager.shared.navigateToItem(item, at: currentIndex, totalItems: items, correlationId: correlationId)
         }
 
-        // Also notify JS so it can dispatch an optimistic reducer update
-        // using the same correlationId. retainUntilConsumed ensures the event
-        // is queued if no listener is attached yet (e.g. app was on the lock screen).
         notifyListeners("queueNavigate", data: [
             "action": action,
             "currentIndex": currentIndex,

--- a/mobile/ios/App/App/SharedConstants.swift
+++ b/mobile/ios/App/App/SharedConstants.swift
@@ -23,6 +23,20 @@ enum SharedConstants {
     static let sizeIdKey = "bs_size_id"
     static let setIdsKey = "bs_set_ids"
     static let pendingActionKey = "bs_pending_action"
+    /// Action ("next" | "previous") associated with the most recent Darwin
+    /// notification. Always written by the intent; the Darwin handler reads
+    /// it before notifying JS. Distinct from `pendingActionKey`, which is
+    /// only written when the HTTP path failed and a WebSocket-mutation
+    /// fallback is required.
+    static let widgetNavigateActionKey = "bs_widget_navigate_action"
+    /// CorrelationId associated with the most recent Darwin notification.
+    /// On HTTP success this is `'widget-navigate'` (matches the constant the
+    /// backend's `/api/widget/navigate` handler uses when broadcasting
+    /// `CurrentClimbChanged`). On HTTP failure this is the UUID the Darwin
+    /// handler generates for its WebSocket-mutation fallback. The JS bridge
+    /// adds whichever value to `pendingCurrentClimbUpdates` so the matching
+    /// server echo is treated as own-echo.
+    static let widgetNavigateCorrelationIdKey = "bs_widget_navigate_correlation_id"
     static let bleBoardConfigKey = "bs_ble_board_config"
     /// Legacy key — auth token now lives in `SharedKeychain` under
     /// `SharedKeychain.authTokenKey`. Kept here only so upgrade paths can

--- a/mobile/ios/App/BoardseshWidgets/ClimbNavigationIntent.swift
+++ b/mobile/ios/App/BoardseshWidgets/ClimbNavigationIntent.swift
@@ -29,14 +29,18 @@ enum ClimbNavigationDirection: String {
 enum ClimbNavigationIntent {
     private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 
+    /// CorrelationId the backend's `/api/widget/navigate` handler uses when it
+    /// broadcasts `CurrentClimbChanged` after a successful HTTP widget call.
+    /// Kept in sync with `widget-navigate.ts`'s `'widget-navigate'` literal —
+    /// changing one without the other breaks the JS reducer's own-echo
+    /// suppression and causes the BLE-paired phone to re-fire the BLE write.
+    static let httpSuccessCorrelationId = "widget-navigate"
+
     static func perform(direction: ClimbNavigationDirection, label: String) async {
-        #if DEBUG
-        // Lets us confirm in Console.app which process iOS chose to perform
-        // the intent in. Kept under DEBUG so production builds don't log on
-        // every tap, but dev builds surface immediately if Apple ever
-        // changes the routing.
-        logger.debug("\(label).perform() running in bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public)")
-        #endif
+        // One notice per intent firing — production TestFlight builds need
+        // this signal to diagnose "widget UI moved but wall didn't" reports.
+        // Volume is bounded by user taps so the log isn't noisy.
+        logger.notice("\(label).perform() running bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public) direction=\(direction.rawValue, privacy: .public)")
 
         guard let defaults = SharedConstants.sharedDefaults else { return }
 
@@ -73,10 +77,24 @@ enum ClimbNavigationIntent {
         #endif
 
         let httpSuccess = await WidgetNetworking.sendNavigation(action: direction.rawValue, currentIndex: newIndex)
-        if !httpSuccess {
+
+        // Always tell the JS side that navigation happened so its reducer can
+        // run the optimistic `dispatchWidgetNavigation` path on board routes.
+        // On HTTP success we use the static correlationId the backend will
+        // echo back; on failure we set pendingActionKey so the Darwin handler
+        // (in the main app) sends a WebSocket mutation fallback with a fresh
+        // UUID before notifying JS.
+        defaults.set(direction.rawValue, forKey: SharedConstants.widgetNavigateActionKey)
+        if httpSuccess {
+            defaults.set(httpSuccessCorrelationId, forKey: SharedConstants.widgetNavigateCorrelationIdKey)
+            defaults.removeObject(forKey: SharedConstants.pendingActionKey)
+        } else {
+            // Mutation-fallback path: handler generates its own UUID, writes
+            // it back to widgetNavigateCorrelationIdKey, then notifies JS.
             defaults.set(direction.rawValue, forKey: SharedConstants.pendingActionKey)
-            postQueueNavigateDarwinNotification()
+            defaults.removeObject(forKey: SharedConstants.widgetNavigateCorrelationIdKey)
         }
+        postQueueNavigateDarwinNotification()
 
         #if !WIDGET_EXTENSION
         await bleWrite

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -946,16 +946,16 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
 
   // Renamed locals so jsx-handler-names sees on*-prefixed identifiers being
   // passed to the on*-prefixed props on LiveActivityBridge below.
-  // Use effectiveActions.setCurrentClimbQueueItem so widget taps route through
-  // the injected GraphQLQueueProvider when on a board route. The adapter's
-  // version writes to local state (no-op in party mode) and would silently
-  // drop widget navigation during an active sesh.
   const onSetCurrentClimb = effectiveActions.setCurrentClimbQueueItem;
-  // Intentional degrade: off-board (adapter-mode) sessions don't populate
-  // `dispatchWidgetNavigation` in `actionsValue` above, so the iOS Live
-  // Activity widget's prev/next taps silently no-op outside of a mounted
-  // board route. Once a board route mounts and injects its own actions,
-  // this falls back to the real dispatcher from GraphQLQueueProvider.
+  // Off-board (adapter-mode) sessions don't populate dispatchWidgetNavigation
+  // in actionsValue above. The LiveActivityBridge handler degrades to
+  // `onSetCurrentClimb` (the adapter's setCurrentClimbQueueItem) which still
+  // sends the server mutation via `ps.setCurrentClimb` in party mode, so the
+  // server broadcasts CurrentClimbChanged, the WebSocket subscription updates
+  // adapter state, and BluetoothAutoSender writes to the wall. Once a board
+  // route mounts and injects its own actions, this picks up the real
+  // dispatcher from GraphQLQueueProvider and the optimistic update keeps the
+  // local reducer ahead of the server echo.
   const onWidgetNavigate = effectiveActions.dispatchWidgetNavigation;
 
   return (

--- a/packages/web/app/lib/live-activity/__tests__/live-activity-bridge.test.tsx
+++ b/packages/web/app/lib/live-activity/__tests__/live-activity-bridge.test.tsx
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import React, { act } from 'react';
+import type { ClimbQueueItem } from '@/app/components/queue-control/types';
+import type { BoardDetails } from '../../types';
+
+// Pretend we're on iOS native so the bridge attaches its plugin listener.
+const mockIsNativeApp = vi.fn(() => true);
+const mockGetPlatform = vi.fn<() => 'ios' | 'android' | 'web'>(() => 'ios');
+
+vi.mock('../../ble/capacitor-utils', () => ({
+  isNativeApp: () => mockIsNativeApp(),
+  getPlatform: () => mockGetPlatform(),
+}));
+
+// useLiveActivity is unused by these tests but the bridge imports it; stub
+// the plugin shims so it doesn't try to talk to the real Capacitor bridge.
+vi.mock('../live-activity-plugin', () => ({
+  isLiveActivityAvailable: () => Promise.resolve(false),
+  startLiveActivitySession: () => Promise.resolve(),
+  endLiveActivitySession: () => Promise.resolve(),
+  updateLiveActivity: () => Promise.resolve(),
+  updateLiveActivityClimb: () => Promise.resolve(),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: null, isAuthenticated: false, isLoading: false, error: null }),
+}));
+
+vi.mock('../../backend-url', () => ({
+  getBackendWsUrl: () => 'ws://localhost:8080/graphql',
+  getGraphQLHttpUrl: () => 'http://localhost:8080/graphql',
+}));
+
+// Capture the listener the bridge registers so each test can fire it directly.
+let registeredQueueNavigateHandler: ((data: Record<string, unknown>) => void) | null = null;
+const removeListenerSpy = vi.fn();
+
+beforeEach(() => {
+  registeredQueueNavigateHandler = null;
+  removeListenerSpy.mockClear();
+
+  const mockPlugin = {
+    addListener: vi.fn((event: string, handler: (data: Record<string, unknown>) => void) => {
+      if (event === 'queueNavigate') registeredQueueNavigateHandler = handler;
+      return { remove: removeListenerSpy };
+    }),
+  };
+
+  (window as unknown as { Capacitor: unknown }).Capacitor = {
+    Plugins: { LiveActivity: mockPlugin },
+  };
+});
+
+afterEach(() => {
+  delete (window as unknown as { Capacitor?: unknown }).Capacitor;
+});
+
+// Import after mocks
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- dynamic import after mock setup
+const { default: LiveActivityBridge } = await import('../live-activity-bridge');
+
+function makeQueueItem(id: string): ClimbQueueItem {
+  return {
+    uuid: id,
+    climb: {
+      uuid: `climb-${id}`,
+      name: `Climb ${id}`,
+      difficulty: 'V4',
+      frames: 'p1r12',
+      angle: 40,
+      setter_username: 'tester',
+      ascensionist_count: 1,
+      quality_average: '3',
+      stars: 3,
+      difficulty_error: '0',
+      benchmark_difficulty: null,
+      mirrored: false,
+    },
+  };
+}
+
+function makeBoardDetails(): BoardDetails {
+  return {
+    images_to_holds: {},
+    holdsData: {},
+    edge_left: 0,
+    edge_right: 100,
+    edge_bottom: 0,
+    edge_top: 100,
+    boardHeight: 100,
+    boardWidth: 100,
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: [1, 2],
+  } as BoardDetails;
+}
+
+type BridgeProps = React.ComponentProps<typeof LiveActivityBridge>;
+
+async function mountBridge(props: BridgeProps) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const ReactDOM = await import('react-dom/client');
+  const root = ReactDOM.createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(LiveActivityBridge, props));
+  });
+  return {
+    async unmount() {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe('LiveActivityBridge queueNavigate handler', () => {
+  const queue = [makeQueueItem('a'), makeQueueItem('b'), makeQueueItem('c')];
+
+  it('routes to onWidgetNavigate when correlationId and the handler are both present (on-board)', async () => {
+    const onSetCurrentClimb = vi.fn();
+    const onWidgetNavigate = vi.fn();
+
+    const view = await mountBridge({
+      queue,
+      currentClimbQueueItem: queue[0],
+      boardDetails: makeBoardDetails(),
+      sessionId: 'session-1',
+      isSessionActive: true,
+      onSetCurrentClimb,
+      onWidgetNavigate,
+    });
+
+    expect(registeredQueueNavigateHandler).not.toBeNull();
+    registeredQueueNavigateHandler!({ currentIndex: 1, correlationId: 'widget-navigate' });
+
+    expect(onWidgetNavigate).toHaveBeenCalledTimes(1);
+    expect(onWidgetNavigate).toHaveBeenCalledWith(queue[1], 'widget-navigate');
+    expect(onSetCurrentClimb).not.toHaveBeenCalled();
+
+    await view.unmount();
+  });
+
+  it('falls back to onSetCurrentClimb when onWidgetNavigate is undefined (off-board adapter mode)', async () => {
+    const onSetCurrentClimb = vi.fn();
+
+    const view = await mountBridge({
+      queue,
+      currentClimbQueueItem: queue[0],
+      boardDetails: makeBoardDetails(),
+      sessionId: 'session-1',
+      isSessionActive: true,
+      onSetCurrentClimb,
+      // No onWidgetNavigate — simulates adapter mode where the off-board
+      // QueueBridge doesn't inject the optimistic dispatcher.
+    });
+
+    registeredQueueNavigateHandler!({ currentIndex: 2, correlationId: 'widget-navigate' });
+
+    expect(onSetCurrentClimb).toHaveBeenCalledTimes(1);
+    expect(onSetCurrentClimb).toHaveBeenCalledWith(queue[2]);
+
+    await view.unmount();
+  });
+
+  it('falls back to onSetCurrentClimb when no correlationId is supplied (legacy intent path)', async () => {
+    const onSetCurrentClimb = vi.fn();
+    const onWidgetNavigate = vi.fn();
+
+    const view = await mountBridge({
+      queue,
+      currentClimbQueueItem: queue[0],
+      boardDetails: makeBoardDetails(),
+      sessionId: 'session-1',
+      isSessionActive: true,
+      onSetCurrentClimb,
+      onWidgetNavigate,
+    });
+
+    registeredQueueNavigateHandler!({ currentIndex: 1 });
+
+    expect(onSetCurrentClimb).toHaveBeenCalledTimes(1);
+    expect(onSetCurrentClimb).toHaveBeenCalledWith(queue[1]);
+    expect(onWidgetNavigate).not.toHaveBeenCalled();
+
+    await view.unmount();
+  });
+
+  it('ignores out-of-bounds currentIndex values', async () => {
+    const onSetCurrentClimb = vi.fn();
+    const onWidgetNavigate = vi.fn();
+
+    const view = await mountBridge({
+      queue,
+      currentClimbQueueItem: queue[0],
+      boardDetails: makeBoardDetails(),
+      sessionId: 'session-1',
+      isSessionActive: true,
+      onSetCurrentClimb,
+      onWidgetNavigate,
+    });
+
+    registeredQueueNavigateHandler!({ currentIndex: 99, correlationId: 'widget-navigate' });
+    registeredQueueNavigateHandler!({ currentIndex: -1, correlationId: 'widget-navigate' });
+
+    expect(onWidgetNavigate).not.toHaveBeenCalled();
+    expect(onSetCurrentClimb).not.toHaveBeenCalled();
+
+    await view.unmount();
+  });
+
+  it('uses the latest queue snapshot when the listener fires after a queue update', async () => {
+    const onWidgetNavigate = vi.fn();
+
+    const view = await mountBridge({
+      queue,
+      currentClimbQueueItem: queue[0],
+      boardDetails: makeBoardDetails(),
+      sessionId: 'session-1',
+      isSessionActive: true,
+      onWidgetNavigate,
+    });
+
+    // Re-render with a different queue ordering; ref should track latest.
+    const ReactDOM = await import('react-dom/client');
+    const container = document.querySelector('div')!;
+    const root = ReactDOM.createRoot(container);
+    const newQueue = [queue[2], queue[0], queue[1]];
+    await act(async () => {
+      root.render(
+        React.createElement(LiveActivityBridge, {
+          queue: newQueue,
+          currentClimbQueueItem: newQueue[0],
+          boardDetails: makeBoardDetails(),
+          sessionId: 'session-1',
+          isSessionActive: true,
+          onWidgetNavigate,
+        }),
+      );
+    });
+
+    registeredQueueNavigateHandler!({ currentIndex: 1, correlationId: 'widget-navigate' });
+    expect(onWidgetNavigate).toHaveBeenCalledWith(newQueue[1], 'widget-navigate');
+
+    await view.unmount();
+  });
+});


### PR DESCRIPTION
## Summary

- iOS Live Activity widget's Next/Prev buttons updated the widget UI but not the LEDs on the wall after the queue-pivot refactor (#2198). The intent's HTTP-success path skipped the JS bridge handoff; only the Darwin-notification fallback ever called `notifyListeners('queueNavigate')`. Without that notify the on-board reducer never optimistically advanced `currentClimbQueueItem`, and the new same-uuid BLE dedup at `bluetooth-context.tsx:166` could suppress the JS rescue write entirely.
- Fix: the intent now always posts the Darwin notification. HTTP-success uses the static `'widget-navigate'` correlationId the backend echoes back; HTTP-failure additionally sets `pendingActionKey` so the handler knows it must send a WebSocket-mutation fallback. The bridge handler in `live-activity-bridge.tsx` now consistently runs `dispatchWidgetNavigation` on board routes.
- Drive-by: log when `displayCurrentItemAwaitingReady` proceeds without `isReadyForWrite` (so we have a single Console.app signal next time "widget moved, wall didn't" lands on TestFlight). Promote the intent-firing log from `.debug` to `.notice`.

## Files

- `mobile/ios/App/BoardseshWidgets/ClimbNavigationIntent.swift` — always posts Darwin notification; encodes HTTP-success vs failure via two UserDefaults keys.
- `mobile/ios/App/App/LiveActivityPlugin.swift` — `handleQueueNavigateFromWidget` splits into success (notify-only) and fallback (mutation + notify); legacy path kept for older intent bundles.
- `mobile/ios/App/App/BoardBleManager.swift` — error-level log when not ready after `waitUntilReady`.
- `mobile/ios/App/App/SharedConstants.swift` — two new keys: `widgetNavigateActionKey`, `widgetNavigateCorrelationIdKey`.
- `packages/web/app/components/queue-control/queue-bridge-context.tsx` — rewrite the off-board widgetNavigation degrade comment: the fallback to `setCurrentClimbQueueItem` is functional in party mode.
- `packages/web/app/lib/live-activity/__tests__/live-activity-bridge.test.tsx` — new test file with 5 cases covering all bridge-handler branches.

## Test plan

- [x] `vp check` — 0 errors. Only pre-existing format issue is `packages/db/drizzle/meta/0099_snapshot.json` (unrelated to this PR).
- [x] `vp run typecheck:web` passes (exit 0).
- [x] `vp test run --project web packages/web/app/lib/live-activity/__tests__/` — 5/5 new bridge tests pass.
- [x] `vp test run --project web packages/web/app/components/queue-control/ packages/web/app/components/graphql-queue/ packages/web/app/components/providers/__tests__/persistent-session-wrapper.test.tsx` — 314/314 pass after rebase.
- [ ] Manual TestFlight verification (requires iOS build):
  - Party session, on a board route, same phone holds BLE pairing. Lock the phone. Tap Next on the Live Activity. Expect: wall LEDs change to the new climb, widget UI updates, Xcode Console shows a `LiveActivityIntent: NextClimbIntent.perform() running bundle=...` notice per tap.
  - Tap Prev. Same.
  - Foreground the app, navigate to `/you` (off-board). Tap Next on the Live Activity. Expect: wall still updates (`onSetCurrentClimb` adapter fallback now sends the server mutation in party mode).
  - HTTP failure simulation (e.g. airplane mode the secondary network): the Darwin fallback path should still send the WebSocket mutation + notify JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)