### PR TITLE
fix(mobile): don't auto-focus beta URL input when PlayDrawer opens

### DIFF
--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -7,12 +7,13 @@ type SheetProps = {
   children: ReactNode;
   snapPoints?: (string | number)[];
   enableDynamicSizing?: boolean;
+  onChange?: (index: number) => void;
   onClose?: () => void;
   enablePanDownToClose?: boolean;
 };
 
 export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
-  { children, snapPoints: customSnapPoints, enableDynamicSizing = false, onClose, enablePanDownToClose = true },
+  { children, snapPoints: customSnapPoints, enableDynamicSizing = false, onChange, onClose, enablePanDownToClose = true },
   ref,
 ) {
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);
@@ -24,9 +25,13 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
     [],
   );
 
-  const handleChange = useCallback((index: number) => {
-    if (index >= 0) hapticMedium();
-  }, []);
+  const handleChange = useCallback(
+    (index: number) => {
+      if (index >= 0) hapticMedium();
+      onChange?.(index);
+    },
+    [onChange],
+  );
 
   return (
     <BottomSheet

--- a/packages/mobile/src/components/play-drawer/BetaVideoAddSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/BetaVideoAddSheet.tsx
@@ -30,12 +30,16 @@ export const BetaVideoAddSheet = forwardRef<BetaVideoAddSheetHandle, Props>(func
   const { t } = useTranslation('session');
   const { showToast } = useToast();
   const bottomSheetRef = useRef<BottomSheet>(null);
+  const inputRef = useRef<TextInput>(null);
   const [url, setUrl] = useState('');
 
   const attach = useAttachBetaLink();
 
   useImperativeHandle(ref, () => ({
-    open: () => bottomSheetRef.current?.snapToIndex(0),
+    open: () => {
+      bottomSheetRef.current?.snapToIndex(0);
+      setTimeout(() => inputRef.current?.focus(), 300);
+    },
     close: () => bottomSheetRef.current?.close(),
   }));
 
@@ -84,6 +88,7 @@ export const BetaVideoAddSheet = forwardRef<BetaVideoAddSheetHandle, Props>(func
           </Text>
 
           <TextInput
+            ref={inputRef}
             value={url}
             onChangeText={setUrl}
             placeholder={t('mobile.betaVideos.urlPlaceholder')}
@@ -91,7 +96,6 @@ export const BetaVideoAddSheet = forwardRef<BetaVideoAddSheetHandle, Props>(func
             keyboardType="url"
             autoCapitalize="none"
             autoCorrect={false}
-            autoFocus
             returnKeyType="send"
             onSubmitEditing={handleSubmit}
             style={styles.input}

--- a/packages/mobile/src/components/play-drawer/BetaVideoAddSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/BetaVideoAddSheet.tsx
@@ -36,12 +36,13 @@ export const BetaVideoAddSheet = forwardRef<BetaVideoAddSheetHandle, Props>(func
   const attach = useAttachBetaLink();
 
   useImperativeHandle(ref, () => ({
-    open: () => {
-      bottomSheetRef.current?.snapToIndex(0);
-      setTimeout(() => inputRef.current?.focus(), 300);
-    },
+    open: () => bottomSheetRef.current?.snapToIndex(0),
     close: () => bottomSheetRef.current?.close(),
   }));
+
+  const handleSheetChange = useCallback((index: number) => {
+    if (index >= 0) inputRef.current?.focus();
+  }, []);
 
   const trimmed = url.trim();
   const hasInput = trimmed.length > 0;
@@ -77,7 +78,7 @@ export const BetaVideoAddSheet = forwardRef<BetaVideoAddSheetHandle, Props>(func
   const snapPoints = useMemo(() => ['40%'], []);
 
   return (
-    <Sheet ref={bottomSheetRef} snapPoints={snapPoints} onClose={handleClose}>
+    <Sheet ref={bottomSheetRef} snapPoints={snapPoints} onChange={handleSheetChange} onClose={handleClose}>
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 24}


### PR DESCRIPTION
## Summary\n\n- **Bug:** Opening the PlayDrawer immediately showed the keyboard because the `TextInput` in `BetaVideoAddSheet` had `autoFocus`, which fired on mount even though the bottom sheet was closed (`index={-1}`)\n- **Fix:** Removed `autoFocus` and instead focus the input programmatically (via ref) when the sheet's `open()` handler is called, with a 300ms delay to let the sheet animation start\n\n## Test plan\n\n- [ ] Open the PlayDrawer — keyboard should NOT appear\n- [ ] Tap the \"+\" button to add a beta video — keyboard should appear and the URL input should be focused\n- [ ] Submit a URL, close the sheet, reopen — focus behavior should be consistent\n- [ ] `vp run typecheck:mobile` passes\n- [ ] `vp test --project mobile` passes\n- [ ] `vp run check:mobile-bundle` passes\n\nhttps://claude.ai/code/session_011KHKwNnm6K3QRRhTSFkuup

---
_Generated by [Claude Code](https://claude.ai/code/session_011KHKwNnm6K3QRRhTSFkuup)_