### PR TITLE
feat(mobile): unified QuickTickBar — attempt button, comment field, consensus chip

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -207,6 +207,7 @@
         "graphql-request": "^7.0.0",
         "graphql-ws": "^6.0.0",
         "i18next": "^23.16.8",
+        "intl-pluralrules": "^2.0.1",
         "react": "19.2.3",
         "react-i18next": "^15.0.0",
         "react-native": "0.85.3",

--- a/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
+++ b/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
@@ -252,7 +252,6 @@ export default function ClimbDetail() {
           setIds={setIds}
           sessionId={sessionId}
           consensusGradeName={climb.difficulty}
-          hasPriorHistory={(climb.userAscents ?? 0) > 0 || (climb.userAttempts ?? 0) > 0}
         />
       )}
     </>

--- a/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
+++ b/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
@@ -242,7 +242,6 @@ export default function ClimbDetail() {
           visible={showLogAscent}
           onDismiss={() => setShowLogAscent(false)}
           climbUuid={climb.uuid}
-          climbName={climb.name}
           boardName={boardName}
           angle={Number(angle)}
           isMirror={climb.mirrored === true}

--- a/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
+++ b/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
@@ -251,6 +251,8 @@ export default function ClimbDetail() {
           sizeId={sizeId ? Number(sizeId) : undefined}
           setIds={setIds}
           sessionId={sessionId}
+          consensusGradeName={climb.difficulty}
+          hasPriorHistory={(climb.userAscents ?? 0) > 0 || (climb.userAttempts ?? 0) > 0}
         />
       )}
     </>

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -63,6 +63,7 @@
     "graphql-request": "^7.0.0",
     "graphql-ws": "^6.0.0",
     "i18next": "^23.16.8",
+    "intl-pluralrules": "^2.0.1",
     "react": "19.2.3",
     "react-i18next": "^15.0.0",
     "react-native": "0.85.3",

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -7,7 +7,7 @@
 // a portal above the play drawer's own modal. `FullWindowOverlay` on iOS
 // lifts the sheet above the tab bar — same pattern as DevicePickerSheet.
 import { useCallback, useEffect, useMemo, useRef, type PropsWithChildren } from 'react';
