### PR TITLE
fix(mobile): unblock iOS simulator after Tailscale Metro pinning

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process';
+import { networkInterfaces } from 'node:os';
 import type { ExpoConfig, ConfigContext } from 'expo/config';
 
 const DEFAULT_EAS_PROJECT_ID = '87499648-655e-4fb8-9856-65da37e55fb1';
@@ -26,6 +27,28 @@ function normalizeHost(host: string): string {
 
 function normalizeHostValues(hostValues: readonly string[]): string[] {
   return hostValues.map(normalizeHost).filter((host) => host.length > 0);
+}
+
+function resolveLanHosts(): string[] {
+  // Cloud builders don't have a useful LAN identity for an on-device dev
+  // client to reach back to. Skip the lookup to keep extras deterministic.
+  if (process.env.CI || process.env.EAS_BUILD || process.env.EAS_BUILD_RUNNER) {
+    return [];
+  }
+
+  const interfaces = networkInterfaces();
+  const addresses: string[] = [];
+  for (const ifaceAddrs of Object.values(interfaces)) {
+    if (!ifaceAddrs) continue;
+    for (const addr of ifaceAddrs) {
+      if (addr.family !== 'IPv4') continue;
+      if (addr.internal) continue;
+      // 169.254/16 link-local addresses aren't routable from another device.
+      if (addr.address.startsWith('169.254.')) continue;
+      addresses.push(addr.address);
+    }
+  }
+  return Array.from(new Set(addresses));
 }
 
 function resolveTailscaleHosts(): string[] {
@@ -76,7 +99,12 @@ function isDevBuildProfile(): boolean {
 export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: boolean } => {
   const devMetadata = resolveDevMetadata();
   const hasDevMetadata = devMetadata.branchName || devMetadata.qaNotes || devMetadata.qaNotesFilePath;
-  const tailscaleHosts = resolveTailscaleHosts();
+  // Hosts the in-app dev-server switcher will probe for live Metro bundlers.
+  // localhost covers the simulator, LAN IPs cover same-Wi-Fi devices, tailnet
+  // names cover off-LAN devices on the same tailnet.
+  const devBundlerHosts = Array.from(
+    new Set(normalizeHostValues(['localhost', ...resolveLanHosts(), ...resolveTailscaleHosts()])),
+  );
   const isDevBuild = isDevBuildProfile();
 
   return {
@@ -181,7 +209,7 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
             },
           }
         : {}),
-      ...(tailscaleHosts.length > 0 ? { tailscaleHosts } : {}),
+      ...(devBundlerHosts.length > 0 ? { devBundlerHosts } : {}),
     },
   };
 };

