### PR TITLE
fix(ci): wire Sentry source-map upload for iOS TestFlight archive

### DIFF
--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -28,6 +28,10 @@ jobs:
     # under Xcode 26's strict C++20 constexpr evaluator.
     runs-on: macos-26
     timeout-minutes: 60
+    # Scopes the job to the Production GitHub Environment so it can read the
+    # Production-scoped SENTRY_AUTH_TOKEN secret. Mirrors production-deploy.yml;
+    # the Production environment has a branch policy only (no approval gate).
+    environment: Production
 
     env:
       WORKSPACE_PATH: packages/mobile/ios/Boardsesh.xcworkspace
@@ -40,6 +44,10 @@ jobs:
       EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
       EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
       EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
+      # Activates Sentry at runtime in the shipped build (src/lib/sentry.ts gates
+      # on this var). Same DSN/project as web + backend; not secret — already
+      # hardcoded in packages/web and packages/backend source.
+      EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
 
     steps:
       - name: Checkout repository
@@ -57,6 +65,7 @@ jobs:
           EXPO_PUBLIC_BACKEND_URL=$EXPO_PUBLIC_BACKEND_URL
           EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
           EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
+          EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
           EOF
 
       - name: Expo prebuild (generate ios/)
@@ -154,10 +163,31 @@ jobs:
           echo "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode \
             > ~/.private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8
 
+      # The @sentry/react-native build phases upload JS source maps + native
+      # dSYMs during `xcodebuild archive`. Without a token the upload errors and
+      # fails the archive (sentry-xcode.sh exits non-zero), so gate it: only
+      # enable the upload when SENTRY_AUTH_TOKEN is present, otherwise skip it and
+      # keep the build green. SENTRY_DISABLE_AUTO_UPLOAD is read by both phases.
+      - name: Configure Sentry source map upload
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          if [ -n "$SENTRY_AUTH_TOKEN" ]; then
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=false" >> "$GITHUB_ENV"
+            echo "Sentry auth token present — source maps + dSYMs will upload."
+          else
+            echo "SENTRY_DISABLE_AUTO_UPLOAD=true" >> "$GITHUB_ENV"
+            echo "::warning::SENTRY_AUTH_TOKEN not set — skipping Sentry source map upload."
+          fi
+
       - name: Archive
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          # Consumed by the @sentry/react-native build phases (sentry-cli). The
+          # SENTRY_DISABLE_AUTO_UPLOAD gate above (via $GITHUB_ENV) decides whether
+          # the upload actually runs.
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           xcodebuild archive \
             -workspace "$WORKSPACE_PATH" \

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -169,7 +169,11 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       // builds — preview/production keep stock Expo ATS so we don't ship an
       // arbitrary-loads relaxation through App Store review.
       ...(isDevBuild ? ['./plugins/with-boardsesh-dev-networking'] : []),
