### PR TITLE
fix(mobile): make @sentry/cli resolvable for iOS bundle phase + add PR guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,6 +460,12 @@ jobs:
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
+      # Catches iOS bundle-phase dep-resolution breaks (e.g. a transitive-only
+      # @sentry/cli unresolvable from packages/mobile under Bun's isolated
+      # linker) here on Linux, instead of in the macOS TestFlight archive on
+      # push-to-main. Runs before the heavier Metro bundle so it fails fast.
+      - name: Check native build-phase deps resolve
+        run: vp run check:mobile-native-deps
       - name: Download built packages
         uses: actions/download-artifact@v4
         with:

--- a/bun.lock
+++ b/bun.lock
@@ -168,6 +168,7 @@
         "@gorhom/bottom-sheet": "^5.2.14",
         "@react-native-async-storage/async-storage": "^3.1.0",
         "@react-native-community/blur": "^4.4.1",
+        "@sentry/cli": "2.53.0",
         "@sentry/react-native": "^6.14.0",
         "@shopify/flash-list": "2.0.2",
         "@tanstack/react-query": "^5.0.0",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -24,6 +24,7 @@
     "@boardsesh/queue-runtime": "*",
     "@boardsesh/shared-schema": "*",
     "@expo/vector-icons": "^15.1.1",
+    "@sentry/cli": "2.53.0",
     "@sentry/react-native": "^6.14.0",
     "@gorhom/bottom-sheet": "^5.2.14",
     "@react-native-async-storage/async-storage": "^3.1.0",

