### PR TITLE
fix: PR-2338 follow-up review findings

### DIFF
--- a/packages/mobile/src/lib/__tests__/abort-timeout.test.ts
+++ b/packages/mobile/src/lib/__tests__/abort-timeout.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { combineAbortSignals, createTimeoutSignal, mapWithConcurrency } from '../abort-timeout';
+
+describe('createTimeoutSignal', () => {
+  it('aborts after the timeout', async () => {
+    const signal = createTimeoutSignal(10);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(signal.aborted).toBe(true);
+  });
+});
+
+describe('combineAbortSignals', () => {
+  it('returns a signal that aborts when the first source aborts', () => {
+    const controllerA = new AbortController();
+    const controllerB = new AbortController();
+    const combined = combineAbortSignals(controllerA.signal, controllerB.signal);
+    expect(combined.aborted).toBe(false);
+    controllerA.abort(new Error('a'));
+    expect(combined.aborted).toBe(true);
+  });
+
+  it('is already aborted if any source was aborted at construction time', () => {
+    const controllerA = new AbortController();
+    controllerA.abort();
+    const controllerB = new AbortController();
+    const combined = combineAbortSignals(controllerA.signal, controllerB.signal);
+    expect(combined.aborted).toBe(true);
+  });
+
+  it('ignores undefined inputs', () => {
+    const controllerA = new AbortController();
+    const combined = combineAbortSignals(undefined, controllerA.signal, undefined);
+    expect(combined.aborted).toBe(false);
+    controllerA.abort();
+    expect(combined.aborted).toBe(true);
+  });
+});
+
+describe('mapWithConcurrency', () => {
+  it('preserves input order in the result array', async () => {
+    const results = await mapWithConcurrency([10, 20, 30, 40, 50], 2, async (value) => {
+      await new Promise((resolve) => setTimeout(resolve, value));
+      return value * 2;
+    });
+    expect(results).toEqual([20, 40, 60, 80, 100]);
+  });
+
+  it('caps in-flight calls at the given concurrency', async () => {
+    let active = 0;
+    let maxActive = 0;
+    await mapWithConcurrency([1, 2, 3, 4, 5, 6, 7, 8], 3, async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active--;
+      return null;
+    });
+    expect(maxActive).toBe(3);
+  });
+
+  it('throws the first error and lets siblings drain', async () => {
+    const completed: number[] = [];
+    const error = new Error('boom on index 2');
+
+    await expect(
+      mapWithConcurrency([0, 1, 2, 3, 4, 5], 3, async (value) => {
+        await new Promise((resolve) => setTimeout(resolve, value * 2));
+        if (value === 2) throw error;
+        completed.push(value);
+        return value;
+      }),
+    ).rejects.toThrow(error);
+
+    // All non-error items should have completed (workers keep draining
+    // after a sibling rejection).
+    expect(completed.sort()).toEqual([0, 1, 3, 4, 5]);
+  });
+
+  it('reports the FIRST error when multiple items reject', async () => {
+    const firstError = new Error('first');
+    const secondError = new Error('second');
+
+    await expect(
+      mapWithConcurrency([0, 1, 2, 3], 1, async (value) => {
+        if (value === 1) throw firstError;
+        if (value === 2) throw secondError;
+        return value;
+      }),
+    ).rejects.toBe(firstError);
+  });
+
+  it('distinguishes a thrown `undefined` from no error', async () => {
+    await expect(
+      mapWithConcurrency([0], 1, async () => {
+        // Legal but unusual — a literally-undefined rejection should still
+        // surface as a throw, not return a result.
+        throw undefined;
+      }),
+    ).rejects.toBeUndefined();
+  });
+
+  it('returns immediately on empty input', async () => {
+    const results = await mapWithConcurrency([], 4, async () => 'unreachable');
+    expect(results).toEqual([]);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/metro-target-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/metro-target-store.test.ts
@@ -47,6 +47,28 @@ describe('metro-target-store', () => {
     await expect(getSavedMetroTargets()).resolves.toEqual(['host-b.example']);
   });
 
+  it('normalizes the input on remove so non-normalized callers still match', async () => {
+    const { addSavedMetroTarget, getSavedMetroTargets, removeSavedMetroTarget } = await import('../metro-target-store');
+
+    // Add via the canonical form
+    await addSavedMetroTarget('host-a.example');
+    // Remove via a non-normalized form (uppercase, trailing slash, URL path).
+    // Without normalization the predicate would compare raw against stored
+    // and silently no-op.
+    await removeSavedMetroTarget('HOST-A.example');
+
+    await expect(getSavedMetroTargets()).resolves.toEqual([]);
+  });
+
+  it('also accepts URL-form remove values that normalize to a stored URL', async () => {
+    const { addSavedMetroTarget, getSavedMetroTargets, removeSavedMetroTarget } = await import('../metro-target-store');
+
+    await addSavedMetroTarget('http://host-a.example:8084');
+    await removeSavedMetroTarget('http://host-a.example:8084/foo');
+
+    await expect(getSavedMetroTargets()).resolves.toEqual([]);
+  });
+
   it('throws for invalid targets', async () => {
     const { addSavedMetroTarget } = await import('../metro-target-store');
 

--- a/packages/mobile/src/lib/abort-timeout.ts
+++ b/packages/mobile/src/lib/abort-timeout.ts
@@ -30,11 +30,18 @@ export function combineAbortSignals(...signals: (AbortSignal | undefined)[]): Ab
 // time. Preserves input order in the returned array. Used to keep the Metro
 // discovery scan from saturating the network stack on multi-host tailnets.
 //
-// If any `fn` call rejects, the worker keeps draining (so siblings already
-// in flight finish cleanly) and the first error is re-thrown once all
-// workers have settled. This matches Promise.all's "first error wins"
-// semantics without leaving uninitialized holes in a partially-completed
-// result array that a caller could read by mistake.
+// Error semantics: if any `fn` call rejects, sibling workers keep draining
+// so in-flight calls finish cleanly, and the first error is re-thrown once
+// all workers have settled. This matches `Promise.all`'s "first error wins"
+// shape.
+//
+// CAVEAT: on the throw path the returned `results` is internal-only — slots
+// for rejected items were never assigned, so the array is sparse (`R[]`
+// with `undefined` holes). The function throws before any caller can
+// observe it, but callers must not catch and then read `results` from a
+// caller-side reference: there isn't one, the variable is local. If you
+// ever expose partial results, return a tagged `{ values, errors }` shape
+// instead.
 export async function mapWithConcurrency<T, R>(
   items: readonly T[],
   concurrency: number,

--- a/packages/mobile/src/lib/metro-target-store.ts
+++ b/packages/mobile/src/lib/metro-target-store.ts
@@ -81,13 +81,18 @@ export async function addSavedMetroTarget(value: string): Promise<string> {
 }
 
 export async function removeSavedMetroTarget(value: string): Promise<void> {
+  // Stored entries are normalized on write (see addSavedMetroTarget +
+  // readStoredTargets), so we have to normalize the incoming value too —
+  // otherwise a caller passing the raw user-typed form ('HOST-A.example')
+  // would silently no-op against a stored entry ('host-a.example').
+  const normalizedValue = normalizeMetroTarget(value) ?? value;
   return enqueue(async () => {
     const stored = await readStoredTargets();
     // Same rule as add: don't overwrite an unparseable stored value.
     if (!stored.ok) {
       throw new Error('Saved Metro server list is corrupted — clear it from app data and retry');
     }
-    const updatedTargets = stored.targets.filter((target) => target !== value);
+    const updatedTargets = stored.targets.filter((target) => target !== normalizedValue);
     await SecureStore.setItemAsync(METRO_TARGETS_KEY, JSON.stringify(updatedTargets));
   });
 }

--- a/scripts/mobile-dev-start.ts
+++ b/scripts/mobile-dev-start.ts
@@ -42,7 +42,12 @@ async function isPortAvailable(port: number): Promise<boolean> {
     server.once('listening', () => {
       server.close(() => resolveAvailable(true));
     });
-    server.listen(port);
+    // Bind to loopback only — `server.listen(port)` listens on 0.0.0.0,
+    // briefly exposing the probe externally. Note there's still a small
+    // TOCTOU window between this close() and Metro's subsequent bind:
+    // Metro auto-bumps to the next free port on collision, so the URL we
+    // print is advisory.
+    server.listen(port, '127.0.0.1');
   });
 }
 


### PR DESCRIPTION
## Summary

Three follow-up correctness fixes from the post-merge review of #2340, plus tests covering both the fixed behaviour and the helper introduced in that PR. One fourth finding (`Self.Online` guard) was a misread of the pre-refactor code and needs no change.

### Fixes

- **`removeSavedMetroTarget` now normalizes its input** (`packages/mobile/src/lib/metro-target-store.ts`). Stored entries are normalized on write, so a caller passing the raw user-typed form (uppercase host, http URL with a path) would silently no-op against a normalized stored entry.
- **`isPortAvailable` binds 127.0.0.1** (`scripts/mobile-dev-start.ts`) instead of `0.0.0.0`, so the probe socket isn't briefly reachable on every interface. Comment explains the residual TOCTOU window vs. Metro's bind (Metro auto-bumps to the next free port on collision, so the printed URL is advisory).
- **`mapWithConcurrency` contract documented** (`packages/mobile/src/lib/abort-timeout.ts`). On the throw path the local `results` array is sparse for rejected items. The function throws before any caller can read it, but the comment now spells the caveat out so future maintainers don't bolt on a partial-success path that depends on uninitialized slots.

### Tests

- 2 new cases in `metro-target-store.test.ts` for the normalization edge case (uppercase host, URL-form input).
- New `abort-timeout.test.ts` covering: concurrency cap, input-order preservation, first-error wins, sibling-drain on rejection, empty input, thrown `undefined`, signal combination semantics.

### Non-fix

The reviewer's `Self.Online` finding was based on a misread — the pre-refactor code never gated `Self.DNSName` on `Self.Online`, only on peers. Both versions are equivalent. No change.

## Test plan

- [x] `vp run typecheck:mobile`
- [x] `vp test --project mobile --reporter=agent` — 373/373 (12 new)
- [x] `vp run check:mobile-bundle` — iOS 6.3 MB, Android 6.4 MB OK
- [ ] Manual smoke on a dev client: remove a saved Metro server via the Switcher, verify it disappears from the list immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)