### PR TITLE
fix(back-to-list): preserve filters from replaceState in header, play view, climb view

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/__tests__/play-view-client.test.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/__tests__/play-view-client.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import PlayViewClient from '../play-view-client';
+import type { BoardDetails } from '@/app/lib/types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+const mockPush = vi.fn();
+
+vi.mock('@/app/lib/i18n/use-locale-router', () => ({
+  useLocaleRouter: () => ({ push: mockPush, replace: vi.fn() }),
+}));
+
+vi.mock('@/app/lib/analytics', () => ({
+  track: vi.fn(),
+}));
+
+vi.mock('@/app/components/graphql-queue', () => ({
+  useCurrentClimb: () => ({ currentClimb: null }),
+  useQueueList: () => ({ queue: [] }),
+  useQueueActions: () => ({
+    setCurrentClimbQueueItem: vi.fn(),
+    getNextClimbQueueItem: vi.fn(() => null),
+    getPreviousClimbQueueItem: vi.fn(() => null),
+  }),
+}));
+
+vi.mock('@/app/components/board-renderer/swipe-board-carousel', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/climb-card/climb-title', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/climb-card/ascent-status', () => ({
+  AscentStatus: () => null,
+}));
+
+vi.mock('@/app/components/play-view/play-view-comments', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/ui/empty-state', () => ({
+  EmptyState: ({ description }: { description: string }) => <div>{description}</div>,
+}));
+
+vi.mock('../play-view.module.css', () => ({
+  default: new Proxy({}, { get: (_target, prop) => String(prop) }),
+}));
+
+const boardDetails = {
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 10,
+  set_ids: [1, 2],
+  layout_name: 'Original',
+  size_name: '12x12',
+  size_description: 'Home',
+  set_names: ['Bolt-On'],
+} as unknown as BoardDetails;
+
+describe('PlayViewClient getBackToListUrl (empty state)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('preserves live URL query string when navigating back to the list', () => {
+    // QueueContext writes filter state to the URL via history.replaceState,
+    // which Next.js's useSearchParams() does not observe. The play view must
+    // read window.location.search directly so filters aren't dropped.
+    window.history.replaceState({}, '', '/kilter/1/10/1,2/40/play/some-climb?minGrade=10&onlyClassics=true');
+
+    render(<PlayViewClient boardDetails={boardDetails} initialClimb={null} angle={40} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /browse climbs/i }));
+
+    const pushedUrl = mockPush.mock.calls[0]?.[0] as string;
+    expect(pushedUrl).toContain('minGrade=10');
+    expect(pushedUrl).toContain('onlyClassics=true');
+  });
+
+  it('does not append a trailing ? when no filters are set', () => {
+    window.history.replaceState({}, '', '/kilter/1/10/1,2/40/play/some-climb');
+
+    render(<PlayViewClient boardDetails={boardDetails} initialClimb={null} angle={40} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /browse climbs/i }));
+
+    const pushedUrl = mockPush.mock.calls[0]?.[0] as string;
+    expect(pushedUrl).not.toContain('?');
+  });
+});

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/play/[climb_uuid]/play-view-client.tsx
@@ -2,7 +2,6 @@
 
 import React, { useCallback, useEffect, useRef } from 'react';
 import MuiButton from '@mui/material/Button';
-import { useSearchParams } from 'next/navigation';
 import { track } from '@/app/lib/analytics';
 import { useTranslation } from 'react-i18next';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
@@ -26,7 +25,6 @@ type PlayViewClientProps = {
 const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialClimb, angle }) => {
   const { t } = useTranslation('session');
   const router = useLocaleRouter();
-  const searchParams = useSearchParams();
   const { currentClimb } = useCurrentClimb();
   const { queue } = useQueueList();
   const { setCurrentClimbQueueItem, getNextClimbQueueItem, getPreviousClimbQueueItem } = useQueueActions();
@@ -70,12 +68,15 @@ const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialCl
       baseUrl = `/${board_name}/${boardDetails.layout_id}/${boardDetails.size_id}/${boardDetails.set_ids.join(',')}/${angle}/list`;
     }
 
-    const queryString = searchParams.toString();
+    // Read live query string from window.location — QueueContext mirrors filter
+    // state via history.replaceState, which Next.js's useSearchParams() does not
+    // observe, so it would otherwise be stale.
+    const queryString = window.location.search.slice(1);
     if (queryString) {
       return `${baseUrl}?${queryString}`;
     }
     return baseUrl;
