### PR TITLE
fix(ci): pass signing settings to xcodebuild for RN TestFlight build

### DIFF
--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -136,7 +136,11 @@ jobs:
             -authenticationKeyPath ~/.private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8 \
             -authenticationKeyID "$APP_STORE_CONNECT_API_KEY_ID" \
             -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
-            CURRENT_PROJECT_VERSION=${{ steps.build_number.outputs.value }}
+            CURRENT_PROJECT_VERSION=${{ steps.build_number.outputs.value }} \
+            DEVELOPMENT_TEAM=9L3HKPZBH3 \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
+            PROVISIONING_PROFILE_SPECIFIER="Boardsesh App Store Distribution Second"
 
       - name: Export archive (uploads to TestFlight)
         env:


### PR DESCRIPTION
## Summary

First run of the RN TestFlight workflow failed at archive:

\`\`\`
error: Signing for \"Boardsesh\" requires a development team. Select a
development team in the Signing & Capabilities editor.
\`\`\`

The Capacitor app's checked-in \`project.pbxproj\` has \`DEVELOPMENT_TEAM\` baked in. The Expo-generated \`project.pbxproj\` (rebuilt on every CI run by \`expo prebuild\`) does not.

Fix: pass the signing settings on the \`xcodebuild archive\` command line, same way \`CURRENT_PROJECT_VERSION\` is already passed:

- \`DEVELOPMENT_TEAM=9L3HKPZBH3\` (same team the Capacitor app uses)
- \`CODE_SIGN_STYLE=Manual\`
- \`CODE_SIGN_IDENTITY=\"Apple Distribution\"\`
- \`PROVISIONING_PROFILE_SPECIFIER=\"Boardsesh App Store Distribution Second\"\` (matches the profile already in \`packages/mobile/ExportOptions.plist\`)

This avoids having to patch the generated project after prebuild.

## Test plan

- [ ] Merge and confirm the next push-to-main triggers the workflow and archives cleanly
- [ ] If still failing on signing, inspect the run log for which setting xcodebuild is unhappy with (Apple Distribution vs iPhone Distribution, profile name mismatch, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)