### PR TITLE
fix(analytics): fire Set Active Climb from central queue mutators

### DIFF
--- a/POSTHOG_INVENTORY.md
+++ b/POSTHOG_INVENTORY.md
@@ -84,7 +84,7 @@ Boardsesh has comprehensive PostHog instrumentation across both web (Next.js) an
 | Climb Info Viewed                 | use-climb-actions.ts:88       | `climbUuid`, `boardLayout`                              | User opened climb details         |
 | Climb Shared                      | use-climb-actions.ts:196,204  | `climbUuid`, `boardLayout`, `method` (native/clipboard) | User shared via web share or copy |
 | Mirror Climb                      | use-climb-actions.ts:174      | `climbUuid`, `boardLayout`                              | User flipped climb horizontally   |
-| Set Active Climb                  | set-active-action.tsx:36      | `climbUuid`, `boardLayout`                              | User marked as current climb      |
+| Set Active Climb                  | QueueContext.tsx:598,740,862; queue-bridge-context.tsx:270,389,536 | `climbUuid`, `boardType`, `layoutId`, `source` (setCurrentClimb / setCurrentClimbQueueItem / takeControl / bridge.*) | User activated a climb (any UI path — button, queue nav, list tap, swipe, playlist, browse). Fired centrally from queue context mutators. |
 | Climb List Row Clicked            | climbs-list.tsx:419           | `climbUuid`                                             | User tapped climb in list view    |
 | Open in Aurora App                | use-climb-actions.ts:160      | `climbUuid`, `boardLayout`                              | User clicked "open in app"        |
 | Create Climb Set Active           | create-climb-form.tsx:747     | `boardLayout`                                           | User toggled active during create |

--- a/packages/web/app/components/climb-actions/actions/__tests__/set-active-action.test.tsx
+++ b/packages/web/app/components/climb-actions/actions/__tests__/set-active-action.test.tsx
@@ -4,11 +4,6 @@ import { SetActiveAction } from '../set-active-action';
 import type { ClimbActionProps } from '../../types';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 
-// Mock dependencies before importing the module
-vi.mock('@/app/lib/analytics', () => ({
-  track: vi.fn(),
-}));
-
 // Stub i18n so the test asserts against the English string the user sees,
 // not the bare key. Tests live outside the i18next provider tree; the real
 // label comes from `packages/web/i18n/locales/en-US/climbs.json:actions.sendToBoard`.

