### PR TITLE
fix(auth): pin secureCookie derivation so a wrong NEXTAUTH_URL can't break ws-auth

### DIFF
--- a/packages/web/app/api/internal/ws-auth/route.ts
+++ b/packages/web/app/api/internal/ws-auth/route.ts
@@ -1,33 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
-
-// TEMP DIAGNOSTIC — remove once we've isolated why getToken returns null on
-// boardsesh.com despite a valid session cookie. Logs cookie NAMES (not values),
-// presence-only env flags, and whether getToken found a token. No secrets.
-function logDiagnostic(request: NextRequest, tokenFound: boolean, error?: unknown) {
-  const cookieNames = request.cookies.getAll().map((c) => c.name);
-  const nextAuthCookieNames = cookieNames.filter((n) => n.includes('next-auth'));
-  const envFlags = {
-    hasSecret: !!process.env.NEXTAUTH_SECRET,
-    secretLen: process.env.NEXTAUTH_SECRET?.length ?? 0,
-    hasNextAuthUrl: !!process.env.NEXTAUTH_URL,
-    nextAuthUrlScheme: process.env.NEXTAUTH_URL?.split('://')[0] ?? null,
-    vercelEnv: process.env.VERCEL_ENV ?? null,
-    vercelUrl: process.env.VERCEL_URL ?? null,
-    nodeEnv: process.env.NODE_ENV ?? null,
-  };
-  console.log(
-    '[ws-auth-debug]',
-    JSON.stringify({
-      cookieCount: cookieNames.length,
-      nextAuthCookieNames,
-      envFlags,
-      tokenFound,
-      errorName: error instanceof Error ? error.name : null,
-      errorMessage: error instanceof Error ? error.message : null,
-    }),
-  );
-}
+import { isSecureCookieContext, sessionCookieName } from '@/app/lib/auth/secure-cookies';
 
 /**
  * API endpoint to get a WebSocket authentication token.
@@ -35,14 +8,17 @@ function logDiagnostic(request: NextRequest, tokenFound: boolean, error?: unknow
  */
 export async function GET(request: NextRequest) {
   try {
-    // Get the NextAuth JWT token from the request
+    const secureCookie = isSecureCookieContext();
+    // Pass cookieName + secureCookie explicitly: next-auth's internal derivation
+    // breaks if NEXTAUTH_URL is set to an http:// value (the `??` only falls back
+    // when NEXTAUTH_URL is unset, not when it's wrong).
     const token = await getToken({
       req: request,
       secret: process.env.NEXTAUTH_SECRET,
-      raw: true, // Get the raw encoded JWT string
+      secureCookie,
+      cookieName: sessionCookieName(),
+      raw: true,
     });
-
-    logDiagnostic(request, !!token);
 
     if (!token) {
       // User is not authenticated - this is OK, just return null
@@ -54,7 +30,6 @@ export async function GET(request: NextRequest) {
       authenticated: true,
     });
   } catch (error) {
-    logDiagnostic(request, false, error);
     console.error('[ws-auth] Error getting token:', error);
     return NextResponse.json({ token: null, authenticated: false, error: 'Failed to get token' }, { status: 500 });
   }

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -9,6 +9,7 @@ import * as schema from '@/app/lib/db/schema';
 import { and, eq, isNull } from 'drizzle-orm';
 import { compare } from 'bcryptjs';
 import { verifyNativeOAuthTransferToken } from '@/app/lib/auth/native-oauth-transfer';
+import { isSecureCookieContext } from '@/app/lib/auth/secure-cookies';
 
 // Build providers array conditionally based on available env vars
 const providers: NextAuthOptions['providers'] = [];
@@ -139,7 +140,7 @@ providers.push(
 // Apple Sign-In posts its callback cross-origin (response_mode=form_post),
 // so verification cookies need SameSite=None (which requires Secure).
 // We override callbackUrl, state, nonce, and pkceCodeVerifier cookies for this reason.
-const useSecureCookies = process.env.NEXTAUTH_URL?.startsWith('https://') ?? !!process.env.VERCEL_URL;
+const useSecureCookies = isSecureCookieContext();
 
 export const authOptions: NextAuthOptions = {
   adapter: DrizzleAdapter(getDb(), {

--- a/packages/web/app/lib/auth/secure-cookies.ts
+++ b/packages/web/app/lib/auth/secure-cookies.ts
@@ -1,0 +1,18 @@
+// next-auth derives `secureCookie` from `NEXTAUTH_URL?.startsWith('https://')
+// ?? !!process.env.VERCEL`. The `??` only kicks in when NEXTAUTH_URL is unset
+// — if it's set to an `http://` value, secureCookie silently becomes false and
+// next-auth reads/writes `next-auth.session-token` instead of
+// `__Secure-next-auth.session-token`. A misconfigured NEXTAUTH_URL in Vercel
+// took ws-auth (and all logbook fetches) down once already; this helper is the
+// floor so it can't happen again.
+export function isSecureCookieContext(): boolean {
+  return (
+    process.env.VERCEL_ENV === 'production' ||
+    process.env.NEXTAUTH_URL?.startsWith('https://') === true ||
+    !!process.env.VERCEL_URL
+  );
+}
+
+export function sessionCookieName(): string {
+  return isSecureCookieContext() ? '__Secure-next-auth.session-token' : 'next-auth.session-token';
+}


### PR DESCRIPTION
Roll-forward for the ws-auth break that took logbook fetches down on boardsesh.com, plus cleanup of the temp diagnostic from #2412.

## Root cause
The `[ws-auth-debug]` log from #2412 fingered it:

```json
{
  "nextAuthCookieNames": ["__Host-next-auth.csrf-token","__Secure-next-auth.callback-url","next-auth.callback-url","__Secure-next-auth.session-token"],
  "envFlags": { "hasSecret": true, "hasNextAuthUrl": true, "nextAuthUrlScheme": "http", "vercelEnv": "production", ... },
  "tokenFound": false
}
```

The browser is sending `__Secure-next-auth.session-token`. Vercel's Production env has `NEXTAUTH_URL` set to a `http://` value. Both next-auth's `getToken`:

```js
secureCookie = process.env.NEXTAUTH_URL?.startsWith("https://") ?? !!process.env.VERCEL
```

and our own `auth-options.ts`:

```ts
const useSecureCookies = process.env.NEXTAUTH_URL?.startsWith('https://') ?? !!process.env.VERCEL_URL;
```

use `??`. The fallback only fires when `NEXTAUTH_URL` is **unset** — a misconfigured `http://` value returns `false` and slips through, so `secureCookie` becomes `false` and `getToken` looks for plain `next-auth.session-token`. The browser never sent that → `tokenFound: false` → ws-auth says you're logged out → logbooks don't fetch.

## Fix
- New `app/lib/auth/secure-cookies.ts` with `isSecureCookieContext()` and `sessionCookieName()`. Stricter derivation: `VERCEL_ENV === 'production'` floor → explicit `https://` check → `VERCEL_URL` fallback. A typo in `NEXTAUTH_URL` can no longer downgrade prod cookies.
- `ws-auth/route.ts` now passes `secureCookie` and `cookieName` to `getToken` explicitly, so it never relies on next-auth's internal `??` derivation again.
- `auth-options.ts` `useSecureCookies` uses the same helper — keeps the OAuth verification cookies (callbackUrl / state / nonce / pkceCodeVerifier) consistent with the session cookie.
- Drops the temp `[ws-auth-debug]` logging from #2412.

## Operator action still needed
Update `NEXTAUTH_URL` in the Vercel Production env to `https://boardsesh.com`. This PR makes the code defensive so the next typo doesn't take auth down, but the env should be correct too.

## Test plan
- [ ] Merge; GH Actions deploys to prod.
- [ ] In a logged-in browser, hit `https://boardsesh.com/api/internal/ws-auth` — should return `{ token: "<jwe>", authenticated: true }`.
- [ ] Confirm logbooks render on a climb page.
- [ ] Separately, fix `NEXTAUTH_URL` to `https://...` in Vercel Production env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)