### PR TITLE
[codex] Fix mobile BLE picker presentation

### DIFF
--- a/packages/mobile/src/components/ble/ConnectionBanner.tsx
+++ b/packages/mobile/src/components/ble/ConnectionBanner.tsx
@@ -106,12 +106,12 @@ export function ConnectionBanner({ visible, onReconnect, onDismiss }: Connection
         <Icon name="bluetooth.off" size={18} color={brandColors.warning} />
 
         <Text variant="subheadline" color={systemColors.label} style={styles.messageText} numberOfLines={1}>
-          {t('settings.ble.disconnected')}
+          {t('ble.disconnected')}
         </Text>
 
         <Pressable onPress={handleReconnect} accessibilityRole="button" style={styles.reconnectButton}>
           <Text variant="subheadline" color={brandColors.primary} style={styles.reconnectLabel}>
-            {t('settings.ble.reconnect')}
+            {t('ble.reconnect')}
           </Text>
         </Pressable>
 

--- a/packages/mobile/src/components/ble/DeviceCard.tsx
+++ b/packages/mobile/src/components/ble/DeviceCard.tsx
@@ -66,7 +66,7 @@ export function DeviceCard({ device, onSelect, boardType }: DeviceCardProps) {
     onSelect(device.deviceId);
   }, [device.deviceId, onSelect]);
 
