### PR TITLE
ci: restrict RN TestFlight deploy to main branch only

### DIFF
--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   build-and-upload:
+    if: github.ref == 'refs/heads/main'
     # macos-26 = Xcode 26 + iOS 26 SDK, which App Store Connect now requires
     # for all uploads. Expo SDK 56 / RN 0.85 ships a fmt that compiles cleanly
     # under Xcode 26's strict C++20 constexpr evaluator.


### PR DESCRIPTION
## Summary\n\n- Adds `if: github.ref == 'refs/heads/main'` guard to the `build-and-upload` job in `ios-testflight-rn.yml`\n- The `push` trigger already filters to `main`, but `workflow_dispatch` allowed manual runs from any branch — this closes that gap\n- Prevents accidental TestFlight deploys from feature branches\n\n## Test plan\n\n- [ ] Verify the workflow still triggers on pushes to `main` that touch `packages/mobile/**`\n- [ ] Verify manual `workflow_dispatch` from a non-main branch skips the job\n\nhttps://claude.ai/code/session_01U8WHEM5iHoWUkSTPRqrHun"

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8WHEM5iHoWUkSTPRqrHun)_