### PR TITLE
refactor(favorites): key by climb UUID only (fixes #2449)

### DIFF
--- a/packages/backend/src/__tests__/favorites.test.ts
+++ b/packages/backend/src/__tests__/favorites.test.ts
@@ -17,6 +17,36 @@ const { mockDb } = vi.hoisted(() => {
 
 vi.mock('../db/client', () => ({ db: mockDb }));
 
+vi.mock('../db/queries/util/table-select', () => ({
+  UNIFIED_TABLES: {
+    climbs: {
+      uuid: 'climbs.uuid',
+      layoutId: 'climbs.layoutId',
+      boardType: 'climbs.boardType',
+      setterUsername: 'climbs.setterUsername',
+      name: 'climbs.name',
+      description: 'climbs.description',
+      frames: 'climbs.frames',
+    },
+    climbStats: {
+      climbUuid: 'climbStats.climbUuid',
+      boardType: 'climbStats.boardType',
+      angle: 'climbStats.angle',
+      ascensionistCount: 'climbStats.ascensionistCount',
+      qualityAverage: 'climbStats.qualityAverage',
+      difficultyAverage: 'climbStats.difficultyAverage',
+      displayDifficulty: 'climbStats.displayDifficulty',
+      benchmarkDifficulty: 'climbStats.benchmarkDifficulty',
+    },
+  },
+  isValidBoardName: () => true,
+}));
+
+vi.mock('@boardsesh/db/queries', () => ({
+  getClimbStars: () => 0,
+  getGradeLabel: () => '',
+}));
+
 const eqSpy = vi.fn();
 const inArraySpy = vi.fn();
 vi.mock('drizzle-orm', async () => {
@@ -36,6 +66,7 @@ vi.mock('drizzle-orm', async () => {
 
 import { favoriteMutations } from '../graphql/resolvers/favorites/mutations';
 import { favoriteQueries } from '../graphql/resolvers/favorites/queries';
+import { favoriteClimbsQuery } from '../graphql/resolvers/favorites/favorite-climbs-query';
 
 function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
   return {
@@ -51,13 +82,18 @@ function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext 
 }
 
 function makeChain(resolveValue: unknown = []) {
+  const calls: Record<string, unknown[][]> = {};
   const chain: Record<string, unknown> = {};
-  const methods = ['select', 'from', 'where', 'limit', 'values'];
+  const methods = ['select', 'from', 'where', 'limit', 'values', 'innerJoin', 'leftJoin', 'orderBy', 'offset'];
   for (const method of methods) {
-    chain[method] = vi.fn(() => chain);
+    calls[method] = [];
+    chain[method] = vi.fn((...args: unknown[]) => {
+      calls[method].push(args);
+      return chain;
+    });
   }
   chain.then = (resolve: (value: unknown) => unknown) => Promise.resolve(resolveValue).then(resolve);
-  return chain;
+  return Object.assign(chain, { _calls: calls });
 }
 
 describe('favorites resolvers (UUID-only keying, #2449)', () => {
@@ -117,6 +153,47 @@ describe('favorites resolvers (UUID-only keying, #2449)', () => {
       );
       expect(result).toEqual([]);
       expect(mockDb.select).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('userFavoriteClimbs — board scoping via boardClimbs join', () => {
+    // Drives the /<board>/.../liked page. After #2449 the favorites table is
+    // board-agnostic, so the resolver must restore board scope by joining
+    // boardClimbs on uuid + boardType. A regression that drops that join
+    // would silently show favorites from every board on each board's page.
+
+    it('joins boardClimbs on (uuid, boardType=boardName) for both count + page queries', async () => {
+      // Count query, then the data query.
+      const countChain = makeChain([{ count: 3 }]);
+      const dataChain = makeChain([]);
+      mockDb.select.mockReturnValueOnce(countChain);
+      mockDb.select.mockReturnValueOnce(dataChain);
+
+      await favoriteClimbsQuery.userFavoriteClimbs(
+        null,
+        {
+          input: {
+            boardName: 'kilter',
+            layoutId: 1,
+            sizeId: 1,
+            setIds: '1,2',
+            angle: 40,
+            page: 0,
+            pageSize: 20,
+          },
+        },
+        makeCtx(),
+      );
+
+      // Both queries must inner-join boardClimbs — that's how favorites get
+      // scoped to the requested board now that user_favorites has no board.
+      expect((countChain as { _calls: Record<string, unknown[][]> })._calls.innerJoin.length).toBe(1);
+      expect((dataChain as { _calls: Record<string, unknown[][]> })._calls.innerJoin.length).toBe(1);
+
+      // The boardName argument must reach an eq() against boardClimbs.boardType
+      // (the mocked sentinel value `climbs.boardType` from UNIFIED_TABLES).
+      const boardFilters = eqSpy.mock.calls.filter(([col, val]) => col === 'climbs.boardType' && val === 'kilter');
+      expect(boardFilters.length).toBeGreaterThanOrEqual(2);
     });
   });
 });

--- a/packages/backend/src/__tests__/favorites.test.ts
+++ b/packages/backend/src/__tests__/favorites.test.ts
@@ -1,0 +1,122 @@
+// Regression guard for #2449: favorites are keyed by (userId, climbUuid) only.
+// Toggling from any board surface and reading from any other board surface
+// must operate on the same canonical row — previously the (board, angle)
+// dimension produced phantom duplicate keys that broke cross-board reads.
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+
+const { mockDb } = vi.hoisted(() => {
+  const mockDb = {
+    select: vi.fn(),
+    insert: vi.fn(),
+    delete: vi.fn(),
+  };
+  return { mockDb };
+});
+
+vi.mock('../db/client', () => ({ db: mockDb }));
+
+const eqSpy = vi.fn();
+const inArraySpy = vi.fn();
+vi.mock('drizzle-orm', async () => {
+  const actual = await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm');
+  return {
+    ...actual,
+    eq: (...args: Parameters<typeof actual.eq>) => {
+      eqSpy(...args);
+      return actual.eq(...args);
+    },
+    inArray: (...args: Parameters<typeof actual.inArray>) => {
+      inArraySpy(...args);
+      return actual.inArray(...args);
+    },
+  };
+});
+
+import { favoriteMutations } from '../graphql/resolvers/favorites/mutations';
+import { favoriteQueries } from '../graphql/resolvers/favorites/queries';
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: true,
+    userId: 'user-123',
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+function makeChain(resolveValue: unknown = []) {
+  const chain: Record<string, unknown> = {};
+  const methods = ['select', 'from', 'where', 'limit', 'values'];
+  for (const method of methods) {
+    chain[method] = vi.fn(() => chain);
+  }
+  chain.then = (resolve: (value: unknown) => unknown) => Promise.resolve(resolveValue).then(resolve);
+  return chain;
+}
+
+describe('favorites resolvers (UUID-only keying, #2449)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('toggleFavorite', () => {
+    it('inserts by (userId, climbUuid) only — no board or angle column referenced', async () => {
+      // Existing-check returns empty → insert path
+      mockDb.select.mockReturnValueOnce(makeChain([]));
+      const insertValuesSpy = vi.fn(() => Promise.resolve());
+      mockDb.insert.mockReturnValueOnce({ values: insertValuesSpy });
+
+      const result = await favoriteMutations.toggleFavorite(null, { input: { climbUuid: 'climb-A' } }, makeCtx());
+
+      expect(result).toEqual({ favorited: true });
+      // Exact-match values: a future regression that re-adds a board or
+      // angle key would fail this assertion (vitest .toHaveBeenCalledWith
+      // is strict about extra properties).
+      expect(insertValuesSpy).toHaveBeenCalledWith({ userId: 'user-123', climbUuid: 'climb-A' });
+    });
+
+    it('deletes by (userId, climbUuid) only when row already exists', async () => {
+      mockDb.select.mockReturnValueOnce(makeChain([{ id: 1n }]));
+      const deleteWhereSpy = vi.fn(() => Promise.resolve());
+      mockDb.delete.mockReturnValueOnce({ where: deleteWhereSpy });
+
+      const result = await favoriteMutations.toggleFavorite(null, { input: { climbUuid: 'climb-A' } }, makeCtx());
+
+      expect(result).toEqual({ favorited: false });
+      expect(deleteWhereSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('favorites query — cross-board read', () => {
+    it('returns the climbUuid regardless of which board surface is asking', async () => {
+      // A single canonical row exists for the climb. The query is the same
+      // regardless of what board the caller is on — this is the #2449 fix.
+      mockDb.select.mockReturnValue(makeChain([{ climbUuid: 'climb-A' }]));
+
+      const fromKilter = await favoriteQueries.favorites(null, { climbUuids: ['climb-A'] }, makeCtx());
+      const fromTension = await favoriteQueries.favorites(null, { climbUuids: ['climb-A'] }, makeCtx());
+
+      expect(fromKilter).toEqual(['climb-A']);
+      expect(fromTension).toEqual(['climb-A']);
+      // Resolver signature carries no board/angle dimension — type system
+      // would catch a regression at compile time, but assert two distinct
+      // call shapes both succeed to make the cross-board intent obvious.
+    });
+
+    it('returns empty array for unauthenticated context', async () => {
+      const result = await favoriteQueries.favorites(
+        null,
+        { climbUuids: ['climb-A'] },
+        makeCtx({ isAuthenticated: false, userId: undefined }),
+      );
+      expect(result).toEqual([]);
+      expect(mockDb.select).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/__tests__/rest-parity.test.ts
+++ b/packages/backend/src/__tests__/rest-parity.test.ts
@@ -176,7 +176,7 @@ describe('REST vs GraphQL Parity Tests', () => {
     it('favorites should return empty array for unauthenticated user', async () => {
       const gqlResult = await fetchGraphQL<{ favorites: string[] }>(
         `query {
-          favorites(boardName: "kilter", climbUuids: ["test-uuid"], angle: 40)
+          favorites(climbUuids: ["test-uuid"])
         }`,
       );
 
@@ -204,7 +204,7 @@ describe('REST vs GraphQL Parity Tests', () => {
       try {
         await fetchGraphQL<unknown>(
           `mutation {
-            toggleFavorite(input: { boardName: "kilter", climbUuid: "test-uuid", angle: 40 }) {
+            toggleFavorite(input: { climbUuid: "test-uuid" }) {
               favorited
             }
           }`,

--- a/packages/backend/src/__tests__/smart-playlists.test.ts
+++ b/packages/backend/src/__tests__/smart-playlists.test.ts
@@ -326,7 +326,10 @@ describe('smartPlaylist resolver', () => {
       ctx,
     );
 
-    const boardFilters = eqSpy.mock.calls.filter(([col, val]) => col === 'boardType' && val === 'kilter');
+    // No board scoping at all — the resolver must not eq() boardType against
+    // any value when boardName is omitted from the input. Without the value
+    // guard, this catches an accidental filter on any board, not just kilter.
+    const boardFilters = eqSpy.mock.calls.filter(([col]) => col === 'boardType');
     expect(boardFilters.length).toBe(0);
   });
 

--- a/packages/backend/src/__tests__/smart-playlists.test.ts
+++ b/packages/backend/src/__tests__/smart-playlists.test.ts
@@ -295,22 +295,19 @@ describe('smartPlaylist resolver', () => {
     expect(pageCalls.limit[0]).toEqual([5]);
     expect(pageCalls.offset[0]).toEqual([5]);
 
-    // Dedup: GROUP BY (climbUuid, boardName)
+    // Dedup: GROUP BY (climbUuid, boardClimbs.boardType) — boardType now derived
+    // by joining the climbs table since favorites are board-agnostic.
     expect(pageCalls.groupBy.length).toBe(1);
-    expect(pageCalls.groupBy[0]).toEqual([dbSchema.userFavorites.climbUuid, dbSchema.userFavorites.boardName]);
-    // Ordered (by max(createdAt) DESC); we just assert orderBy was called
+    expect(pageCalls.groupBy[0]).toEqual([dbSchema.userFavorites.climbUuid, 'boardType']);
     expect(pageCalls.orderBy.length).toBe(1);
 
-    // Both page and count must filter by both userId and boardName — a missing
-    // boardName filter on either side would make the count card show all-boards
-    // while the detail page is board-scoped (or vice versa).
+    // userId must be filtered on both page and count.
     const userIdFilters = eqSpy.mock.calls.filter(
       ([col, val]) => col === dbSchema.userFavorites.userId && val === 'user-123',
     );
     expect(userIdFilters.length).toBeGreaterThanOrEqual(2);
-    const boardFilters = eqSpy.mock.calls.filter(
-      ([col, val]) => col === dbSchema.userFavorites.boardName && val === 'kilter',
-    );
+    // Board scoping is now applied via boardClimbs.boardType, not userFavorites.boardName.
+    const boardFilters = eqSpy.mock.calls.filter(([col, val]) => col === 'boardType' && val === 'kilter');
     expect(boardFilters.length).toBeGreaterThanOrEqual(2);
   });
 
@@ -319,9 +316,6 @@ describe('smartPlaylist resolver', () => {
     mockDb.select.mockReturnValueOnce(makeChain([USER_ROW]).chain);
     mockDb.select.mockReturnValueOnce(makeChain([]).chain);
     mockDb.select.mockReturnValueOnce(makeChain([{ count: 0 }]).chain);
-    // Defensive: hydrate currently short-circuits on an empty refs[], so this
-    // mock is unused today. Kept so the test doesn't blow up cryptically if
-    // that short-circuit is ever removed.
     mockDb.select.mockReturnValueOnce(makeChain([]).chain);
 
     await playlistQueries.smartPlaylist(
@@ -332,7 +326,7 @@ describe('smartPlaylist resolver', () => {
       ctx,
     );
 
-    const boardFilters = eqSpy.mock.calls.filter(([col]) => col === dbSchema.userFavorites.boardName);
+    const boardFilters = eqSpy.mock.calls.filter(([col, val]) => col === 'boardType' && val === 'kilter');
     expect(boardFilters.length).toBe(0);
   });
 

--- a/packages/backend/src/__tests__/smart-playlists.test.ts
+++ b/packages/backend/src/__tests__/smart-playlists.test.ts
@@ -471,4 +471,29 @@ describe('mySmartPlaylistCounts resolver', () => {
     expect(rendered).toMatch(/sent\.climb_uuid\s*=\s*base\.climb_uuid/i);
     expect(rendered).toMatch(/sent\.board_type\s*=\s*base\.board_type/i);
   });
+
+  it('liked_climbs CTE joins boardClimbs to derive board_type (#2449)', async () => {
+    // Post-#2449 user_favorites no longer carries board_name. The CTE must
+    // INNER JOIN boardClimbs on climb_uuid so each favorite contributes its
+    // climb's board, and the COUNT must distinguish by (board_type, climb_uuid)
+    // rather than referencing the dropped column. Asserting SQL shape here so a
+    // serialization regression (e.g. an accidental userFavorites.board_name)
+    // fails in CI instead of at runtime.
+    const ctx = makeCtx();
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    await playlistQueries.mySmartPlaylistCounts(null, undefined, ctx);
+
+    const sqlArg = mockDb.execute.mock.calls[0][0] as { queryChunks?: unknown[] } | undefined;
+    const rendered = (sqlArg?.queryChunks ?? [])
+      .map((chunk) => (typeof chunk === 'string' ? chunk : ((chunk as { value?: string }).value ?? '')))
+      .join(' ');
+
+    // No reference to the dropped column anywhere in the rendered SQL.
+    expect(rendered).not.toMatch(/board_name/i);
+    // liked_climbs CTE counts distinct (board_type, climb_uuid) via the join.
+    expect(rendered).toMatch(/liked_climbs\s+AS\s*\(/i);
+    expect(rendered).toMatch(/COUNT\s*\(\s*DISTINCT\s*\(\s*c\.board_type\s*,\s*uf\.climb_uuid\s*\)\s*\)/i);
+    expect(rendered).toMatch(/INNER\s+JOIN[\s\S]*?ON\s+c\.uuid\s*=\s*uf\.climb_uuid/i);
+  });
 });

--- a/packages/backend/src/graphql/resolvers/favorites/favorite-climbs-query.ts
+++ b/packages/backend/src/graphql/resolvers/favorites/favorite-climbs-query.ts
@@ -39,27 +39,28 @@ export const favoriteClimbsQuery = {
     const pageSize = input.pageSize ?? 20;
     const tables = UNIFIED_TABLES;
 
-    // Get total count of user's favorites for this board
+    // Only count favorites whose climb belongs to the requested board.
     const countResult = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(dbSchema.userFavorites)
-      .where(and(eq(dbSchema.userFavorites.userId, userId), eq(dbSchema.userFavorites.boardName, boardName)));
+      .innerJoin(
+        tables.climbs,
+        and(eq(tables.climbs.uuid, dbSchema.userFavorites.climbUuid), eq(tables.climbs.boardType, boardName)),
+      )
+      .where(eq(dbSchema.userFavorites.userId, userId));
 
     const totalCount = countResult[0]?.count || 0;
 
-    // Get favorite climbs with full climb data
     const results = await db
       .select({
         climbUuid: dbSchema.userFavorites.climbUuid,
         favoritedAt: dbSchema.userFavorites.createdAt,
-        // Climb data
         uuid: tables.climbs.uuid,
         layoutId: tables.climbs.layoutId,
         setter_username: tables.climbs.setterUsername,
         name: tables.climbs.name,
         description: tables.climbs.description,
         frames: tables.climbs.frames,
-        // Stats data
         ascensionist_count: tables.climbStats.ascensionistCount,
         difficulty_id: sql<number | null>`ROUND(${tables.climbStats.displayDifficulty}::numeric, 0)`,
         quality_average: sql<number>`ROUND(${tables.climbStats.qualityAverage}::numeric, 2)`,
@@ -79,7 +80,7 @@ export const favoriteClimbsQuery = {
           eq(tables.climbStats.angle, input.angle),
         ),
       )
-      .where(and(eq(dbSchema.userFavorites.userId, userId), eq(dbSchema.userFavorites.boardName, boardName)))
+      .where(eq(dbSchema.userFavorites.userId, userId))
       .orderBy(desc(dbSchema.userFavorites.createdAt))
       .limit(pageSize + 1)
       .offset(page * pageSize);

--- a/packages/backend/src/graphql/resolvers/favorites/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/favorites/mutations.ts
@@ -6,10 +6,6 @@ import { requireAuthenticated, validateInput } from '../shared/helpers';
 import { ToggleFavoriteInputSchema } from '../../../validation/schemas';
 
 export const favoriteMutations = {
-  /**
-   * Toggle favorite status for a climb
-   * If favorited, removes the favorite; if not favorited, adds it
-   */
   toggleFavorite: async (
     _: unknown,
     { input }: { input: ToggleFavoriteInput },
@@ -19,43 +15,19 @@ export const favoriteMutations = {
     validateInput(ToggleFavoriteInputSchema, input, 'input');
 
     const userId = ctx.userId!;
+    const where = and(eq(dbSchema.userFavorites.userId, userId), eq(dbSchema.userFavorites.climbUuid, input.climbUuid));
 
-    // Check if favorite exists
-    const existing = await db
-      .select()
-      .from(dbSchema.userFavorites)
-      .where(
-        and(
-          eq(dbSchema.userFavorites.userId, userId),
-          eq(dbSchema.userFavorites.boardName, input.boardName),
-          eq(dbSchema.userFavorites.climbUuid, input.climbUuid),
-          eq(dbSchema.userFavorites.angle, input.angle),
-        ),
-      )
-      .limit(1);
+    const existing = await db.select().from(dbSchema.userFavorites).where(where).limit(1);
 
     if (existing.length > 0) {
-      // Remove favorite
-      await db
-        .delete(dbSchema.userFavorites)
-        .where(
-          and(
-            eq(dbSchema.userFavorites.userId, userId),
-            eq(dbSchema.userFavorites.boardName, input.boardName),
-            eq(dbSchema.userFavorites.climbUuid, input.climbUuid),
-            eq(dbSchema.userFavorites.angle, input.angle),
-          ),
-        );
+      await db.delete(dbSchema.userFavorites).where(where);
       return { favorited: false };
-    } else {
-      // Add favorite
-      await db.insert(dbSchema.userFavorites).values({
-        userId,
-        boardName: input.boardName,
-        climbUuid: input.climbUuid,
-        angle: input.angle,
-      });
-      return { favorited: true };
     }
+
+    await db.insert(dbSchema.userFavorites).values({
+      userId,
+      climbUuid: input.climbUuid,
+    });
+    return { favorited: true };
   },
 };

--- a/packages/backend/src/graphql/resolvers/favorites/queries.ts
+++ b/packages/backend/src/graphql/resolvers/favorites/queries.ts
@@ -1,94 +1,27 @@
-import { eq, and, inArray, sql } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
-import { requireAuthenticated, validateInput } from '../shared/helpers';
-import { BoardNameSchema, FavoritesQueryClimbUuidsSchema } from '../../../validation/schemas';
+import { validateInput } from '../shared/helpers';
+import { FavoritesQueryClimbUuidsSchema } from '../../../validation/schemas';
 
 export const favoriteQueries = {
-  /**
-   * Get favorite climb UUIDs for the authenticated user
-   * Filters by board name, angle, and optionally by a list of climb UUIDs
-   */
   favorites: async (
     _: unknown,
-    { boardName, climbUuids, angle }: { boardName: string; climbUuids: string[]; angle: number },
+    { climbUuids }: { climbUuids: string[] },
     ctx: ConnectionContext,
   ): Promise<string[]> => {
     if (!ctx.isAuthenticated || !ctx.userId) {
       return [];
     }
 
-    validateInput(BoardNameSchema, boardName, 'boardName');
     validateInput(FavoritesQueryClimbUuidsSchema, climbUuids, 'climbUuids');
 
     const favorites = await db
       .select({ climbUuid: dbSchema.userFavorites.climbUuid })
       .from(dbSchema.userFavorites)
-      .where(
-        and(
-          eq(dbSchema.userFavorites.userId, ctx.userId),
-          eq(dbSchema.userFavorites.boardName, boardName),
-          eq(dbSchema.userFavorites.angle, angle),
-          inArray(dbSchema.userFavorites.climbUuid, climbUuids),
-        ),
-      );
+      .where(and(eq(dbSchema.userFavorites.userId, ctx.userId), inArray(dbSchema.userFavorites.climbUuid, climbUuids)));
 
     return favorites.map((f) => f.climbUuid);
-  },
-
-  /**
-   * Get count of favorited climbs per board for the current user
-   */
-  userFavoritesCounts: async (
-    _: unknown,
-    __: unknown,
-    ctx: ConnectionContext,
-  ): Promise<Array<{ boardName: string; count: number }>> => {
-    requireAuthenticated(ctx);
-
-    const results = await db
-      .select({
-        boardName: dbSchema.userFavorites.boardName,
-        count: sql<number>`COUNT(DISTINCT ${dbSchema.userFavorites.climbUuid})::int`,
-      })
-      .from(dbSchema.userFavorites)
-      .where(eq(dbSchema.userFavorites.userId, ctx.userId!))
-      .groupBy(dbSchema.userFavorites.boardName);
-
-    return results;
-  },
-
-  /**
-   * Get board names where the current user has playlists or favorites
-   */
-  userActiveBoards: async (_: unknown, __: unknown, ctx: ConnectionContext): Promise<string[]> => {
-    requireAuthenticated(ctx);
-
-    const userId = ctx.userId!;
-
-    // Get distinct board names from playlists
-    const playlistBoards = await db
-      .selectDistinct({ boardName: dbSchema.playlists.boardType })
-      .from(dbSchema.playlists)
-      .innerJoin(dbSchema.playlistOwnership, eq(dbSchema.playlistOwnership.playlistId, dbSchema.playlists.id))
-      .where(eq(dbSchema.playlistOwnership.userId, userId));
-
-    // Get distinct board names from favorites
-    const favoriteBoards = await db
-      .selectDistinct({ boardName: dbSchema.userFavorites.boardName })
-      .from(dbSchema.userFavorites)
-      .where(eq(dbSchema.userFavorites.userId, userId));
-
-    // Combine and deduplicate
-    const boardSet = new Set<string>();
-    for (const row of playlistBoards) {
-      boardSet.add(row.boardName);
-    }
-    for (const row of favoriteBoards) {
-      boardSet.add(row.boardName);
-    }
-
-    return Array.from(boardSet).sort();
   },
 };

--- a/packages/backend/src/graphql/resolvers/playlists/queries/smart-playlists.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/smart-playlists.ts
@@ -333,9 +333,13 @@ export const mySmartPlaylistCounts = async (
       )
     ),
     liked_climbs AS (
-      SELECT COUNT(DISTINCT (board_name, climb_uuid))::int AS count
-      FROM ${dbSchema.userFavorites}
-      WHERE user_id = ${userId}
+      -- Favorites are board-agnostic post-#2449. Derive board via a join
+      -- against the unified climbs table so the count matches the paged
+      -- LIKED_CLIMBS view in selectSmartClimbRefs (which also joins climbs).
+      SELECT COUNT(DISTINCT (c.board_type, uf.climb_uuid))::int AS count
+      FROM ${dbSchema.userFavorites} uf
+      INNER JOIN ${UNIFIED_TABLES.climbs} c ON c.uuid = uf.climb_uuid
+      WHERE uf.user_id = ${userId}
     )
     SELECT 'FIVE_STARS'::text AS type, count FROM five_stars
     UNION ALL

--- a/packages/backend/src/graphql/resolvers/playlists/queries/smart-playlists.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/smart-playlists.ts
@@ -5,6 +5,7 @@ import * as dbSchema from '@boardsesh/db/schema';
 import { applyRateLimit, requireAuthenticated, validateInput } from '../../shared/helpers';
 import { GetSmartPlaylistInputSchema } from '../../../../validation/schemas';
 import { hydrateClimbsByRefs, type ClimbRef } from '../helpers/hydrate-climbs';
+import { UNIFIED_TABLES } from '../../../../db/queries/util/table-select';
 
 type SmartPlaylistType = 'FIVE_STARS' | 'MOST_REPEATED' | 'PROJECTS' | 'LIKED_CLIMBS';
 
@@ -105,18 +106,22 @@ async function selectSmartClimbRefs(
   }
 
   if (type === 'LIKED_CLIMBS') {
+    // Favorites no longer carry a board; derive boardType by joining the
+    // unified climbs table. Optional board filter constrains the join.
+    const climbs = UNIFIED_TABLES.climbs;
     const favConditions: SQL[] = [eq(dbSchema.userFavorites.userId, userId)];
     if (boardName) {
-      favConditions.push(eq(dbSchema.userFavorites.boardName, boardName));
+      favConditions.push(eq(climbs.boardType, boardName));
     }
     const rows = await db
       .select({
         climbUuid: dbSchema.userFavorites.climbUuid,
-        boardType: dbSchema.userFavorites.boardName,
+        boardType: climbs.boardType,
       })
       .from(dbSchema.userFavorites)
+      .innerJoin(climbs, eq(climbs.uuid, dbSchema.userFavorites.climbUuid))
       .where(and(...favConditions))
-      .groupBy(dbSchema.userFavorites.climbUuid, dbSchema.userFavorites.boardName)
+      .groupBy(dbSchema.userFavorites.climbUuid, climbs.boardType)
       .orderBy(desc(max(dbSchema.userFavorites.createdAt)))
       .limit(pageSize)
       .offset(offset);
@@ -180,15 +185,17 @@ async function countSmartClimbRefs(
   }
 
   if (type === 'LIKED_CLIMBS') {
+    const climbs = UNIFIED_TABLES.climbs;
     const favConditions: SQL[] = [eq(dbSchema.userFavorites.userId, userId)];
     if (boardName) {
-      favConditions.push(eq(dbSchema.userFavorites.boardName, boardName));
+      favConditions.push(eq(climbs.boardType, boardName));
     }
     const [row] = await db
       .select({
-        count: sql<number>`COUNT(DISTINCT (${dbSchema.userFavorites.boardName}, ${dbSchema.userFavorites.climbUuid}))::int`,
+        count: sql<number>`COUNT(DISTINCT (${climbs.boardType}, ${dbSchema.userFavorites.climbUuid}))::int`,
       })
       .from(dbSchema.userFavorites)
+      .innerJoin(climbs, eq(climbs.uuid, dbSchema.userFavorites.climbUuid))
       .where(and(...favConditions));
     return row?.count ?? 0;
   }

--- a/packages/backend/src/services/user-data-export.ts
+++ b/packages/backend/src/services/user-data-export.ts
@@ -241,11 +241,8 @@ export async function buildUserAuroraJsonExport(userId: string, boardType: Auror
         createdAt: userFavorites.createdAt,
       })
       .from(userFavorites)
-      .innerJoin(
-        boardClimbs,
-        and(eq(userFavorites.boardName, boardClimbs.boardType), eq(userFavorites.climbUuid, boardClimbs.uuid)),
-      )
-      .where(and(eq(userFavorites.userId, userId), eq(userFavorites.boardName, boardType)))
+      .innerJoin(boardClimbs, and(eq(boardClimbs.boardType, boardType), eq(userFavorites.climbUuid, boardClimbs.uuid)))
+      .where(eq(userFavorites.userId, userId))
       .orderBy(asc(userFavorites.createdAt)),
     dbRead
       .select({

--- a/packages/backend/src/validation/schemas/favorites.ts
+++ b/packages/backend/src/validation/schemas/favorites.ts
@@ -1,23 +1,12 @@
 import { z } from 'zod';
 import { ExternalUUIDSchema, BoardNameSchema } from './primitives';
 
-/**
- * Toggle favorite input validation schema
- */
 export const ToggleFavoriteInputSchema = z.object({
-  boardName: BoardNameSchema,
   climbUuid: ExternalUUIDSchema,
-  angle: z.number().int(),
 });
 
-/**
- * Favorites query climbUuids validation schema (matches playlistsForClimbs limit)
- */
 export const FavoritesQueryClimbUuidsSchema = z.array(ExternalUUIDSchema).min(1).max(500);
 
-/**
- * Get user favorite climbs input validation schema
- */
 export const GetUserFavoriteClimbsInputSchema = z.object({
   boardName: BoardNameSchema,
   layoutId: z.number().int().positive(),

--- a/packages/db/drizzle/0117_unknown_the_renegades.sql
+++ b/packages/db/drizzle/0117_unknown_the_renegades.sql
@@ -1,0 +1,18 @@
+-- Order matters: dedupe BEFORE dropping indexes. user_favorites_user_idx
+-- and the old 4-column unique_user_favorite both give the self-join lookup
+-- paths during DELETE. Dropping them first would force seq-scan +
+-- nested-loop on a potentially large production table.
+-- Dedupe rows that share (user_id, climb_uuid) across different
+-- (board_name, angle), keeping the most recently created (tiebreak on id).
+DELETE FROM "user_favorites" a
+USING "user_favorites" b
+WHERE a."user_id" = b."user_id"
+  AND a."climb_uuid" = b."climb_uuid"
+  AND (a."created_at" < b."created_at"
+       OR (a."created_at" = b."created_at" AND a."id" < b."id"));--> statement-breakpoint
+DROP INDEX "user_favorites_user_idx";--> statement-breakpoint
+DROP INDEX "user_favorites_climb_idx";--> statement-breakpoint
+DROP INDEX "unique_user_favorite";--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_user_favorite" ON "user_favorites" USING btree ("user_id","climb_uuid");--> statement-breakpoint
+ALTER TABLE "user_favorites" DROP COLUMN "board_name";--> statement-breakpoint
+ALTER TABLE "user_favorites" DROP COLUMN "angle";

--- a/packages/db/drizzle/meta/0117_snapshot.json
+++ b/packages/db/drizzle/meta/0117_snapshot.json
@@ -1,0 +1,9423 @@
+{
+  "id": "d8da7b61-0bfa-4c1f-a2ab-7657ef63e45b",
+  "prevId": "f38ee926-11c4-4993-a2a9-391f7f61ab75",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.board_attempts": {
+      "name": "board_attempts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_attempts_board_type_id_pk": {
+          "name": "board_attempts_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_beta_links": {
+      "name": "board_beta_links",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shortcode": {
+          "name": "shortcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_beta_links_shortcode_idx": {
+          "name": "board_beta_links_shortcode_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shortcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"shortcode\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_created_by_idx": {
+          "name": "board_beta_links_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"created_by_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_beta_links_board_type_climb_uuid_link_pk": {
+          "name": "board_beta_links_board_type_climb_uuid_link_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "link"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits": {
+      "name": "board_circuits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_user_fk": {
+          "name": "board_circuits_user_fk",
+          "tableFrom": "board_circuits",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_board_type_uuid_pk": {
+          "name": "board_circuits_board_type_uuid_pk",
+          "columns": [
+            "board_type",
+            "uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits_climbs": {
+      "name": "board_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_climbs_circuit_fk": {
+          "name": "board_circuits_climbs_circuit_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_circuits",
+          "columnsFrom": [
+            "board_type",
+            "circuit_uuid"
+          ],
+          "columnsTo": [
+            "board_type",
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_circuits_climbs_climb_fk": {
+          "name": "board_circuits_climbs_climb_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
+          "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
+          "columns": [
+            "board_type",
+            "circuit_uuid",
+            "climb_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_aliases": {
+      "name": "board_climb_aliases",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_uuid": {
+          "name": "alias_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_uuid": {
+          "name": "canonical_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_aliases_canonical_idx": {
+          "name": "board_climb_aliases_canonical_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_aliases_canonical_fk": {
+          "name": "board_climb_aliases_canonical_fk",
+          "tableFrom": "board_climb_aliases",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "canonical_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_aliases_board_type_alias_uuid_pk": {
+          "name": "board_climb_aliases_board_type_alias_uuid_pk",
+          "columns": [
+            "board_type",
+            "alias_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_climb_aliases_uuids_non_empty": {
+          "name": "board_climb_aliases_uuids_non_empty",
+          "value": "\"board_climb_aliases\".\"alias_uuid\" <> '' AND \"board_climb_aliases\".\"canonical_uuid\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_holds": {
+      "name": "board_climb_holds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_holds_search_idx": {
+          "name": "board_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_holds_climb_fk": {
+          "name": "board_climb_holds_climb_fk",
+          "tableFrom": "board_climb_holds",
+          "tableTo": "board_climbs",
+          "columnsFrom": [
+            "climb_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
+          "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "hold_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_ratings": {
+      "name": "board_climb_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_grade_id": {
+          "name": "difficulty_grade_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_ratings_user_climb_angle_idx": {
+          "name": "board_climb_ratings_user_climb_angle_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_kilter_id_unique": {
+          "name": "board_climb_ratings_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_climb_ratings\".\"kilter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_aurora_id_unique": {
+          "name": "board_climb_ratings_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_climb_ratings\".\"aurora_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_user_kilter_idx": {
+          "name": "board_climb_ratings_user_kilter_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_climb_ratings\".\"kilter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_ratings_user_id_users_id_fk": {
+          "name": "board_climb_ratings_user_id_users_id_fk",
+          "tableFrom": "board_climb_ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_climb_ratings_rating_range": {
+          "name": "board_climb_ratings_rating_range",
+          "value": "\"board_climb_ratings\".\"rating\" IS NULL OR (\"board_climb_ratings\".\"rating\" >= 1 AND \"board_climb_ratings\".\"rating\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats": {
+      "name": "board_climb_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_ascensionist_count": {
+          "name": "aurora_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_ascensionist_count": {
+          "name": "kilter_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardsesh_ascensionist_count": {
+          "name": "boardsesh_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_normalized": {
+          "name": "quality_normalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_stats_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
+          "columns": [
+            "board_type",
+            "climb_uuid",
+            "angle"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats_history": {
+      "name": "board_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_stats_history_lookup_idx": {
+          "name": "board_climb_stats_history_lookup_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climbs": {
+      "name": "board_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_set_ids": {
+          "name": "required_set_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compatible_size_ids": {
+          "name": "compatible_size_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hold_fingerprint": {
+          "name": "hold_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_climbs_board_type_idx": {
+          "name": "board_climbs_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_hold_fingerprint_idx": {
+          "name": "board_climbs_hold_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_search_filter_idx": {
+          "name": "board_climbs_search_filter_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_setter_username_idx": {
+          "name": "board_climbs_setter_username_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_user_id_idx": {
+          "name": "board_climbs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_climbs\".\"user_id\" IS NOT NULL AND \"board_climbs\".\"is_draft\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_name_idx": {
+          "name": "board_climbs_name_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climbs_user_id_users_id_fk": {
+          "name": "board_climbs_user_id_users_id_fk",
+          "tableFrom": "board_climbs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_difficulty_grades": {
+      "name": "board_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_difficulty_grades_board_type_difficulty_pk": {
+          "name": "board_difficulty_grades_board_type_difficulty_pk",
+          "columns": [
+            "board_type",
+            "difficulty"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_holes": {
+      "name": "board_holes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_holes_product_fk": {
+          "name": "board_holes_product_fk",
+          "tableFrom": "board_holes",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_holes_board_type_id_pk": {
+          "name": "board_holes_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_kits": {
+      "name": "board_kits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_autoconnect": {
+          "name": "is_autoconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_kits_board_type_serial_number_pk": {
+          "name": "board_kits_board_type_serial_number_pk",
+          "columns": [
+            "board_type",
+            "serial_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_layout_aliases": {
+      "name": "board_layout_aliases",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_uuid": {
+          "name": "layout_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_layout_aliases_layout_idx": {
+          "name": "board_layout_aliases_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_layout_aliases_layout_fk": {
+          "name": "board_layout_aliases_layout_fk",
+          "tableFrom": "board_layout_aliases",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layout_aliases_board_type_layout_uuid_pk": {
+          "name": "board_layout_aliases_board_type_layout_uuid_pk",
+          "columns": [
+            "board_type",
+            "layout_uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_layout_aliases_uuid_non_empty": {
+          "name": "board_layout_aliases_uuid_non_empty",
+          "value": "\"board_layout_aliases\".\"layout_uuid\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_layouts": {
+      "name": "board_layouts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_layouts_product_fk": {
+          "name": "board_layouts_product_fk",
+          "tableFrom": "board_layouts",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layouts_board_type_id_pk": {
+          "name": "board_layouts_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_leds": {
+      "name": "board_leds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_leds_product_size_fk": {
+          "name": "board_leds_product_size_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_leds_hole_fk": {
+          "name": "board_leds_hole_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_holes",
+          "columnsFrom": [
+            "board_type",
+            "hole_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_leds_board_type_id_pk": {
+          "name": "board_leds_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placement_roles": {
+      "name": "board_placement_roles",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_placement_roles_product_fk": {
+          "name": "board_placement_roles_product_fk",
+          "tableFrom": "board_placement_roles",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placement_roles_board_type_id_pk": {
+          "name": "board_placement_roles_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placements": {
+      "name": "board_placements",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_placements_board_type_layout_id_set_hole_idx": {
+          "name": "board_placements_board_type_layout_id_set_hole_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hole_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_placements_layout_fk": {
+          "name": "board_placements_layout_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_hole_fk": {
+          "name": "board_placements_hole_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_holes",
+          "columnsFrom": [
+            "board_type",
+            "hole_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_set_fk": {
+          "name": "board_placements_set_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_sets",
+          "columnsFrom": [
+            "board_type",
+            "set_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_role_fk": {
+          "name": "board_placements_role_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_placement_roles",
+          "columnsFrom": [
+            "board_type",
+            "default_placement_role_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placements_board_type_id_pk": {
+          "name": "board_placements_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes": {
+      "name": "board_product_sizes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_product_sizes_product_fk": {
+          "name": "board_product_sizes_product_fk",
+          "tableFrom": "board_product_sizes",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_board_type_id_pk": {
+          "name": "board_product_sizes_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes_layouts_sets": {
+      "name": "board_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_psls_product_size_fk": {
+          "name": "board_psls_product_size_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_layout_fk": {
+          "name": "board_psls_layout_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_set_fk": {
+          "name": "board_psls_set_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_sets",
+          "columnsFrom": [
+            "board_type",
+            "set_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_layouts_sets_board_type_id_pk": {
+          "name": "board_product_sizes_layouts_sets_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_products": {
+      "name": "board_products",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_products_board_type_id_pk": {
+          "name": "board_products_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sets": {
+      "name": "board_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_sets_board_type_id_pk": {
+          "name": "board_sets_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_shared_syncs": {
+      "name": "board_shared_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_shared_syncs_board_type_table_name_pk": {
+          "name": "board_shared_syncs_board_type_table_name_pk",
+          "columns": [
+            "board_type",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_tags": {
+      "name": "board_tags",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_tags_board_type_entity_uuid_user_id_name_pk": {
+          "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
+          "columns": [
+            "board_type",
+            "entity_uuid",
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_user_syncs": {
+      "name": "board_user_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_user_syncs_user_fk": {
+          "name": "board_user_syncs_user_fk",
+          "tableFrom": "board_user_syncs",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_user_syncs_board_type_user_id_table_name_pk": {
+          "name": "board_user_syncs_board_type_user_id_table_name_pk",
+          "columns": [
+            "board_type",
+            "user_id",
+            "table_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_users": {
+      "name": "board_users",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_users_board_type_id_pk": {
+          "name": "board_users_board_type_id_pk",
+          "columns": [
+            "board_type",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_walls": {
+      "name": "board_walls",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_walls_user_fk": {
+          "name": "board_walls_user_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_users",
+          "columnsFrom": [
+            "board_type",
+            "user_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_fk": {
+          "name": "board_walls_product_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_products",
+          "columnsFrom": [
+            "board_type",
+            "product_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_layout_fk": {
+          "name": "board_walls_layout_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_layouts",
+          "columnsFrom": [
+            "board_type",
+            "layout_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_size_fk": {
+          "name": "board_walls_product_size_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": [
+            "board_type",
+            "product_size_id"
+          ],
+          "columnsTo": [
+            "board_type",
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_walls_board_type_uuid_pk": {
+          "name": "board_walls_board_type_uuid_pk",
+          "columns": [
+            "board_type",
+            "uuid"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationTokens": {
+      "name": "verificationTokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationTokens_identifier_token_pk": {
+          "name": "verificationTokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_credentials": {
+      "name": "user_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aurora_credentials": {
+      "name": "aurora_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_username": {
+          "name": "encrypted_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_user_id": {
+          "name": "aurora_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_token": {
+          "name": "aurora_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_credential": {
+          "name": "unique_user_board_credential",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_user_idx": {
+          "name": "aurora_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_sync_priority_idx": {
+          "name": "aurora_credentials_sync_priority_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_sync_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"aurora_credentials\".\"sync_status\" IN ('pending', 'active', 'error')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "aurora_credentials_user_id_users_id_fk": {
+          "name": "aurora_credentials_user_id_users_id_fk",
+          "tableFrom": "aurora_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_mappings": {
+      "name": "user_board_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_user_id": {
+          "name": "board_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_user_id_text": {
+          "name": "board_user_id_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_username": {
+          "name": "board_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_mapping": {
+          "name": "unique_user_board_mapping",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_idx": {
+          "name": "board_user_mapping_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_text_idx": {
+          "name": "board_user_mapping_text_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_mappings_user_id_users_id_fk": {
+          "name": "user_board_mappings_user_id_users_id_fk",
+          "tableFrom": "user_board_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mobile_refresh_tokens": {
+      "name": "mobile_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mobile_refresh_tokens_token_hash_idx": {
+          "name": "mobile_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_user_id_idx": {
+          "name": "mobile_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_expires_at_idx": {
+          "name": "mobile_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_revoked_at_partial_idx": {
+          "name": "mobile_refresh_tokens_revoked_at_partial_idx",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"revoked_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mobile_refresh_tokens_user_id_users_id_fk": {
+          "name": "mobile_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "mobile_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_follows": {
+      "name": "gym_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_follows_unique_gym_user": {
+          "name": "gym_follows_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_follows_gym_id_gyms_id_fk": {
+          "name": "gym_follows_gym_id_gyms_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_follows_user_id_users_id_fk": {
+          "name": "gym_follows_user_id_users_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_members": {
+      "name": "gym_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "gym_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_members_unique_gym_user": {
+          "name": "gym_members_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_members_gym_id_gyms_id_fk": {
+          "name": "gym_members_gym_id_gyms_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_members_user_id_users_id_fk": {
+          "name": "gym_members_user_id_users_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gyms": {
+      "name": "gyms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gyms_unique_slug": {
+          "name": "gyms_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_uuid_idx": {
+          "name": "gyms_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_owner_idx": {
+          "name": "gyms_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_public_idx": {
+          "name": "gyms_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gyms_owner_id_users_id_fk": {
+          "name": "gyms_owner_id_users_id_fk",
+          "tableFrom": "gyms",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gyms_uuid_unique": {
+          "name": "gyms_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_follows": {
+      "name": "board_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_follows_unique_user_board": {
+          "name": "board_follows_unique_user_board",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_user_idx": {
+          "name": "board_follows_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_board_uuid_idx": {
+          "name": "board_follows_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_follows_user_id_users_id_fk": {
+          "name": "board_follows_user_id_users_id_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_follows_board_uuid_user_boards_uuid_fk": {
+          "name": "board_follows_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_boards": {
+      "name": "user_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_unlisted": {
+          "name": "is_unlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_location": {
+          "name": "hide_location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_owned": {
+          "name": "is_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "is_angle_adjustable": {
+          "name": "is_angle_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_boards_gym_idx": {
+          "name": "user_boards_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_owner_config": {
+          "name": "user_boards_unique_owner_config",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL AND \"user_boards\".\"owner_id\" != '00000000-0000-0000-0000-000000000000'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_owner_owned_idx": {
+          "name": "user_boards_owner_owned_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_owned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_public_idx": {
+          "name": "user_boards_public_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_slug": {
+          "name": "user_boards_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_uuid_idx": {
+          "name": "user_boards_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_boards_owner_id_users_id_fk": {
+          "name": "user_boards_owner_id_users_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_boards_gym_id_gyms_id_fk": {
+          "name": "user_boards_gym_id_gyms_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "gyms",
+          "columnsFrom": [
+            "gym_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_boards_uuid_unique": {
+          "name": "user_boards_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_serials": {
+      "name": "user_board_serials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_board_serials_unique_user_serial": {
+          "name": "user_board_serials_unique_user_serial",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_serials_serial_idx": {
+          "name": "user_board_serials_serial_idx",
+          "columns": [
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_serials_board_uuid_idx": {
+          "name": "user_board_serials_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_serials_user_id_users_id_fk": {
+          "name": "user_board_serials_user_id_users_id_fk",
+          "tableFrom": "user_board_serials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_board_serials_board_uuid_user_boards_uuid_fk": {
+          "name": "user_board_serials_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "user_board_serials",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_clients": {
+      "name": "board_session_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_leader": {
+          "name": "is_leader",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_clients_session_id_board_sessions_id_fk": {
+          "name": "board_session_clients_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_clients",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_queues": {
+      "name": "board_session_queues",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "current_climb_queue_item": {
+          "name": "current_climb_queue_item",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_queues_session_id_board_sessions_id_fk": {
+          "name": "board_session_queues_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_queues",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sessions": {
+      "name": "board_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_path": {
+          "name": "board_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_permanent": {
+          "name": "is_permanent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_kit_workout_id": {
+          "name": "health_kit_workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_sessions_location_idx": {
+          "name": "board_sessions_location_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discoverable_idx": {
+          "name": "board_sessions_discoverable_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_user_idx": {
+          "name": "board_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_status_idx": {
+          "name": "board_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_last_activity_idx": {
+          "name": "board_sessions_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discovery_idx": {
+          "name": "board_sessions_discovery_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_sessions_created_by_user_id_users_id_fk": {
+          "name": "board_sessions_created_by_user_id_users_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_sessions_board_id_user_boards_id_fk": {
+          "name": "board_sessions_board_id_user_boards_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_boards": {
+      "name": "session_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_boards_session_board_idx": {
+          "name": "session_boards_session_board_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_session_idx": {
+          "name": "session_boards_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_board_idx": {
+          "name": "session_boards_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_boards_session_id_board_sessions_id_fk": {
+          "name": "session_boards_session_id_board_sessions_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_boards_board_id_user_boards_id_fk": {
+          "name": "session_boards_board_id_user_boards_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_favorite": {
+          "name": "unique_user_favorite",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inferred_sessions": {
+      "name": "inferred_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_tick_at": {
+          "name": "first_tick_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_tick_at": {
+          "name": "last_tick_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sends": {
+          "name": "total_sends",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_attempts": {
+          "name": "total_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_flashes": {
+          "name": "total_flashes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tick_count": {
+          "name": "tick_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_kit_workout_id": {
+          "name": "health_kit_workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inferred_sessions_user_idx": {
+          "name": "inferred_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inferred_sessions_user_last_tick_idx": {
+          "name": "inferred_sessions_user_last_tick_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_tick_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inferred_sessions_last_tick_idx": {
+          "name": "inferred_sessions_last_tick_idx",
+          "columns": [
+            {
+              "expression": "last_tick_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inferred_sessions_user_id_users_id_fk": {
+          "name": "inferred_sessions_user_id_users_id_fk",
+          "tableFrom": "inferred_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_member_overrides": {
+      "name": "session_member_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by_user_id": {
+          "name": "added_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_member_overrides_session_idx": {
+          "name": "session_member_overrides_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_member_overrides_user_idx": {
+          "name": "session_member_overrides_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_member_overrides_session_id_inferred_sessions_id_fk": {
+          "name": "session_member_overrides_session_id_inferred_sessions_id_fk",
+          "tableFrom": "session_member_overrides",
+          "tableTo": "inferred_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_member_overrides_user_id_users_id_fk": {
+          "name": "session_member_overrides_user_id_users_id_fk",
+          "tableFrom": "session_member_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_member_overrides_added_by_user_id_users_id_fk": {
+          "name": "session_member_overrides_added_by_user_id_users_id_fk",
+          "tableFrom": "session_member_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_member_overrides_session_user_unique": {
+          "name": "session_member_overrides_session_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boardsesh_ticks": {
+      "name": "boardsesh_ticks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tick_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inferred_session_id": {
+          "name": "inferred_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_inferred_session_id": {
+          "name": "previous_inferred_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "aurora_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_sync_error": {
+          "name": "aurora_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "kilter_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_sync_error": {
+          "name": "kilter_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boardsesh_ticks_user_board_idx": {
+          "name": "boardsesh_ticks_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climb_idx": {
+          "name": "boardsesh_ticks_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_aurora_id_unique": {
+          "name": "boardsesh_ticks_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_sync_pending_idx": {
+          "name": "boardsesh_ticks_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_kilter_id_unique": {
+          "name": "boardsesh_ticks_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_kilter_sync_pending_idx": {
+          "name": "boardsesh_ticks_kilter_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_session_idx": {
+          "name": "boardsesh_ticks_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_inferred_session_idx": {
+          "name": "boardsesh_ticks_inferred_session_idx",
+          "columns": [
+            {
+              "expression": "inferred_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climbed_at_idx": {
+          "name": "boardsesh_ticks_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climbed_at_idx": {
+          "name": "boardsesh_ticks_user_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_climbed_at_idx": {
+          "name": "boardsesh_ticks_board_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_user_idx": {
+          "name": "boardsesh_ticks_board_user_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climb_lookup_idx": {
+          "name": "boardsesh_ticks_user_climb_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boardsesh_ticks_user_id_users_id_fk": {
+          "name": "boardsesh_ticks_user_id_users_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_session_id_board_sessions_id_fk": {
+          "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk": {
+          "name": "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "inferred_sessions",
+          "columnsFrom": [
+            "inferred_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk": {
+          "name": "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "inferred_sessions",
+          "columnsFrom": [
+            "previous_inferred_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_board_id_user_boards_id_fk": {
+          "name": "boardsesh_ticks_board_id_user_boards_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "user_boards",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boardsesh_ticks_uuid_unique": {
+          "name": "boardsesh_ticks_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_climbs": {
+      "name": "playlist_climbs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_climb": {
+          "name": "unique_playlist_climb",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_climb_idx": {
+          "name": "playlist_climbs_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_position_idx": {
+          "name": "playlist_climbs_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_climbs_playlist_id_playlists_id_fk": {
+          "name": "playlist_climbs_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_climbs",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_ownership": {
+      "name": "playlist_ownership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_ownership": {
+          "name": "unique_playlist_ownership",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_ownership_user_idx": {
+          "name": "playlist_ownership_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_ownership_playlist_id_playlists_id_fk": {
+          "name": "playlist_ownership_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_ownership_user_id_users_id_fk": {
+          "name": "playlist_ownership_user_id_users_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlists": {
+      "name": "playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "playlists_board_layout_idx": {
+          "name": "playlists_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_uuid_idx": {
+          "name": "playlists_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_updated_at_idx": {
+          "name": "playlists_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_last_accessed_at_idx": {
+          "name": "playlists_last_accessed_at_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_aurora_id_idx": {
+          "name": "playlists_aurora_id_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_kilter_id_idx": {
+          "name": "playlists_kilter_id_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlists_uuid_unique": {
+          "name": "playlists_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlist_pins": {
+      "name": "user_playlist_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_playlist_pin": {
+          "name": "unique_user_playlist_pin",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlist_pins_user_idx": {
+          "name": "user_playlist_pins_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlist_pins_playlist_idx": {
+          "name": "user_playlist_pins_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_playlist_pins_user_id_users_id_fk": {
+          "name": "user_playlist_pins_user_id_users_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_playlist_pins_playlist_id_playlists_id_fk": {
+          "name": "user_playlist_pins_playlist_id_playlists_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hold_classifications": {
+      "name": "user_hold_classifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_type": {
+          "name": "hold_type",
+          "type": "hold_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_rating": {
+          "name": "hand_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foot_rating": {
+          "name": "foot_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_direction": {
+          "name": "pull_direction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hold_classifications_user_board_idx": {
+          "name": "user_hold_classifications_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_unique_idx": {
+          "name": "user_hold_classifications_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_hold_idx": {
+          "name": "user_hold_classifications_hold_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hold_classifications_user_id_users_id_fk": {
+          "name": "user_hold_classifications_user_id_users_id_fk",
+          "tableFrom": "user_hold_classifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esp32_controllers": {
+      "name": "esp32_controllers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_session_id": {
+          "name": "authorized_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "esp32_controllers_user_idx": {
+          "name": "esp32_controllers_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_api_key_idx": {
+          "name": "esp32_controllers_api_key_idx",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_session_idx": {
+          "name": "esp32_controllers_session_idx",
+          "columns": [
+            {
+              "expression": "authorized_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esp32_controllers_user_id_users_id_fk": {
+          "name": "esp32_controllers_user_id_users_id_fk",
+          "tableFrom": "esp32_controllers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "esp32_controllers_api_key_unique": {
+          "name": "esp32_controllers_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_follows": {
+      "name": "playlist_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_uuid": {
+          "name": "playlist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_follow": {
+          "name": "unique_playlist_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_follower_idx": {
+          "name": "playlist_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_playlist_idx": {
+          "name": "playlist_follows_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_follows_follower_id_users_id_fk": {
+          "name": "playlist_follows_follower_id_users_id_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_follows_playlist_uuid_playlists_uuid_fk": {
+          "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_uuid"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setter_follows": {
+      "name": "setter_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_setter_follow": {
+          "name": "unique_setter_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_follower_idx": {
+          "name": "setter_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_setter_idx": {
+          "name": "setter_follows_setter_idx",
+          "columns": [
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setter_follows_follower_id_users_id_fk": {
+          "name": "setter_follows_follower_id_users_id_fk",
+          "tableFrom": "setter_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_follow": {
+          "name": "unique_user_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_following_idx": {
+          "name": "user_follows_following_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_follow": {
+          "name": "no_self_follow",
+          "value": "\"user_follows\".\"follower_id\" != \"user_follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_entity_created_at_idx": {
+          "name": "comments_entity_created_at_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_user_created_at_idx": {
+          "name": "comments_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_parent_comment_idx": {
+          "name": "comments_parent_comment_idx",
+          "columns": [
+            {
+              "expression": "parent_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comments_uuid_unique": {
+          "name": "comments_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_unique_user_entity": {
+          "name": "votes_unique_user_entity",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_entity_idx": {
+          "name": "votes_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_user_idx": {
+          "name": "votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vote_value_check": {
+          "name": "vote_value_check",
+          "value": "\"votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_created_at_idx": {
+          "name": "notifications_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_dedup_idx": {
+          "name": "notifications_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipient_id_users_id_fk": {
+          "name": "notifications_recipient_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_comments_id_fk": {
+          "name": "notifications_comment_id_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_uuid_unique": {
+          "name": "notifications_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "feed_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_recipient_created_at_idx": {
+          "name": "feed_items_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_recipient_board_created_at_idx": {
+          "name": "feed_items_recipient_board_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_actor_created_at_idx": {
+          "name": "feed_items_actor_created_at_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_created_at_idx": {
+          "name": "feed_items_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_entity_type_entity_id_idx": {
+          "name": "feed_items_entity_type_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_recipient_id_users_id_fk": {
+          "name": "feed_items_recipient_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feed_items_actor_id_users_id_fk": {
+          "name": "feed_items_actor_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_classic_status": {
+      "name": "climb_classic_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_classic": {
+          "name": "is_classic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_classic_status_unique_idx": {
+          "name": "climb_classic_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_classic_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_classic_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "last_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_community_status": {
+      "name": "climb_community_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_grade": {
+          "name": "community_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_community_status_unique_idx": {
+          "name": "climb_community_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_community_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_community_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "last_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_proposals": {
+      "name": "climb_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "climb_proposals_climb_angle_type_idx": {
+          "name": "climb_proposals_climb_angle_type_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_status_idx": {
+          "name": "climb_proposals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_proposer_idx": {
+          "name": "climb_proposals_proposer_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_board_type_idx": {
+          "name": "climb_proposals_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_created_at_idx": {
+          "name": "climb_proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_proposals_proposer_id_users_id_fk": {
+          "name": "climb_proposals_proposer_id_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "climb_proposals_resolved_by_users_id_fk": {
+          "name": "climb_proposals_resolved_by_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "climb_proposals_uuid_unique": {
+          "name": "climb_proposals_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_roles": {
+      "name": "community_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_roles_board_type_idx": {
+          "name": "community_roles_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_roles_user_id_users_id_fk": {
+          "name": "community_roles_user_id_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_roles_granted_by_users_id_fk": {
+          "name": "community_roles_granted_by_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_roles_user_role_board_idx": {
+          "name": "community_roles_user_role_board_idx",
+          "nullsNotDistinct": true,
+          "columns": [
+            "user_id",
+            "role",
+            "board_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_by": {
+          "name": "set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_settings_scope_key_idx": {
+          "name": "community_settings_scope_key_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_settings_set_by_users_id_fk": {
+          "name": "community_settings_set_by_users_id_fk",
+          "tableFrom": "community_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "set_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_votes_unique_user_proposal": {
+          "name": "proposal_votes_unique_user_proposal",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_proposal_idx": {
+          "name": "proposal_votes_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_climb_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "climb_proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_user_id_users_id_fk": {
+          "name": "proposal_votes_user_id_users_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_vote_value_check": {
+          "name": "proposal_vote_value_check",
+          "value": "\"proposal_votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.new_climb_subscriptions": {
+      "name": "new_climb_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "new_climb_subscriptions_unique_user_board_layout": {
+          "name": "new_climb_subscriptions_unique_user_board_layout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_user_idx": {
+          "name": "new_climb_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_board_layout_idx": {
+          "name": "new_climb_subscriptions_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_climb_subscriptions_user_id_users_id_fk": {
+          "name": "new_climb_subscriptions_user_id_users_id_fk",
+          "tableFrom": "new_climb_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_counts": {
+      "name": "vote_counts",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vote_counts_score_idx": {
+          "name": "vote_counts_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_counts_hot_score_idx": {
+          "name": "vote_counts_hot_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hot_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "vote_counts_entity_type_entity_id_pk": {
+          "name": "vote_counts_entity_type_entity_id_pk",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_participants": {
+      "name": "board_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_session_participants_session_idx": {
+          "name": "board_session_participants_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_session_participants_user_idx": {
+          "name": "board_session_participants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_session_participants_session_id_board_sessions_id_fk": {
+          "name": "board_session_participants_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_session_participants_user_id_users_id_fk": {
+          "name": "board_session_participants_user_id_users_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_session_participants_session_id_user_id_pk": {
+          "name": "board_session_participants_session_id_user_id_pk",
+          "columns": [
+            "session_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_feedback": {
+      "name": "app_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_feedback_created_at_idx": {
+          "name": "app_feedback_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_user_idx": {
+          "name": "app_feedback_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_board_idx": {
+          "name": "app_feedback_board_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_feedback_user_id_users_id_fk": {
+          "name": "app_feedback_user_id_users_id_fk",
+          "tableFrom": "app_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_climb_percentiles": {
+      "name": "user_climb_percentiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_distinct_climbs": {
+          "name": "total_distinct_climbs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "percentile": {
+          "name": "percentile",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_active_users": {
+          "name": "total_active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_climb_percentiles_user_id_users_id_fk": {
+          "name": "user_climb_percentiles_user_id_users_id_fk",
+          "tableFrom": "user_climb_percentiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_push_tokens": {
+      "name": "activity_push_tokens",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_push_tokens_session_idx": {
+          "name": "activity_push_tokens_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_push_tokens_user_idx": {
+          "name": "activity_push_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_push_tokens_updated_at_idx": {
+          "name": "activity_push_tokens_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_push_tokens_session_id_board_sessions_id_fk": {
+          "name": "activity_push_tokens_session_id_board_sessions_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "tableTo": "board_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_push_tokens_user_id_users_id_fk": {
+          "name": "activity_push_tokens_user_id_users_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.gym_member_role": {
+      "name": "gym_member_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    },
+    "public.aurora_table_type": {
+      "name": "aurora_table_type",
+      "schema": "public",
+      "values": [
+        "ascents",
+        "bids"
+      ]
+    },
+    "public.kilter_table_type": {
+      "name": "kilter_table_type",
+      "schema": "public",
+      "values": [
+        "logs",
+        "attempts"
+      ]
+    },
+    "public.tick_status": {
+      "name": "tick_status",
+      "schema": "public",
+      "values": [
+        "flash",
+        "send",
+        "attempt"
+      ]
+    },
+    "public.hold_type": {
+      "name": "hold_type",
+      "schema": "public",
+      "values": [
+        "jug",
+        "sloper",
+        "pinch",
+        "crimp",
+        "pocket"
+      ]
+    },
+    "public.social_entity_type": {
+      "name": "social_entity_type",
+      "schema": "public",
+      "values": [
+        "playlist_climb",
+        "climb",
+        "tick",
+        "comment",
+        "proposal",
+        "board",
+        "gym",
+        "session"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "new_follower",
+        "comment_reply",
+        "comment_on_tick",
+        "comment_on_climb",
+        "vote_on_tick",
+        "vote_on_comment",
+        "new_climb",
+        "new_climb_global",
+        "proposal_approved",
+        "proposal_rejected",
+        "proposal_vote",
+        "proposal_created",
+        "new_climbs_synced"
+      ]
+    },
+    "public.feed_item_type": {
+      "name": "feed_item_type",
+      "schema": "public",
+      "values": [
+        "ascent",
+        "new_climb",
+        "comment",
+        "proposal_approved",
+        "session_summary"
+      ]
+    },
+    "public.community_role_type": {
+      "name": "community_role_type",
+      "schema": "public",
+      "values": [
+        "admin",
+        "community_leader"
+      ]
+    },
+    "public.proposal_status": {
+      "name": "proposal_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "approved",
+        "rejected",
+        "superseded"
+      ]
+    },
+    "public.proposal_type": {
+      "name": "proposal_type",
+      "schema": "public",
+      "values": [
+        "grade",
+        "classic",
+        "benchmark"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -820,6 +820,13 @@
       "when": 1780465949650,
       "tag": "0116_backfill_quality_scale_1to5",
       "breakpoints": true
+    },
+    {
+      "idx": 117,
+      "version": "7",
+      "when": 1780487621929,
+      "tag": "0117_unknown_the_renegades",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/app/favorites.ts
+++ b/packages/db/src/schema/app/favorites.ts
@@ -1,7 +1,6 @@
-import { pgTable, bigserial, text, integer, timestamp, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { pgTable, bigserial, text, timestamp, uniqueIndex } from 'drizzle-orm/pg-core';
 import { users } from '../auth/users';
 
-// User favorites for saved/hearted climbs
 export const userFavorites = pgTable(
   'user_favorites',
   {
@@ -9,17 +8,10 @@ export const userFavorites = pgTable(
     userId: text('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
-    boardName: text('board_name').notNull(), // 'kilter', 'tension'
     climbUuid: text('climb_uuid').notNull(),
-    angle: integer('angle').notNull(), // The angle at which the climb was favorited
     createdAt: timestamp('created_at').defaultNow().notNull(),
   },
   (table) => ({
-    // Ensure unique favorite per user per climb per angle
-    uniqueFavorite: uniqueIndex('unique_user_favorite').on(table.userId, table.boardName, table.climbUuid, table.angle),
-    // Index for efficient lookup by user
-    userFavoritesIdx: index('user_favorites_user_idx').on(table.userId),
-    // Index for checking if a climb is favorited
-    climbFavoriteIdx: index('user_favorites_climb_idx').on(table.boardName, table.climbUuid, table.angle),
+    uniqueFavorite: uniqueIndex('unique_user_favorite').on(table.userId, table.climbUuid),
   }),
 );

--- a/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
+++ b/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
@@ -69,16 +69,14 @@ export default function ClimbDetail() {
   }, [climb]);
 
   const handleToggleFavorite = useCallback(() => {
-    if (!climb || !boardName) return;
+    if (!climb) return;
     hapticSuccess();
     toggleFavorite.mutate({
       input: {
-        boardName,
         climbUuid: climb.uuid,
-        angle: Number(angle),
       },
     });
-  }, [climb, boardName, angle, toggleFavorite]);
+  }, [climb, toggleFavorite]);
 
   if (isLoading) {
     return (

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -1,31 +1,110 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Pressable, View, StyleSheet } from 'react-native';
-import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming, runOnJS } from 'react-native-reanimated';
+import { View, StyleSheet } from 'react-native';
+import Animated, {
+  useAnimatedStyle,
+  useAnimatedReaction,
+  interpolate,
+  Extrapolation,
+  runOnJS,
+  type SharedValue,
+} from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import ReanimatedSwipeable, { type SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
 import { useTranslation } from 'react-i18next';
 import type { Climb, BoardName } from '@boardsesh/shared-schema';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { Text } from './Text';
 import { Icon } from './Icon';
-import { ClimbListThumbnail } from './ClimbListThumbnail';
+import { ClimbListThumbnail, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT } from './ClimbListThumbnail';
 import { AscentStatusBadge } from './AscentStatusBadge';
-import { HeartAnimationOverlay } from './HeartAnimationOverlay';
-import { useDoubleTapFavorite } from '../hooks/use-double-tap-favorite';
 import { hapticLight, hapticMedium, hapticSuccess } from '../lib/haptics';
 import { formatSends, formatQuality } from '../lib/format-climb-stats';
-import { getGradeTintColor } from '@boardsesh/play-view';
 import { useGradeFormat } from '../hooks/use-grade-format';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { brandColors } from '../theme/colors';
 import { spacing } from '../theme/tokens';
 
-const MAX_GESTURE_SWIPE = 180;
-const SHORT_ACTION_WIDTH = 120;
-const RIGHT_ACTION_WIDTH = 100;
-const SHORT_SWIPE_THRESHOLD = 60;
-const TRANSITION_START = 115;
-const LONG_SWIPE_THRESHOLD = 150;
+// Swipe tuning. Each side reveals a panel up to ACTION_REVEAL wide; dragging
+// past COMMIT_THRESHOLD and RELEASING commits the action (Spotify-style swipe-
+// to-queue) — no resting-open state, no second tap. friction=1 makes the row
+// track the finger 1:1 (snappy, like Spotify's tracklist swipe). Tunable.
+const ACTION_REVEAL = 150;
+const COMMIT_THRESHOLD = 96;
+const SWIPE_FRICTION = 1;
+
+/**
+ * Leading "Queue" swipe action — Spotify-style commit-on-release (left-to-right
+ * swipe). The panel shows a queue icon that flips to a "✓" once you cross the
+ * commit threshold (with a haptic detent), so you feel and see that releasing
+ * will queue the climb. The add fires from the row's onSwipeableWillOpen.
+ */
+function QueueSwipeAction({ translation }: { translation: SharedValue<number> }) {
+  // Haptic detent the instant the drag crosses the commit threshold.
+  useAnimatedReaction(
+    () => Math.abs(translation.value) >= COMMIT_THRESHOLD,
+    (armed, wasArmed) => {
+      if (armed && !wasArmed) runOnJS(hapticLight)();
+    },
+  );
+  const plusStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(
+      Math.abs(translation.value),
+      [COMMIT_THRESHOLD - 18, COMMIT_THRESHOLD],
+      [1, 0],
+      Extrapolation.CLAMP,
+    ),
+  }));
+  const checkStyle = useAnimatedStyle(() => {
+    const armedProgress = interpolate(
+      Math.abs(translation.value),
+      [COMMIT_THRESHOLD - 8, COMMIT_THRESHOLD + 6],
+      [0, 1],
+      Extrapolation.CLAMP,
+    );
+    return { opacity: armedProgress, transform: [{ scale: 0.6 + armedProgress * 0.4 }] };
+  });
+  return (
+    <View style={[styles.swipeAction, styles.queueAction]}>
+      <View style={styles.swipeIcon}>
+        <Animated.View style={[styles.swipeIconLayer, plusStyle]}>
+          <Icon name="queue" size={26} color={iosSystemColors.white} />
+        </Animated.View>
+        <Animated.View style={[styles.swipeIconLayer, checkStyle]}>
+          <Icon name="tick" size={26} color={iosSystemColors.white} />
+        </Animated.View>
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Trailing "Playlist" swipe action (right-to-left swipe) — commit-on-release
+ * opens the playlist picker. Rose panel with a playlist icon that grows in with
+ * the drag plus a haptic detent at the threshold; the picker opens from
+ * onSwipeableWillOpen.
+ */
+function PlaylistSwipeAction({ translation }: { translation: SharedValue<number> }) {
+  useAnimatedReaction(
+    () => Math.abs(translation.value) >= COMMIT_THRESHOLD,
+    (armed, wasArmed) => {
+      if (armed && !wasArmed) runOnJS(hapticLight)();
+    },
+  );
+  const iconStyle = useAnimatedStyle(() => ({
+    opacity: Math.min(1, Math.abs(translation.value) / (COMMIT_THRESHOLD * 0.35)),
+    transform: [
+      { scale: interpolate(Math.abs(translation.value), [0, COMMIT_THRESHOLD], [0.6, 1], Extrapolation.CLAMP) },
+    ],
+  }));
+  return (
+    <View style={[styles.swipeAction, styles.playlistAction]}>
+      <Animated.View style={iconStyle}>
+        <Icon name="playlist" size={24} color={iosSystemColors.white} />
+      </Animated.View>
+    </View>
+  );
+}
 
 type ClimbListRowProps = {
   climb: Climb;
@@ -42,8 +121,6 @@ type ClimbListRowProps = {
   unsupported?: boolean;
 };
 
-const AnimatedView = Animated.View;
-
 const ClimbListRow = React.memo(function ClimbListRow({
   climb,
   boardName,
@@ -59,43 +136,32 @@ const ClimbListRow = React.memo(function ClimbListRow({
   unsupported,
 }: ClimbListRowProps) {
   const { t } = useTranslation('climbs');
-  const { colorScheme, systemColors } = useTheme();
-  const isDark = colorScheme === 'dark';
+  const { systemColors } = useTheme();
   const { formatGrade } = useGradeFormat();
 
   const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
   const formattedGrade = formatGrade(climb.difficulty);
 
-  // --- Double-tap favorite (ephemeral heart animation only — favorite status
-  // is not available in the search query, so we don't show it in the subtitle) ---
-  const { handleDoubleTap, showHeart, dismissHeart } = useDoubleTapFavorite({
-    climbUuid: climb.uuid,
-  });
+  const swipeableRef = useRef<SwipeableMethods>(null);
 
-  // --- Swipe gesture state ---
-  const translateX = useSharedValue(0);
-  const leftShortOpacity = useSharedValue(0);
-  const leftLongOpacity = useSharedValue(0);
-  const rightActionOpacity = useSharedValue(0);
-  const swipeConfirmed = useSharedValue(false);
-
-  // Reset shared values when the climb changes (FlashList recycles rows)
+  // FlashList recycles rows (same instance, new climb). Snap any open swipe
+  // shut so a recycled row never shows the previous climb's open panel.
+  // reset() (vs close()) skips the animation — an animated slide-shut on a
+  // recycle would read as a glitch. The reset lands on the next UI frame, so a
+  // row recycled mid-swipe can flash its panel for ~1 frame; the opaque
+  // contentRow background occludes the panel once translation returns to 0, so
+  // that background must stay opaque.
   useEffect(() => {
-    translateX.value = 0;
-    leftShortOpacity.value = 0;
-    leftLongOpacity.value = 0;
-    rightActionOpacity.value = 0;
-    swipeConfirmed.value = false;
-  }, [climb.uuid, translateX, leftShortOpacity, leftLongOpacity, rightActionOpacity, swipeConfirmed]);
+    swipeableRef.current?.reset();
+  }, [climb.uuid]);
 
-  // Stable refs for callbacks to avoid gesture closure staleness
+  // Stable refs so gesture/worklet callbacks never close over stale props.
   const onPressRef = useRef(onPress);
   onPressRef.current = onPress;
   const onAddToQueueRef = useRef(onAddToQueue);
   onAddToQueueRef.current = onAddToQueue;
-  const resolvedOpenPlaylist = onOpenPlaylist ?? onOpenActions;
-  const onOpenPlaylistRef = useRef(resolvedOpenPlaylist);
-  onOpenPlaylistRef.current = resolvedOpenPlaylist;
+  const onOpenPlaylistRef = useRef(onOpenPlaylist);
+  onOpenPlaylistRef.current = onOpenPlaylist;
   const onOpenActionsRef = useRef(onOpenActions);
   onOpenActionsRef.current = onOpenActions;
   const climbRef = useRef(climb);
@@ -109,110 +175,37 @@ const ClimbListRow = React.memo(function ClimbListRow({
     onPressRef.current(climbRef.current);
   }, []);
 
-  const handleSwipeAddToQueue = useCallback(() => {
-    hapticSuccess();
-    onAddToQueueRef.current?.(climbRef.current);
-  }, []);
-
-  const handleSwipeOpenActions = useCallback(() => {
+  const handleLongPress = useCallback(() => {
+    if (unsupportedRef.current) return;
     hapticMedium();
     onOpenActionsRef.current?.(climbRef.current);
   }, []);
 
-  const handleSwipePlaylist = useCallback(() => {
+  // Commit-on-release: fired from onSwipeableWillOpen the instant the user
+  // releases past the threshold — no second tap. We close immediately so the
+  // panel snaps back rather than resting open (the Spotify feel).
+  const handleAddToQueue = useCallback(() => {
+    hapticSuccess();
+    onAddToQueueRef.current?.(climbRef.current);
+    swipeableRef.current?.close();
+  }, []);
+
+  const handleOpenPlaylist = useCallback(() => {
     hapticMedium();
     onOpenPlaylistRef.current?.(climbRef.current);
+    swipeableRef.current?.close();
   }, []);
 
-  const panGesture = useMemo(
-    () =>
-      Gesture.Pan()
-        .activeOffsetX([-10, 10])
-        .failOffsetY([-15, 15])
-        .onUpdate((event) => {
-          'worklet';
-          const offset = event.translationX;
-
-          if (offset > 0) {
-            const clamped = Math.min(offset, MAX_GESTURE_SWIPE);
-            translateX.value = clamped;
-
-            const baseOpacity = Math.min(1, clamped / SHORT_SWIPE_THRESHOLD);
-            const transitionRange = LONG_SWIPE_THRESHOLD - TRANSITION_START;
-            const blend =
-              transitionRange > 0 ? Math.max(0, Math.min(1, (clamped - TRANSITION_START) / transitionRange)) : 1;
-
-            leftShortOpacity.value = baseOpacity * (1 - blend);
-            leftLongOpacity.value = baseOpacity * blend;
-            rightActionOpacity.value = 0;
-          } else {
-            const clamped = Math.max(offset, -RIGHT_ACTION_WIDTH - 20);
-            translateX.value = clamped;
-
-            leftShortOpacity.value = 0;
-            leftLongOpacity.value = 0;
-            rightActionOpacity.value = Math.min(1, -clamped / SHORT_SWIPE_THRESHOLD);
-          }
-        })
-        .onEnd(() => {
-          'worklet';
-          const offset = translateX.value;
-
-          if (offset > LONG_SWIPE_THRESHOLD) {
-            translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
-            leftShortOpacity.value = withTiming(0, { duration: 200 });
-            leftLongOpacity.value = withTiming(0, { duration: 200 });
-            runOnJS(handleSwipeOpenActions)();
-          } else if (offset > SHORT_SWIPE_THRESHOLD) {
-            translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
-            leftShortOpacity.value = withTiming(0, { duration: 200 });
-            leftLongOpacity.value = withTiming(0, { duration: 200 });
-            runOnJS(handleSwipePlaylist)();
-          } else if (offset < -SHORT_SWIPE_THRESHOLD) {
-            swipeConfirmed.value = true;
-            translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
-            rightActionOpacity.value = withTiming(0, { duration: 300 }, () => {
-              swipeConfirmed.value = false;
-            });
-            runOnJS(handleSwipeAddToQueue)();
-          } else {
-            translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
-            leftShortOpacity.value = withTiming(0, { duration: 150 });
-            leftLongOpacity.value = withTiming(0, { duration: 150 });
-            rightActionOpacity.value = withTiming(0, { duration: 150 });
-          }
-        }),
-    [
-      translateX,
-      leftShortOpacity,
-      leftLongOpacity,
-      rightActionOpacity,
-      swipeConfirmed,
-      handleSwipeAddToQueue,
-      handleSwipeOpenActions,
-      handleSwipePlaylist,
-    ],
+  const handleSwipeWillOpen = useCallback(
+    (direction: 'left' | 'right') => {
+      // ReanimatedSwipeable reports the SWIPE direction, not the actions side:
+      // 'right' fires when the LEFT actions (Queue) open (left-to-right swipe);
+      // 'left' fires when the RIGHT actions (Playlist) open (right-to-left).
+      if (direction === 'right') handleAddToQueue();
+      else handleOpenPlaylist();
+    },
+    [handleAddToQueue, handleOpenPlaylist],
   );
-
-  // Double-tap gesture on the thumbnail
-  const doubleTapGesture = useMemo(
-    () =>
-      Gesture.Tap()
-        .numberOfTaps(2)
-        .onStart(() => {
-          'worklet';
-          runOnJS(handleDoubleTap)();
-        }),
-    [handleDoubleTap],
-  );
-
-  // Single tap on the whole row — uses ref to avoid hoisting/stale closure issues
-  const handleRowPressRef = useRef(handleRowPress);
-  handleRowPressRef.current = handleRowPress;
-
-  const stableRowPress = useCallback(() => {
-    handleRowPressRef.current();
-  }, []);
 
   const singleTapGesture = useMemo(
     () =>
@@ -221,46 +214,44 @@ const ClimbListRow = React.memo(function ClimbListRow({
         .maxDistance(15)
         .onStart(() => {
           'worklet';
-          runOnJS(stableRowPress)();
+          runOnJS(handleRowPress)();
         }),
-    [stableRowPress],
+    [handleRowPress],
   );
 
-  const handleMenuPress = useCallback(() => {
-    hapticLight();
-    onOpenActionsRef.current?.(climbRef.current);
-  }, []);
+  const longPressGesture = useMemo(
+    () =>
+      Gesture.LongPress()
+        .minDuration(400)
+        .onStart(() => {
+          'worklet';
+          runOnJS(handleLongPress)();
+        }),
+    [handleLongPress],
+  );
 
-  // --- Animated styles ---
-  const contentAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: translateX.value }],
-  }));
+  // Long-press wins over tap; a quick tap fires once the long-press fails.
+  const tapGesture = useMemo(
+    () => Gesture.Exclusive(longPressGesture, singleTapGesture),
+    [longPressGesture, singleTapGesture],
+  );
 
-  const leftShortActionStyle = useAnimatedStyle(() => ({
-    opacity: leftShortOpacity.value,
-  }));
+  // Left actions (revealed by a left-to-right swipe) = Queue; right actions
+  // (right-to-left swipe) = Playlist.
+  const renderLeftActions = useCallback(
+    (_progress: SharedValue<number>, translation: SharedValue<number>) => (
+      <QueueSwipeAction translation={translation} />
+    ),
+    [],
+  );
+  const renderRightActions = useCallback(
+    (_progress: SharedValue<number>, translation: SharedValue<number>) => (
+      <PlaylistSwipeAction translation={translation} />
+    ),
+    [],
+  );
 
-  const leftLongActionStyle = useAnimatedStyle(() => ({
-    opacity: leftLongOpacity.value,
-  }));
-
-  const rightActionAnimatedStyle = useAnimatedStyle(() => ({
-    opacity: rightActionOpacity.value,
-  }));
-
-  const rightConfirmedStyle = useAnimatedStyle(() => ({
-    opacity: withTiming(swipeConfirmed.value ? 1 : 0, { duration: 120 }),
-  }));
-
-  // --- Background color (selected state) ---
-  const backgroundColor = useMemo(() => {
-    if (selected) {
-      return getGradeTintColor(climb.difficulty, 'light', isDark) ?? `${iosSystemColors.systemGray}1A`;
-    }
-    return 'transparent';
-  }, [selected, climb.difficulty, isDark]);
-
-  // --- Subtitle parts (matching web's ClimbTitle gradePosition='right' layout) ---
+  // Subtitle parts: sends · quality★ · setter (each dropped when absent).
   const subtitleText = useMemo(() => {
     const parts: string[] = [];
     if (climb.is_draft) {
@@ -279,80 +270,65 @@ const ClimbListRow = React.memo(function ClimbListRow({
     return parts.length > 0 ? parts.join(' · ') : t('mobile.climbRow.projectFallback');
   }, [climb.is_draft, climb.ascensionist_count, climb.quality_average, climb.setter_username, t]);
 
-  const tapGesture = useMemo(
-    () => Gesture.Exclusive(doubleTapGesture, singleTapGesture),
-    [doubleTapGesture, singleTapGesture],
-  );
-
-  const composedGesture = useMemo(() => Gesture.Race(tapGesture, panGesture), [tapGesture, panGesture]);
-
   return (
     <View style={[styles.outerContainer, unsupported && styles.unsupported]}>
-      {/* Left action layers (revealed on swipe right) */}
-      <View style={styles.leftActionContainer}>
-        <AnimatedView style={[styles.leftShortAction, leftShortActionStyle]}>
-          <Icon name="tag" size={20} color={iosSystemColors.white} />
-        </AnimatedView>
-        <AnimatedView style={[styles.leftLongAction, leftLongActionStyle]}>
-          <Icon name="more" size={20} color={iosSystemColors.white} />
-        </AnimatedView>
-      </View>
+      <ReanimatedSwipeable
+        ref={swipeableRef}
+        friction={SWIPE_FRICTION}
+        leftThreshold={COMMIT_THRESHOLD}
+        rightThreshold={COMMIT_THRESHOLD}
+        overshootLeft={false}
+        overshootRight={false}
+        renderLeftActions={renderLeftActions}
+        renderRightActions={renderRightActions}
+        onSwipeableWillOpen={handleSwipeWillOpen}
+      >
+        <GestureDetector gesture={tapGesture}>
+          <View
+            style={[styles.contentRow, { backgroundColor: systemColors.background }]}
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel={climb.name}
+            accessibilityState={{ selected: !!selected }}
+          >
+            {/* Active-climb highlight: rose wash + left accent bar */}
+            {selected ? <View style={styles.selectedFill} pointerEvents="none" /> : null}
+            {selected ? <View style={styles.selectedAccent} pointerEvents="none" /> : null}
 
-      {/* Right action layer (revealed on swipe left) */}
-      <View style={styles.rightActionContainer}>
-        <AnimatedView style={[styles.rightActionDefault, rightActionAnimatedStyle]}>
-          <Icon name="add" size={20} color={iosSystemColors.white} />
-        </AnimatedView>
-        <AnimatedView style={[styles.rightActionConfirmed, rightConfirmedStyle]}>
-          <Icon name="check.small" size={20} color={iosSystemColors.white} />
-        </AnimatedView>
-      </View>
+            {/* Left: portrait thumbnail with ascent badge */}
+            <View style={styles.thumbnailContainer}>
+              <ClimbListThumbnail
+                frames={climb.frames}
+                boardName={boardName}
+                layoutId={layoutId}
+                sizeId={sizeId}
+                setIds={setIds}
+                mirrored={climb.mirrored ?? false}
+              />
+              <AscentStatusBadge climbUuid={climb.uuid} angle={angle} />
+            </View>
 
-      {/* Main content row — single GestureDetector with composed gestures */}
-      <GestureDetector gesture={composedGesture}>
-        <AnimatedView style={[styles.contentRow, { backgroundColor }, contentAnimatedStyle]}>
-          {/* Left: Thumbnail with ascent badge + heart overlay */}
-          <View style={styles.thumbnailContainer}>
-            <ClimbListThumbnail
-              frames={climb.frames}
-              boardName={boardName}
-              layoutId={layoutId}
-              sizeId={sizeId}
-              setIds={setIds}
-              mirrored={climb.mirrored ?? false}
-            />
-            <HeartAnimationOverlay visible={showHeart} onDismiss={dismissHeart} size={32} />
-            <AscentStatusBadge climbUuid={climb.uuid} angle={angle} />
+            {/* Center: name + subtitle */}
+            <View style={styles.centerColumn}>
+              <Text variant="body" numberOfLines={1} style={styles.climbName}>
+                {climb.name}
+              </Text>
+              <Text variant="footnote" numberOfLines={1} style={styles.subtitle}>
+                {subtitleText}
+              </Text>
+            </View>
+
+            {/* Right: colorized grade */}
+            <View style={styles.rightSection}>
+              <Text variant="headline" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
+                {formattedGrade ?? climb.difficulty}
+              </Text>
+            </View>
           </View>
+        </GestureDetector>
+      </ReanimatedSwipeable>
 
-          {/* Center: Name + subtitle */}
-          <View style={styles.centerColumn}>
-            <Text variant="body" numberOfLines={1} style={styles.climbName}>
-              {climb.name}
-            </Text>
-            <Text variant="footnote" numberOfLines={1} style={styles.subtitle}>
-              {subtitleText}
-            </Text>
-          </View>
-
-          {/* Right: Colorized grade + menu button */}
-          <View style={styles.rightSection}>
-            <Text variant="headline" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
-              {formattedGrade ?? climb.difficulty}
-            </Text>
-            <Pressable
-              onPress={handleMenuPress}
-              hitSlop={spacing[2]}
-              accessibilityRole="button"
-              accessibilityLabel={t('mobile.climbRow.menuAccessibility', { climbName: climb.name })}
-            >
-              <Icon name="more" size={20} color={iosSystemColors.systemGray} />
-            </Pressable>
-          </View>
-        </AnimatedView>
-      </GestureDetector>
-
-      {/* Separator */}
+      {/* Separator — inset to start at the text column (after the thumbnail) */}
       <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />
     </View>
   );
@@ -375,9 +351,29 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
     gap: spacing[3],
   },
+  // Active-climb wash. Brand rose (#8C4A52) — kept distinct from the grade
+  // colour on the right of the row. Behind the content (crisp text). Bumped
+  // from 0.14 → 0.18 so it reads on near-black OLED, where the accent bar
+  // scrolls off during a swipe and the wash is the only state cue left.
+  selectedFill: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(140, 74, 82, 0.18)',
+  },
+  selectedAccent: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: 5,
+    backgroundColor: brandColors.primary,
+  },
   thumbnailContainer: {
-    width: spacing[16],
-    height: spacing[16],
+    width: THUMBNAIL_WIDTH,
+    height: THUMBNAIL_HEIGHT,
     flexShrink: 0,
     position: 'relative',
   },
@@ -394,65 +390,47 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   rightSection: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[2],
     flexShrink: 0,
+    alignItems: 'flex-end',
+    justifyContent: 'center',
   },
   gradeText: {
     fontWeight: '700',
+    minWidth: 34,
+    textAlign: 'right',
   },
   separator: {
     height: StyleSheet.hairlineWidth,
-    marginLeft: spacing[16] + spacing[2] + spacing[3],
+    marginLeft: THUMBNAIL_WIDTH + spacing[2] + spacing[3],
   },
-  // --- Swipe action layers ---
-  leftActionContainer: {
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    bottom: 0,
-    width: SHORT_ACTION_WIDTH,
+  swipeAction: {
+    width: ACTION_REVEAL,
     justifyContent: 'center',
-    alignItems: 'flex-start',
-    paddingLeft: spacing[4],
   },
-  leftShortAction: {
-    ...StyleSheet.absoluteFill,
+  // Pin each icon to the OUTER edge of its panel (queue = right/screen edge,
+  // playlist = left/screen edge) so it appears as soon as the panel starts
+  // revealing, instead of needing half the panel out to see a centred icon.
+  queueAction: {
+    backgroundColor: brandColors.success,
+    alignItems: 'flex-start',
+    paddingLeft: 22,
+  },
+  playlistAction: {
     backgroundColor: brandColors.primary,
-    justifyContent: 'center',
-    alignItems: 'flex-start',
-    paddingLeft: spacing[4],
+    alignItems: 'flex-end',
+    paddingRight: 22,
   },
-  leftLongAction: {
-    ...StyleSheet.absoluteFill,
-    backgroundColor: iosSystemColors.systemGray,
-    justifyContent: 'center',
-    alignItems: 'flex-start',
-    paddingLeft: spacing[4],
+  swipeIcon: {
+    width: 28,
+    height: 28,
   },
-  rightActionContainer: {
+  swipeIconLayer: {
     position: 'absolute',
-    right: 0,
     top: 0,
+    left: 0,
+    right: 0,
     bottom: 0,
-    width: RIGHT_ACTION_WIDTH,
+    alignItems: 'center',
     justifyContent: 'center',
-    alignItems: 'flex-end',
-    paddingRight: spacing[4],
-  },
-  rightActionDefault: {
-    ...StyleSheet.absoluteFill,
-    backgroundColor: brandColors.success,
-    justifyContent: 'center',
-    alignItems: 'flex-end',
-    paddingRight: spacing[4],
-  },
-  rightActionConfirmed: {
-    ...StyleSheet.absoluteFill,
-    backgroundColor: brandColors.success,
-    justifyContent: 'center',
-    alignItems: 'flex-end',
-    paddingRight: spacing[4],
   },
 });

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -1,110 +1,31 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { View, StyleSheet } from 'react-native';
-import Animated, {
-  useAnimatedStyle,
-  useAnimatedReaction,
-  interpolate,
-  Extrapolation,
-  runOnJS,
-  type SharedValue,
-} from 'react-native-reanimated';
+import { Pressable, View, StyleSheet } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming, runOnJS } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import ReanimatedSwipeable, { type SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
 import { useTranslation } from 'react-i18next';
 import type { Climb, BoardName } from '@boardsesh/shared-schema';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { Text } from './Text';
 import { Icon } from './Icon';
-import { ClimbListThumbnail, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT } from './ClimbListThumbnail';
+import { ClimbListThumbnail } from './ClimbListThumbnail';
 import { AscentStatusBadge } from './AscentStatusBadge';
+import { HeartAnimationOverlay } from './HeartAnimationOverlay';
+import { useDoubleTapFavorite } from '../hooks/use-double-tap-favorite';
 import { hapticLight, hapticMedium, hapticSuccess } from '../lib/haptics';
 import { formatSends, formatQuality } from '../lib/format-climb-stats';
+import { getGradeTintColor } from '@boardsesh/play-view';
 import { useGradeFormat } from '../hooks/use-grade-format';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { brandColors } from '../theme/colors';
 import { spacing } from '../theme/tokens';
 
-// Swipe tuning. Each side reveals a panel up to ACTION_REVEAL wide; dragging
-// past COMMIT_THRESHOLD and RELEASING commits the action (Spotify-style swipe-
-// to-queue) — no resting-open state, no second tap. friction=1 makes the row
-// track the finger 1:1 (snappy, like Spotify's tracklist swipe). Tunable.
-const ACTION_REVEAL = 150;
-const COMMIT_THRESHOLD = 96;
-const SWIPE_FRICTION = 1;
-
-/**
- * Leading "Queue" swipe action — Spotify-style commit-on-release (left-to-right
- * swipe). The panel shows a queue icon that flips to a "✓" once you cross the
- * commit threshold (with a haptic detent), so you feel and see that releasing
- * will queue the climb. The add fires from the row's onSwipeableWillOpen.
- */
-function QueueSwipeAction({ translation }: { translation: SharedValue<number> }) {
-  // Haptic detent the instant the drag crosses the commit threshold.
-  useAnimatedReaction(
-    () => Math.abs(translation.value) >= COMMIT_THRESHOLD,
-    (armed, wasArmed) => {
-      if (armed && !wasArmed) runOnJS(hapticLight)();
-    },
-  );
-  const plusStyle = useAnimatedStyle(() => ({
-    opacity: interpolate(
-      Math.abs(translation.value),
-      [COMMIT_THRESHOLD - 18, COMMIT_THRESHOLD],
-      [1, 0],
-      Extrapolation.CLAMP,
-    ),
-  }));
-  const checkStyle = useAnimatedStyle(() => {
-    const armedProgress = interpolate(
-      Math.abs(translation.value),
-      [COMMIT_THRESHOLD - 8, COMMIT_THRESHOLD + 6],
-      [0, 1],
-      Extrapolation.CLAMP,
-    );
-    return { opacity: armedProgress, transform: [{ scale: 0.6 + armedProgress * 0.4 }] };
-  });
-  return (
-    <View style={[styles.swipeAction, styles.queueAction]}>
-      <View style={styles.swipeIcon}>
-        <Animated.View style={[styles.swipeIconLayer, plusStyle]}>
-          <Icon name="queue" size={26} color={iosSystemColors.white} />
-        </Animated.View>
-        <Animated.View style={[styles.swipeIconLayer, checkStyle]}>
-          <Icon name="tick" size={26} color={iosSystemColors.white} />
-        </Animated.View>
-      </View>
-    </View>
-  );
-}
-
-/**
- * Trailing "Playlist" swipe action (right-to-left swipe) — commit-on-release
- * opens the playlist picker. Rose panel with a playlist icon that grows in with
- * the drag plus a haptic detent at the threshold; the picker opens from
- * onSwipeableWillOpen.
- */
-function PlaylistSwipeAction({ translation }: { translation: SharedValue<number> }) {
-  useAnimatedReaction(
-    () => Math.abs(translation.value) >= COMMIT_THRESHOLD,
-    (armed, wasArmed) => {
-      if (armed && !wasArmed) runOnJS(hapticLight)();
-    },
-  );
-  const iconStyle = useAnimatedStyle(() => ({
-    opacity: Math.min(1, Math.abs(translation.value) / (COMMIT_THRESHOLD * 0.35)),
-    transform: [
-      { scale: interpolate(Math.abs(translation.value), [0, COMMIT_THRESHOLD], [0.6, 1], Extrapolation.CLAMP) },
-    ],
-  }));
-  return (
-    <View style={[styles.swipeAction, styles.playlistAction]}>
-      <Animated.View style={iconStyle}>
-        <Icon name="playlist" size={24} color={iosSystemColors.white} />
-      </Animated.View>
-    </View>
-  );
-}
+const MAX_GESTURE_SWIPE = 180;
+const SHORT_ACTION_WIDTH = 120;
+const RIGHT_ACTION_WIDTH = 100;
+const SHORT_SWIPE_THRESHOLD = 60;
+const TRANSITION_START = 115;
+const LONG_SWIPE_THRESHOLD = 150;
 
 type ClimbListRowProps = {
   climb: Climb;
@@ -121,6 +42,8 @@ type ClimbListRowProps = {
   unsupported?: boolean;
 };
 
+const AnimatedView = Animated.View;
+
 const ClimbListRow = React.memo(function ClimbListRow({
   climb,
   boardName,
@@ -136,32 +59,43 @@ const ClimbListRow = React.memo(function ClimbListRow({
   unsupported,
 }: ClimbListRowProps) {
   const { t } = useTranslation('climbs');
-  const { systemColors } = useTheme();
+  const { colorScheme, systemColors } = useTheme();
+  const isDark = colorScheme === 'dark';
   const { formatGrade } = useGradeFormat();
 
   const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
   const formattedGrade = formatGrade(climb.difficulty);
 
-  const swipeableRef = useRef<SwipeableMethods>(null);
+  // --- Double-tap favorite (ephemeral heart animation only — favorite status
+  // is not available in the search query, so we don't show it in the subtitle) ---
+  const { handleDoubleTap, showHeart, dismissHeart } = useDoubleTapFavorite({
+    climbUuid: climb.uuid,
+  });
 
-  // FlashList recycles rows (same instance, new climb). Snap any open swipe
-  // shut so a recycled row never shows the previous climb's open panel.
-  // reset() (vs close()) skips the animation — an animated slide-shut on a
-  // recycle would read as a glitch. The reset lands on the next UI frame, so a
-  // row recycled mid-swipe can flash its panel for ~1 frame; the opaque
-  // contentRow background occludes the panel once translation returns to 0, so
-  // that background must stay opaque.
+  // --- Swipe gesture state ---
+  const translateX = useSharedValue(0);
+  const leftShortOpacity = useSharedValue(0);
+  const leftLongOpacity = useSharedValue(0);
+  const rightActionOpacity = useSharedValue(0);
+  const swipeConfirmed = useSharedValue(false);
+
+  // Reset shared values when the climb changes (FlashList recycles rows)
   useEffect(() => {
-    swipeableRef.current?.reset();
-  }, [climb.uuid]);
+    translateX.value = 0;
+    leftShortOpacity.value = 0;
+    leftLongOpacity.value = 0;
+    rightActionOpacity.value = 0;
+    swipeConfirmed.value = false;
+  }, [climb.uuid, translateX, leftShortOpacity, leftLongOpacity, rightActionOpacity, swipeConfirmed]);
 
-  // Stable refs so gesture/worklet callbacks never close over stale props.
+  // Stable refs for callbacks to avoid gesture closure staleness
   const onPressRef = useRef(onPress);
   onPressRef.current = onPress;
   const onAddToQueueRef = useRef(onAddToQueue);
   onAddToQueueRef.current = onAddToQueue;
-  const onOpenPlaylistRef = useRef(onOpenPlaylist);
-  onOpenPlaylistRef.current = onOpenPlaylist;
+  const resolvedOpenPlaylist = onOpenPlaylist ?? onOpenActions;
+  const onOpenPlaylistRef = useRef(resolvedOpenPlaylist);
+  onOpenPlaylistRef.current = resolvedOpenPlaylist;
   const onOpenActionsRef = useRef(onOpenActions);
   onOpenActionsRef.current = onOpenActions;
   const climbRef = useRef(climb);
@@ -175,37 +109,110 @@ const ClimbListRow = React.memo(function ClimbListRow({
     onPressRef.current(climbRef.current);
   }, []);
 
-  const handleLongPress = useCallback(() => {
-    if (unsupportedRef.current) return;
+  const handleSwipeAddToQueue = useCallback(() => {
+    hapticSuccess();
+    onAddToQueueRef.current?.(climbRef.current);
+  }, []);
+
+  const handleSwipeOpenActions = useCallback(() => {
     hapticMedium();
     onOpenActionsRef.current?.(climbRef.current);
   }, []);
 
-  // Commit-on-release: fired from onSwipeableWillOpen the instant the user
-  // releases past the threshold — no second tap. We close immediately so the
-  // panel snaps back rather than resting open (the Spotify feel).
-  const handleAddToQueue = useCallback(() => {
-    hapticSuccess();
-    onAddToQueueRef.current?.(climbRef.current);
-    swipeableRef.current?.close();
-  }, []);
-
-  const handleOpenPlaylist = useCallback(() => {
+  const handleSwipePlaylist = useCallback(() => {
     hapticMedium();
     onOpenPlaylistRef.current?.(climbRef.current);
-    swipeableRef.current?.close();
   }, []);
 
-  const handleSwipeWillOpen = useCallback(
-    (direction: 'left' | 'right') => {
-      // ReanimatedSwipeable reports the SWIPE direction, not the actions side:
-      // 'right' fires when the LEFT actions (Queue) open (left-to-right swipe);
-      // 'left' fires when the RIGHT actions (Playlist) open (right-to-left).
-      if (direction === 'right') handleAddToQueue();
-      else handleOpenPlaylist();
-    },
-    [handleAddToQueue, handleOpenPlaylist],
+  const panGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .activeOffsetX([-10, 10])
+        .failOffsetY([-15, 15])
+        .onUpdate((event) => {
+          'worklet';
+          const offset = event.translationX;
+
+          if (offset > 0) {
+            const clamped = Math.min(offset, MAX_GESTURE_SWIPE);
+            translateX.value = clamped;
+
+            const baseOpacity = Math.min(1, clamped / SHORT_SWIPE_THRESHOLD);
+            const transitionRange = LONG_SWIPE_THRESHOLD - TRANSITION_START;
+            const blend =
+              transitionRange > 0 ? Math.max(0, Math.min(1, (clamped - TRANSITION_START) / transitionRange)) : 1;
+
+            leftShortOpacity.value = baseOpacity * (1 - blend);
+            leftLongOpacity.value = baseOpacity * blend;
+            rightActionOpacity.value = 0;
+          } else {
+            const clamped = Math.max(offset, -RIGHT_ACTION_WIDTH - 20);
+            translateX.value = clamped;
+
+            leftShortOpacity.value = 0;
+            leftLongOpacity.value = 0;
+            rightActionOpacity.value = Math.min(1, -clamped / SHORT_SWIPE_THRESHOLD);
+          }
+        })
+        .onEnd(() => {
+          'worklet';
+          const offset = translateX.value;
+
+          if (offset > LONG_SWIPE_THRESHOLD) {
+            translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
+            leftShortOpacity.value = withTiming(0, { duration: 200 });
+            leftLongOpacity.value = withTiming(0, { duration: 200 });
+            runOnJS(handleSwipeOpenActions)();
+          } else if (offset > SHORT_SWIPE_THRESHOLD) {
+            translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
+            leftShortOpacity.value = withTiming(0, { duration: 200 });
+            leftLongOpacity.value = withTiming(0, { duration: 200 });
+            runOnJS(handleSwipePlaylist)();
+          } else if (offset < -SHORT_SWIPE_THRESHOLD) {
+            swipeConfirmed.value = true;
+            translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
+            rightActionOpacity.value = withTiming(0, { duration: 300 }, () => {
+              swipeConfirmed.value = false;
+            });
+            runOnJS(handleSwipeAddToQueue)();
+          } else {
+            translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
+            leftShortOpacity.value = withTiming(0, { duration: 150 });
+            leftLongOpacity.value = withTiming(0, { duration: 150 });
+            rightActionOpacity.value = withTiming(0, { duration: 150 });
+          }
+        }),
+    [
+      translateX,
+      leftShortOpacity,
+      leftLongOpacity,
+      rightActionOpacity,
+      swipeConfirmed,
+      handleSwipeAddToQueue,
+      handleSwipeOpenActions,
+      handleSwipePlaylist,
+    ],
   );
+
+  // Double-tap gesture on the thumbnail
+  const doubleTapGesture = useMemo(
+    () =>
+      Gesture.Tap()
+        .numberOfTaps(2)
+        .onStart(() => {
+          'worklet';
+          runOnJS(handleDoubleTap)();
+        }),
+    [handleDoubleTap],
+  );
+
+  // Single tap on the whole row — uses ref to avoid hoisting/stale closure issues
+  const handleRowPressRef = useRef(handleRowPress);
+  handleRowPressRef.current = handleRowPress;
+
+  const stableRowPress = useCallback(() => {
+    handleRowPressRef.current();
+  }, []);
 
   const singleTapGesture = useMemo(
     () =>
@@ -214,44 +221,46 @@ const ClimbListRow = React.memo(function ClimbListRow({
         .maxDistance(15)
         .onStart(() => {
           'worklet';
-          runOnJS(handleRowPress)();
+          runOnJS(stableRowPress)();
         }),
-    [handleRowPress],
+    [stableRowPress],
   );
 
-  const longPressGesture = useMemo(
-    () =>
-      Gesture.LongPress()
-        .minDuration(400)
-        .onStart(() => {
-          'worklet';
-          runOnJS(handleLongPress)();
-        }),
-    [handleLongPress],
-  );
+  const handleMenuPress = useCallback(() => {
+    hapticLight();
+    onOpenActionsRef.current?.(climbRef.current);
+  }, []);
 
-  // Long-press wins over tap; a quick tap fires once the long-press fails.
-  const tapGesture = useMemo(
-    () => Gesture.Exclusive(longPressGesture, singleTapGesture),
-    [longPressGesture, singleTapGesture],
-  );
+  // --- Animated styles ---
+  const contentAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
+  }));
 
-  // Left actions (revealed by a left-to-right swipe) = Queue; right actions
-  // (right-to-left swipe) = Playlist.
-  const renderLeftActions = useCallback(
-    (_progress: SharedValue<number>, translation: SharedValue<number>) => (
-      <QueueSwipeAction translation={translation} />
-    ),
-    [],
-  );
-  const renderRightActions = useCallback(
-    (_progress: SharedValue<number>, translation: SharedValue<number>) => (
-      <PlaylistSwipeAction translation={translation} />
-    ),
-    [],
-  );
+  const leftShortActionStyle = useAnimatedStyle(() => ({
+    opacity: leftShortOpacity.value,
+  }));
 
-  // Subtitle parts: sends · quality★ · setter (each dropped when absent).
+  const leftLongActionStyle = useAnimatedStyle(() => ({
+    opacity: leftLongOpacity.value,
+  }));
+
+  const rightActionAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: rightActionOpacity.value,
+  }));
+
+  const rightConfirmedStyle = useAnimatedStyle(() => ({
+    opacity: withTiming(swipeConfirmed.value ? 1 : 0, { duration: 120 }),
+  }));
+
+  // --- Background color (selected state) ---
+  const backgroundColor = useMemo(() => {
+    if (selected) {
+      return getGradeTintColor(climb.difficulty, 'light', isDark) ?? `${iosSystemColors.systemGray}1A`;
+    }
+    return 'transparent';
+  }, [selected, climb.difficulty, isDark]);
+
+  // --- Subtitle parts (matching web's ClimbTitle gradePosition='right' layout) ---
   const subtitleText = useMemo(() => {
     const parts: string[] = [];
     if (climb.is_draft) {
@@ -270,65 +279,80 @@ const ClimbListRow = React.memo(function ClimbListRow({
     return parts.length > 0 ? parts.join(' · ') : t('mobile.climbRow.projectFallback');
   }, [climb.is_draft, climb.ascensionist_count, climb.quality_average, climb.setter_username, t]);
 
+  const tapGesture = useMemo(
+    () => Gesture.Exclusive(doubleTapGesture, singleTapGesture),
+    [doubleTapGesture, singleTapGesture],
+  );
+
+  const composedGesture = useMemo(() => Gesture.Race(tapGesture, panGesture), [tapGesture, panGesture]);
+
   return (
     <View style={[styles.outerContainer, unsupported && styles.unsupported]}>
-      <ReanimatedSwipeable
-        ref={swipeableRef}
-        friction={SWIPE_FRICTION}
-        leftThreshold={COMMIT_THRESHOLD}
-        rightThreshold={COMMIT_THRESHOLD}
-        overshootLeft={false}
-        overshootRight={false}
-        renderLeftActions={renderLeftActions}
-        renderRightActions={renderRightActions}
-        onSwipeableWillOpen={handleSwipeWillOpen}
-      >
-        <GestureDetector gesture={tapGesture}>
-          <View
-            style={[styles.contentRow, { backgroundColor: systemColors.background }]}
-            accessible
-            accessibilityRole="button"
-            accessibilityLabel={climb.name}
-            accessibilityState={{ selected: !!selected }}
-          >
-            {/* Active-climb highlight: rose wash + left accent bar */}
-            {selected ? <View style={styles.selectedFill} pointerEvents="none" /> : null}
-            {selected ? <View style={styles.selectedAccent} pointerEvents="none" /> : null}
+      {/* Left action layers (revealed on swipe right) */}
+      <View style={styles.leftActionContainer}>
+        <AnimatedView style={[styles.leftShortAction, leftShortActionStyle]}>
+          <Icon name="tag" size={20} color={iosSystemColors.white} />
+        </AnimatedView>
+        <AnimatedView style={[styles.leftLongAction, leftLongActionStyle]}>
+          <Icon name="more" size={20} color={iosSystemColors.white} />
+        </AnimatedView>
+      </View>
 
-            {/* Left: portrait thumbnail with ascent badge */}
-            <View style={styles.thumbnailContainer}>
-              <ClimbListThumbnail
-                frames={climb.frames}
-                boardName={boardName}
-                layoutId={layoutId}
-                sizeId={sizeId}
-                setIds={setIds}
-                mirrored={climb.mirrored ?? false}
-              />
-              <AscentStatusBadge climbUuid={climb.uuid} angle={angle} />
-            </View>
+      {/* Right action layer (revealed on swipe left) */}
+      <View style={styles.rightActionContainer}>
+        <AnimatedView style={[styles.rightActionDefault, rightActionAnimatedStyle]}>
+          <Icon name="add" size={20} color={iosSystemColors.white} />
+        </AnimatedView>
+        <AnimatedView style={[styles.rightActionConfirmed, rightConfirmedStyle]}>
+          <Icon name="check.small" size={20} color={iosSystemColors.white} />
+        </AnimatedView>
+      </View>
 
-            {/* Center: name + subtitle */}
-            <View style={styles.centerColumn}>
-              <Text variant="body" numberOfLines={1} style={styles.climbName}>
-                {climb.name}
-              </Text>
-              <Text variant="footnote" numberOfLines={1} style={styles.subtitle}>
-                {subtitleText}
-              </Text>
-            </View>
-
-            {/* Right: colorized grade */}
-            <View style={styles.rightSection}>
-              <Text variant="headline" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
-                {formattedGrade ?? climb.difficulty}
-              </Text>
-            </View>
+      {/* Main content row — single GestureDetector with composed gestures */}
+      <GestureDetector gesture={composedGesture}>
+        <AnimatedView style={[styles.contentRow, { backgroundColor }, contentAnimatedStyle]}>
+          {/* Left: Thumbnail with ascent badge + heart overlay */}
+          <View style={styles.thumbnailContainer}>
+            <ClimbListThumbnail
+              frames={climb.frames}
+              boardName={boardName}
+              layoutId={layoutId}
+              sizeId={sizeId}
+              setIds={setIds}
+              mirrored={climb.mirrored ?? false}
+            />
+            <HeartAnimationOverlay visible={showHeart} onDismiss={dismissHeart} size={32} />
+            <AscentStatusBadge climbUuid={climb.uuid} angle={angle} />
           </View>
-        </GestureDetector>
-      </ReanimatedSwipeable>
 
-      {/* Separator — inset to start at the text column (after the thumbnail) */}
+          {/* Center: Name + subtitle */}
+          <View style={styles.centerColumn}>
+            <Text variant="body" numberOfLines={1} style={styles.climbName}>
+              {climb.name}
+            </Text>
+            <Text variant="footnote" numberOfLines={1} style={styles.subtitle}>
+              {subtitleText}
+            </Text>
+          </View>
+
+          {/* Right: Colorized grade + menu button */}
+          <View style={styles.rightSection}>
+            <Text variant="headline" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
+              {formattedGrade ?? climb.difficulty}
+            </Text>
+            <Pressable
+              onPress={handleMenuPress}
+              hitSlop={spacing[2]}
+              accessibilityRole="button"
+              accessibilityLabel={t('mobile.climbRow.menuAccessibility', { climbName: climb.name })}
+            >
+              <Icon name="more" size={20} color={iosSystemColors.systemGray} />
+            </Pressable>
+          </View>
+        </AnimatedView>
+      </GestureDetector>
+
+      {/* Separator */}
       <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />
     </View>
   );
@@ -351,29 +375,9 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
     gap: spacing[3],
   },
-  // Active-climb wash. Brand rose (#8C4A52) — kept distinct from the grade
-  // colour on the right of the row. Behind the content (crisp text). Bumped
-  // from 0.14 → 0.18 so it reads on near-black OLED, where the accent bar
-  // scrolls off during a swipe and the wash is the only state cue left.
-  selectedFill: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    backgroundColor: 'rgba(140, 74, 82, 0.18)',
-  },
-  selectedAccent: {
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    bottom: 0,
-    width: 5,
-    backgroundColor: brandColors.primary,
-  },
   thumbnailContainer: {
-    width: THUMBNAIL_WIDTH,
-    height: THUMBNAIL_HEIGHT,
+    width: spacing[16],
+    height: spacing[16],
     flexShrink: 0,
     position: 'relative',
   },
@@ -390,47 +394,65 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   rightSection: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
     flexShrink: 0,
-    alignItems: 'flex-end',
-    justifyContent: 'center',
   },
   gradeText: {
     fontWeight: '700',
-    minWidth: 34,
-    textAlign: 'right',
   },
   separator: {
     height: StyleSheet.hairlineWidth,
-    marginLeft: THUMBNAIL_WIDTH + spacing[2] + spacing[3],
+    marginLeft: spacing[16] + spacing[2] + spacing[3],
   },
-  swipeAction: {
-    width: ACTION_REVEAL,
-    justifyContent: 'center',
-  },
-  // Pin each icon to the OUTER edge of its panel (queue = right/screen edge,
-  // playlist = left/screen edge) so it appears as soon as the panel starts
-  // revealing, instead of needing half the panel out to see a centred icon.
-  queueAction: {
-    backgroundColor: brandColors.success,
-    alignItems: 'flex-start',
-    paddingLeft: 22,
-  },
-  playlistAction: {
-    backgroundColor: brandColors.primary,
-    alignItems: 'flex-end',
-    paddingRight: 22,
-  },
-  swipeIcon: {
-    width: 28,
-    height: 28,
-  },
-  swipeIconLayer: {
+  // --- Swipe action layers ---
+  leftActionContainer: {
     position: 'absolute',
-    top: 0,
     left: 0,
-    right: 0,
+    top: 0,
     bottom: 0,
-    alignItems: 'center',
+    width: SHORT_ACTION_WIDTH,
     justifyContent: 'center',
+    alignItems: 'flex-start',
+    paddingLeft: spacing[4],
+  },
+  leftShortAction: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: brandColors.primary,
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    paddingLeft: spacing[4],
+  },
+  leftLongAction: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: iosSystemColors.systemGray,
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    paddingLeft: spacing[4],
+  },
+  rightActionContainer: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    bottom: 0,
+    width: RIGHT_ACTION_WIDTH,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+    paddingRight: spacing[4],
+  },
+  rightActionDefault: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: brandColors.success,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+    paddingRight: spacing[4],
+  },
+  rightActionConfirmed: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: brandColors.success,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+    paddingRight: spacing[4],
   },
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -240,12 +240,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     setIsFavorited((prev) => !prev);
     toggleFavoriteMutate({
       input: {
-        boardName,
         climbUuid: displayedClimb.uuid,
-        angle,
       },
     });
-  }, [displayedClimb, boardName, angle, toggleFavoriteMutate]);
+  }, [displayedClimb, toggleFavoriteMutate]);
 
   const handleLightbulb = useCallback(() => {
     if (!bluetooth) return;

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
@@ -150,8 +150,7 @@ describe('useMobileClimbActionsData', () => {
       expect(requestMock).not.toHaveBeenCalled();
     });
 
-    it('sends boardName + angle from the active board and returns the favorited flag', async () => {
-      // First the playlists query, then the favorite mutation.
+    it('sends climbUuid only and returns the favorited flag', async () => {
       requestMock.mockResolvedValueOnce({ allUserPlaylists: { playlists: [] } });
       requestMock.mockResolvedValueOnce({ toggleFavorite: { favorited: true } });
 
@@ -161,32 +160,19 @@ describe('useMobileClimbActionsData', () => {
 
       await expect(result.current.favoritesProviderProps.toggleFavorite('climb-x')).resolves.toBe(true);
       expect(requestMock).toHaveBeenCalledWith(TOGGLE_FAVORITE, {
-        input: { boardName: 'kilter', climbUuid: 'climb-x', angle: 40 },
+        input: { climbUuid: 'climb-x' },
       });
     });
 
-    it('rejects with a helpful error when no active board is selected', async () => {
+    it('does not require an active board (favorites are board-agnostic)', async () => {
       withActiveBoard(null);
+      requestMock.mockResolvedValueOnce({ allUserPlaylists: { playlists: [] } });
+      requestMock.mockResolvedValueOnce({ toggleFavorite: { favorited: true } });
+
       const { Wrapper } = makeWrapper();
       const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
 
-      await expect(result.current.favoritesProviderProps.toggleFavorite('climb-x')).rejects.toThrow(/no active board/);
-    });
-
-    it('rejects when the active board has no angle (no silent angle-0 fallback)', async () => {
-      // Active board with angle missing — common during a board switch before
-      // the angle picker has been resolved. Defaulting to 0 would silently
-      // file the favorite under the wrong climb variant.
-      withActiveBoard({ ...kilterBoard, angle: null } as unknown as UserBoard);
-      const { Wrapper } = makeWrapper();
-      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
-
-      await expect(result.current.favoritesProviderProps.toggleFavorite('climb-x')).rejects.toThrow(/no angle/);
-      // Server must not have been called with a fabricated angle.
-      expect(requestMock).not.toHaveBeenCalledWith(
-        TOGGLE_FAVORITE,
-        expect.objectContaining({ input: expect.objectContaining({ angle: 0 }) }),
-      );
+      await expect(result.current.favoritesProviderProps.toggleFavorite('climb-x')).resolves.toBe(true);
     });
   });
 

--- a/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
@@ -8,11 +8,6 @@
 // from the boards tab the cache invalidates and subsequent mutations land
 // against the new board.
 //
-// `toggleFavorite` is also wired against the active board today only because
-// the current GraphQL schema requires `boardName` + `angle` on the input.
-// Tracked in #2449 as a backend cleanup — favorites should be keyed by climb
-// UUID alone. Once #2449 lands, drop those args from the mutation.
-//
 // Favorites Set is left empty: the current `GET_FAVORITES` query takes a
 // `climbUuids` list (web batches it as the user scrolls a climb list), and
 // mobile has no equivalent batched fetcher today. When a mobile screen needs
@@ -91,16 +86,8 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
 
   const toggleFavoriteMutation = useMutation({
     mutationFn: async (climbUuid: string): Promise<{ uuid: string; favorited: boolean }> => {
-      const { activeBoard: board } = mutationDepsRef.current;
-      if (!board) throw new Error('Cannot toggle favorite: no active board selected.');
-      // The favorite key is (userId, boardName, climbUuid, angle) on the
-      // backend today. Defaulting a missing angle to 0 would silently file
-      // the favorite under the wrong climb variant — better to surface the
-      // problem at the call site than write bad data. Stops being relevant
-      // once #2449 lands and the key collapses to (userId, climbUuid).
-      if (board.angle == null) throw new Error('Cannot toggle favorite: active board has no angle.');
       const response = await getHttpClient().request<ToggleFavoriteMutationResponse>(TOGGLE_FAVORITE, {
-        input: { boardName: board.boardType, climbUuid, angle: board.angle },
+        input: { climbUuid },
       });
       return { uuid: climbUuid, favorited: response.toggleFavorite.favorited };
     },

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -208,9 +208,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     if (!climbActions) return;
     toggleFavoriteMutate({
       input: {
-        boardName: climbActions.boardConfig.boardName,
         climbUuid: climbActions.climb.uuid,
-        angle: climbActions.boardConfig.angle,
       },
     });
   }, [climbActions, toggleFavoriteMutate]);

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -637,12 +637,8 @@ input DeleteAccountInput {
 Input for toggling a climb as favorite.
 """
 input ToggleFavoriteInput {
-  "Board type"
-  boardName: String!
   "Climb UUID to favorite/unfavorite"
   climbUuid: String!
-  "Board angle"
-  angle: Int!
 }
 
 """
@@ -1399,16 +1395,6 @@ type Playlist {
   isFollowedByMe: Boolean!
   "Whether the current user has pinned this playlist (false when unauthenticated)"
   isPinnedByMe: Boolean!
-}
-
-"""
-Count of favorited climbs per board.
-"""
-type FavoritesCount {
-  "Board name"
-  boardName: String!
-  "Number of favorited climbs"
-  count: Int!
 }
 
 """
@@ -3614,19 +3600,7 @@ type Query {
   Check which climbs from a list are favorited by the current user.
   Returns array of favorited climb UUIDs.
   """
-  favorites(boardName: String!, climbUuids: [String!]!, angle: Int!): [String!]!
-
-  """
-  Get count of favorited climbs per board for the current user.
-  Requires authentication.
-  """
-  userFavoritesCounts: [FavoritesCount!]!
-
-  """
-  Get board names where the current user has playlists or favorites.
-  Requires authentication.
-  """
-  userActiveBoards: [String!]!
+  favorites(climbUuids: [String!]!): [String!]!
 
   """
   Get user's favorite climbs with full climb data.

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1128,15 +1128,6 @@ export type EventsReplayResponse = {
   events: Array<QueueEvent>;
 };
 
-/** Count of favorited climbs per board. */
-export type FavoritesCount = {
-  __typename?: 'FavoritesCount';
-  /** Board name */
-  boardName: Scalars['String']['output'];
-  /** Number of favorited climbs */
-  count: Scalars['Int']['output'];
-};
-
 /**
  * Free-form debug context attached to a feedback submission. Stored as jsonb.
  * Every field is optional — anonymous submissions made outside a board route
@@ -3231,11 +3222,6 @@ export type Query = {
   /** Get unread notification count for the current user. */
   unreadNotificationCount: Scalars['Int']['output'];
   /**
-   * Get board names where the current user has playlists or favorites.
-   * Requires authentication.
-   */
-  userActiveBoards: Array<Scalars['String']['output']>;
-  /**
    * Get public ascent activity feed for a user.
    * Includes enriched climb data for display.
    */
@@ -3259,11 +3245,6 @@ export type Query = {
    * Requires authentication.
    */
   userFavoriteClimbs: PlaylistClimbsResult;
-  /**
-   * Get count of favorited climbs per board for the current user.
-   * Requires authentication.
-   */
-  userFavoritesCounts: Array<FavoritesCount>;
   /**
    * Get public ascent feed grouped by climb and day.
    * Useful for summary displays.
@@ -3414,8 +3395,6 @@ export type QueryEventsReplayArgs = {
 
 /** Root query type for all read operations. */
 export type QueryFavoritesArgs = {
-  angle: Scalars['Int']['input'];
-  boardName: Scalars['String']['input'];
   climbUuids: Array<Scalars['String']['input']>;
 };
 
@@ -4753,10 +4732,6 @@ export type TimePeriod = 'all' | 'day' | 'hour' | 'month' | 'week' | 'year';
 
 /** Input for toggling a climb as favorite. */
 export type ToggleFavoriteInput = {
-  /** Board angle */
-  angle: Scalars['Int']['input'];
-  /** Board type */
-  boardName: Scalars['String']['input'];
   /** Climb UUID to favorite/unfavorite */
   climbUuid: Scalars['String']['input'];
 };
@@ -5356,7 +5331,6 @@ export type ResolversTypes = ResolversObject<{
   EventsReplayResponse: ResolverTypeWrapper<
     Omit<EventsReplayResponse, 'events'> & { events: Array<ResolversTypes['QueueEvent']> }
   >;
-  FavoritesCount: ResolverTypeWrapper<FavoritesCount>;
   FeedbackContextInput: FeedbackContextInput;
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   FollowBoardInput: FollowBoardInput;
@@ -5614,7 +5588,6 @@ export type ResolversParentTypes = ResolversObject<{
   DiscoverableSession: DiscoverableSession;
   DriverChanged: DriverChanged;
   EventsReplayResponse: Omit<EventsReplayResponse, 'events'> & { events: Array<ResolversParentTypes['QueueEvent']> };
-  FavoritesCount: FavoritesCount;
   FeedbackContextInput: FeedbackContextInput;
   Float: Scalars['Float']['output'];
   FollowBoardInput: FollowBoardInput;
@@ -6345,15 +6318,6 @@ export type EventsReplayResponseResolvers<
 > = ResolversObject<{
   currentSequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   events?: Resolver<Array<ResolversTypes['QueueEvent']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type FavoritesCountResolvers<
-  ContextType = ConnectionContext,
-  ParentType extends ResolversParentTypes['FavoritesCount'] = ResolversParentTypes['FavoritesCount'],
-> = ResolversObject<{
-  boardName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -7586,7 +7550,7 @@ export type QueryResolvers<
     Array<ResolversTypes['String']>,
     ParentType,
     ContextType,
-    RequireFields<QueryFavoritesArgs, 'angle' | 'boardName' | 'climbUuids'>
+    RequireFields<QueryFavoritesArgs, 'climbUuids'>
   >;
   followers?: Resolver<
     ResolversTypes['FollowConnection'],
@@ -7845,7 +7809,6 @@ export type QueryResolvers<
     Partial<QueryTrendingFeedArgs>
   >;
   unreadNotificationCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  userActiveBoards?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   userAscentsFeed?: Resolver<
     ResolversTypes['AscentFeedResult'],
     ParentType,
@@ -7876,7 +7839,6 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QueryUserFavoriteClimbsArgs, 'input'>
   >;
-  userFavoritesCounts?: Resolver<Array<ResolversTypes['FavoritesCount']>, ParentType, ContextType>;
   userGroupedAscentsFeed?: Resolver<
     ResolversTypes['GroupedAscentFeedResult'],
     ParentType,
@@ -8728,7 +8690,6 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   DiscoverableSession?: DiscoverableSessionResolvers<ContextType>;
   DriverChanged?: DriverChangedResolvers<ContextType>;
   EventsReplayResponse?: EventsReplayResponseResolvers<ContextType>;
-  FavoritesCount?: FavoritesCountResolvers<ContextType>;
   FollowConnection?: FollowConnectionResolvers<ContextType>;
   FollowingAscentFeedItem?: FollowingAscentFeedItemResolvers<ContextType>;
   FollowingAscentsFeedResult?: FollowingAscentsFeedResultResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/favorites.ts
+++ b/packages/shared-schema/src/schema/favorites.ts
@@ -7,12 +7,8 @@ export const favoritesTypeDefs = /* GraphQL */ `
   Input for toggling a climb as favorite.
   """
   input ToggleFavoriteInput {
-    "Board type"
-    boardName: String!
     "Climb UUID to favorite/unfavorite"
     climbUuid: String!
-    "Board angle"
-    angle: Int!
   }
 
   """

--- a/packages/shared-schema/src/schema/playlists.ts
+++ b/packages/shared-schema/src/schema/playlists.ts
@@ -44,16 +44,6 @@ export const playlistsTypeDefs = /* GraphQL */ `
   }
 
   """
-  Count of favorited climbs per board.
-  """
-  type FavoritesCount {
-    "Board name"
-    boardName: String!
-    "Number of favorited climbs"
-    count: Int!
-  }
-
-  """
   A climb within a playlist.
   """
   type PlaylistClimb {

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -129,19 +129,7 @@ export const queriesTypeDefs = /* GraphQL */ `
     Check which climbs from a list are favorited by the current user.
     Returns array of favorited climb UUIDs.
     """
-    favorites(boardName: String!, climbUuids: [String!]!, angle: Int!): [String!]!
-
-    """
-    Get count of favorited climbs per board for the current user.
-    Requires authentication.
-    """
-    userFavoritesCounts: [FavoritesCount!]!
-
-    """
-    Get board names where the current user has playlists or favorites.
-    Requires authentication.
-    """
-    userActiveBoards: [String!]!
+    favorites(climbUuids: [String!]!): [String!]!
 
     """
     Get user's favorite climbs with full climb data.

--- a/packages/shared-schema/src/types/favorites.ts
+++ b/packages/shared-schema/src/types/favorites.ts
@@ -1,9 +1,7 @@
 // Favorites types
 
 export type ToggleFavoriteInput = {
-  boardName: string;
   climbUuid: string;
-  angle: number;
 };
 
 export type ToggleFavoriteResult = {

--- a/packages/shared/graphql/src/generated/gql.ts
+++ b/packages/shared/graphql/src/generated/gql.ts
@@ -30,10 +30,8 @@ type Documents = {
   '\n  mutation DeleteComment($commentUuid: ID!) {\n    deleteComment(commentUuid: $commentUuid)\n  }\n': typeof types.DeleteCommentDocument;
   '\n  mutation Vote($input: VoteInput!) {\n    vote(input: $input) {\n      entityType\n      entityId\n      upvotes\n      downvotes\n      voteScore\n      userVote\n    }\n  }\n': typeof types.VoteDocument;
   '\n  mutation CreateSession($input: CreateSessionInput!) {\n    createSession(input: $input) {\n      id\n      name\n      boardPath\n      goal\n      isPublic\n      isPermanent\n      color\n      startedAt\n    }\n  }\n': typeof types.CreateSessionDocument;
-  '\n  query Favorites($boardName: String!, $climbUuids: [String!]!, $angle: Int!) {\n    favorites(boardName: $boardName, climbUuids: $climbUuids, angle: $angle)\n  }\n': typeof types.FavoritesDocument;
+  '\n  query Favorites($climbUuids: [String!]!) {\n    favorites(climbUuids: $climbUuids)\n  }\n': typeof types.FavoritesDocument;
   '\n  mutation ToggleFavorite($input: ToggleFavoriteInput!) {\n    toggleFavorite(input: $input) {\n      favorited\n    }\n  }\n': typeof types.ToggleFavoriteDocument;
-  '\n  query UserFavoritesCounts {\n    userFavoritesCounts {\n      boardName\n      count\n    }\n  }\n': typeof types.UserFavoritesCountsDocument;
-  '\n  query UserActiveBoards {\n    userActiveBoards\n  }\n': typeof types.UserActiveBoardsDocument;
   '\n  query GetUserFavoriteClimbs($input: GetUserFavoriteClimbsInput!) {\n    userFavoriteClimbs(input: $input) {\n      climbs {\n        uuid\n        layoutId\n        setter_username\n        name\n        description\n        frames\n        angle\n        ascensionist_count\n        difficulty\n        quality_average\n        stars\n        difficulty_error\n        benchmark_difficulty\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.GetUserFavoriteClimbsDocument;
   '\n  mutation SubmitAppFeedback($input: SubmitAppFeedbackInput!) {\n    submitAppFeedback(input: $input)\n  }\n': typeof types.SubmitAppFeedbackDocument;
   '\n  query GetNewClimbFeed($input: NewClimbFeedInput!) {\n    newClimbFeed(input: $input) {\n      items {\n        uuid\n        name\n        boardType\n        layoutId\n        setterDisplayName\n        setterAvatarUrl\n        angle\n        frames\n        difficultyName\n        isNoMatch\n        createdAt\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.GetNewClimbFeedDocument;
@@ -155,13 +153,10 @@ const documents: Documents = {
     types.VoteDocument,
   '\n  mutation CreateSession($input: CreateSessionInput!) {\n    createSession(input: $input) {\n      id\n      name\n      boardPath\n      goal\n      isPublic\n      isPermanent\n      color\n      startedAt\n    }\n  }\n':
     types.CreateSessionDocument,
-  '\n  query Favorites($boardName: String!, $climbUuids: [String!]!, $angle: Int!) {\n    favorites(boardName: $boardName, climbUuids: $climbUuids, angle: $angle)\n  }\n':
+  '\n  query Favorites($climbUuids: [String!]!) {\n    favorites(climbUuids: $climbUuids)\n  }\n':
     types.FavoritesDocument,
   '\n  mutation ToggleFavorite($input: ToggleFavoriteInput!) {\n    toggleFavorite(input: $input) {\n      favorited\n    }\n  }\n':
     types.ToggleFavoriteDocument,
-  '\n  query UserFavoritesCounts {\n    userFavoritesCounts {\n      boardName\n      count\n    }\n  }\n':
-    types.UserFavoritesCountsDocument,
-  '\n  query UserActiveBoards {\n    userActiveBoards\n  }\n': types.UserActiveBoardsDocument,
   '\n  query GetUserFavoriteClimbs($input: GetUserFavoriteClimbsInput!) {\n    userFavoriteClimbs(input: $input) {\n      climbs {\n        uuid\n        layoutId\n        setter_username\n        name\n        description\n        frames\n        angle\n        ascensionist_count\n        difficulty\n        quality_average\n        stars\n        difficulty_error\n        benchmark_difficulty\n      }\n      totalCount\n      hasMore\n    }\n  }\n':
     types.GetUserFavoriteClimbsDocument,
   '\n  mutation SubmitAppFeedback($input: SubmitAppFeedbackInput!) {\n    submitAppFeedback(input: $input)\n  }\n':
@@ -448,26 +443,14 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  query Favorites($boardName: String!, $climbUuids: [String!]!, $angle: Int!) {\n    favorites(boardName: $boardName, climbUuids: $climbUuids, angle: $angle)\n  }\n',
-): (typeof documents)['\n  query Favorites($boardName: String!, $climbUuids: [String!]!, $angle: Int!) {\n    favorites(boardName: $boardName, climbUuids: $climbUuids, angle: $angle)\n  }\n'];
+  source: '\n  query Favorites($climbUuids: [String!]!) {\n    favorites(climbUuids: $climbUuids)\n  }\n',
+): (typeof documents)['\n  query Favorites($climbUuids: [String!]!) {\n    favorites(climbUuids: $climbUuids)\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
   source: '\n  mutation ToggleFavorite($input: ToggleFavoriteInput!) {\n    toggleFavorite(input: $input) {\n      favorited\n    }\n  }\n',
 ): (typeof documents)['\n  mutation ToggleFavorite($input: ToggleFavoriteInput!) {\n    toggleFavorite(input: $input) {\n      favorited\n    }\n  }\n'];
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(
-  source: '\n  query UserFavoritesCounts {\n    userFavoritesCounts {\n      boardName\n      count\n    }\n  }\n',
-): (typeof documents)['\n  query UserFavoritesCounts {\n    userFavoritesCounts {\n      boardName\n      count\n    }\n  }\n'];
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(
-  source: '\n  query UserActiveBoards {\n    userActiveBoards\n  }\n',
-): (typeof documents)['\n  query UserActiveBoards {\n    userActiveBoards\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1125,15 +1125,6 @@ export type EventsReplayResponse = {
   events: Array<QueueEvent>;
 };
 
-/** Count of favorited climbs per board. */
-export type FavoritesCount = {
-  __typename?: 'FavoritesCount';
-  /** Board name */
-  boardName: Scalars['String']['output'];
-  /** Number of favorited climbs */
-  count: Scalars['Int']['output'];
-};
-
 /**
  * Free-form debug context attached to a feedback submission. Stored as jsonb.
  * Every field is optional — anonymous submissions made outside a board route
@@ -3228,11 +3219,6 @@ export type Query = {
   /** Get unread notification count for the current user. */
   unreadNotificationCount: Scalars['Int']['output'];
   /**
-   * Get board names where the current user has playlists or favorites.
-   * Requires authentication.
-   */
-  userActiveBoards: Array<Scalars['String']['output']>;
-  /**
    * Get public ascent activity feed for a user.
    * Includes enriched climb data for display.
    */
@@ -3256,11 +3242,6 @@ export type Query = {
    * Requires authentication.
    */
   userFavoriteClimbs: PlaylistClimbsResult;
-  /**
-   * Get count of favorited climbs per board for the current user.
-   * Requires authentication.
-   */
-  userFavoritesCounts: Array<FavoritesCount>;
   /**
    * Get public ascent feed grouped by climb and day.
    * Useful for summary displays.
@@ -3411,8 +3392,6 @@ export type QueryEventsReplayArgs = {
 
 /** Root query type for all read operations. */
 export type QueryFavoritesArgs = {
-  angle: Scalars['Int']['input'];
-  boardName: Scalars['String']['input'];
   climbUuids: Array<Scalars['String']['input']>;
 };
 
@@ -4750,10 +4729,6 @@ export type TimePeriod = 'all' | 'day' | 'hour' | 'month' | 'week' | 'year';
 
 /** Input for toggling a climb as favorite. */
 export type ToggleFavoriteInput = {
-  /** Board angle */
-  angle: Scalars['Int']['input'];
-  /** Board type */
-  boardName: Scalars['String']['input'];
   /** Climb UUID to favorite/unfavorite */
   climbUuid: Scalars['String']['input'];
 };
@@ -5485,9 +5460,7 @@ export type CreateSessionMutation = {
 };
 
 export type FavoritesQueryVariables = Exact<{
-  boardName: Scalars['String']['input'];
   climbUuids: Array<Scalars['String']['input']> | Scalars['String']['input'];
-  angle: Scalars['Int']['input'];
 }>;
 
 export type FavoritesQuery = { __typename?: 'Query'; favorites: Array<string> };
@@ -5500,17 +5473,6 @@ export type ToggleFavoriteMutation = {
   __typename?: 'Mutation';
   toggleFavorite: { __typename?: 'ToggleFavoriteResult'; favorited: boolean };
 };
-
-export type UserFavoritesCountsQueryVariables = Exact<{ [key: string]: never }>;
-
-export type UserFavoritesCountsQuery = {
-  __typename?: 'Query';
-  userFavoritesCounts: Array<{ __typename?: 'FavoritesCount'; boardName: string; count: number }>;
-};
-
-export type UserActiveBoardsQueryVariables = Exact<{ [key: string]: never }>;
-
-export type UserActiveBoardsQuery = { __typename?: 'Query'; userActiveBoards: Array<string> };
 
 export type GetUserFavoriteClimbsQueryVariables = Exact<{
   input: GetUserFavoriteClimbsInput;
@@ -8164,11 +8126,6 @@ export const FavoritesDocument = {
       variableDefinitions: [
         {
           kind: 'VariableDefinition',
-          variable: { kind: 'Variable', name: { kind: 'Name', value: 'boardName' } },
-          type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } } },
-        },
-        {
-          kind: 'VariableDefinition',
           variable: { kind: 'Variable', name: { kind: 'Name', value: 'climbUuids' } },
           type: {
             kind: 'NonNullType',
@@ -8177,11 +8134,6 @@ export const FavoritesDocument = {
               type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } } },
             },
           },
-        },
-        {
-          kind: 'VariableDefinition',
-          variable: { kind: 'Variable', name: { kind: 'Name', value: 'angle' } },
-          type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } } },
         },
       ],
       selectionSet: {
@@ -8193,18 +8145,8 @@ export const FavoritesDocument = {
             arguments: [
               {
                 kind: 'Argument',
-                name: { kind: 'Name', value: 'boardName' },
-                value: { kind: 'Variable', name: { kind: 'Name', value: 'boardName' } },
-              },
-              {
-                kind: 'Argument',
                 name: { kind: 'Name', value: 'climbUuids' },
                 value: { kind: 'Variable', name: { kind: 'Name', value: 'climbUuids' } },
-              },
-              {
-                kind: 'Argument',
-                name: { kind: 'Name', value: 'angle' },
-                value: { kind: 'Variable', name: { kind: 'Name', value: 'angle' } },
               },
             ],
           },
@@ -8253,46 +8195,6 @@ export const ToggleFavoriteDocument = {
     },
   ],
 } as unknown as DocumentNode<ToggleFavoriteMutation, ToggleFavoriteMutationVariables>;
-export const UserFavoritesCountsDocument = {
-  kind: 'Document',
-  definitions: [
-    {
-      kind: 'OperationDefinition',
-      operation: 'query',
-      name: { kind: 'Name', value: 'UserFavoritesCounts' },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'userFavoritesCounts' },
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                { kind: 'Field', name: { kind: 'Name', value: 'boardName' } },
-                { kind: 'Field', name: { kind: 'Name', value: 'count' } },
-              ],
-            },
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<UserFavoritesCountsQuery, UserFavoritesCountsQueryVariables>;
-export const UserActiveBoardsDocument = {
-  kind: 'Document',
-  definitions: [
-    {
-      kind: 'OperationDefinition',
-      operation: 'query',
-      name: { kind: 'Name', value: 'UserActiveBoards' },
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [{ kind: 'Field', name: { kind: 'Name', value: 'userActiveBoards' } }],
-      },
-    },
-  ],
-} as unknown as DocumentNode<UserActiveBoardsQuery, UserActiveBoardsQueryVariables>;
 export const GetUserFavoriteClimbsDocument = {
   kind: 'Document',
   definitions: [

--- a/packages/shared/graphql/src/operations/favorites.ts
+++ b/packages/shared/graphql/src/operations/favorites.ts
@@ -1,8 +1,8 @@
 import { gql } from 'graphql-request';
 
 export const GET_FAVORITES = gql`
-  query Favorites($boardName: String!, $climbUuids: [String!]!, $angle: Int!) {
-    favorites(boardName: $boardName, climbUuids: $climbUuids, angle: $angle)
+  query Favorites($climbUuids: [String!]!) {
+    favorites(climbUuids: $climbUuids)
   }
 `;
 
@@ -14,65 +14,26 @@ export const TOGGLE_FAVORITE = gql`
   }
 `;
 
-// Type for the favorites query variables
 export type FavoritesQueryVariables = {
-  boardName: string;
   climbUuids: string[];
-  angle: number;
 };
 
-// Type for the favorites query response
 export type FavoritesQueryResponse = {
   favorites: string[];
 };
 
-// Type for the toggle favorite mutation variables
 export type ToggleFavoriteMutationVariables = {
   input: {
-    boardName: string;
     climbUuid: string;
-    angle: number;
   };
 };
 
-// Type for the toggle favorite mutation response
 export type ToggleFavoriteMutationResponse = {
   toggleFavorite: {
     favorited: boolean;
   };
 };
 
-// Get user favorites counts per board
-export const GET_USER_FAVORITES_COUNTS = gql`
-  query UserFavoritesCounts {
-    userFavoritesCounts {
-      boardName
-      count
-    }
-  }
-`;
-
-export type FavoritesCount = {
-  boardName: string;
-  count: number;
-};
-
-export type UserFavoritesCountsQueryResponse = {
-  userFavoritesCounts: FavoritesCount[];
-};
-
-// Get active boards for the current user
-export const GET_USER_ACTIVE_BOARDS = gql`
-  query UserActiveBoards {
-    userActiveBoards
-  }
-`;
-
-export type UserActiveBoardsQueryResponse = {
-  userActiveBoards: string[];
-};
-
-// Get user's favorite climbs with full data
 export const GET_USER_FAVORITE_CLIMBS = gql`
   query GetUserFavoriteClimbs($input: GetUserFavoriteClimbsInput!) {
     userFavoriteClimbs(input: $input) {

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/liked/liked-climbs-list.tsx
@@ -228,7 +228,9 @@ export default function LikedClimbsList({ boardDetails, angle }: LikedClimbsList
     }
   }, [error, showMessage]);
 
-  // Show all liked climbs regardless of layout (unlike playlists, favorites span all layouts)
+  // Favorites are stored per-climb (board-agnostic), but this page is rendered
+  // for a specific board+layout — the resolver joins boardClimbs to scope the
+  // list to climbs that exist on this board. Angle is stamped on for rendering.
   const visibleClimbs: Climb[] = useMemo(() => {
     return allClimbs.map((climb) => ({ ...climb, angle }));
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/web/app/api/internal/favorites/route.ts
+++ b/packages/web/app/api/internal/favorites/route.ts
@@ -14,7 +14,9 @@ const favoriteSchema = z
 
 const checkFavoriteSchema = z
   .object({
-    climbUuids: z.array(z.string().min(1)).min(1),
+    // Cap matches packages/backend/src/validation/schemas/favorites.ts so a
+    // caller can't trigger an unbounded inArray() query against the DB.
+    climbUuids: z.array(z.string().min(1)).min(1).max(500),
   })
   .strict();
 

--- a/packages/web/app/api/internal/favorites/route.ts
+++ b/packages/web/app/api/internal/favorites/route.ts
@@ -14,9 +14,10 @@ const favoriteSchema = z
 
 const checkFavoriteSchema = z
   .object({
-    // Cap matches packages/backend/src/validation/schemas/favorites.ts so a
-    // caller can't trigger an unbounded inArray() query against the DB.
-    climbUuids: z.array(z.string().min(1)).min(1).max(500),
+    // Cap matches the backend's FavoritesQueryClimbUuidsSchema so a caller
+    // can't trigger an unbounded inArray() query. No .min() — an empty
+    // array is a valid no-op that returns { favorites: [] }.
+    climbUuids: z.array(z.string().min(1)).max(500),
   })
   .strict();
 

--- a/packages/web/app/api/internal/favorites/route.ts
+++ b/packages/web/app/api/internal/favorites/route.ts
@@ -6,13 +6,17 @@ import { eq, and, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { authOptions } from '@/app/lib/auth/auth-options';
 
-const favoriteSchema = z.object({
-  climbUuid: z.string().min(1),
-});
+const favoriteSchema = z
+  .object({
+    climbUuid: z.string().min(1),
+  })
+  .strict();
 
-const checkFavoriteSchema = z.object({
-  climbUuids: z.array(z.string().min(1)).min(1),
-});
+const checkFavoriteSchema = z
+  .object({
+    climbUuids: z.array(z.string().min(1)).min(1),
+  })
+  .strict();
 
 export async function POST(request: NextRequest) {
   try {

--- a/packages/web/app/api/internal/favorites/route.ts
+++ b/packages/web/app/api/internal/favorites/route.ts
@@ -86,7 +86,10 @@ export async function GET(request: NextRequest) {
       .select({ climbUuid: schema.userFavorites.climbUuid })
       .from(schema.userFavorites)
       .where(
-        and(eq(schema.userFavorites.userId, session.user.id), inArray(schema.userFavorites.climbUuid, climbUuids)),
+        and(
+          eq(schema.userFavorites.userId, session.user.id),
+          inArray(schema.userFavorites.climbUuid, validationResult.data.climbUuids),
+        ),
       );
 
     return NextResponse.json({ favorites: favorites.map((f) => f.climbUuid) });

--- a/packages/web/app/api/internal/favorites/route.ts
+++ b/packages/web/app/api/internal/favorites/route.ts
@@ -2,23 +2,18 @@ import { getServerSession } from 'next-auth/next';
 import { type NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { authOptions } from '@/app/lib/auth/auth-options';
 
 const favoriteSchema = z.object({
-  boardName: z.enum(['kilter', 'tension', 'moonboard', 'soill']),
   climbUuid: z.string().min(1),
-  angle: z.number().int(),
 });
 
 const checkFavoriteSchema = z.object({
-  boardName: z.enum(['kilter', 'tension', 'moonboard', 'soill']),
-  climbUuids: z.array(z.string().min(1)),
-  angle: z.number().int(),
+  climbUuids: z.array(z.string().min(1)).min(1),
 });
 
-// POST: Toggle favorite (add or remove)
 export async function POST(request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
@@ -34,83 +29,46 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
     }
 
-    const { boardName, climbUuid, angle } = validationResult.data;
+    const { climbUuid } = validationResult.data;
     const db = getDb();
+    const where = and(eq(schema.userFavorites.userId, session.user.id), eq(schema.userFavorites.climbUuid, climbUuid));
 
-    // Check if favorite already exists
-    const existing = await db
-      .select()
-      .from(schema.userFavorites)
-      .where(
-        and(
-          eq(schema.userFavorites.userId, session.user.id),
-          eq(schema.userFavorites.boardName, boardName),
-          eq(schema.userFavorites.climbUuid, climbUuid),
-          eq(schema.userFavorites.angle, angle),
-        ),
-      )
-      .limit(1);
+    const existing = await db.select().from(schema.userFavorites).where(where).limit(1);
 
     if (existing.length > 0) {
-      // Remove favorite
-      await db
-        .delete(schema.userFavorites)
-        .where(
-          and(
-            eq(schema.userFavorites.userId, session.user.id),
-            eq(schema.userFavorites.boardName, boardName),
-            eq(schema.userFavorites.climbUuid, climbUuid),
-            eq(schema.userFavorites.angle, angle),
-          ),
-        );
+      await db.delete(schema.userFavorites).where(where);
       return NextResponse.json({ favorited: false });
-    } else {
-      // Add favorite
-      await db.insert(schema.userFavorites).values({
-        userId: session.user.id,
-        boardName,
-        climbUuid,
-        angle,
-      });
-      return NextResponse.json({ favorited: true });
     }
+
+    await db.insert(schema.userFavorites).values({
+      userId: session.user.id,
+      climbUuid,
+    });
+    return NextResponse.json({ favorited: true });
   } catch (error) {
     console.error('Failed to toggle favorite:', error);
     return NextResponse.json({ error: 'Failed to toggle favorite' }, { status: 500 });
   }
 }
 
-// GET: Check if climbs are favorited (batch check)
 export async function GET(request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
 
     if (!session?.user?.id) {
-      // Return empty favorites for non-authenticated users
       return NextResponse.json({ favorites: [] });
     }
 
     const { searchParams } = new URL(request.url);
-    const boardName = searchParams.get('boardName');
     const climbUuidsParam = searchParams.get('climbUuids');
-    const angleParam = searchParams.get('angle');
 
-    if (!boardName || !climbUuidsParam || !angleParam) {
+    if (!climbUuidsParam) {
       return NextResponse.json({ error: 'Missing required parameters' }, { status: 400 });
     }
 
     const climbUuids = climbUuidsParam.split(',');
-    const angle = parseInt(angleParam, 10);
 
-    if (isNaN(angle)) {
-      return NextResponse.json({ error: 'Invalid angle parameter' }, { status: 400 });
-    }
-
-    const validationResult = checkFavoriteSchema.safeParse({
-      boardName,
-      climbUuids,
-      angle,
-    });
+    const validationResult = checkFavoriteSchema.safeParse({ climbUuids });
 
     if (!validationResult.success) {
       return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
@@ -118,22 +76,14 @@ export async function GET(request: NextRequest) {
 
     const db = getDb();
 
-    // Get all favorites for the user matching the given climbs
     const favorites = await db
       .select({ climbUuid: schema.userFavorites.climbUuid })
       .from(schema.userFavorites)
       .where(
-        and(
-          eq(schema.userFavorites.userId, session.user.id),
-          eq(schema.userFavorites.boardName, boardName),
-          eq(schema.userFavorites.angle, angle),
-        ),
+        and(eq(schema.userFavorites.userId, session.user.id), inArray(schema.userFavorites.climbUuid, climbUuids)),
       );
 
-    // Filter to only the requested climb UUIDs
-    const favoritedUuids = favorites.map((f) => f.climbUuid).filter((uuid) => climbUuids.includes(uuid));
-
-    return NextResponse.json({ favorites: favoritedUuids });
+    return NextResponse.json({ favorites: favorites.map((f) => f.climbUuid) });
   } catch (error) {
     console.error('Failed to check favorites:', error);
     return NextResponse.json({ error: 'Failed to check favorites' }, { status: 500 });

--- a/packages/web/app/components/climb-actions/actions/favorite-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/favorite-action.tsx
@@ -47,6 +47,8 @@ export function FavoriteAction({
     } catch {
       // Silently fail
     }
+    // boardDetails.board_name stays in the dep list — it's no longer sent
+    // to the favorites endpoint but is still emitted in the analytics event.
   }, [boardDetails.board_name, climb.uuid]);
 
   const handleClick = useCallback(

--- a/packages/web/app/components/climb-actions/actions/favorite-action.tsx
+++ b/packages/web/app/components/climb-actions/actions/favorite-action.tsx
@@ -35,11 +35,7 @@ export function FavoriteAction({
       const response = await fetch('/api/internal/favorites', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          boardName: boardDetails.board_name,
-          climbUuid: climb.uuid,
-          angle,
-        }),
+        body: JSON.stringify({ climbUuid: climb.uuid }),
       });
       if (response.ok) {
         track('Favorite Toggle', {
@@ -51,7 +47,7 @@ export function FavoriteAction({
     } catch {
       // Silently fail
     }
-  }, [boardDetails.board_name, climb.uuid, angle]);
+  }, [boardDetails.board_name, climb.uuid]);
 
   const handleClick = useCallback(
     async (e?: React.MouseEvent) => {

--- a/packages/web/app/components/climb-actions/favorite-button.tsx
+++ b/packages/web/app/components/climb-actions/favorite-button.tsx
@@ -13,6 +13,8 @@ import { themeTokens } from '@/app/theme/theme-config';
 import { useTranslation } from 'react-i18next';
 
 type FavoriteButtonProps = {
+  // Analytics dimension only — the favorite itself is board-agnostic post-#2449.
+  // Kept required so the track() call always has a board to attribute to.
   boardName: BoardName;
   climbUuid: string;
   climbName?: string;

--- a/packages/web/app/components/climb-actions/favorite-button.tsx
+++ b/packages/web/app/components/climb-actions/favorite-button.tsx
@@ -16,7 +16,6 @@ type FavoriteButtonProps = {
   boardName: BoardName;
   climbUuid: string;
   climbName?: string;
-  angle: number;
   className?: string;
   showLabel?: boolean;
   size?: 'small' | 'default';
@@ -26,7 +25,6 @@ export default function FavoriteButton({
   boardName,
   climbUuid,
   climbName,
-  angle,
   className,
   showLabel = false,
   size = 'default',
@@ -73,11 +71,7 @@ export default function FavoriteButton({
       const response = await fetch('/api/internal/favorites', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          boardName,
-          climbUuid,
-          angle,
-        }),
+        body: JSON.stringify({ climbUuid }),
       });
       if (response.ok) {
         track('Favorite Toggle', {

--- a/packages/web/app/components/climb-actions/favorite-button.tsx
+++ b/packages/web/app/components/climb-actions/favorite-button.tsx
@@ -13,7 +13,7 @@ import { themeTokens } from '@/app/theme/theme-config';
 import { useTranslation } from 'react-i18next';
 
 type FavoriteButtonProps = {
-  // Analytics dimension only — the favorite itself is board-agnostic post-#2449.
+  // Analytics dimension only — the favorite itself is board-agnostic.
   // Kept required so the track() call always has a board to attribute to.
   boardName: BoardName;
   climbUuid: string;

--- a/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
+++ b/packages/web/app/hooks/__tests__/use-climb-actions-data.test.tsx
@@ -144,6 +144,12 @@ describe('useClimbActionsData', () => {
     });
 
     expect(toggleResult).toBe(true);
+    // Regression guard for #2449: the mutation payload must be { climbUuid }
+    // only — no boardName / angle leaking back in. The backend resolver test
+    // covers the server side; this covers the wire shape from the web client.
+    expect(mockRequest).toHaveBeenCalledWith('TOGGLE_FAVORITE', {
+      input: { climbUuid: 'climb-1' },
+    });
   });
 
   it('optimistic update: adds uuid on toggle', async () => {

--- a/packages/web/app/hooks/use-climb-actions-data.tsx
+++ b/packages/web/app/hooks/use-climb-actions-data.tsx
@@ -68,25 +68,23 @@ export function useClimbActionsData({ boardName, layoutId, angle, climbUuids }: 
 
   // === Favorites (incremental) ===
 
-  const favAccKey = useMemo(() => ['favorites', boardName, angle, 'accumulated'] as const, [boardName, angle]);
-  const favFetchKeyPrefix = useMemo(() => ['favorites', boardName, angle, 'fetch'] as const, [boardName, angle]);
+  const favAccKey = useMemo(() => ['favorites', 'accumulated'] as const, []);
+  const favFetchKeyPrefix = useMemo(() => ['favorites', 'fetch'] as const, []);
 
   const favFetchChunk = useCallback(
     async (uuids: string[]): Promise<Set<string>> => {
       const client = createGraphQLHttpClient(token);
       try {
         const result = await client.request<FavoritesQueryResponse>(GET_FAVORITES, {
-          boardName,
           climbUuids: uuids,
-          angle,
         });
         return new Set(result.favorites);
       } catch (error) {
-        console.error(`[GraphQL] Favorites query error for ${boardName} (${uuids.length} uuids):`, error);
+        console.error(`[GraphQL] Favorites query error (${uuids.length} uuids):`, error);
         throw error;
       }
     },
-    [token, boardName, angle],
+    [token],
   );
 
   const {
@@ -96,20 +94,19 @@ export function useClimbActionsData({ boardName, layoutId, angle, climbUuids }: 
   } = useIncrementalQuery<Set<string>>(climbUuids, {
     accumulatedKey: favAccKey,
     fetchKeyPrefix: favFetchKeyPrefix,
-    enabled: isAuthenticated && !isAuthLoading && !!boardName,
+    enabled: isAuthenticated && !isAuthLoading,
     fetchChunk: favFetchChunk,
     merge: mergeSetFn,
     initialValue: EMPTY_SET,
     hasChanged: hasSetSizeChanged,
   });
 
-  // Toggle favorite mutation — targets the accumulated cache key
   const toggleFavoriteMutation = useMutation({
-    mutationKey: ['toggleFavorite', boardName, angle],
+    mutationKey: ['toggleFavorite'],
     mutationFn: async (climbUuid: string): Promise<{ uuid: string; favorited: boolean }> => {
       const client = createGraphQLHttpClient(token);
       const result = await client.request<ToggleFavoriteMutationResponse>(TOGGLE_FAVORITE, {
-        input: { boardName, climbUuid, angle },
+        input: { climbUuid },
       });
       return { uuid: climbUuid, favorited: result.toggleFavorite.favorited };
     },


### PR DESCRIPTION
Fixes #2449.

## Summary
- Favorites are now keyed by `(userId, climbUuid)`, not `(userId, boardName, climbUuid, angle)`. A climb is a climb regardless of the board or angle it's sent at.
- Schema migration `0109_boring_lyja` dedupes existing rows by `(user_id, climb_uuid)` keeping the most recent (`max(created_at)` with `id` tiebreak), then drops `board_name` + `angle` and adds the new unique index.
- GraphQL `ToggleFavoriteInput` → `{ climbUuid }`. `favorites(climbUuids)` drops the board/angle args. Unused `userFavoritesCounts` + `userActiveBoards` queries (no UI callers found) are deleted along with the `FavoritesCount` type.
- Backend resolvers (`toggleFavorite`, `favorites`, `userFavoriteClimbs`, smart-playlists `LIKED_CLIMBS`) all switch to UUID-only matching. Board scoping in `userFavoriteClimbs` and smart-playlists is preserved by joining the unified `boardClimbs` table — so each `/liked` page still only shows climbs that belong to that board.
- User data export (`buildUserAuroraJsonExport`) keeps per-board scoping via the same `boardClimbs` join.
- Web `useClimbActionsData`: cache key collapses to `['favorites', 'accumulated']`. `/api/internal/favorites` POST + GET drop board/angle from the schema and query.
- Mobile: drops the default-board workaround in `useMobileClimbActionsData.toggleFavorite` (the comment that referenced #2449 is gone). `useDoubleTapFavorite`, `drawer-host-provider`, `PlayDrawer`, and `app/(tabs)/climbs/[climbUuid]` no longer pass `boardName`/`angle` to the mutation.

Second commit is a `vp check --fix` sweep that picked up pre-existing formatting drift in unrelated docs/mobile files — kept separate to keep the favorites diff focused.

## Test plan
- [x] `vp run typecheck` (web + mobile + backend + db)
- [x] `vp check` — 0 errors
- [x] `vp test run --reporter=agent` — 7359 passed (backend/web/mobile/shared/db)
- [ ] Migration applied against the dev DB (couldn't bring `boardsesh-dev-db` up locally in this session; SQL inspected — dedupe + drop columns + add unique are straightforward Postgres DDL/DML). QA checklist in `.boardsesh/qa-notes.md`.
- [ ] Manual QA per `.boardsesh/qa-notes.md`: favorite on board A, switch board/angle, heart persists; `/kilter/.../liked` and `/tension/.../liked` each show only their own board's climbs; network requests carry `climbUuid` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)