-  }, [boardDetails, angle, searchParams]);
+  }, [boardDetails, angle]);
 
   const navigateToClimb = useCallback(
     (climb: Climb) => {
@@ -97,13 +98,13 @@ const PlayViewClient: React.FC<PlayViewClientProps> = ({ boardDetails, initialCl
         url = `/${board_name}/${boardDetails.layout_id}/${boardDetails.size_id}/${boardDetails.set_ids.join(',')}/${angle}/play/${climb.uuid}`;
       }
 
-      const queryString = searchParams.toString();
+      const queryString = window.location.search.slice(1);
       if (queryString) {
         url = `${url}?${queryString}`;
       }
       window.history.pushState(null, '', url);
     },
-    [boardDetails, angle, searchParams],
+    [boardDetails, angle],
   );
 
   const handleNext = useCallback(() => {

--- a/packages/web/app/components/board-page/__tests__/header.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/header.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
+import BoardSeshHeader from '../header';
+import type { BoardDetails } from '@/app/lib/types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+const mockPush = vi.fn();
+let mockPathname = '/kilter/1/10/1,2/40/play/some-climb';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+vi.mock('@/app/lib/i18n/use-locale-router', () => ({
+  useLocaleRouter: () => ({ push: mockPush, replace: vi.fn() }),
+}));
+
+vi.mock('../../graphql-queue', () => ({
+  useCurrentClimb: () => ({ currentClimb: null }),
+  useSearchData: () => ({ totalSearchResultCount: 0, isFetchingClimbs: false }),
+}));
+
+vi.mock('../../queue-control/ui-searchparams-provider', () => ({
+  useUISearchParams: () => ({
+    uiSearchParams: DEFAULT_SEARCH_PARAMS,
+    clearClimbSearchParams: vi.fn(),
+    updateFilters: vi.fn(),
+  }),
+}));
+
+vi.mock('../../search-drawer/unified-search-drawer', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../search-drawer/accordion-search-form', () => ({
+  default: () => null,
+}));
+
+vi.mock('../../search-drawer/search-drawer-bridge-context', () => ({
+  SearchDrawerBridgeInjector: () => null,
+}));
+
+vi.mock('../angle-selector', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/components/i18n/locale-link', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../header.module.css', () => ({
+  default: new Proxy({}, { get: (_target, prop) => String(prop) }),
+}));
+
+const boardDetails = {
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 10,
+  set_ids: [1, 2],
+  layout_name: 'Original',
+  size_name: '12x12',
+  size_description: 'Home',
+  set_names: ['Bolt-On'],
+} as unknown as BoardDetails;
+
+describe('BoardSeshHeader getBackToListUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPathname = '/kilter/1/10/1,2/40/play/some-climb';
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('preserves live URL query string when navigating back to the list', () => {
+    // QueueContext writes filter state to the URL via history.replaceState,
+    // which Next.js's useSearchParams() does not observe. The header must
+    // read window.location.search directly so filters aren't dropped on
+    // back-to-list.
+    window.history.replaceState({}, '', '/kilter/1/10/1,2/40/play/some-climb?minGrade=10&onlyClassics=true');
+
+    render(<BoardSeshHeader boardDetails={boardDetails} angle={40} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /back to climb list/i }));
+
+    const pushedUrl = mockPush.mock.calls[0]?.[0] as string;
+    expect(pushedUrl).toContain('minGrade=10');
+    expect(pushedUrl).toContain('onlyClassics=true');
+  });
+
+  it('does not append a trailing ? when no filters are set', () => {
+    window.history.replaceState({}, '', '/kilter/1/10/1,2/40/play/some-climb');
+
+    render(<BoardSeshHeader boardDetails={boardDetails} angle={40} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /back to climb list/i }));
+
+    const pushedUrl = mockPush.mock.calls[0]?.[0] as string;
+    expect(pushedUrl).not.toContain('?');
+  });
+});

--- a/packages/web/app/components/board-page/header.tsx
+++ b/packages/web/app/components/board-page/header.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useCallback } from 'react';
 import IconButton from '@mui/material/IconButton';
 import Box from '@mui/material/Box';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import CircularProgress from '@mui/material/CircularProgress';
 import MuiButton from '@mui/material/Button';
