### PR TITLE
fix(aurora-import): surface partial success + correct flash status (#2370)

### DIFF
--- a/packages/db/drizzle/0108_fix_tick_flash_status.sql
+++ b/packages/db/drizzle/0108_fix_tick_flash_status.sql
@@ -10,30 +10,56 @@
 --   correctFlashStatusForUser. This migration applies the same correction to
 --   every existing row across all users in a single pass.
 --
+-- Expected impact (estimated from production at PR-cut time):
+--   boardsesh_ticks total rows:               ~285,328
+--   status='flash' before migration:          ~194,121  (inflated — bug)
+--   status='send'  before migration:          ~46,525
+--   send + attempt_count=1 (promotion pool):  ~27,873
+--   Bulk of the work is the demotion: most "flashes" of repeat climbs become sends.
+--   We expect 'flash' rows to drop sharply (to the true-first-ever count) and
+--   'send' rows to rise correspondingly. No deletes, no schema changes.
+--
+-- Performance approach:
+--   We materialize per-(user_id, climb_uuid, angle) MIN(climbed_at) in a CTE
+--   once, then drive both UPDATEs off the CTE via equi-join. This is one full
+--   sequential scan + one hash aggregate, not a correlated NOT EXISTS that
+--   probes the table once per candidate row. On the existing indexes
+--   (boardsesh_ticks_user_climb_lookup_idx covers user_id, board_type, angle,
+--   climb_uuid; climbed_at lives in boardsesh_ticks_climbed_at_idx) the
+--   aggregate is cheap and the joins use the lookup index.
+--
 -- Idempotent: re-running it is a no-op once both statements have settled.
 
--- Promote: attempt_count = 1, no earlier tick for same (climb_uuid, angle) → flash
+-- Promote first-evers: the single tick at MIN(climbed_at) for each
+-- (user_id, climb_uuid, angle), if attempt_count=1, becomes a flash.
+WITH first_ticks AS (
+  SELECT user_id, climb_uuid, angle, MIN(climbed_at) AS first_climbed_at
+  FROM boardsesh_ticks
+  GROUP BY user_id, climb_uuid, angle
+)
 UPDATE boardsesh_ticks t
 SET status = 'flash'
-WHERE t.status = 'send'
+FROM first_ticks f
+WHERE t.user_id = f.user_id
+  AND t.climb_uuid = f.climb_uuid
+  AND t.angle = f.angle
+  AND t.climbed_at = f.first_climbed_at
   AND t.attempt_count = 1
-  AND NOT EXISTS (
-    SELECT 1 FROM boardsesh_ticks earlier
-    WHERE earlier.user_id = t.user_id
-      AND earlier.climb_uuid = t.climb_uuid
-      AND earlier.angle = t.angle
-      AND earlier.climbed_at < t.climbed_at
-  );
+  AND t.status = 'send';
 --> statement-breakpoint
 
--- Demote: any 'flash' with a prior tick is actually a send
+-- Demote everything else labeled 'flash' — anything past the first tick of
+-- a given (user_id, climb_uuid, angle) is a send, not a flash.
+WITH first_ticks AS (
+  SELECT user_id, climb_uuid, angle, MIN(climbed_at) AS first_climbed_at
+  FROM boardsesh_ticks
+  GROUP BY user_id, climb_uuid, angle
+)
 UPDATE boardsesh_ticks t
 SET status = 'send'
-WHERE t.status = 'flash'
-  AND EXISTS (
-    SELECT 1 FROM boardsesh_ticks earlier
-    WHERE earlier.user_id = t.user_id
-      AND earlier.climb_uuid = t.climb_uuid
-      AND earlier.angle = t.angle
-      AND earlier.climbed_at < t.climbed_at
-  );
+FROM first_ticks f
+WHERE t.user_id = f.user_id
+  AND t.climb_uuid = f.climb_uuid
+  AND t.angle = f.angle
+  AND t.climbed_at > f.first_climbed_at
+  AND t.status = 'flash';

--- a/packages/db/drizzle/0108_fix_tick_flash_status.sql
+++ b/packages/db/drizzle/0108_fix_tick_flash_status.sql
@@ -1,0 +1,39 @@
+-- Backfill: correct boardsesh_ticks.status across the user_id base.
+--
+-- Context:
+--   The Aurora JSON importer wrote `status = 'flash'` whenever Aurora's
+--   per-session `count` field was 1 — but Aurora's `count` is attempts inside
+--   a single climbed_at session, not "first ever attempt." Any user who had
+--   previously attempted or sent the same (climb_uuid, angle) and later sent
+--   it in one go was marked as a flash. The runtime importer has been fixed
+--   to write a conservative `'send'` and then promote true first-evers via
+--   correctFlashStatusForUser. This migration applies the same correction to
+--   every existing row across all users in a single pass.
+--
+-- Idempotent: re-running it is a no-op once both statements have settled.
+
+-- Promote: attempt_count = 1, no earlier tick for same (climb_uuid, angle) → flash
+UPDATE boardsesh_ticks t
+SET status = 'flash'
+WHERE t.status = 'send'
+  AND t.attempt_count = 1
+  AND NOT EXISTS (
+    SELECT 1 FROM boardsesh_ticks earlier
+    WHERE earlier.user_id = t.user_id
+      AND earlier.climb_uuid = t.climb_uuid
+      AND earlier.angle = t.angle
+      AND earlier.climbed_at < t.climbed_at
+  );
+--> statement-breakpoint
+
+-- Demote: any 'flash' with a prior tick is actually a send
+UPDATE boardsesh_ticks t
+SET status = 'send'
+WHERE t.status = 'flash'
+  AND EXISTS (
+    SELECT 1 FROM boardsesh_ticks earlier
+    WHERE earlier.user_id = t.user_id
+      AND earlier.climb_uuid = t.climb_uuid
+      AND earlier.angle = t.angle
+      AND earlier.climbed_at < t.climbed_at
+  );

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -757,6 +757,13 @@
       "when": 1779580000000,
       "tag": "0107_revoked_at_index",
       "breakpoints": true
+    },
+    {
+      "idx": 108,
+      "version": "7",
+      "when": 1779667200000,
+      "tag": "0108_fix_tick_flash_status",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/app/api/internal/aurora-import/route.ts
+++ b/packages/web/app/api/internal/aurora-import/route.ts
@@ -1,5 +1,6 @@
 import { getServerSession } from 'next-auth/next';
 import { type NextRequest, NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
 import { z } from 'zod';
 import { authOptions } from '@/app/lib/auth/auth-options';
 import {
@@ -56,6 +57,20 @@ export async function POST(request: NextRequest) {
           send({ type: 'complete', results });
         } catch (error) {
           console.error('Aurora JSON import error:', error);
+          Sentry.captureException(error, {
+            tags: { area: 'aurora-import', phase: 'server-stream' },
+            extra: {
+              boardType,
+              userId: session.user.id,
+              skipSessionBuild,
+              dataCounts: {
+                ascents: data.ascents.length,
+                attempts: data.attempts.length,
+                circuits: data.circuits.length,
+                climbs: data.climbs.length,
+              },
+            },
+          });
           send({ type: 'error', error: error instanceof Error ? error.message : 'Import failed' });
         } finally {
           controller.close();
@@ -72,6 +87,7 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error('Aurora JSON import error:', error);
+    Sentry.captureException(error, { tags: { area: 'aurora-import', phase: 'server-route' } });
     return NextResponse.json({ error: error instanceof Error ? error.message : 'Import failed' }, { status: 500 });
   }
 }

--- a/packages/web/app/components/settings/__tests__/board-import-prompt.test.tsx
+++ b/packages/web/app/components/settings/__tests__/board-import-prompt.test.tsx
@@ -371,6 +371,9 @@ describe('BoardImportPrompt', () => {
             circuits: { imported: 0, skipped: 0, failed: 0 },
             climbs: { imported: 0, skipped: 0, failed: 0 },
             unresolvedClimbs: [],
+            unresolvedAscentClimbs: [],
+            unresolvedAttemptClimbs: [],
+            unresolvedCircuitClimbs: [],
           },
         });
       });

