### PR TITLE
fix(web,mobile,shared): second-round PR review follow-ups

### DIFF
--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -21,6 +21,7 @@ import { computePeekOffset, getGradeTintColor } from '@boardsesh/play-view';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { iosSystemColors } from '../../theme/ios-colors';
+import { shadowColor } from '../../theme/tokens';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
@@ -334,7 +335,7 @@ const styles = StyleSheet.create({
     // rounded (Spotify mini-player style).
     borderRadius: 10,
     overflow: 'hidden',
-    shadowColor: '#000',
+    shadowColor,
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.18,
     shadowRadius: 10,

--- a/packages/mobile/src/hooks/use-grade-format.ts
+++ b/packages/mobile/src/hooks/use-grade-format.ts
@@ -13,9 +13,6 @@ import { formatGrade, type GradeDisplayFormat, DEFAULT_GRADE_DISPLAY_FORMAT } fr
 export function useGradeFormat() {
   // TODO: persist via AsyncStorage and surface a toggle in More tab.
   const gradeFormat: GradeDisplayFormat = DEFAULT_GRADE_DISPLAY_FORMAT;
-  // Empty deps: gradeFormat is a module-stable constant today, so the memoized
-  // object never needs to rebuild. When AsyncStorage backing lands, replace
-  // with [gradeFormat] and flip `loaded` to the actual hydration flag.
   return useMemo(
     () => ({
       gradeFormat,

--- a/packages/mobile/src/hooks/use-grade-format.ts
+++ b/packages/mobile/src/hooks/use-grade-format.ts
@@ -13,12 +13,15 @@ import { formatGrade, type GradeDisplayFormat, DEFAULT_GRADE_DISPLAY_FORMAT } fr
 export function useGradeFormat() {
   // TODO: persist via AsyncStorage and surface a toggle in More tab.
   const gradeFormat: GradeDisplayFormat = DEFAULT_GRADE_DISPLAY_FORMAT;
+  // Empty deps: gradeFormat is a module-stable constant today, so the memoized
+  // object never needs to rebuild. When AsyncStorage backing lands, replace
+  // with [gradeFormat] and flip `loaded` to the actual hydration flag.
   return useMemo(
     () => ({
       gradeFormat,
       loaded: true,
       formatGrade: (difficulty: string | null | undefined) => formatGrade(difficulty, gradeFormat),
     }),
-    [gradeFormat],
+    [],
   );
 }

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -104,6 +104,9 @@ type QueueReorderedEvent = {
   __typename: 'QueueReordered';
   sequence: number;
   stateHash: string;
+  // Non-null per the schema — reorder always targets an existing queue item.
+  // See packages/shared-schema/src/types/events.ts QueueReordered. Contrast
+  // with ClimbMirroredEvent.uuid below, which is nullable.
   uuid: string;
   oldIndex: number;
   newIndex: number;

--- a/packages/mobile/src/theme/tokens.ts
+++ b/packages/mobile/src/theme/tokens.ts
@@ -31,37 +31,43 @@ export const borderRadius = {
   full: 9999,
 } as const;
 
+// Single source of truth for the shadow colour used by every elevation preset
+// and any one-off shadow styles (e.g. PersistentQueueBar). Keeping this as a
+// named export lets components import it directly when they don't fit one of
+// the `shadows.*` presets.
+export const shadowColor = '#000' as const;
+
 export const shadows = {
   xs: {
-    shadowColor: '#000',
+    shadowColor,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.05,
     shadowRadius: 1,
     elevation: 1,
   },
   sm: {
-    shadowColor: '#000',
+    shadowColor,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.1,
     shadowRadius: 2,
     elevation: 2,
   },
   md: {
-    shadowColor: '#000',
+    shadowColor,
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.1,
     shadowRadius: 4,
     elevation: 4,
   },
   lg: {
-    shadowColor: '#000',
+    shadowColor,
     shadowOffset: { width: 0, height: 10 },
     shadowOpacity: 0.1,
     shadowRadius: 8,
     elevation: 8,
   },
   xl: {
-    shadowColor: '#000',
+    shadowColor,
     shadowOffset: { width: 0, height: 20 },
     shadowOpacity: 0.1,
     shadowRadius: 12,

--- a/packages/mobile/src/theme/tokens.ts
+++ b/packages/mobile/src/theme/tokens.ts
@@ -31,10 +31,6 @@ export const borderRadius = {
   full: 9999,
 } as const;
 
-// Single source of truth for the shadow colour used by every elevation preset
-// and any one-off shadow styles (e.g. PersistentQueueBar). Keeping this as a
-// named export lets components import it directly when they don't fit one of
-// the `shadows.*` presets.
 export const shadowColor = '#000' as const;
 
 export const shadows = {

--- a/packages/shared/play-view/src/grade-display.ts
+++ b/packages/shared/play-view/src/grade-display.ts
@@ -240,6 +240,9 @@ export function getSoftGradeColorByFormat(
   darkMode?: boolean,
 ): string | undefined {
   if (format === 'font') {
+    // extractFontGrade returns uppercase (e.g. "7A+"); getFontGradeColor
+    // normalizes via .toLowerCase() before the lookup, so no caller-side
+    // case conversion is needed.
     return getSoftFontGradeColor(extractFontGrade(difficulty), darkMode);
   }
   return getSoftVGradeColor(extractVGrade(difficulty), darkMode);

--- a/packages/web/app/components/graphql-queue/hooks/__tests__/to-sync-queue-event.test.ts
+++ b/packages/web/app/components/graphql-queue/hooks/__tests__/to-sync-queue-event.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vite-plus/test';
+import type { Climb, ClimbQueueItem, SubscriptionQueueEvent } from '@boardsesh/shared-schema';
+import { toSyncQueueEvent } from '../use-queue-event-subscription';
+
+const climb: Climb = {
+  uuid: 'climb-1',
+  setter_username: 'setter',
+  name: 'Test',
+  frames: '',
+  angle: 40,
+  ascensionist_count: 0,
+  difficulty: '7',
+  quality_average: '3',
+  stars: 3,
+  difficulty_error: '',
+  benchmark_difficulty: null,
+};
+
+const item: ClimbQueueItem = { uuid: 'q-1', climb };
+
+describe('toSyncQueueEvent', () => {
+  it('maps FullSync, forwarding queue and currentClimbQueueItem', () => {
+    const event: SubscriptionQueueEvent = {
+      __typename: 'FullSync',
+      sequence: 1,
+      state: { sequence: 1, stateHash: 'h', queue: [item], currentClimbQueueItem: item },
+    };
+    expect(toSyncQueueEvent(event)).toEqual({
+      __typename: 'FullSync',
+      state: { queue: [item], currentClimbQueueItem: item },
+    });
+  });
+
+  it('maps FullSync with a null currentClimbQueueItem', () => {
+    const event: SubscriptionQueueEvent = {
+      __typename: 'FullSync',
+      sequence: 1,
+      state: { sequence: 1, stateHash: 'h', queue: [], currentClimbQueueItem: null },
+    };
+    const result = toSyncQueueEvent(event);
+    expect(result.__typename).toBe('FullSync');
+    if (result.__typename === 'FullSync') {
+      expect(result.state.currentClimbQueueItem).toBeNull();
+    }
+  });
+
+  it('maps QueueItemAdded, preserving the addedItem alias and position', () => {
+    const event: SubscriptionQueueEvent = {
+      __typename: 'QueueItemAdded',
+      sequence: 2,
+      stateHash: 'h',
+      addedItem: item,
+      position: 3,
+    };
+    expect(toSyncQueueEvent(event)).toEqual({
+      __typename: 'QueueItemAdded',
+      addedItem: item,
+      position: 3,
+    });
+  });
+
+  it('maps QueueItemRemoved, forwarding uuid', () => {
+    const event: SubscriptionQueueEvent = {
+      __typename: 'QueueItemRemoved',
+      sequence: 3,
+      stateHash: 'h',
+      uuid: 'q-9',
+    };
+    expect(toSyncQueueEvent(event)).toEqual({ __typename: 'QueueItemRemoved', uuid: 'q-9' });
+  });
+
+  it('maps QueueReordered, forwarding uuid + indices', () => {
+    const event: SubscriptionQueueEvent = {
+      __typename: 'QueueReordered',
+      sequence: 4,
+      stateHash: 'h',
+      uuid: 'q-5',
+      oldIndex: 2,
+      newIndex: 0,
+    };
+    expect(toSyncQueueEvent(event)).toEqual({
+      __typename: 'QueueReordered',
+      uuid: 'q-5',
+      oldIndex: 2,
+      newIndex: 0,
+    });
+  });
+
+  it('maps CurrentClimbChanged, preserving the currentItem alias plus echo hints', () => {
+    const event: SubscriptionQueueEvent = {
+      __typename: 'CurrentClimbChanged',
+      sequence: 5,
+      stateHash: 'h',
+      currentItem: item,
+      clientId: 'client-A',
+      correlationId: 'corr-7',
+    };
+    expect(toSyncQueueEvent(event)).toEqual({
+      __typename: 'CurrentClimbChanged',
+      currentItem: item,
+      clientId: 'client-A',
+      correlationId: 'corr-7',
+    });
+  });
+
+  it('maps CurrentClimbChanged with a null currentItem', () => {
+    const event: SubscriptionQueueEvent = {
+      __typename: 'CurrentClimbChanged',
+      sequence: 5,
+      stateHash: 'h',
+      currentItem: null,
+      clientId: null,
+      correlationId: null,
+    };
+    const result = toSyncQueueEvent(event);
+    expect(result.__typename).toBe('CurrentClimbChanged');
+    if (result.__typename === 'CurrentClimbChanged') {
+      expect(result.currentItem).toBeNull();
+      expect(result.clientId).toBeNull();
+      expect(result.correlationId).toBeNull();
+    }
+  });
+
+  it('maps ClimbMirrored, preserving the mirroredUuid alias', () => {
+    const event: SubscriptionQueueEvent = {
+      __typename: 'ClimbMirrored',
+      sequence: 6,
+      stateHash: 'h',
+      mirrored: true,
+      mirroredUuid: 'q-3',
+    };
+    expect(toSyncQueueEvent(event)).toEqual({
+      __typename: 'ClimbMirrored',
+      mirrored: true,
+      mirroredUuid: 'q-3',
+    });
+  });
+
+  it('throws via the assertNever default branch for an unknown __typename', () => {
+    const bogus = { __typename: 'NotARealVariant' } as unknown as SubscriptionQueueEvent;
+    expect(() => toSyncQueueEvent(bogus)).toThrow(/Unhandled SubscriptionQueueEvent variant/);
+  });
+});

--- a/packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts
@@ -6,14 +6,53 @@ import { track } from '@/app/lib/analytics';
 
 /**
  * Adapt a wire-format `SubscriptionQueueEvent` (from `@boardsesh/shared-schema`)
- * to the coordinator's `SyncQueueEvent`. The two unions are structurally
- * compatible — they share `addedItem` / `currentItem` field names and the same
- * `__typename` set — but their `ClimbQueueItem` types come from different
- * packages so TS can't infer assignability directly. Runtime shapes match
- * because both flow from the same GraphQL schema codegen.
+ * to the coordinator's `SyncQueueEvent` (from `@boardsesh/queue`). Both unions
+ * share the same `__typename` set and the same aliased item field names, but
+ * each declares its own `ClimbQueueItem` type so direct assignment isn't
+ * possible without help. We do an explicit per-variant rebuild rather than an
+ * `as unknown as` cast so the TypeScript compiler — not runtime — surfaces any
+ * schema drift between the two unions (new variant, renamed field, narrowed
+ * field type, etc.). Mirrors the mobile mapper in `queue-provider.tsx`.
  */
 function toSyncQueueEvent(event: SubscriptionQueueEvent): SyncQueueEvent {
-  return event as unknown as SyncQueueEvent;
+  switch (event.__typename) {
+    case 'FullSync':
+      return {
+        __typename: 'FullSync',
+        state: {
+          queue: event.state.queue,
+          currentClimbQueueItem: event.state.currentClimbQueueItem,
+        },
+      };
+    case 'QueueItemAdded':
+      return {
+        __typename: 'QueueItemAdded',
+        addedItem: event.addedItem,
+        position: event.position,
+      };
+    case 'QueueItemRemoved':
+      return { __typename: 'QueueItemRemoved', uuid: event.uuid };
+    case 'QueueReordered':
+      return {
+        __typename: 'QueueReordered',
+        uuid: event.uuid,
+        oldIndex: event.oldIndex,
+        newIndex: event.newIndex,
+      };
+    case 'CurrentClimbChanged':
+      return {
+        __typename: 'CurrentClimbChanged',
+        currentItem: event.currentItem,
+        clientId: event.clientId,
+        correlationId: event.correlationId,
+      };
+    case 'ClimbMirrored':
+      return {
+        __typename: 'ClimbMirrored',
+        mirrored: event.mirrored,
+        mirroredUuid: event.mirroredUuid,
+      };
+  }
 }
 
 type UseQueueEventSubscriptionParams = {

--- a/packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts
@@ -14,7 +14,7 @@ import { track } from '@/app/lib/analytics';
  * schema drift between the two unions (new variant, renamed field, narrowed
  * field type, etc.). Mirrors the mobile mapper in `queue-provider.tsx`.
  */
-function toSyncQueueEvent(event: SubscriptionQueueEvent): SyncQueueEvent {
+export function toSyncQueueEvent(event: SubscriptionQueueEvent): SyncQueueEvent {
   switch (event.__typename) {
     case 'FullSync':
       return {
@@ -52,7 +52,13 @@ function toSyncQueueEvent(event: SubscriptionQueueEvent): SyncQueueEvent {
         mirrored: event.mirrored,
         mirroredUuid: event.mirroredUuid,
       };
+    default:
+      return assertNever(event);
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled SubscriptionQueueEvent variant: ${JSON.stringify(value)}`);
 }
 
 type UseQueueEventSubscriptionParams = {


### PR DESCRIPTION
## Summary

Re-targeting PR #2333 (which merged into a since-orphaned parent branch and never reached main). Carries the same two commits, cherry-picked onto current main.

- **Web** `use-queue-event-subscription.ts` — Replace `as unknown as SyncQueueEvent` with an explicit per-variant `switch`, mirroring the mobile mapper. Schema drift between `SubscriptionQueueEvent` and `SyncQueueEvent` now surfaces at compile time. Adds a `default: assertNever(event)` branch so a future variant fails with the right error.
- **Web tests** — 9 new unit tests in `to-sync-queue-event.test.ts` covering every `SubscriptionQueueEvent` variant plus the assertNever throw path.
- **Mobile** `use-grade-format.ts` — Drop the misleading `[gradeFormat]` dep on a module-stable constant.
- **Shared** `grade-display.ts` — Document the uppercase-in / `.toLowerCase()`-internal flow through `getSoftFontGradeColor`.
- **Mobile** `queue-provider.tsx` — Document that `QueueReorderedEvent.uuid` is non-null per the schema (contrasts with the nullable `ClimbMirroredEvent.uuid` right below).
- **Mobile** `theme/tokens.ts` + `persistent-queue-bar.tsx` — Hoist the repeated `'#000'` shadow colour into a single exported `shadowColor` token.

## Test plan

- [x] `vp run typecheck:web` — passes
- [x] `vp run typecheck:mobile` — passes
- [x] `vp test --project web` — 9 new mapper tests pass alongside the existing suite
- [ ] OTA verify the queue bar shadow renders identically on a physical device

🤖 Generated with [Claude Code](https://claude.com/claude-code)