### PR TITLE
fix(mobile): prevent setViewToSnapshot crash on iOS launch

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -54,6 +54,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       permissions: ['BLUETOOTH_SCAN', 'BLUETOOTH_CONNECT', 'ACCESS_FINE_LOCATION'],
     },
     plugins: [
+      './plugins/fix-rns-snapshot-crash',
       'expo-router',
       'expo-secure-store',
       'expo-localization',

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -6,7 +6,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { QueryProvider } from '../src/providers/query-provider';
 import { ThemeProvider } from '../src/providers/theme-provider';
-import { AuthProvider } from '../src/providers/auth-provider';
+import { AuthProvider, useAuth } from '../src/providers/auth-provider';
 import { I18nProvider } from '../src/providers/i18n-provider';
 import { BluetoothProvider } from '../src/providers/bluetooth-provider';
 import { ToastProvider } from '../src/providers/toast-provider';
@@ -23,7 +23,6 @@ function BluetoothProviderWrapper({ children }: { children: ReactNode }) {
   const { data: defaultBoard } = useDefaultBoard();
 
   if (!defaultBoard) {
-    // No board selected yet — BLE only makes sense with a board
     return <>{children}</>;
   }
 
@@ -31,6 +30,25 @@ function BluetoothProviderWrapper({ children }: { children: ReactNode }) {
     <BluetoothProvider boardName={defaultBoard.boardType} layoutId={defaultBoard.layoutId} sizeId={defaultBoard.sizeId}>
       {children}
     </BluetoothProvider>
+  );
+}
+
+function RootNavigator() {
+  const { isAuthenticated } = useAuth();
+
+  return (
+    <ToastProvider>
+      <BottomSheetModalProvider>
+        <QueueProvider>
+          <BluetoothProviderWrapper>
+            <Stack screenOptions={{ headerShown: false }}>
+              <Stack.Screen name="(tabs)" redirect={!isAuthenticated} />
+              <Stack.Screen name="auth" redirect={isAuthenticated} options={{ gestureEnabled: false }} />
+            </Stack>
+          </BluetoothProviderWrapper>
+        </QueueProvider>
+      </BottomSheetModalProvider>
+    </ToastProvider>
   );
 }
 
@@ -46,18 +64,7 @@ export default function RootLayout() {
         <QueryProvider>
           <ThemeProvider>
             <AuthProvider onReady={onAuthReady}>
-              <ToastProvider>
-                <BottomSheetModalProvider>
-                  <QueueProvider>
-                    <BluetoothProviderWrapper>
-                      <Stack screenOptions={{ headerShown: false }} initialRouteName="(tabs)">
-                        <Stack.Screen name="(tabs)" />
-                        <Stack.Screen name="auth" options={{ headerShown: false, gestureEnabled: false }} />
-                      </Stack>
-                    </BluetoothProviderWrapper>
-                  </QueueProvider>
-                </BottomSheetModalProvider>
-              </ToastProvider>
+              <RootNavigator />
             </AuthProvider>
           </ThemeProvider>
         </QueryProvider>

--- a/packages/mobile/plugins/fix-rns-snapshot-crash.js
+++ b/packages/mobile/plugins/fix-rns-snapshot-crash.js
@@ -1,0 +1,75 @@
+// Expo config plugin that patches react-native-screens to prevent a crash
+// in [RNSScreen setViewToSnapshot] when a screen is unmounted before its
+// view has been fully laid out (zero bounds) or when the snapshot returns nil.
+//
+// Upstream issue: the Fabric unmount path calls snapshotViewAfterScreenUpdates:
+// on a view whose layer hasn't been committed to the render server yet,
+// causing CARenderServerSnapshot to crash.
+//
+// This plugin adds two guards:
+// 1. Skip snapshot when the view has empty bounds (layer not yet laid out)
+// 2. Skip snapshot usage when snapshotViewAfterScreenUpdates: returns nil
+
+const { withDangerousMod } = require('@expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+const ORIGINAL_CONDITION = 'if (self.view.window != nil) {';
+
+const PATCHED_CONDITION = 'if (self.view.window != nil && !CGRectIsEmpty(self.view.bounds)) {';
+
+const ORIGINAL_SNAPSHOT_BLOCK = `    UIView *snapshot = [self.view snapshotViewAfterScreenUpdates:afterUpdates];
+    snapshot.frame = self.view.frame;
+    [self.view removeFromSuperview];
+    self.view = snapshot;
+    [superView addSubview:snapshot];`;
+
+const PATCHED_SNAPSHOT_BLOCK = `    UIView *snapshot = [self.view snapshotViewAfterScreenUpdates:afterUpdates];
+    if (snapshot != nil) {
+      snapshot.frame = self.view.frame;
+      [self.view removeFromSuperview];
+      self.view = snapshot;
+      [superView addSubview:snapshot];
+    }`;
+
+function patchRNSScreen(config) {
+  return withDangerousMod(config, [
+    'ios',
+    async (modConfig) => {
+      const rnScreensPath = path.join(
+        modConfig.modRequest.projectRoot,
+        'node_modules',
+        'react-native-screens',
+        'ios',
+        'RNSScreen.mm',
+      );
+
+      if (!fs.existsSync(rnScreensPath)) {
+        console.warn('[fix-rns-snapshot-crash] RNSScreen.mm not found, skipping patch');
+        return modConfig;
+      }
+
+      let source = fs.readFileSync(rnScreensPath, 'utf8');
+
+      if (source.includes('CGRectIsEmpty(self.view.bounds)')) {
+        console.log('[fix-rns-snapshot-crash] Already patched, skipping');
+        return modConfig;
+      }
+
+      if (!source.includes(ORIGINAL_CONDITION)) {
+        console.warn('[fix-rns-snapshot-crash] Could not find target code — react-native-screens version may have changed');
+        return modConfig;
+      }
+
+      source = source.replace(ORIGINAL_CONDITION, PATCHED_CONDITION);
+      source = source.replace(ORIGINAL_SNAPSHOT_BLOCK, PATCHED_SNAPSHOT_BLOCK);
+
+      fs.writeFileSync(rnScreensPath, source, 'utf8');
+      console.log('[fix-rns-snapshot-crash] Patched setViewToSnapshot in RNSScreen.mm');
+
+      return modConfig;
+    },
+  ]);
+}
+
+module.exports = patchRNSScreen;

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -1,5 +1,4 @@
 import { createContext, useContext, useEffect, useRef, useState, useCallback, type ReactNode } from 'react';
-import { useSegments, Redirect } from 'expo-router';
 import { getAuthToken, isTokenExpiringSoon } from '../lib/auth-store';
 import {
   startSignIn,
@@ -38,7 +37,6 @@ type AuthProviderProps = {
 export function AuthProvider({ children, onReady }: AuthProviderProps) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const segments = useSegments();
 
   const checkAuth = useCallback(async () => {
     const token = await getAuthToken();
@@ -96,15 +94,6 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
 
   if (isLoading) {
     return null;
-  }
-
-  const inAuthGroup = segments[0] === 'auth';
-
-  if (!isAuthenticated && !inAuthGroup) {
-    return <Redirect href="/auth/login" />;
-  }
-  if (isAuthenticated && inAuthGroup) {
-    return <Redirect href="/(tabs)/boards" />;
   }
 
   return (


### PR DESCRIPTION
## Summary

- **Expo config plugin** patches `RNSScreen.mm` to add bounds-check and nil-snapshot guards in `setViewToSnapshot`, preventing `CARenderServerSnapshot` from crashing on screens that haven't been laid out yet
- **Auth navigation refactor** removes the `<Redirect>`-instead-of-children pattern from `AuthProvider` and uses Expo Router's `redirect` prop on `Stack.Screen` instead, eliminating the screen mount/unmount race that triggers the crash

## Context

The iOS app crashes ~252ms after launch (TestFlight build 2.0.0/100014, iPhone 16, iOS 26.4.2). The crash is a `SIGABRT` from `[RNSScreen setViewToSnapshot]` calling `CARenderServerSnapshot` on a screen view with no valid render context during a Fabric mounting transaction.

**Root cause**: `AuthProvider` returned `<Redirect>` instead of `children`, preventing the `Stack` navigator from rendering. When the redirect completed and the Stack finally mounted, `initialRouteName="(tabs)"` conflicted with the router state (`auth/login`), causing a brief mount of the `(tabs)` screen followed by immediate unmount — all within a single Fabric transaction before the view was added to a `UIWindow`.

## Test plan

- [ ] Type check: `npx tsc --noEmit --project packages/mobile/tsconfig.json` (no new errors)
- [ ] Unit tests: `npx vitest run --project mobile` (192/192 pass)
- [ ] Metro bundle: `bunx expo export --platform ios` compiles successfully (6.3MB)
- [ ] Cold start (no token): splash → login screen, no crash
- [ ] Cold start (valid token): splash → tabs, no crash
- [ ] Sign in with credentials: login → tabs navigation works
- [ ] Sign out: tabs → login navigation works
- [ ] OAuth callback: auth/callback → tabs after token exchange

https://claude.ai/code/session_01TpTds8jSJFS3hricUmT6fE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpTds8jSJFS3hricUmT6fE)_