### PR TITLE
Improve production deploy Discord notifications

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -429,7 +429,9 @@ jobs:
           # (otherwise the workflow link dominates the message).
           CONTENT=$(printf '⚠️ **Deployed but NOT promoted** on `%s`\nA Vercel Instant Rollback is active, so production stays pinned to the rolled-back deployment.\n• web: %s\n• backend: %s\nClear the rollback (revert the offending commit and re-promote), then promote the staged web deployment and redeploy the backend.\n<%s>' \
             "${COMMIT_SHA:0:7}" "$WEB_LINE" "$BACKEND_LINE" "$RUN_URL")
-          jq -n --arg content "$CONTENT" '{content: $content}' \
+          # allowed_mentions.parse=[] blocks @everyone/@here/role/user pings from
+          # any text we splice in (commit messages, PR titles, etc.).
+          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"
 
@@ -469,7 +471,8 @@ jobs:
           # --fail-with-body surfaces Discord's status + error body (e.g. 429,
           # rotated webhook) in the log instead of failing silently. Don't let a
           # webhook hiccup fail the job — the alert is best-effort.
-          jq -n --arg content "$CONTENT" '{content: $content}' \
+          # allowed_mentions.parse=[] blocks @everyone/@here/role/user pings.
+          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"
 
@@ -488,6 +491,13 @@ jobs:
       && (needs.deploy-web.result == 'success' || needs.deploy-production-backend.result == 'success')
     runs-on: ubuntu-latest
     environment: Production
+    permissions:
+      # Need contents:read to fetch full history and pull-requests:read so
+      # `gh api repos/.../pulls/N` can read titles. Default GITHUB_TOKEN on
+      # push events already includes these, but pinning the job to the
+      # minimum scope keeps it least-privileged.
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -548,6 +558,8 @@ jobs:
           # RUN_URL wrapped in <…> so Discord suppresses the inline preview embed.
           CONTENT=$(printf '✅ **Production deployed** on `%s`\n• web: %s\n• backend: %s%s\n<%s>' \
             "${COMMIT_SHA:0:7}" "$WEB_LINE" "$BACKEND_LINE" "$SHIPPED_SECTION" "$RUN_URL")
-          jq -n --arg content "$CONTENT" '{content: $content}' \
+          # allowed_mentions.parse=[] blocks @everyone/@here/role/user pings —
+          # critical here because PR titles flow straight into $content.
+          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -502,8 +502,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           # Need enough history to walk github.event.before..github.sha for the
-          # PR list. fetch-depth: 0 is the simple-and-correct option here.
-          fetch-depth: 0
+          # PR list. A single push to main is normally 1–5 commits (merge +
+          # squashed PR commits); 50 is a generous buffer for batched-merge
+          # days without paying for a full-history clone. If BEFORE isn't
+          # reachable in the shallow clone, the PR-list step short-circuits
+          # via the `git cat-file -e` check and the notification still posts
+          # (just without the Shipped section).
+          fetch-depth: 50
 
       - name: Notify Discord (deployed + promoted)
         env:

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           # Same digest gets all of these tags. Homelab consumes :staging,
@@ -242,7 +242,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=backend-main
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -425,7 +425,9 @@ jobs:
           if [ "$BACKEND_RESULT" = "success" ]; then
             BACKEND_LINE="image at ${IMAGE}:production in GHCR, Railway NOT redeployed"
           fi
