### PR TITLE
feat(mobile): persistent queue control bar + shared grade-display

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -274,7 +274,6 @@
       "name": "@boardsesh/play-view",
       "version": "1.0.0",
       "dependencies": {
-        "@boardsesh/board-config": "*",
         "@boardsesh/board-constants": "*",
         "@boardsesh/queue": "*",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -274,6 +274,7 @@
       "name": "@boardsesh/play-view",
       "version": "1.0.0",
       "dependencies": {
+        "@boardsesh/board-config": "*",
         "@boardsesh/board-constants": "*",
         "@boardsesh/queue": "*",
       },

--- a/packages/board-constants/package.json
+++ b/packages/board-constants/package.json
@@ -30,6 +30,11 @@
       "import": "./src/grade-colors.ts",
       "default": "./src/grade-colors.ts"
     },
+    "./boulder-grade-mapping": {
+      "types": "./src/boulder-grade-mapping.ts",
+      "import": "./src/boulder-grade-mapping.ts",
+      "default": "./src/boulder-grade-mapping.ts"
+    },
     "./moonboard": {
       "types": "./src/moonboard.ts",
       "import": "./src/moonboard.ts",

--- a/packages/board-constants/src/boulder-grade-mapping.ts
+++ b/packages/board-constants/src/boulder-grade-mapping.ts
@@ -1,0 +1,39 @@
+/**
+ * Boulder-grade taxonomy: the static V ↔ Font mapping table.
+ *
+ * Owned by board-constants (zero deps) so display utilities can import it
+ * without dragging the full @boardsesh/board-config module graph (board
+ * image dimensions, set IDs, moonboard config, etc.) into the bundle.
+ *
+ * @boardsesh/board-config re-exports `BOULDER_GRADES` from here for
+ * back-compat with existing call sites.
+ */
+
+export const BOULDER_GRADES = [
+  { difficulty_id: 10, font_grade: '4a', v_grade: 'V0', difficulty_name: '4a/V0' },
+  { difficulty_id: 11, font_grade: '4b', v_grade: 'V0', difficulty_name: '4b/V0' },
+  { difficulty_id: 12, font_grade: '4c', v_grade: 'V0', difficulty_name: '4c/V0' },
+  { difficulty_id: 13, font_grade: '5a', v_grade: 'V1', difficulty_name: '5a/V1' },
+  { difficulty_id: 14, font_grade: '5b', v_grade: 'V1', difficulty_name: '5b/V1' },
+  { difficulty_id: 15, font_grade: '5c', v_grade: 'V2', difficulty_name: '5c/V2' },
+  { difficulty_id: 16, font_grade: '6a', v_grade: 'V3', difficulty_name: '6a/V3' },
+  { difficulty_id: 17, font_grade: '6a+', v_grade: 'V3', difficulty_name: '6a+/V3' },
+  { difficulty_id: 18, font_grade: '6b', v_grade: 'V4', difficulty_name: '6b/V4' },
+  { difficulty_id: 19, font_grade: '6b+', v_grade: 'V4', difficulty_name: '6b+/V4' },
+  { difficulty_id: 20, font_grade: '6c', v_grade: 'V5', difficulty_name: '6c/V5' },
+  { difficulty_id: 21, font_grade: '6c+', v_grade: 'V5', difficulty_name: '6c+/V5' },
+  { difficulty_id: 22, font_grade: '7a', v_grade: 'V6', difficulty_name: '7a/V6' },
+  { difficulty_id: 23, font_grade: '7a+', v_grade: 'V7', difficulty_name: '7a+/V7' },
+  { difficulty_id: 24, font_grade: '7b', v_grade: 'V8', difficulty_name: '7b/V8' },
+  { difficulty_id: 25, font_grade: '7b+', v_grade: 'V8', difficulty_name: '7b+/V8' },
+  { difficulty_id: 26, font_grade: '7c', v_grade: 'V9', difficulty_name: '7c/V9' },
+  { difficulty_id: 27, font_grade: '7c+', v_grade: 'V10', difficulty_name: '7c+/V10' },
+  { difficulty_id: 28, font_grade: '8a', v_grade: 'V11', difficulty_name: '8a/V11' },
+  { difficulty_id: 29, font_grade: '8a+', v_grade: 'V12', difficulty_name: '8a+/V12' },
+  { difficulty_id: 30, font_grade: '8b', v_grade: 'V13', difficulty_name: '8b/V13' },
+  { difficulty_id: 31, font_grade: '8b+', v_grade: 'V14', difficulty_name: '8b+/V14' },
+  { difficulty_id: 32, font_grade: '8c', v_grade: 'V15', difficulty_name: '8c/V15' },
+  { difficulty_id: 33, font_grade: '8c+', v_grade: 'V16', difficulty_name: '8c+/V16' },
+] as const;
+
+export type BoulderGrade = (typeof BOULDER_GRADES)[number];

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -15,7 +15,7 @@ import {
   DEFAULT_FILTERS,
   type ClimbFilters,
 } from '../../../src/components/ClimbFilterSheet';
-import { PlayDrawer, type PlayDrawerHandle } from '../../../src/components/play-drawer';
+import { useDrawerHost } from '../../../src/providers/drawer-host-provider';
 import { SearchHeader, type SearchHeaderHandle } from '../../../src/components/SearchHeader';
 import { RecentFilterPills } from '../../../src/components/RecentFilterPills';
 import { useDefaultBoard, useSearchClimbs, useGrades } from '../../../src/lib/graphql/hooks';
@@ -38,7 +38,7 @@ const SEARCH_DEBOUNCE_MS = 300;
 export default function ClimbList() {
   const navigation = useNavigation();
   const { t } = useTranslation('climbs');
-  const playDrawerRef = useRef<PlayDrawerHandle>(null);
+  const { openPlayDrawer } = useDrawerHost();
   const searchHeaderRef = useRef<SearchHeaderHandle>(null);
 
   const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -214,9 +214,12 @@ export default function ClimbList() {
     [hasBoardConfig, boardName, layoutId, sizeId, setIds, angle],
   );
 
-  const handleClimbPress = useCallback((climb: Climb) => {
-    playDrawerRef.current?.open(climb);
-  }, []);
+  const handleClimbPress = useCallback(
+    (climb: Climb) => {
+      openPlayDrawer(climb);
+    },
+    [openPlayDrawer],
+  );
 
   const handleApplyFilters = useCallback(
     (newFilters: ClimbFilters) => {
@@ -354,7 +357,6 @@ export default function ClimbList() {
         currentFilters={filters}
         onApply={handleApplyFilters}
       />
-      {boardConfig && <PlayDrawer ref={playDrawerRef} boardConfig={boardConfig} />}
     </View>
   );
 }

--- a/packages/mobile/app/(tabs)/queue/index.tsx
+++ b/packages/mobile/app/(tabs)/queue/index.tsx
@@ -12,10 +12,7 @@ import { ConnectionBanner } from '../../../src/components/ble/ConnectionBanner';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
 import { Button } from '../../../src/components/Button';
-import {
-  BAR_CONTENT_HEIGHT,
-  TAB_BAR_HEIGHT,
-} from '../../../src/components/queue-control/persistent-queue-bar';
+import { BAR_CONTENT_HEIGHT, TAB_BAR_HEIGHT } from '../../../src/components/queue-control/persistent-queue-bar';
 import { useTheme } from '../../../src/providers/theme-provider';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 

--- a/packages/mobile/app/(tabs)/queue/index.tsx
+++ b/packages/mobile/app/(tabs)/queue/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { View, StyleSheet, RefreshControl } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import Animated, { FadeIn } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useQueue } from '../../../src/providers/queue-provider';
@@ -11,6 +12,10 @@ import { ConnectionBanner } from '../../../src/components/ble/ConnectionBanner';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
 import { Button } from '../../../src/components/Button';
+import {
+  BAR_CONTENT_HEIGHT,
+  TAB_BAR_HEIGHT,
+} from '../../../src/components/queue-control/persistent-queue-bar';
 import { useTheme } from '../../../src/providers/theme-provider';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 
@@ -19,6 +24,12 @@ export default function QueueScreen() {
   const { systemColors, brandColors } = useTheme();
   const router = useRouter();
   const { t } = useTranslation('session');
+  const insets = useSafeAreaInsets();
+
+  // Clear the persistent queue bar + tab bar + home-indicator inset.
+  // Derived from the constants exported by PersistentQueueBar so devices
+  // with a non-zero bottom inset (iPhone 14, etc.) don't clip the last row.
+  const listBottomPadding = BAR_CONTENT_HEIGHT + TAB_BAR_HEIGHT + insets.bottom;
 
   const bluetooth = useOptionalBluetoothContext();
   const [bannerDismissed, setBannerDismissed] = useState(false);
@@ -142,7 +153,7 @@ export default function QueueScreen() {
             tintColor={brandColors.primary}
           />
         }
-        contentContainerStyle={styles.listContent}
+        contentContainerStyle={{ paddingBottom: listBottomPadding }}
       />
     </View>
   );
@@ -151,9 +162,6 @@ export default function QueueScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  listContent: {
-    paddingBottom: 120, // Space for the global PersistentQueueBar + tab bar + safe area
   },
   emptyContainer: {
     flex: 1,

--- a/packages/mobile/app/(tabs)/queue/index.tsx
+++ b/packages/mobile/app/(tabs)/queue/index.tsx
@@ -1,58 +1,33 @@
 import { useCallback, useMemo, useState } from 'react';
-import { View, Pressable, StyleSheet, RefreshControl, useColorScheme } from 'react-native';
+import { View, StyleSheet, RefreshControl } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import Animated, { FadeIn } from 'react-native-reanimated';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useQueue } from '../../../src/providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../../src/providers/bluetooth-provider';
 import { QueueItemRow } from '../../../src/components/QueueItemRow';
-import { BluetoothStatusIcon } from '../../../src/components/ble/BluetoothStatusIcon';
 import { ConnectionBanner } from '../../../src/components/ble/ConnectionBanner';
-import { EndSessionSheet } from '../../../src/components/EndSessionSheet';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
 import { Button } from '../../../src/components/Button';
-import { LogAscentSheet } from '../../../src/components/LogAscentSheet';
-import { hapticSelection } from '../../../src/lib/haptics';
 import { useTheme } from '../../../src/providers/theme-provider';
-import { useDefaultBoard } from '../../../src/lib/graphql/hooks';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 
-const TAB_BAR_HEIGHT = 49;
-
 export default function QueueScreen() {
-  const { state, sessionId, removeFromQueue, setCurrentClimb, nextClimb, previousClimb, endSession } = useQueue();
-  const { data: defaultBoard } = useDefaultBoard();
+  const { state, sessionId, removeFromQueue, setCurrentClimb } = useQueue();
   const { systemColors, brandColors } = useTheme();
-  const [showLogAscent, setShowLogAscent] = useState(false);
-  const [showEndSession, setShowEndSession] = useState(false);
-  const [isEnding, setIsEnding] = useState(false);
-  const colorScheme = useColorScheme();
-  const isDark = colorScheme === 'dark';
-  const insets = useSafeAreaInsets();
   const router = useRouter();
   const { t } = useTranslation('session');
 
   const bluetooth = useOptionalBluetoothContext();
   const [bannerDismissed, setBannerDismissed] = useState(false);
 
-  // Show the banner when an unexpected disconnect occurs, hide when dismissed.
-  // bannerDismissed resets when the user reconnects (connect sets
-  // disconnectedUnexpectedly to false, which makes showConnectionBanner
-  // false regardless of bannerDismissed).
+  // Banner shows on unexpected disconnect, hides on dismiss. bannerDismissed
+  // resets implicitly when the user reconnects (connect flips
+  // disconnectedUnexpectedly to false, so showConnectionBanner is false
+  // regardless of bannerDismissed).
   const showConnectionBanner = !!bluetooth?.disconnectedUnexpectedly && !bannerDismissed;
-
-  const handleBluetoothPress = useCallback(() => {
-    if (!bluetooth) return;
-    if (bluetooth.isConnected) {
-      void bluetooth.disconnect();
-    } else {
-      setBannerDismissed(false);
-      void bluetooth.connect();
-    }
-  }, [bluetooth]);
 
   const handleReconnect = useCallback(() => {
     if (!bluetooth) return;
@@ -64,48 +39,9 @@ export default function QueueScreen() {
     setBannerDismissed(true);
   }, []);
 
-  const navBarBackground = isDark ? 'rgba(28, 28, 30, 0.95)' : 'rgba(255, 255, 255, 0.95)';
-  const navBarBottomPadding = insets.bottom + TAB_BAR_HEIGHT;
-
   const { queue, currentClimbQueueItem } = state;
 
-  const currentClimbIndex = useMemo(() => {
-    if (!currentClimbQueueItem) return -1;
-    return queue.findIndex(({ uuid }) => uuid === currentClimbQueueItem.uuid);
-  }, [queue, currentClimbQueueItem]);
-
-  const hasPrevious = currentClimbIndex > 0;
-  const hasNext = currentClimbIndex >= 0 && currentClimbIndex < queue.length - 1;
-
-  const handlePrevious = useCallback(() => {
-    hapticSelection();
-    previousClimb();
-  }, [previousClimb]);
-
-  const handleNext = useCallback(() => {
-    hapticSelection();
-    nextClimb();
-  }, [nextClimb]);
-
-  const handleLogAscent = useCallback(() => {
-    hapticSelection();
-    setShowLogAscent(true);
-  }, []);
-
-  const handleEndSessionPress = useCallback(() => {
-    hapticSelection();
-    setShowEndSession(true);
-  }, []);
-
-  const handleEndSessionConfirm = useCallback(async () => {
-    setIsEnding(true);
-    const summary = await endSession();
-    setIsEnding(false);
-    setShowEndSession(false);
-    if (summary) {
-      router.push({ pathname: '/(tabs)/queue/summary', params: { sessionId: summary.sessionId } });
-    }
-  }, [endSession, router]);
+  const currentClimbUuid = useMemo(() => currentClimbQueueItem?.uuid, [currentClimbQueueItem]);
 
   const handleItemPress = useCallback(
     (item: ClimbQueueItem) => {
@@ -123,7 +59,7 @@ export default function QueueScreen() {
 
   const renderItem = useCallback(
     ({ item, index }: { item: ClimbQueueItem; index: number }) => {
-      const isActive = currentClimbQueueItem?.uuid === item.uuid;
+      const isActive = currentClimbUuid === item.uuid;
       return (
         <QueueItemRow
           item={item}
@@ -134,12 +70,11 @@ export default function QueueScreen() {
         />
       );
     },
-    [currentClimbQueueItem?.uuid, handleItemPress, handleItemRemove],
+    [currentClimbUuid, handleItemPress, handleItemRemove],
   );
 
   const keyExtractor = useCallback((item: ClimbQueueItem) => item.uuid, []);
 
-  // No active session state
   if (!sessionId) {
     return (
       <View style={styles.emptyContainer}>
@@ -156,7 +91,6 @@ export default function QueueScreen() {
     );
   }
 
-  // Empty queue state
   if (queue.length === 0) {
     return (
       <View style={styles.emptyContainer}>
@@ -183,7 +117,6 @@ export default function QueueScreen() {
     );
   }
 
-  // Queue list
   return (
     <View style={styles.container}>
       {bluetooth && (
@@ -203,128 +136,13 @@ export default function QueueScreen() {
           <RefreshControl
             refreshing={false}
             onRefresh={() => {
-              // A pull-to-refresh would trigger a full resync request.
-              // The subscription will deliver a FullSync event automatically
-              // when the WS reconnects. For now this is a no-op placeholder.
+              // Pull-to-refresh as resync trigger — the WS subscription emits a
+              // FullSync on reconnect, so explicit resync isn't needed here yet.
             }}
             tintColor={brandColors.primary}
           />
         }
         contentContainerStyle={styles.listContent}
-      />
-
-      {/* Navigation controls */}
-      <Animated.View
-        entering={FadeIn.duration(200)}
-        style={[
-          styles.navBar,
-          {
-            backgroundColor: navBarBackground,
-            borderTopColor: systemColors.separator,
-            paddingBottom: navBarBottomPadding,
-          },
-        ]}
-      >
-        <Pressable
-          onPress={handlePrevious}
-          disabled={!hasPrevious}
-          accessibilityRole="button"
-          accessibilityLabel={t('mobile.queue.previousClimb')}
-          accessibilityState={{ disabled: !hasPrevious }}
-          style={[styles.navButton, !hasPrevious && styles.navButtonDisabled]}
-          hitSlop={8}
-        >
-          <Icon name="chevron.left" size={22} color={hasPrevious ? brandColors.primary : systemColors.secondaryLabel} />
-        </Pressable>
-
-        <View style={styles.navClimbInfo}>
-          {currentClimbQueueItem ? (
-            <>
-              <Text variant="subheadline" numberOfLines={1} color={systemColors.label} style={styles.navClimbName}>
-                {currentClimbQueueItem.climb?.name ?? t('mobile.queue.unknownClimb')}
-              </Text>
-              {currentClimbQueueItem.climb?.difficulty ? (
-                <Text variant="caption1" color={systemColors.secondaryLabel}>
-                  {currentClimbQueueItem.climb.difficulty}
-                </Text>
-              ) : null}
-            </>
-          ) : (
-            <Text variant="subheadline" color={systemColors.secondaryLabel}>
-              {t('mobile.queue.noClimbSelected')}
-            </Text>
-          )}
-        </View>
-
-        <Pressable
-          onPress={handleNext}
-          disabled={!hasNext}
-          accessibilityRole="button"
-          accessibilityLabel={t('mobile.queue.nextClimb')}
-          accessibilityState={{ disabled: !hasNext }}
-          style={[styles.navButton, !hasNext && styles.navButtonDisabled]}
-          hitSlop={8}
-        >
-          <Icon name="chevron.right" size={22} color={hasNext ? brandColors.primary : systemColors.secondaryLabel} />
-        </Pressable>
-
-        <Pressable
-          onPress={handleLogAscent}
-          disabled={!currentClimbQueueItem}
-          accessibilityRole="button"
-          accessibilityLabel={t('mobile.queue.logAscent')}
-          style={[styles.navButton, !currentClimbQueueItem && styles.navButtonDisabled]}
-          hitSlop={8}
-        >
-          <Icon
-            name="tick"
-            size={22}
-            color={currentClimbQueueItem ? brandColors.primary : systemColors.secondaryLabel}
-          />
-        </Pressable>
-
-        {bluetooth && (
-          <BluetoothStatusIcon
-            isConnected={bluetooth.isConnected}
-            isScanning={bluetooth.loading}
-            onPress={handleBluetoothPress}
-          />
-        )}
-
-        <Pressable
-          onPress={handleEndSessionPress}
-          accessibilityRole="button"
-          accessibilityLabel={t('mobile.queue.endSession')}
-          style={styles.navButton}
-          hitSlop={8}
-        >
-          <Icon name="end.session" size={22} color={brandColors.error} />
-        </Pressable>
-      </Animated.View>
-
-      {currentClimbQueueItem && defaultBoard && (
-        <LogAscentSheet
-          visible={showLogAscent}
-          onDismiss={() => setShowLogAscent(false)}
-          climbUuid={currentClimbQueueItem.climb.uuid}
-          climbName={currentClimbQueueItem.climb.name}
-          boardName={defaultBoard.boardType}
-          angle={currentClimbQueueItem.climb.angle}
-          isMirror={currentClimbQueueItem.climb.mirrored === true}
-          isBenchmark={currentClimbQueueItem.climb.benchmark_difficulty != null}
-          layoutId={defaultBoard.layoutId}
-          sizeId={defaultBoard.sizeId}
-          setIds={defaultBoard.setIds}
-          sessionId={sessionId}
-        />
-      )}
-
-      <EndSessionSheet
-        visible={showEndSession}
-        onDismiss={() => setShowEndSession(false)}
-        onConfirm={handleEndSessionConfirm}
-        isEnding={isEnding}
-        climbCount={queue.length}
       />
     </View>
   );
@@ -335,7 +153,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   listContent: {
-    paddingBottom: 80, // Space for the nav bar
+    paddingBottom: 120, // Space for the global PersistentQueueBar + tab bar + safe area
   },
   emptyContainer: {
     flex: 1,
@@ -357,36 +175,5 @@ const styles = StyleSheet.create({
   },
   browseButton: {
     marginTop: 16,
-  },
-  navBar: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderTopWidth: StyleSheet.hairlineWidth,
-  },
-  navButton: {
-    width: 44,
-    height: 44,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 22,
-  },
-  navButtonDisabled: {
-    opacity: 0.4,
-  },
-  navClimbInfo: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 8,
-  },
-  navClimbName: {
-    fontWeight: '600',
-    textAlign: 'center',
   },
 });

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -11,6 +11,8 @@ import { I18nProvider } from '../src/providers/i18n-provider';
 import { BluetoothProvider } from '../src/providers/bluetooth-provider';
 import { ToastProvider } from '../src/providers/toast-provider';
 import { QueueProvider } from '../src/providers/queue-provider';
+import { DrawerHostProvider } from '../src/providers/drawer-host-provider';
+import { PersistentQueueBar } from '../src/components/queue-control/persistent-queue-bar';
 import { useDefaultBoard } from '../src/lib/graphql/hooks';
 
 SplashScreen.preventAutoHideAsync();
@@ -49,12 +51,15 @@ export default function RootLayout() {
               <ToastProvider>
                 <BottomSheetModalProvider>
                   <QueueProvider>
-                    <BluetoothProviderWrapper>
-                      <Stack screenOptions={{ headerShown: false }} initialRouteName="(tabs)">
-                        <Stack.Screen name="(tabs)" />
-                        <Stack.Screen name="auth" options={{ headerShown: false, gestureEnabled: false }} />
-                      </Stack>
-                    </BluetoothProviderWrapper>
+                    <DrawerHostProvider>
+                      <BluetoothProviderWrapper>
+                        <Stack screenOptions={{ headerShown: false }} initialRouteName="(tabs)">
+                          <Stack.Screen name="(tabs)" />
+                          <Stack.Screen name="auth" options={{ headerShown: false, gestureEnabled: false }} />
+                        </Stack>
+                        <PersistentQueueBar />
+                      </BluetoothProviderWrapper>
+                    </DrawerHostProvider>
                   </QueueProvider>
                 </BottomSheetModalProvider>
               </ToastProvider>

--- a/packages/mobile/src/components/BlurTabBar.tsx
+++ b/packages/mobile/src/components/BlurTabBar.tsx
@@ -7,7 +7,9 @@ import { iosSystemColors, iosDarkColors, iosLightColors } from '../theme/ios-col
 import { useBluetoothConnectedStatus } from '../lib/ble/bluetooth-status-store';
 import { brandColors } from '../theme/colors';
 
-const TAB_BAR_HEIGHT = 49;
+// Exported so the persistent queue bar (which docks above the tab bar) and
+// FlashLists below it can compute their layouts off the same constant.
+export const TAB_BAR_HEIGHT = 49;
 
 type TabIconName = 'view-dashboard' | 'magnify' | 'playlist-play' | 'account' | 'dots-horizontal';
 

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -14,6 +14,7 @@ import { useDoubleTapFavorite } from '../hooks/use-double-tap-favorite';
 import { hapticLight, hapticMedium, hapticSuccess } from '../lib/haptics';
 import { formatSends, formatQuality } from '../lib/format-climb-stats';
 import { getGradeTintColor } from '@boardsesh/play-view';
+import { useGradeFormat } from '../hooks/use-grade-format';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { brandColors } from '../theme/colors';
@@ -60,8 +61,10 @@ const ClimbListRow = React.memo(function ClimbListRow({
   const { t } = useTranslation('climbs');
   const { colorScheme, systemColors } = useTheme();
   const isDark = colorScheme === 'dark';
+  const { formatGrade } = useGradeFormat();
 
   const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
+  const formattedGrade = formatGrade(climb.difficulty);
 
   // --- Double-tap favorite (ephemeral heart animation only — favorite status
   // is not available in the search query, so we don't show it in the subtitle) ---
@@ -337,7 +340,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
           {/* Right: Colorized grade + menu button */}
           <View style={styles.rightSection}>
             <Text variant="headline" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
-              {climb.difficulty}
+              {formattedGrade ?? climb.difficulty}
             </Text>
             <Pressable
               onPress={handleMenuPress}

--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -14,6 +14,7 @@ import { Icon } from './Icon';
 import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
 import { useTheme } from '../providers/theme-provider';
+import { useGradeFormat } from '../hooks/use-grade-format';
 import { hapticSelection, hapticMedium } from '../lib/haptics';
 
 const SWIPE_DELETE_THRESHOLD = -80;
@@ -178,8 +179,10 @@ export function QueueItemRow({
     });
   };
 
+  const { formatGrade } = useGradeFormat();
   const climbName = item.climb?.name ?? t('mobile.queue.unknownClimb');
-  const difficulty = item.climb?.difficulty ?? '';
+  const rawDifficulty = item.climb?.difficulty ?? '';
+  const difficulty = formatGrade(rawDifficulty) ?? rawDifficulty;
 
   const rowContent = (
     <AnimatedPressable

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -13,7 +13,14 @@ type SheetProps = {
 };
 
 export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
-  { children, snapPoints: customSnapPoints, enableDynamicSizing = false, onChange, onClose, enablePanDownToClose = true },
+  {
+    children,
+    snapPoints: customSnapPoints,
+    enableDynamicSizing = false,
+    onChange,
+    onClose,
+    enablePanDownToClose = true,
+  },
   ref,
 ) {
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -28,6 +28,7 @@ import { Icon } from '../Icon';
 import { useQueue } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useToggleFavorite } from '../../lib/graphql/hooks';
+import { useGradeFormat } from '../../hooks/use-grade-format';
 import { getBoardRenderData } from '../../lib/board-details';
 import { hapticSuccess } from '../../lib/haptics';
 import { usePlayDrawerWakeLock } from './use-play-drawer-wake-lock';
@@ -92,6 +93,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const { state, setCurrentClimb, nextClimb, previousClimb, sessionId, addToQueue } = useQueue();
   const bluetooth = useOptionalBluetoothContext();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
+  const { formatGrade } = useGradeFormat();
 
   const { boardName, layoutId, sizeId, setIds, angle } = boardConfig;
 
@@ -284,7 +286,8 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
             <>
               <PlayDrawerHeader
                 name={displayedClimb.name}
-                difficulty={displayedClimb.difficulty}
+                difficulty={formatGrade(displayedClimb.difficulty) ?? displayedClimb.difficulty}
+                rawDifficulty={displayedClimb.difficulty}
                 qualityAverage={displayedClimb.quality_average}
                 ascensionistCount={displayedClimb.ascensionist_count}
                 stars={displayedClimb.stars}

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -9,7 +9,11 @@ import { spacing } from '../../theme/tokens';
 
 type PlayDrawerHeaderProps = {
   name: string;
+  /** Display label (already formatted to V or Font per user preference). */
   difficulty: string;
+  /** Raw difficulty (e.g. "6a/V3") used for grade-color lookup. Optional —
+   *  falls back to `difficulty` if not provided. */
+  rawDifficulty?: string;
   qualityAverage: string;
   ascensionistCount: number;
   stars: number;
@@ -19,13 +23,17 @@ type PlayDrawerHeaderProps = {
 export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   name,
   difficulty,
+  rawDifficulty,
   qualityAverage,
   ascensionistCount,
   stars,
   setterUsername,
 }: PlayDrawerHeaderProps) {
   const { t } = useTranslation('climbs');
-  const gradeColor = useMemo(() => getGradeColor(difficulty) ?? DEFAULT_GRADE_COLOR, [difficulty]);
+  const gradeColor = useMemo(
+    () => getGradeColor(rawDifficulty ?? difficulty) ?? DEFAULT_GRADE_COLOR,
+    [rawDifficulty, difficulty],
+  );
 
   const qualityNum = parseFloat(qualityAverage);
   const qualityDisplay = stars > 0 ? stars.toFixed(1) : qualityNum > 0 ? qualityNum.toFixed(1) : null;

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -276,14 +276,13 @@ export function PersistentQueueBar() {
           </GestureDetector>
 
           <Pressable
-            onPress={handleTick}
-            disabled={!currentClimbQueueItem || !defaultBoard}
+            onPress={handleEndSessionPress}
             accessibilityRole="button"
-            accessibilityLabel={t('mobile.queue.logAscent')}
+            accessibilityLabel={t('mobile.queue.endSession')}
             hitSlop={8}
             style={({ pressed }) => [styles.iconButton, pressed && styles.iconButtonPressed]}
           >
-            <Icon name="tick" size={26} color={brandColors.primary} />
+            <Icon name="end.session" size={24} color={brandColors.error} />
           </Pressable>
 
           {bluetooth ? (
@@ -295,13 +294,14 @@ export function PersistentQueueBar() {
           ) : null}
 
           <Pressable
-            onPress={handleEndSessionPress}
+            onPress={handleTick}
+            disabled={!currentClimbQueueItem || !defaultBoard}
             accessibilityRole="button"
-            accessibilityLabel={t('mobile.queue.endSession')}
+            accessibilityLabel={t('mobile.queue.logAscent')}
             hitSlop={8}
             style={({ pressed }) => [styles.iconButton, pressed && styles.iconButtonPressed]}
           >
-            <Icon name="end.session" size={24} color={brandColors.error} />
+            <Icon name="tick" size={26} color={brandColors.primary} />
           </Pressable>
         </View>
       </Animated.View>

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -35,8 +35,8 @@ import { hapticSelection } from '../../lib/haptics';
 import { useCarouselGesture } from '../play-drawer/use-carousel-gesture';
 import { useRouter } from 'expo-router';
 
-const TAB_BAR_HEIGHT = 49;
-const BAR_CONTENT_HEIGHT = 56;
+export const TAB_BAR_HEIGHT = 49;
+export const BAR_CONTENT_HEIGHT = 56;
 
 type ClimbDisplay = {
   difficulty: string | null | undefined;

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -1,0 +1,392 @@
+/**
+ * PersistentQueueBar — bottom-anchored control bar that mounts at the app
+ * root and is visible on every screen while a current climb is set.
+ *
+ * Layout (condensed for mobile, no thumbnail per design):
+ *   [grade] climb name…              [✓ tick] [BT] [⏻ end]
+ *      ↑ tap opens PlayDrawer    ↑ horizontal swipe = prev/next
+ *
+ * The horizontal swipe mirrors the play-drawer carousel pattern
+ * (`use-carousel-gesture`), reusing the shared timings + peek math from
+ * `@boardsesh/play-view` so the bar and drawer feel identical.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { View, Pressable, StyleSheet, useColorScheme, type ColorValue, type LayoutChangeEvent } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { FadeIn, runOnJS, useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { computePeekOffset, getGradeTintColor } from '@boardsesh/play-view';
+import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { useGradeFormat } from '../../hooks/use-grade-format';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { BluetoothStatusIcon } from '../ble/BluetoothStatusIcon';
+import { EndSessionSheet } from '../EndSessionSheet';
+import { useTheme } from '../../providers/theme-provider';
+import { useQueue } from '../../providers/queue-provider';
+import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
+import { useDrawerHost } from '../../providers/drawer-host-provider';
+import { useDefaultBoard } from '../../lib/graphql/hooks';
+import { hapticSelection } from '../../lib/haptics';
+import { useCarouselGesture } from '../play-drawer/use-carousel-gesture';
+import { useRouter } from 'expo-router';
+
+const TAB_BAR_HEIGHT = 49;
+const BAR_CONTENT_HEIGHT = 56;
+
+type ClimbDisplay = {
+  difficulty: string | null | undefined;
+  name: string | undefined;
+};
+
+function climbDisplay(item: ClimbQueueItem | null | undefined): ClimbDisplay | null {
+  if (!item?.climb) return null;
+  return {
+    difficulty: item.climb.difficulty,
+    name: item.climb.name,
+  };
+}
+
+type ClimbLabelProps = {
+  display: ClimbDisplay;
+  labelColor: ColorValue;
+  formattedGrade: string | null;
+  chipBackground: string;
+};
+
+function ClimbLabel({ display, labelColor, formattedGrade, chipBackground }: ClimbLabelProps) {
+  return (
+    <View style={styles.labelInner}>
+      {formattedGrade ? (
+        <View style={[styles.gradePill, { backgroundColor: chipBackground }]}>
+          <Text variant="caption1" color={iosSystemColors.white} style={styles.gradeText}>
+            {formattedGrade}
+          </Text>
+        </View>
+      ) : null}
+      <Text variant="subheadline" color={labelColor} numberOfLines={1} ellipsizeMode="tail" style={styles.name}>
+        {display.name ?? ''}
+      </Text>
+    </View>
+  );
+}
+
+export function PersistentQueueBar() {
+  const { state, nextClimb, previousClimb, sessionId, endSession } = useQueue();
+  const { openPlayDrawer, openLogAscent } = useDrawerHost();
+  const { data: defaultBoard } = useDefaultBoard();
+  const bluetooth = useOptionalBluetoothContext();
+  const insets = useSafeAreaInsets();
+  const { systemColors, brandColors } = useTheme();
+  const { t } = useTranslation('session');
+  const router = useRouter();
+  const { formatGrade: format } = useGradeFormat();
+  const isDark = useColorScheme() === 'dark';
+
+  const [barWidth, setBarWidth] = useState(0);
+  const [showEndSession, setShowEndSession] = useState(false);
+  const [isEnding, setIsEnding] = useState(false);
+
+  const { currentClimbQueueItem, queue } = state;
+
+  const currentIndex = useMemo(() => {
+    if (!currentClimbQueueItem) return -1;
+    return queue.findIndex(({ uuid }) => uuid === currentClimbQueueItem.uuid);
+  }, [queue, currentClimbQueueItem]);
+
+  const canPrevious = currentIndex > 0;
+  const canNext = currentIndex >= 0 && currentIndex < queue.length - 1;
+  const previousItem = canPrevious ? queue[currentIndex - 1] : null;
+  const nextItem = canNext ? queue[currentIndex + 1] : null;
+
+  const handleNext = useCallback(() => {
+    hapticSelection();
+    nextClimb();
+  }, [nextClimb]);
+
+  const handlePrevious = useCallback(() => {
+    hapticSelection();
+    previousClimb();
+  }, [previousClimb]);
+
+  const { gesture: panGesture, translateX } = useCarouselGesture({
+    onSwipeNext: handleNext,
+    onSwipePrevious: handlePrevious,
+    canSwipeNext: canNext,
+    canSwipePrevious: canPrevious,
+    boardWidth: barWidth,
+    enabled: barWidth > 0,
+  });
+
+  const handleOpenPlay = useCallback(() => {
+    if (!currentClimbQueueItem?.climb) return;
+    openPlayDrawer(currentClimbQueueItem.climb);
+  }, [openPlayDrawer, currentClimbQueueItem]);
+
+  const tapGesture = useMemo(
+    () =>
+      Gesture.Tap()
+        .maxDuration(250)
+        .onEnd(() => {
+          'worklet';
+          runOnJS(handleOpenPlay)();
+        }),
+    [handleOpenPlay],
+  );
+
+  const composedGesture = useMemo(() => Gesture.Race(panGesture, tapGesture), [panGesture, tapGesture]);
+
+  const onLayout = useCallback((event: LayoutChangeEvent) => {
+    setBarWidth(event.nativeEvent.layout.width);
+  }, []);
+
+  const currentLabelStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
+  }));
+
+  const nextPeekX = useDerivedValue(() =>
+    computePeekOffset({ direction: 'next', swipeOffset: translateX.value, viewportWidth: barWidth }),
+  );
+  const prevPeekX = useDerivedValue(() =>
+    computePeekOffset({ direction: 'prev', swipeOffset: translateX.value, viewportWidth: barWidth }),
+  );
+
+  const nextPeekStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: nextPeekX.value }],
+  }));
+  const prevPeekStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: prevPeekX.value }],
+  }));
+
+  const handleTick = useCallback(() => {
+    if (!currentClimbQueueItem?.climb || !defaultBoard) return;
+    hapticSelection();
+    openLogAscent({
+      climbUuid: currentClimbQueueItem.climb.uuid,
+      climbName: currentClimbQueueItem.climb.name,
+      boardName: defaultBoard.boardType,
+      angle: currentClimbQueueItem.climb.angle,
+      isMirror: currentClimbQueueItem.climb.mirrored === true,
+      isBenchmark: currentClimbQueueItem.climb.benchmark_difficulty != null,
+      layoutId: defaultBoard.layoutId,
+      sizeId: defaultBoard.sizeId,
+      setIds: defaultBoard.setIds,
+      sessionId,
+    });
+  }, [openLogAscent, currentClimbQueueItem, defaultBoard, sessionId]);
+
+  const handleBluetoothPress = useCallback(() => {
+    if (!bluetooth) return;
+    if (bluetooth.isConnected) void bluetooth.disconnect();
+    else void bluetooth.connect();
+  }, [bluetooth]);
+
+  const handleEndSessionPress = useCallback(() => {
+    hapticSelection();
+    setShowEndSession(true);
+  }, []);
+
+  const handleEndSessionConfirm = useCallback(async () => {
+    setIsEnding(true);
+    const summary = await endSession();
+    setIsEnding(false);
+    setShowEndSession(false);
+    if (summary) {
+      router.push({ pathname: '/(tabs)/queue/summary', params: { sessionId: summary.sessionId } });
+    }
+  }, [endSession, router]);
+
+  const currentDisplay = climbDisplay(currentClimbQueueItem);
+  const previousDisplay = climbDisplay(previousItem);
+  const nextDisplay = climbDisplay(nextItem);
+
+  if (!currentDisplay) return null;
+
+  // Soft pastel tint derived from the current climb's grade, matching the web
+  // queue bar's `getGradeTintColor(difficulty, 'default', isDark)` call.
+  // Falls back to the neutral system background when the grade is unrecognised.
+  const tintBackground = getGradeTintColor(currentDisplay.difficulty, 'default', isDark);
+
+  const currentFormatted = format(currentDisplay.difficulty);
+  const previousFormatted = previousDisplay ? format(previousDisplay.difficulty) : null;
+  const nextFormatted = nextDisplay ? format(nextDisplay.difficulty) : null;
+
+  // Vivid grade color (`getGradeColor` raw hex) for the chip, matching the
+  // PlayDrawer header pill. Falls back to the default neutral grade color when
+  // the difficulty is unrecognised.
+  const currentChipColor = getGradeColor(currentDisplay.difficulty) ?? DEFAULT_GRADE_COLOR;
+  const previousChipColor = previousDisplay
+    ? (getGradeColor(previousDisplay.difficulty) ?? DEFAULT_GRADE_COLOR)
+    : DEFAULT_GRADE_COLOR;
+  const nextChipColor = nextDisplay
+    ? (getGradeColor(nextDisplay.difficulty) ?? DEFAULT_GRADE_COLOR)
+    : DEFAULT_GRADE_COLOR;
+
+  return (
+    <>
+      <Animated.View
+        entering={FadeIn.duration(200)}
+        pointerEvents="box-none"
+        style={[
+          styles.bar,
+          {
+            // Sit directly above the BlurTabBar (which is height
+            // TAB_BAR_HEIGHT + insets.bottom). Painting at bottom: 0 with a
+            // paddingBottom hack covers the tab bar with the bar's opaque
+            // background and visually hides the navigation buttons.
+            bottom: insets.bottom + TAB_BAR_HEIGHT,
+            backgroundColor: tintBackground ?? systemColors.background,
+            borderTopColor: systemColors.separator,
+          },
+        ]}
+      >
+        <View style={styles.row}>
+          <GestureDetector gesture={composedGesture}>
+            <View style={styles.swipeArea} onLayout={onLayout} accessibilityRole="button">
+              <Animated.View style={[styles.labelSlot, currentLabelStyle]}>
+                <ClimbLabel
+                  display={currentDisplay}
+                  labelColor={systemColors.label}
+                  formattedGrade={currentFormatted}
+                  chipBackground={currentChipColor}
+                />
+              </Animated.View>
+              {nextDisplay ? (
+                <Animated.View style={[styles.peekSlot, nextPeekStyle]} pointerEvents="none">
+                  <ClimbLabel
+                    display={nextDisplay}
+                    labelColor={systemColors.label}
+                    formattedGrade={nextFormatted}
+                    chipBackground={nextChipColor}
+                  />
+                </Animated.View>
+              ) : null}
+              {previousDisplay ? (
+                <Animated.View style={[styles.peekSlot, prevPeekStyle]} pointerEvents="none">
+                  <ClimbLabel
+                    display={previousDisplay}
+                    labelColor={systemColors.label}
+                    formattedGrade={previousFormatted}
+                    chipBackground={previousChipColor}
+                  />
+                </Animated.View>
+              ) : null}
+            </View>
+          </GestureDetector>
+
+          <Pressable
+            onPress={handleTick}
+            disabled={!currentClimbQueueItem || !defaultBoard}
+            accessibilityRole="button"
+            accessibilityLabel={t('mobile.queue.logAscent')}
+            hitSlop={8}
+            style={({ pressed }) => [styles.iconButton, pressed && styles.iconButtonPressed]}
+          >
+            <Icon name="tick" size={26} color={brandColors.primary} />
+          </Pressable>
+
+          {bluetooth ? (
+            <BluetoothStatusIcon
+              isConnected={bluetooth.isConnected}
+              isScanning={bluetooth.loading}
+              onPress={handleBluetoothPress}
+            />
+          ) : null}
+
+          <Pressable
+            onPress={handleEndSessionPress}
+            accessibilityRole="button"
+            accessibilityLabel={t('mobile.queue.endSession')}
+            hitSlop={8}
+            style={({ pressed }) => [styles.iconButton, pressed && styles.iconButtonPressed]}
+          >
+            <Icon name="end.session" size={24} color={brandColors.error} />
+          </Pressable>
+        </View>
+      </Animated.View>
+
+      <EndSessionSheet
+        visible={showEndSession}
+        onDismiss={() => setShowEndSession(false)}
+        onConfirm={handleEndSessionConfirm}
+        isEnding={isEnding}
+        climbCount={queue.length}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    // `bottom` is set inline from safe-area insets + tab-bar height so the
+    // bar sits above the BlurTabBar instead of painting over it.
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: BAR_CONTENT_HEIGHT,
+    paddingHorizontal: 12,
+  },
+  swipeArea: {
+    flex: 1,
+    height: BAR_CONTENT_HEIGHT,
+    overflow: 'hidden',
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+  },
+  labelSlot: {
+    position: 'absolute',
+    left: 4,
+    right: 4,
+    justifyContent: 'center',
+  },
+  peekSlot: {
+    position: 'absolute',
+    left: 4,
+    right: 4,
+    justifyContent: 'center',
+  },
+  labelInner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  gradePill: {
+    // Reserve a 3-char slot ("V10") so the climb name doesn't shift
+    // horizontally as the user swipes between climbs with different
+    // grade widths. 4-char grades like "V10+" still expand slightly.
+    minWidth: 40,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 6,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  gradeText: {
+    fontVariant: ['tabular-nums'],
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  name: {
+    flex: 1,
+    fontWeight: '600',
+  },
+  iconButton: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 22,
+  },
+  iconButtonPressed: {
+    opacity: 0.5,
+  },
+});

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -30,13 +30,15 @@ import { useTheme } from '../../providers/theme-provider';
 import { useQueue } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
-import { useDefaultBoard } from '../../lib/graphql/hooks';
 import { hapticSelection } from '../../lib/haptics';
 import { useCarouselGesture } from '../play-drawer/use-carousel-gesture';
+import { TAB_BAR_HEIGHT } from '../BlurTabBar';
 import { useRouter } from 'expo-router';
 
-export const TAB_BAR_HEIGHT = 49;
 export const BAR_CONTENT_HEIGHT = 56;
+// Re-export so layout consumers that already import bar metrics from this
+// module don't need to know which file owns the tab-bar height.
+export { TAB_BAR_HEIGHT };
 
 type ClimbDisplay = {
   difficulty: string | null | undefined;
@@ -77,8 +79,7 @@ function ClimbLabel({ display, labelColor, formattedGrade, chipBackground }: Cli
 
 export function PersistentQueueBar() {
   const { state, nextClimb, previousClimb, sessionId, endSession } = useQueue();
-  const { openPlayDrawer, openLogAscent } = useDrawerHost();
-  const { data: defaultBoard } = useDefaultBoard();
+  const { boardConfig, openPlayDrawer, openLogAscent } = useDrawerHost();
   const bluetooth = useOptionalBluetoothContext();
   const insets = useSafeAreaInsets();
   const { systemColors, brandColors } = useTheme();
@@ -163,21 +164,21 @@ export function PersistentQueueBar() {
   }));
 
   const handleTick = useCallback(() => {
-    if (!currentClimbQueueItem?.climb || !defaultBoard) return;
+    if (!currentClimbQueueItem?.climb || !boardConfig) return;
     hapticSelection();
     openLogAscent({
       climbUuid: currentClimbQueueItem.climb.uuid,
       climbName: currentClimbQueueItem.climb.name,
-      boardName: defaultBoard.boardType,
+      boardName: boardConfig.boardName,
       angle: currentClimbQueueItem.climb.angle,
       isMirror: currentClimbQueueItem.climb.mirrored === true,
       isBenchmark: currentClimbQueueItem.climb.benchmark_difficulty != null,
-      layoutId: defaultBoard.layoutId,
-      sizeId: defaultBoard.sizeId,
-      setIds: defaultBoard.setIds,
+      layoutId: boardConfig.layoutId,
+      sizeId: boardConfig.sizeId,
+      setIds: boardConfig.setIds,
       sessionId,
     });
-  }, [openLogAscent, currentClimbQueueItem, defaultBoard, sessionId]);
+  }, [openLogAscent, currentClimbQueueItem, boardConfig, sessionId]);
 
   const handleBluetoothPress = useCallback(() => {
     if (!bluetooth) return;
@@ -295,7 +296,7 @@ export function PersistentQueueBar() {
 
           <Pressable
             onPress={handleTick}
-            disabled={!currentClimbQueueItem || !defaultBoard}
+            disabled={!currentClimbQueueItem || !boardConfig}
             accessibilityRole="button"
             accessibilityLabel={t('mobile.queue.logAscent')}
             hitSlop={8}

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -234,13 +234,10 @@ export function PersistentQueueBar() {
         style={[
           styles.bar,
           {
-            // Sit directly above the BlurTabBar (which is height
-            // TAB_BAR_HEIGHT + insets.bottom). Painting at bottom: 0 with a
-            // paddingBottom hack covers the tab bar with the bar's opaque
-            // background and visually hides the navigation buttons.
+            // Sit directly above the BlurTabBar — side margins + rounded
+            // corners give the floating-card look; no extra vertical gap.
             bottom: insets.bottom + TAB_BAR_HEIGHT,
             backgroundColor: tintBackground ?? systemColors.background,
-            borderTopColor: systemColors.separator,
           },
         ]}
       >
@@ -323,11 +320,18 @@ export function PersistentQueueBar() {
 const styles = StyleSheet.create({
   bar: {
     position: 'absolute',
-    left: 0,
-    right: 0,
-    // `bottom` is set inline from safe-area insets + tab-bar height so the
-    // bar sits above the BlurTabBar instead of painting over it.
-    borderTopWidth: StyleSheet.hairlineWidth,
+    left: 8,
+    right: 8,
+    // `bottom` is set inline from safe-area insets + tab-bar height so
+    // the bar sits flush against the tab bar with all four corners
+    // rounded (Spotify mini-player style).
+    borderRadius: 10,
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.18,
+    shadowRadius: 10,
+    elevation: 6,
   },
   row: {
     flexDirection: 'row',

--- a/packages/mobile/src/hooks/use-grade-format.ts
+++ b/packages/mobile/src/hooks/use-grade-format.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { formatGrade, type GradeDisplayFormat, DEFAULT_GRADE_DISPLAY_FORMAT } from '@boardsesh/play-view';
+
+/**
+ * Mobile counterpart to web's `useGradeFormat` hook. Returns the current
+ * grade-display preference and a bound formatter so consumers can render
+ * `climb.difficulty` according to the user's choice.
+ *
+ * Today the preference is hardcoded to V-grade — there's no settings UI on
+ * mobile yet. The hook signature matches web's so a future PR adding the UI
+ * + AsyncStorage backing just needs to flip the source of `gradeFormat`.
+ */
+export function useGradeFormat() {
+  // TODO: persist via AsyncStorage and surface a toggle in More tab.
+  const gradeFormat: GradeDisplayFormat = DEFAULT_GRADE_DISPLAY_FORMAT;
+  return useMemo(
+    () => ({
+      gradeFormat,
+      loaded: true,
+      formatGrade: (difficulty: string | null | undefined) => formatGrade(difficulty, gradeFormat),
+    }),
+    [gradeFormat],
+  );
+}

--- a/packages/mobile/src/lib/__tests__/recent-filter-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/recent-filter-store.test.ts
@@ -69,8 +69,20 @@ describe('getRecentFilters sanitizer', () => {
   it('drops entries whose sortBy is not a known SortOption', async () => {
     const { getRecentFilters } = await import('../recent-filter-store');
     await seed([
-      { id: '1', label: 'legacy', filters: { sortBy: 'newest', sortOrder: 'desc', status: 'any' }, searchText: '', timestamp: 0 },
-      { id: '2', label: 'ok', filters: { sortBy: 'ascents', sortOrder: 'desc', status: 'any' }, searchText: '', timestamp: 1 },
+      {
+        id: '1',
+        label: 'legacy',
+        filters: { sortBy: 'newest', sortOrder: 'desc', status: 'any' },
+        searchText: '',
+        timestamp: 0,
+      },
+      {
+        id: '2',
+        label: 'ok',
+        filters: { sortBy: 'ascents', sortOrder: 'desc', status: 'any' },
+        searchText: '',
+        timestamp: 1,
+      },
     ]);
     const result = await getRecentFilters();
     expect(result).toHaveLength(1);
@@ -80,7 +92,13 @@ describe('getRecentFilters sanitizer', () => {
   it('drops entries whose status is not a known StatusFilter', async () => {
     const { getRecentFilters } = await import('../recent-filter-store');
     await seed([
-      { id: 'bad', label: 'x', filters: { sortBy: 'ascents', sortOrder: 'desc', status: 'mystery' }, searchText: '', timestamp: 0 },
+      {
+        id: 'bad',
+        label: 'x',
+        filters: { sortBy: 'ascents', sortOrder: 'desc', status: 'mystery' },
+        searchText: '',
+        timestamp: 0,
+      },
     ]);
     expect(await getRecentFilters()).toHaveLength(0);
   });

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -816,10 +816,25 @@ export const QUEUE_UPDATES_SUBSCRIPTION = `
         stateHash
         uuid
       }
+      ... on QueueReordered {
+        sequence
+        stateHash
+        uuid
+        oldIndex
+        newIndex
+      }
       ... on CurrentClimbChanged {
         sequence
         stateHash
         item { uuid climb { uuid name frames } }
+        clientId
+        correlationId
+      }
+      ... on ClimbMirrored {
+        sequence
+        stateHash
+        uuid
+        mirrored
       }
     }
   }

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -1,0 +1,109 @@
+/**
+ * DrawerHostProvider mounts PlayDrawer and LogAscentSheet once at the app root
+ * and exposes imperative openers via `useDrawerHost()`. This lets the
+ * persistent queue control bar (and any screen) open them without each tab
+ * having to instantiate its own copy.
+ *
+ * Default board comes from `useDefaultBoard()`; callers can override via the
+ * second arg to `openPlayDrawer` if needed (e.g. opening a climb from a
+ * different board context).
+ */
+
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react';
+import type { Climb } from '@boardsesh/shared-schema';
+import { PlayDrawer, type PlayDrawerHandle } from '../components/play-drawer';
+import { LogAscentSheet } from '../components/LogAscentSheet';
+import { useDefaultBoard } from '../lib/graphql/hooks';
+
+export type BoardConfig = {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
+
+export type LogAscentInput = {
+  climbUuid: string;
+  climbName: string;
+  boardName: string;
+  angle: number;
+  isMirror: boolean;
+  isBenchmark: boolean;
+  layoutId?: number;
+  sizeId?: number;
+  setIds?: string;
+  sessionId?: string | null;
+};
+
+type DrawerHostValue = {
+  openPlayDrawer: (climb: Climb, boardConfig?: BoardConfig) => void;
+  openLogAscent: (input: LogAscentInput) => void;
+};
+
+const DrawerHostContext = createContext<DrawerHostValue | null>(null);
+
+export function useDrawerHost(): DrawerHostValue {
+  const context = useContext(DrawerHostContext);
+  if (!context) throw new Error('useDrawerHost must be used within DrawerHostProvider');
+  return context;
+}
+
+export function DrawerHostProvider({ children }: { children: ReactNode }) {
+  const playDrawerRef = useRef<PlayDrawerHandle>(null);
+  const { data: defaultBoard } = useDefaultBoard();
+  const [boardConfigOverride, setBoardConfigOverride] = useState<BoardConfig | null>(null);
+  const [logAscentInput, setLogAscentInput] = useState<LogAscentInput | null>(null);
+
+  const openPlayDrawer = useCallback((climb: Climb, override?: BoardConfig) => {
+    if (override) setBoardConfigOverride(override);
+    else setBoardConfigOverride(null);
+    // Wait a tick so the boardConfig prop on PlayDrawer is up to date before
+    // its imperative open is called. State setters batch; the subsequent
+    // open() runs after the render flush.
+    requestAnimationFrame(() => playDrawerRef.current?.open(climb));
+  }, []);
+
+  const openLogAscent = useCallback((input: LogAscentInput) => {
+    setLogAscentInput(input);
+  }, []);
+
+  const dismissLogAscent = useCallback(() => setLogAscentInput(null), []);
+
+  const activeBoardConfig: BoardConfig | null = useMemo(() => {
+    if (boardConfigOverride) return boardConfigOverride;
+    if (!defaultBoard) return null;
+    return {
+      boardName: defaultBoard.boardType,
+      layoutId: defaultBoard.layoutId,
+      sizeId: defaultBoard.sizeId,
+      setIds: defaultBoard.setIds,
+      angle: defaultBoard.angle,
+    };
+  }, [boardConfigOverride, defaultBoard]);
+
+  const value = useMemo<DrawerHostValue>(() => ({ openPlayDrawer, openLogAscent }), [openPlayDrawer, openLogAscent]);
+
+  return (
+    <DrawerHostContext.Provider value={value}>
+      {children}
+      {activeBoardConfig ? <PlayDrawer ref={playDrawerRef} boardConfig={activeBoardConfig} /> : null}
+      {logAscentInput ? (
+        <LogAscentSheet
+          visible
+          onDismiss={dismissLogAscent}
+          climbUuid={logAscentInput.climbUuid}
+          climbName={logAscentInput.climbName}
+          boardName={logAscentInput.boardName}
+          angle={logAscentInput.angle}
+          isMirror={logAscentInput.isMirror}
+          isBenchmark={logAscentInput.isBenchmark}
+          layoutId={logAscentInput.layoutId}
+          sizeId={logAscentInput.sizeId}
+          setIds={logAscentInput.setIds}
+          sessionId={logAscentInput.sessionId}
+        />
+      ) : null}
+    </DrawerHostContext.Provider>
+  );
+}

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -6,10 +6,12 @@
  *
  * Default board comes from `useDefaultBoard()`; callers can override via the
  * second arg to `openPlayDrawer` if needed (e.g. opening a climb from a
- * different board context).
+ * different board context). The active boardConfig is exposed through the
+ * context so consumers (like the persistent bar's log-ascent button) don't
+ * have to call `useDefaultBoard()` independently.
  */
 
-import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/shared-schema';
 import { PlayDrawer, type PlayDrawerHandle } from '../components/play-drawer';
 import { LogAscentSheet } from '../components/LogAscentSheet';
@@ -37,6 +39,9 @@ export type LogAscentInput = {
 };
 
 type DrawerHostValue = {
+  /** Currently resolved board config (override OR default board). Null while
+   *  the default board is still loading and no override is set. */
+  boardConfig: BoardConfig | null;
   openPlayDrawer: (climb: Climb, boardConfig?: BoardConfig) => void;
   openLogAscent: (input: LogAscentInput) => void;
 };
@@ -55,20 +60,13 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const [boardConfigOverride, setBoardConfigOverride] = useState<BoardConfig | null>(null);
   const [logAscentInput, setLogAscentInput] = useState<LogAscentInput | null>(null);
 
-  const openPlayDrawer = useCallback((climb: Climb, override?: BoardConfig) => {
-    if (override) setBoardConfigOverride(override);
-    else setBoardConfigOverride(null);
-    // Wait a tick so the boardConfig prop on PlayDrawer is up to date before
-    // its imperative open is called. State setters batch; the subsequent
-    // open() runs after the render flush.
-    requestAnimationFrame(() => playDrawerRef.current?.open(climb));
-  }, []);
-
-  const openLogAscent = useCallback((input: LogAscentInput) => {
-    setLogAscentInput(input);
-  }, []);
-
-  const dismissLogAscent = useCallback(() => setLogAscentInput(null), []);
+  // Climb to open after the boardConfig override has committed. We can't
+  // open synchronously inside openPlayDrawer when an override is supplied
+  // because the new override hasn't propagated to PlayDrawer's `boardConfig`
+  // prop yet — a single requestAnimationFrame is unreliable on low-end
+  // Android. Stash the climb here and let the useEffect below open the
+  // drawer when activeBoardConfig actually matches the override.
+  const pendingOverrideClimbRef = useRef<Climb | null>(null);
 
   const activeBoardConfig: BoardConfig | null = useMemo(() => {
     if (boardConfigOverride) return boardConfigOverride;
@@ -82,7 +80,37 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     };
   }, [boardConfigOverride, defaultBoard]);
 
-  const value = useMemo<DrawerHostValue>(() => ({ openPlayDrawer, openLogAscent }), [openPlayDrawer, openLogAscent]);
+  const openPlayDrawer = useCallback((climb: Climb, override?: BoardConfig) => {
+    if (override) {
+      pendingOverrideClimbRef.current = climb;
+      setBoardConfigOverride(override);
+      return;
+    }
+    setBoardConfigOverride(null);
+    pendingOverrideClimbRef.current = null;
+    playDrawerRef.current?.open(climb);
+  }, []);
+
+  // Open after the override has flowed through `activeBoardConfig` into
+  // PlayDrawer's props.
+  useEffect(() => {
+    if (!pendingOverrideClimbRef.current) return;
+    if (!activeBoardConfig) return;
+    const climb = pendingOverrideClimbRef.current;
+    pendingOverrideClimbRef.current = null;
+    playDrawerRef.current?.open(climb);
+  }, [activeBoardConfig]);
+
+  const openLogAscent = useCallback((input: LogAscentInput) => {
+    setLogAscentInput(input);
+  }, []);
+
+  const dismissLogAscent = useCallback(() => setLogAscentInput(null), []);
+
+  const value = useMemo<DrawerHostValue>(
+    () => ({ boardConfig: activeBoardConfig, openPlayDrawer, openLogAscent }),
+    [activeBoardConfig, openPlayDrawer, openLogAscent],
+  );
 
   return (
     <DrawerHostContext.Provider value={value}>

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -10,7 +10,13 @@ import {
   type ReactNode,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { queueReducer, initialState } from '@boardsesh/queue';
+import {
+  queueReducer,
+  initialState,
+  createQueueSyncCoordinator,
+  generateClientId,
+  type SyncQueueEvent,
+} from '@boardsesh/queue';
 import type { QueueState, QueueAction, QueueSearchParams, ClimbQueueItem } from '@boardsesh/queue';
 import type { SessionSummary } from '@boardsesh/shared-schema';
 import { getWsClient } from '../lib/graphql/ws-client';
@@ -60,6 +66,13 @@ export function useQueue(): QueueContextValue {
 const defaultSearchParams: QueueSearchParams = {};
 
 // -- Subscription event types (used only for the event discriminated union) --
+//
+// Mirrors what the QUEUE_UPDATES_SUBSCRIPTION request asks for. The
+// SubscriptionQueueItem variant comes back nested under each event; the
+// outer envelope carries server bookkeeping (sequence, stateHash) plus the
+// echo-suppression hints (`clientId`, `correlationId`) on CurrentClimbChanged.
+// We adapt these to the coordinator's wider `SyncQueueEvent` shape before
+// dispatching.
 
 type FullSyncEvent = {
   __typename: 'FullSync';
@@ -87,14 +100,86 @@ type QueueItemRemovedEvent = {
   uuid: string;
 };
 
+type QueueReorderedEvent = {
+  __typename: 'QueueReordered';
+  sequence: number;
+  stateHash: string;
+  uuid: string;
+  oldIndex: number;
+  newIndex: number;
+};
+
 type CurrentClimbChangedEvent = {
   __typename: 'CurrentClimbChanged';
   sequence: number;
   stateHash: string;
   item: SubscriptionQueueItem | null;
+  clientId: string | null;
+  correlationId: string | null;
 };
 
-type QueueUpdateEvent = FullSyncEvent | QueueItemAddedEvent | QueueItemRemovedEvent | CurrentClimbChangedEvent;
+type ClimbMirroredEvent = {
+  __typename: 'ClimbMirrored';
+  sequence: number;
+  stateHash: string;
+  uuid: string | null;
+  mirrored: boolean;
+};
+
+type QueueUpdateEvent =
+  | FullSyncEvent
+  | QueueItemAddedEvent
+  | QueueItemRemovedEvent
+  | QueueReorderedEvent
+  | CurrentClimbChangedEvent
+  | ClimbMirroredEvent;
+
+function toSyncQueueEvent(event: QueueUpdateEvent): SyncQueueEvent {
+  switch (event.__typename) {
+    case 'FullSync': {
+      return {
+        __typename: 'FullSync',
+        state: {
+          queue: event.state.queue.map(toClimbQueueItem),
+          currentClimbQueueItem: event.state.currentClimbQueueItem
+            ? toClimbQueueItem(event.state.currentClimbQueueItem)
+            : null,
+        },
+      };
+    }
+    case 'QueueItemAdded':
+      return {
+        __typename: 'QueueItemAdded',
+        item: toClimbQueueItem(event.item),
+        position: event.position,
+      };
+    case 'QueueItemRemoved':
+      return { __typename: 'QueueItemRemoved', uuid: event.uuid };
+    case 'QueueReordered':
+      return {
+        __typename: 'QueueReordered',
+        uuid: event.uuid,
+        oldIndex: event.oldIndex,
+        newIndex: event.newIndex,
+      };
+    case 'CurrentClimbChanged':
+      return {
+        __typename: 'CurrentClimbChanged',
+        item: event.item ? toClimbQueueItem(event.item) : null,
+        clientId: event.clientId,
+        correlationId: event.correlationId,
+      };
+    case 'ClimbMirrored':
+      return {
+        __typename: 'ClimbMirrored',
+        mirrored: event.mirrored,
+        // Server emits the canonical queue-item uuid under `uuid`; the
+        // coordinator forwards it as `mirroredUuid` for the reducer's
+        // race-guard against driver navigating mid-mirror.
+        mirroredUuid: event.uuid,
+      };
+  }
+}
 
 export function QueueProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(queueReducer, defaultSearchParams, initialState);
@@ -106,6 +191,23 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const sessionCreationRef = useRef<Promise<string | null> | null>(null);
   const { showToast } = useToast();
   const { t } = useTranslation('session');
+
+  // Build the sync coordinator once per provider mount. The clientId is
+  // generated fresh per app launch (no persistence needed today — only
+  // matters within a single WebSocket session for echo suppression). Pass
+  // the reducer's dispatch in so the coordinator can prune timed-out
+  // pending correlation IDs.
+  const dispatchRef = useRef(dispatch);
+  dispatchRef.current = dispatch;
+  const coordinator = useMemo(
+    () =>
+      createQueueSyncCoordinator({
+        clientId: generateClientId(),
+        dispatch: (action) => dispatchRef.current(action),
+      }),
+    [],
+  );
+  useEffect(() => () => coordinator.dispose(), [coordinator]);
 
   useEffect(() => {
     sessionIdRef.current = sessionId;
@@ -134,58 +236,8 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       {
         next: ({ data }) => {
           if (!data?.queueUpdates) return;
-          const event = data.queueUpdates;
-
-          switch (event.__typename) {
-            case 'FullSync': {
-              const queueItems = event.state.queue.map(toClimbQueueItem);
-              const currentItem = event.state.currentClimbQueueItem
-                ? toClimbQueueItem(event.state.currentClimbQueueItem)
-                : null;
-
-              dispatch({
-                type: 'INITIAL_QUEUE_DATA',
-                payload: {
-                  queue: queueItems,
-                  currentClimbQueueItem: currentItem,
-                },
-              });
-              break;
-            }
-
-            case 'QueueItemAdded': {
-              const addedItem = toClimbQueueItem(event.item);
-              dispatch({
-                type: 'DELTA_ADD_QUEUE_ITEM',
-                payload: {
-                  item: addedItem,
-                  position: event.position ?? undefined,
-                },
-              });
-              break;
-            }
-
-            case 'QueueItemRemoved': {
-              dispatch({
-                type: 'DELTA_REMOVE_QUEUE_ITEM',
-                payload: { uuid: event.uuid },
-              });
-              break;
-            }
-
-            case 'CurrentClimbChanged': {
-              const changedItem = event.item ? toClimbQueueItem(event.item) : null;
-              dispatch({
-                type: 'DELTA_UPDATE_CURRENT_CLIMB',
-                payload: {
-                  item: changedItem,
-                  isServerEvent: true,
-                  shouldAddToQueue: true,
-                },
-              });
-              break;
-            }
-          }
+          const result = coordinator.mapIncomingEvent(toSyncQueueEvent(data.queueUpdates));
+          if (result.kind === 'dispatch') dispatch(result.action);
         },
         error: () => {
           showToast(t('mobile.queue.syncError'), 'error');
@@ -279,72 +331,45 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const setCurrentClimb = useCallback(
-    (item: ClimbQueueItem) => {
+  // Optimistic local dispatch + correlated SET_CURRENT_CLIMB mutation.
+  // The reducer stores `correlationId` in pendingCurrentClimbUpdates so the
+  // echoed CurrentClimbChanged event (carrying the same id back in
+  // `serverCorrelationId`) is suppressed instead of re-applied.
+  const dispatchSetCurrent = useCallback(
+    (item: ClimbQueueItem, shouldAddToQueue: boolean) => {
+      const correlationId = coordinator.generateCorrelationId();
       dispatch({
         type: 'DELTA_UPDATE_CURRENT_CLIMB',
-        payload: {
-          item,
-          shouldAddToQueue: true,
-          isServerEvent: false,
-        },
+        payload: { item, shouldAddToQueue, isServerEvent: false, correlationId },
       });
-
+      coordinator.trackPendingMutation(correlationId);
       ensureSession().then((activeSessionId) => {
-        if (activeSessionId) {
-          getHttpClient()
-            .request<SetCurrentClimbMutationResponse>(SET_CURRENT_CLIMB, {
-              item: { uuid: item.uuid, climb: item.climb },
-              shouldAddToQueue: true,
-            })
-            .catch(() => showToast(t('mobile.queue.actionFailed'), 'error'));
-        }
+        if (!activeSessionId) return;
+        getHttpClient()
+          .request<SetCurrentClimbMutationResponse>(SET_CURRENT_CLIMB, {
+            item: { uuid: item.uuid, climb: item.climb },
+            shouldAddToQueue,
+            correlationId,
+          })
+          .catch(() => showToast(t('mobile.queue.actionFailed'), 'error'));
       });
     },
-    [ensureSession, showToast, t],
+    [coordinator, ensureSession, showToast, t],
   );
+
+  const setCurrentClimb = useCallback((item: ClimbQueueItem) => dispatchSetCurrent(item, true), [dispatchSetCurrent]);
 
   const nextClimb = useCallback(() => {
     const { queue, currentClimbQueueItem } = stateRef.current;
     const nextItem = findNextQueueItem(queue, currentClimbQueueItem);
-    if (nextItem) {
-      dispatch({
-        type: 'DELTA_UPDATE_CURRENT_CLIMB',
-        payload: { item: nextItem, isServerEvent: false },
-      });
-      ensureSession().then((activeSessionId) => {
-        if (activeSessionId) {
-          getHttpClient()
-            .request<SetCurrentClimbMutationResponse>(SET_CURRENT_CLIMB, {
-              item: { uuid: nextItem.uuid, climb: nextItem.climb },
-              shouldAddToQueue: false,
-            })
-            .catch(() => showToast(t('mobile.queue.actionFailed'), 'error'));
-        }
-      });
-    }
-  }, [ensureSession, showToast, t]);
+    if (nextItem) dispatchSetCurrent(nextItem, false);
+  }, [dispatchSetCurrent]);
 
   const previousClimb = useCallback(() => {
     const { queue, currentClimbQueueItem } = stateRef.current;
     const prevItem = findPreviousQueueItem(queue, currentClimbQueueItem);
-    if (prevItem) {
-      dispatch({
-        type: 'DELTA_UPDATE_CURRENT_CLIMB',
-        payload: { item: prevItem, isServerEvent: false },
-      });
-      ensureSession().then((activeSessionId) => {
-        if (activeSessionId) {
-          getHttpClient()
-            .request<SetCurrentClimbMutationResponse>(SET_CURRENT_CLIMB, {
-              item: { uuid: prevItem.uuid, climb: prevItem.climb },
-              shouldAddToQueue: false,
-            })
-            .catch(() => showToast(t('mobile.queue.actionFailed'), 'error'));
-        }
-      });
-    }
-  }, [ensureSession, showToast, t]);
+    if (prevItem) dispatchSetCurrent(prevItem, false);
+  }, [dispatchSetCurrent]);
 
   const clearSession = useCallback(async () => {
     setSessionId(null);

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -219,6 +219,16 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  // showToast and t aren't stable callbacks — capture via refs so the WS
+  // subscription effect doesn't tear down & re-subscribe on locale change
+  // (which would briefly miss in-flight peer events). coordinator and dispatch
+  // are stable (useMemo([]) / useReducer respectively) so they can sit in the
+  // dep array directly.
+  const showToastRef = useRef(showToast);
+  showToastRef.current = showToast;
+  const tRef = useRef(t);
+  tRef.current = t;
+
   useEffect(() => {
     if (!sessionId) {
       unsubscribeRef.current?.();
@@ -238,9 +248,13 @@ export function QueueProvider({ children }: { children: ReactNode }) {
           if (!data?.queueUpdates) return;
           const result = coordinator.mapIncomingEvent(toSyncQueueEvent(data.queueUpdates));
           if (result.kind === 'dispatch') dispatch(result.action);
+          // TODO(analytics-parity): web's use-queue-event-subscription.ts
+          // tracks peer-broadcast QueueItemAdded/QueueItemRemoved via track().
+          // Mobile lacks an analytics module today; revisit once the mobile
+          // analytics surface exists.
         },
         error: () => {
-          showToast(t('mobile.queue.syncError'), 'error');
+          showToastRef.current(tRef.current('mobile.queue.syncError'), 'error');
         },
         complete: () => {},
       },
@@ -252,7 +266,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       cleanup();
       unsubscribeRef.current = null;
     };
-  }, [sessionId]);
+  }, [sessionId, coordinator]);
 
   const ensureSession = useCallback(async (): Promise<string | null> => {
     if (sessionIdRef.current) return sessionIdRef.current;

--- a/packages/shared/board-config/src/board-data.ts
+++ b/packages/shared/board-config/src/board-data.ts
@@ -210,38 +210,12 @@ export const ANGLES: Record<BoardName, Angle[]> = {
   soill: [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70],
 };
 
-// Unified grade system used by all boards
-// difficulty_id matches board_difficulty_grades table
-// font_grade is the Font/Fontainebleau grade (used for MoonBoard display)
-// difficulty_name includes both Font and V-grade (used for Aurora display)
-export const BOULDER_GRADES = [
-  { difficulty_id: 10, font_grade: '4a', v_grade: 'V0', difficulty_name: '4a/V0' },
-  { difficulty_id: 11, font_grade: '4b', v_grade: 'V0', difficulty_name: '4b/V0' },
-  { difficulty_id: 12, font_grade: '4c', v_grade: 'V0', difficulty_name: '4c/V0' },
-  { difficulty_id: 13, font_grade: '5a', v_grade: 'V1', difficulty_name: '5a/V1' },
-  { difficulty_id: 14, font_grade: '5b', v_grade: 'V1', difficulty_name: '5b/V1' },
-  { difficulty_id: 15, font_grade: '5c', v_grade: 'V2', difficulty_name: '5c/V2' },
-  { difficulty_id: 16, font_grade: '6a', v_grade: 'V3', difficulty_name: '6a/V3' },
-  { difficulty_id: 17, font_grade: '6a+', v_grade: 'V3', difficulty_name: '6a+/V3' },
-  { difficulty_id: 18, font_grade: '6b', v_grade: 'V4', difficulty_name: '6b/V4' },
-  { difficulty_id: 19, font_grade: '6b+', v_grade: 'V4', difficulty_name: '6b+/V4' },
-  { difficulty_id: 20, font_grade: '6c', v_grade: 'V5', difficulty_name: '6c/V5' },
-  { difficulty_id: 21, font_grade: '6c+', v_grade: 'V5', difficulty_name: '6c+/V5' },
-  { difficulty_id: 22, font_grade: '7a', v_grade: 'V6', difficulty_name: '7a/V6' },
-  { difficulty_id: 23, font_grade: '7a+', v_grade: 'V7', difficulty_name: '7a+/V7' },
-  { difficulty_id: 24, font_grade: '7b', v_grade: 'V8', difficulty_name: '7b/V8' },
-  { difficulty_id: 25, font_grade: '7b+', v_grade: 'V8', difficulty_name: '7b+/V8' },
-  { difficulty_id: 26, font_grade: '7c', v_grade: 'V9', difficulty_name: '7c/V9' },
-  { difficulty_id: 27, font_grade: '7c+', v_grade: 'V10', difficulty_name: '7c+/V10' },
-  { difficulty_id: 28, font_grade: '8a', v_grade: 'V11', difficulty_name: '8a/V11' },
-  { difficulty_id: 29, font_grade: '8a+', v_grade: 'V12', difficulty_name: '8a+/V12' },
-  { difficulty_id: 30, font_grade: '8b', v_grade: 'V13', difficulty_name: '8b/V13' },
-  { difficulty_id: 31, font_grade: '8b+', v_grade: 'V14', difficulty_name: '8b+/V14' },
-  { difficulty_id: 32, font_grade: '8c', v_grade: 'V15', difficulty_name: '8c/V15' },
-  { difficulty_id: 33, font_grade: '8c+', v_grade: 'V16', difficulty_name: '8c+/V16' },
-] as const;
-
-export type BoulderGrade = (typeof BOULDER_GRADES)[number];
+// BOULDER_GRADES + BoulderGrade live in @boardsesh/board-constants so display
+// utilities can depend on the grade taxonomy without pulling in the rest of
+// board-config (image dimensions, set IDs, moonboard config). Re-exported
+// here for back-compat with existing call sites.
+import { BOULDER_GRADES, type BoulderGrade } from '@boardsesh/board-constants/boulder-grade-mapping';
+export { BOULDER_GRADES, type BoulderGrade };
 
 // Alias for backwards compatibility
 export const TENSION_KILTER_GRADES = BOULDER_GRADES;

--- a/packages/shared/climb-filters/src/__tests__/filter-state.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/filter-state.test.ts
@@ -256,7 +256,10 @@ describe('applyStatusChange', () => {
   });
 
   it('produces a patch that, when applied to established, flows minAscents=2 through toClimbSearchInput', () => {
-    const patched: ClimbFilterState = { ...DEFAULT_CLIMB_FILTER_STATE, ...applyStatusChange(DEFAULT_CLIMB_FILTER_STATE, 'established') };
+    const patched: ClimbFilterState = {
+      ...DEFAULT_CLIMB_FILTER_STATE,
+      ...applyStatusChange(DEFAULT_CLIMB_FILTER_STATE, 'established'),
+    };
     const input = toClimbSearchInput(patched, board, pagination);
     expect(input.minAscents).toBe(2);
   });

--- a/packages/shared/play-view/package.json
+++ b/packages/shared/play-view/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@boardsesh/board-config": "*",
     "@boardsesh/board-constants": "*",
     "@boardsesh/queue": "*"
   },

--- a/packages/shared/play-view/package.json
+++ b/packages/shared/play-view/package.json
@@ -15,7 +15,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@boardsesh/board-config": "*",
     "@boardsesh/board-constants": "*",
     "@boardsesh/queue": "*"
   },

--- a/packages/shared/play-view/src/__tests__/grade-display.test.ts
+++ b/packages/shared/play-view/src/__tests__/grade-display.test.ts
@@ -5,6 +5,15 @@ import {
   getGradeTextColor,
   getGradeTintColor,
   hexToHSL,
+  formatGrade,
+  formatVGrade,
+  formatFontGrade,
+  softenColor,
+  getSoftGradeColor,
+  getSoftVGradeColor,
+  getSoftFontGradeColor,
+  getSoftGradeColorByFormat,
+  DEFAULT_GRADE_DISPLAY_FORMAT,
 } from '../grade-display';
 
 describe('getGradeColorWithOpacity', () => {
@@ -134,5 +143,116 @@ describe('hexToHSL', () => {
     expect(result.h).toBe(0);
     expect(result.s).toBe(0);
     expect(result.l).toBeCloseTo(1, 5);
+  });
+});
+
+describe('formatVGrade', () => {
+  it('extracts the V part of a combined difficulty', () => {
+    expect(formatVGrade('6a/V3')).toBe('V3');
+    // The Font part has no "+" so no disambiguation suffix, regardless of mapping count.
+    expect(formatVGrade('7b/V8')).toBe('V8');
+  });
+
+  it('adds "+" when the Font part has "+" AND V-grade has multiple Font mappings', () => {
+    // V5 maps from both "6c" and "6c+" in BOULDER_GRADES → "+" is meaningful.
+    expect(formatVGrade('6c+/V5')).toBe('V5+');
+  });
+
+  it('does not add "+" when V-grade has only one Font mapping', () => {
+    // V7 only comes from "7a+" → no disambiguation needed.
+    expect(formatVGrade('7a+/V7')).toBe('V7');
+  });
+
+  it('accepts a bare V label', () => {
+    expect(formatVGrade('V10')).toBe('V10');
+  });
+
+  it('returns null for missing / unparseable input', () => {
+    expect(formatVGrade(null)).toBeNull();
+    expect(formatVGrade(undefined)).toBeNull();
+    expect(formatVGrade('')).toBeNull();
+    expect(formatVGrade('not a grade')).toBeNull();
+  });
+});
+
+describe('formatFontGrade', () => {
+  it('uppercases the Font part of a combined difficulty', () => {
+    expect(formatFontGrade('6a/V3')).toBe('6A');
+    expect(formatFontGrade('7b+/V8')).toBe('7B+');
+  });
+
+  it('falls back to a standalone Font match', () => {
+    expect(formatFontGrade('6a')).toBe('6A');
+    expect(formatFontGrade('7b+')).toBe('7B+');
+  });
+
+  it('returns null for missing / unparseable input', () => {
+    expect(formatFontGrade(null)).toBeNull();
+    expect(formatFontGrade(undefined)).toBeNull();
+    expect(formatFontGrade('')).toBeNull();
+    expect(formatFontGrade('Vasdf')).toBeNull();
+  });
+});
+
+describe('formatGrade', () => {
+  it('routes to V or Font based on format', () => {
+    expect(formatGrade('6c+/V5', 'v-grade')).toBe('V5+');
+    expect(formatGrade('6c+/V5', 'font')).toBe('6C+');
+  });
+
+  it('defaults to V via DEFAULT_GRADE_DISPLAY_FORMAT export', () => {
+    expect(DEFAULT_GRADE_DISPLAY_FORMAT).toBe('v-grade');
+    expect(formatGrade('6a/V3', DEFAULT_GRADE_DISPLAY_FORMAT)).toBe('V3');
+  });
+
+  it('returns null gracefully', () => {
+    expect(formatGrade(null, 'v-grade')).toBeNull();
+    expect(formatGrade(undefined, 'font')).toBeNull();
+  });
+});
+
+describe('softenColor', () => {
+  it('returns a light-mode HSL with the source hue', () => {
+    // #FF0000 is hue 0 (red).
+    expect(softenColor('#FF0000', false)).toBe('hsl(0, 72%, 44%)');
+  });
+
+  it('returns a dark-mode HSL with higher lightness for contrast', () => {
+    expect(softenColor('#FF0000', true)).toBe('hsl(0, 80%, 77%)');
+  });
+
+  it('treats the absence of darkMode as light-mode', () => {
+    expect(softenColor('#FF0000')).toBe(softenColor('#FF0000', false));
+  });
+});
+
+describe('getSoftGradeColor variants', () => {
+  it('returns a softened color for a recognised V-grade', () => {
+    const color = getSoftVGradeColor('V3');
+    expect(color).toMatch(/^hsl\(\d+, 72%, 44%\)$/);
+  });
+
+  it('returns a softened color for a recognised Font grade', () => {
+    const color = getSoftFontGradeColor('6a');
+    expect(color).toMatch(/^hsl\(\d+, 72%, 44%\)$/);
+  });
+
+  it('returns undefined for unknown grades', () => {
+    expect(getSoftVGradeColor('V99')).toBeUndefined();
+    expect(getSoftFontGradeColor('9z')).toBeUndefined();
+    expect(getSoftGradeColor(null)).toBeUndefined();
+    expect(getSoftGradeColor(undefined)).toBeUndefined();
+  });
+
+  it('uses the V part when format is "v-grade"', () => {
+    const byFormat = getSoftGradeColorByFormat('6a/V3', 'v-grade');
+    const byV = getSoftVGradeColor('V3');
+    expect(byFormat).toBe(byV);
+  });
+
+  it('uses the Font part when format is "font"', () => {
+    const byFormat = getSoftGradeColorByFormat('6a/V3', 'font');
+    const byFont = getSoftFontGradeColor('6A');
+    expect(byFormat).toBe(byFont);
   });
 });

--- a/packages/shared/play-view/src/grade-display.ts
+++ b/packages/shared/play-view/src/grade-display.ts
@@ -1,7 +1,77 @@
-import { getGradeColor } from '@boardsesh/board-constants/grade-colors';
+import { getGradeColor, getVGradeColor, getFontGradeColor } from '@boardsesh/board-constants/grade-colors';
+import { BOULDER_GRADES } from '@boardsesh/board-config';
 
 // Re-export for convenience
 export { getGradeColor };
+
+// V-grades that map from multiple Font grades. Only these need "+" disambiguation
+// when the source difficulty's Font part ends with "+". Computed once at module
+// load from BOULDER_GRADES so the set stays in sync with config.
+const V_GRADES_WITH_MULTIPLE_FONT_GRADES: Set<string> = (() => {
+  const countByVGrade = new Map<string, number>();
+  for (const grade of BOULDER_GRADES) {
+    countByVGrade.set(grade.v_grade, (countByVGrade.get(grade.v_grade) ?? 0) + 1);
+  }
+  const result = new Set<string>();
+  for (const [vGrade, count] of countByVGrade) {
+    if (count > 1) result.add(vGrade);
+  }
+  return result;
+})();
+
+function extractVGrade(difficulty: string | null | undefined): string | null {
+  if (!difficulty) return null;
+  const vGradeMatch = difficulty.match(/V\d+/i);
+  return vGradeMatch ? vGradeMatch[0].toUpperCase() : null;
+}
+
+function extractFontGrade(difficulty: string | null | undefined): string | null {
+  if (!difficulty) return null;
+  const slashIndex = difficulty.indexOf('/');
+  if (slashIndex > 0) {
+    return difficulty.substring(0, slashIndex).toUpperCase();
+  }
+  const fontGradeMatch = difficulty.match(/\d[abc]\+?/i);
+  return fontGradeMatch ? fontGradeMatch[0].toUpperCase() : null;
+}
+
+/**
+ * Format a difficulty string to a V-grade display label.
+ * Adds "+" only when the Font grade has "+" AND the V-grade has multiple Font
+ * grade mappings (e.g., "6c+/V5" → "V5+" because V5 maps from both 6c and 6c+).
+ * V-grades with a single Font mapping (e.g., "7a+/V7") never get a "+".
+ */
+export function formatVGrade(difficulty: string | null | undefined): string | null {
+  if (!difficulty) return null;
+  const vGrade = extractVGrade(difficulty);
+  if (!vGrade) return null;
+  const slashIndex = difficulty.indexOf('/');
+  if (slashIndex > 0) {
+    const fontPart = difficulty.substring(0, slashIndex);
+    if (fontPart.endsWith('+') && V_GRADES_WITH_MULTIPLE_FONT_GRADES.has(vGrade)) {
+      return `${vGrade}+`;
+    }
+  }
+  return vGrade;
+}
+
+/**
+ * Format a difficulty string to a Font grade display label (uppercased).
+ */
+export function formatFontGrade(difficulty: string | null | undefined): string | null {
+  return extractFontGrade(difficulty);
+}
+
+export type GradeDisplayFormat = 'v-grade' | 'font';
+export const DEFAULT_GRADE_DISPLAY_FORMAT: GradeDisplayFormat = 'v-grade';
+
+/**
+ * Format a difficulty string according to the user's preference.
+ * `'v-grade'` → V-style label (`"V5"`, `"V5+"`). `'font'` → Font label (`"6A"`).
+ */
+export function formatGrade(difficulty: string | null | undefined, format: GradeDisplayFormat): string | null {
+  return format === 'font' ? formatFontGrade(difficulty) : formatVGrade(difficulty);
+}
 
 /**
  * Convert a hex color to HSL components.
@@ -115,4 +185,59 @@ export function getGradeTintColor(
     return `hsl(${hue}, 35%, 82%)`;
   }
   return `hsl(${hue}, 30%, 88%)`;
+}
+
+/**
+ * Soften a hex color into a readable HSL value for use as text/foreground color.
+ * Preserves hue, picks a lightness band that contrasts with the surface.
+ */
+export function softenColor(hex: string, darkMode?: boolean): string {
+  const { h } = hexToHSL(hex);
+  if (darkMode) {
+    return `hsl(${Math.round(h)}, 80%, 77%)`;
+  }
+  return `hsl(${Math.round(h)}, 72%, 44%)`;
+}
+
+/**
+ * Softened color for a V-grade label (e.g. "V3").
+ */
+export function getSoftVGradeColor(vGrade: string | null | undefined, darkMode?: boolean): string | undefined {
+  const color = getVGradeColor(vGrade);
+  if (!color) return undefined;
+  return softenColor(color, darkMode);
+}
+
+/**
+ * Softened color for a Font-grade label (e.g. "6a", "7b+").
+ */
+export function getSoftFontGradeColor(fontGrade: string | null | undefined, darkMode?: boolean): string | undefined {
+  const color = getFontGradeColor(fontGrade);
+  if (!color) return undefined;
+  return softenColor(color, darkMode);
+}
+
+/**
+ * Softened color for a full difficulty string (e.g. "6a/V3", "V5"). Uses the
+ * embedded V-grade when present.
+ */
+export function getSoftGradeColor(difficulty: string | null | undefined, darkMode?: boolean): string | undefined {
+  const color = getGradeColor(difficulty);
+  if (!color) return undefined;
+  return softenColor(color, darkMode);
+}
+
+/**
+ * Softened color for the user's selected display format. `'font'` reads the
+ * Font part of the difficulty; `'v-grade'` (default) reads the V part.
+ */
+export function getSoftGradeColorByFormat(
+  difficulty: string | null | undefined,
+  format: GradeDisplayFormat,
+  darkMode?: boolean,
+): string | undefined {
+  if (format === 'font') {
+    return getSoftFontGradeColor(extractFontGrade(difficulty), darkMode);
+  }
+  return getSoftVGradeColor(extractVGrade(difficulty), darkMode);
 }

--- a/packages/shared/play-view/src/grade-display.ts
+++ b/packages/shared/play-view/src/grade-display.ts
@@ -1,5 +1,8 @@
 import { getGradeColor, getVGradeColor, getFontGradeColor } from '@boardsesh/board-constants/grade-colors';
-import { BOULDER_GRADES } from '@boardsesh/board-config';
+// Import via the narrow `/boulder-grade-mapping` deep-path so we don't pull
+// the whole @boardsesh/board-config module graph (board image dimensions,
+// set IDs, moonboard config) into anything that touches the grade helpers.
+import { BOULDER_GRADES } from '@boardsesh/board-constants/boulder-grade-mapping';
 
 // Re-export for convenience
 export { getGradeColor };

--- a/packages/shared/queue/src/__tests__/sync-coordinator.test.ts
+++ b/packages/shared/queue/src/__tests__/sync-coordinator.test.ts
@@ -124,7 +124,9 @@ describe('mapQueueEventToAction', () => {
           eventClientId: 'peer-1',
           myClientId: 'me',
           serverCorrelationId: 'corr-7',
-          shouldAddToQueue: false,
+          // Always request insertion when an incoming item is present —
+          // reducer's idempotent guard skips climbs already in the queue.
+          shouldAddToQueue: true,
         },
       });
     });
@@ -138,21 +140,24 @@ describe('mapQueueEventToAction', () => {
       expect(result.action).toMatchObject({ payload: { item, isServerEvent: true } });
     });
 
-    it('threads `suggested: true` through shouldAddToQueue', () => {
-      const item = makeItem('sug', { suggested: true });
-      const event: SyncQueueEvent = { __typename: 'CurrentClimbChanged', currentItem: item };
+    it('requests insertion regardless of whether the incoming item carries `suggested`', () => {
+      // Slim mobile subscription payloads omit `suggested`. The reducer's
+      // idempotent guard handles already-queued climbs, so always asking for
+      // insertion is safe and prevents state drift after a dropped insert.
+      const slimItem = makeItem('slim');
+      const event: SyncQueueEvent = { __typename: 'CurrentClimbChanged', currentItem: slimItem };
       const result = mapQueueEventToAction(event);
       expect(result.kind).toBe('dispatch');
       if (result.kind !== 'dispatch') return;
       expect(result.action).toMatchObject({ payload: { shouldAddToQueue: true } });
     });
 
-    it('preserves an explicit `currentItem: null` (driver cleared the wall)', () => {
+    it('preserves an explicit `currentItem: null` (driver cleared the wall) and does NOT request insertion', () => {
       const event: SyncQueueEvent = { __typename: 'CurrentClimbChanged', currentItem: null };
       const result = mapQueueEventToAction(event);
       expect(result.kind).toBe('dispatch');
       if (result.kind !== 'dispatch') return;
-      expect(result.action).toMatchObject({ payload: { item: null } });
+      expect(result.action).toMatchObject({ payload: { item: null, shouldAddToQueue: false } });
     });
   });
 

--- a/packages/shared/queue/src/__tests__/sync-coordinator.test.ts
+++ b/packages/shared/queue/src/__tests__/sync-coordinator.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createQueueSyncCoordinator,
+  mapQueueEventToAction,
+  generateClientId,
+  generateCorrelationId,
+  DEFAULT_PENDING_TTL_MS,
+  type SyncQueueEvent,
+} from '../sync-coordinator';
+import type { Climb, ClimbQueueItem, QueueAction } from '../types';
+
+const makeClimb = (uuid: string, name = 'Test Climb'): Climb => ({
+  uuid,
+  name,
+  setter_username: 'tester',
+  frames: '',
+  angle: 40,
+  ascensionist_count: 0,
+  difficulty: '20',
+  quality_average: '3',
+  stars: 3,
+  difficulty_error: '0',
+  benchmark_difficulty: null,
+});
+
+const makeItem = (uuid: string, opts?: Partial<ClimbQueueItem>): ClimbQueueItem => ({
+  uuid,
+  climb: makeClimb(uuid),
+  ...opts,
+});
+
+describe('mapQueueEventToAction', () => {
+  it('maps FullSync to INITIAL_QUEUE_DATA', () => {
+    const queue = [makeItem('a'), makeItem('b')];
+    const event: SyncQueueEvent = {
+      __typename: 'FullSync',
+      state: { queue, currentClimbQueueItem: queue[0] },
+    };
+    const result = mapQueueEventToAction(event);
+    expect(result.kind).toBe('dispatch');
+    if (result.kind !== 'dispatch') return;
+    expect(result.action.type).toBe('INITIAL_QUEUE_DATA');
+    expect(result.action).toMatchObject({
+      type: 'INITIAL_QUEUE_DATA',
+      payload: { queue, currentClimbQueueItem: queue[0] },
+    });
+  });
+
+  it('maps QueueItemAdded with `addedItem` (web schema)', () => {
+    const item = makeItem('x');
+    const event: SyncQueueEvent = { __typename: 'QueueItemAdded', addedItem: item, position: 2 };
+    const result = mapQueueEventToAction(event);
+    expect(result.kind).toBe('dispatch');
+    if (result.kind !== 'dispatch') return;
+    expect(result.action.type).toBe('DELTA_ADD_QUEUE_ITEM');
+    expect(result.action).toMatchObject({ payload: { item, position: 2 } });
+    expect(result.item).toBe(item);
+  });
+
+  it('maps QueueItemAdded with `item` (mobile schema)', () => {
+    const item = makeItem('y');
+    const event: SyncQueueEvent = { __typename: 'QueueItemAdded', item };
+    const result = mapQueueEventToAction(event);
+    expect(result.kind).toBe('dispatch');
+    if (result.kind !== 'dispatch') return;
+    expect(result.action).toMatchObject({
+      type: 'DELTA_ADD_QUEUE_ITEM',
+      payload: { item, position: undefined },
+    });
+  });
+
+  it('ignores QueueItemAdded with no payload item', () => {
+    const event: SyncQueueEvent = { __typename: 'QueueItemAdded' };
+    const result = mapQueueEventToAction(event);
+    expect(result.kind).toBe('ignore');
+    if (result.kind !== 'ignore') return;
+    expect(result.reason).toMatch(/no item/);
+  });
+
+  it('maps QueueItemRemoved to DELTA_REMOVE_QUEUE_ITEM', () => {
+    const event: SyncQueueEvent = { __typename: 'QueueItemRemoved', uuid: 'removed-uuid' };
+    const result = mapQueueEventToAction(event);
+    expect(result.kind).toBe('dispatch');
+    if (result.kind !== 'dispatch') return;
+    expect(result.action).toEqual({
+      type: 'DELTA_REMOVE_QUEUE_ITEM',
+      payload: { uuid: 'removed-uuid' },
+    });
+  });
+
+  it('maps QueueReordered to DELTA_REORDER_QUEUE_ITEM', () => {
+    const event: SyncQueueEvent = {
+      __typename: 'QueueReordered',
+      uuid: 'r',
+      oldIndex: 1,
+      newIndex: 4,
+    };
+    const result = mapQueueEventToAction(event);
+    expect(result.kind).toBe('dispatch');
+    if (result.kind !== 'dispatch') return;
+    expect(result.action).toEqual({
+      type: 'DELTA_REORDER_QUEUE_ITEM',
+      payload: { uuid: 'r', oldIndex: 1, newIndex: 4 },
+    });
+  });
+
+  describe('CurrentClimbChanged', () => {
+    it('maps with `currentItem` (web schema) and forwards clientId + correlationId', () => {
+      const item = makeItem('current');
+      const event: SyncQueueEvent = {
+        __typename: 'CurrentClimbChanged',
+        currentItem: item,
+        clientId: 'peer-1',
+        correlationId: 'corr-7',
+      };
+      const result = mapQueueEventToAction(event, { myClientId: 'me' });
+      expect(result.kind).toBe('dispatch');
+      if (result.kind !== 'dispatch') return;
+      expect(result.action.type).toBe('DELTA_UPDATE_CURRENT_CLIMB');
+      expect(result.action).toMatchObject({
+        payload: {
+          item,
+          isServerEvent: true,
+          eventClientId: 'peer-1',
+          myClientId: 'me',
+          serverCorrelationId: 'corr-7',
+          shouldAddToQueue: false,
+        },
+      });
+    });
+
+    it('maps with `item` (mobile schema)', () => {
+      const item = makeItem('current2');
+      const event: SyncQueueEvent = { __typename: 'CurrentClimbChanged', item };
+      const result = mapQueueEventToAction(event);
+      expect(result.kind).toBe('dispatch');
+      if (result.kind !== 'dispatch') return;
+      expect(result.action).toMatchObject({ payload: { item, isServerEvent: true } });
+    });
+
+    it('threads `suggested: true` through shouldAddToQueue', () => {
+      const item = makeItem('sug', { suggested: true });
+      const event: SyncQueueEvent = { __typename: 'CurrentClimbChanged', currentItem: item };
+      const result = mapQueueEventToAction(event);
+      expect(result.kind).toBe('dispatch');
+      if (result.kind !== 'dispatch') return;
+      expect(result.action).toMatchObject({ payload: { shouldAddToQueue: true } });
+    });
+
+    it('preserves an explicit `currentItem: null` (driver cleared the wall)', () => {
+      const event: SyncQueueEvent = { __typename: 'CurrentClimbChanged', currentItem: null };
+      const result = mapQueueEventToAction(event);
+      expect(result.kind).toBe('dispatch');
+      if (result.kind !== 'dispatch') return;
+      expect(result.action).toMatchObject({ payload: { item: null } });
+    });
+  });
+
+  it('maps ClimbMirrored to DELTA_MIRROR_CURRENT_CLIMB', () => {
+    const event: SyncQueueEvent = {
+      __typename: 'ClimbMirrored',
+      mirrored: true,
+      mirroredUuid: 'mirror-target',
+    };
+    const result = mapQueueEventToAction(event);
+    expect(result.kind).toBe('dispatch');
+    if (result.kind !== 'dispatch') return;
+    expect(result.action).toEqual({
+      type: 'DELTA_MIRROR_CURRENT_CLIMB',
+      payload: { mirrored: true, mirroredUuid: 'mirror-target' },
+    });
+  });
+
+  it('coerces missing mirroredUuid to null', () => {
+    const event: SyncQueueEvent = { __typename: 'ClimbMirrored', mirrored: false };
+    const result = mapQueueEventToAction(event);
+    expect(result.kind).toBe('dispatch');
+    if (result.kind !== 'dispatch') return;
+    expect(result.action).toMatchObject({ payload: { mirroredUuid: null } });
+  });
+});
+
+describe('createQueueSyncCoordinator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses provided clientId verbatim', () => {
+    const coordinator = createQueueSyncCoordinator({ dispatch: () => {}, clientId: 'fixed-id' });
+    expect(coordinator.clientId).toBe('fixed-id');
+  });
+
+  it('auto-generates a clientId when not provided', () => {
+    const coordinator = createQueueSyncCoordinator({ dispatch: () => {} });
+    expect(coordinator.clientId).toMatch(/.+/);
+    expect(coordinator.clientId.length).toBeGreaterThan(8);
+  });
+
+  it('threads myClientId into mapIncomingEvent results', () => {
+    const coordinator = createQueueSyncCoordinator({ dispatch: () => {}, clientId: 'me' });
+    const item = makeItem('x');
+    const result = coordinator.mapIncomingEvent({
+      __typename: 'CurrentClimbChanged',
+      currentItem: item,
+      clientId: 'peer',
+    });
+    expect(result.kind).toBe('dispatch');
+    if (result.kind !== 'dispatch') return;
+    expect(result.action).toMatchObject({
+      payload: { eventClientId: 'peer', myClientId: 'me' },
+    });
+  });
+
+  it('schedules a CLEANUP_PENDING_UPDATE dispatch after the TTL', () => {
+    const dispatched: QueueAction[] = [];
+    const coordinator = createQueueSyncCoordinator({
+      dispatch: (action) => dispatched.push(action as QueueAction),
+      clientId: 'me',
+      pendingTtlMs: 5000,
+    });
+    coordinator.trackPendingMutation('corr-a');
+    expect(dispatched).toEqual([]);
+    vi.advanceTimersByTime(4999);
+    expect(dispatched).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(dispatched).toEqual([{ type: 'CLEANUP_PENDING_UPDATE', payload: { correlationId: 'corr-a' } }]);
+  });
+
+  it('honors a per-call TTL override', () => {
+    const dispatched: QueueAction[] = [];
+    const coordinator = createQueueSyncCoordinator({
+      dispatch: (action) => dispatched.push(action as QueueAction),
+      pendingTtlMs: 60_000,
+    });
+    coordinator.trackPendingMutation('corr-x', 1000);
+    vi.advanceTimersByTime(1000);
+    expect(dispatched).toEqual([{ type: 'CLEANUP_PENDING_UPDATE', payload: { correlationId: 'corr-x' } }]);
+  });
+
+  it('replaces an earlier scheduled cleanup when the same id is tracked again', () => {
+    const dispatched: QueueAction[] = [];
+    const coordinator = createQueueSyncCoordinator({
+      dispatch: (action) => dispatched.push(action as QueueAction),
+      pendingTtlMs: 1000,
+    });
+    coordinator.trackPendingMutation('corr-a');
+    vi.advanceTimersByTime(500);
+    coordinator.trackPendingMutation('corr-a'); // resets the timer
+    vi.advanceTimersByTime(500);
+    expect(dispatched).toEqual([]); // would have fired without reset
+    vi.advanceTimersByTime(500);
+    expect(dispatched).toHaveLength(1);
+  });
+
+  it('dispose cancels pending cleanups so no dispatch fires after unmount', () => {
+    const dispatched: QueueAction[] = [];
+    const coordinator = createQueueSyncCoordinator({
+      dispatch: (action) => dispatched.push(action as QueueAction),
+      pendingTtlMs: 1000,
+    });
+    coordinator.trackPendingMutation('corr-a');
+    coordinator.trackPendingMutation('corr-b');
+    coordinator.dispose();
+    vi.advanceTimersByTime(5000);
+    expect(dispatched).toEqual([]);
+  });
+
+  it('uses injected scheduleCleanup', () => {
+    const scheduled: { cb: () => void; delay: number }[] = [];
+    const cancels: number[] = [];
+    let nextId = 0;
+    const coordinator = createQueueSyncCoordinator({
+      dispatch: () => {},
+      scheduleCleanup: (cb, delay) => {
+        const id = ++nextId;
+        scheduled.push({ cb, delay });
+        return () => cancels.push(id);
+      },
+    });
+    coordinator.trackPendingMutation('corr-a');
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].delay).toBe(DEFAULT_PENDING_TTL_MS);
+    coordinator.dispose();
+    expect(cancels).toEqual([1]);
+  });
+
+  it('generateCorrelationId returns unique strings', () => {
+    const coordinator = createQueueSyncCoordinator({ dispatch: () => {} });
+    const ids = new Set([
+      coordinator.generateCorrelationId(),
+      coordinator.generateCorrelationId(),
+      coordinator.generateCorrelationId(),
+    ]);
+    expect(ids.size).toBe(3);
+  });
+});
+
+describe('standalone id generators', () => {
+  it('generateClientId returns a non-empty string', () => {
+    expect(generateClientId()).toMatch(/.+/);
+  });
+
+  it('generateCorrelationId returns a non-empty string', () => {
+    expect(generateCorrelationId()).toMatch(/.+/);
+  });
+});

--- a/packages/shared/queue/src/index.ts
+++ b/packages/shared/queue/src/index.ts
@@ -31,3 +31,19 @@ export {
   getPlaylistPeekQueueItemUuid,
   isPlaylistPeekQueueItemUuid,
 } from './playlist-suggestions';
+
+export {
+  createQueueSyncCoordinator,
+  mapQueueEventToAction,
+  generateClientId,
+  generateCorrelationId,
+  DEFAULT_PENDING_TTL_MS,
+} from './sync-coordinator';
+export type {
+  SyncQueueEvent,
+  MapEventContext,
+  EventMappingResult,
+  SyncCoordinator,
+  SyncCoordinatorOptions,
+  ScheduleCleanupFn,
+} from './sync-coordinator';

--- a/packages/shared/queue/src/sync-coordinator.ts
+++ b/packages/shared/queue/src/sync-coordinator.ts
@@ -142,6 +142,15 @@ export function mapQueueEventToAction<TSearchParams extends QueueSearchParams = 
 
     case 'CurrentClimbChanged': {
       const incoming = event.currentItem !== undefined ? event.currentItem : (event.item ?? null);
+      // Always request insertion when there's an incoming item — the reducer's
+      // idempotent guard skips climbs already in the queue. This is the safe
+      // default for two reasons:
+      //   1. Slim subscription payloads (mobile uses uuid/name/frames only) don't
+      //      carry `suggested`, so gating on incoming?.suggested would silently
+      //      drop legitimate inserts after a dropped QueueItemAdded on reconnect.
+      //   2. Browsing-only navigations on web already pass non-suggested items
+      //      that exist in the queue, so the idempotent guard makes
+      //      shouldAddToQueue:true a no-op there.
       return {
         kind: 'dispatch',
         eventType: 'CurrentClimbChanged',
@@ -150,7 +159,7 @@ export function mapQueueEventToAction<TSearchParams extends QueueSearchParams = 
           type: 'DELTA_UPDATE_CURRENT_CLIMB',
           payload: {
             item: incoming,
-            shouldAddToQueue: incoming?.suggested ?? false,
+            shouldAddToQueue: incoming != null,
             isServerEvent: true,
             eventClientId: event.clientId ?? undefined,
             myClientId: context?.myClientId ?? undefined,

--- a/packages/shared/queue/src/sync-coordinator.ts
+++ b/packages/shared/queue/src/sync-coordinator.ts
@@ -1,0 +1,270 @@
+/**
+ * Queue sync coordinator — protocol-level glue between WebSocket queue events
+ * and the pure queueReducer. No React, no DOM, no network access.
+ *
+ * Responsibilities:
+ *   1. `mapQueueEventToAction` — pure mapping from a normalized WebSocket queue
+ *      event to a reducer action. Centralizes the field-name normalization
+ *      (web uses `addedItem`/`currentItem`; mobile uses `item`) and the echo
+ *      hints (myClientId, serverCorrelationId) the reducer needs.
+ *   2. `createQueueSyncCoordinator` — small stateful factory that owns the
+ *      client identity and tracks pending correlation IDs with auto-cleanup
+ *      via injected timer + dispatch adapters. The reducer's
+ *      `pendingCurrentClimbUpdates` slice is still the source of truth; this
+ *      coordinator just guarantees stale IDs get pruned even if no echo
+ *      arrives.
+ *
+ * Apps own subscription lifecycle, network calls, analytics, and storage —
+ * the coordinator stays platform-agnostic.
+ */
+
+import type { ClimbQueueItem, QueueAction, QueueSearchParams } from './types';
+
+/**
+ * Wide event union — structurally compatible with web's
+ * `SubscriptionQueueEvent` from `@boardsesh/shared-schema` and with mobile's
+ * inline `QueueUpdateEvent` types. Field-name aliases (`item` vs `addedItem`,
+ * `item` vs `currentItem`) are both accepted; the coordinator picks whichever
+ * is present.
+ */
+export type SyncQueueEvent =
+  | {
+      __typename: 'FullSync';
+      state: {
+        queue: ClimbQueueItem[];
+        currentClimbQueueItem: ClimbQueueItem | null;
+      };
+    }
+  | {
+      __typename: 'QueueItemAdded';
+      addedItem?: ClimbQueueItem;
+      item?: ClimbQueueItem;
+      position?: number | null;
+    }
+  | {
+      __typename: 'QueueItemRemoved';
+      uuid: string;
+    }
+  | {
+      __typename: 'QueueReordered';
+      uuid: string;
+      oldIndex: number;
+      newIndex: number;
+    }
+  | {
+      __typename: 'CurrentClimbChanged';
+      currentItem?: ClimbQueueItem | null;
+      item?: ClimbQueueItem | null;
+      clientId?: string | null;
+      correlationId?: string | null;
+    }
+  | {
+      __typename: 'ClimbMirrored';
+      mirrored: boolean;
+      mirroredUuid?: string | null;
+    };
+
+export type MapEventContext = {
+  /** This client's stable id, used for fallback echo suppression. */
+  myClientId?: string | null;
+};
+
+export type EventMappingResult<TSearchParams extends QueueSearchParams = QueueSearchParams> =
+  | {
+      kind: 'dispatch';
+      action: QueueAction<TSearchParams>;
+      eventType: SyncQueueEvent['__typename'];
+      /** The climb item the event carried, if any. Useful for callers that
+       * want to attach analytics (e.g. "added by peer"). */
+      item?: ClimbQueueItem | null;
+    }
+  | { kind: 'ignore'; eventType: SyncQueueEvent['__typename']; reason: string };
+
+/**
+ * Pure mapping from a WebSocket queue event to a reducer action.
+ * Returns `kind: 'ignore'` for events that carry malformed payloads
+ * (e.g., QueueItemAdded with no item). Apps should still treat the absence
+ * of a dispatch as a soft signal that something is off.
+ */
+export function mapQueueEventToAction<TSearchParams extends QueueSearchParams = QueueSearchParams>(
+  event: SyncQueueEvent,
+  context?: MapEventContext,
+): EventMappingResult<TSearchParams> {
+  switch (event.__typename) {
+    case 'FullSync': {
+      return {
+        kind: 'dispatch',
+        eventType: 'FullSync',
+        action: {
+          type: 'INITIAL_QUEUE_DATA',
+          payload: {
+            queue: event.state.queue,
+            currentClimbQueueItem: event.state.currentClimbQueueItem,
+          },
+        },
+      };
+    }
+
+    case 'QueueItemAdded': {
+      const added = event.addedItem ?? event.item;
+      if (!added) {
+        return { kind: 'ignore', eventType: 'QueueItemAdded', reason: 'no item payload' };
+      }
+      return {
+        kind: 'dispatch',
+        eventType: 'QueueItemAdded',
+        item: added,
+        action: {
+          type: 'DELTA_ADD_QUEUE_ITEM',
+          payload: { item: added, position: event.position ?? undefined },
+        },
+      };
+    }
+
+    case 'QueueItemRemoved': {
+      return {
+        kind: 'dispatch',
+        eventType: 'QueueItemRemoved',
+        action: { type: 'DELTA_REMOVE_QUEUE_ITEM', payload: { uuid: event.uuid } },
+      };
+    }
+
+    case 'QueueReordered': {
+      return {
+        kind: 'dispatch',
+        eventType: 'QueueReordered',
+        action: {
+          type: 'DELTA_REORDER_QUEUE_ITEM',
+          payload: { uuid: event.uuid, oldIndex: event.oldIndex, newIndex: event.newIndex },
+        },
+      };
+    }
+
+    case 'CurrentClimbChanged': {
+      const incoming = event.currentItem !== undefined ? event.currentItem : (event.item ?? null);
+      return {
+        kind: 'dispatch',
+        eventType: 'CurrentClimbChanged',
+        item: incoming,
+        action: {
+          type: 'DELTA_UPDATE_CURRENT_CLIMB',
+          payload: {
+            item: incoming,
+            shouldAddToQueue: incoming?.suggested ?? false,
+            isServerEvent: true,
+            eventClientId: event.clientId ?? undefined,
+            myClientId: context?.myClientId ?? undefined,
+            serverCorrelationId: event.correlationId ?? undefined,
+          },
+        },
+      };
+    }
+
+    case 'ClimbMirrored': {
+      return {
+        kind: 'dispatch',
+        eventType: 'ClimbMirrored',
+        action: {
+          type: 'DELTA_MIRROR_CURRENT_CLIMB',
+          payload: { mirrored: event.mirrored, mirroredUuid: event.mirroredUuid ?? null },
+        },
+      };
+    }
+  }
+}
+
+/** Default TTL for pending correlation IDs (ms). Anything not echoed back
+ *  within this window is presumed dropped, and we prune it from the
+ *  reducer's pending set so it doesn't suppress a future genuine event. */
+export const DEFAULT_PENDING_TTL_MS = 30_000;
+
+export type ScheduleCleanupFn = (callback: () => void, delayMs: number) => () => void;
+
+export type SyncCoordinatorOptions<TSearchParams extends QueueSearchParams = QueueSearchParams> = {
+  /** Apps inject their reducer dispatch so the coordinator can prune
+   *  pending correlation IDs on cleanup timeout. */
+  dispatch: (action: QueueAction<TSearchParams>) => void;
+  /** Stable identity for this client; auto-generated if omitted. Web reads
+   *  this from `persistentSession.clientId`; mobile generates and persists. */
+  clientId?: string;
+  /** Override for tests; defaults to crypto-backed UUID generator. */
+  generateId?: () => string;
+  /** Override for tests / RN; defaults to setTimeout+clearTimeout. The
+   *  returned function cancels the scheduled callback. */
+  scheduleCleanup?: ScheduleCleanupFn;
+  /** Pending correlation ID TTL in ms (default 30s). */
+  pendingTtlMs?: number;
+};
+
+export type SyncCoordinator<TSearchParams extends QueueSearchParams = QueueSearchParams> = {
+  readonly clientId: string;
+  generateCorrelationId(): string;
+  /** Track a correlation ID for an in-flight local mutation. The reducer's
+   *  echo-suppression logic will match against the pending set; this
+   *  coordinator schedules a cleanup dispatch after `ttlMs` so the entry is
+   *  pruned even if the echo never arrives. */
+  trackPendingMutation(correlationId: string, ttlMs?: number): void;
+  /** Convenience wrapper around `mapQueueEventToAction` that always passes
+   *  this coordinator's clientId. */
+  mapIncomingEvent(event: SyncQueueEvent): EventMappingResult<TSearchParams>;
+  /** Cancel all in-flight cleanup timers. Call on provider unmount. */
+  dispose(): void;
+};
+
+const defaultScheduleCleanup: ScheduleCleanupFn = (callback, delayMs) => {
+  const id = setTimeout(callback, delayMs);
+  return () => clearTimeout(id);
+};
+
+export function generateClientId(): string {
+  return generateId();
+}
+
+export function generateCorrelationId(): string {
+  return generateId();
+}
+
+function generateId(): string {
+  const cryptoObj: { randomUUID?: () => string } | undefined =
+    typeof globalThis !== 'undefined' && (globalThis as { crypto?: { randomUUID?: () => string } }).crypto
+      ? (globalThis as { crypto: { randomUUID?: () => string } }).crypto
+      : undefined;
+  if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+    return cryptoObj.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 11)}`;
+}
+
+export function createQueueSyncCoordinator<TSearchParams extends QueueSearchParams = QueueSearchParams>(
+  options: SyncCoordinatorOptions<TSearchParams>,
+): SyncCoordinator<TSearchParams> {
+  const generate = options.generateId ?? generateId;
+  const schedule = options.scheduleCleanup ?? defaultScheduleCleanup;
+  const ttl = options.pendingTtlMs ?? DEFAULT_PENDING_TTL_MS;
+  const clientId = options.clientId ?? generate();
+  const cancelByCorrelationId = new Map<string, () => void>();
+
+  return {
+    clientId,
+    generateCorrelationId: () => generate(),
+    trackPendingMutation(correlationId, ttlMs) {
+      const previousCancel = cancelByCorrelationId.get(correlationId);
+      if (previousCancel) previousCancel();
+      const cancel = schedule(() => {
+        cancelByCorrelationId.delete(correlationId);
+        options.dispatch({
+          type: 'CLEANUP_PENDING_UPDATE',
+          payload: { correlationId },
+        });
+      }, ttlMs ?? ttl);
+      cancelByCorrelationId.set(correlationId, cancel);
+    },
+    mapIncomingEvent(event) {
+      return mapQueueEventToAction<TSearchParams>(event, { myClientId: clientId });
+    },
+    dispose() {
+      for (const cancel of cancelByCorrelationId.values()) cancel();
+      cancelByCorrelationId.clear();
+    },
+  };
+}

--- a/packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts
@@ -1,6 +1,7 @@
 import { type Dispatch, type RefObject, useEffect } from 'react';
 import type { SubscriptionQueueEvent } from '@boardsesh/shared-schema';
-import type { ClimbQueueItem, QueueAction } from '../../queue-control/types';
+import { mapQueueEventToAction, type SyncQueueEvent } from '@boardsesh/queue';
+import type { QueueAction } from '../../queue-control/types';
 import { track } from '@/app/lib/analytics';
 
 type UseQueueEventSubscriptionParams = {
@@ -40,24 +41,16 @@ export function useQueueEventSubscription({
     if (!isPersistentSessionActive) return;
 
     const unsubscribe = persistentSession.subscribeToQueueEvents((event: SubscriptionQueueEvent) => {
-      switch (event.__typename) {
-        case 'FullSync':
-          dispatch({
-            type: 'INITIAL_QUEUE_DATA',
-            payload: {
-              queue: event.state.queue as ClimbQueueItem[],
-              currentClimbQueueItem: event.state.currentClimbQueueItem as ClimbQueueItem | null,
-            },
-          });
-          break;
+      // Wire-format → reducer-action mapping lives in @boardsesh/queue so web and
+      // mobile share one source of truth (incl. the echo-suppression hints on
+      // DELTA_UPDATE_CURRENT_CLIMB). Analytics + side effects stay here.
+      const result = mapQueueEventToAction(event as unknown as SyncQueueEvent, {
+        myClientId: persistentSession.clientId ?? undefined,
+      });
+      if (result.kind !== 'dispatch') return;
+      dispatch(result.action as QueueAction);
+      switch (result.eventType) {
         case 'QueueItemAdded':
-          dispatch({
-            type: 'DELTA_ADD_QUEUE_ITEM',
-            payload: {
-              item: event.addedItem as ClimbQueueItem,
-              position: event.position ?? undefined,
-            },
-          });
           track('Climb Added to Queue', {
             boardLayout: boardLayoutName ?? null,
             addedFromTab: 'peer_broadcast',
@@ -66,48 +59,10 @@ export function useQueueEventSubscription({
           });
           break;
         case 'QueueItemRemoved':
-          dispatch({
-            type: 'DELTA_REMOVE_QUEUE_ITEM',
-            payload: { uuid: event.uuid },
-          });
           track('Climb Removed from Queue', {
             boardLayout: boardLayoutName ?? null,
             partyMode: true,
             removedBy: 'peer',
-          });
-          break;
-        case 'QueueReordered':
-          dispatch({
-            type: 'DELTA_REORDER_QUEUE_ITEM',
-            payload: {
-              uuid: event.uuid,
-              oldIndex: event.oldIndex,
-              newIndex: event.newIndex,
-            },
-          });
-          break;
-        case 'CurrentClimbChanged':
-          dispatch({
-            type: 'DELTA_UPDATE_CURRENT_CLIMB',
-            payload: {
-              item: event.currentItem as ClimbQueueItem | null,
-              shouldAddToQueue: (event.currentItem as ClimbQueueItem | null)?.suggested ?? false,
-              isServerEvent: true,
-              eventClientId: event.clientId || undefined,
-              myClientId: persistentSession.clientId || undefined,
-              serverCorrelationId: event.correlationId || undefined,
-            },
-          });
-          break;
-        case 'ClimbMirrored':
-          // Pass the server-issued mirroredUuid so the reducer can suppress
-          // the mutation when the local current climb has drifted to a
-          // different uuid (peer navigated away mid-mirror). Without this
-          // guard the local view would mirror the wrong climb in that race
-          // until the next FullSync corrects it.
-          dispatch({
-            type: 'DELTA_MIRROR_CURRENT_CLIMB',
-            payload: { mirrored: event.mirrored, mirroredUuid: event.mirroredUuid ?? null },
           });
           break;
       }

--- a/packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts
@@ -4,6 +4,18 @@ import { mapQueueEventToAction, type SyncQueueEvent } from '@boardsesh/queue';
 import type { QueueAction } from '../../queue-control/types';
 import { track } from '@/app/lib/analytics';
 
+/**
+ * Adapt a wire-format `SubscriptionQueueEvent` (from `@boardsesh/shared-schema`)
+ * to the coordinator's `SyncQueueEvent`. The two unions are structurally
+ * compatible — they share `addedItem` / `currentItem` field names and the same
+ * `__typename` set — but their `ClimbQueueItem` types come from different
+ * packages so TS can't infer assignability directly. Runtime shapes match
+ * because both flow from the same GraphQL schema codegen.
+ */
+function toSyncQueueEvent(event: SubscriptionQueueEvent): SyncQueueEvent {
+  return event as unknown as SyncQueueEvent;
+}
+
 type UseQueueEventSubscriptionParams = {
   isPersistentSessionActive: boolean;
   dispatch: Dispatch<QueueAction>;
@@ -44,7 +56,7 @@ export function useQueueEventSubscription({
       // Wire-format → reducer-action mapping lives in @boardsesh/queue so web and
       // mobile share one source of truth (incl. the echo-suppression hints on
       // DELTA_UPDATE_CURRENT_CLIMB). Analytics + side effects stay here.
-      const result = mapQueueEventToAction(event as unknown as SyncQueueEvent, {
+      const result = mapQueueEventToAction(toSyncQueueEvent(event), {
         myClientId: persistentSession.clientId ?? undefined,
       });
       if (result.kind !== 'dispatch') return;

--- a/packages/web/app/lib/grade-colors.ts
+++ b/packages/web/app/lib/grade-colors.ts
@@ -1,4 +1,12 @@
-import {
+// Grade color data, lookups, and display utilities are owned by shared
+// packages. This file is a thin re-export layer for back-compat with web
+// call sites that import from '@/app/lib/grade-colors'.
+//
+// Format helpers (`formatGrade`, `formatVGrade`, `formatFontGrade`), softening
+// helpers (`softenColor`, `getSoft*`) and the `GradeDisplayFormat` type now
+// live in `@boardsesh/play-view` so mobile can reuse them.
+
+export {
   V_GRADE_COLORS,
   FONT_GRADE_COLORS,
   DEFAULT_GRADE_COLOR,
@@ -6,196 +14,20 @@ import {
   getFontGradeColor,
   getGradeColor,
 } from '@boardsesh/board-constants/grade-colors';
-import { getGradeTintColor, getGradeColorWithOpacity, isLightColor, getGradeTextColor } from '@boardsesh/play-view';
-import { BOULDER_GRADES } from './board-data';
 
-// Re-export grade color data and core lookups from the canonical source
-export { V_GRADE_COLORS, FONT_GRADE_COLORS, DEFAULT_GRADE_COLOR, getVGradeColor, getFontGradeColor, getGradeColor };
-
-// Re-export shared grade display utilities from @boardsesh/play-view
-export { getGradeTintColor, getGradeColorWithOpacity, isLightColor, getGradeTextColor };
-
-/**
- * Extract V-grade from a difficulty string (e.g., "6a/V3" -> "V3")
- * Internal helper - not exported.
- * @param difficulty - Difficulty string that may contain V-grade
- * @returns Uppercase V-grade string (e.g., "V3") or null if not found
- */
-function extractVGrade(difficulty: string | null | undefined): string | null {
-  if (!difficulty) return null;
-  const vGradeMatch = difficulty.match(/V\d+/i);
-  return vGradeMatch ? vGradeMatch[0].toUpperCase() : null;
-}
-
-// Build set of V-grades that have more than one Font grade mapping.
-// Only these V-grades should show "+" to disambiguate (e.g., V3 vs V3+).
-// V-grades with a single Font grade (e.g., V7 from 7a+) don't need "+".
-const V_GRADES_WITH_MULTIPLE_FONT_GRADES: Set<string> = (() => {
-  const countByVGrade = new Map<string, number>();
-  for (const g of BOULDER_GRADES) {
-    countByVGrade.set(g.v_grade, (countByVGrade.get(g.v_grade) ?? 0) + 1);
-  }
-  const result = new Set<string>();
-  for (const [vGrade, count] of countByVGrade) {
-    if (count > 1) result.add(vGrade);
-  }
-  return result;
-})();
-
-/**
- * Format a difficulty string to a V-grade display label.
- * When the Font grade has a "+" suffix AND the V-grade has multiple Font grade
- * mappings (e.g., "6c+/V5" where V5 maps from both 6c and 6c+), the result
- * includes "+" for disambiguation (e.g., "V5+").
- * When a V-grade has only one Font grade (e.g., V7 from 7a+), no "+" is added.
- * @param difficulty - Difficulty string (e.g., "6c+/V5", "7a+/V7", "V3")
- * @returns Formatted V-grade string (e.g., "V5+", "V7", "V3") or null if not found
- */
-export function formatVGrade(difficulty: string | null | undefined): string | null {
-  if (!difficulty) return null;
-  const vGrade = extractVGrade(difficulty);
-  if (!vGrade) return null;
-
-  // Only add "+" when the Font grade has "+" AND the V-grade has multiple Font grades
-  const slashIndex = difficulty.indexOf('/');
-  if (slashIndex > 0) {
-    const fontPart = difficulty.substring(0, slashIndex);
-    if (fontPart.endsWith('+') && V_GRADES_WITH_MULTIPLE_FONT_GRADES.has(vGrade)) {
-      return `${vGrade}+`;
-    }
-  }
-
-  return vGrade;
-}
-
-/**
- * Extract Font grade from a difficulty string (e.g., "6a/V3" -> "6A")
- * @param difficulty - Difficulty string that may contain Font grade
- * @returns Uppercase Font grade string for display (e.g., "6A", "7B+") or null if not found
- */
-function extractFontGrade(difficulty: string | null | undefined): string | null {
-  if (!difficulty) return null;
-  // Try to extract from "6a/V3" format first
-  const slashIndex = difficulty.indexOf('/');
-  if (slashIndex > 0) {
-    return difficulty.substring(0, slashIndex).toUpperCase();
-  }
-  // Fall back to regex match for standalone Font grade
-  const fontGradeMatch = difficulty.match(/\d[abc]\+?/i);
-  return fontGradeMatch ? fontGradeMatch[0].toUpperCase() : null;
-}
-
-/**
- * Format a difficulty string to a Font grade display label.
- * @param difficulty - Difficulty string (e.g., "6a/V3", "7b+/V8")
- * @returns Font grade string (e.g., "6a", "7b+") or null if not found
- */
-export function formatFontGrade(difficulty: string | null | undefined): string | null {
-  return extractFontGrade(difficulty);
-}
-
-export type GradeDisplayFormat = 'v-grade' | 'font';
-
-/**
- * Format a difficulty string based on the specified format preference.
- * @param difficulty - Difficulty string (e.g., "6a/V3")
- * @param format - Display format: 'v-grade' or 'font'
- * @returns Formatted grade string based on the format, or null if not found
- */
-export function formatGrade(difficulty: string | null | undefined, format: GradeDisplayFormat): string | null {
-  if (format === 'font') {
-    return formatFontGrade(difficulty);
-  }
-  return formatVGrade(difficulty);
-}
-
-/**
- * Get a softened grade color based on the display format.
- * @param difficulty - Difficulty string (e.g., "6a/V3")
- * @param format - Display format: 'v-grade' or 'font'
- * @param darkMode - Whether dark mode is active
- * @returns Softened color string suitable for text display
- */
-export function getSoftGradeColorByFormat(
-  difficulty: string | null | undefined,
-  format: GradeDisplayFormat,
-  darkMode?: boolean,
-): string | undefined {
-  if (format === 'font') {
-    const fontGrade = extractFontGrade(difficulty);
-    return getSoftFontGradeColor(fontGrade, darkMode);
-  }
-  const vGrade = extractVGrade(difficulty);
-  return getSoftVGradeColor(vGrade, darkMode);
-}
-
-/**
- * Convert a hex color to HSL components.
- * @returns Object with h (0-360), s (0-1), l (0-1)
- */
-function hexToHSL(hex: string): { h: number; s: number; l: number } {
-  const clean = hex.replace('#', '');
-  const r = parseInt(clean.substring(0, 2), 16) / 255;
-  const g = parseInt(clean.substring(2, 4), 16) / 255;
-  const b = parseInt(clean.substring(4, 6), 16) / 255;
-
-  const max = Math.max(r, g, b);
-  const min = Math.min(r, g, b);
-  const l = (max + min) / 2;
-
-  if (max === min) return { h: 0, s: 0, l };
-
-  const d = max - min;
-  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-
-  let h: number;
-  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
-  else if (max === g) h = ((b - r) / d + 2) / 6;
-  else h = ((r - g) / d + 4) / 6;
-
-  return { h: h * 360, s, l };
-}
-
-/**
- * Create a softened version of a hex color for use as text color.
- * Preserves the hue with high saturation to stay close to the original color
- * while using controlled lightness for readability on bold/large text.
- * In dark mode, uses higher lightness for readability on dark backgrounds.
- */
-function softenColor(hex: string, darkMode?: boolean): string {
-  const { h } = hexToHSL(hex);
-  if (darkMode) {
-    return `hsl(${Math.round(h)}, 80%, 77%)`;
-  }
-  return `hsl(${Math.round(h)}, 72%, 44%)`;
-}
-
-/**
- * Get a softened color for a V-grade string (e.g., "V3", "V10").
- * Returns a muted version of the grade color suitable for large/bold text in list views.
- */
-export function getSoftVGradeColor(vGrade: string | null | undefined, darkMode?: boolean): string | undefined {
-  const color = getVGradeColor(vGrade);
-  if (!color) return undefined;
-  return softenColor(color, darkMode);
-}
-
-/**
- * Get a softened color for a Font grade string (e.g., "6a", "7b+").
- * Returns a muted version of the grade color suitable for large/bold text in list views.
- */
-export function getSoftFontGradeColor(fontGrade: string | null | undefined, darkMode?: boolean): string | undefined {
-  const color = getFontGradeColor(fontGrade);
-  if (!color) return undefined;
-  return softenColor(color, darkMode);
-}
-
-/**
- * Get a softened color for a difficulty string (e.g., "6a/V3", "V5").
- * Returns a muted version of the grade color suitable for large/bold text in list views.
- */
-export function getSoftGradeColor(difficulty: string | null | undefined, darkMode?: boolean): string | undefined {
-  const color = getGradeColor(difficulty);
-  if (!color) return undefined;
-  return softenColor(color, darkMode);
-}
+export {
+  getGradeTintColor,
+  getGradeColorWithOpacity,
+  isLightColor,
+  getGradeTextColor,
+  formatGrade,
+  formatVGrade,
+  formatFontGrade,
+  softenColor,
+  getSoftGradeColor,
+  getSoftVGradeColor,
+  getSoftFontGradeColor,
+  getSoftGradeColorByFormat,
+  DEFAULT_GRADE_DISPLAY_FORMAT,
+} from '@boardsesh/play-view';
+export type { GradeDisplayFormat } from '@boardsesh/play-view';


### PR DESCRIPTION
## Summary

- **Persistent queue control bar** on mobile (RN): visible on every screen while a climb is active. Horizontal swipe = prev/next, tap = open PlayDrawer, tick/BT/end-session controls. Grade-tinted background, vivid-colored grade chip with a fixed 3-char-wide slot so the climb name doesn't shift between V3/V10.
- **Shared sync coordinator** (`@boardsesh/queue`): pure-TS `createQueueSyncCoordinator` + `mapQueueEventToAction`. Centralizes correlation-ID echo suppression + WS event→reducer-action mapping. Both web and mobile now consume it; mobile gains correlation IDs on `setCurrentClimb` and full party-event coverage (`QueueReordered`, `ClimbMirrored`).
- **Shared grade-display** (`@boardsesh/play-view`): `formatGrade`, `formatVGrade`, `formatFontGrade`, `softenColor`, `getSoft*GradeColor*`, and `GradeDisplayFormat` moved out of `packages/web/app/lib/grade-colors.ts`. Mobile now formats grades as V-only by default (settings UI deferred) and the shared package is the single source of truth.
- **Global drawer host** on mobile: `DrawerHostProvider` hoists `PlayDrawer` + `LogAscentSheet` to root so the bar (and any screen) can open them.

Web behavior is unchanged — `grade-colors.ts` is slimmed to re-exports, `useGradeFormat` + IndexedDB-backed `gradeDisplayFormat` setting + settings page UI are untouched. The web event-subscription hook switches its inline event switch to the shared mapper; analytics stays in the hook.

## Files of note

- New: `packages/shared/queue/src/sync-coordinator.ts` (+ tests)
- New: `packages/mobile/src/components/queue-control/persistent-queue-bar.tsx`
- New: `packages/mobile/src/providers/drawer-host-provider.tsx`
- New: `packages/mobile/src/hooks/use-grade-format.ts`
- Extended: `packages/shared/play-view/src/grade-display.ts` (+ tests, + `@boardsesh/board-config` dep)
- Slimmed: `packages/web/app/lib/grade-colors.ts` → re-exports only
- Rewired: `packages/mobile/src/providers/queue-provider.tsx`, `packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts`
- Deleted local UI: `packages/mobile/app/(tabs)/queue/index.tsx` navBar / LogAscentSheet / EndSessionSheet (now global)

## Test plan

- [x] `vp run typecheck:mobile` + `typecheck:web` — green
- [x] `vp test --project queue/play-view/mobile/web` — 457 mobile/shared + 4752 web tests green (+22 sync-coordinator + 19 grade-display new)
- [x] `vp run check:mobile-bundle` — iOS + Android bundles OK
- [x] `vp run check:mobile-simulator` — build/launch clean, 30s device logs clean
- [x] `vp check` — 0 errors
- [ ] Manual on a device: select a board → tap a climb → bar appears tinted with grade hue, chip shows V-format label in vivid grade color; swipe bar to advance; tap bar to open PlayDrawer; party-mode regression check (two clients, no echo flicker on driver)
- [ ] Pick a preview channel and `vp run mobile:publish` + `eas-cli channel:edit <channel> --branch worktree-queue-control-bar-rn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)