### PR TITLE
[codex] add esp32 mdns discovery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,18 +151,19 @@ Cost is roughly £5 / $5 for the ESP32. Nothing else is needed — no LEDs, no l
    ```
    [WiFi] Connected. IP: 192.168.20.38
    [BLE] Advertising as: Kilter Board#751737@3
+   [mDNS] kilter-board-751737-3-db2a80.local
    [WS] Listening on port 81
    ```
-   Note the IP — the web UI needs it.
+   Note the `.local` hostname or IP. The hostname stays useful when DHCP gives the ESP32 a new IP.
 
 ### Use it from the web app
 
-> **The debug page only works from `http://localhost:3000`.** It opens a plain `ws://<esp32-ip>:81` socket, and browsers block plain WebSockets from HTTPS origins as mixed content. Vercel preview URLs and any other `https://` origin will load the page but the sockets will silently fail. Use a local dev server.
+> **The debug page only works from `http://localhost:3000`.** It opens a plain `ws://<esp32-host>:81` socket, and browsers block plain WebSockets from HTTPS origins as mixed content. Vercel preview URLs and any other `https://` origin will load the page but the sockets will silently fail. Use a local dev server.
 
 1. Run `vp run dev` and open `http://localhost:3000`.
 2. Click your avatar (top-left) → **Development**. The menu entry only appears in development builds.
 3. Click the **+** tab and fill in:
-   - **IP address**: the one the firmware printed.
+   - **Host or IP address**: the `.local` hostname or IP the firmware printed.
    - **Board / Layout / Size / Hold sets / Angle**: same cascading dropdowns as the "Custom Board" flow. Pick whichever board you're testing.
    - **Serial / API level**: any value; they only affect the BLE advertised name (e.g. `Tension Board#480221@3`).
 4. Save. The tab opens a WebSocket to the ESP32 and pushes your config so it re-advertises with the right protocol and name.

--- a/docs/embedded-architecture.md
+++ b/docs/embedded-architecture.md
@@ -102,6 +102,8 @@ The web server (`esp-web-server`) provides these endpoints in both AP and statio
 | `/api/firmware/version` | GET      | Current firmware version   |
 | `/api/firmware/upload`  | POST     | OTA firmware update        |
 
+In station mode, the firmware advertises an mDNS hostname based on the configured device or BLE name plus the last 6 characters of the station MAC address. Examples include `boardsesh-controller-db2a80.local` and `kilter-board-751737-3-db2a80.local`. Controller firmware advertises `_http._tcp` on port 80 and all firmware advertises `_boardsesh._tcp` on its local service port.
+
 ## Settings Screen (Waveshare Display)
 
 The Waveshare 7" touch display includes an interactive settings screen accessible via a touch gesture from the main climb view. The settings screen displays:

