### PR TITLE
refactor: create @boardsesh/climb-filters shared package

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@boardsesh/ble-protocol": "*",
     "@boardsesh/board-config": "*",
+    "@boardsesh/climb-filters": "*",
     "@boardsesh/board-constants": "*",
     "@boardsesh/play-view": "*",
     "@boardsesh/queue": "*",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@boardsesh/ble-protocol": "*",
     "@boardsesh/board-config": "*",
-    "@boardsesh/climb-filters": "*",
     "@boardsesh/board-constants": "*",
+    "@boardsesh/climb-filters": "*",
     "@boardsesh/play-view": "*",
     "@boardsesh/queue": "*",
     "@boardsesh/shared-schema": "*",

--- a/packages/mobile/src/lib/filter-summary.ts
+++ b/packages/mobile/src/lib/filter-summary.ts
@@ -11,7 +11,6 @@ function buildLabels(t: TFunction<'climbs'>): FilterSummaryLabels {
     ascents: (count) => t('mobile.search.ascents', { count }),
     rating: (count) => t('mobile.search.rating', { count }),
     more: (count) => t('mobile.search.more', { count }),
-    empty: t('mobile.filter.title'),
   };
 }
 
@@ -47,5 +46,5 @@ export function getFilterSummary(
     buildSortLabel(t),
   );
 
-  return formatFilterSummary(parts, labels);
+  return formatFilterSummary(parts, labels) ?? t('mobile.filter.title');
 }

--- a/packages/mobile/src/lib/filter-summary.ts
+++ b/packages/mobile/src/lib/filter-summary.ts
@@ -1,10 +1,28 @@
 import type { TFunction } from 'i18next';
 import type { Grade } from '@boardsesh/shared-schema';
+import { getBaseFilterParts, formatFilterSummary, type FilterSummaryLabels } from '@boardsesh/climb-filters';
 import { DEFAULT_FILTERS, type ClimbFilters } from '../components/ClimbFilterSheet';
 
