### PR TITLE
fix(vercel): move config to packages/web so Next.js is detected

### DIFF
--- a/docs/branch-deploys.md
+++ b/docs/branch-deploys.md
@@ -12,6 +12,15 @@ Boardsesh is a monorepo with three deployable services:
 | **Backend** (`packages/backend`) | Railway (Node.js)   | Docker container at `{PRID}.ws.preview.boardsesh.com` |
 | **Database** (`packages/db`)     | Neon PostgreSQL     | `boardsesh-dev-db` Docker image (per PR)              |
 
+### Vercel project settings (production)
+
+The web project deploys from `packages/web`, not the repo root. Two dashboard settings under **Settings → Build & Deployment** are hard prerequisites — `packages/web/vercel.json` does nothing without them (and `vercel.json` is strict JSON, so this can't be a comment in the file):
+
+1. **Root Directory = `packages/web`.** This is how Vercel finds `next` (it lives only in `packages/web/package.json`, not the root). Without it the build fails with `No Next.js version detected`.
+2. **"Include source files outside of the Root Directory in the Build Step" = on.** The build reaches outside `packages/web`: `bun.lock` lives at the repo root (so `bun install --frozen-lockfile` walks up to find it), Next transpiles sibling workspace packages from source, and `outputFileTracingIncludes` pulls the board-renderer WASM from the hoisted root `node_modules`. With the toggle off, Vercel clones only `packages/web` and the install regenerates or rejects the lockfile.
+
+Keep the larger build machine — `bun install` builds `sharp` plus the Expo/React Native native tree and OOMs on the default size.
+
 ### What Broke
 
 Branch deploys stopped working after migrating from Vercel Postgres (which was a managed Neon account under Vercel) to a direct Neon paid account. Specifically:
@@ -1487,7 +1496,7 @@ Backend-affecting paths are defined in two places that must stay in sync:
 | `packages/backend/src/server.ts`              | All backend HTTP routes, session cleanup                                      |
 | `packages/backend/Dockerfile`                 | Backend container build                                                       |
 | `packages/aurora-sync/`                       | Shared sync library used by both web and backend                              |
-| `packages/web/vercel.json`                                 | Build command (migration skip), cron definitions                              |
+| `packages/web/vercel.json`                    | Build command (migration skip), cron definitions                              |
 | `.github/workflows/branch-deploy.yml`         | Build images + trigger Ansible deploy on PR open/sync                         |
 | `.github/workflows/branch-deploy-cleanup.yml` | Trigger Ansible cleanup + GHCR delete on PR close                             |
 | `.github/workflows/branch-deploy-sweep.yml`   | Trigger Ansible sweep on push to main / daily                                 |

--- a/docs/branch-deploys.md
+++ b/docs/branch-deploys.md
@@ -17,7 +17,7 @@ Boardsesh is a monorepo with three deployable services:
 Branch deploys stopped working after migrating from Vercel Postgres (which was a managed Neon account under Vercel) to a direct Neon paid account. Specifically:
 
 1. **Neon branching integration is broken** - The Vercel-Neon integration that automatically created database branches per preview deployment no longer functions. Neon support has not resolved this.
-2. **Migrations are skipped on preview** - `vercel.json` explicitly skips migrations for preview deploys:
+2. **Migrations are skipped on preview** - `packages/web/vercel.json` explicitly skips migrations for preview deploys:
    ```json
    "buildCommand": "if [ \"$VERCEL_ENV\" != \"preview\" ]; then npm run db:migrate; fi && npm run build --workspace=@boardsesh/web"
    ```
@@ -45,7 +45,7 @@ Branch deploys stopped working after migrating from Vercel Postgres (which was a
 
 Drizzle migrations are idempotent - running them against the development database is safe. The current skip was a workaround for the broken Neon branching (to avoid running migrations against a non-existent branch DB). Since branch deploys use the pre-built `boardsesh-dev-db` Docker image (not the production database), migrations should run unconditionally.
 
-**Change in `vercel.json`:**
+**Change in `packages/web/vercel.json`:**
 
 ```json
 {
@@ -1172,7 +1172,7 @@ After API consolidation:
 
 Sync runs in two places:
 
-1. **Vercel crons** (`vercel.json:6-22`):
+1. **Vercel crons** (`packages/web/vercel.json`):
    - `/api/internal/shared-sync/tension` - every 2 hours
    - `/api/internal/shared-sync/kilter` - every 2 hours
    - `/api/internal/user-sync-cron` - every 2 hours
@@ -1209,7 +1209,7 @@ Sync runs in two places:
                -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}"
    ```
 
-4. **Remove Vercel crons** - Delete the `crons` array from `vercel.json` and remove the corresponding API route handlers.
+4. **Remove Vercel crons** - Delete the `crons` array from `packages/web/vercel.json` and remove the corresponding API route handlers.
 
 ### Branch Deploy Sync Strategy
 
@@ -1287,7 +1287,7 @@ What changed → what gets deployed:
 
 | Item                   | Cost                        | Complexity                         |
 | ---------------------- | --------------------------- | ---------------------------------- |
-| Vercel preview deploys | Free (included in plan)     | Minimal - one `vercel.json` change |
+| Vercel preview deploys | Free (included in plan)     | Minimal - one `packages/web/vercel.json` change |
 | GitHub Actions minutes | Free tier (~2000 min/month) | Low - simple workflow              |
 | **Total**              | **$0/month**                | **~1-2 days**                      |
 
@@ -1360,7 +1360,7 @@ What changed → what gets deployed:
 
 ### Phase 1: Frontend-Only Previews
 
-- [ ] Re-enable migrations in `vercel.json` build command
+- [ ] Re-enable migrations in `packages/web/vercel.json` build command
 - [ ] Set `NEXT_PUBLIC_WS_URL` in Vercel Preview environment scope
 - [ ] Create change detection workflow (`.github/workflows/branch-deploy.yml`)
 - [ ] Verify preview deployments connect to production backend
@@ -1487,7 +1487,7 @@ Backend-affecting paths are defined in two places that must stay in sync:
 | `packages/backend/src/server.ts`              | All backend HTTP routes, session cleanup                                      |
 | `packages/backend/Dockerfile`                 | Backend container build                                                       |
 | `packages/aurora-sync/`                       | Shared sync library used by both web and backend                              |
-| `vercel.json`                                 | Build command (migration skip), cron definitions                              |
+| `packages/web/vercel.json`                                 | Build command (migration skip), cron definitions                              |
 | `.github/workflows/branch-deploy.yml`         | Build images + trigger Ansible deploy on PR open/sync                         |
 | `.github/workflows/branch-deploy-cleanup.yml` | Trigger Ansible cleanup + GHCR delete on PR close                             |
 | `.github/workflows/branch-deploy-sweep.yml`   | Trigger Ansible sweep on push to main / daily                                 |

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -132,5 +132,8 @@
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-arm64-gnu": "^4.59.0"
+  },
+  "engines": {
+    "node": "22.x"
   }
 }

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -1,7 +1,6 @@
 {
-  "installCommand": "bun install --frozen-lockfile --concurrent-scripts=1",
+  "installCommand": "bun install --frozen-lockfile",
   "buildCommand": "if [ \"$VERCEL_ENV\" != \"preview\" ]; then bun run --filter=@boardsesh/db db:migrate; fi && bun run --filter=@boardsesh/web build",
-  "outputDirectory": "packages/web/.next",
   "framework": "nextjs",
   "crons": [
     {


### PR DESCRIPTION
## Problem

The Vercel deploy was OOM-ing during `bun install`. That was fixed by moving to a bigger build machine — but with install now completing, the build reaches Vercel's framework-detection step and fails:

```
Warning: Could not identify Next.js version, ensure it is defined as a project dependency.
Error: No Next.js version detected. Make sure your package.json has "next" in either
"dependencies" or "devDependencies". Also check your Root Directory setting matches the
directory of your package.json file.
```

**Root cause:** Vercel's Root Directory is the repo root, so framework detection reads the root `package.json` — which has no `next` (only `react`/`react-dom`). `next` (`^16.1.6`) lives only in `packages/web/package.json`. The deploy log's install line (`bun install --frozen-lockfile --concurrent-scripts=1`) is the repo-root `vercel.json`'s `installCommand` verbatim, confirming Vercel reads the root config.

## Fix

Point Vercel at the package that owns `next`.

**Repo changes (this PR):**
- Move `vercel.json` → `packages/web/vercel.json` (Vercel reads `vercel.json` from the Root Directory).
- Drop `--concurrent-scripts=1` from `installCommand` — it did not fix the OOM on the smaller machine; the bigger machine did.
- Drop `outputDirectory` — relative to the new Root Directory the default `.next` location is already correct (the old `packages/web/.next` value would now resolve wrong).
- Keep the `--filter` build/migrate commands byte-for-byte (they resolve by package name against the workspace root, cwd-independent) — preserves the preview-skips-migration `VERCEL_ENV` guard.
- Pin `engines.node = 22.x` in `packages/web/package.json` so the Node version survives the move (after the Root Directory change Vercel no longer reads the repo-root `.node-version`/`engines`).
- Light doc path fixups in `docs/branch-deploys.md` (references to `vercel.json` → `packages/web/vercel.json`).

## Required Vercel dashboard change (not in this PR)

This PR is inert until the project setting is changed:

- **Settings → Build & Deployment → Root Directory = `packages/web`.**
- Verify **"Include source files outside of the Root Directory in the Build Step"** is on — the build reaches outside `packages/web` (transpiled sibling packages + board-renderer WASM tracing).
- Keep the larger build machine.

## Verification

This PR's **preview deployment is the end-to-end test** once Root Directory is set: it should clear the "No Next.js version detected" error, install the workspace, run `next build` on Node 22.x, and serve a working preview URL (preview skips `db:migrate` via the `VERCEL_ENV` guard). Production then runs `db:migrate` before building.

https://claude.ai/code/session_01DDNQVdEZvT33y8spZ7avXx

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDNQVdEZvT33y8spZ7avXx)_