### PR TITLE
fix(home-ssr): cache popular/beta links, race-proof Create tab, retries 1

### DIFF
--- a/packages/web/app/components/bottom-tab-bar/__tests__/bottom-tab-bar.test.tsx
+++ b/packages/web/app/components/bottom-tab-bar/__tests__/bottom-tab-bar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import type { BoardDetails } from '@/app/lib/types';
 import type { BoardConfigData } from '@/app/lib/server-board-configs';
@@ -165,8 +165,16 @@ vi.mock('../../persistent-session', () => ({
   usePersistentSessionActions: () => ({}),
 }));
 
+let mockLastUsedBoard: {
+  url: string;
+  boardName: string;
+  layoutName: string;
+  sizeName: string;
+  setNames: string[];
+  angle: number;
+} | null = null;
 vi.mock('@/app/lib/last-used-board-db', () => ({
-  getLastUsedBoard: () => Promise.resolve(null),
+  getLastUsedBoard: () => Promise.resolve(mockLastUsedBoard),
 }));
 
 vi.mock('@/app/components/board-lock/use-board-switch-guard', () => ({
@@ -272,6 +280,7 @@ describe('BottomTabBar create flow', () => {
     mockSessionData = null;
     mockSessionStatus = 'unauthenticated';
     mockLanguage = 'en-US';
+    mockLastUsedBoard = null;
   });
 
   it('renders a link to the create climb URL when board details are available', () => {
@@ -315,6 +324,26 @@ describe('BottomTabBar create flow', () => {
 
     expect(mockPush).not.toHaveBeenCalled();
     expect(screen.queryByTestId('drawer-Pick a board')).toBeNull();
+  });
+
+  it('renders a link to last-used-board /create URL when board details are unavailable', async () => {
+    // Slow-network race: QueueBridge hasn't populated effectiveBoardDetails
+    // yet, but the user previously visited a board so IndexedDB has it.
+    // The Create tab must promote to a real <a> rather than waiting on the
+    // drawer-opening button branch.
+    mockLastUsedBoard = {
+      url: '/kilter/original/12x12-square/screw_bolt/40/list',
+      boardName: 'kilter',
+      layoutName: 'Original',
+      sizeName: '12x12',
+      setNames: ['Screw Bolt'],
+      angle: 40,
+    };
+
+    render(<BottomTabBar boardConfigs={boardConfigs} />);
+
+    const createLink = await waitFor(() => screen.getByRole('link', { name: 'Create' }));
+    expect(createLink.getAttribute('href')).toBe('/kilter/original/12x12-square/screw_bolt/40/create');
   });
 });
 

--- a/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
+++ b/packages/web/app/components/bottom-tab-bar/bottom-tab-bar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import BottomNavigation from '@mui/material/BottomNavigation';
 import BottomNavigationAction from '@mui/material/BottomNavigationAction';
@@ -81,6 +81,11 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
   const [isCustomBoardOpen, setIsCustomBoardOpen] = useState(false);
   const [isCustomBoardRendered, setIsCustomBoardRendered] = useState(false);
   const [isCreateClimbFlow, setIsCreateClimbFlow] = useState(false);
+  // Synchronous fallback href for the Create tab: read once from IndexedDB on
+  // mount so the tab can render a stable <a> even before QueueBridge has
+  // populated `effectiveBoardDetails`. Mirrors the climbs-tab pattern that
+  // routes via getLastUsedBoard when no board context is in scope.
+  const [lastUsedCreateHref, setLastUsedCreateHref] = useState<string | null>(null);
 
   // Stable callbacks for drawer unmount-after-close-animation pattern.
   // Avoids invalidating MUI's SlideProps memo on every parent render.
@@ -152,6 +157,31 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
       return `/${board_name}/${generateLayoutSlug(layout_name)}/${generateSizeSlug(size_name, size_description)}/${generateSetSlug(set_names)}/${effectiveAngle}/create`;
     }
     return null;
+  })();
+
+  useEffect(() => {
+    let cancelled = false;
+    void getLastUsedBoard().then((lastUsed) => {
+      if (cancelled || !lastUsed?.url) return;
+      setLastUsedCreateHref(listUrlToCreateUrl(lastUsed.url));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Stable href for the Create tab so it always renders as a real <a> when
+  // we have any signal about what board to create on. Prefer the in-scope
+  // board details; otherwise use the last-used board the user visited.
+  // Only when both are unknown do we fall through to the drawer picker.
+  const createClimbHref = (() => {
+    if (createClimbUrl) return createClimbUrl;
+    if (!lastUsedCreateHref) return null;
+    if (activeSession?.sessionId) {
+      const separator = lastUsedCreateHref.includes('?') ? '&' : '?';
+      return `${lastUsedCreateHref}${separator}session=${activeSession.sessionId}`;
+    }
+    return lastUsedCreateHref;
   })();
 
   const playlistsUrl = getPlaylistsBasePath(pathname);
@@ -346,13 +376,13 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
           onClick={() => track('Bottom Tab Bar', { tab: 'feed' })}
           sx={actionSx}
         />
-        {createClimbUrl ? (
+        {createClimbHref ? (
           <BottomNavigationAction
             label={t('bottomTabBar.create')}
             icon={<AddOutlined sx={{ fontSize: 20 }} />}
             value="create"
             component={LocaleLink}
-            href={createClimbUrl}
+            href={createClimbHref}
             onClick={() => track('Bottom Tab Bar', { tab: 'create' })}
             sx={actionSx}
           />
@@ -362,7 +392,7 @@ function BottomTabBar({ boardDetails, angle, boardConfigs }: BottomTabBarProps) 
             icon={<AddOutlined sx={{ fontSize: 20 }} />}
             value="create"
             onClick={() => {
-              track('Bottom Tab Bar', { tab: 'create' });
+              track('Bottom Tab Bar', { tab: 'create', action: 'open_selector' });
               handleCreateFallback();
             }}
             sx={actionSx}

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -26,17 +26,20 @@ export {
 export const USER_CLIMB_PERCENTILE_CACHE_TAG = 'user-climb-percentile';
 
 /**
- * Execute a GraphQL query via HTTP (non-cached version for internal use)
+ * Execute a GraphQL query via HTTP (non-cached version for internal use).
+ * Pass `signal` to enforce a deadline via `AbortController`.
  */
-async function executeGraphQLInternal<T = unknown, V extends Variables = Variables>(
+export async function executeGraphQLInternal<T = unknown, V extends Variables = Variables>(
   document: RequestDocument,
   variables?: V,
+  signal?: AbortSignal,
 ): Promise<T> {
   const url = getGraphQLHttpUrl();
   const client = new GraphQLClient(url, {
     headers: {
       'Content-Type': 'application/json',
     },
+    signal,
   });
 
   return client.request<T>(document, variables);

--- a/packages/web/app/lib/server-popular-configs.ts
+++ b/packages/web/app/lib/server-popular-configs.ts
@@ -1,42 +1,39 @@
-import React from 'react';
 import 'server-only';
-import { getGraphQLHttpUrl } from '@/app/lib/graphql/client';
+import { unstable_cache } from 'next/cache';
 import { GET_POPULAR_BOARD_CONFIGS, type GetPopularBoardConfigsQueryResponse } from '@/app/lib/graphql/operations';
-import { GraphQLClient } from 'graphql-request';
+import { executeGraphQLInternal } from '@/app/lib/graphql/server-cached-client';
 import type { PopularBoardConfig } from '@boardsesh/shared-schema';
 
-/**
- * Fetches popular board configurations server-side via the GraphQL backend.
- * Uses React.cache() for request deduplication within a single server render.
- * Returns empty array if the backend is unavailable (graceful fallback —
- * the client-side hook will fetch on mount).
- */
-export const getPopularBoardConfigs = React.cache(async (): Promise<PopularBoardConfig[]> => {
-  let url: string;
-  try {
-    url = getGraphQLHttpUrl();
-  } catch {
-    // Backend URL not configured (e.g., local dev without backend running)
-    return [];
-  }
+const CACHE_TAG = 'popular-board-configs';
+const REVALIDATE_SECONDS = 300;
+const FETCH_TIMEOUT_MS = 3000;
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 1000);
+const fetchPopularBoardConfigs = unstable_cache(
+  async (): Promise<PopularBoardConfig[]> => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const result = await executeGraphQLInternal<GetPopularBoardConfigsQueryResponse>(
+        GET_POPULAR_BOARD_CONFIGS,
+        { input: { limit: 12, offset: 0 } },
+        controller.signal,
+      );
+      return result.popularBoardConfigs.configs;
+    } finally {
+      clearTimeout(timer);
+    }
+  },
+  ['popular-board-configs'],
+  { revalidate: REVALIDATE_SECONDS, tags: [CACHE_TAG] },
+);
+
+export async function getPopularBoardConfigs(): Promise<PopularBoardConfig[]> {
   try {
-    const client = new GraphQLClient(url, {
-      headers: { 'Content-Type': 'application/json' },
-      signal: controller.signal,
-    });
-    const result = await client.request<GetPopularBoardConfigsQueryResponse>(GET_POPULAR_BOARD_CONFIGS, {
-      input: { limit: 12, offset: 0 },
-    });
-    return result.popularBoardConfigs.configs;
+    return await fetchPopularBoardConfigs();
   } catch (err) {
-    // Backend unreachable or timed out — client-side hook will retry.
-    // Log the failure so a future regression names itself in Vercel logs.
-    console.error('[home-page-ssr] popularBoardConfigs fetch failed:', err instanceof Error ? err.message : err);
+    if (process.env.NODE_ENV === 'production') {
+      console.error('[home-page-ssr] popularBoardConfigs fetch failed:', err instanceof Error ? err.message : err);
+    }
     return [];
-  } finally {
-    clearTimeout(timer);
   }
-});
+}

--- a/packages/web/app/lib/server-recent-beta-links.ts
+++ b/packages/web/app/lib/server-recent-beta-links.ts
@@ -1,8 +1,7 @@
-import React from 'react';
 import 'server-only';
-import { GraphQLClient } from 'graphql-request';
-import { getGraphQLHttpUrl } from '@/app/lib/graphql/client';
+import { unstable_cache } from 'next/cache';
 import { GET_RECENT_BETA_LINKS } from '@/app/lib/graphql/operations/beta-links';
+import { executeGraphQLInternal } from '@/app/lib/graphql/server-cached-client';
 import type { BetaLinksGqlRow } from '@/app/lib/beta-video-url';
 
 export type RecentBetaLinkRow = {
@@ -15,36 +14,38 @@ type RecentBetaLinksResponse = {
   recentBetaLinks: RecentBetaLinkRow[];
 };
 
-/**
- * Fetches the latest cross-climb beta videos for the home-screen slider.
- * Mirrors `server-popular-configs.ts`: React.cache for request dedupe, a
- * 1s timeout, and a silent fall back to `[]` so a backend hiccup doesn't
- * fail the page render — the client section will retry on mount.
- */
-export const getRecentBetaLinks = React.cache(async (limit = 20): Promise<RecentBetaLinkRow[]> => {
-  let url: string;
-  try {
-    url = getGraphQLHttpUrl();
-  } catch {
-    return [];
-  }
+const CACHE_TAG = 'recent-beta-links';
+const REVALIDATE_SECONDS = 300;
+const FETCH_TIMEOUT_MS = 3000;
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 1000);
+function buildFetcher(limit: number) {
+  return unstable_cache(
+    async (): Promise<RecentBetaLinkRow[]> => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      try {
+        const result = await executeGraphQLInternal<RecentBetaLinksResponse>(
+          GET_RECENT_BETA_LINKS,
+          { limit },
+          controller.signal,
+        );
+        return result.recentBetaLinks;
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+    ['recent-beta-links', String(limit)],
+    { revalidate: REVALIDATE_SECONDS, tags: [CACHE_TAG] },
+  );
+}
+
+export async function getRecentBetaLinks(limit = 20): Promise<RecentBetaLinkRow[]> {
   try {
-    const client = new GraphQLClient(url, {
-      headers: { 'Content-Type': 'application/json' },
-      signal: controller.signal,
-    });
-    const result = await client.request<RecentBetaLinksResponse>(GET_RECENT_BETA_LINKS, { limit });
-    return result.recentBetaLinks;
+    return await buildFetcher(limit)();
   } catch (err) {
-    // Log the failure so a future regression names itself in Vercel logs.
-    // PR #2119 broke this section in prod and the missing log made root
-    // cause analysis slow — keep this line even if cheap.
-    console.error('[home-page-ssr] recentBetaLinks fetch failed:', err instanceof Error ? err.message : err);
+    if (process.env.NODE_ENV === 'production') {
+      console.error('[home-page-ssr] recentBetaLinks fetch failed:', err instanceof Error ? err.message : err);
+    }
     return [];
-  } finally {
-    clearTimeout(timer);
   }
-});
+}

--- a/packages/web/app/lib/server-user-beta-links.ts
+++ b/packages/web/app/lib/server-user-beta-links.ts
@@ -1,45 +1,45 @@
-import React from 'react';
 import 'server-only';
-import { GraphQLClient } from 'graphql-request';
-import { getGraphQLHttpUrl } from '@/app/lib/graphql/client';
+import { unstable_cache } from 'next/cache';
 import { GET_USER_BETA_LINKS } from '@/app/lib/graphql/operations/beta-links';
+import { executeGraphQLInternal } from '@/app/lib/graphql/server-cached-client';
 import type { RecentBetaLinkRow } from '@/app/lib/server-recent-beta-links';
 
 type UserBetaLinksResponse = {
   userBetaLinks: RecentBetaLinkRow[];
 };
 
-/**
- * Fetches a single user's beta videos for the profile-page slider. Same
- * shape as the home slider (RecentBetaLinkRow) — the only difference is
- * the resolver filters by user instead of capping per-poster. Errors and
- * timeouts fall back to `[]` so a backend hiccup doesn't fail the page
- * render; the client section will retry on mount.
- */
-export const getUserBetaLinks = React.cache(async (userId: string, limit = 50): Promise<RecentBetaLinkRow[]> => {
-  let url: string;
-  try {
-    url = getGraphQLHttpUrl();
-  } catch {
-    return [];
-  }
+const REVALIDATE_SECONDS = 300;
+const FETCH_TIMEOUT_MS = 3000;
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 1000);
+function buildFetcher(userId: string, limit: number) {
+  const tag = `user-beta-links-${userId}`;
+  return unstable_cache(
+    async (): Promise<RecentBetaLinkRow[]> => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      try {
+        const result = await executeGraphQLInternal<UserBetaLinksResponse>(
+          GET_USER_BETA_LINKS,
+          { userId, limit },
+          controller.signal,
+        );
+        return result.userBetaLinks;
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+    ['user-beta-links', userId, String(limit)],
+    { revalidate: REVALIDATE_SECONDS, tags: [tag] },
+  );
+}
+
+export async function getUserBetaLinks(userId: string, limit = 50): Promise<RecentBetaLinkRow[]> {
   try {
-    const client = new GraphQLClient(url, {
-      headers: { 'Content-Type': 'application/json' },
-      signal: controller.signal,
-    });
-    const result = await client.request<UserBetaLinksResponse>(GET_USER_BETA_LINKS, { userId, limit });
-    return result.userBetaLinks;
+    return await buildFetcher(userId, limit)();
   } catch (err) {
-    // Surface the failure in Vercel logs so a future regression names
-    // itself. Same observability rationale as server-recent-beta-links.ts
-    // and server-popular-configs.ts.
-    console.error('[home-page-ssr] userBetaLinks fetch failed:', err instanceof Error ? err.message : err);
+    if (process.env.NODE_ENV === 'production') {
+      console.error('[home-page-ssr] userBetaLinks fetch failed:', err instanceof Error ? err.message : err);
+    }
     return [];
-  } finally {
-    clearTimeout(timer);
   }
-});
+}

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -13,8 +13,9 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* 3 retries in CI to absorb infra timing noise; 1 locally to catch genuine flakes */
-  retries: process.env.CI ? 3 : 1,
+  /* 1 retry in CI and locally — enough to absorb a single transient infra blip,
+   * but not enough to bury a hard-broken test the way `retries: 3` did before. */
+  retries: 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 2 : undefined,
   /* Global per-test timeout — some tests (zoom, login flows) need more than Playwright's 30 s default */


### PR DESCRIPTION
## Summary

- **SSR fetch hardening** — Three home/profile self-fetches (`getPopularBoardConfigs`, `getRecentBetaLinks`, `getUserBetaLinks`) now wrap the GraphQL call in `unstable_cache` (5-min revalidate; user-beta variant keyed by `userId`), use a 3 s abort timeout (was 1 s), and only emit the `[home-page-ssr] … fetch failed` line under `NODE_ENV=production`. Shard 8 (and dev/CI generally) stops being spammed when the backend takes >1 s to respond, while Vercel keeps the regression signal. `executeGraphQLInternal` in `server-cached-client.ts` was exported and given an optional `AbortSignal` so the three fetchers share one client setup path.
- **Create tab race-proofed** — `BottomTabBar` now reads `getLastUsedBoard` from IndexedDB on mount and falls back to a synthesized `/create` href when `effectiveBoardDetails` hasn't been populated yet by QueueBridge. Render is always an `<a>` when *either* the in-scope board or the last-used board is known; the drawer-opening button branch is now only reachable when both are absent. This closes the slow-network race where a real user could click and land on the picker drawer instead of a real navigation. Mirrors the existing `climbsHref` fallback pattern in the same file.
- **`retries: 3 → 1`** — The previous PR (#2228) explicitly noted that `retries: 3` was masking hard-broken tests. The two fixes above remove the named shard-8 offenders; dropping to 1 retry lets the next regression name itself in `flake-report.yml` rather than be papered over.

## Test plan

- [x] `vp run typecheck:web` — clean
- [x] `vp test --project web --reporter=agent` — all 4638 tests pass, including new `bottom-tab-bar` fallback test
- [x] `vp check` on touched files — no format/lint errors
- [ ] CI: all 8 e2e shards green with `retries: 1`
- [ ] Manual: load `/` with devtools "Slow 3G" throttling — confirm Create tab in bottom bar renders as an `<a>` (right-click → "Open in new tab" works) before QueueBridge resolves
- [ ] Manual: clear IndexedDB, reload `/` from a fresh session, confirm Create tab still falls through to drawer when last-used board is absent
- [ ] Post-merge: watch `flake-report` comment on next ~5 main runs for surfaced flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)