### PR TITLE
ci: scope test-default with a derived positive project list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,51 +271,33 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: built-packages
-      # Exclude the two projects with infra needs (`backend` needs
-      # postgres+redis services, `moonboard-ocr` needs canvas system libs) —
-      # those run in their own jobs below. Vitest's `--project '!name'`
-      # negation lets new packages get picked up automatically as they're
-      # added to root vite.config.ts's `test.projects` list.
+      # Run every project EXCEPT the two with dedicated infra-bearing jobs
+      # (`backend`: postgres+redis; `moonboard-ocr`: canvas libs) as an explicit
+      # POSITIVE `--project` list. Negation (`--project '!backend'`) does NOT
+      # hold up under `--changed`: Vitest collects test files from the diff and
+      # that spec set drives project init / globalSetup BEFORE the negation
+      # applies, so a diff touching anything `backend` imports pulls its
+      # Postgres-connecting tests into this infra-less job and they fail. A
+      # project absent from a positive list is never loaded. The list is derived
+      # from root vite.config.ts's `test.projects` (see the script) so new
+      # packages are picked up automatically and can't be silently skipped.
       - name: Run tests
         env:
           BASE_REF: ${{ github.base_ref }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           mkdir -p test-results
-          # Explicit positive include list rather than `--project '!backend' --project '!moonboard-ocr'`.
-          # In this vp test version the negation form doesn't actually skip
-          # the project (its globalSetup + tests still load), and the
-          # backend tests then crash without postgres. New projects added
-          # to root vite.config.ts must be appended here when they should
-          # run in this job.
-          PROJECTS=(
-            --project web
-            --project mobile
-            --project aurora-sync
-            --project board-constants
-            --project crypto
-            --project shared-schema
-            --project ble-protocol
-            --project board-config
-            --project board-react
-            --project climb-actions
-            --project climb-filters
-            --project graphql
-            --project graphql-client
-            --project party-profile
-            --project play-view
-            --project queue
-            --project queue-runtime
-            --project queue-react
-          )
+          # $PROJECTS is intentionally UNQUOTED in the two `vp test run` calls
+          # below so the shell word-splits it into separate `--project=<name>`
+          # flags. Do NOT quote it. (Safe: project names are bare identifiers.)
+          PROJECTS="$(node --import tsx scripts/ci-test-default-projects.ts)"
+          echo "test-default projects: $PROJECTS"
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            vp test run --changed "origin/$BASE_REF" \
-              "${PROJECTS[@]}" \
+            vp test run --changed "origin/$BASE_REF" $PROJECTS \
               --reporter=verbose --reporter=github-actions \
               --reporter=junit --outputFile.junit=./test-results/junit-default.xml
           else
-            vp test run \
-              "${PROJECTS[@]}" \
+            vp test run $PROJECTS \
               --reporter=verbose --reporter=github-actions \
               --reporter=junit --outputFile.junit=./test-results/junit-default.xml
           fi

--- a/scripts/__tests__/ci-test-default-projects.test.ts
+++ b/scripts/__tests__/ci-test-default-projects.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { INFRA_PROJECTS, selectTestDefaultProjects, type ConfigReader } from '../ci-test-default-projects';
+
+// Fixtures so tests never touch the real configs: a root config that lists
+// project config paths, and a per-path map of each project's vite.config source.
+function rootConfig(paths: string[]): string {
+  return `import { defineConfig } from 'vite-plus';\nexport default defineConfig({\n  test: {\n    projects: [\n${paths
+    .map((path) => `      '${path}',`)
+    .join('\n')}\n    ],\n  },\n});\n`;
+}
+
+function projectConfig(name: string): string {
+  return `export default defineConfig({ test: { name: '${name}', environment: 'node' } });`;
+}
+
+function reader(map: Record<string, string>): ConfigReader {
+  return (relativePath) => {
+    const source = map[relativePath];
+    if (source === undefined) throw new Error(`unexpected read of ${relativePath}`);
+    return source;
+  };
+}
+
+describe('selectTestDefaultProjects', () => {
+  it('returns every project name except the infra ones, in declared order', () => {
+    const paths = [
+      './packages/web/vite.config.ts',
+      './packages/backend/vite.config.ts',
+      './packages/shared/queue/vite.config.ts',
+      './packages/moonboard-ocr/vite.config.ts',
+      './scripts/vite.config.ts',
+    ];
+    const map = {
+      './packages/web/vite.config.ts': projectConfig('web'),
+      './packages/backend/vite.config.ts': projectConfig('backend'),
+      './packages/shared/queue/vite.config.ts': projectConfig('queue'),
+      './packages/moonboard-ocr/vite.config.ts': projectConfig('moonboard-ocr'),
+      './scripts/vite.config.ts': projectConfig('scripts'),
+    };
+
+    expect(selectTestDefaultProjects(rootConfig(paths), reader(map))).toEqual(['web', 'queue', 'scripts']);
+  });
+
+  it('auto-includes a newly added project (no hand-maintained list to update)', () => {
+    const paths = ['./packages/web/vite.config.ts', './packages/shared/board-react/vite.config.ts'];
+    const map = {
+      './packages/web/vite.config.ts': projectConfig('web'),
+      './packages/shared/board-react/vite.config.ts': projectConfig('board-react'),
+    };
+
+    expect(selectTestDefaultProjects(rootConfig(paths), reader(map))).toContain('board-react');
+  });
+
+  it('reads the name from the test block, ignoring a plugin name: above it', () => {
+    const paths = ['./packages/web/vite.config.ts'];
+    const config = `export default defineConfig({ plugins: [{ name: 'some-plugin' }], test: { name: 'web' } });`;
+
+    expect(selectTestDefaultProjects(rootConfig(paths), reader({ './packages/web/vite.config.ts': config }))).toEqual([
+      'web',
+    ]);
+  });
+
+  it('throws when the root config has no test.projects entries', () => {
+    expect(() => selectTestDefaultProjects(`export default defineConfig({ test: {} });`, reader({}))).toThrow(
+      /no test\.projects entries/,
+    );
+  });
+
+  it('throws (does not silently skip) when a project config has no test name', () => {
+    const paths = ['./packages/web/vite.config.ts'];
+    const config = `export default defineConfig({ test: { environment: 'node' } });`;
+
+    expect(() =>
+      selectTestDefaultProjects(rootConfig(paths), reader({ './packages/web/vite.config.ts': config })),
+    ).toThrow(/could not extract a test "name" from \.\/packages\/web\/vite\.config\.ts/);
+  });
+
+  it('throws when every project is excluded (refuses to run zero projects)', () => {
+    const paths = ['./packages/backend/vite.config.ts', './packages/moonboard-ocr/vite.config.ts'];
+    const map = {
+      './packages/backend/vite.config.ts': projectConfig('backend'),
+      './packages/moonboard-ocr/vite.config.ts': projectConfig('moonboard-ocr'),
+    };
+
+    expect(() => selectTestDefaultProjects(rootConfig(paths), reader(map))).toThrow(/empty/);
+  });
+
+  it('honours a caller-supplied infra set', () => {
+    const paths = ['./packages/web/vite.config.ts', './packages/shared/queue/vite.config.ts'];
+    const map = {
+      './packages/web/vite.config.ts': projectConfig('web'),
+      './packages/shared/queue/vite.config.ts': projectConfig('queue'),
+    };
+
+    expect(selectTestDefaultProjects(rootConfig(paths), reader(map), new Set(['web']))).toEqual(['queue']);
+  });
+
+  it('documents the two infra projects excluded by default', () => {
+    expect([...INFRA_PROJECTS].sort()).toEqual(['backend', 'moonboard-ocr']);
+  });
+});

--- a/scripts/ci-test-default-projects.ts
+++ b/scripts/ci-test-default-projects.ts
@@ -1,0 +1,97 @@
+/// <reference types="node" />
+
+// Emit the positive `--project=` flag list for the CI `test-default` job: every
+// Vitest project declared in root `vite.config.ts` EXCEPT the two that run in
+// their own jobs because they need infra (`backend`: postgres + redis;
+// `moonboard-ocr`: canvas system libs).
+//
+// Why a positive list instead of `--project '!backend'`? Vitest's `--changed`
+// selects test files from the diff, and that spec set drives project init /
+// globalSetup BEFORE the `--project` negation is applied. So a diff that touches
+// anything `backend` imports (its own `packages/backend/**` — even
+// `package.json` — or a `packages/shared/*` it depends on) pulls backend tests,
+// and their Postgres-connecting globalSetup, into `test-default`, which has no
+// services, and they fail (ECONNREFUSED :5433). A project absent from a positive
+// list is never loaded, so this can't happen.
+//
+// The list is DERIVED from `vite.config.ts` (the single source of truth for
+// `test.projects`) so a newly-added package is picked up automatically and can't
+// be silently skipped. Adding another infra-bearing project is a conscious edit
+// to INFRA_PROJECTS below.
+//
+// Structured like scripts/mobile-native-deps-check.ts: a pure, dependency-
+// injected core (`selectTestDefaultProjects`) the unit test drives with
+// fixtures, plus a thin `main()` that wires real fs + stdout. Run in CI:
+// `node --import tsx scripts/ci-test-default-projects.ts`.
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+/** Projects with dedicated CI jobs because they need services/libs `test-default` lacks. */
+export const INFRA_PROJECTS: ReadonlySet<string> = new Set(['backend', 'moonboard-ocr']);
+
+/** Reads a project's `vite.config.ts` source, given its path relative to the repo root. */
+export type ConfigReader = (relativePath: string) => string;
+
+/**
+ * Derive the positive list of Vitest project names `test-default` should run:
+ * every project in root `vite.config.ts`'s `test.projects`, minus `infraProjects`,
+ * in declared order. Pure + dependency-injected so it is unit-testable against
+ * fixtures. Throws (rather than exiting) on any malformed input so callers/tests
+ * surface the failure instead of silently dropping a project.
+ */
+export function selectTestDefaultProjects(
+  rootConfigSource: string,
+  readProjectConfig: ConfigReader,
+  infraProjects: ReadonlySet<string> = INFRA_PROJECTS,
+): string[] {
+  const projectPaths = [...rootConfigSource.matchAll(/['"](\.\/[^'"]+\/vite\.config\.ts)['"]/g)].map(
+    (match) => match[1],
+  );
+  if (projectPaths.length === 0) {
+    throw new Error('no test.projects entries found in vite.config.ts');
+  }
+
+  const names = projectPaths.map((relativePath) => {
+    const source = readProjectConfig(relativePath);
+    // Read the `name:` that belongs to the `test:` block. We slice from the first
+    // `test:` so a plugin `name:` ABOVE the test config can't be mistaken for the
+    // project name. ASSUMPTION: no project config adds a plugin (or other) `name:`
+    // field AFTER its `test:` block — none does today (verified across all
+    // configs); if one ever does, scope this match to the test block more tightly.
+    const testBlockStart = source.indexOf('test:');
+    const haystack = testBlockStart >= 0 ? source.slice(testBlockStart) : source;
+    const nameMatch = haystack.match(/name:\s*['"]([^'"]+)['"]/);
+    if (!nameMatch) {
+      throw new Error(`could not extract a test "name" from ${relativePath}`);
+    }
+    return nameMatch[1];
+  });
+
+  const selected = names.filter((name) => !infraProjects.has(name));
+  if (selected.length === 0) {
+    throw new Error('positive project list is empty — refusing to run zero projects');
+  }
+  return selected;
+}
+
+/** Wire real fs + stdout; returns the process exit code. */
+export function main(): number {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  try {
+    const rootConfigSource = readFileSync(resolve(repoRoot, 'vite.config.ts'), 'utf8');
+    const names = selectTestDefaultProjects(rootConfigSource, (relativePath) =>
+      readFileSync(resolve(repoRoot, relativePath), 'utf8'),
+    );
+    process.stdout.write(`${names.map((name) => `--project=${name}`).join(' ')}\n`);
+    return 0;
+  } catch (error) {
+    console.error(`[ci-test-default-projects] ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}


### PR DESCRIPTION
## Problem

`test-default` runs all non-backend/non-ocr tests via `vp test --changed --project '!backend' --project '!moonboard-ocr'`. But Vitest's `--changed` collects test files from the diff and keys project init / globalSetup off that spec set **before** the `--project` negation applies. So a diff touching anything `backend` imports — its own `packages/backend/**` (even `package.json`) or a `packages/shared/*` it depends on — pulls backend tests, and their Postgres-connecting globalSetup, into `test-default`, which has no services, and they fail (`ECONNREFUSED :5433`, `redis.scan is not a function`). The sibling `test-ocr` job avoids this with a positive `--project moonboard-ocr` — a project absent from a positive list is never loaded.

## Fix

Replace the negation with an explicit **positive** `--project` list, **derived** from root `vite.config.ts`'s `test.projects` (single source of truth) minus the two infra-bearing projects (`backend`, `moonboard-ocr`) that have their own jobs.

- **`scripts/ci-test-default-projects.ts`** — pure, dependency-injected core (`selectTestDefaultProjects`) + thin `main()`, modeled on `scripts/mobile-native-deps-check.ts`. Reads `test.projects`, extracts each project's `test.name`, drops the infra ones, prints `--project=…` flags. **Fails loud** if a project config has no `name:` (never silently skips). New packages are picked up automatically.
- **`scripts/__tests__/ci-test-default-projects.test.ts`** — fixture-based unit tests: ordering, infra exclusion, auto-pickup, test-block name extraction (ignores a plugin `name:` above `test:`), and the fail-loud guards (no projects / no name / empty result).
- **`ci.yml` `test-default`** — `node --import tsx scripts/ci-test-default-projects.ts`; `$PROJECTS` used **unquoted** (commented) so the shell word-splits the flags.

> **Rebased on latest `main`, which independently shipped a *hardcoded* positive list** — but that list already **omitted the newly-added `scripts` project** (it would silently skip its tests), exactly the failure mode this derived + tested version prevents. This supersedes it.

## Validation

- `vitest list` with a backend test forced into `--changed`: old negation collects `[backend] integration.test.ts > …`; the derived list collects **0** backend specs and the affected non-backend tests normally (`[queue]` × 9).
- New unit tests pass (`vp test --project scripts`: 18 tests); `vp check` clean; `ci.yml` YAML valid; `changes`/dorny filter untouched.

## Follow-up

Once merged, the backend-touching PR #2422 (queue integration suite) will have its `test-default` go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)