### PR TITLE
feat(mobile): upgrade climb list to match web UI spec

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -1,11 +1,12 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
-import { View, Pressable, StyleSheet, RefreshControl, Image } from 'react-native';
+import { View, StyleSheet, RefreshControl, Image } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useNavigation, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import type { Climb, BoardName } from '@boardsesh/shared-schema';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { ClimbListRow } from '../../../src/components/ClimbListRow';
+import { ClimbActionsSheet } from '../../../src/components/ClimbActionsSheet';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
@@ -16,10 +17,13 @@ import {
   type ClimbFilters,
 } from '../../../src/components/ClimbFilterSheet';
 import { useDefaultBoard, useSearchClimbs } from '../../../src/lib/graphql/hooks';
+import { useQueue } from '../../../src/providers/queue-provider';
 import { accumulateClimbs } from '../../../src/lib/climb-pagination';
 import { getBoardRenderData } from '../../../src/lib/board-details';
 import { brandColors } from '../../../src/theme/colors';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
+import { hapticSuccess } from '../../../src/lib/haptics';
+import { Pressable } from 'react-native';
 
 const PAGE_SIZE = 30;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -57,13 +61,13 @@ export default function ClimbList() {
         autoCapitalize: 'none',
         hideWhenScrolling: false,
         onChangeText: (event: { nativeEvent: { text: string } }) => {
-          const text = event.nativeEvent.text;
+          const searchText = event.nativeEvent.text;
 
           if (debounceTimerRef.current) {
             clearTimeout(debounceTimerRef.current);
           }
           debounceTimerRef.current = setTimeout(() => {
-            setDebouncedSearch(text);
+            setDebouncedSearch(searchText);
           }, SEARCH_DEBOUNCE_MS);
         },
       },
