### PR TITLE
fix(web): iOS swipe-close snap + review followups (post #2464)

### DIFF
--- a/packages/web/app/components/profile-header-bridge/profile-header-bridge-context.tsx
+++ b/packages/web/app/components/profile-header-bridge/profile-header-bridge-context.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import React, { createContext, useContext, useState, useCallback, useMemo, useLayoutEffect, useEffect } from 'react';
-
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
+import { useIsomorphicLayoutEffect } from '@/app/lib/hooks/use-isomorphic-layout-effect';
 
 type ProfileHeaderShareState = {
   isActive: boolean;

--- a/packages/web/app/components/providers/persistent-session-wrapper.tsx
+++ b/packages/web/app/components/providers/persistent-session-wrapper.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useIsomorphicLayoutEffect } from '@/app/lib/hooks/use-isomorphic-layout-effect';
 import { usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
 import { PartyProfileProvider } from '../party-manager/party-profile-context';
 import { PersistentSessionProvider, usePersistentSession, usePersistentSessionState } from '../persistent-session';
@@ -35,8 +36,6 @@ import { FeedbackPromptBanner } from '../feedback/feedback-prompt-banner';
 const SeshSettingsDrawer = dynamic(() => import('../sesh-settings/sesh-settings-drawer'), {
   ssr: false,
 });
-
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 type PersistentSessionWrapperProps = {
   children: React.ReactNode;

--- a/packages/web/app/components/search-drawer/search-drawer-bridge-context.tsx
+++ b/packages/web/app/components/search-drawer/search-drawer-bridge-context.tsx
@@ -1,18 +1,7 @@
 'use client';
 
-import React, {
-  createContext,
-  useContext,
-  useState,
-  useCallback,
-  useMemo,
-  useRef,
-  useLayoutEffect,
-  useEffect,
-} from 'react';
-
-// useLayoutEffect emits SSR warnings in Next.js; fall back to useEffect on the server.
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+import React, { createContext, useContext, useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { useIsomorphicLayoutEffect } from '@/app/lib/hooks/use-isomorphic-layout-effect';
 
 // -------------------------------------------------------------------
 // State context (consumed by GlobalHeader)

--- a/packages/web/app/components/stats-filter-bridge/stats-filter-bridge-context.tsx
+++ b/packages/web/app/components/stats-filter-bridge/stats-filter-bridge-context.tsx
@@ -1,17 +1,7 @@
 'use client';
 
-import React, {
-  createContext,
-  useContext,
-  useState,
-  useCallback,
-  useMemo,
-  useRef,
-  useLayoutEffect,
-  useEffect,
-} from 'react';
-
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+import React, { createContext, useContext, useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { useIsomorphicLayoutEffect } from '@/app/lib/hooks/use-isomorphic-layout-effect';
 
 // -------------------------------------------------------------------
 // State context (consumed by GlobalHeader)

--- a/packages/web/app/components/swipeable-drawer/__tests__/swipeable-drawer.test.tsx
+++ b/packages/web/app/components/swipeable-drawer/__tests__/swipeable-drawer.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 
 import SwipeableDrawer from '../swipeable-drawer';
@@ -261,6 +261,110 @@ describe('SwipeableDrawer', () => {
       });
       screen.getByTestId('inner').dispatchEvent(event);
 
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  // handleSwipeableClose is MUI's onClose (fired on backdrop click / Esc / swipe
+  // release). jsdom can't dispatch a real swipe-gesture sequence, so we trigger
+  // it via a backdrop click and prime the paper's inline transform to exercise
+  // the synchronous branches the e2e can't isolate.
+  describe('swipe-close handoff (handleSwipeableClose)', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // The paper element handleSwipeableClose mutates is the one captured in
+    // lastPaperRef — the wrapper Box's parent — which is `.MuiDrawer-paper`.
+    function getPaper(): HTMLElement {
+      return document.querySelector('.MuiDrawer-paper') as HTMLElement;
+    }
+    function triggerClose(container: HTMLElement) {
+      // MUI Modal invokes onClose on a backdrop click.
+      fireEvent.click(container.querySelector('.MuiBackdrop-root') as HTMLElement);
+    }
+    function dispatchTransformEnd(paper: HTMLElement) {
+      const event = new Event('transitionend') as TransitionEvent;
+      Object.defineProperty(event, 'propertyName', { value: 'transform' });
+      paper.dispatchEvent(event);
+    }
+
+    it('closes synchronously when the paper carries no gesture transform', () => {
+      // No in-progress swipe → no inline transform → close immediately (the
+      // backdrop / Esc / programmatic path), bypassing the gesture animation.
+      const onClose = vi.fn();
+      const { container } = render(
+        <SwipeableDrawer {...baseProps} placement="bottom" onClose={onClose} keepMounted>
+          <div>body</div>
+        </SwipeableDrawer>,
+      );
+      getPaper().style.transform = '';
+      triggerClose(container);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('defers onClose until the close transition ends when a swipe pre-positioned the paper', () => {
+      vi.useFakeTimers();
+      const onClose = vi.fn();
+      const { container } = render(
+        <SwipeableDrawer {...baseProps} placement="bottom" onClose={onClose} keepMounted>
+          <div>body</div>
+        </SwipeableDrawer>,
+      );
+      const paper = getPaper();
+      Object.defineProperty(paper, 'offsetHeight', { value: 1000, configurable: true });
+      paper.style.transform = 'translateY(600px)'; // gesture pulled it past the half-way gate
+
+      triggerClose(container);
+      // The wrapper animates the paper the rest of the way off-screen first.
+      expect(onClose).not.toHaveBeenCalled();
+      expect(paper.style.transform).toBe('translateY(1000px)');
+
+      act(() => dispatchTransformEnd(paper));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to a timer when transitionend never fires', () => {
+      vi.useFakeTimers();
+      const onClose = vi.fn();
+      const { container } = render(
+        <SwipeableDrawer {...baseProps} placement="bottom" onClose={onClose} keepMounted>
+          <div>body</div>
+        </SwipeableDrawer>,
+      );
+      const paper = getPaper();
+      Object.defineProperty(paper, 'offsetHeight', { value: 1000, configurable: true });
+      paper.style.transform = 'translateY(600px)';
+
+      triggerClose(container);
+      expect(onClose).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(400); // > duration + fallback margin
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels the deferred onClose when the drawer unmounts mid-close', () => {
+      vi.useFakeTimers();
+      const onClose = vi.fn();
+      const { container, unmount } = render(
+        <SwipeableDrawer {...baseProps} placement="bottom" onClose={onClose} keepMounted>
+          <div>body</div>
+        </SwipeableDrawer>,
+      );
+      const paper = getPaper();
+      Object.defineProperty(paper, 'offsetHeight', { value: 1000, configurable: true });
+      paper.style.transform = 'translateY(600px)';
+
+      triggerClose(container);
+      expect(onClose).not.toHaveBeenCalled();
+
+      unmount();
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      dispatchTransformEnd(paper);
       expect(onClose).not.toHaveBeenCalled();
     });
   });

--- a/packages/web/app/components/swipeable-drawer/__tests__/swipeable-drawer.test.tsx
+++ b/packages/web/app/components/swipeable-drawer/__tests__/swipeable-drawer.test.tsx
@@ -368,4 +368,63 @@ describe('SwipeableDrawer', () => {
       expect(onClose).not.toHaveBeenCalled();
     });
   });
+
+  // The opacity guard is the iOS-Safari snap fix: once a gesture has slid the
+  // paper off-screen, the paper is hidden the instant `open` flips false so MUI's
+  // Slide exit can't flash it back at the open position. `gesturePrePositioned`
+  // is read at render time (before Slide's exit mutates the transform), so it
+  // distinguishes a gesture close from a button/Esc close.
+  describe('gesture-close opacity guard', () => {
+    function getPaper(): HTMLElement {
+      return document.querySelector('.MuiDrawer-paper') as HTMLElement;
+    }
+
+    it('hides the off-screen paper when a gesture close flips open to false, and restores on reopen', () => {
+      const onClose = vi.fn();
+      const { rerender } = render(
+        <SwipeableDrawer {...baseProps} placement="bottom" onClose={onClose} keepMounted>
+          <div>body</div>
+        </SwipeableDrawer>,
+      );
+      const paper = getPaper();
+      Object.defineProperty(paper, 'offsetHeight', { value: 1000, configurable: true });
+      // The gesture left the paper translated fully off-screen.
+      paper.style.transform = 'translateY(900px)';
+      expect(paper.style.opacity).not.toBe('0'); // visible while open
+
+      rerender(
+        <SwipeableDrawer {...baseProps} placement="bottom" open={false} onClose={onClose} keepMounted>
+          <div>body</div>
+        </SwipeableDrawer>,
+      );
+      expect(paper.style.opacity).toBe('0');
+
+      // Reopening makes it visible again.
+      rerender(
+        <SwipeableDrawer {...baseProps} placement="bottom" open onClose={onClose} keepMounted>
+          <div>body</div>
+        </SwipeableDrawer>,
+      );
+      expect(paper.style.opacity).toBe('');
+    });
+
+    it('does not hide the paper on a plain close with no gesture transform (button / Esc)', () => {
+      const onClose = vi.fn();
+      const { rerender } = render(
+        <SwipeableDrawer {...baseProps} placement="bottom" onClose={onClose} keepMounted>
+          <div>body</div>
+        </SwipeableDrawer>,
+      );
+      const paper = getPaper();
+      Object.defineProperty(paper, 'offsetHeight', { value: 1000, configurable: true });
+      paper.style.transform = ''; // no in-progress gesture
+
+      rerender(
+        <SwipeableDrawer {...baseProps} placement="bottom" open={false} onClose={onClose} keepMounted>
+          <div>body</div>
+        </SwipeableDrawer>,
+      );
+      expect(paper.style.opacity).not.toBe('0');
+    });
+  });
 });

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -421,6 +421,13 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
   // For a fling, MUI uses an internally-computed `calculatedDurationRef` that
   // overrides `transitionDuration`, but `SlideProps.timeout` is merged onto the
   // transition slot last, so it wins and the exit stays instant on every path.
+  //
+  // NOTE: this reads DOM geometry (`getComputedStyle` / `offsetWidth` via
+  // `readCurrentTranslate`) during render. It's a synchronous read of a ref we
+  // own and only gates the exit duration, so a torn value just falls back to the
+  // animated exit (no correctness impact) — but if this component is ever used
+  // under React concurrent features, move it into a layout effect / event
+  // handler to avoid reading layout in render.
   const exitPaper = lastPaperRef.current;
   const exitIsHorizontal = placement === 'left' || placement === 'right';
   const gesturePrePositioned =

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useCallback, useRef, useEffect } from 'react';
+import React, { useMemo, useCallback, useRef, useEffect, useLayoutEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import MuiSwipeableDrawer from '@mui/material/SwipeableDrawer';
 import Box from '@mui/material/Box';
@@ -10,6 +10,11 @@ import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import { themeTokens } from '@/app/theme/theme-config';
 import { onTransformSettled } from '@/app/lib/hooks/pull-to-close';
 import styles from './swipeable-drawer.module.css';
+
+// Runs before paint in the browser; degrades to useEffect during SSR so it
+// doesn't warn. We need the pre-paint variant so the paper can be hidden in the
+// same frame React `open` flips (see the gesture-close opacity guard below).
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 type Placement = 'left' | 'right' | 'top' | 'bottom';
 
@@ -434,6 +439,24 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
     !!exitPaper &&
     Math.abs(readCurrentTranslate(exitPaper, exitIsHorizontal)) >
       (exitIsHorizontal ? exitPaper.offsetWidth : exitPaper.offsetHeight) * 0.5;
+
+  // Hide the paper the instant `open` flips false on a gesture close. The gesture
+  // has already slid it fully off-screen, so making it invisible is itself
+  // invisible — but it means MUI's Slide exit (which clears + re-measures the
+  // transform and, on iOS WebKit, can paint a single frame at the OPEN position)
+  // can no longer flash the paper back on screen. That stray frame is the "snaps
+  // back up" the exit-duration tweaks alone don't catch on Safari. The opacity is
+  // restored below when `open` returns true (and the play-view open effect
+  // separately clears the leftover transform).
+  useIsomorphicLayoutEffect(() => {
+    const paper = lastPaperRef.current;
+    if (!paper) return;
+    if (!(open ?? false) && gesturePrePositioned) {
+      paper.style.opacity = '0';
+    } else if (open ?? false) {
+      paper.style.opacity = '';
+    }
+  }, [open, gesturePrePositioned]);
 
   const slideProps = useMemo(
     () => ({

--- a/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
+++ b/packages/web/app/components/swipeable-drawer/swipeable-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useCallback, useRef, useEffect, useLayoutEffect } from 'react';
+import React, { useMemo, useCallback, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import MuiSwipeableDrawer from '@mui/material/SwipeableDrawer';
 import Box from '@mui/material/Box';
@@ -9,14 +9,16 @@ import Typography from '@mui/material/Typography';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import { themeTokens } from '@/app/theme/theme-config';
 import { onTransformSettled } from '@/app/lib/hooks/pull-to-close';
+import { useIsomorphicLayoutEffect } from '@/app/lib/hooks/use-isomorphic-layout-effect';
 import styles from './swipeable-drawer.module.css';
 
-// Runs before paint in the browser; degrades to useEffect during SSR so it
-// doesn't warn. We need the pre-paint variant so the paper can be hidden in the
-// same frame React `open` flips (see the gesture-close opacity guard below).
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
-
 type Placement = 'left' | 'right' | 'top' | 'bottom';
+
+/** True when the element is translated past half its own size along `axis`. */
+function isTranslatedOffScreen(el: HTMLElement, horizontal: boolean): boolean {
+  const max = horizontal ? el.offsetWidth : el.offsetHeight;
+  return Math.abs(readCurrentTranslate(el, horizontal)) > max * 0.5;
+}
 
 // When a swipe/pull gesture has already slid the paper off-screen, the MUI Slide
 // EXIT must be instant (0ms) so it doesn't re-animate the paper from the open
@@ -428,17 +430,17 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
   // transition slot last, so it wins and the exit stays instant on every path.
   //
   // NOTE: this reads DOM geometry (`getComputedStyle` / `offsetWidth` via
-  // `readCurrentTranslate`) during render. It's a synchronous read of a ref we
-  // own and only gates the exit duration, so a torn value just falls back to the
-  // animated exit (no correctness impact) — but if this component is ever used
-  // under React concurrent features, move it into a layout effect / event
-  // handler to avoid reading layout in render.
+  // `readCurrentTranslate`) during render. It must be read HERE, not in the
+  // effect below: at render time the paper still carries the GESTURE's inline
+  // transform, but by the time effects run MUI's Slide exit has set an off-screen
+  // transform on the paper for EVERY close (including button/Esc), so an
+  // effect-time read could no longer tell a gesture close from a normal one. The
+  // read is a synchronous read of a ref we own; a torn value under React
+  // concurrent features would only fall back to the animated exit (no
+  // correctness impact), and this drawer is not rendered concurrently today.
   const exitPaper = lastPaperRef.current;
   const exitIsHorizontal = placement === 'left' || placement === 'right';
-  const gesturePrePositioned =
-    !!exitPaper &&
-    Math.abs(readCurrentTranslate(exitPaper, exitIsHorizontal)) >
-      (exitIsHorizontal ? exitPaper.offsetWidth : exitPaper.offsetHeight) * 0.5;
+  const gesturePrePositioned = !!exitPaper && isTranslatedOffScreen(exitPaper, exitIsHorizontal);
 
   // Hide the paper the instant `open` flips false on a gesture close. The gesture
   // has already slid it fully off-screen, so making it invisible is itself
@@ -446,8 +448,8 @@ const SwipeableDrawer: React.FC<SwipeableDrawerProps> = ({
   // transform and, on iOS WebKit, can paint a single frame at the OPEN position)
   // can no longer flash the paper back on screen. That stray frame is the "snaps
   // back up" the exit-duration tweaks alone don't catch on Safari. The opacity is
-  // restored below when `open` returns true (and the play-view open effect
-  // separately clears the leftover transform).
+  // restored when `open` returns true (and the play-view open effect separately
+  // clears the leftover transform).
   useIsomorphicLayoutEffect(() => {
     const paper = lastPaperRef.current;
     if (!paper) return;

--- a/packages/web/app/lib/hooks/pull-to-close.ts
+++ b/packages/web/app/lib/hooks/pull-to-close.ts
@@ -6,7 +6,11 @@ import { useRef, useCallback, useEffect } from 'react';
 
 export const DECELERATE_EASING = 'cubic-bezier(0.0, 0, 0.2, 1)';
 export const CLOSE_ANIMATION_MS = 200;
-export const ANIMATION_DELAY_MS = 210; // CLOSE_ANIMATION_MS + safety margin
+// Total timeout used as the fallback for `onTransformSettled` (and as the
+// post-animation delay when snapping back), a hair longer than the transition so
+// it never cuts the animation short. NOT an additive delay on top of the
+// transition — it's the whole budget.
+export const ANIMATION_FALLBACK_MS = 210; // CLOSE_ANIMATION_MS + safety margin
 
 /**
  * Invoke `cb` once the element's `transform` transition ends, falling back to a
@@ -256,7 +260,7 @@ export function usePullToClose({
       el.style.transition = `transform ${CLOSE_ANIMATION_MS}ms ${DECELERATE_EASING}`;
       el.style.transform = `translateY(${targetY}px)`;
       settleCleanupRef.current?.();
-      settleCleanupRef.current = onTransformSettled(el, ANIMATION_DELAY_MS, () => {
+      settleCleanupRef.current = onTransformSettled(el, ANIMATION_FALLBACK_MS, () => {
         settleCleanupRef.current = null;
         onCloseRef.current();
       });
@@ -269,7 +273,7 @@ export function usePullToClose({
         if (currentEl) {
           currentEl.style.transition = '';
         }
-      }, ANIMATION_DELAY_MS);
+      }, ANIMATION_FALLBACK_MS);
     }
 
     state.isPulling = false;

--- a/packages/web/app/lib/hooks/use-isomorphic-layout-effect.ts
+++ b/packages/web/app/lib/hooks/use-isomorphic-layout-effect.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useEffect, useLayoutEffect } from 'react';
+
+/**
+ * `useLayoutEffect` in the browser, `useEffect` during SSR.
+ *
+ * `useLayoutEffect` runs before the browser paints — needed when an effect must
+ * read or mutate the DOM in the same frame it commits (e.g. measuring layout,
+ * hiding an element before it can flash). React warns when `useLayoutEffect`
+ * runs on the server, so we fall back to `useEffect` there (it's a no-op during
+ * SSR anyway). The branch is on a stable per-environment condition, so the rule
+ * of hooks is preserved.
+ */
+export const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;

--- a/packages/web/e2e/play-view-swipe-close.spec.ts
+++ b/packages/web/e2e/play-view-swipe-close.spec.ts
@@ -72,14 +72,19 @@ async function swipeDown(page: Page, start: { x: number; y: number }, distance: 
   const client = await page.context().newCDPSession(page);
   const pointAt = (y: number) => [{ x: start.x, y, id: 0, radiusX: 2, radiusY: 2, force: 1 }];
 
-  await client.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: pointAt(start.y) });
-  for (let i = 1; i <= steps; i++) {
-    const y = start.y + (distance * i) / steps;
-    await client.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: pointAt(y) });
-    await page.waitForTimeout(16);
+  // Always detach the CDP session, even if a dispatch throws mid-gesture, so it
+  // doesn't leak across tests.
+  try {
+    await client.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: pointAt(start.y) });
+    for (let i = 1; i <= steps; i++) {
+      const y = start.y + (distance * i) / steps;
+      await client.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: pointAt(y) });
+      await page.waitForTimeout(16);
+    }
+    await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+  } finally {
+    await client.detach();
   }
-  await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
-  await client.detach();
 }
 
 /** Assert the sampled translateY series is a single monotonic slide off-screen. */
@@ -143,7 +148,7 @@ test.describe('Play view drawer — swipe to close', () => {
     });
 
     assertMonotonicClose(samples, box.height);
-    await expect(page).not.toHaveURL(/\/view\//);
+    await expect(page).not.toHaveURL(/\/view\//, { timeout: 2000 });
   });
 
   test('drag-handle swipe closes with a single monotonic slide (no snap-back)', async ({ page }, testInfo) => {
@@ -163,6 +168,6 @@ test.describe('Play view drawer — swipe to close', () => {
     });
 
     assertMonotonicClose(samples, box.height);
-    await expect(page).not.toHaveURL(/\/view\//);
+    await expect(page).not.toHaveURL(/\/view\//, { timeout: 2000 });
   });
 });


### PR DESCRIPTION
Follow-up to #2464 (merged), which shipped the core swipe-to-close fix but **before** these two commits landed. This PR carries the remainder.

## 1. iOS Safari snap-back

On iOS Safari the swipe-close still snapped back up. MUI's `Slide` exit clears and re-measures the paper's transform when React `open` flips, and WebKit paints a single frame at the fully-open position before the exit completes — the exit-duration tweaks in #2464 stop the re-animation but not that stray measure-frame.

Fix: hide the paper (`opacity: 0`) the instant `open` flips false on a gesture close, in a pre-paint layout effect. The gesture has already slid it fully off-screen, so making it invisible is itself invisible — but Slide's exit can no longer flash it back on screen. Opacity is restored when `open` returns true. Button / Esc / backdrop closes leave no off-screen transform, so they're untouched. **Confirmed fixed on a real iPhone (Safari).**

## 2. Review followups

- e2e: guard the CDP session with `try/finally` so it can't leak if a dispatch throws mid-gesture.
- e2e: give the post-close URL assertion a 2s timeout (reversion runs through `onClose` → React state → router nav and can lag the settle under CI load).
- `pull-to-close`: rename `ANIMATION_DELAY_MS` → `ANIMATION_FALLBACK_MS` (it's the total fallback budget, not an additive delay).
- `swipeable-drawer`: comment on the in-render DOM-geometry read; add unit tests for `handleSwipeableClose` (sync close with no transform, deferral until `transitionend`, timer fallback, deferred-`onClose` cancellation on unmount).

## Validation

Typecheck, lint, 50 unit tests (the two affected files), and both Chromium e2e variants pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)