### PR TITLE
fix(mobile): lock PlayDrawer to 100% with top safe-area inset

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -239,7 +239,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     [],
   );
 
-  const snapPoints = useMemo(() => ['95%'], []);
+  const snapPoints = useMemo(() => ['100%'], []);
 
   const ascentCount = displayedClimb?.userAscents ?? 0;
   const supportsMirroring = boardSupportsMirroring(boardName, layoutId);
@@ -250,6 +250,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       <BottomSheetModal
         ref={sheetRef}
         snapPoints={snapPoints}
+        topInset={insets.top}
         enablePanDownToClose
         enableContentPanningGesture={!subDrawerOpen}
         enableHandlePanningGesture={!subDrawerOpen}
@@ -258,7 +259,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         handleIndicatorStyle={sheetStyles.indicator}
         backgroundStyle={sheetStyles.background}
       >
-        <BottomSheetScrollView style={styles.content} contentContainerStyle={{ paddingBottom: insets.bottom }}>
+        <BottomSheetScrollView
+          style={styles.content}
+          contentContainerStyle={{ paddingTop: spacing[2], paddingBottom: insets.bottom }}
+        >
           <Pressable
             onPress={() => sheetRef.current?.dismiss()}
             accessibilityRole="button"


### PR DESCRIPTION
## Summary

- Locks the play-view drawer at a single 100% snap point so it can't over-pan into the dynamic island when the user scrolls.
- Adds `topInset={insets.top}` on the `BottomSheetModal` so the sheet's top edge always sits below the dynamic island.
- Adds a small `paddingTop: spacing[2]` to the inner `BottomSheetScrollView` so the climb name + grade have breathing room below the grabber.

Previously the drawer opened at `'95%'`. On first open the climb header sat just below the dynamic island, but as soon as the user scrolled, the gesture would let the sheet expand further and the climb name ended up partially under the dynamic island cutout.

## Test plan

- [ ] Open the Climbs tab on an iPhone with a dynamic island (14 Pro+ simulator) and tap a row.
- [ ] Confirm the play drawer slides up and the climb name + grade sit clearly below the dynamic island, with the grabber visible above them.
- [ ] Scroll the drawer content up and down — the climb name must stay below the dynamic island the entire time (no "expand a bit more" shift).
- [ ] Pan the drawer down to dismiss — confirm it still closes cleanly.
- [ ] Tap the close (✕) button — confirm it still dismisses.
- [ ] Open a queue sub-drawer / actions sheet / angle selector / log ascent sheet on top of the play drawer — confirm none of them regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)