### PR TITLE
fix(mobile): route queue mutations through WS so swipe stops flashing 'Action failed'

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -148,6 +148,7 @@
         "@boardsesh/board-constants": "*",
         "@boardsesh/climb-filters": "*",
         "@boardsesh/graphql": "*",
+        "@boardsesh/graphql-client": "*",
         "@boardsesh/play-view": "*",
         "@boardsesh/queue": "*",
         "@boardsesh/shared-schema": "*",
@@ -271,6 +272,16 @@
         "typescript": "^5.9.3",
       },
     },
+    "packages/shared/graphql-client": {
+      "name": "@boardsesh/graphql-client",
+      "version": "1.0.0",
+      "dependencies": {
+        "graphql-ws": "^6.0.8",
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+      },
+    },
     "packages/shared/play-view": {
       "name": "@boardsesh/play-view",
       "version": "1.0.0",
@@ -308,6 +319,7 @@
         "@boardsesh/crypto": "*",
         "@boardsesh/db": "*",
         "@boardsesh/graphql": "*",
+        "@boardsesh/graphql-client": "*",
         "@boardsesh/play-view": "*",
         "@boardsesh/queue": "*",
         "@boardsesh/shared-schema": "*",
@@ -716,6 +728,8 @@
     "@boardsesh/db": ["@boardsesh/db@workspace:packages/db"],
 
     "@boardsesh/graphql": ["@boardsesh/graphql@workspace:packages/shared/graphql"],
+
+    "@boardsesh/graphql-client": ["@boardsesh/graphql-client@workspace:packages/shared/graphql-client"],
 
     "@boardsesh/mobile": ["@boardsesh/mobile@workspace:packages/mobile"],
 

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -1780,7 +1780,8 @@ A GraphQL mutation would require either the JS GraphQL client (not available in 
 ### Frontend
 
 - `packages/web/app/lib/backend-url.ts` - Runtime backend URL resolver (preview deploys, dev overrides)
-- `packages/web/app/components/graphql-queue/graphql-client.ts` - Browser-based `graphql-ws` client used on web, Android, and iOS Capacitor
+- `packages/shared/graphql-client/` - Platform-agnostic `graphql-ws` helpers (`execute`, `subscribe`, `createGraphQLClient`, `GraphQLOperationError`). Web and the React Native mobile app both consume this; web passes its `SafeWebSocket` wrapper + `connectionManager` registration via the `webSocketImpl` / `onClientCreated` hooks.
+- `packages/web/app/components/graphql-queue/graphql-client.ts` - Thin web wrapper around `@boardsesh/graphql-client` that adds the `SafeWebSocket` DOM-error suppression and `connectionManager` registration. Also re-exports the shared primitives for legacy relative imports.
 - `packages/web/app/components/connection-manager/websocket-connection-manager.ts` - Connection state tracking
 - `packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts` - Session lifecycle
 - `packages/web/app/components/persistent-session/hooks/use-queue-mutations.ts` - Queue mutations

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -15,6 +15,7 @@
     "@boardsesh/board-constants": "*",
     "@boardsesh/climb-filters": "*",
     "@boardsesh/graphql": "*",
+    "@boardsesh/graphql-client": "*",
     "@boardsesh/play-view": "*",
     "@boardsesh/queue": "*",
     "@boardsesh/shared-schema": "*",

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -253,12 +253,25 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     const boardConfig = await getStoredBoardConfig();
     if (!boardConfig) return;
     const boardPath = `${boardConfig.boardName}/${boardConfig.layoutId}/${boardConfig.sizeId}/${boardConfig.setIds}/${boardConfig.angle}`;
+    // Clear the ref if THIS join rejects so the next mutation retries instead
+    // of re-awaiting a stuck-rejected promise. A transient join failure (a
+    // flaky packet, a server hiccup) doesn't trigger a socket reconnect, so
+    // without this every queue action for the rest of the session would
+    // surface the toast.
     const promise = execute(getWsClient(), {
       query: JOIN_SESSION,
       variables: { sessionId: sessionIdToJoin, boardPath },
     });
-    joinPromiseRef.current = { sessionId: sessionIdToJoin, promise };
-    await promise;
+    const entry = { sessionId: sessionIdToJoin, promise };
+    joinPromiseRef.current = entry;
+    try {
+      await promise;
+    } catch (err) {
+      if (joinPromiseRef.current === entry) {
+        joinPromiseRef.current = null;
+      }
+      throw err;
+    }
   }, []);
 
   useEffect(() => {

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -19,6 +19,8 @@ import {
 } from '@boardsesh/queue';
 import type { QueueState, QueueAction, QueueSearchParams, ClimbQueueItem } from '@boardsesh/queue';
 import type { SessionSummary } from '@boardsesh/shared-schema';
+import { execute } from '@boardsesh/graphql-client';
+import { JOIN_SESSION } from '@boardsesh/graphql/operations/queue-session';
 import { getWsClient } from '../lib/graphql/ws-client';
 import { getHttpClient } from '../lib/graphql/client';
 import {
@@ -189,6 +191,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const stateRef = useRef(state);
   stateRef.current = state;
   const sessionCreationRef = useRef<Promise<string | null> | null>(null);
+  // Tracks the in-flight (or completed) joinSession mutation for the current
+  // WS connection. Queue mutations gate on this so a swipe issued right after
+  // CREATE_SESSION still goes out *after* the WS-side joinSession has bound
+  // sessionId into the backend's per-connection context. Stored alongside the
+  // sessionId it was issued for so a session-switch invalidates it.
+  const joinPromiseRef = useRef<{ sessionId: string; promise: Promise<unknown> } | null>(null);
   const { showToast } = useToast();
   const { t } = useTranslation('session');
 
@@ -229,14 +237,58 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const tRef = useRef(t);
   tRef.current = t;
 
+  // Lazily fire JOIN_SESSION over the WS so the backend binds sessionId into
+  // the per-connection ConnectionContext. After this resolves, all WS-routed
+  // queue mutations on the same connection have ctx.sessionId set, which
+  // `requireSession(ctx)` in the queue resolvers checks before allowing the
+  // operation. Idempotent on the server (re-joining the same session is a
+  // no-op for the room manager); we cache the in-flight promise so concurrent
+  // callers share one mutation per (sessionId, connection) pair.
+  const ensureJoined = useCallback(async (sessionIdToJoin: string): Promise<void> => {
+    const current = joinPromiseRef.current;
+    if (current && current.sessionId === sessionIdToJoin) {
+      await current.promise;
+      return;
+    }
+    const boardConfig = await getStoredBoardConfig();
+    if (!boardConfig) return;
+    const boardPath = `${boardConfig.boardName}/${boardConfig.layoutId}/${boardConfig.sizeId}/${boardConfig.setIds}/${boardConfig.angle}`;
+    const promise = execute(getWsClient(), {
+      query: JOIN_SESSION,
+      variables: { sessionId: sessionIdToJoin, boardPath },
+    });
+    joinPromiseRef.current = { sessionId: sessionIdToJoin, promise };
+    await promise;
+  }, []);
+
   useEffect(() => {
     if (!sessionId) {
       unsubscribeRef.current?.();
       unsubscribeRef.current = null;
+      joinPromiseRef.current = null;
       return;
     }
 
     const wsClient = getWsClient();
+
+    // graphql-ws auto-reconnects, and every reconnect gives us a fresh
+    // per-connection ConnectionContext on the backend. The first `connected`
+    // event matches the initial connection — we fire joinSession explicitly
+    // below to set up `joinPromiseRef`. Subsequent `connected` events are
+    // reconnects: invalidate the stale join and refire over the new connection.
+    let isFirstConnect = true;
+    const unsubConnected = wsClient.on('connected', () => {
+      if (isFirstConnect) {
+        isFirstConnect = false;
+        return;
+      }
+      joinPromiseRef.current = null;
+      void ensureJoined(sessionId);
+    });
+
+    // Fire the initial join eagerly so mutations issued before the first user
+    // interaction still find a resolved promise in joinPromiseRef.
+    void ensureJoined(sessionId);
 
     const cleanup = wsClient.subscribe<{ queueUpdates: QueueUpdateEvent }>(
       {
@@ -264,9 +316,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
 
     return () => {
       cleanup();
+      unsubConnected();
       unsubscribeRef.current = null;
+      joinPromiseRef.current = null;
     };
-  }, [sessionId, coordinator]);
+  }, [sessionId, coordinator, ensureJoined]);
 
   const ensureSession = useCallback(async (): Promise<string | null> => {
     if (sessionIdRef.current) return sessionIdRef.current;
@@ -306,44 +360,63 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // deduplicates by item.uuid, so the echo is a no-op.
       dispatch({ type: 'DELTA_ADD_QUEUE_ITEM', payload: { item } });
 
-      ensureSession().then((activeSessionId) => {
-        if (activeSessionId) {
-          getHttpClient()
-            .request<AddQueueItemMutationResponse>(ADD_QUEUE_ITEM, {
-              item: { uuid: item.uuid, climb: item.climb },
-            })
-            .catch(() => showToast(t('mobile.queue.actionFailed'), 'error'));
+      ensureSession().then(async (activeSessionId) => {
+        if (!activeSessionId) return;
+        try {
+          await ensureJoined(activeSessionId);
+          await execute<AddQueueItemMutationResponse>(getWsClient(), {
+            query: ADD_QUEUE_ITEM,
+            variables: { item: { uuid: item.uuid, climb: item.climb } },
+          });
+        } catch {
+          showToast(t('mobile.queue.actionFailed'), 'error');
         }
       });
     },
-    [ensureSession],
+    [ensureSession, ensureJoined, showToast, t],
   );
 
   const removeFromQueue = useCallback(
     (uuid: string) => {
       dispatch({ type: 'DELTA_REMOVE_QUEUE_ITEM', payload: { uuid } });
 
-      if (sessionIdRef.current) {
-        getHttpClient()
-          .request<RemoveQueueItemMutationResponse>(REMOVE_QUEUE_ITEM, { uuid })
-          .catch(() => showToast(t('mobile.queue.actionFailed'), 'error'));
-      }
+      const activeSessionId = sessionIdRef.current;
+      if (!activeSessionId) return;
+      (async () => {
+        try {
+          await ensureJoined(activeSessionId);
+          await execute<RemoveQueueItemMutationResponse>(getWsClient(), {
+            query: REMOVE_QUEUE_ITEM,
+            variables: { uuid },
+          });
+        } catch {
+          showToast(t('mobile.queue.actionFailed'), 'error');
+        }
+      })();
     },
-    [showToast, t],
+    [ensureJoined, showToast, t],
   );
 
   const clearQueue = useCallback(() => {
     const itemsToRemove = stateRef.current.queue;
     dispatch({ type: 'CLEAR_QUEUE' });
 
-    if (sessionIdRef.current) {
-      for (const item of itemsToRemove) {
-        getHttpClient()
-          .request<RemoveQueueItemMutationResponse>(REMOVE_QUEUE_ITEM, { uuid: item.uuid })
-          .catch(() => showToast(t('mobile.queue.actionFailed'), 'error'));
+    const activeSessionId = sessionIdRef.current;
+    if (!activeSessionId) return;
+    (async () => {
+      try {
+        await ensureJoined(activeSessionId);
+        for (const item of itemsToRemove) {
+          execute<RemoveQueueItemMutationResponse>(getWsClient(), {
+            query: REMOVE_QUEUE_ITEM,
+            variables: { uuid: item.uuid },
+          }).catch(() => showToast(t('mobile.queue.actionFailed'), 'error'));
+        }
+      } catch {
+        showToast(t('mobile.queue.actionFailed'), 'error');
       }
-    }
-  }, []);
+    })();
+  }, [ensureJoined, showToast, t]);
 
   // Optimistic local dispatch + correlated SET_CURRENT_CLIMB mutation.
   // The reducer stores `correlationId` in pendingCurrentClimbUpdates so the
@@ -357,18 +430,24 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         payload: { item, shouldAddToQueue, isServerEvent: false, correlationId },
       });
       coordinator.trackPendingMutation(correlationId);
-      ensureSession().then((activeSessionId) => {
+      ensureSession().then(async (activeSessionId) => {
         if (!activeSessionId) return;
-        getHttpClient()
-          .request<SetCurrentClimbMutationResponse>(SET_CURRENT_CLIMB, {
-            item: { uuid: item.uuid, climb: item.climb },
-            shouldAddToQueue,
-            correlationId,
-          })
-          .catch(() => showToast(t('mobile.queue.actionFailed'), 'error'));
+        try {
+          await ensureJoined(activeSessionId);
+          await execute<SetCurrentClimbMutationResponse>(getWsClient(), {
+            query: SET_CURRENT_CLIMB,
+            variables: {
+              item: { uuid: item.uuid, climb: item.climb },
+              shouldAddToQueue,
+              correlationId,
+            },
+          });
+        } catch {
+          showToast(t('mobile.queue.actionFailed'), 'error');
+        }
       });
     },
-    [coordinator, ensureSession, showToast, t],
+    [coordinator, ensureSession, ensureJoined, showToast, t],
   );
 
   const setCurrentClimb = useCallback((item: ClimbQueueItem) => dispatchSetCurrent(item, true), [dispatchSetCurrent]);

--- a/packages/shared/graphql-client/package.json
+++ b/packages/shared/graphql-client/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@boardsesh/graphql-client",
+  "version": "1.0.0",
+  "description": "Platform-agnostic graphql-ws helpers (execute, subscribe, createGraphQLClient) shared by web and mobile",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "graphql-ws": "^6.0.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/shared/graphql-client/src/__tests__/execute.test.ts
+++ b/packages/shared/graphql-client/src/__tests__/execute.test.ts
@@ -87,4 +87,15 @@ describe('execute', () => {
     vi.advanceTimersByTime(150);
     await expect(promise).rejects.toThrow(/timed out after 100ms/);
   });
+
+  it('clears the timeout once the operation settles so timers do not pile up', async () => {
+    const client = makeFakeClient();
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const promise = execute<{ ok: boolean }>(client, { query: 'mutation Foo { ok }' }, 30_000);
+    client.emit({ data: { ok: true } });
+    client.emitComplete();
+    await expect(promise).resolves.toEqual({ ok: true });
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
 });

--- a/packages/shared/graphql-client/src/__tests__/execute.test.ts
+++ b/packages/shared/graphql-client/src/__tests__/execute.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Client, Sink } from 'graphql-ws';
+import { execute } from '../execute';
+import { GraphQLOperationError } from '../errors';
+
+type FakeClient = Client & {
+  emit: (payload: Parameters<NonNullable<Sink['next']>>[0]) => void;
+  emitError: (err: unknown) => void;
+  emitComplete: () => void;
+  unsubscribe: ReturnType<typeof vi.fn>;
+};
+
+function makeFakeClient(): FakeClient {
+  let currentSink: Sink | null = null;
+  const unsubscribe = vi.fn();
+  const client = {
+    subscribe: (_op: unknown, sink: Sink) => {
+      currentSink = sink;
+      return unsubscribe;
+    },
+    on: () => () => {},
+    iterate: () => {
+      throw new Error('not used');
+    },
+    dispose: async () => {},
+    terminate: () => {},
+  } as unknown as Client;
+  return Object.assign(client, {
+    emit: (payload: Parameters<NonNullable<Sink['next']>>[0]) => currentSink?.next?.(payload),
+    emitError: (err: unknown) => currentSink?.error?.(err),
+    emitComplete: () => currentSink?.complete?.(),
+    unsubscribe,
+  }) as FakeClient;
+}
+
+describe('execute', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves with the last data payload received before complete', async () => {
+    const client = makeFakeClient();
+    const promise = execute<{ ok: boolean }>(client, { query: 'mutation Foo { ok }' });
+    client.emit({ data: { ok: true } });
+    client.emitComplete();
+    await expect(promise).resolves.toEqual({ ok: true });
+    expect(client.unsubscribe).toHaveBeenCalled();
+  });
+
+  it('rejects with GraphQLOperationError when next() carries errors', async () => {
+    const client = makeFakeClient();
+    const promise = execute(client, { query: 'mutation Foo { ok }' });
+    client.emit({ data: null, errors: [{ message: 'bad', extensions: { code: 'X' } }] });
+    await expect(promise).rejects.toBeInstanceOf(GraphQLOperationError);
+    await expect(promise).rejects.toMatchObject({ extensions: { code: 'X' } });
+    expect(client.unsubscribe).toHaveBeenCalled();
+  });
+
+  it('rejects with GraphQLOperationError when error() carries a graphql errors array', async () => {
+    const client = makeFakeClient();
+    const promise = execute(client, { query: 'mutation Foo { ok }' });
+    client.emitError([{ message: 'boom', extensions: { code: 'NOPE' } }]);
+    await expect(promise).rejects.toBeInstanceOf(GraphQLOperationError);
+    await expect(promise).rejects.toMatchObject({ extensions: { code: 'NOPE' } });
+  });
+
+  it('rejects with a wrapped Error when error() is an unknown shape', async () => {
+    const client = makeFakeClient();
+    const promise = execute(client, { query: 'mutation Foo { ok }' });
+    client.emitError({ weird: true });
+    await expect(promise).rejects.toBeInstanceOf(Error);
+  });
+
+  it('rejects when complete fires before any data', async () => {
+    const client = makeFakeClient();
+    const promise = execute(client, { query: 'mutation Foo { ok }' });
+    client.emitComplete();
+    await expect(promise).rejects.toThrow(/completed without data/);
+  });
+
+  it('rejects after timeout if neither complete nor error fires', async () => {
+    const client = makeFakeClient();
+    const promise = execute(client, { query: 'mutation Foo { ok }' }, 100);
+    vi.advanceTimersByTime(150);
+    await expect(promise).rejects.toThrow(/timed out after 100ms/);
+  });
+});