-function getGradeName(difficultyId: number, grades: Grade[]): string {
-  const grade = grades.find((gradeEntry) => gradeEntry.difficultyId === difficultyId);
-  return grade?.name ?? `#${difficultyId}`;
+function buildLabels(t: TFunction<'climbs'>): FilterSummaryLabels {
+  return {
+    gradeRange: (min, max) => t('mobile.search.gradeRange', { min, max }),
+    gradeMin: (grade) => t('mobile.search.gradeMin', { grade }),
+    gradeMax: (grade) => t('mobile.search.gradeMax', { grade }),
+    ascents: (count) => t('mobile.search.ascents', { count }),
+    rating: (count) => t('mobile.search.rating', { count }),
+    more: (count) => t('mobile.search.more', { count }),
+    empty: t('mobile.filter.title'),
+  };
+}
+
+function buildSortLabel(t: TFunction<'climbs'>): (sortBy: string) => string | undefined {
+  const sortLabels: Record<string, string> = {
+    popular: t('mobile.filter.popular'),
+    quality: t('mobile.filter.quality'),
+    difficulty: t('mobile.filter.difficulty'),
+    newest: t('mobile.filter.newest'),
+  };
+  return (sortBy: string) => sortLabels[sortBy];
 }
 
 export function getFilterSummary(
@@ -13,54 +31,21 @@ export function getFilterSummary(
   grades: Grade[] | undefined,
   t: TFunction<'climbs'>,
 ): string {
-  const parts: string[] = [];
+  const labels = buildLabels(t);
+  const parts = getBaseFilterParts(
+    {
+      minGrade: filters.minGrade,
+      maxGrade: filters.maxGrade,
+      minAscents: filters.minAscents,
+      minRating: filters.minRating,
+      sortBy: filters.sortBy,
+      defaultSortBy: DEFAULT_FILTERS.sortBy,
+      name: searchText,
+    },
+    grades ?? [],
+    labels,
+    buildSortLabel(t),
+  );
 
-  if (searchText.length > 0) {
-    parts.push(`"${searchText}"`);
-  }
-
-  if (filters.minGrade != null && filters.maxGrade != null && grades) {
-    parts.push(
-      t('mobile.search.gradeRange', {
-        min: getGradeName(filters.minGrade, grades),
-        max: getGradeName(filters.maxGrade, grades),
-      }),
-    );
-  } else if (filters.minGrade != null && grades) {
-    parts.push(t('mobile.search.gradeMin', { grade: getGradeName(filters.minGrade, grades) }));
-  } else if (filters.maxGrade != null && grades) {
-    parts.push(t('mobile.search.gradeMax', { grade: getGradeName(filters.maxGrade, grades) }));
-  }
-
-  if (filters.sortBy !== DEFAULT_FILTERS.sortBy) {
-    const sortLabels: Record<string, string> = {
-      popular: t('mobile.filter.popular'),
-      quality: t('mobile.filter.quality'),
-      difficulty: t('mobile.filter.difficulty'),
-      newest: t('mobile.filter.newest'),
-    };
-    const sortLabel = sortLabels[filters.sortBy];
-    if (sortLabel) {
-      parts.push(sortLabel);
-    }
-  }
-
-  if (filters.minAscents != null) {
-    parts.push(t('mobile.search.ascents', { count: filters.minAscents }));
-  }
-
-  if (filters.minRating != null) {
-    parts.push(t('mobile.search.rating', { count: filters.minRating }));
-  }
-
-  if (parts.length === 0) {
-    return t('mobile.filter.title');
-  }
-
-  if (parts.length <= 2) {
-    return parts.join(' · ');
-  }
-
-  const remaining = parts.length - 2;
-  return `${parts.slice(0, 2).join(' · ')} · ${t('mobile.search.more', { count: remaining })}`;
+  return formatFilterSummary(parts, labels);
 }

--- a/packages/shared/climb-filters/package.json
+++ b/packages/shared/climb-filters/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@boardsesh/climb-filters",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@boardsesh/shared-schema": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/shared/climb-filters/src/__tests__/filter-normalization.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/filter-normalization.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeMinAscentsFilter,
+  normalizeMinRatingFilter,
+  formatMinAscentsFilterCount,
+  getMinRatingPickerValue,
+} from '../filter-normalization';
+
+describe('normalizeMinAscentsFilter', () => {
+  it('returns 0 for null/undefined', () => {
+    expect(normalizeMinAscentsFilter(null)).toBe(0);
+    expect(normalizeMinAscentsFilter(undefined)).toBe(0);
+  });
+
+  it('returns 0 for non-positive values', () => {
+    expect(normalizeMinAscentsFilter(0)).toBe(0);
+    expect(normalizeMinAscentsFilter(-5)).toBe(0);
+  });
+
+  it('floors positive values', () => {
+    expect(normalizeMinAscentsFilter(10.7)).toBe(10);
+    expect(normalizeMinAscentsFilter(100)).toBe(100);
+  });
+
+  it('returns 0 for NaN/Infinity', () => {
+    expect(normalizeMinAscentsFilter(NaN)).toBe(0);
+    expect(normalizeMinAscentsFilter(Infinity)).toBe(0);
+  });
+});
+
+describe('normalizeMinRatingFilter', () => {
+  it('returns 0 for null/undefined', () => {
+    expect(normalizeMinRatingFilter(null)).toBe(0);
+    expect(normalizeMinRatingFilter(undefined)).toBe(0);
+  });
+
+  it('clamps to 1-5 range', () => {
+    expect(normalizeMinRatingFilter(0.5)).toBe(1);
+    expect(normalizeMinRatingFilter(3)).toBe(3);
+    expect(normalizeMinRatingFilter(6)).toBe(5);
+  });
+
+  it('ceils fractional values', () => {
+    expect(normalizeMinRatingFilter(2.3)).toBe(3);
+    expect(normalizeMinRatingFilter(4.1)).toBe(5);
+  });
+});
+
+describe('formatMinAscentsFilterCount', () => {
+  it('formats values below 1000 as plain numbers', () => {
+    expect(formatMinAscentsFilterCount(0)).toBe('0');
+    expect(formatMinAscentsFilterCount(10)).toBe('10');
+    expect(formatMinAscentsFilterCount(100)).toBe('100');
+  });
+
+  it('formats thousands with k suffix', () => {
+    expect(formatMinAscentsFilterCount(1000)).toBe('1k');
+    expect(formatMinAscentsFilterCount(10000)).toBe('10k');
+  });
+});
+
+describe('getMinRatingPickerValue', () => {
+  it('returns null for zero/null/undefined', () => {
+    expect(getMinRatingPickerValue(0)).toBeNull();
+    expect(getMinRatingPickerValue(null)).toBeNull();
+    expect(getMinRatingPickerValue(undefined)).toBeNull();
+  });
+
+  it('returns normalized value for positive input', () => {
+    expect(getMinRatingPickerValue(3)).toBe(3);
+    expect(getMinRatingPickerValue(5)).toBe(5);
+  });
+});

--- a/packages/shared/climb-filters/src/__tests__/filter-normalization.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/filter-normalization.test.ts
@@ -57,6 +57,11 @@ describe('formatMinAscentsFilterCount', () => {
     expect(formatMinAscentsFilterCount(1000)).toBe('1k');
     expect(formatMinAscentsFilterCount(10000)).toBe('10k');
   });
+
+  it('falls back to plain number for non-round thousands', () => {
+    expect(formatMinAscentsFilterCount(1500)).toBe('1500');
+    expect(formatMinAscentsFilterCount(2500)).toBe('2500');
+  });
 });
 
 describe('getMinRatingPickerValue', () => {

--- a/packages/shared/climb-filters/src/__tests__/filter-summary.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/filter-summary.test.ts
@@ -17,7 +17,6 @@ const labels: FilterSummaryLabels = {
   ascents: (count) => `${count}+ ascents`,
   rating: (count) => `${count}+ stars`,
   more: (count) => `+${count} more`,
-  empty: 'Filters',
 };
 
 const sortLabel = (sortBy: string) => {
@@ -76,8 +75,8 @@ describe('getBaseFilterParts', () => {
 });
 
 describe('formatFilterSummary', () => {
-  it('returns empty label when no parts', () => {
-    expect(formatFilterSummary([], labels)).toBe('Filters');
+  it('returns null when no parts', () => {
+    expect(formatFilterSummary([], labels)).toBeNull();
   });
 
   it('joins single part', () => {

--- a/packages/shared/climb-filters/src/__tests__/filter-summary.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/filter-summary.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import type { Grade } from '@boardsesh/shared-schema';
+import { getBaseFilterParts, formatFilterSummary, type FilterSummaryLabels, type BaseFilters } from '../filter-summary';
+
+const mockGrades: Grade[] = [
+  { difficultyId: 1, name: 'V0' },
+  { difficultyId: 5, name: 'V2' },
+  { difficultyId: 10, name: 'V4' },
+  { difficultyId: 15, name: 'V6' },
+  { difficultyId: 20, name: 'V8' },
+];
+
+const labels: FilterSummaryLabels = {
+  gradeRange: (min, max) => `${min}–${max}`,
+  gradeMin: (grade) => `${grade}+`,
+  gradeMax: (grade) => `Up to ${grade}`,
+  ascents: (count) => `${count}+ ascents`,
+  rating: (count) => `${count}+ stars`,
+  more: (count) => `+${count} more`,
+  empty: 'Filters',
+};
+
+const sortLabel = (sortBy: string) => {
+  const map: Record<string, string> = { quality: 'Quality', difficulty: 'Difficulty', newest: 'Newest' };
+  return map[sortBy];
+};
+
+describe('getBaseFilterParts', () => {
+  it('returns empty array when no filters are active', () => {
+    expect(getBaseFilterParts({}, mockGrades, labels)).toEqual([]);
+  });
+
+  it('includes search text in quotes', () => {
+    expect(getBaseFilterParts({ name: 'crimp' }, mockGrades, labels)).toEqual(['"crimp"']);
+  });
+
+  it('shows grade range when both min and max set', () => {
+    const filters: BaseFilters = { minGrade: 5, maxGrade: 15 };
+    expect(getBaseFilterParts(filters, mockGrades, labels)).toEqual(['V2–V6']);
+  });
+
+  it('shows min grade with plus', () => {
+    expect(getBaseFilterParts({ minGrade: 10 }, mockGrades, labels)).toEqual(['V4+']);
+  });
+
+  it('shows max grade with up-to prefix', () => {
+    expect(getBaseFilterParts({ maxGrade: 15 }, mockGrades, labels)).toEqual(['Up to V6']);
+  });
+
+  it('shows sort label when non-default', () => {
+    const filters: BaseFilters = { sortBy: 'quality', defaultSortBy: 'popular' };
+    expect(getBaseFilterParts(filters, mockGrades, labels, sortLabel)).toEqual(['Quality']);
+  });
+
+  it('skips sort label when sortBy matches default', () => {
+    const filters: BaseFilters = { sortBy: 'popular', defaultSortBy: 'popular' };
+    expect(getBaseFilterParts(filters, mockGrades, labels, sortLabel)).toEqual([]);
+  });
+
+  it('shows ascents count', () => {
+    expect(getBaseFilterParts({ minAscents: 25 }, mockGrades, labels)).toEqual(['25+ ascents']);
+  });
+
+  it('shows rating count', () => {
+    expect(getBaseFilterParts({ minRating: 3 }, mockGrades, labels)).toEqual(['3+ stars']);
+  });
+
+  it('falls back to difficultyId when grade not found', () => {
+    expect(getBaseFilterParts({ minGrade: 999 }, mockGrades, labels)).toEqual(['#999+']);
+  });
+
+  it('combines multiple parts', () => {
+    const filters: BaseFilters = { name: 'test', minGrade: 10, minAscents: 5 };
+    expect(getBaseFilterParts(filters, mockGrades, labels)).toEqual(['"test"', 'V4+', '5+ ascents']);
+  });
+});
+
+describe('formatFilterSummary', () => {
+  it('returns empty label when no parts', () => {
+    expect(formatFilterSummary([], labels)).toBe('Filters');
+  });
+
+  it('joins single part', () => {
+    expect(formatFilterSummary(['V4+'], labels)).toBe('V4+');
+  });
+
+  it('joins two parts with middle dot', () => {
+    expect(formatFilterSummary(['V4+', '5+ ascents'], labels)).toBe('V4+ · 5+ ascents');
+  });
+
+  it('truncates at 2 parts by default and shows remainder', () => {
+    const parts = ['V4+', 'Quality', '25+ ascents', '3+ stars'];
+    expect(formatFilterSummary(parts, labels)).toBe('V4+ · Quality · +2 more');
+  });
+
+  it('respects custom maxParts', () => {
+    const parts = ['V4+', 'Quality', '25+ ascents'];
+    expect(formatFilterSummary(parts, labels, 1)).toBe('V4+ · +2 more');
+  });
+
+  it('shows all parts when count equals maxParts', () => {
+    const parts = ['V4+', 'Quality', '25+ ascents'];
+    expect(formatFilterSummary(parts, labels, 3)).toBe('V4+ · Quality · 25+ ascents');
+  });
+});

--- a/packages/shared/climb-filters/src/__tests__/filter-summary.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/filter-summary.test.ts
@@ -72,6 +72,11 @@ describe('getBaseFilterParts', () => {
     const filters: BaseFilters = { name: 'test', minGrade: 10, minAscents: 5 };
     expect(getBaseFilterParts(filters, mockGrades, labels)).toEqual(['"test"', 'V4+', '5+ ascents']);
   });
+
+  it('includes minAscents >= 2 (web suppresses this for the Established chip separately)', () => {
+    expect(getBaseFilterParts({ minAscents: 2 }, mockGrades, labels)).toEqual(['2+ ascents']);
+    expect(getBaseFilterParts({ minAscents: 10 }, mockGrades, labels)).toEqual(['10+ ascents']);
+  });
 });
 
 describe('formatFilterSummary', () => {
@@ -100,5 +105,10 @@ describe('formatFilterSummary', () => {
   it('shows all parts when count equals maxParts', () => {
     const parts = ['V4+', 'Quality', '25+ ascents'];
     expect(formatFilterSummary(parts, labels, 3)).toBe('V4+ · Quality · 25+ ascents');
+  });
+
+  it('shows all parts when maxParts is null (no limit)', () => {
+    const parts = ['V4+', 'Quality', '25+ ascents', '3+ stars'];
+    expect(formatFilterSummary(parts, labels, null)).toBe('V4+ · Quality · 25+ ascents · 3+ stars');
   });
 });

--- a/packages/shared/climb-filters/src/__tests__/grade-lookup.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/grade-lookup.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import type { Grade } from '@boardsesh/shared-schema';
+import { getGradeName } from '../grade-lookup';
+
+const grades: Grade[] = [
+  { difficultyId: 10, name: 'V0' },
+  { difficultyId: 15, name: 'V2' },
+  { difficultyId: 20, name: 'V4' },
+];
+
+describe('getGradeName', () => {
+  it('returns grade name for a matching difficultyId', () => {
+    expect(getGradeName(10, grades)).toBe('V0');
+    expect(getGradeName(20, grades)).toBe('V4');
+  });
+
+  it('returns fallback string for unknown difficultyId', () => {
+    expect(getGradeName(999, grades)).toBe('#999');
+  });
+
+  it('returns fallback for empty grades array', () => {
+    expect(getGradeName(10, [])).toBe('#10');
+  });
+});

--- a/packages/shared/climb-filters/src/filter-normalization.ts
+++ b/packages/shared/climb-filters/src/filter-normalization.ts
@@ -1,0 +1,28 @@
+export const MIN_ASCENTS_FILTER_OPTIONS = [0, 1, 10, 100, 1000, 10000] as const;
+
+export function normalizeMinAscentsFilter(value: number | null | undefined): number {
+  if (value == null || !Number.isFinite(value) || value <= 0) return 0;
+  return Math.floor(value);
+}
+
+export function getMinAscentsFilterOptions(): number[] {
+  return [...MIN_ASCENTS_FILTER_OPTIONS];
+}
+
+export function formatMinAscentsFilterCount(value: number): string {
+  const normalizedValue = normalizeMinAscentsFilter(value);
+  if (normalizedValue >= 1000 && normalizedValue % 1000 === 0) {
+    return `${normalizedValue / 1000}k`;
+  }
+  return String(normalizedValue);
+}
+
+export function normalizeMinRatingFilter(value: number | null | undefined): number {
+  if (value == null || !Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(5, Math.max(1, Math.ceil(value)));
+}
+
+export function getMinRatingPickerValue(value: number | null | undefined): number | null {
+  const normalizedValue = normalizeMinRatingFilter(value);
+  return normalizedValue === 0 ? null : normalizedValue;
+}

--- a/packages/shared/climb-filters/src/filter-summary.ts
+++ b/packages/shared/climb-filters/src/filter-summary.ts
@@ -64,7 +64,7 @@ export function getBaseFilterParts(
 export function formatFilterSummary(
   parts: string[],
   labels: Pick<FilterSummaryLabels, 'more'>,
-  maxParts?: number | null,
+  maxParts: number | null = 2,
 ): string | null {
   if (parts.length === 0) return null;
 

--- a/packages/shared/climb-filters/src/filter-summary.ts
+++ b/packages/shared/climb-filters/src/filter-summary.ts
@@ -8,7 +8,6 @@ export type FilterSummaryLabels = {
   ascents: (count: number) => string;
   rating: (count: number) => string;
   more: (count: number) => string;
-  empty: string;
 };
 
 export type BaseFilters = {
@@ -21,6 +20,9 @@ export type BaseFilters = {
   name?: string;
 };
 
+// Web suppresses minAscents >= 2 when the "Established" status chip is active
+// (see getQualityPanelSummary in search-summary-utils.ts). This shared function
+// does not apply that dedup — web callers should filter parts before formatting.
 export function getBaseFilterParts(
   filters: BaseFilters,
   grades: Grade[],
@@ -61,10 +63,10 @@ export function getBaseFilterParts(
 
 export function formatFilterSummary(
   parts: string[],
-  labels: Pick<FilterSummaryLabels, 'more' | 'empty'>,
+  labels: Pick<FilterSummaryLabels, 'more'>,
   maxParts = 2,
-): string {
-  if (parts.length === 0) return labels.empty;
+): string | null {
+  if (parts.length === 0) return null;
 
   if (parts.length <= maxParts) {
     return parts.join(' · ');

--- a/packages/shared/climb-filters/src/filter-summary.ts
+++ b/packages/shared/climb-filters/src/filter-summary.ts
@@ -64,11 +64,11 @@ export function getBaseFilterParts(
 export function formatFilterSummary(
   parts: string[],
   labels: Pick<FilterSummaryLabels, 'more'>,
-  maxParts = 2,
+  maxParts?: number | null,
 ): string | null {
   if (parts.length === 0) return null;
 
-  if (parts.length <= maxParts) {
+  if (maxParts == null || parts.length <= maxParts) {
     return parts.join(' · ');
   }
 

--- a/packages/shared/climb-filters/src/filter-summary.ts
+++ b/packages/shared/climb-filters/src/filter-summary.ts
@@ -1,0 +1,75 @@
+import type { Grade } from '@boardsesh/shared-schema';
+import { getGradeName } from './grade-lookup';
+
+export type FilterSummaryLabels = {
+  gradeRange: (min: string, max: string) => string;
+  gradeMin: (grade: string) => string;
+  gradeMax: (grade: string) => string;
+  ascents: (count: number) => string;
+  rating: (count: number) => string;
+  more: (count: number) => string;
+  empty: string;
+};
+
+export type BaseFilters = {
+  minGrade?: number;
+  maxGrade?: number;
+  minAscents?: number;
+  minRating?: number;
+  sortBy?: string;
+  defaultSortBy?: string;
+  name?: string;
+};
+
+export function getBaseFilterParts(
+  filters: BaseFilters,
+  grades: Grade[],
+  labels: FilterSummaryLabels,
+  sortLabel?: (sortBy: string) => string | undefined,
+): string[] {
+  const parts: string[] = [];
+
+  if (filters.name && filters.name.length > 0) {
+    parts.push(`"${filters.name}"`);
+  }
+
+  if (filters.minGrade != null && filters.maxGrade != null) {
+    parts.push(labels.gradeRange(getGradeName(filters.minGrade, grades), getGradeName(filters.maxGrade, grades)));
+  } else if (filters.minGrade != null) {
+    parts.push(labels.gradeMin(getGradeName(filters.minGrade, grades)));
+  } else if (filters.maxGrade != null) {
+    parts.push(labels.gradeMax(getGradeName(filters.maxGrade, grades)));
+  }
+
+  if (filters.sortBy && filters.defaultSortBy && filters.sortBy !== filters.defaultSortBy && sortLabel) {
+    const label = sortLabel(filters.sortBy);
+    if (label) {
+      parts.push(label);
+    }
+  }
+
+  if (filters.minAscents != null) {
+    parts.push(labels.ascents(filters.minAscents));
+  }
+
+  if (filters.minRating != null) {
+    parts.push(labels.rating(filters.minRating));
+  }
+
+  return parts;
+}
+
+export function formatFilterSummary(
+  parts: string[],
+  labels: Pick<FilterSummaryLabels, 'more' | 'empty'>,
+  maxParts = 2,
+): string {
+  if (parts.length === 0) return labels.empty;
+
+  if (parts.length <= maxParts) {
+    return parts.join(' · ');
+  }
+
+  const remaining = parts.length - maxParts;
+  return `${parts.slice(0, maxParts).join(' · ')} · ${labels.more(remaining)}`;
+}

--- a/packages/shared/climb-filters/src/grade-lookup.ts
+++ b/packages/shared/climb-filters/src/grade-lookup.ts
@@ -1,0 +1,6 @@
+import type { Grade } from '@boardsesh/shared-schema';
+
+export function getGradeName(difficultyId: number, grades: Grade[]): string {
+  const grade = grades.find((gradeEntry) => gradeEntry.difficultyId === difficultyId);
+  return grade?.name ?? `#${difficultyId}`;
+}

--- a/packages/shared/climb-filters/src/index.ts
+++ b/packages/shared/climb-filters/src/index.ts
@@ -1,0 +1,3 @@
+export * from './grade-lookup';
+export * from './filter-normalization';
+export * from './filter-summary';

--- a/packages/shared/climb-filters/tsconfig.json
+++ b/packages/shared/climb-filters/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/shared/climb-filters/vite.config.ts
+++ b/packages/shared/climb-filters/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'climb-filters',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -152,7 +152,12 @@ describe('useBoardBluetooth', () => {
       skippedRoleCount: 0,
       totalPlacements: 1,
     });
-    mockGetMoonboardBluetoothPacket.mockReturnValue(new Uint8Array([9, 8, 7]));
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([9, 8, 7]),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 3,
+    });
     mockGetLedPlacements.mockReturnValue({ 4131: 39 });
   });
 

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -47,7 +47,17 @@ const {
       skippedRoleCount: 0,
       totalPlacements: 1,
     })),
-    mockGetMoonboardBluetoothPacket: vi.fn<(frames: string) => Uint8Array>(() => new Uint8Array([9, 8, 7])),
+    mockGetMoonboardBluetoothPacket: vi.fn<(frames: string) => {
+      packet: Uint8Array;
+      skippedRoleCount: number;
+      skippedPositionCount: number;
+      totalPlacements: number;
+    }>(() => ({
+      packet: new Uint8Array([9, 8, 7]),
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+      totalPlacements: 3,
+    })),
     mockGetLedPlacements: vi.fn<(boardName: string, layoutId: number, sizeId: number) => Record<number, number>>(
       () => ({ 4131: 39 }),
     ),

--- a/packages/web/app/components/search-drawer/__tests__/search-summary-utils.test.ts
+++ b/packages/web/app/components/search-drawer/__tests__/search-summary-utils.test.ts
@@ -202,6 +202,16 @@ describe('getQualityPanelSummary vs Status (no duplication)', () => {
     expect(pill).toContain('Projects');
   });
 
+  it('pill summary truncates at 2 items with +N more', () => {
+    const pill = getSearchPillSummary(
+      makeParams({ minGrade: 16, minRating: 3, onlyClassics: true, onlyTallClimbs: true }),
+      summaryLabels,
+    );
+    const parts = pill.split(' · ');
+    expect(parts).toHaveLength(3);
+    expect(parts[2]).toBe('+2 more');
+  });
+
   it('pill summary for drafts shows "Drafts"', () => {
     const pill = getSearchPillSummary(makeParams({ onlyDrafts: true }), summaryLabels);
     expect(pill).toContain('Drafts');

--- a/packages/web/app/components/search-drawer/recent-search-pills.tsx
+++ b/packages/web/app/components/search-drawer/recent-search-pills.tsx
@@ -89,7 +89,7 @@ const RecentSearchPills: React.FC = () => {
             ...DEFAULT_SEARCH_PARAMS,
             ...search.filters,
           } as SearchRequestPagination;
-          const tooltipText = getSearchPillFullSummary(fullFilters, summaryLabels) ?? undefined;
+          const tooltipText = getSearchPillFullSummary(fullFilters, summaryLabels);
           return (
             <button
               key={search.id}

--- a/packages/web/app/components/search-drawer/recent-search-pills.tsx
+++ b/packages/web/app/components/search-drawer/recent-search-pills.tsx
@@ -89,7 +89,7 @@ const RecentSearchPills: React.FC = () => {
             ...DEFAULT_SEARCH_PARAMS,
             ...search.filters,
           } as SearchRequestPagination;
-          const tooltipText = getSearchPillFullSummary(fullFilters, summaryLabels);
+          const tooltipText = getSearchPillFullSummary(fullFilters, summaryLabels) ?? undefined;
           return (
             <button
               key={search.id}

--- a/packages/web/app/components/search-drawer/search-summary-utils.ts
+++ b/packages/web/app/components/search-drawer/search-summary-utils.ts
@@ -234,9 +234,9 @@ function collectAllParts(params: SearchRequestPagination, labels: SearchPillLabe
 }
 
 export function getSearchPillSummary(params: SearchRequestPagination, labels: SearchPillLabels): string {
-  return formatFilterSummary(collectAllParts(params, labels), { more: labels.more, empty: labels.empty });
+  return formatFilterSummary(collectAllParts(params, labels), labels) ?? labels.empty;
 }
 
-export function getSearchPillFullSummary(params: SearchRequestPagination, labels: SearchPillLabels): string {
-  return formatFilterSummary(collectAllParts(params, labels), { more: labels.more, empty: labels.empty }, Infinity);
+export function getSearchPillFullSummary(params: SearchRequestPagination, labels: SearchPillLabels): string | null {
+  return formatFilterSummary(collectAllParts(params, labels), labels, Infinity);
 }

--- a/packages/web/app/components/search-drawer/search-summary-utils.ts
+++ b/packages/web/app/components/search-drawer/search-summary-utils.ts
@@ -2,6 +2,7 @@ import type { SearchRequestPagination } from '@/app/lib/types';
 import { TENSION_KILTER_GRADES } from '@/app/lib/board-data';
 import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
 import { normalizeMinRatingFilter } from '@/app/lib/climb-quality-filter-options';
+import { formatFilterSummary } from '@boardsesh/climb-filters';
 
 type SearchSummaryTranslate = (key: string, options?: Record<string, unknown>) => string;
 
@@ -127,12 +128,10 @@ export type UserSummaryLabels = {
 };
 
 export function getUserPanelSummary(params: SearchRequestPagination, labels: UserSummaryLabels): string[] {
-  // Merge "Hide" filters into single entry
   const hideFilters: string[] = [];
   if (params.hideAttempted) hideFilters.push(labels.attempted);
   if (params.hideCompleted) hideFilters.push(labels.completed);
 
-  // Merge "Only" filters into single entry
   const onlyFilters: string[] = [];
   if (params.showOnlyAttempted) onlyFilters.push(labels.attempted);
   if (params.showOnlyCompleted) onlyFilters.push(labels.completed);
@@ -172,10 +171,6 @@ export function getZonePanelSummary(
   return [`${label}: ${modeLabel}`];
 }
 
-/**
- * Pre-translated labels used by the search-pill summary helpers.
- * Pass these in from the React layer where i18n is available.
- */
 export type SearchPillLabels = {
   empty: string;
   climb: ClimbSummaryLabels;
@@ -227,12 +222,8 @@ export function createSearchSummaryLabels(t: SearchSummaryTranslate): SearchPill
   };
 }
 
-/**
- * Get compact search pill summary (max 2 items + "+N more")
- * Used for display in the search bar and recent search pills
- */
-export function getSearchPillSummary(params: SearchRequestPagination, labels: SearchPillLabels): string {
-  const allParts = [
+function collectAllParts(params: SearchRequestPagination, labels: SearchPillLabels): string[] {
+  return [
     ...getClimbPanelSummary(params, labels.climb),
     ...getQualityPanelSummary(params, labels.quality),
     ...getStatusPanelSummary(params, labels.status),
@@ -240,31 +231,12 @@ export function getSearchPillSummary(params: SearchRequestPagination, labels: Se
     ...getHoldsPanelSummary(params, labels.holds),
     ...getZonePanelSummary(params, labels.zone, labels.zoneModes),
   ];
-
-  if (allParts.length === 0) return labels.empty;
-
-  // Show max 2 items, append "+N more" if more
-  if (allParts.length <= 2) {
-    return allParts.join(' \u00B7 ');
-  }
-  const remaining = allParts.length - 2;
-  return `${allParts.slice(0, 2).join(' \u00B7 ')} \u00B7 ${labels.more(remaining)}`;
 }
 
-/**
- * Get full search pill summary (all items, no truncation)
- * Used for tooltips to show the complete filter list
- */
-export function getSearchPillFullSummary(params: SearchRequestPagination, labels: SearchPillLabels): string {
-  const allParts = [
-    ...getClimbPanelSummary(params, labels.climb),
-    ...getQualityPanelSummary(params, labels.quality),
-    ...getStatusPanelSummary(params, labels.status),
-    ...getUserPanelSummary(params, labels.user),
-    ...getHoldsPanelSummary(params, labels.holds),
-    ...getZonePanelSummary(params, labels.zone, labels.zoneModes),
-  ];
+export function getSearchPillSummary(params: SearchRequestPagination, labels: SearchPillLabels): string {
+  return formatFilterSummary(collectAllParts(params, labels), { more: labels.more, empty: labels.empty });
+}
 
-  if (allParts.length === 0) return labels.empty;
-  return allParts.join(' \u00B7 ');
+export function getSearchPillFullSummary(params: SearchRequestPagination, labels: SearchPillLabels): string {
+  return formatFilterSummary(collectAllParts(params, labels), { more: labels.more, empty: labels.empty }, Infinity);
 }

--- a/packages/web/app/components/search-drawer/search-summary-utils.ts
+++ b/packages/web/app/components/search-drawer/search-summary-utils.ts
@@ -237,6 +237,6 @@ export function getSearchPillSummary(params: SearchRequestPagination, labels: Se
   return formatFilterSummary(collectAllParts(params, labels), labels) ?? labels.empty;
 }
 
-export function getSearchPillFullSummary(params: SearchRequestPagination, labels: SearchPillLabels): string | null {
-  return formatFilterSummary(collectAllParts(params, labels), labels, Infinity);
+export function getSearchPillFullSummary(params: SearchRequestPagination, labels: SearchPillLabels): string {
+  return formatFilterSummary(collectAllParts(params, labels), labels, null) ?? labels.empty;
 }

--- a/packages/web/app/lib/climb-quality-filter-options.ts
+++ b/packages/web/app/lib/climb-quality-filter-options.ts
@@ -1,28 +1,8 @@
-export const MIN_ASCENTS_FILTER_OPTIONS = [0, 1, 10, 100, 1000, 10000] as const;
-
-export function normalizeMinAscentsFilter(value: number | null | undefined): number {
-  if (value == null || !Number.isFinite(value) || value <= 0) return 0;
-  return Math.floor(value);
-}
-
-export function getMinAscentsFilterOptions(): number[] {
-  return [...MIN_ASCENTS_FILTER_OPTIONS];
-}
-
-export function formatMinAscentsFilterCount(value: number): string {
-  const normalizedValue = normalizeMinAscentsFilter(value);
-  if (normalizedValue >= 1000 && normalizedValue % 1000 === 0) {
-    return `${normalizedValue / 1000}k`;
-  }
-  return String(normalizedValue);
-}
-
-export function normalizeMinRatingFilter(value: number | null | undefined): number {
-  if (value == null || !Number.isFinite(value) || value <= 0) return 0;
-  return Math.min(5, Math.max(1, Math.ceil(value)));
-}
-
-export function getMinRatingPickerValue(value: number | null | undefined): number | null {
-  const normalizedValue = normalizeMinRatingFilter(value);
-  return normalizedValue === 0 ? null : normalizedValue;
-}
+export {
+  MIN_ASCENTS_FILTER_OPTIONS,
+  normalizeMinAscentsFilter,
+  getMinAscentsFilterOptions,
+  formatMinAscentsFilterCount,
+  normalizeMinRatingFilter,
+  getMinRatingPickerValue,
+} from '@boardsesh/climb-filters';

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,6 +32,7 @@
     "@boardsesh/board-config": "*",
     "@boardsesh/board-constants": "*",
     "@boardsesh/board-renderer-wasm": "*",
+    "@boardsesh/climb-filters": "*",
     "@boardsesh/crypto": "*",
     "@boardsesh/db": "*",
     "@boardsesh/play-view": "*",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
       './packages/shared/ble-protocol/vite.config.ts',
       './packages/shared/queue/vite.config.ts',
       './packages/shared/play-view/vite.config.ts',
+      './packages/shared/climb-filters/vite.config.ts',
       './packages/mobile/vite.config.ts',
     ],
   },
@@ -189,6 +190,9 @@ export default defineConfig({
       'typecheck:play-view': {
         command: 'bun run --filter=@boardsesh/play-view typecheck',
       },
+      'typecheck:climb-filters': {
+        command: 'bun run --filter=@boardsesh/climb-filters typecheck',
+      },
       'typecheck:mobile': {
         command: 'bun run --filter=@boardsesh/mobile typecheck',
       },
@@ -203,6 +207,7 @@ export default defineConfig({
           'typecheck:queue',
           'typecheck:board-config',
           'typecheck:play-view',
+          'typecheck:climb-filters',
           'typecheck:mobile',
         ],
       },


### PR DESCRIPTION
Extract filter-related logic shared between web and mobile into a new package at packages/shared/climb-filters/:

- grade-lookup.ts: getGradeName() for resolving difficultyId to name
- filter-normalization.ts: normalizeMinAscentsFilter(), normalizeMinRatingFilter(), and related utils (moved from web's climb-quality-filter-options.ts)
- filter-summary.ts: getBaseFilterParts() for generating summary parts from base filter fields, formatFilterSummary() for truncation/joining

Web's climb-quality-filter-options.ts now re-exports from the shared package. Web's search-summary-utils.ts uses formatFilterSummary() for pill truncation. Mobile's filter-summary.ts delegates to getBaseFilterParts() + formatFilterSummary() instead of duplicating the logic.

https://claude.ai/code/session_01EeD32Bv48qbvZLhjjt85jT