### PR TITLE
feat(mobile): align play-view swipe carousel with web

### DIFF
--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, StyleSheet, useWindowDimensions } from 'react-native';
 import Animated, { useAnimatedStyle, useDerivedValue, useAnimatedReaction, runOnJS } from 'react-native-reanimated';
 import { GestureDetector } from 'react-native-gesture-handler';
+import { computePeekOffset, type PeekDirection } from '@boardsesh/play-view';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { BoardImageNative } from '../BoardImageNative';
 import { useCarouselGesture } from './use-carousel-gesture';
@@ -59,10 +60,11 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
     transform: [{ translateX: translateX.value }],
   }));
 
-  const peekDirection = useDerivedValue(() => (translateX.value < 0 ? 'next' : 'prev'));
+  const peekDirection = useDerivedValue<PeekDirection>(() => (translateX.value < 0 ? 'next' : 'prev'));
 
-  // Track direction in JS state so PeekBoard can select the correct frames
-  const [jsDirection, setJsDirection] = React.useState<'next' | 'prev'>('next');
+  // Mirror direction into JS state so the React tree can swap the peek board's
+  // climb frames between renders.
+  const [jsDirection, setJsDirection] = React.useState<PeekDirection>('next');
   useAnimatedReaction(
     () => peekDirection.value,
     (direction) => {
@@ -72,16 +74,16 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   );
 
   const peekStyle = useAnimatedStyle(() => {
-    const isSwiping = translateX.value !== 0;
-    if (!isSwiping) return { opacity: 0, transform: [{ translateX: screenWidth }] };
-
-    const peekOffset =
-      peekDirection.value === 'next' ? screenWidth + translateX.value : -screenWidth + translateX.value;
-
-    return {
-      opacity: 1,
-      transform: [{ translateX: peekOffset }],
-    };
+    if (translateX.value === 0) {
+      // Park the peek board off-screen when idle so it does not intercept layout.
+      return { opacity: 0, transform: [{ translateX: screenWidth }] };
+    }
+    const offset = computePeekOffset({
+      direction: peekDirection.value,
+      swipeOffset: translateX.value,
+      viewportWidth: screenWidth,
+    });
+    return { opacity: 1, transform: [{ translateX: offset }] };
   });
 
   const { boardWidth, boardHeight } = boardRenderData;
@@ -103,7 +105,7 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
           />
         </Animated.View>
 
-        <Animated.View style={[styles.peekWrapper, peekStyle]}>
+        <Animated.View style={[styles.peekWrapper, peekStyle]} pointerEvents="none">
           {peekFrames && (
             <BoardImageNative
               frames={peekFrames}

--- a/packages/mobile/src/components/play-drawer/use-carousel-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-carousel-gesture.ts
@@ -1,11 +1,9 @@
 import { useMemo, useRef } from 'react';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import { useSharedValue, withTiming, withSpring, runOnJS, type SharedValue } from 'react-native-reanimated';
+import { SWIPE_THRESHOLD, EXIT_DURATION, CLIP_EXIT_DURATION } from '@boardsesh/play-view';
 import { springs } from '../../theme/animations';
 import { hapticMedium } from '../../lib/haptics';
-
-const SWIPE_THRESHOLD = 80;
-const EXIT_DURATION = 300;
 
 type UseCarouselGestureOptions = {
   onSwipeNext: () => void;
@@ -22,6 +20,16 @@ type UseCarouselGestureReturn = {
   isAnimating: SharedValue<boolean>;
 };
 
+/**
+ * Pan gesture for the board carousel. Matches the web `useCardSwipeNavigation`
+ * delay-navigation flow: the slide-off animation runs for EXIT_DURATION, but the
+ * climb swap fires at CLIP_EXIT_DURATION so the new board appears promptly while
+ * the outgoing peek board provides visual continuity.
+ *
+ * Snap-back below threshold uses `springs.interactive` rather than a fixed
+ * SNAP_BACK_DURATION timing — a spring feels more natural on native, and the
+ * user-visible duration is comparable.
+ */
 export function useCarouselGesture({
   onSwipeNext,
   onSwipePrevious,
@@ -33,6 +41,7 @@ export function useCarouselGesture({
   const translateX = useSharedValue(0);
   const isAnimating = useSharedValue(false);
   const hasTriggeredHaptic = useSharedValue(false);
+  const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const callbacksRef = useRef({ onSwipeNext, onSwipePrevious });
   callbacksRef.current = { onSwipeNext, onSwipePrevious };
@@ -41,12 +50,21 @@ export function useCarouselGesture({
     hapticMedium();
   };
 
-  const handleSwipeNext = () => {
-    callbacksRef.current.onSwipeNext();
-  };
-
-  const handleSwipePrevious = () => {
-    callbacksRef.current.onSwipePrevious();
+  const scheduleCommit = (direction: 'next' | 'previous') => {
+    if (commitTimerRef.current) clearTimeout(commitTimerRef.current);
+    commitTimerRef.current = setTimeout(() => {
+      commitTimerRef.current = null;
+      // Jump-cut the carousel back to center so the freshly swapped climb
+      // renders in place. Assigning translateX.value cancels the in-flight
+      // withTiming on the UI thread.
+      translateX.value = 0;
+      isAnimating.value = false;
+      if (direction === 'next') {
+        callbacksRef.current.onSwipeNext();
+      } else {
+        callbacksRef.current.onSwipePrevious();
+      }
+    }, CLIP_EXIT_DURATION);
   };
 
   const gesture = useMemo(
@@ -83,20 +101,12 @@ export function useCarouselGesture({
 
           if (offset < -SWIPE_THRESHOLD && canSwipeNext) {
             isAnimating.value = true;
-            translateX.value = withTiming(-boardWidth, { duration: EXIT_DURATION }, () => {
-              'worklet';
-              translateX.value = 0;
-              isAnimating.value = false;
-              runOnJS(handleSwipeNext)();
-            });
+            translateX.value = withTiming(-boardWidth, { duration: EXIT_DURATION });
+            runOnJS(scheduleCommit)('next');
           } else if (offset > SWIPE_THRESHOLD && canSwipePrevious) {
             isAnimating.value = true;
-            translateX.value = withTiming(boardWidth, { duration: EXIT_DURATION }, () => {
-              'worklet';
-              translateX.value = 0;
-              isAnimating.value = false;
-              runOnJS(handleSwipePrevious)();
-            });
+            translateX.value = withTiming(boardWidth, { duration: EXIT_DURATION });
+            runOnJS(scheduleCommit)('previous');
           } else {
             translateX.value = withSpring(0, springs.interactive);
           }

--- a/packages/mobile/src/components/play-drawer/use-carousel-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-carousel-gesture.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import { useSharedValue, withTiming, withSpring, runOnJS, type SharedValue } from 'react-native-reanimated';
 import { SWIPE_THRESHOLD, EXIT_DURATION, CLIP_EXIT_DURATION } from '@boardsesh/play-view';
@@ -20,16 +20,8 @@ type UseCarouselGestureReturn = {
   isAnimating: SharedValue<boolean>;
 };
 
-/**
- * Pan gesture for the board carousel. Matches the web `useCardSwipeNavigation`
- * delay-navigation flow: the slide-off animation runs for EXIT_DURATION, but the
- * climb swap fires at CLIP_EXIT_DURATION so the new board appears promptly while
- * the outgoing peek board provides visual continuity.
- *
- * Snap-back below threshold uses `springs.interactive` rather than a fixed
- * SNAP_BACK_DURATION timing — a spring feels more natural on native, and the
- * user-visible duration is comparable.
- */
+// Delay-navigation: matches web — swap climb at CLIP_EXIT_DURATION while the
+// outgoing card finishes its EXIT_DURATION slide-off behind the peek board.
 export function useCarouselGesture({
   onSwipeNext,
   onSwipePrevious,
@@ -46,6 +38,13 @@ export function useCarouselGesture({
   const callbacksRef = useRef({ onSwipeNext, onSwipePrevious });
   callbacksRef.current = { onSwipeNext, onSwipePrevious };
 
+  useEffect(
+    () => () => {
+      if (commitTimerRef.current) clearTimeout(commitTimerRef.current);
+    },
+    [],
+  );
+
   const triggerHaptic = () => {
     hapticMedium();
   };
@@ -54,9 +53,7 @@ export function useCarouselGesture({
     if (commitTimerRef.current) clearTimeout(commitTimerRef.current);
     commitTimerRef.current = setTimeout(() => {
       commitTimerRef.current = null;
-      // Jump-cut the carousel back to center so the freshly swapped climb
-      // renders in place. Assigning translateX.value cancels the in-flight
-      // withTiming on the UI thread.
+      // Hard-set cancels the in-flight withTiming on the UI thread.
       translateX.value = 0;
       isAnimating.value = false;
       if (direction === 'next') {

--- a/packages/shared/play-view/src/__tests__/swipe-carousel.test.ts
+++ b/packages/shared/play-view/src/__tests__/swipe-carousel.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computePeekOffset,
+  decideSwipeDirection,
+  evaluateSwipeOutcome,
+  selectPeekDirection,
+  getEnterDirection,
+  SWIPE_THRESHOLD,
+  DIRECTION_THRESHOLD,
+} from '../swipe-carousel';
+
+describe('computePeekOffset', () => {
+  it('clamps the next-peek to 0 when finger has not moved', () => {
+    expect(computePeekOffset({ direction: 'next', swipeOffset: 0, viewportWidth: 400 })).toBe(400);
+  });
+
+  it('slides the next-peek in from the right as the finger drags left', () => {
+    expect(computePeekOffset({ direction: 'next', swipeOffset: -150, viewportWidth: 400 })).toBe(250);
+  });
+
+  it('never lets the next-peek overshoot past the viewport edge', () => {
+    expect(computePeekOffset({ direction: 'next', swipeOffset: -800, viewportWidth: 400 })).toBe(0);
+  });
+
+  it('slides the prev-peek in from the left as the finger drags right', () => {
+    expect(computePeekOffset({ direction: 'prev', swipeOffset: 150, viewportWidth: 400 })).toBe(-250);
+  });
+
+  it('never lets the prev-peek overshoot past the viewport edge', () => {
+    expect(computePeekOffset({ direction: 'prev', swipeOffset: 800, viewportWidth: 400 })).toBe(0);
+  });
+});
+
+describe('decideSwipeDirection', () => {
+  it('returns null while neither axis exceeds the threshold', () => {
+    expect(decideSwipeDirection(5, 5)).toBeNull();
+    expect(decideSwipeDirection(DIRECTION_THRESHOLD, DIRECTION_THRESHOLD)).toBeNull();
+  });
+
+  it('locks to horizontal when |dx| dominates past the threshold', () => {
+    expect(decideSwipeDirection(20, 5)).toBe('horizontal');
+    expect(decideSwipeDirection(-25, 4)).toBe('horizontal');
+  });
+
+  it('locks to vertical when |dy| dominates past the threshold', () => {
+    expect(decideSwipeDirection(5, 20)).toBe('vertical');
+    expect(decideSwipeDirection(-3, -30)).toBe('vertical');
+  });
+
+  it('honours a custom threshold', () => {
+    expect(decideSwipeDirection(25, 5, 30)).toBeNull();
+    expect(decideSwipeDirection(40, 5, 30)).toBe('horizontal');
+  });
+});
+
+describe('evaluateSwipeOutcome', () => {
+  it('returns next when swipe-left exceeds threshold and canNext is true', () => {
+    expect(evaluateSwipeOutcome({ deltaX: -100, canNext: true, canPrev: true })).toBe('next');
+  });
+
+  it('returns previous when swipe-right exceeds threshold and canPrev is true', () => {
+    expect(evaluateSwipeOutcome({ deltaX: 100, canNext: true, canPrev: true })).toBe('previous');
+  });
+
+  it('cancels when threshold is not met', () => {
+    expect(evaluateSwipeOutcome({ deltaX: -SWIPE_THRESHOLD + 1, canNext: true, canPrev: true })).toBe('cancel');
+    expect(evaluateSwipeOutcome({ deltaX: SWIPE_THRESHOLD - 1, canNext: true, canPrev: true })).toBe('cancel');
+  });
+
+  it('cancels when navigation in the requested direction is blocked', () => {
+    expect(evaluateSwipeOutcome({ deltaX: -200, canNext: false, canPrev: true })).toBe('cancel');
+    expect(evaluateSwipeOutcome({ deltaX: 200, canNext: true, canPrev: false })).toBe('cancel');
+  });
+
+  it('honours a custom threshold', () => {
+    expect(evaluateSwipeOutcome({ deltaX: -50, canNext: true, canPrev: true, threshold: 40 })).toBe('next');
+    expect(evaluateSwipeOutcome({ deltaX: -30, canNext: true, canPrev: true, threshold: 40 })).toBe('cancel');
+  });
+});
+
+describe('selectPeekDirection', () => {
+  it('locks to next when an exit-left animation is in flight', () => {
+    expect(selectPeekDirection({ animationDirection: 'left', swipeOffset: 0 })).toBe('next');
+  });
+
+  it('locks to prev when an exit-right animation is in flight', () => {
+    expect(selectPeekDirection({ animationDirection: 'right', swipeOffset: 0 })).toBe('prev');
+  });
+
+  it('falls back to the live offset sign during an active drag', () => {
+    expect(selectPeekDirection({ animationDirection: null, swipeOffset: -10 })).toBe('next');
+    expect(selectPeekDirection({ animationDirection: null, swipeOffset: 10 })).toBe('prev');
+  });
+
+  it('treats an idle gesture (offset 0) as previous', () => {
+    expect(selectPeekDirection({ animationDirection: null, swipeOffset: 0 })).toBe('prev');
+  });
+});
+
+describe('getEnterDirection', () => {
+  it('maps next-navigation to from-right (new climb enters from the right)', () => {
+    expect(getEnterDirection('next')).toBe('from-right');
+  });
+
+  it('maps previous-navigation to from-left', () => {
+    expect(getEnterDirection('previous')).toBe('from-left');
+  });
+});

--- a/packages/shared/play-view/src/index.ts
+++ b/packages/shared/play-view/src/index.ts
@@ -5,4 +5,5 @@ export * from './grade-display';
 export * from './tick-utils';
 export * from './quick-tick-state';
 export * from './board-utils';
+export * from './swipe-carousel';
 export { buildClimbViewPath } from './url-utils';

--- a/packages/shared/play-view/src/swipe-carousel.ts
+++ b/packages/shared/play-view/src/swipe-carousel.ts
@@ -1,0 +1,115 @@
+/**
+ * Platform-agnostic primitives for the swipe-board carousel.
+ *
+ * Web (`useCardSwipeNavigation`) and mobile (`useCarouselGesture`) implement the
+ * gesture/animation plumbing using their native libraries (react-swipeable + CSS
+ * transitions, react-native-gesture-handler + reanimated). The decision rules,
+ * timings, and peek math live here so both platforms stay in lockstep.
+ */
+
+/** Horizontal displacement (px) required for a swipe to commit. */
+export const SWIPE_THRESHOLD = 80;
+
+/** Minimum movement (px) before we lock a swipe to horizontal or vertical. */
+export const DIRECTION_THRESHOLD = 10;
+
+/** Duration (ms) of the slide-off animation when a swipe commits. */
+export const EXIT_DURATION = 300;
+
+/** Duration (ms) of the snap-back when a swipe is below threshold. */
+export const SNAP_BACK_DURATION = 200;
+
+/**
+ * In delay-navigation mode, the new climb is swapped in this many ms after the
+ * slide-off begins. Shorter than EXIT_DURATION so the user sees the next climb
+ * promptly while the outgoing card finishes leaving the viewport.
+ */
+export const CLIP_EXIT_DURATION = 100;
+
+/** Duration (ms) of the enter-direction crossfade after navigation commits. */
+export const ENTER_ANIMATION_DURATION = 170;
+
+export type SwipeDirection = 'left' | 'right';
+export type AnimationDirection = SwipeDirection | null;
+export type EnterDirection = 'from-left' | 'from-right';
+export type SwipeOutcome = 'next' | 'previous' | 'cancel';
+export type PeekDirection = 'next' | 'prev';
+
+/**
+ * Bounded peek translateX. Matches the web `calc(max(0, 100% + offset))` /
+ * `calc(min(0, -100% + offset))` formulas, expressed in pixels so reanimated
+ * worklets can consume it directly.
+ */
+export function computePeekOffset({
+  direction,
+  swipeOffset,
+  viewportWidth,
+}: {
+  direction: PeekDirection;
+  swipeOffset: number;
+  viewportWidth: number;
+}): number {
+  if (direction === 'next') {
+    return Math.max(0, viewportWidth + swipeOffset);
+  }
+  return Math.min(0, -viewportWidth + swipeOffset);
+}
+
+/**
+ * First-movement direction lock. Returns 'horizontal' once |dx| > |dy| past the
+ * threshold, 'vertical' the other way, or null while still under the threshold.
+ * Callers are expected to keep the decision sticky until a reset.
+ */
+export function decideSwipeDirection(
+  deltaX: number,
+  deltaY: number,
+  threshold: number = DIRECTION_THRESHOLD,
+): 'horizontal' | 'vertical' | null {
+  const absX = Math.abs(deltaX);
+  const absY = Math.abs(deltaY);
+  if (absX <= threshold && absY <= threshold) return null;
+  return absX > absY ? 'horizontal' : 'vertical';
+}
+
+/**
+ * Given a finished swipe, decide whether to navigate next, previous, or cancel.
+ * `deltaX < 0` (finger moved left) maps to `next`; the opposite to `previous`.
+ */
+export function evaluateSwipeOutcome({
+  deltaX,
+  threshold,
+  canNext,
+  canPrev,
+}: {
+  deltaX: number;
+  threshold?: number;
+  canNext: boolean;
+  canPrev: boolean;
+}): SwipeOutcome {
+  const t = threshold ?? SWIPE_THRESHOLD;
+  if (deltaX <= -t && canNext) return 'next';
+  if (deltaX >= t && canPrev) return 'previous';
+  return 'cancel';
+}
+
+/**
+ * Choose which sibling climb to render in the peek slot. During the active
+ * gesture the direction comes from the sign of the live offset; once the swipe
+ * has committed we lock to `animationDirection` (which won't flip mid-exit).
+ */
+export function selectPeekDirection({
+  animationDirection,
+  swipeOffset,
+}: {
+  animationDirection: AnimationDirection;
+  swipeOffset: number;
+}): PeekDirection {
+  if (animationDirection === 'left') return 'next';
+  if (animationDirection === 'right') return 'prev';
+  return swipeOffset < 0 ? 'next' : 'prev';
+}
+
+/** Map a committed navigation to the matching enter-crossfade direction. */
+export function getEnterDirection(navigation: 'next' | 'previous'): EnterDirection {
+  return navigation === 'next' ? 'from-right' : 'from-left';
+}

--- a/packages/shared/play-view/src/swipe-carousel.ts
+++ b/packages/shared/play-view/src/swipe-carousel.ts
@@ -1,32 +1,12 @@
-/**
- * Platform-agnostic primitives for the swipe-board carousel.
- *
- * Web (`useCardSwipeNavigation`) and mobile (`useCarouselGesture`) implement the
- * gesture/animation plumbing using their native libraries (react-swipeable + CSS
- * transitions, react-native-gesture-handler + reanimated). The decision rules,
- * timings, and peek math live here so both platforms stay in lockstep.
- */
+// Web (useCardSwipeNavigation) and mobile (useCarouselGesture) own the gesture
+// plumbing; timings + decision rules live here so both stay in lockstep.
 
-/** Horizontal displacement (px) required for a swipe to commit. */
 export const SWIPE_THRESHOLD = 80;
-
-/** Minimum movement (px) before we lock a swipe to horizontal or vertical. */
 export const DIRECTION_THRESHOLD = 10;
-
-/** Duration (ms) of the slide-off animation when a swipe commits. */
 export const EXIT_DURATION = 300;
-
-/** Duration (ms) of the snap-back when a swipe is below threshold. */
 export const SNAP_BACK_DURATION = 200;
-
-/**
- * In delay-navigation mode, the new climb is swapped in this many ms after the
- * slide-off begins. Shorter than EXIT_DURATION so the user sees the next climb
- * promptly while the outgoing card finishes leaving the viewport.
- */
+// New climb swaps in this many ms after the slide-off begins.
 export const CLIP_EXIT_DURATION = 100;
-
-/** Duration (ms) of the enter-direction crossfade after navigation commits. */
 export const ENTER_ANIMATION_DURATION = 170;
 
 export type SwipeDirection = 'left' | 'right';
@@ -35,11 +15,8 @@ export type EnterDirection = 'from-left' | 'from-right';
 export type SwipeOutcome = 'next' | 'previous' | 'cancel';
 export type PeekDirection = 'next' | 'prev';
 
-/**
- * Bounded peek translateX. Matches the web `calc(max(0, 100% + offset))` /
- * `calc(min(0, -100% + offset))` formulas, expressed in pixels so reanimated
- * worklets can consume it directly.
- */
+// 'worklet' so this is callable from reanimated UI-thread closures on mobile.
+// In non-worklet contexts (web, tests) the directive is a harmless no-op.
 export function computePeekOffset({
   direction,
   swipeOffset,
@@ -49,17 +26,13 @@ export function computePeekOffset({
   swipeOffset: number;
   viewportWidth: number;
 }): number {
+  'worklet';
   if (direction === 'next') {
     return Math.max(0, viewportWidth + swipeOffset);
   }
   return Math.min(0, -viewportWidth + swipeOffset);
 }
 
-/**
- * First-movement direction lock. Returns 'horizontal' once |dx| > |dy| past the
- * threshold, 'vertical' the other way, or null while still under the threshold.
- * Callers are expected to keep the decision sticky until a reset.
- */
 export function decideSwipeDirection(
   deltaX: number,
   deltaY: number,
@@ -71,10 +44,6 @@ export function decideSwipeDirection(
   return absX > absY ? 'horizontal' : 'vertical';
 }
 
-/**
- * Given a finished swipe, decide whether to navigate next, previous, or cancel.
- * `deltaX < 0` (finger moved left) maps to `next`; the opposite to `previous`.
- */
 export function evaluateSwipeOutcome({
   deltaX,
   threshold,
@@ -92,11 +61,6 @@ export function evaluateSwipeOutcome({
   return 'cancel';
 }
 
-/**
- * Choose which sibling climb to render in the peek slot. During the active
- * gesture the direction comes from the sign of the live offset; once the swipe
- * has committed we lock to `animationDirection` (which won't flip mid-exit).
- */
 export function selectPeekDirection({
   animationDirection,
   swipeOffset,
@@ -109,7 +73,6 @@ export function selectPeekDirection({
   return swipeOffset < 0 ? 'next' : 'prev';
 }
 
-/** Map a committed navigation to the matching enter-crossfade direction. */
 export function getEnterDirection(navigation: 'next' | 'previous'): EnterDirection {
   return navigation === 'next' ? 'from-right' : 'from-left';
 }

--- a/packages/web/app/hooks/use-card-swipe-navigation.ts
+++ b/packages/web/app/hooks/use-card-swipe-navigation.ts
@@ -2,12 +2,8 @@
 
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useSwipeable } from 'react-swipeable';
+import { EXIT_DURATION, SNAP_BACK_DURATION, CLIP_EXIT_DURATION, ENTER_ANIMATION_DURATION } from '@boardsesh/play-view';
 import { useSwipeDirection } from './use-swipe-direction';
-
-const EXIT_DURATION = 300; // ms for slide-off animation
-const SNAP_BACK_DURATION = 200; // ms for snap-back animation
-const CLIP_EXIT_DURATION = 100; // ms before starting enter — text leaves narrow clip area faster than full EXIT_DURATION
-const ENTER_ANIMATION_DURATION = 170; // ms for enter crossfade/transition after navigation
 
 export type UseCardSwipeNavigationOptions = {
   onSwipeNext: () => void;

--- a/packages/web/app/hooks/use-swipe-direction.ts
+++ b/packages/web/app/hooks/use-swipe-direction.ts
@@ -1,8 +1,7 @@
 'use client';
 
 import { useRef, useCallback } from 'react';
-
-const DIRECTION_THRESHOLD = 10;
+import { decideSwipeDirection } from '@boardsesh/play-view';
 
 /**
  * Hook to determine whether an in-progress swipe is horizontal or vertical.
@@ -10,16 +9,18 @@ const DIRECTION_THRESHOLD = 10;
  *  - Returns `null` until movement exceeds the threshold
  *  - Returns `true` if horizontal, `false` if vertical
  *  - Once locked, the direction is sticky until `reset()` is called
+ *
+ * The threshold and decision rule live in @boardsesh/play-view so mobile and
+ * web stay in lockstep.
  */
 export function useSwipeDirection() {
   const isHorizontalRef = useRef<boolean | null>(null);
 
   const detect = useCallback((deltaX: number, deltaY: number): boolean | null => {
     if (isHorizontalRef.current === null) {
-      const absX = Math.abs(deltaX);
-      const absY = Math.abs(deltaY);
-      if (absX > DIRECTION_THRESHOLD || absY > DIRECTION_THRESHOLD) {
-        isHorizontalRef.current = absX > absY;
+      const decision = decideSwipeDirection(deltaX, deltaY);
+      if (decision !== null) {
+        isHorizontalRef.current = decision === 'horizontal';
       }
     }
     return isHorizontalRef.current;


### PR DESCRIPTION
## Summary

- Brings mobile Play Drawer swipe interaction to parity with the web `SwipeBoardCarousel`: new climb now appears at `CLIP_EXIT_DURATION` (100 ms) rather than after the full 300 ms slide-off, matching web's `delayNavigation` mode.
- Extracts the swipe timings and pure peek/direction helpers into `@boardsesh/play-view` so web and mobile share one source of truth. New `computePeekOffset`, `decideSwipeDirection`, `evaluateSwipeOutcome`, `selectPeekDirection`, `getEnterDirection` (20 unit tests included).
- Mobile peek transform now uses the bounded `max/min` math from the shared helper, preventing the peek board from overshooting when the finger drags past viewport width.
- Web `use-card-swipe-navigation` and `use-swipe-direction` now import the shared constants/decision rule. No behaviour change on web.

Queue + history business logic was already shared via `@boardsesh/queue` (reducer/types) and `@boardsesh/play-view` (`buildQueueListModel`, `findNext/PreviousQueueItem`, `computeNavigationState`), consumed by both web `QueueContext` and mobile `QueueProvider`/`QueueList` — no work needed there.

Out of scope (later roadmap phases): zoom/pan, double-tap favorite, party-mode drift, BLE lightbulb.

## Test plan

- [x] `vp run typecheck:shared` / `typecheck:mobile` / `typecheck:web` — all pass
- [x] `vp test --project play-view` — 85/85 pass (20 new swipe-carousel tests)
- [x] `vp test --project mobile` — 279/279 pass
- [x] `vp test packages/web/app/hooks/__tests__/use-card-swipe-navigation.test.ts` — 20/20 pass
- [x] `vp check` — 0 errors
- [x] `vp run check:mobile-bundle` — iOS + Android bundles OK
- [ ] Manual QA on iOS simulator: open Play Drawer on a multi-climb queue, verify below-threshold swipe snaps back, above-threshold swipe shows new climb within ~100 ms, peek board doesn't overshoot, swipe back walks queue history, haptic fires once at threshold
- [ ] Web smoke: swipe between climbs in `/view/{uuid}` — behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)