### PR TITLE
feat(db): kilter_* columns on creds, ticks, playlists (PR 1/N)

### DIFF
--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -175,6 +175,11 @@ export const schemaSQL = `
   EXCEPTION WHEN duplicate_object THEN NULL;
   END $$;
 
+  DO $$ BEGIN
+    CREATE TYPE kilter_table_type AS ENUM ('logs', 'attempts');
+  EXCEPTION WHEN duplicate_object THEN NULL;
+  END $$;
+
   DROP TABLE IF EXISTS "boardsesh_ticks" CASCADE;
   CREATE TABLE IF NOT EXISTS "boardsesh_ticks" (
     "id" bigserial PRIMARY KEY NOT NULL,
@@ -200,7 +205,11 @@ export const schemaSQL = `
     "aurora_type" text,
     "aurora_id" text,
     "aurora_synced_at" timestamp,
-    "aurora_sync_error" text
+    "aurora_sync_error" text,
+    "kilter_type" kilter_table_type,
+    "kilter_id" text,
+    "kilter_synced_at" timestamp,
+    "kilter_sync_error" text
   );
 
   DROP TABLE IF EXISTS "board_placements" CASCADE;
@@ -230,7 +239,8 @@ export const schemaSQL = `
     "id" bigserial PRIMARY KEY NOT NULL,
     "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
     "board_type" text NOT NULL,
-    "board_user_id" integer NOT NULL,
+    "board_user_id" integer,
+    "board_user_id_text" text,
     "board_username" text,
     "linked_at" timestamp DEFAULT now() NOT NULL
   );

--- a/packages/backend/src/graphql/resolvers/users/queries.ts
+++ b/packages/backend/src/graphql/resolvers/users/queries.ts
@@ -60,7 +60,7 @@ export const userQueries = {
 
     return credentials.map((c) => ({
       boardType: c.boardType,
-      username: c.encryptedUsername, // Username is stored as-is (not encrypted)
+      username: c.encryptedUsername ?? '', // Username is stored as-is (not encrypted); empty for non-username boards (e.g. Kilter OIDC)
       userId: c.auroraUserId || undefined,
       syncedAt: c.lastSyncAt?.toISOString() || undefined,
       hasToken: !!c.auroraToken,
@@ -92,7 +92,7 @@ export const userQueries = {
     const c = credentials[0];
     return {
       boardType: c.boardType,
-      username: c.encryptedUsername, // Username is stored as-is (not encrypted)
+      username: c.encryptedUsername ?? '', // Username is stored as-is (not encrypted); empty for non-username boards (e.g. Kilter OIDC)
       userId: c.auroraUserId || undefined,
       syncedAt: c.lastSyncAt?.toISOString() || undefined,
       // Note: We don't expose the actual token for security

--- a/packages/db/drizzle/0101_wild_nextwave.sql
+++ b/packages/db/drizzle/0101_wild_nextwave.sql
@@ -1,0 +1,17 @@
+CREATE TYPE "public"."kilter_table_type" AS ENUM('logs', 'attempts');--> statement-breakpoint
+ALTER TABLE "aurora_credentials" ALTER COLUMN "encrypted_username" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "aurora_credentials" ALTER COLUMN "encrypted_password" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "user_board_mappings" ALTER COLUMN "board_user_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "aurora_credentials" ADD COLUMN "encrypted_refresh_token" text;--> statement-breakpoint
+ALTER TABLE "user_board_mappings" ADD COLUMN "board_user_id_text" text;--> statement-breakpoint
+ALTER TABLE "boardsesh_ticks" ADD COLUMN "kilter_type" "kilter_table_type";--> statement-breakpoint
+ALTER TABLE "boardsesh_ticks" ADD COLUMN "kilter_id" text;--> statement-breakpoint
+ALTER TABLE "boardsesh_ticks" ADD COLUMN "kilter_synced_at" timestamp;--> statement-breakpoint
+ALTER TABLE "boardsesh_ticks" ADD COLUMN "kilter_sync_error" text;--> statement-breakpoint
+ALTER TABLE "playlists" ADD COLUMN "kilter_type" text;--> statement-breakpoint
+ALTER TABLE "playlists" ADD COLUMN "kilter_id" text;--> statement-breakpoint
+ALTER TABLE "playlists" ADD COLUMN "kilter_synced_at" timestamp;--> statement-breakpoint
+CREATE INDEX "board_user_mapping_text_idx" ON "user_board_mappings" USING btree ("board_type","board_user_id_text");--> statement-breakpoint
+CREATE UNIQUE INDEX "boardsesh_ticks_kilter_id_unique" ON "boardsesh_ticks" USING btree ("kilter_id");--> statement-breakpoint
+CREATE INDEX "boardsesh_ticks_kilter_sync_pending_idx" ON "boardsesh_ticks" USING btree ("kilter_id","user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "playlists_kilter_id_idx" ON "playlists" USING btree ("kilter_id");

--- a/packages/db/drizzle/meta/0099_snapshot.json
+++ b/packages/db/drizzle/meta/0099_snapshot.json
@@ -8022,6 +8022,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp",
@@ -8067,6 +8073,21 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "activity_push_tokens_user_idx": {
+          "name": "activity_push_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
@@ -8077,6 +8098,15 @@
           "columnsFrom": ["session_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_push_tokens_user_id_users_id_fk": {
+          "name": "activity_push_tokens_user_id_users_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },

--- a/packages/db/drizzle/meta/0101_snapshot.json
+++ b/packages/db/drizzle/meta/0101_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "9aa316ea-9889-4568-85fb-194c17d2a8aa",
-  "prevId": "205a16c6-9c17-4dc7-b582-7b6ea39f858d",
+  "id": "ea5dc714-b257-40e6-8ef7-2b47e6a009e9",
+  "prevId": "9aa316ea-9889-4568-85fb-194c17d2a8aa",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -129,10 +129,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"board_beta_links\".\"shortcode\" IS NOT NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "board_beta_links_created_by_idx": {
           "name": "board_beta_links_created_by_idx",
@@ -151,10 +151,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"board_beta_links\".\"created_by_user_id\" IS NOT NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -233,11 +233,11 @@
         "board_circuits_user_fk": {
           "name": "board_circuits_user_fk",
           "tableFrom": "board_circuits",
-          "columnsFrom": ["board_type", "user_id"],
           "tableTo": "board_users",
+          "columnsFrom": ["board_type", "user_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -285,20 +285,20 @@
         "board_circuits_climbs_circuit_fk": {
           "name": "board_circuits_climbs_circuit_fk",
           "tableFrom": "board_circuits_climbs",
-          "columnsFrom": ["board_type", "circuit_uuid"],
           "tableTo": "board_circuits",
+          "columnsFrom": ["board_type", "circuit_uuid"],
           "columnsTo": ["board_type", "uuid"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         },
         "board_circuits_climbs_climb_fk": {
           "name": "board_circuits_climbs_climb_fk",
           "tableFrom": "board_circuits_climbs",
-          "columnsFrom": ["climb_uuid"],
           "tableTo": "board_climbs",
+          "columnsFrom": ["climb_uuid"],
           "columnsTo": ["uuid"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -378,20 +378,20 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "board_climb_holds_climb_fk": {
           "name": "board_climb_holds_climb_fk",
           "tableFrom": "board_climb_holds",
-          "columnsFrom": ["climb_uuid"],
           "tableTo": "board_climbs",
+          "columnsFrom": ["climb_uuid"],
           "columnsTo": ["uuid"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -597,9 +597,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -781,9 +781,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "board_climbs_search_filter_idx": {
           "name": "board_climbs_search_filter_idx",
@@ -844,9 +844,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "board_climbs_setter_username_idx": {
           "name": "board_climbs_setter_username_idx",
@@ -865,9 +865,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "board_climbs_user_id_idx": {
           "name": "board_climbs_user_id_idx",
@@ -880,10 +880,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"board_climbs\".\"user_id\" IS NOT NULL AND \"board_climbs\".\"is_draft\" = false",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "board_climbs_name_idx": {
           "name": "board_climbs_name_idx",
@@ -902,20 +902,20 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "board_climbs_user_id_users_id_fk": {
           "name": "board_climbs_user_id_users_id_fk",
           "tableFrom": "board_climbs",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -1031,11 +1031,11 @@
         "board_holes_product_fk": {
           "name": "board_holes_product_fk",
           "tableFrom": "board_holes",
-          "columnsFrom": ["board_type", "product_id"],
           "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -1173,11 +1173,11 @@
         "board_layouts_product_fk": {
           "name": "board_layouts_product_fk",
           "tableFrom": "board_layouts",
-          "columnsFrom": ["board_type", "product_id"],
           "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -1231,20 +1231,20 @@
         "board_leds_product_size_fk": {
           "name": "board_leds_product_size_fk",
           "tableFrom": "board_leds",
-          "columnsFrom": ["board_type", "product_size_id"],
           "tableTo": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_size_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         },
         "board_leds_hole_fk": {
           "name": "board_leds_hole_fk",
           "tableFrom": "board_leds",
-          "columnsFrom": ["board_type", "hole_id"],
           "tableTo": "board_holes",
+          "columnsFrom": ["board_type", "hole_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -1316,11 +1316,11 @@
         "board_placement_roles_product_fk": {
           "name": "board_placement_roles_product_fk",
           "tableFrom": "board_placement_roles",
-          "columnsFrom": ["board_type", "product_id"],
           "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -1411,47 +1411,47 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "board_placements_layout_fk": {
           "name": "board_placements_layout_fk",
           "tableFrom": "board_placements",
-          "columnsFrom": ["board_type", "layout_id"],
           "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         },
         "board_placements_hole_fk": {
           "name": "board_placements_hole_fk",
           "tableFrom": "board_placements",
-          "columnsFrom": ["board_type", "hole_id"],
           "tableTo": "board_holes",
+          "columnsFrom": ["board_type", "hole_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         },
         "board_placements_set_fk": {
           "name": "board_placements_set_fk",
           "tableFrom": "board_placements",
-          "columnsFrom": ["board_type", "set_id"],
           "tableTo": "board_sets",
+          "columnsFrom": ["board_type", "set_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         },
         "board_placements_role_fk": {
           "name": "board_placements_role_fk",
           "tableFrom": "board_placements",
-          "columnsFrom": ["board_type", "default_placement_role_id"],
           "tableTo": "board_placement_roles",
+          "columnsFrom": ["board_type", "default_placement_role_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "restrict"
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -1547,11 +1547,11 @@
         "board_product_sizes_product_fk": {
           "name": "board_product_sizes_product_fk",
           "tableFrom": "board_product_sizes",
-          "columnsFrom": ["board_type", "product_id"],
           "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -1617,29 +1617,29 @@
         "board_psls_product_size_fk": {
           "name": "board_psls_product_size_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
-          "columnsFrom": ["board_type", "product_size_id"],
           "tableTo": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_size_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         },
         "board_psls_layout_fk": {
           "name": "board_psls_layout_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
-          "columnsFrom": ["board_type", "layout_id"],
           "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         },
         "board_psls_set_fk": {
           "name": "board_psls_set_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
-          "columnsFrom": ["board_type", "set_id"],
           "tableTo": "board_sets",
+          "columnsFrom": ["board_type", "set_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -1873,11 +1873,11 @@
         "board_user_syncs_user_fk": {
           "name": "board_user_syncs_user_fk",
           "tableFrom": "board_user_syncs",
-          "columnsFrom": ["board_type", "user_id"],
           "tableTo": "board_users",
+          "columnsFrom": ["board_type", "user_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -2015,38 +2015,38 @@
         "board_walls_user_fk": {
           "name": "board_walls_user_fk",
           "tableFrom": "board_walls",
-          "columnsFrom": ["board_type", "user_id"],
           "tableTo": "board_users",
+          "columnsFrom": ["board_type", "user_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         },
         "board_walls_product_fk": {
           "name": "board_walls_product_fk",
           "tableFrom": "board_walls",
-          "columnsFrom": ["board_type", "product_id"],
           "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "restrict"
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
         },
         "board_walls_layout_fk": {
           "name": "board_walls_layout_fk",
           "tableFrom": "board_walls",
-          "columnsFrom": ["board_type", "layout_id"],
           "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "restrict"
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
         },
         "board_walls_product_size_fk": {
           "name": "board_walls_product_size_fk",
           "tableFrom": "board_walls",
-          "columnsFrom": ["board_type", "product_size_id"],
           "tableTo": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_size_id"],
           "columnsTo": ["board_type", "id"],
-          "onUpdate": "cascade",
-          "onDelete": "restrict"
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -2136,11 +2136,11 @@
         "accounts_userId_users_id_fk": {
           "name": "accounts_userId_users_id_fk",
           "tableFrom": "accounts",
-          "columnsFrom": ["userId"],
           "tableTo": "users",
+          "columnsFrom": ["userId"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {
@@ -2182,11 +2182,11 @@
         "sessions_userId_users_id_fk": {
           "name": "sessions_userId_users_id_fk",
           "tableFrom": "sessions",
-          "columnsFrom": ["userId"],
           "tableTo": "users",
+          "columnsFrom": ["userId"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -2324,11 +2324,11 @@
         "user_credentials_user_id_users_id_fk": {
           "name": "user_credentials_user_id_users_id_fk",
           "tableFrom": "user_credentials",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -2385,11 +2385,11 @@
         "user_profiles_user_id_users_id_fk": {
           "name": "user_profiles_user_id_users_id_fk",
           "tableFrom": "user_profiles",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -2424,13 +2424,19 @@
           "name": "encrypted_username",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "encrypted_password": {
           "name": "encrypted_password",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         },
         "aurora_user_id": {
           "name": "aurora_user_id",
@@ -2496,9 +2502,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "aurora_credentials_user_idx": {
           "name": "aurora_credentials_user_idx",
@@ -2511,20 +2517,20 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "aurora_credentials_user_id_users_id_fk": {
           "name": "aurora_credentials_user_id_users_id_fk",
           "tableFrom": "aurora_credentials",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -2559,7 +2565,13 @@
           "name": "board_user_id",
           "type": "integer",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
+        },
+        "board_user_id_text": {
+          "name": "board_user_id_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         },
         "board_username": {
           "name": "board_username",
@@ -2593,9 +2605,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "board_user_mapping_idx": {
           "name": "board_user_mapping_idx",
@@ -2614,20 +2626,41 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
+        },
+        "board_user_mapping_text_idx": {
+          "name": "board_user_mapping_text_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
         "user_board_mappings_user_id_users_id_fk": {
           "name": "user_board_mappings_user_id_users_id_fk",
           "tableFrom": "user_board_mappings",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -2684,29 +2717,29 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "gym_follows_gym_id_gyms_id_fk": {
           "name": "gym_follows_gym_id_gyms_id_fk",
           "tableFrom": "gym_follows",
-          "columnsFrom": ["gym_id"],
           "tableTo": "gyms",
+          "columnsFrom": ["gym_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "gym_follows_user_id_users_id_fk": {
           "name": "gym_follows_user_id_users_id_fk",
           "tableFrom": "gym_follows",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -2770,29 +2803,29 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "gym_members_gym_id_gyms_id_fk": {
           "name": "gym_members_gym_id_gyms_id_fk",
           "tableFrom": "gym_members",
-          "columnsFrom": ["gym_id"],
           "tableTo": "gyms",
+          "columnsFrom": ["gym_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "gym_members_user_id_users_id_fk": {
           "name": "gym_members_user_id_users_id_fk",
           "tableFrom": "gym_members",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -2917,10 +2950,10 @@
             }
           ],
           "isUnique": true,
-          "with": {},
-          "method": "btree",
           "where": "\"gyms\".\"deleted_at\" IS NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "gyms_uuid_idx": {
           "name": "gyms_uuid_idx",
@@ -2933,9 +2966,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "gyms_owner_idx": {
           "name": "gyms_owner_idx",
@@ -2948,10 +2981,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"gyms\".\"deleted_at\" IS NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "gyms_public_idx": {
           "name": "gyms_public_idx",
@@ -2964,29 +2997,29 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"gyms\".\"deleted_at\" IS NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
         "gyms_owner_id_users_id_fk": {
           "name": "gyms_owner_id_users_id_fk",
           "tableFrom": "gyms",
-          "columnsFrom": ["owner_id"],
           "tableTo": "users",
+          "columnsFrom": ["owner_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "gyms_uuid_unique": {
           "name": "gyms_uuid_unique",
-          "columns": ["uuid"],
-          "nullsNotDistinct": false
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -3041,9 +3074,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "board_follows_user_idx": {
           "name": "board_follows_user_idx",
@@ -3056,9 +3089,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "board_follows_board_uuid_idx": {
           "name": "board_follows_board_uuid_idx",
@@ -3071,29 +3104,29 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "board_follows_user_id_users_id_fk": {
           "name": "board_follows_user_id_users_id_fk",
           "tableFrom": "board_follows",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "board_follows_board_uuid_user_boards_uuid_fk": {
           "name": "board_follows_board_uuid_user_boards_uuid_fk",
           "tableFrom": "board_follows",
-          "columnsFrom": ["board_uuid"],
           "tableTo": "user_boards",
+          "columnsFrom": ["board_uuid"],
           "columnsTo": ["uuid"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -3271,9 +3304,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "user_boards_unique_owner_config": {
           "name": "user_boards_unique_owner_config",
@@ -3310,10 +3343,10 @@
             }
           ],
           "isUnique": true,
-          "with": {},
-          "method": "btree",
           "where": "\"user_boards\".\"deleted_at\" IS NULL AND \"user_boards\".\"owner_id\" != '00000000-0000-0000-0000-000000000000'",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "user_boards_owner_owned_idx": {
           "name": "user_boards_owner_owned_idx",
@@ -3332,10 +3365,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"user_boards\".\"deleted_at\" IS NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "user_boards_public_idx": {
           "name": "user_boards_public_idx",
@@ -3360,10 +3393,10 @@
             }
           ],
           "isUnique": false,
-          "with": {},
-          "method": "btree",
           "where": "\"user_boards\".\"deleted_at\" IS NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "user_boards_unique_slug": {
           "name": "user_boards_unique_slug",
@@ -3376,10 +3409,10 @@
             }
           ],
           "isUnique": true,
-          "with": {},
-          "method": "btree",
           "where": "\"user_boards\".\"deleted_at\" IS NULL",
-          "concurrently": false
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "user_boards_uuid_idx": {
           "name": "user_boards_uuid_idx",
@@ -3392,37 +3425,37 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "user_boards_owner_id_users_id_fk": {
           "name": "user_boards_owner_id_users_id_fk",
           "tableFrom": "user_boards",
-          "columnsFrom": ["owner_id"],
           "tableTo": "users",
+          "columnsFrom": ["owner_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "user_boards_gym_id_gyms_id_fk": {
           "name": "user_boards_gym_id_gyms_id_fk",
           "tableFrom": "user_boards",
-          "columnsFrom": ["gym_id"],
           "tableTo": "gyms",
+          "columnsFrom": ["gym_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "user_boards_uuid_unique": {
           "name": "user_boards_uuid_unique",
-          "columns": ["uuid"],
-          "nullsNotDistinct": false
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -3514,9 +3547,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "user_board_serials_serial_idx": {
           "name": "user_board_serials_serial_idx",
@@ -3529,9 +3562,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "user_board_serials_board_uuid_idx": {
           "name": "user_board_serials_board_uuid_idx",
@@ -3544,29 +3577,29 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "user_board_serials_user_id_users_id_fk": {
           "name": "user_board_serials_user_id_users_id_fk",
           "tableFrom": "user_board_serials",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "user_board_serials_board_uuid_user_boards_uuid_fk": {
           "name": "user_board_serials_board_uuid_user_boards_uuid_fk",
           "tableFrom": "user_board_serials",
-          "columnsFrom": ["board_uuid"],
           "tableTo": "user_boards",
+          "columnsFrom": ["board_uuid"],
           "columnsTo": ["uuid"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -3617,11 +3650,11 @@
         "board_session_clients_session_id_board_sessions_id_fk": {
           "name": "board_session_clients_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_clients",
-          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -3681,11 +3714,11 @@
         "board_session_queues_session_id_board_sessions_id_fk": {
           "name": "board_session_queues_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_queues",
-          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -3831,9 +3864,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "board_sessions_discoverable_idx": {
           "name": "board_sessions_discoverable_idx",
@@ -3846,9 +3879,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "board_sessions_user_idx": {
           "name": "board_sessions_user_idx",
@@ -3861,9 +3894,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "board_sessions_status_idx": {
           "name": "board_sessions_status_idx",
@@ -3876,9 +3909,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "board_sessions_last_activity_idx": {
           "name": "board_sessions_last_activity_idx",
@@ -3891,9 +3924,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "board_sessions_discovery_idx": {
           "name": "board_sessions_discovery_idx",
@@ -3918,29 +3951,29 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "board_sessions_created_by_user_id_users_id_fk": {
           "name": "board_sessions_created_by_user_id_users_id_fk",
           "tableFrom": "board_sessions",
-          "columnsFrom": ["created_by_user_id"],
           "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         },
         "board_sessions_board_id_user_boards_id_fk": {
           "name": "board_sessions_board_id_user_boards_id_fk",
           "tableFrom": "board_sessions",
-          "columnsFrom": ["board_id"],
           "tableTo": "user_boards",
+          "columnsFrom": ["board_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -3997,9 +4030,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "session_boards_session_idx": {
           "name": "session_boards_session_idx",
@@ -4012,9 +4045,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "session_boards_board_idx": {
           "name": "session_boards_board_idx",
@@ -4027,29 +4060,29 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "session_boards_session_id_board_sessions_id_fk": {
           "name": "session_boards_session_id_board_sessions_id_fk",
           "tableFrom": "session_boards",
-          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "session_boards_board_id_user_boards_id_fk": {
           "name": "session_boards_board_id_user_boards_id_fk",
           "tableFrom": "session_boards",
-          "columnsFrom": ["board_id"],
           "tableTo": "user_boards",
+          "columnsFrom": ["board_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -4130,9 +4163,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "user_favorites_user_idx": {
           "name": "user_favorites_user_idx",
@@ -4145,9 +4178,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "user_favorites_climb_idx": {
           "name": "user_favorites_climb_idx",
@@ -4172,20 +4205,20 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "user_favorites_user_id_users_id_fk": {
           "name": "user_favorites_user_id_users_id_fk",
           "tableFrom": "user_favorites",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -4294,9 +4327,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "inferred_sessions_user_last_tick_idx": {
           "name": "inferred_sessions_user_last_tick_idx",
@@ -4315,9 +4348,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "inferred_sessions_last_tick_idx": {
           "name": "inferred_sessions_last_tick_idx",
@@ -4330,20 +4363,20 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "inferred_sessions_user_id_users_id_fk": {
           "name": "inferred_sessions_user_id_users_id_fk",
           "tableFrom": "inferred_sessions",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -4400,9 +4433,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "session_member_overrides_user_idx": {
           "name": "session_member_overrides_user_idx",
@@ -4415,46 +4448,46 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "session_member_overrides_session_id_inferred_sessions_id_fk": {
           "name": "session_member_overrides_session_id_inferred_sessions_id_fk",
           "tableFrom": "session_member_overrides",
-          "columnsFrom": ["session_id"],
           "tableTo": "inferred_sessions",
+          "columnsFrom": ["session_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "session_member_overrides_user_id_users_id_fk": {
           "name": "session_member_overrides_user_id_users_id_fk",
           "tableFrom": "session_member_overrides",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "session_member_overrides_added_by_user_id_users_id_fk": {
           "name": "session_member_overrides_added_by_user_id_users_id_fk",
           "tableFrom": "session_member_overrides",
-          "columnsFrom": ["added_by_user_id"],
           "tableTo": "users",
+          "columnsFrom": ["added_by_user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "session_member_overrides_session_user_unique": {
           "name": "session_member_overrides_session_user_unique",
-          "columns": ["session_id", "user_id"],
-          "nullsNotDistinct": false
+          "nullsNotDistinct": false,
+          "columns": ["session_id", "user_id"]
         }
       },
       "policies": {},
@@ -4616,6 +4649,31 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "kilter_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_sync_error": {
+          "name": "kilter_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {
@@ -4636,9 +4694,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "boardsesh_ticks_climb_idx": {
           "name": "boardsesh_ticks_climb_idx",
@@ -4657,9 +4715,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "boardsesh_ticks_aurora_id_unique": {
           "name": "boardsesh_ticks_aurora_id_unique",
@@ -4672,9 +4730,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "boardsesh_ticks_sync_pending_idx": {
           "name": "boardsesh_ticks_sync_pending_idx",
@@ -4693,9 +4751,45 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
+        },
+        "boardsesh_ticks_kilter_id_unique": {
+          "name": "boardsesh_ticks_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_kilter_sync_pending_idx": {
+          "name": "boardsesh_ticks_kilter_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         },
         "boardsesh_ticks_session_idx": {
           "name": "boardsesh_ticks_session_idx",
@@ -4708,9 +4802,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "boardsesh_ticks_inferred_session_idx": {
           "name": "boardsesh_ticks_inferred_session_idx",
@@ -4723,9 +4817,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "boardsesh_ticks_climbed_at_idx": {
           "name": "boardsesh_ticks_climbed_at_idx",
@@ -4738,9 +4832,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "boardsesh_ticks_user_climbed_at_idx": {
           "name": "boardsesh_ticks_user_climbed_at_idx",
@@ -4759,9 +4853,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "boardsesh_ticks_board_climbed_at_idx": {
           "name": "boardsesh_ticks_board_climbed_at_idx",
@@ -4780,9 +4874,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "boardsesh_ticks_board_user_idx": {
           "name": "boardsesh_ticks_board_user_idx",
@@ -4801,9 +4895,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "boardsesh_ticks_user_climb_lookup_idx": {
           "name": "boardsesh_ticks_user_climb_lookup_idx",
@@ -4834,64 +4928,64 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "boardsesh_ticks_user_id_users_id_fk": {
           "name": "boardsesh_ticks_user_id_users_id_fk",
           "tableFrom": "boardsesh_ticks",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "boardsesh_ticks_session_id_board_sessions_id_fk": {
           "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
-          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         },
         "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk": {
           "name": "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
-          "columnsFrom": ["inferred_session_id"],
           "tableTo": "inferred_sessions",
+          "columnsFrom": ["inferred_session_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         },
         "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk": {
           "name": "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
-          "columnsFrom": ["previous_inferred_session_id"],
           "tableTo": "inferred_sessions",
+          "columnsFrom": ["previous_inferred_session_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         },
         "boardsesh_ticks_board_id_user_boards_id_fk": {
           "name": "boardsesh_ticks_board_id_user_boards_id_fk",
           "tableFrom": "boardsesh_ticks",
-          "columnsFrom": ["board_id"],
           "tableTo": "user_boards",
+          "columnsFrom": ["board_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "boardsesh_ticks_uuid_unique": {
           "name": "boardsesh_ticks_uuid_unique",
-          "columns": ["uuid"],
-          "nullsNotDistinct": false
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -4959,9 +5053,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "playlist_climbs_climb_idx": {
           "name": "playlist_climbs_climb_idx",
@@ -4974,9 +5068,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "playlist_climbs_position_idx": {
           "name": "playlist_climbs_position_idx",
@@ -4995,20 +5089,20 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "playlist_climbs_playlist_id_playlists_id_fk": {
           "name": "playlist_climbs_playlist_id_playlists_id_fk",
           "tableFrom": "playlist_climbs",
-          "columnsFrom": ["playlist_id"],
           "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -5072,9 +5166,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "playlist_ownership_user_idx": {
           "name": "playlist_ownership_user_idx",
@@ -5087,29 +5181,29 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "playlist_ownership_playlist_id_playlists_id_fk": {
           "name": "playlist_ownership_playlist_id_playlists_id_fk",
           "tableFrom": "playlist_ownership",
-          "columnsFrom": ["playlist_id"],
           "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "playlist_ownership_user_id_users_id_fk": {
           "name": "playlist_ownership_user_id_users_id_fk",
           "tableFrom": "playlist_ownership",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -5195,6 +5289,24 @@
           "primaryKey": false,
           "notNull": false
         },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp",
@@ -5234,9 +5346,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "playlists_uuid_idx": {
           "name": "playlists_uuid_idx",
@@ -5249,9 +5361,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "playlists_updated_at_idx": {
           "name": "playlists_updated_at_idx",
@@ -5264,9 +5376,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "playlists_last_accessed_at_idx": {
           "name": "playlists_last_accessed_at_idx",
@@ -5279,9 +5391,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "playlists_aurora_id_idx": {
           "name": "playlists_aurora_id_idx",
@@ -5294,9 +5406,24 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
+        },
+        "playlists_kilter_id_idx": {
+          "name": "playlists_kilter_id_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -5304,8 +5431,8 @@
       "uniqueConstraints": {
         "playlists_uuid_unique": {
           "name": "playlists_uuid_unique",
-          "columns": ["uuid"],
-          "nullsNotDistinct": false
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -5360,9 +5487,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "user_playlist_pins_user_idx": {
           "name": "user_playlist_pins_user_idx",
@@ -5375,9 +5502,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "user_playlist_pins_playlist_idx": {
           "name": "user_playlist_pins_playlist_idx",
@@ -5390,29 +5517,29 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "user_playlist_pins_user_id_users_id_fk": {
           "name": "user_playlist_pins_user_id_users_id_fk",
           "tableFrom": "user_playlist_pins",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "user_playlist_pins_playlist_id_playlists_id_fk": {
           "name": "user_playlist_pins_playlist_id_playlists_id_fk",
           "tableFrom": "user_playlist_pins",
-          "columnsFrom": ["playlist_id"],
           "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -5531,9 +5658,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "user_hold_classifications_unique_idx": {
           "name": "user_hold_classifications_unique_idx",
@@ -5570,9 +5697,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "user_hold_classifications_hold_idx": {
           "name": "user_hold_classifications_hold_idx",
@@ -5591,20 +5718,20 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "user_hold_classifications_user_id_users_id_fk": {
           "name": "user_hold_classifications_user_id_users_id_fk",
           "tableFrom": "user_hold_classifications",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -5698,9 +5825,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "esp32_controllers_api_key_idx": {
           "name": "esp32_controllers_api_key_idx",
@@ -5713,9 +5840,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "esp32_controllers_session_idx": {
           "name": "esp32_controllers_session_idx",
@@ -5728,28 +5855,28 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "esp32_controllers_user_id_users_id_fk": {
           "name": "esp32_controllers_user_id_users_id_fk",
           "tableFrom": "esp32_controllers",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "esp32_controllers_api_key_unique": {
           "name": "esp32_controllers_api_key_unique",
-          "columns": ["api_key"],
-          "nullsNotDistinct": false
+          "nullsNotDistinct": false,
+          "columns": ["api_key"]
         }
       },
       "policies": {},
@@ -5804,9 +5931,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "playlist_follows_follower_idx": {
           "name": "playlist_follows_follower_idx",
@@ -5819,9 +5946,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "playlist_follows_playlist_idx": {
           "name": "playlist_follows_playlist_idx",
@@ -5834,29 +5961,29 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "playlist_follows_follower_id_users_id_fk": {
           "name": "playlist_follows_follower_id_users_id_fk",
           "tableFrom": "playlist_follows",
-          "columnsFrom": ["follower_id"],
           "tableTo": "users",
+          "columnsFrom": ["follower_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "playlist_follows_playlist_uuid_playlists_uuid_fk": {
           "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
           "tableFrom": "playlist_follows",
-          "columnsFrom": ["playlist_uuid"],
           "tableTo": "playlists",
+          "columnsFrom": ["playlist_uuid"],
           "columnsTo": ["uuid"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -5913,9 +6040,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "setter_follows_follower_idx": {
           "name": "setter_follows_follower_idx",
@@ -5928,9 +6055,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "setter_follows_setter_idx": {
           "name": "setter_follows_setter_idx",
@@ -5943,20 +6070,20 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "setter_follows_follower_id_users_id_fk": {
           "name": "setter_follows_follower_id_users_id_fk",
           "tableFrom": "setter_follows",
-          "columnsFrom": ["follower_id"],
           "tableTo": "users",
+          "columnsFrom": ["follower_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -6013,9 +6140,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "user_follows_follower_idx": {
           "name": "user_follows_follower_idx",
@@ -6028,9 +6155,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "user_follows_following_idx": {
           "name": "user_follows_following_idx",
@@ -6043,29 +6170,29 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "user_follows_follower_id_users_id_fk": {
           "name": "user_follows_follower_id_users_id_fk",
           "tableFrom": "user_follows",
-          "columnsFrom": ["follower_id"],
           "tableTo": "users",
+          "columnsFrom": ["follower_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "user_follows_following_id_users_id_fk": {
           "name": "user_follows_following_id_users_id_fk",
           "tableFrom": "user_follows",
-          "columnsFrom": ["following_id"],
           "tableTo": "users",
+          "columnsFrom": ["following_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -6171,9 +6298,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "comments_user_created_at_idx": {
           "name": "comments_user_created_at_idx",
@@ -6192,9 +6319,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "comments_parent_comment_idx": {
           "name": "comments_parent_comment_idx",
@@ -6207,28 +6334,28 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "comments_user_id_users_id_fk": {
           "name": "comments_user_id_users_id_fk",
           "tableFrom": "comments",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "comments_uuid_unique": {
           "name": "comments_uuid_unique",
-          "columns": ["uuid"],
-          "nullsNotDistinct": false
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -6302,9 +6429,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "votes_entity_idx": {
           "name": "votes_entity_idx",
@@ -6323,9 +6450,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "votes_user_idx": {
           "name": "votes_user_idx",
@@ -6338,20 +6465,20 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "votes_user_id_users_id_fk": {
           "name": "votes_user_id_users_id_fk",
           "tableFrom": "votes",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -6457,9 +6584,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "notifications_recipient_created_at_idx": {
           "name": "notifications_recipient_created_at_idx",
@@ -6478,9 +6605,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "notifications_dedup_idx": {
           "name": "notifications_dedup_idx",
@@ -6511,9 +6638,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "notifications_created_at_idx": {
           "name": "notifications_created_at_idx",
@@ -6526,46 +6653,46 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "notifications_recipient_id_users_id_fk": {
           "name": "notifications_recipient_id_users_id_fk",
           "tableFrom": "notifications",
-          "columnsFrom": ["recipient_id"],
           "tableTo": "users",
+          "columnsFrom": ["recipient_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "notifications_actor_id_users_id_fk": {
           "name": "notifications_actor_id_users_id_fk",
           "tableFrom": "notifications",
-          "columnsFrom": ["actor_id"],
           "tableTo": "users",
+          "columnsFrom": ["actor_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         },
         "notifications_comment_id_comments_id_fk": {
           "name": "notifications_comment_id_comments_id_fk",
           "tableFrom": "notifications",
-          "columnsFrom": ["comment_id"],
           "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "notifications_uuid_unique": {
           "name": "notifications_uuid_unique",
-          "columns": ["uuid"],
-          "nullsNotDistinct": false
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -6646,21 +6773,21 @@
             },
             {
               "expression": "\"created_at\" desc",
-              "isExpression": true,
               "asc": true,
+              "isExpression": true,
               "nulls": "last"
             },
             {
               "expression": "\"id\" desc",
-              "isExpression": true,
               "asc": true,
+              "isExpression": true,
               "nulls": "last"
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "feed_items_recipient_board_created_at_idx": {
           "name": "feed_items_recipient_board_created_at_idx",
@@ -6679,21 +6806,21 @@
             },
             {
               "expression": "\"created_at\" desc",
-              "isExpression": true,
               "asc": true,
+              "isExpression": true,
               "nulls": "last"
             },
             {
               "expression": "\"id\" desc",
-              "isExpression": true,
               "asc": true,
+              "isExpression": true,
               "nulls": "last"
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "feed_items_actor_created_at_idx": {
           "name": "feed_items_actor_created_at_idx",
@@ -6712,9 +6839,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "feed_items_created_at_idx": {
           "name": "feed_items_created_at_idx",
@@ -6727,9 +6854,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "feed_items_entity_type_entity_id_idx": {
           "name": "feed_items_entity_type_entity_id_idx",
@@ -6748,29 +6875,29 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "feed_items_recipient_id_users_id_fk": {
           "name": "feed_items_recipient_id_users_id_fk",
           "tableFrom": "feed_items",
-          "columnsFrom": ["recipient_id"],
           "tableTo": "users",
+          "columnsFrom": ["recipient_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "feed_items_actor_id_users_id_fk": {
           "name": "feed_items_actor_id_users_id_fk",
           "tableFrom": "feed_items",
-          "columnsFrom": ["actor_id"],
           "tableTo": "users",
+          "columnsFrom": ["actor_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -6840,20 +6967,20 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "climb_classic_status_last_proposal_id_climb_proposals_id_fk": {
           "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
           "tableFrom": "climb_classic_status",
-          "columnsFrom": ["last_proposal_id"],
           "tableTo": "climb_proposals",
+          "columnsFrom": ["last_proposal_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -6941,20 +7068,20 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "climb_community_status_last_proposal_id_climb_proposals_id_fk": {
           "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
           "tableFrom": "climb_community_status",
-          "columnsFrom": ["last_proposal_id"],
           "tableTo": "climb_proposals",
+          "columnsFrom": ["last_proposal_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -7080,9 +7207,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "climb_proposals_status_idx": {
           "name": "climb_proposals_status_idx",
@@ -7095,9 +7222,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "climb_proposals_proposer_idx": {
           "name": "climb_proposals_proposer_idx",
@@ -7110,9 +7237,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "climb_proposals_board_type_idx": {
           "name": "climb_proposals_board_type_idx",
@@ -7125,9 +7252,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "climb_proposals_created_at_idx": {
           "name": "climb_proposals_created_at_idx",
@@ -7140,37 +7267,37 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "climb_proposals_proposer_id_users_id_fk": {
           "name": "climb_proposals_proposer_id_users_id_fk",
           "tableFrom": "climb_proposals",
-          "columnsFrom": ["proposer_id"],
           "tableTo": "users",
+          "columnsFrom": ["proposer_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "climb_proposals_resolved_by_users_id_fk": {
           "name": "climb_proposals_resolved_by_users_id_fk",
           "tableFrom": "climb_proposals",
-          "columnsFrom": ["resolved_by"],
           "tableTo": "users",
+          "columnsFrom": ["resolved_by"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "climb_proposals_uuid_unique": {
           "name": "climb_proposals_uuid_unique",
-          "columns": ["uuid"],
-          "nullsNotDistinct": false
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -7232,37 +7359,37 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "community_roles_user_id_users_id_fk": {
           "name": "community_roles_user_id_users_id_fk",
           "tableFrom": "community_roles",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "community_roles_granted_by_users_id_fk": {
           "name": "community_roles_granted_by_users_id_fk",
           "tableFrom": "community_roles",
-          "columnsFrom": ["granted_by"],
           "tableTo": "users",
+          "columnsFrom": ["granted_by"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "community_roles_user_role_board_idx": {
           "name": "community_roles_user_role_board_idx",
-          "columns": ["user_id", "role", "board_type"],
-          "nullsNotDistinct": true
+          "nullsNotDistinct": true,
+          "columns": ["user_id", "role", "board_type"]
         }
       },
       "policies": {},
@@ -7348,20 +7475,20 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "community_settings_set_by_users_id_fk": {
           "name": "community_settings_set_by_users_id_fk",
           "tableFrom": "community_settings",
-          "columnsFrom": ["set_by"],
           "tableTo": "users",
+          "columnsFrom": ["set_by"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -7431,9 +7558,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "proposal_votes_proposal_idx": {
           "name": "proposal_votes_proposal_idx",
@@ -7446,29 +7573,29 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "proposal_votes_proposal_id_climb_proposals_id_fk": {
           "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
           "tableFrom": "proposal_votes",
-          "columnsFrom": ["proposal_id"],
           "tableTo": "climb_proposals",
+          "columnsFrom": ["proposal_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "proposal_votes_user_id_users_id_fk": {
           "name": "proposal_votes_user_id_users_id_fk",
           "tableFrom": "proposal_votes",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -7542,9 +7669,9 @@
             }
           ],
           "isUnique": true,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "new_climb_subscriptions_user_idx": {
           "name": "new_climb_subscriptions_user_idx",
@@ -7557,9 +7684,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "new_climb_subscriptions_board_layout_idx": {
           "name": "new_climb_subscriptions_board_layout_idx",
@@ -7578,20 +7705,20 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "new_climb_subscriptions_user_id_users_id_fk": {
           "name": "new_climb_subscriptions_user_id_users_id_fk",
           "tableFrom": "new_climb_subscriptions",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -7670,9 +7797,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "vote_counts_hot_score_idx": {
           "name": "vote_counts_hot_score_idx",
@@ -7691,9 +7818,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -7744,9 +7871,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "board_session_participants_user_idx": {
           "name": "board_session_participants_user_idx",
@@ -7759,29 +7886,29 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "board_session_participants_session_id_board_sessions_id_fk": {
           "name": "board_session_participants_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_participants",
-          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "board_session_participants_user_id_users_id_fk": {
           "name": "board_session_participants_user_id_users_id_fk",
           "tableFrom": "board_session_participants",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {
@@ -7897,9 +8024,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "app_feedback_user_idx": {
           "name": "app_feedback_user_idx",
@@ -7912,9 +8039,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "app_feedback_board_idx": {
           "name": "app_feedback_board_idx",
@@ -7927,20 +8054,20 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
+          "with": {}
         }
       },
       "foreignKeys": {
         "app_feedback_user_id_users_id_fk": {
           "name": "app_feedback_user_id_users_id_fk",
           "tableFrom": "app_feedback",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "set null"
+          "onDelete": "set null",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -7993,11 +8120,11 @@
         "user_climb_percentiles_user_id_users_id_fk": {
           "name": "user_climb_percentiles_user_id_users_id_fk",
           "tableFrom": "user_climb_percentiles",
-          "columnsFrom": ["user_id"],
           "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -8055,24 +8182,9 @@
             }
           ],
           "isUnique": false,
-          "with": {},
+          "concurrently": false,
           "method": "btree",
-          "concurrently": false
-        },
-        "activity_push_tokens_updated_at_idx": {
-          "name": "activity_push_tokens_updated_at_idx",
-          "columns": [
-            {
-              "expression": "updated_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "with": {},
-          "method": "btree",
-          "concurrently": false
+          "with": {}
         },
         "activity_push_tokens_user_idx": {
           "name": "activity_push_tokens_user_idx",
@@ -8088,17 +8200,32 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "activity_push_tokens_updated_at_idx": {
+          "name": "activity_push_tokens_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
         "activity_push_tokens_session_id_board_sessions_id_fk": {
           "name": "activity_push_tokens_session_id_board_sessions_id_fk",
           "tableFrom": "activity_push_tokens",
-          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "cascade"
+          "onDelete": "cascade",
+          "onUpdate": "no action"
         },
         "activity_push_tokens_user_id_users_id_fk": {
           "name": "activity_push_tokens_user_id_users_id_fk",
@@ -8127,6 +8254,11 @@
       "name": "aurora_table_type",
       "schema": "public",
       "values": ["ascents", "bids"]
+    },
+    "public.kilter_table_type": {
+      "name": "kilter_table_type",
+      "schema": "public",
+      "values": ["logs", "attempts"]
     },
     "public.tick_status": {
       "name": "tick_status",
@@ -8184,10 +8316,10 @@
     }
   },
   "schemas": {},
-  "views": {},
   "sequences": {},
   "roles": {},
   "policies": {},
+  "views": {},
   "_meta": {
     "columns": {},
     "schemas": {},

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -708,6 +708,13 @@
       "when": 1778933722490,
       "tag": "0100_backfill_boardsesh_climb_averages",
       "breakpoints": true
+    },
+    {
+      "idx": 101,
+      "version": "7",
+      "when": 1779516909402,
+      "tag": "0101_wild_nextwave",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app/ascents.ts
+++ b/packages/db/src/schema/app/ascents.ts
@@ -31,6 +31,13 @@ export const tickStatusEnum = pgEnum('tick_status', ['flash', 'send', 'attempt']
 export const auroraTableTypeEnum = pgEnum('aurora_table_type', ['ascents', 'bids']);
 
 /**
+ * Kilter table type for sync
+ * - logs: Completed climbs (flash/send) sync to Kilter logs table
+ * - attempts: Failed attempts sync to Kilter attempts table
+ */
+export const kilterTableTypeEnum = pgEnum('kilter_table_type', ['logs', 'attempts']);
+
+/**
  * Boardsesh ticks table
  * Unified table for all climb attempts (successful and failed)
  * Links to NextAuth users, not Aurora board users
@@ -84,6 +91,14 @@ export const boardseshTicks = pgTable(
     auroraId: text('aurora_id'), // UUID in Aurora's system
     auroraSyncedAt: timestamp('aurora_synced_at', { mode: 'string' }),
     auroraSyncError: text('aurora_sync_error'), // Last sync error if any
+
+    // Kilter sync tracking - populated by kilter-sync. A single row can
+    // legitimately carry both aurora_id and kilter_id (Kilter historically
+    // imported Aurora-exported logbooks).
+    kilterType: kilterTableTypeEnum('kilter_type'),
+    kilterId: text('kilter_id'),
+    kilterSyncedAt: timestamp('kilter_synced_at', { mode: 'string' }),
+    kilterSyncError: text('kilter_sync_error'),
   },
   (table) => ({
     // Index for efficient user logbook queries
@@ -95,6 +110,10 @@ export const boardseshTicks = pgTable(
     auroraIdUnique: uniqueIndex('boardsesh_ticks_aurora_id_unique').on(table.auroraId),
     // Index for pending sync queries (ticks without aurora_id)
     syncPendingIdx: index('boardsesh_ticks_sync_pending_idx').on(table.auroraId, table.userId),
+    // Unique index for Kilter sync - allows upsert on kilter_id
+    kilterIdUnique: uniqueIndex('boardsesh_ticks_kilter_id_unique').on(table.kilterId),
+    // Index for pending kilter push queries (ticks without kilter_id)
+    kilterSyncPendingIdx: index('boardsesh_ticks_kilter_sync_pending_idx').on(table.kilterId, table.userId),
     // Index for session queries
     sessionIdx: index('boardsesh_ticks_session_idx').on(table.sessionId),
     // Index for inferred session queries
@@ -121,3 +140,4 @@ export type BoardseshTick = typeof boardseshTicks.$inferSelect;
 export type NewBoardseshTick = typeof boardseshTicks.$inferInsert;
 export type TickStatus = 'flash' | 'send' | 'attempt';
 export type AuroraTableType = 'ascents' | 'bids';
+export type KilterTableType = 'logs' | 'attempts';

--- a/packages/db/src/schema/app/playlists.ts
+++ b/packages/db/src/schema/app/playlists.ts
@@ -26,6 +26,11 @@ export const playlists = pgTable(
     auroraId: text('aurora_id'), // The circuit UUID from Aurora
     auroraSyncedAt: timestamp('aurora_synced_at'), // Last sync timestamp
 
+    // Kilter sync tracking (for circuits synced from / pushed to Kilter)
+    kilterType: text('kilter_type'), // 'circuits' when synced from Kilter
+    kilterId: text('kilter_id'), // The circuit UUID from Kilter
+    kilterSyncedAt: timestamp('kilter_synced_at'),
+
     // Timestamps
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
@@ -42,6 +47,8 @@ export const playlists = pgTable(
     lastAccessedAtIdx: index('playlists_last_accessed_at_idx').on(table.lastAccessedAt),
     // Index for Aurora sync conflict resolution
     auroraIdIdx: uniqueIndex('playlists_aurora_id_idx').on(table.auroraId),
+    // Index for Kilter sync conflict resolution
+    kilterIdIdx: uniqueIndex('playlists_kilter_id_idx').on(table.kilterId),
   }),
 );
 

--- a/packages/db/src/schema/auth/mappings.ts
+++ b/packages/db/src/schema/auth/mappings.ts
@@ -1,7 +1,9 @@
 import { pgTable, bigserial, text, integer, timestamp, index, uniqueIndex } from 'drizzle-orm/pg-core';
 import { users } from './users';
 
-// User board mappings table to link NextAuth users with Aurora board users
+// Links a NextAuth user to a board account. board_user_id holds the Aurora
+// numeric ID; board_user_id_text holds a string identity (e.g. Keycloak sub
+// UUID for Kilter accounts). Exactly one is populated per row.
 export const userBoardMappings = pgTable(
   'user_board_mappings',
   {
@@ -9,20 +11,23 @@ export const userBoardMappings = pgTable(
     userId: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
-    boardType: text('board_type').notNull(), // 'kilter', 'tension', etc.
-    boardUserId: integer('board_user_id').notNull(),
-    boardUsername: text('board_username'), // Store username for display
+    boardType: text('board_type').notNull(),
+    boardUserId: integer('board_user_id'),
+    boardUserIdText: text('board_user_id_text'),
+    boardUsername: text('board_username'),
     linkedAt: timestamp('linked_at').defaultNow().notNull(),
   },
   (table) => ({
-    // Ensure unique mapping per board type for each user
     uniqueUserBoard: uniqueIndex('unique_user_board_mapping').on(table.userId, table.boardType),
-    // Index for efficient lookup by board user
     boardUserIdx: index('board_user_mapping_idx').on(table.boardType, table.boardUserId),
+    boardUserTextIdx: index('board_user_mapping_text_idx').on(table.boardType, table.boardUserIdText),
   }),
 );
 
-// Aurora credentials for Kilter/Tension board accounts (encrypted)
+// Encrypted credentials for board accounts. Aurora-flavoured boards
+// (Tension, originally Kilter) populate encrypted_username/password. Kilter
+// (Keycloak OIDC) populates encrypted_refresh_token instead — the other two
+// are nullable to accommodate that.
 export const auroraCredentials = pgTable(
   'aurora_credentials',
   {
@@ -30,21 +35,20 @@ export const auroraCredentials = pgTable(
     userId: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
-    boardType: text('board_type').notNull(), // 'kilter', 'tension'
-    encryptedUsername: text('encrypted_username').notNull(),
-    encryptedPassword: text('encrypted_password').notNull(),
-    auroraUserId: integer('aurora_user_id'), // Aurora board user ID after successful login
-    auroraToken: text('aurora_token'), // Session token (encrypted)
-    lastSyncAt: timestamp('last_sync_at'), // Last successful sync
-    syncStatus: text('sync_status').default('pending').notNull(), // 'pending', 'active', 'error', 'expired'
-    syncError: text('sync_error'), // Error message if sync failed
+    boardType: text('board_type').notNull(),
+    encryptedUsername: text('encrypted_username'),
+    encryptedPassword: text('encrypted_password'),
+    encryptedRefreshToken: text('encrypted_refresh_token'),
+    auroraUserId: integer('aurora_user_id'),
+    auroraToken: text('aurora_token'),
+    lastSyncAt: timestamp('last_sync_at'),
+    syncStatus: text('sync_status').default('pending').notNull(), // 'pending' | 'active' | 'error' | 'expired'
+    syncError: text('sync_error'),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },
   (table) => ({
-    // Ensure unique credential per board type for each user
     uniqueUserBoardCredential: uniqueIndex('unique_user_board_credential').on(table.userId, table.boardType),
-    // Index for efficient lookup by user
     userCredentialsIdx: index('aurora_credentials_user_idx').on(table.userId),
   }),
 );

--- a/packages/web/app/api/internal/aurora-credentials/route.ts
+++ b/packages/web/app/api/internal/aurora-credentials/route.ts
@@ -50,11 +50,15 @@ export async function GET() {
     // Return credentials without sensitive data
     const credentialStatuses: AuroraCredentialStatus[] = credentials.map((cred) => {
       let username: string;
-      try {
-        username = decrypt(cred.encryptedUsername);
-      } catch (decryptError) {
-        console.error(`Failed to decrypt username for ${cred.boardType} credential:`, decryptError);
-        username = '[Decryption Failed]';
+      if (!cred.encryptedUsername) {
+        username = '';
+      } else {
+        try {
+          username = decrypt(cred.encryptedUsername);
+        } catch (decryptError) {
+          console.error(`Failed to decrypt username for ${cred.boardType} credential:`, decryptError);
+          username = '[Decryption Failed]';
+        }
       }
 
       return {

--- a/packages/web/app/lib/auth/user-board-mappings.ts
+++ b/packages/web/app/lib/auth/user-board-mappings.ts
@@ -7,7 +7,8 @@ export type UserBoardMapping = {
   id: string;
   userId: string;
   boardType: BoardName;
-  boardUserId: number;
+  boardUserId: number | null;
+  boardUserIdText: string | null;
   boardUsername: string | null;
   linkedAt: Date;
 };
@@ -69,6 +70,7 @@ export async function getUserBoardMappings(userId: string): Promise<UserBoardMap
     userId: row.userId,
     boardType: row.boardType as BoardName,
     boardUserId: row.boardUserId,
+    boardUserIdText: row.boardUserIdText,
     boardUsername: row.boardUsername,
     linkedAt: row.linkedAt,
   }));


### PR DESCRIPTION
## Summary

First in a series of small PRs adding [Kilter Grips](https://kiltergrips.com) sync to Boardsesh. **Pure plumbing — no behavior change, no callers yet.** Subsequent PRs build the `packages/kilter-sync/` package on top.

- \`aurora_credentials\`: relax \`encrypted_username\` / \`encrypted_password\` to NULLABLE, add \`encrypted_refresh_token\`. Kilter (Keycloak OIDC) rows leave the first two empty.
- \`user_board_mappings\`: relax \`board_user_id\` to NULLABLE, add \`board_user_id_text\` for the Keycloak \`sub\` UUID. Aurora rows keep using the integer column.
- \`boardsesh_ticks\`: parallel \`kilter_type\` / \`kilter_id\` / \`kilter_synced_at\` / \`kilter_sync_error\` alongside the existing \`aurora_*\` columns. A single tick row can carry both IDs (Kilter historically imported Aurora-exported logbooks).
- \`playlists\`: same \`kilter_type\` / \`kilter_id\` / \`kilter_synced_at\` shape.

## Drift fix included

The 0099 and 0100 drizzle snapshots had dropped \`activity_push_tokens.user_id\` (added in migration 0098). Without patching them, every subsequent \`drizzle-kit generate\` would try to re-add that column. The migration SQL is untouched — this only fixes the snapshot files. Happy to split into a separate PR if reviewers prefer; included inline because PR 1 can't generate cleanly otherwise.

## Test plan

- [x] \`vp run typecheck\` (web, backend, db, shared) all green
- [x] \`vp run db:migrate\` applies cleanly against a fresh dev DB
- [x] \`vp lint\` and \`vp fmt\` clean
- [x] Verified column shapes via \`psql\` after apply:
  - \`aurora_credentials.encrypted_username\` / \`encrypted_password\` nullable, \`encrypted_refresh_token\` present
  - \`boardsesh_ticks.kilter_*\` four columns present, unique index on \`kilter_id\`
  - \`playlists.kilter_*\` three columns present, unique index on \`kilter_id\`
- [ ] Re-run aurora-sync end-to-end to confirm Aurora writer unaffected (will smoke test in PR 5 once kilter-sync scaffold is up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)