--- a/packages/shared/graphql-client/src/constants.ts
+++ b/packages/shared/graphql-client/src/constants.ts
@@ -1,0 +1,17 @@
+/** Initial delay before the first retry (milliseconds). */
+export const INITIAL_RETRY_DELAY_MS = 1000;
+
+/** Maximum delay between retries (milliseconds). */
+export const MAX_RETRY_DELAY_MS = 30_000;
+
+/** Multiplier applied to the delay after each successive retry. */
+export const BACKOFF_MULTIPLIER = 2;
+
+/** Maximum number of transient-join retries before treating as definitive failure. */
+export const MAX_TRANSIENT_RETRIES = 5;
+
+/** graphql-ws keepalive ping interval. */
+export const KEEP_ALIVE_MS = 5000;
+
+/** Default timeout applied to a single `execute()` call. */
+export const MUTATION_TIMEOUT_MS = 30_000;

--- a/packages/shared/graphql-client/src/create-client.ts
+++ b/packages/shared/graphql-client/src/create-client.ts
@@ -1,0 +1,79 @@
+import { type Client, createClient } from 'graphql-ws';
+import { INITIAL_RETRY_DELAY_MS, MAX_RETRY_DELAY_MS, BACKOFF_MULTIPLIER, KEEP_ALIVE_MS } from './constants';
+
+export type ExtendedClient = {
+  onReconnect?: (callback: () => void) => void;
+} & Client;
+
+export type CreateGraphQLClientOptions = {
+  url: string;
+  authToken?: string | null;
+  /** Called once after the second `connected` event (i.e. on every reconnect). */
+  onReconnect?: () => void;
+  /** Debug tag used in console logs. */
+  connectionName?: string;
+  /**
+   * Platform-specific WebSocket implementation. Web passes a wrapped
+   * `SafeWebSocket` to swallow native error events; mobile/node can omit
+   * this and graphql-ws will use the global `WebSocket`.
+   */
+  webSocketImpl?: typeof WebSocket;
+  /**
+   * Hook fired immediately after the client is constructed, before it's
+   * returned. Web uses this to register with `connectionManager` and to
+   * wrap `client.dispose` to suppress non-fatal teardown rejections.
+   * Receives `unregister`-capable client; callers may return a cleanup
+   * function that runs inside the wrapped `dispose`.
+   */
+  onClientCreated?: (client: ExtendedClient) => (() => void) | void;
+};
+
+/**
+ * Creates a graphql-ws Client with sane retry/backoff defaults. Exposes
+ * `webSocketImpl` and `onClientCreated` hooks so platform-specific concerns
+ * (DOM-event suppression, connection-manager registration) stay outside
+ * this shared module.
+ */
+export function createGraphQLClient(options: CreateGraphQLClientOptions): ExtendedClient {
+  const { url, authToken, onReconnect: onReconnectCallback, webSocketImpl, onClientCreated } = options;
+
+  let hasConnectedOnce = false;
+
+  const client = createClient({
+    url,
+    ...(webSocketImpl ? { webSocketImpl } : {}),
+    retryAttempts: 10,
+    shouldRetry: () => true,
+    retryWait: async (retryCount) => {
+      const delay = Math.min(INITIAL_RETRY_DELAY_MS * Math.pow(BACKOFF_MULTIPLIER, retryCount), MAX_RETRY_DELAY_MS);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    },
+    lazy: true,
+    keepAlive: KEEP_ALIVE_MS,
+    connectionParams: authToken ? { authToken } : undefined,
+    on: {
+      connected: () => {
+        if (hasConnectedOnce && onReconnectCallback) {
+          onReconnectCallback();
+        }
+        hasConnectedOnce = true;
+      },
+    },
+  }) as ExtendedClient;
+
+  const cleanup = onClientCreated?.(client);
+  if (cleanup) {
+    const originalDispose = client.dispose.bind(client);
+    client.dispose = async () => {
+      cleanup();
+      try {
+        await originalDispose();
+      } catch {
+        // Suppress: dispose errors are non-fatal. The socket is being torn down
+        // and these rejections carry no actionable information.
+      }
+    };
+  }
+
+  return client;
+}

