### PR TITLE
fix(mobile): play view drawer crash on open (SIGABRT)

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
-import { View, Pressable, StyleSheet, Image } from 'react-native';
+import { View, Pressable, StyleSheet } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -104,15 +104,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       setIds: parsedSetIds,
     });
   }, [boardName, layoutId, sizeId, setIds]);
-
-  const imageUrls = boardRenderData?.imageUrls;
-  useEffect(() => {
-    if (imageUrls) {
-      for (const url of imageUrls) {
-        Image.prefetch(url);
-      }
-    }
-  }, [imageUrls]);
 
   const navigationState = useMemo(
     () => computeNavigationState(state.queue, state.currentClimbQueueItem),
@@ -293,6 +284,9 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
                   <SwipeBoardCarousel
                     boardName={boardName as BoardName}
                     boardRenderData={boardRenderData}
+                    layoutId={layoutId}
+                    sizeId={sizeId}
+                    setIds={setIds}
                     currentFrames={displayedClimb.frames}
                     nextFrames={navigationState.nextItem?.climb.frames ?? null}
                     prevFrames={navigationState.prevItem?.climb.frames ?? null}


### PR DESCRIPTION
## Summary

- **Root cause:** The Phase 3 merge (`feat/mobile-play-drawer-phase3`) overwrote `PlayDrawer.tsx` changes from commit `04a8a93` that wired `layoutId`, `sizeId`, and `setIds` into `SwipeBoardCarousel`. Without them, `BoardImageNative` → `useNativeClimbRender` received `undefined` values, causing the Rust FFI renderer to crash with SIGABRT on a background thread.
- **Fix:** Re-apply the lost props (`layoutId`, `sizeId`, `setIds`) to the `SwipeBoardCarousel` call in `PlayDrawer.tsx`
- **Cleanup:** Remove the dead `Image.prefetch` code that was supposed to be removed in the same lost commit — the native renderer uses bundled assets, not network-fetched images

## Test plan

- [ ] Open the play view drawer by tapping any climb — app should no longer crash
- [ ] Verify the board image renders correctly (background layers + hold overlay)
- [ ] Swipe left/right to navigate queue — peek board images should also render
- [ ] Toggle mirror mode — board should flip correctly
- [ ] `vp run typecheck:mobile` passes (no missing-prop errors)
- [ ] `vp run check:mobile-bundle` passes (Metro bundle compiles)

https://claude.ai/code/session_015CK37ARSrze34KPFqbEuC1

---
_Generated by [Claude Code](https://claude.ai/code/session_015CK37ARSrze34KPFqbEuC1)_