### PR TITLE
Add tests for crypto package

### DIFF
--- a/packages/crypto/src/__tests__/crypto.test.ts
+++ b/packages/crypto/src/__tests__/crypto.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { encrypt, decrypt, isEncrypted } from '../crypto';
+
+describe('encrypt and decrypt', () => {
+  it('roundtrips plaintext correctly', () => {
+    const plaintext = 'Hello, World!';
+    const encrypted = encrypt(plaintext);
+    const decrypted = decrypt(encrypted);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it('handles empty strings', () => {
+    const plaintext = '';
+    const encrypted = encrypt(plaintext);
+    const decrypted = decrypt(encrypted);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it('handles unicode and emoji characters', () => {
+    const plaintext = '🧗‍♀️ Climbing! 日本語 émojis';
+    const encrypted = encrypt(plaintext);
+    const decrypted = decrypt(encrypted);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it('handles long strings', () => {
+    const plaintext = 'A'.repeat(10000);
+    const encrypted = encrypt(plaintext);
+    const decrypted = decrypt(encrypted);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it('produces different ciphertext for same plaintext', () => {
+    const plaintext = 'test';
+    const encrypted1 = encrypt(plaintext);
+    const encrypted2 = encrypt(plaintext);
+    // Different IVs should produce different ciphertext
+    expect(encrypted1).not.toBe(encrypted2);
+    // But both should decrypt to the same plaintext
+    expect(decrypt(encrypted1)).toBe(plaintext);
+    expect(decrypt(encrypted2)).toBe(plaintext);
+  });
+
+  it('throws on tampered ciphertext', () => {
+    const encrypted = encrypt('test');
+    // Modify the last character to corrupt the auth tag
+    const tampered = encrypted.slice(0, -1) + 'X';
+    expect(() => decrypt(tampered)).toThrow();
+  });
+
+  it('throws on invalid base64', () => {
+    expect(() => decrypt('not-valid-base64!!!')).toThrow();
+  });
+
+  it('throws on ciphertext that is too short', () => {
+    // Need at least IV (16) + AuthTag (16) + 1 byte = 33 bytes
+    const shortBase64 = Buffer.from('short').toString('base64');
+    expect(() => decrypt(shortBase64)).toThrow();
+  });
+});
+
+describe('isEncrypted', () => {
+  it('returns true for encrypted strings', () => {
+    const encrypted = encrypt('test');
+    expect(isEncrypted(encrypted)).toBe(true);
+  });
+
+  it('returns true for properly formatted encrypted data', () => {
+    const encrypted = encrypt('Hello, World!');
+    expect(isEncrypted(encrypted)).toBe(true);
+  });
+
+  it('returns false for plain text', () => {
+    expect(isEncrypted('hello world')).toBe(false);
+  });
+
+  it('returns false for short base64 strings', () => {
+    // 'test' in base64 - too short to be valid encrypted data
+    expect(isEncrypted('dGVzdA==')).toBe(false);
+  });
+
+  it('returns false for invalid base64', () => {
+    expect(isEncrypted('not valid base64!!!')).toBe(false);
+  });
+
+  it('returns false for empty strings', () => {
+    expect(isEncrypted('')).toBe(false);
+  });
+
+  it('returns false for strings that look like base64 but are too short', () => {
+    // Valid base64 but shorter than IV + AuthTag + 1 byte (33 bytes)
+    const shortValid = Buffer.from('short').toString('base64');
+    expect(isEncrypted(shortValid)).toBe(false);
+  });
+});

--- a/packages/crypto/src/__tests__/key-derivation.test.ts
+++ b/packages/crypto/src/__tests__/key-derivation.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { deriveKey, KEY_LENGTH } from '../key-derivation';
+
+describe('deriveKey', () => {
+  it('produces consistent output for same input', () => {
+    const secret = 'my-secret-key';
+    const key1 = deriveKey(secret);
+    const key2 = deriveKey(secret);
+    expect(key1).toEqual(key2);
+  });
+
+  it('produces different keys for different secrets', () => {
+    const key1 = deriveKey('secret1');
+    const key2 = deriveKey('secret2');
+    expect(key1).not.toEqual(key2);
+  });
+
+  it('returns correct key length for AES-256', () => {
+    const key = deriveKey('test-secret');
+    // AES-256 requires 32 bytes (256 bits)
+    expect(key.length).toBe(KEY_LENGTH);
+    expect(key.length).toBe(32);
+  });
+
+  it('produces valid Buffer output', () => {
+    const key = deriveKey('test');
+    expect(Buffer.isBuffer(key)).toBe(true);
+  });
+
+  it('handles empty string secret', () => {
+    // Should still produce a valid key, even if not recommended
+    const key = deriveKey('');
+    expect(key.length).toBe(KEY_LENGTH);
+  });
+
+  it('handles very long secrets', () => {
+    const longSecret = 'x'.repeat(1000);
+    const key = deriveKey(longSecret);
+    expect(key.length).toBe(KEY_LENGTH);
+  });
+
+  it('handles special characters in secret', () => {
+    const key = deriveKey('!@#$%^&*()_+-=[]{}|;:,.<>?');
+    expect(key.length).toBe(KEY_LENGTH);
+  });
+
+  it('handles unicode characters in secret', () => {
+    const key = deriveKey('🔐 Secret 密钥');
+    expect(key.length).toBe(KEY_LENGTH);
+  });
+});

--- a/packages/crypto/vite.config.ts
+++ b/packages/crypto/vite.config.ts
@@ -1,3 +1,13 @@
 import { defineConfig } from 'vite-plus';
 
-export default defineConfig({});
+export default defineConfig({
+  test: {
+    name: 'crypto',
+    globals: true,
+    environment: 'node',
+    include: ['src/__tests__/**/*.test.ts'],
+    env: {
+      NODE_ENV: 'development',
+    },
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
       './packages/moonboard-ocr/vite.config.ts',
       './packages/board-constants/vite.config.ts',
       './packages/aurora-sync/vite.config.ts',
+      './packages/crypto/vite.config.ts',
       './packages/shared/ble-protocol/vite.config.ts',
       './packages/shared/queue/vite.config.ts',
       './packages/shared/play-view/vite.config.ts',


### PR DESCRIPTION
## Summary
Adds basic tests for the `crypto/` package.

## Changes:
- **23 tests** covering encryption, decryption, and key derivation
- **92.85% code coverage** overall
- Configured crypto package in root `vite.config.ts` with test environment
- Tests cover:
  - Encryption/decryption roundtrips (basic, empty, unicode/emoji, long strings)
  - Security properties (IV randomness, auth tag validation, tampered ciphertext detection)
 - Edge cases (invalid base64, short ciphertext)
 - Key derivation consistency and determinism
 - Key derivation edge cases (empty secrets, long secrets, special characters, unicode) 
 - `isEncrypted()` utility validation

## Motivation
As a first contribution, I wanted to add value to a core component while familiarizing myself with the codebase. I like the mission of Boardsesh and tried it personally at my climbing gym before contributing here. Leveraged Claude Code to familiarize myself with the codebase and structure, setup and run the server, and understand the existing gaps in the repo's code coverage.

## Test plan
* [x] Successfully passed `vp test crypto` in project root
* [x] Successfully passed `vp test` in project root
* [x] No changes to existing functionality
* [x] Follows existing test patterns in the repo