### PR TITLE
feat(mobile): add email/password login to React Native app

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -60,6 +60,7 @@
         "@parse/node-apn": "^8.0.0",
         "@sentry/node": "^10.40.0",
         "@whatwg-node/fetch": "^0.10.13",
+        "bcryptjs": "^3.0.3",
         "busboy": "^1.6.0",
         "dotenv": "^17.3.1",
         "drizzle-orm": "^0.45.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -38,6 +38,7 @@
     "@parse/node-apn": "^8.0.0",
     "@sentry/node": "^10.40.0",
     "@whatwg-node/fetch": "^0.10.13",
+    "bcryptjs": "^3.0.3",
     "busboy": "^1.6.0",
     "dotenv": "^17.3.1",
     "drizzle-orm": "^0.45.1",

--- a/packages/backend/src/__tests__/native-auth-credentials.test.ts
+++ b/packages/backend/src/__tests__/native-auth-credentials.test.ts
@@ -1,0 +1,326 @@
+// @ts-nocheck — __tests__ is excluded from tsconfig.json, so the type-aware
+// lint can't resolve node globals or `node:*` specifiers. Type-checking happens
+// at test-run time via vitest.
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { hash } from 'bcryptjs';
+
+// ---------------------------------------------------------------------------
+// Test secret — must match what generateTokenPair reads from env
+// ---------------------------------------------------------------------------
+
+const TEST_SECRET = 'test-secret-for-native-auth-credentials-tests';
+process.env.NEXTAUTH_SECRET = TEST_SECRET;
+
+// ---------------------------------------------------------------------------
+// Mocks (must be hoisted before importing the handler)
+// ---------------------------------------------------------------------------
+
+// db.select() returns rows queued via mockDbSelectQueue. Every chained call
+// (.from / .where / .limit) is a no-op that returns the same chain object;
+// only the trailing await resolves to the queued result.
+const mockDbSelectQueue: unknown[][] = [];
+const mockDbInsertValues = vi.fn(async () => []);
+
+vi.mock('../db/client', () => {
+  function makeSelectChain(): unknown {
+    const chain = {
+      from() {
+        return chain;
+      },
+      where() {
+        return chain;
+      },
+      limit() {
+        const rows = mockDbSelectQueue.shift() ?? [];
+        return Promise.resolve(rows);
+      },
+    };
+    return chain;
+  }
+
+  const insertChain = {
+    values: (...args: unknown[]) => mockDbInsertValues(...args),
+  };
+
+  return {
+    db: {
+      select: vi.fn(() => makeSelectChain()),
+      insert: vi.fn(() => insertChain),
+    },
+  };
+});
+
+vi.mock('../handlers/cors', () => ({
+  applyCorsHeaders: vi.fn(() => true),
+}));
+
+vi.mock('../redis/client', () => ({
+  redisClientManager: {
+    isRedisConnected: vi.fn(() => false),
+    isRedisConfigured: vi.fn(() => false),
+    getClients: vi.fn(() => ({ publisher: {} })),
+  },
+}));
+
+const { handleNativeAuthCredentials, __resetNativeAuthStateForTests, __fillRateLimitMapForTests } =
+  await import('../handlers/native-auth');
+
+// ---------------------------------------------------------------------------
+// Request / response helpers
+// ---------------------------------------------------------------------------
+
+interface MockReq extends EventEmitter {
+  method?: string;
+  url?: string;
+  headers: Record<string, string | string[]>;
+  socket: Partial<Socket>;
+  destroy: () => void;
+}
+
+function makeRequest(opts: { method: string; body?: unknown; rawBody?: string; remoteAddress?: string }): MockReq {
+  const emitter = new EventEmitter() as MockReq;
+  emitter.method = opts.method;
+  emitter.url = '/auth/native/credentials';
+  emitter.headers = {};
+  emitter.socket = { remoteAddress: opts.remoteAddress ?? '127.0.0.1' };
+  emitter.destroy = vi.fn();
+
+  setImmediate(() => {
+    if (opts.rawBody !== undefined) {
+      emitter.emit('data', Buffer.from(opts.rawBody, 'utf8'));
+    } else if (opts.body !== undefined) {
+      emitter.emit('data', Buffer.from(JSON.stringify(opts.body), 'utf8'));
+    }
+    emitter.emit('end');
+  });
+
+  return emitter;
+}
+
+interface MockRes {
+  statusCode: number;
+  body: string;
+  headers: Record<string, unknown>;
+  headersSent: boolean;
+  writeHead: (status: number, headers?: Record<string, unknown>) => void;
+  end: (body?: string) => void;
+  setHeader: (name: string, value: unknown) => void;
+}
+
+function makeResponse(): MockRes {
+  const res: MockRes = {
+    statusCode: 0,
+    body: '',
+    headers: {},
+    headersSent: false,
+    writeHead(status, headers) {
+      this.statusCode = status;
+      this.headersSent = true;
+      if (headers) Object.assign(this.headers, headers);
+    },
+    end(body) {
+      if (body !== undefined) this.body = body;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+  };
+  return res;
+}
+
+function parseBody(res: MockRes): Record<string, unknown> {
+  return JSON.parse(res.body) as Record<string, unknown>;
+}
+
+function queueSelect(rows: unknown[]): void {
+  mockDbSelectQueue.push(rows);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('handleNativeAuthCredentials', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetNativeAuthStateForTests();
+    mockDbSelectQueue.length = 0;
+    mockDbInsertValues.mockResolvedValue([]);
+  });
+
+  it('returns JWT + refresh token for valid email + password', async () => {
+    const passwordHash = await hash('correct-horse', 10);
+    queueSelect([{ id: 'user-1', email: 'test@example.com' }]);
+    queueSelect([{ userId: 'user-1', passwordHash }]);
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'test@example.com', password: 'correct-horse' },
+    });
+    const res = makeResponse();
+
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+
+    expect(res.statusCode).toBe(200);
+    const body = parseBody(res);
+    expect(body.jwt).toBeDefined();
+    expect(typeof body.jwt).toBe('string');
+    expect(body.refreshToken).toBeDefined();
+    expect(typeof body.refreshToken).toBe('string');
+    expect(body.expiresAt).toBeDefined();
+  });
+
+  it('lower-cases and trims the submitted email before lookup', async () => {
+    const passwordHash = await hash('correct-horse', 10);
+    queueSelect([{ id: 'user-1', email: 'test@example.com' }]);
+    queueSelect([{ userId: 'user-1', passwordHash }]);
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: '  TEST@Example.COM  ', password: 'correct-horse' },
+    });
+    const res = makeResponse();
+
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('returns 401 for an unknown email', async () => {
+    queueSelect([]); // user lookup miss
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'nobody@example.com', password: 'whatever' },
+    });
+    const res = makeResponse();
+
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+
+    expect(res.statusCode).toBe(401);
+    expect(parseBody(res).error).toBe('Invalid email or password');
+  });
+
+  it('returns 401 for a wrong password', async () => {
+    const passwordHash = await hash('correct-horse', 10);
+    queueSelect([{ id: 'user-1', email: 'test@example.com' }]);
+    queueSelect([{ userId: 'user-1', passwordHash }]);
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'test@example.com', password: 'wrong-password' },
+    });
+    const res = makeResponse();
+
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+
+    expect(res.statusCode).toBe(401);
+    expect(parseBody(res).error).toBe('Invalid email or password');
+  });
+
+  it('returns 401 for an OAuth-only user (no userCredentials row)', async () => {
+    queueSelect([{ id: 'user-oauth', email: 'oauth@example.com' }]);
+    queueSelect([]); // no credentials row
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'oauth@example.com', password: 'anything' },
+    });
+    const res = makeResponse();
+
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+
+    expect(res.statusCode).toBe(401);
+    expect(parseBody(res).error).toBe('Invalid email or password');
+  });
+
+  it('returns 400 when email is missing', async () => {
+    const req = makeRequest({ method: 'POST', body: { password: 'x' } });
+    const res = makeResponse();
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).error).toBe('email and password are required');
+  });
+
+  it('returns 400 when password is missing', async () => {
+    const req = makeRequest({ method: 'POST', body: { email: 'x@y.z' } });
+    const res = makeResponse();
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).error).toBe('email and password are required');
+  });
+
+  it('returns 400 when email is the wrong type', async () => {
+    const req = makeRequest({ method: 'POST', body: { email: 123, password: 'x' } });
+    const res = makeResponse();
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for non-object body', async () => {
+    const req = makeRequest({ method: 'POST', body: 'not-an-object' });
+    const res = makeResponse();
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const req = makeRequest({ method: 'POST', rawBody: 'not valid json {{{' });
+    const res = makeResponse();
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).error).toBe('Invalid JSON body');
+  });
+
+  it('returns 405 for non-POST methods', async () => {
+    const req = makeRequest({ method: 'GET' });
+    const res = makeResponse();
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('returns 429 when the per-IP rate limit is exceeded', async () => {
+    const passwordHash = await hash('pw', 10);
+
+    // Make 10 successful requests to fill the bucket (limit is 10/min/IP).
+    for (let i = 0; i < 10; i++) {
+      queueSelect([{ id: 'user-1', email: 'test@example.com' }]);
+      queueSelect([{ userId: 'user-1', passwordHash }]);
+      const req = makeRequest({
+        method: 'POST',
+        body: { email: 'test@example.com', password: 'pw' },
+        remoteAddress: '10.0.0.55',
+      });
+      const res = makeResponse();
+      await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+      expect(res.statusCode).toBe(200);
+    }
+
+    // 11th request from the same IP should be rate limited.
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'test@example.com', password: 'pw' },
+      remoteAddress: '10.0.0.55',
+    });
+    const res = makeResponse();
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(429);
+    expect(res.headers['Retry-After']).toBeDefined();
+  });
+
+  it('returns 503 when the rate limit map is full', async () => {
+    __fillRateLimitMapForTests(50_000);
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'x@y.z', password: 'pw' },
+      remoteAddress: '10.0.0.99',
+    });
+    const res = makeResponse();
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+    expect(res.statusCode).toBe(503);
+    expect(parseBody(res).error).toBe('Service temporarily overloaded');
+  });
+});

