### PR TITLE
fix(queue): surface driver hand-off toast when peer name is unresolved

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -333,36 +333,33 @@ export const GraphQLQueueProvider = ({
         // i18n-keep session:driverToast.firstDriver
         // i18n-keep session:driverToast.tookFromYou
         // i18n-keep session:driverToast.tookFromOther
+        // i18n-keep session:driverToast.unknownDriver
         // (The orphan-key checker can't resolve `latest.t(...)` to a
         // useTranslation binding; the keys are statically used here.)
         if (newDriverId && newDriverId !== localParticipantId) {
-          const newDriverName = latest.users.find((user) => user.id === newDriverId)?.username ?? '';
+          // The new driver can arrive before they show up in `latest.users`
+          // (distributed-state propagation reordering). Falling back to
+          // "Someone" keeps the toast firing — losing the wall to an
+          // unnamed peer is still better than the local user silently
+          // discovering it on their next interaction.
+          const newDriverName =
+            latest.users.find((user) => user.id === newDriverId)?.username ?? latest.t('driverToast.unknownDriver');
           const previousDriverId = event.previousDriverParticipantId ?? null;
-          if (newDriverName) {
-            if (!previousDriverId) {
-              latest.showMessage(latest.t('driverToast.firstDriver', { newDriver: newDriverName }), 'info');
-            } else if (previousDriverId === localParticipantId) {
-              latest.showMessage(latest.t('driverToast.tookFromYou', { newDriver: newDriverName }), 'info');
-            } else {
-              const previousDriverName = latest.users.find((user) => user.id === previousDriverId)?.username ?? '';
-              // The previous driver can be gone from `users` by the time the
-              // event arrives (left the session in the same tick they were
-              // yanked, or distributed-state propagation reordered).
-              // Surfacing "X took the wall from ." is worse than dropping the
-              // attribution — fall through to the simpler firstDriver copy so
-              // the toast still names the new driver and reads cleanly.
-              if (previousDriverName) {
-                latest.showMessage(
-                  latest.t('driverToast.tookFromOther', {
-                    newDriver: newDriverName,
-                    previousDriver: previousDriverName,
-                  }),
-                  'info',
-                );
-              } else {
-                latest.showMessage(latest.t('driverToast.firstDriver', { newDriver: newDriverName }), 'info');
-              }
-            }
+          if (!previousDriverId) {
+            latest.showMessage(latest.t('driverToast.firstDriver', { newDriver: newDriverName }), 'info');
+          } else if (previousDriverId === localParticipantId) {
+            latest.showMessage(latest.t('driverToast.tookFromYou', { newDriver: newDriverName }), 'info');
+          } else {
+            const previousDriverName =
+              latest.users.find((user) => user.id === previousDriverId)?.username ??
+              latest.t('driverToast.unknownDriver');
+            latest.showMessage(
+              latest.t('driverToast.tookFromOther', {
+                newDriver: newDriverName,
+                previousDriver: previousDriverName,
+              }),
+              'info',
+            );
           }
         }
       }

--- a/packages/web/app/components/graphql-queue/__tests__/driver-handoff-toast.test.tsx
+++ b/packages/web/app/components/graphql-queue/__tests__/driver-handoff-toast.test.tsx
@@ -308,13 +308,12 @@ describe('driver hand-off toast', () => {
     expect(mockShowMessage).not.toHaveBeenCalled();
   });
 
-  it('falls back to firstDriver copy when the previous driver is no longer in the users list', () => {
+  it('substitutes "Someone" for an unresolved previous driver instead of suppressing the toast', () => {
     renderHook(() => useQueueContext(), { wrapper: createWrapper() });
 
     // previousDriverParticipantId references a user who has already left the
-    // session — `users.find()` returns undefined and the resolved name is
-    // empty. The toast must drop the attribution rather than render "X took
-    // the wall from ." See bug triage on PR #2249.
+    // session — `users.find()` returns undefined. The toast still fires with
+    // the unknownDriver fallback rather than dropping attribution silently.
     act(() => {
       emitSessionEvent({
         __typename: 'DriverChanged',
@@ -324,12 +323,29 @@ describe('driver hand-off toast', () => {
     });
 
     expect(mockShowMessage).toHaveBeenCalledWith(
-      expect.stringContaining('driverToast.firstDriver|newDriver=Bob'),
+      expect.stringContaining('driverToast.tookFromOther|newDriver=Bob|previousDriver=driverToast.unknownDriver'),
       'info',
     );
-    expect(mockShowMessage).not.toHaveBeenCalledWith(
-      expect.stringContaining('driverToast.tookFromOther'),
-      expect.anything(),
+  });
+
+  it('still fires tookFromYou when the new driver has not propagated into the users list yet', () => {
+    renderHook(() => useQueueContext(), { wrapper: createWrapper() });
+
+    // The new driver's id arrives before they show up in `users` (distributed-
+    // state propagation reordering). The local user just lost the wall — they
+    // must still get the toast, with "Someone" substituted for the unresolved
+    // peer name. See PR #2249 review.
+    act(() => {
+      emitSessionEvent({
+        __typename: 'DriverChanged',
+        driverParticipantId: 'participant-ghost',
+        previousDriverParticipantId: 'participant-1',
+      });
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith(
+      expect.stringContaining('driverToast.tookFromYou|newDriver=driverToast.unknownDriver'),
+      'info',
     );
   });
 });

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -125,12 +125,13 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
     const [playlistClimb, setPlaylistClimb] = useState<Climb | null>(null);
 
     // Toggled by the "Show full history" row at the top of the history region.
-    // Local to each list mount — resets when the drawer remounts so a freshly-
-    // opened list always starts on the 5-item view. Depends on QueueDrawer NOT
-    // passing `keepMounted={true}` to the underlying SwipeableDrawer (default
-    // is false); if a caller starts keeping the drawer mounted, the state will
-    // stick across sessions and this expectation breaks.
+    // Reset whenever the consumer marks the list inactive — callers that keep
+    // the drawer mounted just need to pass `active={open}` to get the spec'd
+    // behavior (a freshly opened list always starts on the 5-item view).
     const [showFullHistory, setShowFullHistory] = useState(false);
+    useEffect(() => {
+      if (!active) setShowFullHistory(false);
+    }, [active]);
 
     const handleOpenActions = useCallback((climb: Climb) => {
       setPlaylistClimb(null);

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -230,7 +230,8 @@
   "driverToast": {
     "firstDriver": "{{newDriver}} is driving the wall.",
     "tookFromOther": "{{newDriver}} took the wall from {{previousDriver}}.",
-    "tookFromYou": "{{newDriver}} took the wall from you."
+    "tookFromYou": "{{newDriver}} took the wall from you.",
+    "unknownDriver": "Someone"
   },
   "playView": {
     "onWallChip": "ON WALL · {{username}}",

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -230,7 +230,8 @@
   "driverToast": {
     "firstDriver": "{{newDriver}} está manejando la pared.",
     "tookFromOther": "{{newDriver}} le quitó la pared a {{previousDriver}}.",
-    "tookFromYou": "{{newDriver}} te quitó la pared."
+    "tookFromYou": "{{newDriver}} te quitó la pared.",
+    "unknownDriver": "Alguien"
   },
   "playView": {
     "onWallChip": "EN EL MURO · {{username}}",

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -230,7 +230,8 @@
   "driverToast": {
     "firstDriver": "{{newDriver}} pilote le mur.",
     "tookFromOther": "{{newDriver}} a pris le mur à {{previousDriver}}.",
-    "tookFromYou": "{{newDriver}} t'a pris le mur."
+    "tookFromYou": "{{newDriver}} t'a pris le mur.",
+    "unknownDriver": "Quelqu'un"
   },
   "playView": {
     "onWallChip": "SUR LE MUR · {{username}}",


### PR DESCRIPTION
## Summary

Two follow-up nits from the [PR #2249](https://github.com/boardsesh/boardsesh/pull/2249) review:

- **QueueContext silently suppressed the entire driver hand-off toast** when the new driver's id hadn't yet propagated into `latest.users` (distributed-state propagation reordering). That swallowed the `tookFromYou` case — the local user just lost the wall and absolutely should be told. Fall back to a localized "Someone" string instead, and apply the same fallback for the previous driver in the `tookFromOther` branch so the attribution still renders cleanly.
- **`QueueList`'s `showFullHistory` reset depended on `QueueDrawer` not setting `keepMounted`** on the underlying `SwipeableDrawer`. Tied the reset to the existing `active` prop explicitly so `keepMounted` callers can opt back in with `active={open}`.

Adds the `driverToast.unknownDriver` key in en-US, es, and fr catalogs.

## Test plan

- [x] `vp run typecheck:web` — pass
- [x] `vp run check:i18n` + `vp run check:i18n:orphans` — pass
- [x] `vp lint` on touched files — clean
- [x] `vp test run --project web` on `driver-handoff-toast`, `queue-list-history-collapse`, `queue-list-active` — 19/19 pass (updated test now covers both the `tookFromOther + unknownDriver` rendering and the previously silent `tookFromYou` case)
- [ ] Manual smoke (optional): in a multi-user session, trigger a driver-change before the new user has propagated into the user list and confirm the toast still fires with "Someone..."
- [ ] Manual smoke: open queue drawer, expand full history, close, reopen — confirm list opens at the 5-item view

🤖 Generated with [Claude Code](https://claude.com/claude-code)