### PR TITLE
[codex] Fix mobile iOS preview build

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -96,15 +96,14 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       'expo-updates',
       'expo-web-browser',
       'react-native-ble-plx',
+      // Register this before @bacons/apple-targets so Expo's mod chain runs it
+      // after the widget target has been created, while keeping the provider last.
+      './plugins/with-boardsesh-widget-build-settings',
       // Adds the BoardseshWidgets Xcode target on every `expo prebuild`. The
       // widget bundle hosts the Live Activity UI (lock screen + Dynamic
       // Island) plus the Next/Previous AppIntents. Target sources live in
       // packages/mobile/targets/BoardseshWidgets/.
       '@bacons/apple-targets',
-      // @bacons/apple-targets owns target creation, but it does not expose
-      // arbitrary Xcode build settings. This follow-up plugin adds the
-      // WIDGET_EXTENSION Swift flag so widget-only compiles skip main-app BLE.
-      './plugins/with-boardsesh-widget-build-settings',
     ],
     extra: {
       ...config.extra,

--- a/packages/mobile/modules/live-activity/README.md
+++ b/packages/mobile/modules/live-activity/README.md
@@ -44,6 +44,7 @@ the files listed below have **byte-identical copies** in both folders:
 - `ClimbSessionAttributes.swift`
 - `SharedConstants.swift`
 - `SharedKeychain.swift`
+- `WidgetNetworking.swift`
 
 When you change one, change the other. The
 `src/lib/live-activity/__tests__/widget-target-drift.test.ts` vitest

--- a/packages/mobile/modules/live-activity/ios/LiveActivityModulePod.podspec
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityModulePod.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = 'Boardsesh'
   s.source         = { git: 'https://github.com/boardsesh/boardsesh' }
-  s.platforms      = { ios: '16.1' }
+  s.platforms      = { ios: '16.4' }
   s.swift_version  = '5.9'
   s.source_files   = '*.swift'
   s.frameworks     = 'ActivityKit', 'CoreBluetooth', 'WidgetKit', 'AppIntents'

--- a/packages/mobile/modules/live-activity/ios/WidgetNetworking.swift
+++ b/packages/mobile/modules/live-activity/ios/WidgetNetworking.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+enum WidgetNetworking {
+    /// Sends a queue navigation request to the backend.
+    /// Returns `true` if the request succeeded (HTTP 200), `false` otherwise.
+    @discardableResult
+    static func sendNavigation(action: String, currentIndex: Int) async -> Bool {
+        // `widgetNavigateUrlKey` is written by `LiveActivityPlugin.startSession`.
+        // If the user upgrades the app mid-session without re-running
+        // `startSession` (e.g. they had a Live Activity running, installed the
+        // new build, didn't relaunch the main app), the key won't be in
+        // UserDefaults and the widget will silently no-op. Acceptable: the
+        // pre-fix build already had broken widget navigation, and the user
+        // gets recovery as soon as they open the main app and start a new
+        // session. The optimistic UI update in the widget intent still fires.
+        guard let defaults = SharedConstants.sharedDefaults,
+              let widgetNavigateUrl = defaults.string(forKey: SharedConstants.widgetNavigateUrlKey),
+              let sessionId = defaults.string(forKey: SharedConstants.sessionIdKey)
+        else { return false }
+
+        guard let url = URL(string: widgetNavigateUrl) else { return false }
+
+        let body: [String: Any] = [
+            "sessionId": sessionId,
+            "action": action,
+            "currentIndex": currentIndex
+        ]
+
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: body) else { return false }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 10
+        request.httpBody = jsonData
+
+        // Attach the APNs Live Activity push token as a Bearer header. The
+        // backend looks up `(token, sessionId)` in `activity_push_tokens` to
+        // authenticate the request. Token is in the shared keychain (App
+        // Group access-group); if it isn't there yet (early in lifecycle),
+        // the request goes out without auth and the backend rejects with
+        // 401 — the widget then quietly does nothing until the next
+        // refresh.
+        if let pushToken = SharedKeychain.get(SharedKeychain.livePushTokenKey),
+           !pushToken.isEmpty
+        {
+            request.setValue("Bearer \(pushToken)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            if statusCode == 200 {
+                return true
+            }
+            if statusCode == 410 {
+                // The push token was rebound to a different session (the main
+                // app joined another session on the same device). Post the
+                // Darwin notification so the main app re-registers; do NOT
+                // clear the keychain entry. The Bearer is still the right
+                // APNs token — the backend just needs to update its
+                // (token, sessionId) mapping. Wiping the keychain here would
+                // turn subsequent widget calls into 401s (no Bearer), which
+                // do NOT trigger the Darwin notification, so the widget
+                // would silently fail until the foreground observer runs.
+                print("[Widget] Navigation request received 410; signaling re-registration")
+                let name = CFNotificationName(SharedConstants.pushRegistrationStaleNotification as CFString)
+                CFNotificationCenterPostNotification(
+                    CFNotificationCenterGetDarwinNotifyCenter(),
+                    name,
+                    nil,
+                    nil,
+                    true
+                )
+                return false
+            }
+            print("[Widget] Navigation request failed with status \(statusCode)")
+            return false
+        } catch {
+            print("[Widget] Navigation request failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+}

--- a/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
+++ b/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
@@ -26,6 +26,7 @@ const DUPLICATED_FILES = [
   'PreviousClimbIntent.swift',
   'SharedConstants.swift',
   'SharedKeychain.swift',
+  'WidgetNetworking.swift',
 ];
 
 function sha(path: string): string {

--- a/packages/mobile/targets/BoardseshWidgets/expo-target.config.js
+++ b/packages/mobile/targets/BoardseshWidgets/expo-target.config.js
@@ -7,7 +7,7 @@
 /// @bacons/apple-targets creates the generated Xcode target.
 ///
 /// Files duplicated from the main app target (ClimbSessionAttributes,
-/// SharedConstants, SharedKeychain) are intentional copies. Each Xcode
+/// SharedConstants, SharedKeychain, WidgetNetworking) are intentional copies. Each Xcode
 /// target compiles its own binary — there's no shared module — so the
 /// duplicates must stay byte-identical or the JSON encoded into shared
 /// UserDefaults will mismatch between processes.


### PR DESCRIPTION
## Summary

Fixes the native iOS preview build used by the Expo dev client on a physical iPhone.

## Root Cause

- The local widget build-settings plugin was registered after `@bacons/apple-targets`, which tripped Expo's mod-provider ordering during prebuild/build.
- `ExpoImage` was installed in JS dependencies but missing from the generated CocoaPods project until Pods were refreshed.
- `ClimbNavigationIntent.swift` is compiled into both the app-side live-activity pod and the widget extension, but `WidgetNetworking.swift` only existed in the widget target, so the app-side pod could not compile.
- `LiveActivityModulePod` declared iOS 16.1 while the app/Podfile target is 16.4 and the code uses ActivityKit APIs available from 16.2+.

## Changes

- Move the widget build-settings plugin before `@bacons/apple-targets` so Expo keeps the target provider last while still applying widget settings after target creation.
- Add `WidgetNetworking.swift` to the live-activity module copy and include it in the drift test/docs for duplicated widget/app Swift files.
- Align `LiveActivityModulePod`'s iOS deployment target with the app's 16.4 floor.

## Validation

- `vp test run --project mobile src/lib/live-activity/__tests__/widget-target-drift.test.ts --reporter=agent`
- `NODE_ENV=development xcodebuild -workspace packages/mobile/ios/Boardsesh.xcworkspace -scheme Boardsesh -configuration Debug -destination 'platform=iOS,id=00008150-001A4C1101A1401C' -derivedDataPath /private/tmp/boardsesh-mobile-derived-data -allowProvisioningUpdates CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=9L3HKPZBH3 -quiet build`
- Installed and launched on Marco's iPhone over Wi-Fi against Metro on port 8082; user confirmed it works.