### PR TITLE
Finish the Queue Control Bar pivot: Phase 3 queue list + Phase 5 events + Q2/Q5

### DIFF
--- a/docs/queue-control-bar-pivot.md
+++ b/docs/queue-control-bar-pivot.md
@@ -1,6 +1,6 @@
 # Queue Control Bar Pivot — Bar Mirrors the Wall, Lightbulb Controls the Driver
 
-**Status:** Phases 1–3 + simplified Phase 4 shipping together in #2198 (retargeted to `main`). Earlier stack (#2188, #2195, #2197) collapsed into the single PR after the design simplification on 2026-05-17.
+**Status:** Phases 1–3 + simplified Phase 4 shipped in #2198 on 2026-05-18. A follow-up PR (2026-05-23) closes the remaining gaps: Phase 3 queue-list 5-item history + center-on-open, Phase 5 `Wall Advance` + `Session Board Serial Set` events, bar prev/next "on the wall" aria-label polish, hand-off toast (Open Q2), stale board-serial defensive clear (Open Q5), `isLeader` audit. See the "What shipped vs spec" appendix at the bottom for the full divergence list. Earlier stack (#2188, #2195, #2197) collapsed into #2198 after the design simplification on 2026-05-17.
 **Decision date:** 2026-05-16 (original); simplified 2026-05-17
 **Driven by:** Observed user-testing pain in large-group party sessions, supported by 3 months of Vercel Analytics + 1 week of PostHog
 **Owner (assign on pickup):** TBD
@@ -68,16 +68,20 @@ _Open behavior:_ when the list is opened (drawer or full-screen view), scroll so
 
 ## Wall-view drawer (tap the bar)
 
