### PR TITLE
fix(ci): update bun lockfile to include @boardsesh/climb-filters workspace

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -145,6 +145,7 @@
         "@boardsesh/ble-protocol": "*",
         "@boardsesh/board-config": "*",
         "@boardsesh/board-constants": "*",
+        "@boardsesh/climb-filters": "*",
         "@boardsesh/play-view": "*",
         "@boardsesh/queue": "*",
         "@boardsesh/shared-schema": "*",
@@ -244,6 +245,16 @@
         "typescript": "^5.9.3",
       },
     },
+    "packages/shared/climb-filters": {
+      "name": "@boardsesh/climb-filters",
+      "version": "1.0.0",
+      "dependencies": {
+        "@boardsesh/shared-schema": "*",
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+      },
+    },
     "packages/shared/play-view": {
       "name": "@boardsesh/play-view",
       "version": "1.0.0",
@@ -277,6 +288,7 @@
         "@boardsesh/board-config": "*",
         "@boardsesh/board-constants": "*",
         "@boardsesh/board-renderer-wasm": "*",
+        "@boardsesh/climb-filters": "*",
         "@boardsesh/crypto": "*",
         "@boardsesh/db": "*",
         "@boardsesh/play-view": "*",
@@ -675,6 +687,8 @@
     "@boardsesh/board-constants": ["@boardsesh/board-constants@workspace:packages/board-constants"],
 
     "@boardsesh/board-renderer-wasm": ["@boardsesh/board-renderer-wasm@workspace:packages/board-renderer/wasm"],
+
+    "@boardsesh/climb-filters": ["@boardsesh/climb-filters@workspace:packages/shared/climb-filters"],
 
     "@boardsesh/crypto": ["@boardsesh/crypto@workspace:packages/crypto"],
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The `@boardsesh/climb-filters` package was added to the monorepo but `bun.lock` was not updated alongside it
- iOS CI builds failed with `lockfile had changes, but lockfile is frozen` because `bun install --frozen-lockfile` detected the stale lockfile
- This PR simply runs `bun install` and commits the 14-line lockfile diff

## Test plan

- [ ] iOS CI build passes (`bun install --frozen-lockfile` succeeds)
- [ ] No other packages changed — diff is lockfile only

https://claude.ai/code/session_015xtsFHXepEgLqUKJXa76UX
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015xtsFHXepEgLqUKJXa76UX)_