### PR TITLE
PR #2255 follow-up: test coverage, code quality, auth hardening

### DIFF
--- a/packages/backend/src/__tests__/native-auth.test.ts
+++ b/packages/backend/src/__tests__/native-auth.test.ts
@@ -54,6 +54,14 @@ vi.mock('../db/client', () => {
       insert: vi.fn(() => insertChain),
       update: vi.fn(() => updateChain),
       delete: vi.fn(() => deleteChain),
+      transaction: vi.fn(async (fn: (tx: unknown) => unknown) => {
+        const tx = {
+          insert: vi.fn(() => insertChain),
+          update: vi.fn(() => updateChain),
+          delete: vi.fn(() => deleteChain),
+        };
+        return fn(tx);
+      }),
     },
   };
 });
@@ -70,8 +78,14 @@ vi.mock('../redis/client', () => ({
   },
 }));
 
-const { handleNativeAuthExchange, handleNativeAuthRefresh, handleNativeAuthRevoke, __resetNativeAuthStateForTests } =
-  await import('../handlers/native-auth');
+const {
+  handleNativeAuthExchange,
+  handleNativeAuthRefresh,
+  handleNativeAuthRevoke,
+  __resetNativeAuthStateForTests,
+  __fillConsumedTokenMapForTests,
+  __fillRateLimitMapForTests,
+} = await import('../handlers/native-auth');
 
 const { validateMobileJwt, validateToken } = await import('../middleware/auth');
 
@@ -107,7 +121,7 @@ interface MockReq extends EventEmitter {
   destroy: () => void;
 }
 
