### PR TITLE
fix(mobile): polyfill Intl.PluralRules for i18next

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -207,6 +207,7 @@
         "graphql-request": "^7.0.0",
         "graphql-ws": "^6.0.0",
         "i18next": "^23.16.8",
+        "intl-pluralrules": "^2.0.1",
         "react": "19.2.3",
         "react-i18next": "^15.0.0",
         "react-native": "0.85.3",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -63,6 +63,7 @@
     "graphql-request": "^7.0.0",
     "graphql-ws": "^6.0.0",
     "i18next": "^23.16.8",
+    "intl-pluralrules": "^2.0.1",
     "react": "19.2.3",
     "react-i18next": "^15.0.0",
     "react-native": "0.85.3",

--- a/packages/mobile/src/lib/i18n/config.ts
+++ b/packages/mobile/src/lib/i18n/config.ts
@@ -1,3 +1,7 @@
+// Hermes ships an incomplete Intl.PluralRules. This side-effect import installs
+// a polyfill so i18next's v4 plural resolver works instead of falling back to
+// v3 handling (which mis-pluralises es/fr). Must run before i18n.init below.
+import 'intl-pluralrules';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import { getLocales } from 'expo-localization';


### PR DESCRIPTION
## Problem

The mobile app logs a console error on every startup:

> i18next::pluralResolver: Your environment seems not to be Intl API compatible, use an Intl.PluralRules polyfill. Will fallback to the compatibilityJSON v3 format handling.

Hermes (React Native's JS engine) ships an incomplete `Intl.PluralRules`. The mobile i18n config (`packages/mobile/src/lib/i18n/config.ts`) initialises i18next with `compatibilityJSON: 'v4'`, which needs a working `Intl.PluralRules`. Without it, i18next can't resolve plurals against the v4 catalogs and silently downgrades to v3 handling, which produces wrong plural forms for `es`/`fr`.

## Fix

Add the `intl-pluralrules` polyfill as a side-effect import at the top of the mobile i18n config, before `i18n.init`. This is the exact pattern the web package already uses — `packages/web` depends on `intl-pluralrules@^2.0.1` and imports it in `app/lib/i18n/server.ts` and `app/lib/i18n/client.tsx`. Mobile simply never added it.

- `packages/mobile/src/lib/i18n/config.ts` — `import 'intl-pluralrules';` before any i18next usage.
- `packages/mobile/package.json` — add `intl-pluralrules@^2.0.1` (same version as web).
- `bun.lock` — add the mobile workspace dependency edge. The package itself was already resolved in the lockfile (it's a web dependency), so only the edge was missing.

`compatibilityJSON: 'v4'` is intentionally kept — the polyfill makes v4 work correctly rather than downgrading to v3.

## Validation

⚠️ Local validation could not run in this environment: the container shipped with an empty `node_modules` and a full `bun install` does not complete here (it pegs CPU and stalls during the link phase; network and registry reachability were confirmed fine). The toolchain (`vp`, `tsc`, Metro) all need `node_modules`, so `vp run typecheck:mobile`, `vp test --project mobile`, and `vp run check:mobile-bundle` could not be exercised. **CI should run these.**

The change is a verbatim mirror of the working web pattern, so risk is low. To verify manually once deps install: launch the app and confirm the `pluralResolver` console error no longer appears on startup, and that count-based strings pluralise correctly under `es`/`fr`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cke48nBbiqvB86oWFDbAfp)_