### PR TITLE
fix(mobile): You-page review follow-ups (worklet width, mutation race, contrast, tests)

### DIFF
--- a/packages/mobile/src/components/you/FeedSocialRow.tsx
+++ b/packages/mobile/src/components/you/FeedSocialRow.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
-import { useVote } from '../../lib/graphql/hooks';
+import { useOptimisticVote } from './use-optimistic-vote';
 import { hapticLight } from '../../lib/haptics';
 import { brandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
@@ -21,30 +20,12 @@ type FeedSocialRowProps = {
 /** Vote + comment row for a session feed card. */
 export function FeedSocialRow({ sessionId, upvotes, userVote, commentCount, onOpenComments }: FeedSocialRowProps) {
   const { systemColors } = useTheme();
-  const vote = useVote();
-
-  // Optimistic override layered over the server values. Null = show server
-  // state. Reset whenever the row is recycled onto a different session
-  // (FlashList reuses component instances), so one card's vote can't bleed
-  // onto another.
-  const [optimistic, setOptimistic] = useState<{ count: number; voted: boolean } | null>(null);
-  useEffect(() => setOptimistic(null), [sessionId]);
-
-  const voted = optimistic ? optimistic.voted : userVote === 1;
-  const count = optimistic ? optimistic.count : upvotes;
+  const { voted, count, toggle, isPending } = useOptimisticVote(sessionId, upvotes, userVote);
 
   const handleVote = () => {
-    if (vote.isPending) return; // guard double-tap
+    if (isPending) return; // guard double-tap (toggle no-ops too)
     hapticLight();
-    const nextVoted = !voted;
-    setOptimistic({ count: count + (nextVoted ? 1 : -1), voted: nextVoted });
-    vote.mutate(
-      { entityType: 'session', entityId: sessionId, value: nextVoted ? 1 : 0 },
-      {
-        onSuccess: (summary) => setOptimistic({ count: summary.upvotes, voted: summary.userVote === 1 }),
-        onError: () => setOptimistic(null),
-      },
-    );
+    toggle();
   };
 
   return (
@@ -52,7 +33,7 @@ export function FeedSocialRow({ sessionId, upvotes, userVote, commentCount, onOp
       <Pressable
         style={styles.button}
         onPress={handleVote}
-        disabled={vote.isPending}
+        disabled={isPending}
         accessibilityRole="button"
         accessibilityState={{ selected: voted }}
         hitSlop={6}

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -35,6 +35,12 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
   const { showToast } = useToast();
   const updateTick = useUpdateTick();
   const deleteTick = useDeleteTick();
+  // Save and delete hit the same tick UUID — never let one fire while the other
+  // is in flight, or a concurrent edit+delete can corrupt the row. Both controls
+  // disable (and both handlers bail) whenever either mutation is pending. The
+  // delete also goes through a modal Alert, which blocks the save button behind
+  // it, so this closes the window completely.
+  const isMutating = updateTick.isPending || deleteTick.isPending;
   const gradesQuery = useGrades(ascent?.boardType ?? '', !!ascent);
   const grades = gradesQuery.data ?? [];
 
@@ -64,7 +70,7 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
   );
 
   const save = () => {
-    if (!ascent) return;
+    if (!ascent || isMutating) return;
     updateTick.mutate(
       {
         uuid: ascent.uuid,
@@ -84,7 +90,7 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
   };
 
   const confirmDelete = () => {
-    if (!ascent) return;
+    if (!ascent || isMutating) return;
     Alert.alert(t('mobile.logbook.deleteTitle'), t('mobile.logbook.deleteConfirm'), [
       { text: t('mobile.cancel'), style: 'cancel' },
       {
@@ -113,7 +119,9 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
       keyboardBehavior="interactive"
       keyboardBlurBehavior="restore"
       android_keyboardInputMode="adjustResize"
-      footer={<Button title={t('mobile.logbook.save')} onPress={save} loading={updateTick.isPending} />}
+      footer={
+        <Button title={t('mobile.logbook.save')} onPress={save} loading={updateTick.isPending} disabled={isMutating} />
+      }
     >
       <Text variant="title3" numberOfLines={1} style={styles.title}>
         {ascent?.climbName ?? t('mobile.logbook.editTitle')}
@@ -184,7 +192,12 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
         />
       </View>
 
-      <Pressable onPress={confirmDelete} style={styles.deleteRow} accessibilityRole="button">
+      <Pressable
+        onPress={confirmDelete}
+        disabled={isMutating}
+        style={[styles.deleteRow, isMutating && styles.deleteRowDisabled]}
+        accessibilityRole="button"
+      >
         <Icon name="delete" size={18} color={brandColors.error} />
         <Text variant="body" color={brandColors.error}>
           {t('mobile.logbook.delete')}
@@ -224,5 +237,8 @@ const styles = StyleSheet.create({
     gap: spacing[2],
     marginTop: spacing[6],
     paddingVertical: spacing[3],
+  },
+  deleteRowDisabled: {
+    opacity: 0.4,
   },
 });

--- a/packages/mobile/src/components/you/StatsSummaryCard.tsx
+++ b/packages/mobile/src/components/you/StatsSummaryCard.tsx
@@ -68,7 +68,6 @@ export function StatsSummaryCard({ statisticsSummary, hardestSend, hardestFlash,
 }
 
 function GradeTile({ highlight, label, icon }: { highlight: RawGradeHighlight; label: string; icon: IconName }) {
-  const { systemColors } = useTheme();
   const background = gradeBadgeColor(highlight.label);
   const textColor = getGradeTextColor(background);
   return (
@@ -79,7 +78,9 @@ function GradeTile({ highlight, label, icon }: { highlight: RawGradeHighlight; l
           {highlight.label}
         </Text>
       </View>
-      <Text variant="caption1" color={systemColors.secondaryLabel}>
+      {/* Match the grade/icon's contrast-aware colour; secondaryLabel is a grey
+          that washes out on saturated grade tiles. Dim slightly for hierarchy. */}
+      <Text variant="caption1" color={textColor} style={styles.gradeTileLabel}>
         {label}
       </Text>
     </View>
@@ -106,6 +107,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[1],
+  },
+  gradeTileLabel: {
+    opacity: 0.85,
   },
   percentile: {
     marginTop: spacing[5],

--- a/packages/mobile/src/components/you/YouTabBar.tsx
+++ b/packages/mobile/src/components/you/YouTabBar.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { View, Pressable, StyleSheet, type LayoutChangeEvent } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, type SharedValue } from 'react-native-reanimated';
 import { Text } from '../Text';
@@ -27,9 +28,12 @@ export function YouTabBar<K extends string>({ tabs, activeIndex, scrollPosition,
   // after a resize / orientation change — the worklet wouldn't see the new width.
   const tabWidth = useSharedValue(0);
 
-  const onLayout = (event: LayoutChangeEvent) => {
-    tabWidth.value = event.nativeEvent.layout.width / tabs.length;
-  };
+  const onLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      tabWidth.value = event.nativeEvent.layout.width / tabs.length;
+    },
+    [tabWidth, tabs.length],
+  );
 
   const indicatorStyle = useAnimatedStyle(() => ({
     width: tabWidth.value,

--- a/packages/mobile/src/components/you/YouTabBar.tsx
+++ b/packages/mobile/src/components/you/YouTabBar.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react';
 import { View, Pressable, StyleSheet, type LayoutChangeEvent } from 'react-native';
-import Animated, { useAnimatedStyle, type SharedValue } from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, useSharedValue, type SharedValue } from 'react-native-reanimated';
 import { Text } from '../Text';
 import { hapticSelection } from '../../lib/haptics';
 import { brandColors } from '../../theme/colors';
@@ -23,14 +22,18 @@ type YouTabBarProps<K extends string> = {
  */
 export function YouTabBar<K extends string>({ tabs, activeIndex, scrollPosition, onTabPress }: YouTabBarProps<K>) {
   const { systemColors } = useTheme();
-  const [width, setWidth] = useState(0);
-  const tabWidth = width > 0 ? width / tabs.length : 0;
+  // Tab width lives on the UI thread so the indicator worklet always reads the
+  // live value. A JS-thread useState captured in the worklet would go stale
+  // after a resize / orientation change — the worklet wouldn't see the new width.
+  const tabWidth = useSharedValue(0);
 
-  const onLayout = (event: LayoutChangeEvent) => setWidth(event.nativeEvent.layout.width);
+  const onLayout = (event: LayoutChangeEvent) => {
+    tabWidth.value = event.nativeEvent.layout.width / tabs.length;
+  };
 
   const indicatorStyle = useAnimatedStyle(() => ({
-    width: tabWidth,
-    transform: [{ translateX: scrollPosition.value * tabWidth }],
+    width: tabWidth.value,
+    transform: [{ translateX: scrollPosition.value * tabWidth.value }],
   }));
 
   return (
@@ -66,7 +69,7 @@ export function YouTabBar<K extends string>({ tabs, activeIndex, scrollPosition,
           </Pressable>
         );
       })}
-      {tabWidth > 0 && <Animated.View style={[styles.indicator, indicatorStyle]} />}
+      <Animated.View style={[styles.indicator, indicatorStyle]} />
     </View>
   );
 }

--- a/packages/mobile/src/components/you/__tests__/use-optimistic-vote.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/use-optimistic-vote.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// useVote wraps a React Query mutation. Stub it so optimistic transitions can be
+// driven deterministically and the outgoing payload inspected. `votePending`
+// lets a test simulate an in-flight vote at render time.
+let votePending = false;
+const mutate = vi.fn();
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useVote: () => ({ mutate, isPending: votePending }),
+}));
+
+import { useOptimisticVote } from '../use-optimistic-vote';
+
+type VoteOpts = {
+  onSuccess: (summary: { upvotes: number; userVote: number }) => void;
+  onError: (error: Error) => void;
+};
+
+describe('useOptimisticVote', () => {
+  beforeEach(() => {
+    mutate.mockReset();
+    votePending = false;
+  });
+
+  it('reflects server state before any interaction', () => {
+    const { result } = renderHook(() => useOptimisticVote('s1', 5, 1));
+    expect(result.current.voted).toBe(true);
+    expect(result.current.count).toBe(5);
+  });
+
+  it('flips optimistically and fires an upvote', () => {
+    const { result } = renderHook(() => useOptimisticVote('s1', 5, null));
+
+    act(() => result.current.toggle());
+
+    expect(result.current.voted).toBe(true);
+    expect(result.current.count).toBe(6);
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate.mock.calls[0][0]).toEqual({ entityType: 'session', entityId: 's1', value: 1 });
+  });
+
+  it('reconciles to the server summary on success', () => {
+    const { result } = renderHook(() => useOptimisticVote('s1', 5, null));
+    act(() => result.current.toggle());
+
+    const opts = mutate.mock.calls[0][1] as VoteOpts;
+    act(() => opts.onSuccess({ upvotes: 9, userVote: 1 }));
+
+    expect(result.current.count).toBe(9);
+    expect(result.current.voted).toBe(true);
+  });
+
+  it('rolls back to server values on error', () => {
+    const { result } = renderHook(() => useOptimisticVote('s1', 5, null));
+    act(() => result.current.toggle());
+    expect(result.current.count).toBe(6); // optimistic
+
+    const opts = mutate.mock.calls[0][1] as VoteOpts;
+    act(() => opts.onError(new Error('nope')));
+
+    expect(result.current.voted).toBe(false);
+    expect(result.current.count).toBe(5);
+  });
+
+  it('ignores a tap while a previous vote is still in flight', () => {
+    votePending = true;
+    const { result } = renderHook(() => useOptimisticVote('s1', 5, null));
+
+    act(() => result.current.toggle());
+
+    expect(mutate).not.toHaveBeenCalled();
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it('resets optimistic state when recycled onto a different session', () => {
+    const { result, rerender } = renderHook(({ id, up, uv }) => useOptimisticVote(id, up, uv), {
+      initialProps: { id: 's1', up: 5, uv: null as number | null },
+    });
+    act(() => result.current.toggle());
+    expect(result.current.count).toBe(6); // optimistic for s1
+
+    rerender({ id: 's2', up: 2, uv: 1 });
+
+    // s2's own server state — the s1 optimistic override must be gone.
+    expect(result.current.voted).toBe(true);
+    expect(result.current.count).toBe(2);
+  });
+});

--- a/packages/mobile/src/components/you/use-optimistic-vote.ts
+++ b/packages/mobile/src/components/you/use-optimistic-vote.ts
@@ -24,7 +24,11 @@ export function useOptimisticVote(
   serverUpvotes: number,
   serverUserVote: number | null,
 ): OptimisticVote {
-  const vote = useVote();
+  // Destructure the stable `mutate` + the `isPending` flag rather than depend on
+  // the whole useMutation result — that object is a fresh reference every render,
+  // so depending on it would needlessly recreate `toggle` (defeating any memo on
+  // consumers). `mutate` is reference-stable; only `isPending` legitimately moves.
+  const { mutate: voteMutate, isPending: voteIsPending } = useVote();
   const [optimistic, setOptimistic] = useState<{ count: number; voted: boolean } | null>(null);
 
   // Recycled onto a different session → drop the previous card's optimistic state.
@@ -34,17 +38,17 @@ export function useOptimisticVote(
   const count = optimistic ? optimistic.count : serverUpvotes;
 
   const toggle = useCallback(() => {
-    if (vote.isPending) return; // guard double-tap
+    if (voteIsPending) return; // guard double-tap
     const nextVoted = !voted;
     setOptimistic({ count: count + (nextVoted ? 1 : -1), voted: nextVoted });
-    vote.mutate(
+    voteMutate(
       { entityType: 'session', entityId: sessionId, value: nextVoted ? 1 : 0 },
       {
         onSuccess: (summary) => setOptimistic({ count: summary.upvotes, voted: summary.userVote === 1 }),
         onError: () => setOptimistic(null),
       },
     );
-  }, [vote, voted, count, sessionId]);
+  }, [voteMutate, voteIsPending, voted, count, sessionId]);
 
-  return { voted, count, toggle, isPending: vote.isPending };
+  return { voted, count, toggle, isPending: voteIsPending };
 }

--- a/packages/mobile/src/components/you/use-optimistic-vote.ts
+++ b/packages/mobile/src/components/you/use-optimistic-vote.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useVote } from '../../lib/graphql/hooks';
+
+export type OptimisticVote = {
+  /** Whether the viewer has upvoted (optimistic while a tap is in flight). */
+  voted: boolean;
+  /** Upvote count (optimistic while a tap is in flight). */
+  count: number;
+  /** Toggle the viewer's vote. No-ops while a previous tap is still in flight. */
+  toggle: () => void;
+  /** True while the vote mutation is in flight. */
+  isPending: boolean;
+};
+
+/**
+ * Optimistic upvote state for a feed entity (currently sessions). Layers a local
+ * override over the server count / `userVote` so the UI flips instantly,
+ * reconciles to the server summary on success, rolls back on error, and resets
+ * when the row is recycled onto a different entity — FlashList reuses component
+ * instances, so without the reset one card's vote would bleed onto another.
+ */
+export function useOptimisticVote(
+  sessionId: string,
+  serverUpvotes: number,
+  serverUserVote: number | null,
+): OptimisticVote {
+  const vote = useVote();
+  const [optimistic, setOptimistic] = useState<{ count: number; voted: boolean } | null>(null);
+
+  // Recycled onto a different session → drop the previous card's optimistic state.
+  useEffect(() => setOptimistic(null), [sessionId]);
+
+  const voted = optimistic ? optimistic.voted : serverUserVote === 1;
+  const count = optimistic ? optimistic.count : serverUpvotes;
+
+  const toggle = useCallback(() => {
+    if (vote.isPending) return; // guard double-tap
+    const nextVoted = !voted;
+    setOptimistic({ count: count + (nextVoted ? 1 : -1), voted: nextVoted });
+    vote.mutate(
+      { entityType: 'session', entityId: sessionId, value: nextVoted ? 1 : 0 },
+      {
+        onSuccess: (summary) => setOptimistic({ count: summary.upvotes, voted: summary.userVote === 1 }),
+        onError: () => setOptimistic(null),
+      },
+    );
+  }, [vote, voted, count, sessionId]);
+
+  return { voted, count, toggle, isPending: vote.isPending };
+}

--- a/packages/shared/board-react/src/__tests__/use-mutate-tick.test.tsx
+++ b/packages/shared/board-react/src/__tests__/use-mutate-tick.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useUpdateTick, useDeleteTick } from '../use-mutate-tick';
+import type { ExecuteHttp } from '../adapter';
+import { createWrapper } from './test-helpers';
+
+// Root keys that invalidateTickDependents refreshes on a successful edit/delete.
+const TICK_DEPENDENT_KEYS = [
+  'userTicks',
+  'userProfileStats',
+  'userClimbPercentile',
+  'userAscentsFeed',
+  'logbook',
+  'climb',
+  'searchClimbs',
+];
+
+const updateVars = {
+  uuid: 'tick-1',
+  input: { status: 'send' as const, difficulty: 16, quality: null, attemptCount: 2, comment: '' },
+};
+
+// First-element (root) of every queryKey passed to invalidateQueries.
+function invalidatedRoots(calls: unknown[][]): unknown[] {
+  return calls.map((call) => (call[0] as { queryKey?: unknown[] } | undefined)?.queryKey?.[0]);
+}
+
+describe('useUpdateTick (shared)', () => {
+  it('rejects with "Not authenticated" and touches neither transport nor caches when signed out', async () => {
+    const executeHttp = vi.fn();
+    const { wrapper, queryClient } = createWrapper({
+      isAuthenticated: false,
+      executeHttp: executeHttp as unknown as ExecuteHttp,
+    });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(updateVars);
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not authenticated');
+    expect(executeHttp).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('invalidates every tick-dependent cache on success', async () => {
+    const executeHttp = vi.fn().mockResolvedValue({ updateTick: { uuid: 'tick-1' } });
+    const { wrapper, queryClient } = createWrapper({ executeHttp: executeHttp as unknown as ExecuteHttp });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(updateVars);
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const roots = invalidatedRoots(invalidateSpy.mock.calls);
+    for (const key of TICK_DEPENDENT_KEYS) expect(roots).toContain(key);
+  });
+
+  it('does NOT invalidate caches when the mutation fails', async () => {
+    const executeHttp = vi.fn().mockRejectedValue(new Error('Server exploded'));
+    const { wrapper, queryClient } = createWrapper({ executeHttp: executeHttp as unknown as ExecuteHttp });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(updateVars);
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('useDeleteTick (shared)', () => {
+  it('rejects with "Not authenticated" and touches neither transport nor caches when signed out', async () => {
+    const executeHttp = vi.fn();
+    const { wrapper, queryClient } = createWrapper({
+      isAuthenticated: false,
+      executeHttp: executeHttp as unknown as ExecuteHttp,
+    });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useDeleteTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate('tick-1');
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not authenticated');
+    expect(executeHttp).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('invalidates tick-dependent caches on success', async () => {
+    const executeHttp = vi.fn().mockResolvedValue({ deleteTick: true });
+    const { wrapper, queryClient } = createWrapper({ executeHttp: executeHttp as unknown as ExecuteHttp });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useDeleteTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate('tick-1');
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidatedRoots(invalidateSpy.mock.calls)).toContain('userTicks');
+  });
+
+  it('does NOT invalidate caches when the delete fails', async () => {
+    const executeHttp = vi.fn().mockRejectedValue(new Error('nope'));
+    const { wrapper, queryClient } = createWrapper({ executeHttp: executeHttp as unknown as ExecuteHttp });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useDeleteTick(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate('tick-1');
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/board-react/src/__tests__/use-mutate-tick.test.tsx
+++ b/packages/shared/board-react/src/__tests__/use-mutate-tick.test.tsx
@@ -106,7 +106,8 @@ describe('useDeleteTick (shared)', () => {
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(invalidatedRoots(invalidateSpy.mock.calls)).toContain('userTicks');
+    const roots = invalidatedRoots(invalidateSpy.mock.calls);
+    for (const key of TICK_DEPENDENT_KEYS) expect(roots).toContain(key);
   });
 
   it('does NOT invalidate caches when the delete fails', async () => {

--- a/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
+++ b/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
@@ -400,4 +400,49 @@ describe('buildVPointsTimeline', () => {
     expect(result.series[0].data[0]).toBe(7); // 6 skipped weeks as base
     expect(result.series[0].data[103]).toBe(110);
   });
+
+  it('handles a single mid-week tick (one week, one cumulative point)', () => {
+    const wednesday = dayjs('2024-06-05'); // mid-week, not a range boundary
+    const result = buildVPointsTimeline(
+      {
+        kilter: [
+          makeEntry({
+            status: 'send',
+            difficulty: 13, // V1 → 1 point
+            climbed_at: wednesday.toISOString(),
+            layoutId: 1,
+            boardType: 'kilter',
+          }),
+        ],
+      },
+      'all',
+    )!;
+    expect(result).not.toBeNull();
+    expect(result.weekLabels).toHaveLength(1);
+    expect(result.series).toHaveLength(1);
+    expect(result.series[0].data).toEqual([1]);
+    expect(result.totalPoints).toBe(1);
+  });
+
+  it('keeps the week for a tick logged on a Sunday (iso-week boundary)', () => {
+    // Sunday is the last day of the iso week; the week-range loop must still
+    // emit exactly one week, not zero (which would null out the whole chart).
+    const sunday = dayjs('2024-06-09');
+    const result = buildVPointsTimeline(
+      {
+        kilter: [
+          makeEntry({
+            status: 'send',
+            difficulty: 13,
+            climbed_at: sunday.toISOString(),
+            layoutId: 1,
+            boardType: 'kilter',
+          }),
+        ],
+      },
+      'all',
+    )!;
+    expect(result.weekLabels).toHaveLength(1);
+    expect(result.series[0].data).toEqual([1]);
+  });
 });


### PR DESCRIPTION
Follow-up review fixes on the native You page (the original work merged in #2479).

## Bugs
- **Reanimated worklet captured a stale `tabWidth`** (`YouTabBar`) — the indicator width came from a JS-thread `useState` closed over in the `useAnimatedStyle` worklet, so the UI thread wouldn't pick up a new width after a resize / orientation change. Moved it to a `useSharedValue` set in `onLayout` (the gate is dropped — a 0-width indicator is simply invisible until measured).
- **Concurrent save+delete race** (`LogbookEditSheet`) — the save button only disabled on `updateTick.isPending` and the delete `Pressable` had no `disabled` at all, so an edit + delete against the same tick UUID could overlap. Both controls now disable (and both handlers bail) while **either** mutation is pending; the delete's modal `Alert` also blocks the save button behind it.
- **GradeTile sub-label ignored tile contrast** (`StatsSummaryCard`) — "Send"/"Flash" used a grey `secondaryLabel` on a saturated grade-colored tile. Now uses the same `getGradeTextColor(background)` as the grade + icon (dimmed to 0.85 for hierarchy).

## Tests
- **`useUpdateTick` / `useDeleteTick`** (`board-react`) — "Not authenticated" branch (no transport call, no cache invalidation) and that `invalidateTickDependents` runs on success but **not** on failure.
- **`useOptimisticVote`** — new hook extracted from `FeedSocialRow` so the optimistic logic is testable without a native renderer; covers optimistic flip + payload, success reconcile, error rollback, `isPending` guarding a double-tap, and reset when a FlashList row is recycled onto a new session.
- **`buildVPointsTimeline`** — single mid-week tick and a Sunday (iso-week boundary) tick each yield exactly one week (guards the day-of-week edge the reviewer flagged).

## Not changed
- **FlashList `estimatedItemSize`** — removed in flash-list v2 (auto-sizing), so it doesn't apply.

## Validation
`vp run typecheck` ✓ · profile-stats **40** ✓ · board-react **50** ✓ · mobile **557** ✓ · formatted (changed files only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)