### PR TITLE
fix(logbook): dirty check covers every editable field, not just notes

### DIFF
--- a/packages/web/app/components/logbook/__tests__/logascent-form-drift-banner.test.tsx
+++ b/packages/web/app/components/logbook/__tests__/logascent-form-drift-banner.test.tsx
@@ -239,6 +239,108 @@ describe('LogAscentForm — wall-drift banner', () => {
     expect(screen.getByText(/Wall moved to.*New Wall Climb B/i)).toBeTruthy();
   });
 
+  // Dirty-detection regression tests — `isFormDirty` used to only check
+  // notes, so editing any other field would silently slip past the
+  // confirm prompt and lose the user's work when they hit Switch.
+  // Each case below mutates exactly one non-notes field, then asserts
+  // that the Switch button triggers `window.confirm`.
+
+  it('prompts window.confirm when attempts is changed (dirty attempts path)', () => {
+    mockWallClimbItem.current = { climb: newWallClimb };
+    const onSwitchClimb = vi.fn();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderForm({
+      currentClimb: lockedClimb,
+      boardDetails: makeBoardDetails(),
+      onClose: vi.fn(),
+      onSwitchClimb,
+    });
+
+    // The attempts field is the only `type="number"` TextField in the
+    // form right now — pick it by selector rather than by label, which
+    // isn't `htmlFor`-associated with the input.
+    const attemptsField = document.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(attemptsField).toBeTruthy();
+    fireEvent.change(attemptsField, { target: { value: '3' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Switch to New Wall Climb B/i }));
+
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(onSwitchClimb).toHaveBeenCalledTimes(1);
+  });
+
+  it('prompts window.confirm when quality is rated (dirty quality path)', () => {
+    mockWallClimbItem.current = { climb: newWallClimb };
+    const onSwitchClimb = vi.fn();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderForm({
+      currentClimb: lockedClimb,
+      boardDetails: makeBoardDetails(),
+      onClose: vi.fn(),
+      onSwitchClimb,
+    });
+
+    // MUI Rating renders one radio per star labelled "<n> Stars" — pick
+    // the 4-star one and click it to bump quality from 0 → 4.
+    const fourStar = screen.getByRole('radio', { name: /4 Stars/i });
+    fireEvent.click(fourStar);
+
+    fireEvent.click(screen.getByRole('button', { name: /Switch to New Wall Climb B/i }));
+
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(onSwitchClimb).toHaveBeenCalledTimes(1);
+  });
+
+  it('prompts window.confirm when video URL is entered (dirty videoUrl path)', () => {
+    mockWallClimbItem.current = { climb: newWallClimb };
+    const onSwitchClimb = vi.fn();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderForm({
+      currentClimb: lockedClimb,
+      boardDetails: makeBoardDetails(),
+      onClose: vi.fn(),
+      onSwitchClimb,
+    });
+
+    // The video field is the only single-line TextField with a URL
+    // placeholder. Use the placeholder copy to locate it without
+    // wiring up label associations. Boardsesh accepts Instagram /
+    // TikTok beta links — value just needs to differ from '' to count
+    // as dirty; URL validity isn't gating the Switch path.
+    const videoField = screen.getByPlaceholderText(/instagram|tiktok/i) as HTMLInputElement;
+    fireEvent.change(videoField, { target: { value: 'https://www.instagram.com/reel/abc123/' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Switch to New Wall Climb B/i }));
+
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(onSwitchClimb).toHaveBeenCalledTimes(1);
+  });
+
+  it('prompts window.confirm when logType is switched to attempt (dirty logType path)', () => {
+    mockWallClimbItem.current = { climb: newWallClimb };
+    const onSwitchClimb = vi.fn();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderForm({
+      currentClimb: lockedClimb,
+      boardDetails: makeBoardDetails(),
+      onClose: vi.fn(),
+      onSwitchClimb,
+    });
+
+    // Toggle from the default 'ascent' to 'attempt'. The
+    // ToggleButtonGroup renders the labels as button text.
+    fireEvent.click(screen.getByRole('button', { name: /^Attempt$/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /Switch to New Wall Climb B/i }));
+
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(onSwitchClimb).toHaveBeenCalledTimes(1);
+  });
+
   it('does not render the Switch button when onSwitchClimb is not provided (graceful fallback)', () => {
     mockWallClimbItem.current = { climb: newWallClimb };
 

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -93,7 +93,12 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
     difficulty: grades.find((grade) => grade.difficulty_name === currentClimb?.difficulty)?.difficulty_id,
   });
 
-  const [formValues, setFormValues] = useState<LogAscentFormValues>(getInitialValues);
+  // Snapshot the values the form opened on so `isFormDirty` can compare
+  // every editable field against the original — not just notes. Without
+  // this snapshot we'd silently discard attempts/quality/difficulty/video
+  // edits whenever the wall-drift banner's "Switch" path fires.
+  const [initialValues] = useState<LogAscentFormValues>(getInitialValues);
+  const [formValues, setFormValues] = useState<LogAscentFormValues>(initialValues);
   const [isMirrored, setIsMirrored] = useState(!!currentClimb?.mirrored);
   const [isSaving, setIsSaving] = useState(false);
   const [logType, setLogType] = useState<LogType>('ascent');
