### PR TITLE
fix(tick-bar): make tick bars opaque in playview and queue bar

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.module.css
+++ b/packages/web/app/components/play-view/play-view-drawer.module.css
@@ -151,8 +151,6 @@
   box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.15);
   touch-action: pan-x;
   transition: padding 200ms ease-out;
-  backdrop-filter: blur(20px) saturate(1.5);
-  -webkit-backdrop-filter: blur(20px) saturate(1.5);
 }
 
 .tickBarContainerActive .tickBarInner {

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -345,10 +345,7 @@ export const PlayViewTickBar = React.memo<PlayViewTickBarProps>(function PlayVie
   const [tickBarExpanded, setTickBarExpanded] = useState(false);
   const quickTickBarRef = useRef<QuickTickBarHandle>(null);
   const isDark = useIsDarkMode();
-  // Match queue control bar tint — 'default' variant.
-  // In dark mode the tint is semi-transparent, so the backdrop-filter blur
-  // fills in behind it. The fallback uses surfaceElevated (#121212) which
-  // is visibly distinct from pure black.
+  // Opaque surface base + grade tint overlay (matches queue control bar pattern).
   const gradeTintColor = useMemo(
     () => getGradeTintColor(currentClimb.difficulty, 'default', isDark),
     [currentClimb.difficulty, isDark],

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -1120,7 +1120,8 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
               {...(tickBarActive ? tickDismissHandlers : {})}
               className={`${styles.tickRow} ${tickBarActive ? styles.tickRowExpanded : ''} ${tickSwipeOffset > 0 ? styles.tickRowSwiping : ''}`}
               style={{
-                backgroundColor: gradeTintColor ?? (isDark ? 'transparent' : 'var(--semantic-surface)'),
+                backgroundColor: isDark ? 'var(--semantic-surfaceElevated)' : 'var(--semantic-surface)',
+                ...(gradeTintColor ? { backgroundImage: `linear-gradient(${gradeTintColor}, ${gradeTintColor})` } : {}),
                 ...tickDismissStyle,
               }}
             >


### PR DESCRIPTION
## Summary\n\n- **Queue control bar tick row**: was using a semi-transparent `hsla()` grade tint as its sole `backgroundColor`, causing content to bleed through in dark mode. Now uses an opaque surface base (`var(--semantic-surfaceElevated)`) with the grade tint layered on top via `linear-gradient`, matching the pattern already used in the PlayView drawer.\n- **PlayView drawer tick bar**: removed dead `backdrop-filter: blur(20px) saturate(1.5)` from `.tickBarInner` CSS — the base color is already opaque so the filter was a no-op adding compositing cost.\n- Trimmed a stale comment in `play-view-drawer.tsx` that referenced the old backdrop-filter design.\n\n## Test plan\n\n- [ ] Dark mode: open queue control bar, tap tick icon — tick row should be fully opaque with subtle grade tint, no page content visible behind\n- [ ] Dark mode: repeat with a climb that has no difficulty — tick row falls back to plain elevated surface, still opaque\n- [ ] Dark mode: open PlayView drawer, tap tick FAB — tick bar should look identical to before (was already opaque; backdrop-filter removal is visual no-op)\n- [ ] Light mode: repeat both flows — confirm no regression (was already opaque)\n\nhttps://claude.ai/code/session_013Hi5Rb4cskJKMkPN631Hx9

---
_Generated by [Claude Code](https://claude.ai/code/session_013Hi5Rb4cskJKMkPN631Hx9)_