### PR TITLE
fix(mobile): climb-list-actions review followups

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -236,13 +236,6 @@ export default function ClimbList() {
     [openPlayDrawer],
   );
 
-  const handleOpenActions = useCallback(
-    (climb: Climb) => {
-      openClimbActions(climb);
-    },
-    [openClimbActions],
-  );
-
   const handleAddToQueue = useCallback(
     (climb: Climb) => {
       addToQueue({ uuid: randomUUID(), climb });
@@ -301,12 +294,12 @@ export default function ClimbList() {
         setIds={setIds}
         angle={angle}
         onPress={handleClimbPress}
-        onOpenActions={handleOpenActions}
-        onOpenPlaylist={handleOpenActions}
+        onOpenActions={openClimbActions}
+        onOpenPlaylist={openClimbActions}
         onAddToQueue={handleAddToQueue}
       />
     ),
-    [boardName, layoutId, sizeId, setIds, angle, handleClimbPress, handleOpenActions, handleAddToQueue],
+    [boardName, layoutId, sizeId, setIds, angle, handleClimbPress, openClimbActions, handleAddToQueue],
   );
 
   if (!hasBoardConfig && !isBoardLoading) {

--- a/packages/mobile/src/components/AscentStatusBadge.tsx
+++ b/packages/mobile/src/components/AscentStatusBadge.tsx
@@ -3,11 +3,7 @@ import { View, StyleSheet } from 'react-native';
 import { useOptionalBoardProvider } from '@boardsesh/board-react';
 import { Icon } from './Icon';
 import { iosSystemColors } from '../theme/ios-colors';
-import {
-  normalizeAscentStatus,
-  pickHighestAscentStatus,
-  type AscentStatusValue,
-} from '../lib/ascent-status-utils';
+import { normalizeAscentStatus, pickHighestAscentStatus, type AscentStatusValue } from '../lib/ascent-status-utils';
 
 type AscentStatusBadgeProps = {
   climbUuid: string;
@@ -50,7 +46,7 @@ const AscentStatusBadge = React.memo(function AscentStatusBadge({
   if (status === 'flash') {
     return (
       <View style={[styles.badge, styles.flashBadge]}>
-        <Icon name="flash" size={10} color="#000000" />
+        <Icon name="flash" size={10} color={iosSystemColors.black} />
       </View>
     );
   }

--- a/packages/mobile/src/lib/__tests__/ascent-status-utils.test.ts
+++ b/packages/mobile/src/lib/__tests__/ascent-status-utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAscentStatus, pickHighestAscentStatus, type AscentStatusValue } from '../ascent-status-utils';
+
+describe('normalizeAscentStatus', () => {
+  it('returns the literal status when set', () => {
+    expect(normalizeAscentStatus({ status: 'flash' })).toBe('flash');
+    expect(normalizeAscentStatus({ status: 'send' })).toBe('send');
+    expect(normalizeAscentStatus({ status: 'attempt' })).toBe('attempt');
+  });
+
+  it('ignores literal status when not a known value and falls through', () => {
+    // @ts-expect-error — exercising the runtime guard for legacy callers
+    expect(normalizeAscentStatus({ status: 'bogus', isAscent: true, tries: 1 })).toBe('flash');
+  });
+
+  it('flashes when ascended in one try', () => {
+    expect(normalizeAscentStatus({ isAscent: true, tries: 1 })).toBe('flash');
+  });
+
+  it('sends when ascended in more than one try', () => {
+    expect(normalizeAscentStatus({ isAscent: true, tries: 2 })).toBe('send');
+    expect(normalizeAscentStatus({ isAscent: true, tries: 10 })).toBe('send');
+  });
+
+  it('sends when ascended without a tries count (unknown is not a flash)', () => {
+    expect(normalizeAscentStatus({ isAscent: true })).toBe('send');
+    expect(normalizeAscentStatus({ isAscent: true, tries: null })).toBe('send');
+  });
+
+  it('attempts when not ascended', () => {
+    expect(normalizeAscentStatus({ isAscent: false })).toBe('attempt');
+    expect(normalizeAscentStatus({})).toBe('attempt');
+    expect(normalizeAscentStatus({ status: null })).toBe('attempt');
+  });
+});
+
+describe('pickHighestAscentStatus', () => {
+  it('returns null on an empty input', () => {
+    expect(pickHighestAscentStatus([])).toBeNull();
+  });
+
+  it('picks flash over send and attempt', () => {
+    expect(pickHighestAscentStatus(['attempt', 'send', 'flash'])).toBe('flash');
+    expect(pickHighestAscentStatus(['flash', 'attempt'])).toBe('flash');
+  });
+
+  it('picks send over attempt when flash is absent', () => {
+    expect(pickHighestAscentStatus(['attempt', 'send'])).toBe('send');
+    expect(pickHighestAscentStatus(['send'])).toBe('send');
+  });
+
+  it('returns attempt only when nothing better is present', () => {
+    expect(pickHighestAscentStatus(['attempt'])).toBe('attempt');
+    expect(pickHighestAscentStatus(['attempt', 'attempt'])).toBe('attempt');
+  });
+
+  it('deduplicates internally so order does not matter beyond priority', () => {
+    const repeated: AscentStatusValue[] = ['send', 'send', 'send', 'flash', 'flash'];
+    expect(pickHighestAscentStatus(repeated)).toBe('flash');
+  });
+
+  it('accepts any iterable, not just arrays', () => {
+    function* gen(): Iterable<AscentStatusValue> {
+      yield 'attempt';
+      yield 'send';
+    }
+    expect(pickHighestAscentStatus(gen())).toBe('send');
+  });
+});

--- a/packages/mobile/src/lib/ascent-status-utils.ts
+++ b/packages/mobile/src/lib/ascent-status-utils.ts
@@ -35,25 +35,3 @@ export function pickHighestAscentStatus(statuses: Iterable<AscentStatusValue>): 
 
   return null;
 }
-
-/**
- * Pick the badge status for a climb from the aggregate counts on its GraphQL
- * row. Mirrors the priority used by web's `pickHighestAscentStatus`.
- *
- * Inputs are tolerant of null/undefined so callers can pass the raw climb
- * fields without pre-coercing them.
- */
-export function ascentStatusFromCounts({
-  userAscents,
-  userFlashes,
-  userAttempts,
-}: {
-  userAscents?: number | null;
-  userFlashes?: number | null;
-  userAttempts?: number | null;
-}): AscentStatusValue | null {
-  if ((userFlashes ?? 0) > 0) return 'flash';
-  if ((userAscents ?? 0) > 0) return 'send';
-  if ((userAttempts ?? 0) > 0) return 'attempt';
-  return null;
-}

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -80,7 +80,6 @@ const CLIMB_SEARCH_FIELDS = `
   created_at
   userAscents
   userAttempts
-  userFlashes
 `;
 
 const CLIMB_DETAIL_FIELDS = `
@@ -100,7 +99,6 @@ const CLIMB_DETAIL_FIELDS = `
   benchmark_difficulty
   userAscents
   userAttempts
-  userFlashes
   is_draft
   created_at
   published_at

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -75,7 +75,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const { data: activeBoard } = useActiveBoard();
   const [boardConfigOverride, setBoardConfigOverride] = useState<BoardConfig | null>(null);
   const [logAscentInput, setLogAscentInput] = useState<LogAscentInput | null>(null);
-  const [climbActionsClimb, setClimbActionsClimb] = useState<Climb | null>(null);
+  const [climbActions, setClimbActions] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const { addToQueue } = useQueue();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
 
@@ -99,6 +99,11 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       angle: activeBoard.angle,
     };
   }, [boardConfigOverride, activeBoard]);
+
+  // Keep a ref so the otherwise empty-dep `openClimbActions` callback can
+  // snapshot the current board config without churning its identity.
+  const activeBoardConfigRef = useRef(activeBoardConfig);
+  activeBoardConfigRef.current = activeBoardConfig;
 
   const openPlayDrawer = useCallback((climb: Climb, options?: OpenPlayDrawerOptions) => {
     const { boardConfig: override, ...openOptions } = options ?? {};
@@ -128,51 +133,49 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
 
   const dismissLogAscent = useCallback(() => setLogAscentInput(null), []);
 
+  // Snapshot the board config at open time so the sheet's per-row handlers
+  // (queue / favorite / tick) keep operating on the same angle even if the
+  // user switches their active board mid-interaction.
   const openClimbActions = useCallback((climb: Climb) => {
-    setClimbActionsClimb(climb);
+    const boardConfig = activeBoardConfigRef.current;
+    if (!boardConfig) return;
+    setClimbActions({ climb, boardConfig });
   }, []);
 
   const closeClimbActions = useCallback(() => {
-    setClimbActionsClimb(null);
+    setClimbActions(null);
   }, []);
 
-  // Pin the boardConfig that was active when the sheet opened so it doesn't
-  // shift mid-interaction if the user's default board changes.
-  const climbActionsBoardConfig = useMemo(
-    () => (climbActionsClimb ? activeBoardConfig : null),
-    [climbActionsClimb, activeBoardConfig],
-  );
-
   const handleClimbActionsAddToQueue = useCallback(() => {
-    if (!climbActionsClimb) return;
-    addToQueue({ uuid: randomUUID(), climb: climbActionsClimb });
-  }, [climbActionsClimb, addToQueue]);
+    if (!climbActions) return;
+    addToQueue({ uuid: randomUUID(), climb: climbActions.climb });
+  }, [climbActions, addToQueue]);
 
   const handleClimbActionsToggleFavorite = useCallback(() => {
-    if (!climbActionsClimb || !climbActionsBoardConfig) return;
+    if (!climbActions) return;
     toggleFavoriteMutate({
       input: {
-        boardName: climbActionsBoardConfig.boardName,
-        climbUuid: climbActionsClimb.uuid,
-        angle: climbActionsBoardConfig.angle,
+        boardName: climbActions.boardConfig.boardName,
+        climbUuid: climbActions.climb.uuid,
+        angle: climbActions.boardConfig.angle,
       },
     });
-  }, [climbActionsClimb, climbActionsBoardConfig, toggleFavoriteMutate]);
+  }, [climbActions, toggleFavoriteMutate]);
 
   const handleClimbActionsTick = useCallback(() => {
-    if (!climbActionsClimb || !climbActionsBoardConfig) return;
+    if (!climbActions) return;
     setLogAscentInput({
-      climbUuid: climbActionsClimb.uuid,
-      climbName: climbActionsClimb.name,
-      boardName: climbActionsBoardConfig.boardName,
-      angle: climbActionsBoardConfig.angle,
+      climbUuid: climbActions.climb.uuid,
+      climbName: climbActions.climb.name,
+      boardName: climbActions.boardConfig.boardName,
+      angle: climbActions.boardConfig.angle,
       isMirror: false,
-      isBenchmark: !!climbActionsClimb.benchmark_difficulty,
-      layoutId: climbActionsBoardConfig.layoutId,
-      sizeId: climbActionsBoardConfig.sizeId,
-      setIds: climbActionsBoardConfig.setIds,
+      isBenchmark: !!climbActions.climb.benchmark_difficulty,
+      layoutId: climbActions.boardConfig.layoutId,
+      sizeId: climbActions.boardConfig.sizeId,
+      setIds: climbActions.boardConfig.setIds,
     });
-  }, [climbActionsClimb, climbActionsBoardConfig]);
+  }, [climbActions]);
 
   const value = useMemo<DrawerHostValue>(
     () => ({ boardConfig: activeBoardConfig, openPlayDrawer, openLogAscent, openClimbActions, closeClimbActions }),
@@ -199,15 +202,15 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           sessionId={logAscentInput.sessionId}
         />
       ) : null}