--- a/scripts/__tests__/mobile-native-deps-check.test.ts
+++ b/scripts/__tests__/mobile-native-deps-check.test.ts
@@ -1,0 +1,171 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  checkNativeBuildPhaseDeps,
+  readMobileDeps,
+  type DepResolver,
+  type NativeDepRule,
+} from '../mobile-native-deps-check';
+
+const MOBILE_PKG = '/repo/packages/mobile/package.json';
+const RN = '@sentry/react-native';
+const CLI = '@sentry/cli';
+const RULES: NativeDepRule[] = [{ trigger: RN, tools: [CLI] }];
+
+/**
+ * Build a fake resolver from explicit maps so tests never touch a real
+ * node_modules tree. `resolveMap` is keyed `"<from>::<request>"`; `versionMap`
+ * is keyed by resolved path. A missing key throws, mirroring Node.
+ */
+function makeResolver(resolveMap: Record<string, string>, versionMap: Record<string, string> = {}): DepResolver {
+  return {
+    resolve(from, request) {
+      const hit = resolveMap[`${from}::${request}`];
+      if (!hit) throw new Error(`Cannot find module '${request}' from '${from}'`);
+      return hit;
+    },
+    readVersion(path) {
+      const version = versionMap[path];
+      if (!version) throw new Error(`no "version" field in ${path}`);
+      return version;
+    },
+  };
+}
+
+describe('checkNativeBuildPhaseDeps', () => {
+  it('passes when the tool resolves and versions are aligned', () => {
+    const resolver = makeResolver(
+      {
+        [`${MOBILE_PKG}::${CLI}/package.json`]: '/store/cli-2.53.0/package.json',
+        [`${MOBILE_PKG}::${RN}/package.json`]: '/store/rn/package.json',
+        [`/store/rn/package.json::${CLI}/package.json`]: '/store/cli-2.53.0/package.json',
+      },
+      { '/store/cli-2.53.0/package.json': '2.53.0' },
+    );
+
+    const result = checkNativeBuildPhaseDeps(MOBILE_PKG, { [RN]: '^6.14.0', [CLI]: '2.53.0' }, RULES, resolver);
+
+    expect(result.checked).toBe(1);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('skips rules whose trigger is not a mobile dependency', () => {
+    const resolver = makeResolver({});
+    const result = checkNativeBuildPhaseDeps(MOBILE_PKG, { expo: '~56.0.0' }, RULES, resolver);
+
+    expect(result.checked).toBe(0);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('fails when the tool is not resolvable from packages/mobile', () => {
+    // The exact regression that broke the TestFlight archive: @sentry/cli is a
+    // transitive-only dep, so resolving it from packages/mobile throws.
+    const resolver = makeResolver({
+      [`${MOBILE_PKG}::${RN}/package.json`]: '/store/rn/package.json',
+    });
+
+    const result = checkNativeBuildPhaseDeps(MOBILE_PKG, { [RN]: '^6.14.0' }, RULES, resolver);
+
+    expect(result.checked).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('not resolvable from packages/mobile');
+    expect(result.errors[0]).toContain(CLI);
+  });
+
+  it('fails on version drift between the direct pin and the trigger requirement', () => {
+    const resolver = makeResolver(
+      {
+        [`${MOBILE_PKG}::${CLI}/package.json`]: '/store/cli-2.53.0/package.json',
+        [`${MOBILE_PKG}::${RN}/package.json`]: '/store/rn/package.json',
+        [`/store/rn/package.json::${CLI}/package.json`]: '/store/cli-2.55.0/package.json',
+      },
+      { '/store/cli-2.53.0/package.json': '2.53.0', '/store/cli-2.55.0/package.json': '2.55.0' },
+    );
+
+    const result = checkNativeBuildPhaseDeps(MOBILE_PKG, { [RN]: '^6.14.0', [CLI]: '2.53.0' }, RULES, resolver);
+
+    expect(result.checked).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('version drift');
+    expect(result.errors[0]).toContain('2.53.0');
+    expect(result.errors[0]).toContain('2.55.0');
+  });
+
+  it('reports an alignment-verification error when the trigger cannot resolve the tool', () => {
+    // Tool resolves from mobile (1) but resolving it from the trigger (2) fails.
+    const resolver = makeResolver(
+      {
+        [`${MOBILE_PKG}::${CLI}/package.json`]: '/store/cli-2.53.0/package.json',
+        [`${MOBILE_PKG}::${RN}/package.json`]: '/store/rn/package.json',
+        // intentionally omit `/store/rn/package.json::@sentry/cli/package.json`
+      },
+      { '/store/cli-2.53.0/package.json': '2.53.0' },
+    );
+
+    const result = checkNativeBuildPhaseDeps(MOBILE_PKG, { [RN]: '^6.14.0', [CLI]: '2.53.0' }, RULES, resolver);
+
+    expect(result.checked).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('could not verify');
+  });
+
+  it('checks every tool in a multi-tool rule', () => {
+    const multiRule: NativeDepRule[] = [{ trigger: RN, tools: [CLI, '@sentry/other-cli'] }];
+    const resolver = makeResolver({
+      [`${MOBILE_PKG}::${RN}/package.json`]: '/store/rn/package.json',
+      // neither tool resolves from mobile
+    });
+
+    const result = checkNativeBuildPhaseDeps(MOBILE_PKG, { [RN]: '^6.14.0' }, multiRule, resolver);
+
+    expect(result.checked).toBe(2);
+    expect(result.errors).toHaveLength(2);
+  });
+});
+
+describe('readMobileDeps', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'mnd-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('merges dependencies and devDependencies (dependencies win)', () => {
+    const pkgPath = join(dir, 'package.json');
+    writeFileSync(
+      pkgPath,
+      JSON.stringify({
+        dependencies: { '@sentry/cli': '2.53.0', expo: '~56.0.0' },
+        devDependencies: { tsx: '^4.0.0', expo: '~55.0.0' },
+      }),
+    );
+
+    const deps = readMobileDeps(pkgPath);
+
+    expect(deps).toEqual({ '@sentry/cli': '2.53.0', expo: '~56.0.0', tsx: '^4.0.0' });
+  });
+
+  it('returns an empty map when neither dependency block is present', () => {
+    const pkgPath = join(dir, 'package.json');
+    writeFileSync(pkgPath, JSON.stringify({ name: '@boardsesh/mobile' }));
+
+    expect(readMobileDeps(pkgPath)).toEqual({});
+  });
+
+  it('throws a helpful error for a missing file', () => {
+    expect(() => readMobileDeps(join(dir, 'does-not-exist.json'))).toThrow(/cannot read/);
+  });
+
+  it('throws a helpful error for malformed JSON', () => {
+    const pkgPath = join(dir, 'package.json');
+    writeFileSync(pkgPath, '{ not valid json');
+
+    expect(() => readMobileDeps(pkgPath)).toThrow(/cannot parse/);
+  });
+});

--- a/scripts/mobile-native-deps-check.ts
+++ b/scripts/mobile-native-deps-check.ts
@@ -1,0 +1,76 @@
+/// <reference types="node" />
+
+/**
+ * Guards against native iOS build-phase dependency-resolution breaks that only
+ * surface during the macOS `xcodebuild archive` on push-to-main (e.g. the
+ * TestFlight RN deploy), long after the PR that caused them merged.
+ *
+ * The iOS "Bundle React Native code and images" phase shells out to helper
+ * scripts that resolve CLIs with Node from inside packages/mobile — most
+ * notably Sentry's `sentry-xcode.sh`, which runs:
+ *
+ *   node --print "require.resolve('@sentry/cli/package.json')"
+ *
+ * Bun's isolated linker only symlinks a workspace's DIRECT deps into its
+ * node_modules, so a transitive-only `@sentry/cli` (pulled in by
+ * @sentry/react-native) is NOT resolvable from packages/mobile and the build
+ * dies under `set -e`. The fix is to declare such tools as direct deps; this
+ * check fails the PR the moment that invariant is broken, on a cheap Linux
+ * runner — no Xcode required.
+ *
+ * Usage: vp run check:mobile-native-deps
+ */
+
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MOBILE_PKG = resolve(ROOT_DIR, 'packages', 'mobile', 'package.json');
+
+/**
+ * If the `trigger` package is a dependency of packages/mobile, then every entry
+ * in `tools` must be resolvable from packages/mobile — mirroring how the iOS
+ * bundle phase resolves them at build time. Add a rule here whenever a new
+ * config plugin injects a build-phase script that `require.resolve`s a CLI.
+ */
+const RULES: ReadonlyArray<{ trigger: string; tools: readonly string[] }> = [
+  { trigger: '@sentry/react-native', tools: ['@sentry/cli/package.json'] },
+];
+
+const mobilePkg = JSON.parse(readFileSync(MOBILE_PKG, 'utf8')) as {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+const declaredDeps = { ...mobilePkg.devDependencies, ...mobilePkg.dependencies };
+
+// Resolve exactly as the iOS build script does: base = packages/mobile.
+const requireFromMobile = createRequire(MOBILE_PKG);
+
+const failures: string[] = [];
+let checked = 0;
+
+for (const { trigger, tools } of RULES) {
+  if (!declaredDeps[trigger]) continue;
+  for (const tool of tools) {
+    checked += 1;
+    try {
+      requireFromMobile.resolve(tool);
+    } catch {
+      failures.push(
+        `${tool} is required at iOS build time by ${trigger}, but is not resolvable from packages/mobile. ` +
+          `Add it as a direct dependency in packages/mobile/package.json ` +
+          `(Bun's isolated linker does not surface transitive deps there).`,
+      );
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('[mobile-native-deps] FAILED — native build-phase deps not resolvable:');
+  for (const failure of failures) console.error(`  ✗ ${failure}`);
+  process.exit(1);
+}
+
+console.log(`[mobile-native-deps] OK — ${checked} native build-phase dep(s) resolvable from packages/mobile.`);

--- a/scripts/mobile-native-deps-check.ts
+++ b/scripts/mobile-native-deps-check.ts
@@ -18,59 +18,176 @@
  * check fails the PR the moment that invariant is broken, on a cheap Linux
  * runner — no Xcode required.
  *
+ * It enforces two invariants per rule:
+ *   1. Resolvable — the tool resolves from packages/mobile (the exact thing the
+ *      bundle phase does). This is what broke the TestFlight archive.
+ *   2. Version-aligned — the copy packages/mobile resolves is the SAME install
+ *      the trigger package resolves. The direct pin we add to dedupe will
+ *      silently drift from the trigger's transitive requirement when either is
+ *      bumped; this catches that so the bundle phase and the JS runtime never
+ *      use mismatched CLI versions.
+ *
  * Usage: vp run check:mobile-native-deps
  */
 
 import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const MOBILE_PKG = resolve(ROOT_DIR, 'packages', 'mobile', 'package.json');
+export interface NativeDepRule {
+  /** A direct dependency of packages/mobile whose Expo config plugin injects an iOS build-phase script. */
+  trigger: string;
+  /** Bare module specifiers that build-phase script resolves via Node from packages/mobile. */
+  tools: readonly string[];
+}
 
 /**
- * If the `trigger` package is a dependency of packages/mobile, then every entry
- * in `tools` must be resolvable from packages/mobile — mirroring how the iOS
- * bundle phase resolves them at build time. Add a rule here whenever a new
- * config plugin injects a build-phase script that `require.resolve`s a CLI.
+ * Rules are MAINTAINED BY HAND. There is no way to enumerate every CLI an iOS
+ * build phase shells out to without running `expo prebuild` + xcodebuild (macOS
+ * only, which defeats the point of a cheap Linux guard). So when a new native
+ * dep adds an Expo config plugin that injects a build-phase `require.resolve`,
+ * add a rule here — otherwise that tool's drift won't be caught until the next
+ * push-to-main archive. Today only @sentry/react-native does this.
  */
-const RULES: ReadonlyArray<{ trigger: string; tools: readonly string[] }> = [
-  { trigger: '@sentry/react-native', tools: ['@sentry/cli/package.json'] },
-];
+export const RULES: readonly NativeDepRule[] = [{ trigger: '@sentry/react-native', tools: ['@sentry/cli'] }];
 
-const mobilePkg = JSON.parse(readFileSync(MOBILE_PKG, 'utf8')) as {
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-};
-const declaredDeps = { ...mobilePkg.devDependencies, ...mobilePkg.dependencies };
+/**
+ * Resolution + version reads, abstracted so {@link checkNativeBuildPhaseDeps}
+ * can be unit-tested without a real node_modules tree.
+ */
+export interface DepResolver {
+  /** Resolve `request` as Node would when required from the package at `fromPackageJson`. Throws if unresolvable. */
+  resolve(fromPackageJson: string, request: string): string;
+  /** Read the `version` field of an installed package.json. Throws if absent/unreadable. */
+  readVersion(packageJsonPath: string): string;
+}
 
-// Resolve exactly as the iOS build script does: base = packages/mobile.
-const requireFromMobile = createRequire(MOBILE_PKG);
+export interface CheckResult {
+  /** Number of (rule, tool) pairs that were applicable and checked. */
+  checked: number;
+  /** Human-readable failure messages; empty means the check passed. */
+  errors: string[];
+}
 
-const failures: string[] = [];
-let checked = 0;
+/**
+ * Pure check: given the mobile dependency map and a resolver, verify every
+ * applicable rule. No filesystem access of its own — all I/O goes through
+ * `resolver`, so tests inject a fake.
+ */
+export function checkNativeBuildPhaseDeps(
+  mobilePackageJsonPath: string,
+  mobileDeps: Record<string, string>,
+  rules: readonly NativeDepRule[],
+  resolver: DepResolver,
+): CheckResult {
+  const errors: string[] = [];
+  let checked = 0;
 
-for (const { trigger, tools } of RULES) {
-  if (!declaredDeps[trigger]) continue;
-  for (const tool of tools) {
-    checked += 1;
-    try {
-      requireFromMobile.resolve(tool);
-    } catch {
-      failures.push(
-        `${tool} is required at iOS build time by ${trigger}, but is not resolvable from packages/mobile. ` +
-          `Add it as a direct dependency in packages/mobile/package.json ` +
-          `(Bun's isolated linker does not surface transitive deps there).`,
-      );
+  for (const { trigger, tools } of rules) {
+    if (!mobileDeps[trigger]) continue;
+    for (const tool of tools) {
+      checked += 1;
+
+      // (1) Resolvability from packages/mobile — exactly what the iOS bundle
+      //     phase does, and the failure that broke the TestFlight archive.
+      let toolFromMobile: string;
+      try {
+        toolFromMobile = resolver.resolve(mobilePackageJsonPath, `${tool}/package.json`);
+      } catch {
+        errors.push(
+          `${tool} is required at iOS build time by ${trigger}, but is not resolvable from ` +
+            `packages/mobile. Add it as a direct dependency in packages/mobile/package.json ` +
+            `(Bun's isolated linker does not surface transitive deps there).`,
+        );
+        continue; // Can't check alignment if it doesn't resolve at all.
+      }
+
+      // (2) Version alignment — compare the copy packages/mobile resolves with
+      //     the copy `trigger` resolves. Equal install path-version means one
+      //     deduped copy; a mismatch means the direct pin drifted from what the
+      //     trigger now requires.
+      try {
+        const triggerPackageJson = resolver.resolve(mobilePackageJsonPath, `${trigger}/package.json`);
+        const toolFromTrigger = resolver.resolve(triggerPackageJson, `${tool}/package.json`);
+        const mobileVersion = resolver.readVersion(toolFromMobile);
+        const triggerVersion = resolver.readVersion(toolFromTrigger);
+        if (mobileVersion !== triggerVersion) {
+          errors.push(
+            `${tool} version drift: packages/mobile resolves ${mobileVersion}, but ${trigger} ` +
+              `resolves ${triggerVersion}. Update the direct "${tool}" pin in ` +
+              `packages/mobile/package.json to ${triggerVersion} so both use one copy.`,
+          );
+        }
+      } catch (error) {
+        errors.push(`could not verify ${tool} version alignment against ${trigger}: ${(error as Error).message}`);
+      }
     }
   }
+
+  return { checked, errors };
 }
 
-if (failures.length > 0) {
-  console.error('[mobile-native-deps] FAILED — native build-phase deps not resolvable:');
-  for (const failure of failures) console.error(`  ✗ ${failure}`);
-  process.exit(1);
+/**
+ * Read and merge the dependency maps of packages/mobile's package.json.
+ * devDependencies first so a real dependency entry wins on conflict.
+ */
+export function readMobileDeps(mobilePackageJsonPath: string): Record<string, string> {
+  let raw: string;
+  try {
+    raw = readFileSync(mobilePackageJsonPath, 'utf8');
+  } catch (error) {
+    throw new Error(`cannot read ${mobilePackageJsonPath}: ${(error as Error).message}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`cannot parse ${mobilePackageJsonPath}: ${(error as Error).message}`);
+  }
+  const pkg = parsed as { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
+  return { ...pkg.devDependencies, ...pkg.dependencies };
 }
 
-console.log(`[mobile-native-deps] OK — ${checked} native build-phase dep(s) resolvable from packages/mobile.`);
+/** Real-filesystem resolver used when the script runs for real. */
+export const nodeResolver: DepResolver = {
+  resolve(fromPackageJson, request) {
+    return createRequire(fromPackageJson).resolve(request);
+  },
+  readVersion(packageJsonPath) {
+    const { version } = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { version?: string };
+    if (!version) throw new Error(`no "version" field in ${packageJsonPath}`);
+    return version;
+  },
+};
+
+/** Wire the real filesystem and run the check. Returns the process exit code. */
+export function main(): number {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  const mobilePackageJson = resolve(repoRoot, 'packages', 'mobile', 'package.json');
+
+  let mobileDeps: Record<string, string>;
+  try {
+    mobileDeps = readMobileDeps(mobilePackageJson);
+  } catch (error) {
+    console.error(`[mobile-native-deps] FAILED — ${(error as Error).message}`);
+    return 1;
+  }
+
+  const { checked, errors } = checkNativeBuildPhaseDeps(mobilePackageJson, mobileDeps, RULES, nodeResolver);
+
+  if (errors.length > 0) {
+    console.error('[mobile-native-deps] FAILED — native build-phase deps not OK:');
+    for (const error of errors) console.error(`  ✗ ${error}`);
+    return 1;
+  }
+
+  console.log(`[mobile-native-deps] OK — ${checked} native build-phase dep(s) resolvable and version-aligned.`);
+  return 0;
+}
+
+// Run only when executed directly (tsx scripts/mobile-native-deps-check.ts),
+// not when imported by tests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/scripts/vite.config.ts
+++ b/scripts/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  test: {
+    name: 'scripts',
+    globals: true,
+    environment: 'node',
+    include: ['**/*.test.ts'],
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
       './packages/shared/graphql-client/vite.config.ts',
       './packages/shared-schema/vite.config.ts',
       './packages/mobile/vite.config.ts',
+      './scripts/vite.config.ts',
     ],
   },
   staged: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -248,6 +248,10 @@ export default defineConfig({
       },
 
       // --- Mobile validation ---
+      'check:mobile-native-deps': {
+        command: 'tsx scripts/mobile-native-deps-check.ts',
+        cache: false,
+      },
       'check:mobile-bundle': {
         command: 'bash scripts/mobile-bundle-check.sh',
         cache: false,


### PR DESCRIPTION
## Why

The **iOS TestFlight Deploy (React Native)** workflow broke on push to `main` ([run 26708466468](https://github.com/boardsesh/boardsesh/actions/runs/26708466468/job/78714150390)). The `Archive` step failed with exit code 65. The real error is in the **"Bundle React Native code and images"** build phase:

```
node --print require('path').dirname(require.resolve('@sentry/cli/package.json'))
Error: Cannot find module '@sentry/cli/package.json'
+ SENTRY_CLI_PACKAGE_PATH=
Command PhaseScriptExecution failed with a nonzero exit code
```

### Root cause

`4dff23af7 feat(mobile): add error boundary and Sentry crash reporting` added `@sentry/react-native` + the `@sentry/react-native/expo` config plugin. During `expo prebuild` that plugin swaps the RN bundle phase for Sentry's `sentry-xcode.sh`, which resolves `@sentry/cli` via Node from `packages/mobile` under `set -e`. `@sentry/react-native@6.22.0` depends on `@sentry/cli@2.53.0`, but **only transitively** — and Bun's isolated `.bun` linker surfaces only a workspace's *direct* deps into its `node_modules`. So `packages/mobile/node_modules/@sentry/cli` never existed, the resolve failed, and the archive died.

Reproduced from a clean checkout:
```
cd packages/mobile/ios && node -e "require.resolve('@sentry/cli/package.json')"  # → fails
```

### Why no PR caught it

The full iOS archive only runs on **push to `main`**. PR-time mobile CI is Linux typecheck + unit tests + Metro bundle — none of which exercise the iOS bundle-phase resolution. So the break first appeared *after* merge.

## What this does

**Fix** — declare `@sentry/cli` as a direct dependency of `packages/mobile`, pinned to the exact version `@sentry/react-native` already requires (`2.53.0`) so Bun dedupes to the existing store copy (no second install). Bun then symlinks it into `packages/mobile/node_modules/@sentry/cli` and the bundle phase resolves it.

**Prevention** — a cheap Linux PR guard, `vp run check:mobile-native-deps` (new `scripts/mobile-native-deps-check.ts`), wired into the `mobile-bundle` job in `ci.yml`. Already covered by the `ci-status` required-check gate, runs on an existing runner, and **would have failed the PR that introduced this**, in seconds. The guard enforces two invariants per rule:

1. **Resolvable** — the tool resolves from `packages/mobile` (exactly what the bundle phase does). This is the failure that broke the archive.
2. **Version-aligned** — the `@sentry/cli` `packages/mobile` resolves is the *same* install `@sentry/react-native` resolves. The direct pin would otherwise silently drift from the transitive requirement on any bump; a mismatch now fails CI with a "bump the pin" message.

The `RULES` table is hand-maintained (documented inline): enumerating every build-phase CLI requires macOS prebuild + xcodebuild, which the Linux guard exists to avoid — so a new native dep that injects a build-phase `require.resolve` needs a rule added.

## Tests

New `scripts` vitest project + `scripts/__tests__/mobile-native-deps-check.test.ts` (10 cases): resolvable+aligned, not-resolvable, version drift, trigger-absent, alignment-verification failure, multi-tool rules, and `readMobileDeps` error paths (missing file, malformed JSON, dep/devDep merge).

## Base

Originally cut off #2433 (`ci/consolidate-js-workflows`); now that it's merged, this is rebased onto `main` and targets `main`.

## Verification

- Resolution from `packages/mobile/ios` now succeeds (`.../.bun/@sentry+cli@2.53.0/...`); `@sentry/cli` resolves to the same `2.53.0` from both `packages/mobile` and `@sentry/react-native`.
- `vp run check:mobile-native-deps` → passes; with `@sentry/cli` removed it exits `1` (and `vp run` propagates the non-zero exit, so the CI step fails).
- `vp test run --project mobile --project scripts` (431 tests), `vp run typecheck:mobile`, and `vp check` on changed files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)