### PR TITLE
fix: useTranslation Mobile Safari crash in SessionProviderWrapper

### DIFF
--- a/packages/web/app/components/providers/__tests__/session-provider-native-oauth.test.tsx
+++ b/packages/web/app/components/providers/__tests__/session-provider-native-oauth.test.tsx
@@ -1,12 +1,11 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { render, act, cleanup } from '@testing-library/react';
 import React from 'react';
-import SessionProviderWrapper from '../session-provider';
+import NativeDeepLinkListener from '../native-deep-link-listener';
 
 // Mock next-auth/react
 const mockSignIn = vi.fn();
 vi.mock('next-auth/react', () => ({
-  SessionProvider: ({ children }: { children: React.ReactNode }) => children,
   signIn: (...args: unknown[]) => mockSignIn(...args),
 }));
 
@@ -18,7 +17,7 @@ vi.mock('@/app/lib/ble/capacitor-utils', () => ({
 
 type AppUrlOpenListener = (event: { url: string }) => void;
 
-describe('SessionProviderWrapper native OAuth deep link', () => {
+describe('NativeDeepLinkListener native OAuth deep link', () => {
   let capturedListener: AppUrlOpenListener | null = null;
   const mockRemove = vi.fn().mockResolvedValue(undefined);
   const mockClose = vi.fn().mockResolvedValue(undefined);
@@ -92,21 +91,13 @@ describe('SessionProviderWrapper native OAuth deep link', () => {
 
   it('does not register listener when not a native app', () => {
     mockIsNativeApp.mockReturnValue(false);
-    render(
-      <SessionProviderWrapper>
-        <div>child</div>
-      </SessionProviderWrapper>,
-    );
+    render(<NativeDeepLinkListener />);
     expect(mockAddListener).not.toHaveBeenCalled();
   });
 
   it('registers appUrlOpen listener in native app', async () => {
     setupCapacitorMock();
-    render(
-      <SessionProviderWrapper>
-        <div>child</div>
-      </SessionProviderWrapper>,
-    );
+    render(<NativeDeepLinkListener />);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 0));
@@ -119,11 +110,7 @@ describe('SessionProviderWrapper native OAuth deep link', () => {
   it('handles malformed deep link URL gracefully', async () => {
     setupCapacitorMock();
 
-    render(
-      <SessionProviderWrapper>
-        <div>child</div>
-      </SessionProviderWrapper>,
-    );
+    render(<NativeDeepLinkListener />);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 0));
@@ -142,11 +129,7 @@ describe('SessionProviderWrapper native OAuth deep link', () => {
 
   it('ignores non-auth deep links', async () => {
     setupCapacitorMock();
-    render(
-      <SessionProviderWrapper>
-        <div>child</div>
-      </SessionProviderWrapper>,
-    );
+    render(<NativeDeepLinkListener />);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 0));
@@ -163,11 +146,7 @@ describe('SessionProviderWrapper native OAuth deep link', () => {
   it('closes browser and redirects to login on error param', async () => {
     setupCapacitorMock();
 
-    render(
-      <SessionProviderWrapper>
-        <div>child</div>
-      </SessionProviderWrapper>,
-    );
+    render(<NativeDeepLinkListener />);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 0));
@@ -187,11 +166,7 @@ describe('SessionProviderWrapper native OAuth deep link', () => {
   it('closes browser and redirects to login when transfer token is missing', async () => {
     setupCapacitorMock();
 
-    render(
-      <SessionProviderWrapper>
-        <div>child</div>
-      </SessionProviderWrapper>,
-    );
+    render(<NativeDeepLinkListener />);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 0));
@@ -212,11 +187,7 @@ describe('SessionProviderWrapper native OAuth deep link', () => {
     setupCapacitorMock();
     mockSignIn.mockResolvedValue({ url: '/dashboard', error: null });
 
-    render(
-      <SessionProviderWrapper>
-        <div>child</div>
-      </SessionProviderWrapper>,
-    );
+    render(<NativeDeepLinkListener />);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 0));
@@ -241,11 +212,7 @@ describe('SessionProviderWrapper native OAuth deep link', () => {
     setupCapacitorMock();
     mockSignIn.mockResolvedValue({ url: null, error: 'CredentialsSignin' });
 
-    render(
-      <SessionProviderWrapper>
-        <div>child</div>
-      </SessionProviderWrapper>,
-    );
+    render(<NativeDeepLinkListener />);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 0));
@@ -264,11 +231,7 @@ describe('SessionProviderWrapper native OAuth deep link', () => {
     setupCapacitorMock();
     mockSignIn.mockResolvedValue({ url: '/', error: null });
 
-    render(
-      <SessionProviderWrapper>
-        <div>child</div>
-      </SessionProviderWrapper>,
-    );
+    render(<NativeDeepLinkListener />);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 0));
@@ -289,11 +252,7 @@ describe('SessionProviderWrapper native OAuth deep link', () => {
 
   it('removes listener on unmount', async () => {
     setupCapacitorMock();
-    const { unmount } = render(
-      <SessionProviderWrapper>
-        <div>child</div>
-      </SessionProviderWrapper>,
-    );
+    const { unmount } = render(<NativeDeepLinkListener />);
 
     await act(async () => {
       await new Promise((r) => setTimeout(r, 0));
@@ -319,11 +278,7 @@ describe('SessionProviderWrapper native OAuth deep link', () => {
     window.addEventListener('unhandledrejection', captureRejection);
 
     try {
-      render(
-        <SessionProviderWrapper>
-          <div>child</div>
-        </SessionProviderWrapper>,
-      );
+      render(<NativeDeepLinkListener />);
 
       await act(async () => {
         await new Promise((r) => setTimeout(r, 0));
@@ -356,11 +311,7 @@ describe('SessionProviderWrapper native OAuth deep link', () => {
       });
     });
 
-    const { unmount } = render(
-      <SessionProviderWrapper>
-        <div>child</div>
-      </SessionProviderWrapper>,
-    );
+    const { unmount } = render(<NativeDeepLinkListener />);
 
     // Unmount before the listener promise resolves
     unmount();

--- a/packages/web/app/components/providers/native-deep-link-listener.tsx
+++ b/packages/web/app/components/providers/native-deep-link-listener.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { signIn } from 'next-auth/react';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
+import { closeCapacitorBrowser } from '@/app/lib/ble/capacitor-browser';
+import { NATIVE_OAUTH_CALLBACK_SCHEME } from '@/app/lib/auth/native-oauth-config';
+
+async function handleAppUrlOpen(url: string): Promise<void> {
+  if (!url.startsWith(NATIVE_OAUTH_CALLBACK_SCHEME)) {
+    return;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    await closeCapacitorBrowser();
+    window.location.assign('/auth/login?error=OAuthCallback');
+    return;
+  }
+
+  const callbackError = parsed.searchParams.get('error');
+  const transferToken = parsed.searchParams.get('transferToken');
+  const nextPath = parsed.searchParams.get('next') ?? '/';
+  const safeCallbackUrl = nextPath.startsWith('/') ? nextPath : '/';
+
+  if (callbackError || !transferToken) {
+    await closeCapacitorBrowser();
+    window.location.assign('/auth/login?error=OAuthCallback');
+    return;
+  }
+
+  const result = await signIn('native-oauth', {
+    transferToken,
+    callbackUrl: safeCallbackUrl,
+    redirect: false,
+  });
+
+  await closeCapacitorBrowser();
+
+  if (result?.error) {
+    window.location.assign('/auth/login?error=OAuthCallback');
+    return;
+  }
+
+  window.location.assign(result?.url ?? safeCallbackUrl);
+}
+
+export default function NativeDeepLinkListener() {
+  const { t } = useTranslation('settings');
+  const [deepLinkError, setDeepLinkError] = useState(false);
+
+  useEffect(() => {
+    if (!isNativeApp()) {
+      return;
+    }
+
+    const appPlugin = window.Capacitor?.Plugins?.App;
+    if (!appPlugin) {
+      return;
+    }
+
+    let cancelled = false;
+    let listenerHandle: { remove: () => Promise<void> } | null = null;
+
+    // addListener may return a PluginListenerHandle directly (Capacitor 6+)
+    // or a Promise<PluginListenerHandle> (Capacitor 5). Wrap with
+    // Promise.resolve to handle both cases safely.
+    const listenerResult = appPlugin.addListener('appUrlOpen', ({ url }) => {
+      void handleAppUrlOpen(url).catch((error) => {
+        console.error('[Native OAuth] Unexpected error handling appUrlOpen:', error);
+      });
+    });
+
+    Promise.resolve(listenerResult)
+      .then((handle) => {
+        if (cancelled) {
+          void handle.remove();
+        } else {
+          listenerHandle = handle;
+        }
+      })
+      .catch((err) => {
+        console.error('[Native OAuth] Failed to register appUrlOpen listener:', err);
+        setDeepLinkError(true);
+      });
+
+    return () => {
+      cancelled = true;
+      void listenerHandle?.remove();
+    };
+  }, []);
+
+  return (
+    <Snackbar open={deepLinkError} autoHideDuration={8000} onClose={() => setDeepLinkError(false)}>
+      <Alert severity="warning" onClose={() => setDeepLinkError(false)}>
+        {t('sessionProvider.deepLinkError')}
+      </Alert>
+    </Snackbar>
+  );
+}

--- a/packages/web/app/components/providers/session-provider.tsx
+++ b/packages/web/app/components/providers/session-provider.tsx
@@ -1,117 +1,16 @@
 'use client';
 
-import React, { useEffect, useState, type ReactNode } from 'react';
-import { useTranslation } from 'react-i18next';
-import { SessionProvider, signIn } from 'next-auth/react';
-import Snackbar from '@mui/material/Snackbar';
-import Alert from '@mui/material/Alert';
-import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
-import { closeCapacitorBrowser } from '@/app/lib/ble/capacitor-browser';
-import { NATIVE_OAUTH_CALLBACK_SCHEME } from '@/app/lib/auth/native-oauth-config';
+import React, { type ReactNode } from 'react';
+import { SessionProvider } from 'next-auth/react';
 
 type SessionProviderWrapperProps = {
   children: ReactNode;
 };
 
-async function handleAppUrlOpen(url: string): Promise<void> {
-  if (!url.startsWith(NATIVE_OAUTH_CALLBACK_SCHEME)) {
-    return;
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    await closeCapacitorBrowser();
-    window.location.assign('/auth/login?error=OAuthCallback');
-    return;
-  }
-
-  const callbackError = parsed.searchParams.get('error');
-  const transferToken = parsed.searchParams.get('transferToken');
-  const nextPath = parsed.searchParams.get('next') ?? '/';
-  const safeCallbackUrl = nextPath.startsWith('/') ? nextPath : '/';
-
-  if (callbackError || !transferToken) {
-    await closeCapacitorBrowser();
-    window.location.assign('/auth/login?error=OAuthCallback');
-    return;
-  }
-
-  const result = await signIn('native-oauth', {
-    transferToken,
-    callbackUrl: safeCallbackUrl,
-    redirect: false,
-  });
-
-  await closeCapacitorBrowser();
-
-  if (result?.error) {
-    window.location.assign('/auth/login?error=OAuthCallback');
-    return;
-  }
-
-  window.location.assign(result?.url ?? safeCallbackUrl);
-}
-
 export default function SessionProviderWrapper({ children }: SessionProviderWrapperProps) {
-  const { t } = useTranslation('settings');
-  const [deepLinkError, setDeepLinkError] = useState(false);
-
-  useEffect(() => {
-    if (!isNativeApp()) {
-      return;
-    }
-
-    const appPlugin = window.Capacitor?.Plugins?.App;
-    if (!appPlugin) {
-      return;
-    }
-
-    let cancelled = false;
-    let listenerHandle: { remove: () => Promise<void> } | null = null;
-
-    // addListener may return a PluginListenerHandle directly (Capacitor 6+)
-    // or a Promise<PluginListenerHandle> (Capacitor 5). Wrap with
-    // Promise.resolve to handle both cases safely.
-    const listenerResult = appPlugin.addListener('appUrlOpen', ({ url }) => {
-      // Run the async work but never let it reject into the Capacitor event
-      // bus. addListener does not consume the listener's return value, so an
-      // uncaught rejection here surfaces as an unhandled promise rejection
-      // (and lands in Sentry).
-      void handleAppUrlOpen(url).catch((error) => {
-        console.error('[Native OAuth] Unexpected error handling appUrlOpen:', error);
-      });
-    });
-
-    Promise.resolve(listenerResult)
-      .then((handle) => {
-        if (cancelled) {
-          // Component unmounted before the listener was registered — clean up
-          void handle.remove();
-        } else {
-          listenerHandle = handle;
-        }
-      })
-      .catch((err) => {
-        console.error('[Native OAuth] Failed to register appUrlOpen listener:', err);
-        setDeepLinkError(true);
-      });
-
-    return () => {
-      cancelled = true;
-      void listenerHandle?.remove();
-    };
-  }, []);
-
   return (
     <SessionProvider refetchOnWindowFocus={false} refetchWhenOffline={false}>
       {children}
-      <Snackbar open={deepLinkError} autoHideDuration={8000} onClose={() => setDeepLinkError(false)}>
-        <Alert severity="warning" onClose={() => setDeepLinkError(false)}>
-          {t('sessionProvider.deepLinkError')}
-        </Alert>
-      </Snackbar>
     </SessionProvider>
   );
 }

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -19,6 +19,7 @@ import { FeatureFlagsProvider } from './components/providers/feature-flags-provi
 import { OnboardingTourProvider } from './components/onboarding/onboarding-tour-provider';
 import OnboardingTourOverlay from './components/onboarding/onboarding-tour-overlay';
 import OnboardingDummySeshMount from './components/onboarding/onboarding-dummy-sesh-mount';
+import NativeDeepLinkListener from './components/providers/native-deep-link-listener';
 import { getLocale } from './lib/i18n/get-locale';
 import { getServerTranslation } from './lib/i18n/server';
 import { LOCALE_HTML_LANG, LOCALE_OG } from './lib/i18n/config';
@@ -96,6 +97,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                   ]}
                 >
                   <SnackbarProvider>
+                    <NativeDeepLinkListener />
                     <AuthModalProvider>
                       <FeatureFlagsProvider flags={EMPTY_FEATURE_FLAGS}>
                         <PersistentSessionWrapper boardConfigs={boardConfigs}>


### PR DESCRIPTION
## Summary

- Fixes `TypeError: undefined is not an object (evaluating 't.length')` on Mobile Safari (iOS 18.7) caused by `useTranslation('settings')` being called in `SessionProviderWrapper`, which renders **outside** `I18nProvider` in the layout tree
- Splits the Capacitor deep-link listener and translated error snackbar into a new `NativeDeepLinkListener` component that renders inside `I18nProvider` where it has proper i18n and MUI theme context
- Simplifies `SessionProviderWrapper` to a thin next-auth `SessionProvider` wrapper with no i18n dependency

## Test plan

- [ ] Verify all existing native OAuth deep-link tests pass (test file updated to target `NativeDeepLinkListener`)
- [ ] Verify `vp run typecheck:web` passes
- [ ] Confirm no regression on desktop browsers — session provider still wraps the app correctly
- [ ] Confirm Mobile Safari no longer throws `TypeError` on the list page route

https://claude.ai/code/session_01Ke3VDBfXGFeuQpsgxxX5rJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ke3VDBfXGFeuQpsgxxX5rJ)_