### PR TITLE
fix(ble): review follow-ups — boardUuid dep, optional-context doc, picker-guard test

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -669,6 +669,34 @@ describe('BluetoothProvider', () => {
       return rendered;
     }
 
+    it('picker select is a no-op when boardDetails is null (off-board inert provider)', async () => {
+      // The single root-level provider is mounted off board routes too, where
+      // boardDetails is null. handlePickerSelect must bail before forwarding the
+      // selection or opening the mismatch dialog (decidePickerSelection needs a
+      // real board to compare against).
+      mockAuth = { token: 'tok', isAuthenticated: true };
+      mockPickerState = {
+        devices: [{ deviceId: 'dev-1', name: 'Kilter Board#KB-99@3', rssi: -55 }],
+        handleSelect: mockPickerHandleSelect,
+        handleCancel: mockPickerHandleCancel,
+      };
+      mockParseSerialNumber.mockReturnValue('KB-99');
+
+      const NullWrapper = ({ children }: { children: React.ReactNode }) => (
+        <BluetoothProvider boardDetails={null}>{children}</BluetoothProvider>
+      );
+      renderHook(() => useBluetoothContext(), { wrapper: NullWrapper });
+
+      expect(lastPickerProps).not.toBeNull();
+      await act(async () => {
+        lastPickerProps?.onSelect('dev-1');
+      });
+
+      // Guard returned early: no forward to the adapter, no mismatch dialog.
+      expect(mockPickerHandleSelect).not.toHaveBeenCalled();
+      expect(lastMismatchProps).toBeNull();
+    });
+
     it('Switch to correct config: pushes the slug-based URL with autoConnect serial', async () => {
       await setupMismatchScenario({ withSlug: true });
 

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -687,12 +687,14 @@ export function useBluetoothContext() {
 }
 
 /**
- * Like `useBluetoothContext` but returns null instead of throwing when no
- * provider is mounted. For components (e.g. the create-climb form) that render
- * both inside the app shell (provider present) and in isolated unit tests
- * (no provider) — mirrors `useOptionalQueueActions`.
+ * Like `useBluetoothContext` but does NOT throw when no provider is mounted: it
+ * returns the context's default value, which is `null` (see
+ * `createContext<BluetoothContextValue | null>(null)` above). For components
+ * (e.g. the create-climb form) that render both inside the app shell (provider
+ * present) and in isolated unit tests (no provider). Callers must null-check
+ * the result. Mirrors `useOptionalQueueActions`.
  */
-export function useOptionalBluetoothContext() {
+export function useOptionalBluetoothContext(): BluetoothContextValue | null {
   return useContext(BluetoothContext);
 }
 

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -1098,12 +1098,17 @@ export function QueueBridgeInjector({ boardDetails, angle, boardUuid = null }: Q
   useEffect(() => {
     if (!queueContext || !queueActions) return;
     if (hasInjectedRef.current) {
+      // updateContext only refreshes the queue context/actions. Board identity
+      // (boardDetails/angle/boardUuid) is owned by the layout effect's inject,
+      // which re-fires on route change — so a boardUuid change can't (and
+      // shouldn't) propagate from here. Read it from the ref on the deferred
+      // path below so it isn't a misleading no-op dependency of this effect.
       updateContext(queueContext, queueActions);
     } else {
-      inject(queueContext, queueActions, boardDetails, angle, baseBoardPath, boardUuid);
+      inject(queueContext, queueActions, boardDetails, angle, baseBoardPath, boardUuidRef.current);
       hasInjectedRef.current = true;
     }
-  }, [queueContext, queueActions, updateContext, inject, boardDetails, angle, baseBoardPath, boardUuid]);
+  }, [queueContext, queueActions, updateContext, inject, boardDetails, angle, baseBoardPath]);
 
   return null;
 }


### PR DESCRIPTION
Three small follow-ups to #2463 (the queue-pivot BLE fix), all from review feedback. No behavior change beyond removing a dead/misleading code path; one new test.

### 1. `boardUuid` dep was misleading in the post-injection update effect
`queue-bridge-context.tsx` — in the `QueueBridgeInjector` update effect, `boardUuid` was in the dependency array, but when it changes while `hasInjectedRef.current` is true the `updateContext` branch runs, which only refreshes the queue context/actions — it never propagates `boardUuid`. So the dep implied a propagation that doesn't happen.

Board identity (`boardDetails`/`angle`/`boardUuid`) is owned by the **layout effect's** `inject`, which re-fires on route change. Fixed by reading `boardUuid` from its ref on the deferred-inject path (matching how the layout effect already treats it) and dropping it from the update effect's deps. Harmless in practice — `boardUuid` is a static URL segment that only changes when the whole route changes (→ layout effect re-injects) — but the code now says what it means.

### 2. `useOptionalBluetoothContext` JSDoc made precise
`bluetooth-context.tsx` — the doc said "returns null instead of throwing." That's actually correct *because* the context is `createContext<BluetoothContextValue | null>(null)` (the default is `null`, not `undefined`), but the doc didn't say why. Reworded to state it returns the context's default value (`null`) and added the explicit return type so callers clearly must null-check.

### 3. Test for the `handlePickerSelect` null-`boardDetails` guard
The inert-provider test only checked that the context renders. Added a test that drives the device-picker `onSelect` on a null-`boardDetails` (off-board) provider and asserts the guard returns early — no forward to the adapter, no mismatch dialog.

### Validation
`vp run typecheck:web` ✓ · affected web tests ✓ (102 across the two suites, incl. the new guard test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)