### PR TITLE
fix(mobile): pass board config props to ClimbListRow so thumbnails render

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -4,7 +4,6 @@ import { FlashList } from '@shopify/flash-list';
 import { useNavigation } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import type { Climb, BoardName } from '@boardsesh/shared-schema';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { ClimbListRow } from '../../../src/components/ClimbListRow';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
 import { Text } from '../../../src/components/Text';
@@ -188,19 +187,18 @@ export default function ClimbList() {
   const isInitialLoading = isBoardLoading || (isClimbsLoading && accumulatedClimbs.length === 0);
 
   const renderClimbItem = useCallback(
-    ({ item: climb }: { item: Climb }) => {
-      const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
-
-      return (
-        <ClimbListRow
-          climb={climb}
-          gradeName={climb.difficulty}
-          gradeColor={gradeColor}
-          onPress={() => handleClimbPress(climb)}
-        />
-      );
-    },
-    [handleClimbPress],
+    ({ item: climb }: { item: Climb }) => (
+      <ClimbListRow
+        climb={climb}
+        boardName={boardName as BoardName}
+        layoutId={layoutId}
+        sizeId={sizeId}
+        setIds={setIds}
+        angle={angle}
+        onPress={handleClimbPress}
+      />
+    ),
+    [boardName, layoutId, sizeId, setIds, angle, handleClimbPress],
   );
 
   if (!hasBoardConfig && !isBoardLoading) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `renderClimbItem` in `app/(tabs)/climbs/index.tsx` was calling `ClimbListRow` without the required `boardName`, `layoutId`, `sizeId`, `setIds`, and `angle` props
- Instead it passed non-existent `gradeName`/`gradeColor` props (silently ignored by TypeScript since they're extra props on a JSX element)
- `ClimbListThumbnail` received `undefined` for all URL parameters, producing broken image requests with no visible error
- Fix: pass the board config values already in scope, remove the dead `getGradeColor`/`DEFAULT_GRADE_COLOR` import

## Test plan

- [ ] Open the climb list in the RN app — thumbnails should appear for each row
- [ ] Scroll rapidly — thumbnails should load and cache correctly at 120fps
- [ ] Switch board config — thumbnails should reflect the new board

https://claude.ai/code/session_01MHoeHwHEjRVWHeFnqzLc1L
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHoeHwHEjRVWHeFnqzLc1L)_