### PR TITLE
Fix shared package portability, error handling, and test coverage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -174,7 +174,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@boardsesh/board-constants": "*",
-        "@boardsesh/shared-schema": "*",
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -183,9 +182,6 @@
     "packages/shared/queue": {
       "name": "@boardsesh/queue",
       "version": "1.0.0",
-      "dependencies": {
-        "@boardsesh/shared-schema": "*",
-      },
       "devDependencies": {
         "typescript": "^5.9.3",
       },

--- a/packages/shared/ble-protocol/package.json
+++ b/packages/shared/ble-protocol/package.json
@@ -30,8 +30,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@boardsesh/board-constants": "*",
-    "@boardsesh/shared-schema": "*"
+    "@boardsesh/board-constants": "*"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/packages/shared/ble-protocol/src/__tests__/aurora.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/aurora.test.ts
@@ -163,6 +163,18 @@ describe('parseBoardTypeFromDeviceName', () => {
   it('returns undefined for unrecognized board name', () => {
     expect(parseBoardTypeFromDeviceName('Unknown Board#1@3')).toBeUndefined();
   });
+
+  it('parses decoy from device name', () => {
+    expect(parseBoardTypeFromDeviceName('Decoy Board#789@3')).toBe('decoy');
+  });
+
+  it('parses touchstone from device name', () => {
+    expect(parseBoardTypeFromDeviceName('Touchstone Board#101@3')).toBe('touchstone');
+  });
+
+  it('parses grasshopper from device name', () => {
+    expect(parseBoardTypeFromDeviceName('Grasshopper Board#202@3')).toBe('grasshopper');
+  });
 });
 
 describe('getAuroraBluetoothPacket', () => {

--- a/packages/shared/ble-protocol/src/__tests__/aurora.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/aurora.test.ts
@@ -156,6 +156,10 @@ describe('parseBoardTypeFromDeviceName', () => {
     expect(parseBoardTypeFromDeviceName('So iLL Board#42@3')).toBe('soill');
   });
 
+  it('parses "So-iLL Board#42@3" as soill (strips hyphens)', () => {
+    expect(parseBoardTypeFromDeviceName('So-iLL Board#42@3')).toBe('soill');
+  });
+
   it('returns undefined for undefined input', () => {
     expect(parseBoardTypeFromDeviceName(undefined)).toBeUndefined();
   });

--- a/packages/shared/ble-protocol/src/__tests__/moonboard.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/moonboard.test.ts
@@ -66,27 +66,39 @@ describe('isMoonboardDeviceName', () => {
 describe('getMoonboardBluetoothPacket', () => {
   it('produces correct output format for a single hold', () => {
     // Role 42 = 'S' (start), placement 1 -> serial position 0
-    const packet = getMoonboardBluetoothPacket('p1r42');
-    const decoded = new TextDecoder().decode(packet);
+    const result = getMoonboardBluetoothPacket('p1r42');
+    const decoded = new TextDecoder().decode(result.packet);
     expect(decoded).toBe('l#S0#');
   });
 
   it('produces correct output for multiple holds', () => {
     // Role 42='S', 43='P', 44='E'
     // placement 1 -> position 0, placement 2 -> position 35
-    const packet = getMoonboardBluetoothPacket('p1r42p2r43');
-    const decoded = new TextDecoder().decode(packet);
+    const result = getMoonboardBluetoothPacket('p1r42p2r43');
+    const decoded = new TextDecoder().decode(result.packet);
     expect(decoded).toBe('l#S0,P35#');
   });
 
   it('includes end hold type', () => {
     // Role 44='E', placement 198 -> position 197
-    const packet = getMoonboardBluetoothPacket('p198r44');
-    const decoded = new TextDecoder().decode(packet);
+    const result = getMoonboardBluetoothPacket('p198r44');
+    const decoded = new TextDecoder().decode(result.packet);
     expect(decoded).toBe('l#E197#');
   });
 
-  it('throws for unsupported role code', () => {
-    expect(() => getMoonboardBluetoothPacket('p1r99')).toThrow('Unsupported MoonBoard hold state code');
+  it('skips unsupported role codes gracefully', () => {
+    const result = getMoonboardBluetoothPacket('p1r99');
+    const decoded = new TextDecoder().decode(result.packet);
+    expect(decoded).toBe('l##');
+    expect(result.skippedRoleCount).toBe(1);
+  });
+
+  it('encodes valid holds and skips invalid role codes', () => {
+    // role 42='S' is valid, role 99 is invalid
+    const result = getMoonboardBluetoothPacket('p1r42p2r99');
+    const decoded = new TextDecoder().decode(result.packet);
+    expect(decoded).toBe('l#S0#');
+    expect(result.skippedRoleCount).toBe(1);
+    expect(result.totalPlacements).toBe(2);
   });
 });

--- a/packages/shared/ble-protocol/src/aurora.ts
+++ b/packages/shared/ble-protocol/src/aurora.ts
@@ -1,6 +1,9 @@
 import { HOLD_STATE_MAP } from '@boardsesh/board-constants/hold-states';
-import { AURORA_BOARDS, type AuroraBoardName, type HoldState } from '@boardsesh/shared-schema';
 import { MESSAGE_BODY_MAX_LENGTH } from './transport';
+
+export const AURORA_BOARDS = ['kilter', 'tension', 'decoy', 'touchstone', 'grasshopper', 'soill'] as const;
+export type AuroraBoardName = (typeof AURORA_BOARDS)[number];
+export type HoldState = 'OFF' | 'STARTING' | 'FINISH' | 'HAND' | 'FOOT' | 'ANY' | 'NOT' | 'AUX';
 
 /** LED placement positions: maps placement ID to LED position index. */
 export type LedPlacements = Record<number, number>;

--- a/packages/shared/ble-protocol/src/aurora.ts
+++ b/packages/shared/ble-protocol/src/aurora.ts
@@ -1,6 +1,9 @@
 import { HOLD_STATE_MAP } from '@boardsesh/board-constants/hold-states';
 import { MESSAGE_BODY_MAX_LENGTH } from './transport';
 
+// Canonical source: @boardsesh/shared-schema (board-config.ts, climb.ts).
+// Duplicated here so ble-protocol stays portable without pulling in
+// shared-schema's full type tree. Keep in sync when adding a new board.
 export const AURORA_BOARDS = ['kilter', 'tension', 'decoy', 'touchstone', 'grasshopper', 'soill'] as const;
 export type AuroraBoardName = (typeof AURORA_BOARDS)[number];
 export type HoldState = 'OFF' | 'STARTING' | 'FINISH' | 'HAND' | 'FOOT' | 'ANY' | 'NOT' | 'AUX';

--- a/packages/shared/ble-protocol/src/moonboard.ts
+++ b/packages/shared/ble-protocol/src/moonboard.ts
@@ -12,6 +12,13 @@ const MOONBOARD_ROLE_MAP = {
   44: 'E',
 } as const;
 
+export type MoonboardPacketResult = {
+  packet: Uint8Array;
+  skippedRoleCount: number;
+  skippedPositionCount: number;
+  totalPlacements: number;
+};
+
 // Note: UART_SERVICE_UUID is available from './transport' — not re-exported
 // here to avoid collisions in the barrel index.
 
@@ -36,34 +43,40 @@ export function getMoonboardSerialPosition(holdId: number): number {
   return colIndex * MOONBOARD_GRID.numRows + (MOONBOARD_GRID.numRows - 1 - rowIndex);
 }
 
-export function getMoonboardBluetoothPacket(frames: string): Uint8Array {
+export function getMoonboardBluetoothPacket(frames: string): MoonboardPacketResult {
   const encodedHolds: string[] = [];
-  let skippedCount = 0;
+  let skippedRoleCount = 0;
+  let skippedPositionCount = 0;
 
-  frames
-    .split('p')
-    .filter(Boolean)
-    .forEach((frame) => {
-      const [placement, role] = frame.split('r');
-      const holdId = Number(placement);
-      const holdType = MOONBOARD_ROLE_MAP[Number(role) as keyof typeof MOONBOARD_ROLE_MAP];
+  const frameParts = frames.split('p').filter(Boolean);
 
-      if (!holdType) {
-        throw new Error(`Unsupported MoonBoard hold state code: ${role}`);
-      }
+  frameParts.forEach((frame) => {
+    const [placement, role] = frame.split('r');
+    const holdId = Number(placement);
+    const holdType = MOONBOARD_ROLE_MAP[Number(role) as keyof typeof MOONBOARD_ROLE_MAP];
 
-      try {
-        encodedHolds.push(`${holdType}${getMoonboardSerialPosition(holdId)}`);
-      } catch {
-        skippedCount++;
-      }
-    });
+    if (!holdType) {
+      skippedRoleCount++;
+      return;
+    }
 
-  if (skippedCount > 0) {
-    console.warn(`[BLE] Skipped ${skippedCount} MoonBoard holds with invalid ids for this payload`);
+    try {
+      encodedHolds.push(`${holdType}${getMoonboardSerialPosition(holdId)}`);
+    } catch {
+      skippedPositionCount++;
+    }
+  });
+
+  if (skippedPositionCount > 0) {
+    console.warn(`[BLE] Skipped ${skippedPositionCount} MoonBoard holds with invalid ids for this payload`);
   }
 
   const holdPayload = encodedHolds.join(',');
 
-  return new TextEncoder().encode(`${MOONBOARD_FRAME_PREFIX}${holdPayload}${MOONBOARD_FRAME_SUFFIX}`);
+  return {
+    packet: new TextEncoder().encode(`${MOONBOARD_FRAME_PREFIX}${holdPayload}${MOONBOARD_FRAME_SUFFIX}`),
+    skippedRoleCount,
+    skippedPositionCount,
+    totalPlacements: frameParts.length,
+  };
 }

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-moonboard.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-moonboard.test.ts
@@ -16,28 +16,41 @@ describe('getMoonboardSerialPosition', () => {
 
 describe('getMoonboardBluetoothPacket', () => {
   it('encodes Moonboard frames as the controller ASCII payload', () => {
-    const packet = getMoonboardBluetoothPacket('p1r42p2r43p198r44');
+    const { packet } = getMoonboardBluetoothPacket('p1r42p2r43p198r44');
 
     expect(new TextDecoder().decode(packet)).toBe('l#S0,P35,E197#');
   });
 
-  it('throws on unsupported Moonboard hold state codes', () => {
-    expect(() => getMoonboardBluetoothPacket('p1r45')).toThrow('Unsupported MoonBoard hold state code: 45');
+  it('skips unsupported Moonboard hold state codes gracefully', () => {
+    const { packet, skippedRoleCount, totalPlacements } = getMoonboardBluetoothPacket('p1r45');
+
+    expect(new TextDecoder().decode(packet)).toBe('l##');
+    expect(skippedRoleCount).toBe(1);
+    expect(totalPlacements).toBe(1);
+  });
+
+  it('encodes valid holds and skips invalid role codes', () => {
+    const { packet, skippedRoleCount, totalPlacements } = getMoonboardBluetoothPacket('p1r42p2r99');
+
+    expect(new TextDecoder().decode(packet)).toBe('l#S0#');
+    expect(skippedRoleCount).toBe(1);
+    expect(totalPlacements).toBe(2);
   });
 
   it('skips invalid Moonboard hold ids and keeps the remaining payload', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const packet = getMoonboardBluetoothPacket('p1r42p999r43p198r44');
+    const { packet, skippedPositionCount } = getMoonboardBluetoothPacket('p1r42p999r43p198r44');
 
     expect(new TextDecoder().decode(packet)).toBe('l#S0,E197#');
+    expect(skippedPositionCount).toBe(1);
     expect(warnSpy).toHaveBeenCalledWith('[BLE] Skipped 1 MoonBoard holds with invalid ids for this payload');
 
     warnSpy.mockRestore();
   });
 
   it('can be split into 20-byte BLE chunks without changing the payload', () => {
-    const packet = getMoonboardBluetoothPacket('p1r42p2r43p3r43p4r43p5r43p6r43p7r43p8r43p198r44');
+    const { packet } = getMoonboardBluetoothPacket('p1r42p2r43p3r43p4r43p5r43p6r43p7r43p8r43p198r44');
 
     const chunks = splitMessages(packet);
 

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-moonboard.ts
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-moonboard.ts
@@ -3,6 +3,7 @@ export {
   isMoonboardDeviceName,
   getMoonboardSerialPosition,
   getMoonboardBluetoothPacket,
+  type MoonboardPacketResult,
 } from '@boardsesh/ble-protocol/moonboard';
 
 import { UART_SERVICE_UUID } from '@boardsesh/ble-protocol/transport';

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -212,8 +212,42 @@ export function useBoardBluetooth({
           // empty frame string — skip the write rather than send a malformed
           // packet to the board.
           if (!frames) return;
-          const { packet: bluetoothPacket } = getMoonboardBluetoothPacket(frames);
-          await adapterRef.current.write(bluetoothPacket, signal);
+          const moonResult = getMoonboardBluetoothPacket(frames);
+          const moonSkipped = moonResult.skippedRoleCount + moonResult.skippedPositionCount;
+
+          if (moonSkipped > 0 && moonResult.totalPlacements === moonSkipped) {
+            Sentry.captureMessage(
+              `[BLE] All ${moonResult.totalPlacements} MoonBoard placements skipped — climb data may be corrupted`,
+              {
+                level: 'warning',
+                tags: { board: 'moonboard' },
+                extra: {
+                  climbUuid,
+                  skippedRoleCount: moonResult.skippedRoleCount,
+                  skippedPositionCount: moonResult.skippedPositionCount,
+                },
+              },
+            );
+            showMessage('This climb has unrecognised hold data and cannot be sent to the board.', 'error');
+            return false;
+          }
+
+          if (moonSkipped > 0) {
+            Sentry.captureMessage(
+              `[BLE] ${moonSkipped} of ${moonResult.totalPlacements} MoonBoard placements skipped`,
+              {
+                level: 'warning',
+                tags: { board: 'moonboard' },
+                extra: {
+                  climbUuid,
+                  skippedRoleCount: moonResult.skippedRoleCount,
+                  skippedPositionCount: moonResult.skippedPositionCount,
+                },
+              },
+            );
+          }
+
+          await adapterRef.current.write(moonResult.packet, signal);
           void incrementBluetoothSends().then(maybeFireFeedbackPromptEvent);
           return true;
         }

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -212,7 +212,7 @@ export function useBoardBluetooth({
           // empty frame string — skip the write rather than send a malformed
           // packet to the board.
           if (!frames) return;
-          const bluetoothPacket = getMoonboardBluetoothPacket(frames);
+          const { packet: bluetoothPacket } = getMoonboardBluetoothPacket(frames);
           await adapterRef.current.write(bluetoothPacket, signal);
           void incrementBluetoothSends().then(maybeFireFeedbackPromptEvent);
           return true;

--- a/packages/web/app/components/play-view/__tests__/mini-session-bar.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/mini-session-bar.test.tsx
@@ -150,12 +150,7 @@ describe('MiniSessionBar', () => {
     render(
       <MiniSessionBar
         {...defaultProps({
-          sessionUsers: [
-            user('me', 'me'),
-            user('sara', 'Sara'),
-            user('jules', 'Jules'),
-            user('driver', 'Marco'),
-          ],
+          sessionUsers: [user('me', 'me'), user('sara', 'Sara'), user('jules', 'Jules'), user('driver', 'Marco')],
           driverParticipantId: 'driver',
           participantId: 'me',
         })}

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -1527,8 +1527,7 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
                 pointerEvents: 'none',
               }}
             >
-              <TickBadgeAvatar user={driverUser} hasTicked={false} isDriver size={18}
-              />
+              <TickBadgeAvatar user={driverUser} hasTicked={false} isDriver size={18} />
             </Box>
           )}
           <div

--- a/packages/web/app/components/queue-control/types.ts
+++ b/packages/web/app/components/queue-control/types.ts
@@ -7,6 +7,20 @@ import type {
   AddToQueueSource,
 } from '@boardsesh/queue';
 
+// TYPE SEAM: The web defines its own ClimbQueueItem, Climb, and QueueItemUser
+// types with web-specific fields (e.g. Climb.boardType). The shared
+// @boardsesh/queue package defines structurally compatible types with wider
+// nullability (e.g. description?: string | null). TypeScript accepts the
+// structural overlap but the two type trees are not identical.
+//
+// QueueState and QueueAction are aliased to the shared generics. Action
+// payloads use the shared ClimbQueueItem (from @boardsesh/queue), while
+// the web QueueContextType surfaces the web's own ClimbQueueItem. This
+// works because the shared ClimbQueueItem's Climb type is structurally
+// wider — the web Climb satisfies it — but callers should be aware that
+// action payloads and context data use different (but compatible) Climb
+// definitions.
+
 // Re-export pure value types from the shared package for backward compatibility.
 // Types that embed Climb (PlaylistSuggestionSource, SetCurrentClimbOptions) are
 // defined locally because they reference the web's Climb type (which carries

--- a/packages/web/app/development/__tests__/payload-decoder.test.ts
+++ b/packages/web/app/development/__tests__/payload-decoder.test.ts
@@ -101,7 +101,7 @@ describe('PayloadDecoder — Aurora v2', () => {
 describe('PayloadDecoder — MoonBoard ASCII', () => {
   it('decodes a single-shot MoonBoard payload back to the original frames', () => {
     const frames = 'p1r42p2r43p198r44';
-    const packet = getMoonboardBluetoothPacket(frames);
+    const { packet } = getMoonboardBluetoothPacket(frames);
     const decoded = decodeOnce(packet, { board: 'moonboard', layoutId: 0, sizeId: 0 });
     if (!decoded || decoded.board !== 'moonboard') throw new Error('expected moonboard frame');
     // MoonBoard reverse-mapping is sort-stable on holdId, so the round-tripped
@@ -123,7 +123,7 @@ describe('PayloadDecoder — MoonBoard ASCII', () => {
     // exceeds that. Drive a payload through the decoder one BLE-sized slice
     // at a time and assert we get exactly one frame at the end.
     const frames = 'p1r42p2r43p10r43p20r43p50r43p100r43p150r43p198r44';
-    const packet = getMoonboardBluetoothPacket(frames);
+    const { packet } = getMoonboardBluetoothPacket(frames);
     expect(packet.length).toBeGreaterThan(20);
 
     const decoder = new PayloadDecoder({ board: 'moonboard', layoutId: 0, sizeId: 0 });


### PR DESCRIPTION
## Summary

Follow-up to #2248. Fixes 6 issues identified in post-merge review.

- **bun.lock out of sync**: Regenerated — stale `@boardsesh/shared-schema` reference removed from `@boardsesh/queue`
- **MoonBoard error handling**: `getMoonboardBluetoothPacket` now skips unknown role codes gracefully (returns `MoonboardPacketResult` with skip counts) instead of throwing, matching Aurora's pattern. All web callers and tests updated.
- **ble-protocol portability**: Removed `@boardsesh/shared-schema` dependency — `AURORA_BOARDS`, `AuroraBoardName`, `HoldState` defined locally. Package now only depends on `@boardsesh/board-constants`.
- **Type seam documented**: Added doc comment in web `types.ts` explaining the structural compatibility between shared and web `ClimbQueueItem` types
- **Missing test coverage**: Added `parseBoardTypeFromDeviceName` tests for decoy, touchstone, grasshopper. Added moonboard graceful-skip tests for unknown role codes.

## Test plan

- [x] `vp run typecheck` passes for ble-protocol, queue, and web (zero errors)
- [x] 104 shared package tests pass (`npx vitest run --project ble-protocol --project queue`)
- [x] Web BLE tests updated for new `MoonboardPacketResult` return type
- [ ] `bun install --frozen-lockfile` succeeds in CI (validates lockfile sync)
- [ ] Verify BLE functionality unchanged (connect to board, send climbs)

https://claude.ai/code/session_01GmHX6G2Un74zg6uFR3jMfr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmHX6G2Un74zg6uFR3jMfr)_