### PR TITLE
fix(backend): accept session and gym in commentUpdates subscription (#2357)

### DIFF
--- a/packages/backend/src/graphql/resolvers/social/__tests__/comment-subscriptions.test.ts
+++ b/packages/backend/src/graphql/resolvers/social/__tests__/comment-subscriptions.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression tests for the commentUpdates subscription resolver (issue #2357).
+ *
+ * The resolver guards `entityType` against an allow-list before opening a
+ * pubsub channel. That list used to be hand-rolled and silently dropped
+ * 'session' and 'gym', so realtime comments on /session/:sessionId and gym
+ * detail pages threw `Invalid entity type: session` on subscribe and never
+ * delivered events. The fix derives the allow-list from the shared Zod enum
+ * `SocialEntityTypeSchema`, so these tests lock the two lists together.
+ *
+ * Validation runs before any DB/Redis access, so pubsub and the async-iterator
+ * helper are mocked — the resolver never touches real infrastructure here.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+
+vi.mock('../../../../pubsub/index', () => ({
+  pubsub: { subscribeComments: vi.fn() },
+}));
+
+// createAsyncIterator resolves to an iterable that completes immediately, so a
+// subscription whose entityType passes validation finishes on the first next().
+vi.mock('../../shared/async-iterators', () => ({
+  createAsyncIterator: vi.fn(async () => ({
+    [Symbol.asyncIterator]() {
+      return { next: async () => ({ value: undefined, done: true }) };
+    },
+  })),
+}));
+
+import { socialCommentSubscriptions } from '../comment-subscriptions';
+import { createAsyncIterator } from '../../shared/async-iterators';
+import { SocialEntityTypeSchema } from '../../../../validation/schemas';
+
+function startSubscription(entityType: string, entityId: string) {
+  return socialCommentSubscriptions.commentUpdates.subscribe(
+    undefined,
+    { entityType, entityId },
+    {} as ConnectionContext,
+  );
+}
+
+describe('commentUpdates subscription — entityType validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accepts every SocialEntityType the schema allows (incl. session and gym)', async () => {
+    // Guard against a future regression: session and gym must stay in the enum.
+    expect(SocialEntityTypeSchema.options).toContain('session');
+    expect(SocialEntityTypeSchema.options).toContain('gym');
+
+    for (const entityType of SocialEntityTypeSchema.options) {
+      const subscription = startSubscription(entityType, 'entity-123');
+      // Passing validation lets the generator reach the (mocked, empty)
+      // iterator and complete without throwing "Invalid entity type".
+      await expect(subscription.next()).resolves.toEqual({ value: undefined, done: true });
+      expect(vi.mocked(createAsyncIterator)).toHaveBeenCalledTimes(1);
+      vi.clearAllMocks();
+    }
+  });
+
+  it('rejects an entityType outside the schema and never opens a channel', async () => {
+    const subscription = startSubscription('user', 'entity-123');
+    await expect(subscription.next()).rejects.toThrow('Invalid entity type: user');
+    expect(vi.mocked(createAsyncIterator)).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty or over-long entityId before opening a channel', async () => {
+    const empty = startSubscription('session', '');
+    await expect(empty.next()).rejects.toThrow('Invalid entity ID');
+
+    const tooLong = startSubscription('session', 'x'.repeat(257));
+    await expect(tooLong.next()).rejects.toThrow('Invalid entity ID');
+
+    expect(vi.mocked(createAsyncIterator)).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/graphql/resolvers/social/comment-subscriptions.ts
+++ b/packages/backend/src/graphql/resolvers/social/comment-subscriptions.ts
@@ -1,8 +1,12 @@
 import type { ConnectionContext, CommentEvent } from '@boardsesh/shared-schema';
 import { pubsub } from '../../../pubsub/index';
 import { createAsyncIterator } from '../shared/async-iterators';
+import { SocialEntityTypeSchema } from '../../../validation/schemas';
 
-const VALID_ENTITY_TYPES = new Set(['playlist_climb', 'climb', 'tick', 'comment', 'proposal', 'board']);
+// Derive the allow-list from the shared Zod enum so it can never drift from
+// SocialEntityType. A hand-rolled list here previously dropped 'session' and
+// 'gym', breaking realtime comments on those pages (issue #2357).
+const VALID_ENTITY_TYPES = new Set<string>(SocialEntityTypeSchema.options);
 
 // Composite entity IDs (e.g. "playlist_uuid:climb_uuid") can be long but
 // should never exceed a reasonable bound. UUIDs are 36 chars, so a composite


### PR DESCRIPTION
## Problem

`commentUpdates` subscriptions throw `Invalid entity type: session` (and would also throw for `gym`) in production. The subscribe handler validated `entityType` against a hand-rolled allow-list:

```ts
const VALID_ENTITY_TYPES = new Set(['playlist_climb', 'climb', 'tick', 'comment', 'proposal', 'board']);
```

It was missing `session` and `gym` — both valid per the `SocialEntityType` enum / `SocialEntityTypeSchema` Zod enum, and both actively used by the web client (`/session/:sessionId`, gym detail, session feed cards). Every subscription for those types threw synchronously in `subscribe()`, so clients never received realtime comment events. Comment **mutations** go through a different resolver and kept working, which masked the breakage — users saw their own comments after a refresh but never saw others' arrive live.

The DB confirms real (non-test) users have posted `session` (6) and `gym` (1) comments, so this was silently broken in production.

## Fix

Derive the allow-list from the shared `SocialEntityTypeSchema` Zod enum (`z.enum(...).options`) — the single source of truth every other social resolver already validates against. The two lists can no longer drift.

```ts
const VALID_ENTITY_TYPES = new Set<string>(SocialEntityTypeSchema.options);
```

This was the only place in the backend hand-rolling this list.

## Test

Adds `comment-subscriptions.test.ts` (the resolver had no tests). The validation runs before any DB/Redis access, so pubsub and the async-iterator helper are mocked. Cases:

- **Drift guard** — every `SocialEntityTypeSchema.options` value (incl. `session` and `gym`) is accepted and opens a channel. Fails on the pre-fix code; locks the two lists together going forward.
- Unknown `entityType` → rejects `Invalid entity type: <type>`, never opens a channel.
- Empty / over-256-char `entityId` → rejects `Invalid entity ID`, never opens a channel.

## Verification

- `vp test --project backend run` — 3/3 pass.
- `vp run typecheck:backend` — clean.
- Pre-commit hook (`vp check --fix` on staged files) — clean.

Fixes #2357

🤖 Generated with [Claude Code](https://claude.com/claude-code)
