### PR TITLE
fix(mobile): portal LogAscent + BoardDetail sheets above tab bar

### DIFF
--- a/packages/mobile/app/(tabs)/boards/search.tsx
+++ b/packages/mobile/app/(tabs)/boards/search.tsx
@@ -198,14 +198,13 @@ export default function BoardSearchScreen() {
       </View>
     ) : null;
 
-  const detailSheet = (
+  const detailSheet = selectedBoard ? (
     <BoardDetailSheet
       board={selectedBoard}
-      visible={selectedBoard != null}
       onClose={() => setSelectedUuid(null)}
       onSetActive={handleSetActive}
     />
-  );
+  ) : null;
 
   // expo-maps unavailable (pre-build client): show a placeholder but keep the
   // search field + results list working so the feature degrades, not crashes.

--- a/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
+++ b/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
@@ -237,9 +237,8 @@ export default function ClimbDetail() {
       </ScrollView>
 
       {/* Log Ascent sheet */}
-      {boardName && (
+      {boardName && showLogAscent ? (
         <LogAscentSheet
-          visible={showLogAscent}
           onDismiss={() => setShowLogAscent(false)}
           climbUuid={climb.uuid}
           climbName={climb.name}
@@ -252,7 +251,7 @@ export default function ClimbDetail() {
           setIds={setIds}
           sessionId={sessionId}
         />
-      )}
+      ) : null}
     </>
   );
 }

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -5,7 +5,6 @@ import {
   BottomSheetModal,
   BottomSheetScrollView,
   type BottomSheetBackdropProps,
-  type BottomSheetScrollViewMethods,
 } from '@gorhom/bottom-sheet';
 import { FullWindowOverlay } from 'react-native-screens';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
