### PR TITLE
Fix empty-state flash and render perf in mobile discover/climbs

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -262,9 +262,11 @@ export default function ClimbList() {
   // Tapping a climb seeds a suggestion source from the search results, anchored
   // at the tapped climb, so the play-drawer swipe continues through the climbs
   // listed after it — mirroring the playlist flow.
+  const allQueueClimbs = useMemo(() => toQueueClimbs(accumulatedClimbs), [accumulatedClimbs]);
+
   const activateClimbListClimb = usePlaylistActivation({
     sourceId: 'climblist',
-    allClimbs: toQueueClimbs(accumulatedClimbs),
+    allClimbs: allQueueClimbs,
     fetchPage: fetchSearchPage,
     refreshErrorMessage: 'Failed to refresh climb-list suggestions:',
   });

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -43,7 +43,7 @@ export default function DiscoverLibrary() {
   const filterLayoutId = boardFilter?.layoutId;
 
   // Smart-playlist counts gate which "Your Picks" cards render.
-  const { data: smartCounts } = useSmartPlaylistCounts({
+  const { data: smartCounts, isLoading: smartCountsLoading } = useSmartPlaylistCounts({
     token: effectiveToken,
     tokenLoading,
     isAuthenticated,
@@ -218,6 +218,7 @@ export default function DiscoverLibrary() {
       {isAuthenticated &&
       !userLoading &&
       !discoverLoading &&
+      !smartCountsLoading &&
       jumpBackIn.length === 0 &&
       discoverItems.length === 0 &&
       smartCardsToShow.length === 0 ? (
@@ -292,7 +293,7 @@ const styles = StyleSheet.create({
   emptyContainer: {
     alignItems: 'center',
     justifyContent: 'center',
-    paddingTop: 80,
+    paddingTop: spacing[10] * 2,
     paddingHorizontal: 32,
     gap: 8,
   },
@@ -305,7 +306,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   loadingContainer: {
-    paddingTop: 120,
+    paddingTop: spacing[10] * 3,
     alignItems: 'center',
     justifyContent: 'center',
   },


### PR DESCRIPTION
## What

Three small, localized fixes in the mobile discover/library tabs.

### 1. Empty-state flash in discover (`discover/index.tsx`)
The empty-state guard checked `!userLoading && !discoverLoading` but not whether smart-playlist counts were still loading. `useSmartPlaylistCounts` returns `undefined` data while fetching, so `smartCardsToShow` was `[]` during that window and the empty state flashed until counts arrived. Now also destructures `isLoading: smartCountsLoading` and adds `!smartCountsLoading` to the guard, matching the existing `userLoading`/`discoverLoading` pattern.

### 2. `allClimbs` recreated every render (`climbs/index.tsx`)
`allClimbs: toQueueClimbs(accumulatedClimbs)` was passed inline, producing a new array each render. Since `allClimbs` is a `useCallback` dependency inside the shared `usePlaylistClimbActivation`, the activation callback rememoized on every render. Wrapped in `useMemo(() => toQueueClimbs(accumulatedClimbs), [accumulatedClimbs])`.

### 3. Hardcoded px in discover styles (`discover/index.tsx`)
`emptyContainer.paddingTop: 80` → `spacing[10] * 2`, `loadingContainer.paddingTop: 120` → `spacing[10] * 3`. Exact same pixel values, now routed through the spacing token scale (`spacing` was already imported).

## Validation
- `vp run typecheck:mobile` — pass
- `vp test --project mobile` — 546 tests pass
- `vp run check:mobile-bundle` — bundle OK

https://claude.ai/code/session_0147UPKEJqyP9G2eSM9GAYPz

---
_Generated by [Claude Code](https://claude.ai/code/session_0147UPKEJqyP9G2eSM9GAYPz)_