### PR TITLE
fix(mobile): guard devBundlerHosts on prod builds + test simulator path

### DIFF
--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -241,6 +241,15 @@ at your machine over Tailscale:
 EXPO_PUBLIC_BACKEND_URL=http://your-machine.tailscale-domain:3000 vp run dev:mobile
 ```
 
+For iOS Simulator runs, append `-- --simulator` (or set
+`BOARDSESH_DEV_SIMULATOR=1`) so Expo pins the bundler to `localhost` and
+skips the Tailscale probe — the simulator's CFNetwork sandbox can't
+reach the host's tailnet hostname:
+
+```bash
+vp run dev:mobile -- --simulator
+```
+
 The dev server picks up `.boardsesh/qa-notes.md` automatically and exposes
 it under the More tab via `DevMetadataPanel`.
 

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
-import { networkInterfaces } from 'node:os';
 import type { ExpoConfig, ConfigContext } from 'expo/config';
+import { resolveLanHosts } from './src/lib/resolve-lan-hosts';
 
 const DEFAULT_EAS_PROJECT_ID = '87499648-655e-4fb8-9856-65da37e55fb1';
 const EAS_PROJECT_ID = process.env.EXPO_PUBLIC_EAS_PROJECT_ID ?? DEFAULT_EAS_PROJECT_ID;
@@ -27,28 +27,6 @@ function normalizeHost(host: string): string {
 
 function normalizeHostValues(hostValues: readonly string[]): string[] {
   return hostValues.map(normalizeHost).filter((host) => host.length > 0);
-}
-
-function resolveLanHosts(): string[] {
-  // Cloud builders don't have a useful LAN identity for an on-device dev
-  // client to reach back to. Skip the lookup to keep extras deterministic.
-  if (process.env.CI || process.env.EAS_BUILD || process.env.EAS_BUILD_RUNNER) {
-    return [];
-  }
-
-  const interfaces = networkInterfaces();
-  const addresses: string[] = [];
-  for (const ifaceAddrs of Object.values(interfaces)) {
-    if (!ifaceAddrs) continue;
-    for (const addr of ifaceAddrs) {
-      if (addr.family !== 'IPv4') continue;
-      if (addr.internal) continue;
-      // 169.254/16 link-local addresses aren't routable from another device.
-      if (addr.address.startsWith('169.254.')) continue;
-      addresses.push(addr.address);
-    }
-  }
-  return Array.from(new Set(addresses));
 }
 
 function resolveTailscaleHosts(): string[] {
@@ -99,13 +77,14 @@ function isDevBuildProfile(): boolean {
 export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: boolean } => {
   const devMetadata = resolveDevMetadata();
   const hasDevMetadata = devMetadata.branchName || devMetadata.qaNotes || devMetadata.qaNotesFilePath;
+  const isDevBuild = isDevBuildProfile();
   // Hosts the in-app dev-server switcher will probe for live Metro bundlers.
   // localhost covers the simulator, LAN IPs cover same-Wi-Fi devices, tailnet
-  // names cover off-LAN devices on the same tailnet.
-  const devBundlerHosts = Array.from(
-    new Set(normalizeHostValues(['localhost', ...resolveLanHosts(), ...resolveTailscaleHosts()])),
-  );
-  const isDevBuild = isDevBuildProfile();
+  // names cover off-LAN devices on the same tailnet. Dev-build only so
+  // preview/production binaries don't ship a list that triggers runtime probes.
+  const devBundlerHosts = isDevBuild
+    ? Array.from(new Set(normalizeHostValues(['localhost', ...resolveLanHosts(), ...resolveTailscaleHosts()])))
+    : [];
 
   return {
     ...config,

--- a/packages/mobile/src/lib/__tests__/resolve-lan-hosts.test.ts
+++ b/packages/mobile/src/lib/__tests__/resolve-lan-hosts.test.ts
@@ -1,0 +1,112 @@
+/// <reference types="node" />
+
+import { describe, it, expect } from 'vitest';
+import type { NetworkInterfaceInfo } from 'node:os';
+import { resolveLanHosts } from '../resolve-lan-hosts';
+
+const baseAddr: NetworkInterfaceInfo = {
+  address: '0.0.0.0',
+  netmask: '255.255.255.0',
+  family: 'IPv4',
+  mac: '00:00:00:00:00:00',
+  internal: false,
+  cidr: '0.0.0.0/24',
+};
+
+const makeInterfaces =
+  (entries: Record<string, Partial<NetworkInterfaceInfo>[]>): (() => NodeJS.Dict<NetworkInterfaceInfo[]>) =>
+  () =>
+    Object.fromEntries(
+      Object.entries(entries).map(([name, addrs]) => [
+        name,
+        addrs.map((addr) => ({ ...baseAddr, ...addr }) as NetworkInterfaceInfo),
+      ]),
+    );
+
+describe('resolveLanHosts', () => {
+  it('returns IPv4 non-internal addresses', () => {
+    const result = resolveLanHosts({
+      env: {},
+      interfaces: makeInterfaces({
+        en0: [{ address: '192.168.1.42' }],
+      }),
+    });
+    expect(result).toEqual(['192.168.1.42']);
+  });
+
+  it('skips loopback / internal interfaces', () => {
+    const result = resolveLanHosts({
+      env: {},
+      interfaces: makeInterfaces({
+        lo0: [{ address: '127.0.0.1', internal: true }],
+        en0: [{ address: '10.0.0.5' }],
+      }),
+    });
+    expect(result).toEqual(['10.0.0.5']);
+  });
+
+  it('skips IPv6 addresses', () => {
+    const result = resolveLanHosts({
+      env: {},
+      interfaces: makeInterfaces({
+        en0: [{ address: 'fe80::1', family: 'IPv6' as NetworkInterfaceInfo['family'] }, { address: '192.168.0.10' }],
+      }),
+    });
+    expect(result).toEqual(['192.168.0.10']);
+  });
+
+  it('skips 169.254/16 link-local addresses', () => {
+    const result = resolveLanHosts({
+      env: {},
+      interfaces: makeInterfaces({
+        en0: [{ address: '169.254.10.20' }, { address: '192.168.0.10' }],
+      }),
+    });
+    expect(result).toEqual(['192.168.0.10']);
+  });
+
+  it('deduplicates repeated addresses across interfaces', () => {
+    const result = resolveLanHosts({
+      env: {},
+      interfaces: makeInterfaces({
+        en0: [{ address: '10.0.0.5' }],
+        en1: [{ address: '10.0.0.5' }],
+      }),
+    });
+    expect(result).toEqual(['10.0.0.5']);
+  });
+
+  it('short-circuits to [] when CI=1', () => {
+    const result = resolveLanHosts({
+      env: { CI: '1' },
+      interfaces: makeInterfaces({ en0: [{ address: '10.0.0.5' }] }),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('short-circuits to [] under EAS_BUILD', () => {
+    expect(
+      resolveLanHosts({
+        env: { EAS_BUILD: '1' },
+        interfaces: makeInterfaces({ en0: [{ address: '10.0.0.5' }] }),
+      }),
+    ).toEqual([]);
+
+    expect(
+      resolveLanHosts({
+        env: { EAS_BUILD_RUNNER: '1' },
+        interfaces: makeInterfaces({ en0: [{ address: '10.0.0.5' }] }),
+      }),
+    ).toEqual([]);
+  });
+
+  it('returns [] when no interfaces match', () => {
+    const result = resolveLanHosts({
+      env: {},
+      interfaces: makeInterfaces({
+        lo0: [{ address: '127.0.0.1', internal: true }],
+      }),
+    });
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/mobile/src/lib/resolve-lan-hosts.d.ts
+++ b/packages/mobile/src/lib/resolve-lan-hosts.d.ts
@@ -1,0 +1,14 @@
+import type { NetworkInterfaceInfo } from 'node:os';
+
+export type ResolveLanHostsEnv = {
+  CI?: string;
+  EAS_BUILD?: string;
+  EAS_BUILD_RUNNER?: string;
+};
+
+export type ResolveLanHostsOptions = {
+  env?: ResolveLanHostsEnv;
+  interfaces?: () => NodeJS.Dict<NetworkInterfaceInfo[]>;
+};
+
+export function resolveLanHosts(options?: ResolveLanHostsOptions): string[];

--- a/packages/mobile/src/lib/resolve-lan-hosts.js
+++ b/packages/mobile/src/lib/resolve-lan-hosts.js
@@ -1,0 +1,30 @@
+// Plain JS so Expo's app.config.ts loader (which doesn't transform child
+// `.ts` imports) can require this from packages/mobile/app.config.ts.
+// Types live in resolve-lan-hosts.d.ts.
+const { networkInterfaces } = require('node:os');
+
+function resolveLanHosts(options = {}) {
+  const env = options.env ?? process.env;
+  // Cloud builders don't have a useful LAN identity for an on-device dev
+  // client to reach back to. Skip the lookup to keep extras deterministic.
+  if (env.CI || env.EAS_BUILD || env.EAS_BUILD_RUNNER) {
+    return [];
+  }
+
+  const getInterfaces = options.interfaces ?? networkInterfaces;
+  const interfaces = getInterfaces();
+  const addresses = [];
+  for (const ifaceAddrs of Object.values(interfaces)) {
+    if (!ifaceAddrs) continue;
+    for (const addr of ifaceAddrs) {
+      if (addr.family !== 'IPv4') continue;
+      if (addr.internal) continue;
+      // 169.254/16 link-local addresses aren't routable from another device.
+      if (addr.address.startsWith('169.254.')) continue;
+      addresses.push(addr.address);
+    }
+  }
+  return Array.from(new Set(addresses));
+}
+
+module.exports = { resolveLanHosts };

--- a/scripts/lib/__tests__/parse-mobile-dev-args.test.ts
+++ b/scripts/lib/__tests__/parse-mobile-dev-args.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { parseMobileDevArgs } from '../parse-mobile-dev-args';
+
+describe('parseMobileDevArgs', () => {
+  it('returns defaults for an empty argv', () => {
+    expect(parseMobileDevArgs([], {})).toEqual({
+      qaNotesFilePath: null,
+      simulator: false,
+      passthroughArgs: [],
+    });
+  });
+
+  it('recognises --simulator and strips it from passthrough', () => {
+    const result = parseMobileDevArgs(['--simulator', '--port', '8084'], {});
+    expect(result.simulator).toBe(true);
+    expect(result.passthroughArgs).toEqual(['--port', '8084']);
+  });
+
+  it('honours BOARDSESH_DEV_SIMULATOR=1 from env', () => {
+    const result = parseMobileDevArgs([], { BOARDSESH_DEV_SIMULATOR: '1' });
+    expect(result.simulator).toBe(true);
+  });
+
+  it('treats BOARDSESH_DEV_SIMULATOR values other than "1" as false', () => {
+    expect(parseMobileDevArgs([], { BOARDSESH_DEV_SIMULATOR: 'true' }).simulator).toBe(false);
+    expect(parseMobileDevArgs([], { BOARDSESH_DEV_SIMULATOR: '0' }).simulator).toBe(false);
+    expect(parseMobileDevArgs([], {}).simulator).toBe(false);
+  });
+
+  it('lets an explicit --simulator override an unset env', () => {
+    const result = parseMobileDevArgs(['--simulator'], {});
+    expect(result.simulator).toBe(true);
+  });
+
+  it('parses --qa-notes-file with a separate value', () => {
+    const result = parseMobileDevArgs(['--qa-notes-file', 'notes.md'], {});
+    expect(result.qaNotesFilePath).toBe('notes.md');
+    expect(result.passthroughArgs).toEqual([]);
+  });
+
+  it('parses --qa-notes-file= inline form', () => {
+    const result = parseMobileDevArgs(['--qa-notes-file=plan.md'], {});
+    expect(result.qaNotesFilePath).toBe('plan.md');
+    expect(result.passthroughArgs).toEqual([]);
+  });
+
+  it('accepts the --qa-plan-file alias', () => {
+    expect(parseMobileDevArgs(['--qa-plan-file', 'p.md'], {}).qaNotesFilePath).toBe('p.md');
+    expect(parseMobileDevArgs(['--qa-plan-file=p.md'], {}).qaNotesFilePath).toBe('p.md');
+  });
+
+  it('throws when --qa-notes-file has no value', () => {
+    expect(() => parseMobileDevArgs(['--qa-notes-file'], {})).toThrow(/requires a file path/);
+    expect(() => parseMobileDevArgs(['--qa-notes-file', '--port'], {})).toThrow(/requires a file path/);
+    expect(() => parseMobileDevArgs(['--qa-notes-file='], {})).toThrow(/requires a file path/);
+  });
+
+  it('passes unknown flags through unchanged', () => {
+    const result = parseMobileDevArgs(['--clear', '--host', 'lan'], {});
+    expect(result.passthroughArgs).toEqual(['--clear', '--host', 'lan']);
+  });
+
+  it('combines --simulator with QA notes and passthrough args', () => {
+    const result = parseMobileDevArgs(['--simulator', '--qa-notes-file=x.md', '--clear'], {});
+    expect(result).toEqual({
+      qaNotesFilePath: 'x.md',
+      simulator: true,
+      passthroughArgs: ['--clear'],
+    });
+  });
+});

--- a/scripts/lib/parse-mobile-dev-args.ts
+++ b/scripts/lib/parse-mobile-dev-args.ts
@@ -1,0 +1,49 @@
+export type ParsedMobileDevArgs = {
+  qaNotesFilePath: string | null;
+  simulator: boolean;
+  passthroughArgs: string[];
+};
+
+export function parseMobileDevArgs(args: string[], env: NodeJS.ProcessEnv = process.env): ParsedMobileDevArgs {
+  let qaNotesFilePath: string | null = null;
+  let simulator = env.BOARDSESH_DEV_SIMULATOR === '1';
+  const passthroughArgs: string[] = [];
+
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--') continue;
+
+    if (argument === '--simulator') {
+      simulator = true;
+      continue;
+    }
+
+    if (argument === '--qa-notes-file' || argument === '--qa-plan-file') {
+      const nextArgument = args[index + 1];
+      if (!nextArgument || nextArgument.startsWith('--')) {
+        throw new Error(`${argument} requires a file path`);
+      }
+      qaNotesFilePath = nextArgument;
+      index++;
+      continue;
+    }
+
+    let consumed = false;
+    for (const prefix of ['--qa-notes-file=', '--qa-plan-file=']) {
+      if (argument.startsWith(prefix)) {
+        const pathValue = argument.slice(prefix.length).trim();
+        if (!pathValue) {
+          throw new Error(`${prefix.slice(0, -1)} requires a file path`);
+        }
+        qaNotesFilePath = pathValue;
+        consumed = true;
+        break;
+      }
+    }
+    if (consumed) continue;
+
+    passthroughArgs.push(argument);
+  }
+
+  return { qaNotesFilePath, simulator, passthroughArgs };
+}

--- a/scripts/mobile-dev-start.ts
+++ b/scripts/mobile-dev-start.ts
@@ -6,6 +6,7 @@ import { createServer } from 'node:net';
 import { resolve, dirname, join, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { parseMobileDevArgs } from './lib/parse-mobile-dev-args';
 import { resolveTailscaleHostname } from './lib/tailscale-hostname';
 
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -60,55 +61,6 @@ const METRO_LOG_PATH = join(BOARDSESH_DIR, 'mobile-metro.log');
 const DEFAULT_QA_NOTES_PATH = join(BOARDSESH_DIR, 'qa-notes.md');
 
 // ---------------------------------------------------------------------------
-// CLI argument parsing
-// ---------------------------------------------------------------------------
-
-function parseArgs(args: string[]): { qaNotesFilePath: string | null; simulator: boolean; passthroughArgs: string[] } {
-  let qaNotesFilePath: string | null = null;
-  let simulator = process.env.BOARDSESH_DEV_SIMULATOR === '1';
-  const passthroughArgs: string[] = [];
-
-  for (let index = 0; index < args.length; index++) {
-    const argument = args[index];
-    if (argument === '--') continue;
-
-    if (argument === '--simulator') {
-      simulator = true;
-      continue;
-    }
-
-    if (argument === '--qa-notes-file' || argument === '--qa-plan-file') {
-      const nextArgument = args[index + 1];
-      if (!nextArgument || nextArgument.startsWith('--')) {
-        throw new Error(`${argument} requires a file path`);
-      }
-      qaNotesFilePath = nextArgument;
-      index++;
-      continue;
-    }
-
-    for (const prefix of ['--qa-notes-file=', '--qa-plan-file=']) {
-      if (argument.startsWith(prefix)) {
-        const pathValue = argument.slice(prefix.length).trim();
-        if (!pathValue) {
-          throw new Error(`${prefix.slice(0, -1)} requires a file path`);
-        }
-        qaNotesFilePath = pathValue;
-        break;
-      }
-    }
-
-    if (argument.startsWith('--qa-notes-file=') || argument.startsWith('--qa-plan-file=')) {
-      continue;
-    }
-
-    passthroughArgs.push(argument);
-  }
-
-  return { qaNotesFilePath, simulator, passthroughArgs };
-}
-
-// ---------------------------------------------------------------------------
 // Resolve dev metadata (branch name, QA notes)
 // ---------------------------------------------------------------------------
 
@@ -155,7 +107,7 @@ function resolveQaNotes(explicitPath: string | null): { contents: string | null;
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const { qaNotesFilePath: cliQaNotesPath, simulator, passthroughArgs } = parseArgs(process.argv.slice(2));
+  const { qaNotesFilePath: cliQaNotesPath, simulator, passthroughArgs } = parseMobileDevArgs(process.argv.slice(2));
   const branchName = resolveCurrentBranchName();
   const commitSha = runGitCommand(['rev-parse', '--short', 'HEAD']);
   const qaNotes = resolveQaNotes(cliQaNotesPath);
@@ -211,9 +163,12 @@ async function main() {
   // and the LAN auto-detect can pick a Tailscale/utun interface the simulator
   // can't reach, which would re-trigger the original "could not connect" bug.
   // Respect a user-supplied --host either way.
+  // --local is Expo CLI's localhost alias (SDK 50+). --lan / --tunnel are the
+  // other two host modes. Any of these means the user already opted in, so we
+  // don't add a default --host.
   const userPassedHost = metroPassthroughArgs.some(
     (arg) =>
-      arg === '--host' || arg.startsWith('--host=') || arg === '--localhost' || arg === '--lan' || arg === '--tunnel',
+      arg === '--host' || arg.startsWith('--host=') || arg === '--local' || arg === '--lan' || arg === '--tunnel',
   );
   // We ship a custom dev client (EAS preview-build flow); Metro must serve the
   // dev-client bundle, not the Expo Go one. Opt out by passing --go.

--- a/scripts/vite.config.ts
+++ b/scripts/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'scripts',
+    globals: true,
+    environment: 'node',
+    include: ['lib/**/*.test.ts'],
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
       './packages/shared/graphql-client/vite.config.ts',
       './packages/shared-schema/vite.config.ts',
       './packages/mobile/vite.config.ts',
+      './scripts/vite.config.ts',
     ],
   },
   staged: {


### PR DESCRIPTION
## Summary
Follow-ups on PR #2362.

- **`extra.devBundlerHosts` now dev-build only.** Preview/production EAS builds skipped the LAN/Tailscale probes but still shipped `['localhost']`, so the in-app dev-server switcher would probe `localhost:8081-8099` on shipped binaries. Guarded by the existing `isDevBuild` check.
- **`--localhost` → `--local`.** That string in the `userPassedHost` detection wasn't a real Expo CLI flag — the localhost alias is `--local` (SDK 50+).
- **Unit-tested the simulator code path.** `parseArgs` is now `scripts/lib/parse-mobile-dev-args.ts` (covers `--simulator`, `BOARDSESH_DEV_SIMULATOR=1`, QA-notes parsing, passthrough). `resolveLanHosts` moved to `packages/mobile/src/lib/resolve-lan-hosts.js` with a `.d.ts` — it has to be CommonJS because Expo's `app.config.ts` loader doesn't transform child `.ts` imports. Tests cover loopback/IPv6/link-local skips, dedup, CI/EAS short-circuit.
- **`scripts/vite.config.ts`** new vitest project so the scripts tests have a home.
- **`docs/live-activity-push-testing.md`** documents the `--simulator` workflow next to the Tailscale-backed device flow.

Stacked on #2362.

## Test plan
- [x] `vp run typecheck:mobile`
- [x] `vp test --project mobile --project scripts --reporter=agent` (380 passed, +19 new across the two new test files)
- [x] `vp check` on all touched files
- [x] `bunx expo config --type=public` (in `packages/mobile/`) — `devBundlerHosts` populated in dev
- [x] `EAS_BUILD_PROFILE=preview bunx expo config --type=public` — `devBundlerHosts` absent from `extra`
- [ ] Manual: `vp run dev:mobile -- --simulator` still works end-to-end (covered by PR #2362)

🤖 Generated with [Claude Code](https://claude.com/claude-code)