### PR TITLE
fix(e2e): align tab-bar selectors + race-proof You/Create + bump badge wait

### DIFF
--- a/packages/web/e2e/bottom-tab-bar.spec.ts
+++ b/packages/web/e2e/bottom-tab-bar.spec.ts
@@ -1,6 +1,6 @@
 import { type Page, test, expect } from '@playwright/test';
 import { loginAs } from './helpers/auth';
-import { waitForBoardListReady } from './helpers/waits';
+import { clickUntilVisible, waitForBoardListReady } from './helpers/waits';
 
 /**
  * E2E tests for the bottom tab bar navigation.
@@ -132,10 +132,17 @@ test.describe('Bottom Tab Bar - Navigation', () => {
     await page.goto('/');
     await waitForPageReady(page);
 
-    await bottomTabButton(page, 'You').click();
-
-    // The auth modal title is the guard defined at bottom-tab-bar.tsx:322
-    await expect(page.getByText('Sign in to see your progress')).toBeVisible({ timeout: 10000 });
+    // The onClick guard in bottom-tab-bar.tsx only short-circuits the NextLink
+    // navigation when `sessionStatus !== 'loading'`. When CI hits the page
+    // before next-auth's /api/auth/session round-trip completes, the click
+    // falls through to the link's default behaviour and navigates to /you
+    // (the layout then bounces unauthenticated users back to /, but the
+    // modal never opens and this test fails). Re-click until the modal
+    // appears — once useSession resolves the very next click takes the
+    // preventDefault path.
+    const modal = page.getByText('Sign in to see your progress');
+    await clickUntilVisible(page, bottomTabButton(page, 'You'), modal, { waitTimeout: 5_000 });
+    await expect(modal).toBeVisible();
     // Should NOT have navigated away from /
     await expect(page).toHaveURL('/');
   });
@@ -153,7 +160,17 @@ test.describe('Bottom Tab Bar - Navigation', () => {
     await page.goto(boardUrl);
     await waitForPageReady(page);
 
-    await bottomTabButton(page, 'Create').click();
+    // The Create tab has two render branches in bottom-tab-bar.tsx: when
+    // `createClimbUrl` is computable (board context is known) it renders as
+    // a NextLink anchor that navigates to `.../create`; otherwise it falls
+    // back to a button that opens a board-selector drawer. boardDetails on
+    // this route is plumbed through the QueueBridge, not SSR props, so on
+    // a fresh navigation there's a brief window where the fallback button
+    // is rendered. Wait for the link variant specifically so the click
+    // never lands on the drawer-opening fallback.
+    const createLink = page.locator(bottomTabBar).getByRole('link', { name: 'Create' });
+    await expect(createLink).toBeVisible({ timeout: 15_000 });
+    await createLink.click();
 
     await expect(page).toHaveURL(/\/create$/, { timeout: 15000 });
     await expect(page.locator(bottomTabBar)).toBeVisible();

--- a/packages/web/e2e/grid-mode-ascent-badge.spec.ts
+++ b/packages/web/e2e/grid-mode-ascent-badge.spec.ts
@@ -42,15 +42,21 @@ test.describe('Grid mode — ascent badge', () => {
     // showOnlyCompleted=true restricts the list to climbs the test user
     // has flashed or sent at the current angle, so every visible card
     // must render an ascent badge.
+    // The badge requires a full client-side chain — next-auth session
+    // resolution → /api/internal/ws-auth → GraphQL `ticks` fetch via
+    // useLogbook → re-render — after a fresh page load. On a slow CI
+    // shard that chain regularly takes >15s, so allow 30s before
+    // declaring the badge missing.
     const listBadges = page.locator(ASCENT_BADGE);
-    await expect(listBadges.first()).toBeVisible({ timeout: 15_000 });
+    await expect(listBadges.first()).toBeVisible({ timeout: 30_000 });
     expect(await listBadges.count()).toBeGreaterThan(0);
 
     // Switch to grid mode
     await page.getByRole('button', { name: 'Grid view' }).click();
     await expect(page.locator(CLIMB_CARD).first()).toBeVisible({ timeout: 15_000 });
 
-    // Grid mode must also show badges
+    // Grid mode must also show badges. Logbook is already hydrated from
+    // the list-mode assertion above, so the default expect timeout is fine.
     const gridBadges = page.locator(CLIMB_CARD).locator(ASCENT_BADGE);
     await expect(gridBadges.first()).toBeVisible({ timeout: 15_000 });
     expect(await gridBadges.count()).toBeGreaterThan(0);

--- a/packages/web/e2e/queue-persistence.spec.ts
+++ b/packages/web/e2e/queue-persistence.spec.ts
@@ -38,9 +38,12 @@ async function verifyQueueShowsClimb(page: Page, expectedClimbName: string, time
   await expect(bar).toContainText(expectedClimbName, { timeout });
 }
 
-// Scoped tab button selector to avoid ambiguity with multiple bars during transitions
+// Scoped tab button selector to avoid ambiguity with multiple bars during transitions.
+// BottomNavigationAction renders as `<a>` (role="link") when component={LocaleLink},
+// or as `<button>` when no static href is available. Match either role.
 function bottomTabButton(page: Page, name: string, exact = false) {
-  return page.locator(bottomTabBar).getByRole('button', { name, exact });
+  const scope = page.locator(bottomTabBar);
+  return scope.getByRole('link', { name, exact }).or(scope.getByRole('button', { name, exact }));
 }
 
 test.describe('Queue Persistence - Local Mode', () => {


### PR DESCRIPTION
## Summary

Stabilize the E2E suite on `main`. Most recent runs were red because `retries: 3` was masking persistent, consistent failures as if they were flakes.

- **queue-persistence.spec** (4 tests, hard-broken on every shard-8 run since May 17): `bottomTabButton` was still scoped to `getByRole('button', …)`. The May 17 LocaleLink rework made the tabs render as `<a>` (role=link), so the helper never resolved. Match `link OR button` (same pattern bottom-tab-bar.spec already uses).
- **bottom-tab-bar.spec "You tab"** (hard-broken on every shard-4 run): the onClick guard at `bottom-tab-bar.tsx:381` only `preventDefault`s when `sessionStatus !== 'loading'`. CI clicks before next-auth's session round-trip completes, so the link navigates and the modal never opens. Wrap the click in `clickUntilVisible` so the retry re-clicks once the session resolves.
- **bottom-tab-bar.spec "Create tab"** (hard-broken on every shard-4 run): the tab swaps between a NextLink anchor and a drawer-opening fallback button based on QueueBridge state, which is populated async. Wait for the link variant specifically before clicking.
- **grid-mode-ascent-badge** (~50% flake on shard-6): the full chain after a page reload — next-auth session → `/api/internal/ws-auth` → GraphQL `ticks` fetch via `useLogbook` → re-render — regularly exceeds 15s on slow CI shards. Bump to 30s, well within the existing 90s test timeout.

These are test-side fixes — no product code changed. The underlying tab-bar render-branch swap (drawer fallback when `effectiveBoardDetails` is null) is a real latent product bug worth a separate change.

## Test plan

- [ ] `vp check` clean
- [ ] `vp run typecheck:web` clean (verified locally)
- [ ] E2E CI run on this branch shows shard 4 and shard 8 green for the previously-hard-broken specs
- [ ] grid-mode-ascent-badge spec passes more reliably on shard 6 (acknowledging some residual variance is possible)

## Follow-ups

- Investigate `[home-page-ssr] popularBoardConfigs fetch failed` SSR-self-fetch log spam observed on shard 8.
- Consider hardening the BottomTabBar so the Create tab always renders a stable `<a>` (e.g. last-used-board fallback similar to the existing climbsHref fallback) — the drawer-swap is reachable in real-user conditions on slow networks.
- Once shards 4/6/8 are stable, consider dropping `retries: 3` → `retries: 1` to surface remaining genuine flakes instead of burying them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)