### PR TITLE
[codex] fix climb list logbook filters

### DIFF
--- a/packages/web/app/components/board-page/__tests__/board-page-climbs-list.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/board-page-climbs-list.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, waitFor } from '@testing-library/react';
+import type { BoardDetails, Climb } from '@/app/lib/types';
+import BoardPageClimbsList from '../board-page-climbs-list';
+import { useSearchData } from '../../graphql-queue';
+import { useOptionalBoardProvider } from '../../board-provider/board-provider-context';
+
+vi.mock('../../graphql-queue', () => ({
+  useCurrentClimb: vi.fn(() => ({ currentClimb: null })),
+  useSearchData: vi.fn(() => ({
+    climbSearchResults: null,
+    hasMoreResults: false,
+    hasDoneFirstFetch: false,
+    isFetchingClimbs: false,
+  })),
+  useQueueActions: vi.fn(() => ({
+    addToQueue: vi.fn(),
+    fetchMoreClimbs: vi.fn(),
+  })),
+}));
+
+vi.mock('../../board-provider/board-provider-context', () => ({
+  useOptionalBoardProvider: vi.fn(),
+}));
+
+vi.mock('../climbs-list', () => ({
+  default: ({ climbs }: { climbs: Climb[] }) => (
+    <div data-testid="climbs-list">{climbs.map((climb) => climb.uuid).join(',')}</div>
+  ),
+}));
+
+vi.mock('../../search-drawer/recent-search-pills', () => ({
+  default: () => <div data-testid="recent-search-pills" />,
+}));
+
+vi.mock('../angle-selector', () => ({
+  default: () => <div data-testid="angle-selector" />,
+}));
+
+vi.mock('../../queue-control/play-drawer-event', () => ({
+  dispatchOpenPlayDrawer: vi.fn(),
+}));
+
+const mockUseSearchData = vi.mocked(useSearchData);
+const mockUseOptionalBoardProvider = vi.mocked(useOptionalBoardProvider);
+
+function makeClimb(uuid: string): Climb {
+  return {
+    uuid,
+    setter_username: 'setter',
+    name: uuid,
+    description: '',
+    frames: 'p1r1',
+    angle: 40,
+    ascensionist_count: 0,
+    difficulty: 'V4',
+    quality_average: '0',
+    stars: 0,
+    difficulty_error: '0',
+    benchmark_difficulty: null,
+  };
+}
+
+function makeBoardDetails(): BoardDetails {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 1,
+    set_ids: [1],
+    images_to_holds: {},
+    holdsData: [],
+    edge_left: 0,
+    edge_right: 100,
+    edge_bottom: 0,
+    edge_top: 100,
+    boardHeight: 100,
+    boardWidth: 100,
+  } as BoardDetails;
+}
+
+function renderBoardPageClimbsList(initialClimbs: Climb[]) {
+  return render(
+    <BoardPageClimbsList
+      board_name="kilter"
+      layout_id={1}
+      size_id={1}
+      set_ids={[1]}
+      angle={40}
+      boardDetails={makeBoardDetails()}
+      initialClimbs={initialClimbs}
+      initialHasMore={false}
+    />,
+  );
+}
+
+describe('BoardPageClimbsList logbook seed', () => {
+  const mockGetLogbook = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseOptionalBoardProvider.mockReturnValue({
+      boardName: 'kilter',
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      isInitialized: true,
+      logbook: [],
+      getLogbook: mockGetLogbook,
+      saveTick: vi.fn(),
+      saveClimb: vi.fn(),
+      updateClimb: vi.fn(),
+    });
+    mockUseSearchData.mockReturnValue({
+      climbSearchParams: {} as never,
+      climbSearchResults: null,
+      totalSearchResultCount: null,
+      hasMoreResults: false,
+      isFetchingClimbs: false,
+      isFetchingNextPage: false,
+      hasDoneFirstFetch: false,
+      parsedParams: {} as never,
+    });
+  });
+
+  it('requests logbook entries for the server-rendered initial climbs', async () => {
+    renderBoardPageClimbsList([makeClimb('climb-b'), makeClimb('climb-a')]);
+
+    await waitFor(() => {
+      expect(mockGetLogbook).toHaveBeenCalledWith(['climb-a', 'climb-b']);
+    });
+  });
+
+  it('requests logbook entries again when client search results replace the initial list', async () => {
+    const view = renderBoardPageClimbsList([makeClimb('initial-climb')]);
+
+    await waitFor(() => {
+      expect(mockGetLogbook).toHaveBeenCalledWith(['initial-climb']);
+    });
+
+    mockUseSearchData.mockReturnValue({
+      climbSearchParams: {} as never,
+      climbSearchResults: [makeClimb('client-climb')],
+      totalSearchResultCount: null,
+      hasMoreResults: false,
+      isFetchingClimbs: false,
+      isFetchingNextPage: false,
+      hasDoneFirstFetch: true,
+      parsedParams: {} as never,
+    });
+    view.rerender(
+      <BoardPageClimbsList
+        board_name="kilter"
+        layout_id={1}
+        size_id={1}
+        set_ids={[1]}
+        angle={40}
+        boardDetails={makeBoardDetails()}
+        initialClimbs={[makeClimb('initial-climb')]}
+        initialHasMore={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetLogbook).toHaveBeenCalledWith(['client-climb']);
+    });
+  });
+});

