### PR TITLE
fix(ci): switch iOS TestFlight build to automatic code signing

### DIFF
--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -81,24 +81,21 @@ jobs:
           require 'xcodeproj'
           project = Xcodeproj::Project.open('packages/mobile/ios/Boardsesh.xcodeproj')
 
-          profiles = {
-            'Boardsesh'        => 'Boardsesh App Store Distribution Second',
-            'BoardseshWidgets' => 'Boardsesh Widgets App Store Distribution',
-          }
+          signing_targets = ['Boardsesh', 'BoardseshWidgets']
 
           project.targets.each do |target|
-            next unless profiles.key?(target.name)
+            next unless signing_targets.include?(target.name)
             target.build_configurations.each do |config|
               next unless config.name == 'Release'
-              config.build_settings['CODE_SIGN_STYLE']                = 'Manual'
-              config.build_settings['DEVELOPMENT_TEAM']               = '9L3HKPZBH3'
-              config.build_settings['CODE_SIGN_IDENTITY']             = 'Apple Distribution'
-              config.build_settings['PROVISIONING_PROFILE_SPECIFIER'] = profiles[target.name]
+              config.build_settings['CODE_SIGN_STYLE']  = 'Automatic'
+              config.build_settings['DEVELOPMENT_TEAM']  = '9L3HKPZBH3'
+              config.build_settings.delete('PROVISIONING_PROFILE_SPECIFIER')
+              config.build_settings.delete('CODE_SIGN_IDENTITY')
             end
           end
 
           project.save
-          puts 'Per-target code signing configured for: ' + profiles.keys.join(', ')
+          puts 'Automatic code signing configured for: ' + signing_targets.join(', ')
           RUBY
 
       - name: Compute build number
@@ -140,10 +137,22 @@ jobs:
           WIDGET_PROFILE_BASE64: ${{ secrets.IOS_WIDGET_PROVISIONING_PROFILE_BASE64 }}
         run: |
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+
           echo "$APP_PROFILE_BASE64" | base64 --decode \
             > ~/Library/MobileDevice/Provisioning\ Profiles/app.mobileprovision
-          echo "$WIDGET_PROFILE_BASE64" | base64 --decode \
-            > ~/Library/MobileDevice/Provisioning\ Profiles/widget.mobileprovision
+
+          if [ -n "$WIDGET_PROFILE_BASE64" ]; then
+            echo "$WIDGET_PROFILE_BASE64" | base64 --decode \
+              > ~/Library/MobileDevice/Provisioning\ Profiles/widget.mobileprovision
+            if ! /usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin \
+                 < <(security cms -D -i ~/Library/MobileDevice/Provisioning\ Profiles/widget.mobileprovision 2>/dev/null) \
+                 >/dev/null 2>&1; then
+              echo "::warning::Widget provisioning profile is invalid — automatic signing will download the correct profile from App Store Connect"
+              rm -f ~/Library/MobileDevice/Provisioning\ Profiles/widget.mobileprovision
+            fi
+          else
+            echo "::notice::IOS_WIDGET_PROVISIONING_PROFILE_BASE64 not set — automatic signing will download the profile from App Store Connect"
+          fi
 
       - name: Setup App Store Connect API key
         env:

--- a/packages/mobile/ExportOptions.plist
+++ b/packages/mobile/ExportOptions.plist
@@ -7,14 +7,7 @@
     <key>teamID</key>
     <string>9L3HKPZBH3</string>
     <key>signingStyle</key>
-    <string>manual</string>
-    <key>provisioningProfiles</key>
-    <dict>
-        <key>com.boardsesh.app</key>
-        <string>Boardsesh App Store Distribution Second</string>
-        <key>com.boardsesh.app.widgets</key>
-        <string>Boardsesh Widgets App Store Distribution</string>
-    </dict>
+    <string>automatic</string>
     <key>uploadBitcode</key>
     <false/>
     <key>uploadSymbols</key>


### PR DESCRIPTION
## Summary\n\n- **Root cause**: The `IOS_WIDGET_PROVISIONING_PROFILE_BASE64` GitHub secret is either empty or contains invalid data, producing a corrupt `widget.mobileprovision` that Xcode rejects with \"Profile is missing the required UUID property\". This prevents code signing of the `BoardseshWidgets` target during archive.\n- **Fix**: Switch both app and widget targets from manual to automatic code signing. The `xcodebuild archive` command already passes `-allowProvisioningUpdates` with App Store Connect API key auth, so Xcode will automatically create/download the correct provisioning profiles from ASC — no manual profile secrets needed for the widget.\n- **Validation**: The profile installation step now validates the widget profile and removes it if corrupt, with a clear warning annotation. If the secret is missing entirely, a notice is logged instead of silently writing a 0-byte file.\n\n## Changes\n\n- `.github/workflows/ios-testflight-rn.yml`: Ruby signing script uses `CODE_SIGN_STYLE = 'Automatic'` instead of `Manual`, removes `PROVISIONING_PROFILE_SPECIFIER`/`CODE_SIGN_IDENTITY`. Widget profile installation validates and gracefully degrades.\n- `packages/mobile/ExportOptions.plist`: `signingStyle` changed from `manual` to `automatic`, `provisioningProfiles` dictionary removed.\n\n## Test plan\n\n- [ ] Trigger the iOS TestFlight Deploy workflow via `workflow_dispatch`\n- [ ] Verify the archive step succeeds without the widget provisioning profile error\n- [ ] Verify the export + TestFlight upload completes\n- [ ] Confirm the widget extension is included in the built IPA\n\nhttps://claude.ai/code/session_01EFqkhJX1ZE3KDRiQrinuHx

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFqkhJX1ZE3KDRiQrinuHx)_