### PR TITLE
fix(mobile): align widget bundle ID with provisioning profile

### DIFF
--- a/packages/mobile/ExportOptions.plist
+++ b/packages/mobile/ExportOptions.plist
@@ -12,7 +12,7 @@
     <dict>
         <key>com.boardsesh.app</key>
         <string>Boardsesh App Store Distribution Second</string>
-        <key>com.boardsesh.app.BoardseshWidgets</key>
+        <key>com.boardsesh.app.widgets</key>
         <string>Boardsesh Widgets App Store Distribution</string>
     </dict>
     <key>uploadBitcode</key>

--- a/packages/mobile/targets/BoardseshWidgets/expo-target.config.js
+++ b/packages/mobile/targets/BoardseshWidgets/expo-target.config.js
@@ -12,7 +12,7 @@
 module.exports = {
   type: 'widget',
   name: 'BoardseshWidgets',
-  bundleIdentifier: 'com.boardsesh.app.BoardseshWidgets',
+  bundleIdentifier: 'com.boardsesh.app.widgets',
   deploymentTarget: '16.1',
   frameworks: ['ActivityKit', 'WidgetKit', 'AppIntents', 'SwiftUI'],
   entitlements: {


### PR DESCRIPTION
The existing provisioning profile uses app ID com.boardsesh.app.widgets but the widget target had bundle ID com.boardsesh.app.BoardseshWidgets. Updated expo-target.config.js and ExportOptions.plist to match.

https://claude.ai/code/session_0121mL88St5npeaVNmdbQvoP