--- a/packages/web/app/components/board-page/board-page-climbs-list.tsx
+++ b/packages/web/app/components/board-page/board-page-climbs-list.tsx
@@ -7,6 +7,7 @@ import { stabilizeClimbArrayRef } from './climb-list-utils';
 import RecentSearchPills from '../search-drawer/recent-search-pills';
 import AngleSelector from './angle-selector';
 import { dispatchOpenPlayDrawer } from '../queue-control/play-drawer-event';
+import { useOptionalBoardProvider } from '../board-provider/board-provider-context';
 
 type BoardPageClimbsListProps = ParsedBoardRouteParameters & {
   boardDetails: BoardDetails;
@@ -35,6 +36,7 @@ const BoardPageClimbsList = ({
   const { currentClimb } = useCurrentClimb();
   const { climbSearchResults, hasMoreResults, hasDoneFirstFetch, isFetchingClimbs } = useSearchData();
   const { addToQueue, fetchMoreClimbs } = useQueueActions();
+  const getLogbook = useOptionalBoardProvider()?.getLogbook;
 
   // Queue Context provider uses React Query infinite to fetch results, which can only happen clientside.
   // That data equals null at the start, so when its null we use the initialClimbs array which we
@@ -59,6 +61,20 @@ const BoardPageClimbsList = ({
     prevClimbsRef.current = deduped;
     return deduped;
   }, [hasDoneFirstFetch, initialClimbs, climbSearchResults]);
+
+  const climbUuidsForLogbookKey = useMemo(
+    () =>
+      climbs
+        .map((climb) => climb.uuid)
+        .sort()
+        .join(','),
+    [climbs],
+  );
+
+  useEffect(() => {
+    if (!getLogbook || climbUuidsForLogbookKey.length === 0) return;
+    void getLogbook(climbUuidsForLogbookKey.split(','));
+  }, [getLogbook, climbUuidsForLogbookKey]);
 
   // Open the play drawer on the requested climb when this component mounts
   // on a /view/{climb_uuid} route. The dispatch is deferred to the next

--- a/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx
@@ -5,6 +5,7 @@ import { useQueueDataFetching } from '../../hooks/use-queue-data-fetching';
 import type { ParsedBoardRouteParameters, SearchRequestPagination, Climb } from '@/app/lib/types';
 import type { ClimbQueue } from '../../types';
 import { useBoardProvider, useOptionalBoardProvider } from '../../../board-provider/board-provider-context';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import React from 'react';
 
 // Mock dependencies
@@ -62,6 +63,7 @@ Object.defineProperty(window, 'location', {
 
 const mockUseBoardProvider = vi.mocked(useBoardProvider);
 const mockUseOptionalBoardProvider = vi.mocked(useOptionalBoardProvider);
+const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
 
 const mockClimb: Climb = {
   uuid: 'climb-1',
@@ -178,6 +180,13 @@ describe('useQueueDataFetching', () => {
       saveClimb: vi.fn(),
       updateClimb: vi.fn(),
       boardName: 'kilter',
+    });
+
+    mockUseWsAuthToken.mockReturnValue({
+      token: 'mock-token',
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
     });
 
     // Mock GraphQL client requests
@@ -405,6 +414,56 @@ describe('useQueueDataFetching', () => {
       expect(requestInputs.length).toBeGreaterThan(0);
       expect(requestInputs.every((input) => input.onlyWideClimbs === true)).toBe(true);
     });
+  });
+
+  it('waits for an auth token before running progress-filtered search and count requests', async () => {
+    mockUseWsAuthToken.mockReturnValue({
+      token: null,
+      isAuthenticated: false,
+      isLoading: true,
+      error: null,
+    });
+    const searchParamsWithProgressFilter = {
+      ...mockSearchParams,
+      showOnlyAttempted: true,
+    };
+
+    const { result, rerender } = renderHook(
+      () =>
+        useQueueDataFetching({
+          searchParams: searchParamsWithProgressFilter,
+          countSearchParams: searchParamsWithProgressFilter,
+          queue: mockQueue,
+          parsedParams: mockParsedParams,
+          hasDoneFirstFetch: false,
+          setHasDoneFirstFetch: mockSetHasDoneFirstFetch,
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(mockGraphQLRequest).not.toHaveBeenCalled();
+    expect(result.current.isFetchingClimbs).toBe(true);
+
+    mockUseWsAuthToken.mockReturnValue({
+      token: 'mock-token',
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
+    rerender();
+
+    await waitFor(() => {
+      expect(mockGraphQLRequest).toHaveBeenCalled();
+    });
+
+    const requestInputs = mockGraphQLRequest.mock.calls
+      .map((call) => (call[1] as { input?: { showOnlyAttempted?: boolean } } | undefined)?.input)
+      .filter((input): input is { showOnlyAttempted?: boolean } => input !== undefined);
+
+    expect(requestInputs.length).toBeGreaterThan(0);
+    expect(requestInputs.every((input) => input.showOnlyAttempted === true)).toBe(true);
   });
 
   it('should handle empty search results', async () => {

--- a/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
+++ b/packages/web/app/components/queue-control/hooks/use-queue-data-fetching.tsx
@@ -32,7 +32,10 @@ export const useQueueDataFetching = ({
   hasDoneFirstFetch,
   setHasDoneFirstFetch,
 }: UseQueueDataFetchingProps) => {
-  const getLogbook = useOptionalBoardProvider()?.getLogbook;
+  const boardProvider = useOptionalBoardProvider();
+  const getLogbook = boardProvider?.getLogbook;
+  const isBoardAuthLoading = boardProvider?.isLoading ?? false;
+  const isBoardAuthenticated = boardProvider?.isAuthenticated ?? false;
   // Use wsAuthToken for GraphQL backend auth (NextAuth session token)
   const { token: wsAuthToken } = useWsAuthToken();
   const fetchedUuidsRef = useRef<string>('');
@@ -48,6 +51,8 @@ export const useQueueDataFetching = ({
     () => USER_SPECIFIC_SEARCH_PARAMS.some((key) => Boolean((searchParams as Record<string, unknown>)[key])),
     [searchParams],
   );
+  const shouldWaitForSearchAuth =
+    usesUserSpecificFilters && (isBoardAuthLoading || isBoardAuthenticated) && !wsAuthToken;
 
   // Create a stable query key with flattened primitive values to avoid object reference changes.
   // The auth token is included only when user-specific filters are active so the cached
@@ -150,6 +155,7 @@ export const useQueueDataFetching = ({
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
     refetchOnWindowFocus: false,
+    enabled: !shouldWaitForSearchAuth,
   });
 
   // Count query uses instant (un-debounced) params so the count updates
@@ -198,6 +204,8 @@ export const useQueueDataFetching = ({
     () => USER_SPECIFIC_SEARCH_PARAMS.some((key) => Boolean((countSearchParams as Record<string, unknown>)[key])),
     [countSearchParams],
   );
+  const shouldWaitForCountAuth =
+    countUsesUserSpecificFilters && (isBoardAuthLoading || isBoardAuthenticated) && !wsAuthToken;
 
   const countQueryKey = useMemo(() => {
     const { page: _, ...paramsWithoutPage } = countSearchParams;
@@ -224,6 +232,7 @@ export const useQueueDataFetching = ({
     },
     staleTime: 24 * 60 * 60 * 1000,
     refetchOnWindowFocus: false,
+    enabled: !shouldWaitForCountAuth,
   });
 
   const totalSearchResultCount = countData ?? null;
@@ -300,7 +309,7 @@ export const useQueueDataFetching = ({
     suggestedClimbs,
     totalSearchResultCount,
     hasMoreResults,
-    isFetchingClimbs: isFetching,
+    isFetchingClimbs: isFetching || shouldWaitForSearchAuth,
     isFetchingNextPage,
     fetchMoreClimbs,
     // Combined climb UUIDs for use by useClimbActionsData

--- a/packages/web/scripts/mobile-i18n-keeps.ts
+++ b/packages/web/scripts/mobile-i18n-keeps.ts
@@ -109,6 +109,9 @@
 // i18n-keep boards.mobile.emptyTitle
 // i18n-keep boards.mobile.emptySubtitle
 // i18n-keep common.mobile.more.title
+// i18n-keep common.mobile.more.development
+// i18n-keep common.mobile.more.metroServersTitle
+// i18n-keep common.mobile.more.metroServersSubtitle
 // i18n-keep common.mobile.nav.boards
 // i18n-keep common.mobile.nav.climbs
 // i18n-keep common.mobile.nav.climb


### PR DESCRIPTION
## What changed

- Seed board-route logbook fetching from the climbs currently rendered by the climb list, including the server-rendered initial list.
- Hold authenticated progress-filtered climb searches/counts until the backend auth token is available, so `showOnlyAttempted`, `hideAttempted`, `showOnlyCompleted`, and `hideCompleted` do not briefly or permanently fall back to anonymous results.
- Add regression coverage for initial climb-list logbook seeding and token-gated progress-filtered searches.
- Add missing mobile i18n keep markers for React Native-only `common.mobile.more.*` keys so the pre-commit orphan check passes.

## Root cause

The climb list displayed SSR climbs before the client search completed, but logbook fetching was only seeded from client search results and queue items. Separately, progress filters could issue GraphQL search/count requests before `/api/internal/ws-auth` returned a token, and the backend ignores those user-specific filters without a user id.

## Validation

- `vp test run --project web packages/web/app/components/queue-control/__tests__/hooks/use-queue-data-fetching.test.tsx packages/web/app/components/board-page/__tests__/board-page-climbs-list.test.tsx packages/web/app/hooks/__tests__/use-logbook.test.ts packages/web/app/components/climb-card/__tests__/ascent-status.test.tsx --reporter=agent`
- `vp test run --project backend packages/backend/src/__tests__/climb-queries.test.ts --reporter=agent`
- `vp run typecheck:web`
- `vp run check:i18n:orphans`

Note: full `vp check` still reports unrelated pre-existing formatting issues in `docs/branch-deploys.md` and `packages/web/board-controller/static/assets/index-DDv0U3S3.js`. The staged pre-commit checks passed for this commit.