### PR TITLE
fix(vercel): serialize lifecycle scripts to prevent OOM during install

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "bun install --frozen-lockfile",
+  "installCommand": "bun install --frozen-lockfile --concurrent-scripts=1",
   "buildCommand": "if [ \"$VERCEL_ENV\" != \"preview\" ]; then bun run --filter=@boardsesh/db db:migrate; fi && bun run --filter=@boardsesh/web build",
   "outputDirectory": "packages/web/.next",
   "framework": "nextjs",


### PR DESCRIPTION
## Summary

- Adds `--concurrent-scripts=1` to the Vercel `installCommand` in `vercel.json`
- Vercel's build was OOMing (SIGKILL) during `bun install --frozen-lockfile` on its 4-core/8 GB container

**Root cause:** `bun install` runs up to 5 lifecycle/postinstall scripts in parallel by default. The recent addition of `sharp` to root `devDependencies` (alongside the existing React Native / Expo native module tree with 40+ packages) pushed the concurrent native binary builds past available memory. Peak usage at 5× parallel native scripts (sharp libvips, expo-modules-core, react-native, etc.) exceeded 8 GB.

**Fix:** `--concurrent-scripts=1` serialises postinstall scripts so peak memory is bounded by the single largest script rather than 5 running simultaneously. Install takes a few seconds longer but reliably completes.

## Test plan

- [ ] Trigger a Vercel preview deploy from this branch and confirm `bun install` completes without OOM
- [ ] Confirm the Next.js build step completes and the preview URL is reachable

https://claude.ai/code/session_01HquVusoNwDCdtEkn6YHXi2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HquVusoNwDCdtEkn6YHXi2)_