-  const displayName = device.name ?? t('settings.ble.unknownBoard');
+  const displayName = device.name ?? t('ble.unknownBoard');
 
   return (
     <Pressable

--- a/packages/mobile/src/components/ble/DevicePickerSheet.tsx
+++ b/packages/mobile/src/components/ble/DevicePickerSheet.tsx
@@ -1,11 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { View, ActivityIndicator, StyleSheet, type ViewStyle } from 'react-native';
-import BottomSheet, {
+import { useCallback, useEffect, useMemo, useRef, type PropsWithChildren } from 'react';
+import { View, ActivityIndicator, Platform, StyleSheet, type ViewStyle } from 'react-native';
+import {
+  BottomSheetModal,
   BottomSheetBackdrop,
   BottomSheetView,
   BottomSheetFlatList,
   type BottomSheetBackdropProps,
 } from '@gorhom/bottom-sheet';
+import { FullWindowOverlay } from 'react-native-screens';
 import { useTranslation } from 'react-i18next';
 import { parseBoardTypeFromDeviceName } from '@boardsesh/ble-protocol';
 import type { DiscoveredDevice } from '../../lib/ble/types';
@@ -24,29 +26,28 @@ type DevicePickerSheetProps = {
   isScanning: boolean;
 };
 
+function DevicePickerModalContainer({ children }: PropsWithChildren) {
+  return <FullWindowOverlay>{children}</FullWindowOverlay>;
+}
+
+const modalContainerComponent = Platform.OS === 'ios' ? DevicePickerModalContainer : undefined;
+
 export function DevicePickerSheet({ visible, devices, onSelect, onDismiss, isScanning }: DevicePickerSheetProps) {
   const { t } = useTranslation('settings');
   const theme = useTheme();
-  const sheetRef = useRef<BottomSheet>(null);
+  const sheetRef = useRef<BottomSheetModal>(null);
 
-  const snapPoints = useMemo(() => ['55%'], []);
+  const snapPoints = useMemo(() => ['72%'], []);
 
   useEffect(() => {
     if (visible) {
-      sheetRef.current?.expand();
+      sheetRef.current?.present();
+    } else {
+      sheetRef.current?.dismiss();
     }
   }, [visible]);
 
   const sortedDevices = useMemo(() => [...devices].sort((deviceA, deviceB) => deviceB.rssi - deviceA.rssi), [devices]);
-
-  const handleSheetChange = useCallback(
-    (index: number) => {
-      if (index === -1) {
-        onDismiss();
-      }
-    },
-    [onDismiss],
-  );
 
   const renderBackdrop = useCallback(
     (backdropProps: BottomSheetBackdropProps) => (
@@ -81,23 +82,26 @@ export function DevicePickerSheet({ visible, devices, onSelect, onDismiss, isSca
   const showEmptyState = !isScanning && devices.length === 0;
 
   return (
-    <BottomSheet
+    <BottomSheetModal
       ref={sheetRef}
+      name="ble-device-picker"
       index={0}
+      stackBehavior="push"
       snapPoints={snapPoints}
+      containerComponent={modalContainerComponent}
       enablePanDownToClose
       backdropComponent={renderBackdrop}
-      onChange={handleSheetChange}
+      onDismiss={onDismiss}
       handleIndicatorStyle={styles.indicator}
       backgroundStyle={backgroundStyle}
     >
       <BottomSheetView style={styles.header}>
         <Text variant="title3" color={systemColors.label}>
-          {t('settings.ble.selectBoard')}
+          {t('ble.selectBoard')}
         </Text>
         {devices.length > 0 && (
           <Text variant="footnote" color={systemColors.secondaryLabel}>
-            {t('settings.ble.devicesFound', { count: devices.length })}
+            {t('ble.devicesFound', { count: devices.length })}
           </Text>
         )}
       </BottomSheetView>
@@ -106,7 +110,7 @@ export function DevicePickerSheet({ visible, devices, onSelect, onDismiss, isSca
         <View style={styles.scanningContainer}>
           <ActivityIndicator size="small" color={theme.brandColors.primary} />
           <Text variant="subheadline" color={systemColors.secondaryLabel}>
-            {t('settings.ble.scanning')}
+            {t('ble.scanning')}
           </Text>
         </View>
       )}
@@ -114,7 +118,7 @@ export function DevicePickerSheet({ visible, devices, onSelect, onDismiss, isSca
       {showEmptyState && (
         <View style={styles.scanningContainer}>
           <Text variant="subheadline" color={systemColors.secondaryLabel}>
-            {t('settings.ble.noDevicesFound')}
+            {t('ble.noDevicesFound')}
           </Text>
         </View>
       )}
@@ -130,9 +134,9 @@ export function DevicePickerSheet({ visible, devices, onSelect, onDismiss, isSca
       )}
 
       <View style={styles.footer}>
-        <Button title={t('settings.ble.cancel')} onPress={onDismiss} variant="text" size="medium" />
+        <Button title={t('ble.cancel')} onPress={onDismiss} variant="text" size="medium" />
       </View>
-    </BottomSheet>
+    </BottomSheetModal>
   );
 }
 

--- a/packages/mobile/src/components/ble/DevicePickerSheet.tsx
+++ b/packages/mobile/src/components/ble/DevicePickerSheet.tsx
@@ -19,7 +19,6 @@ import { spacing } from '../../theme/tokens';
 import { iosSystemColors } from '../../theme/ios-colors';
 
 type DevicePickerSheetProps = {
-  visible: boolean;
   devices: DiscoveredDevice[];
   onSelect: (deviceId: string) => void;
   onDismiss: () => void;
@@ -32,7 +31,7 @@ function DevicePickerModalContainer({ children }: PropsWithChildren) {
 
 const modalContainerComponent = Platform.OS === 'ios' ? DevicePickerModalContainer : undefined;
 
-export function DevicePickerSheet({ visible, devices, onSelect, onDismiss, isScanning }: DevicePickerSheetProps) {
+export function DevicePickerSheet({ devices, onSelect, onDismiss, isScanning }: DevicePickerSheetProps) {
   const { t } = useTranslation('settings');
   const theme = useTheme();
   const sheetRef = useRef<BottomSheetModal>(null);
@@ -40,12 +39,8 @@ export function DevicePickerSheet({ visible, devices, onSelect, onDismiss, isSca
   const snapPoints = useMemo(() => ['72%'], []);
 
   useEffect(() => {
-    if (visible) {
-      sheetRef.current?.present();
-    } else {
-      sheetRef.current?.dismiss();
-    }
-  }, [visible]);
+    sheetRef.current?.present();
+  }, []);
 
   const sortedDevices = useMemo(() => [...devices].sort((deviceA, deviceB) => deviceB.rssi - deviceA.rssi), [devices]);
 
@@ -75,8 +70,6 @@ export function DevicePickerSheet({ visible, devices, onSelect, onDismiss, isSca
     borderTopLeftRadius: 16,
     borderTopRightRadius: 16,
   };
-
-  if (!visible) return null;
 
   const showScanningState = isScanning && devices.length === 0;
   const showEmptyState = !isScanning && devices.length === 0;

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -206,7 +206,7 @@ export function useBoardBluetooth({
           console.error(
             `[BLE] LED placement map is empty for ${boardName} layout=${layoutId} size=${sizeId}. Board configuration may be incorrect or LED data may need regeneration.`,
           );
-          Alert.alert(t('settings.ble.notAvailable'), t('settings.ble.errorLedMissing'));
+          Alert.alert(t('ble.notAvailable'), t('ble.errorLedMissing'));
           return false;
         }
 
@@ -222,7 +222,7 @@ export function useBoardBluetooth({
 
         if (skippedCount > 0 && result.packet.length === 0) {
           console.warn(`[BLE] All ${result.totalPlacements} placements skipped — climb incompatible with board`);
-          Alert.alert(t('settings.ble.notAvailable'), t('settings.ble.errorIncompatible'));
+          Alert.alert(t('ble.notAvailable'), t('ble.errorIncompatible'));
           return false;
         }
 
@@ -258,7 +258,7 @@ export function useBoardBluetooth({
 
         const available = await adapter.isAvailable();
         if (!available) {
-          Alert.alert(t('settings.ble.notAvailable'), t('settings.ble.notAvailable'));
+          Alert.alert(t('ble.notAvailable'), t('ble.notAvailable'));
           return false;
         }
 
@@ -331,7 +331,7 @@ export function useBoardBluetooth({
           /user cancelled|cancel/i.test(errorMessage) || /Device selection cancelled/i.test(errorMessage);
 
         if (!isUserCancel) {
-          Alert.alert(t('settings.ble.notAvailable'), t('settings.ble.errorConnectionFailed'));
+          Alert.alert(t('ble.notAvailable'), t('ble.errorConnectionFailed'));
         }
 
         // TODO: analytics (Phase 6)

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -228,6 +228,7 @@ export function BluetoothProvider({ boardName, layoutId, sizeId, children }: Blu
   return (
     <BluetoothContext.Provider value={value}>
       {isConnected && <BluetoothAutoSender sendFramesToBoard={sendFramesToBoard} />}
+      {children}
       {pickerState && (
         <DevicePickerSheet
           visible
@@ -237,7 +238,6 @@ export function BluetoothProvider({ boardName, layoutId, sizeId, children }: Blu
           isScanning={pickerState.isScanning}
         />
       )}
-      {children}
     </BluetoothContext.Provider>
   );
 }

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -231,7 +231,6 @@ export function BluetoothProvider({ boardName, layoutId, sizeId, children }: Blu
       {children}
       {pickerState && (
         <DevicePickerSheet
-          visible
           devices={pickerState.devices}
           onSelect={pickerState.handleSelect}
           onDismiss={pickerState.handleCancel}


### PR DESCRIPTION
## Summary

- Present the mobile BLE device picker as a Gorhom `BottomSheetModal` so it can stack above the open PlayDrawer.
- Render the picker after the app children from `BluetoothProvider`, which keeps the root queue-bar path above the main stack.
- Open the picker larger by default at 72% height.
- Fix mobile BLE i18n lookups by using keys from the active `settings` namespace (`ble.*`) instead of raw `settings.ble.*` strings.

## Root Cause

The picker used a plain bottom sheet mounted from `BluetoothProvider`, so it could be hidden behind the app stack and especially behind the `PlayDrawer` modal. Some mobile BLE strings also included the namespace in the key path even though `useTranslation('settings')` was already scoped to that namespace.

## Validation

- `vp test run --project mobile packages/mobile/src/lib/ble/__tests__/adapter.test.ts packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts`
- `vp run typecheck:mobile`
- Built and installed the iOS app from source to `Marco's Iphone (26.5)` over USB with `bunx expo run:ios --device 00008150-001A4C1101A1401C`.
- Ran Metro for this worktree on `http://192.168.0.60:8082` and launched the installed dev client against that bundle.