@@ -83,7 +87,7 @@ export default function ClimbList() {
 
   const { data: defaultBoard, isLoading: isBoardLoading } = useDefaultBoard();
 
-  const boardName = defaultBoard?.boardType ?? '';
+  const boardName = (defaultBoard?.boardType ?? '') as BoardName;
   const layoutId = defaultBoard?.layoutId ?? 0;
   const sizeId = defaultBoard?.sizeId ?? 0;
   const setIds = defaultBoard?.setIds ?? '';
@@ -91,22 +95,25 @@ export default function ClimbList() {
 
   const hasBoardConfig = !!defaultBoard;
 
-  // Pre-warm board images so they're cached before the user taps into a climb
-  useEffect(() => {
-    if (!defaultBoard) return;
+  // Compute board render data once for all thumbnails
+  const boardRenderData = useMemo(() => {
+    if (!defaultBoard) return null;
     const parsedSetIds = defaultBoard.setIds.split(',').map(Number);
-    const renderData = getBoardRenderData({
+    return getBoardRenderData({
       boardName: defaultBoard.boardType as BoardName,
       layoutId: defaultBoard.layoutId,
       sizeId: defaultBoard.sizeId,
       setIds: parsedSetIds,
     });
-    if (renderData?.imageUrls) {
-      for (const url of renderData.imageUrls) {
-        Image.prefetch(url);
-      }
-    }
   }, [defaultBoard]);
+
+  // Pre-warm board images so they're cached before the user taps into a climb
+  useEffect(() => {
+    if (!boardRenderData) return;
+    for (const url of boardRenderData.imageUrls) {
+      Image.prefetch(url);
+    }
+  }, [boardRenderData]);
 
   // Track pagination
   const [pageNumber, setPageNumber] = useState(1);
@@ -121,7 +128,7 @@ export default function ClimbList() {
 
   const searchInput = useMemo(
     () => ({
-      boardName,
+      boardName: boardName as string,
       layoutId,
       sizeId,
       setIds,
@@ -175,7 +182,7 @@ export default function ClimbList() {
         pathname: '/(tabs)/climbs/[climbUuid]',
         params: {
           climbUuid: climb.uuid,
-          boardName,
+          boardName: boardName as string,
           layoutId: String(layoutId),
           sizeId: String(sizeId),
           setIds,
@@ -186,22 +193,57 @@ export default function ClimbList() {
     [router, boardName, layoutId, sizeId, setIds, angle],
   );
 
+  // --- Queue integration ---
+  const { addToQueue } = useQueue();
+
+  const handleAddToQueue = useCallback(
+    (climb: Climb) => {
+      hapticSuccess();
+      addToQueue({
+        uuid: `queue-${climb.uuid}-${Date.now()}`,
+        climb,
+      });
+    },
+    [addToQueue],
+  );
+
+  // --- Actions sheet ---
+  const actionsSheetRef = useRef<BottomSheet>(null);
+  const [activeActionClimb, setActiveActionClimb] = useState<Climb | null>(null);
+
+  const handleOpenActions = useCallback((climb: Climb) => {
+    setActiveActionClimb(climb);
+    actionsSheetRef.current?.expand();
+  }, []);
+
+  const handleDismissActions = useCallback(() => {
+    actionsSheetRef.current?.close();
+    setActiveActionClimb(null);
+  }, []);
+
+  const handleActionAddToQueue = useCallback(() => {
+    if (activeActionClimb) {
+      handleAddToQueue(activeActionClimb);
+    }
+  }, [activeActionClimb, handleAddToQueue]);
+
   const isInitialLoading = isBoardLoading || (isClimbsLoading && accumulatedClimbs.length === 0);
 
   const renderClimbItem = useCallback(
     ({ item: climb }: { item: Climb }) => {
-      const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
-
       return (
         <ClimbListRow
           climb={climb}
-          gradeName={climb.difficulty}
-          gradeColor={gradeColor}
+          boardName={boardName}
+          boardRenderData={boardRenderData}
+          angle={angle}
           onPress={() => handleClimbPress(climb)}
+          onAddToQueue={handleAddToQueue}
+          onOpenActions={handleOpenActions}
         />
       );
     },
-    [handleClimbPress],
+    [handleClimbPress, boardName, boardRenderData, angle, handleAddToQueue, handleOpenActions],
   );
 
   if (!hasBoardConfig && !isBoardLoading) {
@@ -234,7 +276,6 @@ export default function ClimbList() {
         data={accumulatedClimbs}
         renderItem={renderClimbItem}
         keyExtractor={keyExtractor}
-        estimatedItemSize={68}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         contentInsetAdjustmentBehavior="automatic"
@@ -269,9 +310,15 @@ export default function ClimbList() {
       <ClimbFilterSheet
         visible={showFilters}
         onDismiss={handleDismissFilters}
-        boardName={boardName}
+        boardName={boardName as string}
         currentFilters={filters}
         onApply={handleApplyFilters}
+      />
+      <ClimbActionsSheet
+        ref={actionsSheetRef}
+        climb={activeActionClimb}
+        onAddToQueue={handleActionAddToQueue}
+        onDismiss={handleDismissActions}
       />
     </View>
   );

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
-import { View, StyleSheet, RefreshControl, Image } from 'react-native';
+import { View, Pressable, StyleSheet, RefreshControl, Image } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useNavigation, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -16,14 +16,13 @@ import {
   DEFAULT_FILTERS,
   type ClimbFilters,
 } from '../../../src/components/ClimbFilterSheet';
-import { useDefaultBoard, useSearchClimbs } from '../../../src/lib/graphql/hooks';
+import { useDefaultBoard, useSearchClimbs, useToggleFavorite } from '../../../src/lib/graphql/hooks';
 import { useQueue } from '../../../src/providers/queue-provider';
 import { accumulateClimbs } from '../../../src/lib/climb-pagination';
 import { getBoardRenderData } from '../../../src/lib/board-details';
 import { brandColors } from '../../../src/theme/colors';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { hapticSuccess } from '../../../src/lib/haptics';
-import { Pressable } from 'react-native';
 
 const PAGE_SIZE = 30;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -227,6 +226,15 @@ export default function ClimbList() {
     }
   }, [activeActionClimb, handleAddToQueue]);
 
+  // --- Favorite toggle from actions sheet ---
+  const { mutate: toggleFavorite } = useToggleFavorite();
+
+  const handleActionToggleFavorite = useCallback(() => {
+    if (activeActionClimb) {
+      toggleFavorite({ input: { boardName, climbUuid: activeActionClimb.uuid, angle } });
+    }
+  }, [activeActionClimb, toggleFavorite, boardName, angle]);
+
   const isInitialLoading = isBoardLoading || (isClimbsLoading && accumulatedClimbs.length === 0);
 
   const renderClimbItem = useCallback(
@@ -318,6 +326,7 @@ export default function ClimbList() {
         ref={actionsSheetRef}
         climb={activeActionClimb}
         onAddToQueue={handleActionAddToQueue}
+        onToggleFavorite={handleActionToggleFavorite}
         onDismiss={handleDismissActions}
       />
     </View>

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -177,11 +177,11 @@ export default function ClimbList() {
   }, [hasMore, isClimbsLoading, isRefetching]);
 
   const handleClimbPress = useCallback(
-    (climb: Climb) => {
+    (pressedClimb: Climb) => {
       router.push({
         pathname: '/(tabs)/climbs/[climbUuid]',
         params: {
-          climbUuid: climb.uuid,
+          climbUuid: pressedClimb.uuid,
           boardName: boardName as string,
           layoutId: String(layoutId),
           sizeId: String(sizeId),
@@ -237,7 +237,7 @@ export default function ClimbList() {
           boardName={boardName}
           boardRenderData={boardRenderData}
           angle={angle}
-          onPress={() => handleClimbPress(climb)}
+          onPress={handleClimbPress}
           onAddToQueue={handleAddToQueue}
           onOpenActions={handleOpenActions}
         />

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -210,10 +210,13 @@ export default function ClimbList() {
   const actionsSheetRef = useRef<BottomSheet>(null);
   const [activeActionClimb, setActiveActionClimb] = useState<Climb | null>(null);
 
-  const handleOpenActions = useCallback((climb: Climb) => {
-    setActiveActionClimb(climb);
+  const handleOpenActions = useCallback((actionClimb: Climb) => {
+    setActiveActionClimb(actionClimb);
     actionsSheetRef.current?.expand();
   }, []);
+
+  // Playlist selector not yet implemented — fall back to actions sheet
+  const handleOpenPlaylist = handleOpenActions;
 
   const handleDismissActions = useCallback(() => {
     actionsSheetRef.current?.close();
@@ -247,11 +250,12 @@ export default function ClimbList() {
           angle={angle}
           onPress={handleClimbPress}
           onAddToQueue={handleAddToQueue}
+          onOpenPlaylist={handleOpenPlaylist}
           onOpenActions={handleOpenActions}
         />
       );
     },
-    [handleClimbPress, boardName, boardRenderData, angle, handleAddToQueue, handleOpenActions],
+    [handleClimbPress, boardName, boardRenderData, angle, handleAddToQueue, handleOpenPlaylist, handleOpenActions],
   );
 
   if (!hasBoardConfig && !isBoardLoading) {

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -284,6 +284,7 @@ export default function ClimbList() {
         data={accumulatedClimbs}
         renderItem={renderClimbItem}
         keyExtractor={keyExtractor}
+        overrideProps={{ estimatedItemSize: 88 }}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         contentInsetAdjustmentBehavior="automatic"
@@ -325,6 +326,11 @@ export default function ClimbList() {
       <ClimbActionsSheet
         ref={actionsSheetRef}
         climb={activeActionClimb}
+        boardName={boardName as string}
+        layoutId={layoutId}
+        sizeId={sizeId}
+        setIds={setIds}
+        angle={angle}
         onAddToQueue={handleActionAddToQueue}
         onToggleFavorite={handleActionToggleFavorite}
         onDismiss={handleDismissActions}

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -215,9 +215,6 @@ export default function ClimbList() {
     actionsSheetRef.current?.expand();
   }, []);
 
-  // Playlist selector not yet implemented — fall back to actions sheet
-  const handleOpenPlaylist = handleOpenActions;
-
   const handleDismissActions = useCallback(() => {
     actionsSheetRef.current?.close();
     setActiveActionClimb(null);
@@ -250,12 +247,11 @@ export default function ClimbList() {
           angle={angle}
           onPress={handleClimbPress}
           onAddToQueue={handleAddToQueue}
-          onOpenPlaylist={handleOpenPlaylist}
           onOpenActions={handleOpenActions}
         />
       );
     },
-    [handleClimbPress, boardName, boardRenderData, angle, handleAddToQueue, handleOpenPlaylist, handleOpenActions],
+    [handleClimbPress, boardName, boardRenderData, angle, handleAddToQueue, handleOpenActions],
   );
 
   if (!hasBoardConfig && !isBoardLoading) {

--- a/packages/mobile/src/components/AscentStatusBadge.tsx
+++ b/packages/mobile/src/components/AscentStatusBadge.tsx
@@ -48,7 +48,6 @@ const styles = StyleSheet.create({
     backgroundColor: iosSystemColors.systemGreen,
   },
   attemptedBadge: {
-    // iOS systemOrange (#FF9500) — not in iosSystemColors yet
-    backgroundColor: '#FF9500',
+    backgroundColor: iosSystemColors.systemOrange,
   },
 });

--- a/packages/mobile/src/components/AscentStatusBadge.tsx
+++ b/packages/mobile/src/components/AscentStatusBadge.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Icon } from './Icon';
+import { iosSystemColors } from '../theme/ios-colors';
+
+type AscentStatusBadgeProps = {
+  userAscents: number | null | undefined;
+  userAttempts: number | null | undefined;
+};
+
+const AscentStatusBadge = React.memo(function AscentStatusBadge({
+  userAscents,
+  userAttempts,
+}: AscentStatusBadgeProps) {
+  if (userAscents && userAscents > 0) {
+    return (
+      <View style={[styles.badge, styles.sentBadge]}>
+        <Icon name="tick.outline" size={10} color={iosSystemColors.white} />
+      </View>
+    );
+  }
+
+  if (userAttempts && userAttempts > 0) {
+    return (
+      <View style={[styles.badge, styles.attemptedBadge]}>
+        <Icon name="close" size={8} color={iosSystemColors.white} />
+      </View>
+    );
+  }
+
+  return null;
+});
+
+export { AscentStatusBadge };
+
+const styles = StyleSheet.create({
+  badge: {
+    position: 'absolute',
+    bottom: 2,
+    right: 2,
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  sentBadge: {
+    backgroundColor: iosSystemColors.systemGreen,
+  },
+  attemptedBadge: {
+    // iOS systemOrange (#FF9500) — not in iosSystemColors yet
+    backgroundColor: '#FF9500',
+  },
+});

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -1,0 +1,85 @@
+import { forwardRef, useCallback, useMemo } from 'react';
+import { View, StyleSheet, Share } from 'react-native';
+import type BottomSheet from '@gorhom/bottom-sheet';
+import { useTranslation } from 'react-i18next';
+import type { Climb } from '@boardsesh/shared-schema';
+import { Sheet } from './Sheet';
+import { ListRow } from './ListRow';
+import { Icon } from './Icon';
+import { brandColors } from '../theme/colors';
+import { iosSystemColors } from '../theme/ios-colors';
+
+type ClimbActionsSheetProps = {
+  climb: Climb | null;
+  onAddToQueue?: () => void;
+  onToggleFavorite?: () => void;
+  onDismiss?: () => void;
+};
+
+const ClimbActionsSheet = forwardRef<BottomSheet, ClimbActionsSheetProps>(function ClimbActionsSheet(
+  { climb, onAddToQueue, onToggleFavorite, onDismiss },
+  ref,
+) {
+  const { t } = useTranslation('climbs');
+
+  const handleAddToQueue = useCallback(() => {
+    onAddToQueue?.();
+    onDismiss?.();
+  }, [onAddToQueue, onDismiss]);
+
+  const handleToggleFavorite = useCallback(() => {
+    onToggleFavorite?.();
+    onDismiss?.();
+  }, [onToggleFavorite, onDismiss]);
+
+  const handleShare = useCallback(() => {
+    if (!climb) return;
+    Share.share({
+      message: climb.name,
+    });
+    onDismiss?.();
+  }, [climb, onDismiss]);
+
+  const handleClose = useCallback(() => {
+    onDismiss?.();
+  }, [onDismiss]);
+
+  const snapPoints = useMemo(() => ['35%'], []);
+
+  return (
+    <Sheet ref={ref} snapPoints={snapPoints} onClose={handleClose} enablePanDownToClose>
+      <View style={styles.content}>
+        {onAddToQueue && (
+          <ListRow
+            title={t('mobile.climbRow.addToQueue')}
+            leading={<Icon name="add" size={22} color={brandColors.success} />}
+            onPress={handleAddToQueue}
+            showSeparator
+          />
+        )}
+        {onToggleFavorite && (
+          <ListRow
+            title={t('mobile.climbRow.toggleFavorite')}
+            leading={<Icon name="favorite" size={22} color={iosSystemColors.systemRed} />}
+            onPress={handleToggleFavorite}
+            showSeparator
+          />
+        )}
+        <ListRow
+          title={t('mobile.climbRow.share')}
+          leading={<Icon name="share" size={22} color={brandColors.primary} />}
+          onPress={handleShare}
+          showSeparator={false}
+        />
+      </View>
+    </Sheet>
+  );
+});
+
+export { ClimbActionsSheet };
+
+const styles = StyleSheet.create({
+  content: {
+    paddingTop: 8,
+  },
+});

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -8,16 +8,35 @@ import { ListRow } from './ListRow';
 import { Icon } from './Icon';
 import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
+import { spacing } from '../theme/tokens';
+
+const WEB_BASE_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'https://www.boardsesh.com';
 
 type ClimbActionsSheetProps = {
   climb: Climb | null;
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
   onAddToQueue?: () => void;
   onToggleFavorite?: () => void;
   onDismiss?: () => void;
 };
 
+function buildClimbUrl(
+  boardName: string,
+  layoutId: number,
+  sizeId: number,
+  setIds: string,
+  angle: number,
+  climbUuid: string,
+): string {
+  return `${WEB_BASE_URL}/${boardName}/${layoutId}/${sizeId}/${setIds}/${angle}/view/${climbUuid}`;
+}
+
 const ClimbActionsSheet = forwardRef<BottomSheet, ClimbActionsSheetProps>(function ClimbActionsSheet(
-  { climb, onAddToQueue, onToggleFavorite, onDismiss },
+  { climb, boardName, layoutId, sizeId, setIds, angle, onAddToQueue, onToggleFavorite, onDismiss },
   ref,
 ) {
   const { t } = useTranslation('climbs');
@@ -34,12 +53,13 @@ const ClimbActionsSheet = forwardRef<BottomSheet, ClimbActionsSheetProps>(functi
 
   const handleShare = useCallback(async () => {
     if (!climb) return;
+    const url = buildClimbUrl(boardName, layoutId, sizeId, setIds, angle, climb.uuid);
     try {
-      await Share.share({ message: climb.name });
+      await Share.share({ message: `${climb.name}\n${url}`, url });
     } finally {
       onDismiss?.();
     }
-  }, [climb, onDismiss]);
+  }, [climb, boardName, layoutId, sizeId, setIds, angle, onDismiss]);
 
   const handleClose = useCallback(() => {
     onDismiss?.();
@@ -81,6 +101,6 @@ export { ClimbActionsSheet };
 
 const styles = StyleSheet.create({
   content: {
-    paddingTop: 8,
+    paddingTop: spacing[2],
   },
 });

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -34,9 +34,7 @@ const ClimbActionsSheet = forwardRef<BottomSheet, ClimbActionsSheetProps>(functi
 
   const handleShare = useCallback(() => {
     if (!climb) return;
-    Share.share({
-      message: climb.name,
-    });
+    Share.share({ message: climb.name }).catch(() => {});
     onDismiss?.();
   }, [climb, onDismiss]);
 

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -32,10 +32,13 @@ const ClimbActionsSheet = forwardRef<BottomSheet, ClimbActionsSheetProps>(functi
     onDismiss?.();
   }, [onToggleFavorite, onDismiss]);
 
-  const handleShare = useCallback(() => {
+  const handleShare = useCallback(async () => {
     if (!climb) return;
-    Share.share({ message: climb.name }).catch(() => {});
-    onDismiss?.();
+    try {
+      await Share.share({ message: climb.name });
+    } finally {
+      onDismiss?.();
+    }
   }, [climb, onDismiss]);
 
   const handleClose = useCallback(() => {

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -137,7 +137,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
     () =>
       Gesture.Pan()
         .activeOffsetX([-10, 10])
-        .failOffsetY([-5, 5])
+        .failOffsetY([-15, 15])
         .onUpdate((event) => {
           'worklet';
           const offset = event.translationX;
@@ -274,7 +274,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
   const subtitleText = useMemo(() => {
     const parts: string[] = [];
     if (climb.is_draft) {
-      parts.push(t('create.draftBadge'));
+      parts.push(t('createClimbForm.draftBadge'));
     }
     if (!climb.is_draft && climb.ascensionist_count) {
       parts.push(formatSends(climb.ascensionist_count));

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -73,8 +73,9 @@ const ClimbListRow = React.memo(function ClimbListRow({
 
   const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
 
-  // --- Double-tap favorite ---
-  const { handleDoubleTap, showHeart, dismissHeart, isFavorited } = useDoubleTapFavorite({
+  // --- Double-tap favorite (ephemeral heart animation only — favorite status
+  // is not available in the search query, so we don't show it in the subtitle) ---
+  const { handleDoubleTap, showHeart, dismissHeart } = useDoubleTapFavorite({
     climbUuid: climb.uuid,
     boardName,
     angle,
@@ -101,8 +102,9 @@ const ClimbListRow = React.memo(function ClimbListRow({
   onPressRef.current = onPress;
   const onAddToQueueRef = useRef(onAddToQueue);
   onAddToQueueRef.current = onAddToQueue;
-  const onOpenPlaylistRef = useRef(onOpenPlaylist);
-  onOpenPlaylistRef.current = onOpenPlaylist;
+  const resolvedOpenPlaylist = onOpenPlaylist ?? onOpenActions;
+  const onOpenPlaylistRef = useRef(resolvedOpenPlaylist);
+  onOpenPlaylistRef.current = resolvedOpenPlaylist;
   const onOpenActionsRef = useRef(onOpenActions);
   onOpenActionsRef.current = onOpenActions;
   const climbRef = useRef(climb);
@@ -284,11 +286,8 @@ const ClimbListRow = React.memo(function ClimbListRow({
     if (climb.setter_username) {
       parts.push(climb.setter_username);
     }
-    if (isFavorited) {
-      parts.push(t('mobile.climbRow.favoritedIndicator'));
-    }
     return parts.length > 0 ? parts.join(' · ') : t('mobile.climbRow.projectFallback');
-  }, [climb.is_draft, climb.ascensionist_count, climb.quality_average, climb.setter_username, isFavorited, t]);
+  }, [climb.is_draft, climb.ascensionist_count, climb.quality_average, climb.setter_username, t]);
 
   // Compose gestures: double-tap takes priority over single-tap;
   // pan runs simultaneously with the tap gestures

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Pressable, View, StyleSheet } from 'react-native';
 import Animated, {
   useAnimatedStyle,
@@ -23,6 +23,7 @@ import { getGradeTintColor } from '../lib/grade-tint-color';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { brandColors } from '../theme/colors';
+import { spacing } from '../theme/tokens';
 import type { HoldPlacement } from './board-renderer/types';
 
 const MAX_GESTURE_SWIPE = 180;
@@ -44,7 +45,7 @@ type ClimbListRowProps = {
   boardName: BoardName;
   boardRenderData: BoardRenderData | null;
   angle: number;
-  onPress: () => void;
+  onPress: (climb: Climb) => void;
   onAddToQueue?: (climb: Climb) => void;
   onOpenActions?: (climb: Climb) => void;
   selected?: boolean;
@@ -84,13 +85,32 @@ const ClimbListRow = React.memo(function ClimbListRow({
   const rightActionOpacity = useSharedValue(0);
   const swipeConfirmed = useSharedValue(false);
 
+  // Reset shared values when the climb changes (FlashList recycles rows)
+  useEffect(() => {
+    translateX.value = 0;
+    leftShortOpacity.value = 0;
+    leftLongOpacity.value = 0;
+    rightActionOpacity.value = 0;
+    swipeConfirmed.value = false;
+  }, [climb.uuid, translateX, leftShortOpacity, leftLongOpacity, rightActionOpacity, swipeConfirmed]);
+
   // Stable refs for callbacks to avoid gesture closure staleness
+  const onPressRef = useRef(onPress);
+  onPressRef.current = onPress;
   const onAddToQueueRef = useRef(onAddToQueue);
   onAddToQueueRef.current = onAddToQueue;
   const onOpenActionsRef = useRef(onOpenActions);
   onOpenActionsRef.current = onOpenActions;
   const climbRef = useRef(climb);
   climbRef.current = climb;
+  const unsupportedRef = useRef(unsupported);
+  unsupportedRef.current = unsupported;
+
+  const handleRowPress = useCallback(() => {
+    if (unsupportedRef.current) return;
+    hapticLight();
+    onPressRef.current(climbRef.current);
+  }, []);
 
   const handleSwipeAddToQueue = useCallback(() => {
     hapticSuccess();
@@ -104,7 +124,6 @@ const ClimbListRow = React.memo(function ClimbListRow({
 
   const handleSwipePlaylist = useCallback(() => {
     hapticMedium();
-    // Playlist selection — for now, delegate to actions sheet
     onOpenActionsRef.current?.(climbRef.current);
   }, []);
 
@@ -118,7 +137,6 @@ const ClimbListRow = React.memo(function ClimbListRow({
           const offset = event.translationX;
 
           if (offset > 0) {
-            // Swiping right — reveals left actions (playlist / more)
             const clamped = Math.min(offset, MAX_GESTURE_SWIPE);
             translateX.value = clamped;
 
@@ -133,7 +151,6 @@ const ClimbListRow = React.memo(function ClimbListRow({
             leftLongOpacity.value = baseOpacity * blend;
             rightActionOpacity.value = 0;
           } else {
-            // Swiping left — reveals right action (add to queue)
             const clamped = Math.max(offset, -RIGHT_ACTION_WIDTH - 20);
             translateX.value = clamped;
 
@@ -147,19 +164,16 @@ const ClimbListRow = React.memo(function ClimbListRow({
           const offset = translateX.value;
 
           if (offset > LONG_SWIPE_THRESHOLD) {
-            // Long swipe right — open actions
             translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
             leftShortOpacity.value = withTiming(0, { duration: 200 });
             leftLongOpacity.value = withTiming(0, { duration: 200 });
             runOnJS(handleSwipeOpenActions)();
           } else if (offset > SHORT_SWIPE_THRESHOLD) {
-            // Short swipe right — playlist
             translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
             leftShortOpacity.value = withTiming(0, { duration: 200 });
             leftLongOpacity.value = withTiming(0, { duration: 200 });
             runOnJS(handleSwipePlaylist)();
           } else if (offset < -SHORT_SWIPE_THRESHOLD) {
-            // Swipe left — add to queue
             swipeConfirmed.value = true;
             translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
             rightActionOpacity.value = withTiming(0, { duration: 300 }, () => {
@@ -167,7 +181,6 @@ const ClimbListRow = React.memo(function ClimbListRow({
             });
             runOnJS(handleSwipeAddToQueue)();
           } else {
-            // Below threshold — snap back
             translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
             leftShortOpacity.value = withTiming(0, { duration: 150 });
             leftLongOpacity.value = withTiming(0, { duration: 150 });
@@ -198,25 +211,17 @@ const ClimbListRow = React.memo(function ClimbListRow({
     [handleDoubleTap],
   );
 
-  // Single tap on the whole row
+  // Single tap on the whole row — must wait for double-tap to fail
   const singleTapGesture = useMemo(
     () =>
-      Gesture.Tap().onStart(() => {
-        'worklet';
-        runOnJS(handleRowPress)();
-      }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- handleRowPress is stable via ref
-    [],
+      Gesture.Tap()
+        .maxDuration(250)
+        .onStart(() => {
+          'worklet';
+          runOnJS(handleRowPress)();
+        }),
+    [handleRowPress],
   );
-
-  const onPressRef = useRef(onPress);
-  onPressRef.current = onPress;
-
-  const handleRowPress = useCallback(() => {
-    if (unsupported) return;
-    hapticLight();
-    onPressRef.current();
-  }, [unsupported]);
 
   const handleMenuPress = useCallback(() => {
     hapticLight();
@@ -241,13 +246,13 @@ const ClimbListRow = React.memo(function ClimbListRow({
   }));
 
   const rightConfirmedStyle = useAnimatedStyle(() => ({
-    opacity: swipeConfirmed.value ? 1 : 0,
+    opacity: withTiming(swipeConfirmed.value ? 1 : 0, { duration: 120 }),
   }));
 
   // --- Background color (selected state) ---
   const backgroundColor = useMemo(() => {
     if (selected) {
-      return getGradeTintColor(climb.difficulty, 'light', isDark) ?? 'rgba(128, 128, 128, 0.1)';
+      return getGradeTintColor(climb.difficulty, 'light', isDark) ?? `${iosSystemColors.systemGray}1A`;
     }
     return 'transparent';
   }, [selected, climb.difficulty, isDark]);
@@ -256,7 +261,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
   const subtitleText = useMemo(() => {
     const parts: string[] = [];
     if (climb.is_draft) {
-      parts.push('Draft');
+      parts.push(t('create.draftBadge'));
     }
     if (!climb.is_draft && climb.ascensionist_count) {
       parts.push(formatSends(climb.ascensionist_count));
@@ -271,13 +276,19 @@ const ClimbListRow = React.memo(function ClimbListRow({
     if (isFavorited) {
       parts.push('♥');
     }
-    return parts.length > 0 ? parts.join(' · ') : 'Project';
-  }, [climb.is_draft, climb.ascensionist_count, climb.quality_average, climb.setter_username, isFavorited]);
+    return parts.length > 0 ? parts.join(' · ') : t('card.title.project');
+  }, [climb.is_draft, climb.ascensionist_count, climb.quality_average, climb.setter_username, isFavorited, t]);
 
-  // Compose gestures: pan + double-tap on thumbnail area
+  // Compose gestures: double-tap takes priority over single-tap;
+  // pan runs simultaneously with the tap gestures
+  const thumbnailTapGesture = useMemo(
+    () => Gesture.Exclusive(doubleTapGesture, singleTapGesture),
+    [doubleTapGesture, singleTapGesture],
+  );
+
   const composedGesture = useMemo(
-    () => Gesture.Race(panGesture, singleTapGesture),
-    [panGesture, singleTapGesture],
+    () => Gesture.Simultaneous(panGesture, thumbnailTapGesture),
+    [panGesture, thumbnailTapGesture],
   );
 
   return (
@@ -302,32 +313,30 @@ const ClimbListRow = React.memo(function ClimbListRow({
         </AnimatedView>
       </View>
 
-      {/* Main content row */}
+      {/* Main content row — single GestureDetector with composed gestures */}
       <GestureDetector gesture={composedGesture}>
         <AnimatedView style={[styles.contentRow, { backgroundColor }, contentAnimatedStyle]}>
           {/* Left: Thumbnail with ascent badge + heart overlay */}
-          <GestureDetector gesture={doubleTapGesture}>
-            <View style={styles.thumbnailContainer}>
-              {boardRenderData ? (
-                <ClimbThumbnail
-                  frames={climb.frames}
-                  boardName={boardName}
-                  boardWidth={boardRenderData.boardWidth}
-                  boardHeight={boardRenderData.boardHeight}
-                  imageUrls={boardRenderData.imageUrls}
-                  holdsData={boardRenderData.holdsData}
-                  mirrored={climb.mirrored ?? false}
-                />
-              ) : (
-                <View style={styles.thumbnailPlaceholder} />
-              )}
-              <HeartAnimationOverlay visible={showHeart} onDismiss={dismissHeart} size={32} />
-              <AscentStatusBadge
-                userAscents={climb.userAscents}
-                userAttempts={climb.userAttempts}
+          <View style={styles.thumbnailContainer}>
+            {boardRenderData ? (
+              <ClimbThumbnail
+                frames={climb.frames}
+                boardName={boardName}
+                boardWidth={boardRenderData.boardWidth}
+                boardHeight={boardRenderData.boardHeight}
+                imageUrls={boardRenderData.imageUrls}
+                holdsData={boardRenderData.holdsData}
+                mirrored={climb.mirrored ?? false}
               />
-            </View>
-          </GestureDetector>
+            ) : (
+              <View style={styles.thumbnailPlaceholder} />
+            )}
+            <HeartAnimationOverlay visible={showHeart} onDismiss={dismissHeart} size={32} />
+            <AscentStatusBadge
+              userAscents={climb.userAscents}
+              userAttempts={climb.userAttempts}
+            />
+          </View>
 
           {/* Center: Name + subtitle */}
           <View style={styles.centerColumn}>
@@ -350,7 +359,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
             </Text>
             <Pressable
               onPress={handleMenuPress}
-              hitSlop={8}
+              hitSlop={spacing[2]}
               accessibilityRole="button"
               accessibilityLabel={t('mobile.climbRow.menuAccessibility', { climbName: climb.name })}
             >
@@ -379,21 +388,21 @@ const styles = StyleSheet.create({
   contentRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: 8,
-    paddingVertical: 8,
-    gap: 12,
+    paddingHorizontal: spacing[2],
+    paddingVertical: spacing[2],
+    gap: spacing[3],
   },
   thumbnailContainer: {
-    width: 64,
-    height: 64,
+    width: spacing[16],
+    height: spacing[16],
     flexShrink: 0,
     position: 'relative',
   },
   thumbnailPlaceholder: {
-    width: 64,
-    height: 64,
-    borderRadius: 8,
-    backgroundColor: 'rgba(128, 128, 128, 0.15)',
+    width: spacing[16],
+    height: spacing[16],
+    borderRadius: spacing[2],
+    backgroundColor: `${iosSystemColors.systemGray}1A`,
   },
   centerColumn: {
     flex: 1,
@@ -410,7 +419,7 @@ const styles = StyleSheet.create({
   rightSection: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
+    gap: spacing[2],
     flexShrink: 0,
   },
   gradeText: {
@@ -418,7 +427,7 @@ const styles = StyleSheet.create({
   },
   separator: {
     height: StyleSheet.hairlineWidth,
-    marginLeft: 84,
+    marginLeft: spacing[16] + spacing[2] + spacing[3],
   },
   // --- Swipe action layers ---
   leftActionContainer: {
@@ -429,21 +438,21 @@ const styles = StyleSheet.create({
     width: SHORT_ACTION_WIDTH,
     justifyContent: 'center',
     alignItems: 'flex-start',
-    paddingLeft: 16,
+    paddingLeft: spacing[4],
   },
   leftShortAction: {
     ...StyleSheet.absoluteFill,
     backgroundColor: brandColors.primary,
     justifyContent: 'center',
     alignItems: 'flex-start',
-    paddingLeft: 16,
+    paddingLeft: spacing[4],
   },
   leftLongAction: {
     ...StyleSheet.absoluteFill,
     backgroundColor: iosSystemColors.systemGray,
     justifyContent: 'center',
     alignItems: 'flex-start',
-    paddingLeft: 16,
+    paddingLeft: spacing[4],
   },
   rightActionContainer: {
     position: 'absolute',
@@ -453,20 +462,20 @@ const styles = StyleSheet.create({
     width: RIGHT_ACTION_WIDTH,
     justifyContent: 'center',
     alignItems: 'flex-end',
-    paddingRight: 16,
+    paddingRight: spacing[4],
   },
   rightActionDefault: {
     ...StyleSheet.absoluteFill,
     backgroundColor: brandColors.success,
     justifyContent: 'center',
     alignItems: 'flex-end',
-    paddingRight: 16,
+    paddingRight: spacing[4],
   },
   rightActionConfirmed: {
     ...StyleSheet.absoluteFill,
     backgroundColor: brandColors.success,
     justifyContent: 'center',
     alignItems: 'flex-end',
-    paddingRight: 16,
+    paddingRight: spacing[4],
   },
 });

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -1,163 +1,472 @@
-import React from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { Pressable, View, StyleSheet } from 'react-native';
-import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+  runOnJS,
+} from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { useTranslation } from 'react-i18next';
+import type { Climb, BoardName } from '@boardsesh/shared-schema';
+import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { Text } from './Text';
 import { Icon } from './Icon';
-import { hapticLight } from '../lib/haptics';
-import { springs } from '../theme/animations';
-import { formatAscentCount } from '../lib/format-ascent-count';
-import { DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
-import { iosSystemColors } from '../theme/ios-colors';
+import { ClimbThumbnail } from './ClimbThumbnail';
+import { AscentStatusBadge } from './AscentStatusBadge';
+import { HeartAnimationOverlay } from './HeartAnimationOverlay';
+import { useDoubleTapFavorite } from '../hooks/use-double-tap-favorite';
+import { hapticLight, hapticMedium, hapticSuccess } from '../lib/haptics';
+import { formatSends, formatQuality } from '../lib/format-climb-stats';
+import { getGradeTintColor } from '../lib/grade-tint-color';
 import { useTheme } from '../providers/theme-provider';
+import { iosSystemColors } from '../theme/ios-colors';
+import { brandColors } from '../theme/colors';
+import type { HoldPlacement } from './board-renderer/types';
 
-type ClimbListRowProps = {
-  climb: {
-    uuid: string;
-    name: string;
-    setter_username: string;
-    difficulty: string;
-    quality_average: string;
-    ascensionist_count: number;
-    stars: number;
-  };
-  gradeName?: string;
-  gradeColor?: string;
-  onPress: () => void;
-  onLongPress?: () => void;
+const MAX_GESTURE_SWIPE = 180;
+const SHORT_ACTION_WIDTH = 120;
+const RIGHT_ACTION_WIDTH = 100;
+const SHORT_SWIPE_THRESHOLD = 60;
+const TRANSITION_START = 115;
+const LONG_SWIPE_THRESHOLD = 150;
+
+type BoardRenderData = {
+  boardWidth: number;
+  boardHeight: number;
+  imageUrls: string[];
+  holdsData: HoldPlacement[];
 };
 
-const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+type ClimbListRowProps = {
+  climb: Climb;
+  boardName: BoardName;
+  boardRenderData: BoardRenderData | null;
+  angle: number;
+  onPress: () => void;
+  onAddToQueue?: (climb: Climb) => void;
+  onOpenActions?: (climb: Climb) => void;
+  selected?: boolean;
+  unsupported?: boolean;
+};
+
+const AnimatedView = Animated.View;
 
 const ClimbListRow = React.memo(function ClimbListRow({
   climb,
-  gradeName,
-  gradeColor,
+  boardName,
+  boardRenderData,
+  angle,
   onPress,
-  onLongPress,
+  onAddToQueue,
+  onOpenActions,
+  selected,
+  unsupported,
 }: ClimbListRowProps) {
-  const { systemColors } = useTheme();
-  const scale = useSharedValue(1);
+  const { t } = useTranslation('climbs');
+  const { colorScheme, systemColors } = useTheme();
+  const isDark = colorScheme === 'dark';
 
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: scale.value }],
+  const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
+
+  // --- Double-tap favorite ---
+  const { handleDoubleTap, showHeart, dismissHeart, isFavorited } = useDoubleTapFavorite({
+    climbUuid: climb.uuid,
+    boardName,
+    angle,
+  });
+
+  // --- Swipe gesture state ---
+  const translateX = useSharedValue(0);
+  const leftShortOpacity = useSharedValue(0);
+  const leftLongOpacity = useSharedValue(0);
+  const rightActionOpacity = useSharedValue(0);
+  const swipeConfirmed = useSharedValue(false);
+
+  // Stable refs for callbacks to avoid gesture closure staleness
+  const onAddToQueueRef = useRef(onAddToQueue);
+  onAddToQueueRef.current = onAddToQueue;
+  const onOpenActionsRef = useRef(onOpenActions);
+  onOpenActionsRef.current = onOpenActions;
+  const climbRef = useRef(climb);
+  climbRef.current = climb;
+
+  const handleSwipeAddToQueue = useCallback(() => {
+    hapticSuccess();
+    onAddToQueueRef.current?.(climbRef.current);
+  }, []);
+
+  const handleSwipeOpenActions = useCallback(() => {
+    hapticMedium();
+    onOpenActionsRef.current?.(climbRef.current);
+  }, []);
+
+  const handleSwipePlaylist = useCallback(() => {
+    hapticMedium();
+    // Playlist selection — for now, delegate to actions sheet
+    onOpenActionsRef.current?.(climbRef.current);
+  }, []);
+
+  const panGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .activeOffsetX([-10, 10])
+        .failOffsetY([-5, 5])
+        .onUpdate((event) => {
+          'worklet';
+          const offset = event.translationX;
+
+          if (offset > 0) {
+            // Swiping right — reveals left actions (playlist / more)
+            const clamped = Math.min(offset, MAX_GESTURE_SWIPE);
+            translateX.value = clamped;
+
+            const baseOpacity = Math.min(1, clamped / SHORT_SWIPE_THRESHOLD);
+            const transitionRange = LONG_SWIPE_THRESHOLD - TRANSITION_START;
+            const blend =
+              transitionRange > 0
+                ? Math.max(0, Math.min(1, (clamped - TRANSITION_START) / transitionRange))
+                : 1;
+
+            leftShortOpacity.value = baseOpacity * (1 - blend);
+            leftLongOpacity.value = baseOpacity * blend;
+            rightActionOpacity.value = 0;
+          } else {
+            // Swiping left — reveals right action (add to queue)
+            const clamped = Math.max(offset, -RIGHT_ACTION_WIDTH - 20);
+            translateX.value = clamped;
+
+            leftShortOpacity.value = 0;
+            leftLongOpacity.value = 0;
+            rightActionOpacity.value = Math.min(1, -clamped / SHORT_SWIPE_THRESHOLD);
+          }
+        })
+        .onEnd(() => {
+          'worklet';
+          const offset = translateX.value;
+
+          if (offset > LONG_SWIPE_THRESHOLD) {
+            // Long swipe right — open actions
+            translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
+            leftShortOpacity.value = withTiming(0, { duration: 200 });
+            leftLongOpacity.value = withTiming(0, { duration: 200 });
+            runOnJS(handleSwipeOpenActions)();
+          } else if (offset > SHORT_SWIPE_THRESHOLD) {
+            // Short swipe right — playlist
+            translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
+            leftShortOpacity.value = withTiming(0, { duration: 200 });
+            leftLongOpacity.value = withTiming(0, { duration: 200 });
+            runOnJS(handleSwipePlaylist)();
+          } else if (offset < -SHORT_SWIPE_THRESHOLD) {
+            // Swipe left — add to queue
+            swipeConfirmed.value = true;
+            translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
+            rightActionOpacity.value = withTiming(0, { duration: 300 }, () => {
+              swipeConfirmed.value = false;
+            });
+            runOnJS(handleSwipeAddToQueue)();
+          } else {
+            // Below threshold — snap back
+            translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
+            leftShortOpacity.value = withTiming(0, { duration: 150 });
+            leftLongOpacity.value = withTiming(0, { duration: 150 });
+            rightActionOpacity.value = withTiming(0, { duration: 150 });
+          }
+        }),
+    [
+      translateX,
+      leftShortOpacity,
+      leftLongOpacity,
+      rightActionOpacity,
+      swipeConfirmed,
+      handleSwipeAddToQueue,
+      handleSwipeOpenActions,
+      handleSwipePlaylist,
+    ],
+  );
+
+  // Double-tap gesture on the thumbnail
+  const doubleTapGesture = useMemo(
+    () =>
+      Gesture.Tap()
+        .numberOfTaps(2)
+        .onStart(() => {
+          'worklet';
+          runOnJS(handleDoubleTap)();
+        }),
+    [handleDoubleTap],
+  );
+
+  // Single tap on the whole row
+  const singleTapGesture = useMemo(
+    () =>
+      Gesture.Tap().onStart(() => {
+        'worklet';
+        runOnJS(handleRowPress)();
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- handleRowPress is stable via ref
+    [],
+  );
+
+  const onPressRef = useRef(onPress);
+  onPressRef.current = onPress;
+
+  const handleRowPress = useCallback(() => {
+    if (unsupported) return;
+    hapticLight();
+    onPressRef.current();
+  }, [unsupported]);
+
+  const handleMenuPress = useCallback(() => {
+    hapticLight();
+    onOpenActionsRef.current?.(climbRef.current);
+  }, []);
+
+  // --- Animated styles ---
+  const contentAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
   }));
 
-  const handlePressIn = () => {
-    scale.value = withSpring(0.98, springs.snappy);
-  };
+  const leftShortActionStyle = useAnimatedStyle(() => ({
+    opacity: leftShortOpacity.value,
+  }));
 
-  const handlePressOut = () => {
-    scale.value = withSpring(1, springs.snappy);
-  };
+  const leftLongActionStyle = useAnimatedStyle(() => ({
+    opacity: leftLongOpacity.value,
+  }));
 
-  const handlePress = () => {
-    hapticLight();
-    onPress();
-  };
+  const rightActionAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: rightActionOpacity.value,
+  }));
 
-  const pillColor = gradeColor ?? DEFAULT_GRADE_COLOR;
-  const qualityNum = parseFloat(climb.quality_average);
-  const showStars = climb.stars > 0 || qualityNum > 0;
+  const rightConfirmedStyle = useAnimatedStyle(() => ({
+    opacity: swipeConfirmed.value ? 1 : 0,
+  }));
 
-  const accessibilityLabel = gradeName ? `${climb.name}, ${gradeName}` : `${climb.name}, ${climb.difficulty}`;
+  // --- Background color (selected state) ---
+  const backgroundColor = useMemo(() => {
+    if (selected) {
+      return getGradeTintColor(climb.difficulty, 'light', isDark) ?? 'rgba(128, 128, 128, 0.1)';
+    }
+    return 'transparent';
+  }, [selected, climb.difficulty, isDark]);
+
+  // --- Subtitle parts (matching web's ClimbTitle gradePosition='right' layout) ---
+  const subtitleText = useMemo(() => {
+    const parts: string[] = [];
+    if (climb.is_draft) {
+      parts.push('Draft');
+    }
+    if (!climb.is_draft && climb.ascensionist_count) {
+      parts.push(formatSends(climb.ascensionist_count));
+    }
+    const qualityNum = parseFloat(climb.quality_average);
+    if (qualityNum > 0) {
+      parts.push(`${formatQuality(climb.quality_average)}★`);
+    }
+    if (climb.setter_username) {
+      parts.push(climb.setter_username);
+    }
+    if (isFavorited) {
+      parts.push('♥');
+    }
+    return parts.length > 0 ? parts.join(' · ') : 'Project';
+  }, [climb.is_draft, climb.ascensionist_count, climb.quality_average, climb.setter_username, isFavorited]);
+
+  // Compose gestures: pan + double-tap on thumbnail area
+  const composedGesture = useMemo(
+    () => Gesture.Race(panGesture, singleTapGesture),
+    [panGesture, singleTapGesture],
+  );
 
   return (
-    <AnimatedPressable
-      onPress={handlePress}
-      onLongPress={onLongPress}
-      onPressIn={handlePressIn}
-      onPressOut={handlePressOut}
-      accessibilityRole="button"
-      accessibilityLabel={accessibilityLabel}
-      style={[animatedStyle, styles.container]}
-    >
-      <View style={styles.row}>
-        <View style={styles.textContainer}>
-          <Text variant="headline" numberOfLines={1}>
-            {climb.name}
-          </Text>
-          <Text variant="footnote" numberOfLines={1} style={styles.setter}>
-            {climb.setter_username}
-          </Text>
-        </View>
-
-        <View style={styles.metadata}>
-          {showStars && (
-            <View style={styles.stars}>
-              <Icon name="star.fill" size={12} color={iosSystemColors.starGold} />
-              <Text variant="caption1" style={styles.starText}>
-                {climb.stars > 0 ? climb.stars.toFixed(1) : qualityNum.toFixed(1)}
-              </Text>
-            </View>
-          )}
-          {climb.ascensionist_count > 0 && (
-            <Text variant="footnote" style={styles.ascents}>
-              {formatAscentCount(climb.ascensionist_count)}
-            </Text>
-          )}
-          <View style={[styles.gradePill, { backgroundColor: pillColor }]}>
-            <Text variant="caption2" color={iosSystemColors.white} style={styles.gradeText}>
-              {gradeName ?? climb.difficulty}
-            </Text>
-          </View>
-        </View>
+    <View style={[styles.outerContainer, unsupported && styles.unsupported]}>
+      {/* Left action layers (revealed on swipe right) */}
+      <View style={styles.leftActionContainer}>
+        <AnimatedView style={[styles.leftShortAction, leftShortActionStyle]}>
+          <Icon name="tag" size={20} color={iosSystemColors.white} />
+        </AnimatedView>
+        <AnimatedView style={[styles.leftLongAction, leftLongActionStyle]}>
+          <Icon name="more" size={20} color={iosSystemColors.white} />
+        </AnimatedView>
       </View>
 
+      {/* Right action layer (revealed on swipe left) */}
+      <View style={styles.rightActionContainer}>
+        <AnimatedView style={[styles.rightActionDefault, rightActionAnimatedStyle]}>
+          <Icon name="add" size={20} color={iosSystemColors.white} />
+        </AnimatedView>
+        <AnimatedView style={[styles.rightActionConfirmed, rightConfirmedStyle]}>
+          <Icon name="check.small" size={20} color={iosSystemColors.white} />
+        </AnimatedView>
+      </View>
+
+      {/* Main content row */}
+      <GestureDetector gesture={composedGesture}>
+        <AnimatedView style={[styles.contentRow, { backgroundColor }, contentAnimatedStyle]}>
+          {/* Left: Thumbnail with ascent badge + heart overlay */}
+          <GestureDetector gesture={doubleTapGesture}>
+            <View style={styles.thumbnailContainer}>
+              {boardRenderData ? (
+                <ClimbThumbnail
+                  frames={climb.frames}
+                  boardName={boardName}
+                  boardWidth={boardRenderData.boardWidth}
+                  boardHeight={boardRenderData.boardHeight}
+                  imageUrls={boardRenderData.imageUrls}
+                  holdsData={boardRenderData.holdsData}
+                  mirrored={climb.mirrored ?? false}
+                />
+              ) : (
+                <View style={styles.thumbnailPlaceholder} />
+              )}
+              <HeartAnimationOverlay visible={showHeart} onDismiss={dismissHeart} size={32} />
+              <AscentStatusBadge
+                userAscents={climb.userAscents}
+                userAttempts={climb.userAttempts}
+              />
+            </View>
+          </GestureDetector>
+
+          {/* Center: Name + subtitle */}
+          <View style={styles.centerColumn}>
+            <Text variant="body" numberOfLines={1} style={styles.climbName}>
+              {climb.name}
+            </Text>
+            <Text variant="footnote" numberOfLines={1} style={styles.subtitle}>
+              {subtitleText}
+            </Text>
+          </View>
+
+          {/* Right: Colorized grade + menu button */}
+          <View style={styles.rightSection}>
+            <Text
+              variant="headline"
+              numberOfLines={1}
+              style={[styles.gradeText, { color: gradeColor }]}
+            >
+              {climb.difficulty}
+            </Text>
+            <Pressable
+              onPress={handleMenuPress}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel={t('mobile.climbRow.menuAccessibility', { climbName: climb.name })}
+            >
+              <Icon name="more" size={20} color={iosSystemColors.systemGray} />
+            </Pressable>
+          </View>
+        </AnimatedView>
+      </GestureDetector>
+
+      {/* Separator */}
       <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />
-    </AnimatedPressable>
+    </View>
   );
 });
 
 export { ClimbListRow };
 
 const styles = StyleSheet.create({
-  container: {
-    backgroundColor: 'transparent',
+  outerContainer: {
+    position: 'relative',
+    overflow: 'hidden',
   },
-  row: {
+  unsupported: {
+    opacity: 0.5,
+  },
+  contentRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    minHeight: 52,
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+    gap: 12,
   },
-  textContainer: {
+  thumbnailContainer: {
+    width: 64,
+    height: 64,
+    flexShrink: 0,
+    position: 'relative',
+  },
+  thumbnailPlaceholder: {
+    width: 64,
+    height: 64,
+    borderRadius: 8,
+    backgroundColor: 'rgba(128, 128, 128, 0.15)',
+  },
+  centerColumn: {
     flex: 1,
+    minWidth: 0,
     justifyContent: 'center',
-    marginRight: 12,
+    gap: 2,
   },
-  setter: {
+  climbName: {
+    fontWeight: '600',
+  },
+  subtitle: {
     opacity: 0.6,
-    marginTop: 2,
   },
-  metadata: {
+  rightSection: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-  },
-  stars: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 3,
-  },
-  starText: {
-    opacity: 0.7,
-  },
-  ascents: {
-    opacity: 0.5,
-  },
-  gradePill: {
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderRadius: 6,
-    minWidth: 36,
-    alignItems: 'center',
+    flexShrink: 0,
   },
   gradeText: {
-    fontWeight: '600',
+    fontWeight: '700',
   },
   separator: {
     height: StyleSheet.hairlineWidth,
-    marginLeft: 16,
+    marginLeft: 84,
+  },
+  // --- Swipe action layers ---
+  leftActionContainer: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: SHORT_ACTION_WIDTH,
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    paddingLeft: 16,
+  },
+  leftShortAction: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: brandColors.primary,
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    paddingLeft: 16,
+  },
+  leftLongAction: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: iosSystemColors.systemGray,
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    paddingLeft: 16,
+  },
+  rightActionContainer: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    bottom: 0,
+    width: RIGHT_ACTION_WIDTH,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+    paddingRight: 16,
+  },
+  rightActionDefault: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: brandColors.success,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+    paddingRight: 16,
+  },
+  rightActionConfirmed: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: brandColors.success,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+    paddingRight: 16,
   },
 });

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -47,6 +47,7 @@ type ClimbListRowProps = {
   angle: number;
   onPress: (climb: Climb) => void;
   onAddToQueue?: (climb: Climb) => void;
+  onOpenPlaylist?: (climb: Climb) => void;
   onOpenActions?: (climb: Climb) => void;
   selected?: boolean;
   unsupported?: boolean;
@@ -61,6 +62,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
   angle,
   onPress,
   onAddToQueue,
+  onOpenPlaylist,
   onOpenActions,
   selected,
   unsupported,
@@ -99,6 +101,8 @@ const ClimbListRow = React.memo(function ClimbListRow({
   onPressRef.current = onPress;
   const onAddToQueueRef = useRef(onAddToQueue);
   onAddToQueueRef.current = onAddToQueue;
+  const onOpenPlaylistRef = useRef(onOpenPlaylist);
+  onOpenPlaylistRef.current = onOpenPlaylist;
   const onOpenActionsRef = useRef(onOpenActions);
   onOpenActionsRef.current = onOpenActions;
   const climbRef = useRef(climb);
@@ -124,7 +128,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
 
   const handleSwipePlaylist = useCallback(() => {
     hapticMedium();
-    onOpenActionsRef.current?.(climbRef.current);
+    onOpenPlaylistRef.current?.(climbRef.current);
   }, []);
 
   const panGesture = useMemo(

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -211,16 +211,23 @@ const ClimbListRow = React.memo(function ClimbListRow({
     [handleDoubleTap],
   );
 
-  // Single tap on the whole row — must wait for double-tap to fail
+  // Single tap on the whole row — uses ref to avoid hoisting/stale closure issues
+  const handleRowPressRef = useRef(handleRowPress);
+  handleRowPressRef.current = handleRowPress;
+
+  const stableRowPress = useCallback(() => {
+    handleRowPressRef.current();
+  }, []);
+
   const singleTapGesture = useMemo(
     () =>
       Gesture.Tap()
         .maxDuration(250)
         .onStart(() => {
           'worklet';
-          runOnJS(handleRowPress)();
+          runOnJS(stableRowPress)();
         }),
-    [handleRowPress],
+    [stableRowPress],
   );
 
   const handleMenuPress = useCallback(() => {
@@ -274,9 +281,9 @@ const ClimbListRow = React.memo(function ClimbListRow({
       parts.push(climb.setter_username);
     }
     if (isFavorited) {
-      parts.push('♥');
+      parts.push(t('mobile.climbRow.favoritedIndicator'));
     }
-    return parts.length > 0 ? parts.join(' · ') : t('card.title.project');
+    return parts.length > 0 ? parts.join(' · ') : t('mobile.climbRow.projectFallback');
   }, [climb.is_draft, climb.ascensionist_count, climb.quality_average, climb.setter_username, isFavorited, t]);
 
   // Compose gestures: double-tap takes priority over single-tap;

--- a/packages/mobile/src/components/ClimbThumbnail.tsx
+++ b/packages/mobile/src/components/ClimbThumbnail.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { BoardRenderer } from './board-renderer/BoardRenderer';
+import type { HoldPlacement } from './board-renderer/types';
+
+type ClimbThumbnailProps = {
+  frames: string;
+  boardName: BoardName;
+  boardWidth: number;
+  boardHeight: number;
+  imageUrls: string[];
+  holdsData: HoldPlacement[];
+  mirrored?: boolean;
+};
+
+const ClimbThumbnail = React.memo(function ClimbThumbnail({
+  frames,
+  boardName,
+  boardWidth,
+  boardHeight,
+  imageUrls,
+  holdsData,
+  mirrored,
+}: ClimbThumbnailProps) {
+  return (
+    <View style={styles.container}>
+      <BoardRenderer
+        frames={frames}
+        boardName={boardName}
+        boardWidth={boardWidth}
+        boardHeight={boardHeight}
+        imageUrls={imageUrls}
+        holdsData={holdsData}
+        mirrored={mirrored}
+        style={styles.board}
+      />
+    </View>
+  );
+});
+
+export { ClimbThumbnail };
+
+const styles = StyleSheet.create({
+  container: {
+    width: 64,
+    height: 64,
+    borderRadius: 8,
+    overflow: 'hidden',
+    backgroundColor: 'rgba(128, 128, 128, 0.1)',
+  },
+  board: {
+    width: 64,
+  },
+});

--- a/packages/mobile/src/components/ClimbThumbnail.tsx
+++ b/packages/mobile/src/components/ClimbThumbnail.tsx
@@ -3,6 +3,8 @@ import { View, StyleSheet } from 'react-native';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { BoardRenderer } from './board-renderer/BoardRenderer';
 import type { HoldPlacement } from './board-renderer/types';
+import { iosSystemColors } from '../theme/ios-colors';
+import { spacing, borderRadius } from '../theme/tokens';
 
 type ClimbThumbnailProps = {
   frames: string;
@@ -43,13 +45,13 @@ export { ClimbThumbnail };
 
 const styles = StyleSheet.create({
   container: {
-    width: 64,
-    height: 64,
-    borderRadius: 8,
+    width: spacing[16],
+    height: spacing[16],
+    borderRadius: borderRadius.md,
     overflow: 'hidden',
-    backgroundColor: 'rgba(128, 128, 128, 0.1)',
+    backgroundColor: `${iosSystemColors.systemGray}1A`,
   },
   board: {
-    width: 64,
+    width: spacing[16],
   },
 });

--- a/packages/mobile/src/components/HeartAnimationOverlay.tsx
+++ b/packages/mobile/src/components/HeartAnimationOverlay.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  withTiming,
+  withSequence,
+  withDelay,
+  runOnJS,
+} from 'react-native-reanimated';
+import { Icon } from './Icon';
+import { iosSystemColors } from '../theme/ios-colors';
+
+type HeartAnimationOverlayProps = {
+  visible: boolean;
+  onDismiss: () => void;
+  size?: number;
+};
+
+const HeartAnimationOverlay = React.memo(function HeartAnimationOverlay({
+  visible,
+  onDismiss,
+  size = 32,
+}: HeartAnimationOverlayProps) {
+  const scale = useSharedValue(0);
+  const opacity = useSharedValue(0);
+
+  useEffect(() => {
+    if (visible) {
+      scale.value = withSequence(
+        withSpring(1.3, { damping: 8, stiffness: 300 }),
+        withSpring(1, { damping: 12, stiffness: 200 }),
+      );
+      opacity.value = withSequence(
+        withTiming(1, { duration: 100 }),
+        withDelay(600, withTiming(0, { duration: 500 }, (finished) => {
+          if (finished) {
+            runOnJS(onDismiss)();
+          }
+        })),
+      );
+    } else {
+      scale.value = 0;
+      opacity.value = 0;
+    }
+  }, [visible, scale, opacity, onDismiss]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+    opacity: opacity.value,
+  }));
+
+  if (!visible) return null;
+
+  return (
+    <Animated.View style={[styles.overlay, animatedStyle]}>
+      <Icon name="favorite.fill" size={size} color={iosSystemColors.white} />
+    </Animated.View>
+  );
+});
+
+export { HeartAnimationOverlay };
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFill,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -35,6 +35,8 @@ export const iconMap = {
   delete: { ios: 'trash', android: 'delete-outline' },
   'delete.fill': { ios: 'trash.fill', android: 'delete' },
   edit: { ios: 'pencil', android: 'pencil-outline' },
+  tag: { ios: 'tag', android: 'tag-outline' },
+  'check.small': { ios: 'checkmark', android: 'check' },
 
   // Climb/Board
   tick: { ios: 'checkmark.circle.fill', android: 'check-circle' },

--- a/packages/mobile/src/hooks/use-double-tap-favorite.ts
+++ b/packages/mobile/src/hooks/use-double-tap-favorite.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { useToggleFavorite } from '../lib/graphql/hooks';
 
 type UseDoubleTapFavoriteParams = {
@@ -19,10 +19,16 @@ export function useDoubleTapFavorite({
   const isFavoritedRef = useRef(initialFavorited);
   isFavoritedRef.current = isFavorited;
 
+  // Re-sync local state when the climb changes (FlashList recycles rows)
+  // or when the server-provided initial value changes.
+  useEffect(() => {
+    setIsFavorited(initialFavorited);
+    setShowHeart(false);
+  }, [climbUuid, initialFavorited]);
+
   const { mutate: toggleFavorite } = useToggleFavorite();
 
   const handleDoubleTap = useCallback(() => {
-    // Instagram-style: double-tap only adds, never removes
     if (!isFavoritedRef.current) {
       setIsFavorited(true);
       toggleFavorite({ input: { boardName, climbUuid, angle } });

--- a/packages/mobile/src/hooks/use-double-tap-favorite.ts
+++ b/packages/mobile/src/hooks/use-double-tap-favorite.ts
@@ -1,0 +1,38 @@
+import { useState, useCallback, useRef } from 'react';
+import { useToggleFavorite } from '../lib/graphql/hooks';
+
+type UseDoubleTapFavoriteParams = {
+  climbUuid: string;
+  boardName: string;
+  angle: number;
+  initialFavorited?: boolean;
+};
+
+export function useDoubleTapFavorite({
+  climbUuid,
+  boardName,
+  angle,
+  initialFavorited = false,
+}: UseDoubleTapFavoriteParams) {
+  const [isFavorited, setIsFavorited] = useState(initialFavorited);
+  const [showHeart, setShowHeart] = useState(false);
+  const isFavoritedRef = useRef(initialFavorited);
+  isFavoritedRef.current = isFavorited;
+
+  const { mutate: toggleFavorite } = useToggleFavorite();
+
+  const handleDoubleTap = useCallback(() => {
+    // Instagram-style: double-tap only adds, never removes
+    if (!isFavoritedRef.current) {
+      setIsFavorited(true);
+      toggleFavorite({ input: { boardName, climbUuid, angle } });
+    }
+    setShowHeart(true);
+  }, [toggleFavorite, boardName, climbUuid, angle]);
+
+  const dismissHeart = useCallback(() => {
+    setShowHeart(false);
+  }, []);
+
+  return { handleDoubleTap, showHeart, dismissHeart, isFavorited };
+}

--- a/packages/mobile/src/lib/__tests__/format-climb-stats.test.ts
+++ b/packages/mobile/src/lib/__tests__/format-climb-stats.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { formatCount, formatSends, formatQuality } from '../format-climb-stats';
+
+describe('formatCount', () => {
+  it('returns the number as a string for counts below 1000', () => {
+    expect(formatCount(0)).toBe('0');
+    expect(formatCount(1)).toBe('1');
+    expect(formatCount(999)).toBe('999');
+  });
+
+  it('formats thousands with one decimal for small thousands', () => {
+    expect(formatCount(1000)).toBe('1k');
+    expect(formatCount(1500)).toBe('1.5k');
+    expect(formatCount(9960)).toBe('10k');
+  });
+
+  it('rounds large thousands to nearest integer', () => {
+    expect(formatCount(10000)).toBe('10k');
+    expect(formatCount(15000)).toBe('15k');
+    expect(formatCount(999000)).toBe('999k');
+  });
+
+  it('formats millions with one decimal', () => {
+    expect(formatCount(1_000_000)).toBe('1m');
+    expect(formatCount(1_500_000)).toBe('1.5m');
+    expect(formatCount(2_300_000)).toBe('2.3m');
+  });
+});
+
+describe('formatSends', () => {
+  it('uses singular for 1 send', () => {
+    expect(formatSends(1)).toBe('1 send');
+  });
+
+  it('uses plural for multiple sends', () => {
+    expect(formatSends(5)).toBe('5 sends');
+    expect(formatSends(0)).toBe('0 sends');
+    expect(formatSends(1500)).toBe('1.5k sends');
+  });
+});
+
+describe('formatQuality', () => {
+  it('rounds to one decimal place', () => {
+    expect(formatQuality('3.456')).toBe('3.5');
+    expect(formatQuality('4.0')).toBe('4.0');
+    expect(formatQuality('2.95')).toBe('3.0');
+  });
+
+  it('returns the input for non-numeric strings', () => {
+    expect(formatQuality('abc')).toBe('abc');
+  });
+});

--- a/packages/mobile/src/lib/ascent-status-utils.ts
+++ b/packages/mobile/src/lib/ascent-status-utils.ts
@@ -1,0 +1,37 @@
+export type AscentStatusValue = 'flash' | 'send' | 'attempt';
+
+export type NormalizeAscentStatusInput = {
+  status?: AscentStatusValue | null;
+  isAscent?: boolean | null;
+  tries?: number | null;
+};
+
+const STATUS_PRIORITY: AscentStatusValue[] = ['flash', 'send', 'attempt'];
+
+export function normalizeAscentStatus({
+  status,
+  isAscent = false,
+  tries,
+}: NormalizeAscentStatusInput): AscentStatusValue {
+  if (status === 'flash' || status === 'send' || status === 'attempt') {
+    return status;
+  }
+
+  if (isAscent) {
+    return tries === 1 ? 'flash' : 'send';
+  }
+
+  return 'attempt';
+}
+
+export function pickHighestAscentStatus(statuses: Iterable<AscentStatusValue>): AscentStatusValue | null {
+  const candidates = new Set(statuses);
+
+  for (const status of STATUS_PRIORITY) {
+    if (candidates.has(status)) {
+      return status;
+    }
+  }
+
+  return null;
+}

--- a/packages/mobile/src/lib/format-climb-stats.ts
+++ b/packages/mobile/src/lib/format-climb-stats.ts
@@ -1,0 +1,27 @@
+/** Format a count compactly: <1000 as-is, 1k–999k compact, ≥1m with decimal + m */
+export function formatCount(count: number): string {
+  if (count >= 1_000_000) {
+    const millions = count / 1_000_000;
+    const fixed = millions.toFixed(1);
+    return `${fixed.endsWith('.0') ? fixed.slice(0, -2) : fixed}m`;
+  }
+  if (count < 1000) return `${count}`;
+  const thousands = count / 1000;
+  if (thousands < 10) {
+    const fixed = thousands.toFixed(1);
+    return `${fixed.endsWith('.0') ? fixed.slice(0, -2) : fixed}k`;
+  }
+  return `${Math.round(thousands)}k`;
+}
+
+/** Format send count with singular/plural label: "1 send", "5 sends", "1.2k sends" */
+export function formatSends(count: number): string {
+  return `${formatCount(count)} send${count === 1 ? '' : 's'}`;
+}
+
+/** Round quality_average to 1 decimal place */
+export function formatQuality(quality: string): string {
+  const n = parseFloat(quality);
+  if (Number.isNaN(n)) return quality;
+  return n.toFixed(1);
+}

--- a/packages/mobile/src/lib/grade-tint-color.ts
+++ b/packages/mobile/src/lib/grade-tint-color.ts
@@ -1,0 +1,61 @@
+import { getGradeColor } from '@boardsesh/board-constants/grade-colors';
+
+function hexToHSL(hex: string): { h: number; s: number; l: number } {
+  const clean = hex.replace('#', '');
+  const r = parseInt(clean.substring(0, 2), 16) / 255;
+  const g = parseInt(clean.substring(2, 4), 16) / 255;
+  const b = parseInt(clean.substring(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+
+  if (max === min) return { h: 0, s: 0, l };
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+  let h: number;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+  else if (max === g) h = ((b - r) / d + 2) / 6;
+  else h = ((r - g) / d + 4) / 6;
+
+  return { h: h * 360, s, l };
+}
+
+function hexToHue(hex: string): number {
+  return hexToHSL(hex).h;
+}
+
+/**
+ * Get a subtle HSL tint color derived from a climb's grade color.
+ * Ported from packages/web/app/lib/grade-colors.ts
+ */
+export function getGradeTintColor(
+  difficulty: string | null | undefined,
+  variant: 'default' | 'light' | 'session' = 'default',
+  darkMode?: boolean,
+): string | undefined {
+  const color = getGradeColor(difficulty);
+  if (!color) return undefined;
+
+  const hue = Math.round(hexToHue(color));
+
+  if (darkMode) {
+    if (variant === 'light') {
+      return `hsl(${hue}, 25%, 22%)`;
+    }
+    if (variant === 'session') {
+      return `hsla(${hue}, 40%, 14%, 0.85)`;
+    }
+    return `hsla(${hue}, 35%, 28%, 0.6)`;
+  }
+
+  if (variant === 'light') {
+    return `hsl(${hue}, 20%, 94%)`;
+  }
+  if (variant === 'session') {
+    return `hsl(${hue}, 35%, 82%)`;
+  }
+  return `hsl(${hue}, 30%, 88%)`;
+}

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -73,6 +73,8 @@ const CLIMB_SEARCH_FIELDS = `
   is_no_match
   published_at
   created_at
+  userAscents
+  userAttempts
 `;
 
 const CLIMB_DETAIL_FIELDS = `

--- a/packages/mobile/src/theme/ios-colors.ts
+++ b/packages/mobile/src/theme/ios-colors.ts
@@ -16,6 +16,8 @@ export const iosSystemColors = {
   systemYellow: '#FFCC00',
   /** iOS systemBlue — default tint, links */
   systemBlue: '#007AFF',
+  /** iOS systemOrange — moderate warnings, attempted indicators */
+  systemOrange: '#FF9500',
   /** iOS systemGray — secondary text, inactive tint */
   systemGray: '#8E8E93',
   /** iOS systemGray4 — chevrons, light chrome */

--- a/packages/web/i18n/locales/en-US/climbs.json
+++ b/packages/web/i18n/locales/en-US/climbs.json
@@ -607,7 +607,9 @@
       "share": "Share climb",
       "viewSetter": "View setter",
       "ascentSent": "Sent",
-      "ascentAttempted": "Attempted"
+      "ascentAttempted": "Attempted",
+      "favoritedIndicator": "♥",
+      "projectFallback": "Project"
     }
   }
 }

--- a/packages/web/i18n/locales/en-US/climbs.json
+++ b/packages/web/i18n/locales/en-US/climbs.json
@@ -596,6 +596,18 @@
       "anyRating": "Any",
       "apply": "Apply filters",
       "reset": "Reset"
+    },
+    "climbRow": {
+      "addedToQueue": "Added to queue",
+      "addToQueue": "Add to queue",
+      "addToPlaylist": "Add to playlist",
+      "moreActions": "More actions",
+      "menuAccessibility": "Actions for {{climbName}}",
+      "toggleFavorite": "Toggle favorite",
+      "share": "Share climb",
+      "viewSetter": "View setter",
+      "ascentSent": "Sent",
+      "ascentAttempted": "Attempted"
     }
   }
 }

--- a/packages/web/i18n/locales/en-US/climbs.json
+++ b/packages/web/i18n/locales/en-US/climbs.json
@@ -598,17 +598,10 @@
       "reset": "Reset"
     },
     "climbRow": {
-      "addedToQueue": "Added to queue",
       "addToQueue": "Add to queue",
-      "addToPlaylist": "Add to playlist",
-      "moreActions": "More actions",
       "menuAccessibility": "Actions for {{climbName}}",
       "toggleFavorite": "Toggle favorite",
       "share": "Share climb",
-      "viewSetter": "View setter",
-      "ascentSent": "Sent",
-      "ascentAttempted": "Attempted",
-      "favoritedIndicator": "♥",
       "projectFallback": "Project"
     }
   }

--- a/packages/web/i18n/locales/es/climbs.json
+++ b/packages/web/i18n/locales/es/climbs.json
@@ -598,17 +598,10 @@
       "reset": "Restablecer"
     },
     "climbRow": {
-      "addedToQueue": "Añadido a la cola",
       "addToQueue": "Añadir a la cola",
-      "addToPlaylist": "Añadir a la lista",
-      "moreActions": "Más acciones",
       "menuAccessibility": "Acciones para {{climbName}}",
       "toggleFavorite": "Alternar favorito",
       "share": "Compartir bloque",
-      "viewSetter": "Ver creador",
-      "ascentSent": "Enviado",
-      "ascentAttempted": "Intentado",
-      "favoritedIndicator": "♥",
       "projectFallback": "Proyecto"
     }
   }

--- a/packages/web/i18n/locales/es/climbs.json
+++ b/packages/web/i18n/locales/es/climbs.json
@@ -596,6 +596,18 @@
       "anyRating": "Todos",
       "apply": "Aplicar filtros",
       "reset": "Restablecer"
+    },
+    "climbRow": {
+      "addedToQueue": "Añadido a la cola",
+      "addToQueue": "Añadir a la cola",
+      "addToPlaylist": "Añadir a la lista",
+      "moreActions": "Más acciones",
+      "menuAccessibility": "Acciones para {{climbName}}",
+      "toggleFavorite": "Alternar favorito",
+      "share": "Compartir bloque",
+      "viewSetter": "Ver creador",
+      "ascentSent": "Enviado",
+      "ascentAttempted": "Intentado"
     }
   }
 }

--- a/packages/web/i18n/locales/es/climbs.json
+++ b/packages/web/i18n/locales/es/climbs.json
@@ -607,7 +607,9 @@
       "share": "Compartir bloque",
       "viewSetter": "Ver creador",
       "ascentSent": "Enviado",
-      "ascentAttempted": "Intentado"
+      "ascentAttempted": "Intentado",
+      "favoritedIndicator": "♥",
+      "projectFallback": "Proyecto"
     }
   }
 }

--- a/packages/web/i18n/locales/fr/climbs.json
+++ b/packages/web/i18n/locales/fr/climbs.json
@@ -598,17 +598,10 @@
       "reset": "Réinitialiser"
     },
     "climbRow": {
-      "addedToQueue": "Ajouté à la file",
       "addToQueue": "Ajouter à la file",
-      "addToPlaylist": "Ajouter à la playlist",
-      "moreActions": "Plus d'actions",
       "menuAccessibility": "Actions pour {{climbName}}",
       "toggleFavorite": "Basculer favori",
       "share": "Partager le bloc",
-      "viewSetter": "Voir le créateur",
-      "ascentSent": "Envoyé",
-      "ascentAttempted": "Tenté",
-      "favoritedIndicator": "♥",
       "projectFallback": "Projet"
     }
   }

--- a/packages/web/i18n/locales/fr/climbs.json
+++ b/packages/web/i18n/locales/fr/climbs.json
@@ -596,6 +596,18 @@
       "anyRating": "Tous",
       "apply": "Appliquer les filtres",
       "reset": "Réinitialiser"
+    },
+    "climbRow": {
+      "addedToQueue": "Ajouté à la file",
+      "addToQueue": "Ajouter à la file",
+      "addToPlaylist": "Ajouter à la playlist",
+      "moreActions": "Plus d'actions",
+      "menuAccessibility": "Actions pour {{climbName}}",
+      "toggleFavorite": "Basculer favori",
+      "share": "Partager le bloc",
+      "viewSetter": "Voir le créateur",
+      "ascentSent": "Envoyé",
+      "ascentAttempted": "Tenté"
     }
   }
 }

--- a/packages/web/i18n/locales/fr/climbs.json
+++ b/packages/web/i18n/locales/fr/climbs.json
@@ -607,7 +607,9 @@
       "share": "Partager le bloc",
       "viewSetter": "Voir le créateur",
       "ascentSent": "Envoyé",
-      "ascentAttempted": "Tenté"
+      "ascentAttempted": "Tenté",
+      "favoritedIndicator": "♥",
+      "projectFallback": "Projet"
     }
   }
 }

--- a/packages/web/scripts/mobile-i18n-keeps.ts
+++ b/packages/web/scripts/mobile-i18n-keeps.ts
@@ -55,6 +55,11 @@
 // i18n-keep climbs.mobile.logAscent.save
 // i18n-keep climbs.mobile.logAscent.send
 // i18n-keep climbs.mobile.logAscent.title
+// i18n-keep climbs.mobile.climbRow.addToQueue
+// i18n-keep climbs.mobile.climbRow.menuAccessibility
+// i18n-keep climbs.mobile.climbRow.toggleFavorite
+// i18n-keep climbs.mobile.climbRow.share
+// i18n-keep climbs.mobile.climbRow.projectFallback
 // i18n-keep session.mobile.queue.noSessionTitle
 // i18n-keep session.mobile.queue.noSessionSubtitle
 // i18n-keep session.mobile.queue.emptyTitle


### PR DESCRIPTION
## Summary

- Rewrites mobile `ClimbListRow` to match the web's `ClimbListItem` layout: 64px board thumbnail with SVG hold overlays, colorized grade on the right, subtitle with sends/quality/setter, menu button, and ascent status badge
- Adds bidirectional swipe gestures (left = add to queue, right short = playlist, right long = actions) with haptic feedback
- Adds double-tap-to-favorite with heart burst animation on the thumbnail
- Creates `ClimbActionsSheet` bottom sheet for climb actions (add to queue, favorite, share)
- Ports shared utilities from web: `format-climb-stats`, `grade-tint-color`, `ascent-status-utils`
- Wires queue integration in the climb list screen and adds `userAscents`/`userAttempts` to search GraphQL fields

## Test plan

- [ ] Type check passes: `vp run typecheck:mobile` (verified — no new errors)
- [ ] All 200 tests pass: `vp test --project mobile` (verified)
- [ ] Metro bundle compiles: `vp run check:mobile-bundle` (verified)
- [ ] Visual: climb list shows board thumbnails with hold overlays
- [ ] Visual: grade text is colorized on the right side of each row
- [ ] Visual: ascent status badge shows on thumbnail for sent/attempted climbs
- [ ] Gesture: swipe left reveals green "add to queue" action
- [ ] Gesture: swipe right short reveals primary-colored playlist action
- [ ] Gesture: swipe right long reveals gray "more actions" action
- [ ] Gesture: double-tap thumbnail shows heart animation and favorites the climb
- [ ] Menu button opens ClimbActionsSheet with queue/favorite/share options
- [ ] Infinite scroll and pull-to-refresh still work correctly

https://claude.ai/code/session_01WHNqXJe5reCiUBGCwJVv78

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHNqXJe5reCiUBGCwJVv78)_