### PR TITLE
docs(kilter): public climbs are REST, not a PowerSync bucket

### DIFF
--- a/docs/KILTER_HTTP_API_SPEC.md
+++ b/docs/KILTER_HTTP_API_SPEC.md
@@ -46,13 +46,19 @@ Networking splits into four planes:
 | **Realtime sync** | `sync1.kiltergrips.com` | HTTPS streaming + WebSocket (PowerSync) | Bidirectional sync of the Postgres-backed catalog into a local SQLite mirror |
 | **Maps** | `places.googleapis.com` | HTTPS / JSON | Gym/wall location autocomplete |
 
-The bulk of the catalog (climbs, climb stats, walls, gyms, users, etc.) is **read from the local SQLite mirror**, not the REST API. The REST API is used for:
+Most reads go to a **local SQLite mirror**, but that mirror is filled by **two different mechanisms**, and the split matters for interop:
 
+- **PowerSync** fills the small reference catalog (holds, hold sets, grades, products, layouts, mounting holes), `gyms`/`walls`, and the signed-in user's own data (logs, attempts, ratings, circuits, settings, social). Confirmed working with a stock `@powersync/node` client — see [`KILTER_POWERSYNC_SPEC.md §6`](KILTER_POWERSYNC_SPEC.md#6-what-syncs-where).
+- **REST** fills the public **climb catalog** (`climbs` + `climb_stats`). The app pages `/api/climbs/climbdetails/{productName}/edges` by board region on first login (the "Downloading data…" screen) and caches the rows locally. This catalog is **not** a PowerSync bucket.
+
+The REST API is therefore used for:
+
+- the public climb catalog read path (`/api/climbs/...edges`, `/curated`, `/all/`, `/climb-stat/all/`, `/delteduuids`)
 - writes (logs, climbs, ratings, circuits)
 - operations PowerSync can't model (image upload, email verification, OAuth-mediated registration)
 - "transactional" endpoints that wrap multi-table writes the server promises to apply atomically
 
-This is the reason the app feels offline-tolerant: almost every read goes to local SQLite, with PowerSync streaming server-side changes back in the background.
+The app feels offline-tolerant because reads hit local SQLite — but populating the climb catalog there is an explicit REST download, not a background PowerSync stream.
 
 ---
 
@@ -84,6 +90,8 @@ Authentication is delegated to Keycloak, with Authorization Code + PKCE.
 | Logout | `https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/logout` |
 
 **Redirect URI scheme**: `com.kiltergrips:/oauthredirect`.
+
+**Client / scope** (confirmed): `client_id=kilter`, `scope=openid offline_access`. There is one realm (`kilter`) and one client; the access token's `aud` is `["kilter", "account"]`. A headless consumer can skip the browser flow entirely and use the Resource-Owner-Password grant (`grant_type=password`) against `/token` with the same `client_id` and `scope` — confirmed working for the PowerSync stream. (The other client-id strings in the app — `androidClientId`, `iosClientId`, `kilter-app-analytics` — are Firebase/Google, not Keycloak.)
 
 **Flow**:
 
@@ -488,7 +496,7 @@ Gym endpoints don't surface as `/api/gyms` paths — gym data appears to be **re
 
 ## 6. PowerSync realtime layer
 
