### PR TITLE
fix(queue): wire active prop from QueueDrawer + handle both-unresolved toast

### DIFF
--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -342,24 +342,30 @@ export const GraphQLQueueProvider = ({
           // "Someone" keeps the toast firing — losing the wall to an
           // unnamed peer is still better than the local user silently
           // discovering it on their next interaction.
-          const newDriverName =
-            latest.users.find((user) => user.id === newDriverId)?.username ?? latest.t('driverToast.unknownDriver');
+          const newDriverUser = latest.users.find((user) => user.id === newDriverId);
+          const newDriverName = newDriverUser?.username ?? latest.t('driverToast.unknownDriver');
           const previousDriverId = event.previousDriverParticipantId ?? null;
           if (!previousDriverId) {
             latest.showMessage(latest.t('driverToast.firstDriver', { newDriver: newDriverName }), 'info');
           } else if (previousDriverId === localParticipantId) {
             latest.showMessage(latest.t('driverToast.tookFromYou', { newDriver: newDriverName }), 'info');
           } else {
-            const previousDriverName =
-              latest.users.find((user) => user.id === previousDriverId)?.username ??
-              latest.t('driverToast.unknownDriver');
-            latest.showMessage(
-              latest.t('driverToast.tookFromOther', {
-                newDriver: newDriverName,
-                previousDriver: previousDriverName,
-              }),
-              'info',
-            );
+            const previousDriverUser = latest.users.find((user) => user.id === previousDriverId);
+            // When both peers are unresolved, "Someone took the wall from
+            // Someone." reads degenerate — fall back to the firstDriver copy
+            // so the toast still names the action without two anonymous slots.
+            if (!newDriverUser && !previousDriverUser) {
+              latest.showMessage(latest.t('driverToast.firstDriver', { newDriver: newDriverName }), 'info');
+            } else {
+              const previousDriverName = previousDriverUser?.username ?? latest.t('driverToast.unknownDriver');
+              latest.showMessage(
+                latest.t('driverToast.tookFromOther', {
+                  newDriver: newDriverName,
+                  previousDriver: previousDriverName,
+                }),
+                'info',
+              );
+            }
           }
         }
       }

--- a/packages/web/app/components/graphql-queue/__tests__/driver-handoff-toast.test.tsx
+++ b/packages/web/app/components/graphql-queue/__tests__/driver-handoff-toast.test.tsx
@@ -328,6 +328,30 @@ describe('driver hand-off toast', () => {
     );
   });
 
+  it('uses firstDriver copy when BOTH peers are unresolved, avoiding "Someone took the wall from Someone."', () => {
+    renderHook(() => useQueueContext(), { wrapper: createWrapper() });
+
+    // Pathological case: neither the new nor the previous driver has
+    // propagated into the users list. Two anonymous slots in tookFromOther
+    // reads degenerate — fall back to the simpler firstDriver phrasing.
+    act(() => {
+      emitSessionEvent({
+        __typename: 'DriverChanged',
+        driverParticipantId: 'participant-ghost-new',
+        previousDriverParticipantId: 'participant-ghost-old',
+      });
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith(
+      expect.stringContaining('driverToast.firstDriver|newDriver=driverToast.unknownDriver'),
+      'info',
+    );
+    expect(mockShowMessage).not.toHaveBeenCalledWith(
+      expect.stringContaining('driverToast.tookFromOther'),
+      expect.anything(),
+    );
+  });
+
   it('still fires tookFromYou when the new driver has not propagated into the users list yet', () => {
     renderHook(() => useQueueContext(), { wrapper: createWrapper() });
 

--- a/packages/web/app/components/play-view/queue-drawer.tsx
+++ b/packages/web/app/components/play-view/queue-drawer.tsx
@@ -248,6 +248,7 @@ const QueueDrawer: React.FC<QueueDrawerProps> = ({
             selectedItems={selectedItems}
             onToggleSelect={handleToggleSelect}
             scrollContainer={queueScrollEl}
+            active={open}
           />
         </div>
         {isEditMode && selectedItems.size > 0 && (

--- a/packages/web/app/components/queue-control/__tests__/queue-list-history-collapse.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-list-history-collapse.test.tsx
@@ -278,6 +278,27 @@ describe('QueueList history collapse', () => {
     expect(screen.queryByRole('button', { name: /show full history/i })).toBeNull();
   });
 
+  it('collapses an expanded history back to 5 items when active transitions to false', () => {
+    const { rerender } = render(<QueueList boardDetails={makeBoardDetails()} active showHistory />);
+
+    // Expand history by clicking the show-all button.
+    fireEvent.click(screen.getByRole('button', { name: /show full history.*3 more/i }));
+    expect(
+      screen.getAllByTestId('queue-climb-list-item').filter((n) => n.getAttribute('data-history') === 'true'),
+    ).toHaveLength(8);
+
+    // Simulate the drawer closing — without unmounting, as would happen with
+    // keepMounted. The reset effect must restore the 5-item view so the next
+    // open of the drawer doesn't stick on the expanded state.
+    rerender(<QueueList boardDetails={makeBoardDetails()} active={false} showHistory />);
+
+    const historyItemsAfter = screen
+      .getAllByTestId('queue-climb-list-item')
+      .filter((n) => n.getAttribute('data-history') === 'true');
+    expect(historyItemsAfter).toHaveLength(5);
+    expect(screen.getByRole('button', { name: /show full history.*3 more/i })).toBeTruthy();
+  });
+
   it('scrollToCurrentClimb centers the current item in the viewport', () => {
     const handle = React.createRef<QueueListHandle>();
     render(<QueueList ref={handle} boardDetails={makeBoardDetails()} active={false} showHistory />);


### PR DESCRIPTION
Follow-up to #2256, addressing three review nits:

## Summary

- **QueueDrawer now passes `active={open}` to QueueList.** Without this, the `showFullHistory` reset effect added in #2256 was unreachable in production — `active` defaults to `true` and never transitions to `false`. (`packages/web/app/components/play-view/queue-drawer.tsx`)
- **Both-unresolved toast edge case.** When both the new and previous driver fail to resolve in `latest.users`, the `tookFromOther` copy reads degenerately ("Someone took the wall from Someone."). Fall back to `firstDriver` ("Someone is driving the wall.") in that case. (`packages/web/app/components/graphql-queue/QueueContext.tsx`)
- **Regression coverage.** Added a `queue-list-history-collapse` test that exercises the full `true → false` transition (render with `active=true`, expand history, rerender with `active=false`, assert the list snaps back to the 5-item view). Added a `driver-handoff-toast` test covering the both-unresolved `firstDriver` fallback.

> Note: this PR is stacked on top of #2256. The base branch is `fix/queue-driver-toast-and-history-reset`. Merge #2256 first, then this will retarget to `main` automatically.

## Test plan

- [x] `vp run typecheck:web` — pass
- [x] `vp lint` on touched files — clean
- [x] `vp test run --project web` on `driver-handoff-toast` and `queue-list-history-collapse` — 12/12 pass
- [ ] Manual smoke: open queue drawer, expand full history, close, reopen — confirm list opens at the 5-item view (this is what the new regression test now guards against)
- [ ] Manual smoke (optional): in a multi-user session, trigger a driver hand-off between two unknown peers (both unresolved at receive time) and confirm the toast reads "Someone is driving the wall." rather than "Someone took the wall from Someone."

🤖 Generated with [Claude Code](https://claude.com/claude-code)