### PR TITLE
docs: trim CLAUDE.md from 618 to 247 lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,63 +1,19 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code working in this repo.
 
 ## Project Overview
 
-Boardsesh is a monorepo containing a Next.js 16 application for controlling standardized interactive climbing training boards (Kilter, Tension). It adds missing functionality to boards using Aurora Climbing's software, including queue management and real-time collaborative control.
+Boardsesh is a monorepo. Next.js 16 web app + React Native (Expo) mobile app for controlling Kilter / Tension / MoonBoard climbing boards. Adds queue management and real-time collaborative control on top of Aurora Climbing's software.
 
 ## Project Rules
 
-- We are slowly moving away from running rest-apis and backend operations in the next.js service, instead packages/backend should implement all backends, ideally using graphql
-- Work autonomously end-to-end. Backend + frontend + deploy + QA. Never stop at "the API is ready but the UI isn't updated."
-- Use subagents (always Opus) for all grunt work. Pair every implementation subagent with a QA/reviewer subagent.
-- Work high-level: divide work, subagents execute, you orchestrate and fix issues.
-- No AI-generated images ever. Real photos or diagrams only.
-- No buzzwords. Concrete numbers and simple language.
-- No unnecessary check-ins. Default to action. Full autonomy except no data deletion without asking.
-
-## GitHub Issue Fix Workflow
-
-When fixing a GitHub issue, follow this sequence:
-
-1. **Work in a fresh git worktree branched off the latest `main`.** Fetch `origin/main` first; do not branch from whatever HEAD happens to be.
-2. **Plan the fix before implementing.** Produce an explicit plan of the change before writing code.
-3. **After implementing, make sure the pre-commit hook passes.** If it fails, fix the underlying issue rather than bypassing it (no `--no-verify`).
-4. **Write the QA plan to a notes file before starting the dev server.** Always create `.boardsesh/qa-notes.md` (the default path the orchestrator auto-detects) with the concrete QA plan: the specific pages/flows to exercise, what correct behavior looks like, and the edge cases worth poking at. The orchestrator surfaces the file's contents inside the running app via `/api/internal/dev-metadata`, so the user can read the plan in the browser while testing. If you have a reason to put the notes somewhere else, start the server with `vp run dev -- --qa-notes-file <path>` (alias: `--qa-plan-file`). Never start the dev server for a GitHub-issue fix without a QA notes file — running it bare drops the in-app QA context the user expects.
-5. **Start the dev server with `vp run dev`** so the user can test the fix in the browser. The orchestrator picks up `.boardsesh/qa-notes.md` automatically; confirm in the startup output that it logged `[dev] QA notes: <path>`.
-6. **Tell the user the dev server URL in a single message** as soon as the server is up. Report whatever URL the server actually prints (typically `http://localhost:3000`) and mention that the QA plan is loaded into the app from `.boardsesh/qa-notes.md`. Don't paste the full QA plan into chat — it's already in the file you wrote and surfaced in-app.
-7. **Always open a PR** for the GitHub issue once the fix is implemented and validated.
-
-This applies to any request framed as "fix issue #N", "this GH issue", "the bug from <issue link>", or similar. It does not apply to ad-hoc edits or feature work the user requested directly without referencing an issue. If the user explicitly opts out of any step for a given task, respect that for the current task only — the default still holds next time.
-
-## Database Hosting (Railway)
-
-We host PostgreSQL on Railway. **Treat Railway as a portable stepping stone, not a permanent marriage.** Railway is currently better gravity than Neon (simpler, less magical, closer to "Docker + Postgres") but it is still a platform. The whole point of leaving Neon was to escape platform gravity — don't accidentally re-create it.
-
-When making infrastructure or backend changes:
-
-- **Keep Postgres vanilla.** Use standard PostgreSQL features. Don't reach for Railway-only addons, Railway-managed extensions, or Railway-flavoured wrappers. Anything you write should run unchanged on a `docker run postgres:17` instance.
-- **No Railway-specific service assumptions in app code.** No `RAILWAY_*` env vars threaded into business logic. No code paths that branch on the deploy target. The app should not be able to tell Railway from a self-hosted box from a developer laptop.
-- **Use standard Docker builds.** No Railway-only build steps, no `railway.toml`-encoded behaviour the app depends on. The Dockerfile should build and run anywhere.
-- **Keep migrations in-repo.** All schema changes live in `packages/db/drizzle/` and run via `bunx drizzle-kit generate` + `vp run db:migrate`. Never use Railway's UI / dashboard to mutate schema.
-- **`pg_dump` / `pg_restore` is the exit plan.** A vanilla logical dump must be sufficient to lift-and-shift Postgres to another host. If you ever need a Railway-specific tool to extract data, you've taken a wrong turn — back out.
-- **Keep object storage, video, and analytics deliberately portable.** Same rule for any other service we add: prefer S3-compatible APIs, OpenTelemetry-shaped exporters, standard connection strings. Avoid platform-specific managed primitives where a portable equivalent exists.
-
-The migration runbook (`docs/neon-migration.md`) documents how to move off Neon. Future migrations off Railway should be similarly straightforward — that's the test for whether we're staying portable.
-
-## Documentation
-
-Before working on a specific part of the codebase, check the `docs/` directory for relevant documentation:
-
-- `docs/websocket-implementation.md` - WebSocket party session architecture, connection flow, failure states and recovery mechanisms
-- `docs/ai-design-guidelines.md` - Comprehensive UI design guidelines, patterns, and tokens for redesigning components
-- `docs/live-activity-push-testing.md` - Local testing guide for APNs Live Activity push notifications and widget navigation
-- `docs/logging.md` - Backend structured logger (winston): output formats, `LOG_LEVEL`, instance-id wiring, and how to spy on it in tests
-
-**Important:**
-
-- Read the relevant documentation first to understand the architecture and design decisions before making changes
-- When making significant changes to documented systems, update the corresponding documentation to keep it in sync
+- Backend work belongs in `packages/backend` (GraphQL), not in the Next.js app. We are slowly moving REST/server logic out of `packages/web`.
+- Work autonomously end-to-end: backend + frontend + QA. Don't stop at "API is ready but UI isn't updated."
+- Use subagents (always Opus) for grunt work. Pair every implementation subagent with a QA/reviewer subagent.
+- No AI-generated images. Real photos or diagrams only.
+- No buzzwords. Concrete numbers, plain language.
+- Default to action. Full autonomy except no data deletion without asking.
 
 ## Monorepo Structure
 
@@ -68,550 +24,224 @@ Before working on a specific part of the codebase, check the `docs/` directory f
   /backend/         # WebSocket backend for party mode (graphql-ws)
   /shared-schema/   # Shared GraphQL schema and TypeScript types
   /shared/