-import { Platform, StyleSheet, type ViewStyle } from 'react-native';
+import { Platform, Pressable, StyleSheet, View, type ViewStyle } from 'react-native';
 import {
   BottomSheetModal,
   BottomSheetBackdrop,
@@ -15,15 +15,17 @@ import {
   type BottomSheetBackdropProps,
 } from '@gorhom/bottom-sheet';
 import { FullWindowOverlay } from 'react-native-screens';
+import { useTranslation } from 'react-i18next';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
+import { spacing } from '../theme/tokens';
+import { Icon } from './Icon';
 import { QuickTickBar } from './play-drawer/QuickTickBar';
 
 type LogAscentSheetProps = {
   visible: boolean;
   onDismiss: () => void;
   climbUuid: string;
-  climbName?: string;
   boardName: string;
   angle: number;
   isMirror: boolean;
@@ -56,20 +58,38 @@ export function LogAscentSheet({
   consensusGradeName,
 }: LogAscentSheetProps) {
   const sheetRef = useRef<BottomSheetModal>(null);
+  // Tracks whether the modal is currently *presented* (mounted into the
+  // gorhom modal stack), independent of the external `visible` prop. After
+  // a pan-down dismiss, gorhom unregisters the modal internally before
+  // `onDismiss` fires — calling `dismiss()` from our `visible` effect at
+  // that moment leaves the modal in an inconsistent state where a later
+  // `present()` is a no-op (the bug: tap tick → swipe down → tap tick →
+  // nothing happens).
+  const isPresentedRef = useRef(false);
   const { systemColors } = useTheme();
+  const { t } = useTranslation('session');
 
   useEffect(() => {
-    if (visible) {
+    if (visible && !isPresentedRef.current) {
       sheetRef.current?.present();
-    } else {
+      isPresentedRef.current = true;
+    } else if (!visible && isPresentedRef.current) {
       sheetRef.current?.dismiss();
+      isPresentedRef.current = false;
     }
   }, [visible]);
 
-  // 60% leaves the climb image visible above the sheet — the UX review
-  // flagged the previous full-cover behaviour (with carousel disabled) as
-  // the wrong tradeoff: users want to glance at the holds while logging.
-  const snapPoints = useMemo(() => ['60%'], []);
+  const handleSheetDismiss = useCallback(() => {
+    isPresentedRef.current = false;
+    onDismiss();
+  }, [onDismiss]);
+
+  // Default to 60% so the climb image stays visible above the sheet (the
+  // UX review flagged full-cover + carousel-disabled as the wrong
+  // tradeoff). The 92% snap is the keyboard-extended state: when the
+  // comment `BottomSheetTextInput` gains focus, gorhom auto-snaps to the
+  // last point so the input and save buttons stay above the keyboard.
+  const snapPoints = useMemo(() => ['60%', '92%'], []);
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
@@ -93,14 +113,30 @@ export function LogAscentSheet({
       snapPoints={snapPoints}
       containerComponent={modalContainerComponent}
       enablePanDownToClose
-      onDismiss={onDismiss}
+      onDismiss={handleSheetDismiss}
       backdropComponent={renderBackdrop}
       handleIndicatorStyle={styles.indicator}
       backgroundStyle={backgroundStyle}
-      keyboardBehavior="interactive"
+      keyboardBehavior="extend"
       keyboardBlurBehavior="restore"
+      android_keyboardInputMode="adjustResize"
     >
       <BottomSheetView style={styles.content}>
+        <View style={styles.closeButtonRow}>
+          <Pressable
+            onPress={onDismiss}
+            accessibilityRole="button"
+            accessibilityLabel={t('playView.tickBar.closeAria')}
+            hitSlop={8}
+            style={({ pressed }) => [
+              styles.closeButton,
+              { backgroundColor: systemColors.fill as string },
+              pressed && styles.closeButtonPressed,
+            ]}
+          >
+            <Icon name="chevron.down" size={18} color={systemColors.secondaryLabel} />
+          </Pressable>
+        </View>
         <QuickTickBar
           climbUuid={climbUuid}
           boardName={boardName}
@@ -128,5 +164,21 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
+  },
+  closeButtonRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[1],
+  },
+  closeButton: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeButtonPressed: {
+    opacity: 0.7,
   },
 });

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -1,16 +1,20 @@
-// Sheet wrapper around the unified QuickTickBar. Used by callers outside
-// PlayDrawer (the persistent queue bar, the climb detail screen) that need
-// a draggable, dismissible bottom sheet with a handle. PlayDrawer's inline
-// FAB flow renders QuickTickBar directly without this wrapper because the
-// FAB already lives inside the drawer's board section and doesn't need
-// another sheet shell.
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { StyleSheet, type ViewStyle } from 'react-native';
-import BottomSheet, {
+// Bottom-sheet wrapper around QuickTickBar. Used by every ticking entry
+// point — the play drawer's tick button, the persistent queue bar, the
+// climb detail screen — so the form, dismissal model (handle + pan-down +
+// backdrop tap), and keyboard handling stay identical across surfaces.
+//
+// Uses `BottomSheetModal` (not the regular `BottomSheet`) so it renders in
+// a portal above the play drawer's own modal. `FullWindowOverlay` on iOS
+// lifts the sheet above the tab bar — same pattern as DevicePickerSheet.
+import { useCallback, useEffect, useMemo, useRef, type PropsWithChildren } from 'react';
+import { Platform, StyleSheet, type ViewStyle } from 'react-native';
+import {
+  BottomSheetModal,
   BottomSheetBackdrop,
   BottomSheetView,
   type BottomSheetBackdropProps,
 } from '@gorhom/bottom-sheet';
+import { FullWindowOverlay } from 'react-native-screens';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { QuickTickBar } from './play-drawer/QuickTickBar';
@@ -29,8 +33,13 @@ type LogAscentSheetProps = {
   setIds?: string;
   sessionId?: string | null;
   consensusGradeName?: string;
-  hasPriorHistory?: boolean;
 };
+
+function LogAscentModalContainer({ children }: PropsWithChildren) {
+  return <FullWindowOverlay>{children}</FullWindowOverlay>;
+}
+
+const modalContainerComponent = Platform.OS === 'ios' ? LogAscentModalContainer : undefined;
 
 export function LogAscentSheet({
   visible,
@@ -45,19 +54,21 @@ export function LogAscentSheet({
   setIds,
   sessionId,
   consensusGradeName,
-  hasPriorHistory,
 }: LogAscentSheetProps) {
-  const sheetRef = useRef<BottomSheet>(null);
+  const sheetRef = useRef<BottomSheetModal>(null);
   const { systemColors } = useTheme();
 
   useEffect(() => {
     if (visible) {
-      sheetRef.current?.expand();
+      sheetRef.current?.present();
     } else {
-      sheetRef.current?.close();
+      sheetRef.current?.dismiss();
     }
   }, [visible]);
 
+  // 60% leaves the climb image visible above the sheet — the UX review
+  // flagged the previous full-cover behaviour (with carousel disabled) as
+  // the wrong tradeoff: users want to glance at the holds while logging.
   const snapPoints = useMemo(() => ['60%'], []);
 
   const renderBackdrop = useCallback(
@@ -67,28 +78,22 @@ export function LogAscentSheet({
     [],
   );
 
-  const handleChange = useCallback(
-    (index: number) => {
-      if (index === -1) onDismiss();
-    },
-    [onDismiss],
-  );
-
   const backgroundStyle: ViewStyle = {
     backgroundColor: systemColors.secondaryBackground as string,
     borderTopLeftRadius: 16,
     borderTopRightRadius: 16,
   };
 
-  if (!visible) return null;
-
   return (
-    <BottomSheet
+    <BottomSheetModal
       ref={sheetRef}
+      name="log-ascent"
       index={0}
+      stackBehavior="push"
       snapPoints={snapPoints}
+      containerComponent={modalContainerComponent}
       enablePanDownToClose
-      onChange={handleChange}
+      onDismiss={onDismiss}
       backdropComponent={renderBackdrop}
       handleIndicatorStyle={styles.indicator}
       backgroundStyle={backgroundStyle}
@@ -97,8 +102,6 @@ export function LogAscentSheet({
     >
       <BottomSheetView style={styles.content}>
         <QuickTickBar
-          visible={visible}
-          embedded
           climbUuid={climbUuid}
           boardName={boardName}
           angle={angle}
@@ -109,11 +112,10 @@ export function LogAscentSheet({
           setIds={setIds}
           sessionId={sessionId}
           consensusGradeName={consensusGradeName}
-          hasPriorHistory={hasPriorHistory}
           onDismiss={onDismiss}
         />
       </BottomSheetView>
-    </BottomSheet>
+    </BottomSheetModal>
   );
 }
 

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -1,35 +1,25 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { View, Pressable, TextInput, ScrollView, StyleSheet, Alert, type ViewStyle } from 'react-native';
+// Sheet wrapper around the unified QuickTickBar. Used by callers outside
+// PlayDrawer (the persistent queue bar, the climb detail screen) that need
+// a draggable, dismissible bottom sheet with a handle. PlayDrawer's inline
+// FAB flow renders QuickTickBar directly without this wrapper because the
+// FAB already lives inside the drawer's board section and doesn't need
+// another sheet shell.
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { StyleSheet, type ViewStyle } from 'react-native';
 import BottomSheet, {
   BottomSheetBackdrop,
   BottomSheetView,
   type BottomSheetBackdropProps,
 } from '@gorhom/bottom-sheet';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useTranslation } from 'react-i18next';
-import type { Grade } from '@boardsesh/shared-schema';
-import { Text } from './Text';
-import { Button } from './Button';
-import { Icon } from './Icon';
-import { Separator } from './Separator';
-import { SegmentedControl } from './SegmentedControl';
-import { StarRating } from './StarRating';
 import { useTheme } from '../providers/theme-provider';
-import { useGrades } from '../lib/graphql/hooks';
-import { useSaveTick } from '@boardsesh/board-react';
-import { toBoardName } from '@boardsesh/board-config';
-import { hapticSuccess, hapticLight, hapticError, hapticSelection } from '../lib/haptics';
-import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
-import { spacing } from '../theme/tokens';
-
-type TickStatus = 'flash' | 'send' | 'attempt';
+import { QuickTickBar } from './play-drawer/QuickTickBar';
 
 type LogAscentSheetProps = {
   visible: boolean;
   onDismiss: () => void;
   climbUuid: string;
-  climbName: string;
+  climbName?: string;
   boardName: string;
   angle: number;
   isMirror: boolean;
@@ -38,49 +28,14 @@ type LogAscentSheetProps = {
   sizeId?: number;
   setIds?: string;
   sessionId?: string | null;
+  consensusGradeName?: string;
+  hasPriorHistory?: boolean;
 };
-
-const STATUS_OPTIONS: TickStatus[] = ['flash', 'send', 'attempt'];
-
-function getMinAttempts(tickStatus: TickStatus): number {
-  if (tickStatus === 'send') return 2;
-  return 1;
-}
-
-function GradeChip({ grade, selected, onPress }: { grade: Grade; selected: boolean; onPress: () => void }) {
-  const chipStyle: ViewStyle = {
-    paddingHorizontal: spacing[3],
-    paddingVertical: spacing[1],
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: selected ? brandColors.primary : iosSystemColors.separator,
-    backgroundColor: selected ? brandColors.primary : 'transparent',
-  };
-
-  return (
-    <Pressable
-      onPress={() => {
-        hapticSelection();
-        onPress();
-      }}
-      accessibilityRole="button"
-      accessibilityState={{ selected }}
-      accessibilityLabel={grade.name}
-    >
-      <View style={chipStyle}>
-        <Text variant="footnote" color={selected ? iosSystemColors.white : undefined} style={styles.gradeChipText}>
-          {grade.name}
-        </Text>
-      </View>
-    </Pressable>
-  );
-}
 
 export function LogAscentSheet({
   visible,
   onDismiss,
   climbUuid,
-  climbName,
   boardName,
   angle,
   isMirror,
@@ -89,179 +44,40 @@ export function LogAscentSheet({
   sizeId,
   setIds,
   sessionId,
+  consensusGradeName,
+  hasPriorHistory,
 }: LogAscentSheetProps) {
-  const { t } = useTranslation('climbs');
-  const theme = useTheme();
-  const { systemColors } = theme;
-  const insets = useSafeAreaInsets();
   const sheetRef = useRef<BottomSheet>(null);
+  const { systemColors } = useTheme();
 
   useEffect(() => {
-    // Sheet mounts when visible becomes true — expand it. Re-run on every
-    // `visible` toggle, since the parent keeps the sheet mounted across
-    // opens, and a [] deps array would only expand on the first open.
     if (visible) {
       sheetRef.current?.expand();
+    } else {
+      sheetRef.current?.close();
     }
   }, [visible]);
 
-  const saveTick = useSaveTick(toBoardName(boardName));
-  const { data: grades } = useGrades(boardName);
-
-  const [status, setStatus] = useState<TickStatus>('flash');
-  const [attemptCount, setAttemptCount] = useState(1);
-  const [quality, setQuality] = useState(0);
-  const [selectedDifficultyId, setSelectedDifficultyId] = useState<number | null>(null);
-  const [comment, setComment] = useState('');
-
-  const snapPoints = useMemo(() => ['85%'], []);
-
-  const statusLabels: Record<TickStatus, string> = useMemo(
-    () => ({
-      flash: t('mobile.logAscent.flash'),
-      send: t('mobile.logAscent.send'),
-      attempt: t('mobile.logAscent.attempt'),
-    }),
-    [t],
-  );
-
-  const segmentOptions = useMemo(
-    () => STATUS_OPTIONS.map((option) => ({ key: option, label: statusLabels[option] })),
-    [statusLabels],
-  );
-
-  const minAttempts = getMinAttempts(status);
-
-  const handleStatusChange = useCallback(
-    (newStatus: string) => {
-      const tickStatus = newStatus as TickStatus;
-      setStatus(tickStatus);
-      if (tickStatus === 'flash') {
-        setAttemptCount(1);
-      } else if (tickStatus === 'send' && attemptCount < 2) {
-        setAttemptCount(2);
-      }
-    },
-    [attemptCount],
-  );
-
-  const handleIncrement = useCallback(() => {
-    hapticLight();
-    setAttemptCount((previous) => previous + 1);
-  }, []);
-
-  const handleDecrement = useCallback(() => {
-    hapticLight();
-    setAttemptCount((previous) => Math.max(minAttempts, previous - 1));
-  }, [minAttempts]);
-
-  const handleQualityChange = useCallback((rating: number | undefined) => {
-    setQuality(rating ?? 0);
-  }, []);
-
-  const resetForm = useCallback(() => {
-    setStatus('flash');
-    setAttemptCount(1);
-    setQuality(0);
-    setSelectedDifficultyId(null);
-    setComment('');
-  }, []);
-
-  const handleSave = useCallback(() => {
-    saveTick.mutate(
-      {
-        climbUuid,
-        angle,
-        isMirror,
-        status,
-        attemptCount,
-        quality: quality > 0 ? quality : null,
-        difficulty: selectedDifficultyId,
-        isBenchmark,
-        comment,
-        climbedAt: new Date().toISOString(),
-        ...(sessionId ? { sessionId } : {}),
-        ...(layoutId != null ? { layoutId } : {}),
-        ...(sizeId != null ? { sizeId } : {}),
-        ...(setIds ? { setIds } : {}),
-      },
-      {
-        onSuccess: () => {
-          hapticSuccess();
-          resetForm();
-          sheetRef.current?.close();
-          onDismiss();
-        },
-        onError: () => {
-          hapticError();
-          Alert.alert(t('mobile.logAscent.errorTitle'), t('mobile.logAscent.errorMessage'));
-        },
-      },
-    );
-  }, [
-    saveTick,
-    climbUuid,
-    angle,
-    isMirror,
-    status,
-    attemptCount,
-    quality,
-    selectedDifficultyId,
-    isBenchmark,
-    comment,
-    sessionId,
-    layoutId,
-    sizeId,
-    setIds,
-    onDismiss,
-    resetForm,
-    t,
-  ]);
-
-  const handleSheetChange = useCallback(
-    (index: number) => {
-      if (index === -1) {
-        onDismiss();
-      }
-    },
-    [onDismiss],
-  );
+  const snapPoints = useMemo(() => ['60%'], []);
 
   const renderBackdrop = useCallback(
-    (backdropProps: BottomSheetBackdropProps) => (
-      <BottomSheetBackdrop {...backdropProps} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.4} />
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.4} pressBehavior="close" />
     ),
     [],
+  );
+
+  const handleChange = useCallback(
+    (index: number) => {
+      if (index === -1) onDismiss();
+    },
+    [onDismiss],
   );
 
   const backgroundStyle: ViewStyle = {
     backgroundColor: systemColors.secondaryBackground as string,
     borderTopLeftRadius: 16,
     borderTopRightRadius: 16,
-  };
-
-  const trackColor = systemColors.fill;
-
-  const stepperButtonStyle: ViewStyle = {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: systemColors.fill as string,
-  };
-
-  const commentInputStyle = {
-    borderWidth: 1,
-    borderColor: systemColors.separator as string,
-    borderRadius: 10,
-    paddingHorizontal: spacing[3],
-    paddingVertical: spacing[2],
-    fontSize: 16,
-    lineHeight: 22,
-    color: systemColors.label as string,
-    minHeight: 80,
-    textAlignVertical: 'top' as const,
   };
 
   if (!visible) return null;
@@ -272,139 +88,30 @@ export function LogAscentSheet({
       index={0}
       snapPoints={snapPoints}
       enablePanDownToClose
+      onChange={handleChange}
       backdropComponent={renderBackdrop}
-      onChange={handleSheetChange}
       handleIndicatorStyle={styles.indicator}
       backgroundStyle={backgroundStyle}
       keyboardBehavior="interactive"
       keyboardBlurBehavior="restore"
     >
       <BottomSheetView style={styles.content}>
-        {/* Header */}
-        <View style={styles.header}>
-          <Text variant="title3">{t('mobile.logAscent.title')}</Text>
-          <Text variant="subheadline" style={styles.climbName}>
-            {climbName}
-          </Text>
-        </View>
-
-        <ScrollView
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={styles.scrollContent}
-          keyboardShouldPersistTaps="handled"
-        >
-          {/* Status segmented control */}
-          <View style={styles.section}>
-            <SegmentedControl
-              options={segmentOptions}
-              selectedKey={status}
-              onSelect={handleStatusChange}
-              trackColor={trackColor}
-            />
-          </View>
-
-          {/* Attempt count stepper */}
-          <View style={styles.section}>
-            <Text variant="subheadline" style={styles.sectionLabel}>
-              {t('mobile.logAscent.attempts')}
-            </Text>
-            <View style={styles.stepperRow}>
-              <Pressable
-                onPress={handleDecrement}
-                disabled={attemptCount <= minAttempts}
-                accessibilityRole="button"
-                accessibilityLabel={t('mobile.logAscent.decreaseAttempts')}
-                style={[stepperButtonStyle, attemptCount <= minAttempts && styles.stepperDisabled]}
-              >
-                <Icon
-                  name="minus.circle"
-                  size={22}
-                  color={attemptCount <= minAttempts ? iosSystemColors.systemGray4 : brandColors.primary}
-                />
-              </Pressable>
-              <Text variant="title3" style={styles.attemptCount}>
-                {attemptCount}
-              </Text>
-              <Pressable
-                onPress={handleIncrement}
-                accessibilityRole="button"
-                accessibilityLabel={t('mobile.logAscent.increaseAttempts')}
-                style={stepperButtonStyle}
-              >
-                <Icon name="add" size={22} color={brandColors.primary} />
-              </Pressable>
-            </View>
-          </View>
-
-          <Separator />
-
-          {/* Quality rating */}
-          <View style={styles.section}>
-            <Text variant="subheadline" style={styles.sectionLabel}>
-              {t('mobile.logAscent.quality')}
-            </Text>
-            <StarRating value={quality} onChange={handleQualityChange} clearValue={0} />
-          </View>
-
-          <Separator />
-
-          {/* Grade opinion */}
-          {grades && grades.length > 0 && (
-            <>
-              <View style={styles.section}>
-                <Text variant="subheadline" style={styles.sectionLabel}>
-                  {t('mobile.logAscent.gradeOpinion')}
-                </Text>
-                <ScrollView
-                  horizontal
-                  showsHorizontalScrollIndicator={false}
-                  contentContainerStyle={styles.gradeChipsContainer}
-                >
-                  {grades.map((grade) => (
-                    <GradeChip
-                      key={grade.difficultyId}
-                      grade={grade}
-                      selected={selectedDifficultyId === grade.difficultyId}
-                      onPress={() =>
-                        setSelectedDifficultyId(selectedDifficultyId === grade.difficultyId ? null : grade.difficultyId)
-                      }
-                    />
-                  ))}
-                </ScrollView>
-              </View>
-
-              <Separator />
-            </>
-          )}
-
-          {/* Comment */}
-          <View style={styles.section}>
-            <Text variant="subheadline" style={styles.sectionLabel}>
-              {t('mobile.logAscent.comment')}
-            </Text>
-            <TextInput
-              value={comment}
-              onChangeText={setComment}
-              placeholder={t('mobile.logAscent.commentPlaceholder')}
-              placeholderTextColor={systemColors.tertiaryLabel as string}
-              multiline
-              style={commentInputStyle}
-            />
-          </View>
-
-        </ScrollView>
-
-        <View style={[styles.footer, { paddingBottom: insets.bottom + spacing[3] }]}>
-          <Button
-            title={t('mobile.logAscent.save')}
-            onPress={handleSave}
-            variant="filled"
-            size="large"
-            loading={saveTick.isPending}
-            disabled={saveTick.isPending}
-            style={styles.saveButton}
-          />
-        </View>
+        <QuickTickBar
+          visible={visible}
+          embedded
+          climbUuid={climbUuid}
+          boardName={boardName}
+          angle={angle}
+          isMirror={isMirror}
+          isBenchmark={isBenchmark}
+          layoutId={layoutId}
+          sizeId={sizeId}
+          setIds={setIds}
+          sessionId={sessionId}
+          consensusGradeName={consensusGradeName}
+          hasPriorHistory={hasPriorHistory}
+          onDismiss={onDismiss}
+        />
       </BottomSheetView>
     </BottomSheet>
   );
@@ -419,55 +126,5 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
-  },
-  scrollContent: {
-    paddingBottom: spacing[4],
-  },
-  header: {
-    paddingHorizontal: spacing[4],
-    paddingBottom: spacing[3],
-    alignItems: 'center',
-    gap: 4,
-  },
-  climbName: {
-    opacity: 0.6,
-  },
-  section: {
-    paddingHorizontal: spacing[4],
-    paddingVertical: spacing[3],
-  },
-  sectionLabel: {
-    opacity: 0.6,
-    marginBottom: spacing[2],
-  },
-  stepperRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: spacing[5],
-  },
-  stepperDisabled: {
-    opacity: 0.4,
-  },
-  attemptCount: {
-    minWidth: 40,
-    textAlign: 'center',
-  },
-  gradeChipsContainer: {
-    gap: spacing[2],
-    paddingVertical: spacing[1],
-  },
-  gradeChipText: {
-    fontWeight: '500',
-  },
-  footer: {
-    paddingHorizontal: spacing[4],
-    paddingTop: spacing[3],
-    paddingBottom: spacing[3],
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: iosSystemColors.separator,
-  },
-  saveButton: {
-    width: '100%',
   },
 });

--- a/packages/mobile/src/components/play-drawer/InlineGradePicker.tsx
+++ b/packages/mobile/src/components/play-drawer/InlineGradePicker.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useRef } from 'react';
-import { View, Pressable, ScrollView, StyleSheet, type ViewStyle } from 'react-native';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { View, Pressable, ScrollView, StyleSheet, type LayoutChangeEvent, type ViewStyle } from 'react-native';
 import type { Grade } from '@boardsesh/shared-schema';
 import { Text } from '../Text';
 import { brandColors } from '../../theme/colors';
@@ -7,6 +7,7 @@ import { iosSystemColors } from '../../theme/ios-colors';
 import { hapticSelection } from '../../lib/haptics';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
+import { computeFocusOffset, type ChipLayout } from './inline-grade-picker-utils';
 
 type InlineGradePickerProps = {
   grades: Grade[];
@@ -14,6 +15,8 @@ type InlineGradePickerProps = {
   consensusDifficultyId: number | undefined;
   onSelect: (difficultyId: number | undefined) => void;
 };
+
+const APPROX_CHIP_WIDTH = 56;
 
 export const InlineGradePicker = React.memo(function InlineGradePicker({
   grades,
@@ -23,20 +26,68 @@ export const InlineGradePicker = React.memo(function InlineGradePicker({
 }: InlineGradePickerProps) {
   const scrollRef = useRef<ScrollView>(null);
   const { systemColors } = useTheme();
-  const chipWidth = 56;
+  // All measured chip layouts, keyed by difficultyId. We need every chip's
+  // measurement (not just the focus chip's) because chip widths vary with
+  // label length and the gap between chips, so a `focusChip.x` measurement
+  // alone is enough for centering — but keeping the full map costs nothing
+  // and means selection changes also center correctly.
+  const chipLayoutsRef = useRef<Map<number, ChipLayout>>(new Map());
+  const [viewportWidth, setViewportWidth] = useState(0);
+  const [contentWidth, setContentWidth] = useState(0);
+  // Bumps whenever the focus chip's layout is captured. Used to re-run the
+  // auto-scroll effect once the measurement we care about lands — refs
+  // alone don't trigger renders, which was the original centering bug.
+  const [focusLayoutTick, setFocusLayoutTick] = useState(0);
+  const hasAutoScrolledRef = useRef(false);
+
+  const focusId = selectedDifficultyId ?? consensusDifficultyId;
+
+  const handleScrollLayout = useCallback((event: LayoutChangeEvent) => {
+    setViewportWidth(event.nativeEvent.layout.width);
+  }, []);
+
+  const handleContentSizeChange = useCallback((width: number) => {
+    setContentWidth(width);
+  }, []);
+
+  // Reset auto-scroll arming when the focus target changes (e.g. parent
+  // re-mounts for a new climb). Otherwise navigating from climb A to climb
+  // B would keep the first scroll permanently locked in.
+  useEffect(() => {
+    hasAutoScrolledRef.current = false;
+  }, [focusId]);
 
   useEffect(() => {
-    const focusId = selectedDifficultyId ?? consensusDifficultyId;
-    if (!focusId) return;
+    if (hasAutoScrolledRef.current) return;
+    if (focusId == null) return;
+    if (viewportWidth === 0) return;
+    // Wait until the ScrollView has measured its content. Calling scrollTo
+    // before content has been laid out is a no-op — the offset gets clamped
+    // to the (still zero) scrollable range.
+    if (contentWidth === 0) return;
     const index = grades.findIndex((g) => g.difficultyId === focusId);
     if (index < 0) return;
-    const timer = setTimeout(() => {
-      scrollRef.current?.scrollTo({ x: Math.max(0, index * chipWidth - chipWidth * 2), animated: false });
-    }, 50);
-    return () => clearTimeout(timer);
-    // Only scroll on mount — don't fight user's manual scrolling
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    const focusChipLayout = chipLayoutsRef.current.get(focusId) ?? null;
+    const targetX = computeFocusOffset({
+      viewportWidth,
+      chipLayout: focusChipLayout,
+      index,
+      approxChipWidth: APPROX_CHIP_WIDTH,
+    });
+    if (targetX == null) return;
+    // Only lock once we've used the real focus-chip measurement. If we
+    // fell back to the index*approxChipWidth approximation, leave the
+    // gate open so we re-attempt when the chip's onLayout finally fires.
+    if (focusChipLayout !== null) {
+      hasAutoScrolledRef.current = true;
+    }
+    // Defer by one frame: even after onContentSizeChange, the underlying
+    // native ScrollView occasionally needs a tick before scrollTo lands.
+    const handle = requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({ x: targetX, animated: false });
+    });
+    return () => cancelAnimationFrame(handle);
+  }, [viewportWidth, contentWidth, grades, focusId, focusLayoutTick]);
 
   const handlePress = useCallback(
     (difficultyId: number) => {
@@ -53,6 +104,8 @@ export const InlineGradePicker = React.memo(function InlineGradePicker({
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={styles.scrollContent}
       keyboardShouldPersistTaps="handled"
+      onLayout={handleScrollLayout}
+      onContentSizeChange={handleContentSizeChange}
     >
       {grades.map((grade) => {
         const isSelected = grade.difficultyId === selectedDifficultyId;
@@ -72,6 +125,16 @@ export const InlineGradePicker = React.memo(function InlineGradePicker({
           <Pressable
             key={grade.difficultyId}
             onPress={() => handlePress(grade.difficultyId)}
+            onLayout={(event) => {
+              const { x, width } = event.nativeEvent.layout;
+              chipLayoutsRef.current.set(grade.difficultyId, { x, width });
+              if (grade.difficultyId === focusId) {
+                // Bump version state so the auto-scroll effect re-runs with
+                // the real focus-chip measurements instead of the
+                // index*approxChipWidth fallback.
+                setFocusLayoutTick((tick) => tick + 1);
+              }
+            }}
             accessibilityRole="button"
             accessibilityState={{ selected: isSelected }}
             accessibilityLabel={grade.name}

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -18,7 +18,7 @@ import type { ActiveSubDrawer } from '@boardsesh/play-view';
 import { SwipeBoardCarousel } from './SwipeBoardCarousel';
 import { PlayDrawerHeader } from './PlayDrawerHeader';
 import { PlayDrawerActionBar } from './PlayDrawerActionBar';
-import { QuickTickBar } from './QuickTickBar';
+import { LogAscentSheet } from '../LogAscentSheet';
 import { DeferredSections } from './DeferredSections';
 import { QueueSheet } from './QueueSheet';
 import { AngleSelectorSheet } from './AngleSelectorSheet';
@@ -394,22 +394,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
                     />
                   )}
 
-                  {/* Quick Tick Bar (expanded mode, triggered by tick button in action bar) */}
-                  <QuickTickBar
-                    visible={isTickBarActive}
-                    climbUuid={displayedClimb.uuid}
-                    boardName={boardName}
-                    angle={angle}
-                    isMirror={isMirrored}
-                    isBenchmark={displayedClimb.benchmark_difficulty != null}
-                    layoutId={layoutId}
-                    sizeId={sizeId}
-                    setIds={setIds}
-                    sessionId={sessionId}
-                    consensusGradeName={displayedClimb.difficulty}
-                    hasPriorHistory={(displayedClimb.userAscents ?? 0) > 0 || (displayedClimb.userAttempts ?? 0) > 0}
-                    onDismiss={handleTickBarDismiss}
-                  />
                 </View>
 
                 <PlayDrawerActionBar
@@ -505,6 +489,26 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         />
       )}
 
+      {/* Tick sheet — sibling of the PlayDrawer modal so it renders above
+          (gorhom `BottomSheetModal` with stackBehavior=push). Snap-point is
+          60% so the climb image above stays visible while logging. */}
+      {displayedClimb && (
+        <LogAscentSheet
+          visible={isTickBarActive}
+          onDismiss={handleTickBarDismiss}
+          climbUuid={displayedClimb.uuid}
+          climbName={displayedClimb.name}
+          boardName={boardName}
+          angle={angle}
+          isMirror={isMirrored}
+          isBenchmark={displayedClimb.benchmark_difficulty != null}
+          layoutId={layoutId}
+          sizeId={sizeId}
+          setIds={setIds}
+          sessionId={sessionId}
+          consensusGradeName={displayedClimb.difficulty}
+        />
+      )}
     </>
   );
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -22,7 +22,6 @@ import { QuickTickBar } from './QuickTickBar';
 import { DeferredSections } from './DeferredSections';
 import { QueueSheet } from './QueueSheet';
 import { AngleSelectorSheet } from './AngleSelectorSheet';
-import { LogAscentSheet } from '../LogAscentSheet';
 import { ClimbActionsSheet } from '../ClimbActionsSheet';
 import { Icon } from '../Icon';
 import { useQueue } from '../../providers/queue-provider';
@@ -78,7 +77,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const insets = useSafeAreaInsets();
   const sheetRef = useRef<BottomSheetModal>(null);
   const [climb, setClimb] = useState<Climb | null>(null);
-  const [showLogAscent, setShowLogAscent] = useState(false);
   const [isMirrored, setIsMirrored] = useState(false);
   const [isFavorited, setIsFavorited] = useState(false);
   const [isTickBarActive, setIsTickBarActive] = useState(false);
@@ -251,8 +249,11 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     setIsTickBarActive(true);
   }, []);
 
+  // Long-press now opens the same QuickTickBar as a short press; LogAscentSheet
+  // has been retired in favour of a single ticking surface (see PR #2366).
   const handleTickFabLongPress = useCallback(() => {
-    setShowLogAscent(true);
+    resetZoomRef.current?.();
+    setIsTickBarActive(true);
   }, []);
 
   const handleTickBarDismiss = useCallback(() => {
@@ -405,6 +406,8 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
                     sizeId={sizeId}
                     setIds={setIds}
                     sessionId={sessionId}
+                    consensusGradeName={displayedClimb.difficulty}
+                    hasPriorHistory={(displayedClimb.userAscents ?? 0) > 0 || (displayedClimb.userAttempts ?? 0) > 0}
                     onDismiss={handleTickBarDismiss}
                   />
                 </View>
@@ -502,23 +505,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         />
       )}
 
-      {/* Log Ascent sheet (full, via long-press) */}
-      {displayedClimb && (
-        <LogAscentSheet
-          visible={showLogAscent}
-          onDismiss={() => setShowLogAscent(false)}
-          climbUuid={displayedClimb.uuid}
-          climbName={displayedClimb.name}
-          boardName={boardName}
-          angle={angle}
-          isMirror={isMirrored}
-          isBenchmark={displayedClimb.benchmark_difficulty != null}
-          layoutId={layoutId}
-          sizeId={sizeId}
-          setIds={setIds}
-          sessionId={sessionId}
-        />
-      )}
     </>
   );
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -497,7 +497,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
           visible={isTickBarActive}
           onDismiss={handleTickBarDismiss}
           climbUuid={displayedClimb.uuid}
-          climbName={displayedClimb.name}
           boardName={boardName}
           angle={angle}
           isMirror={isMirrored}

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -3,7 +3,8 @@
 // pan-down-to-close, and the drag handle. This component is just the
 // pickers + save row.
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { View, Pressable, StyleSheet, TextInput, type TextStyle } from 'react-native';
+import { View, Pressable, StyleSheet, type TextStyle } from 'react-native';
+import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import {
   createInitialTickState,
@@ -67,14 +68,24 @@ export const QuickTickBar = React.memo(function QuickTickBar({
 
   // Mobile's `Climb.userAscents`/`userAttempts` GraphQL fields aren't
   // populated server-side, so we read the user's accumulated logbook
-  // (denormalised via `BoardProvider` → `useLogbook`) directly. Same source
-  // AscentStatusBadge uses for its flash/send/attempt pill.
+  // (denormalised via `BoardProvider` → `useLogbook`) directly. Same
+  // source `AscentStatusBadge` uses for its flash/send/attempt pill.
   //
-  // Pessimistic default when the provider isn't mounted yet: treat the
-  // climb as already-attempted so the primary save button reads "Send"
-  // rather than the optimistic "Flash". Logging a real first-flash as a
-  // send is a one-tap fix; logging a re-send as a flash is unrecoverable.
+  // Two failure modes the save-button label must guard against:
+  // 1. `BoardProvider` not mounted → no logbook context at all → `Send`.
+  // 2. Provider is mounted but this climb's ticks haven't been fetched
+  //    yet → `board.logbook.some(...)` returns false. We trigger
+  //    `getLogbook` on mount (idempotent thanks to useLogbook's fetched-
+  //    uuid dedupe) so the answer becomes authoritative on the next
+  //    render after the fetch resolves. In the brief window before then
+  //    the label may still read `Flash` for a climb that actually has
+  //    history — bounded to flows that bypass the climbs-index
+  //    pre-fetch (e.g. deep link to /climbs/[uuid]).
   const board = useOptionalBoardProvider();
+  useEffect(() => {
+    if (!board) return;
+    void board.getLogbook([climbUuid]);
+  }, [board, climbUuid]);
   const hasPriorHistory = useMemo(() => {
     if (!board) return true;
     return board.logbook.some((entry) => entry.climb_uuid === climbUuid && entry.angle === angle);
@@ -233,7 +244,11 @@ export const QuickTickBar = React.memo(function QuickTickBar({
         <Text variant="footnote" color={iosSystemColors.systemGray} style={styles.rowLabel}>
           {t('playView.tickBar.noteLabel')}
         </Text>
-        <TextInput
+        {/* `BottomSheetTextInput` (vs the bare `TextInput`) is what makes
+            the host sheet auto-expand to its larger snap point when the
+            keyboard appears — otherwise the keyboard covers the comment
+            row and the save buttons. */}
+        <BottomSheetTextInput
           value={comment}
           onChangeText={setComment}
           placeholder={t('playView.tickBar.commentPlaceholder')}
@@ -328,7 +343,10 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[3],
-    paddingHorizontal: spacing[4],
+    // Pull the save buttons inward from the edges — the picker rows above
+    // use spacing[4] for their content gutter, but pill buttons want a
+    // larger visual margin so the green Send doesn't crowd the screen edge.
+    paddingHorizontal: spacing[6],
     paddingTop: spacing[3],
   },
   saveButton: {

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -1,6 +1,9 @@
+// Ticking form contents. Always rendered inside `LogAscentSheet`'s
+// BottomSheetModal — the sheet owns positioning, slide-in, backdrop,
+// pan-down-to-close, and the drag handle. This component is just the
+// pickers + save row.
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { View, Pressable, StyleSheet, TextInput, type TextStyle } from 'react-native';
-import Animated, { useAnimatedStyle, useSharedValue, withTiming, runOnJS } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import {
   createInitialTickState,
@@ -11,22 +14,20 @@ import {
 } from '@boardsesh/play-view';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
-import { GlassSurface } from '../GlassSurface';
 import { InlineStarPicker } from './InlineStarPicker';
 import { InlineGradePicker } from './InlineGradePicker';
 import { InlineTriesPicker } from './InlineTriesPicker';
 import { useTheme } from '../../providers/theme-provider';
 import { useGrades } from '../../lib/graphql/hooks';
-import { useSaveTick } from '@boardsesh/board-react';
+import { useOptionalBoardProvider, useSaveTick } from '@boardsesh/board-react';
 import { toBoardName } from '@boardsesh/board-config';
+import { useToast } from '../../providers/toast-provider';
 import { hapticSuccess, hapticError } from '../../lib/haptics';
 import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
-import { timing } from '../../theme/animations';
 
 type QuickTickBarProps = {
-  visible: boolean;
   climbUuid: string;
   boardName: string;
   angle: number;
@@ -36,29 +37,15 @@ type QuickTickBarProps = {
   sizeId?: number;
   setIds?: string;
   sessionId?: string | null;
-  // The climb's consensus grade label (e.g. "V5", "7a+"). Mapped to a
+  // The climb's consensus grade label (e.g. "V5", "7a+"). Resolved to a
   // numeric difficulty id at render time via the loaded grades list and
   // forwarded to InlineGradePicker so the consensus chip is centered (and
-  // visually outlined) without being preselected. This is just the
-  // existing Climb.difficulty string — getClimbByUuid already produces it
-  // from ROUND(display_difficulty), so no new GraphQL field is needed.
+  // visually outlined) without being preselected.
   consensusGradeName?: string;
-  // True when the user has previously logged an ascent or attempt on this
-  // climb. Drives `deriveAscentType` so the primary save button reads
-  // "Send" (not "Flash") on the first attempt of a re-attempt — a flash
-  // requires no prior history at all.
-  hasPriorHistory?: boolean;
-  // When true, render contents in a passive View instead of the
-  // absolute-positioned animated bar. Use this when a parent (e.g. a
-  // BottomSheet) already owns positioning and slide-in animation. The
-  // `visible` prop still drives mount/unmount so child state resets work
-  // identically across the two modes.
-  embedded?: boolean;
   onDismiss: () => void;
 };
 
 export const QuickTickBar = React.memo(function QuickTickBar({
-  visible,
   climbUuid,
   boardName,
   angle,
@@ -69,19 +56,35 @@ export const QuickTickBar = React.memo(function QuickTickBar({
   setIds,
   sessionId,
   consensusGradeName,
-  hasPriorHistory = false,
-  embedded = false,
   onDismiss,
 }: QuickTickBarProps) {
   const { t } = useTranslation('session');
   const { t: tClimbs } = useTranslation('climbs');
   const { systemColors } = useTheme();
+  const { showToast } = useToast();
   const saveTick = useSaveTick(toBoardName(boardName));
   const { data: grades } = useGrades(boardName);
 
+  // Mobile's `Climb.userAscents`/`userAttempts` GraphQL fields aren't
+  // populated server-side, so we read the user's accumulated logbook
+  // (denormalised via `BoardProvider` → `useLogbook`) directly. Same source
+  // AscentStatusBadge uses for its flash/send/attempt pill.
+  //
+  // Pessimistic default when the provider isn't mounted yet: treat the
+  // climb as already-attempted so the primary save button reads "Send"
+  // rather than the optimistic "Flash". Logging a real first-flash as a
+  // send is a one-tap fix; logging a re-send as a flash is unrecoverable.
+  const board = useOptionalBoardProvider();
+  const hasPriorHistory = useMemo(() => {
+    if (!board) return true;
+    return board.logbook.some((entry) => entry.climb_uuid === climbUuid && entry.angle === angle);
+  }, [board, climbUuid, angle]);
+
   const [tickState, setTickState] = useState(createInitialTickState);
   const [comment, setComment] = useState('');
-  const [mounted, setMounted] = useState(visible);
+  // Renders an inline error row above the save buttons when the last
+  // save attempt failed. Cleared on the next attempt or on success.
+  const [lastError, setLastError] = useState<string | null>(null);
 
   // Resolve the consensus grade *name* (e.g. "V5") to a numeric difficulty
   // id by matching against the loaded grades list. The id is what
@@ -94,33 +97,13 @@ export const QuickTickBar = React.memo(function QuickTickBar({
   const ascentType = deriveAscentType(hasPriorHistory, tickState.attemptCount);
   const minAttempts = useMemo(() => getMinAttempts(ascentType), [ascentType]);
 
+  // Reset form state when the climb context changes underneath an open
+  // sheet (e.g. user swiped to next while the sheet was already open).
   useEffect(() => {
     setTickState(createInitialTickState());
     setComment('');
+    setLastError(null);
   }, [climbUuid]);
-
-  useEffect(() => {
-    if (visible) {
-      setMounted(true);
-    }
-  }, [visible]);
-
-  const translateY = useSharedValue(200);
-
-  useEffect(() => {
-    if (visible) {
-      translateY.value = withTiming(0, { duration: timing.normal });
-    } else {
-      translateY.value = withTiming(200, { duration: timing.fast }, () => {
-        runOnJS(setMounted)(false);
-      });
-    }
-  }, [visible, translateY]);
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: translateY.value }],
-    opacity: translateY.value < 100 ? 1 : 0,
-  }));
 
   const handleQualitySelect = useCallback((value: number | null) => {
     setTickState((prev) => ({ ...prev, quality: value }));
@@ -137,6 +120,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
   const handleSaveWithStatus = useCallback(
     (status: TickStatus) => {
       if (saveTick.isPending) return;
+      setLastError(null);
 
       const finalAttempts = clampAttempts(tickState.attemptCount, status);
 
@@ -160,10 +144,21 @@ export const QuickTickBar = React.memo(function QuickTickBar({
         {
           onSuccess: () => {
             hapticSuccess();
+            // Reset on commit so reopening the sheet on the same climb
+            // doesn't show stale state from the just-saved tick.
+            setTickState(createInitialTickState());
+            setComment('');
+            setLastError(null);
+            showToast(tClimbs('mobile.logAscent.savedToast'), 'success');
             onDismiss();
           },
-          onError: () => {
+          onError: (error: unknown) => {
             hapticError();
+            const message =
+              error instanceof Error && error.message
+                ? error.message
+                : tClimbs('mobile.logAscent.errorMessage');
+            setLastError(message);
           },
         },
       );
@@ -181,22 +176,18 @@ export const QuickTickBar = React.memo(function QuickTickBar({
       tickState,
       comment,
       onDismiss,
+      showToast,
+      tClimbs,
     ],
   );
 
   const handleSave = useCallback(() => handleSaveWithStatus(ascentType), [handleSaveWithStatus, ascentType]);
   const handleAttempt = useCallback(() => handleSaveWithStatus('attempt'), [handleSaveWithStatus]);
 
-  if (!embedded && !mounted) return null;
-  if (embedded && !visible) return null;
-
   const saveLabel = ascentType === 'flash' ? t('playView.tickBar.flashSaveLabel') : t('playView.tickBar.sendSaveLabel');
 
-  // Shared between the inline (Animated.View + GlassSurface) and embedded
-  // (plain View inside a BottomSheet) branches — the only thing those two
-  // differ on is the outer container chrome.
-  const tickBarContents = (
-    <>
+  return (
+    <View style={styles.container}>
       <View style={styles.row}>
         <Text variant="footnote" color={iosSystemColors.systemGray} style={styles.rowLabel}>
           {t('playView.tickBar.gradeLabel')}
@@ -235,7 +226,13 @@ export const QuickTickBar = React.memo(function QuickTickBar({
         </View>
       </View>
 
-      <View style={styles.commentRow}>
+      {/* Compact note row — same label grid as the picker rows above, with
+          a borderless input that auto-grows when focused. Lower visual
+          weight than the previous tall bordered textarea. */}
+      <View style={styles.row}>
+        <Text variant="footnote" color={iosSystemColors.systemGray} style={styles.rowLabel}>
+          {t('playView.tickBar.noteLabel')}
+        </Text>
         <TextInput
           value={comment}
           onChangeText={setComment}
@@ -245,115 +242,73 @@ export const QuickTickBar = React.memo(function QuickTickBar({
           multiline
           style={
             {
-              borderWidth: StyleSheet.hairlineWidth,
-              borderColor: systemColors.separator as string,
-              borderRadius: 10,
-              paddingHorizontal: spacing[3],
-              paddingVertical: spacing[2],
+              flex: 1,
               fontSize: 14,
               lineHeight: 19,
               color: systemColors.label as string,
-              minHeight: 56,
+              minHeight: 36,
+              paddingVertical: spacing[1],
               textAlignVertical: 'top',
             } satisfies TextStyle
           }
         />
       </View>
 
+      {lastError ? (
+        <View style={styles.errorRow}>
+          <Icon name="close" size={14} color={iosSystemColors.systemRed} />
+          <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.errorText}>
+            {lastError}
+          </Text>
+        </View>
+      ) : null}
+
       <View style={styles.saveRow}>
         <Pressable
-          onPress={onDismiss}
+          onPress={handleAttempt}
+          disabled={saveTick.isPending}
           accessibilityRole="button"
-          accessibilityLabel={t('playView.tickBar.cancelLabel')}
-          style={styles.cancelButton}
+          accessibilityLabel={t('playView.tickBar.logAscentAria', { status: 'attempt' })}
+          style={({ pressed }) => [
+            styles.attemptButton,
+            { borderColor: systemColors.separator as string },
+            pressed && styles.buttonPressed,
+            saveTick.isPending && styles.buttonDisabled,
+          ]}
         >
-          <Text variant="footnote" color={iosSystemColors.systemGray}>
-            {t('playView.tickBar.cancelLabel')}
+          <Text
+            variant="footnote"
+            color={systemColors.label}
+            style={styles.attemptLabel}
+          >
+            {tClimbs('mobile.logAscent.attempt')}
           </Text>
         </Pressable>
 
-        <View style={styles.saveRowActions}>
-          <Pressable
-            onPress={handleAttempt}
-            disabled={saveTick.isPending}
-            accessibilityRole="button"
-            accessibilityLabel={t('playView.tickBar.logAscentAria', { status: 'attempt' })}
-            style={({ pressed }) => [
-              styles.attemptButton,
-              pressed && styles.saveButtonPressed,
-              saveTick.isPending && styles.saveButtonDisabled,
-            ]}
-          >
-            <Icon name="tick.outline" size={18} color={iosSystemColors.white} />
-            <Text variant="footnote" color={iosSystemColors.white} style={styles.saveLabel}>
-              {tClimbs('mobile.logAscent.attempt')}
-            </Text>
-          </Pressable>
-
-          <Pressable
-            onPress={handleSave}
-            disabled={saveTick.isPending}
-            accessibilityRole="button"
-            accessibilityLabel={t('playView.tickBar.logAscentAria', { status: ascentType })}
-            style={({ pressed }) => [
-              styles.saveButton,
-              pressed && styles.saveButtonPressed,
-              saveTick.isPending && styles.saveButtonDisabled,
-            ]}
-          >
-            <Icon name="tick.outline" size={18} color={iosSystemColors.white} />
-            <Text variant="footnote" color={iosSystemColors.white} style={styles.saveLabel}>
-              {saveLabel}
-            </Text>
-          </Pressable>
-        </View>
+        <Pressable
+          onPress={handleSave}
+          disabled={saveTick.isPending}
+          accessibilityRole="button"
+          accessibilityLabel={t('playView.tickBar.logAscentAria', { status: ascentType })}
+          style={({ pressed }) => [
+            styles.saveButton,
+            pressed && styles.buttonPressed,
+            saveTick.isPending && styles.buttonDisabled,
+          ]}
+        >
+          <Icon name="tick.outline" size={18} color={iosSystemColors.white} />
+          <Text variant="footnote" color={iosSystemColors.white} style={styles.saveLabel}>
+            {saveLabel}
+          </Text>
+        </Pressable>
       </View>
-    </>
-  );
-
-  if (embedded) {
-    return <View style={styles.embeddedContainer}>{tickBarContents}</View>;
-  }
-
-  return (
-    <Animated.View
-      style={[
-        styles.container,
-        // Solid safety-net background so the bar is always legible even on
-        // dev clients where the glass/blur native module isn't linked, or on
-        // platforms where GlassSurface degrades. Glass effect, when present,
-        // composites over this opaque base.
-        { backgroundColor: systemColors.secondaryBackground, borderTopColor: systemColors.separator },
-        animatedStyle,
-      ]}
-      pointerEvents={visible ? 'auto' : 'none'}
-    >
-      <GlassSurface glassEffectStyle="regular" style={StyleSheet.absoluteFill} pointerEvents="none" />
-      {tickBarContents}
-    </Animated.View>
+    </View>
   );
 });
 
 const styles = StyleSheet.create({
   container: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopLeftRadius: 12,
-    borderTopRightRadius: 12,
-    // Clip the glass / blur material to the rounded top edge.
-    overflow: 'hidden',
-    zIndex: 5,
-    paddingTop: spacing[3],
-    paddingBottom: spacing[3],
-  },
-  // Sibling of `container` for the `embedded` mode: drops absolute
-  // positioning, slide-in animation, and chrome (rounded corners + top
-  // border) since the host BottomSheet owns all of that.
-  embeddedContainer: {
-    paddingTop: spacing[2],
+    paddingTop: spacing[1],
     paddingBottom: spacing[3],
   },
   row: {
@@ -363,7 +318,7 @@ const styles = StyleSheet.create({
     minHeight: 44,
   },
   rowLabel: {
-    width: 48,
+    width: 56,
     fontWeight: '500',
   },
   rowPicker: {
@@ -372,53 +327,53 @@ const styles = StyleSheet.create({
   saveRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
+    gap: spacing[3],
     paddingHorizontal: spacing[4],
-    paddingTop: spacing[2],
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: iosSystemColors.separator,
-    marginTop: spacing[2],
-  },
-  cancelButton: {
-    paddingVertical: spacing[2],
-    paddingHorizontal: spacing[3],
+    paddingTop: spacing[3],
   },
   saveButton: {
+    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'center',
     gap: spacing[1],
-    paddingVertical: spacing[2],
+    paddingVertical: spacing[3],
     paddingHorizontal: spacing[4],
-    borderRadius: 20,
+    borderRadius: 22,
     backgroundColor: brandColors.success,
   },
   attemptButton: {
+    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing[1],
-    paddingVertical: spacing[2],
+    justifyContent: 'center',
+    paddingVertical: spacing[3],
     paddingHorizontal: spacing[4],
-    borderRadius: 20,
-    backgroundColor: iosSystemColors.systemRed,
+    borderRadius: 22,
+    borderWidth: 1,
+    backgroundColor: 'transparent',
   },
-  saveRowActions: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[2],
-  },
-  commentRow: {
-    paddingHorizontal: spacing[4],
-    paddingTop: spacing[2],
-    paddingBottom: spacing[1],
-  },
-  saveButtonPressed: {
-    transform: [{ scale: 0.95 }],
+  buttonPressed: {
+    transform: [{ scale: 0.97 }],
     opacity: 0.9,
   },
-  saveButtonDisabled: {
-    opacity: 0.6,
+  buttonDisabled: {
+    opacity: 0.5,
   },
   saveLabel: {
     fontWeight: '600',
+  },
+  attemptLabel: {
+    fontWeight: '600',
+  },
+  errorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+  },
+  errorText: {
+    flexShrink: 1,
   },
 });

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { View, Pressable, StyleSheet } from 'react-native';
+import { View, Pressable, StyleSheet, TextInput, type TextStyle } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming, runOnJS } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import {
@@ -15,8 +15,8 @@ import { GlassSurface } from '../GlassSurface';
 import { InlineStarPicker } from './InlineStarPicker';
 import { InlineGradePicker } from './InlineGradePicker';
 import { InlineTriesPicker } from './InlineTriesPicker';
-import { useGrades } from '../../lib/graphql/hooks';
 import { useTheme } from '../../providers/theme-provider';
+import { useGrades } from '../../lib/graphql/hooks';
 import { useSaveTick } from '@boardsesh/board-react';
 import { toBoardName } from '@boardsesh/board-config';
 import { hapticSuccess, hapticError } from '../../lib/haptics';
@@ -36,6 +36,24 @@ type QuickTickBarProps = {
   sizeId?: number;
   setIds?: string;
   sessionId?: string | null;
+  // The climb's consensus grade label (e.g. "V5", "7a+"). Mapped to a
+  // numeric difficulty id at render time via the loaded grades list and
+  // forwarded to InlineGradePicker so the consensus chip is centered (and
+  // visually outlined) without being preselected. This is just the
+  // existing Climb.difficulty string — getClimbByUuid already produces it
+  // from ROUND(display_difficulty), so no new GraphQL field is needed.
+  consensusGradeName?: string;
+  // True when the user has previously logged an ascent or attempt on this
+  // climb. Drives `deriveAscentType` so the primary save button reads
+  // "Send" (not "Flash") on the first attempt of a re-attempt — a flash
+  // requires no prior history at all.
+  hasPriorHistory?: boolean;
+  // When true, render contents in a passive View instead of the
+  // absolute-positioned animated bar. Use this when a parent (e.g. a
+  // BottomSheet) already owns positioning and slide-in animation. The
+  // `visible` prop still drives mount/unmount so child state resets work
+  // identically across the two modes.
+  embedded?: boolean;
   onDismiss: () => void;
 };
 
@@ -50,21 +68,35 @@ export const QuickTickBar = React.memo(function QuickTickBar({
   sizeId,
   setIds,
   sessionId,
+  consensusGradeName,
+  hasPriorHistory = false,
+  embedded = false,
   onDismiss,
 }: QuickTickBarProps) {
   const { t } = useTranslation('session');
+  const { t: tClimbs } = useTranslation('climbs');
   const { systemColors } = useTheme();
   const saveTick = useSaveTick(toBoardName(boardName));
   const { data: grades } = useGrades(boardName);
 
   const [tickState, setTickState] = useState(createInitialTickState);
+  const [comment, setComment] = useState('');
   const [mounted, setMounted] = useState(visible);
 
-  const ascentType = deriveAscentType(false, tickState.attemptCount);
+  // Resolve the consensus grade *name* (e.g. "V5") to a numeric difficulty
+  // id by matching against the loaded grades list. The id is what
+  // InlineGradePicker compares against each chip's `difficultyId`.
+  const consensusDifficultyId = useMemo(() => {
+    if (!consensusGradeName || !grades) return undefined;
+    return grades.find((grade) => grade.name === consensusGradeName)?.difficultyId;
+  }, [consensusGradeName, grades]);
+
+  const ascentType = deriveAscentType(hasPriorHistory, tickState.attemptCount);
   const minAttempts = useMemo(() => getMinAttempts(ascentType), [ascentType]);
 
   useEffect(() => {
     setTickState(createInitialTickState());
+    setComment('');
   }, [climbUuid]);
 
   useEffect(() => {
@@ -102,72 +134,69 @@ export const QuickTickBar = React.memo(function QuickTickBar({
     setTickState((prev) => ({ ...prev, attemptCount: value }));
   }, []);
 
-  const handleSave = useCallback(() => {
-    if (saveTick.isPending) return;
+  const handleSaveWithStatus = useCallback(
+    (status: TickStatus) => {
+      if (saveTick.isPending) return;
 
-    const status: TickStatus = ascentType;
-    const finalAttempts = clampAttempts(tickState.attemptCount, status);
+      const finalAttempts = clampAttempts(tickState.attemptCount, status);
 
-    saveTick.mutate(
-      {
-        climbUuid,
-        angle,
-        isMirror,
-        status,
-        attemptCount: finalAttempts,
-        quality: tickState.quality != null && tickState.quality > 0 ? tickState.quality : null,
-        difficulty: tickState.difficulty ?? null,
-        isBenchmark,
-        comment: '',
-        climbedAt: new Date().toISOString(),
-        ...(sessionId ? { sessionId } : {}),
-        ...(layoutId != null ? { layoutId } : {}),
-        ...(sizeId != null ? { sizeId } : {}),
-        ...(setIds ? { setIds } : {}),
-      },
-      {
-        onSuccess: () => {
-          hapticSuccess();
-          onDismiss();
+      saveTick.mutate(
+        {
+          climbUuid,
+          angle,
+          isMirror,
+          status,
+          attemptCount: finalAttempts,
+          quality: tickState.quality != null && tickState.quality > 0 ? tickState.quality : null,
+          difficulty: tickState.difficulty ?? null,
+          isBenchmark,
+          comment,
+          climbedAt: new Date().toISOString(),
+          ...(sessionId ? { sessionId } : {}),
+          ...(layoutId != null ? { layoutId } : {}),
+          ...(sizeId != null ? { sizeId } : {}),
+          ...(setIds ? { setIds } : {}),
         },
-        onError: () => {
-          hapticError();
+        {
+          onSuccess: () => {
+            hapticSuccess();
+            onDismiss();
+          },
+          onError: () => {
+            hapticError();
+          },
         },
-      },
-    );
-  }, [
-    saveTick,
-    climbUuid,
-    angle,
-    isMirror,
-    isBenchmark,
-    sessionId,
-    layoutId,
-    sizeId,
-    setIds,
-    ascentType,
-    tickState,
-    onDismiss,
-  ]);
+      );
+    },
+    [
+      saveTick,
+      climbUuid,
+      angle,
+      isMirror,
+      isBenchmark,
+      sessionId,
+      layoutId,
+      sizeId,
+      setIds,
+      tickState,
+      comment,
+      onDismiss,
+    ],
+  );
 
-  if (!mounted) return null;
+  const handleSave = useCallback(() => handleSaveWithStatus(ascentType), [handleSaveWithStatus, ascentType]);
+  const handleAttempt = useCallback(() => handleSaveWithStatus('attempt'), [handleSaveWithStatus]);
+
+  if (!embedded && !mounted) return null;
+  if (embedded && !visible) return null;
 
   const saveLabel = ascentType === 'flash' ? t('playView.tickBar.flashSaveLabel') : t('playView.tickBar.sendSaveLabel');
 
-  return (
-    <Animated.View
-      style={[
-        styles.container,
-        // Solid safety-net background so the bar is always legible even on
-        // dev clients where the glass/blur native module isn't linked, or on
-        // platforms where GlassSurface degrades. Glass effect, when present,
-        // composites over this opaque base.
-        { backgroundColor: systemColors.secondaryBackground, borderTopColor: systemColors.separator },
-        animatedStyle,
-      ]}
-      pointerEvents={visible ? 'auto' : 'none'}
-    >
-      <GlassSurface glassEffectStyle="regular" style={StyleSheet.absoluteFill} pointerEvents="none" />
+  // Shared between the inline (Animated.View + GlassSurface) and embedded
+  // (plain View inside a BottomSheet) branches — the only thing those two
+  // differ on is the outer container chrome.
+  const tickBarContents = (
+    <>
       <View style={styles.row}>
         <Text variant="footnote" color={iosSystemColors.systemGray} style={styles.rowLabel}>
           {t('playView.tickBar.gradeLabel')}
@@ -177,7 +206,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
             <InlineGradePicker
               grades={grades}
               selectedDifficultyId={tickState.difficulty}
-              consensusDifficultyId={undefined}
+              consensusDifficultyId={consensusDifficultyId}
               onSelect={handleGradeSelect}
             />
           )}
@@ -206,6 +235,31 @@ export const QuickTickBar = React.memo(function QuickTickBar({
         </View>
       </View>
 
+      <View style={styles.commentRow}>
+        <TextInput
+          value={comment}
+          onChangeText={setComment}
+          placeholder={t('playView.tickBar.commentPlaceholder')}
+          placeholderTextColor={systemColors.tertiaryLabel as string}
+          accessibilityLabel={t('playView.tickBar.commentAria')}
+          multiline
+          style={
+            {
+              borderWidth: StyleSheet.hairlineWidth,
+              borderColor: systemColors.separator as string,
+              borderRadius: 10,
+              paddingHorizontal: spacing[3],
+              paddingVertical: spacing[2],
+              fontSize: 14,
+              lineHeight: 19,
+              color: systemColors.label as string,
+              minHeight: 56,
+              textAlignVertical: 'top',
+            } satisfies TextStyle
+          }
+        />
+      </View>
+
       <View style={styles.saveRow}>
         <Pressable
           onPress={onDismiss}
@@ -218,23 +272,64 @@ export const QuickTickBar = React.memo(function QuickTickBar({
           </Text>
         </Pressable>
 
-        <Pressable
-          onPress={handleSave}
-          disabled={saveTick.isPending}
-          accessibilityRole="button"
-          accessibilityLabel={t('playView.tickBar.logAscentAria', { status: ascentType })}
-          style={({ pressed }) => [
-            styles.saveButton,
-            pressed && styles.saveButtonPressed,
-            saveTick.isPending && styles.saveButtonDisabled,
-          ]}
-        >
-          <Icon name="tick.outline" size={18} color={iosSystemColors.white} />
-          <Text variant="footnote" color={iosSystemColors.white} style={styles.saveLabel}>
-            {saveLabel}
-          </Text>
-        </Pressable>
+        <View style={styles.saveRowActions}>
+          <Pressable
+            onPress={handleAttempt}
+            disabled={saveTick.isPending}
+            accessibilityRole="button"
+            accessibilityLabel={t('playView.tickBar.logAscentAria', { status: 'attempt' })}
+            style={({ pressed }) => [
+              styles.attemptButton,
+              pressed && styles.saveButtonPressed,
+              saveTick.isPending && styles.saveButtonDisabled,
+            ]}
+          >
+            <Icon name="tick.outline" size={18} color={iosSystemColors.white} />
+            <Text variant="footnote" color={iosSystemColors.white} style={styles.saveLabel}>
+              {tClimbs('mobile.logAscent.attempt')}
+            </Text>
+          </Pressable>
+
+          <Pressable
+            onPress={handleSave}
+            disabled={saveTick.isPending}
+            accessibilityRole="button"
+            accessibilityLabel={t('playView.tickBar.logAscentAria', { status: ascentType })}
+            style={({ pressed }) => [
+              styles.saveButton,
+              pressed && styles.saveButtonPressed,
+              saveTick.isPending && styles.saveButtonDisabled,
+            ]}
+          >
+            <Icon name="tick.outline" size={18} color={iosSystemColors.white} />
+            <Text variant="footnote" color={iosSystemColors.white} style={styles.saveLabel}>
+              {saveLabel}
+            </Text>
+          </Pressable>
+        </View>
       </View>
+    </>
+  );
+
+  if (embedded) {
+    return <View style={styles.embeddedContainer}>{tickBarContents}</View>;
+  }
+
+  return (
+    <Animated.View
+      style={[
+        styles.container,
+        // Solid safety-net background so the bar is always legible even on
+        // dev clients where the glass/blur native module isn't linked, or on
+        // platforms where GlassSurface degrades. Glass effect, when present,
+        // composites over this opaque base.
+        { backgroundColor: systemColors.secondaryBackground, borderTopColor: systemColors.separator },
+        animatedStyle,
+      ]}
+      pointerEvents={visible ? 'auto' : 'none'}
+    >
+      <GlassSurface glassEffectStyle="regular" style={StyleSheet.absoluteFill} pointerEvents="none" />
+      {tickBarContents}
     </Animated.View>
   );
 });
@@ -252,6 +347,13 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     zIndex: 5,
     paddingTop: spacing[3],
+    paddingBottom: spacing[3],
+  },
+  // Sibling of `container` for the `embedded` mode: drops absolute
+  // positioning, slide-in animation, and chrome (rounded corners + top
+  // border) since the host BottomSheet owns all of that.
+  embeddedContainer: {
+    paddingTop: spacing[2],
     paddingBottom: spacing[3],
   },
   row: {
@@ -289,6 +391,25 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[4],
     borderRadius: 20,
     backgroundColor: brandColors.success,
+  },
+  attemptButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[4],
+    borderRadius: 20,
+    backgroundColor: iosSystemColors.systemRed,
+  },
+  saveRowActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  commentRow: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+    paddingBottom: spacing[1],
   },
   saveButtonPressed: {
     transform: [{ scale: 0.95 }],

--- a/packages/mobile/src/components/play-drawer/__tests__/inline-grade-picker-utils.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/inline-grade-picker-utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { computeFocusOffset } from '../inline-grade-picker-utils';
+
+describe('computeFocusOffset', () => {
+  it('returns null when the viewport width has not been measured yet', () => {
+    expect(
+      computeFocusOffset({
+        viewportWidth: 0,
+        chipLayout: { x: 200, width: 56 },
+        index: 5,
+        approxChipWidth: 56,
+      }),
+    ).toBeNull();
+  });
+
+  it('centers the focus chip within the viewport when its layout is known', () => {
+    // Chip at x=200 with width=56, viewport=320 → center the chip's midpoint
+    // (228) in the viewport → scrollX = 228 - 160 = 68.
+    expect(
+      computeFocusOffset({
+        viewportWidth: 320,
+        chipLayout: { x: 200, width: 56 },
+        index: 5,
+        approxChipWidth: 56,
+      }),
+    ).toBe(68);
+  });
+
+  it('clamps to zero when the focus chip is already near the left edge', () => {
+    // A chip at x=10 in a 320-wide viewport would otherwise resolve to a
+    // negative scroll offset; ScrollViews refuse those, so the helper
+    // clamps to zero.
+    expect(
+      computeFocusOffset({
+        viewportWidth: 320,
+        chipLayout: { x: 10, width: 40 },
+        index: 0,
+        approxChipWidth: 56,
+      }),
+    ).toBe(0);
+  });
+
+  it('falls back to index * approxChipWidth before onLayout has fired', () => {
+    // Without measured layout the helper assumes uniform-width chips so it
+    // can still scroll on the first paint. Index 5 × 56 = 280 → centered in
+    // a 320 viewport: 280 - 160 + 28 = 148.
+    expect(
+      computeFocusOffset({
+        viewportWidth: 320,
+        chipLayout: null,
+        index: 5,
+        approxChipWidth: 56,
+      }),
+    ).toBe(148);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/inline-grade-picker-utils.ts
+++ b/packages/mobile/src/components/play-drawer/inline-grade-picker-utils.ts
@@ -1,0 +1,32 @@
+// Pure helpers extracted from InlineGradePicker so the auto-scroll math
+// can be unit-tested without spinning up the React renderer.
+
+export type ChipLayout = { x: number; width: number };
+
+export type ComputeFocusOffsetInput = {
+  viewportWidth: number;
+  // Layout for the chip we want to center, if known from onLayout. Falls
+  // back to (index * approxChipWidth, approxChipWidth) when null — the
+  // approximation lets us still scroll on the very first paint, before the
+  // chip has dispatched its own onLayout event.
+  chipLayout: ChipLayout | null;
+  index: number;
+  approxChipWidth: number;
+};
+
+/**
+ * Compute the ScrollView x offset that centers the focus chip horizontally
+ * in the viewport. Returns null when the viewport width hasn't been
+ * measured yet (auto-scroll can't be meaningful without it).
+ */
+export function computeFocusOffset({
+  viewportWidth,
+  chipLayout,
+  index,
+  approxChipWidth,
+}: ComputeFocusOffsetInput): number | null {
+  if (viewportWidth <= 0) return null;
+  const chipX = chipLayout?.x ?? index * approxChipWidth;
+  const chipWidth = chipLayout?.width ?? approxChipWidth;
+  return Math.max(0, chipX - viewportWidth / 2 + chipWidth / 2);
+}

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -183,8 +183,6 @@ export function PersistentQueueBar() {
       setIds: boardConfig.setIds,
       sessionId,
       consensusGradeName: currentClimbQueueItem.climb.difficulty,
-      hasPriorHistory:
-        (currentClimbQueueItem.climb.userAscents ?? 0) > 0 || (currentClimbQueueItem.climb.userAttempts ?? 0) > 0,
     });
   }, [openLogAscent, currentClimbQueueItem, boardConfig, sessionId]);
 

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -173,7 +173,6 @@ export function PersistentQueueBar() {
     hapticSelection();
     openLogAscent({
       climbUuid: currentClimbQueueItem.climb.uuid,
-      climbName: currentClimbQueueItem.climb.name,
       boardName: boardConfig.boardName,
       angle: currentClimbQueueItem.climb.angle,
       isMirror: currentClimbQueueItem.climb.mirrored === true,

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -182,6 +182,9 @@ export function PersistentQueueBar() {
       sizeId: boardConfig.sizeId,
       setIds: boardConfig.setIds,
       sessionId,
+      consensusGradeName: currentClimbQueueItem.climb.difficulty,
+      hasPriorHistory:
+        (currentClimbQueueItem.climb.userAscents ?? 0) > 0 || (currentClimbQueueItem.climb.userAttempts ?? 0) > 0,
     });
   }, [openLogAscent, currentClimbQueueItem, boardConfig, sessionId]);
 

--- a/packages/mobile/src/lib/i18n/config.ts
+++ b/packages/mobile/src/lib/i18n/config.ts
@@ -1,3 +1,9 @@
+// Polyfill Intl.PluralRules before i18next initialises. Hermes ships an
+// incomplete Intl implementation; without this, i18next's plural resolver
+// silently falls back to the v3 compatibility format and emits a startup
+// warning, plus picks wrong plural forms for es/fr. Mirrors how web wires
+// the same polyfill in app/lib/i18n/{server.ts,client.tsx}.
+import 'intl-pluralrules';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import { getLocales } from 'expo-localization';

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -31,7 +31,6 @@ export type BoardConfig = {
 
 export type LogAscentInput = {
   climbUuid: string;
-  climbName: string;
   boardName: string;
   angle: number;
   isMirror: boolean;
@@ -171,7 +170,6 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     if (!climbActions) return;
     setLogAscentInput({
       climbUuid: climbActions.climb.uuid,
-      climbName: climbActions.climb.name,
       boardName: climbActions.boardConfig.boardName,
       angle: climbActions.boardConfig.angle,
       isMirror: false,
@@ -197,7 +195,6 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           visible
           onDismiss={dismissLogAscent}
           climbUuid={logAscentInput.climbUuid}
-          climbName={logAscentInput.climbName}
           boardName={logAscentInput.boardName}
           angle={logAscentInput.angle}
           isMirror={logAscentInput.isMirror}

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -40,6 +40,15 @@ export type LogAscentInput = {
   sizeId?: number;
   setIds?: string;
   sessionId?: string | null;
+  // Climb's consensus grade name (just `Climb.difficulty`). Forwarded to
+  // InlineGradePicker so the consensus chip is centered and outlined
+  // without being preselected. Optional — callers that don't have a
+  // freshly fetched climb can omit it.
+  consensusGradeName?: string;
+  // True when the user has previously logged any tick on this climb.
+  // Forwarded to QuickTickBar so the save button reads "Send" instead of
+  // "Flash" on re-attempts.
+  hasPriorHistory?: boolean;
 };
 
 export type OpenPlayDrawerOptions = PlayDrawerOpenOptions & {
@@ -174,6 +183,9 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       layoutId: climbActions.boardConfig.layoutId,
       sizeId: climbActions.boardConfig.sizeId,
       setIds: climbActions.boardConfig.setIds,
+      consensusGradeName: climbActions.climb.difficulty,
+      hasPriorHistory:
+        (climbActions.climb.userAscents ?? 0) > 0 || (climbActions.climb.userAttempts ?? 0) > 0,
     });
   }, [climbActions]);
 
@@ -200,6 +212,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           sizeId={logAscentInput.sizeId}
           setIds={logAscentInput.setIds}
           sessionId={logAscentInput.sessionId}
+          consensusGradeName={logAscentInput.consensusGradeName}
+          hasPriorHistory={logAscentInput.hasPriorHistory}
         />
       ) : null}
       {climbActions ? (

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -45,10 +45,6 @@ export type LogAscentInput = {
   // without being preselected. Optional — callers that don't have a
   // freshly fetched climb can omit it.
   consensusGradeName?: string;
-  // True when the user has previously logged any tick on this climb.
-  // Forwarded to QuickTickBar so the save button reads "Send" instead of
-  // "Flash" on re-attempts.
-  hasPriorHistory?: boolean;
 };
 
 export type OpenPlayDrawerOptions = PlayDrawerOpenOptions & {
@@ -184,8 +180,6 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       sizeId: climbActions.boardConfig.sizeId,
       setIds: climbActions.boardConfig.setIds,
       consensusGradeName: climbActions.climb.difficulty,
-      hasPriorHistory:
-        (climbActions.climb.userAscents ?? 0) > 0 || (climbActions.climb.userAttempts ?? 0) > 0,
     });
   }, [climbActions]);
 
@@ -213,7 +207,6 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           setIds={logAscentInput.setIds}
           sessionId={logAscentInput.sessionId}
           consensusGradeName={logAscentInput.consensusGradeName}
-          hasPriorHistory={logAscentInput.hasPriorHistory}
         />
       ) : null}
       {climbActions ? (

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -570,7 +570,8 @@
       "decreaseAttempts": "Decrease attempts",
       "increaseAttempts": "Increase attempts",
       "errorTitle": "Save failed",
-      "errorMessage": "Could not save your ascent. Please try again."
+      "errorMessage": "Could not save your ascent. Please try again.",
+      "savedToast": "Tick saved"
     },
     "filter": {
       "title": "Filters",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -374,6 +374,7 @@
       "gradeLabel": "Grade",
       "triesLabel": "Tries",
       "starsLabel": "Stars",
+      "noteLabel": "Note",
       "cancelLabel": "Cancel",
       "flashSaveLabel": "Flash",
       "sendSaveLabel": "Send",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -570,7 +570,8 @@
       "decreaseAttempts": "Disminuir intentos",
       "increaseAttempts": "Aumentar intentos",
       "errorTitle": "Error al guardar",
-      "errorMessage": "No se pudo guardar tu ascenso. Inténtalo de nuevo."
+      "errorMessage": "No se pudo guardar tu ascenso. Inténtalo de nuevo.",
+      "savedToast": "Tick guardado"
     },
     "filter": {
       "title": "Filtros",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -374,6 +374,7 @@
       "gradeLabel": "Grado",
       "triesLabel": "Intentos",
       "starsLabel": "Estrellas",
+      "noteLabel": "Nota",
       "cancelLabel": "Cancelar",
       "flashSaveLabel": "Flash",
       "sendSaveLabel": "Envío",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -570,7 +570,8 @@
       "decreaseAttempts": "Diminuer les essais",
       "increaseAttempts": "Augmenter les essais",
       "errorTitle": "Échec de sauvegarde",
-      "errorMessage": "Impossible de sauvegarder votre ascension. Veuillez réessayer."
+      "errorMessage": "Impossible de sauvegarder votre ascension. Veuillez réessayer.",
+      "savedToast": "Tick enregistré"
     },
     "filter": {
       "title": "Filtres",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -374,6 +374,7 @@
       "gradeLabel": "Cotation",
       "triesLabel": "Essais",
       "starsLabel": "Étoiles",
+      "noteLabel": "Note",
       "cancelLabel": "Annuler",
       "flashSaveLabel": "Flash",
       "sendSaveLabel": "Envoi",


### PR DESCRIPTION
## Summary

- **Red Attempt button** in the ticking surface, left of the dynamic Flash/Send button. Fires `useSaveTick` with `status: 'attempt'` regardless of attempt count.
- **Comment field** is back. It was lost when QuickTickBar replaced the long-form log-ascent sheet; multiline `TextInput` now flows into the tick mutation.
- **Consensus grade chip** is centered in `InlineGradePicker` without being preselected. The climb's existing `difficulty` label (already `getGradeLabel(ROUND(display_difficulty))` on the backend) is matched to a `Grade.difficultyId` against the loaded grades list — no new GraphQL field needed.
- **One ticking surface everywhere.** `LogAscentSheet` is now a gorhom `BottomSheet` with a drag handle, pan-down-to-close, and a backdrop, wrapping `QuickTickBar` in `embedded` mode. The long-press FAB, the persistent queue bar's tick action, and the climb detail screen all open the same UI.

## Why the embedded prop

`QuickTickBar` is absolute-positioned + slide-in animated when used inside `PlayDrawer`'s board section. When used as the contents of a real bottom sheet, the parent owns positioning and entrance animation; `embedded={true}` drops the inline chrome so the sheet doesn't fight the bar.

## Centering math

Extracted into `inline-grade-picker-utils.ts` and unit-tested. The previous bug (\"scroll never lands\"):

1. `scrollTo` was being called before the `ScrollView`'s content size was known — native clamps the offset to a zero scrollable range. Fixed by gating on `onContentSizeChange`.
2. The focus chip's measured `x` lived in a ref, so the auto-scroll effect ran once at the wrong time and never re-ran with the real measurement. Fixed by bumping a `focusLayoutTick` state when the focus chip's `onLayout` lands.
3. Fallback path now leaves the gate open so a late chip measurement can still center; only locks once the real measurement was used.

## Test plan

- [ ] Open a climb in PlayDrawer, short-press the tick FAB → QuickTickBar slides up inline; grade strip auto-centers on the consensus grade with a subtle primary border, no chip selected.
- [ ] Long-press the tick FAB → same QuickTickBar (no separate sheet).
- [ ] Tap the red **Attempt** button → tick is saved with `status: 'attempt'`. Verify in logbook.
- [ ] Default tries (1) → Save button label reads **Flash**; bump to 2 → flips to **Send**.
- [ ] Type a comment, save, confirm it persists on the tick.
- [ ] Open the tick UI from the persistent queue bar → `LogAscentSheet` opens as a real bottom sheet with handle + backdrop; pan-down dismisses; same Attempt + Save layout inside.
- [ ] Open `(tabs)/climbs/[climbUuid]` → tap **Log Ascent** → same bottom sheet, consensus chip centered.
- [ ] Mobile typecheck + tests + bundle check pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)