### PR TITLE
Detect pinned Vercel rollback via autoAssignCustomDomains

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -126,14 +126,37 @@ jobs:
             exit 1
           fi
 
-          # lastRollbackTarget is null when no rollback is pinned, an object otherwise.
-          if [ "$(jq -r '.lastRollbackTarget // empty' response.json)" != "" ]; then
+          # Two signals — fire on either:
+          #   autoAssignCustomDomains=false: durable. Vercel flips this off when a
+          #     rollback is pinned and back on when the rollback is undone (or a
+          #     deployment is manually promoted). This is what we rely on.
+          #   lastRollbackTarget non-null: transient (only populated mid-transition
+          #     in our experience). Kept as a secondary OR'd signal in case Vercel
+          #     starts persisting it again.
+          AUTO_ASSIGN=$(jq -r '.autoAssignCustomDomains' response.json)
+          ROLLBACK_TARGET=$(jq -r '.lastRollbackTarget // empty' response.json)
+
+          # Guard against Vercel changing the project payload shape — silently
+          # treating a missing flag as "no rollback" is how we promoted over one.
+          case "$AUTO_ASSIGN" in
+            true|false) ;;
+            *)
+              echo "::error::autoAssignCustomDomains is '$AUTO_ASSIGN' (expected true/false) — cannot confirm rollback state, blocking deploy."
+              cat response.json
+              exit 1
+              ;;
+          esac
+
+          if [ "$AUTO_ASSIGN" = "false" ] || [ -n "$ROLLBACK_TARGET" ]; then
             echo "active=true" >> "$GITHUB_OUTPUT"
             echo "::warning::A Vercel Instant Rollback is active — this run will deploy but NOT promote (production stays pinned)."
-            jq '.lastRollbackTarget' response.json
+            echo "Signals: autoAssignCustomDomains=$AUTO_ASSIGN, lastRollbackTarget present=$([ -n "$ROLLBACK_TARGET" ] && echo yes || echo no)"
+            if [ -n "$ROLLBACK_TARGET" ]; then
+              jq '.lastRollbackTarget' response.json
+            fi
           else
             echo "active=false" >> "$GITHUB_OUTPUT"
-            echo "No active Vercel instant rollback — deploy will promote to production."
+            echo "No rollback signal detected (autoAssignCustomDomains=true, lastRollbackTarget=null) — deploy will promote to production."
           fi
 
   build-web:


### PR DESCRIPTION
## Summary
- `check-rollback` was relying on `lastRollbackTarget`, which Vercel only populates transiently during the rollback transition. Once a rollback was pinned and settled the field reverted to `null`, so the workflow believed no rollback existed and promoted the next deploy over the pinned deployment (see run [26703146031](https://github.com/boardsesh/boardsesh/actions/runs/26703146031) — `notify-no-promote` skipped, `deploy-web` promoted over a real active rollback).
- Switch to `autoAssignCustomDomains: false` as the primary signal — per Vercel's [Instant Rollback docs](https://vercel.com/docs/instant-rollback), this flag is flipped off when a rollback is pinned and back on when the rollback is undone (or a deployment is manually promoted), so it persists for the full duration of the pin.
- Keep `lastRollbackTarget` as a secondary OR'd signal (cheap insurance if Vercel changes behavior), read from the same project request so there's no extra API call or failure surface.
- Fail closed if `autoAssignCustomDomains` is missing or not `true`/`false` — silently treating a missing field as "no rollback" is what bit us last time.

## Test plan
- [x] `bash -n` on the extracted step
- [x] Synthetic dry-run with 5 saved project payloads (normal, settled rollback, fresh rollback, transient-only, schema drift) — all branch as expected
- [ ] Live verification: next dispatched deploy with an active rollback should now skip promotion and fire `notify-no-promote`