@@ -179,7 +178,6 @@ export function ClimbFilterSheet({ onDismiss, boardConfig, currentFilters, onApp
   const { isAuthenticated } = useAuth();
   const insets = useSafeAreaInsets();
   const sheetRef = useRef<BottomSheetModal>(null);
-  const scrollRef = useRef<BottomSheetScrollViewMethods>(null);
   const boardName = boardConfig?.boardName ?? '';
   const { data: grades } = useGrades(boardName);
 
@@ -433,7 +431,6 @@ export function ClimbFilterSheet({ onDismiss, boardConfig, currentFilters, onApp
       </View>
 
       <BottomSheetScrollView
-        ref={scrollRef}
         style={styles.scrollView}
         showsVerticalScrollIndicator={false}
         contentContainerStyle={styles.scrollContent}

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { View, Pressable, TextInput, ScrollView, StyleSheet, Alert, type ViewStyle } from 'react-native';
-import BottomSheet, {
+import { useCallback, useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react';
+import { View, Pressable, TextInput, Platform, ScrollView, StyleSheet, Alert, type ViewStyle } from 'react-native';
+import {
   BottomSheetBackdrop,
-  BottomSheetView,
+  BottomSheetModal,
   type BottomSheetBackdropProps,
 } from '@gorhom/bottom-sheet';
+import { FullWindowOverlay } from 'react-native-screens';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type { Grade } from '@boardsesh/shared-schema';
@@ -26,7 +27,6 @@ import { spacing } from '../theme/tokens';
 type TickStatus = 'flash' | 'send' | 'attempt';
 
 type LogAscentSheetProps = {
-  visible: boolean;
   onDismiss: () => void;
   climbUuid: string;
   climbName: string;
@@ -41,6 +41,13 @@ type LogAscentSheetProps = {
 };
 
 const STATUS_OPTIONS: TickStatus[] = ['flash', 'send', 'attempt'];
+
+// Portal the sheet above the tab bar / persistent queue bar on iOS so the
+// footer Save button isn't hidden behind those overlays.
+function LogAscentSheetContainer({ children }: PropsWithChildren) {
+  return <FullWindowOverlay>{children}</FullWindowOverlay>;
+}
+const modalContainerComponent = Platform.OS === 'ios' ? LogAscentSheetContainer : undefined;
 
 function getMinAttempts(tickStatus: TickStatus): number {
   if (tickStatus === 'send') return 2;
@@ -77,7 +84,6 @@ function GradeChip({ grade, selected, onPress }: { grade: Grade; selected: boole
 }
 
 export function LogAscentSheet({
-  visible,
   onDismiss,
   climbUuid,
   climbName,
@@ -94,16 +100,14 @@ export function LogAscentSheet({
   const theme = useTheme();
   const { systemColors } = theme;
   const insets = useSafeAreaInsets();
-  const sheetRef = useRef<BottomSheet>(null);
+  const sheetRef = useRef<BottomSheetModal>(null);
 
+  // Mount-based control: parent renders this only when the sheet should be
+  // open, so we just present on mount and let the parent unmount on dismiss
+  // (same pattern as ClimbFilterSheet / DevicePickerSheet).
   useEffect(() => {
-    // Sheet mounts when visible becomes true — expand it. Re-run on every
-    // `visible` toggle, since the parent keeps the sheet mounted across
-    // opens, and a [] deps array would only expand on the first open.
-    if (visible) {
-      sheetRef.current?.expand();
-    }
-  }, [visible]);
+    sheetRef.current?.present();
+  }, []);
 
   const saveTick = useSaveTick(toBoardName(boardName));
   const { data: grades } = useGrades(boardName);
@@ -159,14 +163,6 @@ export function LogAscentSheet({
     setQuality(rating ?? 0);
   }, []);
 
-  const resetForm = useCallback(() => {
-    setStatus('flash');
-    setAttemptCount(1);
-    setQuality(0);
-    setSelectedDifficultyId(null);
-    setComment('');
-  }, []);
-
   const handleSave = useCallback(() => {
     saveTick.mutate(
       {
@@ -188,9 +184,7 @@ export function LogAscentSheet({
       {
         onSuccess: () => {
           hapticSuccess();
-          resetForm();
-          sheetRef.current?.close();
-          onDismiss();
+          sheetRef.current?.dismiss();
         },
         onError: () => {
           hapticError();
@@ -213,19 +207,8 @@ export function LogAscentSheet({
     layoutId,
     sizeId,
     setIds,
-    onDismiss,
-    resetForm,
     t,
   ]);
-
-  const handleSheetChange = useCallback(
-    (index: number) => {
-      if (index === -1) {
-        onDismiss();
-      }
-    },
-    [onDismiss],
-  );
 
   const renderBackdrop = useCallback(
     (backdropProps: BottomSheetBackdropProps) => (
@@ -264,149 +247,143 @@ export function LogAscentSheet({
     textAlignVertical: 'top' as const,
   };
 
-  if (!visible) return null;
-
   return (
-    <BottomSheet
+    <BottomSheetModal
       ref={sheetRef}
+      name="log-ascent"
       index={0}
       snapPoints={snapPoints}
+      enableDynamicSizing={false}
+      stackBehavior="push"
+      containerComponent={modalContainerComponent}
       enablePanDownToClose
       backdropComponent={renderBackdrop}
-      onChange={handleSheetChange}
+      onDismiss={onDismiss}
       handleIndicatorStyle={styles.indicator}
       backgroundStyle={backgroundStyle}
       keyboardBehavior="interactive"
       keyboardBlurBehavior="restore"
     >
-      <BottomSheetView style={styles.content}>
-        {/* Header */}
-        <View style={styles.header}>
-          <Text variant="title3">{t('mobile.logAscent.title')}</Text>
-          <Text variant="subheadline" style={styles.climbName}>
-            {climbName}
-          </Text>
-        </View>
+      <View style={styles.header}>
+        <Text variant="title3">{t('mobile.logAscent.title')}</Text>
+        <Text variant="subheadline" style={styles.climbName}>
+          {climbName}
+        </Text>
+      </View>
 
-        <ScrollView
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={styles.scrollContent}
-          keyboardShouldPersistTaps="handled"
-        >
-          {/* Status segmented control */}
-          <View style={styles.section}>
-            <SegmentedControl
-              options={segmentOptions}
-              selectedKey={status}
-              onSelect={handleStatusChange}
-              trackColor={trackColor}
-            />
-          </View>
-
-          {/* Attempt count stepper */}
-          <View style={styles.section}>
-            <Text variant="subheadline" style={styles.sectionLabel}>
-              {t('mobile.logAscent.attempts')}
-            </Text>
-            <View style={styles.stepperRow}>
-              <Pressable
-                onPress={handleDecrement}
-                disabled={attemptCount <= minAttempts}
-                accessibilityRole="button"
-                accessibilityLabel={t('mobile.logAscent.decreaseAttempts')}
-                style={[stepperButtonStyle, attemptCount <= minAttempts && styles.stepperDisabled]}
-              >
-                <Icon
-                  name="minus.circle"
-                  size={22}
-                  color={attemptCount <= minAttempts ? iosSystemColors.systemGray4 : brandColors.primary}
-                />
-              </Pressable>
-              <Text variant="title3" style={styles.attemptCount}>
-                {attemptCount}
-              </Text>
-              <Pressable
-                onPress={handleIncrement}
-                accessibilityRole="button"
-                accessibilityLabel={t('mobile.logAscent.increaseAttempts')}
-                style={stepperButtonStyle}
-              >
-                <Icon name="add" size={22} color={brandColors.primary} />
-              </Pressable>
-            </View>
-          </View>
-
-          <Separator />
-
-          {/* Quality rating */}
-          <View style={styles.section}>
-            <Text variant="subheadline" style={styles.sectionLabel}>
-              {t('mobile.logAscent.quality')}
-            </Text>
-            <StarRating value={quality} onChange={handleQualityChange} clearValue={0} />
-          </View>
-
-          <Separator />
-
-          {/* Grade opinion */}
-          {grades && grades.length > 0 && (
-            <>
-              <View style={styles.section}>
-                <Text variant="subheadline" style={styles.sectionLabel}>
-                  {t('mobile.logAscent.gradeOpinion')}
-                </Text>
-                <ScrollView
-                  horizontal
-                  showsHorizontalScrollIndicator={false}
-                  contentContainerStyle={styles.gradeChipsContainer}
-                >
-                  {grades.map((grade) => (
-                    <GradeChip
-                      key={grade.difficultyId}
-                      grade={grade}
-                      selected={selectedDifficultyId === grade.difficultyId}
-                      onPress={() =>
-                        setSelectedDifficultyId(selectedDifficultyId === grade.difficultyId ? null : grade.difficultyId)
-                      }
-                    />
-                  ))}
-                </ScrollView>
-              </View>
-
-              <Separator />
-            </>
-          )}
-
-          {/* Comment */}
-          <View style={styles.section}>
-            <Text variant="subheadline" style={styles.sectionLabel}>
-              {t('mobile.logAscent.comment')}
-            </Text>
-            <TextInput
-              value={comment}
-              onChangeText={setComment}
-              placeholder={t('mobile.logAscent.commentPlaceholder')}
-              placeholderTextColor={systemColors.tertiaryLabel as string}
-              multiline
-              style={commentInputStyle}
-            />
-          </View>
-
-        </ScrollView>
-
-        <View style={[styles.footer, { paddingBottom: insets.bottom + spacing[3] }]}>
-          <Button
-            title={t('mobile.logAscent.save')}
-            onPress={handleSave}
-            variant="filled"
-            size="large"
-            loading={saveTick.isPending}
-            disabled={saveTick.isPending}
-            style={styles.saveButton}
+      <ScrollView
+        style={styles.scrollView}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.section}>
+          <SegmentedControl
+            options={segmentOptions}
+            selectedKey={status}
+            onSelect={handleStatusChange}
+            trackColor={trackColor}
           />
         </View>
-      </BottomSheetView>
-    </BottomSheet>
+
+        <View style={styles.section}>
+          <Text variant="subheadline" style={styles.sectionLabel}>
+            {t('mobile.logAscent.attempts')}
+          </Text>
+          <View style={styles.stepperRow}>
+            <Pressable
+              onPress={handleDecrement}
+              disabled={attemptCount <= minAttempts}
+              accessibilityRole="button"
+              accessibilityLabel={t('mobile.logAscent.decreaseAttempts')}
+              style={[stepperButtonStyle, attemptCount <= minAttempts && styles.stepperDisabled]}
+            >
+              <Icon
+                name="minus.circle"
+                size={22}
+                color={attemptCount <= minAttempts ? iosSystemColors.systemGray4 : brandColors.primary}
+              />
+            </Pressable>
+            <Text variant="title3" style={styles.attemptCount}>
+              {attemptCount}
+            </Text>
+            <Pressable
+              onPress={handleIncrement}
+              accessibilityRole="button"
+              accessibilityLabel={t('mobile.logAscent.increaseAttempts')}
+              style={stepperButtonStyle}
+            >
+              <Icon name="add" size={22} color={brandColors.primary} />
+            </Pressable>
+          </View>
+        </View>
+
+        <Separator />
+
+        <View style={styles.section}>
+          <Text variant="subheadline" style={styles.sectionLabel}>
+            {t('mobile.logAscent.quality')}
+          </Text>
+          <StarRating value={quality} onChange={handleQualityChange} clearValue={0} />
+        </View>
+
+        <Separator />
+
+        {grades && grades.length > 0 && (
+          <>
+            <View style={styles.section}>
+              <Text variant="subheadline" style={styles.sectionLabel}>
+                {t('mobile.logAscent.gradeOpinion')}
+              </Text>
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.gradeChipsContainer}
+              >
+                {grades.map((grade) => (
+                  <GradeChip
+                    key={grade.difficultyId}
+                    grade={grade}
+                    selected={selectedDifficultyId === grade.difficultyId}
+                    onPress={() =>
+                      setSelectedDifficultyId(selectedDifficultyId === grade.difficultyId ? null : grade.difficultyId)
+                    }
+                  />
+                ))}
+              </ScrollView>
+            </View>
+
+            <Separator />
+          </>
+        )}
+
+        <View style={styles.section}>
+          <Text variant="subheadline" style={styles.sectionLabel}>
+            {t('mobile.logAscent.comment')}
+          </Text>
+          <TextInput
+            value={comment}
+            onChangeText={setComment}
+            placeholder={t('mobile.logAscent.commentPlaceholder')}
+            placeholderTextColor={systemColors.tertiaryLabel as string}
+            multiline
+            style={commentInputStyle}
+          />
+        </View>
+      </ScrollView>
+
+      <View style={[styles.footer, { paddingBottom: insets.bottom + spacing[3] }]}>
+        <Button
+          title={t('mobile.logAscent.save')}
+          onPress={handleSave}
+          variant="filled"
+          size="large"
+          loading={saveTick.isPending}
+          disabled={saveTick.isPending}
+          style={styles.saveButton}
+        />
+      </View>
+    </BottomSheetModal>
   );
 }
 
@@ -417,7 +394,7 @@ const styles = StyleSheet.create({
     height: 5,
     borderRadius: 3,
   },
-  content: {
+  scrollView: {
     flex: 1,
   },
   scrollContent: {
@@ -463,7 +440,6 @@ const styles = StyleSheet.create({
   footer: {
     paddingHorizontal: spacing[4],
     paddingTop: spacing[3],
-    paddingBottom: spacing[3],
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: iosSystemColors.separator,
   },

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -1,16 +1,14 @@
 import { forwardRef, useCallback, useMemo, type ReactNode } from 'react';
-import { Platform, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 import BottomSheet, {
   BottomSheetBackdrop,
   BottomSheetScrollView,
   BottomSheetView,
   type BottomSheetBackdropProps,
 } from '@gorhom/bottom-sheet';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { hapticMedium } from '../lib/haptics';
-import { sheetStyles, spacing } from '../theme/tokens';
+import { sheetStyles } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
-import { iosSystemColors } from '../theme/ios-colors';
 
 type SheetProps = {
   children: ReactNode;
@@ -25,10 +23,6 @@ type SheetProps = {
   // default BottomSheetView breaks gorhom's scroll gesture wiring.
   scrollable?: boolean;
   contentContainerStyle?: StyleProp<ViewStyle>;
-  // Optional bottom action area. Rendered as a sibling below the content with
-  // safe-area-aware bottom padding so the CTA sits comfortably above the home
-  // indicator (instead of flush against the screen edge).
-  footer?: ReactNode;
 };
 
 export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
@@ -41,12 +35,10 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
     enablePanDownToClose = true,
     scrollable = false,
     contentContainerStyle,
-    footer,
   },
   ref,
 ) {
   const { systemColors } = useTheme();
-  const insets = useSafeAreaInsets();
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);
 
   const renderBackdrop = useCallback(
@@ -66,17 +58,6 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
 
   const backgroundStyle = { ...sheetStyles.background, backgroundColor: systemColors.secondaryBackground };
 
-  const footerNode = footer ? (
-    <View
-      style={[
-        styles.footer,
-        { backgroundColor: systemColors.secondaryBackground as string, paddingBottom: insets.bottom + spacing[3] },
-      ]}
-    >
-      {footer}
-    </View>
-  ) : null;
-
   return (
     <BottomSheet
       ref={ref}
@@ -91,28 +72,10 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
       handleIndicatorStyle={sheetStyles.indicator}
       style={styles.sheet}
     >
-      {footer ? (
-        // Footer path: wrap scroll/static body + footer in a BottomSheetView so
-        // they share the sheet's flex column and the footer hugs the bottom.
-        <BottomSheetView style={styles.content}>
-          {scrollable ? (
-            <BottomSheetScrollView
-              style={styles.scrollView}
-              contentContainerStyle={contentContainerStyle}
-              showsVerticalScrollIndicator={false}
-            >
-              {children}
-            </BottomSheetScrollView>
-          ) : (
-            children
-          )}
-          {footerNode}
-        </BottomSheetView>
-      ) : scrollable ? (
-        // No-footer scrollable path stays unchanged for existing consumers:
-        // BottomSheetScrollView as the direct child keeps gorhom's gesture
-        // wiring intact (nesting it inside BottomSheetView is what the wrapper
-        // historically warned against).
+      {scrollable ? (
+        // style (flex: 1) sizes the scroll viewport to fill the sheet; the
+        // caller's padding goes on contentContainerStyle so it scrolls with the
+        // content rather than clipping the scrollable area.
         <BottomSheetScrollView
           style={styles.content}
           contentContainerStyle={contentContainerStyle}
@@ -143,14 +106,5 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
-  },
-  scrollView: {
-    flex: 1,
-  },
-  footer: {
-    paddingHorizontal: spacing[4],
-    paddingTop: spacing[3],
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: iosSystemColors.separator,
   },
 });

--- a/packages/mobile/src/components/board-discovery/BoardDetailSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDetailSheet.tsx
@@ -1,66 +1,108 @@
-import { useEffect, useRef } from 'react';
-import { View, StyleSheet, type ColorValue } from 'react-native';
-import BottomSheet from '@gorhom/bottom-sheet';
+import { useCallback, useEffect, useMemo, useRef, type PropsWithChildren } from 'react';
+import { View, Platform, StyleSheet, type ColorValue, type ViewStyle } from 'react-native';
+import {
+  BottomSheetBackdrop,
+  BottomSheetModal,
+  BottomSheetScrollView,
+  type BottomSheetBackdropProps,
+} from '@gorhom/bottom-sheet';
+import { FullWindowOverlay } from 'react-native-screens';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import { Sheet } from '../Sheet';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { Button } from '../Button';
 import { Avatar } from '../Avatar';
 import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { useTheme } from '../../providers/theme-provider';
-import { spacing, borderRadius } from '../../theme/tokens';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing, borderRadius, sheetStyles } from '../../theme/tokens';
 import { getBoardDetailFields, isActiveBoard } from './board-detail-fields';
 
 type BoardDetailSheetProps = {
-  board: UserBoard | null;
-  visible: boolean;
+  board: UserBoard;
   onClose: () => void;
   onSetActive: (board: UserBoard) => void;
 };
 
-export function BoardDetailSheet({ board, visible, onClose, onSetActive }: BoardDetailSheetProps) {
+// Portal the sheet above the tab bar / persistent queue bar on iOS so the
+// footer button isn't hidden behind those overlays.
+function BoardDetailSheetContainer({ children }: PropsWithChildren) {
+  return <FullWindowOverlay>{children}</FullWindowOverlay>;
+}
+const modalContainerComponent = Platform.OS === 'ios' ? BoardDetailSheetContainer : undefined;
+
+export function BoardDetailSheet({ board, onClose, onSetActive }: BoardDetailSheetProps) {
   const { systemColors } = useTheme();
   const { t } = useTranslation('boards');
   const { data: activeBoard } = useActiveBoard();
-  const sheetRef = useRef<BottomSheet>(null);
+  const insets = useSafeAreaInsets();
+  const sheetRef = useRef<BottomSheetModal>(null);
 
-  // Always-mounted sheet: open/close imperatively off the visible+board state.
-  // Selecting a different board while the sheet is open re-runs snapToIndex(0)
-  // (board is a dep) — harmless; gorhom no-ops if already at that stop.
+  // Mount-based control: parent renders this only when a board is selected,
+  // so we just present on mount and let the parent unmount on dismiss.
   useEffect(() => {
-    if (visible && board) {
-      sheetRef.current?.snapToIndex(0);
-    } else {
-      sheetRef.current?.close();
-    }
-  }, [visible, board]);
+    sheetRef.current?.present();
+  }, []);
 
-  const footer = board
-    ? isActiveBoard(board, activeBoard?.uuid)
-      ? (
-        <View style={[styles.activePill, { backgroundColor: systemColors.tertiaryBackground }]}>
-          <Icon name="tick" size={16} color={systemColors.secondaryLabel} />
-          <Text variant="subheadline" color={systemColors.secondaryLabel}>
-            {t('mobile.boardDetail.alreadyActive')}
-          </Text>
-        </View>
-      )
-      : <Button title={t('mobile.boardDetail.setActive')} size="large" onPress={() => onSetActive(board)} />
-    : null;
+  const snapPoints = useMemo(() => ['55%', '90%'], []);
+
+  const renderBackdrop = useCallback(
+    (backdropProps: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop {...backdropProps} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.4} />
+    ),
+    [],
+  );
+
+  const backgroundStyle: ViewStyle = {
+    ...sheetStyles.background,
+    backgroundColor: systemColors.secondaryBackground,
+  };
+
+  const alreadyActive = isActiveBoard(board, activeBoard?.uuid);
 
   return (
-    <Sheet
+    <BottomSheetModal
       ref={sheetRef}
-      snapPoints={['55%', '90%']}
-      onClose={onClose}
-      scrollable
-      contentContainerStyle={styles.content}
-      footer={footer}
+      name="board-detail"
+      index={0}
+      snapPoints={snapPoints}
+      enableDynamicSizing={false}
+      stackBehavior="push"
+      containerComponent={modalContainerComponent}
+      enablePanDownToClose
+      backdropComponent={renderBackdrop}
+      onDismiss={onClose}
+      handleIndicatorStyle={sheetStyles.indicator}
+      backgroundStyle={backgroundStyle}
     >
-      {board ? <BoardDetailBody board={board} systemColors={systemColors} t={t} /> : null}
-    </Sheet>
+      <BottomSheetScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <BoardDetailBody board={board} systemColors={systemColors} t={t} />
+      </BottomSheetScrollView>
+
+      <View
+        style={[
+          styles.footer,
+          { backgroundColor: systemColors.secondaryBackground as string, paddingBottom: insets.bottom + spacing[3] },
+        ]}
+      >
+        {alreadyActive ? (
+          <View style={[styles.activePill, { backgroundColor: systemColors.tertiaryBackground }]}>
+            <Icon name="tick" size={16} color={systemColors.secondaryLabel} />
+            <Text variant="subheadline" color={systemColors.secondaryLabel}>
+              {t('mobile.boardDetail.alreadyActive')}
+            </Text>
+          </View>
+        ) : (
+          <Button title={t('mobile.boardDetail.setActive')} size="large" onPress={() => onSetActive(board)} />
+        )}
+      </View>
+    </BottomSheetModal>
   );
 }
 
@@ -156,7 +198,10 @@ function SpecRow({ label, value, systemColors }: { label: string; value: string;
 }
 
 const styles = StyleSheet.create({
-  content: {
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
     paddingHorizontal: spacing[4],
     paddingTop: spacing[2],
     paddingBottom: spacing[4],
@@ -203,6 +248,12 @@ const styles = StyleSheet.create({
   },
   specValue: {
     flex: 1,
+  },
+  footer: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: iosSystemColors.separator,
   },
   activePill: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -452,9 +452,8 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       )}
 
       {/* Log Ascent sheet (full, via long-press) */}
-      {displayedClimb && (
+      {displayedClimb && showLogAscent ? (
         <LogAscentSheet
-          visible={showLogAscent}
           onDismiss={() => setShowLogAscent(false)}
           climbUuid={displayedClimb.uuid}
           climbName={displayedClimb.name}
@@ -467,7 +466,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
           setIds={setIds}
           sessionId={sessionId}
         />
-      )}
+      ) : null}
     </>
   );
 });

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -185,7 +185,6 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       {activeBoardConfig ? <PlayDrawer ref={playDrawerRef} boardConfig={activeBoardConfig} /> : null}
       {logAscentInput ? (
         <LogAscentSheet
-          visible
           onDismiss={dismissLogAscent}
           climbUuid={logAscentInput.climbUuid}
           climbName={logAscentInput.climbName}


### PR DESCRIPTION
Same bug class as the filter sheet: both were raw BottomSheet mounted inside a tab screen / drawer host, so the persistent queue bar and tab bar covered the bottom of the sheet — including the sticky CTA we just added.

- LogAscentSheet: BottomSheet → BottomSheetModal + FullWindowOverlay on iOS; mount-based control (parent renders only when showLogAscent). visible prop removed; preserved keyboardBehavior="interactive" and keyboardBlurBehavior="restore" so the keyboard still raises the sheet cleanly. Header / scroll / footer are direct siblings of the modal so scroll gestures stay wired.
- BoardDetailSheet: bypasses the Sheet wrapper now and uses BottomSheetModal directly with FullWindowOverlay. board prop becomes non-nullable (parent only mounts when a board is selected). Removed the imperative snapToIndex/close dance — onDismiss handles closing.
- Sheet wrapper: drops the footer slot (orphaned now that BoardDetail bypasses it) and the BottomSheetView+BottomSheetScrollView nesting it introduced — that nesting was the same pattern that broke scroll on the filter sheet, and the wrapper-level JSDoc has warned against it for as long as the file has existed.
- ClimbFilterSheet: drop the now-unused scrollRef (flagged in review).
- Updated remaining LogAscentSheet call sites (PlayDrawer, drawer-host-provider) to drop the visible prop and conditionally mount.