### PR TITLE
fix(angle-selector): preserve filters when changing angle

### DIFF
--- a/packages/web/app/components/board-page/__tests__/angle-selector.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/angle-selector.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import AngleSelector from '../angle-selector';
+import type { BoardDetails } from '@/app/lib/types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+const mockPush = vi.fn();
+let mockPathname = '/kilter/1/10/1,2/40/list';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+vi.mock('@/app/lib/i18n/use-locale-router', () => ({
+  useLocaleRouter: () => ({ push: mockPush, replace: vi.fn() }),
+}));
+
+vi.mock('@/app/lib/analytics', () => ({
+  track: vi.fn(),
+}));
+
+vi.mock('@/app/hooks/use-is-dark-mode', () => ({
+  useIsDarkMode: () => false,
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: undefined, isLoading: false }),
+}));
+
+vi.mock('../../swipeable-drawer/swipeable-drawer', () => ({
+  default: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="angle-drawer">{children}</div> : null,
+}));
+
+vi.mock('../../climb-card/drawer-climb-header', () => ({
+  default: () => null,
+}));
+
+vi.mock('../angle-selector.module.css', () => ({
+  default: new Proxy({}, { get: (_target, prop) => String(prop) }),
+}));
+
+const boardDetails = {
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 2,
+  set_ids: [1, 2],
+  layout_name: 'Original',
+  size_name: '12x12',
+  size_description: 'Home',
+  set_names: ['Bolt-On'],
+} as unknown as BoardDetails;
+
+describe('AngleSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPathname = '/kilter/1/10/1,2/40/list';
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('replaces the angle segment in the URL when a new angle is picked', () => {
+    render(<AngleSelector boardName="kilter" boardDetails={boardDetails} currentAngle={40} currentClimb={null} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /40/ }));
+    fireEvent.click(screen.getByText('45°'));
+
+    expect(mockPush).toHaveBeenCalledWith('/kilter/1/10/1,2/45/list');
+  });
+
+  it('preserves URL query string (live filter state) when changing angle', () => {
+    // QueueContext writes filter state to the URL via history.replaceState,
+    // which Next.js's useSearchParams() does not observe. The selector must
+    // read window.location.search directly so filters aren't dropped.
+    window.history.replaceState({}, '', '/kilter/1/10/1,2/40/list?minGrade=10&onlyClassics=true');
+
+    render(<AngleSelector boardName="kilter" boardDetails={boardDetails} currentAngle={40} currentClimb={null} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /40/ }));
+    fireEvent.click(screen.getByText('45°'));
+
+    expect(mockPush).toHaveBeenCalledWith('/kilter/1/10/1,2/45/list?minGrade=10&onlyClassics=true');
+  });
+
+  it('delegates to onAngleChange prop and skips URL navigation when provided', () => {
+    const onAngleChange = vi.fn();
+    render(
+      <AngleSelector
+        boardName="kilter"
+        boardDetails={boardDetails}
+        currentAngle={40}
+        currentClimb={null}
+        onAngleChange={onAngleChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /40/ }));
+    fireEvent.click(screen.getByText('45°'));
+
+    expect(onAngleChange).toHaveBeenCalledWith(45);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate when isAngleAdjustable is false', () => {
+    render(
+      <AngleSelector
+        boardName="kilter"
+        boardDetails={boardDetails}
+        currentAngle={40}
+        currentClimb={null}
+        isAngleAdjustable={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /40/ }));
+    fireEvent.click(screen.getByText('45°'));
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/board-page/angle-selector.tsx
+++ b/packages/web/app/components/board-page/angle-selector.tsx
@@ -8,7 +8,7 @@ import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
 import Box from '@mui/material/Box';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { track } from '@/app/lib/analytics';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import { useQuery } from '@tanstack/react-query';
