### PR TITLE
fix(firmware): make the esp32 board discoverable and detect power-off quickly

### DIFF
--- a/docs/embedded-architecture.md
+++ b/docs/embedded-architecture.md
@@ -58,7 +58,7 @@ Feature flags are controlled via build defines: `ENABLE_BLE_PROXY`, `ENABLE_DISP
 
 The ESP32 acts as a drop-in board controller:
 
-1. Exposes a BLE GATT server (Nordic UART Service) compatible with official Kilter/Tension apps
+1. Exposes a BLE GATT server (Nordic UART Service) compatible with official Kilter/Tension apps. The primary advertisement carries only the Aurora service UUID (so filtered scans see the board within the 31-byte legacy advert limit); the Nordic UART service is discovered via GATT after connect.
 2. Receives LED commands from the app via BLE and drives WS2812B LEDs directly
 3. Optionally forwards BLE LED data to the BoardSesh backend for climb identification
 

--- a/embedded/libs/nordic-uart-ble/src/nordic_uart_ble.cpp
+++ b/embedded/libs/nordic-uart-ble/src/nordic_uart_ble.cpp
@@ -32,10 +32,18 @@ void NordicUartBLE::begin(const char* deviceName, bool startAdv) {
 
     pService->start();
 
-    // Always configure advertising data (even if not starting yet)
+    // Always configure advertising data (even if not starting yet).
+    //
+    // Advertise ONLY the Aurora service UUID. The iOS/web/Capacitor apps scan
+    // with a hard filter on this UUID, and a central only sees UUIDs present in
+    // the advertising/scan-response packet. A single 128-bit UUID (18 bytes) plus
+    // the Flags structure (3 bytes) fits the 31-byte legacy advertising limit;
+    // the device name goes in the scan response. We deliberately do NOT advertise
+    // the Nordic UART service — it's discovered via GATT after connect, and adding
+    // a second 128-bit UUID overflowed the 31-byte packet, so NimBLE dropped the
+    // advert (or failed to start it) and the board never showed up in the scan.
     NimBLEAdvertising* pAdvertising = NimBLEDevice::getAdvertising();
     pAdvertising->addServiceUUID(AURORA_ADVERTISED_SERVICE_UUID);
-    pAdvertising->addServiceUUID(NUS_SERVICE_UUID);
     pAdvertising->setScanResponse(true);
     pAdvertising->setMinPreferred(0x06);
     pAdvertising->setMaxPreferred(0x12);
@@ -47,10 +55,17 @@ void NordicUartBLE::begin(const char* deviceName, bool startAdv) {
     pServer->start();
 
     if (startAdv) {
-        pAdvertising->start();
-        advertising = true;
+        bool started = pAdvertising->start();
+        advertising = started;
         advertisingEnabled = true;
-        Logger.logln("BLE: Advertising started");
+        if (started) {
+            Logger.logln("BLE: Advertising started");
+        } else {
+            // A false return almost always means the advertising payload didn't
+            // fit (see the single-UUID note above) — surface it instead of
+            // logging success unconditionally and hiding a dark radio.
+            Logger.logln("BLE: ERROR advertising failed to start");
+        }
     }
 
     Logger.logln("BLE: Server started as '%s'", deviceName);
@@ -107,6 +122,14 @@ void NordicUartBLE::onConnect(NimBLEServer* server, ble_gap_conn_desc* desc) {
     connectedDeviceAddress = NimBLEAddress(desc->peer_ota_addr).toString().c_str();
     connectedDeviceHandle = desc->conn_handle;
     Logger.logln("BLE: Device connected: %s (total: %d)", connectedDeviceAddress.c_str(), pServer->getConnectedCount());
+
+    // Request a bounded supervision timeout so the central detects an abrupt
+    // power-off within ~2s instead of waiting out its long default (which made a
+    // powered-off board look "still connected" indefinitely). Args:
+    // (handle, minInterval, maxInterval, latency, timeout) — intervals in 1.25ms
+    // units, timeout in 10ms units, so 200 = 2000ms. Satisfies the BLE rule
+    // timeout > (1 + latency) * maxInterval * 2. The central may renegotiate.
+    pServer->updateConnParams(desc->conn_handle, 6, 18, 0, 200);
 
     // Flash green to indicate connection
     LEDs.blink(0, 255, 0, 2, 100);
@@ -223,9 +246,14 @@ void NordicUartBLE::startAdvertising() {
     NimBLEAdvertising* pAdvertising = NimBLEDevice::getAdvertising();
 
     // Start advertising (UUIDs and settings already configured in begin())
-    pAdvertising->start();
-    advertising = true;
+    bool started = pAdvertising->start();
+    advertising = started;
     advertisingEnabled = true;  // Enable for future restarts in loop()
 
-    Logger.logln("BLE: Advertising started");
+    if (started) {
+        Logger.logln("BLE: Advertising started");
+    } else {
+        // Leave `advertising` false so loop() retries on the next tick.
+        Logger.logln("BLE: ERROR advertising failed to start");
+    }
 }

--- a/embedded/test/lib/mocks/src/NimBLEDevice.h
+++ b/embedded/test/lib/mocks/src/NimBLEDevice.h
@@ -199,9 +199,10 @@ class NimBLEAdvertising {
 
     void setMaxPreferred(uint8_t maxInterval) { maxInterval_ = maxInterval; }
 
-    void start() {
+    bool start() {
         advertising_ = true;
         startCount_++;
+        return true;
     }
 
     void stop() { advertising_ = false; }
@@ -255,9 +256,17 @@ class NimBLEServer {
             connectedCount_--;
     }
 
+    void updateConnParams(uint16_t connHandle, uint16_t minInterval, uint16_t maxInterval, uint16_t latency,
+                          uint16_t timeout) {
+        lastConnParamsHandle_ = connHandle;
+        lastConnParamsTimeout_ = timeout;
+    }
+
     // Test helpers
     NimBLEServerCallbacks* getCallbacks() const { return callbacks_; }
     uint16_t getDisconnectedHandle() const { return disconnectedHandle_; }
+    uint16_t getLastConnParamsHandle() const { return lastConnParamsHandle_; }
+    uint16_t getLastConnParamsTimeout() const { return lastConnParamsTimeout_; }
 
     void mockConnect(ble_gap_conn_desc* desc) {
         connectedCount_++;
@@ -283,6 +292,8 @@ class NimBLEServer {
     int connectedCount_;
     bool started_;
     uint16_t disconnectedHandle_ = BLE_HS_CONN_HANDLE_NONE;
+    uint16_t lastConnParamsHandle_ = BLE_HS_CONN_HANDLE_NONE;
+    uint16_t lastConnParamsTimeout_ = 0;
 };
 
 // =============================================================================

--- a/embedded/test/test_nordic_uart_ble/test_nordic_uart_ble.cpp
+++ b/embedded/test/test_nordic_uart_ble/test_nordic_uart_ble.cpp
@@ -114,17 +114,15 @@ void test_begin_registers_aurora_service_uuid(void) {
     TEST_ASSERT_TRUE(found);
 }
 
-void test_begin_registers_nus_service_uuid(void) {
+void test_begin_does_not_advertise_nus_service_uuid(void) {
+    // The Nordic UART service must NOT be advertised: two 128-bit UUIDs overflow
+    // the 31-byte advertising packet, which dropped the Aurora UUID and hid the
+    // board from the scan. UART is discovered via GATT after connect instead.
     ble->begin("Test Device");
     const auto& uuids = NimBLEDevice::getAdvertising()->getServiceUUIDs();
-    bool found = false;
     for (const auto& uuid : uuids) {
-        if (uuid == NUS_SERVICE_UUID) {
-            found = true;
-            break;
-        }
+        TEST_ASSERT_TRUE(uuid != NUS_SERVICE_UUID);
     }
-    TEST_ASSERT_TRUE(found);
 }
 
 // =============================================================================
@@ -223,6 +221,21 @@ void test_connection_callback_called_on_disconnect(void) {
     TEST_ASSERT_FALSE(ble->isConnected());
     TEST_ASSERT_EQUAL(1, connectCallbackCount);
     TEST_ASSERT_FALSE(lastConnectState);
+}
+
+void test_connect_requests_bounded_supervision_timeout(void) {
+    ble->begin("Test Device");
+
+    ble_gap_conn_desc desc;
+    memset(&desc, 0, sizeof(desc));
+    desc.conn_handle = 7;
+
+    NimBLEDevice::getServer()->mockConnect(&desc);
+
+    // onConnect requests a short supervision timeout (200 * 10ms = 2s) so the
+    // central detects an abrupt power-off in seconds instead of its long default.
+    TEST_ASSERT_EQUAL(7, NimBLEDevice::getServer()->getLastConnParamsHandle());
+    TEST_ASSERT_EQUAL(200, NimBLEDevice::getServer()->getLastConnParamsTimeout());
 }
 
 // =============================================================================
@@ -520,7 +533,7 @@ int main(int argc, char** argv) {
     RUN_TEST(test_begin_creates_server);
     RUN_TEST(test_begin_starts_advertising);
     RUN_TEST(test_begin_registers_aurora_service_uuid);
-    RUN_TEST(test_begin_registers_nus_service_uuid);
+    RUN_TEST(test_begin_does_not_advertise_nus_service_uuid);
 
     // Callback registration tests
     RUN_TEST(test_set_connect_callback_and_verify_invocation);
@@ -530,6 +543,7 @@ int main(int argc, char** argv) {
     // Connection lifecycle tests
     RUN_TEST(test_connection_callback_called_on_connect);
     RUN_TEST(test_connection_callback_called_on_disconnect);
+    RUN_TEST(test_connect_requests_bounded_supervision_timeout);
 
     // Device address tests
     RUN_TEST(test_connected_device_address_set_on_connect);

--- a/packages/web/app/lib/ble/native-ios-adapter.ts
+++ b/packages/web/app/lib/ble/native-ios-adapter.ts
@@ -5,6 +5,14 @@ import {
 } from '@/app/components/board-bluetooth-control/bluetooth-aurora';
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from './scan-constants';
 
+// Opt-in BLE tracing for on-device debugging. Append `?bleDebug` to the URL and
+// watch the WebView console (Safari Web Inspector) to see whether native
+// disconnect events arrive and whether their deviceId matches the connected one.
+// Silent in normal use; loads live via the web app so no app rebuild is needed.
+function bleDebugEnabled(): boolean {
+  return typeof window !== 'undefined' && window.location.search.includes('bleDebug');
+}
+
 type NativeBoardBlePlugin = NonNullable<NonNullable<Window['Capacitor']>['Plugins']['BoardBle']>;
 type NativeBoardBleListenerHandle = Awaited<ReturnType<NativeBoardBlePlugin['addListener']>>;
 
@@ -166,6 +174,13 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
 
     this.disconnectListenerHandle = await normalizeListenerHandle(
       plugin.addListener('disconnected', (data) => {
+        if (bleDebugEnabled()) {
+          console.debug('[ble] native disconnected event', {
+            received: data.deviceId,
+            expected: this.deviceId,
+            willFire: data.deviceId === this.deviceId,
+          });
+        }
         if (data.deviceId === this.deviceId) {
           this.deviceId = null;
           this.disconnectListenerHandle = null;

--- a/packages/web/app/lib/ble/native-ios-adapter.ts
+++ b/packages/web/app/lib/ble/native-ios-adapter.ts
@@ -10,7 +10,7 @@ import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from './scan-constants';
 // disconnect events arrive and whether their deviceId matches the connected one.
 // Silent in normal use; loads live via the web app so no app rebuild is needed.
 function bleDebugEnabled(): boolean {
-  return typeof window !== 'undefined' && window.location.search.includes('bleDebug');
+  return typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('bleDebug');
 }
 
 type NativeBoardBlePlugin = NonNullable<NonNullable<Window['Capacitor']>['Plugins']['BoardBle']>;


### PR DESCRIPTION
## Problem

Testing the esp32 `board-controller` firmware against the iOS app surfaced two bugs (both reproduced on app 1.2 and 1.3, which pointed at the firmware rather than the app):

1. **The board is never discovered** — the device picker shows an infinite "finding boards nearby" spinner.
2. **Disconnect isn't detected** — after connecting (solo session, lightbulb lit), powering the esp32 off never turns the lightbulb off.

## Root causes (both in the firmware)

**1. Advertising packet overflow** — `nordic_uart_ble.cpp` `begin()` added **two** 128-bit service UUIDs to the advertisement (Aurora `4488b571…` + Nordic UART `6e400001…`). Two 128-bit UUIDs (36 B) plus the Flags structure blow past the **31-byte legacy advertising limit**, so NimBLE drops a UUID or fails to start advertising. The iOS/web/Capacitor scans filter on the **Aurora UUID only**, and a central only sees UUIDs present in the advertisement (GATT-only exposure is invisible to a filtered scan) — so the board never appears.

**2. No bounded supervision timeout** — the native→JS→UI disconnect chain is correct (verified: `CBConnectPeripheralOptionNotifyOnDisconnectionKey` is set, `didDisconnectPeripheral`→`onDisconnect`→JS guard→`handleDisconnection`→`isConnected`; solo lightbulb follows `isConnected`). The firmware never set a connection supervision timeout, so an abrupt power-off only surfaced after the central's long default — feels like "never."

## Changes

- **Advertise only the Aurora UUID** in the primary packet; the UART service is discovered via GATT after connect. One 128-bit UUID (18 B) + Flags (3 B) = 21 B ≤ 31 B; the device name rides the scan response.
- **Surface a failed advertising start** instead of logging `"Advertising started"` unconditionally (in both `begin()` and `startAdvertising()`).
- **Request a ~2s supervision timeout** via `updateConnParams` in `onConnect`, so iOS reports a power-off within seconds.
- **Opt-in BLE tracing** (`?bleDebug`) in the iOS adapter's `disconnected` listener — logs received vs expected `deviceId` and whether it fires, observable in Safari Web Inspector, loads live (no app rebuild). Silent in normal use.
- **Tests**: NimBLE mock gains `bool start()` + `updateConnParams`; firmware tests now assert the UART UUID is **not** advertised and that a bounded supervision timeout is requested on connect.

## Verification

- `vp check` + `vp run typecheck:web` pass for the TS change.
- Firmware native tests (`pio test -e native` from `embedded/test`) could **not** run in the sandbox (the `native` platform package host isn't in the network allowlist) — relying on `firmware-tests.yml` CI. The C++ matches both the mock and real NimBLE-Arduino 1.4.1 signatures.
- **On hardware** (please confirm): flash `pio run -e esp32s3dev -t upload`; the board now appears in the picker within a couple of seconds (cross-check with nRF Connect that the advert lists `4488b571-7806-4df6-bcff-a2897e4953ff`); after connecting, powering off clears the lightbulb within ~2–4s.

## Notes
- Firmware ships by flashing the dev board — independent of the App Store. The iOS app needs no rebuild; the `?bleDebug` diagnostics load live via the web app.
- The firmware decoder handles **both** Aurora API v2 and v3, so the current advertised name (`Kilter Boardsesh`, which parses to API level 2) still lights LEDs correctly — no device-name/API-level change was needed.
- If iOS clamps the requested supervision timeout and power-off still isn't detected, the `?bleDebug` trace will show whether the native event arrives; a fallback app-side keepalive can be added then.

https://claude.ai/code/session_01WPkN6zPKNExqPswuCVYbri

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPkN6zPKNExqPswuCVYbri)_