### PR TITLE
fix(ble): repair mirror, party hand-off & create-climb sends broken by the queue-pivot

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -11,7 +11,6 @@ import { WebSocketConnectionProvider } from '@/app/components/connection-manager
 import { PartyProvider } from '@/app/components/party-manager/party-context';
 import { BoardSessionBridge } from '@/app/components/persistent-session';
 import type { Metadata } from 'next';
-import { BluetoothProvider } from '@/app/components/board-bluetooth-control/bluetooth-context';
 import { UISearchParamsProvider } from '@/app/components/queue-control/ui-searchparams-provider';
 import { QueueBridgeInjector } from '@/app/components/queue-control/queue-bridge-context';
 import LastUsedBoardTracker from '@/app/components/board-page/last-used-board-tracker';
@@ -113,25 +112,23 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
             <WebSocketConnectionProvider>
               <GraphQLQueueProvider parsedParams={parsedParams} boardDetails={boardDetails}>
                 <PartyProvider>
-                  <BluetoothProvider boardDetails={boardDetails}>
-                    <UISearchParamsProvider>
-                      <QueueBridgeInjector boardDetails={boardDetails} angle={angle} />
+                  <UISearchParamsProvider>
+                    <QueueBridgeInjector boardDetails={boardDetails} angle={angle} />
 
-                      <main
-                        id="content-for-scrollable"
-                        style={{
-                          flex: 1,
-                          paddingLeft: `${themeTokens.spacing[2]}px`,
-                          paddingRight: `${themeTokens.spacing[2]}px`,
-                          paddingTop: 'var(--global-header-height)',
-                          paddingBottom: 'var(--bottom-bar-height)',
-                        }}
-                      >
-                        <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
-                        {children}
-                      </main>
-                    </UISearchParamsProvider>
-                  </BluetoothProvider>
+                    <main
+                      id="content-for-scrollable"
+                      style={{
+                        flex: 1,
+                        paddingLeft: `${themeTokens.spacing[2]}px`,
+                        paddingRight: `${themeTokens.spacing[2]}px`,
+                        paddingTop: 'var(--global-header-height)',
+                        paddingBottom: 'var(--bottom-bar-height)',
+                      }}
+                    >
+                      <BoardSeshHeader boardDetails={boardDetails} angle={angle} />
+                      {children}
+                    </main>
+                  </UISearchParamsProvider>
                 </PartyProvider>
               </GraphQLQueueProvider>
             </WebSocketConnectionProvider>

--- a/packages/web/app/b/[board_slug]/[angle]/layout.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/layout.tsx
@@ -9,7 +9,6 @@ import { ConnectionSettingsProvider } from '@/app/components/connection-manager/
 import { WebSocketConnectionProvider } from '@/app/components/connection-manager/websocket-connection-provider';
 import { PartyProvider } from '@/app/components/party-manager/party-context';
 import { BoardSessionBridge } from '@/app/components/persistent-session';
-import { BluetoothProvider } from '@/app/components/board-bluetooth-control/bluetooth-context';
 import { UISearchParamsProvider } from '@/app/components/queue-control/ui-searchparams-provider';
 import { BoardProvider } from '@/app/components/board-provider/board-provider-context';
 import { QueueBridgeInjector } from '@/app/components/queue-control/queue-bridge-context';