@@ -112,7 +117,20 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
   const wallHasMoved = !!wallClimb && wallClimb.uuid !== currentClimb.uuid;
   const showDriftBanner = wallHasMoved && !bannerDismissed;
 
-  const isFormDirty = formValues.notes != null && formValues.notes.length > 0;
+  // Compare every editable field against the mount-time snapshot. Notes
+  // and videoUrl are coalesced to '' so "typed then cleared" reads as
+  // pristine rather than `undefined !== ''`. `date` uses dayjs `.isSame`
+  // (ms precision) — the DateTimePicker only mutates on user interaction.
+  const isFormDirty =
+    !formValues.date.isSame(initialValues.date) ||
+    formValues.angle !== initialValues.angle ||
+    formValues.attempts !== initialValues.attempts ||
+    formValues.quality !== initialValues.quality ||
+    formValues.difficulty !== initialValues.difficulty ||
+    (formValues.notes ?? '') !== (initialValues.notes ?? '') ||
+    (formValues.videoUrl ?? '') !== (initialValues.videoUrl ?? '') ||
+    isMirrored !== !!currentClimb?.mirrored ||
+    logType !== 'ascent';
 
   const handleSwitch = () => {
     if (!wallClimb || !onSwitchClimb) return;

--- a/packages/web/app/components/logbook/logascent-form.tsx
+++ b/packages/web/app/components/logbook/logascent-form.tsx
@@ -100,8 +100,10 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
   const [initialValues] = useState<LogAscentFormValues>(getInitialValues);
   const [formValues, setFormValues] = useState<LogAscentFormValues>(initialValues);
   const [isMirrored, setIsMirrored] = useState(!!currentClimb?.mirrored);
+  const initialMirrored = !!currentClimb?.mirrored;
   const [isSaving, setIsSaving] = useState(false);
-  const [logType, setLogType] = useState<LogType>('ascent');
+  const initialLogType: LogType = 'ascent';
+  const [logType, setLogType] = useState<LogType>(initialLogType);
   const [bannerDismissed, setBannerDismissed] = useState(false);
 
   // TODO: Tension spray doesnt support mirroring
@@ -129,8 +131,8 @@ export const LogAscentForm: React.FC<LogAscentFormProps> = ({ currentClimb, boar
     formValues.difficulty !== initialValues.difficulty ||
     (formValues.notes ?? '') !== (initialValues.notes ?? '') ||
     (formValues.videoUrl ?? '') !== (initialValues.videoUrl ?? '') ||
-    isMirrored !== !!currentClimb?.mirrored ||
-    logType !== 'ascent';
+    isMirrored !== initialMirrored ||
+    logType !== initialLogType;
 
   const handleSwitch = () => {
     if (!wallClimb || !onSwitchClimb) return;


### PR DESCRIPTION
## Summary

`isFormDirty` in `LogAscentForm` (`packages/web/app/components/logbook/logascent-form.tsx:114`) used to read:

```ts
const isFormDirty = formValues.notes != null && formValues.notes.length > 0;
```

The wall-drift "Switch to New Wall Climb" flow consulted this flag at `handleSwitch` to decide whether to fire the `window.confirm("You'll lose what you typed. Switch anyway?")` prompt. A user who changed `attempts`, `quality`, `difficulty`, `videoUrl`, the date, the mirror chip, or the ascent/attempt toggle — but didn't type in notes — bypassed the prompt. The form remounted on the new climb and the edits were silently discarded.

Flagged in reviews 2 through 6 without being addressed.

## Changes

- Snapshot initial form values at mount via a new `initialValues` state cell.
- `isFormDirty` now compares every editable field (`date`, `angle`, `attempts`, `quality`, `difficulty`, `notes`, `videoUrl`) against the snapshot, plus `isMirrored` against the prop-derived seed and `logType` against the literal `'ascent'`.
- `notes` and `videoUrl` coalesce empties to `''` so "typed then cleared" reads as pristine instead of `undefined !== ''`.
- Added regression tests in `logascent-form-drift-banner.test.tsx` covering the dirty paths for attempts, quality, video URL, and logType. Existing notes-dirty test untouched.

## Test plan

- [x] `vp test --project web run packages/web/app/components/logbook/__tests__/logascent-form-drift-banner.test.tsx` — 11/11 pass (7 existing + 4 new).
- [x] `vp run typecheck:web` — passes.
- [x] `vp fmt` on changed files — clean.
- [ ] Manual smoke (optional): two-client party session, change only the attempts count on client A, advance the wall on client B, click Switch on the drift banner and confirm the native prompt fires.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7kbzJk7uX6nS1Mikkz8kV)_