--- a/packages/web/app/components/climb-actions/actions/set-active-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/set-active-action.tsx
@@ -3,7 +3,6 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import PlayCircleOutlineOutlined from '@mui/icons-material/PlayCircleOutlineOutlined';
-import { track } from '@/app/lib/analytics';
 import type { ClimbActionProps, ClimbActionResult } from '../types';
 import { useOptionalQueueActions, useOptionalQueueData } from '../../graphql-queue';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -12,7 +11,6 @@ import { useOptionalPlaylistActivation } from '../playlist-activation-context';
 
 export function SetActiveAction({
   climb,
-  boardDetails,
   viewMode,
   size = 'default',
   showLabel,
@@ -35,24 +33,19 @@ export function SetActiveAction({
 
       if ((!queueActions && !playlistActivation) || isCurrentClimb) return;
 
+      // The PostHog "Set Active Climb" event is fired centrally from the
+      // queue context's setCurrentClimb / setCurrentClimbQueueItem, so we
+      // don't fire it here — that would double-count clicks. The funnel was
+      // dropping to ~6% because the button used to be the only firing site.
       if (playlistActivation) {
         void playlistActivation.activatePlaylistClimb(climb);
       } else {
         void queueActions?.setCurrentClimb(climb, { playlistSuggestionSource: null });
       }
 
-      // PostHog event name stays "Set Active Climb" for analytics continuity
-      // — the time series spans the rename and we don't want to break it.
-      // The user-facing label changes to "Send to board" per the
-      // queue-control-bar pivot (Phase 2 PR3).
-      track('Set Active Climb', {
-        boardLayout: boardDetails.layout_name || '',
-        climbUuid: climb.uuid,
-      });
-
       onComplete?.();
     },
-    [queueActions, playlistActivation, isCurrentClimb, climb, boardDetails.layout_name, onComplete],
+    [queueActions, playlistActivation, isCurrentClimb, climb, onComplete],
   );
 
   const label = isCurrentClimb ? t('actions.sendToBoard.active') : t('actions.sendToBoard.label');

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -589,6 +589,18 @@ export const GraphQLQueueProvider = ({
           playlistSuggestionSource,
         },
       });
+      // Central funnel instrumentation — fires from every UI path that
+      // activates a new climb (queue list tap, browse preview, playlist
+      // activation, SetActiveAction button, solo takeControl). Previously
+      // this event only fired from the SetActiveAction button, missing the
+      // ~7 other entry points and dropping the "Session Started → Set
+      // Active Climb" funnel conversion to ~6%.
+      track('Set Active Climb', {
+        climbUuid: climb.uuid,
+        boardType: climb.boardType ?? null,
+        layoutId: climb.layoutId ?? null,
+        source: 'setCurrentClimb',
+      });
       if (latest.sessionId) incrementSessionClimbsAttempted(latest.sessionId);
       if (latest.isDisconnected && latest.isPersistentSessionActive) {
         latest.offlineBuffer.bufferAddition(newItem);
@@ -725,6 +737,12 @@ export const GraphQLQueueProvider = ({
         type: 'DELTA_UPDATE_CURRENT_CLIMB',
         payload: { item: newItem, shouldAddToQueue: true, insertAfterCurrent: true, correlationId },
       });
+      track('Set Active Climb', {
+        climbUuid: climb.uuid,
+        boardType: climb.boardType ?? null,
+        layoutId: climb.layoutId ?? null,
+        source: 'takeControl',
+      });
 
       if (latest.isDisconnected) {
         latest.offlineBuffer.bufferAddition(newItem);
@@ -840,6 +858,14 @@ export const GraphQLQueueProvider = ({
       type: 'DELTA_UPDATE_CURRENT_CLIMB',
       payload: { item: queueItem, shouldAddToQueue: queueItem.suggested, correlationId },
     });
+    if (queueItem.climb) {
+      track('Set Active Climb', {
+        climbUuid: queueItem.climb.uuid,
+        boardType: queueItem.climb.boardType ?? null,
+        layoutId: queueItem.climb.layoutId ?? null,
+        source: 'setCurrentClimbQueueItem',
+      });
+    }
     if (latest.sessionId) incrementSessionClimbsAttempted(latest.sessionId);
     if (!latest.isDisconnected && latest.hasConnected && latest.isPersistentSessionActive) {
       latest.persistentSession

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -66,6 +66,7 @@ import type {
   SearchDataType,
   SessionDataType,
 } from './types';
+import type { SetActiveClimbSource } from './set-active-climb-event';
 
 // Re-export types so direct importers still work
 export type { GraphQLQueueContextType, GraphQLQueueActionsType, GraphQLQueueDataType } from './types';
@@ -599,7 +600,7 @@ export const GraphQLQueueProvider = ({
         climbUuid: climb.uuid,
         boardType: climb.boardType ?? null,
         layoutId: climb.layoutId ?? null,
-        source: 'setCurrentClimb',
+        source: 'setCurrentClimb' satisfies SetActiveClimbSource,
       });
       if (latest.sessionId) incrementSessionClimbsAttempted(latest.sessionId);
       if (latest.isDisconnected && latest.isPersistentSessionActive) {
@@ -741,7 +742,7 @@ export const GraphQLQueueProvider = ({
         climbUuid: climb.uuid,
         boardType: climb.boardType ?? null,
         layoutId: climb.layoutId ?? null,
-        source: 'takeControl',
+        source: 'takeControl' satisfies SetActiveClimbSource,
       });
 
       if (latest.isDisconnected) {
@@ -863,7 +864,7 @@ export const GraphQLQueueProvider = ({
         climbUuid: queueItem.climb.uuid,
         boardType: queueItem.climb.boardType ?? null,
         layoutId: queueItem.climb.layoutId ?? null,
-        source: 'setCurrentClimbQueueItem',
+        source: 'setCurrentClimbQueueItem' satisfies SetActiveClimbSource,
       });
     }
     if (latest.sessionId) incrementSessionClimbsAttempted(latest.sessionId);

--- a/packages/web/app/components/graphql-queue/set-active-climb-event.ts
+++ b/packages/web/app/components/graphql-queue/set-active-climb-event.ts
@@ -1,0 +1,11 @@
+// Source tags for the centrally-fired PostHog "Set Active Climb" event.
+// Typed as a union so the call sites get compile-time typo protection and
+// PostHog dashboards can rely on this exact set of values for breakdowns.
+export type SetActiveClimbSource =
+  | 'setCurrentClimb'
+  | 'setCurrentClimbQueueItem'
+  | 'takeControl'
+  | 'bridge.setCurrentClimb'
+  | 'bridge.setCurrentClimbQueueItem.party'
+  | 'bridge.setCurrentClimbQueueItem.solo'
+  | 'bridge.takeControl';

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -39,6 +39,7 @@ import { queueAddErrorMessage } from '../board-lock/queue-add-error-messages';
 import { QueueBridgeBoardInfoContext, type QueueBridgeBoardInfo } from './queue-bridge-board-info-context';
 import { dispatchOpenPlayDrawer } from './play-drawer-event';
 import { deriveIsDriver } from '../graphql-queue/driver-state';
+import type { SetActiveClimbSource } from '../graphql-queue/set-active-climb-event';
 import { track } from '@/app/lib/analytics';
 import {
   getPlaylistSuggestedClimbs,
@@ -265,7 +266,7 @@ function usePersistentSessionQueueAdapter(): {
         ? { ...buildQueueItem(item.climb), suggested: item.suggested }
         : item;
       const alreadyInQueue = queue.some((q) => q.uuid === item.uuid);
-      const fireSetActive = (source: string) => {
+      const fireSetActive = (source: SetActiveClimbSource) => {
         if (!queueItem.climb) return;
         track('Set Active Climb', {
           climbUuid: queueItem.climb.uuid,
@@ -390,7 +391,7 @@ function usePersistentSessionQueueAdapter(): {
         climbUuid: climb.uuid,
         boardType: climb.boardType ?? null,
         layoutId: climb.layoutId ?? null,
-        source: 'bridge.setCurrentClimb',
+        source: 'bridge.setCurrentClimb' satisfies SetActiveClimbSource,
       });
       if (ps.activeSession) {
         const correlationId = ps.clientId ? `${ps.clientId}-${++correlationCounterRef.current}` : undefined;
@@ -537,7 +538,7 @@ function usePersistentSessionQueueAdapter(): {
         climbUuid: climb.uuid,
         boardType: climb.boardType ?? null,
         layoutId: climb.layoutId ?? null,
-        source: 'bridge.takeControl',
+        source: 'bridge.takeControl' satisfies SetActiveClimbSource,
       });
       try {
         await ps.takeControl(newItem);

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -39,6 +39,7 @@ import { queueAddErrorMessage } from '../board-lock/queue-add-error-messages';
 import { QueueBridgeBoardInfoContext, type QueueBridgeBoardInfo } from './queue-bridge-board-info-context';
 import { dispatchOpenPlayDrawer } from './play-drawer-event';
 import { deriveIsDriver } from '../graphql-queue/driver-state';
+import { track } from '@/app/lib/analytics';
 import {
   getPlaylistSuggestedClimbs,
   getPlaylistPeekQueueItemUuid,
@@ -264,6 +265,15 @@ function usePersistentSessionQueueAdapter(): {
         ? { ...buildQueueItem(item.climb), suggested: item.suggested }
         : item;
       const alreadyInQueue = queue.some((q) => q.uuid === item.uuid);
+      const fireSetActive = (source: string) => {
+        if (!queueItem.climb) return;
+        track('Set Active Climb', {
+          climbUuid: queueItem.climb.uuid,
+          boardType: queueItem.climb.boardType ?? null,
+          layoutId: queueItem.climb.layoutId ?? null,
+          source,
+        });
+      };
       if (ps.activeSession) {
         // Don't bail on the "already current" optimistic state in party mode —
         // a peer may have moved the current climb away and our local view
@@ -272,12 +282,14 @@ function usePersistentSessionQueueAdapter(): {
         ps.setCurrentClimb(queueItem, queueItem.suggested, correlationId).catch((err: unknown) => {
           console.error('Failed to set current climb queue item:', err);
         });
+        fireSetActive('bridge.setCurrentClimbQueueItem.party');
         return;
       }
       if (alreadyInQueue && current?.uuid === queueItem.uuid) return;
       if (!boardDetails) return;
       const newQueue = alreadyInQueue ? queue : [...queue, queueItem];
       ps.setLocalQueueState(newQueue, queueItem, baseBoardPath, boardDetails);
+      fireSetActive('bridge.setCurrentClimbQueueItem.solo');
     },
     [buildQueueItem],
   );
@@ -374,6 +386,12 @@ function usePersistentSessionQueueAdapter(): {
         setPlaylistSuggestionSourceState(previousPlaylistSuggestionSource);
       };
       setPlaylistSuggestionSourceState(nextPlaylistSuggestionSource);
+      track('Set Active Climb', {
+        climbUuid: climb.uuid,
+        boardType: climb.boardType ?? null,
+        layoutId: climb.layoutId ?? null,
+        source: 'bridge.setCurrentClimb',
+      });
       if (ps.activeSession) {
         const correlationId = ps.clientId ? `${ps.clientId}-${++correlationCounterRef.current}` : undefined;
         // If the climb is already in the queue, reuse the existing item
@@ -515,6 +533,12 @@ function usePersistentSessionQueueAdapter(): {
       }
       if (!validateClimbForQueue(climb)) return null;
       const newItem = buildQueueItem(climb);
+      track('Set Active Climb', {
+        climbUuid: climb.uuid,
+        boardType: climb.boardType ?? null,
+        layoutId: climb.layoutId ?? null,
+        source: 'bridge.takeControl',
+      });
       try {
         await ps.takeControl(newItem);
         return newItem;


### PR DESCRIPTION
## Why the funnel was broken

The PostHog "Session Started → Set Active Climb" funnel was reading ~6% conversion (15 / 257 sessions). That's not real behaviour — most users do activate a climb. The event was just under-instrumented.

`track('Set Active Climb', …)` only fired from the `SetActiveAction` "Send to board" button (`set-active-action.tsx:48`). Every other way of activating a climb was silently skipping the event:

- Queue list double-tap (`queue-climb-list-item.tsx` → `setCurrentClimbQueueItem`)
- Queue list thumbnail tap (same path)
- Swipe next/prev in queue control bar (`queue-control-bar.tsx`)
- Browser back/forward navigation `popstate` handler (`play-view-client.tsx:56`)
- Queue navigation buttons (`queue-nav-button.tsx`)
- Drawer navigation (`play-view-drawer.tsx:789`)
- Playlist activation hook (`use-playlist-climb-activation.ts` → `setCurrentClimb`)
- Browse-preview shortcut (`previewClimbFromBrowse` → `setCurrentClimb`)

That's at least 7 silent paths funnelling through three central mutators on the queue context: `setCurrentClimb`, `setCurrentClimbQueueItem`, and the party-mode branch of `takeControl`.

## The fix

Fire `'Set Active Climb'` from the central mutators in both `QueueContext` (graphql/party-aware) and `queue-bridge-context` (legacy bridge adapter). Every upstream call site contributes to the funnel automatically — including future ones we haven't added yet.

Remove the now-redundant `track()` from `set-active-action.tsx` so button clicks don't double-count (the button calls `setCurrentClimb`, which now fires the event).

## Event shape

```
Set Active Climb {
  climbUuid: string,
  boardType: string | null,    // 'kilter' | 'tension' | ...
  layoutId: number | null,
  source: string,              // 'setCurrentClimb' | 'setCurrentClimbQueueItem'
                               // | 'takeControl' | 'bridge.setCurrentClimb'
                               // | 'bridge.setCurrentClimbQueueItem.party'
                               // | 'bridge.setCurrentClimbQueueItem.solo'
                               // | 'bridge.takeControl'
}
```

The `source` field lets us validate the fix in PostHog by breaking down the new volume by entry point.

`boardLayout` (the human-readable layout name) was dropped because the central mutators don't have `boardDetails` in scope — only the climb. `boardType` + `layoutId` carry the same information in machine-readable form. Existing dashboards that filter on `boardLayout` will need updating; this is a one-time hit to fix the much bigger problem of the event barely firing.

## Files

- `packages/web/app/components/graphql-queue/QueueContext.tsx` — instrument the three central mutators
- `packages/web/app/components/queue-control/queue-bridge-context.tsx` — same for the bridge adapter
- `packages/web/app/components/climb-actions/actions/set-active-action.tsx` — drop the now-redundant `track()` call (and the unused `boardDetails` prop destructure)
- `POSTHOG_INVENTORY.md` — update the event entry

## Test plan

- [ ] After deploy, check PostHog: "Set Active Climb" event volume should rise sharply
- [ ] Funnel "Session Started → Set Active Climb" conversion should jump from ~6% to a realistic rate (probably 60%+)
- [ ] Break down by `source` to confirm events are arriving from multiple entry points (not just `setCurrentClimb` from the button path)
- [ ] Verify no double-counting on `SetActiveAction` button click (should fire once per click, not twice)
- [ ] Existing `Tick Logged` and `Session Ended` events still fire — the funnel's downstream steps should also improve

https://claude.ai/code/session_012ezAWgbw5AdfRchPiw2wDM

---
_Generated by [Claude Code](https://claude.ai/code/session_012ezAWgbw5AdfRchPiw2wDM)_