### PR TITLE
fix(mobile): restore auth loading guard and SplashScreen integration

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react';
+import { useCallback, type ReactNode } from 'react';
 import { StyleSheet } from 'react-native';
-import { Stack } from 'expo-router';
+import { Stack, SplashScreen } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
@@ -11,6 +11,8 @@ import { I18nProvider } from '../src/providers/i18n-provider';
 import { BluetoothProvider } from '../src/providers/bluetooth-provider';
 import { ToastProvider } from '../src/providers/toast-provider';
 import { useDefaultBoard } from '../src/lib/graphql/hooks';
+
+SplashScreen.preventAutoHideAsync();
 
 const styles = StyleSheet.create({
   root: { flex: 1 },
@@ -32,13 +34,17 @@ function BluetoothProviderWrapper({ children }: { children: ReactNode }) {
 }
 
 export default function RootLayout() {
+  const onAuthReady = useCallback(() => {
+    SplashScreen.hideAsync();
+  }, []);
+
   return (
     <GestureHandlerRootView style={styles.root}>
       <StatusBar style="auto" />
       <I18nProvider>
         <QueryProvider>
           <ThemeProvider>
-            <AuthProvider>
+            <AuthProvider onReady={onAuthReady}>
               <ToastProvider>
                 <BottomSheetModalProvider>
                   <BluetoothProviderWrapper>

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useRef, useState, useCallback, type ReactNode } from 'react';
 import { useSegments, Redirect } from 'expo-router';
 import { getAuthToken, isTokenExpiringSoon } from '../lib/auth-store';
 import { startSignIn, signOut as authSignOut, type AuthProvider as AuthProviderType } from '../lib/auth';
@@ -23,7 +23,12 @@ export function useAuth(): AuthState {
   return context;
 }
 
-export function AuthProvider({ children }: { children: ReactNode }) {
+type AuthProviderProps = {
+  children: ReactNode;
+  onReady?: () => void;
+};
+
+export function AuthProvider({ children, onReady }: AuthProviderProps) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const segments = useSegments();
@@ -62,12 +67,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setIsAuthenticated(false);
   }, []);
 
+  const onReadyRef = useRef(onReady);
+  onReadyRef.current = onReady;
+
+  useEffect(() => {
+    if (!isLoading) {
+      onReadyRef.current?.();
+    }
+  }, [isLoading]);
+
+  if (isLoading) {
+    return null;
+  }
+
   const inAuthGroup = segments[0] === 'auth';
 
-  if (!isLoading && !isAuthenticated && !inAuthGroup) {
+  if (!isAuthenticated && !inAuthGroup) {
     return <Redirect href="/auth/login" />;
   }
-  if (!isLoading && isAuthenticated && inAuthGroup) {
+  if (isAuthenticated && inAuthGroup) {
     return <Redirect href="/(tabs)" />;
   }
 


### PR DESCRIPTION
## Summary

- Restores the `isLoading` guard in `AuthProvider` that was accidentally removed in `8a4daf1` — children no longer render while auth state is resolving, preventing a flash of unauthenticated tab screens on cold launch
- Adds `SplashScreen.preventAutoHideAsync()` / `hideAsync()` integration so the native splash stays visible during auth initialization instead of showing a blank screen
- Fixes incident D919FE58 (iOS TestFlight SIGABRT on launch), which was caused by the Expo Router v6 upgrade rendering tab screens before auth resolved

## Test plan

- [ ] Cold start (unauthenticated): splash screen stays visible until login screen appears, no flash of tabs
- [ ] Cold start (authenticated): splash screen stays visible until tabs appear, no flash of login
- [ ] Sign out flow: redirect to login works without splash screen reappearing
- [ ] OAuth callback: after signing in, redirect from auth to tabs works correctly

https://claude.ai/code/session_01U3cviRDUsZ8mcJTi1oQazX

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3cviRDUsZ8mcJTi1oQazX)_