--- a/packages/web/app/components/settings/board-import-prompt.tsx
+++ b/packages/web/app/components/settings/board-import-prompt.tsx
@@ -404,7 +404,12 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
                 <MuiAlert severity="warning" className={styles.unsyncedAlert}>
                   <AlertTitle>{t('aurora.import.results.partialTitle')}</AlertTitle>
                   <Typography variant="body2">{t('aurora.import.results.partialBody')}</Typography>
-                  <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    component="div"
+                    sx={{ mt: 1, whiteSpace: 'pre-line' }}
+                  >
                     {importResult.partialError}
                   </Typography>
                 </MuiAlert>

--- a/packages/web/app/components/settings/board-import-prompt.tsx
+++ b/packages/web/app/components/settings/board-import-prompt.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import * as Sentry from '@sentry/nextjs';
 import Box from '@mui/material/Box';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -60,7 +61,6 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
   const [importProgress, setImportProgress] = useState<ImportProgress | null>(null);
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
-  const receivedCompleteRef = useRef(false);
 
   const fetchCredential = async () => {
     try {
@@ -202,7 +202,6 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
     setImportPhase('importing');
     setImportProgress(null);
     setImportPreview(null);
-    receivedCompleteRef.current = false;
 
     try {
       await streamImport(boardType, importRawData, (event) => {
@@ -216,7 +215,6 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
             });
             break;
           case 'complete':
-            receivedCompleteRef.current = true;
             setImportResult(event.results);
             setImportPhase('complete');
             onImportComplete?.();
@@ -226,24 +224,28 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
                 event.results.ascents.imported +
                 event.results.attempts.imported +
                 event.results.circuits.imported;
-              showMessage(t('aurora.import.successCount', { count: totalImported }), 'success');
+              if (event.results.partialError) {
+                showMessage(t('aurora.import.partialWarning'), 'warning');
+              } else {
+                showMessage(t('aurora.import.successCount', { count: totalImported }), 'success');
+              }
             }
             break;
           case 'error':
-            receivedCompleteRef.current = true;
             setImportError(event.error);
             setImportPhase('error');
             showMessage(event.error, 'error');
             break;
         }
       });
