### PR TITLE
fix(mobile): query EAS branches using the active client platform

### DIFF
--- a/packages/mobile/src/components/BranchSwitcherScreen.tsx
+++ b/packages/mobile/src/components/BranchSwitcherScreen.tsx
@@ -5,6 +5,7 @@ import {
   RefreshControl,
   ActivityIndicator,
   Alert,
+  Platform,
   Pressable,
   StyleSheet,
 } from 'react-native';
@@ -25,7 +26,12 @@ import {
   findChannelIdByName,
   updateChannelBranchMapping,
   type EASBranch,
+  type EASPlatform,
 } from '../lib/eas-api';
+
+function getEASPlatform(): EASPlatform {
+  return Platform.OS === 'android' ? 'android' : 'ios';
+}
 
 function formatRelativeTime(dateStr: string): string {
   const now = Date.now();
@@ -70,9 +76,10 @@ export function BranchSwitcherScreen() {
   const easConfig = preview ? getEASConfig() : null;
   const token = easConfig?.token ?? '';
   const projectId = easConfig?.projectId ?? '';
+  const easPlatform = getEASPlatform();
   const branchesQuery = useQuery({
-    queryKey: ['eas-branches', projectId],
-    queryFn: () => fetchBranches(projectId, token),
+    queryKey: ['eas-branches', projectId, easPlatform],
+    queryFn: () => fetchBranches(projectId, token, easPlatform),
     staleTime: 60_000,
     enabled: preview,
   });

--- a/packages/mobile/src/lib/__tests__/eas-api.test.ts
+++ b/packages/mobile/src/lib/__tests__/eas-api.test.ts
@@ -43,19 +43,39 @@ describe('fetchBranches', () => {
     globalThis.fetch = originalFetch;
   });
 
-  it('returns the data array on success', async () => {
+  it('returns the data array on success and forwards the platform header', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ data: [{ id: 'b1', name: 'main', updates: [] }] }),
     } as Response);
 
-    const result = await fetchBranches('proj-1', 'token-x');
+    const result = await fetchBranches('proj-1', 'token-x', 'ios');
 
     expect(result).toEqual([{ id: 'b1', name: 'main', updates: [] }]);
     expect(globalThis.fetch).toHaveBeenCalledWith(
       'https://api.expo.dev/v2/projects/proj-1/updates/branches?limit=50',
       expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: 'Bearer token-x' }),
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token-x',
+          'expo-platform': 'ios',
+        }),
+      }),
+    );
+  });
+
+  it('sends expo-platform: android when called with android', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    } as Response);
+    globalThis.fetch = fetchMock;
+
+    await fetchBranches('proj-1', 'token-x', 'android');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'expo-platform': 'android' }),
       }),
     );
   });
@@ -66,7 +86,7 @@ describe('fetchBranches', () => {
       statusText: 'Unauthorized',
     } as Response);
 
-    await expect(fetchBranches('proj-1', 'bad-token')).rejects.toThrow('Unauthorized');
+    await expect(fetchBranches('proj-1', 'bad-token', 'ios')).rejects.toThrow('Unauthorized');
   });
 });
 

--- a/packages/mobile/src/lib/eas-api.ts
+++ b/packages/mobile/src/lib/eas-api.ts
@@ -46,12 +46,18 @@ function authHeaders(token: string): Record<string, string> {
   };
 }
 
-export async function fetchBranches(projectId: string, token: string): Promise<EASBranch[]> {
+export type EASPlatform = 'ios' | 'android';
+
+export async function fetchBranches(
+  projectId: string,
+  token: string,
+  platform: EASPlatform,
+): Promise<EASBranch[]> {
   const url = `${EAS_API_BASE}/${projectId}/updates/branches?limit=50`;
   const response = await fetch(url, {
     headers: {
       ...authHeaders(token),
-      'expo-platform': 'ios',
+      'expo-platform': platform,
     },
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #2307 — addresses the Codex review comment on `fetchBranches`.

`fetchBranches()` was hardcoding the `expo-platform: ios` header in the EAS REST call. On an Android preview build that means the branch list comes back filtered through the iOS platform lens, which can:

- Hide branches that only have an Android-compatible runtime version
- Show stale or wrong "latest update" metadata per branch, because the `updates[]` array is platform-scoped

## Changes

- New `EASPlatform = 'ios' | 'android'` type, required as a third arg to `fetchBranches(projectId, token, platform)`.
- `BranchSwitcherScreen` derives the value from `Platform.OS` and threads it into both the call and the React Query key, so iOS and Android caches stay separate.
- Test now covers both `expo-platform: ios` and `expo-platform: android` paths.

## Test plan

- [x] `vp run typecheck:mobile` — clean
- [x] `vp test --project mobile eas-api` — 12 passing (was 11; added the android header test)
- [ ] Manual: open Branch Switcher on iOS preview build, confirm branches still load
- [ ] Manual: open Branch Switcher on Android preview build, confirm branches load and platform-specific metadata is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)