--- a/packages/shared/graphql-client/src/errors.ts
+++ b/packages/shared/graphql-client/src/errors.ts
@@ -1,0 +1,54 @@
+/**
+ * Strict shape for the `extensions` blob the backend attaches to GraphQL
+ * errors. Always carries an optional string `code`; payload fields for
+ * known codes are unioned in so call-sites that narrow via the
+ * `isClimbDuplicateExtension` guard below get strongly-typed payloads.
+ *
+ * Unknown codes (older clients hitting newer servers, codes we haven't
+ * typed yet) flow through with `unknown` payload — callers can still
+ * read `code` to switch on, and must explicitly cast to access anything
+ * else.
+ */
+export type GraphQLErrorExtensions = {
+  code?: string;
+  existingClimbUuid?: string | null;
+  existingClimbName?: string | null;
+  [key: string]: unknown;
+};
+
+/**
+ * Type guard for the CLIMB_IS_DUPLICATE extension shape.
+ */
+export function isClimbDuplicateExtension(
+  extensions: GraphQLErrorExtensions | null | undefined,
+): extensions is GraphQLErrorExtensions & {
+  code: 'CLIMB_IS_DUPLICATE';
+  existingClimbUuid?: string | null;
+  existingClimbName?: string | null;
+} {
+  return extensions?.code === 'CLIMB_IS_DUPLICATE';
+}
+
+/**
+ * Error subclass that preserves GraphQL error extensions. Callers can inspect
+ * `extensions.code` (or any other extension keys) to branch on a typed error
+ * — e.g. CLIMB_IS_DUPLICATE — without resorting to message-string matching.
+ *
+ * `extensions` resolves to the first error that actually carries a `code`,
+ * falling back to the first error's extensions otherwise. This matters when
+ * the server emits multiple errors and the typed one isn't first — picking
+ * blindly by index would silently drop the gate's CLIMB_IS_DUPLICATE code.
+ */
+export class GraphQLOperationError extends Error {
+  readonly extensions: GraphQLErrorExtensions | null;
+  readonly graphqlErrors: ReadonlyArray<{ message: string; extensions?: GraphQLErrorExtensions }>;
+
+  constructor(graphqlErrors: ReadonlyArray<{ message: string; extensions?: GraphQLErrorExtensions }>) {
+    const message = graphqlErrors.map((err) => err.message).join(', ');
+    super(message);
+    this.name = 'GraphQLOperationError';
+    this.graphqlErrors = graphqlErrors;
+    const coded = graphqlErrors.find((err) => err.extensions && typeof err.extensions.code === 'string');
+    this.extensions = coded?.extensions ?? graphqlErrors[0]?.extensions ?? null;
+  }
+}

