### PR TITLE
fix(docker): add queue-react package.json to backend Docker build

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -36,6 +36,7 @@ COPY packages/shared/queue/package.json ./packages/shared/queue/
 # depends on them). The backend itself doesn't import them, so omitting
 # `src/` keeps the image smaller. Don't add COPYs for `src/` "for symmetry"
 # — verify with `grep -rE "from '@boardsesh/" packages/backend/src/`.
+COPY packages/shared/queue-react/package.json ./packages/shared/queue-react/
 COPY packages/shared/queue-runtime/package.json ./packages/shared/queue-runtime/
 COPY packages/shared/party-profile/package.json ./packages/shared/party-profile/
 COPY packages/shared/climb-actions/package.json ./packages/shared/climb-actions/


### PR DESCRIPTION
## Summary

- `@boardsesh/queue-react` is a local workspace package that doesn't exist on npm
- `bun install --frozen-lockfile` in `Dockerfile.backend` was hitting a 404 trying to resolve it from the registry
- Added `COPY packages/shared/queue-react/package.json` so bun can resolve the full workspace graph — backend doesn't import from it, so no `src/` copy is needed

## Test plan

- [ ] Re-run the backend Docker build CI job and confirm it passes
- [ ] Verify the built image starts correctly

https://claude.ai/code/session_01WQWbpbua2V7vQJJKKpFP7F

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQWbpbua2V7vQJJKKpFP7F)_