### PR TITLE
fix(ci): use per-target manual signing for app + widget extension

### DIFF
--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -75,6 +75,32 @@ jobs:
         working-directory: packages/mobile/ios
         run: pod install
 
+      - name: Configure per-target code signing
+        run: |
+          ruby <<'RUBY'
+          require 'xcodeproj'
+          project = Xcodeproj::Project.open('packages/mobile/ios/Boardsesh.xcodeproj')
+
+          profiles = {
+            'Boardsesh'        => 'Boardsesh App Store Distribution Second',
+            'BoardseshWidgets' => 'Boardsesh Widgets App Store Distribution',
+          }
+
+          project.targets.each do |target|
+            next unless profiles.key?(target.name)
+            target.build_configurations.each do |config|
+              next unless config.name == 'Release'
+              config.build_settings['CODE_SIGN_STYLE']                = 'Manual'
+              config.build_settings['DEVELOPMENT_TEAM']               = '9L3HKPZBH3'
+              config.build_settings['CODE_SIGN_IDENTITY']             = 'Apple Distribution'
+              config.build_settings['PROVISIONING_PROFILE_SPECIFIER'] = profiles[target.name]
+            end
+          end
+
+          project.save
+          puts 'Per-target code signing configured for: ' + profiles.keys.join(', ')
+          RUBY
+
       - name: Compute build number
         id: build_number
         run: |
@@ -108,13 +134,16 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
           security list-keychains -d user -s "$KEYCHAIN_NAME" $(security list-keychains -d user | tr -d '"')
 
-      - name: Install provisioning profile
+      - name: Install provisioning profiles
         env:
           APP_PROFILE_BASE64: ${{ secrets.IOS_APP_PROVISIONING_PROFILE_BASE64 }}
+          WIDGET_PROFILE_BASE64: ${{ secrets.IOS_WIDGET_PROVISIONING_PROFILE_BASE64 }}
         run: |
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           echo "$APP_PROFILE_BASE64" | base64 --decode \
             > ~/Library/MobileDevice/Provisioning\ Profiles/app.mobileprovision
+          echo "$WIDGET_PROFILE_BASE64" | base64 --decode \
+            > ~/Library/MobileDevice/Provisioning\ Profiles/widget.mobileprovision
 
       - name: Setup App Store Connect API key
         env:
@@ -141,8 +170,7 @@ jobs:
             -authenticationKeyID "$APP_STORE_CONNECT_API_KEY_ID" \
             -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
             CURRENT_PROJECT_VERSION=${{ steps.build_number.outputs.value }} \
-            DEVELOPMENT_TEAM=9L3HKPZBH3 \
-            CODE_SIGN_STYLE=Automatic
+            DEVELOPMENT_TEAM=9L3HKPZBH3
 
       - name: Export archive (uploads to TestFlight)
         env:

--- a/packages/mobile/ExportOptions.plist
+++ b/packages/mobile/ExportOptions.plist
@@ -7,7 +7,14 @@
     <key>teamID</key>
     <string>9L3HKPZBH3</string>
     <key>signingStyle</key>
-    <string>automatic</string>
+    <string>manual</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>com.boardsesh.app</key>
+        <string>Boardsesh App Store Distribution Second</string>
+        <key>com.boardsesh.app.BoardseshWidgets</key>
+        <string>Boardsesh Widgets App Store Distribution</string>
+    </dict>
     <key>uploadBitcode</key>
     <false/>
     <key>uploadSymbols</key>


### PR DESCRIPTION
The previous attempt used CODE_SIGN_STYLE=Automatic but the API key couldn't resolve provisioning for the widget. This commit:

- Adds a Ruby post-prebuild step that sets PROVISIONING_PROFILE_SPECIFIER per target (Boardsesh + BoardseshWidgets) in the generated .xcodeproj
- Installs both provisioning profiles (app + widget)
- Removes global CODE_SIGN_STYLE/PROVISIONING_PROFILE_SPECIFIER from the xcodebuild command line so project-level per-target settings take effect
- Updates ExportOptions.plist with both bundle ID → profile mappings

Requires new secret: IOS_WIDGET_PROVISIONING_PROFILE_BASE64

https://claude.ai/code/session_0121mL88St5npeaVNmdbQvoP