### PR TITLE
Pass DATABASE_URL into the production web build

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -163,6 +163,13 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+          # Next's "Collecting page data" phase evaluates route modules (e.g.
+          # /api/auth/[...nextauth]), which instantiate the db client and throw
+          # if DATABASE_URL is unset. Native Vercel builds got this from the
+          # project env; in Actions we pass it explicitly (process.env wins over
+          # any .env file in Next). Same Production-environment secret the
+          # migrate job uses.
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: vercel build --prod
 
       - name: Upload prebuilt output


### PR DESCRIPTION
## Summary

The first production deploy on `main` (via the new `production-deploy.yml`) failed during the web build:

```
@boardsesh/web build: Error: DATABASE_URL environment variable is required
@boardsesh/web build: Error: Failed to collect page data for /api/auth/[...nextauth]
```

Now that `vercel build --prod` runs in the `build-web` GitHub Actions job rather than natively on Vercel, Next's **"Collecting page data"** phase evaluates route modules — `/api/auth/[...nextauth]` instantiates the db client (`packages/db/src/client/config.ts:31`), which throws when `DATABASE_URL` is unset. Native Vercel builds inherited `DATABASE_URL` from the Vercel project env; the Actions build step didn't have it (and `process.env` wins over the committed localhost `.env.local` in Next).

## Fix

Pass `DATABASE_URL` into the `Build with Vercel` step from the `Production`-environment secret — the same secret the `migrate` job already uses, and the `build-web` job already declares `environment: Production`, so it resolves.

```yaml
- name: Build with Vercel (prebuilt output)
  env:
    VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
    VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
    VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
    DATABASE_URL: ${{ secrets.DATABASE_URL }}
  run: vercel build --prod
```

## Test plan

- [ ] Merge, watch the `Production Deploy` run: `build-web` completes page-data collection, `vercel deploy --prebuilt --prod` produces a production URL.
- [ ] Confirm `/api/auth/[...nextauth]` and other db-touching routes build without the `DATABASE_URL` error.

https://claude.ai/code/session_01MRTx3uLfSRTHMpkwpDZGXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRTx3uLfSRTHMpkwpDZGXc)_