-      {climbActionsClimb && climbActionsBoardConfig ? (
+      {climbActions ? (
         <ClimbActionsSheet
           visible
-          climb={climbActionsClimb}
-          boardName={climbActionsBoardConfig.boardName}
-          layoutId={climbActionsBoardConfig.layoutId}
-          sizeId={climbActionsBoardConfig.sizeId}
-          setIds={climbActionsBoardConfig.setIds}
-          angle={climbActionsBoardConfig.angle}
+          climb={climbActions.climb}
+          boardName={climbActions.boardConfig.boardName}
+          layoutId={climbActions.boardConfig.layoutId}
+          sizeId={climbActions.boardConfig.sizeId}
+          setIds={climbActions.boardConfig.setIds}
+          angle={climbActions.boardConfig.angle}
           onAddToQueue={handleClimbActionsAddToQueue}
           onToggleFavorite={handleClimbActionsToggleFavorite}
           onTick={handleClimbActionsTick}

--- a/packages/mobile/src/theme/ios-colors.ts
+++ b/packages/mobile/src/theme/ios-colors.ts
@@ -28,6 +28,8 @@ export const iosSystemColors = {
   starGold: '#FFB800',
   /** Pure white — text on colored backgrounds */
   white: '#FFFFFF',
+  /** Pure black — text on light/yellow backgrounds where white wouldn't pass contrast (e.g. flash badge on systemYellow) */
+  black: '#000000',
 } as const;
 
 /**


### PR DESCRIPTION
Follow-up to #2458. Addresses five review nits without changing behavior:

- **Drop dead `ascentStatusFromCounts`** — `AscentStatusBadge` reads from `BoardProvider.logbook` now; the counts-based helper had zero callers anywhere in the repo.
- **Replace hardcoded `#000000`** in `AscentStatusBadge` with a new `iosSystemColors.black` token (commented as the intentional contrast pick for the flash badge on `systemYellow`).
- **Actually pin the boardConfig** for the climb actions sheet. The previous \"pin\" comment was misleading because `climbActionsBoardConfig` was a `useMemo` that reactively followed `activeBoardConfig`. Now `openClimbActions` snapshots the active config into the same state slot as the climb, so a board switch mid-interaction can't shift the sheet's angle.
- **Drop the no-op `handleOpenActions` wrapper** in `app/(tabs)/climbs/index.tsx` and pass `openClimbActions` directly.
- **Add unit tests** for `normalizeAscentStatus` and `pickHighestAscentStatus` (12 cases).

## Test plan

- [x] \`vp run typecheck:mobile\` passes
- [x] New \`ascent-status-utils.test.ts\` passes (12/12). Full mobile suite has 4 pre-existing flakes in \`board-renderer.test.ts\` (5s timeout importing \`@boardsesh/board-constants\`); not introduced here.
- [x] \`vp check --fix\` clean on changed files
- [ ] Manual: ellipsis tap on a climb row → actions sheet opens; flash badge still renders amber-on-black; switching the active board while the actions sheet is open keeps the sheet's angle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)