--- a/packages/mobile/src/components/DevServerSwitcherScreen.tsx
+++ b/packages/mobile/src/components/DevServerSwitcherScreen.tsx
@@ -34,8 +34,8 @@ type ExpoDevLauncherModule = {
 
 const ExpoDevLauncher = requireOptionalNativeModule<ExpoDevLauncherModule>('ExpoDevLauncher');
 
-function getTailscaleHosts(): string[] {
-  const hosts = Constants.expoConfig?.extra?.tailscaleHosts;
+function getDevBundlerHosts(): string[] {
+  const hosts = Constants.expoConfig?.extra?.devBundlerHosts;
   if (!Array.isArray(hosts)) return [];
   return hosts.filter((host): host is string => typeof host === 'string' && host.length > 0);
 }
@@ -67,7 +67,7 @@ export function DevServerSwitcherScreen() {
   const [isAddPromptOpen, setIsAddPromptOpen] = useState(false);
   const [addInputValue, setAddInputValue] = useState('');
 
-  const tailscaleHosts = useMemo(getTailscaleHosts, []);
+  const bundlerHosts = useMemo(getDevBundlerHosts, []);
   const savedTargetsQuery = useQuery({
     queryKey: ['saved-metro-targets'],
     queryFn: getSavedMetroTargets,
@@ -76,11 +76,11 @@ export function DevServerSwitcherScreen() {
   const savedTargets = savedTargetsQuery.data ?? [];
 
   const bundlersQuery = useQuery({
-    queryKey: ['dev-bundlers', tailscaleHosts, savedTargets],
+    queryKey: ['dev-bundlers', bundlerHosts, savedTargets],
     // React Query passes its own AbortSignal — propagate so invalidations
     // (pull-to-refresh, savedTargets change) cancel in-flight port probes
     // instead of leaving them running to completion.
-    queryFn: ({ signal }) => discoverBundlers({ hosts: tailscaleHosts, savedTargets, signal }),
+    queryFn: ({ signal }) => discoverBundlers({ hosts: bundlerHosts, savedTargets, signal }),
     staleTime: 30_000,
     enabled: savedTargetsQuery.isSuccess,
   });
@@ -221,9 +221,9 @@ export function DevServerSwitcherScreen() {
         contentInsetAdjustmentBehavior="automatic"
         refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
       >
-        {/* ---- Tailnet status ---- */}
+        {/* ---- Dev bundlers status ---- */}
         {/* i18n-ignore-next-line */}
-        <SectionHeader title="Tailnet" />
+        <SectionHeader title="Dev bundlers" />
         <View
           style={[
             styles.card,
@@ -235,7 +235,7 @@ export function DevServerSwitcherScreen() {
           ]}
         >
           {/* i18n-ignore-next-line */}
-          <InfoRow label="Hosts embedded" value={String(tailscaleHosts.length)} />
+          <InfoRow label="Hosts probed" value={String(bundlerHosts.length)} />
           {/* i18n-ignore-next-line */}
           <InfoRow label="Saved targets" value={String(savedTargets.length)} />
           {/* i18n-ignore-next-line */}
@@ -278,7 +278,7 @@ export function DevServerSwitcherScreen() {
           <View style={styles.centered}>
             <ActivityIndicator />
           </View>
-        ) : tailscaleHosts.length === 0 && savedTargets.length === 0 ? (
+        ) : bundlerHosts.length === 0 && savedTargets.length === 0 ? (
           <View style={[styles.errorContainer, { marginHorizontal: spacing[4] }]}>
             {/* i18n-ignore-next-line */}
             <Text variant="footnote" color={systemColors.secondaryLabel}>

--- a/scripts/mobile-dev-start.ts
+++ b/scripts/mobile-dev-start.ts
@@ -207,18 +207,24 @@ async function main() {
   }
 
   // Default to --host lan so devices on the same Tailnet/LAN can reach the
-  // bundler. Simulator mode skips this so Expo's auto-detect advertises
-  // localhost for the simulator client. Respect a user-supplied --host either way.
-  const userPassedHost = metroPassthroughArgs.some((arg) => arg === '--host' || arg.startsWith('--host='));
+  // bundler. Simulator mode pins --host localhost — Expo's default is `lan`
+  // and the LAN auto-detect can pick a Tailscale/utun interface the simulator
+  // can't reach, which would re-trigger the original "could not connect" bug.
+  // Respect a user-supplied --host either way.
+  const userPassedHost = metroPassthroughArgs.some(
+    (arg) =>
+      arg === '--host' || arg.startsWith('--host=') || arg === '--localhost' || arg === '--lan' || arg === '--tunnel',
+  );
   // We ship a custom dev client (EAS preview-build flow); Metro must serve the
   // dev-client bundle, not the Expo Go one. Opt out by passing --go.
   const userPickedClient = passthroughArgs.some(
     (arg) => arg === '--dev-client' || arg === '--go' || arg.startsWith('--dev-client=') || arg.startsWith('--go='),
   );
+  const defaultHostArgs = userPassedHost ? [] : simulator ? ['--host', 'localhost'] : ['--host', 'lan'];
   const expoArgs = [
     'expo',
     'start',
-    ...(userPassedHost || simulator ? [] : ['--host', 'lan']),
+    ...defaultHostArgs,
     ...(userPickedClient ? [] : ['--dev-client']),
     ...metroPassthroughArgs,
   ];

--- a/scripts/mobile-dev-start.ts
+++ b/scripts/mobile-dev-start.ts
@@ -63,13 +63,19 @@ const DEFAULT_QA_NOTES_PATH = join(BOARDSESH_DIR, 'qa-notes.md');
 // CLI argument parsing
 // ---------------------------------------------------------------------------
 
-function parseArgs(args: string[]): { qaNotesFilePath: string | null; passthroughArgs: string[] } {
+function parseArgs(args: string[]): { qaNotesFilePath: string | null; simulator: boolean; passthroughArgs: string[] } {
   let qaNotesFilePath: string | null = null;
+  let simulator = process.env.BOARDSESH_DEV_SIMULATOR === '1';
   const passthroughArgs: string[] = [];
 
   for (let index = 0; index < args.length; index++) {
     const argument = args[index];
     if (argument === '--') continue;
+
+    if (argument === '--simulator') {
+      simulator = true;
+      continue;
+    }
 
     if (argument === '--qa-notes-file' || argument === '--qa-plan-file') {
       const nextArgument = args[index + 1];
@@ -99,7 +105,7 @@ function parseArgs(args: string[]): { qaNotesFilePath: string | null; passthroug
     passthroughArgs.push(argument);
   }
 
-  return { qaNotesFilePath, passthroughArgs };
+  return { qaNotesFilePath, simulator, passthroughArgs };
 }
 
 // ---------------------------------------------------------------------------
@@ -149,11 +155,15 @@ function resolveQaNotes(explicitPath: string | null): { contents: string | null;
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const { qaNotesFilePath: cliQaNotesPath, passthroughArgs } = parseArgs(process.argv.slice(2));
+  const { qaNotesFilePath: cliQaNotesPath, simulator, passthroughArgs } = parseArgs(process.argv.slice(2));
   const branchName = resolveCurrentBranchName();
   const commitSha = runGitCommand(['rev-parse', '--short', 'HEAD']);
   const qaNotes = resolveQaNotes(cliQaNotesPath);
-  const tailscale = resolveTailscaleHostname();
+  // Simulator mode skips the tailnet probe entirely. The iOS Simulator's
+  // CFNetwork sandbox can't reach the host's Tailscale MagicDNS hostname
+  // reliably, so pinning REACT_NATIVE_PACKAGER_HOSTNAME to the tailnet name
+  // makes the initial bundle load fail with "could not connect".
+  const tailscale = simulator ? null : resolveTailscaleHostname();
   const metroPort = await resolveMetroPort(passthroughArgs);
   const metroPassthroughArgs = withMetroPort(passthroughArgs, metroPort);
   const startedAt = new Date().toISOString();
@@ -167,12 +177,16 @@ async function main() {
     console.log(`[dev:mobile] QA notes: ${qaNotes.filePath}`);
   }
   console.log(`[dev:mobile] Worktree: ${worktreeLabel}`);
-  console.log(`[dev:mobile] Hostname: ${tailscale.hostname} (${tailscale.source})`);
-  if (tailscale.reason) {
-    console.log(`[dev:mobile] ${tailscale.reason}`);
-  }
-  if (tailscale.source !== 'fallback') {
-    console.log(`[dev:mobile] Metro: http://${tailscale.hostname}:${metroPort}`);
+  if (simulator) {
+    console.log(`[dev:mobile] Simulator mode: serving bundles at http://localhost:${metroPort}`);
+  } else if (tailscale) {
+    console.log(`[dev:mobile] Hostname: ${tailscale.hostname} (${tailscale.source})`);
+    if (tailscale.reason) {
+      console.log(`[dev:mobile] ${tailscale.reason}`);
+    }
+    if (tailscale.source !== 'fallback') {
+      console.log(`[dev:mobile] Metro: http://${tailscale.hostname}:${metroPort}`);
+    }
   }
   console.log(`[dev:mobile] Metro log: .boardsesh/mobile-metro.log`);
 
@@ -188,12 +202,13 @@ async function main() {
   childEnv.BOARDSESH_DEV_WORKTREE_LABEL = worktreeLabel;
   childEnv.BOARDSESH_DEV_STARTED_AT = startedAt;
   childEnv.BOARDSESH_METRO_PORT = String(metroPort);
-  if (tailscale.source !== 'fallback') {
+  if (tailscale && tailscale.source !== 'fallback') {
     childEnv.REACT_NATIVE_PACKAGER_HOSTNAME = tailscale.hostname;
   }
 
-  // Bind Metro on 0.0.0.0 (Expo's --host lan) so devices on the same Tailnet can
-  // reach the bundler. Respect a user-supplied --host so manual overrides win.
+  // Default to --host lan so devices on the same Tailnet/LAN can reach the
+  // bundler. Simulator mode skips this so Expo's auto-detect advertises
+  // localhost for the simulator client. Respect a user-supplied --host either way.
   const userPassedHost = metroPassthroughArgs.some((arg) => arg === '--host' || arg.startsWith('--host='));
   // We ship a custom dev client (EAS preview-build flow); Metro must serve the
   // dev-client bundle, not the Expo Go one. Opt out by passing --go.
@@ -203,7 +218,7 @@ async function main() {
   const expoArgs = [
     'expo',
     'start',
-    ...(userPassedHost ? [] : ['--host', 'lan']),
+    ...(userPassedHost || simulator ? [] : ['--host', 'lan']),
     ...(userPickedClient ? [] : ['--dev-client']),
     ...metroPassthroughArgs,
   ];


### PR DESCRIPTION
## Summary
- Pinning `REACT_NATIVE_PACKAGER_HOSTNAME` to the Mac's tailnet MagicDNS name made the iOS Simulator's first bundle load fail with "could not connect" — the simulator's CFNetwork sandbox can't reliably traverse Tailscale's `utun` back to the host. Add a `--simulator` flag (also `BOARDSESH_DEV_SIMULATOR=1`) on `vp run dev:mobile` that skips the tailnet probe and drops the `--host lan` default so Expo's auto-detect advertises `localhost` to the simulator client.
- The in-app dev-server switcher now probes `localhost`, every non-internal LAN IPv4 address, and the existing tailnet hosts. They're embedded in `extra.devBundlerHosts` at config time so one switcher screen surfaces every reachable bundler. Replaces `extra.tailscaleHosts`.

Stacked on #2340 — base branch is `claude/pr-2338-code-reuse-3Ebx2` so the multi-bundler commits being fixed are in scope.

## Test plan
- [x] `vp run typecheck:mobile`
- [x] `vp test --project mobile --reporter=agent` (361 passed)
- [x] `vp check` on the three touched files
- [ ] Manual: `vp run dev:mobile -- --simulator`, banner shows `Simulator mode: serving bundles at http://localhost:<port>`, simulator dev client loads. Open the dev-server switcher; `localhost`, LAN IPs, and tailnet host all appear under "Dev bundlers".
- [ ] Manual: `vp run dev:mobile` (no flag), physical iPhone on tailnet still loads dev-client as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)