-          CONTENT=$(printf '⚠️ **Deployed but NOT promoted** on `%s`\nA Vercel Instant Rollback is active, so production stays pinned to the rolled-back deployment.\n• web: %s\n• backend: %s\nClear the rollback (revert the offending commit and re-promote), then promote the staged web deployment and redeploy the backend.\n%s' \
+          # URL is wrapped in <…> so Discord suppresses the inline preview embed
+          # (otherwise the workflow link dominates the message).
+          CONTENT=$(printf '⚠️ **Deployed but NOT promoted** on `%s`\nA Vercel Instant Rollback is active, so production stays pinned to the rolled-back deployment.\n• web: %s\n• backend: %s\nClear the rollback (revert the offending commit and re-promote), then promote the staged web deployment and redeploy the backend.\n<%s>' \
             "${COMMIT_SHA:0:7}" "$WEB_LINE" "$BACKEND_LINE" "$RUN_URL")
           jq -n --arg content "$CONTENT" '{content: $content}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
@@ -461,11 +463,91 @@ jobs:
             echo "DISCORD_DEPLOY_WEBHOOK not set — skipping notification"
             exit 0
           fi
-          CONTENT=$(printf '🚨 **Production deploy failed** on \`%s\`\n• detect-changes: %s\n• check-rollback: %s\n• build-web: %s\n• build-backend: %s\n• migrate: %s\n• deploy-web: %s\n• deploy-production-backend: %s\n%s' \
+          # URL wrapped in <…> so Discord suppresses the inline preview embed.
+          CONTENT=$(printf '🚨 **Production deploy failed** on \`%s\`\n• detect-changes: %s\n• check-rollback: %s\n• build-web: %s\n• build-backend: %s\n• migrate: %s\n• deploy-web: %s\n• deploy-production-backend: %s\n<%s>' \
             "${COMMIT_SHA:0:7}" "$DETECT_CHANGES" "$CHECK_ROLLBACK" "$BUILD_WEB" "$BUILD_BACKEND" "$MIGRATE" "$DEPLOY_WEB" "$DEPLOY_BACKEND" "$RUN_URL")
           # --fail-with-body surfaces Discord's status + error body (e.g. 429,
           # rotated webhook) in the log instead of failing silently. Don't let a
           # webhook hiccup fail the job — the alert is best-effort.
+          jq -n --arg content "$CONTENT" '{content: $content}' \
+            | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
+              echo "::warning::Failed to post Discord notification (see status above)"
+
+  # Pings the Discord deploy channel after a successful, PROMOTED production
+  # deploy. Lists the PRs that just shipped (parsed from merge-commit subjects
+  # between github.event.before and github.sha). Fires only when no rollback
+  # is pinning prod, nothing failed or got cancelled, and at least one
+  # component actually deployed. No-ops if DISCORD_DEPLOY_WEBHOOK is unset.
+  notify-success:
+    needs: [check-rollback, detect-changes, build-web, build-backend, migrate, deploy-web, deploy-production-backend]
+    if: >-
+      always()
+      && needs.check-rollback.outputs.active != 'true'
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled')
+      && (needs.deploy-web.result == 'success' || needs.deploy-production-backend.result == 'success')
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need enough history to walk github.event.before..github.sha for the
+          # PR list. fetch-depth: 0 is the simple-and-correct option here.
+          fetch-depth: 0
+
+      - name: Notify Discord (deployed + promoted)
+        env:
+          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEB_RESULT: ${{ needs.deploy-web.result }}
+          BACKEND_RESULT: ${{ needs.deploy-production-backend.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          PR_BASE_URL: ${{ github.server_url }}/${{ github.repository }}/pull
+        run: |
+          if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
+            echo "DISCORD_DEPLOY_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+
+          WEB_LINE="unchanged"
+          if [ "$WEB_RESULT" = "success" ]; then WEB_LINE="deployed"; fi
+          BACKEND_LINE="unchanged"
+          if [ "$BACKEND_RESULT" = "success" ]; then BACKEND_LINE="deployed"; fi
+
+          # Pull PR numbers from merge-commit subjects in BEFORE..SHA. Skip the
+          # section entirely if BEFORE is missing/zero (workflow_dispatch, first
+          # push, force push) rather than guessing.
+          PR_LIST=""
+          if [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ] && git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            PR_NUMS=$(git log --format='%s' "${BEFORE_SHA}..${COMMIT_SHA}" | grep -oE 'Merge pull request #[0-9]+' | grep -oE '[0-9]+' | sort -un || true)
+            while IFS= read -r PR; do
+              # `|| continue` form is safe under `set -e`; `&& continue` can trip it.
+              [ -n "$PR" ] || continue
+              TITLE=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq '.title' 2>/dev/null || true)
+              PR_URL="${PR_BASE_URL}/${PR}"
+              if [ -n "$TITLE" ]; then
+                LINE="• #${PR} — ${TITLE} <${PR_URL}>"
+              else
+                LINE="• #${PR} <${PR_URL}>"
+              fi
+              if [ -z "$PR_LIST" ]; then
+                PR_LIST="$LINE"
+              else
+                PR_LIST="${PR_LIST}"$'\n'"${LINE}"
+              fi
+            done <<< "$PR_NUMS"
+          fi
+
+          SHIPPED_SECTION=""
+          if [ -n "$PR_LIST" ]; then
+            SHIPPED_SECTION=$(printf '\nShipped:\n%s' "$PR_LIST")
+          fi
+
+          # RUN_URL wrapped in <…> so Discord suppresses the inline preview embed.
+          CONTENT=$(printf '✅ **Production deployed** on `%s`\n• web: %s\n• backend: %s%s\n<%s>' \
+            "${COMMIT_SHA:0:7}" "$WEB_LINE" "$BACKEND_LINE" "$SHIPPED_SECTION" "$RUN_URL")
           jq -n --arg content "$CONTENT" '{content: $content}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"

--- a/docs/branch-deploys.md
+++ b/docs/branch-deploys.md
@@ -31,7 +31,10 @@ Flow:
 2. `build-web` runs `vercel pull --environment=production` + `vercel build --prod` and uploads `.vercel` (prebuilt output + project link) as an artifact. `build-backend` builds `Dockerfile.backend` and pushes it to `ghcr.io/boardsesh/boardsesh-daemon` with `:production` / `:staging` / `:sha-<short>` / `:latest` tags.
 3. **The gate:** `migrate` runs `@boardsesh/db db:migrate` only once every *attempted* build passed. A build that ran and failed blocks the gate, which skips both production deploys — nothing reaches prod half-built. (Migrations used to run inside the Vercel build; they moved here so they only run behind the gate.)
 4. `deploy-web` (`vercel deploy --prebuilt --prod`) and `deploy-production-backend` (`railway redeploy`) run after the gate.
-5. `notify-failure` posts to the Discord deploy webhook if any job failed.
+5. One of three Discord notifications fires (all gated on `DISCORD_DEPLOY_WEBHOOK`, all best-effort — webhook failures `::warning::` rather than fail the run, all post with `allowed_mentions.parse=[]` so user-controlled text like PR titles can't ping the channel):
+   - `notify-success` on a promoted deploy — lists the PRs that shipped (parsed from `Merge pull request #N` subjects in `github.event.before..github.sha`, titles via `gh api`).
+   - `notify-no-promote` when a rollback is active (see Instant Rollback below).
+   - `notify-failure` on any job failure or cancellation.
 
 Required GitHub config — these live in the **`Production` GitHub environment** (Settings → Environments), not as repo-level secrets. Every job that reads them declares `environment: Production`; jobs that don't (`detect-changes`, `build-backend`, which uses only the automatic `GITHUB_TOKEN`) are left out. Environment-scoped secrets only resolve for jobs that opt in via `environment:` — without it they expand to empty strings and the run fails (401 from Vercel, empty `DATABASE_URL`, etc.).
 


### PR DESCRIPTION
## Summary

- Add a `notify-success` job that posts a ✅ message listing the PRs that just shipped. PR numbers are pulled from `Merge pull request #N` subjects in the `github.event.before..github.sha` range; titles are fetched via `gh api`.
- Wrap the workflow run URL in angle brackets in `notify-no-promote` and `notify-failure` so Discord suppresses the inline preview embed (the link no longer dominates the message).
- Clear the Node.js 20 deprecation warning in `build-backend`: bump `docker/metadata-action@v5 → v6` and `actions/attest-build-provenance@v1 → v4`. Both now run on Node 24. Inputs we use (`subject-name`, `subject-digest`, `push-to-registry`) are unchanged in v4.

## Sample success message

```
✅ **Production deployed** on `f06fb10`
• web: deployed
• backend: unchanged

Shipped:
• #2409 — Carry the generated openapi.json in the prebuilt web artifact <https://github.com/boardsesh/boardsesh/pull/2409>

<https://github.com/boardsesh/boardsesh/actions/runs/12345>
```

If `github.event.before` is missing/zero (workflow_dispatch, first push, force push), the `Shipped:` section is omitted rather than guessed. The notification is best-effort — `gh api` / `git log` failures fall through silently and the deploy is not marked failed.

## Test plan

- [ ] After merge, watch the first `Production Deploy` run on `main` finish — Discord should receive a `✅` message with a `Shipped:` list and a compact link preview for the workflow URL.
- [ ] Confirm the `build-backend` run summary no longer surfaces the Node.js 20 deprecation warning.
- [ ] If a future deploy lands during an active Vercel Instant Rollback, the existing `notify-no-promote` message should now appear with the workflow URL collapsed (no embed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)