### PR TITLE
[codex] Fix TestFlight widget target build

### DIFF
--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -199,6 +199,7 @@ Source locations:
 
 - Main-app Swift (BoardBleManager, LiveActivityManager, SessionWebSocketManager, intents, helpers): `packages/mobile/modules/live-activity/ios/`
 - Widget extension target (Live Activity SwiftUI, AppIntents, WidgetNetworking, plus byte-identical copies of ClimbSessionAttributes / SharedConstants / SharedKeychain / Intent files): `packages/mobile/targets/BoardseshWidgets/` — managed by `@bacons/apple-targets`
+- Widget target build settings that @bacons/apple-targets does not expose directly, including `WIDGET_EXTENSION`: `packages/mobile/plugins/with-boardsesh-widget-build-settings.js`
 
 #### 1. Generate the native project
 

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -101,6 +101,10 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       // Island) plus the Next/Previous AppIntents. Target sources live in
       // packages/mobile/targets/BoardseshWidgets/.
       '@bacons/apple-targets',
+      // @bacons/apple-targets owns target creation, but it does not expose
+      // arbitrary Xcode build settings. This follow-up plugin adds the
+      // WIDGET_EXTENSION Swift flag so widget-only compiles skip main-app BLE.
+      './plugins/with-boardsesh-widget-build-settings',
     ],
     extra: {
       ...config.extra,

--- a/packages/mobile/modules/live-activity/README.md
+++ b/packages/mobile/modules/live-activity/README.md
@@ -8,9 +8,9 @@ was rewritten as Expo `Module` / `AsyncFunction` / `Events` calls.
 
 ## Exposed Module classes
 
-| Class | JS lookup | What it wraps |
-| --- | --- | --- |
-| `BoardBleModule` | `requireOptionalNativeModule('BoardBle')` | The `BoardBleManager` singleton — scan, connect, write, configureBoard, plus `scanResult` and `disconnected` listener events |
+| Class                | JS lookup                                     | What it wraps                                                                                                                                                   |
+| -------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BoardBleModule`     | `requireOptionalNativeModule('BoardBle')`     | The `BoardBleManager` singleton — scan, connect, write, configureBoard, plus `scanResult` and `disconnected` listener events                                    |
 | `LiveActivityModule` | `requireOptionalNativeModule('LiveActivity')` | The Live Activity lifecycle (start/end/update), push-token registration with the backend, and the widget `queueNavigate` event the Darwin notification surfaces |
 
 Both classes register independently via `expo-module.config.json`. JS
@@ -52,7 +52,7 @@ suite sha-compares the two copies and fails CI on drift. Do not
 plus EAS Build's cache behavior make symlinks unreliable across CI hosts.
 
 The widget target also defines the `WIDGET_EXTENSION` Swift compilation
-flag (via `expo-target.config.js → xcodeProjectSettings.OTHER_SWIFT_FLAGS`)
+flag (via `packages/mobile/plugins/with-boardsesh-widget-build-settings.js`)
 so the `#if !WIDGET_EXTENSION` blocks in `ClimbNavigationIntent.swift`
 skip the `LiveActivityBleBridge` reference when compiled into the widget
 process (it can't link `BoardBleManager`).

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -30,14 +30,8 @@ type BoardBleNativeModule = {
   write(value: string): Promise<void>;
   cancelWrites(): Promise<void>;
   configureBoard(options: NativeBleConfigureBoardOptions): Promise<void>;
-  addListener(
-    event: 'scanResult',
-    listener: (payload: NativeBleScanEvent) => void,
-  ): EventSubscription;
-  addListener(
-    event: 'disconnected',
-    listener: (payload: NativeBleDisconnectEvent) => void,
-  ): EventSubscription;
+  addListener(event: 'scanResult', listener: (payload: NativeBleScanEvent) => void): EventSubscription;
+  addListener(event: 'disconnected', listener: (payload: NativeBleDisconnectEvent) => void): EventSubscription;
 };
 
 // requireOptionalNativeModule returns null in Expo Go or any binary without
@@ -96,10 +90,7 @@ type LiveActivityNativeModule = {
   endSession(): Promise<void>;
   updateActivity(options: LiveActivityUpdateOptions): Promise<void>;
   updateActivityClimb(options: LiveActivityClimbUpdateOptions): Promise<void>;
-  addListener(
-    event: 'queueNavigate',
-    listener: (payload: WidgetQueueNavigateEvent) => void,
-  ): EventSubscription;
+  addListener(event: 'queueNavigate', listener: (payload: WidgetQueueNavigateEvent) => void): EventSubscription;
 };
 
 export const liveActivityNative = requireOptionalNativeModule<LiveActivityNativeModule>('LiveActivity');

--- a/packages/mobile/plugins/with-boardsesh-widget-build-settings.js
+++ b/packages/mobile/plugins/with-boardsesh-widget-build-settings.js
@@ -1,0 +1,49 @@
+const { createRunOncePlugin } = require('expo/config-plugins');
+const { withXcodeProjectBeta } = require('@bacons/apple-targets/build/with-bacons-xcode');
+
+const WIDGET_TARGET_NAME = 'BoardseshWidgets';
+const WIDGET_SWIFT_FLAGS = '$(inherited) -D WIDGET_EXTENSION';
+const WIDGET_DEPLOYMENT_TARGET = '17.0';
+
+function getProjectTargets(project) {
+  return project?.rootObject?.props?.targets ?? [];
+}
+
+function isNativeTarget(candidateTarget) {
+  return candidateTarget?.isa === 'PBXNativeTarget';
+}
+
+function isBoardseshWidgetsTarget(candidateTarget) {
+  return (
+    candidateTarget?.props?.name === WIDGET_TARGET_NAME || candidateTarget?.props?.productName === WIDGET_TARGET_NAME
+  );
+}
+
+function configureBoardseshWidgetTarget(project) {
+  const boardseshWidgetsTarget = getProjectTargets(project).find(
+    (candidateTarget) => isNativeTarget(candidateTarget) && isBoardseshWidgetsTarget(candidateTarget),
+  );
+
+  if (!boardseshWidgetsTarget) {
+    throw new Error(`Could not find ${WIDGET_TARGET_NAME} in the generated Xcode project.`);
+  }
+
+  if (typeof boardseshWidgetsTarget.setBuildSetting !== 'function') {
+    throw new Error(`${WIDGET_TARGET_NAME} target does not support setBuildSetting().`);
+  }
+
+  boardseshWidgetsTarget.setBuildSetting('OTHER_SWIFT_FLAGS', WIDGET_SWIFT_FLAGS);
+  boardseshWidgetsTarget.setBuildSetting('IPHONEOS_DEPLOYMENT_TARGET', WIDGET_DEPLOYMENT_TARGET);
+}
+
+function withBoardseshWidgetBuildSettings(config) {
+  return withXcodeProjectBeta(config, async (modConfig) => {
+    configureBoardseshWidgetTarget(modConfig.modResults);
+    return modConfig;
+  });
+}
+
+module.exports = createRunOncePlugin(withBoardseshWidgetBuildSettings, 'with-boardsesh-widget-build-settings', '1.0.0');
+module.exports.configureBoardseshWidgetTarget = configureBoardseshWidgetTarget;
+module.exports.WIDGET_DEPLOYMENT_TARGET = WIDGET_DEPLOYMENT_TARGET;
+module.exports.WIDGET_SWIFT_FLAGS = WIDGET_SWIFT_FLAGS;

--- a/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
@@ -86,7 +86,7 @@ describe('NativeIosBleAdapter scan timeout', () => {
     expect(nativeMock.stopScan).toHaveBeenCalled();
   });
 
-  it('does NOT reject the picker when devices have been discovered (user just hasn\'t picked yet)', async () => {
+  it("does NOT reject the picker when devices have been discovered (user just hasn't picked yet)", async () => {
     // Returns a promise that resolves only when we call manualPick later —
     // mirrors the user tapping a device in the picker UI after scan times out.
     let manualPick: (deviceId: string) => void = () => {};

--- a/packages/mobile/src/lib/ble/adapter-factory.ts
+++ b/packages/mobile/src/lib/ble/adapter-factory.ts
@@ -8,7 +8,7 @@ import type { BluetoothAdapter, DevicePickerFn } from './types';
 // platform. iOS uses the native Swift BoardBleManager (so widget Live
 // Activity intents can drive the wall synchronously); Android continues to
 // use react-native-ble-plx via RNBleAdapter.
-// 
+//
 // Falls back to RNBleAdapter on iOS only if the native module wasn't linked
 // into the running binary — covers Expo Go and any preview build older than
 // the one that bundled the live-activity module. Production preview builds

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -1,8 +1,4 @@
-import {
-  AURORA_ADVERTISED_SERVICE_UUID,
-  UART_SERVICE_UUID,
-  parseSerialNumber,
-} from '@boardsesh/ble-protocol';
+import { AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID, parseSerialNumber } from '@boardsesh/ble-protocol';
 import {
   boardBleNative,
   type NativeBleConfigureBoardOptions,

--- a/packages/mobile/src/lib/live-activity/__tests__/widget-build-settings.test.ts
+++ b/packages/mobile/src/lib/live-activity/__tests__/widget-build-settings.test.ts
@@ -1,0 +1,69 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+interface WidgetTargetConfig {
+  deploymentTarget: string;
+  xcodeProjectSettings?: unknown;
+}
+
+interface CapturingTarget {
+  isa: 'PBXNativeTarget';
+  props: {
+    name: string;
+    productName: string;
+  };
+  setBuildSetting(settingName: string, settingValue: string): void;
+}
+
+interface CapturingProject {
+  rootObject: {
+    props: {
+      targets: CapturingTarget[];
+    };
+  };
+}
+
+interface WidgetBuildSettingsPlugin {
+  configureBoardseshWidgetTarget(project: CapturingProject): void;
+  WIDGET_DEPLOYMENT_TARGET: string;
+  WIDGET_SWIFT_FLAGS: string;
+}
+
+const widgetTargetConfig = require('../../../../targets/BoardseshWidgets/expo-target.config.js') as WidgetTargetConfig;
+const widgetBuildSettingsPlugin =
+  require('../../../../plugins/with-boardsesh-widget-build-settings.js') as WidgetBuildSettingsPlugin;
+
+describe('BoardseshWidgets prebuild settings', () => {
+  it('targets iOS 17 for the AppIntents-backed Live Activity widget', () => {
+    expect(widgetTargetConfig.deploymentTarget).toBe(widgetBuildSettingsPlugin.WIDGET_DEPLOYMENT_TARGET);
+    expect(widgetTargetConfig.xcodeProjectSettings).toBeUndefined();
+  });
+
+  it('adds the widget Swift flag to the generated Xcode target', () => {
+    const capturedBuildSettings: Record<string, string> = {};
+    const boardseshWidgetsTarget: CapturingTarget = {
+      isa: 'PBXNativeTarget',
+      props: {
+        name: 'BoardseshWidgets',
+        productName: 'BoardseshWidgets',
+      },
+      setBuildSetting(settingName, settingValue) {
+        capturedBuildSettings[settingName] = settingValue;
+      },
+    };
+
+    widgetBuildSettingsPlugin.configureBoardseshWidgetTarget({
+      rootObject: {
+        props: {
+          targets: [boardseshWidgetsTarget],
+        },
+      },
+    });
+
+    expect(capturedBuildSettings.OTHER_SWIFT_FLAGS).toBe(widgetBuildSettingsPlugin.WIDGET_SWIFT_FLAGS);
+    expect(capturedBuildSettings.IPHONEOS_DEPLOYMENT_TARGET).toBe(widgetBuildSettingsPlugin.WIDGET_DEPLOYMENT_TARGET);
+  });
+});

--- a/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
+++ b/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
@@ -37,7 +37,10 @@ describe('Widget target Swift drift', () => {
     it(`${file} stays byte-identical between module and widget target`, () => {
       const moduleHash = sha(join(MODULE_IOS, file));
       const widgetHash = sha(join(WIDGET_TARGET, file));
-      expect(widgetHash, `${file}: widget target copy drifted from module copy. ` + 'Update both copies and re-run this test.').toBe(moduleHash);
+      expect(
+        widgetHash,
+        `${file}: widget target copy drifted from module copy. ` + 'Update both copies and re-run this test.',
+      ).toBe(moduleHash);
     });
   }
 });

--- a/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
+++ b/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
@@ -15,7 +15,7 @@ type LiveActivityBridgeProps = {
 // (fired when the user taps Next/Previous on the Dynamic Island) into
 // the queue reducer so the app's currentClimbQueueItem stays in sync
 // with the widget.
-// 
+//
 // Mount inside BluetoothProviderWrapper (i.e. only when a board has been
 // selected) so a guest user without a board doesn't trigger Live Activity
 // authorization prompts at random.

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -35,12 +35,12 @@ function getGraphqlWsUrl(): string {
 }
 
 // React Native port of `packages/web/app/lib/live-activity/use-live-activity.ts`.
-// 
+//
 // Lifecycle: starts a Live Activity when (iOS) + (session active) + (board
 // selected) + (queue has content) + (Live Activities authorized in Settings).
 // Pushes initial state, then watches the serialized queue (full update) and
 // current climb (lightweight update) to drive ActivityKit pushes.
-// 
+//
 // On non-iOS / Expo Go / preview builds without the native module, every
 // call short-circuits at the plugin layer (`Platform.OS !== 'ios'` or
 // `liveActivityNative == null`) so this hook is safe to mount unconditionally.
@@ -121,8 +121,7 @@ export function useLiveActivity({
   // Start/end session — reacts to session activation, content presence, and
   // board config. Does NOT restart when the current climb changes.
   const hasContent = queue.length > 0 || currentClimbQueueItem !== null;
-  const shouldBeActive =
-    isSessionActive && hasContent && stableBoard !== null && available === true && authTokenLoaded;
+  const shouldBeActive = isSessionActive && hasContent && stableBoard !== null && available === true && authTokenLoaded;
 
   useEffect(() => {
     if (Platform.OS !== 'ios' || available !== true) return;

--- a/packages/mobile/targets/BoardseshWidgets/BoardseshWidgetsBundle.swift
+++ b/packages/mobile/targets/BoardseshWidgets/BoardseshWidgetsBundle.swift
@@ -3,7 +3,10 @@ import SwiftUI
 
 @main
 struct BoardseshWidgetsBundle: WidgetBundle {
+    @WidgetBundleBuilder
     var body: some Widget {
-        ClimbSessionLiveActivity()
+        if #available(iOS 17.0, *) {
+            ClimbSessionLiveActivity()
+        }
     }
 }

--- a/packages/mobile/targets/BoardseshWidgets/expo-target.config.js
+++ b/packages/mobile/targets/BoardseshWidgets/expo-target.config.js
@@ -2,6 +2,9 @@
 /// this folder are compiled into the BoardseshWidgets bundle; their Swift
 /// uses `#if WIDGET_EXTENSION` to gate code that must not run in the widget
 /// process (e.g. LiveActivityBleBridge, which lives in the main app target).
+/// The `WIDGET_EXTENSION` Swift flag is applied by
+/// `packages/mobile/plugins/with-boardsesh-widget-build-settings.js` after
+/// @bacons/apple-targets creates the generated Xcode target.
 ///
 /// Files duplicated from the main app target (ClimbSessionAttributes,
 /// SharedConstants, SharedKeychain) are intentional copies. Each Xcode
@@ -13,17 +16,11 @@ module.exports = {
   type: 'widget',
   name: 'BoardseshWidgets',
   bundleIdentifier: 'com.boardsesh.app.widgets',
-  deploymentTarget: '16.1',
+  deploymentTarget: '17.0',
   frameworks: ['ActivityKit', 'WidgetKit', 'AppIntents', 'SwiftUI'],
   entitlements: {
     'com.apple.security.application-groups': ['group.com.boardsesh.app'],
     'keychain-access-groups': ['$(AppIdentifierPrefix)group.com.boardsesh.app'],
-  },
-  // Adds `-DWIDGET_EXTENSION` so the `#if WIDGET_EXTENSION` guards in
-  // ClimbNavigationIntent.swift skip the LiveActivityBleBridge reference
-  // when compiled into the widget bundle.
-  xcodeProjectSettings: {
-    OTHER_SWIFT_FLAGS: '-DWIDGET_EXTENSION',
   },
   // BoardseshKeychainAccessGroup is read by SharedKeychain.swift to derive
   // the keychain access group. Must match the value in the widget's


### PR DESCRIPTION
## What changed

- Adds a React Native Expo prebuild plugin that applies `OTHER_SWIFT_FLAGS = $(inherited) -D WIDGET_EXTENSION` to the generated `BoardseshWidgets` Xcode target.
- Raises the widget extension deployment target to iOS 17.0, matching the AppIntents-backed Live Activity UI.
- Adds an availability guard around `ClimbSessionLiveActivity()` in the widget bundle entrypoint.
- Adds a focused Vitest check for the widget target config/plugin contract.
- Updates Live Activity docs to point at the plugin-owned widget build settings.

## Why

The TestFlight archive log failed in `BoardseshWidgets` with:

- `ClimbSessionLiveActivity is only available in iOS 17.0 or newer`
- `cannot find LiveActivityBleBridge in scope`

The first failure came from compiling the widget target as iOS 16.1 while its AppIntent button UI is iOS 17-only. The second failure showed that the generated widget target was not receiving the `WIDGET_EXTENSION` Swift flag, so the widget extension compiled the main-app-only BLE path.

## Validation

- `vp test --project mobile packages/mobile/src/lib/live-activity/__tests__/widget-build-settings.test.ts packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts`
- `vp test --project mobile`
- `vp run typecheck:mobile`
- `vp lint app.config.ts plugins/with-boardsesh-widget-build-settings.js src/lib/live-activity/__tests__/widget-build-settings.test.ts` from `packages/mobile/`
- `vp fmt ... --check` on the changed/formatted files
- `git diff --check`

`vp check` now gets past formatting but fails on unrelated existing lint/type warnings across backend, web, embedded, and generated WASM, then Vite+ panics while printing the backlog. I did not fold that unrelated cleanup into this PR.

I could not run the actual Xcode/TestFlight archive in this Linux workspace.