### PR TITLE
fix(join): cookie wins over stale IndexedDB on /join restore

### DIFF
--- a/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
@@ -140,12 +140,8 @@ beforeEach(async () => {
   mockWsAuth.token = 'test-token';
   mockWsAuth.isLoading = false;
 
-  // Reset the climb-session cookie so cookie state from a prior test doesn't
-  // leak into the next (the stale-vs-fresh-/join guard in useQueueStorage
-  // reads document.cookie).
-  if (typeof document !== 'undefined') {
-    document.cookie = 'boardsesh-climb-session-id=; path=/; SameSite=Lax; max-age=0';
-  }
+  // Reset the climb-session cookie so cookie state doesn't leak between tests.
+  document.cookie = 'boardsesh-climb-session-id=; path=/; SameSite=Lax; max-age=0';
 
   // Clear preferences DB
   try {
@@ -530,9 +526,7 @@ describe('Stale IndexedDB vs fresh /join cookie', () => {
     document.cookie = `boardsesh-climb-session-id=${encodeURIComponent(sessionId)}; path=/; SameSite=Lax; max-age=86400`;
   }
 
-  it('discards the IndexedDB entry when the cookie has a different sessionId', async () => {
-    // Simulate the bug scenario: IndexedDB still has the user's previous
-    // session A, but they just clicked /join/B which set the cookie to B.
+  it('skips activation when the cookie has a different sessionId and leaves IndexedDB intact', async () => {
     const stale = {
       sessionId: 'session-A-old',
       boardPath: '/kilter/1/10/1,2/40/list',
@@ -554,16 +548,12 @@ describe('Stale IndexedDB vs fresh /join cookie', () => {
       expect(result.current.isLocalQueueLoaded).toBe(true);
     });
 
-    // The stale session must not be activated — BoardSessionBridge will
-    // activate B from the cookie on the board route.
     expect(result.current.activeSession).toBeNull();
 
-    // IndexedDB should be cleared so a later restore can't replay the stale
-    // entry.
+    // IndexedDB is preserved — BoardSessionBridge overwrites on a successful join, and an unvalidated cookie (e.g. legacy ?session= migration) can still fall back to the persisted entry.
     const stored = await getPreference(ACTIVE_SESSION_KEY);
-    expect(stored).toBeNull();
+    expectSession(stored, stale);
 
-    // The auto-finished pre-flight should never have run for the stale entry.
     expect(mockHttpRequest).not.toHaveBeenCalled();
   });
 

--- a/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/persistent-session-restore.test.tsx
@@ -140,6 +140,13 @@ beforeEach(async () => {
   mockWsAuth.token = 'test-token';
   mockWsAuth.isLoading = false;
 
+  // Reset the climb-session cookie so cookie state from a prior test doesn't
+  // leak into the next (the stale-vs-fresh-/join guard in useQueueStorage
+  // reads document.cookie).
+  if (typeof document !== 'undefined') {
+    document.cookie = 'boardsesh-climb-session-id=; path=/; SameSite=Lax; max-age=0';
+  }
+
   // Clear preferences DB
   try {
     const prefsDb = await openDB(PREFS_DB_NAME, 1, {
@@ -511,5 +518,105 @@ describe('PersistentSessionProvider auto-restore on mount', () => {
       const stored = await getPreference(ACTIVE_SESSION_KEY);
       expect(stored).toBeNull();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Stale IndexedDB session vs. fresh /join cookie
+// ---------------------------------------------------------------------------
+
+describe('Stale IndexedDB vs fresh /join cookie', () => {
+  function setClimbCookie(sessionId: string) {
+    document.cookie = `boardsesh-climb-session-id=${encodeURIComponent(sessionId)}; path=/; SameSite=Lax; max-age=86400`;
+  }
+
+  it('discards the IndexedDB entry when the cookie has a different sessionId', async () => {
+    // Simulate the bug scenario: IndexedDB still has the user's previous
+    // session A, but they just clicked /join/B which set the cookie to B.
+    const stale = {
+      sessionId: 'session-A-old',
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails: createTestBoardDetails(),
+      parsedParams: {
+        board_name: 'kilter' as const,
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1, 2],
+        angle: 40,
+      },
+    };
+    await setPreference(ACTIVE_SESSION_KEY, stale);
+    setClimbCookie('session-B-fresh');
+
+    const { result } = renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLocalQueueLoaded).toBe(true);
+    });
+
+    // The stale session must not be activated — BoardSessionBridge will
+    // activate B from the cookie on the board route.
+    expect(result.current.activeSession).toBeNull();
+
+    // IndexedDB should be cleared so a later restore can't replay the stale
+    // entry.
+    const stored = await getPreference(ACTIVE_SESSION_KEY);
+    expect(stored).toBeNull();
+
+    // The auto-finished pre-flight should never have run for the stale entry.
+    expect(mockHttpRequest).not.toHaveBeenCalled();
+  });
+
+  it('restores normally when the cookie matches the persisted sessionId', async () => {
+    const sessionInfo = {
+      sessionId: 'session-match',
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails: createTestBoardDetails(),
+      parsedParams: {
+        board_name: 'kilter' as const,
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1, 2],
+        angle: 40,
+      },
+    };
+    await setPreference(ACTIVE_SESSION_KEY, sessionInfo);
+    setClimbCookie('session-match');
+
+    const { result } = renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expectSession(result.current.activeSession, sessionInfo);
+    });
+
+    const stored = await getPreference(ACTIVE_SESSION_KEY);
+    expectSession(stored, sessionInfo);
+  });
+
+  it('restores normally when no cookie is set (legacy reload path)', async () => {
+    // No cookie — fresh page reload with no /join interaction. The persisted
+    // session is the only signal we have, so it should be restored.
+    const sessionInfo = {
+      sessionId: 'session-no-cookie',
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails: createTestBoardDetails(),
+      parsedParams: {
+        board_name: 'kilter' as const,
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1, 2],
+        angle: 40,
+      },
+    };
+    await setPreference(ACTIVE_SESSION_KEY, sessionInfo);
+
+    const { result } = renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expectSession(result.current.activeSession, sessionInfo);
+    });
+
+    const stored = await getPreference(ACTIVE_SESSION_KEY);
+    expectSession(stored, sessionInfo);
   });
 });

--- a/packages/web/app/components/persistent-session/hooks/use-queue-storage.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-queue-storage.ts
@@ -91,23 +91,14 @@ export function useQueueStorage({
       try {
         const persisted = await getPreference<ActiveSessionInfo>(ACTIVE_SESSION_KEY);
         if (persisted && persisted.sessionId && persisted.boardPath && persisted.boardDetails) {
-          // Stale-vs-fresh-/join guard: if a cookie session ID is present and
-          // disagrees with what's in IndexedDB, the cookie wins. Cookie writes
-          // are always explicit (start-sesh-drawer, joinSession, the
-          // /api/internal/join route handler, or the legacy ?session=
-          // migration), so a mismatch means the user just joined a new session
-          // and the IndexedDB entry is left over from before. Without this
-          // check the restore can race BoardSessionBridge's cookie-driven
-          // activation and silently join the old session — and on a malformed-
-          // boardPath redirect to `/` the bridge never mounts to correct it.
+          // Cookie wins over stale IndexedDB — skip activation and let BoardSessionBridge activate the cookie's session. Leave IndexedDB intact so an unvalidated cookie (e.g. legacy ?session= migration) can't wipe a recoverable entry.
           const cookieSessionId = getClimbSessionCookie();
           if (cookieSessionId && cookieSessionId !== persisted.sessionId) {
             if (DEBUG)
-              console.info(
-                '[PersistentSession] Cookie session differs from persisted; discarding stale IndexedDB entry.',
-                { cookieSessionId, persistedSessionId: persisted.sessionId },
-              );
-            await removePreference(ACTIVE_SESSION_KEY);
+              console.info('[PersistentSession] Cookie session differs from persisted; skipping restore.', {
+                cookieSessionId,
+                persistedSessionId: persisted.sessionId,
+              });
             hasRunPreflightRef.current = true;
             setIsLocalQueueLoaded(true);
             return;

--- a/packages/web/app/components/persistent-session/hooks/use-queue-storage.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-queue-storage.ts
@@ -5,6 +5,7 @@ import type { BoardDetails } from '@/app/lib/types';
 import { getPreference, removePreference } from '@/app/lib/user-preferences-db';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { GET_SESSION_SUMMARY, type GetSessionSummaryResponse } from '@boardsesh/graphql/operations/sessions';
+import { getClimbSessionCookie } from '@/app/lib/climb-session-cookie';
 import { type ActiveSessionInfo, ACTIVE_SESSION_KEY, DEBUG } from '../types';
 
 type UseQueueStorageArgs = {
@@ -90,6 +91,28 @@ export function useQueueStorage({
       try {
         const persisted = await getPreference<ActiveSessionInfo>(ACTIVE_SESSION_KEY);
         if (persisted && persisted.sessionId && persisted.boardPath && persisted.boardDetails) {
+          // Stale-vs-fresh-/join guard: if a cookie session ID is present and
+          // disagrees with what's in IndexedDB, the cookie wins. Cookie writes
+          // are always explicit (start-sesh-drawer, joinSession, the
+          // /api/internal/join route handler, or the legacy ?session=
+          // migration), so a mismatch means the user just joined a new session
+          // and the IndexedDB entry is left over from before. Without this
+          // check the restore can race BoardSessionBridge's cookie-driven
+          // activation and silently join the old session — and on a malformed-
+          // boardPath redirect to `/` the bridge never mounts to correct it.
+          const cookieSessionId = getClimbSessionCookie();
+          if (cookieSessionId && cookieSessionId !== persisted.sessionId) {
+            if (DEBUG)
+              console.info(
+                '[PersistentSession] Cookie session differs from persisted; discarding stale IndexedDB entry.',
+                { cookieSessionId, persistedSessionId: persisted.sessionId },
+              );
+            await removePreference(ACTIVE_SESSION_KEY);
+            hasRunPreflightRef.current = true;
+            setIsLocalQueueLoaded(true);
+            return;
+          }
+
           if (DEBUG) console.info('[PersistentSession] Restoring persisted session:', persisted.sessionId);
 
           if (!wsAuthToken) {


### PR DESCRIPTION
## Summary

- Joining `/join/<B>` while a prior session sits in IndexedDB could leave the user connected to the old session A instead of B. On the malformed-boardPath fallback to `/`, the user was silently stuck in A (e.g. \"ended up joining someone else's session entirely\").
- Root cause: `useQueueStorage.restoreState` reads IndexedDB and activates the persisted session, racing `BoardSessionBridge`'s cookie-driven activation. The bridge's IndexedDB write is async, so the restore can read stale data and override. On non-board destinations the bridge never mounts at all.
- Fix: in `restoreState`, compare the persisted sessionId to `getClimbSessionCookie()`. If they disagree (and the cookie is set), discard the IndexedDB entry and skip activation — the bridge (or next board navigation) activates the cookie's session. Cookie writes are always explicit, so a mismatch is a deterministic stale signal.

Reported with session `0d51f9fe-124e-4dca-aa8b-ebc6427a5084`.

## Test plan

- [x] `vp test --project web run persistent-session-restore` — 14/14 pass, including 3 new tests (mismatch → discard, match → restore, no-cookie → restore).
- [x] `vp run typecheck:web` — clean.
- [x] `vp check` on the two touched files — clean (other formatting issues in the tree are pre-existing).
- [ ] Manual end-to-end:
  - Sign in, create or join session A. Confirm cookie + IndexedDB show A.
  - In a second tab, open `/join/<B>` for a different existing session. Confirm URL settles on B's boardPath, the queue/bottom bar reflects B, and IndexedDB now shows B.
  - With a deliberately malformed boardPath for B, confirm redirect to `/`, cookie set to B, no session activated; navigating to a board route then activates B.
  - Refresh after ending a session — fresh state, no stale restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)