### PR TITLE
Check out repo in deploy-web so Vercel resolves the project root

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -278,6 +278,8 @@ jobs:
     outputs:
       url: ${{ steps.deploy.outputs.url }}
     steps:
+      - uses: actions/checkout@v6
+
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 
@@ -295,6 +297,9 @@ jobs:
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
           ROLLBACK_ACTIVE: ${{ needs.check-rollback.outputs.active }}
         run: |
+          # vercel deploy --prebuilt still resolves the project's Root Directory
+          # (packages/web), so the repo must be checked out even though the build
+          # is already baked into the downloaded .vercel/output.
           # When a rollback is pinned, --skip-domain builds + uploads the
           # production deployment without assigning it to the production domain,
           # so the pinned (rolled-back) deployment keeps serving traffic.


### PR DESCRIPTION
## Summary

Follow-up to #2405. The production deploy got past the build but failed in `deploy-web`:

```
Retrieving project…
Error: The provided path "~/work/boardsesh/boardsesh/packages/web" does not exist.
```

`vercel deploy --prebuilt` still resolves the Vercel project's **Root Directory** (`packages/web`) from the working tree, but the `deploy-web` job only downloaded the `.vercel` artifact — it never checked out the repo — so `packages/web` didn't exist on the runner. (`build-web` worked because it checks out the repo before `vercel build`.)

## Fix

Add `actions/checkout@v6` as the first step of `deploy-web`, before the artifact download (the download targets `.vercel`, so it isn't clobbered by the checkout).

## Test plan

- [ ] Watch the `Production Deploy` run: `deploy-web` resolves the project and `vercel deploy --prebuilt --prod` returns a production URL.

https://claude.ai/code/session_01MRTx3uLfSRTHMpkwpDZGXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRTx3uLfSRTHMpkwpDZGXc)_