### PR TITLE
fix(mobile): correct BottomSheetModal import to use named export

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -3,7 +3,7 @@ import { View, Pressable, StyleSheet, Image } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import BottomSheetModal, { BottomSheetBackdrop, BottomSheetView, type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
+import { BottomSheetModal, BottomSheetBackdrop, BottomSheetView, type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { randomUUID } from 'expo-crypto';
 import { computeNavigationState, boardSupportsMirroring } from '@boardsesh/play-view';


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes crash introduced by PR #2296 when opening the play drawer
- `@gorhom/bottom-sheet`'s default export is `BottomSheet`; `BottomSheetModal` is a named export
- The migration used `import BottomSheetModal, {...}` (default import) which silently imported `BottomSheet` under the `BottomSheetModal` alias
- `BottomSheet` refs don't have `present()` or `dismiss()` — calling `sheetRef.current?.present()` threw `TypeError: sheetRef.current.present is not a function`, which React Native escalated to `RCTFatal` → SIGABRT crash

**One-line fix:** `import BottomSheetModal,` → `import { BottomSheetModal,`

## Crash analysis

- **Incident:** 6A9C160C-BCEE-47CD-862E-945341D253F4
- **Thread 10** crashed with `RCTFatal → reportFatal → objc_exception_rethrow → std::terminate` — the React Native fatal JS error path
- **Trigger:** user opens a climb card → `sheetRef.current?.present()` → TypeError

## Test plan

- [ ] Open a climb card in the climbs tab — drawer should open without crashing
- [ ] Dismiss the drawer by swiping down or tapping the close button
- [ ] Navigate prev/next climbs via swipe and action bar buttons
- [ ] Verify the drawer renders above the nav header (the goal of the original PR)

https://claude.ai/code/session_01UF54pq4fpR4ryVgFU89t62
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UF54pq4fpR4ryVgFU89t62)_