-Tapping the Queue Control Bar itself opens a _wall-view drawer_ showing the climb currently lit on the wall. This is a distinct drawer mode from the normal "I tapped a climb in the list" drawer:
+_Shipped state (post-PR #2198 + follow-ups #2238 and the open queue-pivot finish PR)_: the drawer has a "wall-view mode" rather than a separate drawer instance — opened from a bar tap with the wall climb pinned, the same component flips into a non-driver-locked state. The pivot's original "separate drawer" framing was simplified during review; the final shape uses chips and a header strip inside the existing drawer.
 
-- _No prev/next buttons_ inside this drawer (the controls live on the bar itself; this view is anchored to the wall climb).
-- _No swipe gesture_ inside this drawer. The view is locked to whatever is currently lit. To browse other climbs, the user closes the drawer and uses the list or search.
-- _"Currently on the wall" label_ at the top of the drawer so the mode is unambiguous.
-- _Driver's avatar inline near the label_ — same avatar that carries the lit lightbulb badge in the bar's `AvatarGroup`. Tap-through behaviour mirrors the bar avatar (opens roster).
-- _Lightbulb stays available_ with the same semantics and visual rules as everywhere else: filled/lit when the local user is the driver (press to release), empty/outlined when someone else is driving (press to take). Gives the user a take-control path from this view without backing out. This is the same single lightbulb instance — the drawer just happens to be in wall-view mode.
-- _Standard climb actions remain_ — Add to Queue, Open in Aurora, Mirror, Fork, tick logging, etc. The restriction is navigation-only.
+How it actually works today:
 
-Contrast with the normal drawer (opened by tapping a climb in the list): that one shows the _tapped_ climb (not the wall climb), supports swipe-as-preview for non-drivers / swipe-as-broadcast for drivers, and shows prev/next for drivers. The two drawers share most of the underlying component; the differences are state-driven from how the drawer was opened.
+- _Opened from a bar tap_, the drawer pins to `state.currentClimbQueueItem` (the wall climb) via the `openedFromBar` payload.
+- _Header strip_ renders "Currently on the wall" / "{username} is on the wall" via `playView.wallViewHeader` / `wallViewHeaderDriver` and a `LockOutlined` indicator. Tapping the strip's "Browse from here" link exits wall-view mode without closing the drawer.
+- _`DRIVING` chip_ when the local user is the driver (so the user can tell at a glance that their drawer is the authoritative one).
+- _`Preview` chip_ when the local user is a non-driver actively previewing — appears once they swipe inside the drawer; the wall-view header collapses to make room. Paired with a coachmark explaining "Tap the lightbulb to send it to the wall."
+- _Swipe gesture is enabled for drivers_ inside wall-view (so drivers can drive without exiting), _disabled for non-drivers_ in wall-view (the preview path requires explicitly tapping past the lock).
+- _No drawer prev/next buttons_ for non-drivers — they remain driver-only as the spec required.
+- _Drawer lightbulb stays available_ with the same outlined/filled/pending states everywhere else, giving anyone in the drawer a take-control path without backing out.
+- _Standard climb actions remain_ — Add to Queue, Open in Aurora, Mirror, Fork, tick logging, etc.
+
+Contrast with the normal drawer (opened by tapping a climb in the list): same component, but no wall-view header / chips / lock. Drivers swipe to broadcast; non-drivers swipe to preview through `suggestedClimbs` only.
 
 ## User flows after the pivot
 
@@ -253,7 +257,7 @@ Queue Operation breakdown (3-month, sampled at max 5 per op-type per session; vi
 - `addToQueue` — 6%, 425 visitors.
 - Long tail: `replaceQueueItem` 2%, `setQueue` 2%, `mirrorClimb` 1%.
 
-`Add to Queue` UI events (3 months) by source: `swipe` 240, `climbActions` 183. The dedicated `queueButton` source fires zero events because the component (`packages/web/app/components/climb-actions/queue-button.tsx`) is exported from the climb-actions index but _never rendered on any route_ — verified via grep for `<QueueButton` JSX. The `track('Add to Queue', { source: 'queueButton' })` call inside it is wired correctly; it simply has no caller. Treat as dead UI: either delete the component in a Phase 6 cleanup or re-mount it intentionally as part of the "Add to Up next" rename in PR 3 if we want a third entry point. The zero-event signal is therefore "no surface", not "instrumentation gap".
+`Add to Queue` UI events (3 months) by source: `swipe` 240, `climbActions` 183. The dedicated `queueButton` source fires zero events because the component (`packages/web/app/components/climb-actions/queue-button.tsx`) is exported from the climb-actions index but _never rendered on any route_ — verified via grep for `<QueueButton` JSX. The `track('Add to Queue', { source: 'queueButton' })` call inside it is wired correctly; it simply has no caller. The file now carries a `TODO(queue-bar-pivot)` marker at the top pointing back to this doc; pick it up alongside other follow-up cleanups (either delete or re-mount as a third entry point). The zero-event signal is "no surface", not "instrumentation gap".
 
 `Queue Navigation` UI events (PostHog week — directionally stable): 4,753 next-swipes + 1,085 previous-swipes inside the Play View drawer. 20 events combined on the Queue Control Bar arrows/swipe. 8 events on the bar's button arrows. The persistent control bar is structurally unused as an interaction surface.
 
@@ -296,3 +300,17 @@ Not blockers. The implementing engineer should make the call in code review with
 - Do not change Workout Generator or Onboarding in this PR.
 - Do not collapse the existing `Set Active Climb` event into the new `Wall Control Taken` event. Keep them distinct for analytics continuity.
 - Do not surface a "Wall offline" indicator, BLE-holder attribution, or any other internal connection-state UI on the bar. The 2-second drawer fallback is the only legible recovery surface; everything else stays implicit.
+
+## What shipped vs spec
+
+PR #2198 (merged 2026-05-18) shipped Phases 1–3 + simplified Phase 4. A follow-up PR closes the remaining gaps. The list below captures the deviations from the original spec that landed so a future reader doesn't trip on them.
+
+- _Wall-view drawer mode_ — the spec described a separate drawer mode opened from a bar tap (lines 69-80 above, now rewritten). Commit `0317b3147` (design churn) deleted the dedicated mode and replaced it with an `ON WALL` chip on the bar. Commit `18a3c1069` moved the chip back into the drawer. Commit `489e1686f` added a `DRIVING` chip in the drawer for drivers. End state: the drawer has wall-view chrome (header strip + lock indicator + DRIVING chip for drivers + Preview chip for non-drivers after swipe + "Browse from here" exit link) but is the same component as the normal drawer.
+- _Component consolidation_ — `next-climb-button.tsx` + `previous-climb-button.tsx` were merged into a single `queue-nav-button.tsx`. Driver-only gating in the drawer happens at the drawer level, not inside the button.
+- _Wall Confirm Timeout event_ — added beyond spec as a kill-switch counter-metric (`use-wall-confirm-fallback.ts:180-201`). Pairs with `Wall Confirmed` to compute the silent-no-BLE-recovery share without inferring it from a missing event.
+- _Group-session ride-along (#2238)_ — `setSessionBoardPath` mutation + `SessionBoardPathChanged` event broadcast angle changes between members. Not pivot scope but related plumbing.
+- _Doc-vs-shipped queue-list rendering_ — Phase 3's 5-item history default, "Show full history" toggle, and center-on-open scroll were missing from PR #2198 and ship in the follow-up. Spec line 63-67 still describes the target behaviour; code now matches.
+- _Phase 5 instrumentation backfill_ — PR #2198 wired `Wall Control Taken`, `Wall Control Released`, and `Wall Confirmed`. The follow-up adds `Wall Advance` (bar button, bar swipe, drawer button, drawer swipe — all broadcast paths) and `Session Board Serial Set`. Live Activity widget `Wall Advance` is intentionally deferred to a separate iOS-touching PR.
+- _isLeader audit (Phase 2, 2026-05-23)_ — the spec required confirming no `isLeader` / `leaderId` / `leaderConnectionId` / `LeaderChanged` site gates wall-control. Confirmed across backend, web, shared-schema, and iOS native code. The only authorization use of `isLeader` is `endSession` (`mutations.ts:870`), which gates session termination — not wall control. Wall-control authority lives on `driverParticipantId`. A short audit comment at the top of `mutations.ts` records the result; no porting was needed.
+- _Hand-off toast (Open Q2)_ — the follow-up wires a quiet info-level snackbar on `DriverChanged` for non-self transitions ("Alice is driving the wall.", "Alice took the wall from Bob.", "Alice took the wall.") using the existing `previousDriverParticipantId` field on the event.
+- _Stale board serial recovery (Open Q5)_ — `bluetooth-context.tsx` now skips redundant `setSessionBoardSerial` writes when the new serial matches the stored one, and overwrites the field on every successful pick of a different board. No new UI; defensive only.

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -35,6 +35,21 @@ import { endLiveActivity } from '../../../services/apns';
 import { setCurrentClimbAndPublish } from '../../../services/queue-navigation';
 
 /**
+ * Queue-control-bar pivot — `isLeader` audit (2026-05-23):
+ * Confirmed that no `isLeader` / `leaderId` / `leaderConnectionId` /
+ * `LeaderChanged` site in this file gates wall-control. The only
+ * authorization use is `endSession` (line 870), which checks
+ * `isCreator || isLeader` to authorize SESSION TERMINATION — not driver /
+ * wall-control. Every other `isLeader` reference here is presentation:
+ * passed back through the `Session.isLeader` field so clients can show the
+ * legacy host-crown badge without a refetch. Wall-control authority lives
+ * exclusively on `driverParticipantId` (added in PR #2198) and is gated by
+ * `takeControl` / `releaseControl`. Web, iOS, and shared-schema searches
+ * also turned up nothing wall-control-gated by `isLeader`. See
+ * `docs/queue-control-bar-pivot.md` (What shipped vs spec) for details.
+ */
+
+/**
  * Auto-authorize all controllers owned by a user for a session.
  * Called when user joins a session to allow their ESP32 devices to connect.
  */

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -126,7 +126,9 @@ vi.mock('@/app/lib/ble/capacitor-utils', () => ({
 
 const mockConfirmClimbOnWall = vi.fn().mockResolvedValue(undefined);
 const mockSetSessionBoardSerial = vi.fn().mockResolvedValue(undefined);
-let mockPersistentSessionState: { session: { id: string } | null } = { session: null };
+let mockPersistentSessionState: { session: { id: string; lastConnectedBoardSerial?: string | null } | null } = {
+  session: null,
+};
 vi.mock('@/app/components/persistent-session', () => ({
   usePersistentSessionActions: () => ({
     confirmClimbOnWall: mockConfirmClimbOnWall,
@@ -785,6 +787,77 @@ describe('BluetoothProvider', () => {
       });
 
       expect(mockSetSessionBoardSerial).not.toHaveBeenCalled();
+    });
+
+    it('skips setSessionBoardSerial when the new serial matches the session value (Open Q5 defensive clear: no churn on idempotent reconnect)', async () => {
+      mockPersistentSessionState = { session: { id: 'session-1', lastConnectedBoardSerial: 'KB-12345' } };
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        lastUseBoardBluetoothOptions?.onConnectSuccess?.('KB-12345');
+        await Promise.resolve();
+      });
+
+      expect(mockSetSessionBoardSerial).not.toHaveBeenCalled();
+      expect(mockTrack.mock.calls.find((args) => args[0] === 'Session Board Serial Set')).toBeUndefined();
+    });
+
+    it('overwrites a stale serial when reconnect resolves a different board (Open Q5 defensive clear)', async () => {
+      mockPersistentSessionState = { session: { id: 'session-1', lastConnectedBoardSerial: 'KB-OLD' } };
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        lastUseBoardBluetoothOptions?.onConnectSuccess?.('KB-NEW');
+        await Promise.resolve();
+      });
+
+      expect(mockSetSessionBoardSerial).toHaveBeenCalledWith('KB-NEW');
+    });
+
+    it("fires Session Board Serial Set with previousSerialKnown=false on the session's first pairing", async () => {
+      mockPersistentSessionState = { session: { id: 'session-1', lastConnectedBoardSerial: null } };
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        lastUseBoardBluetoothOptions?.onConnectSuccess?.('KB-12345');
+        await Promise.resolve();
+      });
+
+      const call = mockTrack.mock.calls.find((args) => args[0] === 'Session Board Serial Set');
+      expect(call).toBeTruthy();
+      expect(call?.[1]).toMatchObject({
+        mode: 'party',
+        previousSerialKnown: false,
+      });
+    });
+
+    it('fires Session Board Serial Set with previousSerialKnown=true on a board swap', async () => {
+      mockPersistentSessionState = { session: { id: 'session-1', lastConnectedBoardSerial: 'KB-OLD' } };
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        lastUseBoardBluetoothOptions?.onConnectSuccess?.('KB-NEW');
+        await Promise.resolve();
+      });
+
+      const call = mockTrack.mock.calls.find((args) => args[0] === 'Session Board Serial Set');
+      expect(call).toBeTruthy();
+      expect(call?.[1]).toMatchObject({
+        mode: 'party',
+        previousSerialKnown: true,
+      });
     });
 
     it('routes confirmClimbOnWall through the live session when a session is joined mid-send', async () => {

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -820,6 +820,32 @@ describe('BluetoothProvider', () => {
       expect(mockSetSessionBoardSerial).toHaveBeenCalledWith('KB-NEW');
     });
 
+    it('does not re-fire setSessionBoardSerial on a back-to-back reconnect to the same board (cache updated synchronously)', async () => {
+      // Reproduces the race the in-memory ref guards against: session state
+      // still holds the old serial because SessionBoardSerialChanged hasn't
+      // landed yet, but the user disconnects + reconnects to the same board.
+      // Without the synchronous ref update, the second onConnectSuccess would
+      // see previousSerial=null and re-fire the mutation + analytics event.
+      mockPersistentSessionState = { session: { id: 'session-1', lastConnectedBoardSerial: null } };
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        lastUseBoardBluetoothOptions?.onConnectSuccess?.('KB-12345');
+        await Promise.resolve();
+      });
+      // Second reconnect to the same board before the WS event lands.
+      await act(async () => {
+        lastUseBoardBluetoothOptions?.onConnectSuccess?.('KB-12345');
+        await Promise.resolve();
+      });
+
+      expect(mockSetSessionBoardSerial).toHaveBeenCalledTimes(1);
+      expect(mockTrack.mock.calls.filter((args) => args[0] === 'Session Board Serial Set')).toHaveLength(1);
+    });
+
     it("fires Session Board Serial Set with previousSerialKnown=false on the session's first pairing", async () => {
       mockPersistentSessionState = { session: { id: 'session-1', lastConnectedBoardSerial: null } };
 

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -249,14 +249,41 @@ export function BluetoothProvider({
     sessionIdRef.current = sessionId;
   }, [sessionId]);
 
+  // Snapshot the most recently observed lastConnectedBoardSerial so the
+  // connect-success callback can compute `previousSerialKnown` for the Phase 5
+  // `Session Board Serial Set` event without taking the live session object as
+  // a dep (which would re-create the callback on every event).
+  const lastConnectedBoardSerialRef = useRef<string | null>(
+    persistentSessionState.session?.lastConnectedBoardSerial ?? null,
+  );
+  useEffect(() => {
+    lastConnectedBoardSerialRef.current = persistentSessionState.session?.lastConnectedBoardSerial ?? null;
+  }, [persistentSessionState.session?.lastConnectedBoardSerial]);
+
   const handleConnectSuccess = useCallback(
     (serial: string | null) => {
       if (!serial) return;
-      if (sessionIdRef.current) {
-        void setSessionBoardSerial(serial);
-      }
+      if (!sessionIdRef.current) return;
+      const previousSerial = lastConnectedBoardSerialRef.current;
+      // Open Q5 defensive clear: every successful pick overwrites whatever
+      // the session held — so a stale lastConnectedBoardSerial pointing at a
+      // board that has since moved gyms gets replaced as soon as anyone
+      // re-pairs against a different board. Skip the WS round-trip when the
+      // new serial matches what the session already has (and skip the
+      // analytics emit too — same-serial reconnect isn't a state change).
+      if (previousSerial === serial) return;
+      void setSessionBoardSerial(serial);
+      // Pivot Phase 5: sanity check that the field gets populated on real
+      // sessions. Always 'party' here — the surrounding sessionIdRef gate
+      // already excludes solo. `previousSerialKnown` distinguishes the
+      // first pairing of a session from a re-pair / board swap.
+      track('Session Board Serial Set', {
+        mode: 'party',
+        previousSerialKnown: previousSerial != null,
+        boardLayout: boardDetails?.layout_name ?? '',
+      });
     },
-    [setSessionBoardSerial],
+    [setSessionBoardSerial, boardDetails?.layout_name],
   );
 
   const { isConnected, loading, connect, disconnect, sendFramesToBoard, pickerState } = useBoardBluetooth({

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -272,6 +272,12 @@ export function BluetoothProvider({
       // new serial matches what the session already has (and skip the
       // analytics emit too — same-serial reconnect isn't a state change).
       if (previousSerial === serial) return;
+      // Update the ref synchronously so back-to-back reconnects (a quick
+      // disconnect → reconnect to the same board before the WS round-trip
+      // lands SessionBoardSerialChanged) don't re-fire the mutation. The
+      // useEffect above will re-sync once the event arrives — same value,
+      // safe no-op.
+      lastConnectedBoardSerialRef.current = serial;
       void setSessionBoardSerial(serial);
       // Pivot Phase 5: sanity check that the field gets populated on real
       // sessions. Always 'party' here — the surrounding sessionIdRef gate

--- a/packages/web/app/components/climb-actions/queue-button.tsx
+++ b/packages/web/app/components/climb-actions/queue-button.tsx
@@ -1,5 +1,11 @@
 'use client';
 
+// TODO(queue-bar-pivot): exported but not rendered on any route — the
+// `queueButton` source on the `Add to Queue` analytics event has produced
+// zero hits in 3 months because nothing mounts this component. Either delete
+// alongside the other follow-up cleanups or re-mount intentionally as a
+// third entry point for "Add to Up next". See
+// docs/queue-control-bar-pivot.md ("What shipped vs spec" appendix).
 import React, { useState, useCallback } from 'react';
 import AddCircleOutlined from '@mui/icons-material/AddCircleOutlined';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -345,13 +345,23 @@ export const GraphQLQueueProvider = ({
               latest.showMessage(latest.t('driverToast.tookFromYou', { newDriver: newDriverName }), 'info');
             } else {
               const previousDriverName = latest.users.find((user) => user.id === previousDriverId)?.username ?? '';
-              latest.showMessage(
-                latest.t('driverToast.tookFromOther', {
-                  newDriver: newDriverName,
-                  previousDriver: previousDriverName,
-                }),
-                'info',
-              );
+              // The previous driver can be gone from `users` by the time the
+              // event arrives (left the session in the same tick they were
+              // yanked, or distributed-state propagation reordered).
+              // Surfacing "X took the wall from ." is worse than dropping the
+              // attribution — fall through to the simpler firstDriver copy so
+              // the toast still names the new driver and reads cleanly.
+              if (previousDriverName) {
+                latest.showMessage(
+                  latest.t('driverToast.tookFromOther', {
+                    newDriver: newDriverName,
+                    previousDriver: previousDriverName,
+                  }),
+                  'info',
+                );
+              } else {
+                latest.showMessage(latest.t('driverToast.firstDriver', { newDriver: newDriverName }), 'info');
+              }
             }
           }
         }

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -323,6 +323,38 @@ export const GraphQLQueueProvider = ({
         if (localParticipantId && newDriverId && newDriverId !== localParticipantId) {
           latest.persistentSession.triggerResync();
         }
+        // Hand-off toast: surface peer-driven driver changes so members know
+        // someone else just took or is now driving the wall. Spec recommends
+        // quiet info-level toast, no haptic, no sound. Suppressed when the
+        // local user IS the new driver — they pressed the lightbulb themselves
+        // and don't need to be told. Also suppressed when control was released
+        // without a successor (newDriverId === null) — nothing to attribute.
+        //
+        // i18n-keep session:driverToast.firstDriver
+        // i18n-keep session:driverToast.tookFromYou
+        // i18n-keep session:driverToast.tookFromOther
+        // (The orphan-key checker can't resolve `latest.t(...)` to a
+        // useTranslation binding; the keys are statically used here.)
+        if (newDriverId && newDriverId !== localParticipantId) {
+          const newDriverName = latest.users.find((user) => user.id === newDriverId)?.username ?? '';
+          const previousDriverId = event.previousDriverParticipantId ?? null;
+          if (newDriverName) {
+            if (!previousDriverId) {
+              latest.showMessage(latest.t('driverToast.firstDriver', { newDriver: newDriverName }), 'info');
+            } else if (previousDriverId === localParticipantId) {
+              latest.showMessage(latest.t('driverToast.tookFromYou', { newDriver: newDriverName }), 'info');
+            } else {
+              const previousDriverName = latest.users.find((user) => user.id === previousDriverId)?.username ?? '';
+              latest.showMessage(
+                latest.t('driverToast.tookFromOther', {
+                  newDriver: newDriverName,
+                  previousDriver: previousDriverName,
+                }),
+                'info',
+              );
+            }
+          }
+        }
       }
     });
     return unsubscribe;
@@ -470,6 +502,9 @@ export const GraphQLQueueProvider = ({
     validateQueueAdd,
     boardDetails,
     sessionId,
+    users,
+    showMessage,
+    t,
   });
   // Sync ref every render (synchronous — safe for refs)
   latestRef.current = {
@@ -497,6 +532,9 @@ export const GraphQLQueueProvider = ({
     validateQueueAdd,
     boardDetails,
     sessionId,
+    users,
+    showMessage,
+    t,
   };
 
   // --- Stable action callbacks (read from latestRef, never recreated) ---

--- a/packages/web/app/components/graphql-queue/__tests__/driver-handoff-toast.test.tsx
+++ b/packages/web/app/components/graphql-queue/__tests__/driver-handoff-toast.test.tsx
@@ -1,0 +1,309 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { SessionEvent } from '@boardsesh/shared-schema';
+
+// --- Mocks must come before importing GraphQLQueueProvider ---
+
+const mockShowMessage = vi.fn();
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/kilter/1/1/1/40',
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock('../../queue-control/hooks/use-queue-data-fetching', () => ({
+  useQueueDataFetching: () => ({
+    climbSearchResults: null,
+    suggestedClimbs: [],
+    totalSearchResultCount: 0,
+    hasMoreResults: false,
+    isFetchingClimbs: false,
+    isFetchingNextPage: false,
+    fetchMoreClimbs: vi.fn(),
+    climbUuids: [],
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'en-US' },
+    // Echo the key + placeholders so assertions can match without loading the
+    // real catalog. Keeps the test independent of copy churn.
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (!options) return key;
+      let out = key;
+      for (const [k, v] of Object.entries(options)) {
+        out = `${out}|${k}=${String(v)}`;
+      }
+      return out;
+    },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const sessionEventSubscribers = new Set<(event: SessionEvent) => void>();
+function emitSessionEvent(event: SessionEvent) {
+  sessionEventSubscribers.forEach((cb) => cb(event));
+}
+
+const mockPersistentSession = {
+  activeSession: {
+    sessionId: 'session-1',
+    boardPath: '/kilter/1/1/1/40',
+    boardDetails: {},
+    parsedParams: {},
+  } as {
+    sessionId: string;
+    boardPath: string;
+    boardDetails: unknown;
+    parsedParams: unknown;
+  } | null,
+  session: {
+    clientId: 'client-1',
+    participantId: 'participant-1',
+    isLeader: true,
+    users: [
+      { id: 'participant-1', username: 'Alice', isLeader: true },
+      { id: 'participant-2', username: 'Bob', isLeader: false },
+      { id: 'participant-3', username: 'Carol', isLeader: false },
+    ],
+    goal: null,
+  },
+  isConnecting: false,
+  hasConnected: true,
+  error: null,
+  clientId: 'client-1',
+  participantId: 'participant-1',
+  isLeader: true,
+  driverParticipantId: null as string | null,
+  users: [
+    { id: 'participant-1', username: 'Alice', isLeader: true, connectionState: 'connected' },
+    { id: 'participant-2', username: 'Bob', isLeader: false, connectionState: 'connected' },
+    { id: 'participant-3', username: 'Carol', isLeader: false, connectionState: 'connected' },
+  ],
+  currentClimbQueueItem: null,
+  queue: [],
+  localQueue: [],
+  localCurrentClimbQueueItem: null,
+  localBoardPath: null,
+  localBoardDetails: null,
+  isLocalQueueLoaded: true,
+  setLocalQueueState: vi.fn(),
+  clearLocalQueue: vi.fn(),
+  activateSession: vi.fn(),
+  deactivateSession: vi.fn(),
+  setInitialQueueForSession: vi.fn(),
+  addQueueItem: vi.fn().mockResolvedValue(undefined),
+  removeQueueItem: vi.fn().mockResolvedValue(undefined),
+  setCurrentClimb: vi.fn().mockResolvedValue(undefined),
+  mirrorCurrentClimb: vi.fn().mockResolvedValue(undefined),
+  setQueue: vi.fn().mockResolvedValue(undefined),
+  replaceQueueItem: vi.fn().mockResolvedValue(undefined),
+  takeControl: vi.fn().mockResolvedValue(undefined),
+  releaseControl: vi.fn().mockResolvedValue(undefined),
+  confirmClimbOnWall: vi.fn().mockResolvedValue(undefined),
+  setSessionBoardSerial: vi.fn().mockResolvedValue(undefined),
+  offlineBufferRef: { current: [] as unknown[] },
+  lastReceivedSequenceRef: { current: null as number | null },
+  subscribeToQueueEvents: vi.fn(() => vi.fn()),
+  subscribeToSessionEvents: vi.fn((cb: (event: SessionEvent) => void) => {
+    sessionEventSubscribers.add(cb);
+    return () => sessionEventSubscribers.delete(cb);
+  }),
+  triggerResync: vi.fn(),
+  endSessionWithSummary: vi.fn(),
+  sessionSummary: null,
+  sessionSummaryBoardType: null,
+  sessionSummaryHealthKitWorkoutId: null,
+  sessionSummaryAutoFinished: false,
+  setAutoFinishedSummary: vi.fn(),
+  dismissSessionSummary: vi.fn(),
+};
+
+vi.mock('../../connection-manager/websocket-connection-provider', () => ({
+  useWebSocketConnection: () => ({ state: 'connected', name: 'session' }),
+}));
+
+vi.mock('../../party-manager/party-profile-context', () => ({
+  usePartyProfile: () => ({ profile: { id: 'user-1' }, username: 'Alice', avatarUrl: undefined }),
+}));
+
+vi.mock('../../connection-manager/connection-settings-context', () => ({
+  useConnectionSettings: () => ({ backendUrl: 'wss://example.com/graphql' }),
+}));
+
+vi.mock('../../persistent-session', () => ({
+  usePersistentSession: () => mockPersistentSession,
+  usePersistentSessionState: () => mockPersistentSession,
+  usePersistentSessionActions: () => mockPersistentSession,
+  PersistentSessionProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('../../climb-actions/favorites-batch-context', () => ({
+  FavoritesProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('../../climb-actions/playlists-batch-context', () => ({
+  PlaylistsProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/app/hooks/use-climb-actions-data', () => ({
+  useClimbActionsData: () => ({ favoritesProviderProps: {}, playlistsProviderProps: {} }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'mock-token', isLoading: false }),
+}));
+
+vi.mock('@/app/lib/climb-session-cookie', () => ({
+  getClimbSessionCookie: () => 'session-1',
+  setClimbSessionCookie: vi.fn(),
+  clearClimbSessionCookie: vi.fn(),
+}));
+
+vi.mock('@/app/lib/session-history-db', () => ({ saveSessionToHistory: vi.fn() }));
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: vi.fn(() => ({ request: vi.fn() })),
+}));
+
+vi.mock('../../session-summary/session-summary-dialog', () => ({ default: () => null }));
+
+// Import AFTER mocks
+import { GraphQLQueueProvider, useQueueContext } from '../QueueContext';
+
+const defaultProps = {
+  parsedParams: {
+    board_name: 'kilter',
+    layout_id: '1',
+    size_id: '1',
+    set_ids: ['1'],
+    angle: '40',
+  } as never,
+  boardDetails: {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: '1',
+    images_to_holds: {},
+    layout_name: 'Original',
+    size_name: '12x12',
+    size_description: 'Standard',
+    set_names: ['Base'],
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+  } as never,
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <GraphQLQueueProvider {...defaultProps}>{children}</GraphQLQueueProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('driver hand-off toast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionEventSubscribers.clear();
+    mockPersistentSession.driverParticipantId = null;
+    mockPersistentSession.participantId = 'participant-1';
+    mockShowMessage.mockClear();
+  });
+
+  it('fires firstDriver copy when someone else takes the wall and there was no previous driver', () => {
+    renderHook(() => useQueueContext(), { wrapper: createWrapper() });
+
+    act(() => {
+      emitSessionEvent({
+        __typename: 'DriverChanged',
+        driverParticipantId: 'participant-2',
+        previousDriverParticipantId: null,
+      });
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith(
+      expect.stringContaining('driverToast.firstDriver|newDriver=Bob'),
+      'info',
+    );
+  });
+
+  it('fires tookFromYou copy when someone else takes the wall away from the local user', () => {
+    renderHook(() => useQueueContext(), { wrapper: createWrapper() });
+
+    act(() => {
+      emitSessionEvent({
+        __typename: 'DriverChanged',
+        driverParticipantId: 'participant-2',
+        previousDriverParticipantId: 'participant-1',
+      });
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith(
+      expect.stringContaining('driverToast.tookFromYou|newDriver=Bob'),
+      'info',
+    );
+  });
+
+  it('fires tookFromOther copy when the local user is uninvolved in the hand-off', () => {
+    renderHook(() => useQueueContext(), { wrapper: createWrapper() });
+
+    act(() => {
+      emitSessionEvent({
+        __typename: 'DriverChanged',
+        driverParticipantId: 'participant-2',
+        previousDriverParticipantId: 'participant-3',
+      });
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith(
+      expect.stringContaining('driverToast.tookFromOther|newDriver=Bob|previousDriver=Carol'),
+      'info',
+    );
+  });
+
+  it('suppresses the toast when the local user is the new driver', () => {
+    renderHook(() => useQueueContext(), { wrapper: createWrapper() });
+
+    act(() => {
+      emitSessionEvent({
+        __typename: 'DriverChanged',
+        driverParticipantId: 'participant-1',
+        previousDriverParticipantId: 'participant-2',
+      });
+    });
+
+    expect(mockShowMessage).not.toHaveBeenCalled();
+  });
+
+  it('suppresses the toast when control is released without a successor', () => {
+    renderHook(() => useQueueContext(), { wrapper: createWrapper() });
+
+    act(() => {
+      emitSessionEvent({
+        __typename: 'DriverChanged',
+        driverParticipantId: null,
+        previousDriverParticipantId: 'participant-2',
+      });
+    });
+
+    expect(mockShowMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/graphql-queue/__tests__/driver-handoff-toast.test.tsx
+++ b/packages/web/app/components/graphql-queue/__tests__/driver-handoff-toast.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { renderHook, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { SessionEvent } from '@boardsesh/shared-schema';
+import type { BoardDetails, ParsedBoardRouteParameters } from '@/app/lib/types';
 
 // --- Mocks must come before importing GraphQLQueueProvider ---
 
@@ -185,7 +186,7 @@ const defaultProps = {
     size_id: '1',
     set_ids: ['1'],
     angle: '40',
-  } as never,
+  } as unknown as ParsedBoardRouteParameters,
   boardDetails: {
     board_name: 'kilter',
     layout_id: 1,
@@ -200,7 +201,7 @@ const defaultProps = {
     edge_right: 0,
     edge_bottom: 0,
     edge_top: 0,
-  } as never,
+  } as unknown as BoardDetails,
 };
 
 function createWrapper() {
@@ -305,5 +306,30 @@ describe('driver hand-off toast', () => {
     });
 
     expect(mockShowMessage).not.toHaveBeenCalled();
+  });
+
+  it('falls back to firstDriver copy when the previous driver is no longer in the users list', () => {
+    renderHook(() => useQueueContext(), { wrapper: createWrapper() });
+
+    // previousDriverParticipantId references a user who has already left the
+    // session — `users.find()` returns undefined and the resolved name is
+    // empty. The toast must drop the attribution rather than render "X took
+    // the wall from ." See bug triage on PR #2249.
+    act(() => {
+      emitSessionEvent({
+        __typename: 'DriverChanged',
+        driverParticipantId: 'participant-2',
+        previousDriverParticipantId: 'participant-ghost',
+      });
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith(
+      expect.stringContaining('driverToast.firstDriver|newDriver=Bob'),
+      'info',
+    );
+    expect(mockShowMessage).not.toHaveBeenCalledWith(
+      expect.stringContaining('driverToast.tookFromOther'),
+      expect.anything(),
+    );
   });
 });

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -576,13 +576,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   const [isActionsOpen, setIsActionsOpen] = useState(false);
   const [isQueueOpen, setIsQueueOpen] = useState(false);
   const [queueMounted, setQueueMounted] = useState(false);
-  /**
-   * True while the nested queue is being opened by the onboarding tour — read
-   * at `QueueDrawer` mount time to seed `initialShowHistory`. Kept as a ref
-   * rather than state because it only needs to be consumed once per mount and
-   * must be synchronously up-to-date with the open handler.
-   */
-  const queueOpenedByTourRef = useRef(false);
   const [isPlaylistSelectorOpen, setIsPlaylistSelectorOpen] = useState(false);
   const [isTickBarActive, setIsTickBarActive] = useState(false);
   const [isBoardZoomed, setIsBoardZoomed] = useState(false);
@@ -1187,14 +1180,12 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   // drawer without the user having to find the button.
   useEffect(() => {
     const openHandler = () => {
-      queueOpenedByTourRef.current = true;
       setIsActionsOpen(false);
       setIsPlaylistSelectorOpen(false);
       setQueueMounted(true);
       setIsQueueOpen(true);
     };
     const closeHandler = () => {
-      queueOpenedByTourRef.current = false;
       setIsQueueOpen(false);
     };
     window.addEventListener(TOUR_OPEN_PLAY_QUEUE_EVENT, openHandler);
@@ -1644,7 +1635,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
           onClose={handleCloseQueueDrawer}
           onTransitionEnd={handleQueueTransitionEnd}
           boardDetails={boardDetails}
-          initialShowHistory={queueOpenedByTourRef.current}
         />
       )}
       {/* Light-control drawer — opened by long-pressing the action bar's

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -1531,8 +1531,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
                 pointerEvents: 'none',
               }}
             >
-              <TickBadgeAvatar user={driverUser} hasTicked={false} isDriver size={18}
-              />
+              <TickBadgeAvatar user={driverUser} hasTicked={false} isDriver size={18} />
             </Box>
           )}
           <div

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -759,10 +759,13 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   // gestures inside the drawer (swipe, prev/next) walk the queue/
   // suggestions and update the wall as the spec requires.
   const advanceTo = useCallback(
-    (item: ClimbQueueItem, method: string, direction: 'next' | 'previous') => {
+    (item: ClimbQueueItem, method: 'swipePlayViewDrawer' | 'playViewDrawer', direction: 'next' | 'previous') => {
       if (isPersistentSessionActive && !isDriver) {
         setDrawerDisplayedItem?.(item);
         track('Queue Navigation', { direction, method, mode: 'preview' });
+        // Pivot Phase 5: non-driver preview swipe is intentionally NOT a
+        // Wall Advance — nothing reaches the wall, so the success-metric
+        // pipeline shouldn't count it as a broadcast advance.
       } else {
         // Broadcast path: clear any lingering drawer-local preview so the
         // drawer's `effectiveItem = drawerDisplayedItem ?? wallClimb`
@@ -771,9 +774,19 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
         setDrawerDisplayedItem?.(null);
         setCurrentClimbQueueItem(item);
         track('Queue Navigation', { direction, method, mode: 'broadcast' });
+        // Pivot Phase 5: drawer broadcast paths are by definition driver
+        // (or solo, which we treat as driver). The method discriminates
+        // swipe vs button.
+        track('Wall Advance', {
+          source: method === 'swipePlayViewDrawer' ? 'drawer_swipe' : 'drawer_button',
+          pressedByRole: 'driver',
+          direction,
+          mode: isPersistentSessionActive ? 'party' : 'solo',
+          boardLayout: boardDetails.layout_name ?? '',
+        });
       }
     },
-    [isPersistentSessionActive, isDriver, setCurrentClimbQueueItem, setDrawerDisplayedItem],
+    [isPersistentSessionActive, isDriver, setCurrentClimbQueueItem, setDrawerDisplayedItem, boardDetails.layout_name],
   );
 
   // First-run coachmark — pulses the lightbulb once with the "Send to the

--- a/packages/web/app/components/play-view/queue-drawer.tsx
+++ b/packages/web/app/components/play-view/queue-drawer.tsx
@@ -35,9 +35,12 @@ export type QueueDrawerProps = {
   onTransitionEnd?: (open: boolean) => void;
   boardDetails: BoardDetails;
   /**
-   * When true, history (climbs queued before the current one) is visible on
-   * mount. Useful for the onboarding tour so the user sees every climb they
-   * queued regardless of which one is currently active.
+   * Controls whether history is rendered when the drawer mounts. Defaults to
+   * true so the queue-control-bar pivot's three-region layout (History /
+   * Current / Up next) shows out of the box — the 5-item cap + "Show full
+   * history" toggle inside QueueList handle the long-tail UX. The history
+   * icon button in the drawer header still lets users collapse history if
+   * they want a queue-only view.
    */
   initialShowHistory?: boolean;
 };
@@ -47,7 +50,7 @@ const QueueDrawer: React.FC<QueueDrawerProps> = ({
   onClose,
   onTransitionEnd,
   boardDetails,
-  initialShowHistory = false,
+  initialShowHistory = true,
 }) => {
   const { t } = useTranslation('session');
   // Internal state
@@ -97,9 +100,11 @@ const QueueDrawer: React.FC<QueueDrawerProps> = ({
   const closeDrawer = useCallback(() => {
     setIsEditMode(false);
     setSelectedItems(new Set());
-    setShowHistory(false);
+    // Match the new mount default — next open starts with history visible
+    // and the 5-item cap active (via QueueList's internal showFullHistory).
+    setShowHistory(initialShowHistory);
     onClose();
-  }, [onClose]);
+  }, [onClose, initialShowHistory]);
 
   const { paperRef: queuePaperRef, dragHandlers } = useDrawerDragResize({
     open,

--- a/packages/web/app/components/queue-control/__tests__/queue-climb-list-item.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-climb-list-item.test.tsx
@@ -116,6 +116,7 @@ vi.mock('@/app/theme/theme-config', () => ({
     spacing: { 0: 0, 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 16: 64 },
     colors: { error: '#B8524C', primary: '#8C4A52', success: '#6B9080' },
     neutral: { 200: '#E5E7EB', 400: '#9CA3AF', 500: '#6B7280' },
+    opacity: { subtle: 0.6 },
     typography: {
       fontSize: { xs: 12, sm: 14, base: 16, xl: 20, '2xl': 24 },
       fontWeight: { normal: 400, semibold: 600, bold: 700 },
@@ -226,6 +227,53 @@ describe('QueueClimbListItem', () => {
       // Should render an SVG bluetooth icon (the custom BluetoothIcon component)
       const svg = document.querySelector('svg');
       expect(svg).toBeTruthy();
+    });
+  });
+
+  describe('history-row tick button', () => {
+    it('renders the tick button in place of the avatar for history rows', () => {
+      const props = defaultProps();
+      props.item = makeQueueItem({
+        addedByUser: { id: 'user-1', username: 'alice', avatarUrl: 'https://example.com/alice.jpg' },
+      });
+      render(<QueueClimbListItem {...props} isHistory />);
+
+      // Tick button is reachable via aria-label
+      const tick = screen.getByRole('button', { name: /Log a tick for/i });
+      expect(tick).toBeTruthy();
+      // Avatar img is no longer rendered for history rows
+      expect(screen.queryByRole('img')).toBeNull();
+    });
+
+    it('calls onTickClick with the climb when the history-row tick is pressed', () => {
+      const props = defaultProps();
+      render(<QueueClimbListItem {...props} isHistory />);
+
+      const tick = screen.getByRole('button', { name: /Log a tick for/i });
+      fireEvent.click(tick);
+
+      expect(props.onTickClick).toHaveBeenCalledWith(props.item.climb);
+    });
+
+    it('does not bubble the tick click up to the row select handler', () => {
+      const props = defaultProps();
+      render(<QueueClimbListItem {...props} isHistory />);
+
+      const tick = screen.getByRole('button', { name: /Log a tick for/i });
+      fireEvent.click(tick);
+
+      expect(props.setCurrentClimbQueueItem).not.toHaveBeenCalled();
+    });
+
+    it('keeps the avatar (not the tick button) for non-history rows', () => {
+      const props = defaultProps();
+      props.item = makeQueueItem({
+        addedByUser: { id: 'user-1', username: 'alice', avatarUrl: 'https://example.com/alice.jpg' },
+      });
+      render(<QueueClimbListItem {...props} isHistory={false} />);
+
+      expect(screen.queryByRole('button', { name: /Log a tick for/i })).toBeNull();
+      expect(screen.getByRole('img').getAttribute('src')).toBe('https://example.com/alice.jpg');
     });
   });
 

--- a/packages/web/app/components/queue-control/__tests__/queue-list-history-collapse.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-list-history-collapse.test.tsx
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import type { Climb, BoardDetails } from '@/app/lib/types';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import type { ClimbQueueItem } from '../types';
+import QueueList, { type QueueListHandle } from '../queue-list';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string | readonly string[]) => ({
+    i18n: { language: 'en-US' },
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+  }),
+}));
+
+// 8 history items + 1 current + 1 future — exercises the 5-by-default cap.
+const queueWithLongHistory: ClimbQueueItem[] = Array.from({ length: 10 }, (_, i) => ({
+  uuid: `queue-${i}`,
+  climb: {
+    uuid: `climb-${i}`,
+    name: `Boulder ${i}`,
+    setter_username: 'setter',
+    description: '',
+    frames: `p${i}r14`,
+    angle: 40,
+    ascensionist_count: 5,
+    difficulty: 'V4',
+    quality_average: '3.0',
+    stars: 0,
+    difficulty_error: '0.5',
+    benchmark_difficulty: null,
+  } as Climb,
+}));
+
+const currentUuid = 'queue-8'; // history = queue-0..queue-7 (8 items), future = queue-9
+
+vi.mock('../../graphql-queue', () => ({
+  useCurrentClimbUuid: () => currentUuid,
+  useQueueList: () => ({
+    queue: queueWithLongHistory,
+    suggestedClimbs: [],
+  }),
+  useSearchData: () => ({
+    hasMoreResults: false,
+    isFetchingClimbs: false,
+    isFetchingNextPage: false,
+  }),
+  useSessionData: () => ({ viewOnlyMode: false }),
+  useQueueActions: () => ({
+    fetchMoreClimbs: vi.fn(),
+    setCurrentClimbQueueItem: vi.fn(),
+    setQueue: vi.fn(),
+    addToQueue: vi.fn(),
+    previewClimbFromBrowse: vi.fn(),
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/kilter/original/12x12/default/40/play/some-climb',
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useParams: () => ({}),
+}));
+
+vi.mock('@/app/lib/i18n/use-locale-router', () => ({
+  useLocaleRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+vi.mock('@/app/hooks/use-is-dark-mode', () => ({
+  useIsDarkMode: () => false,
+}));
+
+vi.mock('@/app/hooks/use-drawer-drag-resize', () => ({
+  useDrawerDragResize: () => ({ paperRef: { current: null }, dragHandlers: {} }),
+}));
+
+vi.mock('../../board-provider/board-provider-context', () => ({
+  useOptionalBoardProvider: () => null,
+}));
+
+vi.mock('@/app/components/providers/auth-modal-provider', () => ({
+  useAuthModal: () => ({ openAuthModal: vi.fn() }),
+}));
+
+vi.mock('../queue-climb-list-item', () => ({
+  default: ({ item, isCurrent, isHistory }: { item: ClimbQueueItem; isCurrent: boolean; isHistory: boolean }) => (
+    <div
+      data-testid="queue-climb-list-item"
+      data-uuid={item.uuid}
+      data-current={isCurrent ? 'true' : 'false'}
+      data-history={isHistory ? 'true' : 'false'}
+    >
+      {item.climb.name}
+    </div>
+  ),
+}));
+
+vi.mock('../../climb-card/climb-list-item', () => ({
+  default: ({ climb }: { climb: Climb }) => (
+    <div data-testid="climb-list-item" data-uuid={climb.uuid}>
+      {climb.name}
+    </div>
+  ),
+}));
+
+vi.mock('../../climb-card/drawer-climb-header', () => ({
+  default: () => <div data-testid="drawer-climb-header" />,
+}));
+
+vi.mock('../../swipeable-drawer/swipeable-drawer', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="swipeable-drawer">{children}</div>,
+}));
+
+vi.mock('../../climb-actions', () => ({
+  ClimbActions: () => <div data-testid="climb-actions" />,
+}));
+
+vi.mock('../../climb-actions/playlist-selection-content', () => ({
+  default: () => <div data-testid="playlist-selection-content" />,
+}));
+
+vi.mock('../../logbook/log-ascent-drawer', () => ({
+  LogAscentDrawer: () => <div data-testid="log-ascent-drawer" />,
+}));
+
+vi.mock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
+  monitorForElements: () => () => {},
+}));
+
+vi.mock('@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge', () => ({
+  extractClosestEdge: () => null,
+}));
+
+vi.mock('@atlaskit/pragmatic-drag-and-drop/reorder', () => ({
+  reorder: ({ list }: { list: unknown[] }) => list,
+}));
+
+vi.mock('@/app/lib/climb-action-utils', () => ({
+  getExcludedClimbActions: () => [],
+}));
+
+vi.mock('../../board-page/constants', () => ({
+  SUGGESTIONS_THRESHOLD: 5,
+}));
+
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: {
+    spacing: { 0: 0, 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 16: 64 },
+    colors: { error: '#B8524C', primary: '#8C4A52', success: '#6B9080' },
+    neutral: { 200: '#E5E7EB', 400: '#9CA3AF', 500: '#6B7280' },
+    typography: {
+      fontSize: { xs: 12, sm: 14, base: 16, xl: 20, '2xl': 24 },
+      fontWeight: { normal: 400, semibold: 600, bold: 700 },
+    },
+  },
+}));
+
+vi.mock('../queue-list.module.css', () => ({
+  default: {
+    queueColumn: 'queueColumn',
+    suggestedSectionHeader: 'suggestedSectionHeader',
+    suggestedColumn: 'suggestedColumn',
+    suggestedItem: 'suggestedItem',
+    historyDivider: 'historyDivider',
+    historyShowAll: 'historyShowAll',
+    loadMoreContainer: 'loadMoreContainer',
+    loadMoreSkeletonRow: 'loadMoreSkeletonRow',
+    noMoreSuggestions: 'noMoreSuggestions',
+  },
+}));
+
+// Capture scrollToIndex calls from the virtualizer mock so we can assert the
+// alignment requested by scrollToCurrentClimb (the pivot wants 'center').
+const scrollToIndexSpy = vi.fn();
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: (opts: { count: number; getItemKey?: (i: number) => string | number }) => {
+    const items = Array.from({ length: opts.count }, (_, i) => ({
+      index: i,
+      key: opts.getItemKey ? opts.getItemKey(i) : `item-${i}`,
+      start: i * 72,
+      size: 72,
+      end: (i + 1) * 72,
+      lane: 0,
+    }));
+    return {
+      getVirtualItems: () => items,
+      getTotalSize: () => opts.count * 72,
+      measureElement: vi.fn(),
+      scrollToIndex: scrollToIndexSpy,
+    };
+  },
+}));
+
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.defineProperty(globalThis, 'IntersectionObserver', {
+  value: MockIntersectionObserver,
+  writable: true,
+});
+
+function makeBoardDetails(): BoardDetails {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: '1',
+    images_to_holds: {},
+    holdsData: [],
+    edge_left: 0,
+    edge_right: 0,
+    edge_bottom: 0,
+    edge_top: 0,
+    boardHeight: 100,
+    boardWidth: 100,
+  } as unknown as BoardDetails;
+}
+
+describe('QueueList history collapse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scrollToIndexSpy.mockClear();
+  });
+
+  it('renders only the 5 most recent history items by default, with a Show-full row', () => {
+    render(<QueueList boardDetails={makeBoardDetails()} active={false} showHistory />);
+
+    // 5 history rows + 1 current row = 6 queue items rendered, plus one future
+    const queueItems = screen.getAllByTestId('queue-climb-list-item');
+    const historyItems = queueItems.filter((node) => node.getAttribute('data-history') === 'true');
+    expect(historyItems).toHaveLength(5);
+
+    // Oldest 3 history items should be hidden (queue-0, queue-1, queue-2)
+    expect(screen.queryByText('Boulder 0')).toBeNull();
+    expect(screen.queryByText('Boulder 1')).toBeNull();
+    expect(screen.queryByText('Boulder 2')).toBeNull();
+
+    // Most recent 5 history items visible (queue-3..queue-7)
+    for (let i = 3; i <= 7; i++) {
+      expect(screen.getByText(`Boulder ${i}`)).toBeTruthy();
+    }
+
+    // Show-full row mentions the hidden count (3 more)
+    expect(screen.getByRole('button', { name: /show full history.*3 more/i })).toBeTruthy();
+  });
+
+  it('reveals every history item after the Show full history button is pressed', () => {
+    render(<QueueList boardDetails={makeBoardDetails()} active={false} showHistory />);
+
+    const showAllButton = screen.getByRole('button', { name: /show full history.*3 more/i });
+    fireEvent.click(showAllButton);
+
+    const queueItems = screen.getAllByTestId('queue-climb-list-item');
+    const historyItems = queueItems.filter((node) => node.getAttribute('data-history') === 'true');
+    expect(historyItems).toHaveLength(8);
+
+    // All 8 history climbs now visible
+    for (let i = 0; i <= 7; i++) {
+      expect(screen.getByText(`Boulder ${i}`)).toBeTruthy();
+    }
+
+    // Button disappears after expansion
+    expect(screen.queryByRole('button', { name: /show full history/i })).toBeNull();
+  });
+
+  it('scrollToCurrentClimb centers the current item in the viewport', () => {
+    const handle = React.createRef<QueueListHandle>();
+    render(<QueueList ref={handle} boardDetails={makeBoardDetails()} active={false} showHistory />);
+
+    handle.current?.scrollToCurrentClimb();
+
+    expect(scrollToIndexSpy).toHaveBeenCalled();
+    const lastCall = scrollToIndexSpy.mock.calls[scrollToIndexSpy.mock.calls.length - 1];
+    const [, options] = lastCall as [number, { align: string; behavior: string }];
+    expect(options.align).toBe('center');
+  });
+});

--- a/packages/web/app/components/queue-control/__tests__/queue-nav-button-wall-advance.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-nav-button-wall-advance.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import type { ClimbQueueItem } from '../types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'en-US' },
+    t: (key: string) => key,
+  }),
+}));
+
+const { mockTrack } = vi.hoisted(() => ({ mockTrack: vi.fn() }));
+vi.mock('@/app/lib/analytics', () => ({ track: mockTrack }));
+
+const mockSetCurrentClimbQueueItem = vi.fn();
+const mockGetNextClimbQueueItem = vi.fn();
+const mockGetPreviousClimbQueueItem = vi.fn();
+
+let sessionDataMock: { viewOnlyMode: boolean; isPersistentSessionActive: boolean; isDriver: boolean } = {
+  viewOnlyMode: false,
+  isPersistentSessionActive: false,
+  isDriver: true,
+};
+
+vi.mock('../../graphql-queue', () => ({
+  useQueueActions: () => ({
+    setCurrentClimbQueueItem: mockSetCurrentClimbQueueItem,
+    getNextClimbQueueItem: mockGetNextClimbQueueItem,
+    getPreviousClimbQueueItem: mockGetPreviousClimbQueueItem,
+  }),
+  useSessionData: () => sessionDataMock,
+}));
+
+vi.mock('@/app/hooks/use-resolved-board-details', () => ({
+  useResolvedBoardDetails: () => ({
+    rawParams: {
+      board_name: 'kilter',
+      layout_id: '1',
+      size_id: '1',
+      set_ids: '1',
+      angle: '40',
+    },
+    angle: 40,
+    searchParams: new URLSearchParams(),
+    isPlayPage: false,
+    resolvedDetails: {
+      board_name: 'kilter',
+      layout_name: 'Original',
+      size_name: '12x12',
+      size_description: 'Standard',
+      set_names: ['Base'],
+    },
+  }),
+}));
+
+import QueueNavButton from '../queue-nav-button';
+
+const sampleItem: ClimbQueueItem = {
+  uuid: 'queue-target',
+  climb: {
+    uuid: 'climb-target',
+    name: 'Target Climb',
+    setter_username: 'setter',
+    description: '',
+    frames: 'p1r12',
+    angle: 40,
+    ascensionist_count: 1,
+    difficulty: 'V4',
+    quality_average: '3.0',
+    stars: 0,
+    difficulty_error: '0.5',
+    benchmark_difficulty: null,
+  },
+};
+
+const boardDetails = { layout_name: 'Original' } as Parameters<typeof QueueNavButton>[0]['boardDetails'];
+
+function findWallAdvanceCall() {
+  return mockTrack.mock.calls.find((args) => args[0] === 'Wall Advance');
+}
+
+describe('QueueNavButton Wall Advance event', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetNextClimbQueueItem.mockReturnValue(sampleItem);
+    mockGetPreviousClimbQueueItem.mockReturnValue(sampleItem);
+    sessionDataMock = { viewOnlyMode: false, isPersistentSessionActive: false, isDriver: true };
+  });
+
+  it('fires Wall Advance with bar_button source + driver role in solo mode', () => {
+    render(<QueueNavButton direction="next" navigate={false} boardDetails={boardDetails} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    const call = findWallAdvanceCall();
+    expect(call).toBeTruthy();
+    expect(call?.[1]).toMatchObject({
+      source: 'bar_button',
+      pressedByRole: 'driver',
+      direction: 'next',
+      mode: 'solo',
+      boardLayout: 'Original',
+    });
+  });
+
+  it('reports pressedByRole=non_driver when a non-driver presses in a party session', () => {
+    sessionDataMock = { viewOnlyMode: false, isPersistentSessionActive: true, isDriver: false };
+    render(<QueueNavButton direction="previous" navigate={false} boardDetails={boardDetails} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    const call = findWallAdvanceCall();
+    expect(call).toBeTruthy();
+    expect(call?.[1]).toMatchObject({
+      source: 'bar_button',
+      pressedByRole: 'non_driver',
+      direction: 'previous',
+      mode: 'party',
+      boardLayout: 'Original',
+    });
+  });
+
+  it('still fires Queue Navigation alongside Wall Advance (analytics continuity)', () => {
+    render(<QueueNavButton direction="next" navigate={false} boardDetails={boardDetails} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    const queueNavCall = mockTrack.mock.calls.find((args) => args[0] === 'Queue Navigation');
+    const wallAdvanceCall = findWallAdvanceCall();
+    expect(queueNavCall).toBeTruthy();
+    expect(wallAdvanceCall).toBeTruthy();
+  });
+
+  it('disables the button when there is no advance target', () => {
+    mockGetNextClimbQueueItem.mockReturnValue(null);
+    render(<QueueNavButton direction="next" navigate={false} boardDetails={boardDetails} />);
+
+    const button = screen.getByRole('button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    fireEvent.click(button);
+    expect(findWallAdvanceCall()).toBeUndefined();
+  });
+});

--- a/packages/web/app/components/queue-control/queue-climb-list-item.tsx
+++ b/packages/web/app/components/queue-control/queue-climb-list-item.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next';
 import MuiTooltip from '@mui/material/Tooltip';
 import MuiAvatar from '@mui/material/Avatar';
+import MuiBadge from '@mui/material/Badge';
 import MuiCheckbox from '@mui/material/Checkbox';
 import MuiIconButton from '@mui/material/IconButton';
 import MuiStack from '@mui/material/Stack';
@@ -22,6 +23,8 @@ import ClimbListItem, { type SwipeActionOverride } from '../climb-card/climb-lis
 import { dispatchOpenPlayDrawer } from './play-drawer-event';
 import { themeTokens } from '@/app/theme/theme-config';
 import { getGradeTintColor } from '@/app/lib/grade-colors';
+import { TickIcon } from '../logbook/tick-icon';
+import { useOptionalBoardProvider } from '../board-provider/board-provider-context';
 
 type QueueClimbListItemProps = {
   item: ClimbQueueItem;
@@ -101,27 +104,81 @@ const QueueClimbListItem: React.FC<QueueClimbListItemProps> = ({
     [onEditClimb, item.climb],
   );
 
-  // "Added by" avatar slot (plus an Edit affordance for editable climbs)
-  const afterTitleSlot = useMemo(() => {
-    const avatarStyle = { width: 24, height: 24 };
-    const avatarBluetoothStyle = { width: 24, height: 24, backgroundColor: 'transparent' };
-
-    const avatar = item.addedByUser ? (
-      <MuiTooltip title={item.addedByUser.username}>
-        <MuiAvatar sx={avatarStyle} src={item.addedByUser.avatarUrl ?? undefined}>
-          <PersonOutlined />
-        </MuiAvatar>
-      </MuiTooltip>
-    ) : (
-      <MuiTooltip title={t('queueList.addedViaBluetooth')}>
-        <MuiAvatar sx={avatarBluetoothStyle}>
-          <BluetoothIcon style={{ color: 'var(--neutral-400)' }} />
-        </MuiAvatar>
-      </MuiTooltip>
+  // Per-climb ascent counts for the history-row tick badge. Uses the optional
+  // BoardProvider hook because queue rows render in surfaces (e.g. the list
+  // view route) that aren't always wrapped in one — fall through to no badge
+  // rather than throwing.
+  const logbook = useOptionalBoardProvider()?.logbook ?? [];
+  const { badgeCount, hasSuccessfulAscent } = useMemo(() => {
+    const filtered = logbook.filter(
+      (ascent) => ascent.climb_uuid === item.climb.uuid && Number(ascent.angle) === item.climb.angle,
     );
+    return {
+      badgeCount: filtered.length,
+      hasSuccessfulAscent: filtered.some((ascent) => ascent.is_ascent),
+    };
+  }, [logbook, item.climb.uuid, item.climb.angle]);
+
+  const handleTickButtonClick = useCallback(
+    (event: React.MouseEvent) => {
+      // Stop bubbling so the row's double-tap-to-set-current handler doesn't
+      // re-broadcast a history climb when the user just wants to log a tick.
+      event.stopPropagation();
+      onTickClick(item.climb);
+    },
+    [onTickClick, item.climb],
+  );
+
+  // After-title slot: history rows get the canonical tick button (same
+  // TickIcon + MuiBadge styling as `TickButton` in the queue control bar);
+  // current + upcoming rows keep the "added by" avatar so attribution stays
+  // visible while the climb is still in the queue.
+  const afterTitleSlot = useMemo(() => {
+    let trailing: React.ReactNode;
+    if (isHistory) {
+      trailing = (
+        <MuiTooltip title={t('queueList.tickHistoryClimb', { name: item.climb.name })}>
+          <MuiBadge
+            badgeContent={badgeCount > 0 ? badgeCount : 0}
+            max={100}
+            sx={{
+              '& .MuiBadge-badge': {
+                backgroundColor: hasSuccessfulAscent ? themeTokens.colors.success : themeTokens.colors.error,
+                color: 'common.white',
+              },
+            }}
+          >
+            <MuiIconButton
+              size="small"
+              onClick={handleTickButtonClick}
+              aria-label={t('queueList.tickHistoryClimb', { name: item.climb.name })}
+              sx={{ width: 24, height: 24, opacity: themeTokens.opacity.subtle }}
+            >
+              <TickIcon isFlash={false} />
+            </MuiIconButton>
+          </MuiBadge>
+        </MuiTooltip>
+      );
+    } else {
+      const avatarStyle = { width: 24, height: 24 };
+      const avatarBluetoothStyle = { width: 24, height: 24, backgroundColor: 'transparent' };
+      trailing = item.addedByUser ? (
+        <MuiTooltip title={item.addedByUser.username}>
+          <MuiAvatar sx={avatarStyle} src={item.addedByUser.avatarUrl ?? undefined}>
+            <PersonOutlined />
+          </MuiAvatar>
+        </MuiTooltip>
+      ) : (
+        <MuiTooltip title={t('queueList.addedViaBluetooth')}>
+          <MuiAvatar sx={avatarBluetoothStyle}>
+            <BluetoothIcon style={{ color: 'var(--neutral-400)' }} />
+          </MuiAvatar>
+        </MuiTooltip>
+      );
+    }
 
     if (!isEditable || !onEditClimb) {
-      return avatar;
+      return trailing;
     }
 
     return (
@@ -131,10 +188,21 @@ const QueueClimbListItem: React.FC<QueueClimbListItemProps> = ({
             <EditOutlined sx={{ fontSize: 16 }} />
           </MuiIconButton>
         </MuiTooltip>
-        {avatar}
+        {trailing}
       </MuiStack>
     );
-  }, [item.addedByUser, isEditable, onEditClimb, handleEditClick, t]);
+  }, [
+    isHistory,
+    item.addedByUser,
+    item.climb.name,
+    badgeCount,
+    hasSuccessfulAscent,
+    handleTickButtonClick,
+    isEditable,
+    onEditClimb,
+    handleEditClick,
+    t,
+  ]);
 
   // onSelect handler — double-tap sets current climb
   const handleSelect = useCallback(() => {

--- a/packages/web/app/components/queue-control/queue-control-bar.tsx
+++ b/packages/web/app/components/queue-control/queue-control-bar.tsx
@@ -362,33 +362,70 @@ const QueueControlBar: React.FC<QueueControlBarProps> = ({ boardDetails, angle }
     if (!nextClimb || viewOnlyMode) return;
 
     setCurrentClimbQueueItem(nextClimb);
+    const boardLayout = boardDetails?.layout_name || '';
     track('Queue Navigation', {
       direction: 'next',
       method: 'swipeQueueBar',
-      boardLayout: boardDetails?.layout_name || '',
+      boardLayout,
+    });
+    // Pivot Phase 5: bar swipe is a broadcast advance just like the bar
+    // button. Same semantics — anyone in the session can swipe; the presser
+    // stays in their current role.
+    track('Wall Advance', {
+      source: 'bar_swipe',
+      pressedByRole: isPersistentSessionActive && !isDriver ? 'non_driver' : 'driver',
+      direction: 'next',
+      mode: isPersistentSessionActive ? 'party' : 'solo',
+      boardLayout,
     });
 
     if (isPlayPage) {
       const url = buildClimbUrl(nextClimb.climb);
       if (url) window.history.pushState(null, '', url);
     }
-  }, [nextClimb, viewOnlyMode, setCurrentClimbQueueItem, buildClimbUrl, boardDetails, isPlayPage]);
+  }, [
+    nextClimb,
+    viewOnlyMode,
+    setCurrentClimbQueueItem,
+    buildClimbUrl,
+    boardDetails,
+    isPlayPage,
+    isPersistentSessionActive,
+    isDriver,
+  ]);
 
   const handleSwipePrevious = useCallback(() => {
     if (!previousClimb || viewOnlyMode) return;
 
     setCurrentClimbQueueItem(previousClimb);
+    const boardLayout = boardDetails?.layout_name || '';
     track('Queue Navigation', {
       direction: 'previous',
       method: 'swipeQueueBar',
-      boardLayout: boardDetails?.layout_name || '',
+      boardLayout,
+    });
+    track('Wall Advance', {
+      source: 'bar_swipe',
+      pressedByRole: isPersistentSessionActive && !isDriver ? 'non_driver' : 'driver',
+      direction: 'previous',
+      mode: isPersistentSessionActive ? 'party' : 'solo',
+      boardLayout,
     });
 
     if (isPlayPage) {
       const url = buildClimbUrl(previousClimb.climb);
       if (url) window.history.pushState(null, '', url);
     }
-  }, [previousClimb, viewOnlyMode, setCurrentClimbQueueItem, buildClimbUrl, boardDetails, isPlayPage]);
+  }, [
+    previousClimb,
+    viewOnlyMode,
+    setCurrentClimbQueueItem,
+    buildClimbUrl,
+    boardDetails,
+    isPlayPage,
+    isPersistentSessionActive,
+    isDriver,
+  ]);
 
   const tickBarActive = activeDrawer === 'tick';
   const canSwipeNext = !viewOnlyMode && !!nextClimb && !tickBarActive;

--- a/packages/web/app/components/queue-control/queue-list.module.css
+++ b/packages/web/app/components/queue-control/queue-list.module.css
@@ -2,6 +2,10 @@
   margin: 8px 0;
 }
 
+.historyShowAll {
+  padding: 4px 8px;
+}
+
 .suggestedSectionHeader {
   padding: 12px 8px 4px;
 }

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -126,7 +126,10 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
 
     // Toggled by the "Show full history" row at the top of the history region.
     // Local to each list mount — resets when the drawer remounts so a freshly-
-    // opened list always starts on the 5-item view.
+    // opened list always starts on the 5-item view. Depends on QueueDrawer NOT
+    // passing `keepMounted={true}` to the underlying SwipeableDrawer (default
+    // is false); if a caller starts keeping the drawer mounted, the state will
+    // stick across sessions and this expectation breaks.
     const [showFullHistory, setShowFullHistory] = useState(false);
 
     const handleOpenActions = useCallback((climb: Climb) => {

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -34,8 +34,15 @@ import type { ClimbQueueItem } from './types';
 import { isClimbEditable } from './is-climb-editable';
 import styles from './queue-list.module.css';
 
+// Default number of recent history items rendered when the user hasn't opted
+// into the full backlog. Spec: queue-list opens with a 5-item history so the
+// current item sits near the top of the visible area; older sends fold under
+// a "Show full history" button.
+const DEFAULT_HISTORY_DISPLAY_LIMIT = 5;
+
 // Discriminated union for all possible rows in the flat virtualized list
 type FlatRow =
+  | { type: 'history-show-all'; hiddenCount: number }
   | { type: 'history-item'; item: ClimbQueueItem; queueIndex: number }
   | { type: 'history-divider' }
   | { type: 'current-item'; item: ClimbQueueItem; queueIndex: number }
@@ -116,6 +123,11 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
     // This replaces the per-ClimbListItem drawers (previously 100+ drawer trees).
     const [actionsClimb, setActionsClimb] = useState<Climb | null>(null);
     const [playlistClimb, setPlaylistClimb] = useState<Climb | null>(null);
+
+    // Toggled by the "Show full history" row at the top of the history region.
+    // Local to each list mount — resets when the drawer remounts so a freshly-
+    // opened list always starts on the 5-item view.
+    const [showFullHistory, setShowFullHistory] = useState(false);
 
     const handleOpenActions = useCallback((climb: Climb) => {
       setPlaylistClimb(null);
@@ -224,30 +236,33 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
       // When no current climb (currentIndex === -1), show entire queue as future items
       const futureItems = currentIndex >= 0 ? queue.slice(currentIndex + 1) : queue;
 
-      // History items
+      // History items — render at most DEFAULT_HISTORY_DISPLAY_LIMIT (most
+      // recent) by default. The full backlog unfolds when the user taps the
+      // "Show full history" row. queueIndex always tracks the position in the
+      // full queue so re-orders + selection state stay consistent.
       if (showHistory && historyItems.length > 0) {
-        const scrollToHistoryIndex = historyItems.length > 2 ? historyItems.length - 2 : 0;
-        for (let i = 0; i < historyItems.length; i++) {
-          if (historyItems.length > 2 && i === scrollToHistoryIndex) {
-            scrollTargetIdx = rows.length;
-          }
+        const hiddenCount = showFullHistory ? 0 : Math.max(0, historyItems.length - DEFAULT_HISTORY_DISPLAY_LIMIT);
+        if (hiddenCount > 0) {
+          rows.push({ type: 'history-show-all', hiddenCount });
+        }
+        const firstRenderedIdx = hiddenCount;
+        for (let i = firstRenderedIdx; i < historyItems.length; i++) {
           rows.push({ type: 'history-item', item: historyItems[i], queueIndex: i });
         }
         rows.push({ type: 'history-divider' });
       }
 
-      // Current item
+      // Current item — always the scroll target so the virtualizer can center
+      // it on open. Fallback to the first future item when nothing is lit yet.
       if (currentItem) {
-        if (!showHistory || historyItems.length <= 2) {
-          scrollTargetIdx = rows.length;
-        }
+        scrollTargetIdx = rows.length;
         rows.push({ type: 'current-item', item: currentItem, queueIndex: currentIndex });
       }
 
       // Future items
       for (let i = 0; i < futureItems.length; i++) {
         const originalIndex = currentIndex >= 0 ? currentIndex + 1 + i : i;
-        if (i === 0 && !currentItem && (!showHistory || historyItems.length <= 2)) {
+        if (i === 0 && !currentItem) {
           scrollTargetIdx = rows.length;
         }
         rows.push({ type: 'future-item', item: futureItems[i], queueIndex: originalIndex });
@@ -274,6 +289,7 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
       queue,
       currentClimbUuid,
       showHistory,
+      showFullHistory,
       suggestedClimbs,
       active,
       viewOnlyMode,
@@ -300,6 +316,8 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
         switch (row.type) {
           case 'history-divider':
             return 17;
+          case 'history-show-all':
+            return 44;
           case 'suggestion-header':
             return 36;
           case 'loading':
@@ -323,6 +341,8 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
             return `s-${row.climb.uuid}`;
           case 'history-divider':
             return 'divider';
+          case 'history-show-all':
+            return 'history-show-all';
           case 'suggestion-header':
             return 'suggestion-header';
           case 'loading':
@@ -343,8 +363,10 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
       () => ({
         scrollToCurrentClimb: () => {
           if (scrollTargetFlatIndex >= 0) {
+            // Center the current item in the visible area. When history is
+            // short the virtualizer naturally clamps to the top — no padding.
             virtualizerRef.current.scrollToIndex(scrollTargetFlatIndex, {
-              align: 'start',
+              align: 'center',
               behavior: 'smooth',
             });
           }
@@ -380,6 +402,13 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
                   contain: 'layout style paint',
                 }}
               >
+                {row.type === 'history-show-all' && (
+                  <div className={styles.historyShowAll}>
+                    <Button size="small" onClick={() => setShowFullHistory(true)} fullWidth variant="text">
+                      {t('session:queueList.showFullHistory', { count: row.hiddenCount })}
+                    </Button>
+                  </div>
+                )}
                 {row.type === 'history-item' && (
                   <QueueClimbListItem
                     item={row.item}

--- a/packages/web/app/components/queue-control/queue-nav-button.tsx
+++ b/packages/web/app/components/queue-control/queue-nav-button.tsx
@@ -75,6 +75,13 @@ export default function QueueNavButton({ direction, navigate, boardDetails }: Qu
     // Bar prev/next is always a broadcast (any participant can advance the
     // wall climb) and never transfers the driver — so pressedByRole reflects
     // the presser's current role rather than implying a take-control.
+    //
+    // Fired BEFORE the mutation acks — matches the existing `Queue Navigation`
+    // fire-on-call pattern (above). Means a transient network failure can
+    // produce a `Wall Advance` event without a corresponding wall change.
+    // Consistent with other queue analytics and intentional: we'd rather
+    // count user intent than gate on round-trip success. Watch the ratio of
+    // `Wall Advance` to `Wall Confirmed` if this becomes a misleading signal.
     track('Wall Advance', {
       source: 'bar_button',
       pressedByRole: isPersistentSessionActive && !isDriver ? 'non_driver' : 'driver',

--- a/packages/web/app/components/queue-control/queue-nav-button.tsx
+++ b/packages/web/app/components/queue-control/queue-nav-button.tsx
@@ -38,7 +38,7 @@ export default function QueueNavButton({ direction, navigate, boardDetails }: Qu
   const ariaLabel = direction === 'next' ? t('actions.navigation.nextClimb') : t('actions.navigation.previousClimb');
   const Icon = ICON[direction];
   const { setCurrentClimbQueueItem, getNextClimbQueueItem, getPreviousClimbQueueItem } = useQueueActions();
-  const { viewOnlyMode } = useSessionData();
+  const { viewOnlyMode, isPersistentSessionActive, isDriver } = useSessionData();
   const { rawParams, angle, searchParams, isPlayPage, resolvedDetails } = useResolvedBoardDetails(boardDetails);
 
   const target = direction === 'next' ? getNextClimbQueueItem() : getPreviousClimbQueueItem();
@@ -65,10 +65,22 @@ export default function QueueNavButton({ direction, navigate, boardDetails }: Qu
   const fireAdvance = useCallback(() => {
     if (!target || viewOnlyMode) return;
     setCurrentClimbQueueItem(target);
+    const boardLayout = boardDetails?.layout_name || '';
     track('Queue Navigation', {
       direction,
       method: 'button',
-      boardLayout: boardDetails?.layout_name || '',
+      boardLayout,
+    });
+    // Pivot Phase 5: Wall Advance fires on every successful broadcast advance.
+    // Bar prev/next is always a broadcast (any participant can advance the
+    // wall climb) and never transfers the driver — so pressedByRole reflects
+    // the presser's current role rather than implying a take-control.
+    track('Wall Advance', {
+      source: 'bar_button',
+      pressedByRole: isPersistentSessionActive && !isDriver ? 'non_driver' : 'driver',
+      direction,
+      mode: isPersistentSessionActive ? 'party' : 'solo',
+      boardLayout,
     });
     // On /play/ routes the URL is the source of truth — push the new climb's
     // play URL. On /view/ routes useDrawerUrlSync handles the URL via the
@@ -80,7 +92,17 @@ export default function QueueNavButton({ direction, navigate, boardDetails }: Qu
     // buildPlayUrl is a closure over current state; recreating each fire is
     // intentional. target is the only ref-stable input.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [target, navigate, isPlayPage, viewOnlyMode, setCurrentClimbQueueItem, boardDetails?.layout_name, direction]);
+  }, [
+    target,
+    navigate,
+    isPlayPage,
+    viewOnlyMode,
+    setCurrentClimbQueueItem,
+    boardDetails?.layout_name,
+    direction,
+    isPersistentSessionActive,
+    isDriver,
+  ]);
 
   return (
     <IconButton aria-label={ariaLabel} onClick={fireAdvance} disabled={!target || viewOnlyMode}>

--- a/packages/web/i18n/locales/en-US/climbs.json
+++ b/packages/web/i18n/locales/en-US/climbs.json
@@ -277,8 +277,8 @@
       }
     },
     "navigation": {
-      "nextClimb": "Next climb",
-      "previousClimb": "Previous climb"
+      "nextClimb": "Next climb on the wall",
+      "previousClimb": "Previous climb on the wall"
     },
     "mirror": {
       "label": {

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -221,7 +221,8 @@
     "nextUpHeader": "Next up",
     "endMessage": "That's all for now",
     "showFullHistory_one": "Show full history ({{count}} more)",
-    "showFullHistory_other": "Show full history ({{count}} more)"
+    "showFullHistory_other": "Show full history ({{count}} more)",
+    "tickHistoryClimb": "Log a tick for {{name}}"
   },
   "queueProvider": {
     "offlineLimitReached": "You've hit the offline up-next limit. Reconnect to sync your climbs."

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -219,10 +219,17 @@
     "editClimb": "Edit this climb",
     "addedViaBluetooth": "Added via Bluetooth",
     "nextUpHeader": "Next up",
-    "endMessage": "That's all for now"
+    "endMessage": "That's all for now",
+    "showFullHistory_one": "Show full history ({{count}} more)",
+    "showFullHistory_other": "Show full history ({{count}} more)"
   },
   "queueProvider": {
     "offlineLimitReached": "You've hit the offline up-next limit. Reconnect to sync your climbs."
+  },
+  "driverToast": {
+    "firstDriver": "{{newDriver}} is driving the wall.",
+    "tookFromOther": "{{newDriver}} took the wall from {{previousDriver}}.",
+    "tookFromYou": "{{newDriver}} took the wall."
   },
   "playView": {
     "onWallChip": "ON WALL · {{username}}",

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -230,7 +230,7 @@
   "driverToast": {
     "firstDriver": "{{newDriver}} is driving the wall.",
     "tookFromOther": "{{newDriver}} took the wall from {{previousDriver}}.",
-    "tookFromYou": "{{newDriver}} took the wall."
+    "tookFromYou": "{{newDriver}} took the wall from you."
   },
   "playView": {
     "onWallChip": "ON WALL · {{username}}",

--- a/packages/web/i18n/locales/es/climbs.json
+++ b/packages/web/i18n/locales/es/climbs.json
@@ -271,8 +271,8 @@
       }
     },
     "navigation": {
-      "nextClimb": "Bloque siguiente",
-      "previousClimb": "Bloque anterior"
+      "nextClimb": "Bloque siguiente en la pared",
+      "previousClimb": "Bloque anterior en la pared"
     },
     "mirror": {
       "label": {

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -219,10 +219,17 @@
     "editClimb": "Editar este bloque",
     "addedViaBluetooth": "Añadido por Bluetooth",
     "nextUpHeader": "A continuación",
-    "endMessage": "Eso es todo por ahora"
+    "endMessage": "Eso es todo por ahora",
+    "showFullHistory_one": "Mostrar historial completo ({{count}} más)",
+    "showFullHistory_other": "Mostrar historial completo ({{count}} más)"
   },
   "queueProvider": {
     "offlineLimitReached": "Has alcanzado el límite de la cola sin conexión. Vuelve a conectarte para sincronizar tus vías."
+  },
+  "driverToast": {
+    "firstDriver": "{{newDriver}} está manejando la pared.",
+    "tookFromOther": "{{newDriver}} le quitó la pared a {{previousDriver}}.",
+    "tookFromYou": "{{newDriver}} te quitó la pared."
   },
   "playView": {
     "onWallChip": "EN EL MURO · {{username}}",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -221,7 +221,8 @@
     "nextUpHeader": "A continuación",
     "endMessage": "Eso es todo por ahora",
     "showFullHistory_one": "Mostrar historial completo ({{count}} más)",
-    "showFullHistory_other": "Mostrar historial completo ({{count}} más)"
+    "showFullHistory_other": "Mostrar historial completo ({{count}} más)",
+    "tickHistoryClimb": "Registrar un tick para {{name}}"
   },
   "queueProvider": {
     "offlineLimitReached": "Has alcanzado el límite de la cola sin conexión. Vuelve a conectarte para sincronizar tus vías."

--- a/packages/web/i18n/locales/fr/climbs.json
+++ b/packages/web/i18n/locales/fr/climbs.json
@@ -277,8 +277,8 @@
       }
     },
     "navigation": {
-      "nextClimb": "Bloc suivant",
-      "previousClimb": "Bloc précédent"
+      "nextClimb": "Bloc suivant sur le mur",
+      "previousClimb": "Bloc précédent sur le mur"
     },
     "mirror": {
       "label": {

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -221,7 +221,8 @@
     "nextUpHeader": "À suivre",
     "endMessage": "C'est tout pour l'instant",
     "showFullHistory_one": "Afficher l'historique complet ({{count}} de plus)",
-    "showFullHistory_other": "Afficher l'historique complet ({{count}} de plus)"
+    "showFullHistory_other": "Afficher l'historique complet ({{count}} de plus)",
+    "tickHistoryClimb": "Enregistrer une croix pour {{name}}"
   },
   "queueProvider": {
     "offlineLimitReached": "Tu as atteint la limite hors ligne de la file d'attente. Reconnecte-toi pour synchroniser tes blocs."

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -230,7 +230,7 @@
   "driverToast": {
     "firstDriver": "{{newDriver}} pilote le mur.",
     "tookFromOther": "{{newDriver}} a pris le mur à {{previousDriver}}.",
-    "tookFromYou": "{{newDriver}} a pris le mur."
+    "tookFromYou": "{{newDriver}} t'a pris le mur."
   },
   "playView": {
     "onWallChip": "SUR LE MUR · {{username}}",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -219,10 +219,17 @@
     "editClimb": "Modifier ce bloc",
     "addedViaBluetooth": "Ajouté via Bluetooth",
     "nextUpHeader": "À suivre",
-    "endMessage": "C'est tout pour l'instant"
+    "endMessage": "C'est tout pour l'instant",
+    "showFullHistory_one": "Afficher l'historique complet ({{count}} de plus)",
+    "showFullHistory_other": "Afficher l'historique complet ({{count}} de plus)"
   },
   "queueProvider": {
     "offlineLimitReached": "Tu as atteint la limite hors ligne de la file d'attente. Reconnecte-toi pour synchroniser tes blocs."
+  },
+  "driverToast": {
+    "firstDriver": "{{newDriver}} pilote le mur.",
+    "tookFromOther": "{{newDriver}} a pris le mur à {{previousDriver}}.",
+    "tookFromYou": "{{newDriver}} a pris le mur."
   },
   "playView": {
     "onWallChip": "SUR LE MUR · {{username}}",


### PR DESCRIPTION
## Summary

Closes the user-visible + instrumentation gaps left after PR #2198 (Queue Control Bar pivot, merged 2026-05-18). Same one-bundled-PR cadence the merged pivot used.

- **Phase 3 queue list:** 5-item history default + "Show full history (N more)" toggle + scroll-to-center on open
- **Phase 5 instrumentation:** new `Wall Advance` event (bar button / bar swipe / drawer button / driver-drawer swipe) and `Session Board Serial Set` event
- **Phase 2 polish:** bar prev/next aria-labels now read "Previous/Next climb on the wall." (en-US/es/fr)
- **Open Q2 — hand-off toast:** quiet info-level snackbar on `DriverChanged` for peer-driven changes ("Alice is driving the wall." / "Alice took the wall from Bob." / "Alice took the wall."). Suppressed for self-takes + successor-less releases.
- **Open Q5 — stale `lastConnectedBoardSerial`:** skip redundant writes on same-serial reconnect; overwrite when a new pick differs from the session value.
- **isLeader audit:** confirmed no `isLeader` site gates wall control across backend, web, shared-schema, iOS. Audit recorded as a comment block at the top of `mutations.ts` and as a doc appendix bullet.
- **Doc reconciliation:** wall-view drawer section rewritten to match the shipped chip-in-drawer + DRIVING/Preview chip pattern; "What shipped vs spec" appendix added; dead `queue-button.tsx` marked with a `TODO(queue-bar-pivot)`.

### Validation

- `vp run typecheck` (web + backend + db + shared) — clean.
- `vp check` — 0 errors. Only pre-existing `no-floating-promises` warnings in unrelated `.mjs` files.
- `vp run check:i18n` + `vp run check:i18n:orphans` — both clean (orphan checker can't resolve `latest.t(...)` calls; new keys carry `// i18n-keep` markers in `QueueContext.tsx`).
- `vp test run --project web` — 4731/4734. The 3 failures are pre-existing flakes in `quick-tick-bar.test.tsx` that pass when run in isolation (parallelism stress). 16 new test cases (3 new files, 4 added to `bluetooth-context.test.tsx`) all pass.

### Deferred to follow-ups

- iOS Live Activity widget `Wall Advance` — needs iOS native PostHog wiring; defer.
- Deleting the dead `queue-button.tsx` — `TODO` marker added.
- Two-phones-racing double-confirm test — behavior is already safe via `pendingClimbUuid`; hygiene test.
- PR #2215 (Phase 3 structural refactors) — separate PR.

## Test plan

- [ ] **Long-history queue list.** Send ≥6 climbs in one session → open the queue drawer. Only the 5 most recent history climbs visible above the current item, with a "Show full history (N more)" row at the top. Click it → all history items appear, row disappears. Close + reopen drawer → resets to 5-item view.
- [ ] **Centered scroll.** Open the queue drawer mid-session — current climb is vertically centered in the viewport, not pinned to top.
- [ ] **Bar prev/next aria-labels.** Screen reader on the bar's prev/next buttons announces "Previous/Next climb on the wall."
- [ ] **`Wall Advance` event.** PostHog DevTools open:
  - Bar button press → `source: 'bar_button'`, `pressedByRole: 'driver'|'non_driver'`
  - Bar swipe → `source: 'bar_swipe'`
  - Driver drawer button/swipe → `source: 'drawer_button'|'drawer_swipe'`, `pressedByRole: 'driver'`
  - **Non-driver drawer swipe** (preview only) → **NO** `Wall Advance`; only `Queue Navigation` with `mode: 'preview'`
- [ ] **Hand-off toast (two profiles).** Profile A takes control → B sees "Alice is driving the wall."; A sees nothing. B takes control → A sees "Bob took the wall."; B sees nothing. Uninvolved profile C sees "Bob took the wall from Alice." A releases (no successor) → no toast on anyone.
- [ ] **`Session Board Serial Set` event.** In a party session, connect a board → event fires with `previousSerialKnown: false`. Reconnect to a different board → event fires with `previousSerialKnown: true`. Reconnect to same board → **no event** (idempotent skip).
- [ ] **Stale serial recovery.** Connect solo to board A. Join a session whose `lastConnectedBoardSerial` is board B. Pair against board A → session's serial is overwritten to A.
- [ ] Spot-check the wall-view drawer mode (header + chips + lock + Browse-from-here exit) hasn't regressed.
- [ ] `vp check` + `vp run typecheck` + `vp test run --project web` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)