### PR TITLE
Carry the generated openapi.json in the prebuilt web artifact

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -173,13 +173,15 @@ jobs:
         run: vercel build --prod
 
       - name: Package prebuilt output
-        # vercel deploy --prebuilt needs .vercel/output AND the trees its Build
-        # Output API symlinks point at: packages/web/.next and
-        # packages/web/public (which holds the build-generated openapi.json, not
-        # committed). actions/upload-artifact dereferences symlinks, so we tar
-        # with symlinks preserved instead. Allowlist only these paths — never
-        # .vercel itself, which holds the pulled .env.production.local secrets.
-        run: tar -czf vercel-output.tar.gz .vercel/output .vercel/project.json packages/web/.next packages/web/public
+        # vercel deploy --prebuilt needs .vercel/output AND the build-generated
+        # files its Build Output API symlinks point at that aren't in git: the
+        # Next build dir (packages/web/.next) and packages/web/public/openapi.json
+        # (written by scripts/generate-openapi.ts; the rest of public/ is committed
+        # and restored by the deploy-web checkout). actions/upload-artifact
+        # dereferences symlinks, so we tar with symlinks preserved. Allowlist only
+        # these paths — never .vercel itself, which holds the pulled
+        # .env.production.local secrets.
+        run: tar -czf vercel-output.tar.gz .vercel/output .vercel/project.json packages/web/.next packages/web/public/openapi.json
 
       - name: Upload prebuilt output
         uses: actions/upload-artifact@v4
@@ -301,7 +303,8 @@ jobs:
 
       - name: Extract prebuilt output
         # Restores .vercel/output, .vercel/project.json, packages/web/.next and
-        # packages/web/public with symlinks intact (into the checked-out tree).
+        # packages/web/public/openapi.json with symlinks intact (over the
+        # checked-out tree, which already has the committed public/ assets).
         run: tar -xzf vercel-output.tar.gz && rm vercel-output.tar.gz
 
       - name: Deploy prebuilt output to production

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -173,12 +173,13 @@ jobs:
         run: vercel build --prod
 
       - name: Package prebuilt output
-        # vercel deploy --prebuilt needs .vercel/output AND the build dir it
-        # references (packages/web/.next). actions/upload-artifact dereferences
-        # symlinks (the Build Output API uses them), so we tar with symlinks
-        # preserved instead. Allowlist only these paths — never .vercel, which
-        # holds the pulled .env.production.local production secrets.
-        run: tar -czf vercel-output.tar.gz .vercel/output .vercel/project.json packages/web/.next
+        # vercel deploy --prebuilt needs .vercel/output AND the trees its Build
+        # Output API symlinks point at: packages/web/.next and
+        # packages/web/public (which holds the build-generated openapi.json, not
+        # committed). actions/upload-artifact dereferences symlinks, so we tar
+        # with symlinks preserved instead. Allowlist only these paths — never
+        # .vercel itself, which holds the pulled .env.production.local secrets.
+        run: tar -czf vercel-output.tar.gz .vercel/output .vercel/project.json packages/web/.next packages/web/public
 
       - name: Upload prebuilt output
         uses: actions/upload-artifact@v4
@@ -299,8 +300,8 @@ jobs:
           path: .
 
       - name: Extract prebuilt output
-        # Restores .vercel/output, .vercel/project.json and packages/web/.next
-        # with symlinks intact (into the checked-out tree from above).
+        # Restores .vercel/output, .vercel/project.json, packages/web/.next and
+        # packages/web/public with symlinks intact (into the checked-out tree).
         run: tar -xzf vercel-output.tar.gz && rm vercel-output.tar.gz
 
       - name: Deploy prebuilt output to production


### PR DESCRIPTION
## Summary

Follow-up to #2408. The web deploy got further but `vercel deploy --prebuilt` failed:

```
Error: File does not exist: "packages/web/public/openapi.json"
```

Vercel's Build Output API symlinks `.vercel/output` into a bounded set of trees (`.next`, `node_modules`, `public`). After a fresh `deploy-web` checkout the only missing pieces are the **build-generated, gitignored** files — `node_modules` (installed, #2407), `.next` (tarred, #2408), and `public/openapi.json`. The rest of `public/` is committed and restored by the checkout.

## Fix

Carry **only `packages/web/public/openapi.json`** in the tar — the one file `generate-openapi.ts` writes that isn't in git. (Verified: `.gitignore:83` ignores exactly `packages/web/public/openapi.json`, and it's the sole gitignored/untracked entry under `public/`.) Tarring the whole `public/` directory would add ~72 MB (520+ committed AVIF/PNG/WASM assets) to every deploy artifact for no reason. Still excludes `.vercel/.env.production.local` (production secrets).

This completes the set of build-generated symlink targets, so it should be the last of this class.

## Test plan

- [ ] Watch the `Production Deploy` run: `deploy-web` extracts the output and `vercel deploy --prebuilt --prod` returns a production URL.

https://claude.ai/code/session_01MRTx3uLfSRTHMpkwpDZGXc