-    /play-view/     # Shared play-drawer logic (queue nav, tick utils, grade display)
-    /queue/          # Queue state machine (reducer, types, event utils)
-    /board-config/   # Board metadata, hold maps, angle tables
-    /board-constants/# Grade colours, difficulty bands
-    /ble-protocol/   # Bluetooth LED control protocol
-  /db/              # Shared database schema, client, and migrations (drizzle)
+    /play-view/     # Play-drawer logic (queue nav, tick utils, grade display)
+    /queue/         # Queue state machine (reducer, types, event utils)
+    /board-config/  # Board metadata, hold maps, angle tables
+    /board-constants/ # Grade colours, difficulty bands
+    /ble-protocol/  # Bluetooth LED control protocol
+  /db/              # Shared database schema, client, migrations (drizzle)
 ```
 
-## Shared Packages (Web ↔ Mobile Code Reuse)
+## Shared Packages (Web ↔ Mobile)
 
-**Code reuse between web and mobile is the highest priority when adding features that exist on both platforms.** Before writing platform-specific logic, check whether the same behaviour already exists in the other app and extract the shared part into a package under `packages/shared/`.
+Code reuse between web and mobile is the highest priority when adding cross-platform features. Before writing platform-specific logic, check whether the same behaviour already exists on the other side and extract the shared part into `packages/shared/`.
 
-### Rules
-
-- **One responsibility per package.** Don't dump everything into a single `@boardsesh/shared` mega-package. Name each package after what it does: `@boardsesh/play-view` for play-drawer logic, `@boardsesh/queue` for the queue state machine, `@boardsesh/board-config` for board metadata. If a new shared concern doesn't fit an existing package, create a new one.
-- **No React, no DOM, no React Native in shared packages.** Shared code must be pure TypeScript — types, pure functions, constants, state machines. Platform-specific rendering stays in `packages/web/` and `packages/mobile/`.
-- **No circular dependencies.** Shared packages may depend on other shared packages (e.g., `@boardsesh/play-view` depends on `@boardsesh/queue`) but never on `web`, `mobile`, or `backend`. Use `vp run typecheck` to verify — TypeScript project references will catch cycles.
-- **Extract, don't duplicate.** When implementing a feature on mobile that the web already has, read the web implementation first. Pull the business logic (validation, state derivation, formatting, URL construction) into the appropriate shared package, then have both platforms import it. A duplicated 10-line helper today becomes two divergent copies with different bugs tomorrow.
-- **Web should adopt shared extractions too.** When you extract logic from web into a shared package for mobile, update the web code to import from the shared package in the same PR. Don't leave the web on its inline copy.
-- **Tests live next to the code.** Every shared package has a `src/__tests__/` directory. New shared functions need tests — the shared package is the most leveraged place to catch bugs since both platforms depend on it.
+- **One responsibility per package.** Name packages after what they do (`@boardsesh/queue`, `@boardsesh/play-view`). No mega-`@boardsesh/shared`.
+- **No React, no DOM, no React Native in shared packages.** Pure TS only — types, pure functions, constants, state machines.
+- **No circular deps.** Shared packages may depend on other shared packages, never on `web`, `mobile`, or `backend`.
+- **Extract, don't duplicate.** When porting a web feature to mobile, pull the business logic into a shared package and update web to import from it in the same PR.
+- **Tests live next to the code** in `src/__tests__/`.
 
 ## Commands
 
-### Development Setup
+Toolchain is [Vite+](https://viteplus.dev) (`vp`). **Never use `bun run`, `bunx`, or `npx` for validation** — they bypass the unified config and can mutate `bun.lock`. The only sanctioned non-`vp` invocations are `bunx drizzle-kit generate` (migrations) and `bun run backend:start` (prod backend).
 
-The development database uses a **pre-built Docker image** (`ghcr.io/boardsesh/boardsesh-dev-db`) that already contains all Kilter, Tension, and MoonBoard board data, a test user, and social seed data with migrations applied. This means `vp run db:up` is fast — it just pulls the image, starts containers, and runs any newer migrations.
+Use `vp check` or `vp run typecheck` to validate — **not** `vp run build` (build interferes with the dev server). `vp check` runs lint + format (the staged pre-commit hook calls `vp check --fix`). Run `vp run typecheck` before pushing.
 
-```bash
-# Install Vite+ CLI (one-time, manages Node.js, linting, formatting, testing)
-curl -fsSL https://vite.plus | bash
+Common commands:
 
-# Environment files are in packages/web/:
-# .env.local contains generic config (tracked in git)
-# .env.development.local contains secrets (NOT tracked in git)
+- `vp check` — format + lint (canonical validation; pre-commit)
+- `vp test` / `vp test run --reporter=agent` — tests (always use `--reporter=agent` to save context)
+- `vp test --project web|backend|mobile` — scope tests
+- `vp run dev` — start DB + backend + web
+- `vp run dev:mobile` — start mobile dev server (Metro)
+- `vp run db:up` / `vp run db:migrate` / `vp run db:studio`
+- `vp run build`, `vp run typecheck` (+ `:web`, `:backend`, `:mobile`, `:db`, `:shared`)
+- `vp run check:i18n` — fails on hardcoded English strings under `packages/web/app/`
+- `vp run check:mobile-bundle` — headless Metro bundle check (Linux-safe)
+- `vp run check:mobile-simulator`, `vp run mobile:screenshot` — macOS only
+- `vp run mobile:publish` — EAS Update for current branch
+- `vp run test:e2e` — Playwright; auto-starts the dev DB + web server
 
-# Mobile OTA updates (optional — only needed for `vp run mobile:publish`):
-# Set EXPO_PUBLIC_EAS_PROJECT_ID in your shell or packages/mobile/.env
-# to override the default project ID committed in app.config.ts
+### Database
 
-# Note: VERCEL_URL is automatically set by Vercel for deployments
-# For local development, the app defaults to http://localhost:3000
+- `bunx drizzle-kit generate` from `packages/db/` to create migrations. **Never hand-write migration SQL** — it must be in `_journal.json`, which `drizzle-kit generate` updates for you.
+- Dev DB is a pre-built image (`ghcr.io/boardsesh/boardsesh-dev-db`) with all board data, a test user (`test@boardsesh.com` / `test`), and seed data. Reset: `docker compose down -v && vp run db:up`.
 
-# Install all dependencies (from root)
-vp install
+### Database hosting (Railway)
 
-# Install Git hooks (runs vp staged on commit)
-vp config
+We host Postgres on Railway but treat it as portable — anything we write should run on a `docker run postgres:17`. No Railway-specific addons, env vars, build steps, or schema mutations via dashboard. `pg_dump`/`pg_restore` must be sufficient to lift-and-shift. Same rule for object storage / video / analytics: prefer S3-compatible APIs, OpenTelemetry exporters, standard connection strings. Exit runbook: `docs/neon-migration.md`.
 
-# Start everything (databases, backend, web)
-# First run pulls the pre-built image (~1GB) with all board data included.
-# Subsequent runs start in seconds.
-# Test user: test@boardsesh.com / test
-vp run dev
-```
+## GitHub Issue Fix Workflow
 
-#### Pre-built database image
+When the request references an issue ("fix issue #N", "this GH issue", a bug link):
 
-The `boardsesh-dev-db` image is published to GHCR and contains PostgreSQL 17 + PostGIS with all Kilter/Tension/MoonBoard board data pre-loaded, a test user (`test@boardsesh.com` / `test`), social seed data (fake users, follows, ticks, comments, notifications), and all drizzle migrations applied. It is rebuilt automatically when files in `packages/db/docker/`, `packages/db/scripts/`, `packages/db/src/schema/`, `packages/db/drizzle/`, or `packages/db/package.json` change on main.
+1. **Work in a fresh git worktree branched off the latest `main`.** Fetch `origin/main` first.
+2. **Plan before implementing.**
+3. **Pre-commit hook must pass** — fix underlying issues, no `--no-verify`.
+4. **Write a QA notes file before starting the dev server.** `.boardsesh/qa-notes.md` is the default path the orchestrator auto-detects and surfaces in-app via `/api/internal/dev-metadata`. Include the specific pages/flows to exercise, expected behaviour, and edge cases. For an alternate path, pass `vp run dev -- --qa-notes-file <path>`. **Never start the dev server for an issue fix without QA notes.**
+5. **Start the dev server with `vp run dev`** (web) or `vp run dev:mobile` (mobile). Confirm the startup log shows `[dev] QA notes: <path>`. For mobile, the orchestrator surfaces QA notes in the `DevMetadataPanel` (More tab); Metro output is tee'd to `.boardsesh/mobile-metro.log`.
+6. **Tell the user the URL in one message** — whatever the server prints (typically `http://localhost:3000`). Don't paste the QA plan into chat; it's already in the file and the app.
+7. **Always open a PR** once validated.
 
