### PR TITLE
fix(mobile): gate Tabs on useActiveBoard settling to fix initialRouteName race

### DIFF
--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -6,12 +6,11 @@ import { useActiveBoard } from '../../src/lib/graphql/use-active-board';
 export default function TabLayout() {
   const { t } = useTranslation('common');
 
-  // Land on the board picker when the user has no active board yet (instead of
-  // an empty climbs tab); otherwise open straight to climbs. `initialRouteName`
-  // is read once on mount — the active board resolves from AsyncStorage well
-  // before first paint, and the tab bar stays fully navigable either way.
   const { data: activeBoard, isLoading } = useActiveBoard();
-  const initialRouteName = !isLoading && !activeBoard ? 'boards' : 'climbs';
+  // initialRouteName is consumed only on first mount; committing <Tabs> before
+  // the AsyncStorage read settles would lock in the wrong tab for new users.
+  if (isLoading) return null;
+  const initialRouteName = !activeBoard ? 'boards' : 'climbs';
 
   return (
     <Tabs

--- a/packages/mobile/src/lib/active-board-store.ts
+++ b/packages/mobile/src/lib/active-board-store.ts
@@ -10,6 +10,12 @@
 // stored (not a remapped subset) so every reader that previously consumed
 // `useDefaultBoard()` keeps the exact same shape after switching to
 // `useActiveBoard()`.
+//
+// Schema migration note: `getPreference` silently returns null when JSON.parse
+// fails, but a stale value whose shape no longer matches `UserBoard` will parse
+// successfully and be cast to the wrong type. If `UserBoard` gains required
+// fields in a future migration, bump `ACTIVE_BOARD_KEY` so stale values are
+// ignored rather than misread.
 
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { getPreference, setPreference, removePreference } from './preference-store';


### PR DESCRIPTION
## Summary

- `initialRouteName` in `(tabs)/_layout.tsx` was computed on first render while `useActiveBoard` was still loading (`isLoading=true`), which always fell through to `'climbs'` — React Navigation reads this prop once on mount and ignores later changes
- New users with no stored board landed on the empty climbs tab instead of the board picker
- Fix: return `null` while `isLoading` so `<Tabs>` is never committed with the wrong `initialRouteName`; once the AsyncStorage read settles (sub-100ms), the correct tab is chosen
- Also documents the silent-null-on-schema-mismatch behaviour in `active-board-store.ts` for future schema migrations

## Test plan

- [ ] Fresh install / clear AsyncStorage → cold-start lands on **Boards** tab
- [ ] With a stored active board → cold-start lands on **Climbs** tab as before
- [ ] `vp run typecheck:mobile` passes
- [ ] `vp test --project mobile` passes
- [ ] `vp run check:mobile-bundle` passes

https://claude.ai/code/session_011SLBgWPHQZKfM3j2qYJmnX

---
_Generated by [Claude Code](https://claude.ai/code/session_011SLBgWPHQZKfM3j2qYJmnX)_