### PR TITLE
feat(mobile): search header with recent filter pills

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
-import { View, Pressable, StyleSheet, RefreshControl, Image } from 'react-native';
+import { View, Pressable, StyleSheet, RefreshControl, Image, Keyboard } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useNavigation } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -15,9 +15,13 @@ import {
   type ClimbFilters,
 } from '../../../src/components/ClimbFilterSheet';
 import { PlayDrawer, type PlayDrawerHandle } from '../../../src/components/play-drawer';
-import { useDefaultBoard, useSearchClimbs } from '../../../src/lib/graphql/hooks';
+import { SearchHeader, type SearchHeaderHandle } from '../../../src/components/SearchHeader';
+import { RecentFilterPills } from '../../../src/components/RecentFilterPills';
+import { useDefaultBoard, useSearchClimbs, useGrades } from '../../../src/lib/graphql/hooks';
 import { accumulateClimbs } from '../../../src/lib/climb-pagination';
 import { getBoardRenderData } from '../../../src/lib/board-details';
+import { getRecentFilters, addRecentFilter, clearRecentFilters, type RecentFilter } from '../../../src/lib/recent-filter-store';
+import { getFilterSummary } from '../../../src/lib/filter-summary';
 import { brandColors } from '../../../src/theme/colors';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 
@@ -28,11 +32,15 @@ export default function ClimbList() {
   const navigation = useNavigation();
   const { t } = useTranslation('climbs');
   const playDrawerRef = useRef<PlayDrawerHandle>(null);
+  const searchHeaderRef = useRef<SearchHeaderHandle>(null);
 
+  const [searchText, setSearchText] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isSearchFocused, setIsSearchFocused] = useState(false);
   const [filters, setFilters] = useState<ClimbFilters>(DEFAULT_FILTERS);
   const [showFilters, setShowFilters] = useState(false);
+  const [recentFilters, setRecentFilters] = useState<RecentFilter[]>([]);
 
   const filtersActive = hasActiveFilters(filters);
 
@@ -44,29 +52,37 @@ export default function ClimbList() {
     setShowFilters(false);
   }, []);
 
