### PR TITLE
fix: await onError, paginate findBoardForConfig, add handleCreateError tests

### DIFF
--- a/packages/web/app/components/board-entity/__tests__/create-board-form.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/create-board-form.test.tsx
@@ -3,6 +3,7 @@ import { render, act } from "@testing-library/react";
 import React from "react";
 import { tFromCatalog } from "@/app/__test-helpers__/i18n-mock";
 import { useWsAuthToken } from "@/app/hooks/use-ws-auth-token";
+import CreateBoardForm from "../create-board-form";
 
 vi.mock("react-i18next", () => ({
   useTranslation: (ns?: string) => ({
@@ -66,8 +67,7 @@ const matchingBoard = {
   angle: 40,
 };
 
-async function renderAndGetOnError(props = defaultProps) {
-  const CreateBoardForm = (await import("../create-board-form")).default;
+function renderAndGetOnError(props = defaultProps) {
   render(React.createElement(CreateBoardForm, props));
   return capturedOnError!;
 }
@@ -83,12 +83,10 @@ describe("CreateBoardForm — handleCreateError", () => {
       isLoading: false,
       error: null,
     });
-    // Reset module so capturedOnError is re-captured on each render
-    vi.resetModules();
   });
 
   it("shows duplicate snackbar with Go to your board action when match found", async () => {
-    const onError = await renderAndGetOnError();
+    const onError = renderAndGetOnError();
     mockRequest.mockResolvedValueOnce({
       myBoards: { boards: [matchingBoard], hasMore: false, totalCount: 1 },
     });
@@ -106,7 +104,7 @@ describe("CreateBoardForm — handleCreateError", () => {
   });
 
   it("falls back to serverMessage when no matching board found", async () => {
-    const onError = await renderAndGetOnError();
+    const onError = renderAndGetOnError();
     mockRequest.mockResolvedValueOnce({
       myBoards: { boards: [], hasMore: false, totalCount: 0 },
     });
@@ -119,7 +117,7 @@ describe("CreateBoardForm — handleCreateError", () => {
   });
 
   it("falls back to i18n error key when no match and no serverMessage", async () => {
-    const onError = await renderAndGetOnError();
+    const onError = renderAndGetOnError();
     mockRequest.mockResolvedValueOnce({
       myBoards: { boards: [], hasMore: false, totalCount: 0 },
     });
@@ -135,7 +133,7 @@ describe("CreateBoardForm — handleCreateError", () => {
   });
 
   it("falls back to serverMessage when findBoardForConfig throws", async () => {
-    const onError = await renderAndGetOnError();
+    const onError = renderAndGetOnError();
     mockRequest.mockRejectedValueOnce(new Error("network failure"));
 
     await act(async () => {
@@ -152,7 +150,7 @@ describe("CreateBoardForm — handleCreateError", () => {
       isLoading: false,
       error: null,
     });
-    const onError = await renderAndGetOnError();
+    const onError = renderAndGetOnError();
 
     await act(async () => {
       await onError(new Error("error"), "server error message");
@@ -163,7 +161,7 @@ describe("CreateBoardForm — handleCreateError", () => {
   });
 
   it("paginates until a match is found across multiple pages", async () => {
-    const onError = await renderAndGetOnError();
+    const onError = renderAndGetOnError();
     // First page: no match, hasMore true
     mockRequest.mockResolvedValueOnce({
       myBoards: {

--- a/packages/web/app/components/board-entity/__tests__/create-board-form.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/create-board-form.test.tsx
@@ -1,69 +1,69 @@
-import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
-import { render, act } from "@testing-library/react";
-import React from "react";
-import { tFromCatalog } from "@/app/__test-helpers__/i18n-mock";
-import { useWsAuthToken } from "@/app/hooks/use-ws-auth-token";
-import CreateBoardForm from "../create-board-form";
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, act } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import CreateBoardForm from '../create-board-form';
 
-vi.mock("react-i18next", () => ({
+vi.mock('react-i18next', () => ({
   useTranslation: (ns?: string) => ({
     t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
-    i18n: { language: "en-US" },
+    i18n: { language: 'en-US' },
   }),
   Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
 }));
 
 const mockShowMessage = vi.fn();
-vi.mock("@/app/components/providers/snackbar-provider", () => ({
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
   useSnackbar: () => ({ showMessage: mockShowMessage }),
 }));
 
-vi.mock("@/app/hooks/use-ws-auth-token", () => ({
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
   useWsAuthToken: vi.fn(),
 }));
 const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
 
 const mockRequest = vi.fn();
-vi.mock("@/app/lib/graphql/client", () => ({
+vi.mock('@/app/lib/graphql/client', () => ({
   createGraphQLHttpClient: () => ({ request: mockRequest }),
 }));
 
-vi.mock("@/app/lib/i18n/use-locale-router", () => ({
+vi.mock('@/app/lib/i18n/use-locale-router', () => ({
   useLocaleRouter: () => ({ push: vi.fn() }),
 }));
 
 let capturedOnError: ((error: unknown, serverMessage: string | null) => Promise<void>) | null = null;
-vi.mock("@/app/hooks/use-entity-mutation", () => ({
+vi.mock('@/app/hooks/use-entity-mutation', () => ({
   useEntityMutation: (_mutation: unknown, opts: { onError?: (e: unknown, s: string | null) => Promise<void> }) => {
     capturedOnError = opts.onError ?? null;
-    return { execute: vi.fn(), token: "test-token" };
+    return { execute: vi.fn(), token: 'test-token' };
   },
 }));
 
-vi.mock("../board-form", () => ({
-  default: () => React.createElement("div", { "data-testid": "board-form" }),
+vi.mock('../board-form', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'board-form' }),
 }));
 
-vi.mock("@boardsesh/graphql/operations", () => ({
-  CREATE_BOARD: "CREATE_BOARD",
-  GET_MY_BOARDS: "GET_MY_BOARDS",
+vi.mock('@boardsesh/graphql/operations', () => ({
+  CREATE_BOARD: 'CREATE_BOARD',
+  GET_MY_BOARDS: 'GET_MY_BOARDS',
 }));
 
 const defaultProps = {
-  boardType: "kilter",
+  boardType: 'kilter',
   layoutId: 1,
   sizeId: 2,
-  setIds: "set-1",
+  setIds: 'set-1',
   defaultAngle: 40,
 };
 
 const matchingBoard = {
-  name: "Home Wall",
-  boardType: "kilter",
+  name: 'Home Wall',
+  boardType: 'kilter',
   layoutId: 1,
   sizeId: 2,
-  setIds: "set-1",
-  slug: "home-wall",
+  setIds: 'set-1',
+  slug: 'home-wall',
   angle: 40,
 };
 
@@ -72,78 +72,78 @@ function renderAndGetOnError(props = defaultProps) {
   return capturedOnError!;
 }
 
-describe("CreateBoardForm — handleCreateError", () => {
+describe('CreateBoardForm — handleCreateError', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mockRequest.mockReset();
     capturedOnError = null;
     mockUseWsAuthToken.mockReturnValue({
-      token: "test-token",
+      token: 'test-token',
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
   });
 
-  it("shows duplicate snackbar with Go to your board action when match found", async () => {
+  it('shows duplicate snackbar with Go to your board action when match found', async () => {
     const onError = renderAndGetOnError();
     mockRequest.mockResolvedValueOnce({
       myBoards: { boards: [matchingBoard], hasMore: false, totalCount: 1 },
     });
 
     await act(async () => {
-      await onError(new Error("duplicate"), "You already have a board with this configuration");
+      await onError(new Error('duplicate'), 'You already have a board with this configuration');
     });
 
     expect(mockShowMessage).toHaveBeenCalledTimes(1);
     const [message, severity, action, duration] = mockShowMessage.mock.calls[0];
-    expect(severity).toBe("error");
+    expect(severity).toBe('error');
     expect(duration).toBe(8000);
-    expect(message).toContain("Home Wall");
+    expect(message).toContain('Home Wall');
     expect(action).toMatchObject({ label: expect.any(String) });
   });
 
-  it("falls back to serverMessage when no matching board found", async () => {
+  it('falls back to serverMessage when no matching board found', async () => {
     const onError = renderAndGetOnError();
     mockRequest.mockResolvedValueOnce({
       myBoards: { boards: [], hasMore: false, totalCount: 0 },
     });
 
     await act(async () => {
-      await onError(new Error("error"), "server error message");
+      await onError(new Error('error'), 'server error message');
     });
 
-    expect(mockShowMessage).toHaveBeenCalledWith("server error message", "error");
+    expect(mockShowMessage).toHaveBeenCalledWith('server error message', 'error');
   });
 
-  it("falls back to i18n error key when no match and no serverMessage", async () => {
+  it('falls back to i18n error key when no match and no serverMessage', async () => {
     const onError = renderAndGetOnError();
     mockRequest.mockResolvedValueOnce({
       myBoards: { boards: [], hasMore: false, totalCount: 0 },
     });
 
     await act(async () => {
-      await onError(new Error("error"), null);
+      await onError(new Error('error'), null);
     });
 
     expect(mockShowMessage).toHaveBeenCalledWith(
-      "Failed to create board. It may already exist for this configuration.",
-      "error",
+      'Failed to create board. It may already exist for this configuration.',
+      'error',
     );
   });
 
-  it("falls back to serverMessage when findBoardForConfig throws", async () => {
+  it('falls back to serverMessage when findBoardForConfig throws', async () => {
     const onError = renderAndGetOnError();
-    mockRequest.mockRejectedValueOnce(new Error("network failure"));
+    mockRequest.mockRejectedValueOnce(new Error('network failure'));
 
     await act(async () => {
-      await onError(new Error("error"), "server error message");
+      await onError(new Error('error'), 'server error message');
     });
 
-    expect(mockShowMessage).toHaveBeenCalledWith("server error message", "error");
+    expect(mockShowMessage).toHaveBeenCalledWith('server error message', 'error');
   });
 
-  it("skips board lookup and falls back to serverMessage when token is null", async () => {
+  it('skips board lookup and falls back to serverMessage when token is null', async () => {
     mockUseWsAuthToken.mockReturnValue({
       token: null,
       isAuthenticated: false,
@@ -153,19 +153,19 @@ describe("CreateBoardForm — handleCreateError", () => {
     const onError = renderAndGetOnError();
 
     await act(async () => {
-      await onError(new Error("error"), "server error message");
+      await onError(new Error('error'), 'server error message');
     });
 
     expect(mockRequest).not.toHaveBeenCalled();
-    expect(mockShowMessage).toHaveBeenCalledWith("server error message", "error");
+    expect(mockShowMessage).toHaveBeenCalledWith('server error message', 'error');
   });
 
-  it("paginates until a match is found across multiple pages", async () => {
+  it('paginates until a match is found across multiple pages', async () => {
     const onError = renderAndGetOnError();
     // First page: no match, hasMore true
     mockRequest.mockResolvedValueOnce({
       myBoards: {
-        boards: [{ ...matchingBoard, boardType: "tension", setIds: "other" }],
+        boards: [{ ...matchingBoard, boardType: 'tension', setIds: 'other' }],
         hasMore: true,
         totalCount: 51,
       },
@@ -176,13 +176,13 @@ describe("CreateBoardForm — handleCreateError", () => {
     });
 
     await act(async () => {
-      await onError(new Error("duplicate"), "You already have a board with this configuration");
+      await onError(new Error('duplicate'), 'You already have a board with this configuration');
     });
 
     expect(mockRequest).toHaveBeenCalledTimes(2);
     const [message, severity, , duration] = mockShowMessage.mock.calls[0];
-    expect(severity).toBe("error");
+    expect(severity).toBe('error');
     expect(duration).toBe(8000);
-    expect(message).toContain("Home Wall");
+    expect(message).toContain('Home Wall');
   });
 });

--- a/packages/web/app/components/board-entity/__tests__/create-board-form.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/create-board-form.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+import { render, act } from "@testing-library/react";
+import React from "react";
+import { tFromCatalog } from "@/app/__test-helpers__/i18n-mock";
+import { useWsAuthToken } from "@/app/hooks/use-ws-auth-token";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: "en-US" },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+const mockShowMessage = vi.fn();
+vi.mock("@/app/components/providers/snackbar-provider", () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+vi.mock("@/app/hooks/use-ws-auth-token", () => ({
+  useWsAuthToken: vi.fn(),
+}));
+const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
+
+const mockRequest = vi.fn();
+vi.mock("@/app/lib/graphql/client", () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock("@/app/lib/i18n/use-locale-router", () => ({
+  useLocaleRouter: () => ({ push: vi.fn() }),
+}));
+
+let capturedOnError: ((error: unknown, serverMessage: string | null) => Promise<void>) | null = null;
+vi.mock("@/app/hooks/use-entity-mutation", () => ({
+  useEntityMutation: (_mutation: unknown, opts: { onError?: (e: unknown, s: string | null) => Promise<void> }) => {
+    capturedOnError = opts.onError ?? null;
+    return { execute: vi.fn(), token: "test-token" };
+  },
+}));
+
+vi.mock("../board-form", () => ({
+  default: () => React.createElement("div", { "data-testid": "board-form" }),
+}));
+
+vi.mock("@boardsesh/graphql/operations", () => ({
+  CREATE_BOARD: "CREATE_BOARD",
+  GET_MY_BOARDS: "GET_MY_BOARDS",
+}));
+
+const defaultProps = {
+  boardType: "kilter",
+  layoutId: 1,
+  sizeId: 2,
+  setIds: "set-1",
+  defaultAngle: 40,
+};
+
+const matchingBoard = {
+  name: "Home Wall",
+  boardType: "kilter",
+  layoutId: 1,
+  sizeId: 2,
+  setIds: "set-1",
+  slug: "home-wall",
+  angle: 40,
+};
+
+async function renderAndGetOnError(props = defaultProps) {
+  const CreateBoardForm = (await import("../create-board-form")).default;
+  render(React.createElement(CreateBoardForm, props));
+  return capturedOnError!;
+}
+
+describe("CreateBoardForm — handleCreateError", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockRequest.mockReset();
+    capturedOnError = null;
+    mockUseWsAuthToken.mockReturnValue({
+      token: "test-token",
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
+    // Reset module so capturedOnError is re-captured on each render
+    vi.resetModules();
+  });
+
+  it("shows duplicate snackbar with Go to your board action when match found", async () => {
+    const onError = await renderAndGetOnError();
+    mockRequest.mockResolvedValueOnce({
+      myBoards: { boards: [matchingBoard], hasMore: false, totalCount: 1 },
+    });
+
+    await act(async () => {
+      await onError(new Error("duplicate"), "You already have a board with this configuration");
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledTimes(1);
+    const [message, severity, action, duration] = mockShowMessage.mock.calls[0];
+    expect(severity).toBe("error");
+    expect(duration).toBe(8000);
+    expect(message).toContain("Home Wall");
+    expect(action).toMatchObject({ label: expect.any(String) });
+  });
+
+  it("falls back to serverMessage when no matching board found", async () => {
+    const onError = await renderAndGetOnError();
+    mockRequest.mockResolvedValueOnce({
+      myBoards: { boards: [], hasMore: false, totalCount: 0 },
+    });
+
+    await act(async () => {
+      await onError(new Error("error"), "server error message");
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith("server error message", "error");
+  });
+
+  it("falls back to i18n error key when no match and no serverMessage", async () => {
+    const onError = await renderAndGetOnError();
+    mockRequest.mockResolvedValueOnce({
+      myBoards: { boards: [], hasMore: false, totalCount: 0 },
+    });
+
+    await act(async () => {
+      await onError(new Error("error"), null);
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith(
+      "Failed to create board. It may already exist for this configuration.",
+      "error",
+    );
+  });
+
+  it("falls back to serverMessage when findBoardForConfig throws", async () => {
+    const onError = await renderAndGetOnError();
+    mockRequest.mockRejectedValueOnce(new Error("network failure"));
+
+    await act(async () => {
+      await onError(new Error("error"), "server error message");
+    });
+
+    expect(mockShowMessage).toHaveBeenCalledWith("server error message", "error");
+  });
+
+  it("skips board lookup and falls back to serverMessage when token is null", async () => {
+    mockUseWsAuthToken.mockReturnValue({
+      token: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+    });
+    const onError = await renderAndGetOnError();
+
+    await act(async () => {
+      await onError(new Error("error"), "server error message");
+    });
+
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(mockShowMessage).toHaveBeenCalledWith("server error message", "error");
+  });
+
+  it("paginates until a match is found across multiple pages", async () => {
+    const onError = await renderAndGetOnError();
+    // First page: no match, hasMore true
+    mockRequest.mockResolvedValueOnce({
+      myBoards: {
+        boards: [{ ...matchingBoard, boardType: "tension", setIds: "other" }],
+        hasMore: true,
+        totalCount: 51,
+      },
+    });
+    // Second page: contains the match
+    mockRequest.mockResolvedValueOnce({
+      myBoards: { boards: [matchingBoard], hasMore: false, totalCount: 51 },
+    });
+
+    await act(async () => {
+      await onError(new Error("duplicate"), "You already have a board with this configuration");
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    const [message, severity, , duration] = mockShowMessage.mock.calls[0];
+    expect(severity).toBe("error");
+    expect(duration).toBe(8000);
+    expect(message).toContain("Home Wall");
+  });
+});

--- a/packages/web/app/components/board-entity/create-board-form.tsx
+++ b/packages/web/app/components/board-entity/create-board-form.tsx
@@ -30,10 +30,10 @@ async function findBoardForConfig(token: string, config: BoardConfig): Promise<U
   try {
     const client = createGraphQLHttpClient(token);
     const pageSize = 50;
-    let offset = 0;
-    for (;;) {
+    const maxPages = 20;
+    for (let page = 0; page < maxPages; page++) {
       const data = await client.request<GetMyBoardsQueryResponse>(GET_MY_BOARDS, {
-        input: { limit: pageSize, offset },
+        input: { limit: pageSize, offset: page * pageSize },
       });
       const match = data.myBoards.boards.find(
         (board) =>
@@ -44,8 +44,8 @@ async function findBoardForConfig(token: string, config: BoardConfig): Promise<U
       );
       if (match) return match;
       if (!data.myBoards.hasMore) return null;
-      offset += pageSize;
     }
+    return null;
   } catch {
     return null;
   }

--- a/packages/web/app/components/board-entity/create-board-form.tsx
+++ b/packages/web/app/components/board-entity/create-board-form.tsx
@@ -29,16 +29,23 @@ type BoardConfig = { boardType: string; layoutId: number; sizeId: number; setIds
 async function findBoardForConfig(token: string, config: BoardConfig): Promise<UserBoard | null> {
   try {
     const client = createGraphQLHttpClient(token);
-    const data = await client.request<GetMyBoardsQueryResponse>(GET_MY_BOARDS, { input: { limit: 50, offset: 0 } });
-    return (
-      data.myBoards.boards.find(
+    const pageSize = 50;
+    let offset = 0;
+    for (;;) {
+      const data = await client.request<GetMyBoardsQueryResponse>(GET_MY_BOARDS, {
+        input: { limit: pageSize, offset },
+      });
+      const match = data.myBoards.boards.find(
         (board) =>
           board.boardType === config.boardType &&
           board.layoutId === config.layoutId &&
           board.sizeId === config.sizeId &&
           board.setIds === config.setIds,
-      ) ?? null
-    );
+      );
+      if (match) return match;
+      if (!data.myBoards.hasMore) return null;
+      offset += pageSize;
+    }
   } catch {
     return null;
   }

--- a/packages/web/app/components/my-boards-drawer/__tests__/my-boards-drawer.test.tsx
+++ b/packages/web/app/components/my-boards-drawer/__tests__/my-boards-drawer.test.tsx
@@ -12,6 +12,19 @@ vi.mock('react-i18next', () => ({
   Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
 }));
 
+// jsdom/happy-dom doesn't implement IntersectionObserver, which the infinite-scroll
+// hook in MyBoardsDrawer instantiates on mount. Provide a no-op stub so the effect
+// doesn't throw during render.
+class IntersectionObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+globalThis.IntersectionObserver = IntersectionObserverStub as unknown as typeof IntersectionObserver;
+
 // Mock data
 let mockBoards: Array<Record<string, unknown>> = [];
 let mockIsLoading = false;
@@ -21,6 +34,9 @@ vi.mock('@/app/hooks/use-my-boards', () => ({
   useMyBoards: () => ({
     boards: mockBoards,
     isLoading: mockIsLoading,
+    isFetchingMore: false,
+    hasMore: false,
+    loadMore: vi.fn(),
     error: mockError,
   }),
 }));

--- a/packages/web/app/components/my-boards-drawer/my-boards-drawer.module.css
+++ b/packages/web/app/components/my-boards-drawer/my-boards-drawer.module.css
@@ -82,6 +82,12 @@
   padding: 32px 0;
 }
 
+.loadingMore {
+  display: flex;
+  justify-content: center;
+  padding: 12px 0;
+}
+
 .editFormContainer {
   padding: 8px 0;
 }

--- a/packages/web/app/components/my-boards-drawer/my-boards-drawer.tsx
+++ b/packages/web/app/components/my-boards-drawer/my-boards-drawer.tsx
@@ -17,6 +17,7 @@ import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import { BoardDetailContent } from '../board-entity/board-detail';
 import BoardSearchResults from '../social/board-search-results';
 import { useMyBoards } from '@/app/hooks/use-my-boards';
+import { useInfiniteScroll } from '@/app/hooks/use-infinite-scroll';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { useTranslation } from 'react-i18next';
 import type { UserBoard } from '@boardsesh/shared-schema';
@@ -36,7 +37,8 @@ type MyBoardsDrawerProps = {
 
 export default function MyBoardsDrawer({ open, onClose, onCreateBoard, onTransitionEnd }: MyBoardsDrawerProps) {
   const { t } = useTranslation('common');
-  const { boards, isLoading, error } = useMyBoards(open);
+  const { boards, isLoading, isFetchingMore, hasMore, loadMore, error } = useMyBoards(open);
+  const { sentinelRef } = useInfiniteScroll({ onLoadMore: loadMore, hasMore, isFetching: isFetchingMore });
   const { token } = useWsAuthToken();
   const [view, setView] = useState<DrawerView>({ type: 'list' });
   const [searchQuery, setSearchQuery] = useState('');
@@ -159,6 +161,12 @@ export default function MyBoardsDrawer({ open, onClose, onCreateBoard, onTransit
             <ChevronRightOutlined className={styles.boardItemAction} />
           </button>
         ))}
+        <div ref={sentinelRef} />
+        {isFetchingMore && (
+          <div className={styles.loadingMore}>
+            <CircularProgress size={20} />
+          </div>
+        )}
       </div>
     );
   };

--- a/packages/web/app/hooks/__tests__/use-entity-mutation.test.ts
+++ b/packages/web/app/hooks/__tests__/use-entity-mutation.test.ts
@@ -1,38 +1,38 @@
-import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import { renderHook, act } from '@testing-library/react';
-import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
-import { useEntityMutation } from '../use-entity-mutation';
+import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+import { renderHook, act } from "@testing-library/react";
+import { useWsAuthToken } from "@/app/hooks/use-ws-auth-token";
+import { useEntityMutation } from "../use-entity-mutation";
 
-vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+vi.mock("@/app/hooks/use-ws-auth-token", () => ({
   useWsAuthToken: vi.fn(),
 }));
 
 const mockShowMessage = vi.fn();
-vi.mock('@/app/components/providers/snackbar-provider', () => ({
+vi.mock("@/app/components/providers/snackbar-provider", () => ({
   useSnackbar: () => ({ showMessage: mockShowMessage }),
 }));
 
 const mockRequest = vi.fn();
-vi.mock('@/app/lib/graphql/client', () => ({
+vi.mock("@/app/lib/graphql/client", () => ({
   createGraphQLHttpClient: () => ({ request: mockRequest }),
 }));
 
-vi.mock('react-i18next', () => ({
+vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string) => (key === 'auth.mustBeSignedIn' ? 'You must be signed in' : key),
+    t: (key: string) => (key === "auth.mustBeSignedIn" ? "You must be signed in" : key),
   }),
 }));
 
 const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
 
-describe('useEntityMutation', () => {
+describe("useEntityMutation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequest.mockReset();
     mockShowMessage.mockReset();
   });
 
-  it('returns null and shows auth error when no token', async () => {
+  it("returns null and shows auth error when no token", async () => {
     mockUseWsAuthToken.mockReturnValue({
       token: null,
       isAuthenticated: false,
@@ -41,48 +41,48 @@ describe('useEntityMutation', () => {
     });
 
     const { result } = renderHook(() =>
-      useEntityMutation('SOME_MUTATION', {
-        errorMessage: 'Failed',
+      useEntityMutation("SOME_MUTATION", {
+        errorMessage: "Failed",
       }),
     );
 
     let returnValue: unknown;
     await act(async () => {
-      returnValue = await result.current.execute({ input: 'test' });
+      returnValue = await result.current.execute({ input: "test" });
     });
 
     expect(returnValue).toBeNull();
-    expect(mockShowMessage).toHaveBeenCalledWith('You must be signed in', 'error');
+    expect(mockShowMessage).toHaveBeenCalledWith("You must be signed in", "error");
   });
 
-  it('executes mutation and returns data on success', async () => {
+  it("executes mutation and returns data on success", async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: 'test-token',
+      token: "test-token",
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    const mockData = { result: 'success' };
+    const mockData = { result: "success" };
     mockRequest.mockResolvedValue(mockData);
 
     const { result } = renderHook(() =>
-      useEntityMutation('SOME_MUTATION', {
-        errorMessage: 'Failed',
+      useEntityMutation("SOME_MUTATION", {
+        errorMessage: "Failed",
       }),
     );
 
     let returnValue: unknown;
     await act(async () => {
-      returnValue = await result.current.execute({ input: 'test' });
+      returnValue = await result.current.execute({ input: "test" });
     });
 
     expect(returnValue).toEqual(mockData);
   });
 
-  it('shows success message when provided', async () => {
+  it("shows success message when provided", async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: 'test-token',
+      token: "test-token",
       isAuthenticated: true,
       isLoading: false,
       error: null,
@@ -91,71 +91,71 @@ describe('useEntityMutation', () => {
     mockRequest.mockResolvedValue({ ok: true });
 
     const { result } = renderHook(() =>
-      useEntityMutation('SOME_MUTATION', {
-        successMessage: 'Done!',
-        errorMessage: 'Failed',
+      useEntityMutation("SOME_MUTATION", {
+        successMessage: "Done!",
+        errorMessage: "Failed",
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: 'test' });
+      await result.current.execute({ input: "test" });
     });
 
-    expect(mockShowMessage).toHaveBeenCalledWith('Done!', 'success');
+    expect(mockShowMessage).toHaveBeenCalledWith("Done!", "success");
   });
 
-  it('shows error message on failure', async () => {
+  it("shows error message on failure", async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: 'test-token',
+      token: "test-token",
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    mockRequest.mockRejectedValue(new Error('Network error'));
+    mockRequest.mockRejectedValue(new Error("Network error"));
 
     const { result } = renderHook(() =>
-      useEntityMutation('SOME_MUTATION', {
-        errorMessage: 'Operation failed',
+      useEntityMutation("SOME_MUTATION", {
+        errorMessage: "Operation failed",
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: 'test' });
+      await result.current.execute({ input: "test" });
     });
 
-    expect(mockShowMessage).toHaveBeenCalledWith('Operation failed', 'error');
+    expect(mockShowMessage).toHaveBeenCalledWith("Operation failed", "error");
   });
 
-  it('logs error on failure', async () => {
+  it("logs error on failure", async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: 'test-token',
+      token: "test-token",
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    const error = new Error('Network error');
+    const error = new Error("Network error");
     mockRequest.mockRejectedValue(error);
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const { result } = renderHook(() =>
-      useEntityMutation('SOME_MUTATION', {
-        errorMessage: 'Operation failed',
+      useEntityMutation("SOME_MUTATION", {
+        errorMessage: "Operation failed",
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: 'test' });
+      await result.current.execute({ input: "test" });
     });
 
-    expect(consoleSpy).toHaveBeenCalledWith('Operation failed', error);
+    expect(consoleSpy).toHaveBeenCalledWith("Operation failed", error);
     consoleSpy.mockRestore();
   });
 
-  it('does not show success message when not provided', async () => {
+  it("does not show success message when not provided", async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: 'test-token',
+      token: "test-token",
       isAuthenticated: true,
       isLoading: false,
       error: null,
@@ -164,116 +164,147 @@ describe('useEntityMutation', () => {
     mockRequest.mockResolvedValue({ ok: true });
 
     const { result } = renderHook(() =>
-      useEntityMutation('SOME_MUTATION', {
-        errorMessage: 'Failed',
+      useEntityMutation("SOME_MUTATION", {
+        errorMessage: "Failed",
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: 'test' });
+      await result.current.execute({ input: "test" });
     });
 
     expect(mockShowMessage).not.toHaveBeenCalled();
   });
 
-  it('surfaces the server error message over the generic one', async () => {
+  it("surfaces the server error message over the generic one", async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: 'test-token',
+      token: "test-token",
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    const clientError = Object.assign(new Error('GraphQL Error'), {
-      response: { errors: [{ message: 'You already have a board with this configuration' }] },
+    const clientError = Object.assign(new Error("GraphQL Error"), {
+      response: { errors: [{ message: "You already have a board with this configuration" }] },
     });
     mockRequest.mockRejectedValue(clientError);
 
     const { result } = renderHook(() =>
-      useEntityMutation('SOME_MUTATION', {
-        errorMessage: 'Generic failure',
+      useEntityMutation("SOME_MUTATION", {
+        errorMessage: "Generic failure",
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: 'test' });
+      await result.current.execute({ input: "test" });
     });
 
-    expect(mockShowMessage).toHaveBeenCalledWith('You already have a board with this configuration', 'error');
+    expect(mockShowMessage).toHaveBeenCalledWith("You already have a board with this configuration", "error");
   });
 
-  it('delegates to onError instead of showing a toast when provided', async () => {
+  it("delegates to onError instead of showing a toast when provided", async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: 'test-token',
+      token: "test-token",
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    const clientError = Object.assign(new Error('GraphQL Error'), {
-      response: { errors: [{ message: 'You already have a board with this configuration' }] },
+    const clientError = Object.assign(new Error("GraphQL Error"), {
+      response: { errors: [{ message: "You already have a board with this configuration" }] },
     });
     mockRequest.mockRejectedValue(clientError);
 
     const onError = vi.fn();
     const { result } = renderHook(() =>
-      useEntityMutation('SOME_MUTATION', {
-        errorMessage: 'Generic failure',
+      useEntityMutation("SOME_MUTATION", {
+        errorMessage: "Generic failure",
         onError,
       }),
     );
 
     let returnValue: unknown;
     await act(async () => {
-      returnValue = await result.current.execute({ input: 'test' });
+      returnValue = await result.current.execute({ input: "test" });
     });
 
     expect(returnValue).toBeNull();
-    expect(onError).toHaveBeenCalledWith(clientError, 'You already have a board with this configuration');
+    expect(onError).toHaveBeenCalledWith(clientError, "You already have a board with this configuration");
     expect(mockShowMessage).not.toHaveBeenCalled();
   });
 
-  it('passes a null server message to onError for non-GraphQL failures', async () => {
+  it("passes a null server message to onError for non-GraphQL failures", async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: 'test-token',
+      token: "test-token",
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    const error = new Error('Network down');
+    const error = new Error("Network down");
     mockRequest.mockRejectedValue(error);
 
     const onError = vi.fn();
     const { result } = renderHook(() =>
-      useEntityMutation('SOME_MUTATION', {
-        errorMessage: 'Generic failure',
+      useEntityMutation("SOME_MUTATION", {
+        errorMessage: "Generic failure",
         onError,
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: 'test' });
+      await result.current.execute({ input: "test" });
     });
 
     expect(onError).toHaveBeenCalledWith(error, null);
     expect(mockShowMessage).not.toHaveBeenCalled();
   });
 
-  it('returns token from useWsAuthToken', () => {
+  it("awaits an async onError so its side-effects are visible before execute resolves", async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: 'my-token-abc',
+      token: "test-token",
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
+
+    mockRequest.mockRejectedValue(new Error("Network error"));
+
+    const sideEffect = vi.fn();
+    const onError = vi.fn().mockImplementation(async () => {
+      await Promise.resolve();
+      sideEffect();
+    });
+
+    const { result } = renderHook(() =>
+      useEntityMutation("SOME_MUTATION", {
+        errorMessage: "Failed",
+        onError,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.execute({ input: "test" });
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(sideEffect).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns token from useWsAuthToken", () => {
+    mockUseWsAuthToken.mockReturnValue({
+      token: "my-token-abc",
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
     const { result } = renderHook(() =>
-      useEntityMutation('SOME_MUTATION', {
-        errorMessage: 'Failed',
+      useEntityMutation("SOME_MUTATION", {
+        errorMessage: "Failed",
       }),
     );
 
-    expect(result.current.token).toBe('my-token-abc');
+    expect(result.current.token).toBe("my-token-abc");
   });
 });

--- a/packages/web/app/hooks/__tests__/use-entity-mutation.test.ts
+++ b/packages/web/app/hooks/__tests__/use-entity-mutation.test.ts
@@ -1,38 +1,38 @@
-import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
-import { renderHook, act } from "@testing-library/react";
-import { useWsAuthToken } from "@/app/hooks/use-ws-auth-token";
-import { useEntityMutation } from "../use-entity-mutation";
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { renderHook, act } from '@testing-library/react';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { useEntityMutation } from '../use-entity-mutation';
 
-vi.mock("@/app/hooks/use-ws-auth-token", () => ({
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
   useWsAuthToken: vi.fn(),
 }));
 
 const mockShowMessage = vi.fn();
-vi.mock("@/app/components/providers/snackbar-provider", () => ({
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
   useSnackbar: () => ({ showMessage: mockShowMessage }),
 }));
 
 const mockRequest = vi.fn();
-vi.mock("@/app/lib/graphql/client", () => ({
+vi.mock('@/app/lib/graphql/client', () => ({
   createGraphQLHttpClient: () => ({ request: mockRequest }),
 }));
 
-vi.mock("react-i18next", () => ({
+vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => (key === "auth.mustBeSignedIn" ? "You must be signed in" : key),
+    t: (key: string) => (key === 'auth.mustBeSignedIn' ? 'You must be signed in' : key),
   }),
 }));
 
 const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
 
-describe("useEntityMutation", () => {
+describe('useEntityMutation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequest.mockReset();
     mockShowMessage.mockReset();
   });
 
-  it("returns null and shows auth error when no token", async () => {
+  it('returns null and shows auth error when no token', async () => {
     mockUseWsAuthToken.mockReturnValue({
       token: null,
       isAuthenticated: false,
@@ -41,48 +41,48 @@ describe("useEntityMutation", () => {
     });
 
     const { result } = renderHook(() =>
-      useEntityMutation("SOME_MUTATION", {
-        errorMessage: "Failed",
+      useEntityMutation('SOME_MUTATION', {
+        errorMessage: 'Failed',
       }),
     );
 
     let returnValue: unknown;
     await act(async () => {
-      returnValue = await result.current.execute({ input: "test" });
+      returnValue = await result.current.execute({ input: 'test' });
     });
 
     expect(returnValue).toBeNull();
-    expect(mockShowMessage).toHaveBeenCalledWith("You must be signed in", "error");
+    expect(mockShowMessage).toHaveBeenCalledWith('You must be signed in', 'error');
   });
 
-  it("executes mutation and returns data on success", async () => {
+  it('executes mutation and returns data on success', async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: "test-token",
+      token: 'test-token',
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    const mockData = { result: "success" };
+    const mockData = { result: 'success' };
     mockRequest.mockResolvedValue(mockData);
 
     const { result } = renderHook(() =>
-      useEntityMutation("SOME_MUTATION", {
-        errorMessage: "Failed",
+      useEntityMutation('SOME_MUTATION', {
+        errorMessage: 'Failed',
       }),
     );
 
     let returnValue: unknown;
     await act(async () => {
-      returnValue = await result.current.execute({ input: "test" });
+      returnValue = await result.current.execute({ input: 'test' });
     });
 
     expect(returnValue).toEqual(mockData);
   });
 
-  it("shows success message when provided", async () => {
+  it('shows success message when provided', async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: "test-token",
+      token: 'test-token',
       isAuthenticated: true,
       isLoading: false,
       error: null,
@@ -91,71 +91,71 @@ describe("useEntityMutation", () => {
     mockRequest.mockResolvedValue({ ok: true });
 
     const { result } = renderHook(() =>
-      useEntityMutation("SOME_MUTATION", {
-        successMessage: "Done!",
-        errorMessage: "Failed",
+      useEntityMutation('SOME_MUTATION', {
+        successMessage: 'Done!',
+        errorMessage: 'Failed',
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: "test" });
+      await result.current.execute({ input: 'test' });
     });
 
-    expect(mockShowMessage).toHaveBeenCalledWith("Done!", "success");
+    expect(mockShowMessage).toHaveBeenCalledWith('Done!', 'success');
   });
 
-  it("shows error message on failure", async () => {
+  it('shows error message on failure', async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: "test-token",
+      token: 'test-token',
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    mockRequest.mockRejectedValue(new Error("Network error"));
+    mockRequest.mockRejectedValue(new Error('Network error'));
 
     const { result } = renderHook(() =>
-      useEntityMutation("SOME_MUTATION", {
-        errorMessage: "Operation failed",
+      useEntityMutation('SOME_MUTATION', {
+        errorMessage: 'Operation failed',
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: "test" });
+      await result.current.execute({ input: 'test' });
     });
 
-    expect(mockShowMessage).toHaveBeenCalledWith("Operation failed", "error");
+    expect(mockShowMessage).toHaveBeenCalledWith('Operation failed', 'error');
   });
 
-  it("logs error on failure", async () => {
+  it('logs error on failure', async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: "test-token",
+      token: 'test-token',
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    const error = new Error("Network error");
+    const error = new Error('Network error');
     mockRequest.mockRejectedValue(error);
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { result } = renderHook(() =>
-      useEntityMutation("SOME_MUTATION", {
-        errorMessage: "Operation failed",
+      useEntityMutation('SOME_MUTATION', {
+        errorMessage: 'Operation failed',
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: "test" });
+      await result.current.execute({ input: 'test' });
     });
 
-    expect(consoleSpy).toHaveBeenCalledWith("Operation failed", error);
+    expect(consoleSpy).toHaveBeenCalledWith('Operation failed', error);
     consoleSpy.mockRestore();
   });
 
-  it("does not show success message when not provided", async () => {
+  it('does not show success message when not provided', async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: "test-token",
+      token: 'test-token',
       isAuthenticated: true,
       isLoading: false,
       error: null,
@@ -164,111 +164,111 @@ describe("useEntityMutation", () => {
     mockRequest.mockResolvedValue({ ok: true });
 
     const { result } = renderHook(() =>
-      useEntityMutation("SOME_MUTATION", {
-        errorMessage: "Failed",
+      useEntityMutation('SOME_MUTATION', {
+        errorMessage: 'Failed',
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: "test" });
+      await result.current.execute({ input: 'test' });
     });
 
     expect(mockShowMessage).not.toHaveBeenCalled();
   });
 
-  it("surfaces the server error message over the generic one", async () => {
+  it('surfaces the server error message over the generic one', async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: "test-token",
+      token: 'test-token',
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    const clientError = Object.assign(new Error("GraphQL Error"), {
-      response: { errors: [{ message: "You already have a board with this configuration" }] },
+    const clientError = Object.assign(new Error('GraphQL Error'), {
+      response: { errors: [{ message: 'You already have a board with this configuration' }] },
     });
     mockRequest.mockRejectedValue(clientError);
 
     const { result } = renderHook(() =>
-      useEntityMutation("SOME_MUTATION", {
-        errorMessage: "Generic failure",
+      useEntityMutation('SOME_MUTATION', {
+        errorMessage: 'Generic failure',
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: "test" });
+      await result.current.execute({ input: 'test' });
     });
 
-    expect(mockShowMessage).toHaveBeenCalledWith("You already have a board with this configuration", "error");
+    expect(mockShowMessage).toHaveBeenCalledWith('You already have a board with this configuration', 'error');
   });
 
-  it("delegates to onError instead of showing a toast when provided", async () => {
+  it('delegates to onError instead of showing a toast when provided', async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: "test-token",
+      token: 'test-token',
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    const clientError = Object.assign(new Error("GraphQL Error"), {
-      response: { errors: [{ message: "You already have a board with this configuration" }] },
+    const clientError = Object.assign(new Error('GraphQL Error'), {
+      response: { errors: [{ message: 'You already have a board with this configuration' }] },
     });
     mockRequest.mockRejectedValue(clientError);
 
     const onError = vi.fn();
     const { result } = renderHook(() =>
-      useEntityMutation("SOME_MUTATION", {
-        errorMessage: "Generic failure",
+      useEntityMutation('SOME_MUTATION', {
+        errorMessage: 'Generic failure',
         onError,
       }),
     );
 
     let returnValue: unknown;
     await act(async () => {
-      returnValue = await result.current.execute({ input: "test" });
+      returnValue = await result.current.execute({ input: 'test' });
     });
 
     expect(returnValue).toBeNull();
-    expect(onError).toHaveBeenCalledWith(clientError, "You already have a board with this configuration");
+    expect(onError).toHaveBeenCalledWith(clientError, 'You already have a board with this configuration');
     expect(mockShowMessage).not.toHaveBeenCalled();
   });
 
-  it("passes a null server message to onError for non-GraphQL failures", async () => {
+  it('passes a null server message to onError for non-GraphQL failures', async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: "test-token",
+      token: 'test-token',
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    const error = new Error("Network down");
+    const error = new Error('Network down');
     mockRequest.mockRejectedValue(error);
 
     const onError = vi.fn();
     const { result } = renderHook(() =>
-      useEntityMutation("SOME_MUTATION", {
-        errorMessage: "Generic failure",
+      useEntityMutation('SOME_MUTATION', {
+        errorMessage: 'Generic failure',
         onError,
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: "test" });
+      await result.current.execute({ input: 'test' });
     });
 
     expect(onError).toHaveBeenCalledWith(error, null);
     expect(mockShowMessage).not.toHaveBeenCalled();
   });
 
-  it("awaits an async onError so its side-effects are visible before execute resolves", async () => {
+  it('awaits an async onError so its side-effects are visible before execute resolves', async () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: "test-token",
+      token: 'test-token',
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
-    mockRequest.mockRejectedValue(new Error("Network error"));
+    mockRequest.mockRejectedValue(new Error('Network error'));
 
     const sideEffect = vi.fn();
     const onError = vi.fn().mockImplementation(async () => {
@@ -277,34 +277,34 @@ describe("useEntityMutation", () => {
     });
 
     const { result } = renderHook(() =>
-      useEntityMutation("SOME_MUTATION", {
-        errorMessage: "Failed",
+      useEntityMutation('SOME_MUTATION', {
+        errorMessage: 'Failed',
         onError,
       }),
     );
 
     await act(async () => {
-      await result.current.execute({ input: "test" });
+      await result.current.execute({ input: 'test' });
     });
 
     expect(onError).toHaveBeenCalledTimes(1);
     expect(sideEffect).toHaveBeenCalledTimes(1);
   });
 
-  it("returns token from useWsAuthToken", () => {
+  it('returns token from useWsAuthToken', () => {
     mockUseWsAuthToken.mockReturnValue({
-      token: "my-token-abc",
+      token: 'my-token-abc',
       isAuthenticated: true,
       isLoading: false,
       error: null,
     });
 
     const { result } = renderHook(() =>
-      useEntityMutation("SOME_MUTATION", {
-        errorMessage: "Failed",
+      useEntityMutation('SOME_MUTATION', {
+        errorMessage: 'Failed',
       }),
     );
 
-    expect(result.current.token).toBe("my-token-abc");
+    expect(result.current.token).toBe('my-token-abc');
   });
 });

--- a/packages/web/app/hooks/use-entity-mutation.ts
+++ b/packages/web/app/hooks/use-entity-mutation.ts
@@ -18,7 +18,7 @@ type UseEntityMutationOptions = {
   // have a board with this configuration"), otherwise null. When provided, the
   // caller owns the error toast; otherwise the hook shows `serverMessage` (when
   // present) and falls back to the generic `errorMessage`.
-  onError?: (error: unknown, serverMessage: string | null) => void;
+  onError?: (error: unknown, serverMessage: string | null) => void | Promise<void>;
 };
 
 export function useEntityMutation<TResponse, TVariables extends Variables = Variables>(
@@ -48,7 +48,7 @@ export function useEntityMutation<TResponse, TVariables extends Variables = Vari
         console.error(errorMessage, error);
         const serverMessage = extractGraphQLErrorMessage(error);
         if (onError) {
-          onError(error, serverMessage);
+          await onError(error, serverMessage);
         } else {
           showMessage(serverMessage ?? errorMessage, 'error');
         }

--- a/packages/web/app/hooks/use-my-boards.ts
+++ b/packages/web/app/hooks/use-my-boards.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { GET_MY_BOARDS, type GetMyBoardsQueryResponse } from '@boardsesh/graphql/operations';
@@ -11,13 +11,21 @@ import type { UserBoard } from '@boardsesh/shared-schema';
  * When `initialBoards` is provided (from SSR), they are used as the initial state
  * so the UI renders immediately without a loading skeleton. The client-side fetch
  * still runs to refresh the data.
+ *
+ * Call `loadMore` to fetch the next page; `hasMore` indicates whether more pages exist.
  */
 export function useMyBoards(enabled: boolean, limit = 50, initialBoards?: UserBoard[] | null) {
   const hasInitialData = initialBoards != null && initialBoards.length > 0;
   const { token, isAuthenticated } = useWsAuthToken();
   const [boards, setBoards] = useState<UserBoard[]>(initialBoards ?? []);
   const [isLoading, setIsLoading] = useState(false);
+  const [isFetchingMore, setIsFetchingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const offsetRef = useRef(0);
+  // Synchronous guard prevents double-fires from the IntersectionObserver
+  const isFetchingMoreRef = useRef(false);
 
   // Track whether we already have data (from SSR or a prior fetch) to avoid
   // re-showing the loading skeleton on refetches. Using a ref instead of reading
@@ -33,6 +41,7 @@ export function useMyBoards(enabled: boolean, limit = 50, initialBoards?: UserBo
       setIsLoading(true);
     }
     setError(null);
+    offsetRef.current = 0;
 
     const client = createGraphQLHttpClient(token);
     client
@@ -40,6 +49,8 @@ export function useMyBoards(enabled: boolean, limit = 50, initialBoards?: UserBo
       .then((data) => {
         if (!cancelled) {
           setBoards(data.myBoards.boards);
+          setHasMore(data.myBoards.hasMore);
+          offsetRef.current = data.myBoards.boards.length;
           hasDataRef.current = true;
         }
       })
@@ -57,5 +68,28 @@ export function useMyBoards(enabled: boolean, limit = 50, initialBoards?: UserBo
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, isAuthenticated, token, limit]);
 
-  return { boards, isLoading, error };
+  const loadMore = useCallback(() => {
+    if (!hasMore || isFetchingMoreRef.current || !token || !isAuthenticated) return;
+
+    isFetchingMoreRef.current = true;
+    setIsFetchingMore(true);
+    const offset = offsetRef.current;
+    const client = createGraphQLHttpClient(token);
+    client
+      .request<GetMyBoardsQueryResponse>(GET_MY_BOARDS, { input: { limit, offset } })
+      .then((data) => {
+        setBoards((prev) => [...prev, ...data.myBoards.boards]);
+        setHasMore(data.myBoards.hasMore);
+        offsetRef.current = offset + data.myBoards.boards.length;
+      })
+      .catch((err) => {
+        console.error('Failed to load more boards:', err);
+      })
+      .finally(() => {
+        isFetchingMoreRef.current = false;
+        setIsFetchingMore(false);
+      });
+  }, [hasMore, token, isAuthenticated, limit]);
+
+  return { boards, isLoading, isFetchingMore, hasMore, loadMore, error };
 }


### PR DESCRIPTION
## Summary

- **Bug fix**: `useEntityMutation` now `await`s the `onError` callback. Previously it was called without `await`, so the async `handleCreateError` ran fire-and-forget — any throw inside was silently swallowed and `showMessage` could fire on an unmounted component if the user navigated away.
- **Correctness fix**: `findBoardForConfig` paginates through all pages using `UserBoardConnection.hasMore`, capped at 20 pages (1 000 boards) to guard against a hypothetical server bug where `hasMore` is permanently `true`. Users with >50 boards now correctly get the "Go to your board" snackbar action on duplicate creates.
- **Test coverage**: New `create-board-form.test.tsx` covers all `handleCreateError` paths — match found, no match (server message), no match with null server message (i18n fallback), lookup throws, no token, and multi-page pagination. Hook-level test verifies `execute()` doesn't resolve until an async `onError` completes. `vi.resetModules()` removed from `beforeEach`; static import used instead.
- **Infinite scroll**: `useMyBoards` now exposes `hasMore`, `isFetchingMore`, and `loadMore`. `MyBoardsDrawer` uses the existing `useInfiniteScroll` hook to fetch the next page as the user scrolls — a small spinner appears while the page loads.

## Test plan

- [ ] `bunx --bun vite-plus test run packages/web/app/hooks/__tests__/use-entity-mutation.test.ts` — all 12 tests pass
- [ ] `bunx --bun vite-plus test run packages/web/app/components/board-entity/__tests__/create-board-form.test.tsx` — all 6 tests pass
- [ ] Create a board that duplicates an existing config → snackbar shows "Go to your board" with action
- [ ] With a user that has >50 boards, open My Boards drawer → first 50 load; scrolling to the bottom loads the next page with a spinner

https://claude.ai/code/session_01TVLTAPUzhucwgMzJpKer4d