@@ -42,7 +42,6 @@ export default function AngleSelector({
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const router = useLocaleRouter();
   const pathname = usePathname();
-  const searchParams = useSearchParams();
   const currentAngleRef = useRef<HTMLDivElement>(null);
   const isDark = useIsDarkMode();
 
@@ -91,8 +90,10 @@ export default function AngleSelector({
       if (angleIndex !== -1) {
         pathSegments[angleIndex] = newAngle.toString();
         let newPath = pathSegments.join('/');
-        // Preserve search params when changing angle
-        const queryString = searchParams.toString();
+        // Read live query string from window.location — QueueContext mirrors
+        // filter state via history.replaceState, which Next.js's
+        // useSearchParams() does not observe, so it would otherwise be stale.
+        const queryString = window.location.search.slice(1);
         if (queryString) {
           newPath = `${newPath}?${queryString}`;
         }

--- a/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer.test.tsx
+++ b/packages/web/app/components/sesh-settings/__tests__/sesh-settings-drawer.test.tsx
@@ -296,6 +296,22 @@ describe('SeshSettingsDrawer', () => {
       expect(screen.queryByTestId('angle-controls')).toBeNull();
       expect(mockPush).not.toHaveBeenCalled();
     });
+
+    it('preserves URL query string (live filter state) when changing angle', () => {
+      mockPathname = '/kilter/1/10/1,2/40/list';
+      mockAngle = 40;
+      // Mirrors what QueueContext does via history.replaceState when the user
+      // edits filters — the Next.js router never sees this, but
+      // window.location.search reflects it.
+      window.history.replaceState({}, '', '/kilter/1/10/1,2/40/list?minGrade=10&onlyClassics=true');
+      try {
+        render(<SeshSettingsDrawer open onClose={vi.fn()} />);
+        fireEvent.click(screen.getByTestId('change-angle-45'));
+        expect(mockPush).toHaveBeenCalledWith('/kilter/1/10/1,2/45/list?minGrade=10&onlyClassics=true');
+      } finally {
+        window.history.replaceState({}, '', '/');
+      }
+    });
   });
 
   describe('handleStopSession', () => {

--- a/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
+++ b/packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx
@@ -110,7 +110,15 @@ export default function SeshSettingsDrawer({
 
       if (angleIndex !== -1) {
         pathSegments[angleIndex] = newAngle.toString();
-        router.push(pathSegments.join('/'));
+        let newPath = pathSegments.join('/');
+        // Read live query string from window.location so filter state
+        // (mirrored to the URL via history.replaceState in QueueContext) is
+        // preserved across the angle change.
+        const queryString = window.location.search.slice(1);
+        if (queryString) {
+          newPath = `${newPath}?${queryString}`;
+        }
+        router.push(newPath);
       }
     },
     [boardDetails, angle, pathname, router],


### PR DESCRIPTION
## Summary

Setting filters on the climb list and then changing the angle wiped every filter. `QueueContext` mirrors filter state into the URL via `window.history.replaceState`, which Next.js's `useSearchParams()` hook does not observe — it stays at whatever it captured during the last real navigation. The angle selector read its query string from `searchParams.toString()` and pushed a route without the live filters; the new route then re-initialized to `DEFAULT_SEARCH_PARAMS`.

Read the live query string from `window.location.search` (which `replaceState` does update) in both angle-change paths.

## Changes

- `packages/web/app/components/board-page/angle-selector.tsx` — read query string from `window.location.search`; drop now-unused `useSearchParams`.
- `packages/web/app/components/sesh-settings/sesh-settings-drawer.tsx` — same fix; the drawer's angle picker previously didn't preserve query params at all.
- Regression tests added for both call sites (`angle-selector.test.tsx`, `sesh-settings-drawer.test.tsx`).

## Known follow-up (out of scope)

`packages/web/app/components/board-page/header.tsx:93` has the same stale-`useSearchParams()` pattern when building `getBackToListUrl()`. Navigating "back to list" after `replaceState`-based filter edits will also drop filters. Worth a separate change.

## Test plan

- [x] `vp test run` for `angle-selector.test.tsx` (4 passing) and `sesh-settings-drawer.test.tsx` (14 passing).
- [x] `vp lint` / `vp fmt --check` on the touched files — clean.
- [x] `vp run typecheck:web` — clean.
- [ ] Manual: open `/kilter/.../40/list`, set min/max grade + onlyClassics + a hold filter, confirm the URL bar shows the params, then open the angle selector and pick a different angle. Filters and URL params should carry over. Repeat from the sesh-settings drawer's angle picker.
- [ ] Manual: change angle with no filters set — no trailing `?` on the new URL.