### PR TITLE
fix(mobile): redirect loop on login and missing QueueProvider

### DIFF
--- a/packages/mobile/app/+not-found.tsx
+++ b/packages/mobile/app/+not-found.tsx
@@ -1,5 +1,5 @@
 import { Redirect } from 'expo-router';
 
 export default function NotFound() {
-  return <Redirect href="/(tabs)" />;
+  return <Redirect href="/(tabs)/boards" />;
 }

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -10,6 +10,7 @@ import { AuthProvider } from '../src/providers/auth-provider';
 import { I18nProvider } from '../src/providers/i18n-provider';
 import { BluetoothProvider } from '../src/providers/bluetooth-provider';
 import { ToastProvider } from '../src/providers/toast-provider';
+import { QueueProvider } from '../src/providers/queue-provider';
 import { useDefaultBoard } from '../src/lib/graphql/hooks';
 
 SplashScreen.preventAutoHideAsync();
@@ -47,12 +48,14 @@ export default function RootLayout() {
             <AuthProvider onReady={onAuthReady}>
               <ToastProvider>
                 <BottomSheetModalProvider>
-                  <BluetoothProviderWrapper>
-                    <Stack screenOptions={{ headerShown: false }} initialRouteName="(tabs)">
-                      <Stack.Screen name="(tabs)" />
-                      <Stack.Screen name="auth" options={{ headerShown: false, gestureEnabled: false }} />
-                    </Stack>
-                  </BluetoothProviderWrapper>
+                  <QueueProvider>
+                    <BluetoothProviderWrapper>
+                      <Stack screenOptions={{ headerShown: false }} initialRouteName="(tabs)">
+                        <Stack.Screen name="(tabs)" />
+                        <Stack.Screen name="auth" options={{ headerShown: false, gestureEnabled: false }} />
+                      </Stack>
+                    </BluetoothProviderWrapper>
+                  </QueueProvider>
                 </BottomSheetModalProvider>
               </ToastProvider>
             </AuthProvider>

--- a/packages/mobile/app/auth/callback.tsx
+++ b/packages/mobile/app/auth/callback.tsx
@@ -25,7 +25,7 @@ export default function AuthCallback() {
       .then(async (result) => {
         if (result.success) {
           await refreshAuthState();
-          router.replace('/(tabs)');
+          router.replace('/(tabs)/boards');
         } else {
           setError(result.error);
         }

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -104,7 +104,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     return <Redirect href="/auth/login" />;
   }
   if (isAuthenticated && inAuthGroup) {
-    return <Redirect href="/(tabs)" />;
+    return <Redirect href="/(tabs)/boards" />;
   }
 
   return (


### PR DESCRIPTION
## Summary

Two bugs found during first end-to-end test of the new email/password native login flow — neither was caught before because the prior flow was OAuth-only and never landed on the same screens.

- **Redirect loop after sign-in.** `AuthProvider` and `+not-found.tsx` both redirected to `/(tabs)`. That group has no `index.tsx`, so expo-router falls through to `+not-found`, which redirects to `/(tabs)`, which loops back to `+not-found` — React eventually throws *Maximum update depth exceeded*. Pointing both redirects at the concrete `/(tabs)/boards` route fixes it.
- **`useQueue must be used within QueueProvider` crash.** Opening the Queue tab (or any climb detail screen) crashed because `QueueProvider` was defined but never mounted in `_layout.tsx`. Added it between `BottomSheetModalProvider` and `BluetoothProviderWrapper`. It has to be above the BT wrapper because `BluetoothAutoSender` (mounted by `BluetoothProvider` when BLE is connected) calls `useQueue`.

## Test plan

- [x] Login with email/password against prod backend → lands on Boards tab, no max-update-depth error.
- [ ] Tap Queue tab → renders without `useQueue must be used within QueueProvider`.
- [ ] Tap a climb detail → renders without the same error.
- [ ] OAuth (Google/Apple) login still works.
- [ ] `vp run typecheck:mobile` is unchanged (pre-existing errors only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)