-function makeRequest(opts: { method: string; body?: unknown; remoteAddress?: string }): MockReq {
+function makeRequest(opts: { method: string; body?: unknown; rawBody?: string; remoteAddress?: string }): MockReq {
   const emitter = new EventEmitter() as MockReq;
   emitter.method = opts.method;
   emitter.url = '/auth/native/exchange';
@@ -116,7 +130,9 @@ function makeRequest(opts: { method: string; body?: unknown; remoteAddress?: str
   emitter.destroy = vi.fn();
 
   setImmediate(() => {
-    if (opts.body !== undefined) {
+    if (opts.rawBody !== undefined) {
+      emitter.emit('data', Buffer.from(opts.rawBody, 'utf8'));
+    } else if (opts.body !== undefined) {
       emitter.emit('data', Buffer.from(JSON.stringify(opts.body), 'utf8'));
     }
     emitter.emit('end');
@@ -264,6 +280,33 @@ describe('handleNativeAuthExchange', () => {
     expect(res.statusCode).toBe(401);
   });
 
+  it('returns 503 when consumed token map is full', async () => {
+    __fillConsumedTokenMapForTests(10_000);
+    const transferToken = createTransferToken('user-abc');
+    const req = makeRequest({ method: 'POST', body: { transferToken } });
+    const res = makeResponse();
+    await handleNativeAuthExchange(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(503);
+    expect(parseBody(res).error).toBe('Service temporarily overloaded');
+  });
+
+  it('returns 503 when rate limit map is full', async () => {
+    __fillRateLimitMapForTests(50_000);
+    const req = makeRequest({ method: 'POST', body: { transferToken: 'payload.sig' }, remoteAddress: '10.0.0.1' });
+    const res = makeResponse();
+    await handleNativeAuthExchange(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(503);
+    expect(parseBody(res).error).toBe('Service temporarily overloaded');
+  });
+
+  it('returns 400 for truly malformed JSON body', async () => {
+    const req = makeRequest({ method: 'POST', rawBody: 'not valid json {{{' });
+    const res = makeResponse();
+    await handleNativeAuthExchange(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).error).toBe('Invalid JSON body');
+  });
+
   it('returns 401 for a transfer token with an unreasonably long lifetime', async () => {
     // Token with a 1-hour lifetime (far exceeding the 125s max)
     const transferToken = createTransferToken('user-abc', { expiresInSeconds: 3600 });
@@ -372,6 +415,34 @@ describe('handleNativeAuthRefresh', () => {
     const res = makeResponse();
     await handleNativeAuthRefresh(req as unknown as IncomingMessage, res as unknown as ServerResponse);
     expect(res.statusCode).toBe(405);
+  });
+
+  it('returns 500 when NEXTAUTH_SECRET is unset during token generation', async () => {
+    // Set up valid refresh token revocation
+    mockDbUpdateReturning.mockResolvedValueOnce([
+      {
+        id: 'token-id',
+        userId: 'user-abc',
+        tokenHash: 'hash',
+        expiresAt: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
+        createdAt: new Date(),
+        revokedAt: new Date(),
+      },
+    ]);
+
+    const savedSecret = process.env.NEXTAUTH_SECRET;
+    delete process.env.NEXTAUTH_SECRET;
+
+    try {
+      const refreshToken = crypto.randomUUID();
+      const req = makeRequest({ method: 'POST', body: { refreshToken } });
+      const res = makeResponse();
+      await handleNativeAuthRefresh(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+      expect(res.statusCode).toBe(500);
+      expect(parseBody(res).error).toBe('Internal server error');
+    } finally {
+      process.env.NEXTAUTH_SECRET = savedSecret;
+    }
   });
 });
 
@@ -592,6 +663,21 @@ describe('handleNativeAuthRevoke', () => {
     expect(res.statusCode).toBe(200);
     const body = parseBody(res);
     expect(body.revoked).toBe(true);
+  });
+
+  it('returns 405 for non-POST methods', async () => {
+    const req = makeRequest({ method: 'GET' });
+    const res = makeResponse();
+    await handleNativeAuthRevoke(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('returns 400 when refreshToken is missing', async () => {
+    const req = makeRequest({ method: 'POST', body: {} });
+    const res = makeResponse();
+    await handleNativeAuthRevoke(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).error).toBe('refreshToken is required');
   });
 
   it('revokes an expired-but-unrevoked token and cleans up the user session', async () => {

--- a/packages/backend/src/handlers/native-auth.ts
+++ b/packages/backend/src/handlers/native-auth.ts
@@ -319,7 +319,10 @@ function verifyTransferToken(token: string): { userId: string } | null {
 // Token generation helpers
 // ---------------------------------------------------------------------------
 
-async function generateTokenPair(userId: string): Promise<{
+async function generateTokenPair(
+  userId: string,
+  txOrDb: { insert: typeof db.insert } = db,
+): Promise<{
   jwt: string;
   refreshToken: string;
   expiresAt: string;
@@ -343,7 +346,7 @@ async function generateTokenPair(userId: string): Promise<{
   const refreshToken = crypto.randomBytes(32).toString('hex');
   const tokenHash = crypto.createHash('sha256').update(refreshToken).digest('hex');
 
-  await db.insert(mobileRefreshTokens).values({
+  await txOrDb.insert(mobileRefreshTokens).values({
     userId,
     tokenHash,
     expiresAt: new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS),
@@ -496,33 +499,37 @@ export async function handleNativeAuthRefresh(req: IncomingMessage, res: ServerR
   const tokenHash = crypto.createHash('sha256').update(refreshToken).digest('hex');
 
   try {
-    // Atomically revoke the token and return it in a single query.
-    // This prevents TOCTOU races: if two concurrent requests present the same
-    // refresh token, only one will get the row back — the other gets an empty
-    // result because the WHERE clause requires revoked_at IS NULL.
-    const revokedRows = await db
-      .update(mobileRefreshTokens)
-      .set({ revokedAt: new Date() })
-      .where(and(eq(mobileRefreshTokens.tokenHash, tokenHash), isNull(mobileRefreshTokens.revokedAt)))
-      .returning();
+    const result = await db.transaction(async (tx) => {
+      // Atomically revoke the token and return it in a single query.
+      // This prevents TOCTOU races: if two concurrent requests present the same
+      // refresh token, only one will get the row back — the other gets an empty
+      // result because the WHERE clause requires revoked_at IS NULL.
+      const revokedRows = await tx
+        .update(mobileRefreshTokens)
+        .set({ revokedAt: new Date() })
+        .where(and(eq(mobileRefreshTokens.tokenHash, tokenHash), isNull(mobileRefreshTokens.revokedAt)))
+        .returning();
 
-    const revokedToken = revokedRows[0];
+      const revokedToken = revokedRows[0];
+      if (!revokedToken) {
+        return { status: 401 as const, error: 'Invalid refresh token' };
+      }
 
-    if (!revokedToken) {
-      sendJson(res, 401, { error: 'Invalid refresh token' });
+      if (revokedToken.expiresAt < new Date()) {
+        return { status: 401 as const, error: 'Refresh token expired' };
+      }
+
+      const tokenPair = await generateTokenPair(revokedToken.userId, tx);
+      return { status: 200 as const, tokenPair, userId: revokedToken.userId };
+    });
+
+    if (result.status !== 200) {
+      sendJson(res, result.status, { error: result.error });
       return;
     }
 
-    if (revokedToken.expiresAt < new Date()) {
-      // Token was already expired — we revoked it for hygiene but won't issue new tokens
-      sendJson(res, 401, { error: 'Refresh token expired' });
-      return;
-    }
-
-    // Issue new token pair
-    const tokenPair = await generateTokenPair(revokedToken.userId);
-    logger.info(`[NativeAuth] Token refresh successful for user ${revokedToken.userId}`);
-    sendJson(res, 200, tokenPair);
+    logger.info(`[NativeAuth] Token refresh successful for user ${result.userId}`);
+    sendJson(res, 200, result.tokenPair);
   } catch (error) {
     logger.error('[NativeAuth] Token refresh failed:', error);
     sendJson(res, 500, { error: 'Internal server error' });
@@ -674,6 +681,22 @@ export function stopRefreshTokenCleanup(): void {
 export function __resetNativeAuthStateForTests(): void {
   authRateLimitMap.clear();
   consumedTransferTokens.clear();
+}
+
+/** Fill the consumed-token map with fresh entries for capacity testing. Test-only. */
+export function __fillConsumedTokenMapForTests(count: number): void {
+  const now = Date.now();
+  for (let i = 0; i < count; i++) {
+    consumedTransferTokens.set(`test-sig-${String(i)}`, now);
+  }
+}
+
+/** Fill the rate-limit map with non-expired entries for capacity testing. Test-only. */
+export function __fillRateLimitMapForTests(count: number): void {
+  const futureReset = Date.now() + AUTH_RATE_LIMIT_WINDOW_MS;
+  for (let i = 0; i < count; i++) {
+    authRateLimitMap.set(`test-ip-${String(i)}`, { count: 1, resetAt: futureReset });
+  }
 }
 
 /** Run the refresh token cleanup tick directly. Test-only. */

--- a/packages/mobile/app/auth/callback.tsx
+++ b/packages/mobile/app/auth/callback.tsx
@@ -21,14 +21,18 @@ export default function AuthCallback() {
     if (exchangedRef.current) return;
     exchangedRef.current = true;
 
-    exchangeTransferToken(transferToken).then(async (result) => {
-      if (result.success) {
-        await refreshAuthState();
-        router.replace('/(tabs)');
-      } else {
-        setError(result.error);
-      }
-    });
+    exchangeTransferToken(transferToken)
+      .then(async (result) => {
+        if (result.success) {
+          await refreshAuthState();
+          router.replace('/(tabs)');
+        } else {
+          setError(result.error);
+        }
+      })
+      .catch((exchangeError: unknown) => {
+        setError(exchangeError instanceof Error ? exchangeError.message : 'Unexpected error');
+      });
   }, [transferToken, router, refreshAuthState]);
 
   if (error) {

--- a/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
@@ -18,6 +18,12 @@ vi.mock('../auth-store', () => ({
   getTokenExpiresAt: vi.fn().mockResolvedValue(null),
 }));
 
+// ── Mock auth module (signOut used by interceptor on 401) ───────────────
+const mockSignOut = vi.fn().mockResolvedValue(undefined);
+vi.mock('../auth', () => ({
+  signOut: (...args: unknown[]) => mockSignOut(...args),
+}));
+
 import { ensureFreshToken, authenticatedFetch } from '../auth-interceptor';
 import { getAuthToken, getRefreshToken, storeTokens, clearTokens, isTokenExpiringSoon } from '../auth-store';
 
@@ -98,6 +104,33 @@ describe('ensureFreshToken', () => {
     // Only one actual fetch despite three concurrent calls
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
+
+  it('returns false without calling fetch when refresh token is null', async () => {
+    mockIsTokenExpiringSoon.mockResolvedValue(true);
+    mockGetRefreshToken.mockResolvedValue(null);
+
+    const result = await ensureFreshToken();
+
+    expect(result).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockStoreTokens).not.toHaveBeenCalled();
+  });
+
+  it('returns false and logs warning when fetch throws', async () => {
+    mockIsTokenExpiringSoon.mockResolvedValue(true);
+    mockGetRefreshToken.mockResolvedValue('some-refresh-token');
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const result = await ensureFreshToken();
+      expect(result).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith('[Auth] Token refresh error:', 'Network error');
+      expect(mockStoreTokens).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 // ── authenticatedFetch ───────────────────────────────────────────────────
@@ -162,8 +195,8 @@ describe('authenticatedFetch', () => {
     const response = await authenticatedFetch('https://api.example.com/data');
 
     expect(response.status).toBe(401);
-    expect(mockClearTokens).toHaveBeenCalledTimes(1);
-    // clearTokens called once in the 401 handler after refresh fails
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    // signOut called once in the 401 handler after refresh fails (revokes + clears tokens)
   });
 
   it('attaches Authorization header from stored token', async () => {
@@ -179,6 +212,30 @@ describe('authenticatedFetch', () => {
     const headers = fetchCall[1].headers as Headers;
     expect(headers.get('Authorization')).toBe('Bearer my-jwt-token');
     expect(headers.get('X-Custom')).toBe('value');
+  });
+
+  it('makes request without Authorization header when no token exists', async () => {
+    mockIsTokenExpiringSoon.mockResolvedValue(false);
+    mockGetAuthToken.mockResolvedValue(null);
+    mockFetch.mockResolvedValueOnce({ status: 200, ok: true });
+
+    await authenticatedFetch('https://api.example.com/data');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const fetchCallHeaders = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(fetchCallHeaders.has('Authorization')).toBe(false);
+  });
+
+  it('returns 401 directly without refresh attempt when no token exists', async () => {
+    mockIsTokenExpiringSoon.mockResolvedValue(false);
+    mockGetAuthToken.mockResolvedValue(null);
+    mockFetch.mockResolvedValueOnce({ status: 401, ok: false });
+
+    const response = await authenticatedFetch('https://api.example.com/data');
+
+    expect(response.status).toBe(401);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockSignOut).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/lib/auth-interceptor.ts
+++ b/packages/mobile/src/lib/auth-interceptor.ts
@@ -1,4 +1,5 @@
-import { getAuthToken, getRefreshToken, storeTokens, clearTokens, isTokenExpiringSoon } from './auth-store';
+import { getAuthToken, getRefreshToken, storeTokens, isTokenExpiringSoon } from './auth-store';
+import { signOut } from './auth';
 
 const BACKEND_URL = process.env.EXPO_PUBLIC_BACKEND_URL ?? 'http://localhost:8080';
 
@@ -66,7 +67,7 @@ export async function authenticatedFetch(url: string | URL | Request, options: R
         return fetch(url, { ...options, headers });
       }
     }
-    await clearTokens();
+    await signOut();
   }
 
   return response;

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
-import { useRouter, useSegments } from 'expo-router';
+import { useSegments, Redirect } from 'expo-router';
 import { getAuthToken, isTokenExpiringSoon } from '../lib/auth-store';
 import { startSignIn, signOut as authSignOut, type AuthProvider as AuthProviderType } from '../lib/auth';
 import { resetHttpClient } from '../lib/graphql/client';
@@ -26,7 +26,6 @@ export function useAuth(): AuthState {
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const router = useRouter();
   const segments = useSegments();
 
   const checkAuth = useCallback(async () => {
@@ -51,18 +50,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     checkAuth();
   }, [checkAuth]);
 
-  // Route protection
-  useEffect(() => {
-    if (isLoading) return;
-    const inAuthGroup = segments[0] === 'auth';
-
-    if (!isAuthenticated && !inAuthGroup) {
-      router.replace('/auth/login');
-    } else if (isAuthenticated && inAuthGroup) {
-      router.replace('/(tabs)');
-    }
-  }, [isAuthenticated, isLoading, segments, router]);
-
   const signIn = useCallback(async (provider: AuthProviderType) => {
     await startSignIn(provider);
   }, []);
@@ -75,8 +62,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setIsAuthenticated(false);
   }, []);
 
-  if (isLoading) {
-    return null;
+  const inAuthGroup = segments[0] === 'auth';
+
+  if (!isLoading && !isAuthenticated && !inAuthGroup) {
+    return <Redirect href="/auth/login" />;
+  }
+  if (!isLoading && isAuthenticated && inAuthGroup) {
+    return <Redirect href="/(tabs)" />;
   }
 
   return (

--- a/packages/mobile/src/providers/query-provider.tsx
+++ b/packages/mobile/src/providers/query-provider.tsx
@@ -1,16 +1,19 @@
-import { type ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 5 * 60 * 1000,
-      gcTime: 30 * 60 * 1000,
-      retry: 2,
-    },
-  },
-});
-
 export function QueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 5 * 60 * 1000,
+            gcTime: 30 * 60 * 1000,
+            retry: 2,
+          },
+        },
+      }),
+  );
+
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }

--- a/packages/shared/board-config/src/board-data.ts
+++ b/packages/shared/board-config/src/board-data.ts
@@ -11,8 +11,6 @@ type ImageDimensions = Record<
   }
 >;
 
-export type SetIdList = number[];
-
 // Conditionally include moonboard based on feature flag
 export const SUPPORTED_BOARDS: BoardName[] = MOONBOARD_ENABLED ? [...ALL_SUPPORTED_BOARDS] : [...AURORA_BOARDS];
 

--- a/packages/shared/board-config/src/index.ts
+++ b/packages/shared/board-config/src/index.ts
@@ -1,4 +1,4 @@
 export * from './board-data';
 export * from './board-compatibility';
 export * from './moonboard-config';
-export type { Angle, ClimbCompatibilityInput, BoardCompatibilityTarget } from './types';
+export type { Angle, SetIdList, ClimbCompatibilityInput, BoardCompatibilityTarget } from './types';

--- a/packages/web/app/components/board-renderer/types.ts
+++ b/packages/web/app/components/board-renderer/types.ts
@@ -1,6 +1,3 @@
-import { MOONBOARD_ENABLED } from '@/app/lib/moonboard-config';
-import type { BoardName } from '@/app/lib/types';
-
 // Re-export hold state types and constants from the canonical source
 export {
   HOLD_STATE_MAP,
@@ -37,8 +34,3 @@ export type HeatmapData = {
 
 /** Thumbnail render width in pixels. Covers 3x retina at ~64px CSS display. */
 export const THUMBNAIL_WIDTH = 200;
-
-// If adding more boards be sure to increment the DB version number for indexeddb
-export const supported_boards: BoardName[] = MOONBOARD_ENABLED
-  ? ['kilter', 'tension', 'moonboard', 'decoy', 'touchstone', 'grasshopper', 'soill']
-  : ['kilter', 'tension', 'decoy', 'touchstone', 'grasshopper', 'soill'];


### PR DESCRIPTION
## Summary

Addresses deferred review findings from PR #2255's 6-reviewer code review round:

- **6 new backend tests** — `NEXTAUTH_SECRET` unset → 500, consumed-token map full → 503, rate-limit map full → 503, malformed JSON body → 400, revoke wrong method → 405, revoke missing body → 400
- **4 new mobile tests** — null refresh token skips fetch, network error returns false + logs warning, null auth token omits Authorization header, 401 without token returns directly
- **Auth hardening** — refresh token rotation wrapped in `db.transaction()` so failed `generateTokenPair` rolls back the revocation; 401 retry failure calls `signOut()` (server-side revoke) instead of bare `clearTokens()`
- **Code quality** — removed duplicate `SetIdList` type and `supported_boards` constant, moved `QueryClient` into `useState`, added `.catch()` to callback promise, replaced imperative `router.replace` with declarative `<Redirect>`
- **Subscription completeness deferred** to Phase 4 (mobile doesn't handle those events yet)

## Test plan

- [x] `vp test run --project backend` — all 1181 tests pass (6 new)
- [x] `vp test run --project mobile` — all 13 tests pass (4 new)
- [x] `vp run typecheck:backend` — clean
- [x] `vp run typecheck:web` — clean
- [x] `vp check` — no lint/format issues in changed files
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)