### PR TITLE
fix: add missing @boardsesh/graphql-client to Docker builds

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -27,6 +27,7 @@ COPY packages/shared/ble-protocol/package.json ./packages/shared/ble-protocol/
 COPY packages/shared/board-config/package.json ./packages/shared/board-config/
 COPY packages/shared/climb-filters/package.json ./packages/shared/climb-filters/
 COPY packages/shared/graphql/package.json ./packages/shared/graphql/
+COPY packages/shared/graphql-client/package.json ./packages/shared/graphql-client/
 COPY packages/shared/play-view/package.json ./packages/shared/play-view/
 COPY packages/shared/queue/package.json ./packages/shared/queue/
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -25,6 +25,10 @@ COPY packages/board-renderer/wasm/package.json ./packages/board-renderer/wasm/
 COPY packages/board-renderer/wasm/pkg/ ./packages/board-renderer/wasm/pkg/
 COPY packages/shared/ble-protocol/package.json ./packages/shared/ble-protocol/
 COPY packages/shared/board-config/package.json ./packages/shared/board-config/
+COPY packages/shared/climb-filters/package.json ./packages/shared/climb-filters/
+COPY packages/shared/graphql/package.json ./packages/shared/graphql/
+COPY packages/shared/graphql-client/package.json ./packages/shared/graphql-client/
+COPY packages/shared/play-view/package.json ./packages/shared/play-view/
 COPY packages/shared/queue/package.json ./packages/shared/queue/
 
 # Install all dependencies (need devDependencies for the build)


### PR DESCRIPTION
## Summary

- `Dockerfile.backend` was missing `packages/shared/graphql-client/package.json`, causing `bun install --frozen-lockfile` to attempt fetching `@boardsesh/graphql-client` from npm (404) instead of resolving it from the workspace.
- `Dockerfile.web` had the same gap, plus missing `climb-filters`, `graphql`, and `play-view` — all shared packages that web depends on but were absent from the deps stage.

## Root cause

When a new workspace package is added to the monorepo, its `package.json` must be explicitly `COPY`-ed into the Docker build context before `bun install` runs. Without it, bun can't recognise the package as a workspace member and falls back to npm resolution.

## Test plan

- [ ] Rebuild the backend Docker image — `bun install --frozen-lockfile` should succeed
- [ ] Rebuild the web Docker image — deps stage should complete without npm 404s
- [ ] Verify backend service starts and `/health` responds 200

https://claude.ai/code/session_018bcvb3GaeJDffV1pGu7BR5

---
_Generated by [Claude Code](https://claude.ai/code/session_018bcvb3GaeJDffV1pGu7BR5)_