--- a/embedded/libs/esp-web-server/src/esp_web_server.cpp
+++ b/embedded/libs/esp-web-server/src/esp_web_server.cpp
@@ -281,8 +281,9 @@ void ESPWebServer::handleRoot() {
                 const status = await res.json();
                 const el = document.getElementById('wifiStatus');
                 if (status.connected) {
+                    const mdnsHostLine = status.mdns_hostname ? '<br>Host: ' + status.mdns_hostname + '.local' : '';
                     el.className = 'status connected';
-                    el.innerHTML = 'Connected to <strong>' + status.ssid + '</strong><br>IP: ' + status.ip + ' | Signal: ' + status.rssi + ' dBm';
+                    el.innerHTML = 'Connected to <strong>' + status.ssid + '</strong><br>IP: ' + status.ip + mdnsHostLine + '<br>Signal: ' + status.rssi + ' dBm';
                 } else if (status.ap_mode) {
                     el.className = 'status disconnected';
                     el.innerHTML = 'Access Point Mode<br>IP: ' + status.ip + '<br><small>Connect to a WiFi network below</small>';
@@ -568,6 +569,8 @@ void ESPWebServer::handleSetConfig() {
         Config.setString("proxy_mac", doc["proxy_mac"]);
     }
 
+    WiFiMgr.setMdnsDeviceName(Config.getString("device_name", "Boardsesh Controller").c_str());
+
     sendJson(200, "{\"success\":true}");
 }
 
@@ -632,6 +635,7 @@ void ESPWebServer::handleWiFiStatus() {
     doc["ssid"] = WiFiMgr.isAPMode() ? "" : WiFiMgr.getSSID();
     doc["ip"] = WiFiMgr.isAPMode() ? WiFiMgr.getAPIP() : WiFiMgr.getIP();
     doc["rssi"] = WiFiMgr.isAPMode() ? 0 : WiFiMgr.getRSSI();
+    doc["mdns_hostname"] = WiFiMgr.getMdnsHostName();
 
     sendJson(200, doc);
 }

--- a/embedded/libs/wifi-utils/src/wifi_utils.cpp
+++ b/embedded/libs/wifi-utils/src/wifi_utils.cpp
@@ -1,12 +1,22 @@
 #include "wifi_utils.h"
 
+#ifndef UNIT_TEST
+#include <ESPmDNS.h>
+#endif
+#include <ctype.h>
+
+#ifndef FIRMWARE_BUILD_ENV
+#define FIRMWARE_BUILD_ENV "unknown"
+#endif
+
 WiFiUtils WiFiMgr;
 
 const char* WiFiUtils::KEY_SSID = "wifi_ssid";
 const char* WiFiUtils::KEY_PASSWORD = "wifi_pass";
 
 WiFiUtils::WiFiUtils()
-    : state(WiFiConnectionState::DISCONNECTED), stateCallback(nullptr), connectStartTime(0), lastReconnectAttempt(0), dnsRunning(false) {}
+    : state(WiFiConnectionState::DISCONNECTED), stateCallback(nullptr), connectStartTime(0), lastReconnectAttempt(0),
+      mdnsServicePort(0), mdnsRunning(false), dnsRunning(false) {}
 
 void WiFiUtils::begin() {
     WiFi.mode(WIFI_STA);
@@ -48,11 +58,14 @@ bool WiFiUtils::connectSaved() {
 }
 
 void WiFiUtils::disconnect() {
+    stopMdns();
     WiFi.disconnect();
     setState(WiFiConnectionState::DISCONNECTED);
 }
 
 bool WiFiUtils::startAP(const char* apName) {
+    stopMdns();
+
     // Stop any existing connection first
     WiFi.disconnect();
 
@@ -77,6 +90,7 @@ bool WiFiUtils::startAP(const char* apName) {
 }
 
 void WiFiUtils::stopAP() {
+    stopMdns();
     if (dnsRunning) {
         dnsServer.stop();
         dnsRunning = false;
@@ -120,17 +134,139 @@ int8_t WiFiUtils::getRSSI() {
     return WiFi.RSSI();
 }
 
+void WiFiUtils::configureMdns(const char* deviceName, const char* serviceType, uint16_t servicePort, const char* role) {
+    mdnsDeviceName = deviceName ? deviceName : "";
+    mdnsServiceType = serviceType ? serviceType : "boardsesh";
+    mdnsServicePort = servicePort;
+    mdnsRole = role ? role : "";
+    restartMdns();
+}
+
+void WiFiUtils::setMdnsDeviceName(const char* deviceName) {
+    mdnsDeviceName = deviceName ? deviceName : "";
+    restartMdns();
+}
+
+void WiFiUtils::restartMdns() {
+    stopMdns();
+    if (WiFi.status() == WL_CONNECTED) {
+        startMdns();
+    }
+}
+
+void WiFiUtils::stopMdns() {
+    bool wasRunning = mdnsRunning;
+#ifndef UNIT_TEST
+    if (wasRunning) {
+        MDNS.end();
+    }
+#endif
+    mdnsRunning = false;
+    mdnsHostName = "";
+}
+
+String WiFiUtils::getMdnsHostName() {
+    return mdnsHostName;
+}
+
 void WiFiUtils::setStateCallback(WiFiStateCallback callback) {
     stateCallback = callback;
 }
 
+String WiFiUtils::buildMdnsHostName(const String& deviceName, const String& macAddress) {
+    String base;
+    bool lastWasDash = false;
+
+    for (size_t i = 0; i < deviceName.length(); i++) {
+        char c = static_cast<char>(tolower(deviceName[i]));
+        bool isAlphaNumeric = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+        if (isAlphaNumeric) {
+            base += c;
+            lastWasDash = false;
+        } else if (!lastWasDash && base.length() > 0) {
+            base += '-';
+            lastWasDash = true;
+        }
+    }
+
+    while (base.endsWith("-")) {
+        base.remove(base.length() - 1);
+    }
+
+    String macSuffix;
+    for (size_t i = 0; i < macAddress.length(); i++) {
+        char c = static_cast<char>(tolower(macAddress[i]));
+        if ((c >= 'a' && c <= 'f') || (c >= '0' && c <= '9')) {
+            macSuffix += c;
+        }
+    }
+    if (macSuffix.length() > 6) {
+        macSuffix = macSuffix.substring(macSuffix.length() - 6);
+    }
+
+    if (base.length() == 0) {
+        base = "boardsesh-esp32";
+    }
+
+    const size_t suffixLength = macSuffix.length() > 0 ? macSuffix.length() + 1 : 0;
+    const size_t maxBaseLength = 63 - suffixLength;
+    if (base.length() > maxBaseLength) {
+        base = base.substring(0, maxBaseLength);
+        while (base.endsWith("-")) {
+            base.remove(base.length() - 1);
+        }
+    }
+
+    if (macSuffix.length() > 0) {
+        base += "-";
+        base += macSuffix;
+    }
+
+    return base;
+}
+
 void WiFiUtils::setState(WiFiConnectionState newState) {
     if (state != newState) {
+        if (newState != WiFiConnectionState::CONNECTED) {
+            stopMdns();
+        }
         state = newState;
+        if (state == WiFiConnectionState::CONNECTED) {
+            startMdns();
+        }
         if (stateCallback) {
             stateCallback(state);
         }
     }
+}
+
+void WiFiUtils::startMdns() {
+    if (mdnsServicePort == 0) {
+        return;
+    }
+
+    mdnsHostName = buildMdnsHostName(mdnsDeviceName, WiFi.macAddress());
+
+#ifndef UNIT_TEST
+    if (!MDNS.begin(mdnsHostName.c_str())) {
+        Serial.printf("mDNS failed for %s.local\n", mdnsHostName.c_str());
+        mdnsHostName = "";
+        mdnsRunning = false;
+        return;
+    }
+
+    MDNS.addService(mdnsServiceType.c_str(), "tcp", mdnsServicePort);
+    MDNS.addServiceTxt(mdnsServiceType.c_str(), "tcp", "role", mdnsRole.c_str());
+    MDNS.addServiceTxt(mdnsServiceType.c_str(), "tcp", "build", FIRMWARE_BUILD_ENV);
+
+    if (mdnsServicePort == 80) {
+        MDNS.addService("http", "tcp", mdnsServicePort);
+        MDNS.addServiceTxt("http", "tcp", "role", mdnsRole.c_str());
+    }
+#endif
+
+    mdnsRunning = true;
+    Serial.printf("mDNS: %s.local\n", mdnsHostName.c_str());
 }
 
 void WiFiUtils::checkConnection() {

--- a/embedded/libs/wifi-utils/src/wifi_utils.h
+++ b/embedded/libs/wifi-utils/src/wifi_utils.h
@@ -42,7 +42,15 @@ class WiFiUtils {
     String getIP();
     int8_t getRSSI();
 
+    void configureMdns(const char* deviceName, const char* serviceType, uint16_t servicePort, const char* role);
+    void setMdnsDeviceName(const char* deviceName);
+    void restartMdns();
+    void stopMdns();
+    String getMdnsHostName();
+
     void setStateCallback(WiFiStateCallback callback);
+
+    static String buildMdnsHostName(const String& deviceName, const String& macAddress);
 
     // Config keys
     static const char* KEY_SSID;
@@ -55,12 +63,19 @@ class WiFiUtils {
     unsigned long lastReconnectAttempt;
     String currentSSID;
     String currentPassword;
+    String mdnsDeviceName;
+    String mdnsHostName;
+    String mdnsServiceType;
+    String mdnsRole;
+    uint16_t mdnsServicePort;
+    bool mdnsRunning;
 
     DNSServer dnsServer;
     bool dnsRunning;
 
     void setState(WiFiConnectionState newState);
     void checkConnection();
+    void startMdns();
 };
 
 extern WiFiUtils WiFiMgr;

--- a/embedded/projects/board-controller/src/main.cpp
+++ b/embedded/projects/board-controller/src/main.cpp
@@ -315,6 +315,8 @@ void setup() {
 
     // Initialize config manager
     Config.begin();
+    WiFiMgr.configureMdns(Config.getString("device_name", DEVICE_NAME).c_str(), "boardsesh", WEB_SERVER_PORT,
+                          "controller");
 
 #ifdef HAS_DISPLAY
     // Initialize display first (before LEDs for visual feedback)

--- a/embedded/projects/moonboard-dev-server/src/main.cpp
+++ b/embedded/projects/moonboard-dev-server/src/main.cpp
@@ -416,10 +416,11 @@ void handleMoonBoardPage(WebServer& server) {
       bleStatus.textContent = currentState.ble_connected ? 'BLE connected' : 'BLE disconnected';
       bleStatus.className = `pill ${currentState.ble_connected ? 'on' : 'off'}`;
 
+      const mdnsHost = currentState.mdns_hostname ? `${currentState.mdns_hostname}.local` : null;
       const wifiText = currentState.ap_mode
         ? `AP mode · ${currentState.ip || '192.168.4.1'}`
         : currentState.wifi_connected
-          ? `WiFi connected · ${currentState.ip || 'no IP'}`
+          ? `WiFi connected · ${mdnsHost || currentState.ip || 'no IP'}`
           : 'WiFi disconnected';
       wifiStatus.textContent = wifiText;
       wifiStatus.className = `pill ${(currentState.ap_mode || currentState.wifi_connected) ? 'on' : 'off'}`;
@@ -577,6 +578,7 @@ void handleSetMoonBoardConfig(WebServer& server) {
     }
 
     storeMoonBoardConfig(config);
+    WiFiMgr.configureMdns(config.deviceName.c_str(), "boardsesh", WEB_SERVER_PORT, "moonboard-dev");
     server.send(200, "application/json", "{\"success\":true}");
 }
 
@@ -604,6 +606,7 @@ void handleGetMoonBoardState(WebServer& server) {
     doc["wifi_connected"] = g_wifiConnected;
     doc["ap_mode"] = WiFiMgr.isAPMode();
     doc["ip"] = WiFiMgr.isAPMode() ? WiFiMgr.getAPIP() : WiFiMgr.getIP();
+    doc["mdns_hostname"] = WiFiMgr.getMdnsHostName();
     doc["revision"] = static_cast<uint32_t>(g_problemRevision);
     doc["last_update_ms"] = static_cast<uint32_t>(g_lastProblemUpdateMs);
     doc["frames"] = g_lastProblem.frames;
@@ -647,6 +650,7 @@ void setup() {
     MoonBLE.setConnectCallback(onBleConnect);
     MoonBLE.setProblemCallback(onMoonBoardProblem);
 
+    WiFiMgr.configureMdns(config.deviceName.c_str(), "boardsesh", WEB_SERVER_PORT, "moonboard-dev");
     WiFiMgr.begin();
     WiFiMgr.setStateCallback(onWiFiStateChange);
     if (!WiFiMgr.connectSaved()) {

--- a/embedded/test/lib/mocks/src/Arduino.h
+++ b/embedded/test/lib/mocks/src/Arduino.h
@@ -163,6 +163,8 @@ class String {
         return 0;
     }
 
+    char operator[](unsigned int index) const { return charAt(index); }
+
     int indexOf(char c) const {
         size_t pos = data_.find(c);
         return pos == std::string::npos ? -1 : (int)pos;
@@ -198,6 +200,27 @@ class String {
         if (prefixLen > data_.length())
             return false;
         return data_.compare(0, prefixLen, prefix) == 0;
+    }
+
+    bool endsWith(const String& suffix) const {
+        if (suffix.length() > data_.length())
+            return false;
+        return data_.compare(data_.length() - suffix.length(), suffix.length(), suffix.c_str()) == 0;
+    }
+
+    bool endsWith(const char* suffix) const {
+        if (!suffix)
+            return false;
+        size_t suffixLen = strlen(suffix);
+        if (suffixLen > data_.length())
+            return false;
+        return data_.compare(data_.length() - suffixLen, suffixLen, suffix) == 0;
+    }
+
+    void remove(unsigned int index) {
+        if (index < data_.length()) {
+            data_.erase(index);
+        }
     }
 
     void toCharArray(char* buf, size_t bufsize) const {

--- a/embedded/test/test_wifi_utils/test_wifi_utils.cpp
+++ b/embedded/test/test_wifi_utils/test_wifi_utils.cpp
@@ -52,6 +52,37 @@ void test_begin_enables_auto_reconnect(void) {
 }
 
 // =============================================================================
+// mDNS Hostname Tests
+// =============================================================================
+
+void test_buildMdnsHostName_uses_device_name_and_mac_suffix(void) {
+    String hostname = WiFiUtils::buildMdnsHostName("Kilter Board#751737@3", "FC:B4:67:DB:2A:80");
+
+    TEST_ASSERT_EQUAL_STRING("kilter-board-751737-3-db2a80", hostname.c_str());
+}
+
+void test_buildMdnsHostName_collapses_invalid_characters(void) {
+    String hostname = WiFiUtils::buildMdnsHostName("  MoonBoard   A!!!", "AA:BB:CC:12:34:56");
+
+    TEST_ASSERT_EQUAL_STRING("moonboard-a-123456", hostname.c_str());
+}
+
+void test_buildMdnsHostName_falls_back_for_empty_name(void) {
+    String hostname = WiFiUtils::buildMdnsHostName("!!!", "AA:BB:CC:12:34:56");
+
+    TEST_ASSERT_EQUAL_STRING("boardsesh-esp32-123456", hostname.c_str());
+}
+
+void test_buildMdnsHostName_keeps_dns_label_under_sixty_three_chars(void) {
+    String hostname =
+        WiFiUtils::buildMdnsHostName("Very Long Boardsesh Controller Name That Exceeds The DNS Label Limit",
+                                     "AA:BB:CC:12:34:56");
+
+    TEST_ASSERT_TRUE(hostname.length() <= 63);
+    TEST_ASSERT_TRUE(hostname.endsWith("-123456"));
+}
+
+// =============================================================================
 // Connect Tests
 // =============================================================================
 
@@ -398,6 +429,12 @@ int main(int argc, char** argv) {
     // Begin tests
     RUN_TEST(test_begin_sets_sta_mode);
     RUN_TEST(test_begin_enables_auto_reconnect);
+
+    // mDNS hostname tests
+    RUN_TEST(test_buildMdnsHostName_uses_device_name_and_mac_suffix);
+    RUN_TEST(test_buildMdnsHostName_collapses_invalid_characters);
+    RUN_TEST(test_buildMdnsHostName_falls_back_for_empty_name);
+    RUN_TEST(test_buildMdnsHostName_keeps_dns_label_under_sixty_three_chars);
 
     // Connect tests
     RUN_TEST(test_connect_starts_connection);

--- a/packages/board-controller/esp32/src/emulator/emulator_main.cpp
+++ b/packages/board-controller/esp32/src/emulator/emulator_main.cpp
@@ -3,8 +3,10 @@
 #include "emulator_main.h"
 
 #include <Arduino.h>
+#include <ESPmDNS.h>
 #include <Preferences.h>
 #include <WiFi.h>
+#include <ctype.h>
 
 #include "ble_emulator.h"
 #include "ws_server.h"
@@ -19,7 +21,9 @@
 namespace {
 
 constexpr const char* NVS_NAMESPACE = "emul";
+constexpr uint16_t WS_PORT = 81;
 Preferences gPrefs;
+bool gMdnsStarted = false;
 
 EmulatorConfig loadConfig() {
     EmulatorConfig cfg;
@@ -39,6 +43,89 @@ void saveConfig(const EmulatorConfig& cfg) {
     gPrefs.putString("serial", cfg.serial);
     gPrefs.putUChar("apiLevel", cfg.apiLevel);
     gPrefs.end();
+}
+
+String buildMdnsHostName(const String& deviceName, const String& macAddress) {
+    String base;
+    bool lastWasDash = false;
+
+    for (size_t i = 0; i < deviceName.length(); i++) {
+        char c = static_cast<char>(tolower(deviceName[i]));
+        bool isAlphaNumeric = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+        if (isAlphaNumeric) {
+            base += c;
+            lastWasDash = false;
+        } else if (!lastWasDash && base.length() > 0) {
+            base += '-';
+            lastWasDash = true;
+        }
+    }
+
+    while (base.endsWith("-")) {
+        base.remove(base.length() - 1);
+    }
+
+    String macSuffix;
+    for (size_t i = 0; i < macAddress.length(); i++) {
+        char c = static_cast<char>(tolower(macAddress[i]));
+        if ((c >= 'a' && c <= 'f') || (c >= '0' && c <= '9')) {
+            macSuffix += c;
+        }
+    }
+    if (macSuffix.length() > 6) {
+        macSuffix = macSuffix.substring(macSuffix.length() - 6);
+    }
+
+    if (base.length() == 0) {
+        base = "boardsesh-esp32";
+    }
+
+    const size_t suffixLength = macSuffix.length() > 0 ? macSuffix.length() + 1 : 0;
+    const size_t maxBaseLength = 63 - suffixLength;
+    if (base.length() > maxBaseLength) {
+        base = base.substring(0, maxBaseLength);
+        while (base.endsWith("-")) {
+            base.remove(base.length() - 1);
+        }
+    }
+
+    if (macSuffix.length() > 0) {
+        base += "-";
+        base += macSuffix;
+    }
+
+    return base;
+}
+
+void stopMdns() {
+    if (!gMdnsStarted) {
+        return;
+    }
+    MDNS.end();
+    gMdnsStarted = false;
+    wsServer.setMdnsHost("");
+}
+
+void startMdns(const EmulatorConfig& cfg) {
+    if (WiFi.status() != WL_CONNECTED) {
+        return;
+    }
+
+    stopMdns();
+
+    const String hostName = buildMdnsHostName(BleEmulator::buildLocalName(cfg), WiFi.macAddress());
+    if (!MDNS.begin(hostName.c_str())) {
+        Serial.printf("[mDNS] Failed to start %s.local\n", hostName.c_str());
+        return;
+    }
+
+    MDNS.addService("boardsesh", "tcp", WS_PORT);
+    MDNS.addServiceTxt("boardsesh", "tcp", "role", "emulator");
+    const String boardName = BleEmulator::boardToString(cfg.board);
+    MDNS.addServiceTxt("boardsesh", "tcp", "board", boardName.c_str());
+    wsServer.setMdnsHost(hostName + ".local");
+    gMdnsStarted = true;
+    Serial.printf("[mDNS] %s.local\n", hostName.c_str());
 }
 
 void connectWifi() {
@@ -105,13 +192,16 @@ void emulatorSetup() {
     wsServer.setOnConfigChange([](const EmulatorConfig& newCfg) {
         bleEmulator.setConfig(newCfg);
         saveConfig(newCfg);
+        startMdns(newCfg);
     });
 
     if (WiFi.status() == WL_CONNECTED) {
-        wsServer.begin(81);
+        startMdns(cfg);
+        wsServer.begin(WS_PORT);
         gWsStarted = true;
         Serial.println("===============================");
-        Serial.printf("  Ready. WS: ws://%s:81/\n", WiFi.localIP().toString().c_str());
+        Serial.printf("  Ready. WS: ws://%s:%u/\n", WiFi.localIP().toString().c_str(),
+                      static_cast<unsigned>(WS_PORT));
         Serial.printf("  BLE:    %s\n", BleEmulator::buildLocalName(cfg).c_str());
         Serial.println("===============================");
     } else {
@@ -124,11 +214,19 @@ void emulatorSetup() {
 
 void emulatorLoop() {
     maintainWifi();
+
+    if (WiFi.status() != WL_CONNECTED) {
+        stopMdns();
+    } else if (!gMdnsStarted) {
+        startMdns(bleEmulator.getConfig());
+    }
+
     // Lazy-start the WS server the first time Wi-Fi comes up.
     if (!gWsStarted && WiFi.status() == WL_CONNECTED) {
-        wsServer.begin(81);
+        wsServer.begin(WS_PORT);
         gWsStarted = true;
-        Serial.printf("[WS] Started: ws://%s:81/\n", WiFi.localIP().toString().c_str());
+        Serial.printf("[WS] Started: ws://%s:%u/\n", WiFi.localIP().toString().c_str(),
+                      static_cast<unsigned>(WS_PORT));
     }
     if (gWsStarted) wsServer.loop();
     delay(1);

--- a/packages/board-controller/esp32/src/emulator/ws_server.cpp
+++ b/packages/board-controller/esp32/src/emulator/ws_server.cpp
@@ -25,13 +25,16 @@ String bytesToHex(const uint8_t* data, size_t length) {
     return out;
 }
 
-String configToHelloJson(const EmulatorConfig& cfg) {
+String configToHelloJson(const EmulatorConfig& cfg, const String& mdnsHost) {
     JsonDocument doc;
     doc["type"]      = "hello";
     doc["fwVersion"] = FW_VERSION;
     doc["board"]     = BleEmulator::boardToString(cfg.board);
     doc["serial"]    = cfg.serial;
     doc["apiLevel"]  = cfg.apiLevel;
+    if (mdnsHost.length() > 0) {
+        doc["mdnsHost"] = mdnsHost;
+    }
     String out;
     serializeJson(doc, out);
     return out;
@@ -101,12 +104,12 @@ void EmulatorWsServer::broadcastBleConnection(bool connected) {
 }
 
 void EmulatorWsServer::broadcastHello(const EmulatorConfig& cfg) {
-    String out = configToHelloJson(cfg);
+    String out = configToHelloJson(cfg, mdnsHost);
     if (gWs) gWs->broadcastTXT(out);
 }
 
 void EmulatorWsServer::handleClientConnected(uint8_t clientId) {
-    String hello = configToHelloJson(bleEmulator.getConfig());
+    String hello = configToHelloJson(bleEmulator.getConfig(), mdnsHost);
     if (gWs) gWs->sendTXT(clientId, hello);
 }
 

--- a/packages/board-controller/esp32/src/emulator/ws_server.h
+++ b/packages/board-controller/esp32/src/emulator/ws_server.h
@@ -26,6 +26,8 @@ public:
     // current state). Includes the current config.
     void broadcastHello(const EmulatorConfig& cfg);
 
+    void setMdnsHost(const String& host) { mdnsHost = host; }
+
     void setOnConfigChange(ConfigChangeCallback cb) { onConfig = std::move(cb); }
 
     // Internal — called by the file-scope WS callback in ws_server.cpp.
@@ -34,6 +36,7 @@ public:
 
 private:
     ConfigChangeCallback onConfig;
+    String mdnsHost;
 };
 
 extern EmulatorWsServer wsServer;

--- a/packages/web/app/development/components/add-esp32-dialog.tsx
+++ b/packages/web/app/development/components/add-esp32-dialog.tsx
@@ -95,8 +95,8 @@ export default function AddEsp32Dialog({ open, boardConfigs, initial, onClose, o
     onSubmit({
       ...form,
       id,
-      // Strip any scheme/path the user might have pasted.
-      ip: form.ip.replace(/^wss?:\/\//, '').replace(/[/:].*$/, ''),
+      // Strip any scheme, port, or path the user might have pasted.
+      ip: form.ip.replace(/^(?:https?|wss?):\/\//, '').replace(/[/:].*$/, ''),
     });
   };
 
@@ -122,10 +122,11 @@ export default function AddEsp32Dialog({ open, boardConfigs, initial, onClose, o
           />
           <TextField
             // i18n-ignore-next-line -- internal dev tool, English only
-            label="IP address"
+            label="Host or IP address"
             value={form.ip}
             onChange={(e) => setForm({ ...form, ip: e.target.value })}
-            placeholder="192.168.1.100"
+            // i18n-ignore-next-line -- internal dev tool, English only
+            placeholder="kilter-board-751737-3-db2a80.local"
             fullWidth
             size="small"
           />

--- a/packages/web/app/development/components/esp32-tab.tsx
+++ b/packages/web/app/development/components/esp32-tab.tsx
@@ -137,6 +137,7 @@ export default function Esp32Tab({ connection, active, onEdit, onRemove }: Esp32
             variant="outlined"
           />
         )}
+        {socket.hello?.mdnsHost && <Chip label={socket.hello.mdnsHost} size="small" variant="outlined" />}
         <Box flexGrow={1} />
         {/* i18n-ignore-next-line -- internal dev tool, English only */}
         <Tooltip title="Reconnect">

--- a/packages/web/app/development/components/use-esp32-socket.ts
+++ b/packages/web/app/development/components/use-esp32-socket.ts
@@ -10,6 +10,7 @@ export type Esp32Hello = {
   board: string;
   serial: string;
   apiLevel: number;
+  mdnsHost?: string;
 };
 
 export type Esp32BleWrite = { type: 'ble-write'; ts: number; hex: string };

--- a/packages/web/app/development/development-content.tsx
+++ b/packages/web/app/development/development-content.tsx
@@ -133,7 +133,7 @@ export default function DevelopmentContent({ boardConfigs }: DevelopmentContentP
               Click the <strong>+</strong> tab to add one. Flash the firmware from
               {/* i18n-ignore-next-line -- internal dev tool, English only */}
               <code> packages/board-controller/esp32/ </code> with <code>pio run -e esp32-emulator -t upload</code> and
-              enter the IP it logs at boot.
+              enter the hostname or IP it logs at boot.
             </Typography>
           </Box>
         ) : (

--- a/packages/web/app/lib/user-preferences-db.ts
+++ b/packages/web/app/lib/user-preferences-db.ts
@@ -10,6 +10,7 @@ const STORE_NAME = 'preferences';
 export type Esp32Connection = {
   id: string;
   label: string;
+  // Hostname or IP address. Kept as `ip` to preserve existing IndexedDB rows.
   ip: string;
   board: BoardName;
   serial: string;


### PR DESCRIPTION
## Summary
- add ESP32 mDNS hostname/service advertising for connected Wi-Fi devices, including controller, moonboard dev server, and legacy emulator builds
- expose mDNS hostnames through firmware status/config responses and the development ESP32 UI
- document `.local` discovery and add hostname sanitization coverage to WiFi utils tests

## Validation
- git diff --check origin/main...HEAD
- g++ -std=c++17 -DUNIT_TEST -Iembedded/test/lib/mocks/src -Iembedded/test/lib/wifi-utils/src -Iembedded/test/lib/config-manager/src embedded/test/test_wifi_utils/test_wifi_utils.cpp embedded/test/lib/wifi-utils/src/wifi_utils.cpp embedded/test/lib/config-manager/src/config_manager.cpp embedded/test/lib/mocks/src/WiFi.cpp embedded/test/lib/mocks/src/Arduino.cpp embedded/test/lib/mocks/src/Preferences.cpp -o /tmp/test_wifi_utils
- /tmp/test_wifi_utils (38 tests, 0 failures)
- vp run check:i18n
- vp run typecheck:web

## Notes
- PlatformIO is not installed in this environment (`command -v pio` returned no result), so hardware firmware builds were not run locally.
