### PR TITLE
fix(docker): add missing shared packages to backend Dockerfile

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -25,6 +25,9 @@ COPY packages/board-renderer/wasm/package.json ./packages/board-renderer/wasm/
 COPY packages/board-renderer/wasm/pkg/ ./packages/board-renderer/wasm/pkg/
 COPY packages/shared/ble-protocol/package.json ./packages/shared/ble-protocol/
 COPY packages/shared/board-config/package.json ./packages/shared/board-config/
+COPY packages/shared/climb-filters/package.json ./packages/shared/climb-filters/
+COPY packages/shared/graphql/package.json ./packages/shared/graphql/
+COPY packages/shared/play-view/package.json ./packages/shared/play-view/
 COPY packages/shared/queue/package.json ./packages/shared/queue/
 
 # Copy source code for all shared packages and backend


### PR DESCRIPTION
## Summary

- `@boardsesh/climb-filters`, `@boardsesh/graphql`, and `@boardsesh/play-view` were added to `packages/shared/` but their `package.json` files were missing from the `Dockerfile.backend` build context
- Without those files, Bun treats them as external npm packages and fails with 404 errors during `bun install --frozen-lockfile`
- Adds three `COPY packages/shared/<pkg>/package.json` lines, consistent with how the other shared packages (`ble-protocol`, `board-config`, `queue`) are handled

## Test plan

- [ ] Trigger a backend Docker build and confirm `bun install --frozen-lockfile` completes without the 404 errors for the three packages

https://claude.ai/code/session_01VgJkThCCgrqHdYsMnUHUqV

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgJkThCCgrqHdYsMnUHUqV)_