### PR TITLE
fix(ble): recover the wall after another device takes the board

### DIFF
--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { AppState, type AppStateStatus } from 'react-native';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { useBoardBluetooth } from '../lib/ble/use-board-bluetooth';
 import { registerBluetoothConnection } from '../lib/ble/bluetooth-status-store';
@@ -123,17 +122,10 @@ type BluetoothProviderProps = {
 };
 
 export function BluetoothProvider({ boardName, layoutId, sizeId, children }: BluetoothProviderProps) {
-  // Track the last connected serial number for auto-reconnect on foreground
-  const lastConnectedSerialRef = useRef<string | null>(null);
-  const handleConnectSuccess = useCallback((serial: string | null) => {
-    lastConnectedSerialRef.current = serial;
-  }, []);
-
   const { isConnected, loading, connect, disconnect, sendFramesToBoard, pickerState } = useBoardBluetooth({
     boardName,
     layoutId,
     sizeId,
-    onConnectSuccess: handleConnectSuccess,
   });
 
   const clearBoard = useCallback(() => sendFramesToBoard(''), [sendFramesToBoard]);
@@ -160,7 +152,6 @@ export function BluetoothProvider({ boardName, layoutId, sizeId, children }: Blu
   // Wrap disconnect to track user-initiated disconnects
   const wrappedDisconnect = useCallback(async () => {
     isUserDisconnectRef.current = true;
-    lastConnectedSerialRef.current = null;
     setDisconnectedUnexpectedly(false);
     try {
       await disconnect();
@@ -169,30 +160,11 @@ export function BluetoothProvider({ boardName, layoutId, sizeId, children }: Blu
     }
   }, [disconnect]);
 
-  // Track app state across effect re-runs so foreground transitions
-  // are never missed when `isConnected` or `connect` identity changes.
-  const appStateRef = useRef<AppStateStatus>(AppState.currentState);
-
-  // Auto-reconnect when the app returns to foreground after a background
-  // disconnect. iOS CBCentralManager restoration handles keeping the
-  // connection alive in most cases, but if the OS killed the connection
-  // while backgrounded, this re-establishes it automatically.
-  useEffect(() => {
-    const subscription = AppState.addEventListener('change', (nextState) => {
-      const wasBackground = appStateRef.current === 'background' || appStateRef.current === 'inactive';
-      const isNowActive = nextState === 'active';
-
-      if (wasBackground && isNowActive && !isConnected && lastConnectedSerialRef.current) {
-        void connect(undefined, undefined, lastConnectedSerialRef.current);
-      }
-
-      appStateRef.current = nextState;
-    });
-
-    return () => {
-      subscription.remove();
-    };
-  }, [isConnected, connect]);
+  // Deliberately NO foreground auto-reconnect. These boards are
+  // last-connection-wins, so silently re-grabbing the board whenever the app
+  // foregrounds would steal it back from another device that legitimately took
+  // it — a ping-pong that flickers the wall. Reconnecting stays user-initiated
+  // (tap the lightbulb), matching the web app.
 
   useEffect(() => {
     if (wasConnectedRef.current && !isConnected && !isUserDisconnectRef.current) {

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -507,6 +507,36 @@ describe('BluetoothProvider', () => {
       expect(mockConfirmClimbOnWall).toHaveBeenCalledTimes(2);
     });
 
+    it('reassertWall() forces a physical re-send of the byte-identical current climb', async () => {
+      // The solo lightbulb "re-take" path bumps a reassert nonce so re-tapping
+      // on an unchanged climb actually re-lights the wall, bypassing the
+      // byte-identical dedup that otherwise skips the write.
+      mockSendFramesToBoard.mockResolvedValue(true);
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'climb-1', frames: 'p1r12', mirrored: false },
+      };
+      mockBluetoothState.isConnected = true;
+
+      const { result } = renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.waitFor(() => expect(mockSendFramesToBoard).toHaveBeenCalledTimes(1));
+      });
+
+      // Re-take: same climb, no broadcast. A plain re-render would dedup; the
+      // reassert nonce punches through it exactly once.
+      act(() => {
+        result.current.reassertWall();
+      });
+
+      await act(async () => {
+        await vi.waitFor(() => expect(mockSendFramesToBoard).toHaveBeenCalledTimes(2));
+      });
+      expect(mockSendFramesToBoard).toHaveBeenLastCalledWith('p1r12', false, expect.any(AbortSignal), 'climb-1');
+    });
+
     it('re-sends when the same climb is mirrored (same uuid, mirror flipped)', async () => {
       // Regression: the old uuid-only dedup swallowed mirror toggles, so the
       // board only mirrored after a disconnect/reconnect.

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -602,6 +602,126 @@ describe('useBoardBluetooth', () => {
     });
   });
 
+  describe('write failure marks the link lost', () => {
+    // Real BoardDetails carry a number[] set_ids; the shared mock lies with a
+    // string, so use array set_ids here (boardIdentityKey joins the array).
+    const arraySetIdsDetails = {
+      ...mockBoardDetails,
+      set_ids: [1, 2],
+    } as unknown as Parameters<typeof useBoardBluetooth>[0]['boardDetails'];
+
+    it('flips isConnected false when a write fails with a disconnect-shaped error', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: arraySetIdsDetails }));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(result.current.isConnected).toBe(true);
+
+      // The board was grabbed by another device — the write throws the GATT
+      // "disconnected" error and no gattserverdisconnected event fires.
+      mockAdapter.write.mockRejectedValueOnce(new DOMException('GATT Server is disconnected.', 'NetworkError'));
+
+      let sendResult: boolean | undefined;
+      await act(async () => {
+        sendResult = await result.current.sendFramesToBoard('p4131r42');
+      });
+
+      expect(sendResult).toBe(false);
+      expect(result.current.isConnected).toBe(false);
+      errorSpy.mockRestore();
+    });
+
+    it('keeps isConnected true when a write fails with a non-disconnect error', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: arraySetIdsDetails }));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      mockAdapter.write.mockRejectedValueOnce(new Error('transient write hiccup'));
+
+      let sendResult: boolean | undefined;
+      await act(async () => {
+        sendResult = await result.current.sendFramesToBoard('p4131r42');
+      });
+
+      expect(sendResult).toBe(false);
+      expect(result.current.isConnected).toBe(true);
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('reconnectSerialForCurrentBoard (solo silent reconnect)', () => {
+    const arraySetIdsDetails = {
+      ...mockBoardDetails,
+      set_ids: [1, 2],
+    } as unknown as Parameters<typeof useBoardBluetooth>[0]['boardDetails'];
+
+    it('remembers the serial on connect and keeps it through an involuntary drop', async () => {
+      let capturedHandler: (() => void) | null = null;
+      mockAdapter.onDisconnect.mockImplementation((handler: () => void) => {
+        capturedHandler = handler;
+        return vi.fn();
+      });
+      mockParseSerialNumber.mockReturnValue('AB1234');
+
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: arraySetIdsDetails }));
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      expect(result.current.reconnectSerialForCurrentBoard).toBe('AB1234');
+
+      // Another device grabs the board — the serial must survive so a tap can
+      // silently reconnect to it.
+      act(() => {
+        capturedHandler?.();
+      });
+      expect(result.current.isConnected).toBe(false);
+      expect(result.current.reconnectSerialForCurrentBoard).toBe('AB1234');
+    });
+
+    it('forgets the serial after an explicit user disconnect', async () => {
+      mockParseSerialNumber.mockReturnValue('AB1234');
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: arraySetIdsDetails }));
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(result.current.reconnectSerialForCurrentBoard).toBe('AB1234');
+
+      await act(async () => {
+        await result.current.disconnect();
+      });
+      expect(result.current.reconnectSerialForCurrentBoard).toBeNull();
+    });
+
+    it('returns null once the user is viewing a different board config', async () => {
+      mockParseSerialNumber.mockReturnValue('AB1234');
+      const otherBoardDetails = {
+        ...mockBoardDetails,
+        set_ids: [3, 4],
+      } as unknown as Parameters<typeof useBoardBluetooth>[0]['boardDetails'];
+
+      const { result, rerender } = renderHook(
+        ({ boardDetails }: { boardDetails: Parameters<typeof useBoardBluetooth>[0]['boardDetails'] }) =>
+          useBoardBluetooth({ boardDetails }),
+        { initialProps: { boardDetails: arraySetIdsDetails } },
+      );
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(result.current.reconnectSerialForCurrentBoard).toBe('AB1234');
+
+      // Switch to a different board (different set_ids) — the remembered serial
+      // no longer applies, so callers fall back to the picker.
+      rerender({ boardDetails: otherBoardDetails });
+      expect(result.current.reconnectSerialForCurrentBoard).toBeNull();
+    });
+  });
+
   describe('Bluetooth Disconnected analytics', () => {
     function findDisconnectCall(): [string, Record<string, unknown>] | undefined {
       return mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Disconnected') as

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -477,17 +477,21 @@ describe('useBoardBluetooth', () => {
   });
 
   describe('unexpected disconnect take-back', () => {
-    it('prompts "take it back" and reopens the board picker (no auto-select)', async () => {
+    it('prompts "take it back" and reconnects to the remembered board', async () => {
       let capturedHandler: (() => void) | null = null;
       mockAdapter.onDisconnect.mockImplementation((handler: () => void) => {
         capturedHandler = handler;
         return vi.fn();
       });
-      // Even when the board carried a serial, take-back must NOT auto-select it —
-      // the user should pick deliberately (gyms can have several boards in range).
+      // Real BoardDetails carry a number[] set_ids; the shared mock lies with a
+      // string, so use array set_ids so the serial gets remembered on connect.
+      const arraySetIdsDetails = {
+        ...mockBoardDetails,
+        set_ids: [1, 2],
+      } as unknown as Parameters<typeof useBoardBluetooth>[0]['boardDetails'];
       mockParseSerialNumber.mockReturnValue('AB1234');
 
-      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: arraySetIdsDetails }));
       await act(async () => {
         await result.current.connect();
       });
@@ -506,13 +510,15 @@ describe('useBoardBluetooth', () => {
       expect(promptCall![1]).toBe('warning');
       expect(promptCall![2].label).toBe('bluetooth.takeItBack');
 
-      // Tapping "take it back" reconnects via the picker — no targetSerial.
+      // Tapping "take it back" reconnects to the board we were on — silently on
+      // native (the adapter falls back to the picker if it's gone), matching the
+      // lightbulb tap.
       await act(async () => {
         promptCall![2].onClick();
         await Promise.resolve();
       });
 
-      expect(mockAdapter.requestAndConnect).toHaveBeenCalledWith(undefined);
+      expect(mockAdapter.requestAndConnect).toHaveBeenCalledWith('AB1234');
     });
 
     it('does not stack prompts when the connection flaps (several drops in a row)', async () => {
@@ -622,6 +628,29 @@ describe('useBoardBluetooth', () => {
       // The board was grabbed by another device — the write throws the GATT
       // "disconnected" error and no gattserverdisconnected event fires.
       mockAdapter.write.mockRejectedValueOnce(new DOMException('GATT Server is disconnected.', 'NetworkError'));
+
+      let sendResult: boolean | undefined;
+      await act(async () => {
+        sendResult = await result.current.sendFramesToBoard('p4131r42');
+      });
+
+      expect(sendResult).toBe(false);
+      expect(result.current.isConnected).toBe(false);
+      errorSpy.mockRestore();
+    });
+
+    it("flips isConnected false on the Capacitor adapter's plain Error('Not connected')", async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: arraySetIdsDetails }));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(result.current.isConnected).toBe(true);
+
+      // The Capacitor / native-iOS adapters reject a write after the link drops
+      // with a plain Error('Not connected') rather than a DOMException.
+      mockAdapter.write.mockRejectedValueOnce(new Error('Not connected'));
 
       let sendResult: boolean | undefined;
       await act(async () => {

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -73,6 +73,20 @@ type BluetoothContextValue = {
   setLedColorOverrides: (next: LedColorOverrides) => void;
   isBluetoothSupported: boolean;
   isIOS: boolean;
+  /**
+   * Force the auto-sender to re-push the current climb to the wall once, even
+   * when the pixels are byte-identical to the last send (which it normally
+   * dedups). The solo lightbulb tap calls this so re-taking control of an
+   * unchanged climb actually re-lights the wall — and, if the link is secretly
+   * dead, the failing write trips disconnect detection. No-op until called.
+   */
+  reassertWall: () => void;
+  /**
+   * Serial to silently reconnect to for the board currently in view (native
+   * shells only), or null when nothing is remembered or the user switched
+   * boards — in which case callers open the device picker instead.
+   */
+  reconnectSerialForCurrentBoard: string | null;
 };
 
 const BluetoothContext = createContext<BluetoothContextValue | null>(null);
@@ -93,6 +107,7 @@ function BluetoothAutoSender({
   layoutName,
   boardName,
   onWallConfirmed,
+  reassertNonce,
 }: {
   sendFramesToBoard: (
     frames: string,
@@ -110,6 +125,13 @@ function BluetoothAutoSender({
    * means BluetoothAutoSender doesn't need to know whether a session exists.
    */
   onWallConfirmed: (climbUuid: string) => void;
+  /**
+   * Bumped by `reassertWall()` to force a one-shot re-send of the current
+   * climb that bypasses the byte-identical dedup below. Each new value clears
+   * the last-sent signature exactly once so the wall re-lights even when the
+   * climb hasn't changed.
+   */
+  reassertNonce: number;
 }) {
   const { currentClimbQueueItem } = useCurrentClimb();
   // Mirror onWallConfirmed so the send loop doesn't re-run when
@@ -147,6 +169,11 @@ function BluetoothAutoSender({
   // uuid, frames, and mirror) still skips the write but re-emits the wall-confirm
   // so a hand-off taker's 2s timer clears even though no physical re-send ran.
   const lastSentSignatureRef = useRef<string | null>(null);
+  // Last `reassertNonce` we've acted on. When the incoming nonce differs, the
+  // send effect clears the dedup signature once so the current climb is
+  // physically re-written even if its pixels are byte-identical to the last
+  // send (the solo lightbulb "re-take" path).
+  const lastReassertNonceRef = useRef(reassertNonce);
   // Single AbortController lives across the AutoSender's lifetime. Aborted
   // exactly once on unmount so the in-flight drain loop (a) cancels the
   // underlying adapter.write via the signal, and (b) returns before firing
@@ -166,6 +193,13 @@ function BluetoothAutoSender({
     if (!currentClimbQueueItem) return;
     const signal = abortControllerRef.current?.signal;
     if (signal?.aborted) return;
+    // A reassert request (lightbulb re-take) forces a fresh write of the
+    // current climb: drop the dedup signature so the byte-identical skip below
+    // doesn't suppress it. Record the nonce so we punch through exactly once.
+    if (reassertNonce !== lastReassertNonceRef.current) {
+      lastReassertNonceRef.current = reassertNonce;
+      lastSentSignatureRef.current = null;
+    }
     if (isWritingRef.current) {
       pendingClimbRef.current = currentClimbQueueItem;
       return;
@@ -253,7 +287,7 @@ function BluetoothAutoSender({
       }
     };
     void drain();
-  }, [currentClimbQueueItem, sendFramesToBoard, layoutName, boardName]);
+  }, [currentClimbQueueItem, sendFramesToBoard, layoutName, boardName, reassertNonce]);
 
   return null;
 }
@@ -331,12 +365,18 @@ export function BluetoothProvider({
     [setSessionBoardSerial, boardDetails?.layout_name],
   );
 
-  const { isConnected, loading, connect, disconnect, sendFramesToBoard, pickerState } = useBoardBluetooth({
-    boardDetails: boardDetails ?? undefined,
-    boardUuid,
-    ledColorOverrides,
-    onConnectSuccess: handleConnectSuccess,
-  });
+  const { isConnected, loading, connect, disconnect, sendFramesToBoard, pickerState, reconnectSerialForCurrentBoard } =
+    useBoardBluetooth({
+      boardDetails: boardDetails ?? undefined,
+      boardUuid,
+      ledColorOverrides,
+      onConnectSuccess: handleConnectSuccess,
+    });
+
+  // Bumped by reassertWall() to force the auto-sender to re-push the current
+  // climb once even when it's byte-identical to the last send.
+  const [reassertNonce, setReassertNonce] = useState(0);
+  const reassertWall = useCallback(() => setReassertNonce((nonce) => nonce + 1), []);
 
   // Always emit on the local wall-confirm bus (so the same phone's drawer
   // dismisses its 2s fallback timer); only fire the WS mutation when a
@@ -565,6 +605,8 @@ export function BluetoothProvider({
       setLedColorOverrides,
       isBluetoothSupported,
       isIOS,
+      reassertWall,
+      reconnectSerialForCurrentBoard,
     }),
     [
       isConnected,
@@ -580,6 +622,8 @@ export function BluetoothProvider({
       setLedColorOverrides,
       isBluetoothSupported,
       isIOS,
+      reassertWall,
+      reconnectSerialForCurrentBoard,
     ],
   );
 
@@ -652,6 +696,7 @@ export function BluetoothProvider({
           layoutName={boardDetails.layout_name ?? ''}
           boardName={boardDetails.board_name}
           onWallConfirmed={handleWallConfirmed}
+          reassertNonce={reassertNonce}
         />
       )}
       {activePickerState && (

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -185,6 +185,12 @@ export function useBoardBluetooth({
   // connection can fire several disconnects in a row. Reset once we reconnect
   // (or the user explicitly disconnects) so the next genuine drop prompts again.
   const boardTakenPromptShownRef = useRef(false);
+  // Latest config-matched reconnect serial, mirrored from the derived value
+  // below so handleDisconnection's "take it back" action can silently reconnect
+  // to the same board without taking the derived value (or boardDetails) as a
+  // dep, which would re-create the callback and re-register the disconnect
+  // listener on every change.
+  const reconnectSerialRef = useRef<string | null>(null);
 
   // Device picker state for custom Capacitor scanning.
   // pickerRejectRef holds the pending promise's reject so unmount cleanup
@@ -254,11 +260,14 @@ export function useBoardBluetooth({
 
     // These boards are last-connection-wins and always advertise, so an
     // unexpected drop usually means another phone grabbed the board. Tell the
-    // user instead of going silent, and offer a take-back that reopens the board
-    // picker so they deliberately choose what to reconnect to — important in
-    // gyms with several boards in range. We deliberately don't auto-reconnect —
-    // that would ping-pong with the other app and flicker the wall. Dedup so a
-    // flapping link doesn't stack prompts.
+    // user instead of going silent, and offer a take-back. We deliberately don't
+    // *auto*-reconnect — that would ping-pong with the other app and flicker the
+    // wall — but the take-back is user-initiated, so it reconnects to the board
+    // they were on (matching the lightbulb tap). On native that's silent; the
+    // adapter falls back to the picker if that board isn't found, so gyms with
+    // several boards in range still get a deliberate choice. On web the serial
+    // is ignored and the picker shows. Dedup so a flapping link doesn't stack
+    // prompts.
     if (boardTakenPromptShownRef.current) return;
     boardTakenPromptShownRef.current = true;
     showMessage(
@@ -267,8 +276,7 @@ export function useBoardBluetooth({
       {
         label: t('bluetooth.takeItBack'),
         onClick: () => {
-          // No targetSerial → the adapter shows the device picker.
-          void connectRef.current?.();
+          void connectRef.current?.(undefined, undefined, reconnectSerialRef.current ?? undefined);
         },
       },
       10000,
@@ -735,6 +743,12 @@ export function useBoardBluetooth({
     lastConnectedBoard && boardDetails && lastConnectedBoard.configKey === boardIdentityKey(boardDetails)
       ? lastConnectedBoard.serial
       : null;
+
+  // Mirror into a ref so handleDisconnection's "take it back" action reads the
+  // current value without taking it as a dep.
+  useEffect(() => {
+    reconnectSerialRef.current = reconnectSerialForCurrentBoard;
+  }, [reconnectSerialForCurrentBoard]);
 
   return {
     isConnected,

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -3,7 +3,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
-import { classifyBleFailure } from '@/app/lib/ble/connection-error';
+import { classifyBleFailure, isDisconnectionError } from '@/app/lib/ble/connection-error';
+import { normaliseSetIds } from '@/app/lib/ble/board-config-match';
 import { track } from '@/app/lib/analytics';
 import * as Sentry from '@sentry/nextjs';
 import type { BoardDetails } from '@/app/lib/types';
@@ -105,6 +106,21 @@ type BoardConfigurationRequest = {
   colorOverrides: LedColorOverrides | undefined;
 };
 
+// Identity of the physical board a serial maps to: board name + the route's
+// layout/size/set config. Used to decide whether a remembered (serial, board)
+// pair still applies — if the user has since switched to a different board the
+// key won't match and we fall back to the picker instead of silently grabbing
+// the old board. Deliberately NOT createBoardConfigurationKey (that also keys on
+// device name + colour overrides, which aren't part of board identity).
+function boardIdentityKey(boardDetails: BoardDetails): string {
+  return [
+    boardDetails.board_name,
+    boardDetails.layout_id,
+    boardDetails.size_id,
+    normaliseSetIds(boardDetails.set_ids.join(',')),
+  ].join('::');
+}
+
 function createBoardConfigurationKey(configuration: BoardConfigurationRequest): string {
   const sortedColorOverrides = Object.entries(configuration.colorOverrides ?? {}).sort(([leftKey], [rightKey]) =>
     leftKey.localeCompare(rightKey),
@@ -130,6 +146,13 @@ export function useBoardBluetooth({
   const { t } = useTranslation('common');
   const [loading, setLoading] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
+  // The board this device last successfully connected to, with the identity of
+  // the board config it was paired against. Drives the solo lightbulb's silent
+  // reconnect: after an involuntary drop a tap reconnects straight to this
+  // serial (no picker) — but only while the current board still matches, so
+  // switching boards falls back to the picker. Survives an involuntary drop;
+  // cleared on an explicit user disconnect.
+  const [lastConnectedBoard, setLastConnectedBoard] = useState<{ serial: string; configKey: string } | null>(null);
 
   // Prevent device from sleeping while connected to the board
   useWakeLock(isConnected);
@@ -435,10 +458,19 @@ export function useBoardBluetooth({
           return;
         }
         console.error('Error sending frames to board:', error);
+        // A write that fails because the GATT link is gone (the board dropped or
+        // another device grabbed it — these boards are last-connection-wins) is
+        // the only signal we get when the adapter's disconnect event never
+        // fires. Mark the connection lost so the lightbulb stops showing
+        // "connected" and a deliberate reconnect can run. handleDisconnection
+        // dedups its own take-back prompt, so a burst of failing writes is safe.
+        if (isDisconnectionError(error)) {
+          handleDisconnection();
+        }
         return false;
       }
     },
-    [boardDetails, showMessage, ledColorOverrides, serialisedWrite],
+    [boardDetails, showMessage, ledColorOverrides, serialisedWrite, handleDisconnection],
   );
 
   const configureConnectedBoard = useCallback(
@@ -536,6 +568,9 @@ export function useBoardBluetooth({
           parsedSerial = parseSerialNumber(connection.deviceName) ?? null;
           if (parsedSerial) {
             recordBoardSerial(parsedSerial, boardDetails, boardUuid);
+            // Remember the board (and which config it was paired against) so a
+            // later involuntary drop can be recovered with a silent reconnect.
+            setLastConnectedBoard({ serial: parsedSerial, configKey: boardIdentityKey(boardDetails) });
           }
         }
 
@@ -644,8 +679,10 @@ export function useBoardBluetooth({
     configuredBoardKeyRef.current = null;
     writeChainRef.current = Promise.resolve();
     // The user chose to disconnect — clear the take-back prompt guard so a
-    // later genuine drop can prompt again.
+    // later genuine drop can prompt again, and forget the board so a later tap
+    // opens the picker rather than silently grabbing this board back.
     boardTakenPromptShownRef.current = false;
+    setLastConnectedBoard(null);
     setIsConnected(false);
     onConnectionChange?.(false);
     if (connectedAt !== null) {
@@ -689,6 +726,16 @@ export function useBoardBluetooth({
     };
   }, []);
 
+  // Serial to silently reconnect to for the board currently in view — only when
+  // the remembered board still matches the route's config. Null when nothing is
+  // remembered or the user has switched boards, so callers fall back to the
+  // picker. (Silent reconnect to a serial only works on native shells; web
+  // callers gate on that and ignore the serial.)
+  const reconnectSerialForCurrentBoard =
+    lastConnectedBoard && boardDetails && lastConnectedBoard.configKey === boardIdentityKey(boardDetails)
+      ? lastConnectedBoard.serial
+      : null;
+
   return {
     isConnected,
     loading,
@@ -696,5 +743,6 @@ export function useBoardBluetooth({
     disconnect,
     sendFramesToBoard,
     pickerState,
+    reconnectSerialForCurrentBoard,
   };
 }

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -22,6 +22,7 @@ import SwipeBoardCarousel from '../board-renderer/swipe-board-carousel';
 import { PlaybackControls } from '../playback/playback-controls';
 import { useWakeLock } from '../board-bluetooth-control/use-wake-lock';
 import { useBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
+import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
 import { useWallConfirmFallback } from './use-wall-confirm-fallback';
 import { useDrawerPlayback } from './use-drawer-playback';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -183,7 +184,13 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     takeControl,
     releaseControl,
   } = useQueueActions();
-  const { isConnected: isBluetoothConnected, isBluetoothSupported, connect: bluetoothConnect } = useBluetoothContext();
+  const {
+    isConnected: isBluetoothConnected,
+    isBluetoothSupported,
+    connect: bluetoothConnect,
+    reassertWall,
+    reconnectSerialForCurrentBoard,
+  } = useBluetoothContext();
 
   // In a party session, the drawer-local `drawerDisplayedItem` (set by browse
   // callers via the open-drawer event payload) takes precedence over the wall
@@ -622,11 +629,26 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
           boardLayout,
           climbUuid: currentClimb?.uuid ?? null,
         });
-        void bluetoothConnect();
+        // Silent reconnect to the board we were last on (native shells only —
+        // Web Bluetooth ignores a target serial and always shows the chooser).
+        // Null when nothing's remembered or the user switched boards, so we
+        // open the picker. Don't pass frames: the fresh AutoSender re-pushes
+        // the current climb on mount (passing them risks a double-write).
+        if (reconnectSerialForCurrentBoard && isNativeApp()) {
+          void bluetoothConnect(undefined, undefined, reconnectSerialForCurrentBoard);
+        } else {
+          void bluetoothConnect();
+        }
         return;
       }
       if (!currentClimb) return;
       void takeControl(currentClimb);
+      // Force a re-push even when the climb is unchanged — re-tapping the
+      // lightbulb should re-light the wall. If the link is secretly dead (the
+      // board was grabbed but no disconnect event fired), the failing write
+      // trips disconnect detection and darkens the bulb so the next tap
+      // reconnects.
+      reassertWall();
       setDrawerDisplayedItem?.(null);
       track('Wall Control Taken', {
         source: 'lightbulb_drawer',
@@ -665,6 +687,8 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     isPersistentSessionActive,
     isBluetoothConnected,
     bluetoothConnect,
+    reassertWall,
+    reconnectSerialForCurrentBoard,
     armWallConfirmWatcher,
     cancelWallConfirmWatcher,
     boardDetails.layout_name,

--- a/packages/web/app/lib/ble/__tests__/capacitor-adapter.test.ts
+++ b/packages/web/app/lib/ble/__tests__/capacitor-adapter.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterAll } from 'vite-plus/test';
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vite-plus/test';
+import type { DevicePickerFn } from '../types';
 import {
   AURORA_OPTIONAL_SERVICE_UUIDS,
   AURORA_SCAN_SERVICE_UUIDS,
@@ -311,6 +312,98 @@ describe('CapacitorBleAdapter', () => {
       await adapter.disconnect();
 
       expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  // The manual-scan path (custom picker + requestLEScan/stopLEScan) is only
+  // taken when a devicePicker is injected. Reconnect-by-serial tries to
+  // auto-select silently, then falls back to the picker if the stored board
+  // doesn't advertise within a short grace window.
+  describe('reconnect-by-serial picker fallback (manual scan)', () => {
+    // Mirrors SERIAL_RECONNECT_GRACE_MS in the adapter (not exported).
+    const GRACE_MS = 4_000;
+
+    type ManualScanPlugin = typeof mockBlePlugin & {
+      requestLEScan?: ReturnType<typeof vi.fn>;
+      stopLEScan?: ReturnType<typeof vi.fn>;
+    };
+    const manualPlugin = mockBlePlugin as ManualScanPlugin;
+
+    let scanResultCb: ((data: unknown) => void) | null = null;
+    let pickerResolve: ((deviceId: string) => void) | null = null;
+    let devicePicker: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      scanResultCb = null;
+      pickerResolve = null;
+      manualPlugin.requestLEScan = vi.fn().mockResolvedValue(undefined);
+      manualPlugin.stopLEScan = vi.fn().mockResolvedValue(undefined);
+      // Route scan-result vs disconnect listeners by event name.
+      manualPlugin.addListener = vi.fn().mockImplementation((event: string, cb: (data: unknown) => void) => {
+        if (event === 'onScanResult') scanResultCb = cb;
+        else disconnectListenerCallback = cb as (data: { deviceId: string }) => void;
+        return Promise.resolve({ remove: mockListenerRemove });
+      });
+      devicePicker = vi.fn((subscribe: (onUpdate: (devices: unknown[]) => void) => void) => {
+        subscribe(() => {});
+        return new Promise<string>((resolve) => {
+          pickerResolve = resolve;
+        });
+      });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      delete manualPlugin.requestLEScan;
+      delete manualPlugin.stopLEScan;
+      // Restore the default disconnect-capturing addListener for other suites.
+      manualPlugin.addListener = vi
+        .fn()
+        .mockImplementation((_event: string, cb: (data: { deviceId: string }) => void) => {
+          disconnectListenerCallback = cb;
+          return Promise.resolve({ remove: mockListenerRemove });
+        });
+    });
+
+    const emitScan = (deviceId: string, name: string) =>
+      scanResultCb?.({ device: { deviceId, name: undefined }, localName: name, rssi: -50 });
+
+    it('auto-selects the stored board silently without opening the picker', async () => {
+      const adapterWithPicker = new CapacitorBleAdapter('kilter', devicePicker as unknown as DevicePickerFn);
+      const connectPromise = adapterWithPicker.requestAndConnect('123');
+
+      // Let the scan listener register + scan start.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      emitScan('dev-x', 'Kilter Board#123@3');
+
+      const connection = await connectPromise;
+      expect(connection.deviceId).toBe('dev-x');
+      expect(devicePicker).not.toHaveBeenCalled();
+      expect(mockBlePlugin.connect).toHaveBeenCalledWith({ deviceId: 'dev-x' });
+    });
+
+    it('opens the picker after the grace window when the stored serial never appears', async () => {
+      vi.useFakeTimers();
+      const adapterWithPicker = new CapacitorBleAdapter('kilter', devicePicker as unknown as DevicePickerFn);
+      const connectPromise = adapterWithPicker.requestAndConnect('999');
+
+      // Flush the awaited addListener + requestLEScan microtasks.
+      await vi.advanceTimersByTimeAsync(0);
+
+      // A different board shows up — not our serial. Picker stays closed for now.
+      emitScan('dev-other', 'Kilter Board#123@3');
+      expect(devicePicker).not.toHaveBeenCalled();
+
+      // Grace elapses → picker opens, seeded with discovered devices.
+      await vi.advanceTimersByTimeAsync(GRACE_MS);
+      expect(devicePicker).toHaveBeenCalledTimes(1);
+
+      // User picks a board → connect proceeds against their choice.
+      pickerResolve?.('dev-other');
+      await connectPromise;
+      expect(mockBlePlugin.connect).toHaveBeenCalledWith({ deviceId: 'dev-other' });
     });
   });
 });

--- a/packages/web/app/lib/ble/__tests__/capacitor-adapter.test.ts
+++ b/packages/web/app/lib/ble/__tests__/capacitor-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vite-plus/test';
 import type { DevicePickerFn } from '../types';
+import { SERIAL_RECONNECT_GRACE_MS } from '../scan-constants';
 import {
   AURORA_OPTIONAL_SERVICE_UUIDS,
   AURORA_SCAN_SERVICE_UUIDS,
@@ -320,9 +321,6 @@ describe('CapacitorBleAdapter', () => {
   // auto-select silently, then falls back to the picker if the stored board
   // doesn't advertise within a short grace window.
   describe('reconnect-by-serial picker fallback (manual scan)', () => {
-    // Mirrors SERIAL_RECONNECT_GRACE_MS in the adapter (not exported).
-    const GRACE_MS = 4_000;
-
     type ManualScanPlugin = typeof mockBlePlugin & {
       requestLEScan?: ReturnType<typeof vi.fn>;
       stopLEScan?: ReturnType<typeof vi.fn>;
@@ -397,7 +395,7 @@ describe('CapacitorBleAdapter', () => {
       expect(devicePicker).not.toHaveBeenCalled();
 
       // Grace elapses → picker opens, seeded with discovered devices.
-      await vi.advanceTimersByTimeAsync(GRACE_MS);
+      await vi.advanceTimersByTimeAsync(SERIAL_RECONNECT_GRACE_MS);
       expect(devicePicker).toHaveBeenCalledTimes(1);
 
       // User picks a board → connect proceeds against their choice.

--- a/packages/web/app/lib/ble/__tests__/connection-error.test.ts
+++ b/packages/web/app/lib/ble/__tests__/connection-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vite-plus/test';
-import { classifyBleFailure, type BleFailureCategory } from '../connection-error';
+import { classifyBleFailure, isDisconnectionError, type BleFailureCategory } from '../connection-error';
 
 describe('classifyBleFailure', () => {
   const cases: Array<{ name: string; error: unknown; stage?: string; expected: BleFailureCategory }> = [
@@ -84,4 +84,46 @@ describe('classifyBleFailure', () => {
     // A cancel can surface after the stage was advanced; the cancel signal must win.
     expect(classifyBleFailure(new Error('Device selection cancelled'), 'gatt_connect')).toBe('user_cancelled');
   });
+});
+
+describe('isDisconnectionError', () => {
+  const disconnects: Array<{ name: string; error: unknown }> = [
+    {
+      name: 'web NetworkError (GATT disconnected)',
+      error: new DOMException('GATT Server is disconnected.', 'NetworkError'),
+    },
+    {
+      name: 'web InvalidStateError (dead handle)',
+      error: new DOMException('GATT operation failed', 'InvalidStateError'),
+    },
+    { name: 'capacitor/native "Not connected"', error: new Error('Not connected') },
+    { name: 'adapter "Device disconnected during write"', error: new Error('Device disconnected during write') },
+    { name: 'plugin peripheral disconnected', error: new Error('The peripheral disconnected unexpectedly') },
+    { name: 'generic gatt-not-connected message', error: new Error('GATT operation failed: not connected') },
+  ];
+
+  for (const { name, error } of disconnects) {
+    it(`treats as disconnect: ${name}`, () => {
+      expect(isDisconnectionError(error)).toBe(true);
+    });
+  }
+
+  const notDisconnects: Array<{ name: string; error: unknown }> = [
+    // Unmount-mid-write must never tear down the connection.
+    { name: 'AbortError', error: new DOMException('The operation was aborted', 'AbortError') },
+    // Picker-dismissed.
+    { name: 'NotFoundError', error: new DOMException('No device chosen', 'NotFoundError') },
+    // Validation-shaped messages from the write path.
+    { name: 'LED data missing', error: new Error('LED placement map is empty') },
+    { name: 'incompatible climb', error: new Error('climb incompatible with board') },
+    // Opaque / non-error values.
+    { name: 'opaque error', error: new Error('something opaque') },
+    { name: 'plain string', error: 'a plain string' },
+  ];
+
+  for (const { name, error } of notDisconnects) {
+    it(`treats as non-disconnect: ${name}`, () => {
+      expect(isDisconnectionError(error)).toBe(false);
+    });
+  }
 });

--- a/packages/web/app/lib/ble/__tests__/connection-error.test.ts
+++ b/packages/web/app/lib/ble/__tests__/connection-error.test.ts
@@ -111,6 +111,12 @@ describe('isDisconnectionError', () => {
   const notDisconnects: Array<{ name: string; error: unknown }> = [
     // Unmount-mid-write must never tear down the connection.
     { name: 'AbortError', error: new DOMException('The operation was aborted', 'AbortError') },
+    // InvalidStateError without a GATT mention is a different DOM failure
+    // (e.g. a closed IDBTransaction) — must not be treated as a disconnect.
+    {
+      name: 'InvalidStateError without GATT',
+      error: new DOMException('The transaction has finished', 'InvalidStateError'),
+    },
     // Picker-dismissed.
     { name: 'NotFoundError', error: new DOMException('No device chosen', 'NotFoundError') },
     // Validation-shaped messages from the write path.

--- a/packages/web/app/lib/ble/capacitor-adapter.ts
+++ b/packages/web/app/lib/ble/capacitor-adapter.ts
@@ -22,6 +22,7 @@ import {
   UART_SERVICE_UUID,
   UART_WRITE_CHARACTERISTIC_UUID,
 } from '@/app/components/board-bluetooth-control/bluetooth-shared';
+import { SERIAL_RECONNECT_GRACE_MS } from './scan-constants';
 
 const DEFAULT_MTU = MAX_BLUETOOTH_MESSAGE_SIZE;
 
@@ -32,12 +33,6 @@ const INTER_CHUNK_DELAY_MS = 5;
 // Auto-stop BLE scan after this duration to prevent indefinite battery drain
 // if the user walks away from the picker dialog.
 const SCAN_TIMEOUT_MS = 30_000;
-
-// How long a reconnect-by-serial waits for the stored board to advertise before
-// falling back to the picker. Short enough that a missing board surfaces the
-// picker quickly; long enough that a present board (which advertises within a
-// second or two) reconnects silently without the picker ever flashing.
-const SERIAL_RECONNECT_GRACE_MS = 4_000;
 
 // Raw Capacitor plugin interface as exposed via window.Capacitor.Plugins.BluetoothLe.
 // The plugin JS is injected by the native shell. We type only the methods we use.

--- a/packages/web/app/lib/ble/capacitor-adapter.ts
+++ b/packages/web/app/lib/ble/capacitor-adapter.ts
@@ -33,6 +33,12 @@ const INTER_CHUNK_DELAY_MS = 5;
 // if the user walks away from the picker dialog.
 const SCAN_TIMEOUT_MS = 30_000;
 
+// How long a reconnect-by-serial waits for the stored board to advertise before
+// falling back to the picker. Short enough that a missing board surfaces the
+// picker quickly; long enough that a present board (which advertises within a
+// second or two) reconnects silently without the picker ever flashing.
+const SERIAL_RECONNECT_GRACE_MS = 4_000;
+
 // Raw Capacitor plugin interface as exposed via window.Capacitor.Plugins.BluetoothLe.
 // The plugin JS is injected by the native shell. We type only the methods we use.
 // IMPORTANT: The raw plugin's write() expects `value` as a continuous hex string (no spaces), not DataView.
@@ -138,27 +144,39 @@ export class CapacitorBleAdapter implements BluetoothAdapter {
 
     if (this.devicePicker && ble.requestLEScan && ble.stopLEScan) {
       // Manual scan with custom picker — deduplicates devices ourselves
+      const devicePicker = this.devicePicker;
       const devices = new Map<string, DiscoveredDevice>();
       let updateListener: ((devices: DiscoveredDevice[]) => void) | null = null;
       const pushDevices = () => updateListener?.([...devices.values()]);
 
-      // When targetSerial is set, auto-resolve instead of waiting for picker
-      let autoSelectResolve: ((deviceId: string) => void) | null = null;
-      let autoSelectReject: ((error: Error) => void) | null = null;
+      // One selection promise resolved by either the silent serial auto-select
+      // or, if that serial never shows up, the picker the grace window opens.
+      let resolveSelection!: (deviceId: string) => void;
+      let rejectSelection!: (error: Error) => void;
+      const selectionPromise = new Promise<string>((resolve, reject) => {
+        resolveSelection = resolve;
+        rejectSelection = reject;
+      });
 
-      // Start the picker promise (resolves when user selects a device)
-      let selectionPromise: Promise<string>;
-      if (targetSerial) {
-        // Skip the picker UI — resolve automatically when matching device is found
-        selectionPromise = new Promise<string>((resolve, reject) => {
-          autoSelectResolve = resolve;
-          autoSelectReject = reject;
-        });
-      } else {
-        selectionPromise = this.devicePicker((onUpdate) => {
+      // True only while we're still silently matching the target serial — flips
+      // false the moment we auto-select or hand off to the picker.
+      let autoSelecting = Boolean(targetSerial);
+      let pickerOpened = false;
+      const openPicker = () => {
+        if (pickerOpened) return;
+        pickerOpened = true;
+        autoSelecting = false;
+        // Seed the picker with whatever we've already discovered, then forward
+        // the user's selection onto the unified selection promise.
+        devicePicker((onUpdate) => {
           updateListener = onUpdate;
           pushDevices();
-        });
+        }).then(resolveSelection, rejectSelection);
+      };
+
+      // No target serial → straight to the picker.
+      if (!targetSerial) {
+        openPicker();
       }
 
       // Register scan result listener BEFORE starting the scan.
@@ -182,12 +200,13 @@ export class CapacitorBleAdapter implements BluetoothAdapter {
         devices.set(dedupeKey, device);
         pushDevices();
 
-        // Auto-select if this device matches the target serial
-        if (autoSelectResolve && targetSerial) {
+        // Auto-select if this device matches the target serial (only until the
+        // picker takes over).
+        if (autoSelecting && targetSerial) {
           const serial = parseSerialNumber(device.name);
           if (serial === targetSerial) {
-            autoSelectResolve(device.deviceId);
-            autoSelectResolve = null;
+            autoSelecting = false;
+            resolveSelection(device.deviceId);
           }
         }
       });
@@ -195,19 +214,27 @@ export class CapacitorBleAdapter implements BluetoothAdapter {
       // Start scanning
       await ble.requestLEScan({ services });
 
-      // Auto-stop scan after timeout to prevent indefinite battery drain.
-      // If auto-selecting by serial, reject the promise so the caller isn't stuck forever.
+      // Grace window: if the stored serial hasn't matched shortly, open the
+      // picker (scan keeps running so it live-updates). Lets the user pick when
+      // their board moved, powered off, or another device is holding it.
+      const pickerFallbackId = targetSerial
+        ? setTimeout(() => {
+            if (autoSelecting) openPicker();
+          }, SERIAL_RECONNECT_GRACE_MS)
+        : undefined;
+
+      // Auto-stop scan after timeout to prevent indefinite battery drain. By now
+      // the picker is open (the grace window is shorter than this), so the user
+      // still sees the last results — matching the no-target picker flow.
       const scanTimeoutId = setTimeout(() => {
-        stopScanQuietly(ble);
-        if (autoSelectReject) {
-          autoSelectReject(new Error('Target board not found during scan'));
-          autoSelectReject = null;
-        }
+        void stopScanQuietly(ble);
+        if (autoSelecting) openPicker();
       }, SCAN_TIMEOUT_MS);
 
       try {
         selectedDeviceId = await selectionPromise;
       } finally {
+        if (pickerFallbackId) clearTimeout(pickerFallbackId);
         clearTimeout(scanTimeoutId);
         await scanListener.remove();
         await stopScanQuietly(ble);

--- a/packages/web/app/lib/ble/connection-error.ts
+++ b/packages/web/app/lib/ble/connection-error.ts
@@ -87,3 +87,32 @@ export function classifyBleFailure(error: unknown, pairingStage?: string): BleFa
 
   return 'unknown';
 }
+
+/**
+ * True when an error thrown from a *write* (not a connect attempt) means the
+ * GATT link is gone — the board dropped, another device grabbed it (these
+ * boards are last-connection-wins), or the OS tore the connection down. The
+ * write path otherwise swallows failures and leaves `isConnected` stuck true,
+ * so the lightbulb keeps showing "connected" on a dead link. Callers use this
+ * to mark the connection lost and offer a deliberate reconnect.
+ *
+ * Deliberately tight to avoid false-positive teardown: `AbortError` (the
+ * unmount-mid-write path) and ordinary value/validation failures must NOT
+ * count — only transport-level disconnect signatures do.
+ */
+export function isDisconnectionError(error: unknown): boolean {
+  const name = errorName(error);
+  // Unmount-mid-write — the AutoSender aborts its in-flight write on unmount.
+  // Not a real disconnect; the caller handles it separately.
+  if (name === 'AbortError') return false;
+  // Web Bluetooth surfaces a dead GATT link as NetworkError ("GATT Server is
+  // disconnected...") and, once the handle is torn down, InvalidStateError.
+  if (name === 'NetworkError' || name === 'InvalidStateError') return true;
+  // Capacitor / native iOS adapters throw plain Errors: "Not connected",
+  // "Device disconnected during write", and CoreBluetooth/Android plugin
+  // rejections that name a disconnected / unreachable peripheral.
+  const message = errorMessage(error);
+  return /GATT (server|operation).*(disconnect|not connected)|not connected|disconnected|peripheral.*(disconnect|unreachable)/i.test(
+    message,
+  );
+}

--- a/packages/web/app/lib/ble/connection-error.ts
+++ b/packages/web/app/lib/ble/connection-error.ts
@@ -105,13 +105,16 @@ export function isDisconnectionError(error: unknown): boolean {
   // Unmount-mid-write — the AutoSender aborts its in-flight write on unmount.
   // Not a real disconnect; the caller handles it separately.
   if (name === 'AbortError') return false;
+  const message = errorMessage(error);
   // Web Bluetooth surfaces a dead GATT link as NetworkError ("GATT Server is
-  // disconnected...") and, once the handle is torn down, InvalidStateError.
-  if (name === 'NetworkError' || name === 'InvalidStateError') return true;
+  // disconnected..."). InvalidStateError can mean the same once the GATT handle
+  // is torn down, but it also fires for unrelated reasons (closed
+  // IDBTransaction, double-read ReadableStream), so require a GATT mention.
+  if (name === 'NetworkError') return true;
+  if (name === 'InvalidStateError') return /gatt/i.test(message);
   // Capacitor / native iOS adapters throw plain Errors: "Not connected",
   // "Device disconnected during write", and CoreBluetooth/Android plugin
   // rejections that name a disconnected / unreachable peripheral.
-  const message = errorMessage(error);
   return /GATT (server|operation).*(disconnect|not connected)|not connected|disconnected|peripheral.*(disconnect|unreachable)/i.test(
     message,
   );

--- a/packages/web/app/lib/ble/native-ios-adapter.ts
+++ b/packages/web/app/lib/ble/native-ios-adapter.ts
@@ -3,13 +3,9 @@ import {
   AURORA_SCAN_SERVICE_UUIDS,
   parseSerialNumber,
 } from '@/app/components/board-bluetooth-control/bluetooth-aurora';
+import { SERIAL_RECONNECT_GRACE_MS } from './scan-constants';
 
 const SCAN_TIMEOUT_MS = 30_000;
-
-// How long a reconnect-by-serial waits for the stored board to advertise before
-// falling back to the picker. Short enough that a missing board surfaces the
-// picker quickly; long enough that a present board reconnects silently.
-const SERIAL_RECONNECT_GRACE_MS = 4_000;
 
 type NativeBoardBlePlugin = NonNullable<NonNullable<Window['Capacitor']>['Plugins']['BoardBle']>;
 type NativeBoardBleListenerHandle = Awaited<ReturnType<NativeBoardBlePlugin['addListener']>>;

--- a/packages/web/app/lib/ble/native-ios-adapter.ts
+++ b/packages/web/app/lib/ble/native-ios-adapter.ts
@@ -6,6 +6,11 @@ import {
 
 const SCAN_TIMEOUT_MS = 30_000;
 
+// How long a reconnect-by-serial waits for the stored board to advertise before
+// falling back to the picker. Short enough that a missing board surfaces the
+// picker quickly; long enough that a present board reconnects silently.
+const SERIAL_RECONNECT_GRACE_MS = 4_000;
+
 type NativeBoardBlePlugin = NonNullable<NonNullable<Window['Capacitor']>['Plugins']['BoardBle']>;
 type NativeBoardBleListenerHandle = Awaited<ReturnType<NativeBoardBlePlugin['addListener']>>;
 
@@ -69,25 +74,38 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
       throw new Error('Native iOS BLE requires the Boardsesh device picker');
     }
 
+    const devicePicker = this.devicePicker;
     const plugin = getNativeBoardBlePlugin();
     const devicesById = new Map<string, DiscoveredDevice>();
     let updateListener: ((devices: DiscoveredDevice[]) => void) | null = null;
     const pushDevices = () => updateListener?.([...devicesById.values()]);
 
-    let autoSelectResolve: ((deviceId: string) => void) | null = null;
-    let autoSelectReject: ((error: Error) => void) | null = null;
-    let selectionPromise: Promise<string>;
+    // One selection promise resolved by either the silent serial auto-select
+    // or, if that serial never shows up, the picker the grace window opens.
+    let resolveSelection!: (deviceId: string) => void;
+    let rejectSelection!: (error: Error) => void;
+    const selectionPromise = new Promise<string>((resolve, reject) => {
+      resolveSelection = resolve;
+      rejectSelection = reject;
+    });
 
-    if (targetSerial) {
-      selectionPromise = new Promise<string>((resolve, reject) => {
-        autoSelectResolve = resolve;
-        autoSelectReject = reject;
-      });
-    } else {
-      selectionPromise = this.devicePicker((onUpdate) => {
+    // True only while we're still silently matching the target serial — flips
+    // false the moment we auto-select or hand off to the picker.
+    let autoSelecting = Boolean(targetSerial);
+    let pickerOpened = false;
+    const openPicker = () => {
+      if (pickerOpened) return;
+      pickerOpened = true;
+      autoSelecting = false;
+      devicePicker((onUpdate) => {
         updateListener = onUpdate;
         pushDevices();
-      });
+      }).then(resolveSelection, rejectSelection);
+    };
+
+    // No target serial → straight to the picker.
+    if (!targetSerial) {
+      openPicker();
     }
 
     const scanListener = await normalizeListenerHandle(
@@ -105,11 +123,13 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
         devicesById.set(deviceId, device);
         pushDevices();
 
-        if (autoSelectResolve && targetSerial) {
+        // Auto-select if this device matches the target serial (only until the
+        // picker takes over).
+        if (autoSelecting && targetSerial) {
           const serial = parseSerialNumber(device.name);
           if (serial === targetSerial) {
-            autoSelectResolve(device.deviceId);
-            autoSelectResolve = null;
+            autoSelecting = false;
+            resolveSelection(device.deviceId);
           }
         }
       }),
@@ -117,12 +137,20 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
 
     await plugin.startScan({ services: [...AURORA_SCAN_SERVICE_UUIDS] });
 
+    // Grace window: if the stored serial hasn't matched shortly, open the picker
+    // (scan keeps running so it live-updates) instead of failing outright.
+    const pickerFallbackId = targetSerial
+      ? setTimeout(() => {
+          if (autoSelecting) openPicker();
+        }, SERIAL_RECONNECT_GRACE_MS)
+      : undefined;
+
+    // Auto-stop scan after timeout to prevent indefinite battery drain. By now
+    // the picker is open (the grace window is shorter), so the user still sees
+    // the last results — matching the no-target picker flow.
     const scanTimeoutId = setTimeout(() => {
       void stopScanQuietly(plugin);
-      if (autoSelectReject) {
-        autoSelectReject(new Error('Target board not found during scan'));
-        autoSelectReject = null;
-      }
+      if (autoSelecting) openPicker();
     }, SCAN_TIMEOUT_MS);
 
     let selectedDeviceId: string;
@@ -131,6 +159,7 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
     try {
       selectedDeviceId = await selectionPromise;
     } finally {
+      if (pickerFallbackId) clearTimeout(pickerFallbackId);
       clearTimeout(scanTimeoutId);
       await scanListener.remove();
       await stopScanQuietly(plugin);

--- a/packages/web/app/lib/ble/scan-constants.ts
+++ b/packages/web/app/lib/ble/scan-constants.ts
@@ -1,0 +1,8 @@
+// Shared BLE scan timing constants. Kept in one place so the platform adapters
+// (capacitor, native iOS) and their tests can't drift apart.
+
+// How long a reconnect-by-serial waits for the stored board to advertise before
+// falling back to the picker. Short enough that a missing board surfaces the
+// picker quickly; long enough that a present board (which advertises within a
+// second or two) reconnects silently without the picker ever flashing.
+export const SERIAL_RECONNECT_GRACE_MS = 4_000;


### PR DESCRIPTION
## Problem

On both iOS and Android, when another device grabs an Aurora board over Bluetooth (these boards are last-connection-wins), the local app didn't recover:

- The phone **never noticed it lost the board** — a write to the hijacked board failed silently, so `isConnected` stayed `true` and the lightbulb kept showing *connected*.
- **Re-taking did nothing** — the auto-sender dedupes byte-identical sends, so tapping the lightbulb on the same climb skipped the write.
- The only recovery was a manual long-press → **Disconnect** → reconnect dance.

Separately, the **React Native app** silently re-grabbed the board on every foreground — re-stealing a board another phone had legitimately taken. That ping-pong was the root of the "Android won't reconnect" reports.

## Fix

**Web / Capacitor (incl. Android)**
- `connection-error.ts` — `isDisconnectionError()`: a tight predicate for GATT/disconnected **write** errors (`AbortError`, validation errors, and bare `InvalidStateError` without a GATT mention excluded).
- `use-board-bluetooth.ts` — a disconnect-shaped write failure marks the link lost via `handleDisconnection`, so the lightbulb darkens. Remembers the `(serial, board-identity)` pair and exposes `reconnectSerialForCurrentBoard`: **same board → silent reconnect serial; switched board → picker.** The "take it back" snackbar now reconnects to the remembered board too (consistent with the lightbulb).
- `bluetooth-context.tsx` — `reassertWall()` forces a one-shot re-push bypassing the dedup.
- `play-view-drawer.tsx` — solo lightbulb tap reasserts the wall when connected, and silently reconnects to the last board (native) / picker (web) when disconnected.
- `capacitor-adapter.ts` + `native-ios-adapter.ts` — reconnect-by-serial tries to auto-select silently for a short grace window (`SERIAL_RECONNECT_GRACE_MS`, shared in `scan-constants.ts`); if the stored board doesn't advertise, it opens the picker (seeded with discovered devices, scan still running) instead of failing after 30s.

**Mobile (React Native)**
- `bluetooth-provider.tsx` — removed the silent foreground auto-reconnect (+ dead plumbing). Reconnect is user-initiated via the lightbulb, ending the ping-pong.

## Behaviour after the fix

1. Another device takes the board → on the next write the lightbulb darkens (shows disconnected).
2. Tap the dark lightbulb (or the snackbar "take it back") → silently reconnects to the same board and re-lights the climb (native); web opens the picker.
3. Re-tapping while connected re-pushes the current climb (dedup bypassed).
4. Switch to a different board, or the stored board isn't found within ~4s → the picker appears.
5. The RN phone no longer auto-steals the board on foreground.

## Validation

- `typecheck:web` ✅ · `typecheck:mobile` ✅
- web tests **4802+** (incl. new BLE detection / serial / reassert / adapter-fallback cases) · mobile tests **517** ✅
- `vp check` on changed files ✅ · `check:mobile-bundle` ✅

## Follow-up

- **#2475** — RN BLE shares the same write-failure-not-detected + UUID-only dedup bugs; tracked separately (not blocking this web/Capacitor fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)