### PR TITLE
Preserve symlinks and .next when shuttling the prebuilt web output

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -172,19 +172,19 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: vercel build --prod
 
+      - name: Package prebuilt output
+        # vercel deploy --prebuilt needs .vercel/output AND the build dir it
+        # references (packages/web/.next). actions/upload-artifact dereferences
+        # symlinks (the Build Output API uses them), so we tar with symlinks
+        # preserved instead. Allowlist only these paths — never .vercel, which
+        # holds the pulled .env.production.local production secrets.
+        run: tar -czf vercel-output.tar.gz .vercel/output .vercel/project.json packages/web/.next
+
       - name: Upload prebuilt output
         uses: actions/upload-artifact@v4
         with:
           name: vercel-output
-          # Allowlist only what `vercel deploy --prebuilt` needs: the Build
-          # Output API result and the project link. Do NOT upload all of
-          # .vercel — `vercel pull` writes .vercel/.env.production.local with the
-          # project's production secrets, and shipping that in an artifact would
-          # leak prod credentials to anyone with artifact access.
-          path: |
-            .vercel/output
-            .vercel/project.json
-          include-hidden-files: true
+          path: vercel-output.tar.gz
           retention-days: 1
 
   build-backend:
@@ -296,7 +296,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: vercel-output
-          path: .vercel
+          path: .
+
+      - name: Extract prebuilt output
+        # Restores .vercel/output, .vercel/project.json and packages/web/.next
+        # with symlinks intact (into the checked-out tree from above).
+        run: tar -xzf vercel-output.tar.gz && rm vercel-output.tar.gz
 
       - name: Deploy prebuilt output to production
         id: deploy


### PR DESCRIPTION
## Summary

Follow-up to #2407. The web deploy got past dependency installation but `vercel deploy --prebuilt` then failed:

```
Error: File does not exist: "packages/web/.next/package.json"
```

Two problems with how the prebuilt output was shuttled between `build-web` and `deploy-web`:

1. **`.vercel/output` references the Next build dir** (`packages/web/.next`), but the artifact only carried `.vercel/output` + `.vercel/project.json` — not `.next`.
2. **`actions/upload-artifact` dereferences symlinks**, and Vercel's Build Output API relies on symlinks inside `.vercel/output`, so even the uploaded output was structurally wrong on download.

## Fix

Package the prebuilt output as a tarball (symlinks preserved) including `packages/web/.next`, and extract it in `deploy-web`:

- `build-web`: `tar -czf vercel-output.tar.gz .vercel/output .vercel/project.json packages/web/.next`, upload the tarball.
- `deploy-web`: download to `.`, `tar -xzf` into the checked-out tree, then deploy.

Still allowlists only `output` + `project.json` + `.next` — never `.vercel/.env.production.local` (the pulled production secrets), so the no-secrets-in-artifact property from the earlier P1 fix holds.

## Test plan

- [ ] Watch the `Production Deploy` run: `deploy-web` extracts the output and `vercel deploy --prebuilt --prod` returns a production URL.

https://claude.ai/code/session_01MRTx3uLfSRTHMpkwpDZGXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRTx3uLfSRTHMpkwpDZGXc)_