### PR TITLE
ci(mobile): remove push trigger, run only on pull_request

### DIFF
--- a/.github/workflows/mobile-tests.yml
+++ b/.github/workflows/mobile-tests.yml
@@ -1,15 +1,6 @@
 name: Mobile CI
 
 on:
-  push:
-    branches-ignore: [main]
-    paths:
-      - 'packages/mobile/**'
-      - 'packages/shared/**'
-      - 'packages/board-constants/**'
-      - 'packages/shared-schema/**'
-      - 'vite.config.ts'
-      - '.github/workflows/mobile-tests.yml'
   pull_request:
     paths:
       - 'packages/mobile/**'


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes the `push` trigger from Mobile CI so jobs only run on `pull_request` (and `workflow_dispatch`)
- Eliminates the duplicate runs visible in CI: each branch push was firing both a push job and a PR job

## Test plan

- [ ] Verify Mobile CI no longer appears on direct branch pushes
- [ ] Verify Mobile CI still runs on PR open/update

https://claude.ai/code/session_01K1C7u92yLmDqKAoqnu2SuC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1C7u92yLmDqKAoqnu2SuC)_