--- a/packages/backend/src/handlers/native-auth.ts
+++ b/packages/backend/src/handlers/native-auth.ts
@@ -1,12 +1,24 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import crypto from 'crypto';
 import { SignJWT } from 'jose';
+import { compare } from 'bcryptjs';
 import { eq, and, isNull, lt, or, isNotNull } from 'drizzle-orm';
-import { mobileRefreshTokens } from '@boardsesh/db/schema/auth';
+import { mobileRefreshTokens, users, userCredentials } from '@boardsesh/db/schema/auth';
 import { db } from '../db/client';
 import { redisClientManager } from '../redis/client';
 import { applyCorsHeaders } from './cors';
 import { logger } from '../utils/logger';
+
+/**
+ * Fixed dummy bcrypt hash used to keep the credentials handler's response
+ * time roughly constant for unknown emails / OAuth-only users. Without it,
+ * an attacker could enumerate registered accounts by timing the response.
+ * The plaintext is irrelevant — `compare` always returns false against it.
+ */
+const DUMMY_PASSWORD_HASH = '$2b$10$CwTycUXWue0Thq9StjUM0uJ8/oQbk1Ec7T0p/7K8nXfRzC2VyM4dy';
+
+/** Generic error returned for all credential validation failures. */
+const INVALID_CREDENTIALS_ERROR = 'Invalid email or password';
 
 // Transfer tokens are short-lived (120s) and exchanged between our own
 // servers, so 5s tolerance is sufficient. Long-lived JWTs use 60s in
