### PR TITLE
fix(mobile): standard header height + PlayDrawer renders above nav bar

### DIFF
--- a/packages/mobile/app/(tabs)/boards/_layout.tsx
+++ b/packages/mobile/app/(tabs)/boards/_layout.tsx
@@ -8,7 +8,6 @@ export default function BoardsLayout() {
     <Stack
       screenOptions={{
         headerLargeTitle: false,
-        headerLargeTitleShadowVisible: false,
         headerTransparent: true,
         headerBlurEffect: 'systemMaterial',
         contentStyle: { backgroundColor: 'transparent' },

--- a/packages/mobile/app/(tabs)/boards/_layout.tsx
+++ b/packages/mobile/app/(tabs)/boards/_layout.tsx
@@ -7,7 +7,7 @@ export default function BoardsLayout() {
   return (
     <Stack
       screenOptions={{
-        headerLargeTitle: true,
+        headerLargeTitle: false,
         headerLargeTitleShadowVisible: false,
         headerTransparent: true,
         headerBlurEffect: 'systemMaterial',

--- a/packages/mobile/app/(tabs)/climbs/_layout.tsx
+++ b/packages/mobile/app/(tabs)/climbs/_layout.tsx
@@ -7,7 +7,7 @@ export default function ClimbsLayout() {
   return (
     <Stack
       screenOptions={{
-        headerLargeTitle: true,
+        headerLargeTitle: false,
         headerLargeTitleShadowVisible: false,
         headerTransparent: true,
         headerBlurEffect: 'systemMaterial',

--- a/packages/mobile/app/(tabs)/climbs/_layout.tsx
+++ b/packages/mobile/app/(tabs)/climbs/_layout.tsx
@@ -8,7 +8,6 @@ export default function ClimbsLayout() {
     <Stack
       screenOptions={{
         headerLargeTitle: false,
-        headerLargeTitleShadowVisible: false,
         headerTransparent: true,
         headerBlurEffect: 'systemMaterial',
         contentStyle: { backgroundColor: 'transparent' },
@@ -24,7 +23,6 @@ export default function ClimbsLayout() {
         name="[climbUuid]"
         options={{
           title: t('mobile.nav.climb'),
-          headerLargeTitle: false,
         }}
       />
     </Stack>

--- a/packages/mobile/app/(tabs)/more/_layout.tsx
+++ b/packages/mobile/app/(tabs)/more/_layout.tsx
@@ -8,7 +8,6 @@ export default function MoreLayout() {
     <Stack
       screenOptions={{
         headerLargeTitle: false,
-        headerLargeTitleShadowVisible: false,
         headerTransparent: true,
         headerBlurEffect: 'systemMaterial',
         contentStyle: { backgroundColor: 'transparent' },

--- a/packages/mobile/app/(tabs)/more/_layout.tsx
+++ b/packages/mobile/app/(tabs)/more/_layout.tsx
@@ -7,7 +7,7 @@ export default function MoreLayout() {
   return (
     <Stack
       screenOptions={{
-        headerLargeTitle: true,
+        headerLargeTitle: false,
         headerLargeTitleShadowVisible: false,
         headerTransparent: true,
         headerBlurEffect: 'systemMaterial',

--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -7,7 +7,7 @@ export default function ProfileLayout() {
   return (
     <Stack
       screenOptions={{
-        headerLargeTitle: true,
+        headerLargeTitle: false,
         headerLargeTitleShadowVisible: false,
         headerTransparent: true,
         headerBlurEffect: 'systemMaterial',

--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -8,7 +8,6 @@ export default function ProfileLayout() {
     <Stack
       screenOptions={{
         headerLargeTitle: false,
-        headerLargeTitleShadowVisible: false,
         headerTransparent: true,
         headerBlurEffect: 'systemMaterial',
         contentStyle: { backgroundColor: 'transparent' },

--- a/packages/mobile/app/(tabs)/queue/_layout.tsx
+++ b/packages/mobile/app/(tabs)/queue/_layout.tsx
@@ -8,7 +8,6 @@ export default function QueueLayout() {
     <Stack
       screenOptions={{
         headerLargeTitle: false,
-        headerLargeTitleShadowVisible: false,
         headerTransparent: true,
         headerBlurEffect: 'systemMaterial',
         contentStyle: { backgroundColor: 'transparent' },
@@ -20,7 +19,6 @@ export default function QueueLayout() {
         options={{
           title: t('summary.dialogTitle'),
           presentation: 'modal',
-          headerLargeTitle: false,
         }}
       />
     </Stack>

--- a/packages/mobile/app/(tabs)/queue/_layout.tsx
+++ b/packages/mobile/app/(tabs)/queue/_layout.tsx
@@ -7,7 +7,7 @@ export default function QueueLayout() {
   return (
     <Stack
       screenOptions={{
-        headerLargeTitle: true,
+        headerLargeTitle: false,
         headerLargeTitleShadowVisible: false,
         headerTransparent: true,
         headerBlurEffect: 'systemMaterial',

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -113,6 +113,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       setIsMirrored(false);
       setIsFavorited(false);
       setIsTickBarActive(false);
+      setIsSheetOpen(true);
       const queueItem = {
         uuid: randomUUID(),
         climb: {
@@ -138,10 +139,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       sheetRef.current?.dismiss();
     },
   }));
-
-  const handleSheetChange = useCallback((index: number) => {
-    setIsSheetOpen(index >= 0);
-  }, []);
 
   const handleClose = useCallback(() => {
     setClimb(null);
@@ -224,7 +221,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         snapPoints={snapPoints}
         enablePanDownToClose
         backdropComponent={renderBackdrop}
-        onChange={handleSheetChange}
         onDismiss={handleClose}
         handleIndicatorStyle={styles.indicator}
         backgroundStyle={styles.background}
@@ -314,7 +310,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         </BottomSheetView>
       </BottomSheetModal>
 
-      {/* Log Ascent sheet (full, via long-press) */}
+      {/* Log Ascent sheet (full, via long-press).
+          TODO: still uses BottomSheet (not BottomSheetModal), so it renders
+          within the screen content area and can appear behind the nav header.
+          Follow-up: convert to BottomSheetModal once PlayDrawer is stable. */}
       {displayedClimb && (
         <LogAscentSheet
           visible={showLogAscent}

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -3,7 +3,7 @@ import { View, Pressable, StyleSheet, Image } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import BottomSheet, { BottomSheetBackdrop, BottomSheetView, type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
+import BottomSheetModal, { BottomSheetBackdrop, BottomSheetView, type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { randomUUID } from 'expo-crypto';
 import { computeNavigationState, boardSupportsMirroring } from '@boardsesh/play-view';
@@ -46,7 +46,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
 ) {
   const { t } = useTranslation('session');
   const insets = useSafeAreaInsets();
-  const sheetRef = useRef<BottomSheet>(null);
+  const sheetRef = useRef<BottomSheetModal>(null);
   const [climb, setClimb] = useState<Climb | null>(null);
   const [showLogAscent, setShowLogAscent] = useState(false);
   const [isMirrored, setIsMirrored] = useState(false);
@@ -132,10 +132,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         },
       };
       setCurrentClimb(queueItem);
-      sheetRef.current?.snapToIndex(0);
+      sheetRef.current?.present();
     },
     close: () => {
-      sheetRef.current?.close();
+      sheetRef.current?.dismiss();
     },
   }));
 
@@ -219,20 +219,19 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
 
   return (
     <>
-      <BottomSheet
+      <BottomSheetModal
         ref={sheetRef}
-        index={-1}
         snapPoints={snapPoints}
         enablePanDownToClose
         backdropComponent={renderBackdrop}
         onChange={handleSheetChange}
-        onClose={handleClose}
+        onDismiss={handleClose}
         handleIndicatorStyle={styles.indicator}
         backgroundStyle={styles.background}
       >
         <BottomSheetView style={[styles.content, { paddingBottom: insets.bottom }]}>
           <Pressable
-            onPress={() => sheetRef.current?.close()}
+            onPress={() => sheetRef.current?.dismiss()}
             accessibilityRole="button"
             accessibilityLabel={t('playView.closeAria')}
             hitSlop={8}
@@ -313,7 +312,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
             </>
           )}
         </BottomSheetView>
-      </BottomSheet>
+      </BottomSheetModal>
 
       {/* Log Ascent sheet (full, via long-press) */}
       {displayedClimb && (


### PR DESCRIPTION
## Summary

- **Header height**: Change `headerLargeTitle` from `true` → `false` in all 5 tab Stack layouts (`boards`, `climbs`, `queue`, `profile`, `more`). The large-title iOS header expands to ~88–96 px at the top of a scroll; standard is ~44 px.
- **PlayDrawer layering**: Switch `PlayDrawer` from `BottomSheet` to `BottomSheetModal`. The regular `BottomSheet` renders within the screen's content region, so the native iOS navigation bar always appears above it. `BottomSheetModal` portals to `BottomSheetModalProvider` at the app root (already present in `_layout.tsx`), placing the drawer above all navigation layers. Updated API: `snapToIndex(0)` → `present()`, `close()` → `dismiss()`, `onClose` → `onDismiss`.

## Test plan

- [ ] Open the Climbs tab — header should be standard height, not large-title
- [ ] Tap a climb row — PlayDrawer slides up and fully covers the navigation bar at 95% height
- [ ] Pan drawer down — dismisses correctly, `handleClose` fires and clears state
- [ ] Long-press the tick FAB — LogAscentSheet opens (secondary sheet, separate follow-up if also layering)
- [ ] Check all other tabs (Boards, Queue, Profile, More) — all show standard-height headers

https://claude.ai/code/session_016tqJhfUcp8TXD7XQAepQZi

---
_Generated by [Claude Code](https://claude.ai/code/session_016tqJhfUcp8TXD7XQAepQZi)_