### PR TITLE
fix(mobile): redirect entry to /(tabs)/boards (expo-router v6 fix)

### DIFF
--- a/packages/mobile/app/index.tsx
+++ b/packages/mobile/app/index.tsx
@@ -1,5 +1,5 @@
 import { Redirect } from 'expo-router';
 
 export default function Index() {
-  return <Redirect href="/(tabs)" />;
+  return <Redirect href="/(tabs)/boards" />;
 }


### PR DESCRIPTION
## Summary

Tested the SDK 56 build from PR #2270 on the iOS simulator. App launches but lands on \"Unmatched Route\" on cold start — expo-router v6 doesn't resolve \`<Redirect href=\"/(tabs)\" />\` to a route group like v5 did.

Pointing the redirect at a concrete tab leaf (\`/(tabs)/boards\`) restores the expected boot flow: AuthProvider intercepts the unauthenticated session and routes to the sign-in screen.

## Before / after on iPhone 15 Pro Max simulator

| Before | After |
|---|---|
| \"Unmatched Route\" on cold launch | Sign-in screen renders correctly |

## Note for TestFlight

The TestFlight build that landed from PR #2270 has this bug — testers on that build will see \"Unmatched Route\" on first open. Merging this will trigger a fresh TestFlight upload.

## Test plan

- [ ] Local: \`cd packages/mobile && bunx expo start --dev-client\` then launch on simulator — should land on auth screen, not \"Unmatched Route\"
- [ ] TestFlight: after merge to main, install the new build and verify cold launch lands on auth screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)