### PR TITLE
fix(queue-nav): backward stops at history, drop suggestion fallback

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -102,9 +102,8 @@ const findUnqueuedNeighborInSearchResults = (
   return null;
 };
 
-// First unqueued climb in `suggestedClimbs` whose uuid isn't the anchor. Named
-// helper rather than an inlined `find(...)` to make the cross-search-session
-// continuity intent explicit at the call site.
+// Used by the forward fallback for cross-search-session continuity: anchor
+// isn't in current climbSearchResults, surface a suggestion that isn't queued.
 const pickUnqueuedSuggestion = (
   suggestedClimbs: readonly Climb[],
   queue: readonly ClimbQueueItem[],
@@ -116,9 +115,7 @@ const pickUnqueuedSuggestion = (
 
 // Factory that captures the per-render `latest` snapshot so the returned
 // closure has the right clientId / user / playlist mode without taking those
-// as positional args at every call. Used by both forward and backward getters
-// to build a suggested ClimbQueueItem from a Climb, applying the playlist
-// peek-uuid rewrite when a playlist suggestion source is active.
+// as positional args at every call site.
 const makeBuildSuggestedQueueItem =
   (latest: {
     clientId: UserName;
@@ -997,6 +994,11 @@ export const GraphQLQueueProvider = ({
         const prevClimb = latest.suggestedClimbs[anchorIdx - 1];
         return prevClimb ? buildSuggestedQueueItem(prevClimb) : null;
       }
+      // No anchor (no current climb, no `from`): backward navigation has no
+      // semantic answer — don't fabricate one from suggestions. Forward
+      // surfaces queue[0] to start an unactivated queue; backward has no
+      // symmetric "start" semantics.
+      if (anchorUuid == null) return null;
       const queue = latest.state.queue;
       const queueItemIndex = queue.findIndex((queueItem: ClimbQueueItem) => queueItem.uuid === anchorUuid);
       if (queueItemIndex > 0) return queue[queueItemIndex - 1];
@@ -1005,19 +1007,17 @@ export const GraphQLQueueProvider = ({
       // only. Don't fall through to climbSearchResults, that would surface
       // unrelated results.
       if (latest.state.playlistSuggestionSource) return null;
-      const fromSearch = findUnqueuedNeighborInSearchResults(
+      // Backward navigation is history-oriented: the queue walk above is the
+      // history step. When neither queue nor search results yield a backward
+      // neighbour, don't fall through to suggestedClimbs — that's discovery
+      // (the forward direction).
+      return findUnqueuedNeighborInSearchResults(
         latest.climbSearchResults,
         anchorClimbUuid,
         queue,
         -1,
         buildSuggestedQueueItem,
       );
-      if (fromSearch) return fromSearch;
-      // Cross-search-session continuity (symmetric to forward): surface the
-      // first unqueued suggestion when the anchor isn't in current search
-      // results.
-      const fallback = pickUnqueuedSuggestion(latest.suggestedClimbs, queue, anchorClimbUuid);
-      return fallback ? buildSuggestedQueueItem(fallback) : null;
     },
     [],
   );

--- a/packages/web/app/components/graphql-queue/__tests__/suggestions-navigation.test.tsx
+++ b/packages/web/app/components/graphql-queue/__tests__/suggestions-navigation.test.tsx
@@ -665,9 +665,10 @@ describe('getPreviousClimbQueueItem main-branch climbSearchResults walk', () => 
     expect(result.current.getPreviousClimbQueueItem({ from: anchorAtStart })).toBeNull();
   });
 
-  it('falls back to the first unqueued suggestion when the anchor is not in climbSearchResults', () => {
-    // Symmetric with the forward branch: cross-search-session anchor surfaces
-    // the first unqueued suggestion rather than dead-ending.
+  it('returns null when the anchor is not in climbSearchResults (no suggestion fallback)', () => {
+    // Backward navigation is history-oriented: walking off the queue + search
+    // walk means we have nothing in history to step back to. Don't fall
+    // through to suggestedClimbs — that's discovery (the forward direction).
     const searchList = [makeClimb('search-0', 'A'), makeClimb('search-1', 'B')];
     mockClimbSearchResults = searchList;
     mockSuggestedClimbs = searchList;
@@ -679,9 +680,19 @@ describe('getPreviousClimbQueueItem main-branch climbSearchResults walk', () => 
       climb: makeClimb('not-in-results', 'P'),
       suggested: false,
     };
-    const prev = result.current.getPreviousClimbQueueItem({ from: orphanAnchor });
-    expect(prev?.climb.uuid).toBe('search-0');
-    expect(prev?.suggested).toBe(true);
+    expect(result.current.getPreviousClimbQueueItem({ from: orphanAnchor })).toBeNull();
+  });
+
+  it('returns null when there is no current climb and suggestions are populated', () => {
+    // Regression guard: backward had no null-anchor short-circuit and would
+    // silently surface suggestedClimbs[0] (the same forward-looking discovery
+    // climb as Next). "Previous" with no active climb has no semantic answer.
+    const suggestion = makeClimb('first-suggestion', 'S');
+    mockSuggestedClimbs = [suggestion];
+
+    const { result } = renderHook(() => useQueueContext(), { wrapper: createWrapper() });
+
+    expect(result.current.getPreviousClimbQueueItem()).toBeNull();
   });
 
   it('falls through to climbSearchResults when the anchor is the queue head', () => {


### PR DESCRIPTION
## Summary

`getPreviousClimbQueueItem` in `QueueContext.tsx` had several asymmetries vs `getNextClimbQueueItem` that produced semantically odd backward navigation:

- **No null-anchor guard.** With no current climb and no `from`, the function fell through to `pickUnqueuedSuggestion` and silently surfaced `suggestedClimbs[0]` — the same forward-looking discovery climb as Next. Untested.
- **Backward fallback surfaced a forward-looking suggestion.** When the anchor was at the head of search results, the function called `pickUnqueuedSuggestion` and returned `suggestedClimbs[0]` — exactly what the forward fallback returns. Walking "backward" to land on the first suggestion felt like going forward.

Backward navigation is history-oriented: the queue is the activated-climb history (climbs get appended via `DELTA_UPDATE_CURRENT_CLIMB` with `shouldAddToQueue: true`), and the queue walk at `queueItemIndex > 0` already covers that path. The fix:

- Add `if (anchorUuid == null) return null;` short-circuit.
- Drop the `pickUnqueuedSuggestion` call from the end of `getPreviousClimbQueueItem` — when neither queue nor search results yield a backward neighbour, return what `findUnqueuedNeighborInSearchResults` returns (which is `null` in that case). Don't fabricate a forward-looking step out of suggestions.
- Trim the WHAT-only commentary from `pickUnqueuedSuggestion` and `makeBuildSuggestedQueueItem` to the WHY only (per the codebase comment rule).
- Add the missing symmetric backward null-anchor test; update the existing fallback test to assert `null`.

`pickUnqueuedSuggestion` is still called by `getNextClimbQueueItem` for cross-search-session continuity on the forward direction — only the backward branch changes.

## Test plan

- [x] `vp test --project web run packages/web/app/components/graphql-queue/__tests__/suggestions-navigation.test.tsx` — 28/28 passing (includes the new null-anchor backward test and the rewritten "anchor not in climbSearchResults returns null" test)
- [x] `vp lint` on modified files — 0 warnings, 0 errors
- [x] `vp fmt --check` on modified files — clean
- [x] `vp run typecheck:web` — exits 0
- [ ] Manual smoke in `vp run dev`: fresh session with suggestions + empty queue → Previous on the queue bar is a no-op (does not jump to first suggestion); activated climb at queue[0] → Previous when search results don't contain it → no suggestion surfaced; mid-queue activated → Previous → walks to `queue[index-1]` (unchanged).

https://claude.ai/code/session_011ZofUr5zepSQhV9fKLZZyC

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZofUr5zepSQhV9fKLZZyC)_