### PR TITLE
fix(mobile): address Phase 3 play-drawer review findings

### DIFF
--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import * as Clipboard from 'expo-clipboard';
 import * as WebBrowser from 'expo-web-browser';
 import type { Climb } from '@boardsesh/shared-schema';
+import { buildClimbViewPath } from '@boardsesh/play-view';
 import { Sheet } from './Sheet';
 import { ListRow } from './ListRow';
 import { Icon } from './Icon';
@@ -26,17 +27,6 @@ type ClimbActionsSheetProps = {
   onToggleFavorite?: () => void;
   onClose: () => void;
 };
-
-function buildClimbUrl(
-  boardName: string,
-  layoutId: number,
-  sizeId: number,
-  setIds: string,
-  angle: number,
-  climbUuid: string,
-): string {
-  return `${WEB_BASE_URL}/${boardName}/${layoutId}/${sizeId}/${setIds}/${angle}/view/${climbUuid}`;
-}
 
 function ClimbActionsSheet({
   visible,
@@ -74,7 +64,7 @@ function ClimbActionsSheet({
 
   const handleShare = useCallback(async () => {
     if (!climb) return;
-    const url = buildClimbUrl(boardName, layoutId, sizeId, setIds, angle, climb.uuid);
+    const url = `${WEB_BASE_URL}${buildClimbViewPath(boardName, layoutId, sizeId, setIds, angle, climb.uuid)}`;
     try {
       await Share.share({ message: `${climb.name}\n${url}`, url });
     } finally {
@@ -84,7 +74,7 @@ function ClimbActionsSheet({
 
   const handleCopyLink = useCallback(async () => {
     if (!climb) return;
-    const url = buildClimbUrl(boardName, layoutId, sizeId, setIds, angle, climb.uuid);
+    const url = `${WEB_BASE_URL}${buildClimbViewPath(boardName, layoutId, sizeId, setIds, angle, climb.uuid)}`;
     await Clipboard.setStringAsync(url);
     showToast(t('mobile.climbActions.linkCopied'), 'info');
     onClose();
@@ -92,7 +82,7 @@ function ClimbActionsSheet({
 
   const handleReport = useCallback(async () => {
     if (!climb) return;
-    const reportUrl = `${WEB_BASE_URL}/${boardName}/${layoutId}/${sizeId}/${setIds}/${angle}/view/${climb.uuid}?report=true`;
+    const reportUrl = `${WEB_BASE_URL}${buildClimbViewPath(boardName, layoutId, sizeId, setIds, angle, climb.uuid)}?report=true`;
     await WebBrowser.openBrowserAsync(reportUrl);
     onClose();
   }, [climb, boardName, layoutId, sizeId, setIds, angle, onClose]);

--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import { Pressable, View, StyleSheet } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming, runOnJS } from 'react-native-reanimated';
 import {
@@ -86,6 +86,15 @@ export function QueueItemRow({
 
   // Disable swipe for edit mode and history items
   const swipeEnabled = !isEditMode && !isHistoryItem;
+
+  // Reset swipe position when swipe gets disabled (e.g. entering edit mode)
+  useEffect(() => {
+    if (!swipeEnabled) {
+      translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
+      isSwipeOpen.value = false;
+      runOnJS(setIsOpen)(false);
+    }
+  }, [swipeEnabled]);
 
   const handleRemove = useCallback(() => {
     hapticMedium();

--- a/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
@@ -56,12 +56,24 @@ export const AngleSelectorSheet = memo(function AngleSelectorSheet({
 
   const angles = useMemo(() => anglesData ?? [], [anglesData]);
 
+  // Refs to access latest values without adding deps that re-fire the effect
+  const isOpenRef = useRef(false);
+  const anglesRef = useRef(angles);
+  anglesRef.current = angles;
+  const currentAngleRef = useRef(currentAngle);
+  currentAngleRef.current = currentAngle;
+
   useEffect(() => {
     if (visible) {
+      if (isOpenRef.current) {
+        // Already open — skip re-triggering
+        return undefined;
+      }
+      isOpenRef.current = true;
       sheetRef.current?.snapToIndex(0);
 
       // Auto-scroll to current angle after a short delay to let the list render
-      const currentIndex = angles.findIndex((angleItem) => angleItem.angle === currentAngle);
+      const currentIndex = anglesRef.current.findIndex((angleItem) => angleItem.angle === currentAngleRef.current);
       if (currentIndex >= 0) {
         const scrollTimer = setTimeout(() => {
           try {
@@ -77,10 +89,11 @@ export const AngleSelectorSheet = memo(function AngleSelectorSheet({
         return () => clearTimeout(scrollTimer);
       }
     } else {
+      isOpenRef.current = false;
       sheetRef.current?.close();
     }
     return undefined;
-  }, [visible, angles, currentAngle]);
+  }, [visible]);
 
   const handleClose = useCallback(() => {
     onClose();

--- a/packages/mobile/src/components/play-drawer/CollapsibleSection.tsx
+++ b/packages/mobile/src/components/play-drawer/CollapsibleSection.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useCallback, useState } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
-import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import Animated, { FadeIn, FadeOut, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -45,7 +45,11 @@ export function CollapsibleSection({ title, defaultExpanded = false, children }:
         </Animated.View>
       </Pressable>
 
-      {expanded && <View style={styles.content}>{children}</View>}
+      {expanded && (
+        <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(150)} style={styles.content}>
+          {children}
+        </Animated.View>
+      )}
     </View>
   );
 }

--- a/packages/mobile/src/components/play-drawer/InlineStarPicker.tsx
+++ b/packages/mobile/src/components/play-drawer/InlineStarPicker.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Icon } from '../Icon';
 import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -11,10 +12,9 @@ type InlineStarPickerProps = {
   onSelect: (value: number | null) => void;
 };
 
-export const InlineStarPicker = React.memo(function InlineStarPicker({
-  quality,
-  onSelect,
-}: InlineStarPickerProps) {
+export const InlineStarPicker = React.memo(function InlineStarPicker({ quality, onSelect }: InlineStarPickerProps) {
+  const { t } = useTranslation('session');
+
   const handlePress = useCallback(
     (value: number) => {
       hapticSelection();
@@ -30,7 +30,7 @@ export const InlineStarPicker = React.memo(function InlineStarPicker({
           key={star}
           onPress={() => handlePress(star)}
           accessibilityRole="button"
-          accessibilityLabel={`${star} star${star > 1 ? 's' : ''}`}
+          accessibilityLabel={t('playView.tickBar.starRating', { count: star })}
           accessibilityState={{ selected: quality === star }}
           style={styles.starButton}
         >
@@ -54,6 +54,9 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
   },
   starButton: {
-    padding: spacing[1],
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/packages/mobile/src/components/play-drawer/InlineTriesPicker.tsx
+++ b/packages/mobile/src/components/play-drawer/InlineTriesPicker.tsx
@@ -69,9 +69,9 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
   },
   button: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
+    width: 44,
+    height: 44,
+    borderRadius: 22,
     backgroundColor: iosSystemColors.separator,
     alignItems: 'center',
     justifyContent: 'center',

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -10,6 +10,7 @@ import {
   type BottomSheetBackdropProps,
 } from '@gorhom/bottom-sheet';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
+import type { ClimbQueueItem } from '@boardsesh/queue';
 import { randomUUID } from 'expo-crypto';
 import { computeNavigationState, boardSupportsMirroring } from '@boardsesh/play-view';
 import type { ActiveSubDrawer } from '@boardsesh/play-view';
@@ -32,6 +33,27 @@ import { usePlayDrawerWakeLock } from './use-play-drawer-wake-lock';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, sheetStyles } from '../../theme/tokens';
 import { timing } from '../../theme/animations';
+
+function climbToQueueItem(climb: Climb): ClimbQueueItem {
+  return {
+    uuid: randomUUID(),
+    climb: {
+      uuid: climb.uuid,
+      name: climb.name,
+      frames: climb.frames,
+      setter_username: climb.setter_username,
+      angle: climb.angle,
+      ascensionist_count: climb.ascensionist_count,
+      difficulty: climb.difficulty,
+      quality_average: climb.quality_average,
+      stars: climb.stars,
+      difficulty_error: climb.difficulty_error,
+      benchmark_difficulty: climb.benchmark_difficulty,
+      userAscents: climb.userAscents,
+      userAttempts: climb.userAttempts,
+    },
+  };
+}
 
 type BoardConfig = {
   boardName: string;
@@ -127,25 +149,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       setIsTickBarActive(false);
       setIsSheetOpen(true);
       setActiveSubDrawer('none');
-      const queueItem = {
-        uuid: randomUUID(),
-        climb: {
-          uuid: selectedClimb.uuid,
-          name: selectedClimb.name,
-          frames: selectedClimb.frames,
-          setter_username: selectedClimb.setter_username,
-          angle: selectedClimb.angle,
-          ascensionist_count: selectedClimb.ascensionist_count,
-          difficulty: selectedClimb.difficulty,
-          quality_average: selectedClimb.quality_average,
-          stars: selectedClimb.stars,
-          difficulty_error: selectedClimb.difficulty_error,
-          benchmark_difficulty: selectedClimb.benchmark_difficulty,
-          userAscents: selectedClimb.userAscents,
-          userAttempts: selectedClimb.userAttempts,
-        },
-      };
-      setCurrentClimb(queueItem);
+      setCurrentClimb(climbToQueueItem(selectedClimb));
       sheetRef.current?.present();
     },
     close: () => {
@@ -229,24 +233,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       setClimb(similarClimb);
       setIsMirrored(false);
       setIsFavorited(false);
-      const queueItem = {
-        uuid: randomUUID(),
-        climb: {
-          uuid: similarClimb.uuid,
-          name: similarClimb.name,
-          frames: similarClimb.frames,
-          setter_username: similarClimb.setter_username,
-          angle: similarClimb.angle,
-          ascensionist_count: similarClimb.ascensionist_count,
-          difficulty: similarClimb.difficulty,
-          quality_average: similarClimb.quality_average,
-          stars: similarClimb.stars,
-          difficulty_error: similarClimb.difficulty_error,
-          benchmark_difficulty: similarClimb.benchmark_difficulty,
-          userAscents: similarClimb.userAscents,
-          userAttempts: similarClimb.userAttempts,
-        },
-      };
+      const queueItem = climbToQueueItem(similarClimb);
       addToQueue(queueItem);
       setCurrentClimb(queueItem);
     },
@@ -284,7 +271,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
             onPress={() => sheetRef.current?.dismiss()}
             accessibilityRole="button"
             accessibilityLabel={t('playView.closeAria')}
-            hitSlop={8}
             style={styles.closeButton}
           >
             <Icon name="close" size={20} color={iosSystemColors.systemGray} />
@@ -382,49 +368,55 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       </BottomSheetModal>
 
       {/* Sub-drawer: Queue */}
-      <QueueSheet
-        visible={activeSubDrawer === 'queue'}
-        onClose={handleCloseSubDrawer}
-        onClimbPress={(item) => {
-          setClimb(item.climb);
-          setCurrentClimb(item);
-          handleCloseSubDrawer();
-        }}
-      />
+      {activeSubDrawer === 'queue' && (
+        <QueueSheet
+          visible={true}
+          onClose={handleCloseSubDrawer}
+          onClimbPress={(item) => {
+            setClimb(item.climb);
+            setCurrentClimb(item);
+            handleCloseSubDrawer();
+          }}
+        />
+      )}
 
       {/* Sub-drawer: Climb actions */}
-      <ClimbActionsSheet
-        visible={activeSubDrawer === 'actions'}
-        climb={displayedClimb ?? null}
-        boardName={boardName}
-        layoutId={layoutId}
-        sizeId={sizeId}
-        setIds={setIds}
-        angle={angle}
-        onAddToQueue={() => {
-          if (displayedClimb) {
-            addToQueue({
-              uuid: randomUUID(),
-              climb: displayedClimb,
-            });
-          }
-        }}
-        onToggleFavorite={handleToggleFavorite}
-        onClose={handleCloseSubDrawer}
-      />
+      {activeSubDrawer === 'actions' && (
+        <ClimbActionsSheet
+          visible={true}
+          climb={displayedClimb ?? null}
+          boardName={boardName}
+          layoutId={layoutId}
+          sizeId={sizeId}
+          setIds={setIds}
+          angle={angle}
+          onAddToQueue={() => {
+            if (displayedClimb) {
+              addToQueue({
+                uuid: randomUUID(),
+                climb: displayedClimb,
+              });
+            }
+          }}
+          onToggleFavorite={handleToggleFavorite}
+          onClose={handleCloseSubDrawer}
+        />
+      )}
 
       {/* Sub-drawer: Angle selector */}
-      <AngleSelectorSheet
-        visible={activeSubDrawer === 'angleSelector'}
-        onClose={handleCloseSubDrawer}
-        boardName={boardName}
-        layoutId={layoutId}
-        currentAngle={angle}
-        onAngleChange={(newAngle) => {
-          onAngleChange?.(newAngle);
-          handleCloseSubDrawer();
-        }}
-      />
+      {activeSubDrawer === 'angleSelector' && (
+        <AngleSelectorSheet
+          visible={true}
+          onClose={handleCloseSubDrawer}
+          boardName={boardName}
+          layoutId={layoutId}
+          currentAngle={angle}
+          onAngleChange={(newAngle) => {
+            onAngleChange?.(newAngle);
+            handleCloseSubDrawer();
+          }}
+        />
+      )}
 
       {/* Log Ascent sheet (full, via long-press) */}
       {displayedClimb && (
@@ -456,9 +448,9 @@ const styles = StyleSheet.create({
     top: 8,
     right: 8,
     zIndex: 2,
-    width: 32,
-    height: 32,
-    borderRadius: 16,
+    width: 44,
+    height: 44,
+    borderRadius: 22,
     backgroundColor: 'rgba(120, 120, 128, 0.12)',
     alignItems: 'center',
     justifyContent: 'center',

--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
 import { BottomSheetFlatList } from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
@@ -13,36 +13,31 @@ import { brandColors } from '../../theme/colors';
 
 type QueueListProps = {
   queue: ClimbQueueItem[];
-  currentClimbUuid: string | null;
+  currentItemUuid: string | null;
   isEditMode: boolean;
   showHistory: boolean;
   showFullHistory: boolean;
   selectedItems: Set<string>;
+  autoScrollOnMount?: boolean;
   onToggleSelect: (uuid: string) => void;
   onClimbPress: (item: ClimbQueueItem) => void;
   onRemove: (uuid: string) => void;
   onShowFullHistory: () => void;
 };
 
-export type QueueListHandle = {
-  scrollToCurrentClimb: () => void;
-};
-
-export const QueueList = forwardRef<QueueListHandle, QueueListProps>(function QueueList(
-  {
-    queue,
-    currentClimbUuid,
-    isEditMode,
-    showHistory,
-    showFullHistory,
-    selectedItems,
-    onToggleSelect,
-    onClimbPress,
-    onRemove,
-    onShowFullHistory,
-  },
-  ref,
-) {
+export function QueueList({
+  queue,
+  currentItemUuid,
+  isEditMode,
+  showHistory,
+  showFullHistory,
+  selectedItems,
+  autoScrollOnMount,
+  onToggleSelect,
+  onClimbPress,
+  onRemove,
+  onShowFullHistory,
+}: QueueListProps) {
   const { t } = useTranslation('session');
   const { systemColors } = useTheme();
   const flatListRef = useRef<InstanceType<typeof BottomSheetFlatList>>(null);
@@ -57,28 +52,27 @@ export const QueueList = forwardRef<QueueListHandle, QueueListProps>(function Qu
   }, []);
 
   const { flatRows, currentItemFlatIndex } = useMemo(
-    () => buildQueueListModel(queue, currentClimbUuid, { showHistory, showFullHistory }),
-    [queue, currentClimbUuid, showHistory, showFullHistory],
+    () => buildQueueListModel(queue, currentItemUuid, { showHistory, showFullHistory }),
+    [queue, currentItemUuid, showHistory, showFullHistory],
   );
 
-  useImperativeHandle(ref, () => ({
-    scrollToCurrentClimb: () => {
-      if (currentItemFlatIndex >= 0 && flatRows.length > 0) {
-        if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
-        scrollTimerRef.current = setTimeout(() => {
-          (
-            flatListRef.current as unknown as {
-              scrollToIndex?: (params: { index: number; animated: boolean; viewPosition: number }) => void;
-            }
-          )?.scrollToIndex?.({
-            index: currentItemFlatIndex,
-            animated: true,
-            viewPosition: 0.3,
-          });
-        }, 300);
-      }
-    },
-  }));
+  useEffect(() => {
+    if (autoScrollOnMount && currentItemFlatIndex >= 0 && flatRows.length > 0) {
+      const timer = setTimeout(() => {
+        (
+          flatListRef.current as {
+            scrollToIndex?: (params: { index: number; animated: boolean; viewPosition: number }) => void;
+          }
+        )?.scrollToIndex?.({
+          index: currentItemFlatIndex,
+          animated: true,
+          viewPosition: 0.3,
+        });
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [autoScrollOnMount, currentItemFlatIndex, flatRows.length]);
 
   const keyExtractor = useCallback((row: QueueFlatRow, index: number): string => {
     switch (row.type) {
@@ -102,7 +96,12 @@ export const QueueList = forwardRef<QueueListHandle, QueueListProps>(function Qu
       switch (row.type) {
         case 'history-show-all':
           return (
-            <Pressable onPress={onShowFullHistory} style={styles.showAllRow} accessibilityRole="button">
+            <Pressable
+              onPress={onShowFullHistory}
+              style={styles.showAllRow}
+              accessibilityRole="button"
+              accessibilityLabel={t('queueList.showFullHistoryAria', { count: row.hiddenCount })}
+            >
               <Text variant="subheadline" color={brandColors.primary}>
                 {t('queueList.showFullHistory', { count: row.hiddenCount })}
               </Text>
@@ -185,7 +184,7 @@ export const QueueList = forwardRef<QueueListHandle, QueueListProps>(function Qu
       }}
     />
   );
-});
+}
 
 const styles = StyleSheet.create({
   listContent: {

--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -5,7 +5,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { QueueSheetHeader } from './QueueSheetHeader';
-import { QueueList, type QueueListHandle } from './QueueList';
+import { QueueList } from './QueueList';
 import { Text } from '../Text';
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
@@ -25,10 +25,8 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
   const insets = useSafeAreaInsets();
   const { systemColors } = useTheme();
   const sheetRef = useRef<BottomSheet>(null);
-  const listRef = useRef<QueueListHandle>(null);
-  const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { state, removeFromQueue } = useQueue();
+  const { state, removeFromQueue, clearQueue } = useQueue();
   const { queue, currentClimbQueueItem } = state;
 
   const [isEditMode, setIsEditMode] = useState(false);
@@ -38,23 +36,14 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
 
   const snapPoints = useMemo(() => ['60%', '90%'], []);
 
-  const currentClimbUuid = currentClimbQueueItem?.climb.uuid ?? null;
+  const currentItemUuid = currentClimbQueueItem?.uuid ?? null;
 
   useEffect(() => {
     if (visible) {
       sheetRef.current?.snapToIndex(0);
-      scrollTimerRef.current = setTimeout(() => {
-        listRef.current?.scrollToCurrentClimb();
-      }, 400);
     } else {
       sheetRef.current?.close();
     }
-    return () => {
-      if (scrollTimerRef.current) {
-        clearTimeout(scrollTimerRef.current);
-        scrollTimerRef.current = null;
-      }
-    };
   }, [visible]);
 
   const resetState = useCallback(() => {
@@ -108,12 +97,10 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
 
   const handleClearAll = useCallback(() => {
     hapticWarning();
-    for (const item of queue) {
-      removeFromQueue(item.uuid);
-    }
+    clearQueue();
     setIsEditMode(false);
     setSelectedItems(new Set());
-  }, [queue, removeFromQueue]);
+  }, [clearQueue]);
 
   const handleBulkRemove = useCallback(() => {
     hapticMedium();
@@ -166,13 +153,13 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
       />
 
       <QueueList
-        ref={listRef}
         queue={queue}
-        currentClimbUuid={currentClimbUuid}
+        currentItemUuid={currentItemUuid}
         isEditMode={isEditMode}
         showHistory={showHistory}
         showFullHistory={showFullHistory}
         selectedItems={selectedItems}
+        autoScrollOnMount={visible}
         onToggleSelect={handleToggleSelect}
         onClimbPress={onClimbPress}
         onRemove={handleRemove}

--- a/packages/mobile/src/components/play-drawer/QueueSheetHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheetHeader.tsx
@@ -154,11 +154,11 @@ const styles = StyleSheet.create({
     gap: spacing[2],
   },
   headerButton: {
-    width: 36,
-    height: 36,
+    width: 44,
+    height: 44,
     alignItems: 'center',
     justifyContent: 'center',
-    borderRadius: 18,
+    borderRadius: 22,
     backgroundColor: `${iosSystemColors.systemGray}1F`,
   },
   headerButtonActive: {

--- a/packages/mobile/src/components/play-drawer/index.ts
+++ b/packages/mobile/src/components/play-drawer/index.ts
@@ -6,7 +6,7 @@ export { SwipeBoardCarousel } from './SwipeBoardCarousel';
 export { QuickTickBar } from './QuickTickBar';
 export { QueueSheet } from './QueueSheet';
 export { QueueSheetHeader } from './QueueSheetHeader';
-export { QueueList, type QueueListHandle } from './QueueList';
+export { QueueList } from './QueueList';
 export { AngleSelectorSheet } from './AngleSelectorSheet';
 export { DeferredSections } from './DeferredSections';
 export { CollapsibleSection } from './CollapsibleSection';

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -41,6 +41,7 @@ type QueueContextValue = {
   setSessionId: (id: string | null) => void;
   addToQueue: (item: ClimbQueueItem) => void;
   removeFromQueue: (uuid: string) => void;
+  clearQueue: () => void;
   setCurrentClimb: (item: ClimbQueueItem) => void;
   nextClimb: () => void;
   previousClimb: () => void;
@@ -264,6 +265,19 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  const clearQueue = useCallback(() => {
+    const itemsToRemove = stateRef.current.queue;
+    dispatch({ type: 'CLEAR_QUEUE' });
+
+    if (sessionIdRef.current) {
+      for (const item of itemsToRemove) {
+        getHttpClient()
+          .request<RemoveQueueItemMutationResponse>(REMOVE_QUEUE_ITEM, { uuid: item.uuid })
+          .catch(() => showToast(t('mobile.queue.actionFailed'), 'error'));
+      }
+    }
+  }, []);
+
   const setCurrentClimb = useCallback(
     (item: ClimbQueueItem) => {
       dispatch({
@@ -365,6 +379,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       setSessionId,
       addToQueue,
       removeFromQueue,
+      clearQueue,
       setCurrentClimb,
       nextClimb,
       previousClimb,
@@ -376,6 +391,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       sessionId,
       addToQueue,
       removeFromQueue,
+      clearQueue,
       setCurrentClimb,
       nextClimb,
       previousClimb,

--- a/packages/shared/play-view/src/__tests__/queue-list-model.test.ts
+++ b/packages/shared/play-view/src/__tests__/queue-list-model.test.ts
@@ -40,7 +40,7 @@ describe('buildQueueListModel', () => {
 
   it('splits queue into history, current, and future', () => {
     const queue = [makeItem('q1', 'c1'), makeItem('q2', 'c2'), makeItem('q3', 'c3'), makeItem('q4', 'c4')];
-    const result = buildQueueListModel(queue, 'c2', { showHistory: true, showFullHistory: false });
+    const result = buildQueueListModel(queue, 'q2', { showHistory: true, showFullHistory: false });
 
     const types = result.flatRows.map((row) => row.type);
     expect(types).toEqual(['history-item', 'history-divider', 'current-item', 'future-item', 'future-item']);
@@ -51,7 +51,7 @@ describe('buildQueueListModel', () => {
 
   it('hides history items beyond the limit', () => {
     const queue = Array.from({ length: 10 }, (_, i) => makeItem(`q${i}`, `c${i}`));
-    const result = buildQueueListModel(queue, 'c8', {
+    const result = buildQueueListModel(queue, 'q8', {
       showHistory: true,
       showFullHistory: false,
       historyDisplayLimit: 3,
@@ -68,7 +68,7 @@ describe('buildQueueListModel', () => {
 
   it('shows all history when showFullHistory is true', () => {
     const queue = Array.from({ length: 10 }, (_, i) => makeItem(`q${i}`, `c${i}`));
-    const result = buildQueueListModel(queue, 'c8', {
+    const result = buildQueueListModel(queue, 'q8', {
       showHistory: true,
       showFullHistory: true,
       historyDisplayLimit: 3,
@@ -83,7 +83,7 @@ describe('buildQueueListModel', () => {
 
   it('skips history entirely when showHistory is false', () => {
     const queue = [makeItem('q1', 'c1'), makeItem('q2', 'c2'), makeItem('q3', 'c3')];
-    const result = buildQueueListModel(queue, 'c2', { showHistory: false, showFullHistory: false });
+    const result = buildQueueListModel(queue, 'q2', { showHistory: false, showFullHistory: false });
 
     const types = result.flatRows.map((row) => row.type);
     expect(types).toEqual(['current-item', 'future-item']);
@@ -91,7 +91,7 @@ describe('buildQueueListModel', () => {
 
   it('handles current climb at queue start', () => {
     const queue = [makeItem('q1', 'c1'), makeItem('q2', 'c2')];
-    const result = buildQueueListModel(queue, 'c1', { showHistory: true, showFullHistory: false });
+    const result = buildQueueListModel(queue, 'q1', { showHistory: true, showFullHistory: false });
 
     const types = result.flatRows.map((row) => row.type);
     expect(types).toEqual(['current-item', 'future-item']);
@@ -100,7 +100,7 @@ describe('buildQueueListModel', () => {
 
   it('handles current climb at queue end', () => {
     const queue = [makeItem('q1', 'c1'), makeItem('q2', 'c2')];
-    const result = buildQueueListModel(queue, 'c2', { showHistory: true, showFullHistory: false });
+    const result = buildQueueListModel(queue, 'q2', { showHistory: true, showFullHistory: false });
 
     const types = result.flatRows.map((row) => row.type);
     expect(types).toEqual(['history-item', 'history-divider', 'current-item']);
@@ -109,7 +109,7 @@ describe('buildQueueListModel', () => {
 
   it('preserves queueIndex for all item rows', () => {
     const queue = [makeItem('q0', 'c0'), makeItem('q1', 'c1'), makeItem('q2', 'c2'), makeItem('q3', 'c3')];
-    const result = buildQueueListModel(queue, 'c1', { showHistory: true, showFullHistory: true });
+    const result = buildQueueListModel(queue, 'q1', { showHistory: true, showFullHistory: true });
 
     const itemRows = result.flatRows.filter(
       (row): row is Extract<QueueFlatRow, { type: 'history-item' | 'current-item' | 'future-item' }> =>
@@ -119,9 +119,28 @@ describe('buildQueueListModel', () => {
     expect(itemRows.map((row) => row.queueIndex)).toEqual([0, 1, 2, 3]);
   });
 
+  it('matches correct queue-item when same climb appears twice in queue', () => {
+    // Same climb UUID but different queue-item UUIDs
+    const queue = [makeItem('q1', 'shared-climb'), makeItem('q2', 'shared-climb'), makeItem('q3', 'c3')];
+    const result = buildQueueListModel(queue, 'q2', { showHistory: true, showFullHistory: true });
+
+    const types = result.flatRows.map((row) => row.type);
+    expect(types).toEqual(['history-item', 'history-divider', 'current-item', 'future-item']);
+
+    // The current item should be the second queue entry (q2), not the first (q1)
+    const currentRow = result.flatRows[result.currentItemFlatIndex] as Extract<QueueFlatRow, { type: 'current-item' }>;
+    expect(currentRow.item.uuid).toBe('q2');
+    expect(currentRow.item.climb.uuid).toBe('shared-climb');
+
+    // The first entry (q1) should be in history
+    const historyRow = result.flatRows[0] as Extract<QueueFlatRow, { type: 'history-item' }>;
+    expect(historyRow.item.uuid).toBe('q1');
+    expect(historyRow.item.climb.uuid).toBe('shared-climb');
+  });
+
   it('uses default history limit of 5', () => {
     const queue = Array.from({ length: 12 }, (_, i) => makeItem(`q${i}`, `c${i}`));
-    const result = buildQueueListModel(queue, 'c10', { showHistory: true, showFullHistory: false });
+    const result = buildQueueListModel(queue, 'q10', { showHistory: true, showFullHistory: false });
 
     const showAllRow = result.flatRows.find((row) => row.type === 'history-show-all') as
       | Extract<QueueFlatRow, { type: 'history-show-all' }>

--- a/packages/shared/play-view/src/__tests__/url-utils.test.ts
+++ b/packages/shared/play-view/src/__tests__/url-utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { buildClimbViewPath } from '../url-utils';
+
+describe('buildClimbViewPath', () => {
+  it('builds a correct climb view path', () => {
+    expect(buildClimbViewPath('kilter', 1, 10, '12,34', 40, 'abc-123')).toBe('/kilter/1/10/12,34/40/view/abc-123');
+  });
+
+  it('handles different board names', () => {
+    expect(buildClimbViewPath('tension', 2, 20, '56', 25, 'xyz-789')).toBe('/tension/2/20/56/25/view/xyz-789');
+  });
+});

--- a/packages/shared/play-view/src/index.ts
+++ b/packages/shared/play-view/src/index.ts
@@ -5,3 +5,4 @@ export * from './grade-display';
 export * from './tick-utils';
 export * from './quick-tick-state';
 export * from './board-utils';
+export { buildClimbViewPath } from './url-utils';

--- a/packages/shared/play-view/src/queue-list-model.ts
+++ b/packages/shared/play-view/src/queue-list-model.ts
@@ -16,7 +16,7 @@ export type QueueListModel = {
 
 export function buildQueueListModel(
   queue: ClimbQueue,
-  currentClimbUuid: string | null,
+  currentItemUuid: string | null,
   options: {
     showHistory: boolean;
     showFullHistory: boolean;
@@ -27,7 +27,7 @@ export function buildQueueListModel(
   const rows: QueueFlatRow[] = [];
   let currentItemFlatIndex = -1;
 
-  const currentIndex = currentClimbUuid ? queue.findIndex((item) => item.climb.uuid === currentClimbUuid) : -1;
+  const currentIndex = currentItemUuid ? queue.findIndex((item) => item.uuid === currentItemUuid) : -1;
 
   const historyItems = currentIndex > 0 ? queue.slice(0, currentIndex) : [];
   const currentItem = currentIndex >= 0 ? queue[currentIndex] : null;

--- a/packages/shared/play-view/src/url-utils.ts
+++ b/packages/shared/play-view/src/url-utils.ts
@@ -1,0 +1,10 @@
+export function buildClimbViewPath(
+  boardName: string,
+  layoutId: number,
+  sizeId: number,
+  setIds: string,
+  angle: number,
+  climbUuid: string,
+): string {
+  return `/${boardName}/${layoutId}/${sizeId}/${setIds}/${angle}/view/${climbUuid}`;
+}

--- a/packages/shared/queue/src/reducer.ts
+++ b/packages/shared/queue/src/reducer.ts
@@ -376,6 +376,14 @@ export function queueReducer<TSearchParams extends QueueSearchParams>(
         needsResync: false,
       };
 
+    case 'CLEAR_QUEUE':
+      return {
+        ...state,
+        queue: [],
+        currentClimbQueueItem: null,
+        playlistSuggestionSource: null,
+      };
+
     case 'OPTIMISTIC_SET_DRIVER':
       // Fired from `takeControl` so the lightbulb flips before the server
       // round-trip. Idempotent — re-setting the same participant id is a no-op

--- a/packages/shared/queue/src/types.ts
+++ b/packages/shared/queue/src/types.ts
@@ -130,4 +130,5 @@ export type QueueAction<TSearchParams extends QueueSearchParams = QueueSearchPar
   | { type: 'CLEANUP_PENDING_UPDATES_BATCH'; payload: { correlationIds: string[] } }
   | { type: 'CLEAR_RESYNC_FLAG' }
   | { type: 'OPTIMISTIC_SET_DRIVER'; payload: { participantId: string } }
-  | { type: 'OPTIMISTIC_CLEAR_DRIVER' };
+  | { type: 'OPTIMISTIC_CLEAR_DRIVER' }
+  | { type: 'CLEAR_QUEUE' };

--- a/packages/web/app/components/queue-control/queue-list.tsx
+++ b/packages/web/app/components/queue-control/queue-list.tsx
@@ -15,6 +15,7 @@ import type { Climb, BoardDetails } from '@/app/lib/types';
 import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
 import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
 import { reorder } from '@atlaskit/pragmatic-drag-and-drop/reorder';
+import { buildQueueListModel, type QueueFlatRow } from '@boardsesh/play-view';
 import { usePathname, useParams } from 'next/navigation';
 import { useLocaleRouter } from '@/app/lib/i18n/use-locale-router';
 import { useSession } from 'next-auth/react';
@@ -231,54 +232,21 @@ const QueueList = forwardRef<QueueListHandle, QueueListProps>(
 
     // Build the flat row model for the unified virtualizer
     const { flatRows, scrollTargetFlatIndex } = useMemo(() => {
-      const rows: FlatRow[] = [];
-      let scrollTargetIdx = -1;
+      const sharedModel = buildQueueListModel(queue, currentClimbUuid, {
+        showHistory,
+        showFullHistory,
+        historyDisplayLimit: DEFAULT_HISTORY_DISPLAY_LIMIT,
+      });
 
-      const currentIndex = queue.findIndex((item) => item.uuid === currentClimbUuid);
-      const historyItems = currentIndex > 0 ? queue.slice(0, currentIndex) : [];
-      const currentItem = currentIndex >= 0 ? queue[currentIndex] : null;
-      // When no current climb (currentIndex === -1), show entire queue as future items
-      const futureItems = currentIndex >= 0 ? queue.slice(currentIndex + 1) : queue;
+      const rows: FlatRow[] = [...(sharedModel.flatRows as FlatRow[])];
+      const scrollTargetIdx = sharedModel.currentItemFlatIndex;
 
-      // History items — render at most DEFAULT_HISTORY_DISPLAY_LIMIT (most
-      // recent) by default. The full backlog unfolds when the user taps the
-      // "Show full history" row. queueIndex always tracks the position in the
-      // full queue so re-orders + selection state stay consistent.
-      if (showHistory && historyItems.length > 0) {
-        const hiddenCount = showFullHistory ? 0 : Math.max(0, historyItems.length - DEFAULT_HISTORY_DISPLAY_LIMIT);
-        if (hiddenCount > 0) {
-          rows.push({ type: 'history-show-all', hiddenCount });
-        }
-        const firstRenderedIdx = hiddenCount;
-        for (let i = firstRenderedIdx; i < historyItems.length; i++) {
-          rows.push({ type: 'history-item', item: historyItems[i], queueIndex: i });
-        }
-        rows.push({ type: 'history-divider' });
-      }
-
-      // Current item — always the scroll target so the virtualizer can center
-      // it on open. Fallback to the first future item when nothing is lit yet.
-      if (currentItem) {
-        scrollTargetIdx = rows.length;
-        rows.push({ type: 'current-item', item: currentItem, queueIndex: currentIndex });
-      }
-
-      // Future items
-      for (let i = 0; i < futureItems.length; i++) {
-        const originalIndex = currentIndex >= 0 ? currentIndex + 1 + i : i;
-        if (i === 0 && !currentItem) {
-          scrollTargetIdx = rows.length;
-        }
-        rows.push({ type: 'future-item', item: futureItems[i], queueIndex: originalIndex });
-      }
-
-      // Next up section (only when active and not viewOnlyMode)
+      // Web-only: suggestion section (only when active and not viewOnlyMode)
       if (active && !viewOnlyMode) {
         rows.push({ type: 'suggestion-header' });
         for (let i = 0; i < suggestedClimbs.length; i++) {
           rows.push({ type: 'suggestion', climb: suggestedClimbs[i] });
         }
-        // Loading or end message
         if (suggestedClimbs.length > 0 || isFetchingClimbs || isFetchingNextPage) {
           if (isFetchingClimbs || isFetchingNextPage) {
             rows.push({ type: 'loading' });

--- a/packages/web/i18n/locales/en-US/session.json
+++ b/packages/web/i18n/locales/en-US/session.json
@@ -222,6 +222,8 @@
     "endMessage": "That's all for now",
     "showFullHistory_one": "Show full history ({{count}} more)",
     "showFullHistory_other": "Show full history ({{count}} more)",
+    "showFullHistoryAria_one": "Show {{count}} more item from history",
+    "showFullHistoryAria_other": "Show {{count}} more items from history",
     "tickHistoryClimb": "Log a tick for {{name}}"
   },
   "queueProvider": {
@@ -348,7 +350,9 @@
       "sendSaveLabel": "Send",
       "logAscentAria": "Log {{status}}",
       "decreaseTriesAria": "Decrease attempts",
-      "increaseTriesAria": "Increase attempts"
+      "increaseTriesAria": "Increase attempts",
+      "starRating_one": "{{count}} star",
+      "starRating_other": "{{count}} stars"
     }
   }
 }

--- a/packages/web/i18n/locales/es/session.json
+++ b/packages/web/i18n/locales/es/session.json
@@ -222,6 +222,8 @@
     "endMessage": "Eso es todo por ahora",
     "showFullHistory_one": "Mostrar historial completo ({{count}} más)",
     "showFullHistory_other": "Mostrar historial completo ({{count}} más)",
+    "showFullHistoryAria_one": "Mostrar {{count}} elemento más del historial",
+    "showFullHistoryAria_other": "Mostrar {{count}} elementos más del historial",
     "tickHistoryClimb": "Registrar un tick para {{name}}"
   },
   "queueProvider": {
@@ -340,15 +342,17 @@
       "tickLabel": "marca",
       "logAttemptAria": "Registrar intento",
       "saveTickAria": "Guardar marca",
-      "gradeLabel": "Grade",
-      "triesLabel": "Tries",
-      "starsLabel": "Stars",
-      "cancelLabel": "Cancel",
+      "gradeLabel": "Grado",
+      "triesLabel": "Intentos",
+      "starsLabel": "Estrellas",
+      "cancelLabel": "Cancelar",
       "flashSaveLabel": "Flash",
-      "sendSaveLabel": "Send",
-      "logAscentAria": "Log {{status}}",
-      "decreaseTriesAria": "Decrease attempts",
-      "increaseTriesAria": "Increase attempts"
+      "sendSaveLabel": "Envío",
+      "logAscentAria": "Registrar {{status}}",
+      "decreaseTriesAria": "Disminuir intentos",
+      "increaseTriesAria": "Aumentar intentos",
+      "starRating_one": "{{count}} estrella",
+      "starRating_other": "{{count}} estrellas"
     }
   }
 }

--- a/packages/web/i18n/locales/fr/session.json
+++ b/packages/web/i18n/locales/fr/session.json
@@ -222,6 +222,8 @@
     "endMessage": "C'est tout pour l'instant",
     "showFullHistory_one": "Afficher l'historique complet ({{count}} de plus)",
     "showFullHistory_other": "Afficher l'historique complet ({{count}} de plus)",
+    "showFullHistoryAria_one": "Afficher {{count}} element de plus de l'historique",
+    "showFullHistoryAria_other": "Afficher {{count}} elements de plus de l'historique",
     "tickHistoryClimb": "Enregistrer une croix pour {{name}}"
   },
   "queueProvider": {
@@ -340,15 +342,17 @@
       "tickLabel": "tick",
       "logAttemptAria": "Enregistrer un essai",
       "saveTickAria": "Enregistrer le tick",
-      "gradeLabel": "Grade",
-      "triesLabel": "Tries",
-      "starsLabel": "Stars",
-      "cancelLabel": "Cancel",
+      "gradeLabel": "Cotation",
+      "triesLabel": "Essais",
+      "starsLabel": "Étoiles",
+      "cancelLabel": "Annuler",
       "flashSaveLabel": "Flash",
-      "sendSaveLabel": "Send",
-      "logAscentAria": "Log {{status}}",
-      "decreaseTriesAria": "Decrease attempts",
-      "increaseTriesAria": "Increase attempts"
+      "sendSaveLabel": "Envoi",
+      "logAscentAria": "Enregistrer {{status}}",
+      "decreaseTriesAria": "Diminuer les essais",
+      "increaseTriesAria": "Augmenter les essais",
+      "starRating_one": "{{count}} etoile",
+      "starRating_other": "{{count}} etoiles"
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes 15 of 20 code review findings from #2306 (review of PR #2303).

- **Critical bug**: `buildQueueListModel` matched by climb UUID instead of queue-item UUID — duplicate climbs in queue highlighted wrong row
- **3 more bugs**: leaked timer on rapid open/close, angle sheet effect re-firing on refetch, stale swipe visual on edit toggle
- **Design**: imperative `QueueListHandle` → declarative `autoScrollOnMount`, sub-drawers conditionally rendered, `CLEAR_QUEUE` batch action, animated `CollapsibleSection`, extracted `climbToQueueItem` helper
- **Shared code**: web adopts shared `buildQueueListModel`, new shared `buildClimbViewPath` in `@boardsesh/play-view`
- **i18n**: 9 tickBar keys translated to Spanish/French, star rating a11y label translated
- **Accessibility**: 4 components bumped to 44dp hit targets, added missing `accessibilityLabel` on "Show N more"

### Deferred to follow-up

| # | Item | Why |
|---|------|-----|
| 13 | Angle selector GraphQL→static | Static data needs layout-dimension extension |
| 12 | formatLogbookSummary extraction | 4-line branching, not worth coupling |
| 18 | Section ordering | Intentional mobile UX divergence |
| 19 | Missing ClimbActions | Net-new features (playlist, edit, Instagram) |
| 20 | Per-angle stats | Net-new feature requiring data fetching |

## Test plan

- [ ] Open play drawer → queue sheet shows correct current climb highlight
- [ ] Add same climb twice → both rows get distinct highlights
- [ ] Toggle edit mode mid-swipe → swiped row snaps back
- [ ] Open/close sub-drawers rapidly → no leaked scroll or crash
- [ ] Angle selector stays stable on background refetch
- [ ] Clear All in queue edit mode → single state update, queue empties
- [ ] CollapsibleSection expands/collapses with fade animation
- [ ] Verify 44dp touch targets on queue header, tries picker, stars, close button
- [ ] Switch device to Spanish/French → tickBar labels show translated text
- [ ] `vp test run` — shared play-view tests pass (65/65)
- [ ] `vp run check:mobile-bundle` — Metro bundles compile
- [ ] `vp run typecheck:web` — web typecheck passes

Closes #2306

🤖 Generated with [Claude Code](https://claude.com/claude-code)