### PR TITLE
fix(docker): correct board-renderer-wasm path in Dockerfiles

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -21,8 +21,8 @@ COPY packages/aurora-sync/package.json ./packages/aurora-sync/
 COPY packages/backend/package.json ./packages/backend/
 COPY packages/mobile/package.json ./packages/mobile/
 COPY packages/moonboard-ocr/package.json ./packages/moonboard-ocr/
-COPY packages/board-renderer-wasm/package.json ./packages/board-renderer-wasm/
-COPY packages/board-renderer-wasm/pkg/ ./packages/board-renderer-wasm/pkg/
+COPY packages/board-renderer/wasm/package.json ./packages/board-renderer/wasm/
+COPY packages/board-renderer/wasm/pkg/ ./packages/board-renderer/wasm/pkg/
 COPY packages/shared/ble-protocol/package.json ./packages/shared/ble-protocol/
 COPY packages/shared/board-config/package.json ./packages/shared/board-config/
 COPY packages/shared/queue/package.json ./packages/shared/queue/

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -21,8 +21,8 @@ COPY packages/aurora-sync/package.json ./packages/aurora-sync/
 COPY packages/backend/package.json ./packages/backend/
 COPY packages/mobile/package.json ./packages/mobile/
 COPY packages/moonboard-ocr/package.json ./packages/moonboard-ocr/
-COPY packages/board-renderer-wasm/package.json ./packages/board-renderer-wasm/
-COPY packages/board-renderer-wasm/pkg/ ./packages/board-renderer-wasm/pkg/
+COPY packages/board-renderer/wasm/package.json ./packages/board-renderer/wasm/
+COPY packages/board-renderer/wasm/pkg/ ./packages/board-renderer/wasm/pkg/
 COPY packages/shared/ble-protocol/package.json ./packages/shared/ble-protocol/
 COPY packages/shared/board-config/package.json ./packages/shared/board-config/
 COPY packages/shared/queue/package.json ./packages/shared/queue/


### PR DESCRIPTION
## Summary

- Both `Dockerfile.web` and `Dockerfile.backend` referenced `packages/board-renderer-wasm/` which does not exist
- The actual package lives at `packages/board-renderer/wasm/` (a nested directory, registered as a workspace in `package.json`)
- Docker build was failing on the `COPY packages/board-renderer-wasm/pkg/` step with a "not found" cache key error

## Test plan

- [ ] Docker build for web image completes without the "not found" error on `board-renderer-wasm/pkg`
- [ ] Docker build for backend image likewise succeeds past the dependency-copy stage

https://claude.ai/code/session_01LVTCgXVqugeWfNmHLQ17PB

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVTCgXVqugeWfNmHLQ17PB)_