-The Kilter app uses [PowerSync](https://www.powersync.com) to mirror the Postgres-backed catalog into a local SQLite database with bidirectional sync — this is what makes the app feel offline-first. The protocol details, table inventory, and Boardsesh implementation plan live in [`KILTER_POWERSYNC_SPEC.md`](KILTER_POWERSYNC_SPEC.md).
+The Kilter app uses [PowerSync](https://www.powersync.com) to mirror the **reference catalog, `gyms`/`walls`, and per-user data** from Postgres into local SQLite. (The public climb catalog is the exception — it's REST-fetched, see [§1](#1-architecture-overview).) The protocol details, table inventory, and the PowerSync-vs-REST split live in [`KILTER_POWERSYNC_SPEC.md`](KILTER_POWERSYNC_SPEC.md).
 
 Quick summary:
 
@@ -635,10 +643,10 @@ Local-only history table; not synced.
 Gaps that need traffic capture or direct confirmation from Kilter to close:
 
 1. **Exact `/v2/users/` semantics** — is it a versioning bump, an admin/internal namespace, or a paginated variant?
-2. **OAuth `client_id`** — Keycloak realm config is public via `.well-known/openid-configuration`, but the specific `client_id` the client uses is not externally visible. Easy to confirm by inspecting one round-trip.
-3. **Exact JSON casing on the wire** — the REST side is most likely camelCase but unverified. The PowerSync side uses snake_case (Postgres mirror).
+2. ~~**OAuth `client_id`**~~ — **Resolved**: `client_id=kilter`, `scope=openid offline_access` (see [§3](#3-authentication-keycloak--oidc)).
+3. **Exact JSON casing on the wire** — the REST side is most likely camelCase but unverified. The PowerSync side mirrors Postgres columns as-is (mostly snake_case, with some camelCase — the confirmed `gyms` schema has both).
 4. **PUT vs PATCH for updates** — `*/update-climb/transaction` endpoints accept POST, but for simple updates (rating, settings) PUT vs PATCH cannot be distinguished from the path list alone.
-5. **PowerSync sync rules YAML** — bucketing, partitioning by `user_uuid`, and the global-public-data buckets are inferred. The server-side rules would make the access model fully explicit.
+5. **Catalog REST pagination contract** — the `/api/climbs/climbdetails/{productName}/edges` params (`edge*`, `limit`, `offset`), page-size cap, and whether `/api/climbs/all/` is an unpaginated bulk pull. The single most useful capture for an interop consumer (this is the public-catalog read path — see [§1](#1-architecture-overview)).
 6. **Errors** — only `RegistrationError` is a typed model. Other endpoints probably return a generic shape (`{ "error": "...", "message": "..." }`) but this isn't established.
 7. **Rate limits / pagination defaults** — no headers or limits surfaced.
 8. **The two static pages at `app.kiltergrips.com`** — `/privacy` and `/terms` are the only routes seen.

--- a/docs/KILTER_POWERSYNC_SPEC.md
+++ b/docs/KILTER_POWERSYNC_SPEC.md
@@ -1,11 +1,14 @@
 # Kilter PowerSync Specification
 
 **Covered version**: Kilter Board mobile app, current as of 2026-05-23
+**Re-verified**: 2026-06-01 against the decompiled APK (`libapp.so` / `libpowersync.so` string dumps)
 **Sibling docs**: [KILTER_HTTP_API_SPEC.md](KILTER_HTTP_API_SPEC.md), [AURORA_BLUETOOTH_PROTOCOL_SPEC.md](AURORA_BLUETOOTH_PROTOCOL_SPEC.md), [aurora-sync.md](aurora-sync.md)
 
-> Kilter's catalog (climbs, ratings, walls, users, logs, etc.) is **not** served by classical REST endpoints. It's mirrored from Postgres into the client via [PowerSync](https://www.powersync.com), an open-source bidirectional sync layer. To consume Kilter user data from Boardsesh — the analogue of what `@boardsesh/aurora-sync` does for Tension/Decoy/So-iLL — Boardsesh needs to act as a **PowerSync client** against `sync1.kiltergrips.com`. This document describes Kilter's PowerSync setup and the implementation plan for a Kilter sync runner inside Boardsesh.
+> Kilter mirrors part of its Postgres database into the client over [PowerSync](https://www.powersync.com), an open-source sync layer. To consume Kilter user data from Boardsesh — the analogue of what `@boardsesh/aurora-sync` does for Tension/Decoy/So-iLL — Boardsesh acts as a **PowerSync client** against `sync1.kiltergrips.com`. This document describes Kilter's PowerSync setup.
 >
 > Where confidence is lower than HIGH, sections are explicitly marked.
+
+> **Correction (2026-06-01).** Earlier drafts of this doc assumed the *entire* catalog — including the world-readable climb catalog — is mirrored through PowerSync, served from inferred `public_climbs` / `global_catalog` buckets. The decompiled app shows that is **wrong**. PowerSync carries only (a) the small global **reference catalog** (holds, hold sets, grades, products, layouts, mounting holes, placement types) and (b) **per-user data** (the signed-in user's logs, attempts, ratings, circuits, walls, settings, social graph). The **public climb catalog (`climbs` + `climb_stats`) is fetched over REST**, paginated by board region, and cached into local SQLite — see [§6](#6-what-syncs-where) and [KILTER_HTTP_API_SPEC.md §5.2](KILTER_HTTP_API_SPEC.md#52-climbs). There is no PowerSync bucket that streams every public climb to every client. If you are trying to "sync the `public_climbs` bucket", stop — it does not exist; pull the catalog via REST instead.
 
 ---
 
@@ -16,7 +19,7 @@
 3. [Authentication for the sync stream](#3-authentication-for-the-sync-stream)
 4. [Wire protocol](#4-wire-protocol)
 5. [Synced tables and indexes](#5-synced-tables-and-indexes)
-6. [Bucket model (inferred)](#6-bucket-model-inferred)
+6. [What syncs where (PowerSync vs REST)](#6-what-syncs-where)
 7. [Client-side writes (CRUD queue)](#7-client-side-writes-crud-queue)
 8. [Boardsesh implementation plan](#8-boardsesh-implementation-plan)
 9. [Open questions and risks](#9-open-questions-and-risks)
@@ -62,7 +65,9 @@ PowerSync's client and protocol are open-source: see [`powersync-ja/powersync-se
 | Property | Value |
 | --- | --- |
 | Service host | `https://sync1.kiltergrips.com` |
-| Client SDK | PowerSync Dart SDK; SQLite extension pinned to `>=0.2.0 <1.0.0` |
+| Sync core | **Rust core `0.4.10`** (`powersync_rs_version` string in `libpowersync.so`), wrapped by the PowerSync Dart SDK |
+| Local schema mode | **Raw tables** — the app declares real `CREATE TABLE`s and PowerSync applies oplog rows through configured INSERT/UPDATE/DELETE statements, instead of the default auto-generated `ps_data_*` views (`RawTable` / `raw_tables` / `PendingStatement` in `libpowersync.so`) |
+| Sync model | PowerSync **Sync Streams** (`ps_stream_subscriptions`, `StreamSubscriptionRequest`, `subscribe`/`unsubscribe`, per-subscription `ttl`) — the newer stream-subscription protocol, not classic JWT-only bucket derivation |
 | Storage | Local SQLite + the PowerSync SQLite extension |
 | Backend connector | Custom — Kilter implements their own connector backed by the REST API |
 | Auth mode | **Keycloak access token used directly** as PowerSync JWT (see [§3](#3-authentication-for-the-sync-stream)) |
@@ -72,26 +77,58 @@ PowerSync's client and protocol are open-source: see [`powersync-ja/powersync-se
 
 The client identifies itself with a stable UUID returned by `SELECT powersync_client_id()` — the PowerSync extension generates and persists this per install. It's appended to write-checkpoint calls so the server can correlate uploaded writes with the streaming session.
 
-> Confidence: HIGH for endpoint, content-type, and client_id flow.
+A Boardsesh `@powersync/node` client connects with a plain `Schema` of the tables it wants, calls `waitForFirstSync()`, and reads the local mirror. This is **confirmed working** for `gyms` and `walls` against the live service — see the connector example in [§3](#3-authentication-for-the-sync-stream). The same client returns nothing for the public climb catalog, because those rows do not stream (see [§6](#6-what-syncs-where)).
+
+> Confidence: HIGH for endpoint, content-type, client_id flow, sync-core version, raw-table mode, and that a stock `@powersync/node` client syncs the buckets the token grants.
 
 ---
 
 ## 3. Authentication for the sync stream
 
-Kilter does **not** appear to mint a separate PowerSync JWT. Instead, the standard Keycloak `access_token` is passed directly as the bearer token to `sync1.kiltergrips.com`. The PowerSync service is configured to validate JWTs against `https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/certs` (the Keycloak JWKS endpoint), with `sub` mapped to the user identifier.
+Kilter does **not** mint a separate PowerSync JWT. The standard Keycloak `access_token` is passed directly as the bearer token to `sync1.kiltergrips.com`. The PowerSync service validates JWTs against the realm's JWKS (`https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/certs`), with `sub` as the user identifier.
 
-Why this is the most likely model:
+This is **confirmed working** by a standalone `@powersync/node` scraper that syncs `gyms` + `walls`:
 
-- No `/auth/token`, `/sync-token`, or `/api/auth` style endpoint surfaces alongside the public Kilter API. The only token endpoint is the standard Keycloak `/protocol/openid-connect/token`.
-- PowerSync's `BackendConnector.fetchCredentials()` typically returns `{ endpoint, token, expiresAt, userID }`. With `endpoint` = `https://sync1.kiltergrips.com` and `token` = Keycloak access JWT, this works as long as PowerSync is configured to trust the Keycloak issuer — which it can be via the standard JWKS configuration.
+```ts
+const KILTER_AUTH_URL  = "https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/token";
+const KILTER_SYNC_ENDPOINT = "https://sync1.kiltergrips.com";
+const KILTER_CLIENT_ID  = "kilter";              // the realm's public client
+const KILTER_SCOPE      = "openid offline_access";
+
+// Resource-Owner-Password grant → access_token, used verbatim as the PowerSync token.
+const body = new URLSearchParams({
+  grant_type: "password", client_id: KILTER_CLIENT_ID, username, password, scope: KILTER_SCOPE,
+});
+const { access_token, expires_in } = await (await fetch(KILTER_AUTH_URL, {
+  method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" }, body,
+})).json();
+
+const connector: PowerSyncBackendConnector = {
+  fetchCredentials: async () => ({
+    endpoint: KILTER_SYNC_ENDPOINT,
+    token: access_token,                          // Keycloak JWT, no exchange
+    expiresAt: new Date(Date.now() + (expires_in - 60) * 1000),
+  }),
+  uploadData: async () => { /* read-only scraper */ },
+};
+```
+
+The minted access token carries `aud: ["kilter", "account"]` (the `account` audience is auto-added by Keycloak; `kilter` is the client). That is sufficient for the sync stream.
+
+**Two token theories that are NOT the answer** — both come up when the public climb catalog fails to sync, and both are dead ends:
+
+1. *"A different scope (`kilter-catalog`, `portal`, …) would mint `aud: ["kilter-portal", …]` and unlock more buckets."* The app binary contains exactly one OAuth scope (`offline_access`, plus implicit `openid`) and one realm/client. There is no second audience or catalog scope anywhere in `libapp.so`. PowerSync checks `aud` **once per connection**, not per bucket — if the token authenticates the stream at all (it does; gyms/walls sync), audience is not gating any particular table.
+2. *"The portal/web uses a different `client_id` that gets broader buckets."* The only Keycloak client is `kilter`. The other client-id strings in the binary (`androidClientId`, `iosClientId`, `kilter-app-analytics`, `…firebasestorage.app`) are **Firebase / Google** identifiers for Google Sign-In, Places, and analytics — unrelated to PowerSync auth.
+
+The real reason the catalog doesn't sync is structural, not credential: the public climb catalog is not served by PowerSync at all (see [§6](#6-what-syncs-where)). No token change unlocks it.
 
 **Implications for Boardsesh**:
 
-- No separate token-exchange endpoint is needed — once Boardsesh has a Keycloak access_token, it can talk to PowerSync directly.
-- Token TTL matches Keycloak's `access_token` lifetime (commonly 5–15 minutes). The sync agent must refresh proactively, either via the OIDC refresh_token grant or by re-running ROPC against `/token` if Boardsesh's auth flow uses that.
-- Since the same JWT validates both REST API calls (`portal.kiltergrips.com/api/*`) and the sync stream, one credential store covers both planes.
+- No separate token-exchange endpoint — a Keycloak access_token talks to PowerSync directly.
+- Token TTL matches Keycloak's `access_token` lifetime (5–15 min). Refresh proactively via the `refresh_token` grant, or re-run the password grant. The connector's `expiresAt` drives PowerSync's own refresh.
+- The same JWT validates REST API calls (`portal.kiltergrips.com/api/*`) **and** the sync stream, so one credential store covers both planes — including the REST catalog fetch in [§6](#6-what-syncs-where).
 
-> Confidence: MEDIUM-HIGH. A 30-second traffic capture against one real login would confirm definitively.
+> Confidence: HIGH. Corroborated by a working scraper (`kilter` client, `openid offline_access`, token used directly) plus the binary's single-client / single-scope OAuth config.
 
 ---
 
@@ -147,30 +184,16 @@ This means the streaming endpoint is **read-only from the client's perspective**
 
 ## 5. Synced tables and indexes
 
-The client schema is registered programmatically using PowerSync's standard `replace_schema` flow. The table/index inventory below is what the client maintains in its local SQLite mirror.
+The client uses PowerSync **raw tables**: it declares its own `CREATE TABLE`s and supplies the INSERT/UPDATE/DELETE statements PowerSync runs when applying oplog rows. The inventory below is split by **where each table's rows actually come from** — this is the key correction over earlier drafts. The PowerSync-synced set is identified by PowerSync's `<table>__<column>` index naming present in `libapp.so`; the REST-cached set is identified by direct app `INSERT INTO <table>` statements plus the REST endpoints that feed them.
 
-### 5.1 Master inventory
+### 5.1 Synced via PowerSync
+
+These rows stream from `sync1.kiltergrips.com` and are confirmed (`gyms`, `walls`) or strongly indicated (the rest, via `<table>__<column>` indexes) to arrive over the sync stream.
+
+**Global reference catalog** (small, identical for every user — the "static" board data):
 
 | Table | Indexed columns (and inferred PK) | Notes |
 | --- | --- | --- |
-| `users` | `user_uuid` (pk), `email` | Public-ish user profiles |
-| `user_settings` | `user_uuid` (pk) | Per-user preferences |
-| `user_analytics` | `user_uuid` (pk) | Aggregated stats |
-| `user_followers` | `user_uuid` | Follower edges (per follower) |
-| `user_blocked_climbs` | `user_uuid`, `climb_uuid` | Composite |
-| `user_notifications` | `user_uuid`, `receiver_uuid` | Notification feed |
-| `gym_followers` | `user_uuid` | Gym follow edges |
-| `gym_notifications` | `gym_uuid`, `receiver_uuid` | Notifications scoped to a gym |
-| `climbs` | `climb_uuid` (pk), `user_uuid`, `product_name`, `created_at`, `accumulated_hold_set_value` | Schema in [KILTER_HTTP_API_SPEC.md §7](KILTER_HTTP_API_SPEC.md#7-local-sqlite-schema-client-side-mirror) |
-| `climb_stats` | `climb_uuid_angle` (composite pk), `climb_uuid`, `angle` | Schema in HTTP spec §7 |
-| `climb_ratings` | `climb_rating_uuid` (pk), `user_uuid`, `climb_uuid`, `wall_uuid`, `gym_uuid`, `product_layout_uuid`, `difficulty_grade_id` | Heavily indexed — many query angles |
-| `climb_mounting_holes` | `climb_uuid`, `product_layout_uuid`, `mounting_hole_uuid`, `hold_placement_id`, `placement_type`, `default_placement_type`, `hold_id` | Highly denormalized |
-| `climb_beta_links` | `climb_uuid`, `angle`, `link` | External beta video/post links |
-| `circuits` | (inferred: `circuit_uuid` pk; user filters via `circuit_climbs`) | Curated route lists |
-| `circuit_climbs` | `circuit_uuid`, `climb_uuid` | Many-to-many |
-| `logs` | `user_uuid`, `climb_uuid`, `product_layout_uuid`, `created_at` | Confirmed ascents |
-| `attempts` | `user_uuid`, `product_layout_uuid`, `angle` | **Separate** from `logs` — tracks attempts/bids vs sends |
-| `walls` | `wall_uuid` (pk), `product_layout_uuid`, `product_name`, `gym_uuid` | Physical boards |
 | `products` | `product_name` (pk) | Board models (Kilter Original / Homewall / Mini / Grasshopper / etc.) |
 | `product_layouts` | `product_layout_uuid` (pk), `product_name` | Specific layout variants per product |
 | `mounting_holes` | `mounting_hole_uuid` (pk), `product_name` | Hardware catalog — every hole on every board |
@@ -178,35 +201,108 @@ The client schema is registered programmatically using PowerSync's standard `rep
 | `hold_sets` | `hold_set_name` (pk) | Hold-set groupings (Kilter HS, KS, etc.) |
 | `placement_types` | `placement_type` (pk), `short_ref` | start/hand/foot/finish enum |
 | `difficulty_grades` | `difficulty_grade_id` (pk) | Grade catalog (V-scale, font-scale) |
+| `gyms` | `gym_uuid` (pk) | Gym directory — schema confirmed (see [§5.3](#53-gyms-table-confirmed-schema)) |
+| `walls` | `wall_uuid` (pk), `product_layout_uuid`, `product_name`, `gym_uuid` | Physical boards |
 
-A separate local-only table — `recently_tried_climbs` — is not synced; it's populated by the client and never leaves the device. (See [KILTER_HTTP_API_SPEC.md §7](KILTER_HTTP_API_SPEC.md#7-local-sqlite-schema-client-side-mirror).)
+**Per-user data** (scoped to the authenticated `sub` by server-side stream rules):
 
-### 5.2 Notes on schema vs. PowerSync semantics
+| Table | Indexed columns (and inferred PK) | Notes |
+| --- | --- | --- |
+| `users` | `user_uuid` (pk), `email` | Profiles |
+| `user_settings` | `user_uuid` (pk) | Per-user preferences |
+| `user_analytics` | `user_uuid` (pk) | Aggregated stats |
+| `user_followers` | `user_uuid` | Follower edges |
+| `user_blocked_climbs` | `user_uuid`, `climb_uuid` | Composite |
+| `user_notifications` | `user_uuid`, `receiver_uuid` | Notification feed |
+| `gym_followers` | `user_uuid` | Gym follow edges |
+| `gym_notifications` | `gym_uuid`, `receiver_uuid` | Notifications scoped to a gym |
+| `logs` | `user_uuid`, `climb_uuid`, `product_layout_uuid`, `created_at` | Confirmed ascents |
+| `attempts` | `user_uuid`, `product_layout_uuid`, `angle` | **Separate** from `logs` — attempts/bids vs sends |
+| `climb_ratings` | `climb_rating_uuid` (pk), `user_uuid`, `climb_uuid`, `wall_uuid`, `gym_uuid`, `product_layout_uuid`, `difficulty_grade_id` | Heavily indexed |
+| `circuits` | `circuit_uuid` (pk) | Curated route lists |
+| `circuit_climbs` | `circuit_uuid`, `climb_uuid` | Many-to-many |
+| `climb_mounting_holes` | `climb_uuid`, `product_layout_uuid`, `mounting_hole_uuid`, `hold_placement_id`, `placement_type`, `default_placement_type`, `hold_id` | Hold placements per climb |
+| `climb_beta_links` | `climb_uuid`, `angle`, `link` | External beta video/post links |
+
+> The app writes `logs`, `attempts`, `climb_ratings`, `circuits`, `circuit_climbs`, `walls`, `user_settings`, `user_blocked_climbs` locally (direct `INSERT … RETURNING *`) for optimistic UI, then uploads via REST; PowerSync mirrors the server's version back. For a read-only Boardsesh consumer, treat them as read-only sync targets.
+
+### 5.2 NOT synced via PowerSync — the public climb catalog (REST-cached)
+
+These are plain local SQLite tables the app fills itself. **They are not PowerSync buckets.** This is the correction at the heart of this revision.
+
+| Table | Populated by | Notes |
+| --- | --- | --- |
+| `climbs` | REST: `GET /api/climbs/climbdetails/{productName}/edges?…limit=&offset=` (paginated by board region), `/api/climbs/curated`, `/api/climbs/all/` | Direct `INSERT INTO climbs (id, climb_uuid, …)` in app code. The full public climb catalog. |
+| `climb_stats` | REST: `/api/climb-stat/all/` (and inline with climb detail) | Direct `INSERT INTO climb_stats (…)`. Per-climb-angle aggregates. |
+| `climbs_for_product_fetch_info` | App bookkeeping | Tracks paginated-fetch progress per `(product_name, edge_*)`; drives the "Downloading data…" preparing screen on first login. Proof that the catalog is pulled, not streamed. |
+| `product_layout_updates` | App bookkeeping | Per-layout cache-invalidation marker (`updated_at`). |
+| `recently_tried_climbs` | App-local | Device-only history; never leaves the device. |
+
+See [§6](#6-what-syncs-where) for the full data-flow picture and [KILTER_HTTP_API_SPEC.md §5.2](KILTER_HTTP_API_SPEC.md#52-climbs) for the catalog endpoints and `climbs` schema.
+
+### 5.3 `gyms` table (confirmed schema)
+
+Recovered verbatim from a working `@powersync/node` sync. Note the mixed snake_case / camelCase column names — they mirror the Postgres source columns as-is:
+
+```
+gym_uuid, name, address, city, country, countryCode, postal_code,
+latitude, longitude, gymLogo, bannerLogo, instagramUsername, isListed
+```
+
+### 5.4 Notes on schema vs. PowerSync semantics
 
 - PowerSync types are coerced to SQLite's three storage classes (`TEXT`, `INTEGER`, `REAL`). Booleans on the wire become `INTEGER 0/1`. Timestamps are `TEXT` ISO-8601.
-- Every synced table carries an additional client-side `id TEXT PRIMARY KEY` column injected by PowerSync if the table doesn't declare one explicitly. Kilter's tables all have natural primary keys (`*_uuid` etc.), but PowerSync still adds `id` under the hood — Boardsesh's translator should ignore it.
+- Every synced row carries an `id TEXT` column (PowerSync's oplog row id). The working `gyms`/`walls` sync selects `id` directly alongside the natural `*_uuid` key. Kilter's tables all have natural primary keys (`*_uuid` etc.); a Boardsesh translator keys on those and can ignore `id`.
 - The `attempts` vs `logs` split matches Aurora's `bids` vs `ascents` distinction. Boardsesh already dual-writes both into `boardsesh_ticks` ([aurora-sync.md](aurora-sync.md)); the Kilter equivalent should follow the same pattern.
 
-> Confidence: HIGH that the listed tables sync. MEDIUM-HIGH on PK / index column choices. The `attempts` table is worth explicit confirmation when wiring up the dual-write rule.
+> Confidence: HIGH that `gyms`/`walls` sync (working scraper) and HIGH that `climbs`/`climb_stats` do **not** (REST-fed, per [§5.2](#52-not-synced-via-powersync--the-public-climb-catalog-rest-cached)). MEDIUM-HIGH that the remaining per-user/reference tables sync over the stream — they carry PowerSync index naming but each is worth confirming when wiring up the translator.
 
 ---
 
-## 6. Bucket model (inferred)
+## 6. What syncs where
 
-PowerSync sync rules are server-side YAML; we don't have them. The likely bucket structure based on the table/index inventory and PowerSync conventions:
+Kilter splits catalog data across **two transports**, and that split is the answer to "how do I sync the public climbs". The full route catalog is too large to mirror onto every device, so only the small/static and the per-user slices go through PowerSync; the big public climb catalog is paged over REST and cached.
 
-| Bucket name (likely) | Parameters | Tables | Notes |
-| --- | --- | --- | --- |
-| `global_catalog` | — | `products`, `product_layouts`, `mounting_holes`, `holds`, `hold_sets`, `placement_types`, `difficulty_grades` | Public, identical for every user |
-| `public_climbs` | — | `climbs` (where `is_listed = true AND is_draft = false`), `climb_stats`, `climb_mounting_holes` for listed climbs, `climb_beta_links` | World-readable route catalog |
-| `walls_public` | — | `walls` (where `is_listed = true`), possibly all gym-affiliated walls | Gym wall catalog |
-| `user_owned[uid]` | `uid = request.user_id()` | `users` row for self; `climbs` / `walls` where `user_uuid = uid`; `climb_mounting_holes` for those climbs; `user_settings`; `user_analytics`; `user_blocked_climbs`; `circuits` (own) | The user's own writeable content |
-| `user_activity[uid]` | `uid = request.user_id()` | `logs`, `attempts`, `climb_ratings` where `user_uuid = uid` | Activity log |
-| `user_social[uid]` | `uid = request.user_id()` | `user_followers` where source or target = `uid`; `user_notifications` where `receiver_uuid = uid`; `gym_followers` where `user_uuid = uid`; `gym_notifications` where `receiver_uuid = uid` | Social graph + inbox |
+```
+                         ┌─────────────────────────────────────────────┐
+   PowerSync stream  ───▶│ reference catalog: products, product_layouts │  small, static,
+   sync1.kiltergrips.com │   mounting_holes, holds, hold_sets,          │  same for everyone
+   (Keycloak JWT)        │   placement_types, difficulty_grades, gyms,  │
+                         │   walls                                       │
+                         ├─────────────────────────────────────────────┤
+                         │ per-user (scoped to sub): logs, attempts,    │  one user's data
+                         │   climb_ratings, circuits, circuit_climbs,   │
+                         │   climb_mounting_holes, climb_beta_links,    │
+                         │   users, user_settings, user_analytics,      │
+                         │   user_*/gym_* social                        │
+                         └─────────────────────────────────────────────┘
 
-If Kilter has chosen finer-grained buckets (e.g. one bucket per circuit, one per gym), the index pattern doesn't directly reveal it. The above is the simplest model that matches the observed indexing.
+   REST (same JWT)   ───▶  climbs + climb_stats  ← the public climb catalog
+   portal.kiltergrips.com  GET /api/climbs/climbdetails/{productName}/edges?
+                              edgeLeft=&edgeRight=&edgeBottom=&edgeTop=&limit=&offset=
+                            GET /api/climbs/climbdetails/{productName}/edges/count
+                            GET /api/climbs/curated   ·   GET /api/climbs/all/
+                            GET /api/climb-stat/all/  ·   GET /api/climbs/delteduuids
+                            → app pages through them, INSERTs into local `climbs`/`climb_stats`,
+                              tracks progress in `climbs_for_product_fetch_info`
+```
 
-> Confidence: MEDIUM. Bucket names and exact membership are unverifiable from the client side alone. The *categories* (global catalog vs per-user) are HIGH confidence because the auth model leaves no other way to partition.
+### Why the catalog is REST, not a bucket
+
+Five independent signals in the app, all pointing the same way:
+
+1. **Direct inserts.** The app issues `INSERT INTO climbs (id, climb_uuid, climb_concat, name, …)` and `INSERT INTO climb_stats (…)` itself — you don't hand-write inserts into a PowerSync-managed view.
+2. **A progress table.** `climbs_for_product_fetch_info(product_name, count, progress, edge_left, edge_right, edge_bottom, edge_top, last_updated_at)` exists only to track *paginated fetching* of climbs by board region. PowerSync tracks its own sync state; a per-region progress counter is a REST-pagination artifact.
+3. **A count endpoint.** `/edges/count` returns a total so the client can drive a progress bar — a REST/pagination idiom, meaningless for a streamed bucket.
+4. **A "preparing" screen.** `preparing_screen.dart` shows "Downloading data…" on first login while it pages the catalog in. PowerSync's first sync needs no app-driven download loop.
+5. **It's confirmed empty over PowerSync.** A working `@powersync/node` scraper syncs `gyms`/`walls` fine but gets no public catalog when it adds `climbs` to the schema — because nothing streams there.
+
+### For Boardsesh
+
+- **Catalog (Flow A):** pull `climbs` + `climb_stats` over REST, paging `/api/climbs/climbdetails/{productName}/edges` per product per board region (or try `/api/climbs/all/` + `/api/climb-stat/all/` for a bulk pull), using the same Keycloak token. Do **not** model it as a PowerSync bucket. See [kilter-sync.md → Catalog sync (Flow A)](kilter-sync.md#catalog-sync-flow-a).
+- **Per-user (Flow B):** a normal `@powersync/node` connection with the user's token streams their `logs` / `attempts` / `climb_ratings` / `circuits`, plus the reference catalog and `gyms`/`walls`. This is the part PowerSync is genuinely for.
+
+> Confidence: HIGH that the public catalog is REST-fed (five signals + the working scraper). HIGH that reference + per-user data is PowerSync. The exact server-side stream/bucket *names* remain server-side and unverifiable from the client, but they no longer matter for the integration — the client never names a bucket, it declares tables and the server fills them.
 
 ---
 
@@ -233,11 +329,18 @@ See [`kilter-sync.md`](kilter-sync.md) for the integration design — schema mig
 
 ## 9. Open questions and risks
 
-1. **Token-exchange endpoint?** We're assuming the Keycloak access_token is the PowerSync JWT. If Kilter adds a middleman (e.g. minted by an `/api/auth/sync-token` endpoint), the auth flow flips and we need to discover that endpoint first. **Validation cost**: one traffic capture.
-2. **Ratelimits or anti-scraping**: Kilter may enforce a per-user concurrency cap (one active PowerSync stream per `sub`). If we open a sync stream while the user has the app open, one of us may get disconnected. The daemon should serialize per-user.
-3. **Schema drift**: Kilter ships new client releases. The synced tables and their indexes can grow. We need a smoke-test that fails loudly on schema mismatches rather than silently dropping rows.
-4. **ToS / abuse considerations**: this is doing what their app does, on behalf of users who explicitly opt in by handing over Keycloak credentials. Same shape as `aurora-sync`. Worth a parallel section in CLAUDE.md / LEGAL.md once we move from POC to production.
-5. **`attempts` table semantics**: confirm whether Kilter's `attempts` is "all attempts including sends" or "non-sends only" — this affects the `boardsesh_ticks` dual-write rule.
-6. **Bucket model**: section [§6](#6-bucket-model-inferred) is inferred. Catalog rows we expect to be in `global_catalog` might actually only stream to authenticated users — if so, "open a stream as one user, capture catalog for all" works regardless, but understanding the rules helps reason about access control.
-7. **Sync rules format**: PowerSync has had two sync-rule formats over its history; the choice affects which client SDK protocol version Kilter speaks. Our connection request must match.
-8. **Refresh token lifetime**: Keycloak refresh_tokens often expire (default 30 days or "session idle"). The daemon needs to detect expired refresh and surface a re-auth prompt to the user rather than silently failing.
+**Resolved since the first draft:**
+
+- ~~Token-exchange endpoint?~~ **Resolved.** The Keycloak access_token is used directly; no middleman. Confirmed by the working scraper ([§3](#3-authentication-for-the-sync-stream)).
+- ~~Which client / scope / audience unlocks the catalog?~~ **Resolved — wrong question.** One client (`kilter`), one scope (`openid offline_access`); `aud: ["kilter","account"]` is sufficient. The catalog isn't gated by the token at all ([§3](#3-authentication-for-the-sync-stream), [§6](#6-what-syncs-where)).
+- ~~Bucket model / does `public_climbs` stream to everyone?~~ **Resolved.** There is no public-climb bucket; the catalog is REST ([§6](#6-what-syncs-where)).
+- ~~Sync rules format / protocol version?~~ **Largely resolved.** Rust sync core `0.4.10` with Sync Streams ([§2](#2-kilters-powersync-deployment)). `@powersync/node` at a recent version speaks it (the scraper works).
+
+**Still open:**
+
+1. **Catalog REST contract details.** The `/api/climbs/climbdetails/{productName}/edges` params (`edgeLeft/Right/Bottom/Top`, `limit`, `offset`) and the exact response shape are read off the binary, not captured. Confirm the page size cap, whether `/api/climbs/all/` returns the unpaginated catalog, and the JSON casing before building the runner. **Validation cost**: a few authenticated requests.
+2. **Ratelimits or anti-scraping.** Kilter may cap concurrent streams per `sub`, or rate-limit the catalog REST endpoints. If we sync while the user has the app open, one side may get disconnected. Serialize per-user; back off on 429.
+3. **Schema drift.** New client releases can grow the synced tables/indexes and the REST DTOs. Smoke-test that fails loudly on a mismatch rather than silently dropping rows.
+4. **ToS / abuse considerations.** This does what their app does, on behalf of users who opt in by handing over Keycloak credentials. Same shape as `aurora-sync`. Worth a parallel section in CLAUDE.md / LEGAL.md before production.
+5. **`attempts` table semantics.** Confirm whether Kilter's `attempts` is "all attempts including sends" or "non-sends only" — affects the `boardsesh_ticks` dual-write rule.
+6. **Refresh-token lifetime.** Keycloak refresh_tokens expire (default 30 days / session-idle). The daemon must detect expired refresh and surface a re-auth prompt rather than failing silently.

--- a/docs/kilter-sync.md
+++ b/docs/kilter-sync.md
@@ -8,7 +8,7 @@ This document describes how Kilter Grips' backend (`portal.kiltergrips.com` REST
 
 Kilter has split from Aurora's backend and runs on Keycloak + PowerSync + Postgres. Two flows:
 
-1. **Catalog sync** (Kilter → Boardsesh, anonymous-ish). Periodic, cooldown-throttled. Pulls public climbs, walls, holds, hold sets, and the supporting reference tables into Boardsesh's `board_*` schema.
+1. **Catalog sync** (Kilter → Boardsesh). Periodic, cooldown-throttled. The public climb catalog (`climbs` + `climb_stats`) is pulled over **REST**, paginated by board region; the small reference tables (holds, hold sets, grades, products, layouts, mounting holes) and `gyms`/`walls` come over **PowerSync**. See [`KILTER_POWERSYNC_SPEC.md §6`](KILTER_POWERSYNC_SPEC.md#6-what-syncs-where) for why the catalog is REST and not a bucket.
 2. **Per-user sync** (bidirectional, opt-in). One PowerSync stream per cycle for one Kilter-linked user — pulls their logs/attempts/circuits/ratings into Boardsesh, then pushes Boardsesh-recorded ticks/ratings/circuits back to Kilter via the REST API.
 
 The Bluetooth path is unchanged — Kilter's hardware uses the same Aurora-shared protocol covered in [`AURORA_BLUETOOTH_PROTOCOL_SPEC.md`](AURORA_BLUETOOTH_PROTOCOL_SPEC.md).
@@ -163,12 +163,16 @@ A single helper `resolveCanonicalClimbUuid(boardType, uuid) → uuid` is consult
 
 ## Catalog sync (Flow A)
 
-Periodic, **not long-lived**. Each cycle:
+Periodic, **not long-lived**. The catalog spans two transports — don't try to get the climb catalog from PowerSync; it isn't there ([`KILTER_POWERSYNC_SPEC.md §6`](KILTER_POWERSYNC_SPEC.md#6-what-syncs-where)). Each cycle:
 
-1. Acquire an access token (service account or piggyback — see §6).
-2. Open a `@powersync/node` connection to `sync1.kiltergrips.com/sync/stream` scoped to the catalog buckets (all the global / public buckets — see [`KILTER_POWERSYNC_SPEC.md §6`](KILTER_POWERSYNC_SPEC.md#6-bucket-model-inferred)).
-3. Wait for the initial `StreamingSyncCheckpointComplete`. PowerSync now has every catalog row in a local SQLite mirror.
-4. For each table in the FK-safe processing order (mirroring `aurora-sync/src/sync/shared-sync.ts:60-75` — products → product_layouts → mounting_holes → holds → hold_sets → placement_types → difficulty_grades → climbs → climb_stats → climb_mounting_holes → climb_beta_links → walls), read the SQLite mirror and translate into Boardsesh's `board_*` tables.
+1. Acquire an access token (service account or piggyback — see below). The same token authorizes both the PowerSync stream and the REST catalog endpoints.
+2. **Reference tables over PowerSync.** Open a `@powersync/node` connection with a schema covering `products`, `product_layouts`, `mounting_holes`, `holds`, `hold_sets`, `placement_types`, `difficulty_grades`, `gyms`, `walls`. `await waitForFirstSync()`, then read the local mirror. These are small and identical for every user.
+3. **Climb catalog over REST.** For each product, page the public catalog:
+   - `GET /api/climbs/climbdetails/{productName}/edges/count` → total, to bound the loop.
+   - `GET /api/climbs/climbdetails/{productName}/edges?edgeLeft=&edgeRight=&edgeBottom=&edgeTop=&limit=&offset=` → pages of climbs with their stats. Walk `offset` until the count is covered. (Confirm whether `/api/climbs/all/` + `/api/climb-stat/all/` give a simpler unpaginated bulk pull — open question.)
+   - `GET /api/climbs/delteduuids` → UUIDs to soft-delete from `board_climbs` since last run.
+   - Mirror the app's own first-login flow (`preparing_screen.dart`): it pages exactly these endpoints into a local `climbs` table.
+4. Translate into Boardsesh's `board_*` tables in FK-safe order (mirroring `aurora-sync/src/sync/shared-sync.ts:60-75`): products → product_layouts → mounting_holes → holds → hold_sets → placement_types → difficulty_grades → climbs → climb_stats → climb_mounting_holes → climb_beta_links → walls. (`climb_mounting_holes` / `climb_beta_links` are per-user over PowerSync — for an anonymous catalog pull, source hold placements from `/api/climb-mounting-holes/{climbUuid}` on demand, or defer to the per-user flow.)
 5. Run the climb dedup logic from §3 for every `climbs` row.
 6. After `climbs` ingest, gather the set of canonical UUIDs that were newly inserted (not just newly aliased) and call `createSetterSyncNotifications` exactly like `shared-sync.ts:892-986` does.
 7. Close the PowerSync connection.
@@ -216,8 +220,8 @@ One PowerSync stream per cycle, one Kilter-linked user at a time. Inside the cyc
 | `circuits` + `circuit_climbs` | `playlists` + `playlist_climbs` + `playlistOwnership`; record origin via `playlists.kilterId` | Full-replace pattern from `user-sync.ts:325-389` — delete then re-insert children. Existing `playlists.auroraId` untouched |
 | `climb_ratings` | New `board_climb_ratings` table — see §5 | First-class table so push-back has a single source of truth |
 | `user_settings` | `kilter_user_settings` (JSON blob, optional in v1) | Defer until we have a use case |
-| `walls` where `gym_uuid IS NULL AND user_uuid = self` | `user_boards` | Homewalls appear in Boardsesh |
-| `climbs` where `user_uuid = self AND is_listed = false` | Leave as alias-table entries only; don't promote drafts to public `board_climbs` | Drafts stay Kilter-local |
+| `walls` where `gym_uuid IS NULL AND user_uuid = self` | `user_boards` | Homewalls appear in Boardsesh — `walls` streams over PowerSync |
+| the user's own `climbs` (incl. unlisted drafts) | Leave as alias-table entries only; don't promote drafts to public `board_climbs` | **Not on the PowerSync stream** — pull from REST `GET /api/climbs/climbdetails/user` if needed. Drafts stay Kilter-local |
 
 On transient errors (network, 5xx, timeout) leave `syncStatus` unchanged and re-throw — same policy as `sync-runner.ts:268-278`. On 401 from Keycloak, set `syncStatus='expired'`.
 
@@ -289,7 +293,7 @@ Single daemon process mirroring `aurora-sync/src/runner/daemon.ts`:
 - One Kilter-linked user picked per cycle: oldest `lastSyncAt` first, NULL ahead of any timestamp.
 - Random 1–15 minute delay between cycles.
 - Abort signal honored mid-cycle.
-- Catalog sync piggybacks: after a successful per-user cycle, if `board_shared_syncs.lastSyncedAt` for `board_type='kilter'` is older than the cooldown (1 hour default), open a second short-lived PowerSync stream for the catalog buckets, drain, close.
+- Catalog sync piggybacks: after a successful per-user cycle, if `board_shared_syncs.lastSyncedAt` for `board_type='kilter'` is older than the cooldown (1 hour default), run the catalog cycle (REST climb pull + a short-lived PowerSync connection for the reference tables), then close.
 - Per-user serialization — one active stream per Keycloak `sub`. If the user has the Kilter app open we may get disconnected; treat as transient, retry next cycle.
 - Schema-drift detection — if the stream emits a column we don't have in the translator, fail the cycle with a loud error and skip the user (but stamp `lastSyncAt` so they're not first in line next time). Same for inverse.
 
@@ -325,8 +329,8 @@ The daemon deploys alongside aurora-sync on Railway, hitting the same `/sync-cro
 
 ## Phased rollout
 
-1. **Traffic capture** — sign in to Kilter with one of our accounts, capture the `/sync/stream` request. Confirms the Keycloak-token-is-PowerSync-token assumption, the wire content-type, and the first few `StreamingSyncCheckpoint` payloads. Closes the top open question.
-2. **Standalone POC** — Node script outside the Boardsesh repo: authenticate one user against Keycloak, open a PowerSync stream, print the `logs` table rows. No DB writes.
+1. **Confirm the catalog REST contract** — the Keycloak-token-is-PowerSync-token assumption is already confirmed (a working `@powersync/node` scraper syncs `gyms`/`walls` with the `kilter` client + `openid offline_access`). The remaining unknown is the climb-catalog REST shape: authenticate one account, then call `/api/climbs/climbdetails/{productName}/edges/count` and `…/edges?…limit=&offset=` and record the params, page size, and JSON casing. Check whether `/api/climbs/all/` is a simpler bulk pull.
+2. **Standalone POC** — Node script outside the Boardsesh repo: authenticate one user against Keycloak, (a) open a PowerSync stream and print `logs` + `gyms`, (b) page the REST catalog and print a `climbs` count. No DB writes.
 3. **Promote to `packages/kilter-sync/`** — write into `board_climbs` and `boardsesh_ticks` behind a per-user feature flag. Read-only (no push to Kilter yet). Dedup logic + alias table land here.
 4. **Catalog spin-up** — add the cooldown-throttled catalog cycle and the `kilter_ascensionist_count` writer. Update aurora-sync and the recompute path to recognize the new column in the sum.
 5. **Push-back: logs first**, then ratings, then circuits — each behind its own flag. Watch for tick duplication after enabling logs.


### PR DESCRIPTION
## What

Corrects the three Kilter integration docs after re-verifying them against the decompiled APK (`libapp.so` / `libpowersync.so` string dumps in `.local-work/`) **and** a working `@powersync/node` gym-sync.

**Core correction:** the public climb catalog is **not** a PowerSync bucket. `climbs` + `climb_stats` are plain local SQLite tables the app fills over **REST**, paginated by board region. PowerSync carries only the small reference catalog (holds, grades, products, layouts, …), `gyms`/`walls`, and per-user data. Earlier drafts modelled a `public_climbs` / `global_catalog` bucket that does not exist — so a consumer trying to "sync the `public_climbs` bucket" gets nothing regardless of token.

## Why it's not a token problem

A working scraper syncs `gyms`/`walls` with `client_id=kilter`, `scope=openid offline_access`, Keycloak `access_token` used verbatim. Two "broader token" theories are ruled out:

- **Different scope → `aud: ['kilter-portal']`** — the binary has one scope (`offline_access` + implicit `openid`); `aud: ['kilter','account']` is standard; PowerSync checks `aud` once per connection, not per bucket.
- **Different `client_id` for the portal** — only one Keycloak client (`kilter`). The other client IDs in the app (`androidClientId`, `iosClientId`, `kilter-app-analytics`) are Firebase/Google.

The five tells that the catalog is REST: direct `INSERT INTO climbs (…)` in app code; a `climbs_for_product_fetch_info` pagination-progress table keyed by board region; an `/edges/count` endpoint; the `preparing_screen.dart` "Downloading data…" flow; and the scraper getting an empty `climbs` table over PowerSync.

## Changes

- **`KILTER_POWERSYNC_SPEC.md`** — Rust sync core `0.4.10` + raw tables + Sync Streams; auth confirmed and both token theories killed; table inventory split into PowerSync-synced vs REST-cached; confirmed `gyms` schema; §6 rewritten as "What syncs where" (two-transport diagram); open questions resolved.
- **`kilter-sync.md`** — Catalog sync (Flow A) rewritten from a PowerSync stream to REST paging (+ PowerSync for reference tables); Flow B own-climbs row, daemon piggyback, and phased-rollout step 1 fixed.
- **`KILTER_HTTP_API_SPEC.md`** — clarified the two mechanisms that fill the local mirror; recorded confirmed `client_id`/`scope`; fixed the PowerSync summary and open questions.

Docs-only; no code changes.

## Open item to confirm next

The exact `/api/climbs/climbdetails/{productName}/edges` params + response shape are read off the binary, not captured — and whether `/api/climbs/all/` is a simpler bulk pull. One authenticated request closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)