### PR TITLE
feat(dev): expose Metro bundler over Tailscale

### DIFF
--- a/packages/web/scripts/dev-with-tailscale.ts
+++ b/packages/web/scripts/dev-with-tailscale.ts
@@ -1,96 +1,15 @@
-import { execFileSync, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { resolveTailscaleHostname } from '../../../scripts/lib/tailscale-hostname';
+
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const rootDirectory = resolve(scriptDirectory, '../../..');
 
-type HostResolution = {
-  hostname: string;
-  source: 'env' | 'tailscale' | 'fallback';
-  reason?: string;
-};
-
 const DEFAULT_WEB_PORT = '3000';
 const DEFAULT_BACKEND_PORT = '8080';
-const TAILSCALE_STATUS_TIMEOUT_MS = 1500;
-
-function normalizeHostname(value: string): string | null {
-  const trimmed = value.trim().replace(/\.$/, '');
-  if (!trimmed) return null;
-
-  if (trimmed.includes('://') || trimmed.includes('/') || trimmed.includes(':')) {
-    return null;
-  }
-
-  if (!/^[a-zA-Z0-9.-]+$/.test(trimmed)) {
-    return null;
-  }
-
-  return trimmed.toLowerCase();
-}
-
-function resolveHostname(): HostResolution {
-  const envHostnameRaw = process.env.TAILSCALE_HOSTNAME;
-  if (envHostnameRaw !== undefined) {
-    const envHostname = normalizeHostname(envHostnameRaw);
-    if (envHostname) {
-      return { hostname: envHostname, source: 'env' };
-    }
-
-    return {
-      hostname: 'localhost',
-      source: 'fallback',
-      reason: 'TAILSCALE_HOSTNAME is invalid; falling back to localhost',
-    };
-  }
-
-  try {
-    const statusJson = execFileSync('tailscale', ['status', '--json'], {
-      encoding: 'utf8',
-      timeout: TAILSCALE_STATUS_TIMEOUT_MS,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-
-    const parsed = JSON.parse(statusJson) as { Self?: { DNSName?: string } };
-    const dnsName = parsed.Self?.DNSName;
-
-    if (!dnsName) {
-      return {
-        hostname: 'localhost',
-        source: 'fallback',
-        reason: 'tailscale status missing Self.DNSName; falling back to localhost',
-      };
-    }
-
-    const normalizedDnsName = normalizeHostname(dnsName);
-    if (!normalizedDnsName) {
-      return {
-        hostname: 'localhost',
-        source: 'fallback',
-        reason: 'tailscale DNSName invalid; falling back to localhost',
-      };
-    }
-
-    return { hostname: normalizedDnsName, source: 'tailscale' };
-  } catch (error) {
-    const errorCode = (error as NodeJS.ErrnoException).code;
-    if (errorCode === 'ENOENT') {
-      return {
-        hostname: 'localhost',
-        source: 'fallback',
-        reason: 'tailscale CLI not installed; falling back to localhost',
-      };
-    }
-
-    return {
-      hostname: 'localhost',
-      source: 'fallback',
-      reason: 'tailscale unavailable; falling back to localhost',
-    };
-  }
-}
 
 function setDefaultEnv(key: string, value: string): void {
   if (!process.env[key]) {
@@ -133,7 +52,7 @@ function main(): void {
 
   const webPort = process.env.PORT || DEFAULT_WEB_PORT;
   const backendPort = process.env.BACKEND_PORT || DEFAULT_BACKEND_PORT;
-  const resolution = resolveHostname();
+  const resolution = resolveTailscaleHostname();
 
   // HTTPS mode: orchestrator has provisioned a Tailscale cert and injected
   // DEV_HTTPS_CERT_FILE / DEV_HTTPS_KEY_FILE. Both must be present to switch

--- a/scripts/dev-orchestrator.ts
+++ b/scripts/dev-orchestrator.ts
@@ -9,6 +9,8 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { resolveTailscaleHostname as resolveTailscaleHostResolution } from './lib/tailscale-hostname';
+
 // `vp run dev` always launches its own backend so that two worktrees / two
 // branches can never accidentally share one backend instance — that path
 // silently lets the frontend on branch A talk to the backend built from
@@ -23,7 +25,6 @@ const HEALTH_CHECK_TIMEOUT_MS = 5000;
 const HEALTH_CHECK_INTERVAL_MS = 500;
 const HEALTH_CHECK_MAX_ATTEMPTS = HEALTH_CHECK_TIMEOUT_MS / HEALTH_CHECK_INTERVAL_MS;
 
-const TAILSCALE_STATUS_TIMEOUT_MS = 1500;
 const TAILSCALE_CERT_TIMEOUT_MS = 60_000;
 
 // OOM guard configuration. The dev host has crashed twice from running too many
@@ -226,23 +227,13 @@ function loadGeneratedDevDbEnv(): DevDbEnv {
   return env;
 }
 
-/**
- * Resolve the Tailscale hostname from `tailscale status --json`. Returns null
- * if Tailscale isn't installed, not logged in, or not reporting a DNS name.
- */
+// Resolve the Tailscale hostname using the shared helper, narrowing to
+// `string | null` since the orchestrator only cares about "do we have a
+// Tailnet hostname or not?" — the structured fallback reason is only useful
+// for the dev-script logging paths.
 function resolveTailscaleHostname(): string | null {
-  try {
-    const statusJson = execFileSync('tailscale', ['status', '--json'], {
-      encoding: 'utf8',
-      timeout: TAILSCALE_STATUS_TIMEOUT_MS,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    const parsed = JSON.parse(statusJson) as { Self?: { DNSName?: string } };
-    const dns = parsed.Self?.DNSName?.trim().replace(/\.$/, '');
-    return dns && /^[a-zA-Z0-9.-]+$/.test(dns) ? dns.toLowerCase() : null;
-  } catch {
-    return null;
-  }
+  const resolution = resolveTailscaleHostResolution();
+  return resolution.source === 'fallback' ? null : resolution.hostname;
 }
 
 type ProvisionResult = {

--- a/scripts/lib/tailscale-hostname.ts
+++ b/scripts/lib/tailscale-hostname.ts
@@ -38,34 +38,13 @@ export function resolveTailscaleHostname(): TailscaleHostResolution {
     };
   }
 
+  let statusJson: string;
   try {
-    const statusJson = execFileSync('tailscale', ['status', '--json'], {
+    statusJson = execFileSync('tailscale', ['status', '--json'], {
       encoding: 'utf8',
       timeout: TAILSCALE_STATUS_TIMEOUT_MS,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-
-    const parsed = JSON.parse(statusJson) as { Self?: { DNSName?: string } };
-    const dnsName = parsed.Self?.DNSName;
-
-    if (!dnsName) {
-      return {
-        hostname: 'localhost',
-        source: 'fallback',
-        reason: 'tailscale status missing Self.DNSName; falling back to localhost',
-      };
-    }
-
-    const normalizedDnsName = normalizeHostname(dnsName);
-    if (!normalizedDnsName) {
-      return {
-        hostname: 'localhost',
-        source: 'fallback',
-        reason: 'tailscale DNSName invalid; falling back to localhost',
-      };
-    }
-
-    return { hostname: normalizedDnsName, source: 'tailscale' };
   } catch (error) {
     const errorCode = (error as NodeJS.ErrnoException).code;
     if (errorCode === 'ENOENT') {
@@ -82,4 +61,43 @@ export function resolveTailscaleHostname(): TailscaleHostResolution {
       reason: 'tailscale unavailable; falling back to localhost',
     };
   }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(statusJson);
+  } catch {
+    return {
+      hostname: 'localhost',
+      source: 'fallback',
+      reason: 'tailscale status returned malformed JSON; falling back to localhost',
+    };
+  }
+
+  const dnsName = extractSelfDnsName(parsed);
+  if (!dnsName) {
+    return {
+      hostname: 'localhost',
+      source: 'fallback',
+      reason: 'tailscale status missing Self.DNSName; falling back to localhost',
+    };
+  }
+
+  const normalizedDnsName = normalizeHostname(dnsName);
+  if (!normalizedDnsName) {
+    return {
+      hostname: 'localhost',
+      source: 'fallback',
+      reason: 'tailscale DNSName invalid; falling back to localhost',
+    };
+  }
+
+  return { hostname: normalizedDnsName, source: 'tailscale' };
+}
+
+function extractSelfDnsName(parsed: unknown): string | null {
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const self = (parsed as { Self?: unknown }).Self;
+  if (typeof self !== 'object' || self === null) return null;
+  const dnsName = (self as { DNSName?: unknown }).DNSName;
+  return typeof dnsName === 'string' ? dnsName : null;
 }

--- a/scripts/lib/tailscale-hostname.ts
+++ b/scripts/lib/tailscale-hostname.ts
@@ -1,0 +1,85 @@
+import { execFileSync } from 'node:child_process';
+
+export type TailscaleHostResolution = {
+  hostname: string;
+  source: 'env' | 'tailscale' | 'fallback';
+  reason?: string;
+};
+
+const TAILSCALE_STATUS_TIMEOUT_MS = 1500;
+
+function normalizeHostname(value: string): string | null {
+  const trimmed = value.trim().replace(/\.$/, '');
+  if (!trimmed) return null;
+
+  if (trimmed.includes('://') || trimmed.includes('/') || trimmed.includes(':')) {
+    return null;
+  }
+
+  if (!/^[a-zA-Z0-9.-]+$/.test(trimmed)) {
+    return null;
+  }
+
+  return trimmed.toLowerCase();
+}
+
+export function resolveTailscaleHostname(): TailscaleHostResolution {
+  const envHostnameRaw = process.env.TAILSCALE_HOSTNAME;
+  if (envHostnameRaw !== undefined) {
+    const envHostname = normalizeHostname(envHostnameRaw);
+    if (envHostname) {
+      return { hostname: envHostname, source: 'env' };
+    }
+
+    return {
+      hostname: 'localhost',
+      source: 'fallback',
+      reason: 'TAILSCALE_HOSTNAME is invalid; falling back to localhost',
+    };
+  }
+
+  try {
+    const statusJson = execFileSync('tailscale', ['status', '--json'], {
+      encoding: 'utf8',
+      timeout: TAILSCALE_STATUS_TIMEOUT_MS,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const parsed = JSON.parse(statusJson) as { Self?: { DNSName?: string } };
+    const dnsName = parsed.Self?.DNSName;
+
+    if (!dnsName) {
+      return {
+        hostname: 'localhost',
+        source: 'fallback',
+        reason: 'tailscale status missing Self.DNSName; falling back to localhost',
+      };
+    }
+
+    const normalizedDnsName = normalizeHostname(dnsName);
+    if (!normalizedDnsName) {
+      return {
+        hostname: 'localhost',
+        source: 'fallback',
+        reason: 'tailscale DNSName invalid; falling back to localhost',
+      };
+    }
+
+    return { hostname: normalizedDnsName, source: 'tailscale' };
+  } catch (error) {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === 'ENOENT') {
+      return {
+        hostname: 'localhost',
+        source: 'fallback',
+        reason: 'tailscale CLI not installed; falling back to localhost',
+      };
+    }
+
+    return {
+      hostname: 'localhost',
+      source: 'fallback',
+      reason: 'tailscale unavailable; falling back to localhost',
+    };
+  }
+}

--- a/scripts/mobile-dev-start.ts
+++ b/scripts/mobile-dev-start.ts
@@ -5,7 +5,10 @@ import { existsSync, readFileSync, mkdirSync, createWriteStream } from 'node:fs'
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { resolveTailscaleHostname } from './lib/tailscale-hostname';
+
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const METRO_DEFAULT_PORT = '8081';
 const BOARDSESH_DIR = join(ROOT_DIR, '.boardsesh');
 const METRO_LOG_PATH = join(BOARDSESH_DIR, 'mobile-metro.log');
 const DEFAULT_QA_NOTES_PATH = join(BOARDSESH_DIR, 'qa-notes.md');
@@ -98,10 +101,18 @@ function resolveQaNotes(explicitPath: string | null): { contents: string | null;
 const { qaNotesFilePath: cliQaNotesPath, passthroughArgs } = parseArgs(process.argv.slice(2));
 const branchName = resolveCurrentBranchName();
 const qaNotes = resolveQaNotes(cliQaNotesPath);
+const tailscale = resolveTailscaleHostname();
 
 console.log(`[dev:mobile] Branch: ${branchName ?? '(detached)'}`);
 if (qaNotes.filePath) {
   console.log(`[dev:mobile] QA notes: ${qaNotes.filePath}`);
+}
+console.log(`[dev:mobile] Hostname: ${tailscale.hostname} (${tailscale.source})`);
+if (tailscale.reason) {
+  console.log(`[dev:mobile] ${tailscale.reason}`);
+}
+if (tailscale.source !== 'fallback') {
+  console.log(`[dev:mobile] Metro: http://${tailscale.hostname}:${METRO_DEFAULT_PORT}`);
 }
 console.log(`[dev:mobile] Metro log: .boardsesh/mobile-metro.log`);
 
@@ -112,8 +123,18 @@ const childEnv: NodeJS.ProcessEnv = { ...process.env };
 if (branchName) childEnv.BOARDSESH_DEV_BRANCH_NAME = branchName;
 if (qaNotes.contents) childEnv.BOARDSESH_DEV_QA_NOTES = qaNotes.contents;
 if (qaNotes.filePath) childEnv.BOARDSESH_DEV_QA_NOTES_FILE = qaNotes.filePath;
+if (tailscale.source !== 'fallback') {
+  childEnv.REACT_NATIVE_PACKAGER_HOSTNAME = tailscale.hostname;
+}
 
-const child = spawn('bunx', ['expo', 'start', ...passthroughArgs], {
+// Bind Metro on 0.0.0.0 (Expo's --host lan) so devices on the same Tailnet can
+// reach the bundler. Respect a user-supplied --host so manual overrides win.
+const userPassedHost = passthroughArgs.some((arg) => arg === '--host' || arg.startsWith('--host='));
+const expoArgs = userPassedHost
+  ? ['expo', 'start', ...passthroughArgs]
+  : ['expo', 'start', '--host', 'lan', ...passthroughArgs];
+
+const child = spawn('bunx', expoArgs, {
   cwd: join(ROOT_DIR, 'packages', 'mobile'),
   env: childEnv,
   stdio: ['inherit', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
- `vp run dev:mobile` now resolves the laptop's Tailscale MagicDNS name and passes it to Expo via `REACT_NATIVE_PACKAGER_HOSTNAME`, so physical devices on the Tailnet can reach the Metro bundler (previously Expo advertised a LAN IP that isn't routable over Tailscale).
- Always binds Metro on `0.0.0.0` (`--host lan`) unless the user explicitly passes their own `--host`. Falls back silently to Expo's normal LAN behavior when Tailscale isn't installed or logged in.
- Extracts the existing web hostname resolver from `packages/web/scripts/dev-with-tailscale.ts` into a shared `scripts/lib/tailscale-hostname.ts` so the web dev server and mobile dev script share the same logic.

## Test plan
- [x] `vp run typecheck` passes
- [x] With Tailscale up: `vp run dev:mobile` prints `Hostname: <machine>.tail<...>.ts.net (tailscale)` and `Metro: http://<host>:8081`, and Expo starts with `--host lan`
- [ ] With `sudo tailscale down`: `vp run dev:mobile` prints `Hostname: localhost (fallback)` and Expo falls back to its normal LAN IP discovery
- [ ] `vp run dev:mobile -- --host tunnel` does not append a second `--host lan`
- [ ] `vp run dev` (web) still works end to end — `dev-with-tailscale.ts` refactor is behavior-preserving

🤖 Generated with [Claude Code](https://claude.com/claude-code)