### PR TITLE
test(ble): add dispatchMoonboardPacket + fix import ordering + CI pull_request trigger

### DIFF
--- a/.github/workflows/mobile-tests.yml
+++ b/.github/workflows/mobile-tests.yml
@@ -10,6 +10,14 @@ on:
       - 'packages/shared-schema/**'
       - 'vite.config.ts'
       - '.github/workflows/mobile-tests.yml'
+  pull_request:
+    paths:
+      - 'packages/mobile/**'
+      - 'packages/shared/**'
+      - 'packages/board-constants/**'
+      - 'packages/shared-schema/**'
+      - 'vite.config.ts'
+      - '.github/workflows/mobile-tests.yml'
   workflow_dispatch:
 
 jobs:

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -16,10 +16,11 @@ import { springs } from '../theme/animations';
 import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
-export type { ClimbFilters } from '../lib/climb-filter-types';
-export { DEFAULT_FILTERS } from '../lib/climb-filter-types';
 import type { ClimbFilters } from '../lib/climb-filter-types';
 import { DEFAULT_FILTERS } from '../lib/climb-filter-types';
+
+export type { ClimbFilters };
+export { DEFAULT_FILTERS };
 
 type ClimbFilterSheetProps = {
   visible: boolean;

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { HoldPlacement } from '../../../components/board-renderer/types';
 
 // ── Mock native modules that use-board-bluetooth.ts imports transitively ──
@@ -18,17 +18,18 @@ vi.mock('@boardsesh/ble-protocol/aurora', () => ({
   parseSerialNumber: vi.fn(),
 }));
 
+const mockGetMoonboardBluetoothPacket = vi.hoisted(() => vi.fn());
 vi.mock('@boardsesh/ble-protocol/moonboard', () => ({
-  getMoonboardBluetoothPacket: vi.fn(),
+  getMoonboardBluetoothPacket: mockGetMoonboardBluetoothPacket,
 }));
 
 vi.mock('../adapter', () => ({
   RNBleAdapter: vi.fn(),
 }));
 
-import { convertToMirroredFramesString } from '../use-board-bluetooth';
+import { convertToMirroredFramesString, dispatchMoonboardPacket } from '../use-board-bluetooth';
 
-// ── Factory helper ──────────────────────────────────────────────────────
+// ── Factory helper ─────────────────────────────────────────────────────────
 
 function makePlacement(id: number, mirroredHoldId: number | null): HoldPlacement {
   return { id, mirroredHoldId, cx: 0, cy: 0, r: 10 };
@@ -116,5 +117,55 @@ describe('convertToMirroredFramesString', () => {
     const result = convertToMirroredFramesString(frames, holdsData);
 
     expect(result).toBe('p20r1');
+  });
+});
+
+// ── dispatchMoonboardPacket ─────────────────────────────────────────────────
+
+describe('dispatchMoonboardPacket', () => {
+  beforeEach(() => {
+    mockGetMoonboardBluetoothPacket.mockReset();
+  });
+
+  it('calls write() with the packet bytes, not the full packet object', async () => {
+    const fakePacket = new Uint8Array([0x01, 0x02, 0x03]);
+    mockGetMoonboardBluetoothPacket.mockReturnValue({ packet: fakePacket });
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    await dispatchMoonboardPacket('p1r12p2r14', write);
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith(fakePacket, undefined);
+    // Confirm the full object was NOT passed (catches the `.packet` omission regression)
+    expect(write).not.toHaveBeenCalledWith({ packet: fakePacket }, undefined);
+  });
+
+  it('returns true on success', async () => {
+    mockGetMoonboardBluetoothPacket.mockReturnValue({ packet: new Uint8Array([0x00]) });
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    const result = await dispatchMoonboardPacket('p1r12', write);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns undefined and skips write when frames is empty', async () => {
+    const write = vi.fn();
+
+    const result = await dispatchMoonboardPacket('', write);
+
+    expect(result).toBeUndefined();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('forwards the AbortSignal to write()', async () => {
+    const fakePacket = new Uint8Array([0xaa]);
+    mockGetMoonboardBluetoothPacket.mockReturnValue({ packet: fakePacket });
+    const write = vi.fn().mockResolvedValue(undefined);
+    const controller = new AbortController();
+
+    await dispatchMoonboardPacket('p5r3', write, controller.signal);
+
+    expect(write).toHaveBeenCalledWith(fakePacket, controller.signal);
   });
 });

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -14,6 +14,18 @@ import { RNBleAdapter } from './adapter';
 import type { BluetoothAdapter, DevicePickerFn, DiscoveredDevice } from './types';
 import type { HoldPlacement } from '../../components/board-renderer/types';
 
+// Exported for testing — isolates the .packet extraction so regressions are caught.
+export async function dispatchMoonboardPacket(
+  frames: string,
+  write: BluetoothAdapter['write'],
+  signal?: AbortSignal,
+): Promise<true | undefined> {
+  if (!frames) return undefined;
+  const { packet } = getMoonboardBluetoothPacket(frames);
+  await write(packet, signal);
+  return true;
+}
+
 export type PickerState = {
   devices: DiscoveredDevice[];
   isScanning: boolean;
@@ -130,11 +142,8 @@ export function useBoardBluetooth({
 
       try {
         if (boardName === 'moonboard') {
-          if (!frames) return;
-          const bluetoothPacket = getMoonboardBluetoothPacket(frames);
-          await adapterRef.current.write(bluetoothPacket.packet, signal);
           // TODO: analytics (Phase 6)
-          return true;
+          return dispatchMoonboardPacket(frames, adapterRef.current.write.bind(adapterRef.current), signal);
         }
 
         // Empty frames = "clear all LEDs" for Aurora boards

--- a/packages/mobile/src/lib/recent-filter-store.ts
+++ b/packages/mobile/src/lib/recent-filter-store.ts
@@ -1,6 +1,8 @@
 import * as SecureStore from 'expo-secure-store';
 import type { ClimbFilters } from './climb-filter-types';
-export { getFilterKey } from './filter-key';
+import { getFilterKey } from './filter-key';
+
+export { getFilterKey };
 
 export type RecentFilter = {
   id: string;
@@ -12,8 +14,6 @@ export type RecentFilter = {
 
 const RECENT_FILTERS_KEY = 'boardsesh_recent_filters';
 const MAX_ITEMS = 10;
-
-import { getFilterKey } from './filter-key';
 
 export async function getRecentFilters(): Promise<RecentFilter[]> {
   try {


### PR DESCRIPTION
## Summary

- **Medium**: Extracts the MoonBoard BLE write path into `dispatchMoonboardPacket` (exported helper) and adds 4 unit tests asserting `write()` receives `Uint8Array` bytes — not the full packet object. Wrong bytes = LEDs don't light up; this test catches that regression directly.
- **Low**: Fixes interleaved import/export ordering in `ClimbFilterSheet.tsx` and `recent-filter-store.ts` — imports now appear before re-exports as convention requires.
- **Low**: Adds `pull_request` trigger to `.github/workflows/mobile-tests.yml` so CI runs when a PR is first opened without a subsequent push.

## Test plan

- [ ] `node_modules/.bin/vitest run --project mobile` → 267 tests pass (was 263 before this PR)
- [ ] Verify the 4 new `dispatchMoonboardPacket` tests appear in output
- [ ] Confirm `ClimbFilterSheet.tsx` and `recent-filter-store.ts` compile without errors (type check)
- [ ] Open a PR touching `packages/mobile/**` and confirm CI fires without needing a follow-up push

https://claude.ai/code/session_01HkRaeoY4cq1gAVtwcvEjYV

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkRaeoY4cq1gAVtwcvEjYV)_