### PR TITLE
fix(backend): allow same-origin WebSocket upgrades (#2358)

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -194,7 +194,7 @@ sequenceDiagram
 
 ### Key Points
 
-1. **Origin Validation**: WebSocket connections are validated against allowed origins
+1. **Origin Validation**: WebSocket upgrades are validated against the allowed-origins list (`BOARDSESH_URL` + `www.` variant, Vercel/homelab preview patterns, dev origins). Two additional paths are accepted: connections with **no** `Origin` header (native/direct clients), and genuine **same-origin** upgrades where the `Origin`'s hostname equals the request's `Host` header (`isSameOriginUpgrade` in `handlers/cors.ts`). The same-origin path is why the React Native **Android** app connects — RN derives `Origin` from the `wss://` URL (`https://ws.boardsesh.com`, the backend's own host, never on the website allow-list) — and why preview WS hosts (`{N}.ws.preview.boardsesh.com`) work without per-PR config. It's safe against cross-site WebSocket hijacking because a cross-site attacker's `Origin` is its own domain, and WS auth is token-based (`connectionParams`), not cookie-based. Rejected upgrades log `{ origin, host, userAgent, forwardedFor, remoteAddress }` for attribution.
 2. **Authentication**: Auth token passed in `connectionParams` — web supplies a static `authToken` string; mobile supplies an async `connectionParams` provider (re-reads the token from secure storage on every reconnect). Both paths and the `shouldRetry` predicate (mobile rejects 4401 auth-error close codes) are handled by the shared `createGraphQLClient` factory in `@boardsesh/graphql-client`.
 3. **Eager Subscription**: Queue subscription starts BEFORE fetching state to prevent race conditions
 4. **Session Restoration**: Sessions can be restored from Redis (warm cache) or PostgreSQL (dormant durable state)

--- a/packages/backend/src/__tests__/cors.test.ts
+++ b/packages/backend/src/__tests__/cors.test.ts
@@ -4,7 +4,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { execFileSync } from 'node:child_process';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
-import { initCors, isOriginAllowed, applyCorsHeaders, getAllowedOrigins } from '../handlers/cors';
+import { initCors, isOriginAllowed, isSameOriginUpgrade, applyCorsHeaders, getAllowedOrigins } from '../handlers/cors';
 
 vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
@@ -208,12 +208,66 @@ describe('CORS Handler', () => {
     });
   });
 
