### PR TITLE
Add Liked Climbs smart playlist + merge Pinned into Jump Back In

### DIFF
--- a/packages/backend/src/__tests__/smart-playlists.test.ts
+++ b/packages/backend/src/__tests__/smart-playlists.test.ts
@@ -264,6 +264,74 @@ describe('smartPlaylist resolver', () => {
     expect(notInArraySpy).not.toHaveBeenCalled();
   });
 
+  it('LIKED_CLIMBS reads user_favorites, applies board filter, dedups across angles, orders by latest like', async () => {
+    const ctx = makeCtx();
+
+    // user lookup
+    mockDb.select.mockReturnValueOnce(makeChain([USER_ROW]).chain);
+    // page query — favorites have an angle column, so we dedupe via GROUP BY
+    // (board_name, climb_uuid) to avoid returning the same climb twice when a
+    // user has favourited it at multiple angles.
+    const { chain: pageChain, calls: pageCalls } = makeChain([
+      { climbUuid: 'fav1', boardType: 'kilter' },
+      { climbUuid: 'fav2', boardType: 'kilter' },
+    ]);
+    mockDb.select.mockReturnValueOnce(pageChain);
+    // count query
+    mockDb.select.mockReturnValueOnce(makeChain([{ count: 7 }]).chain);
+    // hydrate (called with refs array)
+    mockDb.select.mockReturnValueOnce(makeChain([]).chain);
+
+    const result = await playlistQueries.smartPlaylist(
+      null,
+      {
+        input: { type: 'LIKED_CLIMBS', userId: 'user-123', boardName: 'kilter', page: 1, pageSize: 5 },
+      },
+      ctx,
+    );
+
+    expect(result.totalCount).toBe(7);
+    expect(result.hasMore).toBe(false); // (1+1)*5 = 10 >= 7
+    expect(pageCalls.limit[0]).toEqual([5]);
+    expect(pageCalls.offset[0]).toEqual([5]);
+
+    // Dedup: GROUP BY (climbUuid, boardName)
+    expect(pageCalls.groupBy.length).toBe(1);
+    expect(pageCalls.groupBy[0]).toEqual([dbSchema.userFavorites.climbUuid, dbSchema.userFavorites.boardName]);
+    // Ordered (by max(createdAt) DESC); we just assert orderBy was called
+    expect(pageCalls.orderBy.length).toBe(1);
+
+    // Both page and count must filter by both userId and boardName — a missing
+    // boardName filter on either side would make the count card show all-boards
+    // while the detail page is board-scoped (or vice versa).
+    const userIdFilters = eqSpy.mock.calls.filter(
+      ([col, val]) => col === dbSchema.userFavorites.userId && val === 'user-123',
+    );
+    expect(userIdFilters.length).toBeGreaterThanOrEqual(2);
+    const boardFilters = eqSpy.mock.calls.filter(
+      ([col, val]) => col === dbSchema.userFavorites.boardName && val === 'kilter',
+    );
+    expect(boardFilters.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('LIKED_CLIMBS without boardName does not filter by board (cross-board view)', async () => {
+    const ctx = makeCtx();
+    mockDb.select.mockReturnValueOnce(makeChain([USER_ROW]).chain);
+    mockDb.select.mockReturnValueOnce(makeChain([]).chain);
+    mockDb.select.mockReturnValueOnce(makeChain([{ count: 0 }]).chain);
+
+    await playlistQueries.smartPlaylist(
+      null,
+      {
+        input: { type: 'LIKED_CLIMBS', userId: 'user-123' },
+      },
+      ctx,
+    );
+
+    const boardFilters = eqSpy.mock.calls.filter(([col]) => col === dbSchema.userFavorites.boardName);
+    expect(boardFilters.length).toBe(0);
+  });
+
   it('throws when user does not exist', async () => {
     const ctx = makeCtx();
     mockDb.select.mockReturnValueOnce(makeChain([]).chain);
@@ -363,6 +431,44 @@ describe('mySmartPlaylistCounts resolver', () => {
       { type: 'PROJECTS', count: 0 },
       { type: 'LIKED_CLIMBS', count: 0 },
     ]);
+  });
+
+  it('surfaces a non-zero LIKED_CLIMBS count from the CTE', async () => {
+    const ctx = makeCtx();
+
+    mockDb.execute.mockResolvedValueOnce([
+      { type: 'FIVE_STARS', count: 7 },
+      { type: 'MOST_REPEATED', count: 3 },
+      { type: 'PROJECTS', count: 5 },
+      { type: 'LIKED_CLIMBS', count: 12 },
+    ]);
+
+    const result = await playlistQueries.mySmartPlaylistCounts(null, undefined, ctx);
+    expect(result).toContainEqual({ type: 'LIKED_CLIMBS', count: 12 });
+  });
+
+  it('CTE queries user_favorites and unions a LIKED_CLIMBS row', async () => {
+    // The library page renders the heart card from this count — if the CTE
+    // ever stops emitting a LIKED_CLIMBS row, the card silently disappears.
+    const ctx = makeCtx();
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    await playlistQueries.mySmartPlaylistCounts(null, undefined, ctx);
+
+    const sqlArg = mockDb.execute.mock.calls[0][0] as { queryChunks?: unknown[] } | undefined;
+    const rendered = (sqlArg?.queryChunks ?? [])
+      .map((chunk) => (typeof chunk === 'string' ? chunk : ((chunk as { value?: string }).value ?? '')))
+      .join(' ');
+
+    // The favourites CTE: dedicated SELECT (not derived from `base`, which is
+    // boardsesh_ticks-only), counts (board_name, climb_uuid) tuples, filters
+    // by the connection's user_id, and emits a 'LIKED_CLIMBS' union row so the
+    // resolver picks it up.
+    expect(rendered).toMatch(/liked_climbs\s+AS/i);
+    expect(rendered).toMatch(/COUNT\(DISTINCT\s*\(board_name,\s*climb_uuid\)\)/i);
+    expect(rendered).toMatch(/WHERE\s+user_id\s*=/i);
+    expect(rendered).toMatch(/'LIKED_CLIMBS'/);
+    expect(rendered).toMatch(/FROM\s+liked_climbs/i);
   });
 
   it('CTE scopes the sent-climbs check by both board_type and climb_uuid', async () => {

--- a/packages/backend/src/__tests__/smart-playlists.test.ts
+++ b/packages/backend/src/__tests__/smart-playlists.test.ts
@@ -319,6 +319,10 @@ describe('smartPlaylist resolver', () => {
     mockDb.select.mockReturnValueOnce(makeChain([USER_ROW]).chain);
     mockDb.select.mockReturnValueOnce(makeChain([]).chain);
     mockDb.select.mockReturnValueOnce(makeChain([{ count: 0 }]).chain);
+    // Defensive: hydrate currently short-circuits on an empty refs[], so this
+    // mock is unused today. Kept so the test doesn't blow up cryptically if
+    // that short-circuit is ever removed.
+    mockDb.select.mockReturnValueOnce(makeChain([]).chain);
 
     await playlistQueries.smartPlaylist(
       null,
@@ -447,29 +451,6 @@ describe('mySmartPlaylistCounts resolver', () => {
     expect(result).toContainEqual({ type: 'LIKED_CLIMBS', count: 12 });
   });
 
-  it('CTE queries user_favorites and unions a LIKED_CLIMBS row', async () => {
-    // The library page renders the heart card from this count — if the CTE
-    // ever stops emitting a LIKED_CLIMBS row, the card silently disappears.
-    const ctx = makeCtx();
-    mockDb.execute.mockResolvedValueOnce([]);
-
-    await playlistQueries.mySmartPlaylistCounts(null, undefined, ctx);
-
-    const sqlArg = mockDb.execute.mock.calls[0][0] as { queryChunks?: unknown[] } | undefined;
-    const rendered = (sqlArg?.queryChunks ?? [])
-      .map((chunk) => (typeof chunk === 'string' ? chunk : ((chunk as { value?: string }).value ?? '')))
-      .join(' ');
-
-    // The favourites CTE: dedicated SELECT (not derived from `base`, which is
-    // boardsesh_ticks-only), counts (board_name, climb_uuid) tuples, filters
-    // by the connection's user_id, and emits a 'LIKED_CLIMBS' union row so the
-    // resolver picks it up.
-    expect(rendered).toMatch(/liked_climbs\s+AS/i);
-    expect(rendered).toMatch(/COUNT\(DISTINCT\s*\(board_name,\s*climb_uuid\)\)/i);
-    expect(rendered).toMatch(/WHERE\s+user_id\s*=/i);
-    expect(rendered).toMatch(/'LIKED_CLIMBS'/);
-    expect(rendered).toMatch(/FROM\s+liked_climbs/i);
-  });
 
   it('CTE scopes the sent-climbs check by both board_type and climb_uuid', async () => {
     // Pin the joint-scoping fix: a kilter send must NOT exclude a tension

--- a/packages/backend/src/__tests__/smart-playlists.test.ts
+++ b/packages/backend/src/__tests__/smart-playlists.test.ts
@@ -326,6 +326,7 @@ describe('mySmartPlaylistCounts resolver', () => {
       { type: 'FIVE_STARS', count: 7 },
       { type: 'MOST_REPEATED', count: 3 },
       { type: 'PROJECTS', count: 5 },
+      { type: 'LIKED_CLIMBS', count: 0 },
     ]);
     expect(mockDb.execute).toHaveBeenCalledTimes(1);
   });
@@ -346,6 +347,7 @@ describe('mySmartPlaylistCounts resolver', () => {
       { type: 'FIVE_STARS', count: 1 },
       { type: 'MOST_REPEATED', count: 2 },
       { type: 'PROJECTS', count: 3 },
+      { type: 'LIKED_CLIMBS', count: 0 },
     ]);
   });
 
@@ -359,6 +361,7 @@ describe('mySmartPlaylistCounts resolver', () => {
       { type: 'FIVE_STARS', count: 9 },
       { type: 'MOST_REPEATED', count: 0 },
       { type: 'PROJECTS', count: 0 },
+      { type: 'LIKED_CLIMBS', count: 0 },
     ]);
   });
 

--- a/packages/backend/src/graphql/resolvers/playlists/queries/smart-playlists.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/smart-playlists.ts
@@ -6,7 +6,7 @@ import { applyRateLimit, requireAuthenticated, validateInput } from '../../share
 import { GetSmartPlaylistInputSchema } from '../../../../validation/schemas';
 import { hydrateClimbsByRefs, type ClimbRef } from '../helpers/hydrate-climbs';
 
-type SmartPlaylistType = 'FIVE_STARS' | 'MOST_REPEATED' | 'PROJECTS';
+type SmartPlaylistType = 'FIVE_STARS' | 'MOST_REPEATED' | 'PROJECTS' | 'LIKED_CLIMBS';
 
 type SmartPlaylistInput = {
   type: SmartPlaylistType;
@@ -104,6 +104,25 @@ async function selectSmartClimbRefs(
     return rows.map((row) => ({ climbUuid: row.climbUuid, boardType: row.boardType }));
   }
 
+  if (type === 'LIKED_CLIMBS') {
+    const favConditions: SQL[] = [eq(dbSchema.userFavorites.userId, userId)];
+    if (boardName) {
+      favConditions.push(eq(dbSchema.userFavorites.boardName, boardName));
+    }
+    const rows = await db
+      .select({
+        climbUuid: dbSchema.userFavorites.climbUuid,
+        boardType: dbSchema.userFavorites.boardName,
+      })
+      .from(dbSchema.userFavorites)
+      .where(and(...favConditions))
+      .groupBy(dbSchema.userFavorites.climbUuid, dbSchema.userFavorites.boardName)
+      .orderBy(desc(max(dbSchema.userFavorites.createdAt)))
+      .limit(pageSize)
+      .offset(offset);
+    return rows.map((row) => ({ climbUuid: row.climbUuid, boardType: row.boardType }));
+  }
+
   // PROJECTS — climbs the user has logged but never sent on this (board, climb).
   // The NOT EXISTS check matches on both board_type and climb_uuid, so a sent
   // Kilter climb doesn't accidentally exclude a Tension climb with the same
@@ -157,6 +176,20 @@ async function countSmartClimbRefs(
       .having(sql`SUM(${dbSchema.boardseshTicks.attemptCount}) > 1`)
       .as('repeated');
     const [row] = await db.select({ count: sql<number>`COUNT(*)::int` }).from(subquery);
+    return row?.count ?? 0;
+  }
+
+  if (type === 'LIKED_CLIMBS') {
+    const favConditions: SQL[] = [eq(dbSchema.userFavorites.userId, userId)];
+    if (boardName) {
+      favConditions.push(eq(dbSchema.userFavorites.boardName, boardName));
+    }
+    const [row] = await db
+      .select({
+        count: sql<number>`COUNT(DISTINCT (${dbSchema.userFavorites.boardName}, ${dbSchema.userFavorites.climbUuid}))::int`,
+      })
+      .from(dbSchema.userFavorites)
+      .where(and(...favConditions));
     return row?.count ?? 0;
   }
 
@@ -291,12 +324,19 @@ export const mySmartPlaylistCounts = async (
         WHERE sent.climb_uuid = base.climb_uuid
           AND sent.board_type = base.board_type
       )
+    ),
+    liked_climbs AS (
+      SELECT COUNT(DISTINCT (board_name, climb_uuid))::int AS count
+      FROM ${dbSchema.userFavorites}
+      WHERE user_id = ${userId}
     )
     SELECT 'FIVE_STARS'::text AS type, count FROM five_stars
     UNION ALL
     SELECT 'MOST_REPEATED'::text, count FROM most_repeated
     UNION ALL
     SELECT 'PROJECTS'::text, count FROM projects
+    UNION ALL
+    SELECT 'LIKED_CLIMBS'::text, count FROM liked_climbs
   `);
 
   // db.execute returns either an iterable of rows directly or `{ rows }`
@@ -315,5 +355,6 @@ export const mySmartPlaylistCounts = async (
     { type: 'FIVE_STARS', count: byType.get('FIVE_STARS') ?? 0 },
     { type: 'MOST_REPEATED', count: byType.get('MOST_REPEATED') ?? 0 },
     { type: 'PROJECTS', count: byType.get('PROJECTS') ?? 0 },
+    { type: 'LIKED_CLIMBS', count: byType.get('LIKED_CLIMBS') ?? 0 },
   ];
 };

--- a/packages/backend/src/validation/schemas/playlists.ts
+++ b/packages/backend/src/validation/schemas/playlists.ts
@@ -111,7 +111,7 @@ export const SearchPlaylistsInputSchema = z.object({
   offset: z.number().int().min(0).optional().default(0),
 });
 
-export const SmartPlaylistTypeSchema = z.enum(['FIVE_STARS', 'MOST_REPEATED', 'PROJECTS']);
+export const SmartPlaylistTypeSchema = z.enum(['FIVE_STARS', 'MOST_REPEATED', 'PROJECTS', 'LIKED_CLIMBS']);
 
 export const GetSmartPlaylistInputSchema = z.object({
   type: SmartPlaylistTypeSchema,

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -1734,15 +1734,17 @@ input GetUserFavoriteClimbsInput {
 # ============================================
 
 """
-A computed playlist generated from a user's logbook.
+A computed playlist generated from a user's logbook or favourites.
 - FIVE_STARS: climbs the user has rated 5/5
 - MOST_REPEATED: climbs the user has logged the most attempts on
 - PROJECTS: climbs with the most attempts that have never been sent
+- LIKED_CLIMBS: climbs the user has favourited
 """
 enum SmartPlaylistType {
   FIVE_STARS
   MOST_REPEATED
   PROJECTS
+  LIKED_CLIMBS
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4511,12 +4511,13 @@ export type SmartPlaylistResult = {
 };
 
 /**
- * A computed playlist generated from a user's logbook.
+ * A computed playlist generated from a user's logbook or favourites.
  * - FIVE_STARS: climbs the user has rated 5/5
  * - MOST_REPEATED: climbs the user has logged the most attempts on
  * - PROJECTS: climbs with the most attempts that have never been sent
+ * - LIKED_CLIMBS: climbs the user has favourited
  */
-export type SmartPlaylistType = 'FIVE_STARS' | 'MOST_REPEATED' | 'PROJECTS';
+export type SmartPlaylistType = 'FIVE_STARS' | 'LIKED_CLIMBS' | 'MOST_REPEATED' | 'PROJECTS';
 
 export type SocialEntityType =
   | 'board'

--- a/packages/shared-schema/src/schema/playlists.ts
+++ b/packages/shared-schema/src/schema/playlists.ts
@@ -390,15 +390,17 @@ export const playlistsTypeDefs = /* GraphQL */ `
   # ============================================
 
   """
-  A computed playlist generated from a user's logbook.
+  A computed playlist generated from a user's logbook or favourites.
   - FIVE_STARS: climbs the user has rated 5/5
   - MOST_REPEATED: climbs the user has logged the most attempts on
   - PROJECTS: climbs with the most attempts that have never been sent
+  - LIKED_CLIMBS: climbs the user has favourited
   """
   enum SmartPlaylistType {
     FIVE_STARS
     MOST_REPEATED
     PROJECTS
+    LIKED_CLIMBS
   }
 
   """

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -4508,12 +4508,13 @@ export type SmartPlaylistResult = {
 };
 
 /**
- * A computed playlist generated from a user's logbook.
+ * A computed playlist generated from a user's logbook or favourites.
  * - FIVE_STARS: climbs the user has rated 5/5
  * - MOST_REPEATED: climbs the user has logged the most attempts on
  * - PROJECTS: climbs with the most attempts that have never been sent
+ * - LIKED_CLIMBS: climbs the user has favourited
  */
-export type SmartPlaylistType = 'FIVE_STARS' | 'MOST_REPEATED' | 'PROJECTS';
+export type SmartPlaylistType = 'FIVE_STARS' | 'LIKED_CLIMBS' | 'MOST_REPEATED' | 'PROJECTS';
 
 export type SocialEntityType =
   | 'board'

--- a/packages/shared/graphql/src/operations/playlists.ts
+++ b/packages/shared/graphql/src/operations/playlists.ts
@@ -620,7 +620,7 @@ export type UnfollowPlaylistMutationResponse = {
 // Smart (computed) Playlist Types and Operations
 // ============================================
 
-export type SmartPlaylistType = 'FIVE_STARS' | 'MOST_REPEATED' | 'PROJECTS';
+export type SmartPlaylistType = 'FIVE_STARS' | 'MOST_REPEATED' | 'PROJECTS' | 'LIKED_CLIMBS';
 
 export type SmartPlaylistMeta = {
   type: SmartPlaylistType;

--- a/packages/web/app/lib/smart-playlists.ts
+++ b/packages/web/app/lib/smart-playlists.ts
@@ -1,7 +1,7 @@
 import type { SmartPlaylistType } from '@boardsesh/graphql/operations/playlists';
 import { themeTokens } from '@/app/theme/theme-config';
 
-export type SmartPlaylistSlug = 'five-stars' | 'most-repeated' | 'projects';
+export type SmartPlaylistSlug = 'five-stars' | 'most-repeated' | 'projects' | 'liked-climbs';
 
 export type SmartPlaylistPresentation = {
   type: SmartPlaylistType;
@@ -38,6 +38,14 @@ export const SMART_PLAYLISTS: SmartPlaylistPresentation[] = [
     color: themeTokens.colors.accentRose,
     titleI18nKey: 'library.smart.projects.title',
     descriptionI18nKey: 'library.smart.projects.description',
+  },
+  {
+    type: 'LIKED_CLIMBS',
+    slug: 'liked-climbs',
+    icon: '❤️',
+    color: themeTokens.colors.pink,
+    titleI18nKey: 'library.smart.likedClimbs.title',
+    descriptionI18nKey: 'library.smart.likedClimbs.description',
   },
 ];
 

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -376,6 +376,16 @@ export default function LibraryPageContent({
     [refetchPlaylists, router, getPlaylistUrl],
   );
 
+  // Jump Back In list — pinned playlists lead, then the rest of the owned
+  // playlists with pinned items removed so they don't appear twice. Server
+  // query already filters by boardType + layoutId; no client-side filter needed.
+  // Computed before the error-state early return so the hook order stays
+  // stable across renders that switch into/out of the error UI.
+  const jumpBackInPlaylists = useMemo(() => {
+    const pinnedUuidSet = new Set(pinnedPlaylists.map((p) => p.uuid));
+    return [...pinnedPlaylists, ...playlists.filter((p) => !pinnedUuidSet.has(p.uuid))];
+  }, [pinnedPlaylists, playlists]);
+
   // Error state (only for authenticated users with fetch errors)
   if (isAuthenticated && error) {
     return (
@@ -396,14 +406,6 @@ export default function LibraryPageContent({
 
   const isLoading = playlistsLoading || tokenLoading || (!hasServerUserData && sessionStatus === 'loading');
   const discoverItems = getDiscoverPlaylists();
-
-  // Jump Back In list — pinned playlists lead, then the rest of the owned
-  // playlists with pinned items removed so they don't appear twice. Server
-  // query already filters by boardType + layoutId; no client-side filter needed.
-  const jumpBackInPlaylists = useMemo(() => {
-    const pinnedUuidSet = new Set(pinnedPlaylists.map((p) => p.uuid));
-    return [...pinnedPlaylists, ...playlists.filter((p) => !pinnedUuidSet.has(p.uuid))];
-  }, [pinnedPlaylists, playlists]);
 
   // Smart playlists prepended to the playlist card grid for the signed-in user.
   // Skip entries with count === 0 so the grid only shows non-empty smart playlists.

--- a/packages/web/app/playlists/library-page-content.tsx
+++ b/packages/web/app/playlists/library-page-content.tsx
@@ -14,12 +14,6 @@ import {
   type GetMySmartPlaylistCountsQueryResponse,
   type Playlist,
   type DiscoverablePlaylist,
-  type PinPlaylistMutationResponse,
-  type PinPlaylistMutationVariables,
-  type UnpinPlaylistMutationResponse,
-  type UnpinPlaylistMutationVariables,
-  PIN_PLAYLIST,
-  UNPIN_PLAYLIST,
   GET_MY_SMART_PLAYLIST_COUNTS,
 } from '@boardsesh/graphql/operations/playlists';
 import { useUserPlaylists } from '@/app/hooks/use-user-playlists';
@@ -35,7 +29,6 @@ import { deriveIsAuthenticated } from '@/app/lib/derive-auth-status';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
-import PlaylistCardGrid from '@/app/components/library/playlist-card-grid';
 import PlaylistScrollSection from '@/app/components/library/playlist-scroll-section';
 import PlaylistCard from '@/app/components/library/playlist-card';
 import CreatePlaylistDrawer from '@/app/components/library/create-playlist-drawer';
@@ -175,20 +168,13 @@ export default function LibraryPageContent({
   // every playlists/board/recents change.
   const {
     pinned: pinnedPlaylists,
-    source: pinnedSource,
     isLoading: pinnedLoading,
-    refetch: refetchPinned,
   } = usePinnedPlaylists({
     token: isAuthenticated ? token : null,
     boardType: selectedBoard?.boardType,
     layoutId: selectedBoard?.layoutId,
     candidatePlaylists: playlists,
   });
-
-  const pinnedUuids = useMemo(
-    () => new Set(pinnedSource === 'pinned' ? pinnedPlaylists.map((p) => p.uuid) : []),
-    [pinnedPlaylists, pinnedSource],
-  );
 
   // Discover playlists — paginated horizontal scroll. Reset on board filter
   // change. Two parallel cursors (popular + recent) live inside the hook;
@@ -211,36 +197,6 @@ export default function LibraryPageContent({
     initialRecentHasMore: hasInitialDiscoverData ? initialDiscoverPlaylists.recentHasMore : undefined,
   });
   const error = playlistsHasError;
-
-  // Pin / unpin a playlist. Optimistic refetch — wait for the mutation, then
-  // re-pull both the pinned list (server source of truth) and the page-1 of
-  // owned playlists (so the "Jump Back In" ordering reflects any server-side
-  // touches). Rate-limit handling is upstream in executeGraphQL.
-  const handleTogglePin = useCallback(
-    async (uuid: string, nextPinned: boolean) => {
-      if (!token) return;
-      try {
-        if (nextPinned) {
-          await executeGraphQL<PinPlaylistMutationResponse, PinPlaylistMutationVariables>(
-            PIN_PLAYLIST,
-            { input: { playlistUuid: uuid } },
-            token,
-          );
-        } else {
-          await executeGraphQL<UnpinPlaylistMutationResponse, UnpinPlaylistMutationVariables>(
-            UNPIN_PLAYLIST,
-            { input: { playlistUuid: uuid } },
-            token,
-          );
-        }
-        refetchPinned();
-      } catch (err) {
-        console.error('Failed to toggle pin:', err);
-        showMessage(t(nextPinned ? 'library.pin.pinFailed' : 'library.pin.unpinFailed'), 'error');
-      }
-    },
-    [token, refetchPinned, showMessage, t],
-  );
 
   // Smart playlist counts — react-query handles caching across the session and
   // dedupes if the page remounts. The token is part of the key so we refetch
@@ -441,9 +397,13 @@ export default function LibraryPageContent({
   const isLoading = playlistsLoading || tokenLoading || (!hasServerUserData && sessionStatus === 'loading');
   const discoverItems = getDiscoverPlaylists();
 
-  // Server query already filters by boardType + layoutId; no client-side filter needed
-  const filteredPlaylists = playlists;
-  const showPinnedSection = isAuthenticated && (pinnedLoading || pinnedPlaylists.length > 0);
+  // Jump Back In list — pinned playlists lead, then the rest of the owned
+  // playlists with pinned items removed so they don't appear twice. Server
+  // query already filters by boardType + layoutId; no client-side filter needed.
+  const jumpBackInPlaylists = useMemo(() => {
+    const pinnedUuidSet = new Set(pinnedPlaylists.map((p) => p.uuid));
+    return [...pinnedPlaylists, ...playlists.filter((p) => !pinnedUuidSet.has(p.uuid))];
+  }, [pinnedPlaylists, playlists]);
 
   // Smart playlists prepended to the playlist card grid for the signed-in user.
   // Skip entries with count === 0 so the grid only shows non-empty smart playlists.
@@ -528,25 +488,6 @@ export default function LibraryPageContent({
         </>
       )}
 
-      {/* Pinned grid (top, small). Filled with server-side pins when present;
-          falls back to per-device IndexedDB recents so the grid isn't empty
-          for users who haven't pinned anything yet. */}
-      {showPinnedSection && (
-        <>
-          <div className={styles.sectionTitle}>{t('library.sections.pinned')}</div>
-          <PlaylistCardGrid
-            playlists={pinnedPlaylists}
-            getPlaylistUrl={getPlaylistUrl}
-            loading={pinnedLoading && pinnedPlaylists.length === 0}
-            // Only show the pin button on rows that came from server pins —
-            // recents fallback rows aren't "pinned" yet, but tapping the pin
-            // pins them. Both cases use handleTogglePin.
-            onTogglePin={handleTogglePin}
-            pinnedUuids={pinnedUuids}
-          />
-        </>
-      )}
-
       {/* Empty state if no playlists at all (authenticated, no pinned + no owned) */}
       {isAuthenticated && !isLoading && !pinnedLoading && playlists.length === 0 && pinnedPlaylists.length === 0 && (
         <div className={styles.emptyContainer}>
@@ -560,10 +501,11 @@ export default function LibraryPageContent({
         </div>
       )}
 
-      {/* Jump Back In — paginated horizontal scroll of all owned playlists.
-          IntersectionObserver in PlaylistScrollSection fires loadMore when the
-          right-edge sentinel comes into view. */}
-      {isAuthenticated && (isLoading || filteredPlaylists.length > 0) && (
+      {/* Jump Back In — paginated horizontal scroll. Pinned playlists lead;
+          the rest of the user's owned playlists follow. IntersectionObserver
+          in PlaylistScrollSection fires loadMore when the right-edge sentinel
+          comes into view. */}
+      {isAuthenticated && (isLoading || jumpBackInPlaylists.length > 0) && (
         <PlaylistScrollSection
           title={t('library.sections.jumpBackIn')}
           loading={isLoading}
@@ -571,7 +513,7 @@ export default function LibraryPageContent({
           hasMore={playlistsHasMore}
           isLoadingMore={playlistsLoadingMore}
         >
-          {filteredPlaylists.map((p, i) => (
+          {jumpBackInPlaylists.map((p, i) => (
             <PlaylistCard
               key={p.uuid}
               name={p.name}

--- a/packages/web/i18n/locales/en-US/playlists.json
+++ b/packages/web/i18n/locales/en-US/playlists.json
@@ -42,6 +42,10 @@
         "title": "Projects",
         "description": "Climbs you've worked the most without sending."
       },
+      "likedClimbs": {
+        "title": "Liked Climbs",
+        "description": "All climbs you've hearted."
+      },
       "notFound": {
         "title": "Smart playlist not found",
         "description": "This smart playlist doesn't exist."

--- a/packages/web/i18n/locales/es/playlists.json
+++ b/packages/web/i18n/locales/es/playlists.json
@@ -42,6 +42,10 @@
         "title": "Proyectos",
         "description": "Bloques en los que más has trabajado sin encadenar."
       },
+      "likedClimbs": {
+        "title": "Bloques favoritos",
+        "description": "Todos los bloques que has marcado con corazón."
+      },
       "notFound": {
         "title": "Playlist inteligente no encontrada",
         "description": "Esta playlist inteligente no existe."

--- a/packages/web/i18n/locales/fr/playlists.json
+++ b/packages/web/i18n/locales/fr/playlists.json
@@ -42,6 +42,10 @@
         "title": "Projets",
         "description": "Les voies que vous avez le plus travaillées sans les enchaîner."
       },
+      "likedClimbs": {
+        "title": "Voies aimées",
+        "description": "Toutes les voies que vous avez aimées."
+      },
       "notFound": {
         "title": "Playlist intelligente introuvable",
         "description": "Cette playlist intelligente n'existe pas."


### PR DESCRIPTION
## Summary

- Adds **Liked Climbs** as a 4th smart playlist (alongside Five Stars, Most Repeated, Projects). Computed from `user_favorites`, deduped across angles, ordered by most recently liked. Heart icon, pink card.
- Drops the separate **Pinned** grid section and leads the **Jump Back In** horizontal slider with pinned playlists (deduplicated against owned). Saves vertical space and avoids long-name overflow in small pinned cells.

## Implementation notes

- Smart playlist plumbing is fully generic — added `LIKED_CLIMBS` to the GraphQL enum, validation schema, resolver branches (`selectSmartClimbRefs`, `countSmartClimbRefs`, `mySmartPlaylistCounts` CTE), and frontend `SMART_PLAYLISTS` config. The existing detail page and library card grid pick it up automatically.
- i18n added in `en-US`, `es`, `fr`.
- Pin/unpin UI is removed from the library page. Users can still pin/unpin from the playlist detail view.

## Test plan

- [ ] Sign in, navigate to `/playlists` — verify Liked Climbs card appears in Your Picks (heart icon, pink) when count > 0
- [ ] Click the card — navigates to `/discover/liked-climbs/{userId}` and shows favourited climbs
- [ ] Like a new climb, return to library — verify count increments
- [ ] Verify Jump Back In slider leads with pinned playlists, no duplicates
- [ ] Verify the separate Pinned grid is gone
- [ ] Verify the empty state still works when user has zero playlists and zero pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)