### PR TITLE
refactor(mobile): board-detail-sheet review nits

### DIFF
--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -76,6 +76,9 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
       style={styles.sheet}
     >
       {scrollable ? (
+        // style (flex: 1) sizes the scroll viewport to fill the sheet; the
+        // caller's padding goes on contentContainerStyle so it scrolls with the
+        // content rather than clipping the scrollable area.
         <BottomSheetScrollView style={styles.content} contentContainerStyle={contentContainerStyle} showsVerticalScrollIndicator={false}>
           {children}
         </BottomSheetScrollView>

--- a/packages/mobile/src/components/board-discovery/BoardDetailSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDetailSheet.tsx
@@ -26,6 +26,9 @@ export function BoardDetailSheet({ board, visible, onClose, onSetActive }: Board
   const { data: activeBoard } = useActiveBoard();
   const sheetRef = useRef<BottomSheet>(null);
 
+  // Always-mounted sheet: open/close imperatively off the visible+board state.
+  // Selecting a different board while the sheet is open re-runs snapToIndex(0)
+  // (board is a dep) — harmless; gorhom no-ops if already at that stop.
   useEffect(() => {
     if (visible && board) {
       sheetRef.current?.snapToIndex(0);

--- a/packages/mobile/src/components/board-discovery/board-detail-fields.ts
+++ b/packages/mobile/src/components/board-discovery/board-detail-fields.ts
@@ -13,9 +13,7 @@ export type BoardDetailFields = {
 export function getBoardDetailFields(board: UserBoard): BoardDetailFields {
   const subLocation = board.gymName ?? board.locationName ?? undefined;
   const setNames = (board.setNames ?? []).join(' · ');
-  const sizeText = board.sizeDescription
-    ? `${board.sizeName ?? ''} · ${board.sizeDescription}`.trim().replace(/^· /, '')
-    : (board.sizeName ?? undefined);
+  const sizeText = [board.sizeName, board.sizeDescription].filter(Boolean).join(' · ') || undefined;
   return { subLocation, setNames, sizeText };
 }
 


### PR DESCRIPTION
Followup to #2459 (merged) — addresses the remaining review nits.

## Changes
- **`sizeText`**: `[sizeName, sizeDescription].filter(Boolean).join(' · ')` replaces the template-literal + `replace(/^· /, '')` strip. Same output, self-documenting (covered by the existing board-detail-fields tests).
- **Comments**: document `BoardDetailSheet`'s `snapToIndex(0)`-on-board-change behaviour, and the `Sheet` `scrollable` split between `style` (flex viewport) and `contentContainerStyle` (caller padding).

The other two review notes (the `router.back()` → `navigate` sequencing and the snap-point-on-board-change UX) were flagged "fine for now" by the reviewer; no behavioural change needed beyond the clarifying comment.

## Test plan
- [x] `vp run typecheck:mobile`
- [x] `vp test --project mobile board-detail-fields` (12 passed — unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)