@@ -86,29 +85,27 @@ export default async function BoardSlugLayout(props: PropsWithChildren<{ params:
               <WebSocketConnectionProvider>
                 <GraphQLQueueProvider parsedParams={parsedParams} boardDetails={boardDetails}>
                   <PartyProvider>
-                    <BluetoothProvider boardDetails={boardDetails} boardUuid={board.uuid}>
-                      <UISearchParamsProvider>
-                        <QueueBridgeInjector boardDetails={boardDetails} angle={angle} />
+                    <UISearchParamsProvider>
+                      <QueueBridgeInjector boardDetails={boardDetails} angle={angle} boardUuid={board.uuid} />
 
-                        <main
-                          id="content-for-scrollable"
-                          style={{
-                            flex: 1,
-                            paddingLeft: `${themeTokens.spacing[2]}px`,
-                            paddingRight: `${themeTokens.spacing[2]}px`,
-                            paddingTop: 'var(--global-header-height)',
-                            paddingBottom: 'var(--bottom-bar-height)',
-                          }}
-                        >
-                          <BoardSeshHeader
-                            boardDetails={boardDetails}
-                            angle={angle}
-                            isAngleAdjustable={board.isAngleAdjustable}
-                          />
-                          {children}
-                        </main>
-                      </UISearchParamsProvider>
-                    </BluetoothProvider>
+                      <main
+                        id="content-for-scrollable"
+                        style={{
+                          flex: 1,
+                          paddingLeft: `${themeTokens.spacing[2]}px`,
+                          paddingRight: `${themeTokens.spacing[2]}px`,
+                          paddingTop: 'var(--global-header-height)',
+                          paddingBottom: 'var(--bottom-bar-height)',
+                        }}
+                      >
+                        <BoardSeshHeader
+                          boardDetails={boardDetails}
+                          angle={angle}
+                          isAngleAdjustable={board.isAngleAdjustable}
+                        />
+                        {children}
+                      </main>
+                    </UISearchParamsProvider>
                   </PartyProvider>
                 </GraphQLQueueProvider>
               </WebSocketConnectionProvider>

--- a/packages/web/app/components/board-bluetooth-control/__tests__/auto-connect-handler.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/auto-connect-handler.test.tsx
@@ -150,7 +150,7 @@ describe('AutoConnectHandler', () => {
     expect(mockConnect).not.toHaveBeenCalled();
   });
 
-  it('does not trigger twice on re-render (triggeredRef guard)', async () => {
+  it('does not trigger twice on re-render while the same param is still present', async () => {
     mockSearchParams = new URLSearchParams('autoConnect=751737');
 
     const { rerender } = render(<AutoConnectHandler connect={mockConnect} isBluetoothSupported />);
@@ -169,6 +169,54 @@ describe('AutoConnectHandler', () => {
     });
 
     expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fires for a NEW serial without remounting (persistent root handler)', async () => {
+    // The handler lives once at the app root and never remounts on navigation.
+    // A new ?autoConnect serial (mismatch "Switch" / a second board-discovery
+    // tap) must still auto-connect — a fire-once boolean would swallow it.
+    mockSearchParams = new URLSearchParams('autoConnect=751737');
+    const { rerender } = render(<AutoConnectHandler connect={mockConnect} isBluetoothSupported />);
+
+    await act(async () => {
+      await vi.waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(1));
+    });
+    expect(mockConnect).toHaveBeenLastCalledWith('p1r12p2r13', false, '751737');
+
+    // A different board is chosen — new serial arrives on the SAME handler.
+    mockSearchParams = new URLSearchParams('autoConnect=480221');
+    rerender(<AutoConnectHandler connect={mockConnect} isBluetoothSupported />);
+
+    await act(async () => {
+      await vi.waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(2));
+    });
+    expect(mockConnect).toHaveBeenLastCalledWith('p1r12p2r13', false, '480221');
+  });
+
+  it('re-fires for the SAME serial after the param is stripped and re-added', async () => {
+    // After firing we strip the param; a later navigation back to the same
+    // board re-adds it. The latch resets when the param is absent, so the
+    // repeat connects again.
+    mockSearchParams = new URLSearchParams('autoConnect=751737');
+    const { rerender } = render(<AutoConnectHandler connect={mockConnect} isBluetoothSupported />);
+
+    await act(async () => {
+      await vi.waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(1));
+    });
+
+    // Param stripped (mockReplace is a no-op, so simulate it here).
+    mockSearchParams = new URLSearchParams();
+    rerender(<AutoConnectHandler connect={mockConnect} isBluetoothSupported />);
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Same serial navigated to again.
+    mockSearchParams = new URLSearchParams('autoConnect=751737');
+    rerender(<AutoConnectHandler connect={mockConnect} isBluetoothSupported />);
+    await act(async () => {
+      await vi.waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(2));
+    });
   });
 
   it('rejects non-alphanumeric serial numbers', async () => {

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -234,6 +234,20 @@ describe('BluetoothProvider', () => {
       expect(result.current.isConnected).toBe(false);
       expect(result.current.loading).toBe(false);
     });
+
+    it('renders an inert context with null boardDetails (off-board route)', () => {
+      // The single root-level provider spans every route; off a board route it
+      // gets null boardDetails and must still provide a usable (inert) context
+      // rather than throwing for any stray consumer.
+      const NullWrapper = ({ children }: { children: React.ReactNode }) => (
+        <BluetoothProvider boardDetails={null}>{children}</BluetoothProvider>
+      );
+      const { result } = renderHook(() => useBluetoothContext(), { wrapper: NullWrapper });
+
+      expect(result.current.boardDetails).toBeNull();
+      expect(result.current.isConnected).toBe(false);
+      expect(typeof result.current.sendFramesToBoard).toBe('function');
+    });
   });
 
   describe('auto-send on climb change', () => {
@@ -444,11 +458,13 @@ describe('BluetoothProvider', () => {
       expect(mockSendFramesToBoard).toHaveBeenLastCalledWith('p5r16', false, expect.any(AbortSignal), 'climb-3');
     });
 
-    it('deduplicates back-to-back same-uuid broadcasts — single send + single confirmClimbOnWall', async () => {
-      // The reducer now lets duplicate CurrentClimbChanged events through
-      // (so the BLE phone re-sends on every event, including takeControl
-      // re-broadcasts of the same climb). The AutoSender must skip the
-      // re-send so analytics + confirmClimbOnWall don't double-fire.
+    it('deduplicates the WRITE for byte-identical re-broadcasts but re-confirms the wall', async () => {
+      // The reducer lets duplicate CurrentClimbChanged events through (so the
+      // BLE phone reacts to every event, including a peer's takeControl
+      // re-broadcast of the same climb). The AutoSender skips the physical
+      // re-WRITE (no double GATT write, no double "Climb Sent" analytics) — but
+      // still re-emits the wall-confirm so a non-BLE hand-off taker's 2-second
+      // timer clears even though the wall already shows the climb.
       mockPersistentSessionState = { session: { id: 'session-1' } };
       mockSendFramesToBoard.mockResolvedValue(true);
       mockCurrentClimbQueueItem = {
@@ -468,7 +484,7 @@ describe('BluetoothProvider', () => {
         });
       });
 
-      // Same uuid re-broadcast (new object identity, but uuid unchanged).
+      // Same uuid + frames + mirror re-broadcast (new object identity).
       mockCurrentClimbQueueItem = {
         climb: { uuid: 'climb-1', frames: 'p1r12', mirrored: false },
       };
@@ -480,14 +496,74 @@ describe('BluetoothProvider', () => {
         await Promise.resolve();
       });
 
-      // No additional send / confirm fired for the duplicate.
+      // No additional physical write or success analytics for the duplicate...
       expect(mockSendFramesToBoard).toHaveBeenCalledTimes(1);
-      expect(mockConfirmClimbOnWall).toHaveBeenCalledTimes(1);
       expect(
         mockTrack.mock.calls.filter(
           (call) => call[0] === 'Climb Sent to Board Success' && call[1]?.climbUuid === 'climb-1',
         ),
       ).toHaveLength(1);
+      // ...but the wall-confirm re-fires so a hand-off taker's timer clears.
+      expect(mockConfirmClimbOnWall).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-sends when the same climb is mirrored (same uuid, mirror flipped)', async () => {
+      // Regression: the old uuid-only dedup swallowed mirror toggles, so the
+      // board only mirrored after a disconnect/reconnect.
+      mockSendFramesToBoard.mockResolvedValue(true);
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'climb-1', frames: 'p1r12', mirrored: false },
+      };
+      mockBluetoothState.isConnected = true;
+
+      const { rerender } = renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.waitFor(() => expect(mockSendFramesToBoard).toHaveBeenCalledTimes(1));
+      });
+      expect(mockSendFramesToBoard).toHaveBeenLastCalledWith('p1r12', false, expect.any(AbortSignal), 'climb-1');
+
+      // Mirror the current climb: same uuid + frames, mirrored now true.
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'climb-1', frames: 'p1r12', mirrored: true },
+      };
+      rerender();
+
+      await act(async () => {
+        await vi.waitFor(() => expect(mockSendFramesToBoard).toHaveBeenCalledTimes(2));
+      });
+      expect(mockSendFramesToBoard).toHaveBeenLastCalledWith('p1r12', true, expect.any(AbortSignal), 'climb-1');
+    });
+
+    it('re-sends when the same climb uuid gets edited frames (create-form live preview)', async () => {
+      // Regression: building a climb reuses a stable uuid while the frames
+      // change on every hold edit; the uuid-only dedup froze the wall.
+      mockSendFramesToBoard.mockResolvedValue(true);
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'draft-1', frames: 'p1r12', mirrored: false },
+      };
+      mockBluetoothState.isConnected = true;
+
+      const { rerender } = renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.waitFor(() => expect(mockSendFramesToBoard).toHaveBeenCalledTimes(1));
+      });
+
+      // Edit a hold: same uuid, new frames.
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'draft-1', frames: 'p1r12p2r13', mirrored: false },
+      };
+      rerender();
+
+      await act(async () => {
+        await vi.waitFor(() => expect(mockSendFramesToBoard).toHaveBeenCalledTimes(2));
+      });
+      expect(mockSendFramesToBoard).toHaveBeenLastCalledWith('p1r12p2r13', false, expect.any(AbortSignal), 'draft-1');
     });
   });
 

