### PR TITLE
fix(mobile): use correct i18n key for invalid-credentials error

### DIFF
--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -91,7 +91,7 @@ export default function LoginScreen() {
         if (result.error === 'network') {
           setError(t('nativeStart.networkError'));
         } else if (result.status === 401) {
-          setError(t('login.errors.invalidCredentials'));
+          setError(t('login.toasts.invalidCredentials'));
         } else {
           setError(result.error);
         }
@@ -115,11 +115,7 @@ export default function LoginScreen() {
   ];
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 0}
-    >
+    <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
       <ScrollView
         contentContainerStyle={styles.container}
         keyboardShouldPersistTaps="handled"


### PR DESCRIPTION
## Summary

Two small bugs in the native login screen shipped with #2279:

1. **Missing i18n key on 401.** `setError(t('login.errors.invalidCredentials'))` pointed at a key that doesn't exist in any auth catalog. i18next fell back to rendering the raw key string, so every user who entered a wrong password saw `login.errors.invalidCredentials` instead of "Invalid email or password". The correct key — already translated in `en-US`, `es`, `fr` — is `login.toasts.invalidCredentials`.
2. **Dead ternary on `keyboardVerticalOffset`.** `Platform.OS === 'ios' ? 0 : 0` is a no-op. Removed the offset prop entirely so the default (0) applies on all platforms.

## Test plan

- [x] `vp run typecheck:mobile` — no new errors in `login.tsx`
- [ ] On the iOS simulator, submit wrong credentials — the error renders the translated string ("Invalid email or password"), not the raw key
- [ ] Sanity-check the keyboard still doesn't cover the form (no offset regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)