--- a/packages/shared/graphql-client/src/execute.ts
+++ b/packages/shared/graphql-client/src/execute.ts
@@ -1,0 +1,81 @@
+import type { Client } from 'graphql-ws';
+import { GraphQLOperationError } from './errors';
+import { getOperationName } from './operation-name';
+import { MUTATION_TIMEOUT_MS } from './constants';
+
+/**
+ * Execute a GraphQL mutation (or one-shot query) over a graphql-ws client.
+ *
+ * graphql-ws models everything as subscriptions: a mutation emits one `next`
+ * payload, then `complete`. We resolve with the captured payload on
+ * `complete`, reject on `error`, and apply a wall-clock timeout to keep the
+ * caller from hanging if the connection is wedged. Caller can pass a custom
+ * `timeoutMs` for long-running queries.
+ */
+export function execute<TData = unknown, TVariables = Record<string, unknown>>(
+  client: Client,
+  operation: { query: string; variables?: TVariables },
+  timeoutMs: number = MUTATION_TIMEOUT_MS,
+): Promise<TData> {
+  const opName = getOperationName(operation, 'mutation');
+
+  const executionPromise = new Promise<TData>((resolve, reject) => {
+    let result: TData | undefined;
+    let hasResolved = false;
+
+    const unsubscribe = client.subscribe<TData>(
+      { query: operation.query, variables: operation.variables as Record<string, unknown> },
+      {
+        next: (data) => {
+          // GraphQL can return null data values; keep the latest payload when present.
+          if ('data' in data) {
+            result = data.data as TData;
+          }
+          if (data.errors) {
+            if (!hasResolved) {
+              hasResolved = true;
+              unsubscribe();
+              reject(new GraphQLOperationError(data.errors));
+            }
+          }
+        },
+        error: (err) => {
+          if (!hasResolved) {
+            hasResolved = true;
+            unsubscribe();
+            // graphql-ws also reports server-emitted GraphQL errors through the
+            // error callback when the server closes the stream with them (e.g.
+            // single-error mutation rejects). Preserve extensions in that path
+            // too, otherwise fall back to a generic Error.
+            if (Array.isArray(err) && err.length > 0 && typeof err[0]?.message === 'string') {
+              reject(new GraphQLOperationError(err));
+            } else if (err instanceof Error) {
+              reject(err);
+            } else {
+              reject(new Error(String(err)));
+            }
+          }
+        },
+        complete: () => {
+          if (!hasResolved) {
+            hasResolved = true;
+            unsubscribe();
+            if (result === undefined) {
+              reject(new Error(`GraphQL operation '${opName}' completed without data`));
+              return;
+            }
+            resolve(result);
+          }
+        },
+      },
+    );
+  });
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => {
+      reject(new Error(`GraphQL mutation '${opName}' timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  return Promise.race([executionPromise, timeoutPromise]);
+}

--- a/packages/shared/graphql-client/src/execute.ts
+++ b/packages/shared/graphql-client/src/execute.ts
@@ -71,11 +71,14 @@ export function execute<TData = unknown, TVariables = Record<string, unknown>>(
     );
   });
 
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => {
+    timeoutId = setTimeout(() => {
       reject(new Error(`GraphQL mutation '${opName}' timed out after ${timeoutMs}ms`));
     }, timeoutMs);
   });
 
-  return Promise.race([executionPromise, timeoutPromise]);
+  return Promise.race([executionPromise, timeoutPromise]).finally(() => {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  });
 }

--- a/packages/shared/graphql-client/src/index.ts
+++ b/packages/shared/graphql-client/src/index.ts
@@ -1,0 +1,21 @@
+export type { Client, Sink } from 'graphql-ws';
+
+export {
+  INITIAL_RETRY_DELAY_MS,
+  MAX_RETRY_DELAY_MS,
+  BACKOFF_MULTIPLIER,
+  MAX_TRANSIENT_RETRIES,
+  KEEP_ALIVE_MS,
+  MUTATION_TIMEOUT_MS,
+} from './constants';
+
+export type { GraphQLErrorExtensions } from './errors';
+export { GraphQLOperationError, isClimbDuplicateExtension } from './errors';
+
+export { getOperationName } from './operation-name';
+
+export { execute } from './execute';
+export { subscribe } from './subscribe';
+
+export type { CreateGraphQLClientOptions, ExtendedClient } from './create-client';
+export { createGraphQLClient } from './create-client';

--- a/packages/shared/graphql-client/src/operation-name.ts
+++ b/packages/shared/graphql-client/src/operation-name.ts
@@ -1,0 +1,13 @@
+// Cache for parsed operation names to avoid regex on every call.
+const operationNameCache = new WeakMap<{ query: string }, string>();
+
+export function getOperationName(operation: { query: string }, type: 'mutation' | 'query' | 'subscription'): string {
+  const cached = operationNameCache.get(operation);
+  if (cached) return cached;
+
+  const pattern = type === 'subscription' ? /subscription\s+(\w+)/ : /(?:mutation|query)\s+(\w+)/;
+  const match = operation.query.match(pattern);
+  const name = match ? match[1] : 'unknown';
+  operationNameCache.set(operation, name);
+  return name;
+}

--- a/packages/shared/graphql-client/src/operation-name.ts
+++ b/packages/shared/graphql-client/src/operation-name.ts
@@ -1,13 +1,5 @@
-// Cache for parsed operation names to avoid regex on every call.
-const operationNameCache = new WeakMap<{ query: string }, string>();
-
 export function getOperationName(operation: { query: string }, type: 'mutation' | 'query' | 'subscription'): string {
-  const cached = operationNameCache.get(operation);
-  if (cached) return cached;
-
   const pattern = type === 'subscription' ? /subscription\s+(\w+)/ : /(?:mutation|query)\s+(\w+)/;
   const match = operation.query.match(pattern);
-  const name = match ? match[1] : 'unknown';
-  operationNameCache.set(operation, name);
-  return name;
+  return match ? match[1] : 'unknown';
 }

--- a/packages/shared/graphql-client/src/subscribe.ts
+++ b/packages/shared/graphql-client/src/subscribe.ts
@@ -1,0 +1,36 @@
+import type { Client, Sink } from 'graphql-ws';
+
+/**
+ * Subscribe to a GraphQL subscription and receive events via callback.
+ * Returns an unsubscribe function. Wraps `Client.subscribe` to coerce
+ * graphql-ws's raw DOM error events into proper `Error` instances and to
+ * flatten `data.errors` arrays into the `error` sink.
+ */
+export function subscribe<TData = unknown, TVariables = Record<string, unknown>>(
+  client: Client,
+  operation: { query: string; variables?: TVariables },
+  sink: Sink<TData>,
+): () => void {
+  return client.subscribe<TData>(
+    { query: operation.query, variables: operation.variables as Record<string, unknown> },
+    {
+      next: (data) => {
+        if (data.data) {
+          sink.next?.(data.data);
+        }
+        if (data.errors) {
+          sink.error?.(new Error(data.errors.map((e) => e.message).join(', ')));
+        }
+      },
+      error: (error) => {
+        // graphql-ws passes raw DOM Events (ErrorEvent/CloseEvent) when the WebSocket
+        // connection fails. Always forward a proper Error so callers and Sentry never
+        // receive "Event `Event` (type=error) captured as promise rejection".
+        sink.error?.(error instanceof Error ? error : new Error(String(error)));
+      },
+      complete: () => {
+        sink.complete?.();
+      },
+    },
+  );
+}

--- a/packages/shared/graphql-client/tsconfig.json
+++ b/packages/shared/graphql-client/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/shared/graphql-client/vite.config.ts
+++ b/packages/shared/graphql-client/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'graphql-client',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/web/app/components/graphql-queue/graphql-client.ts
+++ b/packages/web/app/components/graphql-queue/graphql-client.ts
@@ -1,100 +1,49 @@
-import { type Client, type Sink, createClient } from 'graphql-ws';
-import { connectionManager, KEEP_ALIVE_MS } from '../connection-manager/websocket-connection-manager';
-import { INITIAL_RETRY_DELAY_MS, MAX_RETRY_DELAY_MS, BACKOFF_MULTIPLIER } from './retry-constants';
-
-export type { Client };
+import {
+  createGraphQLClient as createSharedGraphQLClient,
+  type CreateGraphQLClientOptions,
+  type ExtendedClient,
+} from '@boardsesh/graphql-client';
+import { connectionManager } from '../connection-manager/websocket-connection-manager';
 
 const DEBUG = process.env.NODE_ENV === 'development';
-const MUTATION_TIMEOUT_MS = 30_000; // 30 second timeout for mutations
+let safeWsCounter = 0;
 
-let clientCounter = 0;
-
-// Cache for parsed operation names to avoid regex on every call
-const operationNameCache = new WeakMap<{ query: string }, string>();
-
-function getOperationName(operation: { query: string }, type: 'mutation' | 'query' | 'subscription'): string {
-  const cached = operationNameCache.get(operation);
-  if (cached) return cached;
-
-  const pattern = type === 'subscription' ? /subscription\s+(\w+)/ : /(?:mutation|query)\s+(\w+)/;
-  const match = operation.query.match(pattern);
-  const name = match ? match[1] : 'unknown';
-  operationNameCache.set(operation, name);
-  return name;
-}
-
-export type ExtendedClient = {
-  onReconnect?: (callback: () => void) => void;
-} & Client;
+// Re-export shared primitives so existing relative imports under
+// `app/components/graphql-queue/graphql-client` keep working.
+export {
+  execute,
+  subscribe,
+  getOperationName,
+  GraphQLOperationError,
+  isClimbDuplicateExtension,
+} from '@boardsesh/graphql-client';
+export type { Client, ExtendedClient, GraphQLErrorExtensions } from '@boardsesh/graphql-client';
 
 /**
- * Strict shape for the `extensions` blob the backend attaches to GraphQL
- * errors. Always carries an optional string `code`; payload fields for
- * known codes are unioned in so call-sites that narrow via the
- * `isClimbDuplicateExtension` guard below get strongly-typed payloads.
- *
- * Unknown codes (older clients hitting newer servers, codes we haven't
- * typed yet) flow through with `unknown` payload — callers can still
- * read `code` to switch on, and must explicitly cast to access anything
- * else.
+ * Wrap WebSocket to prevent native error events from leaking as unhandled
+ * promise rejections. graphql-ws uses promises internally for connection
+ * management, and on some code paths (retry, dispose) the native WebSocket
+ * error Event can escape as an unhandled rejection. The noop listener
+ * ensures the event is always "handled" at the source.
  */
-export type GraphQLErrorExtensions = {
-  code?: string;
-  existingClimbUuid?: string | null;
-  existingClimbName?: string | null;
-  [key: string]: unknown;
-};
-
-/**
- * Type guard for the CLIMB_IS_DUPLICATE extension shape. Narrows
- * `extensions` to the variant where `existingClimbUuid` and
- * `existingClimbName` are typed `string | null | undefined` rather than
- * `unknown`, so call-sites don't need ad-hoc `typeof` guards.
- */
-export function isClimbDuplicateExtension(
-  extensions: GraphQLErrorExtensions | null | undefined,
-): extensions is GraphQLErrorExtensions & {
-  code: 'CLIMB_IS_DUPLICATE';
-  existingClimbUuid?: string | null;
-  existingClimbName?: string | null;
-} {
-  return extensions?.code === 'CLIMB_IS_DUPLICATE';
-}
-
-/**
- * Error subclass that preserves GraphQL error extensions. Callers can inspect
- * `extensions.code` (or any other extension keys) to branch on a typed error
- * — e.g. CLIMB_IS_DUPLICATE — without resorting to message-string matching.
- *
- * `extensions` resolves to the first error that actually carries a `code`,
- * falling back to the first error's extensions otherwise. This matters when
- * the server emits multiple errors and the typed one isn't first — picking
- * blindly by index would silently drop the gate's CLIMB_IS_DUPLICATE code.
- */
-export class GraphQLOperationError extends Error {
-  readonly extensions: GraphQLErrorExtensions | null;
-  readonly graphqlErrors: ReadonlyArray<{ message: string; extensions?: GraphQLErrorExtensions }>;
-
-  constructor(graphqlErrors: ReadonlyArray<{ message: string; extensions?: GraphQLErrorExtensions }>) {
-    const message = graphqlErrors.map((err) => err.message).join(', ');
-    super(message);
-    this.name = 'GraphQLOperationError';
-    this.graphqlErrors = graphqlErrors;
-    const coded = graphqlErrors.find((err) => err.extensions && typeof err.extensions.code === 'string');
-    this.extensions = coded?.extensions ?? graphqlErrors[0]?.extensions ?? null;
+class SafeWebSocket extends WebSocket {
+  constructor(url: string | URL, protocols?: string | string[]) {
+    super(url, protocols);
+    const id = ++safeWsCounter;
+    this.addEventListener('error', (event) => {
+      if (DEBUG) console.info(`[GraphQL] SafeWebSocket #${id} native error suppressed`, event);
+    });
   }
 }
 