--- a/packages/web/app/components/board-bluetooth-control/auto-connect-handler.tsx
+++ b/packages/web/app/components/board-bluetooth-control/auto-connect-handler.tsx
@@ -25,25 +25,40 @@ export function AutoConnectHandler({ connect, isBluetoothSupported }: AutoConnec
   const router = useLocaleRouter();
   const { climbSearchResults, hasDoneFirstFetch } = useSearchData();
   const { setCurrentClimb } = useQueueActions();
-  const triggeredRef = useRef(false);
+  // The serial we've already acted on for the *current* occurrence of the
+  // ?autoConnect param. NOT a fire-once boolean: this handler is mounted once
+  // at the app root (inside the persistent BluetoothProvider) and never
+  // remounts across navigation, so a boolean latch would swallow every
+  // auto-connect after the first — breaking the board-config mismatch "Switch"
+  // hand-off and repeated board-discovery taps, both of which client-navigate
+  // with a fresh ?autoConnect each time. We strip the param after firing, so
+  // resetting to null when it's absent lets the next occurrence (even the same
+  // serial) auto-connect again, while still ignoring re-renders within one
+  // occurrence.
+  const triggeredForSerialRef = useRef<string | null>(null);
 
   const autoConnectSerial = searchParams.get('autoConnect');
 
   useEffect(() => {
+    if (!autoConnectSerial) {
+      // Param absent (initial load, or stripped after a prior auto-connect) —
+      // clear the latch so a later navigation re-adding it fires.
+      triggeredForSerialRef.current = null;
+      return;
+    }
     // Match the route's Zod schema: 1–64 chars, alphanumerics plus hyphens.
     // The mismatch-dialog "Switch" flow appends serials directly, including
     // hyphenated ones (KB-99, SN-1, etc.), so the validator must accept them.
     if (
-      !autoConnectSerial ||
       !/^[A-Za-z0-9-]+$/.test(autoConnectSerial) ||
       autoConnectSerial.length > 64 ||
-      triggeredRef.current
+      triggeredForSerialRef.current === autoConnectSerial
     )
       return;
     if (!hasDoneFirstFetch || !climbSearchResults || climbSearchResults.length === 0) return;
     if (!isBluetoothSupported) return;
 
-    triggeredRef.current = true;
+    triggeredForSerialRef.current = autoConnectSerial;
 
     // Remove the param from URL immediately to prevent re-trigger
     const params = new URLSearchParams(searchParams.toString());

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -55,9 +55,11 @@ type BluetoothContextValue = {
   ) => Promise<boolean | undefined>;
   /** Send a "clear all LEDs" packet to the connected board. */
   clearBoard: () => Promise<boolean | undefined>;
-  /** Board configuration for the current route — exposed so light-show
-   * features (party mode) can read holdsData and edge bounds. */
-  boardDetails: BoardDetails;
+  /** Board configuration for the current route, or null when the single
+   * root-level provider is mounted off a board route. Consumers that need a
+   * guaranteed board (e.g. the light-show drawer) take it as a prop from a
+   * board-scoped parent instead of reading it here. */
+  boardDetails: BoardDetails | null;
   /** Which non-queue light show is driving the board, if any. The
    * auto-sender stops emitting queue frames whenever this is non-'off'.
    * 'glyphs' spells BOARDSESH across the wall; 'disco' strobes the
@@ -133,12 +135,18 @@ function BluetoothAutoSender({
   // as the old abort-and-restart pattern, but no overlapping GATT calls.
   const isWritingRef = useRef(false);
   const pendingClimbRef = useRef<ClimbQueueItem | null>(null);
-  // Deduplicate same-uuid broadcasts. The reducer now lets duplicate
+  // Deduplicate truly-identical re-broadcasts. The reducer lets duplicate
   // CurrentClimbChanged events through (so the BLE phone re-sends on each
-  // event), but the wall is already showing the climb — re-sending double-
-  // counts analytics and double-fires confirmClimbOnWall. Skip the send when
-  // the pending uuid matches the last one we actually wrote.
-  const lastSentUuidRef = useRef<string | null>(null);
+  // event) — but the wall is already showing those exact pixels, so re-sending
+  // would double-count analytics and double-fire confirmClimbOnWall. We key the
+  // skip on the *rendered payload* (climb uuid + frames + mirror), NOT the uuid
+  // alone: a mirror toggle, a hold edit (create form), or a driver hand-off all
+  // keep the same uuid while needing a fresh write, and a uuid-only key swallows
+  // them (the wall would only update after a disconnect/reconnect reset this
+  // ref — exactly the regression users reported). A genuine duplicate (same
+  // uuid, frames, and mirror) still skips the write but re-emits the wall-confirm
+  // so a hand-off taker's 2s timer clears even though no physical re-send ran.
+  const lastSentSignatureRef = useRef<string | null>(null);
   // Single AbortController lives across the AutoSender's lifetime. Aborted
   // exactly once on unmount so the in-flight drain loop (a) cancels the
   // underlying adapter.write via the signal, and (b) returns before firing
@@ -169,14 +177,6 @@ function BluetoothAutoSender({
         while (toSend) {
           if (signal?.aborted) return;
           const item = toSend;
-          // Deduplicate same-uuid re-broadcasts. The board is idempotent so a
-          // re-send is functionally fine, but we'd double-fire analytics and
-          // confirmClimbOnWall — skip the send entirely instead.
-          if (item.climb.uuid === lastSentUuidRef.current) {
-            toSend = pendingClimbRef.current;
-            pendingClimbRef.current = null;
-            continue;
-          }
           // For variable-speed climbs (`frames` is a sequence of comma-
           // separated delta frames using `p<id>r<role>` for sets and
           // `x<id>` for offs) the BLE encoder doesn't understand commas
@@ -192,19 +192,33 @@ function BluetoothAutoSender({
           // by lighting the wrong colours. The playback engine on /play
           // handles subsequent ticks for multi-frame climbs.
           const rawFrames = item.climb.frames ?? '';
+          const mirrored = !!item.climb.mirrored;
+          // Skip only a byte-identical re-broadcast (same climb, same frames,
+          // same mirror). A changed climb, an edited hold, or a flipped mirror
+          // all change this signature and fall through to a real write.
+          const sendSignature = `${item.climb.uuid}::${rawFrames}::${mirrored ? 1 : 0}`;
+          if (sendSignature === lastSentSignatureRef.current) {
+            // Same pixels already on the wall — skip the physical write (so we
+            // don't double-count analytics) but still confirm so a hand-off
+            // taker's 2s wall-confirm timer clears; the wall already shows it.
+            onWallConfirmedRef.current(item.climb.uuid);
+            toSend = pendingClimbRef.current;
+            pendingClimbRef.current = null;
+            continue;
+          }
           const isSingleFrame = rawFrames.length > 0 && !rawFrames.includes(',') && !rawFrames.includes('x');
           const firstFrame = isSingleFrame
             ? rawFrames
             : (accumulatedMapsToFrameStrings(accumulateFramesToMaps(rawFrames, boardName), boardName)[0] ?? '');
           const climbHoldCount = countClimbHolds(firstFrame);
           try {
-            const result = await sendFramesToBoard(firstFrame, !!item.climb.mirrored, signal, item.climb.uuid);
+            const result = await sendFramesToBoard(firstFrame, mirrored, signal, item.climb.uuid);
             // After the await, the AutoSender may have unmounted — skip the
             // post-send side effects so a navigated-away climb doesn't fire
             // analytics or confirmClimbOnWall for a session the user has left.
             if (signal?.aborted) return;
             if (result === true) {
-              lastSentUuidRef.current = item.climb.uuid;
+              lastSentSignatureRef.current = sendSignature;
               track('Climb Sent to Board Success', {
                 climbUuid: item.climb?.uuid,
                 boardLayout: layoutName,
@@ -249,7 +263,9 @@ export function BluetoothProvider({
   boardUuid,
   children,
 }: {
-  boardDetails: BoardDetails;
+  /** Null when the single root-level provider is mounted off a board route;
+   * BLE stays inert (connect/send are no-ops) until a board route supplies it. */
+  boardDetails: BoardDetails | null;
   /** Saved board UUID when this provider sits under a /b/{slug}/... route. */
   boardUuid?: string;
   children: React.ReactNode;
@@ -316,7 +332,7 @@ export function BluetoothProvider({
   );
 
   const { isConnected, loading, connect, disconnect, sendFramesToBoard, pickerState } = useBoardBluetooth({
-    boardDetails,
+    boardDetails: boardDetails ?? undefined,
     boardUuid,
     ledColorOverrides,
     onConnectSuccess: handleConnectSuccess,
@@ -580,7 +596,9 @@ export function BluetoothProvider({
 
   const handlePickerSelect = useCallback(
     (deviceId: string) => {
-      if (!activePickerState) return;
+      // No board on this route → nothing to match against; the picker can't be
+      // open here anyway (connect needs boardDetails), so bail defensively.
+      if (!activePickerState || !boardDetails) return;
       const decision = decidePickerSelection(deviceId, activePickerState.devices, activeResolvedBoards, boardDetails);
       if (decision.kind === 'forward') {
         activePickerState.handleSelect(deviceId);
@@ -628,7 +646,7 @@ export function BluetoothProvider({
 
   return (
     <BluetoothContext.Provider value={value}>
-      {isConnected && partyMode === 'off' && (
+      {isConnected && partyMode === 'off' && boardDetails && (
         <BluetoothAutoSender
           sendFramesToBoard={sendFramesToBoard}
           layoutName={boardDetails.layout_name ?? ''}
@@ -666,6 +684,16 @@ export function useBluetoothContext() {
     throw new Error('useBluetoothContext must be used within a BluetoothProvider');
   }
   return context;
+}
+
+/**
+ * Like `useBluetoothContext` but returns null instead of throwing when no
+ * provider is mounted. For components (e.g. the create-climb form) that render
+ * both inside the app shell (provider present) and in isolated unit tests
+ * (no provider) — mirrors `useOptionalQueueActions`.
+ */
+export function useOptionalBluetoothContext() {
+  return useContext(BluetoothContext);
 }
 
 export { BluetoothContext };

--- a/packages/web/app/components/board-page/__tests__/light-control-drawer.test.tsx
+++ b/packages/web/app/components/board-page/__tests__/light-control-drawer.test.tsx
@@ -36,6 +36,7 @@ vi.mock('../../graphql-queue', () => ({
 }));
 
 import { LightControlDrawer } from '../light-control-drawer';
+import type { BoardDetails } from '@/app/lib/types';
 
 const boardDetails = {
   board_name: 'kilter',
@@ -44,7 +45,7 @@ const boardDetails = {
   edge_right: 100,
   edge_top: 100,
   edge_bottom: 0,
-};
+} as unknown as BoardDetails;
 
 describe('LightControlDrawer light-show failure guard', () => {
   beforeEach(() => {
@@ -55,7 +56,7 @@ describe('LightControlDrawer light-show failure guard', () => {
       sendFramesToBoard: mockSendFramesToBoard,
       clearBoard: mockClearBoard,
       disconnect: vi.fn(),
-      boardDetails,
+      // boardDetails now comes in as a prop, not from the BLE context.
       partyMode: 'glyphs',
       setPartyMode: mockSetPartyMode,
       ledColorOverrides: {},
@@ -71,7 +72,7 @@ describe('LightControlDrawer light-show failure guard', () => {
     // Every write fails — a dead connection while the show is running.
     mockSendFramesToBoard.mockResolvedValue(false);
 
-    render(<LightControlDrawer open onClose={() => {}} />);
+    render(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
 
     // Mount tick (failure 1) + one interval tick (failure 2) trips the guard.
     await act(async () => {
@@ -85,7 +86,7 @@ describe('LightControlDrawer light-show failure guard', () => {
   it('keeps the show running while writes succeed', async () => {
     mockSendFramesToBoard.mockResolvedValue(true);
 
-    render(<LightControlDrawer open onClose={() => {}} />);
+    render(<LightControlDrawer open onClose={() => {}} boardDetails={boardDetails} />);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1400);

--- a/packages/web/app/components/board-page/light-control-drawer.tsx
+++ b/packages/web/app/components/board-page/light-control-drawer.tsx
@@ -28,6 +28,7 @@ import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { GLYPHS, PARTY_LETTERS, buildPartyFrames, mapGlyphToHolds } from './party-glyphs';
 import { CUSTOMISABLE_LED_ROLES, type CustomisableLedRole } from '@/app/lib/led-color-overrides-db';
 import type { BoardName } from '@boardsesh/shared-schema';
+import type { BoardDetails } from '@/app/lib/types';
 
 const PARTY_TICK_MS = 600;
 const DISCO_TICK_MS = 450;
@@ -40,6 +41,10 @@ const LIGHT_SHOW_MAX_CONSECUTIVE_FAILURES = 2;
 type LightControlDrawerProps = {
   open: boolean;
   onClose: () => void;
+  /** Board config for this route. Passed as a prop (not read from the BLE
+   * context) because the single root-level BluetoothProvider exposes a nullable
+   * boardDetails; this drawer only ever renders under a real board. */
+  boardDetails: BoardDetails;
 };
 
 /**
@@ -75,7 +80,7 @@ function getDefaultRoleColor(role: CustomisableLedRole, boardName: BoardName): s
   return HOLD_STATE_MAP[boardName]?.[code]?.color ?? '#0000ff';
 }
 
-export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, onClose }) => {
+export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, onClose, boardDetails }) => {
   const { t } = useTranslation('common');
   const { showMessage } = useSnackbar();
   const {
@@ -83,7 +88,6 @@ export const LightControlDrawer: React.FC<LightControlDrawerProps> = ({ open, on
     sendFramesToBoard,
     clearBoard,
     disconnect,
-    boardDetails,
     partyMode,
     setPartyMode,
     ledColorOverrides,

--- a/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
@@ -827,6 +827,51 @@ describe('CreateClimbForm — Aurora rendering', () => {
     });
   });
 
+  it('stops the direct board preview once the climb is Set Active (queue path owns the wall)', async () => {
+    // While building (queueItemUuid == null) hold edits send directly; once the
+    // climb lands in the queue, the replaceQueueItem → AutoSender path owns the
+    // wall, so the direct preview must stand down to avoid double-writes.
+    vi.mocked(useOptionalBluetoothContext).mockReturnValue({
+      isConnected: true,
+      sendFramesToBoard: mockSendFramesToBoard,
+    } as unknown as ReturnType<typeof useOptionalBluetoothContext>);
+    mockSetCurrentClimb.mockResolvedValue({ uuid: 'queue-item-1' });
+    mockQueueActions = {
+      setCurrentClimb: mockSetCurrentClimb,
+      replaceQueueItem: mockReplaceQueueItem,
+      addToQueue: vi.fn(),
+      removeFromQueue: vi.fn(),
+    };
+    mockAuroraCreateState = {
+      isValid: true,
+      totalHolds: 1,
+      litUpHoldsMap: { 1: { state: 'HAND', color: '#blue', displayColor: '#blue' } } as LitUpHoldsMap,
+    };
+    vi.mocked(useCreateClimb).mockReturnValue({
+      litUpHoldsMap: mockAuroraCreateState.litUpHoldsMap,
+      setHoldState: mockSetAuroraHoldState,
+      startingCount: 0,
+      finishCount: 0,
+      totalHolds: 1,
+      isValid: true,
+      resetHolds: mockResetAuroraHolds,
+      generateFramesString: mockGenerateAuroraFramesString,
+      loadHolds: mockLoadAuroraHolds,
+    });
+
+    renderAuroraComponent();
+
+    // Mount preview send fires while the climb is still a draft.
+    await waitFor(() => expect(mockSendFramesToBoard).toHaveBeenCalledTimes(1));
+
+    // Set Active → queueItemUuid is set → direct preview must stand down.
+    mockSendFramesToBoard.mockClear();
+    fireEvent.click(screen.getByLabelText('Set as active climb'));
+    await waitFor(() => expect(mockReplaceQueueItem).toHaveBeenCalled());
+
+    expect(mockSendFramesToBoard).not.toHaveBeenCalled();
+  });
+
   it('does not show duplicate checking alert for Aurora', () => {
     renderAuroraComponent();
     expect(screen.queryByText('createClimbForm.alerts.checkingMoonBoardDuplicate')).toBeNull();

--- a/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
@@ -6,7 +6,7 @@ import CreateClimbForm from '../create-climb-form';
 import { useBoardProvider } from '../../board-provider/board-provider-context';
 import { useCreateClimb } from '../use-create-climb';
 import { useMoonBoardCreateClimb } from '../use-moonboard-create-climb';
-import { useBoardBluetooth } from '../../board-bluetooth-control/use-board-bluetooth';
+import { useOptionalBluetoothContext } from '../../board-bluetooth-control/bluetooth-context';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 import type { LitUpHoldsMap } from '@boardsesh/shared-schema';
 import type { BoardContextType } from '../../board-provider/board-provider-context';
@@ -65,8 +65,8 @@ vi.mock('../../board-provider/board-provider-context', () => ({
   })),
 }));
 
-vi.mock('../../board-bluetooth-control/use-board-bluetooth', () => ({
-  useBoardBluetooth: vi.fn(() => ({ isConnected: false, sendFramesToBoard: mockSendFramesToBoard })),
+vi.mock('../../board-bluetooth-control/bluetooth-context', () => ({
+  useOptionalBluetoothContext: vi.fn(() => ({ isConnected: false, sendFramesToBoard: mockSendFramesToBoard })),
 }));
 
 vi.mock('../use-create-climb', () => ({
@@ -799,10 +799,10 @@ describe('CreateClimbForm — Aurora rendering', () => {
   });
 
   it('sends frames to board via Bluetooth when connected and holds change', async () => {
-    vi.mocked(useBoardBluetooth).mockReturnValue({
+    vi.mocked(useOptionalBluetoothContext).mockReturnValue({
       isConnected: true,
       sendFramesToBoard: mockSendFramesToBoard,
-    } as unknown as ReturnType<typeof useBoardBluetooth>);
+    } as unknown as ReturnType<typeof useOptionalBluetoothContext>);
     mockAuroraCreateState = {
       isValid: true,
       totalHolds: 1,

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -42,7 +42,7 @@ import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { useCreateClimb } from './use-create-climb';
 import { useMoonBoardCreateClimb } from './use-moonboard-create-climb';
-import { useBoardBluetooth } from '../board-bluetooth-control/use-board-bluetooth';
+import { useOptionalBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
 import type { MoonBoardClimbDuplicateMatch, UpdateClimbInput } from '@boardsesh/shared-schema';
 import type { BoardDetails, BoardName, Climb } from '@/app/lib/types';
 import { convertLitUpHoldsStringToMap } from '../board-renderer/util';
@@ -181,10 +181,13 @@ export default function CreateClimbForm({
   const setLitUpHoldsMap = boardType === 'moonboard' ? moonboardClimb.setLitUpHoldsMap : undefined;
   const loadAuroraHolds = boardType === 'aurora' ? auroraClimb.loadHolds : undefined;
 
-  // Bluetooth for Aurora boards
-  const { isConnected, sendFramesToBoard } = useBoardBluetooth({
-    boardDetails: boardType === 'aurora' ? boardDetails : undefined,
-  });
+  // Bluetooth for Aurora boards. Share the single root-level connection (the
+  // one the lightbulb actually drives) instead of spinning up a second adapter
+  // that nothing ever connects. Optional so the form still renders in isolated
+  // unit tests that don't mount a BluetoothProvider.
+  const bluetooth = useOptionalBluetoothContext();
+  const isConnected = bluetooth?.isConnected ?? false;
+  const sendFramesToBoard = bluetooth?.sendFramesToBoard;
 
   // Refs
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -440,13 +443,18 @@ export default function CreateClimbForm({
       : 'This hold pattern already exists. Change at least one hold to save.';
   }, [moonBoardDuplicateMatch]);
 
-  // Send frames to board whenever litUpHoldsMap changes (Aurora only)
+  // Live board preview while BUILDING: push raw frames to the shared connection
+  // on every hold edit. Only while the climb isn't in the queue yet
+  // (queueItemUuid == null) — once it's been Set Active / saved, the queue's
+  // replaceQueueItem → BluetoothAutoSender path owns the wall, so sending here
+  // too would double-write. Local-only (no WS broadcast), matching the pivot's
+  // "building doesn't broadcast" rule.
   useEffect(() => {
+    if (queueItemUuid != null) return;
     if (boardType === 'aurora' && isConnected && generateFramesString) {
-      const frames = generateFramesString();
-      void sendFramesToBoard(frames);
+      void sendFramesToBoard?.(generateFramesString());
     }
-  }, [boardType, litUpHoldsMap, isConnected, generateFramesString, sendFramesToBoard]);
+  }, [boardType, litUpHoldsMap, isConnected, generateFramesString, sendFramesToBoard, queueItemUuid]);
 
   // As soon as the user edits the climb after a successful save, flip the
   // button back to its normal "Save" state so they can save the revision.
@@ -519,7 +527,7 @@ export default function CreateClimbForm({
     // form, not party state.
     setQueueItemUuid(null);
     if (boardType === 'aurora' && isConnected) {
-      void sendFramesToBoard('');
+      void sendFramesToBoard?.('');
     }
     if (boardType === 'moonboard') {
       setUserGrade(undefined);

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -610,9 +610,9 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     // needed; there's no other device that might emit a wall-confirm).
     // Tap when paired sends the displayed climb to the wall — `takeControl`
     // short-circuits to `setCurrentClimb` in solo, which the BLE AutoSender
-    // picks up. Re-pressing the same climb is deduped at the BLE layer via
-    // `lastSentUuidRef`; the deeper "actually disconnect BLE" path stays on
-    // the long-press into the light-control drawer.
+    // picks up. Re-pressing the exact same frames is deduped at the BLE layer
+    // by the send-payload signature; the deeper "actually disconnect BLE" path
+    // stays on the long-press into the light-control drawer.
     if (!isPersistentSessionActive) {
       if (!isBluetoothConnected) {
         track('Wall Control Taken', {
@@ -1196,7 +1196,9 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
           lightbulb. Hosts disco/glyph light shows, palette customisation,
           and the manual BLE disconnect that the old ShareBoardButton
           used to own. Mounted lazily on first open. */}
-      {hasOpenedLightDrawer && <LightControlDrawer open={lightDrawerOpen} onClose={handleCloseLightDrawer} />}
+      {hasOpenedLightDrawer && (
+        <LightControlDrawer open={lightDrawerOpen} onClose={handleCloseLightDrawer} boardDetails={boardDetails} />
+      )}
     </SwipeableDrawer>
   );
 };

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -59,12 +59,14 @@ export default function PersistentSessionWrapper({ children, boardConfigs }: Per
             <SearchDrawerBridgeProvider>
               <StatsFilterBridgeProvider>
                 <ProfileHeaderShareProvider>
-                  <GlobalHeader boardConfigs={boardConfigs} />
-                  {children}
-                  <RootBottomBar boardConfigs={boardConfigs} />
-                  <RootSessionSummaryDialog />
-                  <RootSeshSettingsDrawer />
-                  <SessionWakeLock />
+                  <RootBluetoothProvider>
+                    <GlobalHeader boardConfigs={boardConfigs} />
+                    {children}
+                    <RootBottomBar boardConfigs={boardConfigs} />
+                    <RootSessionSummaryDialog />
+                    <RootSeshSettingsDrawer />
+                    <SessionWakeLock />
+                  </RootBluetoothProvider>
                 </ProfileHeaderShareProvider>
               </StatsFilterBridgeProvider>
             </SearchDrawerBridgeProvider>
@@ -72,6 +74,27 @@ export default function PersistentSessionWrapper({ children, boardConfigs }: Per
         </QueueBridgeProvider>
       </PersistentSessionProvider>
     </PartyProfileProvider>
+  );
+}
+
+/**
+ * Single, app-wide BluetoothProvider. Mounted once here so the *same* BLE
+ * adapter + AutoSender are shared by both the persistent bottom bar (lightbulb,
+ * play drawer) and the route page content (climb list, create-climb form) —
+ * previously each route layout and the bottom bar mounted their own provider,
+ * so a connection made via the lightbulb was invisible to the page content and
+ * two dormant AutoSenders/AutoConnectHandlers raced on a last-wins board.
+ *
+ * boardDetails comes from the queue bridge (null on off-board routes, where BLE
+ * stays inert). Living at the root means the connection now persists across
+ * route navigation instead of tearing down when a route layout unmounts.
+ */
+function RootBluetoothProvider({ children }: { children: React.ReactNode }) {
+  const { boardDetails, boardUuid } = useQueueBridgeBoardInfo();
+  return (
+    <BluetoothProvider boardDetails={boardDetails} boardUuid={boardUuid ?? undefined}>
+      {children}
+    </BluetoothProvider>
   );
 }
 
@@ -220,9 +243,9 @@ export function RootBottomBar({ boardConfigs }: { boardConfigs: BoardConfigData 
           <BoardProvider boardName={boardDetails.board_name}>
             <ConnectionSettingsProvider>
               <WebSocketConnectionProvider>
-                <BluetoothProvider boardDetails={boardDetails}>
-                  <RootQueueControlBarWithProviders boardDetails={boardDetails} angle={angle} />
-                </BluetoothProvider>
+                {/* BLE is provided once at the root (RootBluetoothProvider), an
+                    ancestor of this bar — no per-bar provider needed. */}
+                <RootQueueControlBarWithProviders boardDetails={boardDetails} angle={angle} />
               </WebSocketConnectionProvider>
             </ConnectionSettingsProvider>
           </BoardProvider>

--- a/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
@@ -1415,7 +1415,7 @@ describe('queue-bridge-context', () => {
      * The hook reads from the bridge's QueueContext (root level), while
      * the injector reads from the inner QueueContext (board route level).
      */
-    function renderInjector(boardRouteCtx: GraphQLQueueContextType | undefined) {
+    function renderInjector(boardRouteCtx: GraphQLQueueContextType | undefined, boardUuid?: string) {
       const actions = boardRouteCtx ? extractActions(boardRouteCtx) : undefined;
       const wrapper = ({ children }: { children: React.ReactNode }) => (
         <QueueBridgeProvider>
@@ -1424,7 +1424,7 @@ describe('queue-bridge-context', () => {
           {/* Inner providers simulate GraphQLQueueProvider on board route */}
           <QueueActionsContext.Provider value={actions}>
             <QueueContext.Provider value={boardRouteCtx}>
-              <QueueBridgeInjector boardDetails={bd} angle={angle} />
+              <QueueBridgeInjector boardDetails={bd} angle={angle} boardUuid={boardUuid} />
             </QueueContext.Provider>
           </QueueActionsContext.Provider>
         </QueueBridgeProvider>
@@ -1448,9 +1448,19 @@ describe('queue-bridge-context', () => {
       expect(result.current.boardInfo.hasActiveQueue).toBe(true);
       expect(result.current.boardInfo.boardDetails).toEqual(bd);
       expect(result.current.boardInfo.angle).toBe(40);
+      // No /b/{slug} uuid passed → null (standard board routes don't carry one).
+      expect(result.current.boardInfo.boardUuid).toBeNull();
       // The bridge's exposed QueueContext should be the injected one
       expect(result.current.queueCtx).toBe(fakeCtx);
       expect(result.current.currentClimbUuid).toBeNull();
+    });
+
+    it('surfaces boardUuid when a /b/{slug} route injects it', () => {
+      const fakeCtx = createFakeQueueContext({ queue: [createTestQueueItem()] });
+      const { result } = renderInjector(fakeCtx, 'board-uuid-xyz');
+      // Flows injector → bridge → boardInfo so the root BluetoothProvider can
+      // link a paired serial to the saved board.
+      expect(result.current.boardInfo.boardUuid).toBe('board-uuid-xyz');
     });
 
     it('clears on unmount', () => {

--- a/packages/web/app/components/queue-control/__tests__/use-playlist-climb-activation.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/use-playlist-climb-activation.test.tsx
@@ -50,7 +50,7 @@ function makeQueueActions(
 }
 
 function makeBoardInfo(): QueueBridgeBoardInfo {
-  return { boardDetails, angle: 40, hasResolvedAngle: true, hasActiveQueue: true, isHydrated: true };
+  return { boardDetails, boardUuid: null, angle: 40, hasResolvedAngle: true, hasActiveQueue: true, isHydrated: true };
 }
 
 describe('usePlaylistClimbActivation', () => {

--- a/packages/web/app/components/queue-control/queue-bridge-board-info-context.ts
+++ b/packages/web/app/components/queue-control/queue-bridge-board-info-context.ts
@@ -5,6 +5,10 @@ import type { Angle, BoardDetails } from '@/app/lib/types';
 
 export type QueueBridgeBoardInfo = {
   boardDetails: BoardDetails | null;
+  /** Saved-board UUID when on a `/b/{slug}` route, else null. Lets the
+   * root-level BluetoothProvider link a freshly-paired BLE serial to the saved
+   * board (the route layout no longer mounts its own provider). */
+  boardUuid: string | null;
   angle: Angle;
   /**
    * Whether `angle` came from a real source (route / session boardPath /
@@ -28,6 +32,7 @@ export type QueueBridgeBoardInfo = {
 
 export const QueueBridgeBoardInfoContext = createContext<QueueBridgeBoardInfo>({
   boardDetails: null,
+  boardUuid: null,
   angle: 0,
   hasResolvedAngle: false,
   hasActiveQueue: false,

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -92,6 +92,7 @@ type QueueBridgeSetters = {
     bd: BoardDetails,
     angle: Angle,
     baseBoardPath: string,
+    boardUuid: string | null,
   ) => void;
   updateContext: (ctx: GraphQLQueueContextType, actions: GraphQLQueueActionsType) => void;
   clear: () => void;
@@ -765,6 +766,8 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
   // Board details and angle from the injector (stable across context updates)
   const [injectedBoardDetails, setInjectedBoardDetails] = useState<BoardDetails | null>(null);
   const [injectedAngle, setInjectedAngle] = useState<Angle>(0);
+  // Saved-board UUID from a `/b/{slug}` injector (null for non-saved board routes).
+  const [injectedBoardUuid, setInjectedBoardUuid] = useState<string | null>(null);
 
   // Injected values stored in refs to avoid cleanup/setup cycles. The combined
   // context now carries every data field, so the separate `injectedDataRef`
@@ -804,6 +807,9 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
   }, [isInjected, adapter.actionsValue, _actionsVersion]);
 
   const effectiveBoardDetails = isInjected ? injectedBoardDetails : adapter.boardDetails;
+  // Only board-route injectors carry a saved-board UUID; the solo/session
+  // adapter path has none.
+  const effectiveBoardUuid = isInjected ? injectedBoardUuid : null;
   const effectiveAngle = isInjected ? injectedAngle : adapter.angle;
   // The injector path passes a fully-resolved angle from the board route
   // segment, so injected => resolved by definition.
@@ -818,12 +824,20 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
   const boardInfo = useMemo<QueueBridgeBoardInfo>(
     () => ({
       boardDetails: effectiveBoardDetails,
+      boardUuid: effectiveBoardUuid,
       angle: effectiveAngle,
       hasResolvedAngle: effectiveHasResolvedAngle,
       hasActiveQueue: effectiveHasActiveQueue,
       isHydrated: effectiveIsHydrated,
     }),
-    [effectiveBoardDetails, effectiveAngle, effectiveHasResolvedAngle, effectiveHasActiveQueue, effectiveIsHydrated],
+    [
+      effectiveBoardDetails,
+      effectiveBoardUuid,
+      effectiveAngle,
+      effectiveHasResolvedAngle,
+      effectiveHasActiveQueue,
+      effectiveIsHydrated,
+    ],
   );
 
   const inject = useCallback(
@@ -833,6 +847,7 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
       bd: BoardDetails,
       a: Angle,
       baseBoardPath: string,
+      bu: string | null,
     ) => {
       injectedContextRef.current = ctx;
       injectedActionsRef.current = actions;
@@ -840,6 +855,7 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
       injectedBaseBoardPathRef.current = baseBoardPath;
       setInjectedBoardDetails(bd);
       setInjectedAngle(a);
+      setInjectedBoardUuid(bu);
       setIsInjected(true);
       setActionsVersion((v) => v + 1);
       setDataVersion((v) => v + 1);
@@ -884,6 +900,7 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
     setIsInjected(false);
     setInjectedBoardDetails(null);
     setInjectedAngle(0);
+    setInjectedBoardUuid(null);
     setActionsVersion((v) => v + 1);
     setDataVersion((v) => v + 1);
   }, []);
@@ -1034,9 +1051,12 @@ export function QueueBridgeProvider({ children }: { children: React.ReactNode })
 type QueueBridgeInjectorProps = {
   boardDetails: BoardDetails;
   angle: Angle;
+  /** Saved-board UUID on `/b/{slug}` routes so the root BluetoothProvider can
+   * link a paired serial to the saved board. Omitted on standard board routes. */
+  boardUuid?: string | null;
 };
 
-export function QueueBridgeInjector({ boardDetails, angle }: QueueBridgeInjectorProps) {
+export function QueueBridgeInjector({ boardDetails, angle, boardUuid = null }: QueueBridgeInjectorProps) {
   const { inject, updateContext, clear } = useContext(QueueBridgeSetterContext);
   const pathname = usePathname();
   const baseBoardPath = useMemo(() => getBaseBoardPath(pathname), [pathname]);
@@ -1053,10 +1073,14 @@ export function QueueBridgeInjector({ boardDetails, angle }: QueueBridgeInjector
   const baseBoardPathRef = useRef(baseBoardPath);
   baseBoardPathRef.current = baseBoardPath;
 
+  // Same ref trick for boardUuid so the layout effect doesn't re-run on it.
+  const boardUuidRef = useRef(boardUuid);
+  boardUuidRef.current = boardUuid;
+
   // Initial injection: set board details + context on mount
   useLayoutEffect(() => {
     if (queueContext && queueActions) {
-      inject(queueContext, queueActions, boardDetails, angle, baseBoardPathRef.current);
+      inject(queueContext, queueActions, boardDetails, angle, baseBoardPathRef.current, boardUuidRef.current);
       hasInjectedRef.current = true;
     }
     // Only clean up on unmount (navigating away from board route)
@@ -1076,10 +1100,10 @@ export function QueueBridgeInjector({ boardDetails, angle }: QueueBridgeInjector
     if (hasInjectedRef.current) {
       updateContext(queueContext, queueActions);
     } else {
-      inject(queueContext, queueActions, boardDetails, angle, baseBoardPath);
+      inject(queueContext, queueActions, boardDetails, angle, baseBoardPath, boardUuid);
       hasInjectedRef.current = true;
     }
-  }, [queueContext, queueActions, updateContext, inject, boardDetails, angle, baseBoardPath]);
+  }, [queueContext, queueActions, updateContext, inject, boardDetails, angle, baseBoardPath, boardUuid]);
 
   return null;
 }

--- a/packages/web/app/hooks/__tests__/use-effective-angle.test.tsx
+++ b/packages/web/app/hooks/__tests__/use-effective-angle.test.tsx
@@ -19,6 +19,7 @@ import { useEffectiveAngle } from '../use-effective-angle';
 function wrapper(bridge: Partial<QueueBridgeBoardInfo>) {
   const value: QueueBridgeBoardInfo = {
     boardDetails: null,
+    boardUuid: null,
     angle: 0,
     hasResolvedAngle: false,
     hasActiveQueue: false,

--- a/packages/web/i18n/locales/en-US/common.json
+++ b/packages/web/i18n/locales/en-US/common.json
@@ -49,9 +49,9 @@
     }
   },
   "bluetooth": {
-    "boardTaken": "Lost the board. Another app may have taken it.",
+    "boardTaken": "Lost the board — another phone or app connected to it.",
     "takeItBack": "Take it back",
-    "boardNotFound": "Couldn't find your board. Make sure it's powered on and nearby.",
+    "boardNotFound": "Couldn't find your board. Make sure it's on and nearby — and if another phone is connected to it, disconnect there first.",
     "connectFailed": "Couldn't connect. Move closer to the board and try again.",
     "serviceMissing": "Connected, but the board didn't respond. Power-cycle it and try again.",
     "unavailable": "Bluetooth is off. Turn it on to connect to your board.",

--- a/packages/web/i18n/locales/es/common.json
+++ b/packages/web/i18n/locales/es/common.json
@@ -247,9 +247,9 @@
     }
   },
   "bluetooth": {
-    "boardTaken": "Se perdió la tabla. Quizá otra app la tomó.",
+    "boardTaken": "Se perdió la tabla: otro teléfono o app se conectó a ella.",
     "takeItBack": "Recuperarla",
-    "boardNotFound": "No se encontró tu tabla. Asegúrate de que esté encendida y cerca.",
+    "boardNotFound": "No se encontró tu tabla. Asegúrate de que esté encendida y cerca; y si otro teléfono está conectado, desconéctalo allí primero.",
     "connectFailed": "No se pudo conectar. Acércate a la tabla e inténtalo de nuevo.",
     "serviceMissing": "Conectado, pero la tabla no respondió. Reiníciala e inténtalo de nuevo.",
     "unavailable": "El Bluetooth está apagado. Actívalo para conectar con tu tabla.",

--- a/packages/web/i18n/locales/fr/common.json
+++ b/packages/web/i18n/locales/fr/common.json
@@ -49,9 +49,9 @@
     }
   },
   "bluetooth": {
-    "boardTaken": "Board perdu. Une autre app l'a peut-être pris.",
+    "boardTaken": "Board perdu : un autre téléphone ou une autre app s'y est connecté.",
     "takeItBack": "Le reprendre",
-    "boardNotFound": "Board introuvable. Vérifiez qu'il est allumé et à proximité.",
+    "boardNotFound": "Board introuvable. Vérifiez qu'il est allumé et à proximité ; et si un autre téléphone y est connecté, déconnectez-le d'abord.",
     "connectFailed": "Connexion impossible. Rapprochez-vous du board et réessayez.",
     "serviceMissing": "Connecté, mais le board n'a pas répondu. Redémarrez-le et réessayez.",
     "unavailable": "Le Bluetooth est éteint. Activez-le pour vous connecter à votre board.",


### PR DESCRIPTION
## Why

Users reported three Bluetooth regressions in the web + Capacitor apps, all of which **"worked before the session driver changes"** (the queue-control-bar "driver" pivot, PR #2198 + follow-ups) and all of which were worked around by **disconnect + reconnect**:

1. Toggling **Mirror** didn't mirror the board LEDs until you reconnected.
2. **Switching control between two people** required manually disconnecting BLE each time (reported both in a party session and with no session, "just flicking between us").
3. **Create-climb** couldn't send to the board without a connect/disconnect dance.

## Root cause

The pivot added a `BluetoothAutoSender` send-dedup keyed **only on `climb.uuid`** (`bluetooth-context.tsx`). It swallowed every legitimate re-send where the uuid stayed the same:

- **Mirror** flips `climb.mirrored` but keeps the uuid → skipped.
- **Driver hand-off** of the same climb re-broadcasts the same uuid → skipped (the reducer was *deliberately* changed to let peer re-broadcasts through so the BLE relay re-sends — the dedup then defeated it).
- **Create-climb** edits reuse a stable preview uuid while frames change → skipped.

"Reconnect fixes it" because the AutoSender only mounts while connected, so a disconnect resets the dedup ref. Two latent architecture quirks made it worse: the app mounted **two `BluetoothProvider`s** (route layout + bottom bar) and the create-climb form spun up a **third, never-connected** adapter.

## What changed (web-only; ships to Capacitor via the WebView bundle)

- **Dedup on the rendered payload** (`uuid + frames + mirror`) instead of the uuid alone; on a byte-identical skip we still re-emit the wall-confirm so a hand-off taker's 2-second timer clears. Fixes #1, #2 (session), and #3 (after Set Active).
- **Collapsed the two providers into one** root-level `BluetoothProvider` shared by the bottom bar and the route page content — the BLE connection now persists across navigation, and there's a single AutoSender/AutoConnectHandler. The provider tolerates a null `boardDetails` (inert off-board).
- **Rewired create-climb** onto the shared connection (deleted its dead own adapter); live hold preview sends **local-only** while building, the queue→AutoSender path owns the wall after **Set Active** (gated so it doesn't double-write).
- **Threaded `boardUuid`** through the queue bridge so `/b/{slug}` serial recording still links to the saved board.
- **Clearer hand-off copy** ("…if another phone is connected to it, disconnect there first") for the no-session two-phone case, where the board only advertises when free.

## Tests / validation

- `vp run typecheck` ✓ · `vp test --project web` ✓ · `vp run check:i18n` + `:orphans` ✓ · changed files pass `vp check`.
- New/updated unit tests: payload dedup (mirror re-send, edited-frames re-send, identical-skip still confirms), inert null-`boardDetails` provider, create-climb shared-context wiring, `LightControlDrawer` boardDetails-as-prop.

## QA (needs a physical board)

Mirror re-lights live with no reconnect · create-climb hold edits light the board live · party hand-off updates the relay phone's wall without disconnecting · two phones no-session shows the clearer "board held elsewhere" message · solo tap-to-send + play-view prev/next/swipe + multi-frame playback unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)