@@ -45,7 +45,6 @@ export default function BoardSeshHeader({ boardDetails, angle, isAngleAdjustable
   const { currentClimb } = useCurrentClimb();
   const { totalSearchResultCount, isFetchingClimbs } = useSearchData();
   const { uiSearchParams, clearClimbSearchParams, updateFilters } = useUISearchParams();
-  const searchParams = useSearchParams();
   const router = useLocaleRouter();
   const [searchDropdownOpen, setSearchDropdownOpen] = useState(false);
   const isCreatePage = pathname.includes('/create');
@@ -89,8 +88,10 @@ export default function BoardSeshHeader({ boardDetails, angle, isAngleAdjustable
       baseUrl = `/${board_name}/${boardDetails.layout_id}/${boardDetails.size_id}/${boardDetails.set_ids.join(',')}/${angle}/list`;
     }
 
-    // Preserve search params when going back
-    const queryString = searchParams.toString();
+    // Read live query string from window.location — QueueContext mirrors filter
+    // state via history.replaceState, which Next.js's useSearchParams() does not
+    // observe, so it would otherwise be stale.
+    const queryString = window.location.search.slice(1);
     if (queryString) {
       return `${baseUrl}?${queryString}`;
     }

--- a/packages/web/app/components/climb-view/__tests__/climb-view-actions.test.tsx
+++ b/packages/web/app/components/climb-view/__tests__/climb-view-actions.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import ClimbViewActions from '../climb-view-actions';
+import type { BoardDetails, Climb } from '@/app/lib/types';
+
+let mockPathname = '/kilter/original/12x12-home/bolt-on/40/view/some-climb';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+// Mock BackButton so we can inspect the fallbackUrl prop.
+vi.mock('../../back-button', () => ({
+  default: ({ fallbackUrl, className }: { fallbackUrl?: string; className?: string }) => (
+    <button data-testid="back-button" data-fallback-url={fallbackUrl} className={className}>
+      back
+    </button>
+  ),
+}));
+
+// ClimbActions has a deep tree we don't care about here.
+vi.mock('../../climb-actions', () => ({
+  ClimbActions: () => null,
+}));
+
+vi.mock('../climb-view-actions.module.css', () => ({
+  default: new Proxy({}, { get: (_target, prop) => String(prop) }),
+}));
+
+const boardDetails = {
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 10,
+  set_ids: [1, 2],
+  layout_name: 'Original',
+  size_name: '12x12',
+  size_description: 'Home',
+  set_names: ['Bolt-On'],
+} as unknown as BoardDetails;
+
+const climb = {
+  uuid: 'some-climb',
+  name: 'Test Climb',
+} as unknown as Climb;
+
+describe('ClimbViewActions getBackToListUrl', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('preserves live URL query string in the BackButton fallback URL', () => {
+    // QueueContext writes filter state to the URL via history.replaceState,
+    // which Next.js's useSearchParams() does not observe. The view page's
+    // back button fallback must read window.location.search so filters
+    // aren't dropped when there's no in-app history to pop.
+    window.history.replaceState(
+      {},
+      '',
+      '/kilter/original/12x12-home/bolt-on/40/view/some-climb?minGrade=10&onlyClassics=true',
+    );
+
+    render(<ClimbViewActions climb={climb} boardDetails={boardDetails} angle={40} />);
+
+    const buttons = screen.getAllByTestId('back-button');
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const button of buttons) {
+      const fallback = button.getAttribute('data-fallback-url') ?? '';
+      expect(fallback).toContain('minGrade=10');
+      expect(fallback).toContain('onlyClassics=true');
+    }
+  });
+
+  it('does not append a trailing ? when no filters are set', () => {
+    window.history.replaceState({}, '', '/kilter/original/12x12-home/bolt-on/40/view/some-climb');
+
+    render(<ClimbViewActions climb={climb} boardDetails={boardDetails} angle={40} />);
+
+    const buttons = screen.getAllByTestId('back-button');
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const button of buttons) {
+      const fallback = button.getAttribute('data-fallback-url') ?? '';
+      expect(fallback).not.toContain('?');
+    }
+  });
+});