-export type GraphQLClientOptions = {
-  url: string;
-  authToken?: string | null;
-  onReconnect?: () => void;
-  connectionName?: string;
-};
+export type GraphQLClientOptions = Omit<CreateGraphQLClientOptions, 'webSocketImpl' | 'onClientCreated'>;
 
 /**
- * Creates a GraphQL-WS client for connecting to the Boardsesh backend
- * @param options - Client configuration including URL and optional auth token
+ * Web wrapper around the shared `createGraphQLClient`. Injects:
+ *   - `SafeWebSocket` as `webSocketImpl` so native error events don't leak.
+ *   - `connectionManager` registration so the centralized health monitor
+ *     knows about every client and can drive reconnection.
+ *   - `client.dispose` wrapping to suppress non-fatal teardown rejections.
  */
 export function createGraphQLClient(options: GraphQLClientOptions): ExtendedClient;
 /**
@@ -105,211 +54,24 @@ export function createGraphQLClient(
   urlOrOptions: string | GraphQLClientOptions,
   onReconnect?: () => void,
 ): ExtendedClient {
-  // Handle both signatures for backwards compatibility
   const options: GraphQLClientOptions =
     typeof urlOrOptions === 'string' ? { url: urlOrOptions, onReconnect } : urlOrOptions;
 
-  const { url, authToken, onReconnect: onReconnectCallback, connectionName } = options;
-  const managerConnectionName = connectionName ?? 'primary';
+  const managerConnectionName = options.connectionName ?? 'primary';
 
-  const clientId = ++clientCounter;
-
-  if (DEBUG) console.info(`[GraphQL] Creating client #${clientId} for ${url} (authenticated: ${!!authToken})`);
-
-  let hasConnectedOnce = false;
-
-  // Wrap WebSocket to prevent native error events from leaking as unhandled
-  // promise rejections. graphql-ws uses promises internally for connection
-  // management, and on some code paths (retry, dispose) the native WebSocket
-  // error Event can escape as an unhandled rejection. The noop listener
-  // ensures the event is always "handled" at the source.
-  class SafeWebSocket extends WebSocket {
-    constructor(url: string | URL, protocols?: string | string[]) {
-      super(url, protocols);
-      this.addEventListener('error', (event) => {
-        if (DEBUG) console.info(`[GraphQL] Client #${clientId} WebSocket native error suppressed`, event);
-      });
-    }
-  }
-
-  const client = createClient({
-    url,
+  return createSharedGraphQLClient({
+    ...options,
     webSocketImpl: SafeWebSocket,
-    retryAttempts: 10, // More attempts with exponential backoff
-    shouldRetry: () => true,
-    // Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s, 30s, ...
-    retryWait: async (retryCount) => {
-      const delay = Math.min(INITIAL_RETRY_DELAY_MS * Math.pow(BACKOFF_MULTIPLIER, retryCount), MAX_RETRY_DELAY_MS);
-      if (DEBUG) console.info(`[GraphQL] Client #${clientId} retry #${retryCount + 1}, waiting ${delay}ms`);
-      await new Promise((resolve) => setTimeout(resolve, delay));
+    onClientCreated: (client) => {
+      // graphql-ws dispose() is async and can reject with a raw DOM Event (ErrorEvent)
+      // when the WebSocket was mid-connection or retrying at teardown time. All call
+      // sites use fire-and-forget (no await), so an unhandled rejection with a DOM
+      // Event would escape to window.onunhandledrejection — exactly what Sentry
+      // captures as "Event `Event` (type=error) captured as promise rejection" on
+      // iOS WKWebView. The shared `createGraphQLClient` wraps dispose() to suppress
+      // these once `onClientCreated` returns a cleanup function.
+      if (typeof window === 'undefined') return;
+      return connectionManager.registerClient(client, managerConnectionName);
     },
-    // Lazy connection - only connects when first subscription/mutation is made
-    lazy: true,
-    // Keep alive to detect disconnections
-    keepAlive: KEEP_ALIVE_MS,
-    // Pass auth token in connection params for backend validation
-    connectionParams: authToken ? { authToken } : undefined,
-    on: {
-      connected: () => {
-        if (DEBUG) console.info(`[GraphQL] Client #${clientId} connected (first: ${!hasConnectedOnce})`);
-        if (hasConnectedOnce && onReconnectCallback) {
-          if (DEBUG) console.info(`[GraphQL] Client #${clientId} reconnected, calling onReconnect`);
-          onReconnectCallback();
-        }
-        hasConnectedOnce = true;
-      },
-      closed: (event) => {
-        if (DEBUG) console.info(`[GraphQL] Client #${clientId} closed`, event);
-      },
-      error: (error) => {
-        if (DEBUG) console.info(`[GraphQL] Client #${clientId} error`, error);
-      },
-    },
-  }) as ExtendedClient;
-
-  // Register with the centralized connection manager for proactive reconnection/health checks
-  if (typeof window !== 'undefined') {
-    const unregister = connectionManager.registerClient(client, managerConnectionName);
-    const originalDispose = client.dispose.bind(client);
-    // graphql-ws dispose() is async and can reject with a raw DOM Event (ErrorEvent)
-    // when the WebSocket was mid-connection or retrying at teardown time. All call sites
-    // use fire-and-forget (no await), so an unhandled rejection with a DOM Event would
-    // escape to window.onunhandledrejection — exactly what Sentry captures as
-    // "Event `Event` (type=error) captured as promise rejection" on iOS WKWebView.
-    // Wrapping here silences the rejection at the source for all consumers.
-    client.dispose = async () => {
-      unregister();
-      try {
-        await originalDispose();
-      } catch {
-        // Suppress: dispose errors are non-fatal. The socket is being torn down
-        // and these rejections carry no actionable information.
-      }
-    };
-  }
-
-  return client;
-}
-
-/**
- * Execute a GraphQL mutation and return the result as a promise
- * Includes automatic cleanup and timeout handling
- */
-export function execute<TData = unknown, TVariables = Record<string, unknown>>(
-  client: Client,
-  operation: { query: string; variables?: TVariables },
-  timeoutMs: number = MUTATION_TIMEOUT_MS,
-): Promise<TData> {
-  const opName = getOperationName(operation, 'mutation');
-
-  if (DEBUG) console.info(`[GraphQL] execute START: ${opName}`);
-
-  const executionPromise = new Promise<TData>((resolve, reject) => {
-    let result: TData | undefined;
-    let hasResolved = false;
-
-    const unsubscribe = client.subscribe<TData>(
-      { query: operation.query, variables: operation.variables as Record<string, unknown> },
-      {
-        next: (data) => {
-          if (DEBUG)
-            console.info(
-              `[GraphQL] execute NEXT: ${opName}`,
-              data.data ? 'has data' : 'no data',
-              data.errors ? 'has errors' : 'no errors',
-            );
-          // GraphQL can return null data values; keep the latest payload when present.
-          if ('data' in data) {
-            result = data.data as TData;
-          }
-          if (data.errors) {
-            if (!hasResolved) {
-              hasResolved = true;
-              unsubscribe();
-              reject(new GraphQLOperationError(data.errors));
-            }
-          }
-        },
-        error: (err) => {
-          if (DEBUG) console.info(`[GraphQL] execute ERROR: ${opName}`, err);
-          if (!hasResolved) {
-            hasResolved = true;
-            unsubscribe();
-            // graphql-ws also reports server-emitted GraphQL errors through the
-            // error callback when the server closes the stream with them (e.g.
-            // single-error mutation rejects). Preserve extensions in that path
-            // too, otherwise fall back to a generic Error.
-            if (Array.isArray(err) && err.length > 0 && typeof err[0]?.message === 'string') {
-              reject(new GraphQLOperationError(err));
-            } else if (err instanceof Error) {
-              reject(err);
-            } else {
-              reject(new Error(String(err)));
-            }
-          }
-        },
-        complete: () => {
-          if (DEBUG) console.info(`[GraphQL] execute COMPLETE: ${opName}`);
-          if (!hasResolved) {
-            hasResolved = true;
-            unsubscribe();
-            if (result === undefined) {
-              reject(new Error(`GraphQL operation '${opName}' completed without data`));
-              return;
-            }
-            resolve(result);
-          }
-        },
-      },
-    );
   });
-
-  // Add timeout to prevent mutations from hanging forever
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => {
-      reject(new Error(`GraphQL mutation '${opName}' timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-  });
-
-  return Promise.race([executionPromise, timeoutPromise]);
-}
-
-/**
- * Subscribe to a GraphQL subscription and receive events via callback
- * Returns an unsubscribe function
- */
-export function subscribe<TData = unknown, TVariables = Record<string, unknown>>(
-  client: Client,
-  operation: { query: string; variables?: TVariables },
-  sink: Sink<TData>,
-): () => void {
-  const opName = getOperationName(operation, 'subscription');
-
-  if (DEBUG) console.info(`[GraphQL] subscribe START: ${opName}`);
-
-  return client.subscribe<TData>(
-    { query: operation.query, variables: operation.variables as Record<string, unknown> },
-    {
-      next: (data) => {
-        if (DEBUG) console.info(`[GraphQL] subscribe NEXT: ${opName}`);
-        if (data.data) {
-          sink.next?.(data.data);
-        }
-        if (data.errors) {
-          sink.error?.(new Error(data.errors.map((e) => e.message).join(', ')));
-        }
-      },
-      error: (error) => {
-        if (DEBUG) console.info(`[GraphQL] subscribe ERROR: ${opName}`, error);
-        // graphql-ws passes raw DOM Events (ErrorEvent/CloseEvent) when the WebSocket
-        // connection fails. Always forward a proper Error so callers and Sentry never
-        // receive "Event `Event` (type=error) captured as promise rejection".
-        sink.error?.(error instanceof Error ? error : new Error(String(error)));
-      },
-      complete: () => {
-        if (DEBUG) console.info(`[GraphQL] subscribe COMPLETE: ${opName}`);
-        sink.complete?.();
-      },
-    },
-  );
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,6 +36,7 @@
     "@boardsesh/crypto": "*",
     "@boardsesh/db": "*",
     "@boardsesh/graphql": "*",
+    "@boardsesh/graphql-client": "*",
     "@boardsesh/play-view": "*",
     "@boardsesh/queue": "*",
     "@boardsesh/shared-schema": "*",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
       './packages/shared/play-view/vite.config.ts',
       './packages/shared/climb-filters/vite.config.ts',
       './packages/shared/graphql/vite.config.ts',
+      './packages/shared/graphql-client/vite.config.ts',
       './packages/shared-schema/vite.config.ts',
       './packages/mobile/vite.config.ts',
     ],
@@ -200,6 +201,9 @@ export default defineConfig({
         command: 'bun run --filter=@boardsesh/graphql typecheck',
         dependsOn: ['codegen'],
       },
+      'typecheck:graphql-client': {
+        command: 'bun run --filter=@boardsesh/graphql-client typecheck',
+      },
       'typecheck:mobile': {
         command: 'bun run --filter=@boardsesh/mobile typecheck',
       },
@@ -216,6 +220,7 @@ export default defineConfig({
           'typecheck:play-view',
           'typecheck:climb-filters',
           'typecheck:graphql',
+          'typecheck:graphql-client',
           'typecheck:mobile',
         ],
       },


### PR DESCRIPTION
## Summary

- Mobile queue mutations (SET_CURRENT_CLIMB / ADD_QUEUE_ITEM / REMOVE_QUEUE_ITEM) were going over HTTP, but the backend's HTTP context hard-codes `sessionId: undefined` (`packages/backend/src/graphql/yoga.ts:45`) and each queue resolver calls `requireSession(ctx)` (`packages/backend/src/graphql/resolvers/shared/helpers.ts:36`). Every queue mutation rejected. The optimistic dispatch already updated UI (climb opened), so the user saw the climb *and* the `mobile.queue.actionFailed` toast.
- Route mobile queue mutations through the same `graphql-ws` client that runs the subscription, and call `joinSession(sessionId, boardPath)` on every WS `connected` event so the backend binds sessionId into the per-connection `ConnectionContext`. Same protocol the iOS Swift Live Activity widget already uses (`packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift:452-490`).
- Extract `execute` / `subscribe` / `createGraphQLClient` / `GraphQLOperationError` from `packages/web/app/components/graphql-queue/graphql-client.ts` into a new `@boardsesh/graphql-client` shared package. Web keeps its `SafeWebSocket` + `connectionManager` registration by passing them through the new `webSocketImpl` and `onClientCreated` hooks — no behavior change on web.

This also fixes party-mode sync from mobile as a side-effect (every queue change now reaches the server, so peer clients see it).

`CREATE_SESSION` and `END_SESSION` stay HTTP — the backend uses `requireAuthenticated`, not `requireSession`, on those.

## Test plan

- [x] `vp run typecheck` (all projects)
- [x] `vp test --project web --project mobile --project graphql-client` (web `session-events.test.tsx` included) — 5059 tests pass
- [x] `vp check` clean on touched files
- [x] `vp run check:mobile-bundle` — iOS + Android
- [ ] On a real iOS device with the live-activity build: tap a climb in PlayDrawer → no error toast; swipe through queue → no error toast; swipe in PersistentQueueBar → no error toast; add climbs → no error toast.
- [ ] Party-mode parity: open the same session on web, make changes on mobile, web reflects them in real time.
- [ ] Live Activity parity: lock the phone mid-session, use the Dynamic Island/lock-screen widget to swipe; unlock and the JS UI matches.
- [ ] Background/foreground the app to force WS reconnect → next swipe still works (rejoin-on-reconnect listener).

🤖 Generated with [Claude Code](https://claude.com/claude-code)