-- **Pull directly**: `docker pull ghcr.io/boardsesh/boardsesh-dev-db:latest`
-- **Reset your local database**: `docker compose down -v && vp run db:up`
-- **Build locally** (e.g. to test Dockerfile changes): `docker compose up -d --build postgres`
+Ad-hoc edits and direct feature requests don't trigger this workflow. If the user opts out of a step, respect that for the current task only.
 
-### Common Commands (from root)
+## Documentation
 
-This project uses [Vite+](https://viteplus.dev) (`vp`) as its unified toolchain for testing, linting, formatting, type checking, and task running. Most commands use `vp` directly or `vp run` for tasks defined in the root `vite.config.ts`.
+Read relevant `docs/` before working on the matching area; update docs when the system changes.
 
-- `vp check` - Run format, lint, and type checks (this is the canonical validation command and what runs in pre-commit)
-- `vp test` - Run all tests
-- `vp test run` - Run tests once without watch mode
-- `vp lint` - Lint all packages
-- `vp fmt` - Format all files with Oxfmt
-- `vp run dev` - Start development databases, backend, and web server
-- `vp run dev:backend` - Start database and backend only
-- `vp run dev:web` - Start database and web server only
-- `vp run db:up` - Start development databases and run migrations only
-- `vp run build` - Build all packages (dependency graph handles ordering and parallelism)
-- `vp run build:web` - Build web package and its dependencies
-- `vp run build:backend` - Build backend package and its dependencies
-- `vp run typecheck` - Type check all packages (builds dependencies first)
-- `vp run typecheck:web` - Type check web package only
-- `vp run typecheck:backend` - Type check backend package only
-- `vp run typecheck:db` - Type check db package only
-- `vp run typecheck:shared` - Type check shared-schema package only
-- `vp run check:i18n` - Scan `packages/web/app/**/*.tsx` for hardcoded user-facing English strings. Runs in CI on every PR; fails the build if a new untranslated string is introduced. Run `bun packages/web/scripts/check-untranslated-strings.ts --fix` to bulk-insert `// i18n-ignore-next-line` markers above existing violations.
-- `vp run check:mobile-bundle` - Headless Metro bundle check for React Native (works on Linux, no simulator needed)
-- `vp run check:mobile-simulator` - Build and launch RN app on iOS simulator (macOS only, skips on Linux)
-- `vp run mobile:screenshot` - Capture iOS simulator screenshot (macOS only, skips on Linux)
-- `vp run mobile:publish` - Publish an EAS Update for the current branch (testers on the preview build receive it OTA)
-- `vp run mobile:preview-build` - Trigger an EAS Build for the "preview" profile (testers install this once)
-- `bun run backend:start` - Start backend in production mode
-
-### Running E2E Tests
-
-- `vp run test:e2e` - Full Playwright run: brings up the pre-built dev DB, exports the seeded test user, and runs every spec in `packages/web/e2e/`. Playwright's `webServer` config auto-starts `vp run dev` (backend + web) for you.
-- `vp run test:e2e:setup` - Only bring up the dev DB. Useful when iterating on a single spec: after setup, run `bun run --filter=@boardsesh/web test:e2e -- e2e/<spec>.spec.ts` (or use `test:e2e:ui` for the Playwright UI).
-- The seeded test user is `test@boardsesh.com` / `test`, exported as `TEST_USER_EMAIL`/`TEST_USER_PASSWORD` by the script so screenshot specs (`app-store-screenshots`, `help-screenshots`) run end-to-end without 1Password.
-
-### Database Commands (run from root or packages/db/)
-
-- `vp run db:migrate` - Start dev DB and apply migrations
-- `vp run db:studio` - Start dev DB and open Drizzle Studio for database exploration
-- From packages/db: `bunx drizzle-kit generate` - Generate new migrations
-
-### Creating Database Migrations
-
-**IMPORTANT**: Always use `bunx drizzle-kit generate` from `packages/db/` to create new migrations. This command:
-
-1. Detects schema changes in `packages/db/src/schema/`
-2. Generates the SQL migration file in `packages/db/drizzle/`
-3. Automatically adds the migration to `packages/db/drizzle/meta/_journal.json`
-
-**Never manually create migration SQL files** without adding them to `_journal.json`. The journal tracks which migrations drizzle-kit should run - migrations missing from the journal will be silently skipped during deployment.
-
-```bash
-# From packages/db directory:
-bunx drizzle-kit generate
-
-# Then apply locally to test:
-vp run db:migrate
-```
+- `docs/websocket-implementation.md` — WebSocket party session architecture
+- `docs/ai-design-guidelines.md` — UI design tokens and patterns
+- `docs/live-activity-push-testing.md` — APNs Live Activity push testing
+- `docs/logging.md` — backend structured logger (winston)
 
 ## Architecture Overview
 
-### Routing Pattern
+### Web routing
 
-The app uses deeply nested dynamic routes:
+Deeply nested dynamic routes: `/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/...`. Routes mirror `/api/v1/...`. Board names: `kilter`, `tension`. Next.js App Router — prefer server components wherever possible (queue/realtime components are necessarily client).
 
-```
-/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/...
-```
+### Key components
 
-- Routes mirror the API structure at `/api/v1/...`
-- Board names: "kilter", "tension"
-- All route segments are required for board-specific pages
+- **BoardProvider** (`packages/web/app/components/board-provider-context.tsx`) — auth, sessions, logbook, IndexedDB.
+- **QueueProvider** (`packages/web/app/components/queue-control/queue-context.tsx`) — climb queue (reducer), search, GraphQL-WS sync.
 
-We are using next.js app router, it's important we try to use server side components as much as possible.
+### Data flow
 
-### Key Architectural Components
+- Server components fetch initial data.
+- Client components use React Query.
+- API: `/api/internal/...` for server-side ops; `/api/v1/[board]/proxy/...` for Aurora proxies.
+- State: Context + `useReducer` for complex state; URL params as source of truth for board config.
 
-#### Context Providers
+### Integration points
 
-1. **BoardProvider** (`packages/web/app/components/board-provider-context.tsx`)
-   - Manages authentication and user sessions
-   - Handles logbook entries and ascent tracking
-   - Uses IndexedDB for offline persistence
+Web Bluetooth (board LEDs), GraphQL-WS backend, Redis (pub/sub for multi-instance), IndexedDB (client persistence), Aurora API (user sync).
 
-2. **QueueProvider** (`packages/web/app/components/queue-control/queue-context.tsx`)
-   - Manages climb queue with reducer pattern
-   - Integrates with search results and suggestions
-   - Syncs with backend via GraphQL subscriptions
+### Types
 
-#### Data Flow
-
-1. **Server Components**: Initial data fetching in page components
-2. **Client Components**: Interactive features with React Query (`@tanstack/react-query`) for data fetching
-3. **API Routes**: Two patterns:
-   - `/api/internal/...` - Server-side data operations
-   - `/api/v1/[board]/proxy/...` - Aurora API proxies
-4. **State Management**: React Context + useReducer for complex state
-
-### Database Schema
-
-- Separate tables for each board type (kilter*\*, tension*\*)
-- Key entities: climbs, holds, layouts, sizes, sets, user_syncs
-- Stats tracking with history tables
-- See `packages/db/src/schema/` for full schema (re-exported via `packages/web/app/lib/db/schema.ts`)
-
-### Key Integration Points
-
-1. **Web Bluetooth**: Board LED control via Web Bluetooth API
-2. **GraphQL-WS Backend**: Real-time collaboration via WebSocket GraphQL subscriptions
-3. **Redis**: Pub/sub for multi-instance backend scaling
-4. **IndexedDB**: Offline storage for auth and queue state
-5. **Aurora API**: External API integration for user data sync
-
-### Type System
-
-- Core types in `packages/web/app/lib/types.ts`
-- Shared types in `packages/shared-schema/src/types.ts`
-- GraphQL schema in `packages/shared-schema/src/schema.ts`
-- Zod schemas for API validation
-- Strict TypeScript configuration
+Web types in `packages/web/app/lib/types.ts`; shared types in `packages/shared-schema/src/types.ts`; GraphQL schema in `packages/shared-schema/src/schema.ts`. Zod for API validation.
 
 ### Testing
 
-- Tests use Vitest via Vite+ (`vp test`)
-- Run `vp test run --reporter=agent` for CI-friendly output
-- Run `vp test --project web` to run only web tests
-- Run `vp test --project backend` to run only backend tests
-- Backend tests auto-start a postgres+redis docker stack via `packages/backend/docker-compose.test.yml` (idempotent, left running between runs). Set `SKIP_TEST_INFRA=1` to skip orchestration; set `CI=1` to rely on caller-provided services.
-- `packages/db` uses Node.js native test runner (`tsx --test`), not Vitest
+Vitest via `vp test`. Backend tests auto-start postgres+redis via `packages/backend/docker-compose.test.yml`; set `SKIP_TEST_INFRA=1` to skip, `CI=1` for caller-provided services. `packages/db` uses Node's native test runner (`tsx --test`).
 
 ## Development Guidelines
 
 ### Important rules
 
-- **Validation must go through `vp` — never `bun run`, `bunx`, or `npx`.** This repo's toolchain is Vite+ (`vp`). For lint, format, typecheck, test, build, and dev, use `vp` and `vp run` exclusively. Do not invoke `bun run check`, `bun run lint`, `bun run test`, `bun run --filter=... typecheck`, `bunx tsc`, `npx eslint`, etc. — they bypass the unified config, can mutate `bun.lock`, and skip the typecheck/lint settings wired into `vite.config.ts`. The only sanctioned non-`vp` invocations are: (a) `bunx drizzle-kit generate` for migrations (no `vp` wrapper exists), and (b) `bun run backend:start` for production backend startup. If you find yourself reaching for `bun run` or `bunx` for anything else, stop and use the `vp` equivalent.
-- **Use `vp check` or `vp run typecheck` instead of `vp run build` for validation** - Running build interferes with the local dev server and `bunx` commands can mess with lock files. `vp check` runs lint + format (the staged pre-commit hook calls `vp check --fix`). TypeScript type checking is run separately via `vp run typecheck` and in the typecheck CI job — `lint.options.typeCheck` is intentionally off in `vite.config.ts` because oxlint's type-aware mode surfaces a backlog of pre-existing violations across bundled assets and unrelated files. Run `vp run typecheck` (or one of `vp run typecheck:web|backend|db|shared`) before pushing.
-- Always try to use server side rendering wherever possibe. But do note that for some parts such as the QueueList and related components, thats impossible, so dont try to force SSR there.
-- Always use MUI (Material UI) components and their properties.
-- Try to avoid use of the style property
-- Always use design tokens from `packages/web/app/theme/theme-config.ts` for colors, spacing, and other design values - never use hardcoded values
-- Always use CSS media queries for mobile/responsive design
-- For rendering avoid JavaScript breakpoint detection & Grid.useBreakpoint()
-- While we work together, be careful to remove any code you no longer use, so we dont end up with lots of deadcode
-- **Dark mode uses white input fields** — This is intentional for contrast. All input components (TextField, Select, Autocomplete, etc.) have white backgrounds in dark mode via `darkTokens.semantic.inputSurface`. Do not change them to dark backgrounds.
-- **Never use `any` type** - The `no-explicit-any` lint rule is set to `deny` across all packages. Use `unknown`, proper types, or `as unknown as SpecificType` for type assertions. No exceptions - `any` defeats the purpose of TypeScript
-- **Never hardcode user-facing strings** - All visible text must come from the i18n catalogs in `packages/web/i18n/locales/`. See the Internationalisation section below for the call-site pattern. CI runs `vp run check:i18n` on every PR, which fails the build if a `.tsx` file under `packages/web/app/` introduces a hardcoded English string. Pre-existing violations are silenced with `// i18n-ignore-next-line` (or `{/* i18n-ignore-next-line */}`) comments — chip away at these by translating them and removing the marker.
-- **No orphaned i18n keys** - CI also runs `vp run check:i18n:orphans` on every PR, which fails the build if a key in `packages/web/i18n/locales/en-US/*.json` has no live reference under `packages/web/app/` or `packages/web/scripts/`. Delete the key from every locale catalog (`en-US`, `es`, `fr`) when removing the last call site. For keys referenced from outside the scanned tree or via a dynamic lookup we can't statically resolve, add `// i18n-keep namespace.dotted.key` anywhere in the file set. The linter hard-fails on `t(variable)` and `t('a' + b)` — refactor to a string literal or template literal we can statically analyse.
-- **Variable names must describe their contents** - No single-letter aliases (`r`, `x`, `s`) or vague placeholders (`data`, `info`, `latest`, `temp`, `value`) outside of tight loops or well-known math conventions. The name should tell the next reader what's inside without forcing them to scroll back to the declaration. Prefer destructuring at the use site over a generic alias — `const { queue, currentClimb } = stateRef.current` reads better than `const s = stateRef.current` followed by `s.queue` / `s.currentClimb`.
+- **Never use `any`.** `typescript/no-explicit-any` is `deny` everywhere. Use `unknown` or `as unknown as T`.
+- **Validation goes through `vp` only** (see Commands above).
+- Always prefer server-side rendering. Queue/realtime components are the exception — don't force SSR there.
+- **Web uses MUI.** Always MUI components and props. Avoid the `style` prop. Always use design tokens from `packages/web/app/theme/theme-config.ts` for colours/spacing — no hardcoded values.
+- Use CSS media queries for responsive design. Avoid JS breakpoint detection (`Grid.useBreakpoint()`).
+- Remove dead code as you go.
+- **Dark mode uses white input fields.** Intentional for contrast (`darkTokens.semantic.inputSurface`). Do not change.
+- **Never hardcode user-facing strings** in `packages/web/app/**/*.tsx` — all visible text via i18n catalogs. CI runs `vp run check:i18n` and `vp run check:i18n:orphans`. Mark unresolvable dynamic lookups with `// i18n-keep namespace.dotted.key`.
+- **Variable names describe contents.** No single-letter aliases (`r`, `x`, `s`) or vague placeholders (`data`, `info`, `temp`, `value`) outside tight loops. Destructure at the use site instead of generic aliases.
+- **Drizzle ORM over raw SQL.** Use `db.select/insert/update/delete()`. Raw `sql` from `drizzle-orm` only when the query genuinely can't be expressed otherwise. Importing `sql` from `@/app/lib/db/db` (raw Neon HTTP client) is lint-blocked.
+- **IndexedDB only for client-side storage.** `localStorage`/`sessionStorage` are lint-blocked (`no-restricted-globals`). Use `packages/web/app/lib/user-preferences-db.ts` for simple key-value or create a domain-specific `*-db.ts` (see `tab-navigation-db.ts`, `onboarding-db.ts`). Always SSR-guard with `typeof window === 'undefined'`. One-time `localStorage` migration code is the only legitimate exception — mark with `// oxlint-disable-next-line no-restricted-globals`.
 
 ### Internationalisation
 
-Boardsesh ships English (`en-US`) at root paths and Spanish (`es`) at `/es/*`. The i18n stack is `i18next` + `react-i18next` with JSON catalogs under `packages/web/i18n/locales/<locale>/<namespace>.json`. Locale detection is path-based — middleware (`packages/web/middleware.ts`) reads the `/es/` prefix, rewrites the URL internally, and sets the `x-boardsesh-locale` request header.
+Supported locales: `en-US` (root), `es` (`/es/*`), `fr`. Path-based detection via middleware (`packages/web/middleware.ts`). Catalogs in `packages/web/i18n/locales/<locale>/<namespace>.json`. Namespaces: `common`, `marketing` (add new ones in `SEED_NAMESPACES` in `app/lib/i18n/config.ts`).
 
-**Adding new copy**
+- **Add every new key to every locale.** `i18n-catalog-completeness.test.ts` enforces parity per namespace.
+- Server: `const { t } = await getServerTranslation('marketing')`.
+- Client: `const { t } = useTranslation('marketing')`.
+- Internal links: `<LocaleLink>` from `@/app/components/i18n/locale-link` (not raw `next/link`). MUI: `<MuiLink component={LocaleLink} href="...">`.
+- Page metadata: use `createPageMetadata({ title, description, path, locale })` for hreflang alternates.
+- Inline formatting with multiple tags: react-i18next `<Trans>` (see `app/legal/legal-content.tsx`).
+- Use ICU placeholders: `"greeting": "Hello {{name}}"`.
+- **Don't translate** code samples in `<pre>` blocks, brand names (Boardsesh, Kilter, Tension, MoonBoard), or user-generated content.
+- Linter hard-fails on `t(variable)` / `t('a' + b)` — use string literals or template literals only.
 
-- Add the key to **every** supported locale catalog: `packages/web/i18n/locales/<locale>/<namespace>.json` for each entry in `SUPPORTED_LOCALES` (currently `en-US`, `es`, `fr`). Catalogs must stay at full parity — missing keys would fall back to English at runtime via i18next's `fallbackLng`, but they show up as warnings in Sentry and ship silently-English copy to non-English users. `packages/web/app/__tests__/i18n-catalog-completeness.test.ts` enforces parity per namespace for every supported locale and will fail the build if you add an English key without its `es` and `fr` translations.
-- Pick the right namespace. Currently `common` (shared chrome) and `marketing` (about/help/docs/legal/privacy/home). Add a new namespace by adding it to `SEED_NAMESPACES` in `packages/web/app/lib/i18n/config.ts` and creating `<lang>/<namespace>.json` files for each supported locale.
-- Use ICU-style placeholders for interpolation: `"greeting": "Hello {{name}}"`.
+Adding a new locale: update `SUPPORTED_LOCALES` and friends in `app/lib/i18n/config.ts`, add catalog dir, language switcher, sitemap.
 
-**Server components**
+### Copy & microcopy
 
-```ts
-import { getServerTranslation } from '@/app/lib/i18n/server';
+- Describe what the user gets, not what the feature does.
+- Active verbs in CTAs. "See the feed", "Build a playlist", not "Go to..." / "View your...".
+- Climber voice: "sends", "crew", "beta", "project" over "hub", "platform", "all-in-one solution".
+- Empty states / error messages carry the voice too. "No one's here yet" over "No data available."
+- Frame migrations and warnings around what users gain, not lose.
+- Avoid AI-writing tells: em dash overuse, "not only X but Y", triple parallel structures, bolded-keyword-colon-explanation bullets, generic adjectives ("seamless", "comprehensive"). See https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing
 
-export default async function Page() {
-  const { t } = await getServerTranslation('marketing');
-  return <h1>{t('about.headerTitle')}</h1>;
-}
-```
+### Trademark usage (Kilter, Tension, MoonBoard)
 
-**Client components** (`'use client'`)
+- Capitalise correctly: **MoonBoard**, **Kilter**, **Tension**.
+- Describe compatibility, not branding: "Works with Kilter" not "Kilter app". "One app for your boards" not "One app for Kilter".
+- Never imply endorsement of Aurora, Moon Climbing, or any manufacturer. See `/legal` and `LEGAL.md`.
 
-```tsx
-import { useTranslation } from 'react-i18next';
+## SEO for new web pages
 
-export default function Foo() {
-  const { t } = useTranslation('marketing');
-  return <span>{t('home.hero.title')}</span>;
-}
-```
+Decide up front: is this a search surface (landing, public board, climb view, public profile, public setter, public playlist) or a utility surface (`/auth`, `/settings`, `/join`, `/notifications`, session flows, `/play/...`)? Default utility pages to `robots: { index: false, follow: true }`.
 
-**Internal links** must preserve the active locale — use `<LocaleLink>` (from `@/app/components/i18n/locale-link`), not raw `next/link`. For MUI links: `<MuiLink component={LocaleLink} href="/docs">`. External links (`https://`, `mailto:`) and `router.push()` calls are unaffected for now (locale-preserving navigation helpers for `router.push` are a follow-up).
+For indexable pages:
 
-**Page metadata** must use the locale-aware helper — `createPageMetadata` already populates `alternates.languages` (en-US, es, x-default) when given a `path`:
-
-```ts
-export async function generateMetadata() {
-  const { t, locale } = await getServerTranslation('marketing');
-  return createPageMetadata({
-    title: t('metadata.foo.title'),
-    description: t('metadata.foo.description'),
-    path: '/foo',
-    locale,
-  });
-}
-```
-
-**Inline formatting** (`<strong>`, `<em>`, links inside a paragraph) — prefer splitting into label/body keys for simple cases. For prose with multiple inline tags, use react-i18next's `<Trans components={{ em: <em />, strong: <strong /> }}>` so translators see the sentence as one unit. See `packages/web/app/legal/legal-content.tsx` for the `<Trans>` pattern.
-
-**Adding a new page**
-
-- Make it reachable at both `/path` (English) and `/es/path` (Spanish). Verify in the dev server.
-- Use `generateMetadata` with the pattern above so hreflang alternates are emitted.
-- Add the URL to `packages/web/app/sitemap.ts` if it should be indexable — sitemap entries automatically get per-locale variants.
-
-**Adding a new locale**
-
-Touch all of: `SUPPORTED_LOCALES` and `LOCALE_HTML_LANG`/`LOCALE_OG`/`LOCALE_LABELS` in `packages/web/app/lib/i18n/config.ts`, every catalog directory under `packages/web/i18n/locales/`, the language switcher options, and the sitemap. `detectLocale` (`packages/web/app/lib/i18n/detect-locale.ts`) iterates `SUPPORTED_LOCALES` and needs no edit — adding the locale to `config.ts` is sufficient for routing. Don't ship a partial locale — middleware will rewrite paths but pages will fall back to English everywhere.
-
-**Don't translate** code samples in `<pre>` blocks (e.g. `app/docs/docs-client.tsx`), brand names ("Boardsesh", "Kilter", "Tension", "MoonBoard"), or user-generated content (climb names, comments, usernames). Trademark phrasing in CLAUDE.md still applies.
-
-A handful of style rules are enforced as oxlint errors so they fail `vp check`. See `.oxlintrc.json` for the exact rule names and config; the current lint-enforced set includes `typescript/no-explicit-any` (no `any`), `no-nested-ternary`, `no-restricted-globals` (no `localStorage` / `sessionStorage`), and `no-restricted-imports` (no raw Neon `sql` client from `@/app/lib/db/db`).
-
-### Copy & Microcopy
-
-When writing user-facing text, follow these rules:
-
-- Describe what the user gets, not what the feature does. "Line up your climbs before you get to the gym" is better than "Organize climbs into collections for your sessions."
-- Users opened the app for a reason. Don't ask "Ready to climb?" when you can say "Get on the wall."
-- If a sentence has three commas, it's a feature list in disguise. Pick the strongest point or break it up.
-- Write like a climber talks. "Sends", "crew", "beta", "project" over "hub", "platform", "all-in-one solution."
-- Empty states, error messages, and button labels carry the voice too. "No one's here yet" over "No data available."
-- Use active verbs in CTAs. "See the feed", "Build a playlist", "Start climbing." Avoid "Go to..." and "View your..."
-- Frame migrations and warnings around what users gain, not what they lose.
-- Watch for AI-writing tells: em dash overuse, "not only X but Y" constructions, triple parallel structures, bolded-keyword-colon-explanation bullets, and generic adjectives like "seamless" or "comprehensive." See https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing
-
-## SEO for New Pages
-
-When adding a new route in `packages/web/app/`, decide up front whether it is a search surface or a utility surface. Do not let every page default to "indexable".
-
-### Decide if the page should rank
-
-- Treat landing pages, public board pages, climb view pages, public profiles, public setter pages, and public playlists as SEO surfaces by default.
-- Treat `/auth`, `/settings`, `/join`, `/notifications`, session utilities, and similar signed-in flows as non-SEO surfaces by default.
-- Treat alternate experiences like `/play/...` as duplicate or utility surfaces unless there is a strong reason to index them separately.
-- If a page is private, auth-gated, ephemeral, or only useful inside an active session, default to `robots: { index: false, follow: true }`.
-
-### Metadata requirements
-
-- Every indexable page must define a unique `title`, `description`, canonical URL via `alternates.canonical`, Open Graph metadata, and Twitter metadata.
-- Every non-indexable page must set an explicit `robots` directive instead of relying on default behavior.
-- Avoid generic metadata like `Profile | Boardsesh`, `Playlist | Boardsesh`, `Play Mode | Boardsesh`, or `View details and climbs`.
-- Prefer title formats like `Topic or Entity | Boardsesh`.
-- Lead titles with the thing people actually search for, then the brand.
-- Match search intent naturally in titles and descriptions. Descriptive phrases like `Kilter Board app alternative` are okay when the page clearly states Boardsesh is a compatible alternative and not the official Kilter app.
-
-Good examples:
-
-- `Kilter Board App Alternative | Boardsesh`
-- `MoonBoard Screenshot Import | Boardsesh`
-- `Marco's Kilter Sessions | Boardsesh`
-
-Bad examples:
-
-- `Home | Boardsesh`
-- `Profile | Boardsesh`
-- `Play Mode | Boardsesh`
-
-### First-render content requirements
-
-- If a page should rank, the first server-rendered HTML must include meaningful public content.
-- Ship one clear `h1`, one or more descriptive paragraphs, and crawlable internal links near the top of the page.
-- Put primary copy above heavy widgets, drawers, or client-only controls.
-- Do not ship an indexable page whose first render is only a spinner, app shell, board canvas, or client-fetched placeholder.
-- If the important content can only be loaded client-side, either move the summary content into a server component or mark the page `noindex`.
-
-### Canonical and noindex defaults
-
-- Canonicalize filtered, sorted, paginated, and query-param variants to the clean base page unless the variant is intentionally indexable as its own document.
-- Canonicalize alternate experiences to the primary route. In this app, `/play/...` should normally point to the equivalent `/view/...` route.
-- Keep private, auth-gated, utility, and session-entry routes out of the index.
-- Do not let duplicate numeric and slug-based URLs compete if one is the preferred public route.
-
-### Internal linking requirements
-
-- Important public pages must be reachable through crawlable `Link href` or `<a href>` links.
-- Do not rely on `router.push`, clickable cards built from `div`s, or button-only flows for key SEO destinations.
-- Every new indexable page should have at least 2 to 3 meaningful internal links to or from other public pages.
-- Use descriptive anchor text like `Browse Kilter climbs`, `Migrate from the old Kilter app`, or `Open Marco's profile` instead of generic text like `Click here` or `Learn more`.
-
-### Structured data defaults
-
-- Use JSON-LD when the page type clearly supports it.
-- Homepage: consider `Organization` and `WebSite`.
-- Page hierarchies: consider `BreadcrumbList`.
-- Public profile-like pages: consider `ProfilePage`.
-- Only add structured data that matches the visible content on the page.
-- Validate rich-result markup before shipping when relevant.
-
-### Sitemap inclusion
-
-- Review sitemap generation whenever you add a new public page type.
-- Add only public, canonical, indexable URLs to the sitemap.
-- Keep utility, duplicate, filtered, query-param, and auth-only routes out of the sitemap.
-- Use real content timestamps where possible instead of setting every entry to the current time.
-
-### Boardsesh-specific examples
-
-- Public board pages, climb view pages, migration pages, and search-focused landing pages are SEO surfaces.
-- Settings, auth, session-join flows, notifications, and alternate `/play/...` views are non-SEO surfaces by default.
-- If you add a new public page type, update the sitemap implementation in `packages/web/app/sitemap.ts` or its replacement sitemap handlers in the same change.
-- Prefer server components for page summaries and metadata generation wherever possible.
-- Reconcile keyword targeting with trademark-safe wording: describe compatibility and alternatives clearly, but never imply endorsement or affiliation.
-
-### Pre-ship SEO checklist
-
-- Is this page supposed to rank?
-- Does it have unique metadata and a canonical URL?
-- Does the first server-rendered HTML contain useful copy without hydration?
-- Should it be `noindex` instead?
-- Can crawlers reach it through normal links?
-- Should it be added to the sitemap?
-- If trademarked board names are used, is the wording descriptive and non-affiliative?
-
-### Trademark Usage (Kilter, Tension, MoonBoard)
-
-- Always capitalize correctly: **MoonBoard** (not Moonboard), **Kilter**, **Tension**
-- Use names to describe compatibility, not to brand Boardsesh: "Works with Kilter" not "Kilter app"
-- Prefer "your" to signal the user's hardware: "One app for your boards" not "One app for Kilter"
-- Never imply endorsement or affiliation with Aurora Climbing, Moon Climbing, or any manufacturer
-- See `/legal` route and `LEGAL.md` for the full trademark disclaimer
-
-### Component Structure
-
-- Server Components by default
-- Client Components only when needed (interactivity, browser APIs)
-- Feature-based organization in `packages/web/app/components/`
-
-### API Development
-
-- Follow existing REST patterns
-- Use Zod for request/response validation
-- Implement both internal and proxy endpoints as needed
-
-### Database Queries: Prefer Drizzle ORM
-
-**Always use Drizzle ORM query builder** (`db.select()`, `db.insert()`, `db.update()`, `db.delete()`) for database operations. Only fall back to raw SQL (`sql` template literals from `drizzle-orm`) when the query genuinely cannot be expressed with the query builder (complex JOINs with type casts, window functions, CTEs, EXISTS subqueries, complex aggregations).
-
-- Importing `sql` from `@/app/lib/db/db` (the raw Neon HTTP client) is blocked by lint (`no-restricted-imports`). Use Drizzle's `db` instance instead (`getDb()` or `dbz`).
-- When raw SQL is necessary, use `db.execute(sql`...`)` with Drizzle's `sql` from `drizzle-orm` — not the Neon HTTP client directly.
-- Both are safe from SQL injection (parameterized), but Drizzle gives you type safety and schema awareness.
-
-### Client-Side Storage: IndexedDB Only
-
-All client-side persistence must use IndexedDB via the `idb` package. Bare `localStorage` and `sessionStorage` references are blocked by lint (`no-restricted-globals`); the only legitimate uses are one-time migration code that reads old data and deletes it, plus a couple of e2e test affordances that need synchronous reads at render time. Mark those sites with `// oxlint-disable-next-line no-restricted-globals` and a short reason. Do not bypass the rule by writing `window.localStorage` / `window.sessionStorage` — write the bare global and disable the rule explicitly so the exception is greppable.
-
-- **Simple key-value preferences** (e.g., view mode, party mode): Use the shared utility at `packages/web/app/lib/user-preferences-db.ts` which provides `getPreference<T>(key)`, `setPreference(key, value)`, and `removePreference(key)`.
-- **Domain-specific data** (e.g., recent searches, session history, onboarding status): Create a dedicated `*-db.ts` file in `packages/web/app/lib/` following the established pattern (lazy `dbPromise` init, SSR guard, try-catch error handling). See `tab-navigation-db.ts` or `onboarding-db.ts` for examples.
-- All IndexedDB access must be guarded with `typeof window === 'undefined'` checks for SSR compatibility.
-- When migrating a value from `localStorage` to IndexedDB, include one-time migration logic that reads the old key, writes to IndexedDB, and deletes the localStorage key. See `user-preferences-db.ts` (`getPreference` fallback), `recent-searches-storage.ts`, and `party-profile-db.ts` for examples.
-
-### State Management
-
-- URL parameters as source of truth for board configuration
-- Context for cross-component state
-- IndexedDB for persistence
-
-### Mobile Considerations (Web)
-
-- iOS Safari lacks Web Bluetooth support
-- Recommend Bluefy browser for iOS users
-- Progressive enhancement for core features
+- Unique `title`, `description`, `alternates.canonical`, OG + Twitter metadata. No generic titles like `Profile | Boardsesh` — lead with what people search for (`Marco's Kilter Sessions | Boardsesh`).
+- First server-rendered HTML must contain meaningful copy: one `h1`, descriptive paragraphs, crawlable links. No indexable spinner-only pages.
+- Canonicalise filtered/sorted/paginated variants to the clean base URL. Canonicalise `/play/...` to the equivalent `/view/...`.
+- Reachable via real `<a href>` / `Link href` — not `router.push` or click-handlers on `<div>`s. ≥2–3 internal links per page with descriptive anchor text.
+- JSON-LD where it fits: `Organization`/`WebSite` (homepage), `BreadcrumbList` (hierarchies), `ProfilePage` (profiles).
+- Update `packages/web/app/sitemap.ts` when adding a new public page type. Real content timestamps, not `new Date()`.
+- Keep trademark wording compatible-not-affiliative.
 
 ## Mobile Development (packages/mobile/)
 
-The React Native app lives at `packages/mobile/` and uses Expo SDK 53, React Native 0.79, and Expo Router 5 for file-based routing.
+React Native + Expo SDK 53, React Native 0.79, Expo Router 5.
 
 ### Stack
 
-- **Routing**: `packages/mobile/app/` — Expo Router file-based routing (auth, tabs)
-- **Components**: `packages/mobile/src/components/` — native RN components (no MUI)
-- **Theme**: `packages/mobile/src/providers/theme-provider.tsx` — iOS system colors, spacing, radii
-- **Providers**: `packages/mobile/src/providers/` — auth, i18n, query, queue, theme
+- **Routing**: `packages/mobile/app/` (Expo Router file-based)
+- **Components**: `packages/mobile/src/components/` (native RN, no MUI)
+- **Theme**: `packages/mobile/src/providers/theme-provider.tsx` (iOS system colors, spacing, radii)
+- **Providers**: `packages/mobile/src/providers/` (auth, i18n, query, queue, theme)
 - **Shared packages**: `@boardsesh/ble-protocol`, `@boardsesh/board-config`, `@boardsesh/board-constants`, `@boardsesh/queue`, `@boardsesh/shared-schema`
-- **Bundler**: Metro via `packages/mobile/metro.config.js` — watches monorepo root
+- **Bundler**: Metro via `packages/mobile/metro.config.js` (watches monorepo root)
 
-### Mobile Agent Validation Sequence
+### Mobile vs. web
 
-Run these commands after making changes to `packages/mobile/`. Steps 1–3 work on any platform (including Linux cloud agents). Steps 4–5 require macOS with Xcode.
+- **No `vp check` lint** — mobile is excluded. Use `vp run typecheck:mobile`.
+- **Own i18n provider** at `packages/mobile/src/providers/i18n-provider.tsx`. No web i18n rules apply.
+- **No web dev-server workflow** — use `vp run dev:mobile` (Metro) instead. The QA-notes-into-`/api/internal/dev-metadata` flow is web-only; on mobile the `DevMetadataPanel` (More tab) reads `.boardsesh/qa-notes.md` via env injection.
+- **Styling**: `StyleSheet.create` + theme provider. No MUI, no `style`-prop avoidance rule.
+- **Dev mode**: `__DEV__` global, not `process.env.NODE_ENV`.
+- **Storage**: `expo-secure-store` for credentials, not IndexedDB.
+- **Navigation**: Expo Router, not Next.js App Router.
 
-```bash
-# 1. Type check (always run)
-vp run typecheck:mobile
+### Validation sequence
 
-# 2. Unit tests (always run)
-vp test --project mobile
+After mobile changes:
 
-# 3. Metro bundle compilation (always run — works on Linux)
-vp run check:mobile-bundle
+1. `vp run typecheck:mobile` — always.
+2. `vp test --project mobile` — always.
+3. `vp run check:mobile-bundle` — Metro bundle check (Linux-safe; highest-value).
+4. `vp run check:mobile-simulator` — macOS only; skips on Linux.
+5. `vp run mobile:screenshot` — macOS only.
 
-# 4. Full simulator build and launch (macOS only — skips on Linux)
-vp run check:mobile-simulator
+### OTA preview distribution (EAS Update)
 
-# 5. Capture simulator screenshot (macOS only — skips on Linux)
-vp run mobile:screenshot
-```
+Multiple worktrees can publish independent previews. Testers install the "preview" build once and receive JS-only OTA updates.
 
-`check:mobile-bundle` is the highest-value check: it proves all imports resolve and the JS bundle compiles, without needing a simulator. On Linux, steps 4–5 print a skip message and exit 0.
+One-time: `vp run mobile:preview-build` produces an installable `.ipa`/`.apk`. Testers install it (iOS ad-hoc, Android APK).
 
-### Mobile QA Notes
+Four preview channels (`preview-1` ... `preview-4`), one per test device. Publish: `vp run mobile:publish` (defaults to current git branch; pass `--branch`, `--message`, `--platform ios` to override). Point a channel at a branch: `bunx eas-cli@16 channel:edit preview-N --branch <branch>`.
 
-Same workflow as web. Write `.boardsesh/qa-notes.md` before starting `vp run dev:mobile`. The orchestrator (`scripts/mobile-dev-start.ts`) reads the file, injects it via env vars into the Expo config, and the `DevMetadataPanel` component shows branch name + QA notes in the More tab during dev builds.
+CI: `mobile-eas-update.yml` auto-publishes on every push to a non-main branch touching `packages/mobile/` or shared packages, and comments on the PR. `EXPO_TOKEN` secret required.
 
-```bash
-# Start mobile dev server with QA notes
-vp run dev:mobile
+A new preview build is only needed when native deps change (new Expo plugin, new native module, SDK bump). JS/TS changes ride OTA.
 
-# Or specify a custom notes file
-vp run dev:mobile -- --qa-notes-file path/to/notes.md
-```
+### Agent workflow for mobile changes
 
-Metro output is also tee'd to `.boardsesh/mobile-metro.log` for post-hoc error inspection.
-
-### OTA Preview Distribution (EAS Update)
-
-Multiple worktrees can publish independent mobile previews via EAS Update. Testers install the "preview" build once, then receive JS-only updates OTA when you publish from any branch.
-
-**One-time setup:**
-
-1. Build the preview client: `vp run mobile:preview-build` — this produces an installable `.ipa`/`.apk` with the native runtime + expo-updates baked in. Share the install link with testers.
-2. Testers install it on their device (iOS via ad-hoc provisioning, Android via APK).
-
-**Preview channels:**
-
-There are 4 preview channels available, each mapped to a different test device or tester:
-
-| Channel     | Purpose                |
-| ----------- | ---------------------- |
-| `preview-1` | Primary test device    |
-| `preview-2` | Secondary test device  |
-| `preview-3` | Third tester / device  |
-| `preview-4` | Fourth tester / device |
-
-Each channel can independently point to a different EAS Update branch. This lets multiple worktrees deliver updates to different phones simultaneously.
-
-**Publishing updates (per branch):**
-
-```bash
-# From any worktree — publishes current JS bundle to an EAS branch matching git branch
-vp run mobile:publish
-
-# Explicit branch name or message
-vp run mobile:publish -- --branch my-feature --message "fix nav regression"
-
-# iOS only
-vp run mobile:publish -- --platform ios
-```
-
-**Pointing a channel at a branch:**
-
-```bash
-# Switch preview-1 to receive updates from a specific branch
-bunx eas-cli@16 channel:edit preview-1 --branch my-feature-branch
-```
-
-**CI integration:** The `mobile-eas-update.yml` workflow auto-publishes an update on every push to a non-main branch that touches `packages/mobile/` or shared packages. It posts an update comment on the PR with instructions.
-
-**When you need a new preview build:** Only required when native dependencies change (new Expo plugin, new native module, SDK version bump). Pure JS/TS changes are covered by OTA updates.
-
-**Environment:** The preview build uses production backend (`https://www.boardsesh.com`). The `EXPO_TOKEN` secret must be set in GitHub Actions for CI publishing; locally use `bunx eas login`.
-
-### Agent workflow for React Native changes
-
-When making changes to `packages/mobile/` or shared packages that affect the mobile app, **always ask the user which preview channel to publish to** before pushing a test update. Example:
+**Always ask which preview channel to publish to** before pushing a test update:
 
 > "Changes are ready. Which preview channel should I publish to? (preview-1, preview-2, preview-3, preview-4)"
 
-After the user responds, publish and point the channel:
+Then publish and point the channel:
 
 ```bash
 vp run mobile:publish
 bunx eas-cli@16 channel:edit <channel> --branch <current-branch>
 ```
 
-Do not assume a channel — the user knows which device they're testing on. If the user has previously stated a preferred channel in this session, reuse it without asking again.
-
-### Mobile vs. Web Differences
-
-- **No lint via `vp check`** — mobile is excluded from the lint config. Use `vp run typecheck:mobile` for type checking.
-- **No i18n check** — mobile has its own i18n provider at `packages/mobile/src/providers/i18n-provider.tsx`.
-- **Styling** — `StyleSheet.create` + theme provider, not MUI or CSS. No `style` prop avoidance rule.
-- **Dev mode** — use `__DEV__` (React Native global), not `process.env.NODE_ENV`.
-- **Storage** — `expo-secure-store` for credentials, not IndexedDB.
-- **Navigation** — Expo Router (`expo-router`), not Next.js App Router.
+Don't assume a channel. If the user has stated a preferred channel earlier in this session, reuse it without asking.


### PR DESCRIPTION
## Summary
- Cuts CLAUDE.md from 618 to 247 lines (~60% reduction) without dropping any actual rules
- Compresses verbose explanations (Railway hosting, SEO checklist, i18n code examples, command listings, architecture walkthrough) into rules-only form
- Clarifies that the QA-notes / `vp run dev` / in-app `/api/internal/dev-metadata` workflow is web-only — mobile work uses `vp run dev:mobile` (Metro) and the `DevMetadataPanel` instead

## What stayed verbatim
- All "Important rules" (no `any`, MUI + design tokens, IndexedDB-only, Drizzle-over-raw-SQL, variable naming, i18n catalog parity)
- Trademark wording rules
- EAS preview channel workflow including the "ask which channel before publishing" requirement
- Shared package rules (one-responsibility, no React/DOM, no circular deps, extract-don't-duplicate)

## Test plan
- [ ] Re-read CLAUDE.md end-to-end and confirm every load-bearing rule from the old file is still present
- [ ] Confirm the mobile vs. web dev-server distinction reads cleanly to someone working in `packages/mobile/`