### PR TITLE
feat(mobile): EAS Update branch-based OTA preview distribution

### DIFF
--- a/.github/workflows/mobile-eas-update.yml
+++ b/.github/workflows/mobile-eas-update.yml
@@ -1,0 +1,141 @@
+name: Mobile EAS Update (Branch Preview)
+
+on:
+  push:
+    branches-ignore: [main]
+    paths:
+      - 'packages/mobile/**'
+      - 'packages/shared-schema/**'
+      - 'packages/board-constants/**'
+      - 'packages/board-config/**'
+      - 'packages/ble-protocol/**'
+      - 'packages/queue/**'
+      - '.github/workflows/mobile-eas-update.yml'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'EAS Update branch name (defaults to git branch)'
+        required: false
+      platform:
+        description: 'Platform to publish (ios, android, all)'
+        required: false
+        default: 'all'
+
+concurrency:
+  group: mobile-eas-update-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Setup EAS CLI
+        run: bun add -g eas-cli
+
+      - name: Determine branch name
+        id: branch
+        run: |
+          if [ -n "${{ github.event.inputs.branch }}" ]; then
+            echo "name=${{ github.event.inputs.branch }}" >> "$GITHUB_OUTPUT"
+          else
+            # Sanitize branch name for EAS (alphanumeric, dots, dashes)
+            raw="${GITHUB_REF_NAME}"
+            sanitized=$(echo "$raw" | sed 's/[^a-zA-Z0-9._-]/-/g')
+            echo "name=$sanitized" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine platform
+        id: platform
+        run: |
+          echo "value=${{ github.event.inputs.platform || 'all' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish EAS Update
+        working-directory: packages/mobile
+        run: |
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          COMMIT_MSG=$(git log -1 --format='%s')
+          UPDATE_MSG="${COMMIT_HASH} ${COMMIT_MSG}"
+
+          echo "Publishing update to branch: ${{ steps.branch.outputs.name }}"
+          echo "Message: ${UPDATE_MSG}"
+          echo "Platform: ${{ steps.platform.outputs.value }}"
+
+          bunx eas update \
+            --branch "${{ steps.branch.outputs.name }}" \
+            --message "${UPDATE_MSG}" \
+            --platform "${{ steps.platform.outputs.value }}" \
+            --non-interactive
+
+      - name: Post update link to PR
+        if: github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = '${{ steps.branch.outputs.name }}';
+            const sha = context.sha.slice(0, 7);
+
+            // Find open PR for this branch
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${context.payload.ref.replace('refs/heads/', '')}`,
+              state: 'open',
+            });
+
+            if (prs.length === 0) return;
+
+            const pr = prs[0];
+            const marker = '<!-- mobile-eas-update -->';
+            const body = [
+              marker,
+              `### 📱 Mobile Preview Update`,
+              '',
+              `**Branch:** \`${branch}\``,
+              `**Commit:** \`${sha}\``,
+              `**Platform:** ${{ steps.platform.outputs.value }}`,
+              '',
+              'Testers with the **preview** build installed will receive this update automatically',
+              'if their channel points to this branch.',
+              '',
+              '```bash',
+              `# Point the preview channel at this branch:`,
+              `bunx eas channel:edit preview --branch ${branch}`,
+              '```',
+            ].join('\n');
+
+            // Update or create comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+            });
+
+            const existing = comments.find(c => c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body,
+              });
+            }

--- a/.github/workflows/mobile-eas-update.yml
+++ b/.github/workflows/mobile-eas-update.yml
@@ -21,6 +21,10 @@ on:
         required: false
         default: 'all'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: mobile-eas-update-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/mobile-eas-update.yml
+++ b/.github/workflows/mobile-eas-update.yml
@@ -36,6 +36,7 @@ jobs:
 
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      EXPO_PUBLIC_EAS_PROJECT_ID: ${{ vars.EXPO_PUBLIC_EAS_PROJECT_ID }}
       INPUT_BRANCH: ${{ github.event.inputs.branch }}
       INPUT_PLATFORM: ${{ github.event.inputs.platform || 'all' }}
 

--- a/.github/workflows/mobile-eas-update.yml
+++ b/.github/workflows/mobile-eas-update.yml
@@ -114,7 +114,7 @@ jobs:
               '',
               '```bash',
               `# Point the preview channel at this branch:`,
-              `bunx eas-cli@16 channel:edit preview --branch ${branch}`,
+              `bunx eas-cli@16 channel:edit preview --branch "${branch}"`,
               '```',
             ].join('\n');
 

--- a/.github/workflows/mobile-eas-update.yml
+++ b/.github/workflows/mobile-eas-update.yml
@@ -36,6 +36,8 @@ jobs:
 
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      INPUT_BRANCH: ${{ github.event.inputs.branch }}
+      INPUT_PLATFORM: ${{ github.event.inputs.platform || 'all' }}
 
     steps:
       - name: Checkout repository
@@ -46,52 +48,47 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Setup EAS CLI
-        run: bun add -g eas-cli
-
       - name: Determine branch name
         id: branch
         run: |
