### PR TITLE
feat(playback): route speed slider, frame stepping, no-loop replay + analytics

### DIFF
--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -973,7 +973,6 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
             frameCount={playback.frameCount}
             isPlaying={playback.isPlaying}
             speed={playback.speed}
-            paceMs={playback.paceMs}
             onPlay={playback.play}
             onPause={playback.pause}
             onSeek={playback.seek}

--- a/packages/web/app/components/play-view/use-drawer-playback.ts
+++ b/packages/web/app/components/play-view/use-drawer-playback.ts
@@ -19,7 +19,6 @@ type UseDrawerPlaybackInput = {
 type UseDrawerPlaybackOutput = {
   isAnimatable: boolean;
   frameCount: number;
-  paceMs: number;
   currentFrameString: string;
   frameIndex: number;
   isPlaying: boolean;
@@ -209,6 +208,22 @@ export function useDrawerPlayback({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- climbFrames.frameStrings is captured via frameStringsKey
   }, [isOpen, playback.isAnimatable, frameStringsKey, isMirrored, boardDetails]);
 
+  // Track deliberate user Play presses on a route. Peer-driven playback
+  // converges via `setIsPlaying` inside the engine and never calls `play()`,
+  // so this stays a user-only signal (no double counting from party sync).
+  const playWithTracking = useCallback(() => {
+    if (playback.isAnimatable) {
+      track('Route Played', {
+        boardName: boardDetails.board_name,
+        layoutName: boardDetails.layout_name ?? '',
+        frameCount: climbFrames.frameStrings.length,
+        speed: playback.speed,
+        climbUuid: activeClimbUuid,
+      });
+    }
+    playback.play();
+  }, [playback, boardDetails, climbFrames.frameStrings.length, activeClimbUuid]);
+
   // Stable reference so the drawer's `aboveFold` memo and the
   // `SwipeBoardCarousel` props don't bust on every render that doesn't
   // change observable playback state.
@@ -216,16 +231,15 @@ export function useDrawerPlayback({
     () => ({
       isAnimatable: playback.isAnimatable,
       frameCount: climbFrames.frameStrings.length,
-      paceMs: climbFrames.paceMs,
       currentFrameString: playback.currentFrameString,
       frameIndex: playback.frameIndex,
       isPlaying: playback.isPlaying,
       speed: playback.speed,
-      play: playback.play,
+      play: playWithTracking,
       pause: playback.pause,
       seek: playback.seek,
       setSpeed: playback.setSpeed,
     }),
-    [playback, climbFrames.frameStrings.length, climbFrames.paceMs],
+    [playback, climbFrames.frameStrings.length, playWithTracking],
   );
 }

--- a/packages/web/app/components/playback/__tests__/use-playback-engine.test.ts
+++ b/packages/web/app/components/playback/__tests__/use-playback-engine.test.ts
@@ -53,16 +53,35 @@ describe('usePlaybackEngine', () => {
     expect(result.current.frameIndex).toBe(2);
   });
 
-  it('wraps to frame 0 after the last frame', () => {
+  it('stops at the last frame instead of looping', () => {
     const { frames, frameStrings } = decode(TENSION_FRAMES);
     const { result } = renderHook(() => usePlaybackEngine({ frames, frameStrings, paceMs: 300, clientId: 'a' }));
     act(() => {
       result.current.play();
     });
     act(() => {
-      vi.advanceTimersByTime(300 * frameStrings.length);
+      // Advance well past the end; the engine should rest on the last frame.
+      vi.advanceTimersByTime(300 * (frameStrings.length + 2));
+    });
+    expect(result.current.frameIndex).toBe(frameStrings.length - 1);
+    expect(result.current.isPlaying).toBe(false);
+  });
+
+  it('restarts from frame 0 when play is pressed on the last frame', () => {
+    const { frames, frameStrings } = decode(TENSION_FRAMES);
+    const { result } = renderHook(() => usePlaybackEngine({ frames, frameStrings, paceMs: 300, clientId: 'a' }));
+    act(() => {
+      result.current.play();
+    });
+    act(() => {
+      vi.advanceTimersByTime(300 * (frameStrings.length + 2));
+    });
+    expect(result.current.frameIndex).toBe(frameStrings.length - 1);
+    act(() => {
+      result.current.play();
     });
     expect(result.current.frameIndex).toBe(0);
+    expect(result.current.isPlaying).toBe(true);
   });
 
   it('halves tick interval at speed=2', () => {
@@ -212,10 +231,12 @@ describe('usePlaybackEngine', () => {
     const { result } = renderHook(() =>
       usePlaybackEngine({ frames, frameStrings, paceMs: 200, clientId: 'self', externalState: external }),
     );
-    // paceMs=0 clamped to MIN_PACE_MS (200) → 1000ms / 200ms = 5 steps,
-    // (0 + 5) % 4 frames = frame 1. No divide-by-zero, no Infinity.
+    // paceMs=0 clamped to MIN_PACE_MS (200) → 1000ms / 200ms = 5 steps.
+    // Playback no longer loops, so the projection clamps to the last frame
+    // and the engine reports stopped. No divide-by-zero, no Infinity.
     expect(Number.isFinite(result.current.frameIndex)).toBe(true);
-    expect(result.current.frameIndex).toBe(1);
+    expect(result.current.frameIndex).toBe(frameStrings.length - 1);
+    expect(result.current.isPlaying).toBe(false);
   });
 
   it('emits onLocalStateChange on user actions but not on auto ticks', () => {

--- a/packages/web/app/components/playback/__tests__/use-playback-engine.test.ts
+++ b/packages/web/app/components/playback/__tests__/use-playback-engine.test.ts
@@ -275,4 +275,26 @@ describe('usePlaybackEngine', () => {
     });
     expect(onLocalStateChange).toHaveBeenCalledTimes(1);
   });
+
+  it('broadcasts the stop when playback reaches the last frame', () => {
+    const { frames, frameStrings } = decode(TENSION_FRAMES);
+    const onLocalStateChange = vi.fn();
+    const { result } = renderHook(() =>
+      usePlaybackEngine({ frames, frameStrings, paceMs: 200, clientId: 'self', onLocalStateChange }),
+    );
+    act(() => {
+      result.current.play();
+    });
+    onLocalStateChange.mockClear();
+    act(() => {
+      // Run through every frame; the terminal tick stops and broadcasts.
+      vi.advanceTimersByTime(200 * (frameStrings.length + 1));
+    });
+    expect(onLocalStateChange).toHaveBeenCalledTimes(1);
+    expect(onLocalStateChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isPlaying: false, frameIndex: frameStrings.length - 1 }),
+    );
+    expect(result.current.frameIndex).toBe(frameStrings.length - 1);
+    expect(result.current.isPlaying).toBe(false);
+  });
 });

--- a/packages/web/app/components/playback/playback-controls.tsx
+++ b/packages/web/app/components/playback/playback-controls.tsx
@@ -23,7 +23,10 @@ type PlaybackControlsProps = {
 
 /** Speeds with their own toggle button; anything else is a custom slider value. */
 const PRESET_SPEEDS = [0.5, 1];
-const MIN_CUSTOM_SPEED = 1;
+// Lower bound sits just above the 1× preset so the slider can never land on a
+// preset value — otherwise dragging to exactly 1.0 would re-activate the 1×
+// toggle while the popover is still open, leaving the custom button as "…".
+const MIN_CUSTOM_SPEED = 1.1;
 const MAX_CUSTOM_SPEED = 10;
 
 /** 1-decimal, trailing `.0` stripped: 7.0 → "7", 6.3 → "6.3". */
@@ -54,7 +57,7 @@ export function PlaybackControls({
   // the per-minute rate-limit bucket — so we only call `onSpeedChange` on
   // `onChangeCommitted` (release / keyboard step).
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  const [draftSpeed, setDraftSpeed] = useState<number>(2);
+  const [draftSpeed, setDraftSpeed] = useState<number>(MIN_CUSTOM_SPEED);
 
   const isCustomSpeed = !PRESET_SPEEDS.includes(speed);
   // Stopped on the final frame: the primary button becomes a replay control
@@ -186,6 +189,7 @@ export function PlaybackControls({
             }}
             onChangeCommitted={(_, value) => {
               if (typeof value === 'number') onSpeedChange(value);
+              setAnchorEl(null);
             }}
             size="small"
           />

--- a/packages/web/app/components/playback/playback-controls.tsx
+++ b/packages/web/app/components/playback/playback-controls.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { Box, IconButton, Slider, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { Box, IconButton, Popover, Slider, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import PauseIcon from '@mui/icons-material/Pause';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import SkipPreviousIcon from '@mui/icons-material/SkipPrevious';
+import SkipNextIcon from '@mui/icons-material/SkipNext';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import { useTranslation } from 'react-i18next';
 
 type PlaybackControlsProps = {
@@ -11,15 +14,22 @@ type PlaybackControlsProps = {
   frameCount: number;
   isPlaying: boolean;
   speed: number;
-  /** Native per-frame pace in ms (already speed-adjusted upstream is OK; this
-   * component re-applies `speed` for the slider crawl so the thumb tracks
-   * the actual interval the engine uses). */
-  paceMs: number;
   onPlay: () => void;
   onPause: () => void;
   onSeek: (index: number) => void;
   onSpeedChange: (speed: number) => void;
 };
+
+/** Speeds with their own toggle button; anything else is a custom slider value. */
+const PRESET_SPEEDS = [0.5, 1];
+const MIN_CUSTOM_SPEED = 1;
+const MAX_CUSTOM_SPEED = 10;
+
+/** 1-decimal, trailing `.0` stripped: 7.0 → "7", 6.3 → "6.3". */
+function formatSpeed(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
 
 /**
  * Compact strip that drives `usePlaybackEngine`. Renders only when the
@@ -30,7 +40,6 @@ export function PlaybackControls({
   frameCount,
   isPlaying,
   speed,
-  paceMs,
   onPlay,
   onPause,
   onSeek,
@@ -38,44 +47,15 @@ export function PlaybackControls({
 }: PlaybackControlsProps) {
   const { t } = useTranslation('common');
 
-  // Crawl the slider thumb smoothly toward the next frame instead of
-  // jumping when the engine ticks. `smoothValue` is `frameIndex + progress`
-  // where progress ranges 0..1 across the current frame's duration; we
-  // drive it with rAF so the animation is local to this component and
-  // doesn't trigger engine re-renders.
-  const [smoothValue, setSmoothValue] = useState<number>(frameIndex);
-  // While the user is dragging the slider, override the rAF-driven crawl
-  // with the local drag position. `null` outside drags. Splitting the
-  // visual update from the engine seek keeps `onChange` fully local
-  // (60 events/sec from per-pixel drag) and only fires the broadcast
-  // on `onChangeCommitted` — without this, a single 2-second drag
-  // exhausts the queue mutation rate-limit bucket (default 60/min).
-  const [scrubValue, setScrubValue] = useState<number | null>(null);
-  const lastFrameRef = useRef(frameIndex);
-  useEffect(() => {
-    lastFrameRef.current = frameIndex;
-    if (!isPlaying) {
-      setSmoothValue(frameIndex);
-      return;
-    }
-    if (frameCount <= 1 || paceMs <= 0) {
-      setSmoothValue(frameIndex);
-      return;
-    }
-    const startedAt = performance.now();
-    const effectivePace = paceMs / Math.max(speed, 0.01);
-    let rafId = 0;
-    const step = (now: number) => {
-      const elapsed = now - startedAt;
-      const progress = Math.min(1, elapsed / effectivePace);
-      setSmoothValue(frameIndex + progress);
-      if (progress < 1 && lastFrameRef.current === frameIndex) {
-        rafId = requestAnimationFrame(step);
-      }
-    };
-    rafId = requestAnimationFrame(step);
-    return () => cancelAnimationFrame(rafId);
-  }, [frameIndex, frameCount, isPlaying, paceMs, speed]);
+  // Anchor + in-drag value for the custom-speed popover slider. `draftSpeed`
+  // keeps the slider crawl fully local: committing on every pointer pixel
+  // would broadcast a `publishPlaybackState` mutation per event and exhaust
+  // the per-minute rate-limit bucket — so we only call `onSpeedChange` on
+  // `onChangeCommitted` (release / keyboard step).
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [draftSpeed, setDraftSpeed] = useState<number>(2);
+
+  const isCustomSpeed = !PRESET_SPEEDS.includes(speed);
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -87,20 +67,26 @@ export function PlaybackControls({
         (isPlaying ? onPause : onPlay)();
       } else if (event.code === 'ArrowRight') {
         event.preventDefault();
-        onSeek((frameIndex + 1) % frameCount);
+        onSeek(Math.min(frameCount - 1, frameIndex + 1));
       } else if (event.code === 'ArrowLeft') {
         event.preventDefault();
-        onSeek((frameIndex - 1 + frameCount) % frameCount);
+        onSeek(Math.max(0, frameIndex - 1));
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [frameIndex, frameCount, isPlaying, onPlay, onPause, onSeek]);
 
+  const openSpeedPopover = (event: React.MouseEvent<HTMLElement>) => {
+    const seed = speed >= MIN_CUSTOM_SPEED ? Math.min(MAX_CUSTOM_SPEED, speed) : 2;
+    setDraftSpeed(seed);
+    setAnchorEl(event.currentTarget);
+  };
+
   return (
     <Box
       role="group"
-      aria-label={t('playback.seek')}
+      aria-label={t('playback.controls')}
       sx={{
         display: 'flex',
         alignItems: 'center',
@@ -127,59 +113,35 @@ export function PlaybackControls({
       >
         {isPlaying ? <PauseIcon /> : <PlayArrowIcon />}
       </IconButton>
-      <Stack direction="row" alignItems="center" spacing={2} sx={{ flex: 1, minWidth: 0 }}>
-        <Slider
-          value={scrubValue ?? smoothValue}
-          min={0}
-          max={Math.max(0, frameCount - 1)}
-          // MUI Slider snapping: `step={null}` requires `marks` to define
-          // the valid stops. For short routes we render an integer mark per
-          // frame so the thumb snaps cleanly to each frame. For long routes
-          // (Driftwood is 43 frames; rendering 43 mark dots looks like a
-          // dashed line and there's no room for them visually) we drop the
-          // marks — but then `step={null} + marks={false}` leaves the
-          // slider with no valid stops at all and it stops responding to
-          // input. Branch on count: step={1} when marks are off so the
-          // thumb still snaps to integer positions.
-          step={frameCount <= 16 ? null : 1}
-          marks={frameCount <= 16 ? Array.from({ length: frameCount }, (_, index) => ({ value: index })) : false}
-          aria-label={t('playback.seek')}
-          onChange={(_, value) => {
-            // Drag feedback only: do NOT call onSeek here. MUI fires
-            // onChange per pointer-pixel (~60 events/sec); calling onSeek
-            // would broadcast a publishPlaybackState mutation for each one
-            // and exhaust the per-minute rate-limit bucket within a
-            // single 2-second drag.
-            if (typeof value === 'number') setScrubValue(value);
-          }}
-          onChangeCommitted={(_, value) => {
-            // Commit on release / keyboard step — this is what actually
-            // moves the engine and broadcasts to peers.
-            if (typeof value === 'number') onSeek(Math.round(value));
-            setScrubValue(null);
-          }}
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <IconButton
+          onClick={() => onSeek(frameIndex - 1)}
+          disabled={frameIndex === 0}
+          aria-label={t('playback.prevFrame')}
           size="small"
-          sx={{
-            flex: 1,
-            // Marks render at integer frame positions; without explicit
-            // mark styling MUI hides them when step={null}. Force them on
-            // so the user can still see frame boundaries while scrubbing.
-            '& .MuiSlider-mark': { opacity: 0.5, height: 6, width: 2, borderRadius: 1 },
-            '& .MuiSlider-markActive': { opacity: 1 },
-          }}
-        />
+        >
+          <SkipPreviousIcon />
+        </IconButton>
         <Typography variant="caption" sx={{ whiteSpace: 'nowrap', color: 'text.secondary' }}>
-          {t('playback.frameOfTotal', {
-            index: (scrubValue !== null ? Math.round(scrubValue) : frameIndex) + 1,
-            total: frameCount,
-          })}
+          {t('playback.frameOfTotal', { index: frameIndex + 1, total: frameCount })}
         </Typography>
+        <IconButton
+          onClick={() => onSeek(frameIndex + 1)}
+          disabled={frameIndex >= frameCount - 1}
+          aria-label={t('playback.nextFrame')}
+          size="small"
+        >
+          <SkipNextIcon />
+        </IconButton>
       </Stack>
+      <Box sx={{ flex: 1 }} />
       <ToggleButtonGroup
         size="small"
         exclusive
-        value={speed}
+        value={isCustomSpeed ? 'custom' : speed}
         onChange={(_, value) => {
+          // The custom button manages its own popover via onClick; ignore the
+          // group's value event for it (and `null` from deselecting).
           if (typeof value === 'number') onSpeedChange(value);
         }}
         aria-label={t('playback.speed')}
@@ -191,10 +153,43 @@ export function PlaybackControls({
         <ToggleButton value={1} aria-label={t('playback.speedNormal')}>
           {t('playback.speedNormal')}
         </ToggleButton>
-        <ToggleButton value={2} aria-label={t('playback.speedDouble')}>
-          {t('playback.speedDouble')}
+        <ToggleButton value="custom" aria-label={t('playback.speedCustomLabel')} onClick={openSpeedPopover}>
+          {isCustomSpeed ? (
+            t('playback.speedCustom', { value: formatSpeed(speed) })
+          ) : (
+            <MoreHorizIcon fontSize="small" />
+          )}
         </ToggleButton>
       </ToggleButtonGroup>
+      <Popover
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Box sx={{ px: 3, py: 2, width: 220 }}>
+          <Typography variant="caption" sx={{ display: 'block', mb: 1, color: 'text.secondary' }}>
+            {t('playback.speedCustom', { value: formatSpeed(draftSpeed) })}
+          </Typography>
+          <Slider
+            value={draftSpeed}
+            min={MIN_CUSTOM_SPEED}
+            max={MAX_CUSTOM_SPEED}
+            step={0.1}
+            aria-label={t('playback.speed')}
+            valueLabelDisplay="auto"
+            valueLabelFormat={(value) => formatSpeed(value)}
+            onChange={(_, value) => {
+              if (typeof value === 'number') setDraftSpeed(value);
+            }}
+            onChangeCommitted={(_, value) => {
+              if (typeof value === 'number') onSpeedChange(value);
+            }}
+            size="small"
+          />
+        </Box>
+      </Popover>
     </Box>
   );
 }

--- a/packages/web/app/components/playback/playback-controls.tsx
+++ b/packages/web/app/components/playback/playback-controls.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Box, IconButton, Popover, Slider, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import PauseIcon from '@mui/icons-material/Pause';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import ReplayIcon from '@mui/icons-material/Replay';
 import SkipPreviousIcon from '@mui/icons-material/SkipPrevious';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
@@ -56,6 +57,9 @@ export function PlaybackControls({
   const [draftSpeed, setDraftSpeed] = useState<number>(2);
 
   const isCustomSpeed = !PRESET_SPEEDS.includes(speed);
+  // Stopped on the final frame: the primary button becomes a replay control
+  // that restarts from frame 0 (the engine's play() handles the reset).
+  const isAtEnd = !isPlaying && frameIndex >= frameCount - 1;
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -108,10 +112,10 @@ export function PlaybackControls({
     >
       <IconButton
         onClick={isPlaying ? onPause : onPlay}
-        aria-label={isPlaying ? t('playback.pause') : t('playback.play')}
+        aria-label={isPlaying ? t('playback.pause') : isAtEnd ? t('playback.replay') : t('playback.play')}
         size="small"
       >
-        {isPlaying ? <PauseIcon /> : <PlayArrowIcon />}
+        {isPlaying ? <PauseIcon /> : isAtEnd ? <ReplayIcon /> : <PlayArrowIcon />}
       </IconButton>
       <Stack direction="row" alignItems="center" spacing={1}>
         <IconButton
@@ -168,17 +172,14 @@ export function PlaybackControls({
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
-        <Box sx={{ px: 3, py: 2, width: 220 }}>
-          <Typography variant="caption" sx={{ display: 'block', mb: 1, color: 'text.secondary' }}>
-            {t('playback.speedCustom', { value: formatSpeed(draftSpeed) })}
-          </Typography>
+        <Box sx={{ px: 3, pt: 4, pb: 2, width: 220 }}>
           <Slider
             value={draftSpeed}
             min={MIN_CUSTOM_SPEED}
             max={MAX_CUSTOM_SPEED}
             step={0.1}
             aria-label={t('playback.speed')}
-            valueLabelDisplay="auto"
+            valueLabelDisplay="on"
             valueLabelFormat={(value) => formatSpeed(value)}
             onChange={(_, value) => {
               if (typeof value === 'number') setDraftSpeed(value);

--- a/packages/web/app/components/playback/use-playback-engine.ts
+++ b/packages/web/app/components/playback/use-playback-engine.ts
@@ -134,7 +134,16 @@ export function usePlaybackEngine({
     const tick = () => {
       timerRef.current = null;
       if (!isPlayingRef.current) return;
-      const nextIndex = (frameIndexRef.current + 1) % frameStrings.length;
+      const lastIndex = frameStrings.length - 1;
+      // Stop at the end instead of looping. Broadcast the stop (unlike the
+      // mid-sequence ticks below) so peers also halt on the last frame.
+      if (frameIndexRef.current >= lastIndex) {
+        isPlayingRef.current = false;
+        setIsPlaying(false);
+        emitLocalState(lastIndex, false, speedRef.current);
+        return;
+      }
+      const nextIndex = frameIndexRef.current + 1;
       // Update the ref synchronously so back-to-back ticks (e.g. fake timers
       // firing several callbacks inside one `act`) see the advanced index
       // instead of reading the stale value through the next render.
@@ -147,7 +156,7 @@ export function usePlaybackEngine({
     };
     scheduleNext();
     return clearTimer;
-  }, [isPlaying, frameStrings.length, paceMs]);
+  }, [isPlaying, frameStrings.length, paceMs, emitLocalState]);
 
   // Converge to external (peer) state when its clientId differs from ours.
   // Peer state arrives over the wire — clamp every numeric field before we
@@ -168,17 +177,29 @@ export function usePlaybackEngine({
     const elapsed = Math.max(0, Date.now() - safeAnchor);
     const effectivePace = Math.max(MIN_PACE_MS, safePaceMs / safeSpeed);
     const stepsAdvanced = externalState.isPlaying && effectivePace > 0 ? Math.floor(elapsed / effectivePace) : 0;
-    const projected = (safeFrameIndex + stepsAdvanced) % frameStrings.length;
+    // Clamp to the last frame instead of wrapping — playback no longer loops,
+    // so a peer that extrapolated past the end has stopped on the last frame.
+    const lastIndex = frameStrings.length - 1;
+    const reachedEnd = externalState.isPlaying && safeFrameIndex + stepsAdvanced >= lastIndex;
+    const projected = Math.min(lastIndex, safeFrameIndex + stepsAdvanced);
     setFrameIndex(projected);
-    setIsPlaying(externalState.isPlaying);
+    setIsPlaying(externalState.isPlaying && !reachedEnd);
     setSpeedState(safeSpeed);
   }, [externalState, clientId, frameStrings.length]);
 
   const play = useCallback(() => {
     if (!isAnimatable) return;
+    // Pressing play on the last frame replays from the start — without this
+    // the engine would immediately stop again (no looping).
+    let startIndex = frameIndexRef.current;
+    if (startIndex >= frameStrings.length - 1) {
+      startIndex = 0;
+      frameIndexRef.current = 0;
+      setFrameIndex(0);
+    }
     setIsPlaying(true);
-    emitLocalState(frameIndexRef.current, true, speedRef.current);
-  }, [isAnimatable, emitLocalState]);
+    emitLocalState(startIndex, true, speedRef.current);
+  }, [isAnimatable, emitLocalState, frameStrings.length]);
 
   const pause = useCallback(() => {
     if (!isAnimatable) return;

--- a/packages/web/app/lib/i18n/config.ts
+++ b/packages/web/app/lib/i18n/config.ts
@@ -125,6 +125,8 @@ export const DEFAULT_LOCALE: Locale = 'en-US';
 // i18n-keep climbs:mobile.filter.cancel
 // i18n-keep climbs:mobile.filter.done
 // i18n-keep climbs:mobile.filter.clearAll
+// Mobile board switcher
+// i18n-keep boards:mobile.boardSwitchError
 // i18n-keep session:playView.tickBar.cancelLabel
 // i18n-keep session:playView.tickBar.decreaseTriesAria
 // i18n-keep session:playView.tickBar.flashSaveLabel

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -271,6 +271,7 @@
   "playback": {
     "play": "Play",
     "pause": "Pause",
+    "replay": "Replay",
     "controls": "Playback controls",
     "speed": "Speed",
     "frameOfTotal": "Frame {{index}} of {{total}}",

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -271,11 +271,14 @@
   "playback": {
     "play": "Play",
     "pause": "Pause",
+    "controls": "Playback controls",
     "speed": "Speed",
     "frameOfTotal": "Frame {{index}} of {{total}}",
-    "seek": "Scrub frames",
+    "prevFrame": "Previous frame",
+    "nextFrame": "Next frame",
     "speedHalf": "0.5×",
     "speedNormal": "1×",
-    "speedDouble": "2×"
+    "speedCustom": "{{value}}×",
+    "speedCustomLabel": "Custom speed"
   }
 }

--- a/packages/web/i18n/locales/es/common.json
+++ b/packages/web/i18n/locales/es/common.json
@@ -271,11 +271,14 @@
   "playback": {
     "play": "Reproducir",
     "pause": "Pausar",
+    "controls": "Controles de reproducción",
     "speed": "Velocidad",
     "frameOfTotal": "Cuadro {{index}} de {{total}}",
-    "seek": "Desplazar cuadros",
+    "prevFrame": "Cuadro anterior",
+    "nextFrame": "Cuadro siguiente",
     "speedHalf": "0.5×",
     "speedNormal": "1×",
-    "speedDouble": "2×"
+    "speedCustom": "{{value}}×",
+    "speedCustomLabel": "Velocidad personalizada"
   }
 }

--- a/packages/web/i18n/locales/es/common.json
+++ b/packages/web/i18n/locales/es/common.json
@@ -271,6 +271,7 @@
   "playback": {
     "play": "Reproducir",
     "pause": "Pausar",
+    "replay": "Repetir",
     "controls": "Controles de reproducción",
     "speed": "Velocidad",
     "frameOfTotal": "Cuadro {{index}} de {{total}}",

--- a/packages/web/i18n/locales/fr/common.json
+++ b/packages/web/i18n/locales/fr/common.json
@@ -271,6 +271,7 @@
   "playback": {
     "play": "Lire",
     "pause": "Pause",
+    "replay": "Rejouer",
     "controls": "Commandes de lecture",
     "speed": "Vitesse",
     "frameOfTotal": "Image {{index}} sur {{total}}",

--- a/packages/web/i18n/locales/fr/common.json
+++ b/packages/web/i18n/locales/fr/common.json
@@ -271,11 +271,14 @@
   "playback": {
     "play": "Lire",
     "pause": "Pause",
+    "controls": "Commandes de lecture",
     "speed": "Vitesse",
     "frameOfTotal": "Image {{index}} sur {{total}}",
-    "seek": "Parcourir les images",
+    "prevFrame": "Image précédente",
+    "nextFrame": "Image suivante",
     "speedHalf": "0.5×",
     "speedNormal": "1×",
-    "speedDouble": "2×"
+    "speedCustom": "{{value}}×",
+    "speedCustomLabel": "Vitesse personnalisée"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to the routes (multi-frame Aurora climb) playback work on #2232. Reworks the playback strip in the play-view drawer and adds usage analytics.

- **Variable speed**: the `2×` preset is replaced by a `…` button that opens a popover slider for any speed **1–10 (0.1 steps)**. Once a custom speed is set, the button shows it (e.g. `6.3×`). `½×` and `1×` presets remain. The slider's value tooltip is the single source of truth (no duplicate label).
- **Frame stepping**: added prev / next frame buttons around "Frame X of Y"; removed the seek slider.
- **No looping**: playback stops on the last frame instead of wrapping. When stopped at the end, the primary button becomes a **replay** icon that restarts from frame 0. Peer (party-mode) convergence clamps to the last frame instead of wrapping.
- **Analytics**: a `Route Played` PostHog event fires on local Play presses for multi-frame routes (peer-driven play does not fire it), so we can measure how often routes are used.

Speed travels to peers as a GraphQL `Float!` with no max validation and the engine only floors it (`Math.max(0.1, …)`), so 1–10 is safe end-to-end with no backend change. Mobile has no playback UI — web-only.

## Test plan

- [x] `vp run typecheck:web` — clean
- [x] `vp check` — lint + format clean
- [x] `vp run check:i18n` + i18n catalog completeness (en-US/es/fr parity) — clean
- [x] `vp test --project web` — 90/90 in play-view + playback, incl. rewritten no-loop / restart-from-end engine tests
- [ ] Manual: open the play drawer on a multi-frame route (e.g. Kilter "Driftwood"); verify prev/next stepping, the `…` → 1–10 slider, custom value on the button, stop-at-end with the replay icon, and a single `Route Played` console event per Play press (run with `NEXT_PUBLIC_ANALYTICS_DEBUG=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)