### PR TITLE
Add Grade Over Time chart to play view analytics

### DIFF
--- a/packages/web/app/components/charts/__tests__/climb-analytics.test.tsx
+++ b/packages/web/app/components/charts/__tests__/climb-analytics.test.tsx
@@ -4,21 +4,42 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import ClimbAnalytics from '../climb-analytics';
-import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 
-vi.mock('react-i18next', () => ({
-  useTranslation: (ns?: string) => ({
-    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
-    i18n: { language: 'en-US' },
-  }),
-  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
-}));
+vi.mock('react-i18next', () => {
+  const keys: Record<string, string> = {
+    'analytics.noData': 'No analytics data available yet. Data is collected during sync.',
+    'analytics.ascentsOverTime': 'Ascents Over Time',
+    'analytics.qualityOverTime': 'Quality Over Time',
+    'analytics.gradeOverTime': 'Grade Over Time',
+  };
+  return {
+    useTranslation: () => ({
+      t: (key: string) => keys[key] ?? key,
+      i18n: { language: 'en-US' },
+    }),
+    Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+  };
+});
 
 const mockRequest = vi.fn();
 const mockLineChart = vi.fn();
 
 vi.mock('@/app/lib/graphql/client', () => ({
   createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    gradeFormat: 'v-grade' as const,
+    formatGrade: (d: string | null | undefined) => {
+      if (!d) return null;
+      const match = d.match(/V\d+/i);
+      return match ? match[0].toUpperCase() : d;
+    },
+    getGradeColor: () => undefined,
+    loaded: true,
+    setGradeFormat: () => Promise.resolve(),
+  }),
 }));
 
 vi.mock('@mui/x-charts/LineChart', () => ({
@@ -39,40 +60,40 @@ const MOCK_RESPONSE = {
       angle: 25,
       ascensionistCount: 10,
       qualityAverage: 2.6,
-      difficultyAverage: null,
-      displayDifficulty: null,
+      difficultyAverage: 16.2,
+      displayDifficulty: 16,
       createdAt: '2024-01-15T00:00:00.000Z',
     },
     {
       angle: 25,
       ascensionistCount: 12,
       qualityAverage: 2.8,
-      difficultyAverage: null,
-      displayDifficulty: null,
+      difficultyAverage: 16.8,
+      displayDifficulty: 17,
       createdAt: '2024-02-15T00:00:00.000Z',
     },
     {
       angle: 40,
       ascensionistCount: 5,
       qualityAverage: 3.1,
-      difficultyAverage: null,
-      displayDifficulty: null,
+      difficultyAverage: 18.1,
+      displayDifficulty: 18,
       createdAt: '2024-01-20T00:00:00.000Z',
     },
     {
       angle: 40,
       ascensionistCount: 8,
       qualityAverage: 3.3,
-      difficultyAverage: null,
-      displayDifficulty: null,
+      difficultyAverage: 18.5,
+      displayDifficulty: 19,
       createdAt: '2024-02-20T00:00:00.000Z',
     },
   ],
 };
 
-function getLatestChartProps(): [MockLineChartProps, MockLineChartProps] {
-  const calls = mockLineChart.mock.calls.slice(-2);
-  return [calls[0][0] as MockLineChartProps, calls[1][0] as MockLineChartProps];
+function getLatestChartProps(): [MockLineChartProps, MockLineChartProps, MockLineChartProps] {
+  const calls = mockLineChart.mock.calls.slice(-3);
+  return [calls[0][0] as MockLineChartProps, calls[1][0] as MockLineChartProps, calls[2][0] as MockLineChartProps];
 }
 
 describe('ClimbAnalytics', () => {
@@ -86,10 +107,10 @@ describe('ClimbAnalytics', () => {
     render(<ClimbAnalytics climbUuid="climb-1" boardType="kilter" />);
 
     await waitFor(() => {
-      expect(screen.getAllByTestId('mui-line-chart')).toHaveLength(2);
+      expect(screen.getAllByTestId('mui-line-chart')).toHaveLength(3);
     });
 
-    const [ascentsChart, qualityChart] = getLatestChartProps();
+    const [ascentsChart, qualityChart, gradeChart] = getLatestChartProps();
 
     expect(ascentsChart.series).toHaveLength(2);
     expect(ascentsChart.series).toEqual([
@@ -126,17 +147,33 @@ describe('ClimbAnalytics', () => {
     expect(qualityChart.series.every((series) => !('area' in series))).toBe(true);
     expect(qualityChart.series.every((series) => !('stack' in series))).toBe(true);
     expect(typeof qualityChart.xAxis[0]?.tickInterval).toBe('function');
+
+    expect(gradeChart.series).toHaveLength(2);
+    expect(gradeChart.series).toEqual([
+      expect.objectContaining({
+        label: '25°',
+        data: [16.2, 16.8],
+        showMark: true,
+      }),
+      expect.objectContaining({
+        label: '40°',
+        data: [18.1, 18.5],
+        showMark: true,
+      }),
+    ]);
+    expect(typeof gradeChart.xAxis[0]?.tickInterval).toBe('function');
   });
 
   it('does not render the removed total ascents chart', async () => {
     render(<ClimbAnalytics climbUuid="climb-1" boardType="kilter" />);
 
     await waitFor(() => {
-      expect(screen.getAllByTestId('mui-line-chart')).toHaveLength(2);
+      expect(screen.getAllByTestId('mui-line-chart')).toHaveLength(3);
     });
 
     expect(screen.getByText('Ascents Over Time')).toBeTruthy();
     expect(screen.getByText('Quality Over Time')).toBeTruthy();
+    expect(screen.getByText('Grade Over Time')).toBeTruthy();
     expect(screen.queryByText('Total Ascents (All Angles)')).toBeNull();
   });
 
@@ -144,27 +181,31 @@ describe('ClimbAnalytics', () => {
     render(<ClimbAnalytics climbUuid="climb-1" boardType="kilter" />);
 
     await waitFor(() => {
-      expect(screen.getAllByTestId('mui-line-chart')).toHaveLength(2);
+      expect(screen.getAllByTestId('mui-line-chart')).toHaveLength(3);
     });
 
     fireEvent.click(screen.getByRole('button', { name: '25°' }));
 
     await waitFor(() => {
-      const [ascentsChart, qualityChart] = getLatestChartProps();
+      const [ascentsChart, qualityChart, gradeChart] = getLatestChartProps();
       expect(ascentsChart.series).toHaveLength(1);
       expect(qualityChart.series).toHaveLength(1);
+      expect(gradeChart.series).toHaveLength(1);
       expect(ascentsChart.series[0]).toEqual(expect.objectContaining({ label: '40°' }));
       expect(qualityChart.series[0]).toEqual(expect.objectContaining({ label: '40°' }));
+      expect(gradeChart.series[0]).toEqual(expect.objectContaining({ label: '40°' }));
     });
 
     fireEvent.click(screen.getByRole('button', { name: '40°' }));
 
     await waitFor(() => {
-      const [ascentsChart, qualityChart] = getLatestChartProps();
+      const [ascentsChart, qualityChart, gradeChart] = getLatestChartProps();
       expect(ascentsChart.series).toHaveLength(1);
       expect(qualityChart.series).toHaveLength(1);
+      expect(gradeChart.series).toHaveLength(1);
       expect(ascentsChart.series[0]).toEqual(expect.objectContaining({ label: '40°' }));
       expect(qualityChart.series[0]).toEqual(expect.objectContaining({ label: '40°' }));
+      expect(gradeChart.series[0]).toEqual(expect.objectContaining({ label: '40°' }));
     });
   });
 });

--- a/packages/web/app/components/charts/__tests__/climb-analytics.test.tsx
+++ b/packages/web/app/components/charts/__tests__/climb-analytics.test.tsx
@@ -4,22 +4,15 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import ClimbAnalytics from '../climb-analytics';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 
-vi.mock('react-i18next', () => {
-  const keys: Record<string, string> = {
-    'analytics.noData': 'No analytics data available yet. Data is collected during sync.',
-    'analytics.ascentsOverTime': 'Ascents Over Time',
-    'analytics.qualityOverTime': 'Quality Over Time',
-    'analytics.gradeOverTime': 'Grade Over Time',
-  };
-  return {
-    useTranslation: () => ({
-      t: (key: string) => keys[key] ?? key,
-      i18n: { language: 'en-US' },
-    }),
-    Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
-  };
-});
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
 
 const mockRequest = vi.fn();
 const mockLineChart = vi.fn();
@@ -52,6 +45,7 @@ vi.mock('@mui/x-charts/LineChart', () => ({
 type MockLineChartProps = {
   series: Array<Record<string, unknown>>;
   xAxis: Array<{ tickInterval?: (value: string, index: number) => boolean }>;
+  yAxis?: Array<{ tickInterval?: number[] }>;
 };
 
 const MOCK_RESPONSE = {
@@ -91,9 +85,17 @@ const MOCK_RESPONSE = {
   ],
 };
 
-function getLatestChartProps(): [MockLineChartProps, MockLineChartProps, MockLineChartProps] {
-  const calls = mockLineChart.mock.calls.slice(-3);
-  return [calls[0][0] as MockLineChartProps, calls[1][0] as MockLineChartProps, calls[2][0] as MockLineChartProps];
+const MOCK_RESPONSE_NO_GRADES = {
+  climbStatsHistory: MOCK_RESPONSE.climbStatsHistory.map((entry) => ({
+    ...entry,
+    difficultyAverage: null,
+    displayDifficulty: null,
+  })),
+};
+
+function getLatestChartProps(count: number): MockLineChartProps[] {
+  const calls = mockLineChart.mock.calls.slice(-count);
+  return calls.map((call) => call[0] as MockLineChartProps);
 }
 
 describe('ClimbAnalytics', () => {
@@ -110,7 +112,7 @@ describe('ClimbAnalytics', () => {
       expect(screen.getAllByTestId('mui-line-chart')).toHaveLength(3);
     });
 
-    const [ascentsChart, qualityChart, gradeChart] = getLatestChartProps();
+    const [ascentsChart, qualityChart, gradeChart] = getLatestChartProps(3);
 
     expect(ascentsChart.series).toHaveLength(2);
     expect(ascentsChart.series).toEqual([
@@ -162,6 +164,7 @@ describe('ClimbAnalytics', () => {
       }),
     ]);
     expect(typeof gradeChart.xAxis[0]?.tickInterval).toBe('function');
+    expect(Array.isArray(gradeChart.yAxis?.[0]?.tickInterval)).toBe(true);
   });
 
   it('does not render the removed total ascents chart', async () => {
@@ -177,6 +180,20 @@ describe('ClimbAnalytics', () => {
     expect(screen.queryByText('Total Ascents (All Angles)')).toBeNull();
   });
 
+  it('omits grade chart when difficultyAverage is null for all entries', async () => {
+    mockRequest.mockResolvedValue(MOCK_RESPONSE_NO_GRADES);
+
+    render(<ClimbAnalytics climbUuid="climb-1" boardType="kilter" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('mui-line-chart')).toHaveLength(2);
+    });
+
+    expect(screen.getByText('Ascents Over Time')).toBeTruthy();
+    expect(screen.getByText('Quality Over Time')).toBeTruthy();
+    expect(screen.queryByText('Grade Over Time')).toBeNull();
+  });
+
   it('updates visible series when filtering and keeps the last angle selected', async () => {
     render(<ClimbAnalytics climbUuid="climb-1" boardType="kilter" />);
 
@@ -187,7 +204,7 @@ describe('ClimbAnalytics', () => {
     fireEvent.click(screen.getByRole('button', { name: '25°' }));
 
     await waitFor(() => {
-      const [ascentsChart, qualityChart, gradeChart] = getLatestChartProps();
+      const [ascentsChart, qualityChart, gradeChart] = getLatestChartProps(3);
       expect(ascentsChart.series).toHaveLength(1);
       expect(qualityChart.series).toHaveLength(1);
       expect(gradeChart.series).toHaveLength(1);
@@ -199,7 +216,7 @@ describe('ClimbAnalytics', () => {
     fireEvent.click(screen.getByRole('button', { name: '40°' }));
 
     await waitFor(() => {
-      const [ascentsChart, qualityChart, gradeChart] = getLatestChartProps();
+      const [ascentsChart, qualityChart, gradeChart] = getLatestChartProps(3);
       expect(ascentsChart.series).toHaveLength(1);
       expect(qualityChart.series).toHaveLength(1);
       expect(gradeChart.series).toHaveLength(1);

--- a/packages/web/app/components/charts/climb-analytics.tsx
+++ b/packages/web/app/components/charts/climb-analytics.tsx
@@ -384,7 +384,9 @@ export default function ClimbAnalytics({ climbUuid, boardType }: ClimbAnalyticsP
               {
                 valueFormatter: (value: number) => formatDifficultyTick(value, gradeFormat),
                 tickLabelStyle: { fontSize: 10 },
-                tickMinStep: 1,
+                tickInterval: gradeTickValues,
+                min: gradeTickValues[0],
+                max: gradeTickValues[gradeTickValues.length - 1],
               },
             ]}
             height={220}

--- a/packages/web/app/components/charts/climb-analytics.tsx
+++ b/packages/web/app/components/charts/climb-analytics.tsx
@@ -14,6 +14,9 @@ import {
   type ClimbStatsHistoryResponse,
 } from '@boardsesh/graphql/operations/climb-stats-history';
 import { themeTokens } from '@/app/theme/theme-config';
+import { useGradeFormat } from '@/app/hooks/use-grade-format';
+import { BOULDER_GRADES, type BoulderGrade } from '@boardsesh/board-constants/boulder-grade-mapping';
+import type { GradeDisplayFormat } from '@boardsesh/play-view';
 
 // Consistent color palette for angle lines, using design tokens
 const ANGLE_COLORS = [
@@ -31,6 +34,25 @@ function getAngleColor(index: number): string {
   return ANGLE_COLORS[index % ANGLE_COLORS.length];
 }
 
+const GRADE_BY_ID: Map<number, BoulderGrade> = new Map(BOULDER_GRADES.map((g) => [g.difficulty_id, g]));
+
+const V_GRADE_TICK_IDS: number[] = BOULDER_GRADES.filter(
+  (g, i, arr) => i === 0 || g.v_grade !== arr[i - 1].v_grade,
+).map((g) => g.difficulty_id);
+
+const FONT_GRADE_TICK_IDS: number[] = BOULDER_GRADES.map((g) => g.difficulty_id);
+
+function getGradeTickIds(format: GradeDisplayFormat): number[] {
+  return format === 'font' ? FONT_GRADE_TICK_IDS : V_GRADE_TICK_IDS;
+}
+
+function formatDifficultyTick(value: number, format: GradeDisplayFormat): string {
+  const rounded = Math.round(value);
+  const grade = GRADE_BY_ID.get(rounded);
+  if (!grade) return '';
+  return format === 'font' ? grade.font_grade.toUpperCase() : grade.v_grade;
+}
+
 type GroupedData = {
   byAngle: Map<number, { date: string; value: number }[]>;
   labels: string[];
@@ -44,7 +66,7 @@ type LineSeriesOptions = {
 
 function groupByAngleAndMonth(
   rows: ClimbStatsHistoryEntry[],
-  valueKey: 'ascensionistCount' | 'qualityAverage',
+  valueKey: 'ascensionistCount' | 'qualityAverage' | 'difficultyAverage',
 ): GroupedData {
   const angleMap = new Map<number, Map<string, number[]>>();
 
@@ -139,6 +161,7 @@ type ClimbAnalyticsProps = {
 
 export default function ClimbAnalytics({ climbUuid, boardType }: ClimbAnalyticsProps) {
   const { t } = useTranslation('profile');
+  const { gradeFormat } = useGradeFormat();
   const [rows, setRows] = useState<ClimbStatsHistoryEntry[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -204,6 +227,27 @@ export default function ClimbAnalytics({ climbUuid, boardType }: ClimbAnalyticsP
     if (!rows) return null;
     return groupByAngleAndMonth(rows, 'qualityAverage');
   }, [rows]);
+
+  const gradeData = useMemo(() => {
+    if (!rows) return null;
+    return groupByAngleAndMonth(rows, 'difficultyAverage');
+  }, [rows]);
+
+  const gradeTickValues = useMemo(() => {
+    if (!gradeData) return [];
+    let dataMin = Infinity;
+    let dataMax = -Infinity;
+    for (const points of gradeData.byAngle.values()) {
+      for (const point of points) {
+        if (point.value < dataMin) dataMin = point.value;
+        if (point.value > dataMax) dataMax = point.value;
+      }
+    }
+    if (!isFinite(dataMin)) return [];
+    const lo = Math.floor(dataMin) - 1;
+    const hi = Math.ceil(dataMax) + 1;
+    return getGradeTickIds(gradeFormat).filter((id) => id >= lo && id <= hi);
+  }, [gradeData, gradeFormat]);
 
   if (loading) {
     return (
@@ -308,6 +352,43 @@ export default function ClimbAnalytics({ climbUuid, boardType }: ClimbAnalyticsP
             ]}
             height={220}
             margin={{ top: 10, bottom: 30, left: 40, right: 10 }}
+            hideLegend={filteredAngles.length <= 1}
+            slotProps={{
+              legend: {
+                sx: { fontSize: 11 },
+              },
+            }}
+          />
+        </Box>
+      )}
+
+      {gradeData && gradeData.labels.length > 0 && gradeTickValues.length > 0 && (
+        <Box>
+          <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+            {t('analytics.gradeOverTime')}
+          </Typography>
+          <LineChart
+            series={buildLineSeries(gradeData).map((s) => ({
+              ...s,
+              valueFormatter: (v: number | null) => (v != null ? formatDifficultyTick(v, gradeFormat) : ''),
+            }))}
+            xAxis={[
+              {
+                data: gradeData.labels.map(formatMonthLabel),
+                scaleType: 'band' as const,
+                tickLabelStyle: { fontSize: 10 },
+                tickInterval: buildTickInterval(gradeData.labels.length),
+              },
+            ]}
+            yAxis={[
+              {
+                valueFormatter: (value: number) => formatDifficultyTick(value, gradeFormat),
+                tickLabelStyle: { fontSize: 10 },
+                tickMinStep: 1,
+              },
+            ]}
+            height={220}
+            margin={{ top: 10, bottom: 30, left: 50, right: 10 }}
             hideLegend={filteredAngles.length <= 1}
             slotProps={{
               legend: {

--- a/packages/web/i18n/locales/en-US/profile.json
+++ b/packages/web/i18n/locales/en-US/profile.json
@@ -82,7 +82,8 @@
   "analytics": {
     "noData": "No analytics data available yet. Data is collected during sync.",
     "ascentsOverTime": "Ascents Over Time",
-    "qualityOverTime": "Quality Over Time"
+    "qualityOverTime": "Quality Over Time",
+    "gradeOverTime": "Grade Over Time"
   },
   "logbook": {
     "section": {

--- a/packages/web/i18n/locales/es/profile.json
+++ b/packages/web/i18n/locales/es/profile.json
@@ -82,7 +82,8 @@
   "analytics": {
     "noData": "Sin datos analíticos disponibles todavía. Los datos se recopilan durante la sincronización.",
     "ascentsOverTime": "Ascensos a lo largo del tiempo",
-    "qualityOverTime": "Calidad a lo largo del tiempo"
+    "qualityOverTime": "Calidad a lo largo del tiempo",
+    "gradeOverTime": "Grado a lo largo del tiempo"
   },
   "logbook": {
     "section": {

--- a/packages/web/i18n/locales/fr/profile.json
+++ b/packages/web/i18n/locales/fr/profile.json
@@ -82,7 +82,8 @@
   "analytics": {
     "noData": "Pas encore de données. Elles arrivent à la prochaine synchro.",
     "ascentsOverTime": "Enchaînements dans le temps",
-    "qualityOverTime": "Qualité dans le temps"
+    "qualityOverTime": "Qualité dans le temps",
+    "gradeOverTime": "Cotation dans le temps"
   },
   "logbook": {
     "section": {


### PR DESCRIPTION
## Summary

- Adds a "Grade Over Time" line chart to the play view drawer's analytics section, showing how the community-assessed difficulty of a climb trends over time
- Y-axis displays V-grade (V3, V4...) or Font grade (6A, 6B...) labels based on the user's grade format preference, using the existing `difficultyAverage` field from the `CLIMB_STATS_HISTORY` GraphQL query
- Respects the existing angle filter chips — grade chart filters alongside ascents and quality charts
- Tooltips also show grade labels instead of raw numeric values

## Test plan

- [ ] Verify the grade chart renders in the play view drawer analytics section after quality chart
- [ ] Toggle grade format in settings (V-grade ↔ Font) and confirm Y-axis labels update
- [ ] Filter angles via chips and confirm the grade chart series update accordingly
- [ ] Test with a climb that has no `difficultyAverage` data — grade chart should not render
- [ ] Confirm all three i18n locales (en-US, es, fr) display correct chart titles

https://claude.ai/code/session_01LTsrwDxZQN4gfBxFCjHwME

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTsrwDxZQN4gfBxFCjHwME)_