-          if [ -n "${{ github.event.inputs.branch }}" ]; then
-            echo "name=${{ github.event.inputs.branch }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$INPUT_BRANCH" ]; then
+            sanitized=$(printf '%s' "$INPUT_BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
           else
-            # Sanitize branch name for EAS (alphanumeric, dots, dashes)
-            raw="${GITHUB_REF_NAME}"
-            sanitized=$(echo "$raw" | sed 's/[^a-zA-Z0-9._-]/-/g')
-            echo "name=$sanitized" >> "$GITHUB_OUTPUT"
+            sanitized=$(printf '%s' "$GITHUB_REF_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g')
           fi
-
-      - name: Determine platform
-        id: platform
-        run: |
-          echo "value=${{ github.event.inputs.platform || 'all' }}" >> "$GITHUB_OUTPUT"
+          echo "name=$sanitized" >> "$GITHUB_OUTPUT"
 
       - name: Publish EAS Update
         working-directory: packages/mobile
         run: |
           COMMIT_HASH=$(git rev-parse --short HEAD)
-          COMMIT_MSG=$(git log -1 --format='%s')
+          COMMIT_MSG=$(git log -1 --format='%s' | tr -d "'\"\`" | cut -c1-80)
           UPDATE_MSG="${COMMIT_HASH} ${COMMIT_MSG}"
 
-          echo "Publishing update to branch: ${{ steps.branch.outputs.name }}"
+          echo "Publishing update to branch: $BRANCH_NAME"
           echo "Message: ${UPDATE_MSG}"
-          echo "Platform: ${{ steps.platform.outputs.value }}"
+          echo "Platform: $INPUT_PLATFORM"
 
-          bunx eas update \
-            --branch "${{ steps.branch.outputs.name }}" \
-            --message "${UPDATE_MSG}" \
-            --platform "${{ steps.platform.outputs.value }}" \
+          bunx eas-cli@16 update \
+            --branch "$BRANCH_NAME" \
+            --message "$UPDATE_MSG" \
+            --platform "$INPUT_PLATFORM" \
             --non-interactive
+        env:
+          BRANCH_NAME: ${{ steps.branch.outputs.name }}
 
       - name: Post update link to PR
         if: github.event_name == 'push'
         uses: actions/github-script@v7
+        env:
+          BRANCH_NAME: ${{ steps.branch.outputs.name }}
+          UPDATE_PLATFORM: ${{ env.INPUT_PLATFORM }}
         with:
           script: |
-            const branch = '${{ steps.branch.outputs.name }}';
+            const branch = process.env.BRANCH_NAME;
+            const platform = process.env.UPDATE_PLATFORM;
             const sha = context.sha.slice(0, 7);
 
-            // Find open PR for this branch
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -109,18 +106,17 @@ jobs:
               '',
               `**Branch:** \`${branch}\``,
               `**Commit:** \`${sha}\``,
-              `**Platform:** ${{ steps.platform.outputs.value }}`,
+              `**Platform:** ${platform}`,
               '',
               'Testers with the **preview** build installed will receive this update automatically',
               'if their channel points to this branch.',
               '',
               '```bash',
               `# Point the preview channel at this branch:`,
-              `bunx eas channel:edit preview --branch ${branch}`,
+              `bunx eas-cli@16 channel:edit preview --branch ${branch}`,
               '```',
             ].join('\n');
 
-            // Update or create comment
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/mobile-eas-update.yml
+++ b/.github/workflows/mobile-eas-update.yml
@@ -36,7 +36,6 @@ jobs:
 
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-      EXPO_PUBLIC_EAS_PROJECT_ID: ${{ vars.EXPO_PUBLIC_EAS_PROJECT_ID }}
       INPUT_BRANCH: ${{ github.event.inputs.branch }}
       INPUT_PLATFORM: ${{ github.event.inputs.platform || 'all' }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ curl -fsSL https://vite.plus | bash
 
 # Mobile OTA updates (optional — only needed for `vp run mobile:publish`):
 # Set EXPO_PUBLIC_EAS_PROJECT_ID in your shell or packages/mobile/.env
-# Get the value from expo.dev → project settings → Project ID
+# to override the default project ID committed in app.config.ts
 
 # Note: VERCEL_URL is automatically set by Vercel for deployments
 # For local development, the app defaults to http://localhost:3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,8 @@ This project uses [Vite+](https://viteplus.dev) (`vp`) as its unified toolchain 
 - `vp run check:mobile-bundle` - Headless Metro bundle check for React Native (works on Linux, no simulator needed)
 - `vp run check:mobile-simulator` - Build and launch RN app on iOS simulator (macOS only, skips on Linux)
 - `vp run mobile:screenshot` - Capture iOS simulator screenshot (macOS only, skips on Linux)
+- `vp run mobile:publish` - Publish an EAS Update for the current branch (testers on the preview build receive it OTA)
+- `vp run mobile:preview-build` - Trigger an EAS Build for the "preview" profile (testers install this once)
 - `bun run backend:start` - Start backend in production mode
 
 ### Running E2E Tests
@@ -517,6 +519,38 @@ vp run dev:mobile -- --qa-notes-file path/to/notes.md
 ```
 
 Metro output is also tee'd to `.boardsesh/mobile-metro.log` for post-hoc error inspection.
+
+### OTA Preview Distribution (EAS Update)
+
+Multiple worktrees can publish independent mobile previews via EAS Update. Testers install the "preview" build once, then receive JS-only updates OTA when you publish from any branch.
+
+**One-time setup:**
+1. Build the preview client: `vp run mobile:preview-build` — this produces an installable `.ipa`/`.apk` with the native runtime + expo-updates baked in. Share the install link with testers.
+2. Testers install it on their device (iOS via ad-hoc provisioning, Android via APK).
+
+**Publishing updates (per branch):**
+```bash
+# From any worktree — publishes current JS bundle to an EAS branch matching git branch
+vp run mobile:publish
+
+# Explicit branch name or message
+vp run mobile:publish -- --branch my-feature --message "fix nav regression"
+
+# iOS only
+vp run mobile:publish -- --platform ios
+```
+
+**Pointing testers at a specific branch:**
+```bash
+# Switch the preview channel to receive updates from a specific branch
+bunx eas channel:edit preview --branch my-feature-branch
+```
+
+**CI integration:** The `mobile-eas-update.yml` workflow auto-publishes an update on every push to a non-main branch that touches `packages/mobile/` or shared packages. It posts an update comment on the PR with instructions.
+
+**When you need a new preview build:** Only required when native dependencies change (new Expo plugin, new native module, SDK version bump). Pure JS/TS changes are covered by OTA updates.
+
+**Environment:** The preview build uses production backend (`https://www.boardsesh.com`). The `EXPO_TOKEN` secret must be set in GitHub Actions for CI publishing; locally use `bunx eas login`.
 
 ### Mobile vs. Web Differences
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,10 @@ curl -fsSL https://vite.plus | bash
 # .env.local contains generic config (tracked in git)
 # .env.development.local contains secrets (NOT tracked in git)
 
+# Mobile OTA updates (optional — only needed for `vp run mobile:publish`):
+# Set EXPO_PUBLIC_EAS_PROJECT_ID in your shell or packages/mobile/.env
+# Get the value from expo.dev → project settings → Project ID
+
 # Note: VERCEL_URL is automatically set by Vercel for deployments
 # For local development, the app defaults to http://localhost:3000
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -532,6 +532,19 @@ Multiple worktrees can publish independent mobile previews via EAS Update. Teste
 1. Build the preview client: `vp run mobile:preview-build` — this produces an installable `.ipa`/`.apk` with the native runtime + expo-updates baked in. Share the install link with testers.
 2. Testers install it on their device (iOS via ad-hoc provisioning, Android via APK).
 
+**Preview channels:**
+
+There are 4 preview channels available, each mapped to a different test device or tester:
+
+| Channel | Purpose |
+|---------|---------|
+| `preview-1` | Primary test device |
+| `preview-2` | Secondary test device |
+| `preview-3` | Third tester / device |
+| `preview-4` | Fourth tester / device |
+
+Each channel can independently point to a different EAS Update branch. This lets multiple worktrees deliver updates to different phones simultaneously.
+
 **Publishing updates (per branch):**
 ```bash
 # From any worktree — publishes current JS bundle to an EAS branch matching git branch
@@ -544,10 +557,10 @@ vp run mobile:publish -- --branch my-feature --message "fix nav regression"
 vp run mobile:publish -- --platform ios
 ```
 
-**Pointing testers at a specific branch:**
+**Pointing a channel at a branch:**
 ```bash
-# Switch the preview channel to receive updates from a specific branch
-bunx eas channel:edit preview --branch my-feature-branch
+# Switch preview-1 to receive updates from a specific branch
+bunx eas-cli@16 channel:edit preview-1 --branch my-feature-branch
 ```
 
 **CI integration:** The `mobile-eas-update.yml` workflow auto-publishes an update on every push to a non-main branch that touches `packages/mobile/` or shared packages. It posts an update comment on the PR with instructions.
@@ -555,6 +568,20 @@ bunx eas channel:edit preview --branch my-feature-branch
 **When you need a new preview build:** Only required when native dependencies change (new Expo plugin, new native module, SDK version bump). Pure JS/TS changes are covered by OTA updates.
 
 **Environment:** The preview build uses production backend (`https://www.boardsesh.com`). The `EXPO_TOKEN` secret must be set in GitHub Actions for CI publishing; locally use `bunx eas login`.
+
+### Agent workflow for React Native changes
+
+When making changes to `packages/mobile/` or shared packages that affect the mobile app, **always ask the user which preview channel to publish to** before pushing a test update. Example:
+
+> "Changes are ready. Which preview channel should I publish to? (preview-1, preview-2, preview-3, preview-4)"
+
+After the user responds, publish and point the channel:
+```bash
+vp run mobile:publish
+bunx eas-cli@16 channel:edit <channel> --branch <current-branch>
+```
+
+Do not assume a channel — the user knows which device they're testing on. If the user has previously stated a preferred channel in this session, reuse it without asking again.
 
 ### Mobile vs. Web Differences
 

--- a/bun.lock
+++ b/bun.lock
@@ -166,6 +166,7 @@
         "expo-secure-store": "~56.0.4",
         "expo-status-bar": "~56.0.4",
         "expo-symbols": "~56.0.5",
+        "expo-updates": "~56.0.16",
         "expo-web-browser": "~56.0.5",
         "graphql": "^16.0.0",
         "graphql-request": "^7.0.0",
@@ -2203,7 +2204,7 @@
 
     "arc": ["arc@0.2.0", "", {}, "sha512-8NFOo126uYKQJyXNSLY/jSklgfLQL+XWAcPXGo876JwEQ8nSOPXWNI3TV2jLZMN8QEw8uksJ1ZwS4npjBca8MA=="],
 
-    "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
+    "arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -2641,6 +2642,8 @@
 
     "expo-crypto": ["expo-crypto@56.0.3", "", { "peerDependencies": { "expo": "*" } }, "sha512-Ehiub29JVhN69RbMfaBoZbrrT55o9zU5YojHg48W63aCSN7lGyFz5g8JdUN3mXMaZCAUoExdk24NJPvMgbFZ+w=="],
 
+    "expo-eas-client": ["expo-eas-client@56.0.1", "", {}, "sha512-r8h0ZIExacCrSRgY+ARfhMvFqosLHLJt1L7jyhvabfr1DN/ZDKDsYbovss2tzkpEUZGxZ3BPcB5epCwUsBBdOA=="],
+
     "expo-file-system": ["expo-file-system@56.0.7", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-dcKzo8ShPloM7jgfnMcJStgQebhP8owVjCkNI/aX6NMFV1CYB8bxKGMdnzJ3mXk5nfaiW+F/lSKr2UIJ02WAUA=="],
 
     "expo-font": ["expo-font@56.0.5", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-WLoDu9hlEgPRKXJRR01HFLJ6Z2tFcORX/WFPRYBndmYc5kjQrFGH/j4BRaF3aBRPyYEAUXiUJybNLXkKCwEXQw=="],
@@ -2651,11 +2654,15 @@
 
     "expo-image": ["expo-image@56.0.9", "", { "dependencies": { "sf-symbols-typescript": "^2.2.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-FifiRehXnMul5XeUVHWv+COHFUeCAdsYf5MiCPUBlhr4pRb0sxjA4/floi/TEDpATOIw6GqxbrC4FdZBoyrJmw=="],
 
+    "expo-json-utils": ["expo-json-utils@56.0.0", "", {}, "sha512-lUqyv9aIGDbYTQ5Nux2FnH2/Dz0w5uJ8Pr080eS0StXi2jr5OmuMNErpzUnpfnYOU55xKotd4AHv68PfV/ludg=="],
+
     "expo-keep-awake": ["expo-keep-awake@56.0.3", "", { "peerDependencies": { "expo": "*", "react": "*" } }, "sha512-CLMJXtEiMKknD3Rpm8CRwE6ZJUzu2yCEmRk1sgfHAJ1zIbuEWY3dpPDubtsnuzWm+2k6Sru+yaFbYsvPWmTiBA=="],
 
     "expo-linking": ["expo-linking@56.0.11", "", { "dependencies": { "expo-constants": "~56.0.14", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-MEPgML2mqm2Y8rP6zTleOpCmYiFyfQfNSOBpDIb7CYpbDQleStugvceKsEsL4v8C0Dl5u7e8KkkrbqmgpOOIBw=="],
 
     "expo-localization": ["expo-localization@56.0.6", "", { "dependencies": { "rtl-detect": "^1.0.2" }, "peerDependencies": { "expo": "*", "react": "*" } }, "sha512-zzBVoUFHCVNBywcxGsspoZeIXebihOo/AnmQYE4jMv8gHCSKlLNFT+ft+0+mWcZCMs9necvUs8S8TDonAu/xBA=="],
+
+    "expo-manifests": ["expo-manifests@56.0.4", "", { "dependencies": { "expo-json-utils": "~56.0.0" }, "peerDependencies": { "expo": "*" } }, "sha512-Fokawl2UkiExIF0bqGoblRFA8lYpROVD+EpvDwSW4LgqQyPwNua1gLSgHZjdl5GsVugfRMMWE3LHaibDyX93hw=="],
 
     "expo-modules-autolinking": ["expo-modules-autolinking@56.0.12", "", { "dependencies": { "@expo/require-utils": "^56.1.3", "@expo/spawn-async": "^1.8.0", "chalk": "^4.1.0", "commander": "^7.2.0" }, "bin": { "expo-modules-autolinking": "bin/expo-modules-autolinking.js" } }, "sha512-Sn/LiLSL4as/YOGoatsuRQYS7rxAQHK2oYbFMT/I3iIXHLSeb0DQeuAIytVQ9ypWWck9s2krH2T6NeztyftnaA=="],
 
@@ -2671,7 +2678,13 @@
 
     "expo-status-bar": ["expo-status-bar@56.0.4", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-IGs/fDfkHXofy2ZQrGiXayhFK04HB85FZXorhcEhDZEcqASKgSqpak+HwUtAaR0MeTJwWyHNF7I6VmVbbp8EcA=="],
 
+    "expo-structured-headers": ["expo-structured-headers@56.0.0", "", {}, "sha512-Yv4x+SQxNnMQm4nu8NFfzx197YaDhdYH2N0u7tGErwWTmH9Tm1SAhqo7bLbBWLC9kf7W+kdzTshLU9rTiCXWGw=="],
+
     "expo-symbols": ["expo-symbols@56.0.5", "", { "dependencies": { "@expo-google-fonts/material-symbols": "^0.4.1", "sf-symbols-typescript": "^2.0.0" }, "peerDependencies": { "expo": "*", "expo-font": "*", "react": "*", "react-native": "*" } }, "sha512-RIukH0Xo80C7RU8qreipL2SPy2Py+Km8JFPbCmbPQpHkM3DW9Znlmg6VfhzbtUOlO5EuNSF0lAJ3l2VJi6qYrw=="],
+
+    "expo-updates": ["expo-updates@56.0.16", "", { "dependencies": { "@expo/code-signing-certificates": "^0.0.6", "@expo/plist": "^0.7.0", "@expo/spawn-async": "^1.8.0", "arg": "^4.1.0", "chalk": "^4.1.2", "debug": "^4.3.4", "expo-eas-client": "~56.0.0", "expo-manifests": "~56.0.4", "expo-structured-headers": "~56.0.0", "expo-updates-interface": "~56.0.1", "getenv": "^2.0.0", "glob": "^13.0.0", "ignore": "^5.3.1", "nullthrows": "^1.1.1", "resolve-from": "^5.0.0" }, "peerDependencies": { "expo": "*", "expo-dev-client": "*", "react": "*", "react-native": "*" }, "optionalPeers": ["expo-dev-client"], "bin": { "expo-updates": "bin/cli.js" } }, "sha512-4yTr6iST/5oFzaAuyB+YWKzd3aiLbYa7mlMuwtSGiepy7QEZMEYr0acp7K3R8+vgn/tEJkGT54mVsW42r2NosQ=="],
+
+    "expo-updates-interface": ["expo-updates-interface@56.0.2", "", { "peerDependencies": { "expo": "*" } }, "sha512-eWTwSZ9y8vrULG2oBn2TQSSIwBGSq/TxGJ3jY6tuVS2FWH/ASRIiKs3zkUZTRoC3ZuV2alz0mUClYV7nNrFx8g=="],
 
     "expo-web-browser": ["expo-web-browser@56.0.5", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-kaN+wcR5lHwPCH1IgrU1XyPUQvBRzdF1TMp65uAF9iUCyipqYnmrvV87eqAmrdkFFopWVgU7FcxPu1UZw+gvUQ=="],
 
@@ -4139,6 +4152,8 @@
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": "bin/esbuild" }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
+    "@expo/cli/arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
+
     "@expo/cli/ora": ["ora@3.4.0", "", { "dependencies": { "chalk": "^2.4.2", "cli-cursor": "^2.1.0", "cli-spinners": "^2.0.0", "log-symbols": "^2.2.0", "strip-ansi": "^5.2.0", "wcwidth": "^1.0.1" } }, "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg=="],
 
     "@expo/cli/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -4148,6 +4163,8 @@
     "@expo/config/deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "@expo/devcert/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "@expo/fingerprint/arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
     "@expo/metro-config/postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -1,6 +1,7 @@
 import type { ExpoConfig, ConfigContext } from 'expo/config';
 
-const EAS_PROJECT_ID = process.env.EXPO_PUBLIC_EAS_PROJECT_ID ?? null;
+const DEFAULT_EAS_PROJECT_ID = '87499648-655e-4fb8-9856-65da37e55fb1';
+const EAS_PROJECT_ID = process.env.EXPO_PUBLIC_EAS_PROJECT_ID ?? DEFAULT_EAS_PROJECT_ID;
 
 function resolveDevMetadata(): {
   branchName: string | null;

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -27,6 +27,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     ...config,
     name: 'Boardsesh',
     slug: 'boardsesh',
+    owner: 'boardsesh',
     version: '2.0.0',
     scheme: 'com.boardsesh.app',
     orientation: 'portrait',

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -1,13 +1,6 @@
 import type { ExpoConfig, ConfigContext } from 'expo/config';
 
-const EAS_PROJECT_ID = process.env.EXPO_PUBLIC_EAS_PROJECT_ID;
-
-if (!EAS_PROJECT_ID) {
-  throw new Error(
-    'EXPO_PUBLIC_EAS_PROJECT_ID is required. Run `bunx eas init` from packages/mobile/ ' +
-      'and set the resulting project ID as EXPO_PUBLIC_EAS_PROJECT_ID in your environment.',
-  );
-}
+const EAS_PROJECT_ID = process.env.EXPO_PUBLIC_EAS_PROJECT_ID ?? null;
 
 function resolveDevMetadata(): {
   branchName: string | null;
@@ -39,12 +32,12 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     icon: './assets/icon.png',
     userInterfaceStyle: 'automatic',
     newArchEnabled: true,
-    runtimeVersion: {
-      policy: 'appVersion',
-    },
-    updates: {
-      url: `https://u.expo.dev/${EAS_PROJECT_ID}`,
-    },
+    ...(EAS_PROJECT_ID
+      ? {
+          runtimeVersion: { policy: 'appVersion' as const },
+          updates: { url: `https://u.expo.dev/${EAS_PROJECT_ID}` },
+        }
+      : {}),
     ios: {
       bundleIdentifier: 'com.boardsesh.app',
       supportsTablet: false,
@@ -77,9 +70,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     ],
     extra: {
       ...config.extra,
-      eas: {
-        projectId: EAS_PROJECT_ID,
-      },
+      ...(EAS_PROJECT_ID ? { eas: { projectId: EAS_PROJECT_ID } } : {}),
       ...(hasDevMetadata
         ? {
             devMetadata: {

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -1,5 +1,7 @@
 import type { ExpoConfig, ConfigContext } from 'expo/config';
 
+const EAS_PROJECT_ID = process.env.EXPO_PUBLIC_EAS_PROJECT_ID ?? '0195d3e5-7326-7251-b498-79b3cf7de62a';
+
 function resolveDevMetadata(): {
   branchName: string | null;
   qaNotes: string | null;
@@ -10,8 +12,6 @@ function resolveDevMetadata(): {
   const qaNotesFilePath = process.env.BOARDSESH_DEV_QA_NOTES_FILE ?? null;
 
   if (!branchName && !qaNotes) {
-    // Env vars are set by `vp run dev:mobile` (scripts/mobile-dev-start.ts).
-    // Without the orchestrator, no dev metadata is injected — this is fine.
     return { branchName: null, qaNotes: null, qaNotesFilePath: null };
   }
 
@@ -32,6 +32,12 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     icon: './assets/icon.png',
     userInterfaceStyle: 'automatic',
     newArchEnabled: true,
+    runtimeVersion: {
+      policy: 'appVersion',
+    },
+    updates: {
+      url: `https://u.expo.dev/${EAS_PROJECT_ID}`,
+    },
     ios: {
       bundleIdentifier: 'com.boardsesh.app',
       supportsTablet: false,
@@ -58,20 +64,24 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       'expo-secure-store',
       'expo-localization',
       'expo-status-bar',
+      'expo-updates',
       'expo-web-browser',
       'react-native-ble-plx',
     ],
-    ...(hasDevMetadata
-      ? {
-          extra: {
-            ...config.extra,
+    extra: {
+      ...config.extra,
+      eas: {
+        projectId: EAS_PROJECT_ID,
+      },
+      ...(hasDevMetadata
+        ? {
             devMetadata: {
               branchName: devMetadata.branchName,
               qaNotes: devMetadata.qaNotes,
               qaNotesFilePath: devMetadata.qaNotesFilePath,
             },
-          },
-        }
-      : {}),
+          }
+        : {}),
+    },
   };
 };

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -1,6 +1,13 @@
 import type { ExpoConfig, ConfigContext } from 'expo/config';
 
-const EAS_PROJECT_ID = process.env.EXPO_PUBLIC_EAS_PROJECT_ID ?? '0195d3e5-7326-7251-b498-79b3cf7de62a';
+const EAS_PROJECT_ID = process.env.EXPO_PUBLIC_EAS_PROJECT_ID;
+
+if (!EAS_PROJECT_ID) {
+  throw new Error(
+    'EXPO_PUBLIC_EAS_PROJECT_ID is required. Run `bunx eas init` from packages/mobile/ ' +
+      'and set the resulting project ID as EXPO_PUBLIC_EAS_PROJECT_ID in your environment.',
+  );
+}
 
 function resolveDevMetadata(): {
   branchName: string | null;

--- a/packages/mobile/eas.json
+++ b/packages/mobile/eas.json
@@ -7,16 +7,20 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "channel": "development",
       "ios": {
         "simulator": true
       }
     },
     "preview": {
       "distribution": "internal",
+      "channel": "preview",
       "ios": {
         "simulator": false
       }
     },
-    "production": {}
+    "production": {
+      "channel": "production"
+    }
   }
 }

--- a/packages/mobile/eas.json
+++ b/packages/mobile/eas.json
@@ -14,7 +14,7 @@
     },
     "preview": {
       "distribution": "internal",
-      "channel": "preview",
+      "channel": "preview-1",
       "ios": {
         "simulator": false
       }

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -34,6 +34,7 @@
     "expo-secure-store": "~56.0.4",
     "expo-status-bar": "~56.0.4",
     "expo-symbols": "~56.0.5",
+    "expo-updates": "~56.0.16",
     "expo-web-browser": "~56.0.5",
     "graphql": "^16.0.0",
     "graphql-request": "^7.0.0",

--- a/scripts/mobile-preview-build.ts
+++ b/scripts/mobile-preview-build.ts
@@ -38,7 +38,14 @@ function parseArgs(args: string[]): { platform: string } {
   return { platform };
 }
 
+const VALID_PLATFORMS = ['ios', 'android', 'all'] as const;
+
 const { platform } = parseArgs(process.argv.slice(2));
+
+if (!VALID_PLATFORMS.includes(platform as (typeof VALID_PLATFORMS)[number])) {
+  console.error(`[mobile:preview-build] Invalid platform "${platform}". Must be one of: ${VALID_PLATFORMS.join(', ')}`);
+  process.exit(1);
+}
 
 console.log(`[mobile:preview-build] Profile:  preview`);
 console.log(`[mobile:preview-build] Platform: ${platform}`);

--- a/scripts/mobile-preview-build.ts
+++ b/scripts/mobile-preview-build.ts
@@ -1,0 +1,82 @@
+/// <reference types="node" />
+
+/**
+ * Triggers an EAS Build for the "preview" profile. Testers install this build
+ * once — it contains the native runtime and can receive OTA updates from any
+ * EAS Update branch via `vp run mobile:publish`.
+ *
+ * Usage:
+ *   vp run mobile:preview-build                    # iOS + Android
+ *   vp run mobile:preview-build -- --platform ios  # iOS only
+ *   vp run mobile:preview-build -- --platform android
+ */
+
+import { spawnSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
+
+function parseArgs(args: string[]): { platform: string } {
+  let platform = 'all';
+
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--') continue;
+
+    if (argument === '--platform' || argument === '-p') {
+      platform = args[++index] ?? 'all';
+      continue;
+    }
+    if (argument.startsWith('--platform=')) {
+      platform = argument.slice('--platform='.length);
+      continue;
+    }
+  }
+
+  return { platform };
+}
+
+const { platform } = parseArgs(process.argv.slice(2));
+
+console.log(`[mobile:preview-build] Profile:  preview`);
+console.log(`[mobile:preview-build] Platform: ${platform}`);
+console.log(`[mobile:preview-build] Distribution: internal (ad-hoc / APK)`);
+console.log('');
+console.log('[mobile:preview-build] This build is the "shell" that testers install once.');
+console.log('[mobile:preview-build] After install, they receive JS updates via `vp run mobile:publish`.');
+console.log('');
+
+const easArgs = [
+  'eas',
+  'build',
+  '--profile',
+  'preview',
+  '--platform',
+  platform,
+  '--non-interactive',
+];
+
+console.log(`[mobile:preview-build] Running: bunx ${easArgs.join(' ')}`);
+console.log('');
+
+const result = spawnSync('bunx', easArgs, {
+  cwd: MOBILE_DIR,
+  stdio: 'inherit',
+  env: { ...process.env },
+});
+
+if (result.status !== 0) {
+  console.error('');
+  console.error('[mobile:preview-build] Build submission failed.');
+  if (result.status === 1) {
+    console.error('[mobile:preview-build] Make sure you are logged in: bunx eas login');
+  }
+  process.exit(result.status ?? 1);
+}
+
+console.log('');
+console.log('[mobile:preview-build] Build submitted to EAS.');
+console.log('[mobile:preview-build] Once complete, share the install link from the EAS dashboard');
+console.log('[mobile:preview-build] or run: bunx eas build:list --profile preview --status finished');

--- a/scripts/mobile-preview-build.ts
+++ b/scripts/mobile-preview-build.ts
@@ -49,7 +49,7 @@ console.log('[mobile:preview-build] After install, they receive JS updates via `
 console.log('');
 
 const easArgs = [
-  'eas',
+  'eas-cli@16',
   'build',
   '--profile',
   'preview',

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -1,0 +1,156 @@
+/// <reference types="node" />
+
+/**
+ * Publishes an EAS Update for the current branch so testers on the "preview"
+ * build can receive it OTA. Each git branch gets its own EAS Update branch,
+ * meaning multiple worktrees can publish independently and testers switch
+ * between them by scanning a QR code or selecting the branch in the app.
+ *
+ * Usage:
+ *   vp run mobile:publish              # publishes to current git branch
+ *   vp run mobile:publish -- --branch my-feature  # explicit branch name
+ *   vp run mobile:publish -- --message "fix nav bug"  # custom update message
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
+
+function resolveCurrentBranchName(): string | null {
+  try {
+    const branchName = execFileSync('git', ['branch', '--show-current'], {
+      cwd: ROOT_DIR,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return branchName || null;
+  } catch {
+    return null;
+  }
+}
+
+function getShortCommitHash(): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+      cwd: ROOT_DIR,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function getCommitSubject(): string {
+  try {
+    return execFileSync('git', ['log', '-1', '--format=%s'], {
+      cwd: ROOT_DIR,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function parseArgs(args: string[]): { branch: string | null; message: string | null; platform: string } {
+  let branch: string | null = null;
+  let message: string | null = null;
+  let platform = 'all';
+
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--') continue;
+
+    if (argument === '--branch' || argument === '-b') {
+      branch = args[++index] ?? null;
+      continue;
+    }
+    if (argument.startsWith('--branch=')) {
+      branch = argument.slice('--branch='.length);
+      continue;
+    }
+
+    if (argument === '--message' || argument === '-m') {
+      message = args[++index] ?? null;
+      continue;
+    }
+    if (argument.startsWith('--message=')) {
+      message = argument.slice('--message='.length);
+      continue;
+    }
+
+    if (argument === '--platform' || argument === '-p') {
+      platform = args[++index] ?? 'all';
+      continue;
+    }
+    if (argument.startsWith('--platform=')) {
+      platform = argument.slice('--platform='.length);
+      continue;
+    }
+  }
+
+  return { branch, message, platform };
+}
+
+const { branch: explicitBranch, message: explicitMessage, platform } = parseArgs(process.argv.slice(2));
+
+const branchName = explicitBranch ?? resolveCurrentBranchName();
+if (!branchName) {
+  console.error('[mobile:publish] Could not determine branch name. Use --branch <name> or run from a git branch.');
+  process.exit(1);
+}
+
+const sanitizedBranch = branchName.replace(/[^a-zA-Z0-9._-]/g, '-');
+const commitHash = getShortCommitHash();
+const commitSubject = getCommitSubject();
+const updateMessage = explicitMessage ?? `${commitHash} ${commitSubject}`.trim();
+
+console.log(`[mobile:publish] Branch:   ${sanitizedBranch}`);
+console.log(`[mobile:publish] Message:  ${updateMessage}`);
+console.log(`[mobile:publish] Platform: ${platform}`);
+console.log('');
+
+const easArgs = [
+  'eas',
+  'update',
+  '--branch',
+  sanitizedBranch,
+  '--message',
+  updateMessage,
+  '--platform',
+  platform,
+  '--non-interactive',
+];
+
+console.log(`[mobile:publish] Running: bunx ${easArgs.join(' ')}`);
+console.log('');
+
+const result = spawnSync('bunx', easArgs, {
+  cwd: MOBILE_DIR,
+  stdio: 'inherit',
+  env: { ...process.env },
+});
+
+if (result.status !== 0) {
+  console.error('');
+  console.error('[mobile:publish] Update failed.');
+  if (result.status === 1) {
+    console.error('[mobile:publish] Make sure you are logged in: bunx eas login');
+    console.error('[mobile:publish] And the project is linked: bunx eas init (from packages/mobile/)');
+  }
+  process.exit(result.status ?? 1);
+}
+
+console.log('');
+console.log(`[mobile:publish] Published to branch "${sanitizedBranch}".`);
+console.log(`[mobile:publish] Testers on the "preview" build will receive this update.`);
+console.log('');
+console.log(`[mobile:publish] To point a preview build at this branch:`);
+console.log(`  bunx eas channel:edit preview --branch ${sanitizedBranch}`);
+console.log('');
+console.log(`[mobile:publish] Or give testers this deep link to switch:`);
+console.log(`  exp+boardsesh://expo-development-client/?url=https://u.expo.dev/update/${sanitizedBranch}`);

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -96,7 +96,14 @@ function parseArgs(args: string[]): { branch: string | null; message: string | n
   return { branch, message, platform };
 }
 
+const VALID_PLATFORMS = ['ios', 'android', 'all'] as const;
+
 const { branch: explicitBranch, message: explicitMessage, platform } = parseArgs(process.argv.slice(2));
+
+if (!VALID_PLATFORMS.includes(platform as (typeof VALID_PLATFORMS)[number])) {
+  console.error(`[mobile:publish] Invalid platform "${platform}". Must be one of: ${VALID_PLATFORMS.join(', ')}`);
+  process.exit(1);
+}
 
 const branchName = explicitBranch ?? resolveCurrentBranchName();
 if (!branchName) {

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -115,7 +115,7 @@ console.log(`[mobile:publish] Platform: ${platform}`);
 console.log('');
 
 const easArgs = [
-  'eas',
+  'eas-cli@16',
   'update',
   '--branch',
   sanitizedBranch,
@@ -150,7 +150,4 @@ console.log(`[mobile:publish] Published to branch "${sanitizedBranch}".`);
 console.log(`[mobile:publish] Testers on the "preview" build will receive this update.`);
 console.log('');
 console.log(`[mobile:publish] To point a preview build at this branch:`);
-console.log(`  bunx eas channel:edit preview --branch ${sanitizedBranch}`);
-console.log('');
-console.log(`[mobile:publish] Or give testers this deep link to switch:`);
-console.log(`  exp+boardsesh://expo-development-client/?url=https://u.expo.dev/update/${sanitizedBranch}`);
+console.log(`  bunx eas-cli@16 channel:edit preview --branch ${sanitizedBranch}`);

--- a/scripts/mobile-setup-channels.sh
+++ b/scripts/mobile-setup-channels.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Creates the 4 preview channels on EAS. Run once after `eas init`.
+# Each channel can independently point to a different EAS Update branch,
+# allowing multiple worktrees to deliver updates to different test devices.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MOBILE_DIR="$SCRIPT_DIR/../packages/mobile"
+
+cd "$MOBILE_DIR"
+
+echo "[mobile:setup-channels] Creating preview channels..."
+
+for i in 1 2 3 4; do
+  echo "[mobile:setup-channels] Creating preview-$i..."
+  bunx eas-cli@16 channel:create "preview-$i" --non-interactive 2>/dev/null || \
+    echo "[mobile:setup-channels] preview-$i already exists"
+done
+
+echo ""
+echo "[mobile:setup-channels] Done. Available channels:"
+echo "  preview-1, preview-2, preview-3, preview-4"
+echo ""
+echo "[mobile:setup-channels] Point a channel at a branch:"
+echo "  bunx eas-cli@16 channel:edit preview-1 --branch my-feature"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -220,6 +220,14 @@ export default defineConfig({
         command: 'bash scripts/mobile-screenshot.sh',
         cache: false,
       },
+      'mobile:publish': {
+        command: 'tsx scripts/mobile-publish.ts',
+        cache: false,
+      },
+      'mobile:preview-build': {
+        command: 'tsx scripts/mobile-preview-build.ts',
+        cache: false,
+      },
 
       // --- Dev servers ---
       'dev:mobile': {


### PR DESCRIPTION
## Summary\n\n- Add EAS Update support so each git branch/worktree can publish independent OTA updates to testers\n- Testers install the \"preview\" build once, then receive JS updates instantly when any branch publishes via `vp run mobile:publish`\n- CI auto-publishes on every push to non-main branches that touch mobile or shared packages\n\n## What's included\n\n- `expo-updates` dependency + `app.config.ts` wired with `runtimeVersion` (appVersion policy) and update URL\n- `eas.json` build profiles now have channel assignments (development/preview/production)\n- `scripts/mobile-publish.ts` — publishes OTA update to a branch-named EAS Update branch\n- `scripts/mobile-preview-build.ts` — triggers EAS Build for the preview profile (install-once shell)\n- `.github/workflows/mobile-eas-update.yml` — auto-publishes on PR branches, posts update info as PR comment\n- `vp run mobile:publish` and `vp run mobile:preview-build` task definitions\n- CLAUDE.md documentation for the full workflow\n\n## How it works\n\n1. **One-time**: Build and distribute the preview client (`vp run mobile:preview-build`)\n2. **Per branch**: Push OTA updates (`vp run mobile:publish`) — CI does this automatically\n3. **Testers**: Point preview channel at any branch (`bunx eas channel:edit preview --branch <name>`)\n\n## Setup required\n\n- `EXPO_TOKEN` secret in GitHub Actions for CI publishing\n- EAS project must be initialized (`bunx eas init` from `packages/mobile/`)\n- Update the `EAS_PROJECT_ID` in `app.config.ts` if it differs from the placeholder\n\n## Test plan\n\n- [x] Metro bundle compiles cleanly with expo-updates included\n- [ ] `bunx eas login` + `vp run mobile:publish` publishes successfully\n- [ ] Preview build installs on device and receives OTA update\n- [ ] CI workflow triggers on mobile file changes and publishes update\n\nhttps://claude.ai/code/session_01GysbcwngKT4t2Fst4U5GmM"

---
_Generated by [Claude Code](https://claude.ai/code/session_01GysbcwngKT4t2Fst4U5GmM)_