+  describe('isSameOriginUpgrade', () => {
+    it('allows a genuine same-origin upgrade even in production', () => {
+      // The same-origin allowance is NOT gated behind the dev-only branches —
+      // this is what unblocks the React Native Android app (Origin derived from
+      // wss://ws.boardsesh.com) and preview WS hosts against the prod backend.
+      const originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      try {
+        expect(isSameOriginUpgrade('https://ws.boardsesh.com', 'ws.boardsesh.com')).toBe(true);
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    });
+
+    it('allows preview WS hosts without per-environment config', () => {
+      expect(isSameOriginUpgrade('https://42.ws.preview.boardsesh.com', '42.ws.preview.boardsesh.com')).toBe(true);
+    });
+
+    it('ignores a port on the Host header (compares hostname only)', () => {
+      expect(isSameOriginUpgrade('https://ws.boardsesh.com', 'ws.boardsesh.com:443')).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+      expect(isSameOriginUpgrade('https://WS.Boardsesh.com', 'ws.boardsesh.com')).toBe(true);
+    });
+
+    it('ignores a trailing dot on the Origin hostname', () => {
+      expect(isSameOriginUpgrade('https://ws.boardsesh.com.', 'ws.boardsesh.com')).toBe(true);
+    });
+
+    it('ignores userinfo in the Origin', () => {
+      expect(isSameOriginUpgrade('https://user:pass@ws.boardsesh.com', 'ws.boardsesh.com')).toBe(true);
+    });
+
+    it('rejects a cross-origin upgrade', () => {
+      expect(isSameOriginUpgrade('https://evil.com', 'ws.boardsesh.com')).toBe(false);
+    });
+
+    it('rejects a look-alike host that is not an exact hostname match', () => {
+      expect(isSameOriginUpgrade('https://ws.boardsesh.com.evil.com', 'ws.boardsesh.com')).toBe(false);
+    });
+
+    it('fails closed on a malformed Origin (does not throw)', () => {
+      expect(isSameOriginUpgrade('http://[not-a-url', 'ws.boardsesh.com')).toBe(false);
+    });
+
+    it('fails closed when the Host header is missing', () => {
+      expect(isSameOriginUpgrade('https://ws.boardsesh.com', undefined)).toBe(false);
+    });
+  });
+
   /* eslint-disable @typescript-eslint/unbound-method -- all assertions target vi.fn() mocks, no `this` concern */
   describe('applyCorsHeaders', () => {
-    function createMockReq(method: string, origin?: string) {
+    function createMockReq(method: string, origin?: string, host?: string) {
+      const headers: Record<string, string> = {};
+      if (origin) headers.origin = origin;
+      if (host) headers.host = host;
       return {
         method,
-        headers: origin ? { origin } : {},
+        headers,
       } as unknown as IncomingMessage;
     }
 
@@ -247,6 +301,26 @@ describe('CORS Handler', () => {
 
     it('does NOT set origin-specific headers when origin is not allowed', () => {
       const req = createMockReq('GET', 'https://evil.com');
+      const res = createMockRes();
+      applyCorsHeaders(req, res);
+
+      expect(res.setHeader).not.toHaveBeenCalledWith('Access-Control-Allow-Origin', expect.anything());
+      expect(res.setHeader).not.toHaveBeenCalledWith('Access-Control-Allow-Credentials', expect.anything());
+    });
+
+    it('echoes the origin for a same-origin request not on the allow-list', () => {
+      // ws.boardsesh.com is the backend's own host, never on the website
+      // allow-list, but a request whose Origin matches its Host is same-origin.
+      const req = createMockReq('GET', 'https://ws.boardsesh.com', 'ws.boardsesh.com');
+      const res = createMockRes();
+      applyCorsHeaders(req, res);
+
+      expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', 'https://ws.boardsesh.com');
+      expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Credentials', 'true');
+    });
+
+    it('does NOT echo the origin when Origin and Host differ and origin is not allowed', () => {
+      const req = createMockReq('GET', 'https://evil.com', 'ws.boardsesh.com');
       const res = createMockRes();
       applyCorsHeaders(req, res);
 

--- a/packages/backend/src/handlers/cors.ts
+++ b/packages/backend/src/handlers/cors.ts
@@ -149,6 +149,57 @@ export function isOriginAllowed(origin: string): boolean {
 }
 
 /**
+ * Reduce a Host header or URL hostname to a bare, comparable hostname:
+ * lowercase, no trailing dot, no surrounding IPv6 brackets, no port.
+ * Bracket-aware so the colons inside an IPv6 literal aren't read as a port
+ * separator.
+ */
+function normalizeHostForCompare(value: string): string {
+  let host = value.trim().toLowerCase().replace(/\.$/, '');
+  if (host.startsWith('[')) {
+    // IPv6 literal: [::1] or [::1]:3000 — take what's between the brackets.
+    const closing = host.indexOf(']');
+    return closing === -1 ? '' : host.slice(1, closing);
+  }
+  const colon = host.indexOf(':');
+  if (colon !== -1) host = host.slice(0, colon);
+  return host;
+}
+
+/**
+ * Allow a connection when its Origin is the same host it is connecting to.
+ *
+ * A genuine same-origin upgrade — the Origin's hostname equals the Host header
+ * the client is connecting to — cannot be a cross-site WebSocket hijack: a
+ * cross-site attacker's Origin is always their own domain, never our host. WS
+ * auth here is token-based (`connectionParams.authToken`), not cookie-based, so
+ * there is no ambient-credential surface to abuse either. This is strictly
+ * narrower than the no-Origin branch the WS upgrade handler already allows.
+ *
+ * This is what lets the React Native Android app connect: RN derives the Origin
+ * from the wss:// URL (https://ws.boardsesh.com), which equals the backend's own
+ * host. It also covers preview WS hosts ({N}.ws.preview.boardsesh.com) with no
+ * per-environment config, because the Railway/Cloudflare edge forwards the real
+ * public host — the same value join.ts already trusts to build redirect URLs.
+ *
+ * Compares hostnames only (case-insensitive, trailing dot / port / IPv6 brackets
+ * normalized away); scheme and port are intentionally not part of the
+ * comparison. Fails closed on a missing Host header or an unparseable Origin.
+ */
+export function isSameOriginUpgrade(origin: string, host: string | undefined): boolean {
+  if (!origin || !host) return false;
+  let originHostname: string;
+  try {
+    originHostname = new URL(origin).hostname;
+  } catch {
+    return false;
+  }
+  const normalizedOrigin = normalizeHostForCompare(originHostname);
+  const normalizedHost = normalizeHostForCompare(host);
+  return normalizedOrigin !== '' && normalizedOrigin === normalizedHost;
+}
+
+/**
  * Apply CORS headers to a response.
  * Returns false if this was an OPTIONS request and response was sent.
  * Returns true if processing should continue.
@@ -156,7 +207,7 @@ export function isOriginAllowed(origin: string): boolean {
 export function applyCorsHeaders(req: IncomingMessage, res: ServerResponse): boolean {
   const origin = req.headers.origin;
 
-  if (origin && isOriginAllowed(origin)) {
+  if (origin && (isOriginAllowed(origin) || isSameOriginUpgrade(origin, req.headers.host))) {
     res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Access-Control-Allow-Credentials', 'true');
   }

--- a/packages/backend/src/websocket/setup.ts
+++ b/packages/backend/src/websocket/setup.ts
@@ -10,7 +10,7 @@ import { validateQueryDepth } from '../graphql/query-depth';
 import { roomManager } from '../services/room-manager';
 import { pubsub } from '../pubsub/index';
 import { validateToken, extractAuthToken, extractControllerApiKey, validateControllerApiKey } from '../middleware/auth';
-import { isOriginAllowed } from '../handlers/cors';
+import { isOriginAllowed, isSameOriginUpgrade } from '../handlers/cors';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { logger } from '../utils/logger';
 
@@ -59,13 +59,27 @@ export function setupWebSocketServer(httpServer: HttpServer): {
         return;
       }
 
-      // Check if origin is in allowed list or matches Vercel preview pattern
-      if (isOriginAllowed(origin)) {
+      // Allow if the origin is on the website allow-list / a preview pattern, OR
+      // if it's a genuine same-origin upgrade (Origin host === the host being
+      // connected to). The latter unblocks the React Native Android app, whose
+      // WebSocket sets Origin from the wss:// URL (https://ws.boardsesh.com),
+      // and preview WS hosts — without weakening CSWSH protection. See
+      // isSameOriginUpgrade for the security rationale.
+      if (isOriginAllowed(origin) || isSameOriginUpgrade(origin, info.req.headers.host)) {
         callback(true);
         return;
       }
 
-      logger.warn(`[WebSocket] Rejected connection from unauthorized origin: ${origin}`);
+      // Remaining rejections are genuinely unauthorized origins. Log attribution
+      // (User-Agent + IP) so they can be traced. forwardedFor is forensic only —
+      // it is user-controlled and never used for an allow/deny decision.
+      logger.warn('[WebSocket] Rejected connection from unauthorized origin', {
+        origin,
+        host: info.req.headers.host,
+        userAgent: info.req.headers['user-agent'],
+        forwardedFor: info.req.headers['x-forwarded-for'],
+        remoteAddress: info.req.socket.remoteAddress,
+      });
       callback(false, 403, 'Origin not allowed');
     },
   });


### PR DESCRIPTION
## What & why

Closes #2358. Production logs showed the WS `verifyClient` hook rejecting ~62 upgrades over 6h with `Origin: https://ws.boardsesh.com` — the backend's *own* host. Traced to a real, legitimate client: **the React Native app on Android**.

- RN's Android `WebSocketModule.getDefaultOrigin` auto-injects an `Origin` header derived from the `wss://` URL when the app supplies none. Our mobile `ws-client.ts` passes no headers / no `webSocketImpl`, so `wss://ws.boardsesh.com/graphql` → `Origin: https://ws.boardsesh.com`.
- The allow-list (`initCors`) is seeded only from the website URL `BOARDSESH_URL` (+ `www.` variant), never the backend's own WS host → the upgrade was 403'd. **Android party-mode WebSocket was silently broken in production.**
- iOS RN sends no Origin (`RCTWebSocketModule.mm` doesn't inject one) → allowed by the existing no-Origin passthrough. The old Capacitor app loads its WebView from `https://www.boardsesh.com` → sends an allow-listed page origin. Web/ESP32 unaffected. The low, distributed volume fits a handful of Android testers with graphql-ws `retryAttempts: 10` load-balancing across instances.

## Change

**Allow genuine same-origin upgrades.** New `isSameOriginUpgrade(origin, host)` in `cors.ts`: if the Origin's hostname equals the request's `Host` header, allow. Wired into both `verifyClient` and `applyCorsHeaders`.

**Why this is safe (pre-empting the security question):** a same-origin upgrade cannot be a cross-site WebSocket hijack — a cross-site attacker's `Origin` is always its own domain, never our host. WS auth here is token-based (`connectionParams.authToken`), not cookie-based, so there's no ambient-credential surface either. This is *strictly narrower* than the no-Origin branch we already allow. It needs no new env var and also covers preview WS hosts (`{N}.ws.preview.boardsesh.com`), because the Railway/Cloudflare edge forwards the real public host — the same value `join.ts` already trusts to build redirect URLs.

**Attribution logging.** Rejected upgrades now log `{ origin, host, userAgent, forwardedFor, remoteAddress }` (per the issue's request). After this change, legitimate Android traffic is allowed and no longer logged, so remaining rejections are genuinely unauthorized origins — exactly where attribution matters. `forwardedFor` is forensic-only and never used for an allow/deny decision.

No mobile changes — the server-side fix repairs already-deployed Android builds the moment the backend deploys (no OTA / app-store round-trip).

## Hostname comparison

Compares hostnames only (case-insensitive; trailing dot, port, and IPv6 brackets normalized away); scheme and port are intentionally not compared. Fails closed on a missing Host header or an unparseable Origin.

## Tests / verification

- `cors.test.ts`: 12 new cases incl. the headline `NODE_ENV='production'` same-origin allow (proves it's not gated behind dev-only branches), preview host, port/case/trailing-dot/userinfo normalization, cross-origin + look-alike + malformed + missing-host rejection, and two `applyCorsHeaders` HTTP-path assertions. **48/48 pass.**
- `typecheck:backend` ✅, `vp check` clean for changed files.
- **Live probe against a running dev backend:** `Origin == Host` (not on the dev allow-list) → accepted via the new branch; cross-origin → 403 + the new attribution log line; no-Origin → accepted (unchanged).

`docs/websocket-implementation.md` updated (Origin Validation key-point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)