### PR TITLE
Install workspace deps in deploy-web before vercel deploy --prebuilt

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -280,6 +280,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        # vercel deploy --prebuilt validates the prebuilt output's file traces
+        # against the filesystem; those traces reference the hoisted
+        # node_modules/.bun tree, so the workspace must be installed even though
+        # the build itself is already baked into .vercel/output.
+        run: bun install --frozen-lockfile
+
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 


### PR DESCRIPTION
## Summary

Follow-up to #2406. The web deploy got past project resolution but `vercel deploy --prebuilt` then failed:

```
Error: Please ensure project dependencies have been installed:
File does not exist: "node_modules/.bun/@opentelemetry+api@1.9.1/node_modules/@opentelemetry/api/build/src/api/context.js"
```

`vercel deploy --prebuilt` validates the prebuilt output's file traces against the filesystem. Those traces reference the hoisted `node_modules/.bun/...` tree (e.g. `@opentelemetry/api`), but `deploy-web` checked out the repo (#2406) without ever running an install — so `node_modules` was absent.

## Fix

Add `oven-sh/setup-bun@v2` + `bun install --frozen-lockfile` to `deploy-web` before the deploy step. The build itself is still baked into the downloaded `.vercel/output`; the install only satisfies the file-trace validation.

## Test plan

- [ ] Watch the `Production Deploy` run: `deploy-web` installs deps and `vercel deploy --prebuilt --prod` returns a production URL.

https://claude.ai/code/session_01MRTx3uLfSRTHMpkwpDZGXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRTx3uLfSRTHMpkwpDZGXc)_