-
-      if (!receivedCompleteRef.current) {
-        setImportError(t('aurora.import.interrupted'));
-        setImportPhase('error');
-        showMessage(t('aurora.import.interruptedShort'), 'error');
-      }
     } catch (error) {
+      // streamImport now captures chunk failures itself; reaching here means
+      // a setup-level failure (no body, network unreachable, etc.) — worth
+      // sending to Sentry so we can spot patterns.
+      Sentry.captureException(error, {
+        tags: { area: 'aurora-import', phase: 'client-setup' },
+        extra: { boardType },
+      });
       const msg = error instanceof Error ? error.message : t('aurora.import.failed');
       setImportError(msg);
       setImportPhase('error');
@@ -398,6 +400,15 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
 
           {importPhase === 'complete' && importResult && (
             <>
+              {importResult.partialError && (
+                <MuiAlert severity="warning" className={styles.unsyncedAlert}>
+                  <AlertTitle>{t('aurora.import.results.partialTitle')}</AlertTitle>
+                  <Typography variant="body2">{t('aurora.import.results.partialBody')}</Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                    {importResult.partialError}
+                  </Typography>
+                </MuiAlert>
+              )}
               <List dense>
                 {(importResult.climbs.imported > 0 || importResult.climbs.failed > 0) && (
                   <ListItem>
@@ -442,21 +453,69 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
                   />
                 </ListItem>
               </List>
-              {importResult.unresolvedClimbs.length > 0 && (
+              {importResult.unresolvedAscentClimbs.length > 0 && (
                 <MuiAlert severity="warning" className={styles.unsyncedAlert}>
                   <AlertTitle>
-                    {t('aurora.import.results.unresolvedTitle', { count: importResult.unresolvedClimbs.length })}
+                    {t('aurora.import.results.unresolvedAscentsTitle', {
+                      count: importResult.unresolvedAscentClimbs.length,
+                    })}
                   </AlertTitle>
                   <div className={styles.unresolvedList}>
-                    {importResult.unresolvedClimbs.slice(0, 20).map((name) => (
+                    {importResult.unresolvedAscentClimbs.slice(0, 20).map((name) => (
                       <Typography key={name} variant="body2">
                         {name}
                       </Typography>
                     ))}
-                    {importResult.unresolvedClimbs.length > 20 && (
+                    {importResult.unresolvedAscentClimbs.length > 20 && (
                       <Typography variant="body2" color="text.secondary">
                         {t('aurora.import.results.unresolvedMore', {
-                          count: importResult.unresolvedClimbs.length - 20,
+                          count: importResult.unresolvedAscentClimbs.length - 20,
+                        })}
+                      </Typography>
+                    )}
+                  </div>
+                </MuiAlert>
+              )}
+              {importResult.unresolvedAttemptClimbs.length > 0 && (
+                <MuiAlert severity="warning" className={styles.unsyncedAlert}>
+                  <AlertTitle>
+                    {t('aurora.import.results.unresolvedAttemptsTitle', {
+                      count: importResult.unresolvedAttemptClimbs.length,
+                    })}
+                  </AlertTitle>
+                  <div className={styles.unresolvedList}>
+                    {importResult.unresolvedAttemptClimbs.slice(0, 20).map((name) => (
+                      <Typography key={name} variant="body2">
+                        {name}
+                      </Typography>
+                    ))}
+                    {importResult.unresolvedAttemptClimbs.length > 20 && (
+                      <Typography variant="body2" color="text.secondary">
+                        {t('aurora.import.results.unresolvedMore', {
+                          count: importResult.unresolvedAttemptClimbs.length - 20,
+                        })}
+                      </Typography>
+                    )}
+                  </div>
+                </MuiAlert>
+              )}
+              {importResult.unresolvedCircuitClimbs.length > 0 && (
+                <MuiAlert severity="warning" className={styles.unsyncedAlert}>
+                  <AlertTitle>
+                    {t('aurora.import.results.unresolvedCircuitsTitle', {
+                      count: importResult.unresolvedCircuitClimbs.length,
+                    })}
+                  </AlertTitle>
+                  <div className={styles.unresolvedList}>
+                    {importResult.unresolvedCircuitClimbs.slice(0, 20).map((name) => (
+                      <Typography key={name} variant="body2">
+                        {name}
+                      </Typography>
+                    ))}
+                    {importResult.unresolvedCircuitClimbs.length > 20 && (
+                      <Typography variant="body2" color="text.secondary">
+                        {t('aurora.import.results.unresolvedMore', {
+                          count: importResult.unresolvedCircuitClimbs.length - 20,
                         })}
                       </Typography>
                     )}

--- a/packages/web/app/lib/data-sync/aurora/__tests__/json-import-stream.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/json-import-stream.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import type { ImportProgressEvent, ImportResult } from '../json-import';
 import type { streamImport as _streamImportType } from '../json-import-stream';
 
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers to build a mock ReadableStream from chunks
 // ---------------------------------------------------------------------------
@@ -40,6 +44,9 @@ const emptyResult: ImportResult = {
   circuits: { imported: 0, skipped: 0, failed: 0 },
   climbs: { imported: 0, skipped: 0, failed: 0 },
   unresolvedClimbs: [],
+  unresolvedAscentClimbs: [],
+  unresolvedAttemptClimbs: [],
+  unresolvedCircuitClimbs: [],
 };
 
 function makeResult(overrides: Partial<ImportResult> = {}): ImportResult {
@@ -131,7 +138,7 @@ describe('streamImport', () => {
   });
 
   describe('error handling', () => {
-    it('throws on non-ok response with JSON error body', async () => {
+    it('captures non-ok response with JSON error body as partialError', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(
         mockFetchResponse(null, {
           ok: false,
@@ -140,10 +147,17 @@ describe('streamImport', () => {
         }),
       );
 
-      await expect(streamImport('kilter', { user: { username: 'test' } }, vi.fn())).rejects.toThrow('Bad request data');
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' } }, (e) => received.push(e));
+
+      const complete = received.find((e) => e.type === 'complete');
+      expect(complete).toBeDefined();
+      if (complete?.type === 'complete') {
+        expect(complete.results.partialError).toBe('Bad request data');
+      }
     });
 
-    it('throws generic message on non-ok response with non-JSON body', async () => {
+    it('captures generic message on non-ok response with non-JSON body as partialError', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: false,
         status: 500,
@@ -151,13 +165,27 @@ describe('streamImport', () => {
         body: null,
       } as unknown as Response);
 
-      await expect(streamImport('kilter', { user: { username: 'test' } }, vi.fn())).rejects.toThrow('Import failed');
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' } }, (e) => received.push(e));
+
+      const complete = received.find((e) => e.type === 'complete');
+      expect(complete).toBeDefined();
+      if (complete?.type === 'complete') {
+        expect(complete.results.partialError).toBe('Import failed');
+      }
     });
 
-    it('throws when response has no body', async () => {
+    it('captures missing response body as partialError', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(null));
 
-      await expect(streamImport('kilter', { user: { username: 'test' } }, vi.fn())).rejects.toThrow('No response body');
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' } }, (e) => received.push(e));
+
+      const complete = received.find((e) => e.type === 'complete');
+      expect(complete).toBeDefined();
+      if (complete?.type === 'complete') {
+        expect(complete.results.partialError).toBe('No response body');
+      }
     });
 
     it('skips malformed JSON lines without throwing', async () => {
@@ -182,7 +210,7 @@ describe('streamImport', () => {
       expect(warnSpy).toHaveBeenCalledWith('Failed to parse import stream line:', 'not valid json');
     });
 
-    it('propagates server error events from stream', async () => {
+    it('captures server error events as partialError', async () => {
       const errorEvent: ImportProgressEvent = {
         type: 'error',
         error: 'Database connection failed',
@@ -190,9 +218,14 @@ describe('streamImport', () => {
       const stream = createMockReadableStream([JSON.stringify(errorEvent) + '\n']);
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
 
-      await expect(streamImport('kilter', { user: { username: 'test' }, ascents: [1] }, vi.fn())).rejects.toThrow(
-        'Database connection failed',
-      );
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' }, ascents: [1] }, (e) => received.push(e));
+
+      const complete = received.find((e) => e.type === 'complete');
+      expect(complete).toBeDefined();
+      if (complete?.type === 'complete') {
+        expect(complete.results.partialError).toBe('Database connection failed');
+      }
     });
 
     it('skips malformed JSON in remaining buffer without throwing', async () => {
@@ -208,7 +241,7 @@ describe('streamImport', () => {
       expect(warnSpy).toHaveBeenCalledWith('Failed to parse import stream buffer:', 'not json at all');
     });
 
-    it('throws when server stream ends without a complete or error event', async () => {
+    it('captures interruption when server stream ends without a complete or error event', async () => {
       // Stream with only progress events, no complete/error
       const progressOnly: ImportProgressEvent = {
         type: 'progress',
@@ -218,18 +251,28 @@ describe('streamImport', () => {
       const stream = createMockReadableStream([JSON.stringify(progressOnly) + '\n']);
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
 
-      await expect(streamImport('kilter', { user: { username: 'test' }, ascents: [1] }, vi.fn())).rejects.toThrow(
-        'Import was interrupted: server response ended without a result',
-      );
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' }, ascents: [1] }, (e) => received.push(e));
+
+      const complete = received.find((e) => e.type === 'complete');
+      expect(complete).toBeDefined();
+      if (complete?.type === 'complete') {
+        expect(complete.results.partialError).toContain('Import was interrupted');
+      }
     });
 
-    it('throws when server stream is completely empty', async () => {
+    it('captures interruption when server stream is completely empty', async () => {
       const stream = createMockReadableStream([]);
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse(stream));
 
-      await expect(streamImport('kilter', { user: { username: 'test' } }, vi.fn())).rejects.toThrow(
-        'Import was interrupted: server response ended without a result',
-      );
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' } }, (e) => received.push(e));
+
+      const complete = received.find((e) => e.type === 'complete');
+      expect(complete).toBeDefined();
+      if (complete?.type === 'complete') {
+        expect(complete.results.partialError).toContain('Import was interrupted');
+      }
     });
   });
 
@@ -374,24 +417,62 @@ describe('streamImport', () => {
       expect(body.data.circuits).toHaveLength(0);
     });
 
-    it('stops and throws on chunk error without sending remaining chunks', async () => {
-      const ascents = Array.from({ length: 600 }, (_, i) => ({ id: i }));
+    it('captures chunk error as partialError and stops sending remaining chunks', async () => {
+      // 1500 ascents → 3 chunks (500 + 500 + 500). First succeeds, second errors;
+      // third must NOT be sent.
+      const ascents = Array.from({ length: 1500 }, (_, i) => ({ id: i }));
 
-      // First chunk succeeds, second fails
+      const firstResult = makeResult({ ascents: { imported: 500, skipped: 0, failed: 0 } });
       const errorEvent: ImportProgressEvent = { type: 'error', error: 'Server overloaded' };
       const errorStream = createMockReadableStream([JSON.stringify(errorEvent) + '\n']);
 
       const fetchSpy = vi
         .spyOn(globalThis, 'fetch')
-        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(emptyResult)))
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(firstResult)))
         .mockResolvedValueOnce(mockFetchResponse(errorStream));
 
-      await expect(streamImport('kilter', { user: { username: 'test' }, ascents }, vi.fn())).rejects.toThrow(
-        'Server overloaded',
-      );
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' }, ascents }, (e) => received.push(e));
 
-      // Only 2 calls made (stopped at the error)
+      // No third request — the loop bailed
       expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+      const complete = received.find((e) => e.type === 'complete');
+      expect(complete).toBeDefined();
+      if (complete?.type === 'complete') {
+        expect(complete.results.partialError).toBe('Server overloaded');
+        // First chunk's imports survive in the merged result
+        expect(complete.results.ascents.imported).toBe(500);
+      }
+    });
+
+    it('merges per-source unresolved arrays across chunks with Set-dedup', async () => {
+      const ascents = Array.from({ length: 600 }, (_, i) => ({ id: i }));
+      const result1 = makeResult({
+        unresolvedAscentClimbs: ['A1', 'A2'],
+        unresolvedAttemptClimbs: ['T1'],
+        unresolvedCircuitClimbs: ['C1'],
+      });
+      const result2 = makeResult({
+        unresolvedAscentClimbs: ['A2', 'A3'],
+        unresolvedAttemptClimbs: ['T1', 'T2'],
+        unresolvedCircuitClimbs: ['C2'],
+      });
+
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(result1)))
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(result2)));
+
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' }, ascents }, (e) => received.push(e));
+
+      const complete = received.find((e) => e.type === 'complete');
+      expect(complete).toBeDefined();
+      if (complete?.type === 'complete') {
+        expect(complete.results.unresolvedAscentClimbs).toEqual(['A1', 'A2', 'A3']);
+        expect(complete.results.unresolvedAttemptClimbs).toEqual(['T1', 'T2']);
+        expect(complete.results.unresolvedCircuitClimbs).toEqual(['C1', 'C2']);
+      }
     });
   });
 

--- a/packages/web/app/lib/data-sync/aurora/__tests__/json-import-stream.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/json-import-stream.test.ts
@@ -446,6 +446,35 @@ describe('streamImport', () => {
       }
     });
 
+    it('joins partialError from a server-returned result with a later chunk error', async () => {
+      // First chunk returns a complete result that already carries a
+      // partialError (e.g. the server-side flash-correction step failed).
+      // Second chunk fails outright. Both messages must survive the merge so
+      // we don't lose diagnostics in Sentry or the UI banner.
+      const ascents = Array.from({ length: 1000 }, (_, i) => ({ id: i }));
+
+      const firstResult = makeResult({
+        ascents: { imported: 500, skipped: 0, failed: 0 },
+        partialError: 'Flash status correction failed',
+      });
+      const errorEvent: ImportProgressEvent = { type: 'error', error: 'Server overloaded' };
+      const errorStream = createMockReadableStream([JSON.stringify(errorEvent) + '\n']);
+
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockFetchResponse(makeCompleteStream(firstResult)))
+        .mockResolvedValueOnce(mockFetchResponse(errorStream));
+
+      const received: ImportProgressEvent[] = [];
+      await streamImport('kilter', { user: { username: 'test' }, ascents }, (e) => received.push(e));
+
+      const complete = received.find((e) => e.type === 'complete');
+      expect(complete).toBeDefined();
+      if (complete?.type === 'complete') {
+        expect(complete.results.partialError).toContain('Flash status correction failed');
+        expect(complete.results.partialError).toContain('Server overloaded');
+      }
+    });
+
     it('merges per-source unresolved arrays across chunks with Set-dedup', async () => {
       const ascents = Array.from({ length: 600 }, (_, i) => ({ id: i }));
       const result1 = makeResult({

--- a/packages/web/app/lib/data-sync/aurora/json-import-stream.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import-stream.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import type { ImportProgressEvent, ImportResult } from './json-import';
 import type { AuroraBoardName } from '@boardsesh/shared-schema';
 
@@ -30,7 +31,7 @@ function chunk<T>(arr: T[], size: number): T[][] {
  * Merges two ImportResult objects by summing their counts.
  */
 function mergeResults(a: ImportResult, b: ImportResult): ImportResult {
-  return {
+  const merged: ImportResult = {
     ascents: {
       imported: a.ascents.imported + b.ascents.imported,
       skipped: a.ascents.skipped + b.ascents.skipped,
@@ -52,7 +53,15 @@ function mergeResults(a: ImportResult, b: ImportResult): ImportResult {
       failed: a.climbs.failed + b.climbs.failed,
     },
     unresolvedClimbs: [...new Set([...a.unresolvedClimbs, ...b.unresolvedClimbs])],
+    unresolvedAscentClimbs: [...new Set([...a.unresolvedAscentClimbs, ...b.unresolvedAscentClimbs])].sort(),
+    unresolvedAttemptClimbs: [...new Set([...a.unresolvedAttemptClimbs, ...b.unresolvedAttemptClimbs])].sort(),
+    unresolvedCircuitClimbs: [...new Set([...a.unresolvedCircuitClimbs, ...b.unresolvedCircuitClimbs])].sort(),
   };
+  // partialError from either side wins (b's is more recent, prefer it)
+  if (b.partialError ?? a.partialError) {
+    merged.partialError = b.partialError ?? a.partialError;
+  }
+  return merged;
 }
 
 /**
@@ -228,6 +237,9 @@ export async function streamImport(
     circuits: { imported: 0, skipped: 0, failed: 0 },
     climbs: { imported: 0, skipped: 0, failed: 0 },
     unresolvedClimbs: [],
+    unresolvedAscentClimbs: [],
+    unresolvedAttemptClimbs: [],
+    unresolvedCircuitClimbs: [],
   };
 
   let merged = emptyResult;
@@ -240,8 +252,33 @@ export async function streamImport(
       message: `Processing batch ${i + 1} of ${totalChunks}...`,
     });
 
-    const chunkResult = await sendChunk(allChunks[i], onEvent);
-    merged = mergeResults(merged, chunkResult);
+    const chunk = allChunks[i];
+    try {
+      const chunkResult = await sendChunk(chunk, onEvent);
+      merged = mergeResults(merged, chunkResult);
+    } catch (error) {
+      // Earlier chunks may have already committed server-side. Capture the
+      // failure with rich context, attach a partialError to the merged result,
+      // and let the UI render the summary panel as a partial success.
+      const message = error instanceof Error ? error.message : 'Import failed';
+      Sentry.captureException(error, {
+        tags: { area: 'aurora-import', phase: 'client-chunk' },
+        extra: {
+          boardType,
+          chunkIndex: i,
+          totalChunks,
+          chunkSummary: {
+            ascents: chunk.data.ascents.length,
+            attempts: chunk.data.attempts.length,
+            circuits: chunk.data.circuits.length,
+            climbs: chunk.data.climbs.length,
+          },
+          mergedSoFar: merged,
+        },
+      });
+      merged = { ...merged, partialError: message };
+      break;
+    }
   }
 
   onEvent({ type: 'complete', results: merged });

--- a/packages/web/app/lib/data-sync/aurora/json-import-stream.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import-stream.ts
@@ -57,9 +57,11 @@ function mergeResults(a: ImportResult, b: ImportResult): ImportResult {
     unresolvedAttemptClimbs: [...new Set([...a.unresolvedAttemptClimbs, ...b.unresolvedAttemptClimbs])].sort(),
     unresolvedCircuitClimbs: [...new Set([...a.unresolvedCircuitClimbs, ...b.unresolvedCircuitClimbs])].sort(),
   };
-  // partialError from either side wins (b's is more recent, prefer it)
-  if (b.partialError ?? a.partialError) {
-    merged.partialError = b.partialError ?? a.partialError;
+  // Preserve every chunk's error — if multiple chunks fail, dropping earlier
+  // messages would hide diagnostics. Join with a separator the UI can split on.
+  const errors = [a.partialError, b.partialError].filter((m): m is string => !!m);
+  if (errors.length > 0) {
+    merged.partialError = errors.join('\n');
   }
   return merged;
 }
@@ -276,7 +278,10 @@ export async function streamImport(
           mergedSoFar: merged,
         },
       });
-      merged = { ...merged, partialError: message };
+      merged = {
+        ...merged,
+        partialError: merged.partialError ? `${merged.partialError}\n${message}` : message,
+      };
       break;
     }
   }

--- a/packages/web/app/lib/data-sync/aurora/json-import.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import.ts
@@ -395,35 +395,42 @@ export async function correctFlashStatusForUser(
   db: PgDatabase<PgQueryResultHKT, Record<string, unknown>>,
   userId: string,
 ): Promise<void> {
-  // Promote: attempt_count=1, no earlier tick for same (climb_uuid, angle) → flash
+  // Materialize per-(climb_uuid, angle) MIN(climbed_at) once, then drive both
+  // updates off it. Cheaper than the correlated NOT EXISTS / EXISTS variant on
+  // users with thousands of ticks. Same shape as migration 0108.
   await db.execute(sql`
+    WITH first_ticks AS (
+      SELECT climb_uuid, angle, MIN(climbed_at) AS first_climbed_at
+      FROM boardsesh_ticks
+      WHERE user_id = ${userId}
+      GROUP BY climb_uuid, angle
+    )
     UPDATE boardsesh_ticks t
     SET status = 'flash'
+    FROM first_ticks f
     WHERE t.user_id = ${userId}
-      AND t.status = 'send'
+      AND t.climb_uuid = f.climb_uuid
+      AND t.angle = f.angle
+      AND t.climbed_at = f.first_climbed_at
       AND t.attempt_count = 1
-      AND NOT EXISTS (
-        SELECT 1 FROM boardsesh_ticks earlier
-        WHERE earlier.user_id = t.user_id
-          AND earlier.climb_uuid = t.climb_uuid
-          AND earlier.angle = t.angle
-          AND earlier.climbed_at < t.climbed_at
-      )
+      AND t.status = 'send'
   `);
 
-  // Demote: any 'flash' that turns out to have a prior tick is a send
   await db.execute(sql`
+    WITH first_ticks AS (
+      SELECT climb_uuid, angle, MIN(climbed_at) AS first_climbed_at
+      FROM boardsesh_ticks
+      WHERE user_id = ${userId}
+      GROUP BY climb_uuid, angle
+    )
     UPDATE boardsesh_ticks t
     SET status = 'send'
+    FROM first_ticks f
     WHERE t.user_id = ${userId}
+      AND t.climb_uuid = f.climb_uuid
+      AND t.angle = f.angle
+      AND t.climbed_at > f.first_climbed_at
       AND t.status = 'flash'
-      AND EXISTS (
-        SELECT 1 FROM boardsesh_ticks earlier
-        WHERE earlier.user_id = t.user_id
-          AND earlier.climb_uuid = t.climb_uuid
-          AND earlier.angle = t.angle
-          AND earlier.climbed_at < t.climbed_at
-      )
   `);
 }
 
@@ -921,6 +928,10 @@ export async function importJsonExportData(
 
   // Step 9: Final-chunk-only steps. Earlier chunks may have imported ticks
   // even if this chunk only contains circuits — always run when not skipped.
+  // Both steps are best-effort: the user's ticks are already committed and
+  // we don't want to fail the whole import on a post-pass blip. But we do
+  // surface the failure on `partialError` so the UI can warn them their
+  // flashes or sessions may need a re-run.
   if (!options?.skipSessionBuild) {
     // 9a: Correct flash/send status across the user's full tick history.
     // Runs before session-build so per-session flash counts come out right.
@@ -928,6 +939,8 @@ export async function importJsonExportData(
       await correctFlashStatusForUser(db, userId);
     } catch (error) {
       console.error('Error correcting flash status after JSON import:', error);
+      const msg = error instanceof Error ? error.message : 'Flash status correction failed';
+      result.partialError = result.partialError ? `${result.partialError}\n${msg}` : msg;
     }
 
     // 9b: Build inferred sessions for all unassigned ticks
@@ -939,6 +952,8 @@ export async function importJsonExportData(
       }
     } catch (error) {
       console.error('Error building inferred sessions after JSON import:', error);
+      const msg = error instanceof Error ? error.message : 'Session build failed';
+      result.partialError = result.partialError ? `${result.partialError}\n${msg}` : msg;
     }
   }
 

--- a/packages/web/app/lib/data-sync/aurora/json-import.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import.ts
@@ -98,6 +98,12 @@ export type ImportResult = {
   circuits: ImportCounts;
   climbs: ImportCounts;
   unresolvedClimbs: string[];
+  unresolvedAscentClimbs: string[];
+  unresolvedAttemptClimbs: string[];
+  unresolvedCircuitClimbs: string[];
+  // Set by the streaming client when an earlier chunk committed but a later
+  // chunk failed — keeps the user from being told the whole import failed.
+  partialError?: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -370,6 +376,58 @@ async function getExistingTickKeys(
 }
 
 // ---------------------------------------------------------------------------
+// Flash-status correction
+// ---------------------------------------------------------------------------
+
+/**
+ * Correct flash/send labels for one user across all their ticks.
+ *
+ * A "flash" is the first-ever tick of a (climb_uuid, angle) pair, sent in a
+ * single attempt. The Aurora export only gives us per-session attempt counts,
+ * not first-ever-ness, so the importer writes everything as 'send' and we
+ * fix things here once all their history is in the DB.
+ *
+ * Two statements because PostgreSQL's UPDATE doesn't see its own mid-statement
+ * changes — the promotion must commit before the demotion's prior-tick check
+ * can rely on it.
+ */
+export async function correctFlashStatusForUser(
+  db: PgDatabase<PgQueryResultHKT, Record<string, unknown>>,
+  userId: string,
+): Promise<void> {
+  // Promote: attempt_count=1, no earlier tick for same (climb_uuid, angle) → flash
+  await db.execute(sql`
+    UPDATE boardsesh_ticks t
+    SET status = 'flash'
+    WHERE t.user_id = ${userId}
+      AND t.status = 'send'
+      AND t.attempt_count = 1
+      AND NOT EXISTS (
+        SELECT 1 FROM boardsesh_ticks earlier
+        WHERE earlier.user_id = t.user_id
+          AND earlier.climb_uuid = t.climb_uuid
+          AND earlier.angle = t.angle
+          AND earlier.climbed_at < t.climbed_at
+      )
+  `);
+
+  // Demote: any 'flash' that turns out to have a prior tick is a send
+  await db.execute(sql`
+    UPDATE boardsesh_ticks t
+    SET status = 'send'
+    WHERE t.user_id = ${userId}
+      AND t.status = 'flash'
+      AND EXISTS (
+        SELECT 1 FROM boardsesh_ticks earlier
+        WHERE earlier.user_id = t.user_id
+          AND earlier.climb_uuid = t.climb_uuid
+          AND earlier.angle = t.angle
+          AND earlier.climbed_at < t.climbed_at
+      )
+  `);
+}
+
+// ---------------------------------------------------------------------------
 // Batch insert helper
 // ---------------------------------------------------------------------------
 
@@ -424,6 +482,9 @@ export async function importJsonExportData(
     circuits: { imported: 0, skipped: 0, failed: 0 },
     climbs: { imported: 0, skipped: 0, failed: 0 },
     unresolvedClimbs: [],
+    unresolvedAscentClimbs: [],
+    unresolvedAttemptClimbs: [],
+    unresolvedCircuitClimbs: [],
   };
 
   // Capture a single "now" for all timestamps in this import
@@ -619,7 +680,26 @@ export async function importJsonExportData(
   });
   const nameToUuid = await resolveClimbNames(db, boardType, [...allClimbNames], userId);
 
-  // Track unresolved names
+  // Track unresolved names, split per-source so the UI can show each section
+  // separately (an ascent with an unmatched climb is a different user story
+  // from a circuit referencing an unmatched climb).
+  const unresolvedAscentSet = new Set<string>();
+  const unresolvedAttemptSet = new Set<string>();
+  const unresolvedCircuitSet = new Set<string>();
+  for (const ascent of data.ascents) {
+    if (!nameToUuid.has(ascent.climb)) unresolvedAscentSet.add(ascent.climb);
+  }
+  for (const attempt of data.attempts) {
+    if (!nameToUuid.has(attempt.climb)) unresolvedAttemptSet.add(attempt.climb);
+  }
+  for (const circuit of data.circuits) {
+    for (const climbName of circuit.climbs) {
+      if (!nameToUuid.has(climbName)) unresolvedCircuitSet.add(climbName);
+    }
+  }
+  result.unresolvedAscentClimbs = [...unresolvedAscentSet].sort();
+  result.unresolvedAttemptClimbs = [...unresolvedAttemptSet].sort();
+  result.unresolvedCircuitClimbs = [...unresolvedCircuitSet].sort();
   result.unresolvedClimbs = [...allClimbNames].filter((name) => !nameToUuid.has(name));
 
   // Step 4: Get existing tick keys for cross-source dedup
@@ -651,7 +731,11 @@ export async function importJsonExportData(
       climbUuid,
       angle: ascent.angle,
       isMirror: false,
-      status: ascent.count === 1 ? 'flash' : 'send',
+      // Conservative initial value. Aurora's `count` is attempts within a
+      // single climbed_at session, not "no prior attempts ever" — so we can't
+      // call this a flash here. correctFlashStatusForUser runs on the final
+      // chunk and promotes true first-evers across the user's full history.
+      status: 'send',
       attemptCount: ascent.count,
       // The JSON export 'stars' field is already on a 1-5 scale (user-facing),
       // unlike the Aurora API 'quality' field which is 0-3.
@@ -835,11 +919,18 @@ export async function importJsonExportData(
     });
   }
 
-  // Step 9: Build inferred sessions for imported ticks (skipped during chunked imports
-  // until the final chunk to avoid rebuilding sessions on every batch).
-  // Always run on the final chunk — earlier chunks may have imported ticks even if
-  // this chunk only contains circuits.
+  // Step 9: Final-chunk-only steps. Earlier chunks may have imported ticks
+  // even if this chunk only contains circuits — always run when not skipped.
   if (!options?.skipSessionBuild) {
+    // 9a: Correct flash/send status across the user's full tick history.
+    // Runs before session-build so per-session flash counts come out right.
+    try {
+      await correctFlashStatusForUser(db, userId);
+    } catch (error) {
+      console.error('Error correcting flash status after JSON import:', error);
+    }
+
+    // 9b: Build inferred sessions for all unassigned ticks
     onProgress?.({ type: 'progress', step: 'sessions', message: 'Building sessions...' });
     try {
       const assigned = await buildInferredSessionsForUser(userId);

--- a/packages/web/app/lib/i18n/config.ts
+++ b/packages/web/app/lib/i18n/config.ts
@@ -76,6 +76,10 @@ export const DEFAULT_LOCALE: Locale = 'en-US';
 // i18n-keep climbs:mobile.climbActions.copyLink
 // i18n-keep climbs:mobile.climbActions.linkCopied
 // i18n-keep climbs:mobile.climbActions.report
+// Mobile More tab — dev tools
+// i18n-keep common:mobile.more.development
+// i18n-keep common:mobile.more.metroServersTitle
+// i18n-keep common:mobile.more.metroServersSubtitle
 // Mobile climb filter sheet
 // i18n-keep common:mobile.nav.setters
 // i18n-keep climbs:mobile.filter.section.climb

--- a/packages/web/i18n/locales/en-US/settings.json
+++ b/packages/web/i18n/locales/en-US/settings.json
@@ -221,10 +221,9 @@
       "tooLarge": "File is too large (max 200MB). Please check you selected the correct file.",
       "parseError": "Failed to parse JSON file. Please check the file format.",
       "readError": "Failed to read file. Please try again.",
-      "interrupted": "Import was interrupted. The server may have timed out. Your data may have been partially imported.",
-      "interruptedShort": "Import was interrupted",
       "failed": "Import failed",
       "successCount": "Successfully imported {{count}} items",
+      "partialWarning": "Import partially completed — see details",
       "dialog": {
         "previewTitle": "Import Aurora Data",
         "importingTitle": "Importing Aurora Data...",
@@ -250,9 +249,15 @@
         "attemptsSummary": "{{imported}} imported, {{skipped}} skipped (already exist), {{failed}} unmatched",
         "circuits": "Circuits",
         "circuitsSummary": "{{imported}} imported, {{skipped}} skipped, {{failed}} failed",
-        "unresolvedTitle_one": "{{count}} climb could not be matched",
-        "unresolvedTitle_other": "{{count}} climbs could not be matched",
-        "unresolvedMore": "...and {{count}} more"
+        "unresolvedAscentsTitle_one": "{{count}} ascent had no matching climb",
+        "unresolvedAscentsTitle_other": "{{count}} ascents had no matching climb",
+        "unresolvedAttemptsTitle_one": "{{count}} attempt had no matching climb",
+        "unresolvedAttemptsTitle_other": "{{count}} attempts had no matching climb",
+        "unresolvedCircuitsTitle_one": "{{count}} circuit climb couldn't be matched",
+        "unresolvedCircuitsTitle_other": "{{count}} circuit climbs couldn't be matched",
+        "unresolvedMore": "...and {{count}} more",
+        "partialTitle": "Import was interrupted",
+        "partialBody": "Some data may not have been imported. Re-importing the same file is safe and will fill in the gaps."
       }
     },
     "kilterEmail": {

--- a/packages/web/i18n/locales/es/settings.json
+++ b/packages/web/i18n/locales/es/settings.json
@@ -221,10 +221,9 @@
       "tooLarge": "El archivo es demasiado grande (máx. 200 MB). Comprueba que has elegido el archivo correcto.",
       "parseError": "No se pudo leer el archivo JSON. Comprueba el formato del archivo.",
       "readError": "No se pudo leer el archivo. Inténtalo de nuevo.",
-      "interrupted": "La importación se interrumpió. El servidor pudo agotar el tiempo de espera. Puede que tus datos se hayan importado parcialmente.",
-      "interruptedShort": "Importación interrumpida",
       "failed": "Importación fallida",
       "successCount": "{{count}} elementos importados correctamente",
+      "partialWarning": "Importación parcial — revisa los detalles",
       "dialog": {
         "previewTitle": "Importar datos de Aurora",
         "importingTitle": "Importando datos de Aurora...",
@@ -250,9 +249,15 @@
         "attemptsSummary": "{{imported}} importados, {{skipped}} omitidos (ya existían), {{failed}} sin emparejar",
         "circuits": "Circuitos",
         "circuitsSummary": "{{imported}} importados, {{skipped}} omitidos, {{failed}} fallidos",
-        "unresolvedTitle_one": "No se pudo emparejar {{count}} vía",
-        "unresolvedTitle_other": "No se pudieron emparejar {{count}} vías",
-        "unresolvedMore": "...y {{count}} más"
+        "unresolvedAscentsTitle_one": "{{count}} encadene sin vía asociada",
+        "unresolvedAscentsTitle_other": "{{count}} encadenes sin vía asociada",
+        "unresolvedAttemptsTitle_one": "{{count}} intento sin vía asociada",
+        "unresolvedAttemptsTitle_other": "{{count}} intentos sin vía asociada",
+        "unresolvedCircuitsTitle_one": "{{count}} vía del circuito no se pudo emparejar",
+        "unresolvedCircuitsTitle_other": "{{count}} vías del circuito no se pudieron emparejar",
+        "unresolvedMore": "...y {{count}} más",
+        "partialTitle": "La importación se interrumpió",
+        "partialBody": "Es posible que algunos datos no se hayan importado. Volver a importar el mismo archivo es seguro y completará lo que falte."
       }
     },
     "kilterEmail": {

--- a/packages/web/i18n/locales/fr/settings.json
+++ b/packages/web/i18n/locales/fr/settings.json
@@ -221,10 +221,9 @@
       "tooLarge": "Fichier trop volumineux (max 200 Mo). Vérifiez que vous avez choisi le bon fichier.",
       "parseError": "Lecture du JSON impossible. Vérifiez le format du fichier.",
       "readError": "Lecture du fichier impossible. Réessayez.",
-      "interrupted": "Importation interrompue. Le serveur a peut-être expiré. Une partie de vos données a peut-être été importée.",
-      "interruptedShort": "Importation interrompue",
       "failed": "Échec de l'importation",
       "successCount": "{{count}} éléments importés",
+      "partialWarning": "Importation partielle — voir les détails",
       "dialog": {
         "previewTitle": "Importer les données Aurora",
         "importingTitle": "Importation des données Aurora...",
@@ -250,9 +249,15 @@
         "attemptsSummary": "{{imported}} importés, {{skipped}} ignorés (déjà existants), {{failed}} non associés",
         "circuits": "Circuits",
         "circuitsSummary": "{{imported}} importés, {{skipped}} ignorés, {{failed}} échoués",
-        "unresolvedTitle_one": "{{count}} bloc n'a pas pu être associé",
-        "unresolvedTitle_other": "{{count}} blocs n'ont pas pu être associés",
-        "unresolvedMore": "...et {{count}} de plus"
+        "unresolvedAscentsTitle_one": "{{count}} enchaînement sans bloc associé",
+        "unresolvedAscentsTitle_other": "{{count}} enchaînements sans bloc associé",
+        "unresolvedAttemptsTitle_one": "{{count}} essai sans bloc associé",
+        "unresolvedAttemptsTitle_other": "{{count}} essais sans bloc associé",
+        "unresolvedCircuitsTitle_one": "{{count}} bloc du circuit n'a pas pu être associé",
+        "unresolvedCircuitsTitle_other": "{{count}} blocs du circuit n'ont pas pu être associés",
+        "unresolvedMore": "...et {{count}} de plus",
+        "partialTitle": "Importation interrompue",
+        "partialBody": "Certaines données n'ont peut-être pas été importées. Réimporter le même fichier est sûr et complétera ce qui manque."
       }
     },
     "kilterEmail": {


### PR DESCRIPTION
## Summary

Closes #2370.

- **Partial-success UX.** Chunk failures no longer hide the work earlier chunks already committed. `streamImport` captures chunk errors, attaches `partialError` to the merged `ImportResult`, and emits a final `complete` event — the completion dialog now renders the counts plus a clear warning banner instead of the generic "Import failed" dialog. Snackbar switches to a warning variant. The dead "interrupted" branch in `handleImportConfirm` is gone.
- **Per-source unresolved climbs.** `unresolvedClimbs` is split into `unresolvedAscentClimbs` / `unresolvedAttemptClimbs` / `unresolvedCircuitClimbs`. The dialog now renders three separate "no matching climb" alerts so a user can tell which of ascents, attempts, or circuit entries dropped.
- **Flash status — going forward and historically.** The importer used to read Aurora's per-session `count == 1` as if it meant "first ever try." It doesn't. The new behaviour writes a conservative `'send'` and then runs `correctFlashStatusForUser` on the final chunk to promote true first-evers and demote prior-tick "flashes". Migration `0108_fix_tick_flash_status` applies the same correction across every existing `boardsesh_ticks` row.
- **Sentry instrumentation.** `Sentry.captureException` fires client-side with `{ chunkIndex, totalChunks, chunkSummary, mergedSoFar }` and server-side with `{ boardType, userId, dataCounts }`. The next James-shaped failure will tell us exactly which chunk and how big.

### What we found while investigating James's case

Matched him in the readonly DB by his exact ascent/attempt counts. Every chunk completed server-side — all 2834 ticks landed, status/`attempt_count`/timestamps preserved exactly, all 38 circuits became playlists, 254 inferred sessions covered every tick. **The UI lied to him.** A later chunk's response stream was cut short between DB commit and the `complete` event reaching the client, so `sendChunk` threw and the catch branch showed a generic error.

For his specific data the dropped-ascents path didn't actually fire (816/816 unique climb names resolve cleanly), so that part of the fix is for other users. The 2 silently-dropped draft climbs (29 → 27) are a separate frame-conversion issue worth a follow-up.

The flash bug surfaced during the investigation: James's DB shows 1878 "flashes" out of 1879 ascents, which is wrong by definition. The migration corrects this for him and everyone else in one pass.

## Test plan

- [x] `vp run typecheck` — clean (all 23 tasks pass).
- [x] `vp test run --project web --reporter=agent` (focused on aurora + import-prompt) — 4791 tests pass.
- [x] `vp run check:i18n` — no hardcoded strings.
- [x] `vp run check:i18n:orphans` — no new orphans introduced (3 pre-existing mobile keys flagged, unrelated).
- [x] `vp check` — formatting clean for all modified files (3 unrelated files have pre-existing format issues: `docs/branch-deploys.md`, `packages/web/board-controller/static/assets/index-DDv0U3S3.js`, and the test export `export-jamesthurley.json`).
- [ ] Apply `0108_fix_tick_flash_status.sql` against the dev DB; spot-check that `flash` counts drop sharply for users with repeats.
- [ ] Import `export-jamesthurley.json` as the test user; confirm completion dialog renders the counts with no error banner.
- [ ] Force a partial failure (temporarily make the third chunk throw); confirm warning snackbar, banner, counts from earlier chunks, and Sentry event.
- [ ] Drop some climbs from the local DB and re-import; confirm per-source unresolved sections render correctly.
- [ ] Re-import the same export twice; confirm idempotency (everything "skipped (already exist)", no flash churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)