### PR TITLE
debug(ws-auth): log cookie names + env presence to isolate logbook auth break

### DIFF
--- a/packages/web/app/api/internal/ws-auth/route.ts
+++ b/packages/web/app/api/internal/ws-auth/route.ts
@@ -1,6 +1,34 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 
+// TEMP DIAGNOSTIC — remove once we've isolated why getToken returns null on
+// boardsesh.com despite a valid session cookie. Logs cookie NAMES (not values),
+// presence-only env flags, and whether getToken found a token. No secrets.
+function logDiagnostic(request: NextRequest, tokenFound: boolean, error?: unknown) {
+  const cookieNames = request.cookies.getAll().map((c) => c.name);
+  const nextAuthCookieNames = cookieNames.filter((n) => n.includes('next-auth'));
+  const envFlags = {
+    hasSecret: !!process.env.NEXTAUTH_SECRET,
+    secretLen: process.env.NEXTAUTH_SECRET?.length ?? 0,
+    hasNextAuthUrl: !!process.env.NEXTAUTH_URL,
+    nextAuthUrlScheme: process.env.NEXTAUTH_URL?.split('://')[0] ?? null,
+    vercelEnv: process.env.VERCEL_ENV ?? null,
+    vercelUrl: process.env.VERCEL_URL ?? null,
+    nodeEnv: process.env.NODE_ENV ?? null,
+  };
+  console.log(
+    '[ws-auth-debug]',
+    JSON.stringify({
+      cookieCount: cookieNames.length,
+      nextAuthCookieNames,
+      envFlags,
+      tokenFound,
+      errorName: error instanceof Error ? error.name : null,
+      errorMessage: error instanceof Error ? error.message : null,
+    }),
+  );
+}
+
 /**
  * API endpoint to get a WebSocket authentication token.
  * Returns the NextAuth JWT token that can be passed to the WebSocket backend.
@@ -14,6 +42,8 @@ export async function GET(request: NextRequest) {
       raw: true, // Get the raw encoded JWT string
     });
 
+    logDiagnostic(request, !!token);
+
     if (!token) {
       // User is not authenticated - this is OK, just return null
       return NextResponse.json({ token: null, authenticated: false });
@@ -24,6 +54,7 @@ export async function GET(request: NextRequest) {
       authenticated: true,
     });
   } catch (error) {
+    logDiagnostic(request, false, error);
     console.error('[ws-auth] Error getting token:', error);
     return NextResponse.json({ token: null, authenticated: false, error: 'Failed to get token' }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- Logbook fetches on boardsesh.com fail because `/api/internal/ws-auth` returns `{authenticated: false}` for users with a valid session.
- `ws-auth/route.ts`, `next-auth`'s `getToken`, and Next's `NextRequest.cookies` are all byte-identical to the last-known-good build (#2345), so the suspects are deploy-infra (Root Directory move in #04d0695d4, GH Actions deploy switch in #2404) or a Next 16.1.6→16.2.6 runtime change.
- Adds a temp diagnostic that logs cookie **names** (values redacted), presence-only env flags (`NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `VERCEL_ENV`, `VERCEL_URL`, `NODE_ENV`), and whether `getToken` returned a token or threw.
- Revert as soon as we've captured one logged-in request from prod.

## What the logs will tell us
| Field | What it isolates |
| --- | --- |
| `nextAuthCookieNames` empty | Cookie isn't reaching the function (domain / `--prebuilt` deploy target / middleware drop). |
| `hasSecret: false` | `NEXTAUTH_SECRET` not in runtime env — `vercel pull` / project config issue. |
| `nextAuthUrlScheme !== 'https'` | `secureCookie` derivation flips to `false`, `getToken` looks for `next-auth.session-token` instead of `__Secure-next-auth.session-token`. |
| `tokenFound: false` with cookie + secret present | Cookie value found but decryption failed — secret mismatch between issuer and verifier. |

## Test plan
- [ ] Merge to main; GH Actions deploys to production.
- [ ] In a logged-in browser, hit `https://boardsesh.com/api/internal/ws-auth`.
- [ ] Pull the Vercel function log for that invocation; capture the `[ws-auth-debug]` line.
- [ ] Open a follow-up PR reverting this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)