### PR TITLE
fix(ci): pin RN TestFlight to macos-15 for fmt/Xcode 26 compat

### DIFF
--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -22,7 +22,11 @@ concurrency:
 
 jobs:
   build-and-upload:
-    runs-on: macos-26
+    # macos-15 pins us to Xcode 16, where RN 0.79's vendored fmt library compiles.
+    # Under Xcode 26 (macos-26) clang's stricter C++20 constexpr evaluator
+    # rejects fmt's `format_str_.remove_prefix(...)` as non-constexpr. Bumping
+    # back here once RN ships a fmt fix that compiles on Xcode 26.
+    runs-on: macos-15
     timeout-minutes: 60
 
     env:


### PR DESCRIPTION
## Summary

Run [#26347867574](https://github.com/boardsesh/boardsesh/actions/runs/26347867574/job/77560763895) cleared signing but archive failed compiling \`fmt/src/format.cc\`:

\`\`\`
note: subexpression not valid in a constant expression
   format_str_.remove_prefix(detail::to_unsigned(it - begin()));
5 errors generated.
\`\`\`

Xcode 26's clang is stricter about C++20 \`constexpr\` and rejects the \`fmt\` library vendored by React Native 0.79. The Capacitor workflow doesn't hit this because it doesn't link \`fmt\`.

Switching the RN workflow to \`macos-15\` (Xcode 16) sidesteps the issue. Bump back to \`macos-26\` once RN ships a fmt fix that compiles cleanly on Xcode 26 — comment in the workflow file flags this.

Alternatives considered:
- **Use \`maxim-lobanov/setup-xcode\`** to pin Xcode 16 on macos-26 — works but adds an action dependency for a one-line outcome.
- **Patch fmt via Podfile post_install** — invasive, fragile across RN bumps.
- **Upgrade React Native to 0.81+** where this is patched — out of scope for a CI fix.

## Test plan

- [ ] Merge and confirm the next push-to-main triggers a successful archive
- [ ] If archive succeeds, confirm IPA uploads to TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)