### PR TITLE
fix(mobile): remove index.tsx redirect, use initialRouteName + not-found handler

### DIFF
--- a/packages/mobile/app/+not-found.tsx
+++ b/packages/mobile/app/+not-found.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from 'expo-router';
+
+export default function NotFound() {
+  return <Redirect href="/(tabs)" />;
+}

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout() {
           <ThemeProvider>
             <AuthProvider>
               <BottomSheetModalProvider>
-                <Stack screenOptions={{ headerShown: false }}>
+                <Stack screenOptions={{ headerShown: false }} initialRouteName="(tabs)">
                   <Stack.Screen name="(tabs)" />
                   <Stack.Screen name="auth" options={{ headerShown: false, gestureEnabled: false }} />
                 </Stack>

--- a/packages/mobile/app/index.tsx
+++ b/packages/mobile/app/index.tsx
@@ -1,5 +1,0 @@
-import { Redirect } from 'expo-router';
-
-export default function Index() {
-  return <Redirect href="/(tabs)/boards" />;
-}


### PR DESCRIPTION
The root index.tsx was not declared as a Stack.Screen in the root layout,
causing expo-router v6 to show "Unmatched Route" on cold launch. The
built-in Unmatched screen's Sitemap button calls window.location.origin
(web-only API), which crashes with SIGABRT on native.

- Delete app/index.tsx — the redirect races with AuthProvider's own
  redirect logic and the undeclared screen confuses the route manifest
- Set initialRouteName="(tabs)" on the root Stack so the navigator
  defaults to the tabs group without a redirect file
- Add app/+not-found.tsx that redirects to /(tabs) instead of showing
  expo-router's broken Sitemap UI

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>