@@ -447,6 +459,91 @@ export async function handleNativeAuthExchange(req: IncomingMessage, res: Server
     sendJson(res, 200, tokenPair);
   } catch (error) {
     logger.error('[NativeAuth] Token generation failed:', error);
+    sendJson(res, 500, { error: 'Internal server error' });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /auth/native/credentials
+// ---------------------------------------------------------------------------
+
+export async function handleNativeAuthCredentials(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (!applyCorsHeaders(req, res)) return;
+
+  if (req.method !== 'POST') {
+    sendJson(res, 405, { error: 'Method not allowed' });
+    return;
+  }
+
+  // Rate limit by IP (shared limiter with the other native-auth endpoints)
+  const clientIp = getClientIp(req);
+  const retryAfter = checkAuthRateLimit(clientIp);
+  if (retryAfter === -1) {
+    sendJson(res, 503, { error: 'Service temporarily overloaded' });
+    return;
+  }
+  if (retryAfter !== null) {
+    res.setHeader('Retry-After', String(retryAfter));
+    sendJson(res, 429, { error: `Rate limit exceeded. Try again in ${retryAfter} seconds.` });
+    return;
+  }
+
+  let body: unknown;
+  try {
+    const raw = await readBody(req);
+    body = JSON.parse(raw);
+  } catch {
+    sendJson(res, 400, { error: 'Invalid JSON body' });
+    return;
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    sendJson(res, 400, { error: 'Request body must be a JSON object' });
+    return;
+  }
+
+  const { email, password } = body as Record<string, unknown>;
+  if (typeof email !== 'string' || email.length === 0 || typeof password !== 'string' || password.length === 0) {
+    sendJson(res, 400, { error: 'email and password are required' });
+    return;
+  }
+
+  // Normalize the email to match how NextAuth's adapter stores it.
+  const normalizedEmail = email.trim().toLowerCase();
+
+  try {
+    const userRows = await db.select().from(users).where(eq(users.email, normalizedEmail)).limit(1);
+    const user = userRows[0];
+
+    if (!user) {
+      // Dummy compare against a fixed hash to mask the user-lookup miss in
+      // response time. Result is intentionally discarded.
+      await compare(password, DUMMY_PASSWORD_HASH);
+      sendJson(res, 401, { error: INVALID_CREDENTIALS_ERROR });
+      return;
+    }
+
+    const credentialRows = await db.select().from(userCredentials).where(eq(userCredentials.userId, user.id)).limit(1);
+    const credentials = credentialRows[0];
+
+    if (!credentials) {
+      // OAuth-only user with no password. Same dummy compare for timing parity.
+      await compare(password, DUMMY_PASSWORD_HASH);
+      sendJson(res, 401, { error: INVALID_CREDENTIALS_ERROR });
+      return;
+    }
+
+    const passwordMatches = await compare(password, credentials.passwordHash);
+    if (!passwordMatches) {
+      sendJson(res, 401, { error: INVALID_CREDENTIALS_ERROR });
+      return;
+    }
+
+    const tokenPair = await generateTokenPair(user.id);
+    logger.info(`[NativeAuth] Credentials sign-in successful for user ${user.id}`);
+    sendJson(res, 200, tokenPair);
+  } catch (error) {
+    logger.error('[NativeAuth] Credentials sign-in failed:', error);
     sendJson(res, 500, { error: 'Internal server error' });
   }
 }

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -17,6 +17,7 @@ import { handlePosthogProxy } from './handlers/posthog';
 import { handleUserDataExport, handleUserDataExportDownload } from './handlers/user-data-export';
 import { handleWidgetNavigate } from './handlers/widget-navigate';
 import {
+  handleNativeAuthCredentials,
   handleNativeAuthExchange,
   handleNativeAuthRefresh,
   handleNativeAuthRevoke,
@@ -342,6 +343,11 @@ export async function startServer(): Promise<ServerResources> {
         return;
       }
 
+      if (pathname === '/auth/native/credentials' && (req.method === 'POST' || req.method === 'OPTIONS')) {
+        await handleNativeAuthCredentials(req, res);
+        return;
+      }
+
       if (pathname === '/auth/native/refresh' && (req.method === 'POST' || req.method === 'OPTIONS')) {
         await handleNativeAuthRefresh(req, res);
         return;
@@ -417,6 +423,7 @@ export async function startServer(): Promise<ServerResources> {
     logger.info(`  User data export: ${httpScheme}://0.0.0.0:${PORT}/api/user-data-export`);
     logger.info(`  Widget navigate: ${httpScheme}://0.0.0.0:${PORT}/api/widget/navigate`);
     logger.info(`  Native auth exchange: ${httpScheme}://0.0.0.0:${PORT}/auth/native/exchange`);
+    logger.info(`  Native auth credentials: ${httpScheme}://0.0.0.0:${PORT}/auth/native/credentials`);
     logger.info(`  Native auth refresh: ${httpScheme}://0.0.0.0:${PORT}/auth/native/refresh`);
     logger.info(`  Native auth revoke: ${httpScheme}://0.0.0.0:${PORT}/auth/native/revoke`);
     logger.info(`  Sync cron: ${httpScheme}://0.0.0.0:${PORT}/sync-cron`);

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -1,14 +1,38 @@
-import { View, Text, Pressable, StyleSheet, Platform } from 'react-native';
+import { useRef, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  type TextInput as RNTextInput,
+} from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../src/providers/auth-provider';
+import { useTheme } from '../../src/providers/theme-provider';
 import { hapticLight } from '../../src/lib/haptics';
 import { brandColors } from '../../src/theme/colors';
 import { iosSystemColors } from '../../src/theme/ios-colors';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
-function SignInButton({ title, onPress }: { title: string; onPress: () => void }) {
+// Minimal email regex — same shape as the web validator, intentionally lax
+// so we don't reject anything the server would accept.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function SignInButton({
+  title,
+  onPress,
+  disabled = false,
+}: {
+  title: string;
+  onPress: () => void;
+  disabled?: boolean;
+}) {
   const scale = useSharedValue(1);
 
   const animatedStyle = useAnimatedStyle(() => ({
@@ -18,16 +42,19 @@ function SignInButton({ title, onPress }: { title: string; onPress: () => void }
   return (
     <AnimatedPressable
       onPress={() => {
+        if (disabled) return;
         hapticLight();
         onPress();
       }}
       onPressIn={() => {
+        if (disabled) return;
         scale.value = withSpring(0.97, { damping: 20, stiffness: 300, mass: 0.7 });
       }}
       onPressOut={() => {
+        if (disabled) return;
         scale.value = withSpring(1, { damping: 20, stiffness: 300, mass: 0.7 });
       }}
-      style={[animatedStyle, styles.button]}
+      style={[animatedStyle, styles.button, disabled && styles.buttonDisabled]}
     >
       <Text style={styles.buttonText}>{title}</Text>
     </AnimatedPressable>
@@ -35,35 +62,183 @@ function SignInButton({ title, onPress }: { title: string; onPress: () => void }
 }
 
 export default function LoginScreen() {
-  const { signIn } = useAuth();
+  const { signIn, signInWithCredentials } = useAuth();
   const { t } = useTranslation('auth');
+  const theme = useTheme();
+  const passwordRef = useRef<RNTextInput>(null);
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const trimmedEmail = email.trim();
+  const canSubmit = !submitting && trimmedEmail.length > 0 && password.length > 0;
+
+  async function onSubmit() {
+    if (!canSubmit) return;
+
+    if (!EMAIL_REGEX.test(trimmedEmail)) {
+      setError(t('login.validation.emailInvalid'));
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+    try {
+      const result = await signInWithCredentials(trimmedEmail, password);
+      if (!result.success) {
+        if (result.error === 'network') {
+          setError(t('nativeStart.networkError'));
+        } else if (result.status === 401) {
+          setError(t('login.errors.invalidCredentials'));
+        } else {
+          setError(result.error);
+        }
+      }
+      // On success, AuthProvider flips isAuthenticated and the redirect handles navigation.
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // Input styling — dark-mode input fields are intentionally white (matches web).
+  const isDark = theme.colorScheme === 'dark';
+  const inputBackground = isDark ? iosSystemColors.white : '#FFFFFF';
+  const inputBorder = isDark ? 'rgba(60, 60, 67, 0.36)' : 'rgba(60, 60, 67, 0.18)';
+  const inputTextColor = '#000000';
+  const inputPlaceholderColor = 'rgba(60, 60, 67, 0.6)';
+
+  const inputStyle = [
+    styles.input,
+    { backgroundColor: inputBackground, borderColor: inputBorder, color: inputTextColor },
+  ];
 
   return (
-    <View style={styles.container}>
-      <View style={styles.header}>
-        <Text style={styles.title}>Boardsesh</Text>
-        <Text style={styles.subtitle}>{t('nativeStart.tagline')}</Text>
-      </View>
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 0}
+    >
+      <ScrollView
+        contentContainerStyle={styles.container}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="interactive"
+      >
+        <View style={styles.header}>
+          <Text style={styles.title}>Boardsesh</Text>
+          <Text style={styles.subtitle}>{t('nativeStart.tagline')}</Text>
+        </View>
 
-      <View style={styles.buttons}>
-        {Platform.OS === 'ios' && <SignInButton title={t('nativeStart.signInApple')} onPress={() => signIn('apple')} />}
-        <SignInButton title={t('nativeStart.signInGoogle')} onPress={() => signIn('google')} />
-      </View>
-    </View>
+        <View style={styles.form}>
+          <TextInput
+            style={inputStyle}
+            value={email}
+            onChangeText={setEmail}
+            placeholder={t('login.placeholders.email')}
+            placeholderTextColor={inputPlaceholderColor}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="email-address"
+            textContentType="emailAddress"
+            autoComplete="email"
+            returnKeyType="next"
+            onSubmitEditing={() => passwordRef.current?.focus()}
+            editable={!submitting}
+            accessibilityLabel={t('login.fields.email')}
+          />
+          <TextInput
+            ref={passwordRef}
+            style={inputStyle}
+            value={password}
+            onChangeText={setPassword}
+            placeholder={t('login.placeholders.password')}
+            placeholderTextColor={inputPlaceholderColor}
+            secureTextEntry
+            autoCapitalize="none"
+            autoCorrect={false}
+            textContentType="password"
+            autoComplete="password"
+            returnKeyType="done"
+            onSubmitEditing={() => {
+              void onSubmit();
+            }}
+            editable={!submitting}
+            accessibilityLabel={t('login.fields.password')}
+          />
+          <SignInButton
+            title={submitting ? t('nativeStart.signingIn') : t('nativeStart.signIn')}
+            onPress={() => {
+              void onSubmit();
+            }}
+            disabled={!canSubmit}
+          />
+          {error ? (
+            <Text style={styles.errorText} accessibilityLiveRegion="polite">
+              {error}
+            </Text>
+          ) : null}
+        </View>
+
+        <View style={styles.dividerRow}>
+          <View style={styles.dividerLine} />
+          <Text style={styles.dividerLabel}>{t('nativeStart.orContinueWith')}</Text>
+          <View style={styles.dividerLine} />
+        </View>
+
+        <View style={styles.buttons}>
+          {Platform.OS === 'ios' && (
+            <SignInButton title={t('nativeStart.signInApple')} onPress={() => signIn('apple')} />
+          )}
+          <SignInButton title={t('nativeStart.signInGoogle')} onPress={() => signIn('google')} />
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', padding: 24 },
-  header: { alignItems: 'center', marginBottom: 48 },
+  container: { flexGrow: 1, justifyContent: 'center', padding: 24 },
+  header: { alignItems: 'center', marginBottom: 32 },
   title: { fontSize: 34, fontWeight: '700', marginBottom: 8, color: brandColors.primary },
   subtitle: { fontSize: 17, opacity: 0.7 },
+  form: { gap: 12 },
+  input: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 14,
+    fontSize: 17,
+  },
+  errorText: {
+    color: '#FF3B30',
+    fontSize: 15,
+    marginTop: 4,
+  },
+  dividerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 24,
+    gap: 12,
+  },
+  dividerLine: {
+    flex: 1,
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: 'rgba(60, 60, 67, 0.36)',
+  },
+  dividerLabel: {
+    fontSize: 13,
+    opacity: 0.6,
+  },
   buttons: { gap: 12 },
   button: {
     backgroundColor: brandColors.primary,
     paddingVertical: 16,
     borderRadius: 12,
     alignItems: 'center',
+  },
+  buttonDisabled: {
+    opacity: 0.5,
   },
   buttonText: {
     color: iosSystemColors.white,

--- a/packages/mobile/src/lib/auth.ts
+++ b/packages/mobile/src/lib/auth.ts
@@ -36,6 +36,40 @@ export async function exchangeTransferToken(
   }
 }
 
+export type CredentialsSignInResult = { success: true } | { success: false; status: number | null; error: string };
+
+export async function signInWithCredentials(email: string, password: string): Promise<CredentialsSignInResult> {
+  let response: Response;
+  try {
+    response = await fetch(`${BACKEND_URL}/auth/native/credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch {
+    // Network failure / timeout. The caller maps this to a translated message.
+    return { success: false, status: null, error: 'network' };
+  }
+
+  if (!response.ok) {
+    let serverError = `HTTP ${response.status}`;
+    try {
+      const parsed = (await response.json()) as { error?: unknown };
+      if (typeof parsed.error === 'string' && parsed.error.length > 0) {
+        serverError = parsed.error;
+      }
+    } catch {
+      // Body wasn't JSON; fall back to the HTTP status string above.
+    }
+    return { success: false, status: response.status, error: serverError };
+  }
+
+  const data = (await response.json()) as { jwt: string; refreshToken: string; expiresAt: string };
+  await storeTokens(data.jwt, data.refreshToken, data.expiresAt);
+  return { success: true };
+}
+
 export async function signOut(): Promise<void> {
   const refreshToken = await getRefreshToken();
   if (refreshToken) {

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -1,7 +1,13 @@
 import { createContext, useContext, useEffect, useRef, useState, useCallback, type ReactNode } from 'react';
 import { useSegments, Redirect } from 'expo-router';
 import { getAuthToken, isTokenExpiringSoon } from '../lib/auth-store';
-import { startSignIn, signOut as authSignOut, type AuthProvider as AuthProviderType } from '../lib/auth';
+import {
+  startSignIn,
+  signOut as authSignOut,
+  signInWithCredentials as authSignInWithCredentials,
+  type AuthProvider as AuthProviderType,
+  type CredentialsSignInResult,
+} from '../lib/auth';
 import { resetHttpClient } from '../lib/graphql/client';
 import { disposeWsClient } from '../lib/graphql/ws-client';
 import { clearStoredSessionId } from '../lib/session-store';
@@ -11,6 +17,7 @@ type AuthState = {
   isAuthenticated: boolean;
   isLoading: boolean;
   signIn: (provider: AuthProviderType) => Promise<void>;
+  signInWithCredentials: (email: string, password: string) => Promise<CredentialsSignInResult>;
   signOut: () => Promise<void>;
   refreshAuthState: () => Promise<void>;
 };
@@ -59,6 +66,17 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     await startSignIn(provider);
   }, []);
 
+  const signInWithCredentials = useCallback(
+    async (email: string, password: string): Promise<CredentialsSignInResult> => {
+      const result = await authSignInWithCredentials(email, password);
+      if (result.success) {
+        await checkAuth();
+      }
+      return result;
+    },
+    [checkAuth],
+  );
+
   const signOut = useCallback(async () => {
     await authSignOut();
     await Promise.all([clearStoredSessionId(), clearStoredBoardConfig()]);
@@ -90,7 +108,16 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   }
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, isLoading, signIn, signOut, refreshAuthState: checkAuth }}>
+    <AuthContext.Provider
+      value={{
+        isAuthenticated,
+        isLoading,
+        signIn,
+        signInWithCredentials,
+        signOut,
+        refreshAuthState: checkAuth,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/packages/mobile/tsconfig.json
+++ b/packages/mobile/tsconfig.json
@@ -6,6 +6,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx", "app/**/*.ts", "app/**/*.tsx", ".expo/types/**/*.ts"],
+  "include": ["**/*.ts", "**/*.tsx", "app/**/*.ts", "app/**/*.tsx"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/web/i18n/locales/en-US/auth.json
+++ b/packages/web/i18n/locales/en-US/auth.json
@@ -96,7 +96,10 @@
     "signingIn": "Signing in...",
     "tagline": "One app for your boards",
     "signInApple": "Sign in with Apple",
-    "signInGoogle": "Sign in with Google"
+    "signInGoogle": "Sign in with Google",
+    "signIn": "Sign in",
+    "orContinueWith": "or continue with",
+    "networkError": "Could not reach Boardsesh. Check your connection and try again."
   },
   "metadata": {
     "login": {

--- a/packages/web/i18n/locales/es/auth.json
+++ b/packages/web/i18n/locales/es/auth.json
@@ -96,7 +96,10 @@
     "signingIn": "Iniciando sesión...",
     "tagline": "Una app para todas tus tablas",
     "signInApple": "Iniciar sesión con Apple",
-    "signInGoogle": "Iniciar sesión con Google"
+    "signInGoogle": "Iniciar sesión con Google",
+    "signIn": "Iniciar sesión",
+    "orContinueWith": "o continúa con",
+    "networkError": "No se pudo conectar con Boardsesh. Comprueba tu conexión e inténtalo de nuevo."
   },
   "metadata": {
     "login": {

--- a/packages/web/i18n/locales/fr/auth.json
+++ b/packages/web/i18n/locales/fr/auth.json
@@ -96,7 +96,10 @@
     "signingIn": "Connexion en cours...",
     "tagline": "Une app pour tous vos boards",
     "signInApple": "Se connecter avec Apple",
-    "signInGoogle": "Se connecter avec Google"
+    "signInGoogle": "Se connecter avec Google",
+    "signIn": "Se connecter",
+    "orContinueWith": "ou continuez avec",
+    "networkError": "Impossible de joindre Boardsesh. Vérifiez votre connexion et réessayez."
   },
   "metadata": {
     "login": {


### PR DESCRIPTION
## Summary

The mobile app only supported Google and Apple sign-in. This PR adds email/password as a first-class option so users can sign in with the same credentials they set on web (e.g. the local `test@boardsesh.com` / `test` dev account).

- **Backend** — new `POST /auth/native/credentials` in `packages/backend/src/handlers/native-auth.ts` that validates `{ email, password }` against `user_credentials` with `bcryptjs.compare` and issues the same `{ jwt, refreshToken, expiresAt }` token pair as the existing OAuth exchange. Reuses the per-IP rate limiter (10/min) and runs a dummy bcrypt compare on the unknown-email / OAuth-only paths to keep response time roughly constant — prevents account enumeration via timing.
- **Mobile** — `signInWithCredentials()` on `AuthProvider`; tokens land in `expo-secure-store` via the same `storeTokens` helper. Login screen now shows email + password fields above the social buttons with an "or continue with" divider. `KeyboardAvoidingView` keeps the form above the keyboard; inputs are white (intentional dark-mode behavior, matches web).
- **i18n** — three new `nativeStart.*` keys (`signIn`, `orContinueWith`, `networkError`) added to `en-US`, `es`, `fr` auth catalogs. All other form copy reuses existing `login.fields.*`, `login.placeholders.*`, `login.validation.*`, `login.errors.invalidCredentials`.

## Test plan

- [x] `vp run typecheck:backend` passes
- [x] `vp run typecheck:mobile` — no new errors introduced in touched files (pre-existing errors in unrelated files)
- [x] `SKIP_TEST_INFRA=1 vp test run --project backend src/__tests__/native-auth-credentials.test.ts` — 13 new tests pass (happy path, wrong password, unknown email, OAuth-only user, malformed/missing fields, rate-limit 429, rate-limit-full 503)
- [x] `vp test run --project backend src/__tests__/native-auth.test.ts` — existing 39 tests still pass
- [x] `vp test run --project web app/__tests__/i18n-catalog-completeness.test.ts` — i18n parity holds
- [x] `vp check --fix` — lint + format clean
- [x] `vp run check:mobile-bundle` — Metro bundle compiles
- [ ] Sign in with `test@boardsesh.com` / `test` on the iOS simulator — redirects into tabs
- [ ] Wrong password shows the generic `invalidCredentials` message inline
- [ ] Unknown email shows the same generic message (no enumeration)
- [ ] Apple and Google buttons still work
- [ ] Rate limit: 11+ POSTs to `/auth/native/credentials` from the same IP within a minute returns 429 with `Retry-After`

🤖 Generated with [Claude Code](https://claude.com/claude-code)