### PR TITLE
design(wall-view): delete wall-view mode, put ON WALL on the bar

### DIFF
--- a/packages/web/app/components/play-view/__tests__/mini-session-bar.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/mini-session-bar.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from 'vite-plus/test';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { SessionUser } from '@boardsesh/shared-schema';
+import { MiniSessionBar } from '../mini-session-bar';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import type { ClimbQueueItem } from '../../queue-control/types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('@mui/icons-material/Lightbulb', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-lightbulb' }),
+}));
+vi.mock('@mui/icons-material/ArrowBackOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-back' }),
+}));
+vi.mock('@mui/icons-material/CheckOutlined', () => ({
+  default: () => React.createElement('svg', { 'data-testid': 'icon-check' }),
+}));
+
+const user = (id: string, username: string, overrides: Partial<SessionUser> = {}): SessionUser =>
+  ({
+    id,
+    username,
+    isLeader: false,
+    connectionState: 'connected',
+    ...overrides,
+  }) as SessionUser;
+
+const climbItem = (uuid: string, name: string): ClimbQueueItem =>
+  ({
+    uuid: `q-${uuid}`,
+    suggested: false,
+    climb: {
+      uuid,
+      name,
+      tickedBy: [],
+    },
+  }) as unknown as ClimbQueueItem;
+
+function defaultProps(overrides: Partial<React.ComponentProps<typeof MiniSessionBar>> = {}) {
+  return {
+    isDriver: false,
+    isPersistentSessionActive: true,
+    sessionUsers: [user('me', 'me'), user('driver', 'Marco'), user('sara', 'Sara')],
+    participantId: 'me',
+    driverParticipantId: 'driver',
+    currentClimbQueueItem: climbItem('wall-uuid', 'Bone Saw'),
+    drawerDisplayedItem: null,
+    onReturnToWallClimb: vi.fn(),
+    ...overrides,
+  } satisfies React.ComponentProps<typeof MiniSessionBar>;
+}
+
+describe('MiniSessionBar', () => {
+  it('renders nothing for solo users (isPersistentSessionActive=false)', () => {
+    const { container } = render(<MiniSessionBar {...defaultProps({ isPersistentSessionActive: false })} />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('mini-session-bar')).toBeNull();
+  });
+
+  it('renders nothing when there is no wall climb yet', () => {
+    const { container } = render(<MiniSessionBar {...defaultProps({ currentClimbQueueItem: null })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders ON WALL · driver for a non-driver on the wall climb (no drift)', () => {
+    render(<MiniSessionBar {...defaultProps()} />);
+    expect(screen.getByTestId('mini-session-bar')).toBeTruthy();
+    expect(screen.getByText('ON WALL · Marco')).toBeTruthy();
+    // Back-button morph does not render when not drifted
+    expect(screen.queryByTestId('mini-session-bar-back')).toBeNull();
+  });
+
+  it('falls back to plain ON WALL when there is no driver', () => {
+    render(<MiniSessionBar {...defaultProps({ driverParticipantId: null })} />);
+    expect(screen.getByText('ON WALL')).toBeTruthy();
+  });
+
+  it('renders DRIVING for the driver, never the back-button morph', () => {
+    render(<MiniSessionBar {...defaultProps({ isDriver: true })} />);
+    expect(screen.getByText('DRIVING')).toBeTruthy();
+    expect(screen.queryByTestId('mini-session-bar-back')).toBeNull();
+  });
+
+  it('renders the back-button morph when a non-driver has drifted off the wall climb', () => {
+    render(
+      <MiniSessionBar
+        {...defaultProps({
+          drawerDisplayedItem: climbItem('other-uuid', 'Crimpy Business'),
+        })}
+      />,
+    );
+    const back = screen.getByTestId('mini-session-bar-back');
+    expect(back).toBeTruthy();
+    // Aria-label reads naturally for screen readers
+    expect(back.getAttribute('aria-label')).toBe("Return to Marco's wall climb");
+    // Visible label name interpolation hits the catalog
+    expect(screen.getByText('Marco · Bone Saw')).toBeTruthy();
+  });
+
+  it('does not show drift back-button when drawerDisplayedItem matches the wall climb', () => {
+    render(
+      <MiniSessionBar
+        {...defaultProps({
+          drawerDisplayedItem: climbItem('wall-uuid', 'Bone Saw'),
+        })}
+      />,
+    );
+    expect(screen.queryByTestId('mini-session-bar-back')).toBeNull();
+    expect(screen.getByText('ON WALL · Marco')).toBeTruthy();
+  });
+
+  it('does not show drift back-button for a driver even when drawerDisplayedItem differs', () => {
+    render(
+      <MiniSessionBar
+        {...defaultProps({
+          isDriver: true,
+          drawerDisplayedItem: climbItem('other-uuid', 'Crimpy Business'),
+        })}
+      />,
+    );
+    expect(screen.queryByTestId('mini-session-bar-back')).toBeNull();
+    expect(screen.getByText('DRIVING')).toBeTruthy();
+  });
+
+  it('tapping the back-button morph calls onReturnToWallClimb', () => {
+    const onReturnToWallClimb = vi.fn();
+    render(
+      <MiniSessionBar
+        {...defaultProps({
+          drawerDisplayedItem: climbItem('other-uuid', 'Crimpy Business'),
+          onReturnToWallClimb,
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('mini-session-bar-back'));
+    expect(onReturnToWallClimb).toHaveBeenCalledOnce();
+  });
+
+  it('renders an audience AvatarGroup excluding the local user, driver-first', () => {
+    render(
+      <MiniSessionBar
+        {...defaultProps({
+          sessionUsers: [
+            user('me', 'me'),
+            user('sara', 'Sara'),
+            user('jules', 'Jules'),
+            user('driver', 'Marco'),
+          ],
+          driverParticipantId: 'driver',
+          participantId: 'me',
+        })}
+      />,
+    );
+    const audience = screen.getByTestId('mini-session-bar-audience');
+    expect(audience).toBeTruthy();
+    // Aria-label exposes count to assistive tech (excludes self → 3 others)
+    expect(audience.getAttribute('aria-label')).toBe('3 others watching');
+    // Driver should be the first avatar so the lit-bulb badge anchors the stack.
+    // AvatarGroup wraps avatars in <div role="img" aria-label=Marco> via Avatar's alt.
+    const avatars = audience.querySelectorAll('.MuiAvatar-root');
+    // First user-rendered avatar (after AvatarGroup's overflow placeholder, if any)
+    // is the driver — query by alt is most stable across MUI versions.
+    const driverAvatar = audience.querySelector('img[alt="Marco"], [aria-label*="Marco"]');
+    expect(driverAvatar).not.toBeNull();
+    expect(avatars.length).toBeGreaterThan(0);
+  });
+
+  it('renders no audience block when the session has only the local user', () => {
+    render(
+      <MiniSessionBar
+        {...defaultProps({
+          sessionUsers: [user('me', 'me')],
+          driverParticipantId: null,
+        })}
+      />,
+    );
+    expect(screen.queryByTestId('mini-session-bar-audience')).toBeNull();
+  });
+});

--- a/packages/web/app/components/play-view/__tests__/play-view-action-bar.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/play-view-action-bar.test.tsx
@@ -168,28 +168,7 @@ describe('PlayViewActionBar', () => {
     expect(screen.getByText('5')).toBeTruthy();
   });
 
-  // ---------------------------------------------------------------------
-  // wallViewLocked behaviour — non-drivers (locked) hide prev/next,
-  // drivers see the full bar. Pins the role-based gate Marco asked for
-  // in the group-session feedback round.
-  // ---------------------------------------------------------------------
-
-  it('hides prev/next when wallViewLocked=true (non-driver in wall-view)', () => {
-    render(<PlayViewActionBar {...buildProps({ wallViewLocked: true })} />);
-    expect(screen.queryByTestId('icon-skip-prev')).toBeNull();
-    expect(screen.queryByTestId('icon-skip-next')).toBeNull();
-  });
-
-  it('shows prev/next when wallViewLocked=false (driver, or plain non-wallView drawer)', () => {
-    render(<PlayViewActionBar {...buildProps({ wallViewLocked: false })} />);
-    expect(screen.getByTestId('icon-skip-prev')).toBeTruthy();
-    expect(screen.getByTestId('icon-skip-next')).toBeTruthy();
-  });
-
-  it('keeps prev/next visible by default (the locked semantic must be opt-in)', () => {
-    // The prop defaults to false at the component level. Regression
-    // guard: a future refactor that flipped the default would silently
-    // hide prev/next on every drawer until callers opted out.
+  it('always shows prev/next (wall-view mode is gone — drawer is always browse mode)', () => {
     render(<PlayViewActionBar {...buildProps()} />);
     expect(screen.getByTestId('icon-skip-prev')).toBeTruthy();
     expect(screen.getByTestId('icon-skip-next')).toBeTruthy();

--- a/packages/web/app/components/play-view/mini-session-bar.tsx
+++ b/packages/web/app/components/play-view/mini-session-bar.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import Box from '@mui/material/Box';
+import MuiAvatar from '@mui/material/Avatar';
+import MuiButton from '@mui/material/Button';
+import AvatarGroup from '@mui/material/AvatarGroup';
+import Lightbulb from '@mui/icons-material/Lightbulb';
+import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined';
+import type { SessionUser } from '@boardsesh/shared-schema';
+import { themeTokens } from '@/app/theme/theme-config';
+import { TickBadgeAvatar } from '@/app/components/session/tick-badge-avatar';
+import type { ClimbQueueItem } from '../queue-control/types';
+
+export type MiniSessionBarProps = {
+  /** Local user is the wall driver (their swipes light up the wall). */
+  isDriver: boolean;
+  /** Active party session with > 1 participant. Solo / no-session → bar hides. */
+  isPersistentSessionActive: boolean;
+  /** Full session-user list. The bar excludes the local user and floats the
+   *  driver to position 0 internally. */
+  sessionUsers: SessionUser[];
+  /** Local user's session participantId; used to exclude self from the
+   *  audience. */
+  participantId: string | null;
+  /** Session participantId of the current driver, or null if no one holds the
+   *  wall yet. */
+  driverParticipantId: string | null;
+  /** The wall climb (what the driver has lit). The bar morphs to a "back to
+   *  wall climb" button when the drawer is showing something else. */
+  currentClimbQueueItem: ClimbQueueItem | null;
+  /** What the drawer is locally displaying. When non-null and ≠ wall climb,
+   *  a non-driver is in the drifted (preview) state. */
+  drawerDisplayedItem: ClimbQueueItem | null;
+  /** Called when the non-driver taps the back-button morph to snap the
+   *  drawer back to the wall climb. */
+  onReturnToWallClimb: () => void;
+};
+
+/**
+ * Mini session bar that sits between the board renderer and the action bar
+ * inside the play-view drawer. Single slot that morphs by role + drift state:
+ *
+ *  - **Non-driver on wall**: avatar + "ON WALL · {driver}"; audience AvatarGroup right.
+ *  - **Non-driver drifted**: back-arrow + avatar + "{driver} · {wall climb}" button;
+ *    tapping it clears `drawerDisplayedItem` so the drawer snaps back to the wall.
+ *  - **Driver**: lit lightbulb + "DRIVING"; audience AvatarGroup right.
+ *  - **Solo / no party**: returns null.
+ *
+ * The bar morphs in place so the climb header above it never reflows on role
+ * handoff. Extracted from `play-view-drawer.tsx` so the behavior is testable
+ * without the full drawer dependency tree.
+ */
+export function MiniSessionBar({
+  isDriver,
+  isPersistentSessionActive,
+  sessionUsers,
+  participantId,
+  driverParticipantId,
+  currentClimbQueueItem,
+  drawerDisplayedItem,
+  onReturnToWallClimb,
+}: MiniSessionBarProps) {
+  const { t } = useTranslation('session');
+
+  const driverUser = useMemo(() => {
+    if (!driverParticipantId) return null;
+    return sessionUsers.find((u) => u.id === driverParticipantId) ?? null;
+  }, [sessionUsers, driverParticipantId]);
+
+  const wallClimb = currentClimbQueueItem?.climb ?? null;
+
+  const driftedFromWall =
+    !isDriver &&
+    isPersistentSessionActive &&
+    drawerDisplayedItem != null &&
+    currentClimbQueueItem != null &&
+    drawerDisplayedItem.climb.uuid !== currentClimbQueueItem.climb.uuid;
+
+  // Tick badges reflect "who has done THIS climb" — the climb the drawer is
+  // currently displaying, not necessarily the wall climb. For a non-driver
+  // browsing in preview mode that's `drawerDisplayedItem`; otherwise the
+  // wall climb (drawerDisplayedItem is null and the drawer falls through).
+  const effectiveItem = drawerDisplayedItem ?? currentClimbQueueItem;
+  const tickedBySet = useMemo(() => new Set(effectiveItem?.tickedBy ?? []), [effectiveItem]);
+
+  const audienceUsers = useMemo(() => {
+    if (!isPersistentSessionActive) return [];
+    const others = sessionUsers.filter((u) => u.id !== participantId);
+    if (!driverParticipantId) return others;
+    const driverIdx = others.findIndex((u) => u.id === driverParticipantId);
+    if (driverIdx <= 0) return others;
+    const reordered = [...others];
+    const [driver] = reordered.splice(driverIdx, 1);
+    reordered.unshift(driver);
+    return reordered;
+  }, [isPersistentSessionActive, sessionUsers, participantId, driverParticipantId]);
+
+  if (!isPersistentSessionActive || currentClimbQueueItem == null) return null;
+
+  return (
+    <Box
+      data-testid="mini-session-bar"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        px: 2,
+        py: 0.75,
+        borderTop: '1px solid var(--neutral-200)',
+        // Warm whisper tint — the IA + iOS-HIG designers' pick. Gives the
+        // band a reason to exist visually without painting it like an alert.
+        // ~5% theme warning so it sits between the neutral climb area above
+        // and the neutral action bar below.
+        backgroundColor: `color-mix(in srgb, ${themeTokens.colors.warning} 5%, transparent)`,
+        minHeight: 36,
+      }}
+    >
+      {isDriver ? (
+        <>
+          <Lightbulb sx={{ fontSize: 16, color: themeTokens.colors.warning }} aria-hidden="true" />
+          <Box
+            component="span"
+            sx={{ fontSize: 11, fontWeight: 600, letterSpacing: 0.5, color: themeTokens.colors.warning }}
+          >
+            {t('playView.drivingChip')}
+          </Box>
+        </>
+      ) : driftedFromWall && wallClimb ? (
+        <MuiButton
+          data-testid="mini-session-bar-back"
+          onClick={onReturnToWallClimb}
+          aria-label={
+            driverUser
+              ? t('queueBar.ariaLabels.returnToWallClimb', { username: driverUser.username })
+              : t('queueBar.ariaLabels.returnToWallClimbNoDriver')
+          }
+          size="small"
+          variant="text"
+          disableElevation
+          startIcon={<ArrowBackOutlined sx={{ fontSize: 16, color: 'text.secondary' }} />}
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            justifyContent: 'flex-start',
+            // Match the "ON WALL · {driver}" text style on the other side of
+            // the morph so the bar's typography stays consistent across drift
+            // states — same fontSize/weight/letterSpacing/color, just a label
+            // that names the wall climb instead of the on-wall status.
+            textTransform: 'none',
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: 0.5,
+            color: 'text.secondary',
+            py: 0,
+            px: 0.5,
+            gap: 0.5,
+            '& .MuiButton-startIcon': { mr: 0.5 },
+          }}
+        >
+          {driverUser && (
+            <MuiAvatar
+              alt={driverUser.username}
+              src={driverUser.avatarUrl ?? undefined}
+              sx={{ width: 20, height: 20, mr: 0.75 }}
+            />
+          )}
+          <Box
+            component="span"
+            sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}
+          >
+            {driverUser
+              ? t('playView.returnToWallPill', {
+                  username: driverUser.username,
+                  climbName: wallClimb.name,
+                })
+              : wallClimb.name}
+          </Box>
+        </MuiButton>
+      ) : (
+        <>
+          {driverUser && (
+            <MuiAvatar
+              alt={driverUser.username}
+              src={driverUser.avatarUrl ?? undefined}
+              sx={{ width: 20, height: 20 }}
+            />
+          )}
+          <Box
+            component="span"
+            sx={{
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: 0.5,
+              color: 'text.secondary',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+            }}
+          >
+            {driverUser
+              ? t('playView.onWallChip', { username: driverUser.username })
+              : t('playView.onWallChipNoDriver')}
+          </Box>
+        </>
+      )}
+      {audienceUsers.length > 0 && (
+        <Box
+          data-testid="mini-session-bar-audience"
+          sx={{ ml: 'auto', flexShrink: 0 }}
+          aria-label={t('playView.audienceCount', { count: audienceUsers.length })}
+        >
+          <AvatarGroup
+            max={3}
+            sx={{
+              '& .MuiAvatar-root': {
+                width: 22,
+                height: 22,
+                fontSize: 10,
+                border: '2px solid transparent',
+              },
+            }}
+          >
+            {audienceUsers.map((user) => (
+              <TickBadgeAvatar
+                key={user.id}
+                user={user}
+                hasTicked={tickedBySet.has(user.id) || (user.userId != null && tickedBySet.has(user.userId))}
+                isDriver={driverParticipantId != null && user.id === driverParticipantId}
+                size={22}
+              />
+            ))}
+          </AvatarGroup>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -856,12 +856,17 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   // user is back on the wall climb (no drift). Until they swipe, the
   // drawer auto-follows the wall via the `effectiveItem` fallback at the
   // top of the component, so no pill is needed.
+  // Non-driver-in-party gate for the wall-context chip. Always shown while
+  // open so the user always knows what's on the wall right now (the bar's
+  // ON WALL chip is hidden behind the drawer when it's open). The chip
+  // morphs based on drift: on the wall climb, it's an informational
+  // "ON WALL · {driver}" badge; once they swipe off, it becomes a
+  // clickable "← {driver} · {wallClimb}" return-pill.
+  const showWallContextChip = !isDriver && isPersistentSessionActive && currentClimbQueueItem != null;
   const driftedFromWall =
-    !isDriver &&
-    isPersistentSessionActive &&
+    showWallContextChip &&
     drawerDisplayedItem != null &&
-    currentClimbQueueItem != null &&
-    drawerDisplayedItem.climb.uuid !== currentClimbQueueItem.climb.uuid;
+    drawerDisplayedItem.climb.uuid !== currentClimbQueueItem!.climb.uuid;
   const wallClimb = currentClimbQueueItem?.climb ?? null;
   const handleReturnToWallClimb = useCallback(() => {
     setDrawerDisplayedItem?.(null);
@@ -1306,32 +1311,60 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     if (!currentClimb) return null;
     return (
       <>
-        {driftedFromWall && driverUser && wallClimb && (
-          // Return-to-wall pill: visible only when a non-driver has actively
-          // swiped off the wall climb in browse mode. Tap snaps the drawer
-          // back to the wall climb (clears drawerDisplayedItem). The bar
-          // beneath the drawer carries the persistent "ON WALL" cue —
-          // this pill is the bridge for when drawer-view and bar-view have
-          // drifted apart.
+        {showWallContextChip && driverUser && wallClimb && (
+          // Wall-context chip: always visible for a non-driver in a party
+          // session while the drawer is open, so the wall-climb identity is
+          // never hidden behind the drawer (the bar's ON WALL chip is
+          // covered while this drawer is on top). Morphs by drift state:
+          //   - On the wall climb: informational "ON WALL · {driver}".
+          //   - Drifted (after a local swipe): clickable
+          //     "← {driver} · {wallClimb}" that snaps back to the wall climb.
           <Box sx={{ display: 'flex', justifyContent: 'center', px: 2, pt: 1 }}>
-            <MuiChip
-              clickable
-              onClick={handleReturnToWallClimb}
-              size="small"
-              variant="outlined"
-              color="info"
-              icon={<ArrowBackOutlined sx={{ fontSize: 14, ml: 0.5 }} />}
-              avatar={
-                <MuiAvatar
-                  alt={driverUser.username}
-                  src={driverUser.avatarUrl ?? undefined}
-                  sx={{ width: 20, height: 20 }}
-                />
-              }
-              label={t('playView.returnToWallPill', { username: driverUser.username, climbName: wallClimb.name })}
-              aria-label={t('queueBar.ariaLabels.returnToWallClimb', { username: driverUser.username })}
-              sx={{ fontSize: 12, maxWidth: '100%' }}
-            />
+            {driftedFromWall ? (
+              <MuiChip
+                clickable
+                onClick={handleReturnToWallClimb}
+                size="small"
+                variant="outlined"
+                color="info"
+                icon={<ArrowBackOutlined sx={{ fontSize: 14, ml: 0.5 }} />}
+                avatar={
+                  <MuiAvatar
+                    alt={driverUser.username}
+                    src={driverUser.avatarUrl ?? undefined}
+                    sx={{ width: 20, height: 20 }}
+                  />
+                }
+                label={t('playView.returnToWallPill', {
+                  username: driverUser.username,
+                  climbName: wallClimb.name,
+                })}
+                aria-label={t('queueBar.ariaLabels.returnToWallClimb', { username: driverUser.username })}
+                sx={{ fontSize: 12, maxWidth: '100%' }}
+              />
+            ) : (
+              <MuiChip
+                size="small"
+                variant="outlined"
+                color="info"
+                role="status"
+                avatar={
+                  <MuiAvatar
+                    alt={driverUser.username}
+                    src={driverUser.avatarUrl ?? undefined}
+                    sx={{ width: 20, height: 20 }}
+                  />
+                }
+                label={t('playView.onWallChip', { username: driverUser.username })}
+                sx={{
+                  fontSize: 10,
+                  fontWeight: 600,
+                  letterSpacing: 0.5,
+                  maxWidth: '100%',
+                  '& .MuiChip-label': { px: 0.75 },
+                }}
+              />
+            )}
           </Box>
         )}
         {/* Header: Grade | Name */}
@@ -1475,6 +1508,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     isPersistentSessionActive,
     isBluetoothConnected,
     driverUser,
+    showWallContextChip,
     driftedFromWall,
     wallClimb,
     handleReturnToWallClimb,

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -857,20 +857,35 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   // drawer auto-follows the wall via the `effectiveItem` fallback at the
   // top of the component, so no pill is needed.
   // Non-driver-in-party gate for the wall-context chip. Always shown while
-  // open so the user always knows what's on the wall right now (the bar's
-  // ON WALL chip is hidden behind the drawer when it's open). The chip
-  // morphs based on drift: on the wall climb, it's an informational
-  // "ON WALL · {driver}" badge; once they swipe off, it becomes a
-  // clickable "← {driver} · {wallClimb}" return-pill.
-  const showWallContextChip = !isDriver && isPersistentSessionActive && currentClimbQueueItem != null;
+  // Drift detection feeds the mini session bar's back-button morph: a
+  // non-driver has actively swiped off the wall climb in browse mode.
+  // `drawerDisplayedItem` is non-null only after a local swipe; if it matches
+  // `currentClimbQueueItem` the user is back on the wall climb (no drift).
+  // Until they swipe, the drawer auto-follows the wall via the
+  // `effectiveItem` fallback at the top of the component.
   const driftedFromWall =
-    showWallContextChip &&
+    !isDriver &&
+    isPersistentSessionActive &&
     drawerDisplayedItem != null &&
-    drawerDisplayedItem.climb.uuid !== currentClimbQueueItem!.climb.uuid;
+    currentClimbQueueItem != null &&
+    drawerDisplayedItem.climb.uuid !== currentClimbQueueItem.climb.uuid;
   const wallClimb = currentClimbQueueItem?.climb ?? null;
   const handleReturnToWallClimb = useCallback(() => {
     setDrawerDisplayedItem?.(null);
   }, [setDrawerDisplayedItem]);
+
+  // Audience count for the mini session bar's co-watcher dots. Excludes the
+  // local user always, and excludes the driver from a non-driver's count
+  // (the driver is already represented by their own avatar in the bar).
+  // Drivers see the count of everyone else in the session.
+  const audienceCount = useMemo(() => {
+    if (!isPersistentSessionActive) return 0;
+    const total = sessionUsers.length;
+    if (total <= 1) return 0;
+    if (isDriver) return total - 1;
+    if (driverUser) return Math.max(0, total - 2);
+    return total - 1;
+  }, [isPersistentSessionActive, sessionUsers, isDriver, driverUser]);
 
   const navigate = useCallback(
     (direction: 'next' | 'previous', source: 'swipePlayViewDrawer' | 'playViewDrawer') => {
@@ -1311,101 +1326,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     if (!currentClimb) return null;
     return (
       <>
-        {isDriver && isPersistentSessionActive && currentClimbQueueItem != null && (
-          // Driver chip: counterpart to the non-driver ON WALL chip below.
-          // Sits in the same slot at the top of the drawer so both roles get
-          // the same anchoring cue — for the driver, the cue is "your taps
-          // here move the wall."
-          <Box sx={{ display: 'flex', justifyContent: 'center', px: 2, pt: 1 }}>
-            <MuiChip
-              size="small"
-              variant="outlined"
-              color="warning"
-              role="status"
-              icon={<Lightbulb sx={{ fontSize: 14, color: themeTokens.colors.warning }} aria-hidden="true" />}
-              label={t('playView.drivingChip')}
-              sx={{
-                fontSize: 10,
-                fontWeight: 600,
-                letterSpacing: 0.5,
-                maxWidth: '100%',
-                '& .MuiChip-label': { px: 0.75 },
-              }}
-            />
-          </Box>
-        )}
-        {showWallContextChip && wallClimb && (
-          // Wall-context chip: always visible for a non-driver in a party
-          // session while the drawer is open, so the wall-climb identity is
-          // never hidden behind the drawer (the bar's ON WALL chip is
-          // covered while this drawer is on top). Morphs by drift state:
-          //   - On the wall climb: informational "ON WALL · {driver}" (or
-          //     plain "ON WALL" when no driver is set yet).
-          //   - Drifted (after a local swipe): clickable
-          //     "← {driver} · {wallClimb}" that snaps back, or
-          //     "← {wallClimb}" when no driver.
-          <Box sx={{ display: 'flex', justifyContent: 'center', px: 2, pt: 1 }}>
-            {driftedFromWall ? (
-              <MuiChip
-                clickable
-                onClick={handleReturnToWallClimb}
-                size="small"
-                variant="outlined"
-                color="info"
-                avatar={
-                  driverUser ? (
-                    <MuiAvatar
-                      alt={driverUser.username}
-                      src={driverUser.avatarUrl ?? undefined}
-                      sx={{ width: 20, height: 20 }}
-                    />
-                  ) : undefined
-                }
-                label={
-                  <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
-                    <ArrowBackOutlined sx={{ fontSize: 14 }} aria-hidden="true" />
-                    {driverUser
-                      ? t('playView.returnToWallPill', {
-                          username: driverUser.username,
-                          climbName: wallClimb.name,
-                        })
-                      : wallClimb.name}
-                  </Box>
-                }
-                aria-label={
-                  driverUser
-                    ? t('queueBar.ariaLabels.returnToWallClimb', { username: driverUser.username })
-                    : t('queueBar.ariaLabels.returnToWallClimbNoDriver')
-                }
-                sx={{ fontSize: 12, maxWidth: '100%' }}
-              />
-            ) : (
-              <MuiChip
-                size="small"
-                variant="outlined"
-                color="info"
-                role="status"
-                avatar={
-                  driverUser ? (
-                    <MuiAvatar
-                      alt={driverUser.username}
-                      src={driverUser.avatarUrl ?? undefined}
-                      sx={{ width: 20, height: 20 }}
-                    />
-                  ) : undefined
-                }
-                label={driverUser ? t('playView.onWallChip', { username: driverUser.username }) : t('playView.onWallChipNoDriver')}
-                sx={{
-                  fontSize: 10,
-                  fontWeight: 600,
-                  letterSpacing: 0.5,
-                  maxWidth: '100%',
-                  '& .MuiChip-label': { px: 0.75 },
-                }}
-              />
-            )}
-          </Box>
-        )}
         {/* Header: Grade | Name */}
         <div className={styles.headerSection}>
           <ClimbDetailHeader climb={currentClimb} />
@@ -1470,6 +1390,142 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
             />
           )}
         </div>
+
+        {/* Mini session bar — sits between the board and the action bar. One
+            slot that morphs by role + drift, so the climb-header above never
+            reflows when the local user takes/releases control (the moment
+            that should feel smooth). Visible in party sessions only — solo
+            users get no row. Audience is rendered as quiet dots (one dot per
+            co-watcher) capped at 5 with a +N overflow. */}
+        {isPersistentSessionActive && currentClimbQueueItem != null && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              px: 2,
+              py: 0.75,
+              borderTop: '1px solid var(--neutral-200)',
+              minHeight: 36,
+            }}
+          >
+            {isDriver ? (
+              <>
+                <Lightbulb sx={{ fontSize: 16, color: themeTokens.colors.warning }} aria-hidden="true" />
+                <Box
+                  component="span"
+                  sx={{ fontSize: 11, fontWeight: 600, letterSpacing: 0.5, color: themeTokens.colors.warning }}
+                >
+                  {t('playView.drivingChip')}
+                </Box>
+              </>
+            ) : driftedFromWall && wallClimb ? (
+              <Box
+                component="button"
+                onClick={handleReturnToWallClimb}
+                aria-label={
+                  driverUser
+                    ? t('queueBar.ariaLabels.returnToWallClimb', { username: driverUser.username })
+                    : t('queueBar.ariaLabels.returnToWallClimbNoDriver')
+                }
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 0.75,
+                  flex: 1,
+                  minWidth: 0,
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  cursor: 'pointer',
+                  color: 'inherit',
+                  textAlign: 'left',
+                }}
+              >
+                <ArrowBackOutlined sx={{ fontSize: 16, color: 'text.secondary' }} aria-hidden="true" />
+                {driverUser && (
+                  <MuiAvatar
+                    alt={driverUser.username}
+                    src={driverUser.avatarUrl ?? undefined}
+                    sx={{ width: 20, height: 20 }}
+                  />
+                )}
+                <Box
+                  component="span"
+                  sx={{
+                    fontSize: 12,
+                    fontWeight: 500,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    minWidth: 0,
+                  }}
+                >
+                  {driverUser
+                    ? t('playView.returnToWallPill', {
+                        username: driverUser.username,
+                        climbName: wallClimb.name,
+                      })
+                    : wallClimb.name}
+                </Box>
+              </Box>
+            ) : (
+              <>
+                {driverUser && (
+                  <MuiAvatar
+                    alt={driverUser.username}
+                    src={driverUser.avatarUrl ?? undefined}
+                    sx={{ width: 20, height: 20 }}
+                  />
+                )}
+                <Box
+                  component="span"
+                  sx={{
+                    fontSize: 11,
+                    fontWeight: 600,
+                    letterSpacing: 0.5,
+                    color: 'text.secondary',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    minWidth: 0,
+                  }}
+                >
+                  {driverUser
+                    ? t('playView.onWallChip', { username: driverUser.username })
+                    : t('playView.onWallChipNoDriver')}
+                </Box>
+              </>
+            )}
+            {audienceCount > 0 && (
+              <Box
+                component="span"
+                aria-label={t('playView.audienceCount', { count: audienceCount })}
+                sx={{
+                  ml: 'auto',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 0.25,
+                  fontSize: 12,
+                  color: 'text.secondary',
+                  letterSpacing: 1,
+                  flexShrink: 0,
+                }}
+              >
+                {Array.from({ length: Math.min(audienceCount, 5) }).map((_, i) => (
+                  <Box key={i} component="span" aria-hidden="true">
+                    •
+                  </Box>
+                ))}
+                {audienceCount > 5 && (
+                  <Box component="span" sx={{ ml: 0.25, fontSize: 10, letterSpacing: 0 }} aria-hidden="true">
+                    +{audienceCount - 5}
+                  </Box>
+                )}
+              </Box>
+            )}
+          </Box>
+        )}
 
         {/* Action bar */}
         {isOpen && (
@@ -1548,10 +1604,10 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     isBluetoothConnected,
     currentClimbQueueItem,
     driverUser,
-    showWallContextChip,
     driftedFromWall,
     wallClimb,
     handleReturnToWallClimb,
+    audienceCount,
     lightbulbCoachmarkText,
   ]);
 
@@ -1591,6 +1647,34 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
           >
             <CloseOutlined />
           </IconButton>
+          {/* Grabber-row driver dot: a small driver avatar pinned to the
+              top-left, beside the drawer's grabber. Gives a peripheral
+              "who's driving" cue even when the user's eye is on the climb
+              header or board renderer (the mini session bar lives near the
+              bottom of the drawer). Renders only in a party session with a
+              driver present; the local user being the driver hides it
+              (they don't need to be told they're driving). */}
+          {isPersistentSessionActive && driverUser && !isDriver && (
+            <Box
+              sx={{
+                position: 'absolute',
+                top: 10,
+                left: 12,
+                zIndex: 2,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.5,
+                pointerEvents: 'none',
+              }}
+              aria-label={t('queueBar.ariaLabels.userIsDriving', { username: driverUser.username })}
+            >
+              <MuiAvatar
+                alt={driverUser.username}
+                src={driverUser.avatarUrl ?? undefined}
+                sx={{ width: 18, height: 18 }}
+              />
+            </Box>
+          )}
           <div
             className={styles.drawerContent}
             onTouchStart={handleBoardTouchStart}

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -1371,7 +1371,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
                     />
                   ) : undefined
                 }
-                label={driverUser ? t('playView.onWallChip', { username: driverUser.username }) : t('queueBar.onWall')}
+                label={driverUser ? t('playView.onWallChip', { username: driverUser.username }) : t('playView.onWallChipNoDriver')}
                 sx={{
                   fontSize: 10,
                   fontWeight: 600,

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -860,17 +860,36 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     [getNextClimbQueueItem, getPreviousClimbQueueItem, navigateFromItem, swipeSuggestionsOnly, viewOnlyMode, advanceTo],
   );
 
+  // When a non-driver has swiped off the wall climb in browse mode, the
+  // most-recent "previous" climb in their mental model is the wall climb
+  // itself (where they just came from). Snap-back via swipe-left mirrors
+  // the mini session bar's "return to wall climb" button so both gestures
+  // resolve drift the same way.
+  const isDriftedFromWall =
+    !isDriver &&
+    isPersistentSessionActive &&
+    drawerDisplayedItem != null &&
+    currentClimbQueueItem != null &&
+    drawerDisplayedItem.climb.uuid !== currentClimbQueueItem.climb.uuid;
+
   const handleSwipeNext = useCallback(() => {
     maybeArmPreviewCoachmark();
     navigate('next', 'swipePlayViewDrawer');
   }, [navigate, maybeArmPreviewCoachmark]);
   const handleSwipePrevious = useCallback(() => {
+    if (isDriftedFromWall) {
+      setDrawerDisplayedItem?.(null);
+      return;
+    }
     maybeArmPreviewCoachmark();
     navigate('previous', 'swipePlayViewDrawer');
-  }, [navigate, maybeArmPreviewCoachmark]);
+  }, [navigate, maybeArmPreviewCoachmark, isDriftedFromWall, setDrawerDisplayedItem]);
 
   const canSwipeNext = !viewOnlyMode && !!nextItem;
-  const canSwipePrevious = !viewOnlyMode && !!prevItem;
+  // While drifted from the wall, "previous" always resolves to the wall climb
+  // (handleSwipePrevious snap-back path), so swipe-back is always enabled even
+  // if the suggestions feed has no further previous item.
+  const canSwipePrevious = !viewOnlyMode && (isDriftedFromWall || !!prevItem);
 
   // Tick FAB → inline tick bar
   const handleTickFabClick = useCallback(() => {
@@ -891,7 +910,13 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     showMessage(t('playView.tickError'), 'error');
   }, [showMessage, t]);
 
-  const handlePrevNavClick = useCallback(() => navigate('previous', 'playViewDrawer'), [navigate]);
+  const handlePrevNavClick = useCallback(() => {
+    if (isDriftedFromWall) {
+      setDrawerDisplayedItem?.(null);
+      return;
+    }
+    navigate('previous', 'playViewDrawer');
+  }, [navigate, isDriftedFromWall, setDrawerDisplayedItem]);
   // Wall-confirm watcher: armed by handleLightbulbClick, dismissed by the
   // local wall-confirm bus or fires a connect fallback after 2 s. Owns its
   // own unmount cleanup so the drawer doesn't need to thread that wiring.
@@ -1301,7 +1326,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
               boardDetails={boardDetails}
               currentClimb={currentClimb}
               nextClimb={nextItem?.climb}
-              previousClimb={prevItem?.climb}
+              previousClimb={isDriftedFromWall ? (currentClimbQueueItem?.climb ?? prevItem?.climb) : prevItem?.climb}
               onSwipeNext={handleSwipeNext}
               onSwipePrevious={handleSwipePrevious}
               canSwipeNext={canSwipeNext}

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -1327,7 +1327,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
                 size="small"
                 variant="outlined"
                 color="info"
-                icon={<ArrowBackOutlined sx={{ fontSize: 14, ml: 0.5 }} />}
                 avatar={
                   <MuiAvatar
                     alt={driverUser.username}
@@ -1335,10 +1334,15 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
                     sx={{ width: 20, height: 20 }}
                   />
                 }
-                label={t('playView.returnToWallPill', {
-                  username: driverUser.username,
-                  climbName: wallClimb.name,
-                })}
+                label={
+                  <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+                    <ArrowBackOutlined sx={{ fontSize: 14 }} aria-hidden="true" />
+                    {t('playView.returnToWallPill', {
+                      username: driverUser.username,
+                      climbName: wallClimb.name,
+                    })}
+                  </Box>
+                }
                 aria-label={t('queueBar.ariaLabels.returnToWallClimb', { username: driverUser.username })}
                 sx={{ fontSize: 12, maxWidth: '100%' }}
               />

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -1311,6 +1311,29 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     if (!currentClimb) return null;
     return (
       <>
+        {isDriver && isPersistentSessionActive && currentClimbQueueItem != null && (
+          // Driver chip: counterpart to the non-driver ON WALL chip below.
+          // Sits in the same slot at the top of the drawer so both roles get
+          // the same anchoring cue — for the driver, the cue is "your taps
+          // here move the wall."
+          <Box sx={{ display: 'flex', justifyContent: 'center', px: 2, pt: 1 }}>
+            <MuiChip
+              size="small"
+              variant="outlined"
+              color="warning"
+              role="status"
+              icon={<Lightbulb sx={{ fontSize: 14, color: themeTokens.colors.warning }} aria-hidden="true" />}
+              label={t('playView.drivingChip')}
+              sx={{
+                fontSize: 10,
+                fontWeight: 600,
+                letterSpacing: 0.5,
+                maxWidth: '100%',
+                '& .MuiChip-label': { px: 0.75 },
+              }}
+            />
+          </Box>
+        )}
         {showWallContextChip && wallClimb && (
           // Wall-context chip: always visible for a non-driver in a party
           // session while the drawer is open, so the wall-climb identity is
@@ -1523,6 +1546,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     t,
     isPersistentSessionActive,
     isBluetoothConnected,
+    currentClimbQueueItem,
     driverUser,
     showWallContextChip,
     driftedFromWall,

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -7,6 +7,8 @@ import MuiBadge from '@mui/material/Badge';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import MuiAvatar from '@mui/material/Avatar';
+import AvatarGroup from '@mui/material/AvatarGroup';
+import { TickBadgeAvatar } from '@/app/components/session/tick-badge-avatar';
 import MuiChip from '@mui/material/Chip';
 import Tooltip from '@mui/material/Tooltip';
 import TextField from '@mui/material/TextField';
@@ -874,18 +876,26 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     setDrawerDisplayedItem?.(null);
   }, [setDrawerDisplayedItem]);
 
-  // Audience count for the mini session bar's co-watcher dots. Excludes the
-  // local user always, and excludes the driver from a non-driver's count
-  // (the driver is already represented by their own avatar in the bar).
-  // Drivers see the count of everyone else in the session.
-  const audienceCount = useMemo(() => {
-    if (!isPersistentSessionActive) return 0;
-    const total = sessionUsers.length;
-    if (total <= 1) return 0;
-    if (isDriver) return total - 1;
-    if (driverUser) return Math.max(0, total - 2);
-    return total - 1;
-  }, [isPersistentSessionActive, sessionUsers, isDriver, driverUser]);
+  // Audience for the mini session bar's AvatarGroup. Everyone in the session
+  // except the local user; the driver-first sort keeps them at position 0 of
+  // the stack so the driver's lit-bulb badge anchors the strip. Tick badges
+  // are sourced from `effectiveItem.tickedBy` so the audience reflects "who
+  // has done THIS climb" (matching what the user is currently looking at,
+  // which may be the wall climb or a non-driver preview).
+  const tickedBySet = useMemo(() => {
+    return new Set(effectiveItem?.tickedBy ?? []);
+  }, [effectiveItem]);
+  const audienceUsers = useMemo(() => {
+    if (!isPersistentSessionActive) return [];
+    const others = sessionUsers.filter((u) => u.id !== participantId);
+    if (!driverParticipantId) return others;
+    const driverIdx = others.findIndex((u) => u.id === driverParticipantId);
+    if (driverIdx <= 0) return others;
+    const reordered = [...others];
+    const [driver] = reordered.splice(driverIdx, 1);
+    reordered.unshift(driver);
+    return reordered;
+  }, [isPersistentSessionActive, sessionUsers, participantId, driverParticipantId]);
 
   const navigate = useCallback(
     (direction: 'next' | 'previous', source: 'swipePlayViewDrawer' | 'playViewDrawer') => {
@@ -1406,6 +1416,13 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
               px: 2,
               py: 0.75,
               borderTop: '1px solid var(--neutral-200)',
+              // Warm whisper tint — gives the band a reason to exist visually
+              // without painting it. The IA/iOS-HIG designers' pick:
+              // signals "this row is about who's here," not just chrome.
+              // Uses theme `warning` (the same amber the driver chip used)
+              // at ~5% opacity so it sits between the neutral climb area and
+              // the neutral action bar without competing with either.
+              backgroundColor: `color-mix(in srgb, ${themeTokens.colors.warning} 5%, transparent)`,
               minHeight: 36,
             }}
           >
@@ -1497,31 +1514,34 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
                 </Box>
               </>
             )}
-            {audienceCount > 0 && (
+            {audienceUsers.length > 0 && (
               <Box
-                component="span"
-                aria-label={t('playView.audienceCount', { count: audienceCount })}
-                sx={{
-                  ml: 'auto',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 0.25,
-                  fontSize: 12,
-                  color: 'text.secondary',
-                  letterSpacing: 1,
-                  flexShrink: 0,
-                }}
+                sx={{ ml: 'auto', flexShrink: 0 }}
+                aria-label={t('playView.audienceCount', { count: audienceUsers.length })}
               >
-                {Array.from({ length: Math.min(audienceCount, 5) }).map((_, i) => (
-                  <Box key={i} component="span" aria-hidden="true">
-                    •
-                  </Box>
-                ))}
-                {audienceCount > 5 && (
-                  <Box component="span" sx={{ ml: 0.25, fontSize: 10, letterSpacing: 0 }} aria-hidden="true">
-                    +{audienceCount - 5}
-                  </Box>
-                )}
+                <AvatarGroup
+                  max={3}
+                  sx={{
+                    '& .MuiAvatar-root': {
+                      width: 22,
+                      height: 22,
+                      fontSize: 10,
+                      border: '2px solid transparent',
+                    },
+                  }}
+                >
+                  {audienceUsers.map((user) => (
+                    <TickBadgeAvatar
+                      key={user.id}
+                      user={user}
+                      hasTicked={
+                        tickedBySet.has(user.id) || (user.userId != null && tickedBySet.has(user.userId))
+                      }
+                      isDriver={driverParticipantId != null && user.id === driverParticipantId}
+                      size={22}
+                    />
+                  ))}
+                </AvatarGroup>
               </Box>
             )}
           </Box>
@@ -1607,7 +1627,9 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     driftedFromWall,
     wallClimb,
     handleReturnToWallClimb,
-    audienceCount,
+    audienceUsers,
+    tickedBySet,
+    driverParticipantId,
     lightbulbCoachmarkText,
   ]);
 

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -1311,14 +1311,16 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     if (!currentClimb) return null;
     return (
       <>
-        {showWallContextChip && driverUser && wallClimb && (
+        {showWallContextChip && wallClimb && (
           // Wall-context chip: always visible for a non-driver in a party
           // session while the drawer is open, so the wall-climb identity is
           // never hidden behind the drawer (the bar's ON WALL chip is
           // covered while this drawer is on top). Morphs by drift state:
-          //   - On the wall climb: informational "ON WALL · {driver}".
+          //   - On the wall climb: informational "ON WALL · {driver}" (or
+          //     plain "ON WALL" when no driver is set yet).
           //   - Drifted (after a local swipe): clickable
-          //     "← {driver} · {wallClimb}" that snaps back to the wall climb.
+          //     "← {driver} · {wallClimb}" that snaps back, or
+          //     "← {wallClimb}" when no driver.
           <Box sx={{ display: 'flex', justifyContent: 'center', px: 2, pt: 1 }}>
             {driftedFromWall ? (
               <MuiChip
@@ -1328,22 +1330,30 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
                 variant="outlined"
                 color="info"
                 avatar={
-                  <MuiAvatar
-                    alt={driverUser.username}
-                    src={driverUser.avatarUrl ?? undefined}
-                    sx={{ width: 20, height: 20 }}
-                  />
+                  driverUser ? (
+                    <MuiAvatar
+                      alt={driverUser.username}
+                      src={driverUser.avatarUrl ?? undefined}
+                      sx={{ width: 20, height: 20 }}
+                    />
+                  ) : undefined
                 }
                 label={
                   <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
                     <ArrowBackOutlined sx={{ fontSize: 14 }} aria-hidden="true" />
-                    {t('playView.returnToWallPill', {
-                      username: driverUser.username,
-                      climbName: wallClimb.name,
-                    })}
+                    {driverUser
+                      ? t('playView.returnToWallPill', {
+                          username: driverUser.username,
+                          climbName: wallClimb.name,
+                        })
+                      : wallClimb.name}
                   </Box>
                 }
-                aria-label={t('queueBar.ariaLabels.returnToWallClimb', { username: driverUser.username })}
+                aria-label={
+                  driverUser
+                    ? t('queueBar.ariaLabels.returnToWallClimb', { username: driverUser.username })
+                    : t('queueBar.ariaLabels.returnToWallClimbNoDriver')
+                }
                 sx={{ fontSize: 12, maxWidth: '100%' }}
               />
             ) : (
@@ -1353,13 +1363,15 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
                 color="info"
                 role="status"
                 avatar={
-                  <MuiAvatar
-                    alt={driverUser.username}
-                    src={driverUser.avatarUrl ?? undefined}
-                    sx={{ width: 20, height: 20 }}
-                  />
+                  driverUser ? (
+                    <MuiAvatar
+                      alt={driverUser.username}
+                      src={driverUser.avatarUrl ?? undefined}
+                      sx={{ width: 20, height: 20 }}
+                    />
+                  ) : undefined
                 }
-                label={t('playView.onWallChip', { username: driverUser.username })}
+                label={driverUser ? t('playView.onWallChip', { username: driverUser.username }) : t('queueBar.onWall')}
                 sx={{
                   fontSize: 10,
                   fontWeight: 600,

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -6,7 +6,6 @@ import { track } from '@/app/lib/analytics';
 import MuiBadge from '@mui/material/Badge';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
-import MuiButton from '@mui/material/Button';
 import MuiAvatar from '@mui/material/Avatar';
 import MuiChip from '@mui/material/Chip';
 import Tooltip from '@mui/material/Tooltip';
@@ -19,8 +18,7 @@ import SkipPreviousOutlined from '@mui/icons-material/SkipPreviousOutlined';
 import SkipNextOutlined from '@mui/icons-material/SkipNextOutlined';
 import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
 import Lightbulb from '@mui/icons-material/Lightbulb';
-import LockOutlined from '@mui/icons-material/LockOutlined';
-import ArrowForwardOutlined from '@mui/icons-material/ArrowForwardOutlined';
+import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined';
 import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import KeyboardArrowUpOutlined from '@mui/icons-material/KeyboardArrowUpOutlined';
@@ -158,11 +156,6 @@ type PlayViewActionBarProps = {
   /** Fired when the coachmark animation runs once — the parent persists
    *  the seen flag and clears `lightbulbCoachmark`. */
   onLightbulbCoachmarkSeen?: () => void;
-  /** Wall-view *locked* — non-driver opened the drawer from the bar body
-   *  in a party session. Hides prev/next; the lightbulb stays. Drivers
-   *  in wall-view don't reach this branch (the parent never passes true
-   *  for them — they get a normal browse drawer on the wall climb). */
-  wallViewLocked?: boolean;
   /** Name of the currently displayed climb. Used in the lightbulb's aria
    *  label so screen-reader users hear what they're sending. */
   displayedClimbName: string | null;
@@ -198,7 +191,6 @@ export const PlayViewActionBar = React.memo(function PlayViewActionBar({
   displayedClimbName,
   onLightbulb,
   onLightbulbLongPress,
-  wallViewLocked = false,
   angleSelector,
 }: PlayViewActionBarProps) {
   const { t } = useTranslation('session');
@@ -224,11 +216,9 @@ export const PlayViewActionBar = React.memo(function PlayViewActionBar({
   }, [consumeLongPress, onLightbulb]);
   return (
     <div className={styles.actionBar}>
-      {!wallViewLocked && (
-        <IconButton disabled={!canSwipePrevious} onClick={onPrevClick}>
-          <SkipPreviousOutlined />
-        </IconButton>
-      )}
+      <IconButton disabled={!canSwipePrevious} onClick={onPrevClick}>
+        <SkipPreviousOutlined />
+      </IconButton>
       {supportsMirroring && (
         <IconButton
           color={isMirrored ? 'primary' : 'default'}
@@ -305,11 +295,9 @@ export const PlayViewActionBar = React.memo(function PlayViewActionBar({
           <FormatListBulletedOutlined />
         </IconButton>
       </MuiBadge>
-      {!wallViewLocked && (
-        <IconButton disabled={!canSwipeNext} onClick={onNextClick}>
-          <SkipNextOutlined />
-        </IconButton>
-      )}
+      <IconButton disabled={!canSwipeNext} onClick={onNextClick}>
+        <SkipNextOutlined />
+      </IconButton>
     </div>
   );
 });
@@ -575,16 +563,6 @@ type PlayViewDrawerProps = {
    * no-op — subsequent close/open cycles animate normally.
    */
   initialOpenWithoutAnimation?: boolean;
-  /** Wall-view mode (queue-control-bar pivot Phase 3). When true the drawer
-   *  was opened from the bar body and renders in a read-only navigation
-   *  state: hides prev/next, disables swipe, shows the "Currently on the
-   *  wall" header. The lightbulb and standard climb actions remain. */
-  wallView?: boolean;
-  /** Drop out of wall-view mode without closing the drawer — wired to the
-   *  "Browse from here" affordance that tester feedback asked for. The drawer
-   *  stays open on the same climb but in the normal browse state (swipe
-   *  enabled, prev/next visible for driver). */
-  onExitWallView?: () => void;
 };
 
 const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
@@ -596,8 +574,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   drawerDisplayedItem = null,
   setDrawerDisplayedItem,
   initialOpenWithoutAnimation = false,
-  wallView = false,
-  onExitWallView,
 }) => {
   const { t } = useTranslation('session');
   const isOpen = activeDrawer === 'play';
@@ -752,11 +728,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     boardDetails,
     angle: currentAngle,
     onClose: handleUrlSyncClose,
-    // Wall-view mode is a peek gesture at the wall climb, not a shareable
-    // /view/{uuid} surface — skip the URL push so the address bar stays put.
-    // Drivers can still navigate in wall-view (their swipes broadcast), so
-    // they need the URL to follow normally.
-    enabled: !wallView || isDriver,
   });
   const filteredLogbook = useMemo(() => {
     if (!logbook || !currentClimb) return [];
@@ -869,63 +840,32 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     });
   }, [swipeSuggestionsOnly, t]);
 
-  // Wall-view is "locked" only for non-drivers — the lock semantics
-  // (no swipe, no prev/next, no URL push) is the "you can't change the
-  // wall right now" cue. Drivers in wall-view get full nav: swipe walks
-  // queue → search → suggestions and broadcasts. Marco's group-session
-  // feedback — the blanket lock confused drivers who tapped the bar
-  // body. If driver status flips while the drawer is open, the lock UI
-  // appears/disappears reactively because `isDriver` is derived live
-  // from session data.
-  const wallViewLocked = wallView && !isDriver;
-
-  // Wall-view one-shot hint (group-session feedback fix). Show a
-  // "Locked to the wall climb. Close to browse." cue once per user,
-  // then never again. Gate on `wallViewLocked` rather than `wallView`
-  // so a driver who opens wallView doesn't mark the hint "seen" without
-  // ever seeing it.
-  const [showWallViewHint, setShowWallViewHint] = useState(false);
-  useEffect(() => {
-    if (!isOpen || !wallViewLocked) {
-      setShowWallViewHint(false);
-      return;
-    }
-    let cancelled = false;
-    void getPreference<boolean>('swipeHint:wallViewSeen').then((seen) => {
-      if (cancelled) return;
-      if (!seen) setShowWallViewHint(true);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, wallViewLocked]);
-  const handleWallViewHintSeen = useCallback(() => {
-    setShowWallViewHint(false);
-    void setPreference('swipeHint:wallViewSeen', true);
-  }, []);
-
-  // Mark the hint seen once the user actually closes the wall-view drawer —
-  // they've encountered the mode at least once. Avoids leaving the cue
-  // pulsing forever for users who never tap "Browse from here".
-  const wallViewHintSeenLatchRef = useRef(false);
-  useEffect(() => {
-    if (showWallViewHint) {
-      wallViewHintSeenLatchRef.current = true;
-    }
-    if (!isOpen && wallViewHintSeenLatchRef.current) {
-      wallViewHintSeenLatchRef.current = false;
-      void setPreference('swipeHint:wallViewSeen', true);
-    }
-  }, [isOpen, showWallViewHint]);
-
-  // Resolve the driver's user record so the wall-view header strip shows
-  // their avatar + name ("X is on the wall"). Falls back gracefully — if
-  // we can't find the user (driver dropped, optimistic-claim race, etc.)
-  // the strip just renders the climb-name + lock without the avatar.
+  // Resolve the driver's user record so the "return to wall climb" pill
+  // can show their avatar + name when a non-driver has drifted off the
+  // wall climb in browse mode. Falls back gracefully — if we can't find
+  // the user (driver dropped, optimistic-claim race, etc.) the pill
+  // skips rendering.
   const driverUser = useMemo(() => {
     if (!driverParticipantId) return null;
     return sessionUsers.find((u) => u.id === driverParticipantId) ?? null;
   }, [driverParticipantId, sessionUsers]);
+
+  // Drift detection: a non-driver in a party session has actively swiped
+  // off the wall climb in browse mode. `drawerDisplayedItem` is non-null
+  // only after a local swipe; if it matches `currentClimbQueueItem` the
+  // user is back on the wall climb (no drift). Until they swipe, the
+  // drawer auto-follows the wall via the `effectiveItem` fallback at the
+  // top of the component, so no pill is needed.
+  const driftedFromWall =
+    !isDriver &&
+    isPersistentSessionActive &&
+    drawerDisplayedItem != null &&
+    currentClimbQueueItem != null &&
+    drawerDisplayedItem.climb.uuid !== currentClimbQueueItem.climb.uuid;
+  const wallClimb = currentClimbQueueItem?.climb ?? null;
+  const handleReturnToWallClimb = useCallback(() => {
+    setDrawerDisplayedItem?.(null);
+  }, [setDrawerDisplayedItem]);
 
   const navigate = useCallback(
     (direction: 'next' | 'previous', source: 'swipePlayViewDrawer' | 'playViewDrawer') => {
@@ -946,12 +886,8 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     navigate('previous', 'swipePlayViewDrawer');
   }, [navigate, maybeArmPreviewCoachmark]);
 
-  // Wall-view mode is a read-only display of the wall climb for non-drivers
-  // (locked, no swipe). For drivers it behaves like the normal drawer — they
-  // can swipe and the queue/search/suggestions fall-through navigates as
-  // usual. See `wallViewLocked` above for the role-based gate.
-  const canSwipeNext = !viewOnlyMode && !wallViewLocked && !!nextItem;
-  const canSwipePrevious = !viewOnlyMode && !wallViewLocked && !!prevItem;
+  const canSwipeNext = !viewOnlyMode && !!nextItem;
+  const canSwipePrevious = !viewOnlyMode && !!prevItem;
 
   // Tick FAB → inline tick bar
   const handleTickFabClick = useCallback(() => {
@@ -1370,127 +1306,37 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     if (!currentClimb) return null;
     return (
       <>
-        {wallView && (
-          // Wall-view header strip: "X is on the wall" for everyone, plus
-          // the lock + hint + "Browse from here →" escape hatch only when
-          // the local user isn't the driver. Drivers keep swipe and the
-          // standard prev/next buttons (Marco's group-session feedback —
-          // the lock is the "you can't change the wall" cue, which doesn't
-          // apply to the driver). Re-renders reactively when driver status
-          // flips mid-drawer: if the user loses the wall while this is open,
-          // the lock + hint slide in on the next render tick.
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 1,
-              px: 2,
-              py: 1,
-              backgroundColor: 'var(--semantic-selected-light, var(--semantic-selected))',
-              borderBottom: '1px solid var(--neutral-200)',
-            }}
-          >
-            {wallViewLocked && <LockOutlined aria-hidden="true" sx={{ fontSize: 18, color: 'text.secondary' }} />}
-            {driverUser ? (
-              <MuiAvatar
-                alt={driverUser.username}
-                src={driverUser.avatarUrl ?? undefined}
-                sx={{ width: 24, height: 24 }}
-              />
-            ) : null}
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              <Box
-                component="span"
-                sx={{
-                  display: 'block',
-                  fontSize: 13,
-                  fontWeight: 600,
-                  color: 'text.primary',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {driverUser
-                  ? t('playView.wallViewHeaderDriver', { username: driverUser.username })
-                  : t('playView.wallViewHeader')}
-              </Box>
-              {wallViewLocked && showWallViewHint && (
-                <Box
-                  component="span"
-                  sx={{
-                    display: 'block',
-                    fontSize: 11,
-                    color: 'text.secondary',
-                    mt: 0.25,
-                  }}
-                >
-                  {t('playView.wallViewHint')}
-                </Box>
-              )}
-            </Box>
-            {wallViewLocked && onExitWallView && (
-              <>
-                {/* CSS-driven responsive swap (per CLAUDE.md — JS
-                    breakpoint detection is prohibited). The text button
-                    competes for width with the driver username on narrow
-                    phones; below the MUI `sm` breakpoint we collapse to
-                    an icon-only IconButton. Render both, let the cascade
-                    pick. */}
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    handleWallViewHintSeen();
-                    onExitWallView();
-                  }}
-                  aria-label={t('playView.wallViewBrowseFromHere')}
-                  sx={{ display: { xs: 'inline-flex', sm: 'none' } }}
-                >
-                  <ArrowForwardOutlined sx={{ fontSize: 18 }} />
-                </IconButton>
-                <MuiButton
-                  size="medium"
-                  variant="text"
-                  endIcon={<ArrowForwardOutlined sx={{ fontSize: 16 }} />}
-                  onClick={() => {
-                    handleWallViewHintSeen();
-                    onExitWallView();
-                  }}
-                  sx={{
-                    textTransform: 'none',
-                    fontSize: 12,
-                    display: { xs: 'none', sm: 'inline-flex' },
-                  }}
-                >
-                  {t('playView.wallViewBrowseFromHere')}
-                </MuiButton>
-              </>
-            )}
+        {driftedFromWall && driverUser && wallClimb && (
+          // Return-to-wall pill: visible only when a non-driver has actively
+          // swiped off the wall climb in browse mode. Tap snaps the drawer
+          // back to the wall climb (clears drawerDisplayedItem). The bar
+          // beneath the drawer carries the persistent "ON WALL" cue —
+          // this pill is the bridge for when drawer-view and bar-view have
+          // drifted apart.
+          <Box sx={{ display: 'flex', justifyContent: 'center', px: 2, pt: 1 }}>
+            <MuiChip
+              clickable
+              onClick={handleReturnToWallClimb}
+              size="small"
+              variant="outlined"
+              color="info"
+              icon={<ArrowBackOutlined sx={{ fontSize: 14, ml: 0.5 }} />}
+              avatar={
+                <MuiAvatar
+                  alt={driverUser.username}
+                  src={driverUser.avatarUrl ?? undefined}
+                  sx={{ width: 20, height: 20 }}
+                />
+              }
+              label={t('playView.returnToWallPill', { username: driverUser.username, climbName: wallClimb.name })}
+              aria-label={t('queueBar.ariaLabels.returnToWallClimb', { username: driverUser.username })}
+              sx={{ fontSize: 12, maxWidth: '100%' }}
+            />
           </Box>
         )}
         {/* Header: Grade | Name */}
         <div className={styles.headerSection}>
           <ClimbDetailHeader climb={currentClimb} />
-          {swipeSuggestionsOnly && !wallView && (
-            // Preview chip (group-session feedback fix): tells a non-driver
-            // their swipe is previewing only — the wall hasn't moved and
-            // nobody else sees this navigation. Sits next to the climb name
-            // so it's hard to miss without competing with the lightbulb cue.
-            // MUI `Chip` so design tokens + a11y semantics ride for free
-            // (the UI review caught that the prior `<Box component="span">`
-            // shipped a CSS-var fallback to `--semantic-selected` — the
-            // same rose tint the wall-view header strip uses — because
-            // `--semantic-info-light` is never defined).
-            <MuiChip
-              size="small"
-              variant="outlined"
-              color="info"
-              role="status"
-              aria-label={t('playView.previewChip')}
-              label={t('playView.previewChip')}
-              sx={{ ml: 1, fontSize: 11, fontWeight: 500 }}
-            />
-          )}
         </div>
 
         {/* Board renderer with card-swipe and floating Tick FAB */}
@@ -1576,7 +1422,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
             displayedClimbName={currentClimb?.name ?? null}
             onLightbulb={handleLightbulbClick}
             onLightbulbLongPress={handleOpenLightDrawer}
-            wallViewLocked={wallViewLocked}
             angleSelector={
               <AngleSelector
                 boardName={boardDetails.board_name}
@@ -1620,7 +1465,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     isDriver,
     handleLightbulbClick,
     handleOpenLightDrawer,
-    wallView,
     angle,
     handleTickBarClose,
     handleTickBarError,
@@ -1631,11 +1475,9 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     isPersistentSessionActive,
     isBluetoothConnected,
     driverUser,
-    showWallViewHint,
-    handleWallViewHintSeen,
-    onExitWallView,
-    swipeSuggestionsOnly,
-    wallViewLocked,
+    driftedFromWall,
+    wallClimb,
+    handleReturnToWallClimb,
     lightbulbCoachmarkText,
   ]);
 

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -6,10 +6,8 @@ import { track } from '@/app/lib/analytics';
 import MuiBadge from '@mui/material/Badge';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
-import MuiAvatar from '@mui/material/Avatar';
-import AvatarGroup from '@mui/material/AvatarGroup';
 import { TickBadgeAvatar } from '@/app/components/session/tick-badge-avatar';
-import MuiChip from '@mui/material/Chip';
+import { MiniSessionBar } from './mini-session-bar';
 import Tooltip from '@mui/material/Tooltip';
 import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -20,7 +18,6 @@ import SkipPreviousOutlined from '@mui/icons-material/SkipPreviousOutlined';
 import SkipNextOutlined from '@mui/icons-material/SkipNextOutlined';
 import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
 import Lightbulb from '@mui/icons-material/Lightbulb';
-import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined';
 import MoreHorizOutlined from '@mui/icons-material/MoreHorizOutlined';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import KeyboardArrowUpOutlined from '@mui/icons-material/KeyboardArrowUpOutlined';
@@ -842,60 +839,16 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     });
   }, [swipeSuggestionsOnly, t]);
 
-  // Resolve the driver's user record so the "return to wall climb" pill
-  // can show their avatar + name when a non-driver has drifted off the
-  // wall climb in browse mode. Falls back gracefully — if we can't find
-  // the user (driver dropped, optimistic-claim race, etc.) the pill
-  // skips rendering.
+  // Resolve the driver's user record for the grabber-row peripheral cue.
+  // The mini session bar resolves its own copy from the same fields.
   const driverUser = useMemo(() => {
     if (!driverParticipantId) return null;
     return sessionUsers.find((u) => u.id === driverParticipantId) ?? null;
   }, [driverParticipantId, sessionUsers]);
 
-  // Drift detection: a non-driver in a party session has actively swiped
-  // off the wall climb in browse mode. `drawerDisplayedItem` is non-null
-  // only after a local swipe; if it matches `currentClimbQueueItem` the
-  // user is back on the wall climb (no drift). Until they swipe, the
-  // drawer auto-follows the wall via the `effectiveItem` fallback at the
-  // top of the component, so no pill is needed.
-  // Non-driver-in-party gate for the wall-context chip. Always shown while
-  // Drift detection feeds the mini session bar's back-button morph: a
-  // non-driver has actively swiped off the wall climb in browse mode.
-  // `drawerDisplayedItem` is non-null only after a local swipe; if it matches
-  // `currentClimbQueueItem` the user is back on the wall climb (no drift).
-  // Until they swipe, the drawer auto-follows the wall via the
-  // `effectiveItem` fallback at the top of the component.
-  const driftedFromWall =
-    !isDriver &&
-    isPersistentSessionActive &&
-    drawerDisplayedItem != null &&
-    currentClimbQueueItem != null &&
-    drawerDisplayedItem.climb.uuid !== currentClimbQueueItem.climb.uuid;
-  const wallClimb = currentClimbQueueItem?.climb ?? null;
   const handleReturnToWallClimb = useCallback(() => {
     setDrawerDisplayedItem?.(null);
   }, [setDrawerDisplayedItem]);
-
-  // Audience for the mini session bar's AvatarGroup. Everyone in the session
-  // except the local user; the driver-first sort keeps them at position 0 of
-  // the stack so the driver's lit-bulb badge anchors the strip. Tick badges
-  // are sourced from `effectiveItem.tickedBy` so the audience reflects "who
-  // has done THIS climb" (matching what the user is currently looking at,
-  // which may be the wall climb or a non-driver preview).
-  const tickedBySet = useMemo(() => {
-    return new Set(effectiveItem?.tickedBy ?? []);
-  }, [effectiveItem]);
-  const audienceUsers = useMemo(() => {
-    if (!isPersistentSessionActive) return [];
-    const others = sessionUsers.filter((u) => u.id !== participantId);
-    if (!driverParticipantId) return others;
-    const driverIdx = others.findIndex((u) => u.id === driverParticipantId);
-    if (driverIdx <= 0) return others;
-    const reordered = [...others];
-    const [driver] = reordered.splice(driverIdx, 1);
-    reordered.unshift(driver);
-    return reordered;
-  }, [isPersistentSessionActive, sessionUsers, participantId, driverParticipantId]);
 
   const navigate = useCallback(
     (direction: 'next' | 'previous', source: 'swipePlayViewDrawer' | 'playViewDrawer') => {
@@ -1401,151 +1354,16 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
           )}
         </div>
 
-        {/* Mini session bar — sits between the board and the action bar. One
-            slot that morphs by role + drift, so the climb-header above never
-            reflows when the local user takes/releases control (the moment
-            that should feel smooth). Visible in party sessions only — solo
-            users get no row. Audience is rendered as quiet dots (one dot per
-            co-watcher) capped at 5 with a +N overflow. */}
-        {isPersistentSessionActive && currentClimbQueueItem != null && (
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 1,
-              px: 2,
-              py: 0.75,
-              borderTop: '1px solid var(--neutral-200)',
-              // Warm whisper tint — gives the band a reason to exist visually
-              // without painting it. The IA/iOS-HIG designers' pick:
-              // signals "this row is about who's here," not just chrome.
-              // Uses theme `warning` (the same amber the driver chip used)
-              // at ~5% opacity so it sits between the neutral climb area and
-              // the neutral action bar without competing with either.
-              backgroundColor: `color-mix(in srgb, ${themeTokens.colors.warning} 5%, transparent)`,
-              minHeight: 36,
-            }}
-          >
-            {isDriver ? (
-              <>
-                <Lightbulb sx={{ fontSize: 16, color: themeTokens.colors.warning }} aria-hidden="true" />
-                <Box
-                  component="span"
-                  sx={{ fontSize: 11, fontWeight: 600, letterSpacing: 0.5, color: themeTokens.colors.warning }}
-                >
-                  {t('playView.drivingChip')}
-                </Box>
-              </>
-            ) : driftedFromWall && wallClimb ? (
-              <Box
-                component="button"
-                onClick={handleReturnToWallClimb}
-                aria-label={
-                  driverUser
-                    ? t('queueBar.ariaLabels.returnToWallClimb', { username: driverUser.username })
-                    : t('queueBar.ariaLabels.returnToWallClimbNoDriver')
-                }
-                sx={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 0.75,
-                  flex: 1,
-                  minWidth: 0,
-                  background: 'none',
-                  border: 'none',
-                  padding: 0,
-                  cursor: 'pointer',
-                  color: 'inherit',
-                  textAlign: 'left',
-                }}
-              >
-                <ArrowBackOutlined sx={{ fontSize: 16, color: 'text.secondary' }} aria-hidden="true" />
-                {driverUser && (
-                  <MuiAvatar
-                    alt={driverUser.username}
-                    src={driverUser.avatarUrl ?? undefined}
-                    sx={{ width: 20, height: 20 }}
-                  />
-                )}
-                <Box
-                  component="span"
-                  sx={{
-                    fontSize: 12,
-                    fontWeight: 500,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    minWidth: 0,
-                  }}
-                >
-                  {driverUser
-                    ? t('playView.returnToWallPill', {
-                        username: driverUser.username,
-                        climbName: wallClimb.name,
-                      })
-                    : wallClimb.name}
-                </Box>
-              </Box>
-            ) : (
-              <>
-                {driverUser && (
-                  <MuiAvatar
-                    alt={driverUser.username}
-                    src={driverUser.avatarUrl ?? undefined}
-                    sx={{ width: 20, height: 20 }}
-                  />
-                )}
-                <Box
-                  component="span"
-                  sx={{
-                    fontSize: 11,
-                    fontWeight: 600,
-                    letterSpacing: 0.5,
-                    color: 'text.secondary',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    minWidth: 0,
-                  }}
-                >
-                  {driverUser
-                    ? t('playView.onWallChip', { username: driverUser.username })
-                    : t('playView.onWallChipNoDriver')}
-                </Box>
-              </>
-            )}
-            {audienceUsers.length > 0 && (
-              <Box
-                sx={{ ml: 'auto', flexShrink: 0 }}
-                aria-label={t('playView.audienceCount', { count: audienceUsers.length })}
-              >
-                <AvatarGroup
-                  max={3}
-                  sx={{
-                    '& .MuiAvatar-root': {
-                      width: 22,
-                      height: 22,
-                      fontSize: 10,
-                      border: '2px solid transparent',
-                    },
-                  }}
-                >
-                  {audienceUsers.map((user) => (
-                    <TickBadgeAvatar
-                      key={user.id}
-                      user={user}
-                      hasTicked={
-                        tickedBySet.has(user.id) || (user.userId != null && tickedBySet.has(user.userId))
-                      }
-                      isDriver={driverParticipantId != null && user.id === driverParticipantId}
-                      size={22}
-                    />
-                  ))}
-                </AvatarGroup>
-              </Box>
-            )}
-          </Box>
-        )}
+        <MiniSessionBar
+          isDriver={isDriver}
+          isPersistentSessionActive={isPersistentSessionActive}
+          sessionUsers={sessionUsers}
+          participantId={participantId}
+          driverParticipantId={driverParticipantId}
+          currentClimbQueueItem={currentClimbQueueItem}
+          drawerDisplayedItem={drawerDisplayedItem}
+          onReturnToWallClimb={handleReturnToWallClimb}
+        />
 
         {/* Action bar */}
         {isOpen && (
@@ -1623,13 +1441,11 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     isPersistentSessionActive,
     isBluetoothConnected,
     currentClimbQueueItem,
-    driverUser,
-    driftedFromWall,
-    wallClimb,
-    handleReturnToWallClimb,
-    audienceUsers,
-    tickedBySet,
+    sessionUsers,
+    participantId,
     driverParticipantId,
+    drawerDisplayedItem,
+    handleReturnToWallClimb,
     lightbulbCoachmarkText,
   ]);
 
@@ -1688,12 +1504,8 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
                 gap: 0.5,
                 pointerEvents: 'none',
               }}
-              aria-label={t('queueBar.ariaLabels.userIsDriving', { username: driverUser.username })}
             >
-              <MuiAvatar
-                alt={driverUser.username}
-                src={driverUser.avatarUrl ?? undefined}
-                sx={{ width: 18, height: 18 }}
+              <TickBadgeAvatar user={driverUser} hasTicked={false} isDriver size={18}
               />
             </Box>
           )}

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-pivot.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-pivot.test.tsx
@@ -429,7 +429,7 @@ describe('QueueControlBar pivot', () => {
     expect(title).toBeTruthy();
     expect(title!.getAttribute('role')).toBe('button');
     expect(title!.getAttribute('tabindex')).toBe('0');
-    expect(title!.getAttribute('aria-label')).toBe("Show what's on the wall");
+    expect(title!.getAttribute('aria-label')).toBe('Open the wall climb');
   });
 
   // --- Driver-first ordering (P1-C) ----------------------------------------

--- a/packages/web/app/components/queue-control/__tests__/queue-control-bar-pivot.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-control-bar-pivot.test.tsx
@@ -353,9 +353,13 @@ describe('QueueControlBar pivot', () => {
     mockSetPreference.mockResolvedValue(undefined);
   });
 
-  // --- Wall-view dispatch (P0-2) -------------------------------------------
+  // --- Play-drawer dispatch from the bar -----------------------------------
+  // Wall-view mode is gone: the bar now dispatches with no payload + no flags
+  // for both thumbnail and title taps. The drawer always opens in browse mode
+  // on the wall climb (via the `effectiveItem` fallback). Identity of the
+  // wall climb lives on the bar's ON WALL chip, not inside the drawer.
 
-  it('tapping the climb-title region dispatches wallView=true on the play-drawer event', async () => {
+  it('tapping the climb-title region dispatches the play-drawer event with no wallView flag', async () => {
     const seenDetails: PlayDrawerEventDetail[] = [];
     const handler = (event: Event) => {
       const detail = readPlayDrawerEventDetail(event);
@@ -375,19 +379,18 @@ describe('QueueControlBar pivot', () => {
         fireEvent.click(title!);
       });
 
-      // At least one dispatch fired, and the most recent had wallView=true.
       expect(seenDetails.length).toBeGreaterThan(0);
       const last = seenDetails[seenDetails.length - 1];
-      expect(last.wallView).toBe(true);
+      expect((last as PlayDrawerEventDetail & { wallView?: unknown }).wallView).toBeUndefined();
       // No climb payload on the bar's body-tap path — the drawer falls back
-      // to the wall climb.
+      // to the wall climb via `effectiveItem`.
       expect(last.climb).toBeUndefined();
     } finally {
       window.removeEventListener(PLAY_DRAWER_EVENT, handler);
     }
   });
 
-  it('keyboard Enter on the climb-title region dispatches wallView=true', async () => {
+  it('keyboard Enter on the climb-title region dispatches the play-drawer event with no wallView flag', async () => {
     const seenDetails: PlayDrawerEventDetail[] = [];
     const handler = (event: Event) => {
       const detail = readPlayDrawerEventDetail(event);
@@ -408,7 +411,8 @@ describe('QueueControlBar pivot', () => {
       });
 
       expect(seenDetails.length).toBeGreaterThan(0);
-      expect(seenDetails[seenDetails.length - 1].wallView).toBe(true);
+      const last = seenDetails[seenDetails.length - 1];
+      expect((last as PlayDrawerEventDetail & { wallView?: unknown }).wallView).toBeUndefined();
     } finally {
       window.removeEventListener(PLAY_DRAWER_EVENT, handler);
     }

--- a/packages/web/app/components/queue-control/play-drawer-event.ts
+++ b/packages/web/app/components/queue-control/play-drawer-event.ts
@@ -17,36 +17,14 @@ import type { Climb } from '@/app/lib/types';
  */
 export const PLAY_DRAWER_EVENT = 'boardsesh:open-play-drawer';
 
-/**
- * Options for `dispatchOpenPlayDrawer`. Kept in a dedicated type so call sites
- * (and tests) can reuse it without restating the shape.
- *
- * - `wallView`: opens the drawer in read-only "Currently on the wall" mode.
- *   The bar's body-tap (title region + thumbnail) sets this so the user can
- *   inspect the wall climb without the normal browse affordances (no
- *   prev/next, no swipe). The lightbulb and standard climb actions remain.
- */
-export type OpenPlayDrawerOptions = {
-  wallView?: boolean;
-};
-
 export type PlayDrawerEventDetail = {
   climb?: Climb;
-  /**
-   * When true, the drawer opens in "wall-view mode" (queue-control-bar pivot,
-   * Phase 3): renders a "Currently on the wall" header with the driver avatar
-   * inline, hides prev/next, disables swipe. The lightbulb and standard
-   * climb actions remain. Set by the bar's body-tap handler so users can
-   * inspect the wall climb in detail without the normal browsing affordances.
-   */
-  wallView?: boolean;
 };
 
-export const dispatchOpenPlayDrawer = (climb?: Climb, options?: OpenPlayDrawerOptions): void => {
+export const dispatchOpenPlayDrawer = (climb?: Climb): void => {
   if (typeof window === 'undefined') return;
   const detail: PlayDrawerEventDetail = {};
   if (climb) detail.climb = climb;
-  if (options?.wallView) detail.wallView = true;
   window.dispatchEvent(new CustomEvent<PlayDrawerEventDetail>(PLAY_DRAWER_EVENT, { detail }));
 };
 

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1216,7 +1216,7 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                         }
                         role={tickBarActive ? undefined : 'button'}
                         tabIndex={tickBarActive ? undefined : 0}
-                        aria-label={tickBarActive ? undefined : t('queueBar.ariaLabels.openWallView')}
+                        aria-label={tickBarActive ? undefined : t('queueBar.ariaLabels.openPlayDrawer')}
                         className={styles.queueToggle}
                         style={{
                           transform: tickBarActive ? undefined : `translateX(${swipeOffset}px)`,

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -74,9 +74,6 @@ export type ActiveDrawer = 'none' | 'play' | 'queue' | 'tick';
 
 const QUEUE_BADGE_SX = { '& .MuiBadge-badge': themeTokens.badge.small } as const;
 
-// `TickBadgeAvatar` extracted to `@/app/components/session/tick-badge-avatar`
-// so the play-view drawer's mini session bar uses the same component.
-
 export type QueueControlBarProps = {
   boardDetails: BoardDetails;
   angle: Angle;

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -52,7 +52,6 @@ import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutl
 import InputAdornment from '@mui/material/InputAdornment';
 import Avatar from '@mui/material/Avatar';
 import AvatarGroup from '@mui/material/AvatarGroup';
-import MuiChip from '@mui/material/Chip';
 import Badge from '@mui/material/Badge';
 import Lightbulb from '@mui/icons-material/Lightbulb';
 import Typography from '@mui/material/Typography';
@@ -529,14 +528,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     const me = sessionUsers.find((u) => u.id === clientId);
     return me?.userId ?? clientId;
   }, [sessionUsers, clientId]);
-
-  // Resolve the driver's session-user record so the bar's ON WALL chip
-  // can show their avatar. Null when there is no driver or when the
-  // driver participant isn't in the users list yet (claim race).
-  const driverUser = useMemo(() => {
-    if (!driverParticipantId) return null;
-    return sessionUsers.find((u) => u.id === driverParticipantId) ?? null;
-  }, [sessionUsers, driverParticipantId]);
 
   // Track which participants have ticked the current climb.
   // Merges backend-provided tickedBy with locally tracked ticks.
@@ -1270,40 +1261,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                 {/* Left section: Thumbnail and climb info */}
                 <Box sx={{ flex: 1 }} className={styles.climbInfoCol}>
                   <div className={styles.climbInfoInner} style={{ gap: themeTokens.spacing[2] }}>
-                    {/* ON WALL chip — visible in any active party session for
-                        a non-driver. When a driver is set, the chip carries
-                        their avatar; without a driver (nobody's hands on the
-                        wheel right now), just the ON WALL label. Anchors the
-                        bar visually as "this climb is on the wall" so the
-                        wall-climb identity lives on the bar (always visible)
-                        rather than inside the drawer. */}
-                    {!isDriver && isPersistentSessionActive && currentClimb && (
-                      <MuiChip
-                        size="small"
-                        variant="outlined"
-                        color="info"
-                        role="status"
-                        avatar={
-                          driverUser ? (
-                            <Avatar
-                              alt={driverUser.username}
-                              src={driverUser.avatarUrl ?? undefined}
-                              sx={{ width: 18, height: 18 }}
-                            />
-                          ) : undefined
-                        }
-                        label={t('queueBar.onWall')}
-                        sx={{
-                          flexShrink: 0,
-                          fontSize: 10,
-                          fontWeight: 600,
-                          letterSpacing: 0.5,
-                          height: 22,
-                          '& .MuiChip-label': { px: 0.75 },
-                        }}
-                      />
-                    )}
-
                     {/* Board preview — STATIC, with crossfade on enter */}
                     <div className={`${styles.boardPreviewContainer} ${enterDirection ? styles.thumbnailEnter : ''}`}>
                       <ClimbThumbnail

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1270,22 +1270,27 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                 {/* Left section: Thumbnail and climb info */}
                 <Box sx={{ flex: 1 }} className={styles.climbInfoCol}>
                   <div className={styles.climbInfoInner} style={{ gap: themeTokens.spacing[2] }}>
-                    {/* ON WALL chip — non-drivers only, when a driver is set.
-                        Anchors the bar visually as "this climb is on the wall,
-                        driven by {driver}" so the wall-climb identity lives on
-                        the bar (always visible) rather than inside the drawer. */}
-                    {!isDriver && driverUser && currentClimb && (
+                    {/* ON WALL chip — visible in any active party session for
+                        a non-driver. When a driver is set, the chip carries
+                        their avatar; without a driver (nobody's hands on the
+                        wheel right now), just the ON WALL label. Anchors the
+                        bar visually as "this climb is on the wall" so the
+                        wall-climb identity lives on the bar (always visible)
+                        rather than inside the drawer. */}
+                    {!isDriver && isPersistentSessionActive && currentClimb && (
                       <MuiChip
                         size="small"
                         variant="outlined"
                         color="info"
                         role="status"
                         avatar={
-                          <Avatar
-                            alt={driverUser.username}
-                            src={driverUser.avatarUrl ?? undefined}
-                            sx={{ width: 18, height: 18 }}
-                          />
+                          driverUser ? (
+                            <Avatar
+                              alt={driverUser.username}
+                              src={driverUser.avatarUrl ?? undefined}
+                              sx={{ width: 18, height: 18 }}
+                            />
+                          ) : undefined
                         }
                         label={t('queueBar.onWall')}
                         sx={{

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -53,7 +53,7 @@ import InputAdornment from '@mui/material/InputAdornment';
 import Avatar from '@mui/material/Avatar';
 import AvatarGroup from '@mui/material/AvatarGroup';
 import Badge from '@mui/material/Badge';
-import Lightbulb from '@mui/icons-material/Lightbulb';
+import { TickBadgeAvatar } from '@/app/components/session/tick-badge-avatar';
 import Typography from '@mui/material/Typography';
 import { getGradeTintColor } from '@/app/lib/grade-colors';
 import { useColorMode } from '@/app/hooks/use-color-mode';
@@ -74,85 +74,8 @@ export type ActiveDrawer = 'none' | 'play' | 'queue' | 'tick';
 
 const QUEUE_BADGE_SX = { '& .MuiBadge-badge': themeTokens.badge.small } as const;
 
-const TICK_BADGE_SX = {
-  '& .MuiBadge-badge': {
-    backgroundColor: themeTokens.colors.success,
-    color: 'common.white',
-    width: 16,
-    height: 16,
-    minWidth: 16,
-    borderRadius: '50%',
-    border: '2px solid transparent',
-  },
-} as const;
-
-const DRIVER_BADGE_SX = {
-  '& .MuiBadge-badge': {
-    ...themeTokens.badge.small,
-    backgroundColor: themeTokens.colors.primary,
-    color: 'common.white',
-    borderRadius: '50%',
-    border: '2px solid transparent',
-  },
-} as const;
-
-function TickBadgeAvatar({
-  user,
-  hasTicked,
-  size = 28,
-  isDriver = false,
-}: {
-  user: { id: string; username: string; avatarUrl?: string };
-  hasTicked: boolean;
-  size?: number;
-  /** Queue-control-bar pivot: when true, overlay a small lit lightbulb badge
-   *  on the top-right corner of the avatar so the driver is unambiguous in
-   *  the bar's AvatarGroup. Composes with the tick badge (which lives
-   *  bottom-right) so a driver who has also ticked the current climb shows
-   *  both. */
-  isDriver?: boolean;
-}) {
-  const { t } = useTranslation('session');
-  // Accessible label: when the user is driving, screen readers should hear
-  // "<username> is driving" — relying on `alt` is invisible because Avatar
-  // without `src` renders the username initial as text, not an <img>. Apply
-  // aria-label to the Avatar root so the SR sees it regardless of the
-  // src/initials branch.
-  const driverAriaLabel = isDriver ? t('queueBar.ariaLabels.userIsDriving', { username: user.username }) : undefined;
-  const baseAvatar = (
-    <Avatar
-      alt={user.username}
-      src={user.avatarUrl ?? undefined}
-      aria-label={driverAriaLabel}
-      sx={size !== 28 ? { width: size, height: size } : undefined}
-    />
-  );
-  // Compose tick badge (bottom-right) inside driver badge (top-right) so both
-  // can show on the same avatar without overlapping.
-  const withTick = hasTicked ? (
-    <Badge
-      overlap="circular"
-      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-      badgeContent={<CheckOutlined sx={{ fontSize: 10 }} />}
-      sx={TICK_BADGE_SX}
-    >
-      {baseAvatar}
-    </Badge>
-  ) : (
-    baseAvatar
-  );
-  if (!isDriver) return withTick;
-  return (
-    <Badge
-      overlap="circular"
-      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-      badgeContent={<Lightbulb sx={{ fontSize: 10 }} />}
-      sx={DRIVER_BADGE_SX}
-    >
-      {withTick}
-    </Badge>
-  );
-}
+// `TickBadgeAvatar` extracted to `@/app/components/session/tick-badge-avatar`
+// so the play-view drawer's mini session bar uses the same component.
 
 export type QueueControlBarProps = {
   boardDetails: BoardDetails;

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -52,6 +52,7 @@ import ChatBubbleOutlineOutlined from '@mui/icons-material/ChatBubbleOutlineOutl
 import InputAdornment from '@mui/material/InputAdornment';
 import Avatar from '@mui/material/Avatar';
 import AvatarGroup from '@mui/material/AvatarGroup';
+import MuiChip from '@mui/material/Chip';
 import Badge from '@mui/material/Badge';
 import Lightbulb from '@mui/icons-material/Lightbulb';
 import Typography from '@mui/material/Typography';
@@ -188,7 +189,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   useEffect(() => {
     if (activeDrawer !== 'play') {
       setDrawerDisplayedItem(null);
-      setDrawerWallView(false);
     }
   }, [activeDrawer]);
 
@@ -223,10 +223,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   // tapped (drawer also reads the wall climb in that case). Reset to null on
   // drawer close.
   const [drawerDisplayedItem, setDrawerDisplayedItem] = useState<ClimbQueueItem | null>(null);
-  // Wall-view mode (pivot Phase 3): set by the bar's body-tap handler. When
-  // true the drawer hides prev/next, disables swipe, and shows the
-  // "Currently on the wall" header. Reset on close.
-  const [drawerWallView, setDrawerWallView] = useState(false);
 
   // Listen for play drawer open requests from climb list items that live
   // outside this component's React tree (board page, liked list, queue
@@ -251,7 +247,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
       } else {
         setDrawerDisplayedItem(null);
       }
-      setDrawerWallView(!!detail?.wallView);
       setActiveDrawer('play');
     };
     window.addEventListener(PLAY_DRAWER_EVENT, handler);
@@ -272,16 +267,13 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
   } = useQueueActions();
   const handleThumbnailClick = useCallback(() => {
     if (!currentClimb || viewOnlyMode) return;
-    // No-payload dispatch + wallView flag: drawer falls back to the wall
-    // climb (the bar's own thumbnail mirrors the wall). The wall-view
-    // mode adds the locked "Currently on the wall" treatment for
-    // non-drivers — for drivers there's nothing to lock (they're already
-    // controlling the wall), so they skip wallView entirely and open the
-    // normal browse drawer on the wall climb. Group-session feedback
-    // fix; the prior follow-up commit kept wallView=true for drivers
-    // and the mode paid no rent on top of the normal drawer.
-    dispatchOpenPlayDrawer(undefined, { wallView: !isDriver });
-  }, [currentClimb, viewOnlyMode, isDriver]);
+    // No-payload dispatch: drawer falls back to `currentClimbQueueItem` (the
+    // wall climb) via the `effectiveItem` derivation. Drawer is always in
+    // browse mode now — swipe works, and the bar's ON WALL chip + the
+    // drawer's drift pill carry the "who's driving / where the wall is"
+    // wayfinding.
+    dispatchOpenPlayDrawer();
+  }, [currentClimb, viewOnlyMode]);
 
   const { showMessage } = useSnackbar();
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
@@ -538,6 +530,14 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     return me?.userId ?? clientId;
   }, [sessionUsers, clientId]);
 
+  // Resolve the driver's session-user record so the bar's ON WALL chip
+  // can show their avatar. Null when there is no driver or when the
+  // driver participant isn't in the users list yet (claim race).
+  const driverUser = useMemo(() => {
+    if (!driverParticipantId) return null;
+    return sessionUsers.find((u) => u.id === driverParticipantId) ?? null;
+  }, [sessionUsers, driverParticipantId]);
+
   // Track which participants have ticked the current climb.
   // Merges backend-provided tickedBy with locally tracked ticks.
   // Uses both connection IDs and stable userIds so the badge matches
@@ -787,12 +787,10 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
 
   const handleClimbInfoClick = useCallback(() => {
     if (!currentClimb || viewOnlyMode) return;
-    // Route through dispatchOpenPlayDrawer with wallView:true so the title
-    // region matches the thumbnail's path. The previous direct setActiveDrawer
-    // call skipped the drawer-local wallView wiring and opened the normal
-    // browse drawer, even though the title region is the dominant tap target
-    // for "show me what's on the wall right now."
-    dispatchOpenPlayDrawer(undefined, { wallView: true });
+    // Routes through the same no-payload dispatch as the thumbnail. Drawer
+    // opens in browse mode on the wall climb; the bar's ON WALL chip stays
+    // visible behind it so wall-climb identity is never hidden.
+    dispatchOpenPlayDrawer();
     track('Play Drawer Opened', {
       boardLayout: boardDetails.layout_name || '',
       source: 'bar_tap',
@@ -1272,6 +1270,35 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
                 {/* Left section: Thumbnail and climb info */}
                 <Box sx={{ flex: 1 }} className={styles.climbInfoCol}>
                   <div className={styles.climbInfoInner} style={{ gap: themeTokens.spacing[2] }}>
+                    {/* ON WALL chip — non-drivers only, when a driver is set.
+                        Anchors the bar visually as "this climb is on the wall,
+                        driven by {driver}" so the wall-climb identity lives on
+                        the bar (always visible) rather than inside the drawer. */}
+                    {!isDriver && driverUser && currentClimb && (
+                      <MuiChip
+                        size="small"
+                        variant="outlined"
+                        color="info"
+                        role="status"
+                        avatar={
+                          <Avatar
+                            alt={driverUser.username}
+                            src={driverUser.avatarUrl ?? undefined}
+                            sx={{ width: 18, height: 18 }}
+                          />
+                        }
+                        label={t('queueBar.onWall')}
+                        sx={{
+                          flexShrink: 0,
+                          fontSize: 10,
+                          fontWeight: 600,
+                          letterSpacing: 0.5,
+                          height: 22,
+                          '& .MuiChip-label': { px: 0.75 },
+                        }}
+                      />
+                    )}
+
                     {/* Board preview — STATIC, with crossfade on enter */}
                     <div className={`${styles.boardPreviewContainer} ${enterDirection ? styles.thumbnailEnter : ''}`}>
                       <ClimbThumbnail
@@ -1431,8 +1458,6 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
         drawerDisplayedItem={drawerDisplayedItem}
         setDrawerDisplayedItem={setDrawerDisplayedItem}
         initialOpenWithoutAnimation={isViewPage}
-        wallView={drawerWallView}
-        onExitWallView={() => setDrawerWallView(false)}
       />
 
       <StartSeshDrawer open={startSeshOpen} onClose={() => setStartSeshOpen(false)} />

--- a/packages/web/app/components/session/tick-badge-avatar.tsx
+++ b/packages/web/app/components/session/tick-badge-avatar.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Avatar from '@mui/material/Avatar';
+import Badge from '@mui/material/Badge';
+import CheckOutlined from '@mui/icons-material/CheckOutlined';
+import Lightbulb from '@mui/icons-material/Lightbulb';
+import { themeTokens } from '@/app/theme/theme-config';
+
+const TICK_BADGE_SX = {
+  '& .MuiBadge-badge': {
+    backgroundColor: themeTokens.colors.success,
+    color: 'common.white',
+    width: 16,
+    height: 16,
+    minWidth: 16,
+    borderRadius: '50%',
+    border: '2px solid transparent',
+  },
+} as const;
+
+const DRIVER_BADGE_SX = {
+  '& .MuiBadge-badge': {
+    ...themeTokens.badge.small,
+    backgroundColor: themeTokens.colors.primary,
+    color: 'common.white',
+    borderRadius: '50%',
+    border: '2px solid transparent',
+  },
+} as const;
+
+export type TickBadgeAvatarProps = {
+  user: { id: string; username: string; avatarUrl?: string };
+  hasTicked: boolean;
+  size?: number;
+  /** Overlay a small lit lightbulb badge on the top-right corner of the
+   *  avatar so the driver is unambiguous in any AvatarGroup. Composes with
+   *  the tick badge (bottom-right) so a driver who has also ticked the
+   *  current climb shows both. */
+  isDriver?: boolean;
+};
+
+/** Avatar with optional tick (bottom-right) and driver (top-right) badges.
+ *  Shared between the queue-control bar's session header and the play-view
+ *  drawer's mini session bar so the audience treatment is identical across
+ *  surfaces. */
+export function TickBadgeAvatar({ user, hasTicked, size = 28, isDriver = false }: TickBadgeAvatarProps) {
+  const { t } = useTranslation('session');
+  const driverAriaLabel = isDriver ? t('queueBar.ariaLabels.userIsDriving', { username: user.username }) : undefined;
+  const baseAvatar = (
+    <Avatar
+      alt={user.username}
+      src={user.avatarUrl ?? undefined}
+      aria-label={driverAriaLabel}
+      sx={size !== 28 ? { width: size, height: size } : undefined}
+    />
+  );
+  const withTick = hasTicked ? (
+    <Badge
+      overlap="circular"
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      badgeContent={<CheckOutlined sx={{ fontSize: 10 }} />}
+      sx={TICK_BADGE_SX}
+    >
+      {baseAvatar}
+    </Badge>
+  ) : (
+    baseAvatar
+  );
+  if (!isDriver) return withTick;
+  return (
+    <Badge
+      overlap="circular"
+      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      badgeContent={<Lightbulb sx={{ fontSize: 10 }} />}
+      sx={DRIVER_BADGE_SX}
+    >
+      {withTick}
+    </Badge>
+  );
+}

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -228,6 +228,8 @@
     "onWallChip": "ON WALL · {{username}}",
     "onWallChipNoDriver": "ON WALL",
     "drivingChip": "DRIVING",
+    "audienceCount_one": "{{count}} other watching",
+    "audienceCount_other": "{{count}} others watching",
     "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Previewing. Tap the lightbulb to send it to the wall.",
     "yourAscents_one": "Your Ascent ({{count}})",

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -227,6 +227,7 @@
   "playView": {
     "onWallChip": "ON WALL · {{username}}",
     "onWallChipNoDriver": "ON WALL",
+    "drivingChip": "DRIVING",
     "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Previewing. Tap the lightbulb to send it to the wall.",
     "yourAscents_one": "Your Ascent ({{count}})",

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -195,7 +195,7 @@
       "logAttempt": "Log attempt",
       "showParticipants": "Show participants",
       "hideParticipants": "Hide participants",
-      "openWallView": "Show what's on the wall",
+      "openPlayDrawer": "Open the wall climb",
       "userIsDriving": "{{username}} is driving",
       "returnToWallClimb": "Return to {{username}}'s wall climb",
       "returnToWallClimbNoDriver": "Return to the wall climb"

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -225,6 +225,7 @@
     "offlineLimitReached": "You've hit the offline up-next limit. Reconnect to sync your climbs."
   },
   "playView": {
+    "onWallChip": "ON WALL · {{username}}",
     "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Previewing. Tap the lightbulb to send it to the wall.",
     "yourAscents_one": "Your Ascent ({{count}})",

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -167,6 +167,7 @@
     "cancelReconnectConfirm": "Cancelling will leave the session. Is that what you want?",
     "shellMessage": "No climb selected",
     "startSesh": "Start sesh",
+    "onWall": "ON WALL",
     "linkCopied": "Link copied!",
     "shareFailed": "Failed to share",
     "leaveFailed": "Unable to leave session. Please try again.",
@@ -196,7 +197,8 @@
       "showParticipants": "Show participants",
       "hideParticipants": "Hide participants",
       "openWallView": "Show what's on the wall",
-      "userIsDriving": "{{username}} is driving"
+      "userIsDriving": "{{username}} is driving",
+      "returnToWallClimb": "Return to {{username}}'s wall climb"
     },
     "offline": {
       "idle": "Offline",
@@ -223,11 +225,7 @@
     "offlineLimitReached": "You've hit the offline up-next limit. Reconnect to sync your climbs."
   },
   "playView": {
-    "wallViewHeader": "Currently on the wall",
-    "wallViewHeaderDriver": "{{username}} is on the wall",
-    "wallViewHint": "Locked to the wall climb. Close to browse.",
-    "wallViewBrowseFromHere": "Browse from here",
-    "previewChip": "Preview",
+    "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Previewing. Tap the lightbulb to send it to the wall.",
     "yourAscents_one": "Your Ascent ({{count}})",
     "yourAscents_other": "Your Ascents ({{count}})",

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -167,7 +167,6 @@
     "cancelReconnectConfirm": "Cancelling will leave the session. Is that what you want?",
     "shellMessage": "No climb selected",
     "startSesh": "Start sesh",
-    "onWall": "ON WALL",
     "linkCopied": "Link copied!",
     "shareFailed": "Failed to share",
     "leaveFailed": "Unable to leave session. Please try again.",
@@ -227,6 +226,7 @@
   },
   "playView": {
     "onWallChip": "ON WALL · {{username}}",
+    "onWallChipNoDriver": "ON WALL",
     "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Previewing. Tap the lightbulb to send it to the wall.",
     "yourAscents_one": "Your Ascent ({{count}})",

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -198,7 +198,8 @@
       "hideParticipants": "Hide participants",
       "openWallView": "Show what's on the wall",
       "userIsDriving": "{{username}} is driving",
-      "returnToWallClimb": "Return to {{username}}'s wall climb"
+      "returnToWallClimb": "Return to {{username}}'s wall climb",
+      "returnToWallClimbNoDriver": "Return to the wall climb"
     },
     "offline": {
       "idle": "Offline",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -195,7 +195,7 @@
       "logAttempt": "Registrar intento",
       "showParticipants": "Mostrar participantes",
       "hideParticipants": "Ocultar participantes",
-      "openWallView": "Show what's on the wall",
+      "openPlayDrawer": "Abrir el bloque del muro",
       "userIsDriving": "{{username}} is driving",
       "returnToWallClimb": "Volver al bloque de {{username}}",
       "returnToWallClimbNoDriver": "Volver al bloque del muro"

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -166,7 +166,6 @@
   "queueBar": {
     "cancelReconnectConfirm": "Cancelar te sacará de la sesión. ¿Es lo que quieres?",
     "shellMessage": "Sin bloque seleccionado",
-    "onWall": "EN EL MURO",
     "startSesh": "Empezar sesh",
     "linkCopied": "¡Enlace copiado!",
     "shareFailed": "Error al compartir",
@@ -227,6 +226,7 @@
   },
   "playView": {
     "onWallChip": "EN EL MURO · {{username}}",
+    "onWallChipNoDriver": "EN EL MURO",
     "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Vista previa. Toca la bombilla para enviar al muro.",
     "yourAscents_one": "Tu ascenso ({{count}})",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -196,7 +196,7 @@
       "showParticipants": "Mostrar participantes",
       "hideParticipants": "Ocultar participantes",
       "openPlayDrawer": "Abrir el bloque del muro",
-      "userIsDriving": "{{username}} is driving",
+      "userIsDriving": "{{username}} está al mando",
       "returnToWallClimb": "Volver al bloque de {{username}}",
       "returnToWallClimbNoDriver": "Volver al bloque del muro"
     },

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -198,7 +198,8 @@
       "hideParticipants": "Ocultar participantes",
       "openWallView": "Show what's on the wall",
       "userIsDriving": "{{username}} is driving",
-      "returnToWallClimb": "Volver al bloque de {{username}}"
+      "returnToWallClimb": "Volver al bloque de {{username}}",
+      "returnToWallClimbNoDriver": "Volver al bloque del muro"
     },
     "offline": {
       "idle": "Sin conexión",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -228,6 +228,8 @@
     "onWallChip": "EN EL MURO · {{username}}",
     "onWallChipNoDriver": "EN EL MURO",
     "drivingChip": "AL MANDO",
+    "audienceCount_one": "{{count}} más mirando",
+    "audienceCount_other": "{{count}} más mirando",
     "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Vista previa. Toca la bombilla para enviar al muro.",
     "yourAscents_one": "Tu ascenso ({{count}})",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -166,6 +166,7 @@
   "queueBar": {
     "cancelReconnectConfirm": "Cancelar te sacará de la sesión. ¿Es lo que quieres?",
     "shellMessage": "Sin bloque seleccionado",
+    "onWall": "EN EL MURO",
     "startSesh": "Empezar sesh",
     "linkCopied": "¡Enlace copiado!",
     "shareFailed": "Error al compartir",
@@ -196,7 +197,8 @@
       "showParticipants": "Mostrar participantes",
       "hideParticipants": "Ocultar participantes",
       "openWallView": "Show what's on the wall",
-      "userIsDriving": "{{username}} is driving"
+      "userIsDriving": "{{username}} is driving",
+      "returnToWallClimb": "Volver al bloque de {{username}}"
     },
     "offline": {
       "idle": "Sin conexión",
@@ -223,11 +225,7 @@
     "offlineLimitReached": "Has alcanzado el límite de la cola sin conexión. Vuelve a conectarte para sincronizar tus vías."
   },
   "playView": {
-    "wallViewHeader": "Actualmente en el muro",
-    "wallViewHeaderDriver": "{{username}} está en el muro",
-    "wallViewHint": "Anclado al bloque del muro. Cierra para explorar.",
-    "wallViewBrowseFromHere": "Explorar desde aquí",
-    "previewChip": "Vista previa",
+    "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Vista previa. Toca la bombilla para enviar al muro.",
     "yourAscents_one": "Tu ascenso ({{count}})",
     "yourAscents_other": "Tus ascensos ({{count}})",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -225,6 +225,7 @@
     "offlineLimitReached": "Has alcanzado el límite de la cola sin conexión. Vuelve a conectarte para sincronizar tus vías."
   },
   "playView": {
+    "onWallChip": "EN EL MURO · {{username}}",
     "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Vista previa. Toca la bombilla para enviar al muro.",
     "yourAscents_one": "Tu ascenso ({{count}})",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -227,6 +227,7 @@
   "playView": {
     "onWallChip": "EN EL MURO · {{username}}",
     "onWallChipNoDriver": "EN EL MURO",
+    "drivingChip": "AL MANDO",
     "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Vista previa. Toca la bombilla para enviar al muro.",
     "yourAscents_one": "Tu ascenso ({{count}})",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -196,7 +196,7 @@
       "showParticipants": "Afficher les participants",
       "hideParticipants": "Masquer les participants",
       "openPlayDrawer": "Ouvrir le bloc du mur",
-      "userIsDriving": "{{username}} is driving",
+      "userIsDriving": "{{username}} est au contrôle",
       "returnToWallClimb": "Revenir au bloc de {{username}}",
       "returnToWallClimbNoDriver": "Revenir au bloc du mur"
     },

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -227,6 +227,7 @@
   "playView": {
     "onWallChip": "SUR LE MUR · {{username}}",
     "onWallChipNoDriver": "SUR LE MUR",
+    "drivingChip": "AU CONTRÔLE",
     "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Aperçu. Touche l'ampoule pour envoyer au mur.",
     "yourAscents_one": "Ton ascension ({{count}})",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -228,6 +228,8 @@
     "onWallChip": "SUR LE MUR · {{username}}",
     "onWallChipNoDriver": "SUR LE MUR",
     "drivingChip": "AU CONTRÔLE",
+    "audienceCount_one": "{{count}} autre en train de regarder",
+    "audienceCount_other": "{{count}} autres en train de regarder",
     "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Aperçu. Touche l'ampoule pour envoyer au mur.",
     "yourAscents_one": "Ton ascension ({{count}})",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -167,7 +167,6 @@
     "cancelReconnectConfirm": "Annuler quittera la session. C'est ce que tu veux ?",
     "shellMessage": "Aucun bloc sélectionné",
     "startSesh": "Lancer la sesh",
-    "onWall": "SUR LE MUR",
     "linkCopied": "Lien copié !",
     "shareFailed": "Échec du partage",
     "leaveFailed": "Impossible de quitter la session. Réessaie.",
@@ -227,6 +226,7 @@
   },
   "playView": {
     "onWallChip": "SUR LE MUR · {{username}}",
+    "onWallChipNoDriver": "SUR LE MUR",
     "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Aperçu. Touche l'ampoule pour envoyer au mur.",
     "yourAscents_one": "Ton ascension ({{count}})",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -198,7 +198,8 @@
       "hideParticipants": "Masquer les participants",
       "openWallView": "Show what's on the wall",
       "userIsDriving": "{{username}} is driving",
-      "returnToWallClimb": "Revenir au bloc de {{username}}"
+      "returnToWallClimb": "Revenir au bloc de {{username}}",
+      "returnToWallClimbNoDriver": "Revenir au bloc du mur"
     },
     "offline": {
       "idle": "Hors ligne",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -167,6 +167,7 @@
     "cancelReconnectConfirm": "Annuler quittera la session. C'est ce que tu veux ?",
     "shellMessage": "Aucun bloc sélectionné",
     "startSesh": "Lancer la sesh",
+    "onWall": "SUR LE MUR",
     "linkCopied": "Lien copié !",
     "shareFailed": "Échec du partage",
     "leaveFailed": "Impossible de quitter la session. Réessaie.",
@@ -196,7 +197,8 @@
       "showParticipants": "Afficher les participants",
       "hideParticipants": "Masquer les participants",
       "openWallView": "Show what's on the wall",
-      "userIsDriving": "{{username}} is driving"
+      "userIsDriving": "{{username}} is driving",
+      "returnToWallClimb": "Revenir au bloc de {{username}}"
     },
     "offline": {
       "idle": "Hors ligne",
@@ -223,11 +225,7 @@
     "offlineLimitReached": "Tu as atteint la limite hors ligne de la file d'attente. Reconnecte-toi pour synchroniser tes blocs."
   },
   "playView": {
-    "wallViewHeader": "Actuellement sur le mur",
-    "wallViewHeaderDriver": "{{username}} est sur le mur",
-    "wallViewHint": "Verrouillé sur le bloc du mur. Ferme pour explorer.",
-    "wallViewBrowseFromHere": "Explorer depuis ici",
-    "previewChip": "Aperçu",
+    "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Aperçu. Touche l'ampoule pour envoyer au mur.",
     "yourAscents_one": "Ton ascension ({{count}})",
     "yourAscents_other": "Tes ascensions ({{count}})",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -225,6 +225,7 @@
     "offlineLimitReached": "Tu as atteint la limite hors ligne de la file d'attente. Reconnecte-toi pour synchroniser tes blocs."
   },
   "playView": {
+    "onWallChip": "SUR LE MUR · {{username}}",
     "returnToWallPill": "{{username}} · {{climbName}}",
     "previewCoachmark": "Aperçu. Touche l'ampoule pour envoyer au mur.",
     "yourAscents_one": "Ton ascension ({{count}})",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -195,7 +195,7 @@
       "logAttempt": "Enregistrer un essai",
       "showParticipants": "Afficher les participants",
       "hideParticipants": "Masquer les participants",
-      "openWallView": "Show what's on the wall",
+      "openPlayDrawer": "Ouvrir le bloc du mur",
       "userIsDriving": "{{username}} is driving",
       "returnToWallClimb": "Revenir au bloc de {{username}}",
       "returnToWallClimbNoDriver": "Revenir au bloc du mur"


### PR DESCRIPTION
## Summary

Pivots on PR #2240's design exploration. After living with the minimalist redesign there, the conclusion was that **less chrome was worse**, not better — the upstream banner's obvious lock + escape button was carrying real information, and slimming it down lost more than it gained.

This PR takes the other fork the design team flagged (IA pragmatist): **delete the wall-view mode entirely.** The queue-control bar (always visible at the bottom of every page) becomes the persistent "what's on the wall right now" surface. The drawer is always browse mode for everyone.

Closes the surface area introduced for wall-view: −309 lines, +133 lines.

## What changes

### 1. ON WALL chip on the bar (non-drivers only)

In a party session, the bar grows a small `(◉) ON WALL` chip on the left (driver mini-avatar + uppercase label). Drivers and solo users see the bar unchanged.

### 2. Drawer is always browse mode

Removes from `PlayViewDrawer`:
- `wallView` and `onExitWallView` props
- `wallViewLocked` derivation and all its gates
- Colored header banner (lock icon + driver avatar + "X is on the wall")
- One-shot snackbar hint + IndexedDB latch
- Bottom escape link
- The action bar's prev/next-hiding logic (`PlayViewActionBar.wallViewLocked`)
- Preview chip (the bar's ON WALL chip + drift pill carry the same meaning more directly)
- `useDrawerUrlSync`'s `enabled: !wallView || isDriver` gate (URL always syncs now)
- `useMediaQuery` + `isNarrowViewport` (no longer needed)

Non-drivers swipe just like drivers — the broadcast/no-broadcast distinction is gated upstream in `swipeSuggestionsOnly`, not in the drawer. Until they swipe, the drawer auto-follows the wall via the existing `drawerDisplayedItem ?? currentClimbQueueItem` fallback.

Also drops `wallView` from `PLAY_DRAWER_EVENT` and both bar dispatch sites.

### 3. Drift pill at top of drawer

When a non-driver has swiped off the wall climb (`drawerDisplayedItem` set + uuid ≠ `currentClimbQueueItem.climb.uuid`), a small chip slides in at the top: `← (◉) Marco · Bone Saw`. Tap clears `drawerDisplayedItem`, drawer snaps back to the wall climb, pill disappears. Updates reactively when the driver changes the wall mid-drift (pill's climb name re-renders).

### 4. i18n cleanup

Drops `playView.wallViewHeader*`, `playView.wallViewHint`, `playView.wallViewBrowseFromHere`, `playView.previewChip` from all three locales. Adds `queueBar.onWall`, `queueBar.ariaLabels.returnToWallClimb`, `playView.returnToWallPill`.

## Tradeoffs

- **Re-opens scope PR #2238 settled.** PR #2238's wall-view mode was the answer to "the drawer doesn't allow swiping" tester feedback. This PR answers the same feedback differently: drawer DOES allow swiping for everyone, and the bar (always visible) becomes the source of truth for the wall climb.
- **Spotify-style dissonance.** A non-driver swipes; drawer shows climb B; bar still says "ON WALL · Climb A · Marco". The drift pill is the bridge. This is the same model Spotify/Apple Music users handle daily.
- **Driver-side asymmetry.** Drivers don't see the ON WALL chip (they ARE the wall). For them the bar looks like solo — fine, the chip is for the "I'm watching, not driving" case.

## Test plan

- [x] `vp check` clean (only pre-existing wasm warning in a sibling worktree, not from this branch)
- [x] `vp run typecheck:web` clean
- [x] `vp test run --project web` clean (4684 tests pass)
- [x] `bun packages/web/scripts/check-orphaned-i18n-keys.ts` clean
- [x] `bun packages/web/scripts/check-untranslated-strings.ts` clean
- [ ] Two-device party session:
  - Non-driver: bar shows `(◉) ON WALL` chip on the left.
  - Driver: bar unchanged.
  - Solo: bar unchanged.
  - Tap bar (non-driver) → drawer opens in browse mode on the wall climb. No banner, no presence row, no escape link. Prev/next visible.
  - Driver changes wall while non-driver's drawer is on the wall climb (no drift) → drawer auto-follows reactively.
  - Non-driver swipes → drawer shows climb B; bar still shows climb A; drift pill `← Marco · Bone Saw` appears at top.
  - Tap pill → drawer snaps back to wall climb; pill disappears.
  - Driver changes wall while non-driver is drifted → pill's climb name updates; drawer stays on user's previewed climb.
  - Driver moves wall TO the climb the non-driver was previewing → drift becomes false naturally (uuids match), pill disappears.
- [ ] `/es/...` and `/fr/...` — chip and pill render in active locale.

## Note on base + supersedes

Based on `fix/group-session-swipe-angle-logging` (PR #2238). **Closes #2240** (the minimalist redesign on the same shared design ground).

🤖 Generated with [Claude Code](https://claude.com/claude-code)