### PR TITLE
perf(ci): halve E2E pipeline wall-clock — parallelize screenshots, trim shards, fix 04-queue flake

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -347,6 +347,11 @@ jobs:
         # image rebuild publishes asynchronously and may still be stale.
         if: github.event_name == 'pull_request'
         run: |
+          # actions/checkout@v6 sets safe.directory inside its own action,
+          # but ad-hoc git commands in subsequent steps don't inherit that
+          # config when the repo is owned by a different uid than the
+          # container user (git 2.35.2+ refuses with "dubious ownership").
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --depth=1 origin main
           if git diff --quiet origin/main HEAD -- packages/db/drizzle/meta/_journal.json; then
             echo "needed=false" >> "$GITHUB_OUTPUT"
@@ -551,6 +556,11 @@ jobs:
         # image rebuild publishes asynchronously and may still be stale.
         if: github.event_name == 'pull_request'
         run: |
+          # actions/checkout@v6 sets safe.directory inside its own action,
+          # but ad-hoc git commands in subsequent steps don't inherit that
+          # config when the repo is owned by a different uid than the
+          # container user (git 2.35.2+ refuses with "dubious ownership").
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --depth=1 origin main
           if git diff --quiet origin/main HEAD -- packages/db/drizzle/meta/_journal.json; then
             echo "needed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -229,7 +229,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [1, 2, 3, 4, 5, 6]
     container:
       image: mcr.microsoft.com/playwright:v1.58.0-noble
 
@@ -337,7 +337,25 @@ jobs:
           tar -xf built-packages.tar
           rm built-packages.tar
 
+      - name: Check for new migrations vs main
+        id: migrations
+        # On PRs whose drizzle journal matches `origin/main`, the dev DB
+        # image (rebuilt on every journal change by dev-db-docker.yml)
+        # already has every migration applied — so the migrate step is
+        # pure overhead (~20s of bun + drizzle-kit startup). Skip it.
+        # Push events to main run migrations unconditionally because the
+        # image rebuild publishes asynchronously and may still be stale.
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --depth=1 origin main
+          if git diff --quiet origin/main HEAD -- packages/db/drizzle/meta/_journal.json; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run database migrations
+        if: github.event_name != 'pull_request' || steps.migrations.outputs.needed == 'true'
         run: bunx drizzle-kit migrate
         working-directory: packages/db
         env:
@@ -356,13 +374,13 @@ jobs:
           NEXTAUTH_URL: http://localhost:3000
           NEXT_PUBLIC_WS_URL: ws://localhost:8080/graphql
 
-      - name: Run Playwright shard ${{ matrix.shard }}/8
+      - name: Run Playwright shard ${{ matrix.shard }}/6
         # `--project=chromium` keeps screenshot specs (app-store/help/layout)
         # out of the functional shards. Those projects already run in the
         # dedicated `screenshots` job below; without this filter every
         # screenshot test ran twice per PR and contributed double to the
         # flake budget.
-        run: bunx playwright test --project=chromium --shard=${{ matrix.shard }}/8
+        run: bunx playwright test --project=chromium --shard=${{ matrix.shard }}/6
         working-directory: packages/web
         env:
           PLAYWRIGHT_TEST_BASE_URL: http://localhost:3000
@@ -401,21 +419,26 @@ jobs:
       # Screenshot capture runs in the dedicated `screenshots` job below.
 
   # ---------------------------------------------------------------------------
-  # Screenshots — like an e2e shard but runs the three screenshot Playwright
-  # projects. `needs: e2e` sequences it after the functional tests so the
-  # two don't fight over shared containers; `if: always()` makes sure a
-  # failing shard doesn't skip the capture (screenshots are informational).
+  # Screenshots — one matrix job per Playwright screenshot project, run in
+  # parallel with the functional `e2e` shards. We don't gate on `e2e` because
+  # the screenshot jobs don't share infra with the functional shards (each
+  # one spins up its own Postgres service and its own web/backend processes)
+  # and are `continue-on-error: true` anyway — they're informational, not a
+  # merge gate. Fanning out across `app-store-screenshots`,
+  # `layout-screenshots`, and `help-screenshots` turns wall-clock from
+  # sum-of-projects into max-of-projects.
   # ---------------------------------------------------------------------------
   screenshots:
-    name: Capture PR screenshots
-    needs: [typecheck, build, e2e]
-    # `always()` so a failing e2e shard doesn't suppress the screenshot
-    # capture — screenshots are informational, not a merge gate. Paired
-    # with `continue-on-error: true` for soft-fail semantics.
+    name: Capture PR screenshots (${{ matrix.project }})
+    needs: [typecheck, build]
     if: always() && github.event_name == 'pull_request'
     continue-on-error: true
     timeout-minutes: 20
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [app-store-screenshots, layout-screenshots, help-screenshots]
     container:
       image: mcr.microsoft.com/playwright:v1.58.0-noble
 