-      '@sentry/react-native/expo',
+      // org/project make `expo prebuild` write a valid ios/sentry.properties so
+      // the build-phase source-map + dSYM upload can find the Sentry project.
+      // The auth token is supplied via the SENTRY_AUTH_TOKEN env var in CI
+      // (never committed); url defaults to https://sentry.io/ (US region).
+      ['@sentry/react-native/expo', { organization: 'boardsesh', project: 'boardsesh' }],
     ],
     extra: {
       ...config.extra,

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -1,6 +1,5 @@
 import type { ComponentType } from 'react';
 import * as Sentry from '@sentry/react-native';
-import Constants from 'expo-constants';
 
 const sentryDsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
 
@@ -14,8 +13,12 @@ if (isSentryEnabled) {
   Sentry.init({
     dsn: sentryDsn,
     tracesSampleRate: 0.1,
-    // Attach release info so source maps match
-    release: Constants.expoConfig?.version ?? undefined,
+    // release/dist are intentionally left unset so @sentry/react-native
+    // auto-detects them from the native build (CFBundleShortVersionString +
+    // CFBundleVersion). Those are the exact values `sentry-cli react-native
+    // xcode` tags the uploaded source maps with, so stack traces symbolicate.
+    // Hardcoding release here (e.g. "2.0.0" without dist) would mismatch the
+    // uploaded artifacts and break symbolication.
   });
 }
 


### PR DESCRIPTION
## Problem

The **iOS TestFlight Deploy (React Native)** workflow has failed on **every push to `main` since 06:33 today** (it was green at 06:01). The break came from #2276 ("add error boundary and Sentry crash reporting"), which registered `@sentry/react-native/expo` in `packages/mobile/app.config.ts`.

That plugin injects a build-time source-map upload into the iOS *Bundle React Native code and images* build phase (`sentry-cli react-native xcode`). No Sentry org/project/auth token was configured for mobile, so `sentry-cli` aborted during `xcodebuild archive`:

```
error: An organization ID or slug is required (provide with --org)
** ARCHIVE FAILED **
  PhaseScriptExecution Bundle React Native code and images ... (in target 'Boardsesh')
(2 failures) → exit code 65
```

Runtime Sentry was also dormant: `EXPO_PUBLIC_SENTRY_DSN` was never set by the workflow, so `src/lib/sentry.ts` kept Sentry off in shipped builds — even a passing archive would capture nothing.

## Fix (full wiring, not just disabling upload)

Reuses the existing org `boardsesh` / project `boardsesh` Sentry setup that web + backend already use.

- **`app.config.ts`** — pass `{ organization: 'boardsesh', project: 'boardsesh' }` to the Sentry Expo plugin so `expo prebuild` writes a valid `ios/sentry.properties`. The auth token stays out of the repo (supplied via `SENTRY_AUTH_TOKEN` env in CI; the plugin warns against committing it). Verified the generated file:
  ```
  defaults.org=boardsesh
  defaults.project=boardsesh
  # Using SENTRY_AUTH_TOKEN environment variable
  ```
- **`src/lib/sentry.ts`** — drop the hardcoded `release: '2.0.0'` override (and the now-unused `expo-constants` import) so `@sentry/react-native` auto-detects `release`+`dist` from the native build. Those match what `sentry-cli react-native xcode` tags uploaded source maps with; the old hardcoded value would have broken symbolication.
- **`ios-testflight-rn.yml`** —
  - `environment: Production` on the job so it can read the Production-scoped `SENTRY_AUTH_TOKEN` secret (mirrors `production-deploy.yml`; the Production environment has a branch policy only, **no approval gate**).
  - Inline `EXPO_PUBLIC_SENTRY_DSN` (same DSN as web/backend, already public in their source) so Sentry initializes at runtime.
  - A **safety gate**: a step sets `SENTRY_DISABLE_AUTO_UPLOAD` based on token presence. If the secret is missing the archive still succeeds with the upload skipped (CI warning) — so this is safe to merge before the secret lands.

> Note: `sentry-xcode.sh` v6.22 does **not** honor `SENTRY_ALLOW_FAILURE` for the bundle phase — `SENTRY_DISABLE_AUTO_UPLOAD` is the only env lever that keeps it green. Both Sentry phases (JS source maps + native dSYMs) honor it.

## Required follow-up (deployer)

Add `SENTRY_AUTH_TOKEN` to the GitHub **Production** environment (reuse the web token value from Vercel; same org/project — no new token needed). Until then the build is green but source maps are not uploaded.

## Verification

- ✅ `expo prebuild` generates `ios/sentry.properties` with org/project (shown above)
- ✅ `vp run typecheck:mobile`
- ✅ `vp run check:mobile-bundle` (7.6 MB bundle OK)
- ✅ `vp test --project mobile` (421 passed)
- ⏳ Full `xcodebuild archive` only runs on `main` (macOS, `if: github.ref == 'refs/heads/main'`) — watch the post-merge run; with the secret present, confirm a release + artifacts appear in Sentry for `com.boardsesh.app@2.0.0+<build>`.

## Out of scope
- Dedicated `boardsesh-mobile` Sentry project (needs a new project + DSN in the dashboard).
- Android source-map upload (`android-release.yml`) would need the same token wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)