-  const handleApplyFilters = useCallback((newFilters: ClimbFilters) => {
-    setFilters(newFilters);
-    setShowFilters(false);
+  const handleSearchChange = useCallback((text: string) => {
+    setSearchText(text);
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+    debounceTimerRef.current = setTimeout(() => {
+      setDebouncedSearch(text);
+    }, SEARCH_DEBOUNCE_MS);
   }, []);
 
-  // Wire up the native search bar's onChangeText and header right filter button
+  const handleSearchFocus = useCallback(() => {
+    setIsSearchFocused(true);
+  }, []);
+
+  const handleSearchBlur = useCallback(() => {
+    setIsSearchFocused(false);
+  }, []);
+
   useEffect(() => {
     navigation.setOptions({
-      headerSearchBarOptions: {
-        placeholder: t('search.placeholders.climbs'),
-        autoCapitalize: 'none',
-        hideWhenScrolling: false,
-        onChangeText: (event: { nativeEvent: { text: string } }) => {
-          const text = event.nativeEvent.text;
-
-          if (debounceTimerRef.current) {
-            clearTimeout(debounceTimerRef.current);
-          }
-          debounceTimerRef.current = setTimeout(() => {
-            setDebouncedSearch(text);
-          }, SEARCH_DEBOUNCE_MS);
-        },
-      },
+      headerTitle: () => (
+        <SearchHeader
+          ref={searchHeaderRef}
+          value={searchText}
+          placeholder={t('search.placeholders.climbs')}
+          onChangeText={handleSearchChange}
+          onFocus={handleSearchFocus}
+          onBlur={handleSearchBlur}
+        />
+      ),
       headerRight: () => (
         <Pressable onPress={handleOpenFilters} hitSlop={8} accessibilityRole="button">
           <Icon name="filter" size={22} color={filtersActive ? brandColors.primary : iosSystemColors.systemGray} />
@@ -79,7 +95,12 @@ export default function ClimbList() {
         clearTimeout(debounceTimerRef.current);
       }
     };
-  }, [navigation, t, filtersActive, handleOpenFilters]);
+  }, [navigation, t, filtersActive, handleOpenFilters, searchText, handleSearchChange, handleSearchFocus, handleSearchBlur]);
+
+  // Load recent filters on mount
+  useEffect(() => {
+    getRecentFilters().then(setRecentFilters).catch(() => {});
+  }, []);
 
   const { data: defaultBoard, isLoading: isBoardLoading } = useDefaultBoard();
 
@@ -90,6 +111,8 @@ export default function ClimbList() {
   const angle = defaultBoard?.angle ?? 0;
 
   const hasBoardConfig = !!defaultBoard;
+
+  const { data: gradesData } = useGrades(boardName);
 
   // Pre-warm board images so they're cached before the user taps into a climb
   useEffect(() => {
@@ -184,6 +207,45 @@ export default function ClimbList() {
     [],
   );
 
+  const handleApplyFilters = useCallback(
+    (newFilters: ClimbFilters) => {
+      setFilters(newFilters);
+      setShowFilters(false);
+
+      if (hasActiveFilters(newFilters) || debouncedSearch.length > 0) {
+        const label = getFilterSummary(newFilters, debouncedSearch, gradesData, t);
+        addRecentFilter(label, newFilters, debouncedSearch)
+          .then(() => getRecentFilters())
+          .then(setRecentFilters)
+          .catch(() => {});
+      }
+    },
+    [debouncedSearch, gradesData, t],
+  );
+
+  const handleApplyRecentFilter = useCallback(
+    (pillFilters: ClimbFilters, pillSearchText: string) => {
+      setFilters(pillFilters);
+      setSearchText(pillSearchText);
+      setDebouncedSearch(pillSearchText);
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+      Keyboard.dismiss();
+      searchHeaderRef.current?.blur();
+      setIsSearchFocused(false);
+    },
+    [],
+  );
+
+  const handleClearRecentFilters = useCallback(() => {
+    clearRecentFilters()
+      .then(() => setRecentFilters([]))
+      .catch(() => {});
+  }, []);
+
+  const showRecentPills = isSearchFocused && searchText.length === 0 && recentFilters.length > 0;
+
   const isInitialLoading = isBoardLoading || (isClimbsLoading && accumulatedClimbs.length === 0);
 
   const renderClimbItem = useCallback(
@@ -235,8 +297,20 @@ export default function ClimbList() {
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         contentInsetAdjustmentBehavior="automatic"
+        keyboardShouldPersistTaps="handled"
         refreshControl={
           <RefreshControl refreshing={isRefetching} onRefresh={handleRefresh} tintColor={brandColors.primary} />
+        }
+        ListHeaderComponent={
+          showRecentPills ? (
+            <RecentFilterPills
+              recentFilters={recentFilters}
+              currentFilters={filters}
+              currentSearchText={debouncedSearch}
+              onApply={handleApplyRecentFilter}
+              onClear={handleClearRecentFilters}
+            />
+          ) : null
         }
         ListFooterComponent={
           isClimbsLoading && accumulatedClimbs.length > 0 ? (

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -34,10 +34,11 @@ export default function ClimbList() {
   const playDrawerRef = useRef<PlayDrawerHandle>(null);
   const searchHeaderRef = useRef<SearchHeaderHandle>(null);
 
-  const [searchText, setSearchText] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
+  const debouncedSearchRef = useRef('');
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isSearchFocused, setIsSearchFocused] = useState(false);
+  const [searchTextLength, setSearchTextLength] = useState(0);
   const [filters, setFilters] = useState<ClimbFilters>(DEFAULT_FILTERS);
   const [showFilters, setShowFilters] = useState(false);
   const [recentFilters, setRecentFilters] = useState<RecentFilter[]>([]);
@@ -53,12 +54,13 @@ export default function ClimbList() {
   }, []);
 
   const handleSearchChange = useCallback((text: string) => {
-    setSearchText(text);
+    setSearchTextLength(text.length);
 
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
     }
     debounceTimerRef.current = setTimeout(() => {
+      debouncedSearchRef.current = text;
       setDebouncedSearch(text);
     }, SEARCH_DEBOUNCE_MS);
   }, []);
@@ -71,31 +73,40 @@ export default function ClimbList() {
     setIsSearchFocused(false);
   }, []);
 
+  // Set up header once — SearchHeader manages its own text state internally
   useEffect(() => {
     navigation.setOptions({
       headerTitle: () => (
         <SearchHeader
           ref={searchHeaderRef}
-          value={searchText}
           placeholder={t('search.placeholders.climbs')}
           onChangeText={handleSearchChange}
           onFocus={handleSearchFocus}
           onBlur={handleSearchBlur}
         />
       ),
+    });
+  }, [navigation, t, handleSearchChange, handleSearchFocus, handleSearchBlur]);
+
+  // Separate effect for headerRight since it depends on filtersActive
+  useEffect(() => {
+    navigation.setOptions({
       headerRight: () => (
         <Pressable onPress={handleOpenFilters} hitSlop={8} accessibilityRole="button">
           <Icon name="filter" size={22} color={filtersActive ? brandColors.primary : iosSystemColors.systemGray} />
         </Pressable>
       ),
     });
+  }, [navigation, filtersActive, handleOpenFilters]);
 
+  // Clean up debounce timer on unmount
+  useEffect(() => {
     return () => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
       }
     };
-  }, [navigation, t, filtersActive, handleOpenFilters, searchText, handleSearchChange, handleSearchFocus, handleSearchBlur]);
+  }, []);
 
   // Load recent filters on mount
   useEffect(() => {
@@ -113,6 +124,8 @@ export default function ClimbList() {
   const hasBoardConfig = !!defaultBoard;
 
   const { data: gradesData } = useGrades(boardName);
+  const gradesRef = useRef(gradesData);
+  gradesRef.current = gradesData;
 
   // Pre-warm board images so they're cached before the user taps into a climb
   useEffect(() => {
@@ -212,22 +225,25 @@ export default function ClimbList() {
       setFilters(newFilters);
       setShowFilters(false);
 
-      if (hasActiveFilters(newFilters) || debouncedSearch.length > 0) {
-        const label = getFilterSummary(newFilters, debouncedSearch, gradesData, t);
-        addRecentFilter(label, newFilters, debouncedSearch)
+      const currentSearch = debouncedSearchRef.current;
+      if (hasActiveFilters(newFilters) || currentSearch.length > 0) {
+        const label = getFilterSummary(newFilters, currentSearch, gradesRef.current, t);
+        addRecentFilter(label, newFilters, currentSearch)
           .then(() => getRecentFilters())
           .then(setRecentFilters)
           .catch(() => {});
       }
     },
-    [debouncedSearch, gradesData, t],
+    [t],
   );
 
   const handleApplyRecentFilter = useCallback(
     (pillFilters: ClimbFilters, pillSearchText: string) => {
       setFilters(pillFilters);
-      setSearchText(pillSearchText);
+      debouncedSearchRef.current = pillSearchText;
       setDebouncedSearch(pillSearchText);
+      setSearchTextLength(pillSearchText.length);
+      searchHeaderRef.current?.setText(pillSearchText);
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
       }
@@ -244,7 +260,7 @@ export default function ClimbList() {
       .catch(() => {});
   }, []);
 
-  const showRecentPills = isSearchFocused && searchText.length === 0 && recentFilters.length > 0;
+  const showRecentPills = isSearchFocused && searchTextLength === 0 && recentFilters.length > 0;
 
   const isInitialLoading = isBoardLoading || (isClimbsLoading && accumulatedClimbs.length === 0);
 

--- a/packages/mobile/src/components/RecentFilterPills.tsx
+++ b/packages/mobile/src/components/RecentFilterPills.tsx
@@ -26,11 +26,11 @@ const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 function Pill({
   filter,
   isActive,
-  onPress,
+  onApply,
 }: {
   filter: RecentFilter;
   isActive: boolean;
-  onPress: () => void;
+  onApply: (filters: ClimbFilters, searchText: string) => void;
 }) {
   const scale = useSharedValue(1);
 
@@ -46,12 +46,14 @@ function Pill({
     scale.value = withSpring(1, springs.snappy);
   };
 
+  const handlePress = useCallback(() => {
+    hapticSelection();
+    onApply(filter.filters, filter.searchText);
+  }, [filter.filters, filter.searchText, onApply]);
+
   return (
     <AnimatedPressable
-      onPress={() => {
-        hapticSelection();
-        onPress();
-      }}
+      onPress={handlePress}
       onPressIn={handlePressIn}
       onPressOut={handlePressOut}
       accessibilityRole="button"
@@ -90,13 +92,6 @@ export function RecentFilterPills({
   const { t } = useTranslation('climbs');
   const currentKey = getFilterKey(currentFilters, currentSearchText);
 
-  const handleApply = useCallback(
-    (filter: RecentFilter) => {
-      onApply(filter.filters, filter.searchText);
-    },
-    [onApply],
-  );
-
   if (recentFilters.length === 0) return null;
 
   return (
@@ -122,7 +117,7 @@ export function RecentFilterPills({
             key={filter.id}
             filter={filter}
             isActive={getFilterKey(filter.filters, filter.searchText) === currentKey}
-            onPress={() => handleApply(filter)}
+            onApply={onApply}
           />
         ))}
       </ScrollView>
@@ -162,10 +157,10 @@ const styles = StyleSheet.create({
   },
   pillActive: {
     borderColor: brandColors.primary,
-    backgroundColor: 'rgba(140, 74, 82, 0.08)',
+    backgroundColor: `${brandColors.primary}14`,
   },
   pillInactive: {
-    borderColor: 'rgba(60, 60, 67, 0.18)',
+    borderColor: iosSystemColors.separator,
     backgroundColor: 'transparent',
   },
   pillLabel: {

--- a/packages/mobile/src/components/RecentFilterPills.tsx
+++ b/packages/mobile/src/components/RecentFilterPills.tsx
@@ -1,0 +1,175 @@
+import { useCallback } from 'react';
+import { View, ScrollView, Pressable, StyleSheet } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import { useTranslation } from 'react-i18next';
+import { Text } from './Text';
+import { Icon } from './Icon';
+import type { RecentFilter } from '../lib/recent-filter-store';
+import { getFilterKey } from '../lib/recent-filter-store';
+import type { ClimbFilters } from './ClimbFilterSheet';
+import { brandColors } from '../theme/colors';
+import { iosSystemColors } from '../theme/ios-colors';
+import { spacing } from '../theme/tokens';
+import { springs } from '../theme/animations';
+import { hapticSelection } from '../lib/haptics';
+
+type RecentFilterPillsProps = {
+  recentFilters: RecentFilter[];
+  currentFilters: ClimbFilters;
+  currentSearchText: string;
+  onApply: (filters: ClimbFilters, searchText: string) => void;
+  onClear: () => void;
+};
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+function Pill({
+  filter,
+  isActive,
+  onPress,
+}: {
+  filter: RecentFilter;
+  isActive: boolean;
+  onPress: () => void;
+}) {
+  const scale = useSharedValue(1);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  const handlePressIn = () => {
+    scale.value = withSpring(0.95, springs.snappy);
+  };
+
+  const handlePressOut = () => {
+    scale.value = withSpring(1, springs.snappy);
+  };
+
+  return (
+    <AnimatedPressable
+      onPress={() => {
+        hapticSelection();
+        onPress();
+      }}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      accessibilityRole="button"
+      accessibilityState={{ selected: isActive }}
+      accessibilityLabel={filter.label}
+      style={[
+        animatedStyle,
+        styles.pill,
+        isActive ? styles.pillActive : styles.pillInactive,
+      ]}
+    >
+      <Icon
+        name="history"
+        size={14}
+        color={isActive ? brandColors.primary : iosSystemColors.systemGray}
+      />
+      <Text
+        variant="caption1"
+        color={isActive ? brandColors.primary : undefined}
+        numberOfLines={1}
+        style={styles.pillLabel}
+      >
+        {filter.label}
+      </Text>
+    </AnimatedPressable>
+  );
+}
+
+export function RecentFilterPills({
+  recentFilters,
+  currentFilters,
+  currentSearchText,
+  onApply,
+  onClear,
+}: RecentFilterPillsProps) {
+  const { t } = useTranslation('climbs');
+  const currentKey = getFilterKey(currentFilters, currentSearchText);
+
+  const handleApply = useCallback(
+    (filter: RecentFilter) => {
+      onApply(filter.filters, filter.searchText);
+    },
+    [onApply],
+  );
+
+  if (recentFilters.length === 0) return null;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text variant="footnote" style={styles.headerLabel}>
+          {t('mobile.search.recentFilters')}
+        </Text>
+        <Pressable onPress={onClear} hitSlop={8} accessibilityRole="button">
+          <Text variant="footnote" color={brandColors.primary}>
+            {t('mobile.search.clearRecent')}
+          </Text>
+        </Pressable>
+      </View>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.pillList}
+        keyboardShouldPersistTaps="handled"
+      >
+        {recentFilters.map((filter) => (
+          <Pill
+            key={filter.id}
+            filter={filter}
+            isActive={getFilterKey(filter.filters, filter.searchText) === currentKey}
+            onPress={() => handleApply(filter)}
+          />
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: spacing[2],
+    paddingBottom: spacing[3],
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing[4],
+    marginBottom: spacing[2],
+  },
+  headerLabel: {
+    opacity: 0.5,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  pillList: {
+    paddingHorizontal: spacing[4],
+    gap: spacing[2],
+  },
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    borderRadius: 20,
+    borderWidth: 1,
+  },
+  pillActive: {
+    borderColor: brandColors.primary,
+    backgroundColor: 'rgba(140, 74, 82, 0.08)',
+  },
+  pillInactive: {
+    borderColor: 'rgba(60, 60, 67, 0.18)',
+    backgroundColor: 'transparent',
+  },
+  pillLabel: {
+    fontWeight: '500',
+    maxWidth: 200,
+  },
+});

--- a/packages/mobile/src/components/SearchHeader.tsx
+++ b/packages/mobile/src/components/SearchHeader.tsx
@@ -1,5 +1,5 @@
-import { forwardRef, useImperativeHandle, useRef } from 'react';
-import { View, TextInput, Pressable, StyleSheet, type TextInput as TextInputType } from 'react-native';
+import { forwardRef, useImperativeHandle, useRef, useState, useCallback } from 'react';
+import { View, TextInput, Pressable, StyleSheet } from 'react-native';
 import { Icon } from './Icon';
 import { useTheme } from '../providers/theme-provider';
 import { spacing } from '../theme/tokens';
@@ -8,10 +8,11 @@ import { iosSystemColors } from '../theme/ios-colors';
 export type SearchHeaderHandle = {
   blur: () => void;
   focus: () => void;
+  getText: () => string;
+  setText: (text: string) => void;
 };
 
 type SearchHeaderProps = {
-  value: string;
   placeholder: string;
   onChangeText: (text: string) => void;
   onFocus: () => void;
@@ -19,27 +20,42 @@ type SearchHeaderProps = {
 };
 
 export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(
-  function SearchHeader({ value, placeholder, onChangeText, onFocus, onBlur }, ref) {
-    const inputRef = useRef<TextInputType>(null);
+  function SearchHeader({ placeholder, onChangeText, onFocus, onBlur }, ref) {
+    const inputRef = useRef<TextInput>(null);
     const { systemColors } = useTheme();
+    const [text, setText] = useState('');
 
     useImperativeHandle(ref, () => ({
       blur: () => inputRef.current?.blur(),
       focus: () => inputRef.current?.focus(),
+      getText: () => text,
+      setText: (newText: string) => {
+        setText(newText);
+        onChangeText(newText);
+      },
     }));
 
-    const handleClear = () => {
+    const handleChange = useCallback(
+      (newText: string) => {
+        setText(newText);
+        onChangeText(newText);
+      },
+      [onChangeText],
+    );
+
+    const handleClear = useCallback(() => {
+      setText('');
       onChangeText('');
       inputRef.current?.focus();
-    };
+    }, [onChangeText]);
 
     return (
       <View style={[styles.container, { backgroundColor: systemColors.fill as string }]}>
         <Icon name="search" size={16} color={iosSystemColors.systemGray} />
         <TextInput
           ref={inputRef}
-          value={value}
-          onChangeText={onChangeText}
+          value={text}
+          onChangeText={handleChange}
           onFocus={onFocus}
           onBlur={onBlur}
           placeholder={placeholder}
@@ -49,9 +65,15 @@ export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(
           returnKeyType="search"
           clearButtonMode="never"
           style={[styles.input, { color: systemColors.label as string }]}
+          accessibilityLabel={placeholder}
         />
-        {value.length > 0 && (
-          <Pressable onPress={handleClear} hitSlop={8} accessibilityRole="button">
+        {text.length > 0 && (
+          <Pressable
+            onPress={handleClear}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel="Clear search"
+          >
             <View style={styles.clearButton}>
               <Icon name="close" size={12} color={iosSystemColors.white} />
             </View>
@@ -81,7 +103,8 @@ const styles = StyleSheet.create({
     width: 18,
     height: 18,
     borderRadius: 9,
-    backgroundColor: 'rgba(142, 142, 147, 0.6)',
+    backgroundColor: iosSystemColors.systemGray,
+    opacity: 0.6,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/packages/mobile/src/components/SearchHeader.tsx
+++ b/packages/mobile/src/components/SearchHeader.tsx
@@ -1,0 +1,88 @@
+import { forwardRef, useImperativeHandle, useRef } from 'react';
+import { View, TextInput, Pressable, StyleSheet, type TextInput as TextInputType } from 'react-native';
+import { Icon } from './Icon';
+import { useTheme } from '../providers/theme-provider';
+import { spacing } from '../theme/tokens';
+import { iosSystemColors } from '../theme/ios-colors';
+
+export type SearchHeaderHandle = {
+  blur: () => void;
+  focus: () => void;
+};
+
+type SearchHeaderProps = {
+  value: string;
+  placeholder: string;
+  onChangeText: (text: string) => void;
+  onFocus: () => void;
+  onBlur: () => void;
+};
+
+export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(
+  function SearchHeader({ value, placeholder, onChangeText, onFocus, onBlur }, ref) {
+    const inputRef = useRef<TextInputType>(null);
+    const { systemColors } = useTheme();
+
+    useImperativeHandle(ref, () => ({
+      blur: () => inputRef.current?.blur(),
+      focus: () => inputRef.current?.focus(),
+    }));
+
+    const handleClear = () => {
+      onChangeText('');
+      inputRef.current?.focus();
+    };
+
+    return (
+      <View style={[styles.container, { backgroundColor: systemColors.fill as string }]}>
+        <Icon name="search" size={16} color={iosSystemColors.systemGray} />
+        <TextInput
+          ref={inputRef}
+          value={value}
+          onChangeText={onChangeText}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          placeholder={placeholder}
+          placeholderTextColor={iosSystemColors.systemGray}
+          autoCapitalize="none"
+          autoCorrect={false}
+          returnKeyType="search"
+          clearButtonMode="never"
+          style={[styles.input, { color: systemColors.label as string }]}
+        />
+        {value.length > 0 && (
+          <Pressable onPress={handleClear} hitSlop={8} accessibilityRole="button">
+            <View style={styles.clearButton}>
+              <Icon name="close" size={12} color={iosSystemColors.white} />
+            </View>
+          </Pressable>
+        )}
+      </View>
+    );
+  },
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: 36,
+    borderRadius: 10,
+    paddingHorizontal: spacing[2],
+    gap: spacing[1],
+    flex: 1,
+  },
+  input: {
+    flex: 1,
+    fontSize: 17,
+    paddingVertical: 0,
+  },
+  clearButton: {
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    backgroundColor: 'rgba(142, 142, 147, 0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -87,6 +87,7 @@ export const iconMap = {
   location: { ios: 'location', android: 'map-marker-outline' },
   'location.fill': { ios: 'location.fill', android: 'map-marker' },
   clock: { ios: 'clock', android: 'clock-outline' },
+  history: { ios: 'clock.arrow.circlepath', android: 'history' },
   filter: { ios: 'line.3.horizontal.decrease', android: 'filter-variant' },
   sort: { ios: 'arrow.up.arrow.down', android: 'sort-variant' },
   refresh: { ios: 'arrow.clockwise', android: 'refresh' },

--- a/packages/mobile/src/lib/__tests__/filter-summary.test.ts
+++ b/packages/mobile/src/lib/__tests__/filter-summary.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import type { Grade } from '@boardsesh/shared-schema';
+import { getFilterSummary } from '../filter-summary';
+import { DEFAULT_FILTERS, type ClimbFilters } from '../../components/ClimbFilterSheet';
+
+const mockGrades: Grade[] = [
+  { difficultyId: 1, name: 'V0' },
+  { difficultyId: 5, name: 'V2' },
+  { difficultyId: 10, name: 'V4' },
+  { difficultyId: 15, name: 'V6' },
+  { difficultyId: 20, name: 'V8' },
+];
+
+const mockT = ((key: string, options?: Record<string, unknown>) => {
+  const translations: Record<string, string> = {
+    'mobile.filter.title': 'Filters',
+    'mobile.filter.quality': 'Quality',
+    'mobile.filter.difficulty': 'Difficulty',
+    'mobile.filter.newest': 'Newest',
+    'mobile.filter.popular': 'Popular',
+  };
+  if (translations[key]) return translations[key];
+
+  if (key === 'mobile.search.gradeRange') return `${options?.min}–${options?.max}`;
+  if (key === 'mobile.search.gradeMin') return `${options?.grade}+`;
+  if (key === 'mobile.search.gradeMax') return `Up to ${options?.grade}`;
+  if (key === 'mobile.search.ascents') return `${options?.count}+ ascents`;
+  if (key === 'mobile.search.rating') return `${options?.count}+ stars`;
+  if (key === 'mobile.search.more') return `+${options?.count} more`;
+
+  return key;
+}) as unknown as Parameters<typeof getFilterSummary>[3];
+
+describe('getFilterSummary', () => {
+  it('returns fallback label when no filters are active', () => {
+    expect(getFilterSummary(DEFAULT_FILTERS, '', mockGrades, mockT)).toBe('Filters');
+  });
+
+  it('shows search text in quotes', () => {
+    expect(getFilterSummary(DEFAULT_FILTERS, 'crimp', mockGrades, mockT)).toBe('"crimp"');
+  });
+
+  it('shows grade range when both min and max are set', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, minGrade: 5, maxGrade: 15 };
+    expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('V2–V6');
+  });
+
+  it('shows min grade with plus sign', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, minGrade: 10 };
+    expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('V4+');
+  });
+
+  it('shows max grade with up-to prefix', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, maxGrade: 15 };
+    expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('Up to V6');
+  });
+
+  it('shows non-default sort label', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, sortBy: 'quality' };
+    expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('Quality');
+  });
+
+  it('joins two parts with middle dot', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, minGrade: 10, minAscents: 25 };
+    expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('V4+ · 25+ ascents');
+  });
+
+  it('truncates at 2 parts and shows remainder count', () => {
+    const filters: ClimbFilters = {
+      ...DEFAULT_FILTERS,
+      sortBy: 'quality',
+      minGrade: 10,
+      minAscents: 25,
+      minRating: 3,
+    };
+    const result = getFilterSummary(filters, '', mockGrades, mockT);
+    expect(result).toBe('V4+ · Quality · +2 more');
+  });
+
+  it('falls back to difficultyId when grade name not found', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, minGrade: 999 };
+    expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('#999+');
+  });
+
+  it('skips grade parts when grades data is undefined', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, minGrade: 10, minAscents: 5 };
+    expect(getFilterSummary(filters, '', undefined, mockT)).toBe('5+ ascents');
+  });
+
+  it('includes search text as first part before filter parts', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, minGrade: 10 };
+    expect(getFilterSummary(filters, 'test', mockGrades, mockT)).toBe('"test" · V4+');
+  });
+});

--- a/packages/mobile/src/lib/__tests__/recent-filter-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/recent-filter-store.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { getFilterKey } from '../recent-filter-store';
+import type { ClimbFilters } from '../../components/ClimbFilterSheet';
+
+const defaultFilters: ClimbFilters = {
+  sortBy: 'popular',
+  sortOrder: 'desc',
+};
+
+describe('getFilterKey', () => {
+  it('produces a stable key regardless of property insertion order', () => {
+    const filtersA: ClimbFilters = { sortBy: 'popular', sortOrder: 'desc', minGrade: 10 };
+    const filtersB: ClimbFilters = { minGrade: 10, sortOrder: 'desc', sortBy: 'popular' };
+    expect(getFilterKey(filtersA, '')).toBe(getFilterKey(filtersB, ''));
+  });
+
+  it('includes search text in the key', () => {
+    const keyWithText = getFilterKey(defaultFilters, 'hello');
+    const keyWithoutText = getFilterKey(defaultFilters, '');
+    expect(keyWithText).not.toBe(keyWithoutText);
+  });
+
+  it('differentiates filters with different values', () => {
+    const filtersA: ClimbFilters = { ...defaultFilters, minGrade: 5 };
+    const filtersB: ClimbFilters = { ...defaultFilters, minGrade: 10 };
+    expect(getFilterKey(filtersA, '')).not.toBe(getFilterKey(filtersB, ''));
+  });
+
+  it('treats undefined optional fields as absent', () => {
+    const filtersA: ClimbFilters = { sortBy: 'popular', sortOrder: 'desc' };
+    const filtersB: ClimbFilters = { sortBy: 'popular', sortOrder: 'desc', minGrade: undefined };
+    expect(getFilterKey(filtersA, '')).toBe(getFilterKey(filtersB, ''));
+  });
+
+  it('returns valid JSON', () => {
+    const key = getFilterKey(defaultFilters, 'test');
+    expect(() => JSON.parse(key)).not.toThrow();
+  });
+});

--- a/packages/mobile/src/lib/filter-summary.ts
+++ b/packages/mobile/src/lib/filter-summary.ts
@@ -1,0 +1,57 @@
+import type { TFunction } from 'i18next';
+import type { Grade } from '@boardsesh/shared-schema';
+import { DEFAULT_FILTERS, type ClimbFilters } from '../components/ClimbFilterSheet';
+
+function getGradeName(difficultyId: number, grades: Grade[]): string {
+  const grade = grades.find((gradeEntry) => gradeEntry.difficultyId === difficultyId);
+  return grade?.name ?? `#${difficultyId}`;
+}
+
+export function getFilterSummary(
+  filters: ClimbFilters,
+  searchText: string,
+  grades: Grade[] | undefined,
+  t: TFunction<'climbs'>,
+): string {
+  const parts: string[] = [];
+
+  if (searchText.length > 0) {
+    parts.push(`"${searchText}"`);
+  }
+
+  if (filters.minGrade != null && filters.maxGrade != null && grades) {
+    parts.push(
+      t('mobile.search.gradeRange', {
+        min: getGradeName(filters.minGrade, grades),
+        max: getGradeName(filters.maxGrade, grades),
+      }),
+    );
+  } else if (filters.minGrade != null && grades) {
+    parts.push(t('mobile.search.gradeMin', { grade: getGradeName(filters.minGrade, grades) }));
+  } else if (filters.maxGrade != null && grades) {
+    parts.push(t('mobile.search.gradeMax', { grade: getGradeName(filters.maxGrade, grades) }));
+  }
+
+  if (filters.sortBy !== DEFAULT_FILTERS.sortBy) {
+    parts.push(t(`mobile.filter.${filters.sortBy}`));
+  }
+
+  if (filters.minAscents != null) {
+    parts.push(t('mobile.search.ascents', { count: filters.minAscents }));
+  }
+
+  if (filters.minRating != null) {
+    parts.push(t('mobile.search.rating', { count: filters.minRating }));
+  }
+
+  if (parts.length === 0) {
+    return t('mobile.filter.title');
+  }
+
+  if (parts.length <= 2) {
+    return parts.join(' · ');
+  }
+
+  const remaining = parts.length - 2;
+  return `${parts.slice(0, 2).join(' · ')} · ${t('mobile.search.more', { count: remaining })}`;
+}

--- a/packages/mobile/src/lib/filter-summary.ts
+++ b/packages/mobile/src/lib/filter-summary.ts
@@ -33,7 +33,16 @@ export function getFilterSummary(
   }
 
   if (filters.sortBy !== DEFAULT_FILTERS.sortBy) {
-    parts.push(t(`mobile.filter.${filters.sortBy}`));
+    const sortLabels: Record<string, string> = {
+      popular: t('mobile.filter.popular'),
+      quality: t('mobile.filter.quality'),
+      difficulty: t('mobile.filter.difficulty'),
+      newest: t('mobile.filter.newest'),
+    };
+    const sortLabel = sortLabels[filters.sortBy];
+    if (sortLabel) {
+      parts.push(sortLabel);
+    }
   }
 
   if (filters.minAscents != null) {

--- a/packages/mobile/src/lib/graphql/hooks.ts
+++ b/packages/mobile/src/lib/graphql/hooks.ts
@@ -114,12 +114,13 @@ export function useBoardsBySerialNumbers(serialNumbers: string[]) {
 // Board Configuration
 // ============================================
 
-export function useGrades(boardName: string) {
+export function useGrades(boardName: string, enabled = true) {
   return useQuery({
     queryKey: ['grades', boardName],
     queryFn: () => getHttpClient().request<GetGradesQueryResponse>(GET_GRADES, { boardName }),
     select: (data) => data.grades,
-    staleTime: 24 * 60 * 60 * 1000, // Grades rarely change
+    staleTime: 24 * 60 * 60 * 1000,
+    enabled: enabled && boardName.length > 0,
   });
 }
 

--- a/packages/mobile/src/lib/recent-filter-store.ts
+++ b/packages/mobile/src/lib/recent-filter-store.ts
@@ -1,0 +1,59 @@
+import * as SecureStore from 'expo-secure-store';
+import type { ClimbFilters } from '../components/ClimbFilterSheet';
+
+export type RecentFilter = {
+  id: string;
+  label: string;
+  filters: ClimbFilters;
+  searchText: string;
+  timestamp: number;
+};
+
+const RECENT_FILTERS_KEY = 'boardsesh_recent_filters';
+const MAX_ITEMS = 10;
+
+export function getFilterKey(filters: ClimbFilters, searchText: string): string {
+  const combined = { ...filters, name: searchText };
+  return JSON.stringify(combined, Object.keys(combined).sort());
+}
+
+export async function getRecentFilters(): Promise<RecentFilter[]> {
+  try {
+    const value = await SecureStore.getItemAsync(RECENT_FILTERS_KEY);
+    return value ? JSON.parse(value) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function addRecentFilter(
+  label: string,
+  filters: ClimbFilters,
+  searchText: string,
+): Promise<void> {
+  try {
+    const existing = await getRecentFilters();
+    const filterKey = getFilterKey(filters, searchText);
+
+    const deduplicated = existing.filter(
+      (entry) => getFilterKey(entry.filters, entry.searchText) !== filterKey,
+    );
+
+    const newEntry: RecentFilter = {
+      id: `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      label,
+      filters,
+      searchText,
+      timestamp: Date.now(),
+    };
+
+    const updated = [newEntry, ...deduplicated].slice(0, MAX_ITEMS);
+    await SecureStore.setItemAsync(RECENT_FILTERS_KEY, JSON.stringify(updated));
+  } catch {
+    // Storage failure is non-critical
+  }
+}
+
+export async function clearRecentFilters(): Promise<void> {
+  await SecureStore.deleteItemAsync(RECENT_FILTERS_KEY);
+}

--- a/packages/mobile/src/lib/recent-filter-store.ts
+++ b/packages/mobile/src/lib/recent-filter-store.ts
@@ -55,5 +55,9 @@ export async function addRecentFilter(
 }
 
 export async function clearRecentFilters(): Promise<void> {
-  await SecureStore.deleteItemAsync(RECENT_FILTERS_KEY);
+  try {
+    await SecureStore.deleteItemAsync(RECENT_FILTERS_KEY);
+  } catch {
+    // Storage failure is non-critical
+  }
 }

--- a/packages/shared/play-view/src/grade-display.ts
+++ b/packages/shared/play-view/src/grade-display.ts
@@ -7,7 +7,7 @@ export { getGradeColor };
  * Convert a hex color to HSL components.
  * @returns Object with h (0-360), s (0-1), l (0-1)
  */
-function hexToHSL(hex: string): { h: number; s: number; l: number } {
+export function hexToHSL(hex: string): { h: number; s: number; l: number } {
   const clean = hex.replace('#', '');
   const r = parseInt(clean.substring(0, 2), 16) / 255;
   const g = parseInt(clean.substring(2, 4), 16) / 255;

--- a/packages/web/i18n/locales/en-US/climbs.json
+++ b/packages/web/i18n/locales/en-US/climbs.json
@@ -597,6 +597,16 @@
       "apply": "Apply filters",
       "reset": "Reset"
     },
+    "search": {
+      "recentFilters": "Recent",
+      "clearRecent": "Clear",
+      "gradeRange": "{{min}}–{{max}}",
+      "gradeMin": "{{grade}}+",
+      "gradeMax": "Up to {{grade}}",
+      "ascents": "{{count}}+ ascents",
+      "rating": "{{count}}+ stars",
+      "more": "+{{count}} more"
+    },
     "climbRow": {
       "addToQueue": "Add to queue",
       "menuAccessibility": "Actions for {{climbName}}",

--- a/packages/web/i18n/locales/es/climbs.json
+++ b/packages/web/i18n/locales/es/climbs.json
@@ -597,6 +597,16 @@
       "apply": "Aplicar filtros",
       "reset": "Restablecer"
     },
+    "search": {
+      "recentFilters": "Recientes",
+      "clearRecent": "Borrar",
+      "gradeRange": "{{min}}–{{max}}",
+      "gradeMin": "{{grade}}+",
+      "gradeMax": "Hasta {{grade}}",
+      "ascents": "{{count}}+ ascensos",
+      "rating": "{{count}}+ estrellas",
+      "more": "+{{count}} más"
+    },
     "climbRow": {
       "addToQueue": "Añadir a la cola",
       "menuAccessibility": "Acciones para {{climbName}}",

--- a/packages/web/i18n/locales/fr/climbs.json
+++ b/packages/web/i18n/locales/fr/climbs.json
@@ -597,6 +597,16 @@
       "apply": "Appliquer les filtres",
       "reset": "Réinitialiser"
     },
+    "search": {
+      "recentFilters": "Récents",
+      "clearRecent": "Effacer",
+      "gradeRange": "{{min}}–{{max}}",
+      "gradeMin": "{{grade}}+",
+      "gradeMax": "Jusqu'à {{grade}}",
+      "ascents": "{{count}}+ ascensions",
+      "rating": "{{count}}+ étoiles",
+      "more": "+{{count}} de plus"
+    },
     "climbRow": {
       "addToQueue": "Ajouter à la file",
       "menuAccessibility": "Actions pour {{climbName}}",

--- a/packages/web/scripts/mobile-i18n-keeps.ts
+++ b/packages/web/scripts/mobile-i18n-keeps.ts
@@ -60,6 +60,14 @@
 // i18n-keep climbs.mobile.climbRow.toggleFavorite
 // i18n-keep climbs.mobile.climbRow.share
 // i18n-keep climbs.mobile.climbRow.projectFallback
+// i18n-keep climbs.mobile.search.recentFilters
+// i18n-keep climbs.mobile.search.clearRecent
+// i18n-keep climbs.mobile.search.gradeRange
+// i18n-keep climbs.mobile.search.gradeMin
+// i18n-keep climbs.mobile.search.gradeMax
+// i18n-keep climbs.mobile.search.ascents
+// i18n-keep climbs.mobile.search.rating
+// i18n-keep climbs.mobile.search.more
 // i18n-keep session.mobile.queue.noSessionTitle
 // i18n-keep session.mobile.queue.noSessionSubtitle
 // i18n-keep session.mobile.queue.emptyTitle


### PR DESCRIPTION
## Summary

- Replace native iOS `headerSearchBarOptions` with a custom `SearchHeader` TextInput component that tracks focus state
- When the search bar is focused without text typed, show recent filter combinations as horizontal tappable pills above the climb list
- When the user types, hide the pills and filter climbs by name (existing debounced search behavior)
- Tapping a recent filter pill restores both the filter settings (grade, sort, rating, ascents) and the search text
- Filter combinations are persisted to `expo-secure-store` (max 10, deduplicated) when the user applies filters via the ClimbFilterSheet
- Compact labels generated from filter state (e.g. "V3–V7 · 10+ ascents")

## New files

- `packages/mobile/src/lib/recent-filter-store.ts` — expo-secure-store backed storage for recent filter combos
- `packages/mobile/src/lib/filter-summary.ts` — compact label generation from ClimbFilters state
- `packages/mobile/src/components/SearchHeader.tsx` — custom iOS-style search TextInput with clear button
- `packages/mobile/src/components/RecentFilterPills.tsx` — horizontal scrolling pills with history icon and haptic feedback

## Test plan

- [ ] Focus the search bar with no text — recent filter pills should appear (after at least one filter has been applied)
- [ ] Type in the search bar — pills disappear, climb list filters by name
- [ ] Clear search text while focused — pills reappear
- [ ] Open filter sheet, set filters, tap Apply — filter is saved as a recent entry
- [ ] Focus search bar again — the saved filter appears as a pill
- [ ] Tap a recent filter pill — filters and search text are restored, keyboard dismisses
- [ ] Tap "Clear" on the recent filters header — all recent filters are removed
- [ ] Apply 10+ different filter combos — only the 10 most recent are kept
- [ ] Duplicate filter combos are deduplicated (same combo moves to front)
- [ ] Dark mode: search bar and pills adapt correctly

https://claude.ai/code/session_01EeD32Bv48qbvZLhjjt85jT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeD32Bv48qbvZLhjjt85jT)_