@@ -518,7 +541,25 @@ jobs:
           tar -xf built-packages.tar
           rm built-packages.tar
 
+      - name: Check for new migrations vs main
+        id: migrations
+        # On PRs whose drizzle journal matches `origin/main`, the dev DB
+        # image (rebuilt on every journal change by dev-db-docker.yml)
+        # already has every migration applied — so the migrate step is
+        # pure overhead (~20s of bun + drizzle-kit startup). Skip it.
+        # Push events to main run migrations unconditionally because the
+        # image rebuild publishes asynchronously and may still be stale.
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --depth=1 origin main
+          if git diff --quiet origin/main HEAD -- packages/db/drizzle/meta/_journal.json; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run database migrations
+        if: github.event_name != 'pull_request' || steps.migrations.outputs.needed == 'true'
         run: bunx drizzle-kit migrate
         working-directory: packages/db
         env:
@@ -549,11 +590,7 @@ jobs:
                 packages/web/e2e/screenshots/layouts/*.png
 
       - name: Capture screenshots
-        run: |
-          bunx playwright test \
-            --project=app-store-screenshots \
-            --project=layout-screenshots \
-            --project=help-screenshots
+        run: bunx playwright test --project=${{ matrix.project }}
         working-directory: packages/web
         env:
           PLAYWRIGHT_TEST_BASE_URL: http://localhost:3000
@@ -574,18 +611,33 @@ jobs:
 
       - name: Stage screenshots for upload
         if: always()
+        # Each matrix job stages only its own project's PNGs into the
+        # subfolder that `report-screenshots` already reads from
+        # (`screenshots-out/{app-store,layouts,help}/`). Per-project
+        # artifacts are merged in the report job via
+        # `download-artifact` + `merge-multiple: true`.
         run: |
-          mkdir -p screenshots-out/app-store screenshots-out/layouts screenshots-out/help
-          cp mobile/screenshots/*.png                     screenshots-out/app-store/ 2>/dev/null || true
-          cp packages/web/e2e/screenshots/layouts/*.png    screenshots-out/layouts/   2>/dev/null || true
-          cp packages/web/public/help/*.png                screenshots-out/help/      2>/dev/null || true
+          case "${{ matrix.project }}" in
+            app-store-screenshots)
+              mkdir -p screenshots-out/app-store
+              cp mobile/screenshots/*.png screenshots-out/app-store/ 2>/dev/null || true
+              ;;
+            layout-screenshots)
+              mkdir -p screenshots-out/layouts
+              cp packages/web/e2e/screenshots/layouts/*.png screenshots-out/layouts/ 2>/dev/null || true
+              ;;
+            help-screenshots)
+              mkdir -p screenshots-out/help
+              cp packages/web/public/help/*.png screenshots-out/help/ 2>/dev/null || true
+              ;;
+          esac
           ls -R screenshots-out || true
 
       - name: Upload screenshots artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: screenshots-current
+          name: screenshots-current-${{ matrix.project }}
           path: screenshots-out/
           if-no-files-found: warn
           retention-days: 14
@@ -610,7 +662,12 @@ jobs:
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          name: screenshots-current
+          # The three screenshot matrix jobs each upload to
+          # `screenshots-current-${{ matrix.project }}`; `merge-multiple`
+          # flattens them back into one tree at `screenshots-out/`, with
+          # the per-project subfolders the gallery script expects.
+          pattern: screenshots-current-*
+          merge-multiple: true
           path: screenshots-out/
 
       - name: Push screenshots to per-PR branch

--- a/packages/web/e2e/app-store-screenshots.spec.ts
+++ b/packages/web/e2e/app-store-screenshots.spec.ts
@@ -140,12 +140,12 @@ test.describe('App Store Screenshots', () => {
       maxAttempts: 6,
     });
 
-    // The play drawer's queue toggle can be in the DOM but not interactive
-    // until the drawer's open animation settles. Without an explicit
-    // visibility wait, the click fired on slow CI runners before the button
-    // was hittable, producing the recurring 04-queue flake.
+    // The play drawer's queue toggle renders after the drawer animates in
+    // and the in-drawer content loads — on slow CI runners this can take
+    // longer than the default 15s actionTimeout that `.click()` waits.
+    // Wait explicitly with a generous budget before clicking.
     const openQueueButton = page.getByRole('button', { name: 'Open queue' });
-    await expect(openQueueButton).toBeVisible();
+    await openQueueButton.waitFor({ state: 'visible', timeout: 30_000 });
     await openQueueButton.click();
     // The queue drawer is the second swipeable drawer (stacked above play).
     await waitForDrawerOpen(page, 1);

--- a/packages/web/e2e/app-store-screenshots.spec.ts
+++ b/packages/web/e2e/app-store-screenshots.spec.ts
@@ -22,7 +22,7 @@
  *   - 6.9" (iPhone 16 Pro Max): 1320x2868 -- App Store Connect accepts 6.5" for this slot
  *   - 12.9" iPad: 2048x2732 -- optional, not covered here
  */
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import path from 'path';
 import {
   clickWithDomFallback,
@@ -140,7 +140,13 @@ test.describe('App Store Screenshots', () => {
       maxAttempts: 6,
     });
 
-    await page.getByRole('button', { name: 'Open queue' }).click();
+    // The play drawer's queue toggle can be in the DOM but not interactive
+    // until the drawer's open animation settles. Without an explicit
+    // visibility wait, the click fired on slow CI runners before the button
+    // was hittable, producing the recurring 04-queue flake.
+    const openQueueButton = page.getByRole('button', { name: 'Open queue' });
+    await expect(openQueueButton).toBeVisible();
+    await openQueueButton.click();
     // The queue drawer is the second swipeable drawer (stacked above play).
     await waitForDrawerOpen(page, 1);
     // Toggle history so previously-played climbs are listed alongside the


### PR DESCRIPTION
## Summary

Cuts a typical PR's `E2E Tests` workflow wall-clock from ~23-25 min to ~12 min by removing the serial gate between `e2e` and `screenshots`, fanning the screenshots job out across its three Playwright projects, and fixing the dominant flake in the app-store-screenshots run.

Baseline data (representative PR run on a recent `board_sessions` PR, 2026-05-20):

| Stage | Before | After (expected) |
| --- | --- | --- |
| typecheck \|\| build | 5:21 | 5:21 |
| e2e (longest shard) | 6:30 (critical path) | 5:30–6:30 (off critical path) |
| screenshots (longest job) | 11:46 (serial after e2e) | ~5:30 (parallel with e2e) |
| **Wall-clock total** | **~23:30** | **~11:30–12:30** |

## What changed

- **`screenshots` no longer waits on `e2e`** — drops `needs: e2e`, runs in parallel with the functional shards. Each job already has its own postgres service and web/backend processes, so there's no shared infra to sequence around. The `continue-on-error: true` semantics are unchanged.
- **`screenshots` is a 3-way matrix over Playwright projects** — `app-store-screenshots`, `layout-screenshots`, `help-screenshots` run in parallel and each upload `screenshots-current-<project>`. `report-screenshots` merges them with `download-artifact` `pattern` + `merge-multiple: true` — the existing gallery script keeps reading from `screenshots-out/{app-store,layouts,help}/`.
- **E2E shards reduced 8 → 6** — 47 functional tests across 7 specs, 8 shards was paying a ~2:20 container/setup tax for ~1 min of test work per shard. 6 shards keeps the longest shard inside the new screenshots wall-clock ceiling and saves roughly 6 min of CI minutes per run with no wall-clock harm (e2e is no longer the bottleneck).
- **04-queue screenshot flake fixed** — `packages/web/e2e/app-store-screenshots.spec.ts:143` now waits for the `Open queue` button to be visible before clicking. The race was the play drawer's open animation under CI load; each retry was burning 15-30s on the screenshots job.
- **`drizzle-kit migrate` gated by journal diff on PR runs** — the dev DB image is rebuilt on every change to `packages/db/drizzle/`, so on PRs whose `_journal.json` matches `origin/main` the migrate step is pure overhead. Skip it on those PRs (~20s per shard × 9 shards = ~3 min CI). `push` events still run unconditionally so we don't race the async image rebuild.

## Test plan

- [ ] Verify the new run's three screenshot jobs start at the same time as the e2e shards (no `e2e` gate). View with `gh run view <id> --json jobs --jq '.jobs[] | {name, startedAt}'`.
- [ ] Verify e2e shard count is 6, named `E2E (shard 1)` through `E2E (shard 6)`.
- [ ] Verify the longest screenshot matrix job is ≤6 min including container setup.
- [ ] Verify the sticky `E2E Screenshots` PR comment renders the same gallery as before (App flow / Board layouts / Help docs sections all populated).
- [ ] Push 1-2 follow-up commits and confirm `04-queue` passes on its first attempt (i.e., not relying on a retry).
- [ ] On the next migration PR (any change under `packages/db/drizzle/`), confirm the migrate step still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)