### PR TITLE
fix(mobile): wire PlayDrawer lightbulb to BLE connect + auto-sender

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -26,6 +26,7 @@ import { LogAscentSheet } from '../LogAscentSheet';
 import { ClimbActionsSheet } from '../ClimbActionsSheet';
 import { Icon } from '../Icon';
 import { useQueue } from '../../providers/queue-provider';
+import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useToggleFavorite } from '../../lib/graphql/hooks';
 import { getBoardRenderData } from '../../lib/board-details';
 import { hapticSuccess } from '../../lib/haptics';
@@ -89,6 +90,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const [activeSubDrawer, setActiveSubDrawer] = useState<ActiveSubDrawer>('none');
 
   const { state, setCurrentClimb, nextClimb, previousClimb, sessionId, addToQueue } = useQueue();
+  const bluetooth = useOptionalBluetoothContext();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
 
   const { boardName, layoutId, sizeId, setIds, angle } = boardConfig;
@@ -188,8 +190,14 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   }, [displayedClimb, boardName, angle, toggleFavoriteMutate]);
 
   const handleLightbulb = useCallback(() => {
-    // Phase 5: BLE integration
-  }, []);
+    if (!bluetooth) return;
+    if (!bluetooth.isConnected) {
+      void bluetooth.connect();
+      return;
+    }
+    if (!displayedClimb) return;
+    setCurrentClimb(climbToQueueItem(displayedClimb));
+  }, [bluetooth, displayedClimb, setCurrentClimb]);
 
   const handleOpenActions = useCallback(() => {
     setActiveSubDrawer('actions');
@@ -338,7 +346,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
                 supportsMirroring={supportsMirroring}
                 isFavorited={isFavorited}
                 remainingQueueCount={navigationState.remainingCount}
-                lightbulbActive={false}
+                lightbulbActive={bluetooth?.isConnected ?? false}
                 onPrevClick={handlePrev}
                 onNextClick={handleNext}
                 onMirror={handleMirror}


### PR DESCRIPTION
## Summary

- The mobile PlayDrawer lightbulb did nothing because `handleLightbulb` in `packages/mobile/src/components/play-drawer/PlayDrawer.tsx` was an empty `// Phase 5: BLE integration` stub and `lightbulbActive={false}` was hardcoded.
- The rest of the mobile BLE stack — `RNBleAdapter` (`react-native-ble-plx`), `useBoardBluetooth`, `BluetoothProvider`, `BluetoothAutoSender`, runtime permissions, device picker sheet — was already a structural port of the web stack, and `@boardsesh/ble-protocol` is shared verbatim across both apps. Only the button wiring was missing.
- This wires the lightbulb to `useOptionalBluetoothContext()`, mirroring the web solo-mode path in `packages/web/app/components/play-view/play-view-drawer.tsx:593-616`:
  - Not connected → `bluetooth.connect()` opens the existing `DevicePickerSheet`.
  - Connected → `setCurrentClimb(climbToQueueItem(displayedClimb))`, which the existing `BluetoothAutoSender` (only mounted while `isConnected`) picks up and broadcasts. Re-tapping the same climb is deduped by `lastSentUuidRef` in the auto-sender.
  - `lightbulbActive` now reads from `bluetooth?.isConnected` so the icon fills when paired (matches web "filled = a board is paired").
- Party-mode parity (`takeControl`/`releaseControl`/wall-confirm watcher) is deliberately out of scope — mobile's queue provider doesn't have that machinery yet. That's a separate larger task; when it lands, the web `handleLightbulbClick` decision tree becomes a good candidate to lift into `@boardsesh/play-view`.

One-file change: `packages/mobile/src/components/play-drawer/PlayDrawer.tsx` (+11/-3).

## Test plan

- [x] `vp run typecheck:mobile` — clean
- [x] `vp test --project mobile` — 279/279 passing
- [x] `vp run check:mobile-bundle` — android bundle OK (6.3 MB)
- [ ] Manual QA on a physical device (BLE doesn't work in the simulator) via preview-1 OTA:
  - [ ] Open a climb in PlayDrawer. Lightbulb icon is outline (not filled).
  - [ ] Tap lightbulb → `DevicePickerSheet` opens, board appears, select it.
  - [ ] Lightbulb fills (warning color); the climb's holds light up on the wall.
  - [ ] Swipe to next climb → wall updates (AutoSender path).
  - [ ] Tap a different climb in the queue → wall updates.
  - [ ] Tap lightbulb again on the already-displayed climb → no duplicate haptic / no errors (dedupe via `lastSentUuidRef`).
  - [ ] Tap lightbulb without ever having paired → picker opens (first-time case).
  - [ ] Background the app, return → connection persists (existing `AppState` reconnect logic).

OTA published to EAS branch \`worktree-fix-mobile-ble\`; channel \`preview-1\` points at it. Update group \`b4f7867d-935f-4295-aa3b-4c27ae41ce27\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)