### PR TITLE
ci(mobile): trigger RN TestFlight workflow on push to main

### DIFF
--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -1,6 +1,14 @@
 name: iOS TestFlight Deploy (React Native)
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/mobile/**'
+      - 'packages/shared/**'
+      - 'packages/board-constants/**'
+      - 'packages/shared-schema/**'
+      - '.github/workflows/ios-testflight-rn.yml'
   workflow_dispatch:
     inputs:
       build_number_offset:


### PR DESCRIPTION
## Summary

- Adds a `push: branches: [main]` trigger to `ios-testflight-rn.yml` so the RN TestFlight build runs automatically when the mobile app or its shared deps land on `main`. Same pattern the Capacitor workflow uses.
- `workflow_dispatch` stays available for manual runs.

Paths watched:
- `packages/mobile/**`
- `packages/shared/**` (ble-protocol, board-config, queue)
- `packages/board-constants/**`
- `packages/shared-schema/**`
- the workflow file itself

## Test plan

- [ ] Merge this PR into `mobile-next-phase`
- [ ] When `mobile-next-phase` next lands on `main`, confirm the workflow fires automatically and uploads to TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)