--- a/packages/web/app/components/climb-view/climb-view-actions.tsx
+++ b/packages/web/app/components/climb-view/climb-view-actions.tsx
@@ -21,13 +21,16 @@ const ClimbViewActions = ({ climb, boardDetails, auroraAppUrl, angle }: ClimbVie
   const getBackToListUrl = () => {
     const { board_name, layout_name, size_name, size_description, set_names } = boardDetails;
 
-    // Use slug-based URL construction if slug names are available
-    if (layout_name && size_name && set_names) {
-      return constructClimbListWithSlugs(board_name, layout_name, size_name, size_description, set_names, angle);
-    }
+    const baseUrl =
+      layout_name && size_name && set_names
+        ? constructClimbListWithSlugs(board_name, layout_name, size_name, size_description, set_names, angle)
+        : `/${board_name}/${boardDetails.layout_id}/${boardDetails.size_id}/${boardDetails.set_ids.join(',')}/${angle}/list`;
 
-    // Fallback to numeric format
-    return `/${board_name}/${boardDetails.layout_id}/${boardDetails.size_id}/${boardDetails.set_ids.join(',')}/${angle}/list`;
+    // Read live query string from window.location — QueueContext mirrors filter
+    // state via history.replaceState, which Next.js's useSearchParams() does not
+    // observe, so it would otherwise be stale.
+    const queryString = typeof window === 'undefined' ? '' : window.location.search.slice(1);
+    return queryString ? `${baseUrl}?${queryString}` : baseUrl;
   };
 
   return (


### PR DESCRIPTION
## Summary

Follow-up to #2221's "Known follow-up (out of scope)" note. `QueueContext` mirrors filter state into the URL via `window.history.replaceState` (see `packages/web/app/components/graphql-queue/QueueContext.tsx:760-768`), which Next.js's `useSearchParams()` hook does not observe — it stays stuck at whatever it captured during the last real navigation. Three more call sites built back-to-list URLs from stale `searchParams.toString()` and dropped every filter the user had set after the page was first rendered:

- **`packages/web/app/components/board-page/header.tsx`** (the original line `header.tsx:93` from #2221's follow-up note) — the play-page back button now reads `window.location.search` at click time.
- **`packages/web/app/[board_name]/.../play/[climb_uuid]/play-view-client.tsx`** — both `getBackToListUrl()` (empty-state fallback) and `navigateToClimb()` (next/prev swipe) read `window.location.search` at click time. Both had the same bug.
- **`packages/web/app/components/climb-view/climb-view-actions.tsx`** — the `BackButton`'s `fallbackUrl` now preserves the live query string too. Previously this one didn't preserve query params at all; same user-visible symptom, slightly different cause. SSR-guarded with `typeof window`.

Approach mirrors PR #2221 exactly: swap `useSearchParams().toString()` for `window.location.search.slice(1)`, drop the now-unused `useSearchParams` import, and add the explanatory comment about why we're bypassing the React hook.

## Test plan

Regression tests added next to each fixed call site, mirroring the scaffolding from `angle-selector.test.tsx`:

- [x] `vp test run --project web packages/web/app/components/board-page/__tests__/header.test.tsx` — 2 passing
- [x] `vp test run --project web packages/web/app/components/climb-view/__tests__/climb-view-actions.test.tsx` — 2 passing
- [x] `vp test run --project web packages/web/app/[board_name]/.../play/[climb_uuid]/__tests__/play-view-client.test.tsx` — 2 passing
- [x] `vp test run --project web packages/web/app/components/board-page packages/web/app/components/climb-view` — 65 tests across 8 files, all green (no regressions in neighboring suites)
- [x] `vp run typecheck:web` — clean
- [x] `vp lint` — 126 warnings / 0 errors (same baseline as `main`)
- [ ] Manual: open `/kilter/.../40/list`, set min/max grade + a hold filter, confirm URL bar shows the params (proves `replaceState` ran). Click into a play view, then tap the header back button. Filters and URL params should carry over. Repeat the swipe-next-climb flow.
- [ ] Manual: open a view page directly with `?minGrade=10` in the URL, with no in-app history, click `BackButton`. Filters should be preserved on the list page.
- [ ] Manual: with no filters set, none of the resulting URLs should have a trailing `?`.

Each test asserts both directions: that filter params survive, and that an empty `window.location.search` does not produce a stray trailing `?`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpAW9zD23z9t4cARngc46X)_