### PR TITLE
Fix backend deploy: copy queue/board-config/graphql source into image

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -37,6 +37,9 @@ COPY packages/board-constants/src ./packages/board-constants/src
 COPY packages/crypto/src ./packages/crypto/src
 COPY packages/db/src ./packages/db/src
 COPY packages/aurora-sync/src ./packages/aurora-sync/src
+COPY packages/shared/board-config/src ./packages/shared/board-config/src
+COPY packages/shared/graphql/src ./packages/shared/graphql/src
+COPY packages/shared/queue/src ./packages/shared/queue/src
 COPY packages/backend/src ./packages/backend/src
 
 # Install dependencies (--production is incompatible with --frozen-lockfile in Bun)


### PR DESCRIPTION
## Problem

Backend deployment crashes at startup:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'/app/packages/backend/node_modules/@boardsesh/queue/src/index.ts'
imported from /app/packages/backend/src/services/room-manager/queue-state.ts
```

## Root cause

The backend runs TypeScript directly via `tsx` in production (`Dockerfile.backend`: `CMD ["bunx", "tsx", "src/index.ts"]`) — there is no compile/`dist` step. Every `@boardsesh/*` shared package resolves through its `exports`/`main` to `./src/index.ts`, transpiled on the fly. For that to work in the container, each shared package's `src/` must be present in the image.

`Dockerfile.backend` copied `src/` for only 5 shared packages (shared-schema, board-constants, crypto, db, aurora-sync), but the backend also imports `@boardsesh/queue`, `@boardsesh/board-config`, and `@boardsesh/graphql`. Their `src/` was never copied — `bun install` symlinks the workspace package into `node_modules`, but the symlink target's `src/` is absent, so `tsx` fails with `ERR_MODULE_NOT_FOUND`. `queue` is just the first of the three reached at runtime.

Transitive deps of the three missing packages are only `shared-schema` and `board-constants`, both already copied — no further packages needed.

## Change

Add three `COPY` lines to `Dockerfile.backend` for the missing source directories, matching the existing explicit per-package style.

## Verification

- `docker build -f Dockerfile.backend .` completes without COPY errors.
- Container start no longer shows `ERR_MODULE_NOT_FOUND` for `@boardsesh/queue` (or board-config / graphql).

## Follow-up (not in scope)

The Dockerfile enumerates each shared package's `src/` by hand, so every new backend shared-dependency must be added here too — easy to forget (this bug is the result). A `packages/shared/*/src` glob would be more durable but broadens the change beyond this failure.

https://claude.ai/code/session_013ujJbjhbEmW41Tx2YDqKgt

---
_Generated by [Claude Code](https://claude.ai/code/session_013ujJbjhbEmW41Tx2YDqKgt)_