### PR TITLE
feat(mobile): board-detail peek sheet + fix map marker flicker

### DIFF
--- a/packages/mobile/app/(tabs)/boards/search.tsx
+++ b/packages/mobile/app/(tabs)/boards/search.tsx
@@ -125,9 +125,11 @@ export default function BoardSearchScreen() {
 
   const handleSetActive = useCallback(
     async (board: UserBoard) => {
-      setSelectedUuid(null);
       try {
         await setActiveBoard(board);
+        // Only close the sheet once the board is saved — if it throws, the
+        // sheet stays open so the error toast has visible context.
+        setSelectedUuid(null);
         // router.back() is the same foreground unmount the X button uses —
         // proven safe for expo-maps — then switch to the climbs tab.
         router.back();

--- a/packages/mobile/app/(tabs)/boards/search.tsx
+++ b/packages/mobile/app/(tabs)/boards/search.tsx
@@ -13,6 +13,7 @@ import { hapticSelection } from '../../../src/lib/haptics';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
 import { BoardCarousel } from '../../../src/components/board-discovery/BoardCarousel';
+import { BoardDetailSheet } from '../../../src/components/board-discovery/BoardDetailSheet';
 import { userBoardToItem } from '../../../src/components/board-discovery/board-items';
 import type { DiscoveryBoardItem } from '../../../src/components/board-discovery/BoardDiscoveryCard';
 import { brandColors } from '../../../src/theme/colors';
@@ -35,6 +36,13 @@ try {
 const DEFAULT_CENTER = { latitude: 20, longitude: 0 };
 const DEFAULT_ZOOM = 3;
 const NEARBY_ZOOM = 11;
+
+// iOS → Apple Maps (no API key); Android → Google Maps (env-supplied key).
+// Resolved at module scope: Platform.OS is constant for the process lifetime,
+// so there's no value in re-checking on every render — and a stable MapView
+// reference helps the markers memo below avoid spurious invalidations.
+const isApple = Platform.OS === 'ios';
+const MapView = isApple ? expoMaps?.AppleMaps.View : expoMaps?.GoogleMaps.View;
 
 type Camera = { latitude: number; longitude: number; zoom: number };
 
@@ -93,36 +101,42 @@ export default function BoardSearchScreen() {
     [boards, selectedUuid],
   );
 
-  const activateBoard = useCallback(
+  // The selected board drives both the pin recolour and the detail sheet.
+  // Detail is a sheet *over* the live map — never a pushed screen — because
+  // expo-maps crashes when its view is unmounted from a backgrounded stack.
+  const selectedBoard = useMemo(
+    () => boards.find((b) => b.uuid === selectedUuid) ?? null,
+    [boards, selectedUuid],
+  );
+
+  const openBoardDetail = useCallback((uuid: string) => {
+    hapticSelection();
+    setSelectedUuid(uuid);
+  }, []);
+
+  const onSelectItem = useCallback(
+    (item: DiscoveryBoardItem) => openBoardDetail(item.key),
+    [openBoardDetail],
+  );
+
+  // Tapping a pin recolours it and opens its detail sheet (no recenter — keep
+  // the map exactly where it is so closing the sheet returns to the same view).
+  const onMarkerClick = useCallback((uuid: string) => openBoardDetail(uuid), [openBoardDetail]);
+
+  const handleSetActive = useCallback(
     async (board: UserBoard) => {
-      hapticSelection();
+      setSelectedUuid(null);
       try {
         await setActiveBoard(board);
+        // router.back() is the same foreground unmount the X button uses —
+        // proven safe for expo-maps — then switch to the climbs tab.
+        router.back();
         router.navigate('/(tabs)/climbs');
       } catch {
         showToast(t('mobile.boardSwitchError'), 'error');
       }
     },
     [setActiveBoard, router, showToast, t],
-  );
-
-  const onSelectItem = useCallback(
-    (item: DiscoveryBoardItem) => {
-      const board = boards.find((b) => b.uuid === item.key);
-      if (board) void activateBoard(board);
-    },
-    [boards, activateBoard],
-  );
-
-  // Tapping a pin selects its board and centers the map on it.
-  const onMarkerClick = useCallback(
-    (uuid: string) => {
-      const board = boards.find((b) => b.uuid === uuid);
-      if (!board || board.latitude == null || board.longitude == null) return;
-      setSelectedUuid(uuid);
-      setCameraTarget({ latitude: board.latitude, longitude: board.longitude, zoom: Math.max(camera.zoom, NEARBY_ZOOM) });
-    },
-    [boards, camera.zoom],
   );
 
   // Memoised so the native MapView doesn't re-bind the handler every render.
@@ -133,6 +147,30 @@ export default function BoardSearchScreen() {
     setCamera({ latitude, longitude, zoom: event.zoom });
     setHasRealViewport(true);
   }, []);
+
+  // Apple markers take an SF Symbol + tint (so the selected pin recolours);
+  // Google markers only share id/coordinates/title — pass just those there.
+  // Memoised on [pinned, selectedUuid]: any other render must NOT produce a new
+  // array reference, or expo-maps will redraw all annotations on every pan
+  // (this was the source of the visible flicker on scroll).
+  const markers = useMemo(
+    () =>
+      pinned.map((board) => {
+        const base = {
+          id: board.uuid,
+          coordinates: { latitude: board.latitude as number, longitude: board.longitude as number },
+          title: board.name,
+        };
+        return isApple
+          ? {
+              ...base,
+              systemImage: 'mappin.circle.fill',
+              tintColor: board.uuid === selectedUuid ? brandColors.primary : brandColors.success,
+            }
+          : base;
+      }),
+    [pinned, selectedUuid],
+  );
 
   const searchField = (
     <View style={[styles.searchField, { backgroundColor: systemColors.secondaryBackground, top: insets.top + spacing[2] }]}>
@@ -159,9 +197,18 @@ export default function BoardSearchScreen() {
       </View>
     ) : null;
 
+  const detailSheet = (
+    <BoardDetailSheet
+      board={selectedBoard}
+      visible={selectedBoard != null}
+      onClose={() => setSelectedUuid(null)}
+      onSetActive={handleSetActive}
+    />
+  );
+
   // expo-maps unavailable (pre-build client): show a placeholder but keep the
   // search field + results list working so the feature degrades, not crashes.
-  if (!expoMaps) {
+  if (!expoMaps || !MapView) {
     return (
       <View style={[styles.flex, { backgroundColor: systemColors.background }]}>
         {searchField}
@@ -172,6 +219,7 @@ export default function BoardSearchScreen() {
           </Text>
         </View>
         {resultStrip}
+        {detailSheet}
       </View>
     );
   }
@@ -180,27 +228,6 @@ export default function BoardSearchScreen() {
     coordinates: { latitude: cameraTarget.latitude, longitude: cameraTarget.longitude },
     zoom: cameraTarget.zoom,
   };
-
-  // iOS → Apple Maps (no API key); Android → Google Maps (env-supplied key).
-  const isApple = Platform.OS === 'ios';
-  const MapView = isApple ? expoMaps.AppleMaps.View : expoMaps.GoogleMaps.View;
-
-  // Apple markers take an SF Symbol + tint (so the selected pin recolours);
-  // Google markers only share id/coordinates/title — pass just those there.
-  const markers = pinned.map((board) => {
-    const base = {
-      id: board.uuid,
-      coordinates: { latitude: board.latitude as number, longitude: board.longitude as number },
-      title: board.name,
-    };
-    return isApple
-      ? {
-          ...base,
-          systemImage: 'mappin.circle.fill',
-          tintColor: board.uuid === selectedUuid ? brandColors.primary : brandColors.success,
-        }
-      : base;
-  });
 
   return (
     <View style={styles.flex}>
@@ -213,6 +240,7 @@ export default function BoardSearchScreen() {
       />
       {searchField}
       {resultStrip}
+      {detailSheet}
     </View>
   );
 }

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -1,6 +1,11 @@
 import { forwardRef, useCallback, useMemo, type ReactNode } from 'react';
-import { Platform, StyleSheet } from 'react-native';
-import BottomSheet, { BottomSheetBackdrop, BottomSheetView, type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
+import { Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import BottomSheet, {
+  BottomSheetBackdrop,
+  BottomSheetScrollView,
+  BottomSheetView,
+  type BottomSheetBackdropProps,
+} from '@gorhom/bottom-sheet';
 import { hapticMedium } from '../lib/haptics';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
@@ -12,6 +17,12 @@ type SheetProps = {
   onChange?: (index: number) => void;
   onClose?: () => void;
   enablePanDownToClose?: boolean;
+  // Render the content inside a BottomSheetScrollView instead of a plain
+  // BottomSheetView. Use this for content taller than the sheet — never wrap
+  // your own BottomSheetScrollView in the children, as nesting it inside the
+  // default BottomSheetView breaks gorhom's scroll gesture wiring.
+  scrollable?: boolean;
+  contentContainerStyle?: StyleProp<ViewStyle>;
 };
 
 export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
@@ -22,6 +33,8 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
     onChange,
     onClose,
     enablePanDownToClose = true,
+    scrollable = false,
+    contentContainerStyle,
   },
   ref,
 ) {
@@ -62,7 +75,13 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
       backgroundStyle={backgroundStyle}
       style={styles.sheet}
     >
-      <BottomSheetView style={styles.content}>{children}</BottomSheetView>
+      {scrollable ? (
+        <BottomSheetScrollView style={styles.content} contentContainerStyle={contentContainerStyle} showsVerticalScrollIndicator={false}>
+          {children}
+        </BottomSheetScrollView>
+      ) : (
+        <BottomSheetView style={styles.content}>{children}</BottomSheetView>
+      )}
     </BottomSheet>
   );
 });

--- a/packages/mobile/src/components/board-discovery/BoardDetailSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDetailSheet.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useRef } from 'react';
+import { View, StyleSheet, type ColorValue } from 'react-native';
+import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { useTranslation } from 'react-i18next';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { Sheet } from '../Sheet';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { Button } from '../Button';
+import { Avatar } from '../Avatar';
+import { useActiveBoard } from '../../lib/graphql/use-active-board';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+type BoardDetailSheetProps = {
+  board: UserBoard | null;
+  visible: boolean;
+  onClose: () => void;
+  onSetActive: (board: UserBoard) => void;
+};
+
+export function BoardDetailSheet({ board, visible, onClose, onSetActive }: BoardDetailSheetProps) {
+  const { systemColors } = useTheme();
+  const { t } = useTranslation('boards');
+  const { data: activeBoard } = useActiveBoard();
+  const sheetRef = useRef<BottomSheet>(null);
+
+  useEffect(() => {
+    if (visible && board) {
+      sheetRef.current?.snapToIndex(0);
+    } else {
+      sheetRef.current?.close();
+    }
+  }, [visible, board]);
+
+  return (
+    <Sheet ref={sheetRef} snapPoints={['55%', '90%']} onClose={onClose}>
+      {board ? (
+        <BottomSheetScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+          <BoardDetailBody board={board} systemColors={systemColors} t={t} />
+          {activeBoard?.uuid === board.uuid ? (
+            <View style={[styles.activePill, { backgroundColor: systemColors.tertiaryBackground }]}>
+              <Icon name="tick" size={16} color={systemColors.secondaryLabel} />
+              <Text variant="subheadline" color={systemColors.secondaryLabel}>
+                {t('mobile.boardDetail.alreadyActive')}
+              </Text>
+            </View>
+          ) : (
+            <Button title={t('mobile.boardDetail.setActive')} size="large" onPress={() => onSetActive(board)} />
+          )}
+        </BottomSheetScrollView>
+      ) : null}
+    </Sheet>
+  );
+}
+
+type SystemColors = ReturnType<typeof useTheme>['systemColors'];
+type TFn = ReturnType<typeof useTranslation>['t'];
+
+function BoardDetailBody({ board, systemColors, t }: { board: UserBoard; systemColors: SystemColors; t: TFn }) {
+  const subLocation = board.gymName ?? board.locationName ?? undefined;
+  const setNames = (board.setNames ?? []).join(' · ');
+  const sizeText = board.sizeDescription
+    ? `${board.sizeName ?? ''} · ${board.sizeDescription}`.trim().replace(/^· /, '')
+    : (board.sizeName ?? undefined);
+
+  return (
+    <>
+      <View style={styles.header}>
+        <Text variant="title1">{board.name}</Text>
+        {subLocation ? (
+          <Text variant="subheadline" color={systemColors.secondaryLabel}>
+            {subLocation}
+          </Text>
+        ) : null}
+        {board.ownerDisplayName ? (
+          <View style={styles.ownerRow}>
+            <Avatar uri={board.ownerAvatarUrl ?? undefined} name={board.ownerDisplayName} size={28} />
+            <Text variant="footnote" color={systemColors.secondaryLabel}>
+              {board.ownerDisplayName}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+
+      <View style={[styles.statsRow, { backgroundColor: systemColors.tertiaryBackground }]}>
+        <Stat value={board.totalAscents} label={t('mobile.boardDetail.stats.ascents')} systemColors={systemColors} />
+        <StatDivider color={systemColors.separator} />
+        <Stat value={board.uniqueClimbers} label={t('mobile.boardDetail.stats.climbers')} systemColors={systemColors} />
+        <StatDivider color={systemColors.separator} />
+        <Stat value={board.followerCount} label={t('mobile.boardDetail.stats.followers')} systemColors={systemColors} />
+      </View>
+
+      <View style={[styles.specCard, { backgroundColor: systemColors.tertiaryBackground }]}>
+        {board.layoutName ? (
+          <SpecRow label={t('mobile.boardDetail.spec.layout')} value={board.layoutName} systemColors={systemColors} />
+        ) : null}
+        {sizeText ? (
+          <SpecRow label={t('mobile.boardDetail.spec.size')} value={sizeText} systemColors={systemColors} />
+        ) : null}
+        {setNames.length > 0 ? (
+          <SpecRow label={t('mobile.boardDetail.spec.sets')} value={setNames} systemColors={systemColors} />
+        ) : null}
+        <SpecRow
+          label={t('mobile.boardDetail.spec.angle')}
+          value={
+            board.isAngleAdjustable
+              ? `${board.angle}° · ${t('mobile.boardDetail.spec.adjustable')}`
+              : `${board.angle}°`
+          }
+          systemColors={systemColors}
+        />
+      </View>
+
+      {board.description ? (
+        <Text variant="body" color={systemColors.label}>
+          {board.description}
+        </Text>
+      ) : null}
+    </>
+  );
+}
+
+function Stat({ value, label, systemColors }: { value: number; label: string; systemColors: SystemColors }) {
+  return (
+    <View style={styles.stat}>
+      <Text variant="title2" color={systemColors.label}>
+        {value}
+      </Text>
+      <Text variant="caption1" color={systemColors.secondaryLabel}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+function StatDivider({ color }: { color: ColorValue }) {
+  return <View style={[styles.statSeparator, { backgroundColor: color }]} />;
+}
+
+function SpecRow({ label, value, systemColors }: { label: string; value: string; systemColors: SystemColors }) {
+  return (
+    <View style={styles.specRow}>
+      <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.specLabel}>
+        {label}
+      </Text>
+      <Text variant="body" color={systemColors.label} style={styles.specValue}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+    paddingBottom: spacing[8],
+    gap: spacing[4],
+  },
+  header: {
+    gap: spacing[2],
+  },
+  ownerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    marginTop: spacing[1],
+  },
+  statsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: borderRadius.lg,
+    paddingVertical: spacing[3],
+  },
+  stat: {
+    flex: 1,
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  statSeparator: {
+    width: StyleSheet.hairlineWidth,
+    alignSelf: 'stretch',
+    marginVertical: spacing[2],
+  },
+  specCard: {
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    gap: spacing[3],
+  },
+  specRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: spacing[3],
+  },
+  specLabel: {
+    width: 80,
+  },
+  specValue: {
+    flex: 1,
+  },
+  activePill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[2],
+    paddingVertical: spacing[3],
+    borderRadius: borderRadius.lg,
+  },
+});

--- a/packages/mobile/src/components/board-discovery/BoardDetailSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDetailSheet.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { View, StyleSheet, type ColorValue } from 'react-native';
-import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import BottomSheet from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { Sheet } from '../Sheet';
@@ -11,6 +11,7 @@ import { Avatar } from '../Avatar';
 import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { useTheme } from '../../providers/theme-provider';
 import { spacing, borderRadius } from '../../theme/tokens';
+import { getBoardDetailFields, isActiveBoard } from './board-detail-fields';
 
 type BoardDetailSheetProps = {
   board: UserBoard | null;
@@ -34,11 +35,11 @@ export function BoardDetailSheet({ board, visible, onClose, onSetActive }: Board
   }, [visible, board]);
 
   return (
-    <Sheet ref={sheetRef} snapPoints={['55%', '90%']} onClose={onClose}>
+    <Sheet ref={sheetRef} snapPoints={['55%', '90%']} onClose={onClose} scrollable contentContainerStyle={styles.content}>
       {board ? (
-        <BottomSheetScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <>
           <BoardDetailBody board={board} systemColors={systemColors} t={t} />
-          {activeBoard?.uuid === board.uuid ? (
+          {isActiveBoard(board, activeBoard?.uuid) ? (
             <View style={[styles.activePill, { backgroundColor: systemColors.tertiaryBackground }]}>
               <Icon name="tick" size={16} color={systemColors.secondaryLabel} />
               <Text variant="subheadline" color={systemColors.secondaryLabel}>
@@ -48,7 +49,7 @@ export function BoardDetailSheet({ board, visible, onClose, onSetActive }: Board
           ) : (
             <Button title={t('mobile.boardDetail.setActive')} size="large" onPress={() => onSetActive(board)} />
           )}
-        </BottomSheetScrollView>
+        </>
       ) : null}
     </Sheet>
   );
@@ -58,11 +59,7 @@ type SystemColors = ReturnType<typeof useTheme>['systemColors'];
 type TFn = ReturnType<typeof useTranslation>['t'];
 
 function BoardDetailBody({ board, systemColors, t }: { board: UserBoard; systemColors: SystemColors; t: TFn }) {
-  const subLocation = board.gymName ?? board.locationName ?? undefined;
-  const setNames = (board.setNames ?? []).join(' · ');
-  const sizeText = board.sizeDescription
-    ? `${board.sizeName ?? ''} · ${board.sizeDescription}`.trim().replace(/^· /, '')
-    : (board.sizeName ?? undefined);
+  const { subLocation, setNames, sizeText } = getBoardDetailFields(board);
 
   return (
     <>

--- a/packages/mobile/src/components/board-discovery/__tests__/board-detail-fields.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-detail-fields.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { getBoardDetailFields, isActiveBoard } from '../board-detail-fields';
+
+const base = {
+  uuid: 'b-1',
+  name: 'Home Board',
+  gymName: null,
+  locationName: null,
+  setNames: null,
+  sizeName: null,
+  sizeDescription: null,
+} as unknown as UserBoard;
+
+describe('getBoardDetailFields', () => {
+  it('prefers gymName for the subLocation', () => {
+    const board = { ...base, gymName: 'Boulder World', locationName: 'Berlin' } as UserBoard;
+    expect(getBoardDetailFields(board).subLocation).toBe('Boulder World');
+  });
+
+  it('falls back to locationName when there is no gym', () => {
+    const board = { ...base, gymName: null, locationName: 'Berlin' } as UserBoard;
+    expect(getBoardDetailFields(board).subLocation).toBe('Berlin');
+  });
+
+  it('leaves subLocation undefined when neither is set', () => {
+    expect(getBoardDetailFields(base).subLocation).toBeUndefined();
+  });
+
+  it('joins set names with a middot', () => {
+    const board = { ...base, setNames: ['Bolt Ons', 'Screw Ons'] } as UserBoard;
+    expect(getBoardDetailFields(board).setNames).toBe('Bolt Ons · Screw Ons');
+  });
+
+  it('returns an empty string when there are no set names', () => {
+    expect(getBoardDetailFields(base).setNames).toBe('');
+  });
+
+  it('combines size name and description', () => {
+    const board = { ...base, sizeName: '12x12', sizeDescription: 'Home' } as UserBoard;
+    expect(getBoardDetailFields(board).sizeText).toBe('12x12 · Home');
+  });
+
+  it('uses just the description (no leading middot) when size name is missing', () => {
+    const board = { ...base, sizeName: null, sizeDescription: 'Home' } as UserBoard;
+    expect(getBoardDetailFields(board).sizeText).toBe('Home');
+  });
+
+  it('uses just the size name when there is no description', () => {
+    const board = { ...base, sizeName: '12x12', sizeDescription: null } as UserBoard;
+    expect(getBoardDetailFields(board).sizeText).toBe('12x12');
+  });
+
+  it('leaves sizeText undefined when neither size field is set', () => {
+    expect(getBoardDetailFields(base).sizeText).toBeUndefined();
+  });
+});
+
+describe('isActiveBoard', () => {
+  it('is true when the uuid matches the active board', () => {
+    expect(isActiveBoard(base, 'b-1')).toBe(true);
+  });
+
+  it('is false for a different active board', () => {
+    expect(isActiveBoard(base, 'b-2')).toBe(false);
+  });
+
+  it('is false when there is no active board', () => {
+    expect(isActiveBoard(base, null)).toBe(false);
+    expect(isActiveBoard(base, undefined)).toBe(false);
+  });
+});

--- a/packages/mobile/src/components/board-discovery/board-detail-fields.ts
+++ b/packages/mobile/src/components/board-discovery/board-detail-fields.ts
@@ -1,0 +1,25 @@
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+export type BoardDetailFields = {
+  /** Gym name if linked, else the free-text location, else undefined. */
+  subLocation: string | undefined;
+  /** Hold sets joined for display, '' when none. */
+  setNames: string;
+  /** "<size> · <description>", or just the size, or undefined. */
+  sizeText: string | undefined;
+};
+
+/** Derive the display strings shown in the board-detail sheet. Pure. */
+export function getBoardDetailFields(board: UserBoard): BoardDetailFields {
+  const subLocation = board.gymName ?? board.locationName ?? undefined;
+  const setNames = (board.setNames ?? []).join(' · ');
+  const sizeText = board.sizeDescription
+    ? `${board.sizeName ?? ''} · ${board.sizeDescription}`.trim().replace(/^· /, '')
+    : (board.sizeName ?? undefined);
+  return { subLocation, setNames, sizeText };
+}
+
+/** Whether `board` is the user's currently-active board. */
+export function isActiveBoard(board: UserBoard, activeUuid: string | null | undefined): boolean {
+  return board.uuid === activeUuid;
+}

--- a/packages/mobile/src/lib/graphql/use-search-boards-map.ts
+++ b/packages/mobile/src/lib/graphql/use-search-boards-map.ts
@@ -9,7 +9,7 @@
 // useInfiniteQuery like the web hook.
 
 import { useEffect, useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { getHttpClient } from './client';
 import { SEARCH_BOARDS, type SearchBoardsQueryResponse } from './operations';
@@ -75,6 +75,9 @@ export function useSearchBoardsMap({
     select: (response) => response.searchBoards,
     enabled: enabled && (hasCoords || hasQuery),
     staleTime: 30 * 1000,
+    // Keep the previous result visible while the next region's query is in
+    // flight, so map markers don't blink to empty between pans.
+    placeholderData: keepPreviousData,
   });
 
   return {

--- a/packages/web/app/lib/i18n/config.ts
+++ b/packages/web/app/lib/i18n/config.ts
@@ -127,6 +127,17 @@ export const DEFAULT_LOCALE: Locale = 'en-US';
 // i18n-keep climbs:mobile.filter.clearAll
 // Mobile board switcher
 // i18n-keep boards:mobile.boardSwitchError
+// Mobile board-detail sheet (packages/mobile BoardDetailSheet)
+// i18n-keep boards:mobile.boardDetail.setActive
+// i18n-keep boards:mobile.boardDetail.alreadyActive
+// i18n-keep boards:mobile.boardDetail.stats.ascents
+// i18n-keep boards:mobile.boardDetail.stats.climbers
+// i18n-keep boards:mobile.boardDetail.stats.followers
+// i18n-keep boards:mobile.boardDetail.spec.layout
+// i18n-keep boards:mobile.boardDetail.spec.size
+// i18n-keep boards:mobile.boardDetail.spec.sets
+// i18n-keep boards:mobile.boardDetail.spec.angle
+// i18n-keep boards:mobile.boardDetail.spec.adjustable
 // i18n-keep session:playView.tickBar.cancelLabel
 // i18n-keep session:playView.tickBar.decreaseTriesAria
 // i18n-keep session:playView.tickBar.flashSaveLabel

--- a/packages/web/i18n/locales/en-US/boards.json
+++ b/packages/web/i18n/locales/en-US/boards.json
@@ -74,7 +74,6 @@
     "boardDetail": {
       "setActive": "Set as active board",
       "alreadyActive": "Active board",
-      "loadError": "Couldn't load that board.",
       "stats": {
         "ascents": "ascents",
         "climbers": "climbers",

--- a/packages/web/i18n/locales/en-US/boards.json
+++ b/packages/web/i18n/locales/en-US/boards.json
@@ -70,6 +70,23 @@
     "search": {
       "placeholder": "Search by name or place",
       "mapUnavailable": "Update the app to see the map. You can still search by name."
+    },
+    "boardDetail": {
+      "setActive": "Set as active board",
+      "alreadyActive": "Active board",
+      "loadError": "Couldn't load that board.",
+      "stats": {
+        "ascents": "ascents",
+        "climbers": "climbers",
+        "followers": "followers"
+      },
+      "spec": {
+        "layout": "Layout",
+        "size": "Size",
+        "sets": "Sets",
+        "angle": "Angle",
+        "adjustable": "adjustable"
+      }
     }
   },
   "boardEntity": {

--- a/packages/web/i18n/locales/es/boards.json
+++ b/packages/web/i18n/locales/es/boards.json
@@ -74,7 +74,6 @@
     "boardDetail": {
       "setActive": "Usar esta tabla",
       "alreadyActive": "Tabla activa",
-      "loadError": "No se pudo cargar la tabla.",
       "stats": {
         "ascents": "ascensiones",
         "climbers": "escaladores",

--- a/packages/web/i18n/locales/es/boards.json
+++ b/packages/web/i18n/locales/es/boards.json
@@ -70,6 +70,23 @@
     "search": {
       "placeholder": "Busca por nombre o lugar",
       "mapUnavailable": "Actualiza la app para ver el mapa. Puedes buscar por nombre."
+    },
+    "boardDetail": {
+      "setActive": "Usar esta tabla",
+      "alreadyActive": "Tabla activa",
+      "loadError": "No se pudo cargar la tabla.",
+      "stats": {
+        "ascents": "ascensiones",
+        "climbers": "escaladores",
+        "followers": "seguidores"
+      },
+      "spec": {
+        "layout": "Layout",
+        "size": "Tamaño",
+        "sets": "Sets",
+        "angle": "Ángulo",
+        "adjustable": "ajustable"
+      }
     }
   },
   "boardEntity": {

--- a/packages/web/i18n/locales/fr/boards.json
+++ b/packages/web/i18n/locales/fr/boards.json
@@ -74,7 +74,6 @@
     "boardDetail": {
       "setActive": "Utiliser ce board",
       "alreadyActive": "Board actif",
-      "loadError": "Impossible de charger ce board.",
       "stats": {
         "ascents": "ascensions",
         "climbers": "grimpeurs",

--- a/packages/web/i18n/locales/fr/boards.json
+++ b/packages/web/i18n/locales/fr/boards.json
@@ -70,6 +70,23 @@
     "search": {
       "placeholder": "Cherche par nom ou lieu",
       "mapUnavailable": "Mets à jour l'app pour voir la carte. Tu peux chercher par nom."
+    },
+    "boardDetail": {
+      "setActive": "Utiliser ce board",
+      "alreadyActive": "Board actif",
+      "loadError": "Impossible de charger ce board.",
+      "stats": {
+        "ascents": "ascensions",
+        "climbers": "grimpeurs",
+        "followers": "abonnés"
+      },
+      "spec": {
+        "layout": "Layout",
+        "size": "Taille",
+        "sets": "Sets",
+        "angle": "Angle",
+        "adjustable": "ajustable"
+      }
     }
   },
   "boardEntity": {


### PR DESCRIPTION
Stacked on #2451 (Search Boards map mode).

## Summary
- **Board-detail peek sheet.** Tapping a marker or result-strip card on the map now opens a bottom sheet with board details (header, stats, layout/size/sets/angle, description) over the **live map**. The map never unmounts, so closing the sheet returns to the exact same view — no lost context.
- **"Set as active board"** from the sheet closes the map via the same foreground `router.back()` the X button uses, then switches to the Climbs tab. Shows an "Active board" pill instead when it's already active.
- **Marker flicker fix.** The `markers` array is memoised, and the search query keeps previous results visible during a refetch (`placeholderData: keepPreviousData`), so pins no longer blink to empty while panning.

## Why a sheet, not a route
`expo-maps` (v56.0.6, alpha) crashes/freezes when its view is unmounted from a **backgrounded** stack. Pushing a detail route on top of the map and later dismissing it reliably froze the app. A sheet over the still-mounted map sidesteps the native lifecycle entirely, and "Set as active" only ever unmounts the map on the proven-safe foreground path.

## Test plan
- [x] `vp run typecheck:mobile`
- [x] `vp test --project mobile` (1 pre-existing flaky board-constants import; unrelated)
- [x] On device (iPhone 17 Pro, dev client): tap markers → sheet peeks, swipe down → same map preserved; result-strip card → same sheet; "Set as active" → clean dismiss to Climbs (no freeze); already-active board shows the pill; repeated pan/zoom stays smooth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)