### PR TITLE
fix: prevent subscription auth failures on WebSocket reconnection

### DIFF
--- a/packages/backend/src/graphql/resolvers/queue/subscriptions.ts
+++ b/packages/backend/src/graphql/resolvers/queue/subscriptions.ts
@@ -3,6 +3,7 @@ import { roomManager } from '../../../services/room-manager';
 import { pubsub } from '../../../pubsub/index';
 import { requireSessionMember } from '../shared/helpers';
 import { createEagerAsyncIterator } from '../shared/async-iterators';
+import { logger } from '../../../utils/logger';
 
 export const queueSubscriptions = {
   /**
@@ -14,7 +15,17 @@ export const queueSubscriptions = {
     subscribe: async function* (_: unknown, { sessionId }: { sessionId: string }, ctx: ConnectionContext) {
       // Verify user is a member of the session they're subscribing to
       // Uses retry logic to handle race conditions with joinSession
-      await requireSessionMember(ctx, sessionId);
+      try {
+        await requireSessionMember(ctx, sessionId);
+      } catch (error) {
+        // Only swallow the expected reconnection-race auth failure. Real
+        // infrastructure errors (Redis, network) must still propagate.
+        if (error instanceof Error && error.message.startsWith('Unauthorized')) {
+          logger.warn(`[Queue] Subscription ended: connection ${ctx.connectionId} not in session ${sessionId}`);
+          return;
+        }
+        throw error;
+      }
 
       // IMPORTANT: Subscribe to pubsub FIRST, before fetching state.
       // This prevents a race condition where events could be published

--- a/packages/backend/src/graphql/resolvers/sessions/subscriptions.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/subscriptions.ts
@@ -2,6 +2,7 @@ import type { ConnectionContext, SessionEvent } from '@boardsesh/shared-schema';
 import { pubsub } from '../../../pubsub/index';
 import { requireSessionMember } from '../shared/helpers';
 import { createAsyncIterator } from '../shared/async-iterators';
+import { logger } from '../../../utils/logger';
 
 export const sessionSubscriptions = {
   /**
@@ -13,7 +14,17 @@ export const sessionSubscriptions = {
     subscribe: async function* (_: unknown, { sessionId }: { sessionId: string }, ctx: ConnectionContext) {
       // Verify user is a member of the session they're subscribing to
       // Uses retry logic to handle race conditions with joinSession
-      await requireSessionMember(ctx, sessionId);
+      try {
+        await requireSessionMember(ctx, sessionId);
+      } catch (error) {
+        // Only swallow the expected reconnection-race auth failure. Real
+        // infrastructure errors (Redis, network) must still propagate.
+        if (error instanceof Error && error.message.startsWith('Unauthorized')) {
+          logger.warn(`[Session] Subscription ended: connection ${ctx.connectionId} not in session ${sessionId}`);
+          return;
+        }
+        throw error;
+      }
 
       // Create async iterator for subscription
       // NOTE: We await here to ensure Redis subscription is established

--- a/packages/backend/src/graphql/resolvers/shared/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/shared/helpers.ts
@@ -109,13 +109,13 @@ export async function requireSessionMember(
   }
 
   if (!finalCtx?.sessionId) {
-    logger.error(
+    logger.warn(
       `[Auth] requireSessionMember failed after ${maxRetries} retries: not in any session. connectionId=${ctx.connectionId}, requested=${sessionId}`,
     );
     throw new Error(`Unauthorized: not in any session (connectionId: ${ctx.connectionId}, requested: ${sessionId})`);
   }
   if (finalCtx.sessionId !== sessionId) {
-    logger.error(
+    logger.warn(
       `[Auth] requireSessionMember failed: session mismatch. connectionId=${ctx.connectionId}, have=${finalCtx.sessionId}, requested=${sessionId}`,
     );
     throw new Error(`Unauthorized: session mismatch (have: ${finalCtx.sessionId}, requested: ${sessionId})`);

--- a/packages/shared/graphql-client/src/__tests__/create-client.test.ts
+++ b/packages/shared/graphql-client/src/__tests__/create-client.test.ts
@@ -51,4 +51,22 @@ describe('createGraphQLClient', () => {
     createGraphQLClient({ url: 'ws://localhost/graphql' });
     expect(mocks.capturedOptions.current.connectionParams).toBeUndefined();
   });
+
+  it('invokes onDisconnect from the graphql-ws closed handler', () => {
+    const onDisconnect = vi.fn();
+    createGraphQLClient({ url: 'ws://localhost/graphql', onDisconnect });
+
+    const handlers = mocks.capturedOptions.current.on as { closed?: () => void };
+    expect(handlers.closed).toBeTypeOf('function');
+    expect(onDisconnect).not.toHaveBeenCalled();
+
+    handlers.closed?.();
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('tolerates a missing onDisconnect when the connection closes', () => {
+    createGraphQLClient({ url: 'ws://localhost/graphql' });
+    const handlers = mocks.capturedOptions.current.on as { closed?: () => void };
+    expect(() => handlers.closed?.()).not.toThrow();
+  });
 });

--- a/packages/shared/graphql-client/src/create-client.ts
+++ b/packages/shared/graphql-client/src/create-client.ts
@@ -9,6 +9,14 @@ export type BaseClientOptions = {
   url: string;
   /** Called once after the second `connected` event (i.e. on every reconnect). */
   onReconnect?: () => void;
+  /**
+   * Called on every `closed` event. Web uses this to tear down active
+   * subscriptions before graphql-ws retries them on the new connection —
+   * otherwise the library re-sends subscription operations that fail
+   * `requireSessionMember` because `joinSession` hasn't run on the new
+   * connection yet.
+   */
+  onDisconnect?: () => void;
   /** Debug tag used in console logs. */
   connectionName?: string;
   /**
@@ -54,6 +62,7 @@ export function createGraphQLClient(options: CreateGraphQLClientOptions): Extend
     authToken,
     connectionParams: connectionParamsProvider,
     onReconnect: onReconnectCallback,
+    onDisconnect: onDisconnectCallback,
     webSocketImpl,
     shouldRetry,
     onClientCreated,
@@ -85,6 +94,9 @@ export function createGraphQLClient(options: CreateGraphQLClientOptions): Extend
           onReconnectCallback();
         }
         hasConnectedOnce = true;
+      },
+      closed: () => {
+        onDisconnectCallback?.();
       },
     },
   }) as ExtendedClient;

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -509,6 +509,10 @@ export function useSessionLifecycle({
       }
 
       isReconnectingRef.current = true;
+      if (subscriptionRestartTimeout) {
+        clearTimeout(subscriptionRestartTimeout);
+        subscriptionRestartTimeout = null;
+      }
       try {
         if (DEBUG) console.info('[PersistentSession] Reconnecting...');
 
@@ -615,6 +619,7 @@ export function useSessionLifecycle({
       if (isCleaningUp || !mountedRef.current) return;
       if (connectionGenerationRef.current !== connectionGeneration) return;
       if (subscriptionRestartTimeout) return;
+      if (isReconnectingRef.current) return;
 
       subscriptionRetryCount++;
       if (subscriptionRetryCount > MAX_TRANSIENT_RETRIES) {
@@ -732,6 +737,16 @@ export function useSessionLifecycle({
           url: backendUrl!,
           authToken: wsAuthTokenRef.current,
           onReconnect: () => void handleReconnect(),
+          onDisconnect: () => {
+            // Tear down subscriptions BEFORE graphql-ws retries them on the new
+            // connection. Without this, the library re-sends subscription operations
+            // that fail requireSessionMember because joinSession hasn't been called
+            // on the new connection yet.
+            queueUnsubscribeRef.current?.();
+            queueUnsubscribeRef.current = null;
+            sessionUnsubscribeRef.current?.();
+            sessionUnsubscribeRef.current = null;
+          },
           connectionName: 'session',
         });
         // Capture a non-null local reference. The outer `graphqlClient` (a


### PR DESCRIPTION
## Summary

- **Fix race condition** where `graphql-ws` auto-retries active subscriptions on a new WebSocket connection before `joinSession` has been called, causing `requireSessionMember` to fail after 8 retries with "not in any session"
- **Add `onDisconnect` callback** to the GraphQL client that tears down subscriptions before the library can retry them, ensuring fresh subscriptions are only created after `joinSession` completes on reconnect
- **Guard subscription recovery** against running during active reconnection and cancel stale recovery timeouts
- **Downgrade backend log severity** from `error` to `warn` for expected reconnection-race auth failures, and catch auth errors in subscription resolvers to complete gracefully instead of propagating GraphQL errors

## Test plan

- [ ] Verify TypeScript compiles cleanly for both `backend` and `web` packages
- [ ] Connect to a party session, then simulate a connection drop (toggle airplane mode, switch networks, or close laptop lid)
- [ ] Verify the session recovers without showing errors to the user
- [ ] Check backend logs: should see `warn` level "[Queue/Session] Subscription ended" messages instead of `error` level "requireSessionMember failed" messages
- [ ] Verify no cascading subscription retries that exhaust `MAX_TRANSIENT_RETRIES` and force-clear the session
- [ ] Test on mobile (iOS Safari/Bluefy) where connection drops are more frequent

https://claude.ai/code/session_01SgaoxdRHF3M3JQ93c3uw6n

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgaoxdRHF3M3JQ93c3uw6n)_