### PR TITLE
feat(mobile): Spotify-style queue list — snackbar, thumbnails, drag-reorder, history tick

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -21,6 +21,7 @@ import { I18nProvider } from '../src/providers/i18n-provider';
 import { BluetoothProvider } from '../src/providers/bluetooth-provider';
 import { ToastProvider } from '../src/providers/toast-provider';
 import { QueueProvider } from '../src/providers/queue-provider';
+import { QueueSnackbarProvider } from '../src/providers/queue-snackbar-provider';
 import { DrawerHostProvider } from '../src/providers/drawer-host-provider';
 import { SessionScreenProvider } from '../src/providers/session-screen-provider';
 import { SessionScreenHost } from '../src/components/session-screen/SessionScreenHost';
@@ -201,11 +202,12 @@ function RootLayout() {
                   <ConnectionSettingsProvider>
                     <ToastProvider>
                       <ClimbActionsDataWrapper>
-                        <QueueProvider>
-                          <BoardAdapterWrapper>
-                            <PlaylistsAdapterWrapper>
-                              <BoardProviderWrapper>
-                                {/* BottomSheetModalProvider sits inside the board
+                        <QueueSnackbarProvider>
+                          <QueueProvider>
+                            <BoardAdapterWrapper>
+                              <PlaylistsAdapterWrapper>
+                                <BoardProviderWrapper>
+                                  {/* BottomSheetModalProvider sits inside the board
                                     providers (gorhom's BottomSheetModal portals
                                     PlayDrawer → QuickTickBar here, so the host
                                     must be able to see BoardAdapter/BoardProvider
@@ -216,29 +218,30 @@ function RootLayout() {
                                     exist before the picker mounts or gorhom
                                     throws "BottomSheetModalInternalContext
                                     cannot be null". */}
-                                <BottomSheetModalProvider>
-                                  <BluetoothProviderWrapper>
-                                    <SessionScreenProvider>
-                                      <DrawerHostProvider>
-                                        <ThemedNavigation>
-                                          <Stack screenOptions={{ headerShown: false }} initialRouteName="(tabs)">
-                                            <Stack.Screen name="(tabs)" />
-                                            <Stack.Screen
-                                              name="auth"
-                                              options={{ headerShown: false, gestureEnabled: false }}
-                                            />
-                                          </Stack>
-                                        </ThemedNavigation>
-                                        <PersistentQueueBar />
-                                        <SessionScreenHost />
-                                      </DrawerHostProvider>
-                                    </SessionScreenProvider>
-                                  </BluetoothProviderWrapper>
-                                </BottomSheetModalProvider>
-                              </BoardProviderWrapper>
-                            </PlaylistsAdapterWrapper>
-                          </BoardAdapterWrapper>
-                        </QueueProvider>
+                                  <BottomSheetModalProvider>
+                                    <BluetoothProviderWrapper>
+                                      <SessionScreenProvider>
+                                        <DrawerHostProvider>
+                                          <ThemedNavigation>
+                                            <Stack screenOptions={{ headerShown: false }} initialRouteName="(tabs)">
+                                              <Stack.Screen name="(tabs)" />
+                                              <Stack.Screen
+                                                name="auth"
+                                                options={{ headerShown: false, gestureEnabled: false }}
+                                              />
+                                            </Stack>
+                                          </ThemedNavigation>
+                                          <PersistentQueueBar />
+                                          <SessionScreenHost />
+                                        </DrawerHostProvider>
+                                      </SessionScreenProvider>
+                                    </BluetoothProviderWrapper>
+                                  </BottomSheetModalProvider>
+                                </BoardProviderWrapper>
+                              </PlaylistsAdapterWrapper>
+                            </BoardAdapterWrapper>
+                          </QueueProvider>
+                        </QueueSnackbarProvider>
                       </ClimbActionsDataWrapper>
                     </ToastProvider>
                   </ConnectionSettingsProvider>

--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -8,16 +8,19 @@ const config = getDefaultConfig(projectRoot);
 
 config.watchFolders = [monorepoRoot];
 
-// Exclude Claude Code's nested git worktrees from Metro's crawl/watch. Each of
-// the 30+ worktrees under <root>/.claude/worktrees/ carries its own full
-// node_modules (~5M files combined), which otherwise makes the haste-map crawl
-// hang for minutes on startup and exhausts the inotify watch limit (ENOSPC).
-// Nothing the app imports lives there, so pruning it is safe and lets the dev
-// server boot in seconds.
-const claudeWorktreesBlock = /[/\\]\.claude[/\\].*/;
+// Exclude non-source directories from Metro's crawl/watch:
+//  - <root>/.claude/worktrees/* — 30+ nested git worktrees, each with its own
+//    full node_modules (~5M files combined), which otherwise makes the haste-map
+//    crawl hang for minutes and exhausts the inotify watch limit (ENOSPC).
+//  - <root>/.local-work/* — local tooling scratch (e.g. an Android SDK install
+//    whose ephemeral unzip temp dirs vanish mid-watch and crash the file watcher
+//    with ENOENT, exit code 7).
+// Nothing the app imports lives in either, so pruning them is safe and lets the
+// dev server boot in seconds.
+const ignoredRoots = [/[/\\]\.claude[/\\].*/, /[/\\]\.local-work[/\\].*/];
 config.resolver.blockList = config.resolver.blockList
-  ? [].concat(config.resolver.blockList, claudeWorktreesBlock)
-  : claudeWorktreesBlock;
+  ? [].concat(config.resolver.blockList, ignoredRoots)
+  : ignoredRoots;
 
 config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -1,0 +1,146 @@
+import React, { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { Text } from './Text';
+import { ClimbListThumbnail, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT } from './ClimbListThumbnail';
+import { AscentStatusBadge } from './AscentStatusBadge';
+import { formatSends, formatQuality } from '../lib/format-climb-stats';
+import { useGradeFormat } from '../hooks/use-grade-format';
+
+/**
+ * The shared visual of a climb list item: portrait thumbnail (with ascent
+ * badge) + name/subtitle + colorized grade. Returns the three blocks as a
+ * fragment so the host row owns the flex container (padding, gap, background,
+ * selected/dimmed overlays) — this keeps `ClimbListRow`'s search-list layout
+ * byte-for-byte identical while letting the queue row reuse the same visual
+ * around its own position indicator and trailing actions.
+ */
+/**
+ * Minimal structural climb shape this visual needs. Kept permissive so BOTH the
+ * web-schema `Climb` (search list) and the `@boardsesh/queue` `Climb` (queue
+ * items / playlist suggestions) satisfy it without a cast — the two declare
+ * their own `Climb` types.
+ */
+export type ClimbListItemClimb = {
+  uuid: string;
+  name: string;
+  frames: string;
+  difficulty: string;
+  mirrored?: boolean | null;
+  is_draft?: boolean | null;
+  ascensionist_count?: number | null;
+  quality_average: string;
+  setter_username?: string | null;
+};
+
+type ClimbListItemContentProps = {
+  climb: ClimbListItemClimb;
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
+
+const ClimbListItemContent = React.memo(function ClimbListItemContent({
+  climb,
+  boardName,
+  layoutId,
+  sizeId,
+  setIds,
+  angle,
+}: ClimbListItemContentProps) {
+  const { t } = useTranslation('climbs');
+  const { formatGrade } = useGradeFormat();
+
+  const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
+  const formattedGrade = formatGrade(climb.difficulty);
+
+  // Subtitle parts: sends · quality★ · setter (each dropped when absent).
+  const subtitleText = useMemo(() => {
+    const parts: string[] = [];
+    if (climb.is_draft) {
+      parts.push(t('createClimbForm.draftBadge'));
+    }
+    if (!climb.is_draft && climb.ascensionist_count) {
+      parts.push(formatSends(climb.ascensionist_count));
+    }
+    const qualityNum = parseFloat(climb.quality_average);
+    if (qualityNum > 0) {
+      parts.push(`${formatQuality(climb.quality_average)}★`);
+    }
+    if (climb.setter_username) {
+      parts.push(climb.setter_username);
+    }
+    return parts.length > 0 ? parts.join(' · ') : t('mobile.climbRow.projectFallback');
+  }, [climb.is_draft, climb.ascensionist_count, climb.quality_average, climb.setter_username, t]);
+
+  return (
+    <>
+      {/* Left: portrait thumbnail with ascent badge */}
+      <View style={styles.thumbnailContainer}>
+        <ClimbListThumbnail
+          frames={climb.frames}
+          boardName={boardName}
+          layoutId={layoutId}
+          sizeId={sizeId}
+          setIds={setIds}
+          mirrored={climb.mirrored ?? false}
+        />
+        <AscentStatusBadge climbUuid={climb.uuid} angle={angle} />
+      </View>
+
+      {/* Center: name + subtitle */}
+      <View style={styles.centerColumn}>
+        <Text variant="body" numberOfLines={1} style={styles.climbName}>
+          {climb.name}
+        </Text>
+        <Text variant="footnote" numberOfLines={1} style={styles.subtitle}>
+          {subtitleText}
+        </Text>
+      </View>
+
+      {/* Right: colorized grade */}
+      <View style={styles.rightSection}>
+        <Text variant="headline" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
+          {formattedGrade ?? climb.difficulty}
+        </Text>
+      </View>
+    </>
+  );
+});
+
+export { ClimbListItemContent };
+
+const styles = StyleSheet.create({
+  thumbnailContainer: {
+    width: THUMBNAIL_WIDTH,
+    height: THUMBNAIL_HEIGHT,
+    flexShrink: 0,
+    position: 'relative',
+  },
+  centerColumn: {
+    flex: 1,
+    minWidth: 0,
+    justifyContent: 'center',
+    gap: 2,
+  },
+  climbName: {
+    fontWeight: '600',
+  },
+  subtitle: {
+    opacity: 0.6,
+  },
+  rightSection: {
+    flexShrink: 0,
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+  },
+  gradeText: {
+    fontWeight: '700',
+    minWidth: 34,
+    textAlign: 'right',
+  },
+});

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -10,14 +10,6 @@ import { formatSends, formatQuality } from '../lib/format-climb-stats';
 import { useGradeFormat } from '../hooks/use-grade-format';
 
 /**
- * The shared visual of a climb list item: portrait thumbnail (with ascent
- * badge) + name/subtitle + colorized grade. Returns the three blocks as a
- * fragment so the host row owns the flex container (padding, gap, background,
- * selected/dimmed overlays) — this keeps `ClimbListRow`'s search-list layout
- * byte-for-byte identical while letting the queue row reuse the same visual
- * around its own position indicator and trailing actions.
- */
-/**
  * Minimal structural climb shape this visual needs. Kept permissive so BOTH the
  * web-schema `Climb` (search list) and the `@boardsesh/queue` `Climb` (queue
  * items / playlist suggestions) satisfy it without a cast — the two declare
@@ -44,6 +36,14 @@ type ClimbListItemContentProps = {
   angle: number;
 };
 
+/**
+ * The shared visual of a climb list item: portrait thumbnail (with ascent
+ * badge) + name/subtitle + colorized grade. Returns the three blocks as a
+ * fragment so the host row owns the flex container (padding, gap, background,
+ * selected/dimmed overlays) — this keeps `ClimbListRow`'s search-list layout
+ * byte-for-byte identical while letting the queue row reuse the same visual
+ * around its own position indicator and trailing actions.
+ */
 const ClimbListItemContent = React.memo(function ClimbListItemContent({
   climb,
   boardName,

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -10,16 +10,11 @@ import Animated, {
 } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import ReanimatedSwipeable, { type SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
-import { useTranslation } from 'react-i18next';
 import type { Climb, BoardName } from '@boardsesh/shared-schema';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
-import { Text } from './Text';
 import { Icon } from './Icon';
-import { ClimbListThumbnail, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT } from './ClimbListThumbnail';
-import { AscentStatusBadge } from './AscentStatusBadge';
+import { THUMBNAIL_WIDTH } from './ClimbListThumbnail';
+import { ClimbListItemContent } from './ClimbListItemContent';
 import { hapticLight, hapticMedium, hapticSuccess } from '../lib/haptics';
-import { formatSends, formatQuality } from '../lib/format-climb-stats';
-import { useGradeFormat } from '../hooks/use-grade-format';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { brandColors } from '../theme/colors';
@@ -135,12 +130,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
   selected,
   unsupported,
 }: ClimbListRowProps) {
-  const { t } = useTranslation('climbs');
   const { systemColors } = useTheme();
-  const { formatGrade } = useGradeFormat();
-
-  const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
-  const formattedGrade = formatGrade(climb.difficulty);
 
   const swipeableRef = useRef<SwipeableMethods>(null);
 
@@ -182,22 +172,33 @@ const ClimbListRow = React.memo(function ClimbListRow({
   }, []);
 
   // Commit-on-release: fired from onSwipeableWillOpen the instant the user
-  // releases past the threshold — no second tap. We close immediately so the
-  // panel snaps back rather than resting open (the Spotify feel).
+  // releases past the threshold — no second tap. We deliberately do NOT close
+  // here: closing mid-"will open" raced ReanimatedSwipeable's open animation
+  // and left its open/closed state machine out of sync, so only every OTHER
+  // swipe fired willOpen. The row finishes opening and is snapped shut from
+  // onSwipeableOpen (handleSwipeableOpened) instead — a clean closed→open→
+  // closed cycle that fires on every swipe.
   const handleAddToQueue = useCallback(() => {
     hapticSuccess();
     onAddToQueueRef.current?.(climbRef.current);
-    swipeableRef.current?.close();
   }, []);
 
   const handleOpenPlaylist = useCallback(() => {
     hapticMedium();
     onOpenPlaylistRef.current?.(climbRef.current);
+  }, []);
+
+  // Snap the row shut once it has fully settled open. Runs after the action
+  // already fired on willOpen, so the user sees an instant commit and the row
+  // springs back.
+  const handleSwipeableOpened = useCallback(() => {
     swipeableRef.current?.close();
   }, []);
 
   const handleSwipeWillOpen = useCallback(
     (direction: 'left' | 'right') => {
+      // TEMP DIAGNOSTIC (Bug 2): trace which direction each swipe reports.
+      if (__DEV__) console.warn(`[swipe] willOpen direction=${direction} climb=${climbRef.current?.name}`);
       // ReanimatedSwipeable reports the SWIPE direction, not the actions side:
       // 'right' fires when the LEFT actions (Queue) open (left-to-right swipe);
       // 'left' fires when the RIGHT actions (Playlist) open (right-to-left).
@@ -251,25 +252,6 @@ const ClimbListRow = React.memo(function ClimbListRow({
     [],
   );
 
-  // Subtitle parts: sends · quality★ · setter (each dropped when absent).
-  const subtitleText = useMemo(() => {
-    const parts: string[] = [];
-    if (climb.is_draft) {
-      parts.push(t('createClimbForm.draftBadge'));
-    }
-    if (!climb.is_draft && climb.ascensionist_count) {
-      parts.push(formatSends(climb.ascensionist_count));
-    }
-    const qualityNum = parseFloat(climb.quality_average);
-    if (qualityNum > 0) {
-      parts.push(`${formatQuality(climb.quality_average)}★`);
-    }
-    if (climb.setter_username) {
-      parts.push(climb.setter_username);
-    }
-    return parts.length > 0 ? parts.join(' · ') : t('mobile.climbRow.projectFallback');
-  }, [climb.is_draft, climb.ascensionist_count, climb.quality_average, climb.setter_username, t]);
-
   return (
     <View style={[styles.outerContainer, unsupported && styles.unsupported]}>
       <ReanimatedSwipeable
@@ -282,6 +264,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
         renderLeftActions={renderLeftActions}
         renderRightActions={renderRightActions}
         onSwipeableWillOpen={handleSwipeWillOpen}
+        onSwipeableOpen={handleSwipeableOpened}
       >
         <GestureDetector gesture={tapGesture}>
           <View
@@ -295,35 +278,14 @@ const ClimbListRow = React.memo(function ClimbListRow({
             {selected ? <View style={styles.selectedFill} pointerEvents="none" /> : null}
             {selected ? <View style={styles.selectedAccent} pointerEvents="none" /> : null}
 
-            {/* Left: portrait thumbnail with ascent badge */}
-            <View style={styles.thumbnailContainer}>
-              <ClimbListThumbnail
-                frames={climb.frames}
-                boardName={boardName}
-                layoutId={layoutId}
-                sizeId={sizeId}
-                setIds={setIds}
-                mirrored={climb.mirrored ?? false}
-              />
-              <AscentStatusBadge climbUuid={climb.uuid} angle={angle} />
-            </View>
-
-            {/* Center: name + subtitle */}
-            <View style={styles.centerColumn}>
-              <Text variant="body" numberOfLines={1} style={styles.climbName}>
-                {climb.name}
-              </Text>
-              <Text variant="footnote" numberOfLines={1} style={styles.subtitle}>
-                {subtitleText}
-              </Text>
-            </View>
-
-            {/* Right: colorized grade */}
-            <View style={styles.rightSection}>
-              <Text variant="headline" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
-                {formattedGrade ?? climb.difficulty}
-              </Text>
-            </View>
+            <ClimbListItemContent
+              climb={climb}
+              boardName={boardName}
+              layoutId={layoutId}
+              sizeId={sizeId}
+              setIds={setIds}
+              angle={angle}
+            />
           </View>
         </GestureDetector>
       </ReanimatedSwipeable>
@@ -370,34 +332,6 @@ const styles = StyleSheet.create({
     bottom: 0,
     width: 5,
     backgroundColor: brandColors.primary,
-  },
-  thumbnailContainer: {
-    width: THUMBNAIL_WIDTH,
-    height: THUMBNAIL_HEIGHT,
-    flexShrink: 0,
-    position: 'relative',
-  },
-  centerColumn: {
-    flex: 1,
-    minWidth: 0,
-    justifyContent: 'center',
-    gap: 2,
-  },
-  climbName: {
-    fontWeight: '600',
-  },
-  subtitle: {
-    opacity: 0.6,
-  },
-  rightSection: {
-    flexShrink: 0,
-    alignItems: 'flex-end',
-    justifyContent: 'center',
-  },
-  gradeText: {
-    fontWeight: '700',
-    minWidth: 34,
-    textAlign: 'right',
   },
   separator: {
     height: StyleSheet.hairlineWidth,

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -197,8 +197,6 @@ const ClimbListRow = React.memo(function ClimbListRow({
 
   const handleSwipeWillOpen = useCallback(
     (direction: 'left' | 'right') => {
-      // TEMP DIAGNOSTIC (Bug 2): trace which direction each swipe reports.
-      if (__DEV__) console.warn(`[swipe] willOpen direction=${direction} climb=${climbRef.current?.name}`);
       // ReanimatedSwipeable reports the SWIPE direction, not the actions side:
       // 'right' fires when the LEFT actions (Queue) open (left-to-right swipe);
       // 'left' fires when the RIGHT actions (Playlist) open (right-to-left).

--- a/packages/mobile/src/components/QueueAddedSnackbar.tsx
+++ b/packages/mobile/src/components/QueueAddedSnackbar.tsx
@@ -10,6 +10,7 @@ import { useTheme } from '../providers/theme-provider';
 import { useQueue } from '../providers/queue-provider';
 import { TAB_BAR_HEIGHT } from './BlurTabBar';
 import { BAR_CONTENT_HEIGHT } from '../theme/layout';
+import { queueSnackbarBottomOffset } from './queue-snackbar-position';
 
 const DEFAULT_DURATION = 4000;
 
@@ -49,7 +50,13 @@ export function QueueAddedSnackbar({
 
   // Sit above the queue bar when it's showing; otherwise just above the tab bar.
   const barVisible = !!state.currentClimbQueueItem;
-  const bottom = insets.bottom + TAB_BAR_HEIGHT + (barVisible ? BAR_CONTENT_HEIGHT + spacing[2] : 0) + spacing[2];
+  const bottom = queueSnackbarBottomOffset({
+    insetsBottom: insets.bottom,
+    tabBarHeight: TAB_BAR_HEIGHT,
+    barContentHeight: BAR_CONTENT_HEIGHT,
+    gap: spacing[2],
+    barVisible,
+  });
 
   return (
     <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>

--- a/packages/mobile/src/components/QueueAddedSnackbar.tsx
+++ b/packages/mobile/src/components/QueueAddedSnackbar.tsx
@@ -1,0 +1,107 @@
+import { useEffect } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import Animated, { FadeInDown, FadeOutDown } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { Text } from './Text';
+import { brandColors } from '../theme/colors';
+import { borderRadius, spacing, shadowColor } from '../theme/tokens';
+import { useTheme } from '../providers/theme-provider';
+import { useQueue } from '../providers/queue-provider';
+import { TAB_BAR_HEIGHT } from './BlurTabBar';
+import { BAR_CONTENT_HEIGHT } from '../theme/layout';
+
+const DEFAULT_DURATION = 4000;
+
+type QueueAddedSnackbarProps = {
+  visible: boolean;
+  /** Changes on each show so the timer resets + the entrance replays. */
+  nonce: number;
+  onDismiss: () => void;
+  onOpen: () => void;
+  duration?: number;
+};
+
+/**
+ * Bottom-anchored "Climb added to queue · Open" snackbar that floats just above
+ * the persistent queue bar. Rendered inside DrawerHostProvider so it can read
+ * the queue state (to drop lower when the bar is hidden) and bind "Open" to the
+ * host's `openQueueSheet`. Unlike the top toast, its overlay is `box-none` so
+ * the "Open" button is tappable.
+ */
+export function QueueAddedSnackbar({
+  visible,
+  nonce,
+  onDismiss,
+  onOpen,
+  duration = DEFAULT_DURATION,
+}: QueueAddedSnackbarProps) {
+  const insets = useSafeAreaInsets();
+  const { systemColors } = useTheme();
+  const { t } = useTranslation('session');
+  const { state } = useQueue();
+
+  useEffect(() => {
+    if (!visible) return undefined;
+    const timer = setTimeout(onDismiss, duration);
+    return () => clearTimeout(timer);
+  }, [visible, nonce, duration, onDismiss]);
+
+  // Sit above the queue bar when it's showing; otherwise just above the tab bar.
+  const barVisible = !!state.currentClimbQueueItem;
+  const bottom = insets.bottom + TAB_BAR_HEIGHT + (barVisible ? BAR_CONTENT_HEIGHT + spacing[2] : 0) + spacing[2];
+
+  return (
+    <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+      {visible ? (
+        <Animated.View
+          key={nonce}
+          entering={FadeInDown.duration(220)}
+          exiting={FadeOutDown.duration(180)}
+          style={[styles.snackbar, { bottom, backgroundColor: systemColors.secondaryBackground }]}
+          accessibilityRole="alert"
+        >
+          <Text variant="subheadline" color={systemColors.label} style={styles.message} numberOfLines={1}>
+            {t('mobile.queueSnackbar.added')}
+          </Text>
+          <Pressable
+            onPress={onOpen}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={t('mobile.queueSnackbar.openAria')}
+          >
+            <Text variant="subheadline" color={brandColors.primary} style={styles.open}>
+              {t('mobile.queueSnackbar.open')}
+            </Text>
+          </Pressable>
+        </Animated.View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  snackbar: {
+    position: 'absolute',
+    left: spacing[2],
+    right: spacing[2],
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    columnGap: spacing[3],
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[4],
+    borderRadius: borderRadius.lg,
+    shadowColor,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.18,
+    shadowRadius: 10,
+    elevation: 6,
+  },
+  message: {
+    flexShrink: 1,
+  },
+  open: {
+    fontWeight: '700',
+  },
+});

--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -9,20 +9,37 @@ import {
 } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
 import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { BoardName } from '@boardsesh/shared-schema';
 import { Text } from './Text';
 import { Icon } from './Icon';
+import { ClimbListItemContent } from './ClimbListItemContent';
+import { THUMBNAIL_WIDTH } from './ClimbListThumbnail';
 import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
+import { spacing } from '../theme/tokens';
+import { springs } from '../theme/animations';
 import { useTheme } from '../providers/theme-provider';
-import { useGradeFormat } from '../hooks/use-grade-format';
 import { hapticSelection, hapticMedium } from '../lib/haptics';
+import type { QueueDragControls } from './play-drawer/use-queue-drag';
 
 const SWIPE_DELETE_THRESHOLD = -80;
 const DELETE_BUTTON_WIDTH = 80;
+const POSITION_SLOT_WIDTH = 28;
+// Inset the separator to start under the climb name (after position + thumbnail).
+const SEPARATOR_INSET = spacing[3] + POSITION_SLOT_WIDTH + spacing[3] + THUMBNAIL_WIDTH + spacing[3];
+
+export type QueueItemRowBoard = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
 
 type QueueItemRowProps = {
   item: ClimbQueueItem;
   position: number;
+  board: QueueItemRowBoard;
   isCurrentClimb: boolean;
   onPress: (item: ClimbQueueItem) => void;
   onRemove: (uuid: string) => void;
@@ -30,6 +47,16 @@ type QueueItemRowProps = {
   isSelected?: boolean;
   isHistoryItem?: boolean;
   onToggleSelect?: (uuid: string) => void;
+  /** Open the log-ascent sheet for an already-climbed (history) row. */
+  onTickHistory?: (item: ClimbQueueItem) => void;
+  /** Drag-to-reorder wiring (only passed for upcoming/future rows). */
+  drag?: QueueDragControls;
+  /** This row's index within the flat list (drag coordinate). */
+  rowIndex?: number;
+  /** This row's index within the queue array (drag commit). */
+  queueIndex?: number;
+  /** Whether this row may be dragged (future rows, not in edit mode). */
+  isDraggable?: boolean;
 };
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
@@ -69,6 +96,7 @@ function PositionIndicator({
 export function QueueItemRow({
   item,
   position,
+  board,
   isCurrentClimb,
   onPress,
   onRemove,
@@ -76,6 +104,11 @@ export function QueueItemRow({
   isSelected = false,
   isHistoryItem = false,
   onToggleSelect,
+  onTickHistory,
+  drag,
+  rowIndex,
+  queueIndex,
+  isDraggable = false,
 }: QueueItemRowProps) {
   const { systemColors } = useTheme();
   const { t } = useTranslation('session');
@@ -85,7 +118,7 @@ export function QueueItemRow({
   const isSwipeOpen = useSharedValue(false);
   const [isOpen, setIsOpen] = useState(false);
 
-  // Disable swipe for edit mode and history items
+  // Disable swipe-to-delete for edit mode and history items.
   const swipeEnabled = !isEditMode && !isHistoryItem;
 
   // Reset swipe position when swipe gets disabled (e.g. entering edit mode)
@@ -132,12 +165,48 @@ export function QueueItemRow({
             runOnJS(setIsOpen)(false);
           }
         }),
-    [swipeEnabled, translateX, isSwipeOpen, handleRemove],
+    [swipeEnabled, translateX, isSwipeOpen],
   );
+
+  // Long-press drag handle gesture (future rows only). Memoized on the row's
+  // identity so it doesn't churn while the list re-renders.
+  const dragHandleGesture = useMemo(() => {
+    if (!isDraggable || !drag || rowIndex == null || queueIndex == null) return null;
+    return drag.makeHandleGesture(rowIndex, item.uuid, queueIndex);
+  }, [isDraggable, drag, rowIndex, queueIndex, item.uuid]);
 
   const rowAnimatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: translateX.value }],
   }));
+
+  // Lift the dragged row and shift its siblings to open a gap. Reads the
+  // list-level drag shared values; for non-future rows (no `drag`) it stays at
+  // rest. `active`/`target` always fall inside the future window, so history /
+  // current rows never shift even though they share this style.
+  // Capture only the shared-values bag (not the whole `drag` object, which holds
+  // JS functions that can't cross to the UI thread).
+  const dragShared = drag?.shared;
+  const dragAnimatedStyle = useAnimatedStyle(() => {
+    if (!dragShared || dragShared.activeUuid.value === null) {
+      return { transform: [{ translateY: 0 }], zIndex: 0, elevation: 0 };
+    }
+    if (dragShared.activeUuid.value === item.uuid) {
+      return {
+        transform: [{ translateY: dragShared.dragTranslateY.value }, { scale: 1.02 }],
+        zIndex: 30,
+        elevation: 10,
+      };
+    }
+    const active = dragShared.activeRowIndex.value;
+    const target = dragShared.targetRowIndex.value;
+    const height = dragShared.rowHeight.value;
+    let shift = 0;
+    if (rowIndex != null) {
+      if (active < target && rowIndex > active && rowIndex <= target) shift = -height;
+      else if (active > target && rowIndex >= target && rowIndex < active) shift = height;
+    }
+    return { transform: [{ translateY: withSpring(shift, springs.interactive) }], zIndex: 0, elevation: 0 };
+  });
 
   const deleteButtonStyle = useAnimatedStyle(() => {
     const width = Math.min(Math.abs(translateX.value), DELETE_BUTTON_WIDTH);
@@ -179,10 +248,22 @@ export function QueueItemRow({
     });
   };
 
-  const { formatGrade } = useGradeFormat();
+  const handleTickPress = useCallback(() => {
+    hapticSelection();
+    onTickHistory?.(item);
+  }, [onTickHistory, item]);
+
+  const handleRowLayout = useCallback(
+    (height: number) => {
+      if (isDraggable) drag?.onRowHeight(height);
+    },
+    [isDraggable, drag],
+  );
+
   const climbName = item.climb?.name ?? t('mobile.queue.unknownClimb');
-  const rawDifficulty = item.climb?.difficulty ?? '';
-  const difficulty = formatGrade(rawDifficulty) ?? rawDifficulty;
+
+  const showTick = isHistoryItem && !isEditMode && !!onTickHistory;
+  const showDragHandle = !!dragHandleGesture && !isEditMode;
 
   const rowContent = (
     <AnimatedPressable
@@ -192,12 +273,13 @@ export function QueueItemRow({
       accessibilityState={{ selected: isEditMode ? isSelected : isCurrentClimb }}
       style={[
         styles.row,
+        { backgroundColor: systemColors.secondaryBackground },
         isCurrentClimb && !isHistoryItem && styles.currentClimbRow,
         isHistoryItem && styles.historyRow,
         rowAnimatedStyle,
       ]}
     >
-      {/* Position number or checkbox */}
+      {/* Position number / play indicator / edit checkbox */}
       <View style={styles.positionContainer}>
         <PositionIndicator
           isEditMode={isEditMode}
@@ -207,34 +289,46 @@ export function QueueItemRow({
         />
       </View>
 
-      {/* Climb info */}
-      <View style={styles.climbInfo}>
-        <Text
-          variant="body"
-          numberOfLines={1}
-          style={isCurrentClimb && !isHistoryItem ? styles.currentClimbText : undefined}
-        >
-          {climbName}
-        </Text>
-      </View>
+      {/* Shared climb visual: thumbnail + name/subtitle + grade */}
+      <ClimbListItemContent
+        climb={item.climb}
+        boardName={board.boardName}
+        layoutId={board.layoutId}
+        sizeId={board.sizeId}
+        setIds={board.setIds}
+        angle={board.angle}
+      />
 
-      {/* Grade pill */}
-      {difficulty ? (
-        <View style={[styles.gradePill, isCurrentClimb && !isHistoryItem && styles.currentGradePill]}>
-          <Text
-            variant="caption1"
-            color={isCurrentClimb && !isHistoryItem ? brandColors.primary : iosSystemColors.systemGray}
-            style={styles.gradeText}
+      {/* Trailing action: tick (history) or drag handle (upcoming) */}
+      {showTick ? (
+        <Pressable
+          onPress={handleTickPress}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={t('mobile.queue.logAscent')}
+          style={styles.trailingButton}
+        >
+          <Icon name="tick" size={26} color={brandColors.success} />
+        </Pressable>
+      ) : showDragHandle && dragHandleGesture ? (
+        <GestureDetector gesture={dragHandleGesture}>
+          <View
+            style={styles.trailingButton}
+            accessibilityRole="button"
+            accessibilityLabel={t('mobile.queue.dragHandleAria', { name: climbName })}
           >
-            {difficulty}
-          </Text>
-        </View>
+            <Icon name="drag.handle" size={22} color={iosSystemColors.systemGray} />
+          </View>
+        </GestureDetector>
       ) : null}
     </AnimatedPressable>
   );
 
   return (
-    <Animated.View style={containerAnimatedStyle}>
+    <Animated.View
+      style={[containerAnimatedStyle, dragAnimatedStyle]}
+      onLayout={(event) => handleRowLayout(event.nativeEvent.layout.height)}
+    >
       <View style={styles.swipeContainer}>
         {/* Delete action behind the row */}
         {swipeEnabled && (
@@ -254,7 +348,7 @@ export function QueueItemRow({
       </View>
 
       {/* Separator */}
-      <View style={[styles.separator, { marginLeft: 52, backgroundColor: systemColors.separator }]} />
+      <View style={[styles.separator, { marginLeft: SEPARATOR_INSET, backgroundColor: systemColors.separator }]} />
     </Animated.View>
   );
 }
@@ -268,10 +362,9 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    minHeight: 52,
-    backgroundColor: 'transparent',
+    columnGap: spacing[3],
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[3],
   },
   currentClimbRow: {
     backgroundColor: `${brandColors.primary}14`,
@@ -280,35 +373,20 @@ const styles = StyleSheet.create({
     opacity: 0.5,
   },
   positionContainer: {
-    width: 28,
+    width: POSITION_SLOT_WIDTH,
     alignItems: 'center',
     justifyContent: 'center',
-    marginRight: 8,
   },
   positionText: {
     fontWeight: '500',
     fontVariant: ['tabular-nums'],
   },
-  climbInfo: {
-    flex: 1,
+  trailingButton: {
+    width: 36,
+    height: 44,
+    alignItems: 'center',
     justifyContent: 'center',
-    gap: 2,
-  },
-  currentClimbText: {
-    fontWeight: '600',
-  },
-  gradePill: {
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderRadius: 6,
-    backgroundColor: `${iosSystemColors.systemGray}1F`,
-    marginLeft: 8,
-  },
-  currentGradePill: {
-    backgroundColor: `${brandColors.primary}1F`,
-  },
-  gradeText: {
-    fontWeight: '600',
+    flexShrink: 0,
   },
   deleteAction: {
     position: 'absolute',

--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -21,6 +21,7 @@ import { springs } from '../theme/animations';
 import { useTheme } from '../providers/theme-provider';
 import { hapticSelection, hapticMedium } from '../lib/haptics';
 import type { QueueDragControls } from './play-drawer/use-queue-drag';
+import { rowReorderShift } from './play-drawer/queue-drag-math';
 
 const SWIPE_DELETE_THRESHOLD = -80;
 const DELETE_BUTTON_WIDTH = 80;
@@ -197,14 +198,15 @@ export function QueueItemRow({
         elevation: 10,
       };
     }
-    const active = dragShared.activeRowIndex.value;
-    const target = dragShared.targetRowIndex.value;
-    const height = dragShared.rowHeight.value;
-    let shift = 0;
-    if (rowIndex != null) {
-      if (active < target && rowIndex > active && rowIndex <= target) shift = -height;
-      else if (active > target && rowIndex >= target && rowIndex < active) shift = height;
-    }
+    const shift =
+      rowIndex == null
+        ? 0
+        : rowReorderShift(
+            rowIndex,
+            dragShared.activeRowIndex.value,
+            dragShared.targetRowIndex.value,
+            dragShared.rowHeight.value,
+          );
     return { transform: [{ translateY: withSpring(shift, springs.interactive) }], zIndex: 0, elevation: 0 };
   });
 

--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -25,9 +25,12 @@ import { rowReorderShift } from './play-drawer/queue-drag-math';
 
 const SWIPE_DELETE_THRESHOLD = -80;
 const DELETE_BUTTON_WIDTH = 80;
-const POSITION_SLOT_WIDTH = 28;
+// Width of the leading position/play/checkbox slot. Exported so the queue list's
+// suggestion rows reserve the same gutter and align their thumbnails + separator
+// with the queue rows from a single source of truth.
+export const POSITION_SLOT_WIDTH = 28;
 // Inset the separator to start under the climb name (after position + thumbnail).
-const SEPARATOR_INSET = spacing[3] + POSITION_SLOT_WIDTH + spacing[3] + THUMBNAIL_WIDTH + spacing[3];
+export const SEPARATOR_INSET = spacing[3] + POSITION_SLOT_WIDTH + spacing[3] + THUMBNAIL_WIDTH + spacing[3];
 
 export type QueueItemRowBoard = {
   boardName: BoardName;

--- a/packages/mobile/src/components/__tests__/queue-snackbar-position.test.ts
+++ b/packages/mobile/src/components/__tests__/queue-snackbar-position.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { queueSnackbarBottomOffset } from '../queue-snackbar-position';
+
+// Representative metrics: tab bar 49, queue bar 56, gap 8, bottom inset 34.
+const BASE = { insetsBottom: 34, tabBarHeight: 49, barContentHeight: 56, gap: 8 };
+
+describe('queueSnackbarBottomOffset', () => {
+  it('floats one gap above the tab bar when the queue bar is hidden', () => {
+    // 34 + 49 + 0 + 8
+    expect(queueSnackbarBottomOffset({ ...BASE, barVisible: false })).toBe(91);
+  });
+
+  it('clears the queue bar (bar height + gap) when it is visible', () => {
+    // 34 + 49 + (56 + 8) + 8
+    expect(queueSnackbarBottomOffset({ ...BASE, barVisible: true })).toBe(155);
+  });
+
+  it('the bar-visible offset is exactly barContentHeight + gap higher than hidden', () => {
+    const hidden = queueSnackbarBottomOffset({ ...BASE, barVisible: false });
+    const shown = queueSnackbarBottomOffset({ ...BASE, barVisible: true });
+    expect(shown - hidden).toBe(BASE.barContentHeight + BASE.gap);
+  });
+
+  it('handles a zero safe-area inset', () => {
+    expect(queueSnackbarBottomOffset({ ...BASE, insetsBottom: 0, barVisible: false })).toBe(57);
+  });
+});

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -83,6 +83,7 @@ export const iconMap = {
   'end.session': { ios: 'stop.circle', android: 'stop-circle-outline' },
   'skip.previous': { ios: 'backward.end', android: 'skip-previous' },
   'skip.next': { ios: 'forward.end', android: 'skip-next' },
+  'drag.handle': { ios: 'line.3.horizontal', android: 'drag-horizontal-variant' },
 
   // Math
   minus: { ios: 'minus', android: 'minus' },

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -20,11 +20,11 @@ import { PlayDrawerHeader } from './PlayDrawerHeader';
 import { PlayDrawerActionBar } from './PlayDrawerActionBar';
 import { LogAscentSheet } from '../LogAscentSheet';
 import { DeferredSections } from './DeferredSections';
-import { QueueSheet } from './QueueSheet';
 import { AngleSelectorSheet } from './AngleSelectorSheet';
 import { ClimbActionsSheet } from '../ClimbActionsSheet';
 import { Icon } from '../Icon';
 import { useQueue } from '../../providers/queue-provider';
+import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useToast } from '../../providers/toast-provider';
@@ -113,6 +113,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
 
   const { state, setCurrentClimb, nextClimb, previousClimb, playlistSuggestionSource, sessionId, addToQueue } =
     useQueue();
+  const { openQueueSheet } = useDrawerHost();
   const bluetooth = useOptionalBluetoothContext();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
   const { formatGrade } = useGradeFormat();
@@ -236,8 +237,8 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   }, []);
 
   const handleOpenQueue = useCallback(() => {
-    setActiveSubDrawer('queue');
-  }, []);
+    openQueueSheet();
+  }, [openQueueSheet]);
 
   const handleOpenAngleSelector = useCallback(() => {
     setActiveSubDrawer('angleSelector');
@@ -396,7 +397,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
                       enabled={!isTickBarActive}
                     />
                   )}
-
                 </View>
 
                 <PlayDrawerActionBar
@@ -440,19 +440,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
           )}
         </BottomSheetScrollView>
       </BottomSheetModal>
-
-      {/* Sub-drawer: Queue */}
-      {activeSubDrawer === 'queue' && (
-        <QueueSheet
-          visible={true}
-          onClose={handleCloseSubDrawer}
-          onClimbPress={(item) => {
-            setClimb(item.climb);
-            setCurrentClimb(item);
-            handleCloseSubDrawer();
-          }}
-        />
-      )}
 
       {/* Sub-drawer: Climb actions */}
       {activeSubDrawer === 'actions' && (

--- a/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
@@ -3,7 +3,6 @@ import { View, Pressable, Platform, StyleSheet, type ViewStyle } from 'react-nat
 import { SymbolView } from 'expo-symbols';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../Icon';
-import { Badge } from '../Badge';
 import { Text } from '../Text';
 import { BleLightbulbButton } from '../ble/BleLightbulbButton';
 import { brandColors } from '../../theme/colors';
@@ -209,19 +208,12 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
         <View style={styles.spacer} />
 
         <ShareButton size="sm" onPress={handleShare} accessibilityLabel={tClimbs('mobile.climbRow.share')} />
-        <View>
-          <ActionButton
-            size="sm"
-            iconName="queue"
-            onPress={onOpenQueue}
-            accessibilityLabel={t('playView.actionBar.queueCountAria', { count: remainingQueueCount })}
-          />
-          {remainingQueueCount > 0 && (
-            <View style={styles.badgeContainer}>
-              <Badge count={remainingQueueCount} color={brandColors.primary} size="small" />
-            </View>
-          )}
-        </View>
+        <ActionButton
+          size="sm"
+          iconName="queue"
+          onPress={onOpenQueue}
+          accessibilityLabel={t('playView.actionBar.queueCountAria', { count: remainingQueueCount })}
+        />
       </View>
     </View>
   );
@@ -249,10 +241,7 @@ function ActionButton({
   accessibilityLabel,
 }: ActionButtonProps) {
   const { dim, icon } = SIZES[size];
-  const buttonStyle: ViewStyle[] = [
-    styles.actionButton,
-    { width: dim, height: dim, borderRadius: dim / 2 },
-  ];
+  const buttonStyle: ViewStyle[] = [styles.actionButton, { width: dim, height: dim, borderRadius: dim / 2 }];
   if (active && activeColor) {
     buttonStyle.push({ backgroundColor: `${activeColor}20` });
   }
@@ -391,11 +380,6 @@ const styles = StyleSheet.create({
   actionButtonPressed: {
     opacity: 0.6,
     transform: [{ scale: 0.9 }],
-  },
-  badgeContainer: {
-    position: 'absolute',
-    top: 0,
-    right: 0,
   },
   anglePill: {
     paddingHorizontal: 14,

--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -2,62 +2,117 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
 import { BottomSheetFlatList, type BottomSheetFlatListMethods } from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
-import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { Climb, ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
+import { getPlaylistSuggestedClimbs } from '@boardsesh/queue';
 import { buildQueueListModel, type QueueFlatRow } from '@boardsesh/play-view';
-import { QueueItemRow } from '../QueueItemRow';
+import { QueueItemRow, type QueueItemRowBoard } from '../QueueItemRow';
+import { ClimbListItemContent } from '../ClimbListItemContent';
+import { THUMBNAIL_WIDTH } from '../ClimbListThumbnail';
 import { Text } from '../Text';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 import { brandColors } from '../../theme/colors';
+import { hapticSelection } from '../../lib/haptics';
+import { useQueueDrag } from './use-queue-drag';
+
+const POSITION_SLOT_WIDTH = 28;
+// Match QueueItemRow's separator inset so suggestion separators line up.
+const SEPARATOR_INSET = spacing[3] + POSITION_SLOT_WIDTH + spacing[3] + THUMBNAIL_WIDTH + spacing[3];
+
+type SuggestionRow = { type: 'suggestion'; climb: Climb };
+type QueueListRow = QueueFlatRow | SuggestionRow;
 
 type QueueListProps = {
   queue: ClimbQueueItem[];
   currentItemUuid: string | null;
+  board: QueueItemRowBoard;
   isEditMode: boolean;
   showHistory: boolean;
   showFullHistory: boolean;
   selectedItems: Set<string>;
+  playlistSuggestionSource: PlaylistSuggestionSource | null;
   autoScrollOnMount?: boolean;
   onToggleSelect: (uuid: string) => void;
   onClimbPress: (item: ClimbQueueItem) => void;
   onRemove: (uuid: string) => void;
   onShowFullHistory: () => void;
+  onTickHistory: (item: ClimbQueueItem) => void;
+  onSuggestionPress: (climb: Climb) => void;
+  reorderQueue: (uuid: string, oldIndex: number, newIndex: number) => void;
+  onDraggingChange?: (dragging: boolean) => void;
 };
 
 export function QueueList({
   queue,
   currentItemUuid,
+  board,
   isEditMode,
   showHistory,
   showFullHistory,
   selectedItems,
+  playlistSuggestionSource,
   autoScrollOnMount,
   onToggleSelect,
   onClimbPress,
   onRemove,
   onShowFullHistory,
+  onTickHistory,
+  onSuggestionPress,
+  reorderQueue,
+  onDraggingChange,
 }: QueueListProps) {
   const { t } = useTranslation('session');
   const { systemColors } = useTheme();
   const flatListRef = useRef<BottomSheetFlatListMethods | null>(null);
-  const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (scrollTimerRef.current) {
-        clearTimeout(scrollTimerRef.current);
-      }
-    };
-  }, []);
 
   const { flatRows, currentItemFlatIndex } = useMemo(
     () => buildQueueListModel(queue, currentItemUuid, { showHistory, showFullHistory }),
     [queue, currentItemUuid, showHistory, showFullHistory],
   );
 
+  // Suggested (playlist) climbs flow directly after the queue rows — NO header,
+  // NO divider (the intentional divergence from web).
+  const suggestions = useMemo(
+    () => getPlaylistSuggestedClimbs(playlistSuggestionSource, queue),
+    [playlistSuggestionSource, queue],
+  );
+
+  const rows = useMemo<QueueListRow[]>(
+    () => [...flatRows, ...suggestions.map((climb): SuggestionRow => ({ type: 'suggestion', climb }))],
+    [flatRows, suggestions],
+  );
+
+  // The contiguous draggable window: the `future-item` rows (upcoming queue).
+  const { firstFutureRowIndex, lastFutureRowIndex, firstFutureQueueIndex } = useMemo(() => {
+    let first = -1;
+    let last = -1;
+    let firstQueue = -1;
+    rows.forEach((row, index) => {
+      if (row.type === 'future-item') {
+        if (first === -1) {
+          first = index;
+          firstQueue = row.queueIndex;
+        }
+        last = index;
+      }
+    });
+    return { firstFutureRowIndex: first, lastFutureRowIndex: last, firstFutureQueueIndex: firstQueue };
+  }, [rows]);
+
+  const drag = useQueueDrag({
+    reorderQueue,
+    firstFutureRowIndex,
+    lastFutureRowIndex,
+    firstFutureQueueIndex,
+  });
+
   useEffect(() => {
-    if (autoScrollOnMount && currentItemFlatIndex >= 0 && flatRows.length > 0) {
+    onDraggingChange?.(drag.isDragging);
+  }, [drag.isDragging, onDraggingChange]);
+
+  useEffect(() => {
+    if (autoScrollOnMount && currentItemFlatIndex >= 0 && rows.length > 0) {
       const timer = setTimeout(() => {
         flatListRef.current?.scrollToIndex?.({
           index: currentItemFlatIndex,
@@ -68,9 +123,9 @@ export function QueueList({
       return () => clearTimeout(timer);
     }
     return undefined;
-  }, [autoScrollOnMount, currentItemFlatIndex, flatRows.length]);
+  }, [autoScrollOnMount, currentItemFlatIndex, rows.length]);
 
-  const keyExtractor = useCallback((row: QueueFlatRow, index: number): string => {
+  const keyExtractor = useCallback((row: QueueListRow, index: number): string => {
     switch (row.type) {
       case 'history-show-all':
         return 'history-show-all';
@@ -82,13 +137,23 @@ export function QueueList({
         return `current-${row.item.uuid}`;
       case 'future-item':
         return `future-${row.item.uuid}`;
+      case 'suggestion':
+        return `suggestion-${row.climb.uuid}`;
       default:
         return `row-${String(index)}`;
     }
   }, []);
 
+  const handleSuggestionPress = useCallback(
+    (climb: Climb) => {
+      hapticSelection();
+      onSuggestionPress(climb);
+    },
+    [onSuggestionPress],
+  );
+
   const renderRow = useCallback(
-    ({ item: row }: { item: QueueFlatRow }) => {
+    ({ item: row, index }: { item: QueueListRow; index: number }) => {
       switch (row.type) {
         case 'history-show-all':
           return (
@@ -112,6 +177,7 @@ export function QueueList({
             <QueueItemRow
               item={row.item}
               position={row.queueIndex + 1}
+              board={board}
               isCurrentClimb={false}
               isHistoryItem
               isEditMode={isEditMode}
@@ -119,6 +185,7 @@ export function QueueList({
               onPress={onClimbPress}
               onRemove={onRemove}
               onToggleSelect={onToggleSelect}
+              onTickHistory={onTickHistory}
             />
           );
 
@@ -127,6 +194,7 @@ export function QueueList({
             <QueueItemRow
               item={row.item}
               position={row.queueIndex + 1}
+              board={board}
               isCurrentClimb
               isEditMode={isEditMode}
               isSelected={selectedItems.has(row.item.uuid)}
@@ -141,23 +209,65 @@ export function QueueList({
             <QueueItemRow
               item={row.item}
               position={row.queueIndex + 1}
+              board={board}
               isCurrentClimb={false}
               isEditMode={isEditMode}
               isSelected={selectedItems.has(row.item.uuid)}
               onPress={onClimbPress}
               onRemove={onRemove}
               onToggleSelect={onToggleSelect}
+              drag={drag}
+              rowIndex={index}
+              queueIndex={row.queueIndex}
+              isDraggable={!isEditMode}
             />
+          );
+
+        case 'suggestion':
+          return (
+            <View>
+              <Pressable
+                onPress={() => handleSuggestionPress(row.climb)}
+                accessibilityRole="button"
+                accessibilityLabel={row.climb.name}
+                style={[styles.suggestionRow, { backgroundColor: systemColors.secondaryBackground }]}
+              >
+                <View style={styles.suggestionSpacer} />
+                <ClimbListItemContent
+                  climb={row.climb}
+                  boardName={board.boardName}
+                  layoutId={board.layoutId}
+                  sizeId={board.sizeId}
+                  setIds={board.setIds}
+                  angle={board.angle}
+                />
+              </Pressable>
+              <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />
+            </View>
           );
 
         default:
           return null;
       }
     },
-    [isEditMode, selectedItems, onClimbPress, onRemove, onToggleSelect, onShowFullHistory, systemColors.separator, t],
+    [
+      board,
+      drag,
+      isEditMode,
+      selectedItems,
+      onClimbPress,
+      onRemove,
+      onToggleSelect,
+      onTickHistory,
+      onShowFullHistory,
+      handleSuggestionPress,
+      systemColors.separator,
+      systemColors.secondaryBackground,
+      t,
+    ],
   );
 
-  if (flatRows.length === 0) {
+  if (rows.length === 0) {
     return (
       <View style={styles.emptyContainer}>
         <Text variant="body" color={iosSystemColors.systemGray}>
@@ -170,11 +280,12 @@ export function QueueList({
   return (
     <BottomSheetFlatList
       ref={flatListRef}
-      data={flatRows}
+      data={rows}
       keyExtractor={keyExtractor}
       renderItem={renderRow}
       contentContainerStyle={styles.listContent}
       showsVerticalScrollIndicator={false}
+      scrollEnabled={!drag.isDragging}
       onScrollToIndexFailed={() => {
         // Silently handle if scroll target isn't rendered yet
       }}
@@ -201,5 +312,19 @@ const styles = StyleSheet.create({
     height: StyleSheet.hairlineWidth,
     marginVertical: spacing[1],
     marginHorizontal: spacing[4],
+  },
+  suggestionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: spacing[3],
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[3],
+  },
+  suggestionSpacer: {
+    width: POSITION_SLOT_WIDTH,
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    marginLeft: SEPARATOR_INSET,
   },
 });

--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -3,11 +3,10 @@ import { View, Pressable, StyleSheet } from 'react-native';
 import { BottomSheetFlatList, type BottomSheetFlatListMethods } from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { Climb, ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
-import { getPlaylistSuggestedClimbs } from '@boardsesh/queue';
+import { getPlaylistSuggestedClimbs, createPlaylistSuggestionSource, getQueueBoardKey } from '@boardsesh/queue';
 import { buildQueueListModel, type QueueFlatRow } from '@boardsesh/play-view';
-import { QueueItemRow, type QueueItemRowBoard } from '../QueueItemRow';
+import { QueueItemRow, type QueueItemRowBoard, POSITION_SLOT_WIDTH, SEPARATOR_INSET } from '../QueueItemRow';
 import { ClimbListItemContent } from '../ClimbListItemContent';
-import { THUMBNAIL_WIDTH } from '../ClimbListThumbnail';
 import { Text } from '../Text';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
@@ -18,9 +17,9 @@ import { useSearchClimbs } from '../../lib/graphql/hooks';
 import { toClimbSearchInput, DEFAULT_CLIMB_FILTER_STATE } from '@boardsesh/climb-filters';
 import { useQueueDrag } from './use-queue-drag';
 
-const POSITION_SLOT_WIDTH = 28;
-// Match QueueItemRow's separator inset so suggestion separators line up.
-const SEPARATOR_INSET = spacing[3] + POSITION_SLOT_WIDTH + spacing[3] + THUMBNAIL_WIDTH + spacing[3];
+// Synthetic suggestion-source id for tapping a climb from the queue sheet's
+// suggestion feed — distinct from real playlist activations.
+const QUEUE_SUGGESTION_SOURCE_ID = 'queue-suggestions';
 
 type SuggestionRow = { type: 'suggestion'; climb: Climb };
 type QueueListRow = QueueFlatRow | SuggestionRow;
@@ -45,7 +44,7 @@ type QueueListProps = {
   onRemove: (uuid: string) => void;
   onShowFullHistory: () => void;
   onTickHistory: (item: ClimbQueueItem) => void;
-  onSuggestionPress: (climb: Climb) => void;
+  onSuggestionPress: (climb: Climb, source: PlaylistSuggestionSource) => void;
   reorderQueue: (uuid: string, oldIndex: number, newIndex: number) => void;
   onDraggingChange?: (dragging: boolean) => void;
 };
@@ -86,9 +85,11 @@ export function QueueList({
   // Suggested climbs flow directly after the queue rows — NO header, NO divider
   // (the intentional divergence from web). Playlist suggestions (when a playlist
   // is active) come first, then a popular (by-ascents) feed for the board tops
-  // the list up. The feed is ALWAYS fetched (not gated on the playlist source)
-  // so suggestions never vanish when the source flips or its climbs go empty —
-  // they just fall back to the feed. Everything already in the queue is excluded.
+  // the list up. The feed query is enabled unconditionally (not gated on the
+  // playlist source) — but this list only mounts while the queue sheet is open,
+  // so it only runs then. Fetching regardless of the source means suggestions
+  // never vanish when the source flips or its climbs go empty; they fall back to
+  // the feed. Everything already in the queue is excluded.
   const playlistSuggestions = useMemo(
     () => getPlaylistSuggestedClimbs(playlistSuggestionSource, queue),
     [playlistSuggestionSource, queue],
@@ -185,9 +186,24 @@ export function QueueList({
   const handleSuggestionPress = useCallback(
     (climb: Climb) => {
       hapticSelection();
-      onSuggestionPress(climb);
+      // Build a suggestion source anchored at the tapped climb from the CURRENT
+      // suggestions list, so the play drawer can keep swiping forward through the
+      // rest of the suggestions (mirrors how the climbs-list browse activation
+      // seeds a source from its loaded climbs).
+      const source = createPlaylistSuggestionSource({
+        playlistUuid: QUEUE_SUGGESTION_SOURCE_ID,
+        activatedClimb: climb,
+        climbs: suggestions,
+        boardKey: getQueueBoardKey({
+          board_name: board.boardName,
+          layout_id: board.layoutId,
+          size_id: board.sizeId,
+          set_ids: board.setIds,
+        }),
+      });
+      onSuggestionPress(climb, source);
     },
-    [onSuggestionPress],
+    [onSuggestionPress, suggestions, board],
   );
 
   const renderRow = useCallback(

--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -14,6 +14,8 @@ import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 import { brandColors } from '../../theme/colors';
 import { hapticSelection } from '../../lib/haptics';
+import { useSearchClimbs } from '../../lib/graphql/hooks';
+import { toClimbSearchInput, DEFAULT_CLIMB_FILTER_STATE } from '@boardsesh/climb-filters';
 import { useQueueDrag } from './use-queue-drag';
 
 const POSITION_SLOT_WIDTH = 28;
@@ -22,6 +24,11 @@ const SEPARATOR_INSET = spacing[3] + POSITION_SLOT_WIDTH + spacing[3] + THUMBNAI
 
 type SuggestionRow = { type: 'suggestion'; climb: Climb };
 type QueueListRow = QueueFlatRow | SuggestionRow;
+
+// Show only the last 2 climbed by default; "show full history" expands the rest.
+const HISTORY_DISPLAY_LIMIT = 2;
+// How many popular climbs to pull for the no-playlist suggestion feed.
+const SUGGESTION_PAGE_SIZE = 50;
 
 type QueueListProps = {
   queue: ClimbQueueItem[];
@@ -67,16 +74,47 @@ export function QueueList({
   const flatListRef = useRef<BottomSheetFlatListMethods | null>(null);
 
   const { flatRows, currentItemFlatIndex } = useMemo(
-    () => buildQueueListModel(queue, currentItemUuid, { showHistory, showFullHistory }),
+    () =>
+      buildQueueListModel(queue, currentItemUuid, {
+        showHistory,
+        showFullHistory,
+        historyDisplayLimit: HISTORY_DISPLAY_LIMIT,
+      }),
     [queue, currentItemUuid, showHistory, showFullHistory],
   );
 
-  // Suggested (playlist) climbs flow directly after the queue rows — NO header,
-  // NO divider (the intentional divergence from web).
-  const suggestions = useMemo(
+  // Suggested climbs flow directly after the queue rows — NO header, NO divider
+  // (the intentional divergence from web). Playlist suggestions (when a playlist
+  // is active) come first, then a popular (by-ascents) feed for the board tops
+  // the list up. The feed is ALWAYS fetched (not gated on the playlist source)
+  // so suggestions never vanish when the source flips or its climbs go empty —
+  // they just fall back to the feed. Everything already in the queue is excluded.
+  const playlistSuggestions = useMemo(
     () => getPlaylistSuggestedClimbs(playlistSuggestionSource, queue),
     [playlistSuggestionSource, queue],
   );
+
+  const searchInput = useMemo(
+    () => toClimbSearchInput(DEFAULT_CLIMB_FILTER_STATE, board, { page: 1, pageSize: SUGGESTION_PAGE_SIZE }),
+    [board],
+  );
+  const { data: searchResult } = useSearchClimbs(searchInput, true);
+
+  const suggestions = useMemo<Climb[]>(() => {
+    const queued = new Set(queue.map((item) => item.climb?.uuid).filter((uuid): uuid is string => !!uuid));
+    const seen = new Set<string>();
+    const out: Climb[] = [];
+    const add = (climbs: readonly Climb[]) => {
+      for (const climb of climbs) {
+        if (!climb?.uuid || queued.has(climb.uuid) || seen.has(climb.uuid)) continue;
+        seen.add(climb.uuid);
+        out.push(climb);
+      }
+    };
+    add(playlistSuggestions);
+    add(searchResult?.climbs ?? []);
+    return out;
+  }, [playlistSuggestions, searchResult, queue]);
 
   const rows = useMemo<QueueListRow[]>(
     () => [...flatRows, ...suggestions.map((climb): SuggestionRow => ({ type: 'suggestion', climb }))],

--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -18,8 +18,14 @@ import { toClimbSearchInput, DEFAULT_CLIMB_FILTER_STATE } from '@boardsesh/climb
 import { useQueueDrag } from './use-queue-drag';
 
 // Synthetic suggestion-source id for tapping a climb from the queue sheet's
-// suggestion feed — distinct from real playlist activations.
+// suggestion feed — distinct from real playlist activations. This is a plain
+// string identifier (PlaylistSuggestionSource.playlistUuid is typed `string`
+// and nothing validates UUID format — the climbs list likewise uses 'climblist').
 const QUEUE_SUGGESTION_SOURCE_ID = 'queue-suggestions';
+// Keep the suggestion feed warm across sheet opens so reopening the queue reuses
+// the cached page instead of refiring a 50-item request each time.
+const SUGGESTION_STALE_MS = 5 * 60 * 1000;
+const SUGGESTION_GC_MS = 10 * 60 * 1000;
 
 type SuggestionRow = { type: 'suggestion'; climb: Climb };
 type QueueListRow = QueueFlatRow | SuggestionRow;
@@ -99,7 +105,10 @@ export function QueueList({
     () => toClimbSearchInput(DEFAULT_CLIMB_FILTER_STATE, board, { page: 1, pageSize: SUGGESTION_PAGE_SIZE }),
     [board],
   );
-  const { data: searchResult } = useSearchClimbs(searchInput, true);
+  const { data: searchResult } = useSearchClimbs(searchInput, true, {
+    staleTime: SUGGESTION_STALE_MS,
+    gcTime: SUGGESTION_GC_MS,
+  });
 
   const suggestions = useMemo<Climb[]>(() => {
     const queued = new Set(queue.map((item) => item.climb?.uuid).filter((uuid): uuid is string => !!uuid));

--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -55,7 +55,7 @@ export function QueueSheet({
   const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
   const [isDragging, setIsDragging] = useState(false);
 
-  const snapPoints = useMemo(() => ['60%', '90%'], []);
+  const snapPoints = useMemo(() => ['70%', '95%'], []);
 
   const currentItemUuid = currentClimbQueueItem?.uuid ?? null;
 

--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -4,7 +4,7 @@ import { BottomSheetModal, BottomSheetBackdrop, type BottomSheetBackdropProps } 
 import { FullWindowOverlay } from 'react-native-screens';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
-import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
+import type { Climb, ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import { QueueSheetHeader } from './QueueSheetHeader';
 import { QueueList } from './QueueList';
 import { Text } from '../Text';
@@ -27,9 +27,12 @@ const modalContainerComponent = Platform.OS === 'ios' ? ModalSheetContainer : un
 type QueueSheetProps = {
   visible: boolean;
   board: QueueItemRowBoard;
+  /** Request an animated close (header button) — host flips `visible` to false. */
   onClose: () => void;
+  /** Fired AFTER the dismiss animation finishes so the host can unmount. */
+  onDismissed: () => void;
   onClimbPress: (item: ClimbQueueItem) => void;
-  onSuggestionPress: (climb: Climb) => void;
+  onSuggestionPress: (climb: Climb, source: PlaylistSuggestionSource) => void;
   onTickHistory: (item: ClimbQueueItem) => void;
 };
 
@@ -37,6 +40,7 @@ export function QueueSheet({
   visible,
   board,
   onClose,
+  onDismissed,
   onClimbPress,
   onSuggestionPress,
   onTickHistory,
@@ -73,10 +77,12 @@ export function QueueSheet({
     setShowFullHistory(false);
   }, []);
 
-  const handleClose = useCallback(() => {
+  // The modal's dismiss animation has finished (header request, backdrop, or
+  // pan-down). Reset local UI state and let the host unmount.
+  const handleDismissed = useCallback(() => {
     resetState();
-    onClose();
-  }, [resetState, onClose]);
+    onDismissed();
+  }, [resetState, onDismissed]);
 
   const handleToggleEditMode = useCallback(() => {
     setIsEditMode((prev) => {
@@ -156,7 +162,7 @@ export function QueueSheet({
       enableHandlePanningGesture={!isDragging}
       backdropComponent={renderBackdrop}
       containerComponent={modalContainerComponent}
-      onDismiss={handleClose}
+      onDismiss={handleDismissed}
       handleIndicatorStyle={sheetStyles.indicator}
       backgroundStyle={backgroundStyle}
       style={styles.sheet}
@@ -169,7 +175,7 @@ export function QueueSheet({
         viewOnlyMode={viewOnlyMode}
         onToggleEditMode={handleToggleEditMode}
         onToggleHistory={handleToggleHistory}
-        onClose={handleClose}
+        onClose={onClose}
         onClearAll={handleClearAll}
       />
 

--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -1,12 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { View, Pressable, Platform, StyleSheet } from 'react-native';
-import BottomSheet, { BottomSheetBackdrop, type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
+import { BottomSheetModal, BottomSheetBackdrop, type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
+import { FullWindowOverlay } from 'react-native-screens';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
-import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
 import { QueueSheetHeader } from './QueueSheetHeader';
 import { QueueList } from './QueueList';
 import { Text } from '../Text';
+import type { QueueItemRowBoard } from '../QueueItemRow';
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { hapticMedium, hapticWarning } from '../../lib/haptics';
@@ -14,25 +16,44 @@ import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, sheetStyles } from '../../theme/tokens';
 
+// iOS renders the modal in a native window overlay so it sits above the
+// persistent queue bar (mirrors ModalSheet / LogAscentSheet); Android's modal
+// portal already covers it.
+function ModalSheetContainer({ children }: { children?: ReactNode }) {
+  return <FullWindowOverlay>{children}</FullWindowOverlay>;
+}
+const modalContainerComponent = Platform.OS === 'ios' ? ModalSheetContainer : undefined;
+
 type QueueSheetProps = {
   visible: boolean;
+  board: QueueItemRowBoard;
   onClose: () => void;
   onClimbPress: (item: ClimbQueueItem) => void;
+  onSuggestionPress: (climb: Climb) => void;
+  onTickHistory: (item: ClimbQueueItem) => void;
 };
 
-export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) {
+export function QueueSheet({
+  visible,
+  board,
+  onClose,
+  onClimbPress,
+  onSuggestionPress,
+  onTickHistory,
+}: QueueSheetProps) {
   const { t } = useTranslation('session');
   const insets = useSafeAreaInsets();
   const { systemColors } = useTheme();
-  const sheetRef = useRef<BottomSheet>(null);
+  const sheetRef = useRef<BottomSheetModal>(null);
 
-  const { state, removeFromQueue, clearQueue } = useQueue();
+  const { state, removeFromQueue, clearQueue, reorderQueue, playlistSuggestionSource } = useQueue();
   const { queue, currentClimbQueueItem } = state;
 
   const [isEditMode, setIsEditMode] = useState(false);
   const [showHistory, setShowHistory] = useState(true);
   const [showFullHistory, setShowFullHistory] = useState(false);
   const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
+  const [isDragging, setIsDragging] = useState(false);
 
   const snapPoints = useMemo(() => ['60%', '90%'], []);
 
@@ -40,9 +61,9 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
 
   useEffect(() => {
     if (visible) {
-      sheetRef.current?.snapToIndex(0);
+      sheetRef.current?.present();
     } else {
-      sheetRef.current?.close();
+      sheetRef.current?.dismiss();
     }
   }, [visible]);
 
@@ -56,15 +77,6 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
     resetState();
     onClose();
   }, [resetState, onClose]);
-
-  const handleSheetChange = useCallback(
-    (index: number) => {
-      if (index < 0) {
-        handleClose();
-      }
-    },
-    [handleClose],
-  );
 
   const handleToggleEditMode = useCallback(() => {
     setIsEditMode((prev) => {
@@ -120,7 +132,7 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
-      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.4} />
+      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.4} pressBehavior="close" />
     ),
     [],
   );
@@ -130,14 +142,21 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
   const viewOnlyMode = queue.length === 0;
 
   return (
-    <BottomSheet
+    <BottomSheetModal
       ref={sheetRef}
-      index={-1}
+      index={0}
       snapPoints={snapPoints}
+      // Stack above the play drawer (when opened from its queue button) instead
+      // of replacing it, so closing the queue sheet reveals the drawer again.
+      stackBehavior="push"
       enablePanDownToClose
+      // Freeze the sheet pan while a row is being dragged so scroll-to-expand
+      // never fights the reorder gesture.
+      enableContentPanningGesture={!isDragging}
+      enableHandlePanningGesture={!isDragging}
       backdropComponent={renderBackdrop}
-      onChange={handleSheetChange}
-      onClose={handleClose}
+      containerComponent={modalContainerComponent}
+      onDismiss={handleClose}
       handleIndicatorStyle={sheetStyles.indicator}
       backgroundStyle={backgroundStyle}
       style={styles.sheet}
@@ -157,15 +176,21 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
       <QueueList
         queue={queue}
         currentItemUuid={currentItemUuid}
+        board={board}
         isEditMode={isEditMode}
         showHistory={showHistory}
         showFullHistory={showFullHistory}
         selectedItems={selectedItems}
+        playlistSuggestionSource={playlistSuggestionSource}
         autoScrollOnMount={visible}
         onToggleSelect={handleToggleSelect}
         onClimbPress={onClimbPress}
         onRemove={handleRemove}
         onShowFullHistory={handleShowFullHistory}
+        onTickHistory={onTickHistory}
+        onSuggestionPress={onSuggestionPress}
+        reorderQueue={reorderQueue}
+        onDraggingChange={setIsDragging}
       />
 
       {isEditMode && selectedItems.size > 0 && (
@@ -191,7 +216,7 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
           </Pressable>
         </View>
       )}
-    </BottomSheet>
+    </BottomSheetModal>
   );
 }
 

--- a/packages/mobile/src/components/play-drawer/QueueSheetHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheetHeader.tsx
@@ -121,7 +121,7 @@ export const QueueSheetHeader = memo(function QueueSheetHeader({
           hitSlop={8}
           style={styles.headerButton}
         >
-          <Icon name="close" size={18} color={iosSystemColors.systemGray} />
+          <Icon name="chevron.down" size={20} color={iosSystemColors.systemGray} />
         </Pressable>
       </View>
     </View>

--- a/packages/mobile/src/components/play-drawer/__tests__/queue-drag-math.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/queue-drag-math.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { queueIndexForRow, clampRowIndex, dropRowIndex, rowReorderShift } from '../queue-drag-math';
+import {
+  queueIndexForRow,
+  clampRowIndex,
+  dropRowIndex,
+  rowReorderShift,
+  resolveReorderCommit,
+} from '../queue-drag-math';
 
 // The future-item window is a contiguous block of flat-list rows that maps 1:1
 // onto a contiguous slice of the queue array. Example used throughout: history
@@ -85,5 +91,31 @@ describe('rowReorderShift', () => {
   it('no shift when target equals active (no movement)', () => {
     expect(rowReorderShift(4, 5, 5, H)).toBe(0);
     expect(rowReorderShift(6, 5, 5, H)).toBe(0);
+  });
+});
+
+describe('resolveReorderCommit', () => {
+  // Future window: flat rows 3..6 ↔ queue indices 3..6 (offset 0 here).
+  const WINDOW = { firstRowIndex: 3, firstQueueIndex: 3 };
+
+  it('maps the drop row to a queue move', () => {
+    expect(resolveReorderCommit('a', 3, 5, WINDOW)).toEqual({ uuid: 'a', oldIndex: 3, newIndex: 5 });
+  });
+
+  it('honours a row/queue index offset', () => {
+    // history "show all" row shifts flat indices +1 vs queue indices
+    expect(resolveReorderCommit('a', 2, 6, { firstRowIndex: 4, firstQueueIndex: 2 })).toEqual({
+      uuid: 'a',
+      oldIndex: 2,
+      newIndex: 4,
+    });
+  });
+
+  it('returns null when the item did not move', () => {
+    expect(resolveReorderCommit('a', 4, 4, WINDOW)).toBeNull();
+  });
+
+  it('returns null when there is no draggable window', () => {
+    expect(resolveReorderCommit('a', 0, 0, { firstRowIndex: -1, firstQueueIndex: -1 })).toBeNull();
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/queue-drag-math.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/queue-drag-math.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { queueIndexForRow, clampRowIndex, dropRowIndex, rowReorderShift } from '../queue-drag-math';
+
+// The future-item window is a contiguous block of flat-list rows that maps 1:1
+// onto a contiguous slice of the queue array. Example used throughout: history
+// (rows 0–1) + current (row 2) + future rows 3,4,5,6 → queue indices 3,4,5,6,
+// so firstRowIndex = 3 and firstQueueIndex = 3 (they happen to match here), and
+// a case where they DON'T match to prove the offset is honoured.
+
+describe('queueIndexForRow', () => {
+  it('maps a future row index to its queue index by constant offset', () => {
+    expect(queueIndexForRow(3, 3, 3)).toBe(3);
+    expect(queueIndexForRow(6, 3, 3)).toBe(6);
+  });
+
+  it('honours an offset between row index and queue index', () => {
+    // e.g. a collapsed history "show all" row shifts flat indices by 1 vs queue
+    // indices: future rows 4,5,6 → queue 2,3,4 (firstRowIndex 4, firstQueueIndex 2)
+    expect(queueIndexForRow(4, 4, 2)).toBe(2);
+    expect(queueIndexForRow(6, 4, 2)).toBe(4);
+  });
+});
+
+describe('clampRowIndex', () => {
+  it('clamps below the window to the first row', () => {
+    expect(clampRowIndex(1, 3, 6)).toBe(3);
+  });
+  it('clamps above the window to the last row', () => {
+    expect(clampRowIndex(9, 3, 6)).toBe(6);
+  });
+  it('passes values already inside the window through', () => {
+    expect(clampRowIndex(4, 3, 6)).toBe(4);
+  });
+});
+
+describe('dropRowIndex', () => {
+  const FIRST = 3;
+  const LAST = 6;
+  const H = 100;
+
+  it('returns the start row for no movement', () => {
+    expect(dropRowIndex(4, 0, H, FIRST, LAST)).toBe(4);
+  });
+  it('rounds a partial drag to the nearest row', () => {
+    expect(dropRowIndex(4, 60, H, FIRST, LAST)).toBe(5); // +0.6 row → +1
+    expect(dropRowIndex(4, 40, H, FIRST, LAST)).toBe(4); // +0.4 row → 0
+  });
+  it('moves multiple rows down', () => {
+    expect(dropRowIndex(3, 250, H, FIRST, LAST)).toBe(6); // +2.5 → +3 → clamp 6
+  });
+  it('moves up and clamps at the first future row (cannot enter history/current)', () => {
+    expect(dropRowIndex(5, -500, H, FIRST, LAST)).toBe(FIRST);
+  });
+  it('clamps at the last future row (cannot enter suggestions)', () => {
+    expect(dropRowIndex(4, 500, H, FIRST, LAST)).toBe(LAST);
+  });
+});
+
+describe('rowReorderShift', () => {
+  const H = 100;
+
+  it('does not shift the dragged row itself', () => {
+    expect(rowReorderShift(4, 4, 6, H)).toBe(0);
+  });
+
+  it('shifts rows the dragged row passes while moving DOWN up by one row', () => {
+    // dragging row 3 down to 5: rows 4 and 5 move up by H, row 6 stays
+    expect(rowReorderShift(4, 3, 5, H)).toBe(-H);
+    expect(rowReorderShift(5, 3, 5, H)).toBe(-H);
+    expect(rowReorderShift(6, 3, 5, H)).toBe(0);
+  });
+
+  it('shifts rows the dragged row passes while moving UP down by one row', () => {
+    // dragging row 6 up to 4: rows 4 and 5 move down by H, row 3 stays
+    expect(rowReorderShift(5, 6, 4, H)).toBe(H);
+    expect(rowReorderShift(4, 6, 4, H)).toBe(H);
+    expect(rowReorderShift(3, 6, 4, H)).toBe(0);
+  });
+
+  it('does not shift rows outside the dragged span', () => {
+    expect(rowReorderShift(3, 4, 6, H)).toBe(0); // below the span
+    expect(rowReorderShift(7, 4, 6, H)).toBe(0); // above the span
+  });
+
+  it('no shift when target equals active (no movement)', () => {
+    expect(rowReorderShift(4, 5, 5, H)).toBe(0);
+    expect(rowReorderShift(6, 5, 5, H)).toBe(0);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/queue-drag-math.ts
+++ b/packages/mobile/src/components/play-drawer/queue-drag-math.ts
@@ -1,0 +1,54 @@
+// Pure index / offset math for the queue drag-to-reorder hook. Extracted so the
+// non-trivial mapping (flat-row index ↔ queue-array index, drop clamping, and
+// the sibling gap-shift) is unit-testable without the Reanimated / gesture-
+// handler runtime. Each helper carries the 'worklet' directive so it can also be
+// called from UI-thread worklets (the directive is an inert string statement in
+// plain JS / the test runner). This mirrors the codebase's existing pattern of
+// importing 'worklet' helpers into worklets (e.g. computePeekOffset).
+
+/** Map a flat-list row index in the future window to its queue-array index. */
+export function queueIndexForRow(rowIndex: number, firstRowIndex: number, firstQueueIndex: number): number {
+  'worklet';
+  return firstQueueIndex + (rowIndex - firstRowIndex);
+}
+
+/** Clamp a (possibly out-of-range) row index to the draggable window. */
+export function clampRowIndex(rowIndex: number, firstRowIndex: number, lastRowIndex: number): number {
+  'worklet';
+  if (rowIndex < firstRowIndex) return firstRowIndex;
+  if (rowIndex > lastRowIndex) return lastRowIndex;
+  return rowIndex;
+}
+
+/**
+ * Where the dragged row would drop, given its starting row index and the finger
+ * delta, clamped to the draggable window. `rowHeight` must be > 0.
+ */
+export function dropRowIndex(
+  startRowIndex: number,
+  translateY: number,
+  rowHeight: number,
+  firstRowIndex: number,
+  lastRowIndex: number,
+): number {
+  'worklet';
+  const raw = Math.round(startRowIndex + translateY / rowHeight);
+  return clampRowIndex(raw, firstRowIndex, lastRowIndex);
+}
+
+/**
+ * Vertical offset a sibling row animates to so a gap opens under the lifted row:
+ * rows the dragged row has crossed shift one row-height toward the drag origin;
+ * the dragged row itself and untouched rows return 0.
+ */
+export function rowReorderShift(
+  rowIndex: number,
+  activeRowIndex: number,
+  targetRowIndex: number,
+  rowHeight: number,
+): number {
+  'worklet';
+  if (activeRowIndex < targetRowIndex && rowIndex > activeRowIndex && rowIndex <= targetRowIndex) return -rowHeight;
+  if (activeRowIndex > targetRowIndex && rowIndex >= targetRowIndex && rowIndex < activeRowIndex) return rowHeight;
+  return 0;
+}

--- a/packages/mobile/src/components/play-drawer/queue-drag-math.ts
+++ b/packages/mobile/src/components/play-drawer/queue-drag-math.ts
@@ -36,6 +36,27 @@ export function dropRowIndex(
   return clampRowIndex(raw, firstRowIndex, lastRowIndex);
 }
 
+/** The draggable window mapping needed to turn a drop into a queue reorder. */
+export type ReorderWindow = { firstRowIndex: number; firstQueueIndex: number };
+
+/**
+ * Decide the reorder to commit when a drag ends: maps the drop row index to a
+ * queue index and returns the move, or null when there's no draggable window
+ * (`firstRowIndex < 0`) or the item didn't actually move. Pure so the hook's
+ * JS-thread commit path is unit-testable without the gesture runtime.
+ */
+export function resolveReorderCommit(
+  uuid: string,
+  oldQueueIndex: number,
+  toRowIndex: number,
+  window: ReorderWindow,
+): { uuid: string; oldIndex: number; newIndex: number } | null {
+  if (window.firstRowIndex < 0) return null;
+  const newQueueIndex = queueIndexForRow(toRowIndex, window.firstRowIndex, window.firstQueueIndex);
+  if (newQueueIndex === oldQueueIndex) return null;
+  return { uuid, oldIndex: oldQueueIndex, newIndex: newQueueIndex };
+}
+
 /**
  * Vertical offset a sibling row animates to so a gap opens under the lifted row:
  * rows the dragged row has crossed shift one row-height toward the drag origin;

--- a/packages/mobile/src/components/play-drawer/use-queue-drag.ts
+++ b/packages/mobile/src/components/play-drawer/use-queue-drag.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import { useSharedValue, runOnJS, type SharedValue } from 'react-native-reanimated';
 import { hapticSelection } from '../../lib/haptics';
+import { dropRowIndex, queueIndexForRow } from './queue-drag-math';
 
 // Press-and-hold this long on a handle before the drag arms. Short enough to
 // feel instant on a deliberate grab, long enough that a quick flick scrolls
@@ -78,11 +79,13 @@ export function useQueueDrag({
   const windowRef = useRef({ firstRowIndex: firstFutureRowIndex, firstQueueIndex: firstFutureQueueIndex });
   windowRef.current = { firstRowIndex: firstFutureRowIndex, firstQueueIndex: firstFutureQueueIndex };
 
-  const measuredRef = useRef(false);
+  // Track the latest measured row height (don't latch the first one) so a board
+  // switch with differently-shaped thumbnails keeps the drag step distance
+  // correct. Future rows are uniform, so the >1px guard avoids churn from the
+  // several rows reporting the same height.
   const onRowHeight = useCallback(
     (height: number) => {
-      if (height > 0 && !measuredRef.current) {
-        measuredRef.current = true;
+      if (height > 0 && Math.abs(rowHeight.value - height) > 1) {
         rowHeight.value = height;
       }
     },
@@ -93,7 +96,7 @@ export function useQueueDrag({
     (uuid: string, oldQueueIndex: number, toRowIndex: number) => {
       const { firstRowIndex, firstQueueIndex } = windowRef.current;
       if (firstRowIndex < 0) return;
-      const newQueueIndex = firstQueueIndex + (toRowIndex - firstRowIndex);
+      const newQueueIndex = queueIndexForRow(toRowIndex, firstRowIndex, firstQueueIndex);
       if (newQueueIndex === oldQueueIndex) return;
       reorderQueue(uuid, oldQueueIndex, newQueueIndex);
     },
@@ -117,9 +120,7 @@ export function useQueueDrag({
           'worklet';
           dragTranslateY.value = event.translationY;
           const height = rowHeight.value || DEFAULT_ROW_HEIGHT;
-          let next = Math.round(rowIndex + event.translationY / height);
-          if (next < firstRowIndexSV.value) next = firstRowIndexSV.value;
-          if (next > lastRowIndexSV.value) next = lastRowIndexSV.value;
+          const next = dropRowIndex(rowIndex, event.translationY, height, firstRowIndexSV.value, lastRowIndexSV.value);
           if (next !== targetRowIndex.value) {
             targetRowIndex.value = next;
             runOnJS(hapticSelection)();

--- a/packages/mobile/src/components/play-drawer/use-queue-drag.ts
+++ b/packages/mobile/src/components/play-drawer/use-queue-drag.ts
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Gesture, type GestureType } from 'react-native-gesture-handler';
+import { useSharedValue, runOnJS, type SharedValue } from 'react-native-reanimated';
+import { hapticSelection } from '../../lib/haptics';
+
+// Press-and-hold this long on a handle before the drag arms. Short enough to
+// feel instant on a deliberate grab, long enough that a quick flick scrolls
+// the list (gorhom's BottomSheetFlatList scroll/scroll-to-expand) instead of
+// lifting a row.
+const LONG_PRESS_MS = 120;
+// Fallback row height until the first future row reports its measured height.
+// Queue rows are ~thumbnail (96) + vertical padding + separator.
+const DEFAULT_ROW_HEIGHT = 120;
+
+export type QueueDragShared = {
+  activeUuid: SharedValue<string | null>;
+  dragTranslateY: SharedValue<number>;
+  activeRowIndex: SharedValue<number>;
+  targetRowIndex: SharedValue<number>;
+  rowHeight: SharedValue<number>;
+};
+
+type UseQueueDragOptions = {
+  /** Optimistically reorder + broadcast (queue-array indices). */
+  reorderQueue: (uuid: string, oldIndex: number, newIndex: number) => void;
+  /** flatRows index of the first/last contiguous `future-item` row (-1 when none). */
+  firstFutureRowIndex: number;
+  lastFutureRowIndex: number;
+  /** queue-array index of the first future row — maps a row index to a queue index. */
+  firstFutureQueueIndex: number;
+};
+
+export type QueueDragControls = {
+  /** True while a row is lifted — drives the FlatList scroll + sheet-pan lock. */
+  isDragging: boolean;
+  /** Shared values read by each row's animated style (lift + sibling shift). */
+  shared: QueueDragShared;
+  /** Report a future row's measured height (call once from onLayout). */
+  onRowHeight: (height: number) => void;
+  /** Build the long-press drag Pan for a future row's handle. */
+  makeHandleGesture: (rowIndex: number, uuid: string, queueIndex: number) => GestureType;
+};
+
+/**
+ * Custom always-on drag-to-reorder for the contiguous `future-item` window of
+ * the queue list. Lives at the list level (one instance per QueueList) so the
+ * dragged row and its siblings share a single coordinate space. Each future
+ * row's ≡ handle gets a `Gesture.Pan().activateAfterLongPress` from
+ * `makeHandleGesture`; the row reads `shared` to lift itself and shift siblings
+ * to open a gap. On release it maps (rowIndex → queueIndex) and calls
+ * `reorderQueue`. While a drag is active `isDragging` flips so the host can
+ * disable the list scroll and the sheet pan (so scroll-to-expand never fights
+ * the drag).
+ */
+export function useQueueDrag({
+  reorderQueue,
+  firstFutureRowIndex,
+  lastFutureRowIndex,
+  firstFutureQueueIndex,
+}: UseQueueDragOptions): QueueDragControls {
+  const activeUuid = useSharedValue<string | null>(null);
+  const dragTranslateY = useSharedValue(0);
+  const activeRowIndex = useSharedValue(-1);
+  const targetRowIndex = useSharedValue(-1);
+  const rowHeight = useSharedValue(DEFAULT_ROW_HEIGHT);
+  // Window bounds the drag clamps to; mirrored into shared values for the
+  // onUpdate worklet.
+  const firstRowIndexSV = useSharedValue(firstFutureRowIndex);
+  const lastRowIndexSV = useSharedValue(lastFutureRowIndex);
+  const [isDragging, setIsDragging] = useState(false);
+
+  useEffect(() => {
+    firstRowIndexSV.value = firstFutureRowIndex;
+    lastRowIndexSV.value = lastFutureRowIndex;
+  }, [firstFutureRowIndex, lastFutureRowIndex, firstRowIndexSV, lastRowIndexSV]);
+
+  // Latest window mapping read on the JS thread when committing.
+  const windowRef = useRef({ firstRowIndex: firstFutureRowIndex, firstQueueIndex: firstFutureQueueIndex });
+  windowRef.current = { firstRowIndex: firstFutureRowIndex, firstQueueIndex: firstFutureQueueIndex };
+
+  const measuredRef = useRef(false);
+  const onRowHeight = useCallback(
+    (height: number) => {
+      if (height > 0 && !measuredRef.current) {
+        measuredRef.current = true;
+        rowHeight.value = height;
+      }
+    },
+    [rowHeight],
+  );
+
+  const commit = useCallback(
+    (uuid: string, oldQueueIndex: number, toRowIndex: number) => {
+      const { firstRowIndex, firstQueueIndex } = windowRef.current;
+      if (firstRowIndex < 0) return;
+      const newQueueIndex = firstQueueIndex + (toRowIndex - firstRowIndex);
+      if (newQueueIndex === oldQueueIndex) return;
+      reorderQueue(uuid, oldQueueIndex, newQueueIndex);
+    },
+    [reorderQueue],
+  );
+
+  const makeHandleGesture = useCallback(
+    (rowIndex: number, uuid: string, queueIndex: number): GestureType =>
+      Gesture.Pan()
+        .activateAfterLongPress(LONG_PRESS_MS)
+        .onStart(() => {
+          'worklet';
+          activeUuid.value = uuid;
+          activeRowIndex.value = rowIndex;
+          targetRowIndex.value = rowIndex;
+          dragTranslateY.value = 0;
+          runOnJS(setIsDragging)(true);
+          runOnJS(hapticSelection)();
+        })
+        .onUpdate((event) => {
+          'worklet';
+          dragTranslateY.value = event.translationY;
+          const height = rowHeight.value || DEFAULT_ROW_HEIGHT;
+          let next = Math.round(rowIndex + event.translationY / height);
+          if (next < firstRowIndexSV.value) next = firstRowIndexSV.value;
+          if (next > lastRowIndexSV.value) next = lastRowIndexSV.value;
+          if (next !== targetRowIndex.value) {
+            targetRowIndex.value = next;
+            runOnJS(hapticSelection)();
+          }
+        })
+        .onEnd(() => {
+          'worklet';
+          runOnJS(commit)(uuid, queueIndex, targetRowIndex.value);
+        })
+        .onFinalize(() => {
+          'worklet';
+          activeUuid.value = null;
+          dragTranslateY.value = 0;
+          activeRowIndex.value = -1;
+          targetRowIndex.value = -1;
+          runOnJS(setIsDragging)(false);
+        }),
+    [activeUuid, activeRowIndex, targetRowIndex, dragTranslateY, rowHeight, firstRowIndexSV, lastRowIndexSV, commit],
+  );
+
+  return {
+    isDragging,
+    shared: { activeUuid, dragTranslateY, activeRowIndex, targetRowIndex, rowHeight },
+    onRowHeight,
+    makeHandleGesture,
+  };
+}

--- a/packages/mobile/src/components/play-drawer/use-queue-drag.ts
+++ b/packages/mobile/src/components/play-drawer/use-queue-drag.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import { useSharedValue, runOnJS, type SharedValue } from 'react-native-reanimated';
 import { hapticSelection } from '../../lib/haptics';
-import { dropRowIndex, queueIndexForRow } from './queue-drag-math';
+import { dropRowIndex, resolveReorderCommit } from './queue-drag-math';
 
 // Press-and-hold this long on a handle before the drag arms. Short enough to
 // feel instant on a deliberate grab, long enough that a quick flick scrolls
@@ -94,11 +94,8 @@ export function useQueueDrag({
 
   const commit = useCallback(
     (uuid: string, oldQueueIndex: number, toRowIndex: number) => {
-      const { firstRowIndex, firstQueueIndex } = windowRef.current;
-      if (firstRowIndex < 0) return;
-      const newQueueIndex = queueIndexForRow(toRowIndex, firstRowIndex, firstQueueIndex);
-      if (newQueueIndex === oldQueueIndex) return;
-      reorderQueue(uuid, oldQueueIndex, newQueueIndex);
+      const move = resolveReorderCommit(uuid, oldQueueIndex, toRowIndex, windowRef.current);
+      if (move) reorderQueue(move.uuid, move.oldIndex, move.newIndex);
     },
     [reorderQueue],
   );

--- a/packages/mobile/src/components/queue-snackbar-position.ts
+++ b/packages/mobile/src/components/queue-snackbar-position.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure layout math for the "Climb added to queue" snackbar's bottom offset.
+ * Extracted from QueueAddedSnackbar so the (small but easy-to-break) positioning
+ * rule is unit-testable: the pill floats one `gap` above the tab bar, and a
+ * further `barContentHeight + gap` higher when the persistent queue bar is
+ * showing so it never overlaps the bar.
+ */
+export function queueSnackbarBottomOffset(params: {
+  /** Safe-area bottom inset. */
+  insetsBottom: number;
+  /** Height of the tab bar the snackbar floats above. */
+  tabBarHeight: number;
+  /** Height of the persistent queue bar (only added when it's visible). */
+  barContentHeight: number;
+  /** Spacing unit used both above the tab bar and above the queue bar. */
+  gap: number;
+  /** Whether the persistent queue bar is currently showing. */
+  barVisible: boolean;
+}): number {
+  const { insetsBottom, tabBarHeight, barContentHeight, gap, barVisible } = params;
+  return insetsBottom + tabBarHeight + (barVisible ? barContentHeight + gap : 0) + gap;
+}

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -4,12 +4,14 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { BoardName } from '@boardsesh/shared-schema';
 import { Text } from '../../Text';
 import { Button } from '../../Button';
-import { QueueItemRow } from '../../QueueItemRow';
+import { QueueItemRow, type QueueItemRowBoard } from '../../QueueItemRow';
 import { EndSessionSheet } from '../../EndSessionSheet';
 import { useTheme } from '../../../providers/theme-provider';
 import { useQueue } from '../../../providers/queue-provider';
+import { useDrawerHost } from '../../../providers/drawer-host-provider';
 import { useSessionScreen } from '../../../providers/session-screen-provider';
 import { useSessionSummary } from '../../../lib/graphql/hooks';
 import { spacing, borderRadius } from '../../../theme/tokens';
@@ -23,7 +25,18 @@ export function InSessionView() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { close } = useSessionScreen();
+  const { boardConfig } = useDrawerHost();
   const { state, sessionId, setCurrentClimb, removeFromQueue, endSession } = useQueue();
+
+  const board: QueueItemRowBoard | null = boardConfig
+    ? {
+        boardName: boardConfig.boardName as BoardName,
+        layoutId: boardConfig.layoutId,
+        sizeId: boardConfig.sizeId,
+        setIds: boardConfig.setIds,
+        angle: boardConfig.angle,
+      }
+    : null;
 
   // Live summary: same query as the post-session view, just polled while the
   // overlay is open so the live tiles stay current as the user logs ticks.
@@ -72,7 +85,7 @@ export function InSessionView() {
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
             {t('mobile.session.inQueueTitle')}
           </Text>
-          {queue.length === 0 ? (
+          {queue.length === 0 || !board ? (
             <View style={[styles.emptyCard, { backgroundColor: systemColors.secondaryBackground }]}>
               <Text variant="body" color={systemColors.secondaryLabel}>
                 {t('mobile.session.inQueueEmpty')}
@@ -84,6 +97,7 @@ export function InSessionView() {
                 key={item.uuid}
                 item={item}
                 position={index + 1}
+                board={board}
                 isCurrentClimb={currentUuid === item.uuid}
                 onPress={handlePressItem}
                 onRemove={handleRemoveItem}

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -7,6 +7,7 @@ import type { ClimbQueueItem } from '@boardsesh/queue';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { Text } from '../../Text';
 import { Button } from '../../Button';
+import { ActivityIndicator } from '../../ActivityIndicator';
 import { QueueItemRow, type QueueItemRowBoard } from '../../QueueItemRow';
 import { EndSessionSheet } from '../../EndSessionSheet';
 import { useTheme } from '../../../providers/theme-provider';
@@ -85,11 +86,17 @@ export function InSessionView() {
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
             {t('mobile.session.inQueueTitle')}
           </Text>
-          {queue.length === 0 || !board ? (
+          {queue.length === 0 ? (
             <View style={[styles.emptyCard, { backgroundColor: systemColors.secondaryBackground }]}>
               <Text variant="body" color={systemColors.secondaryLabel}>
                 {t('mobile.session.inQueueEmpty')}
               </Text>
+            </View>
+          ) : !board ? (
+            // Items exist but the active board (for thumbnails) is still
+            // resolving — show a spinner rather than a misleading empty state.
+            <View style={[styles.emptyCard, { backgroundColor: systemColors.secondaryBackground }]}>
+              <ActivityIndicator />
             </View>
           ) : (
             queue.map((item, index) => (

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -194,8 +194,9 @@ export function useSearchClimbs(
     queryFn: () => getHttpClient().request<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input }),
     select: (data) => data.searchClimbs,
     enabled,
-    ...(options?.staleTime !== undefined ? { staleTime: options.staleTime } : {}),
-    ...(options?.gcTime !== undefined ? { gcTime: options.gcTime } : {}),
+    // undefined → React Query's defaults.
+    staleTime: options?.staleTime,
+    gcTime: options?.gcTime,
   });
 }
 

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -184,12 +184,18 @@ export function useAngles(boardName: string, layoutId: number) {
 // Climb Queries
 // ============================================
 
-export function useSearchClimbs(input: ClimbSearchInput, enabled = true) {
+export function useSearchClimbs(
+  input: ClimbSearchInput,
+  enabled = true,
+  options?: { staleTime?: number; gcTime?: number },
+) {
   return useQuery({
     queryKey: ['searchClimbs', input],
     queryFn: () => getHttpClient().request<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input }),
     select: (data) => data.searchClimbs,
     enabled,
+    ...(options?.staleTime !== undefined ? { staleTime: options.staleTime } : {}),
+    ...(options?.gcTime !== undefined ? { gcTime: options.gcTime } : {}),
   });
 }
 

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -168,8 +168,6 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
 
   const openAddToPlaylist = useCallback((climb: Climb) => {
     const boardConfig = activeBoardConfigRef.current;
-    // TEMP DIAGNOSTIC (Bug 2): confirm the handler fires + board config present.
-    if (__DEV__) console.warn(`[drawer] openAddToPlaylist climb=${climb?.name} hasBoardConfig=${!!boardConfig}`);
     if (!boardConfig) return;
     setPlaylistClimb({ climb, boardConfig });
   }, []);

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -13,14 +13,20 @@
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { randomUUID } from 'expo-crypto';
-import type { Climb } from '@boardsesh/shared-schema';
+import type { BoardName, Climb } from '@boardsesh/shared-schema';
+import type { Climb as QueueClimb, ClimbQueueItem } from '@boardsesh/queue';
 import { PlayDrawer, type PlayDrawerHandle, type PlayDrawerOpenOptions } from '../components/play-drawer';
 import { LogAscentSheet } from '../components/LogAscentSheet';
+import { QueueSheet } from '../components/play-drawer/QueueSheet';
+import { QueueAddedSnackbar } from '../components/QueueAddedSnackbar';
+import type { QueueItemRowBoard } from '../components/QueueItemRow';
 import { useActiveBoard } from '../lib/graphql/use-active-board';
 import { ClimbActionsSheet } from '../components/ClimbActionsSheet';
 import { AddToPlaylistSheet } from '../components/AddToPlaylistSheet';
 import { useToggleFavorite } from '../lib/graphql/hooks';
+import { climbToQueueItem } from '../lib/climb-to-queue-item';
 import { useQueue } from './queue-provider';
+import { useQueueSnackbar } from './queue-snackbar-provider';
 
 export type BoardConfig = {
   boardName: string;
@@ -68,6 +74,9 @@ type DrawerHostValue = {
   /** Opens the add-to-playlist bottom sheet for the given climb. Snapshots the
    *  active boardConfig (for the angle) at open time. */
   openAddToPlaylist: (climb: Climb) => void;
+  /** Opens the queue list sheet (from the play-drawer queue button or the
+   *  "Climb added to queue" snackbar's Open action). */
+  openQueueSheet: () => void;
 };
 
 const DrawerHostContext = createContext<DrawerHostValue | null>(null);
@@ -85,7 +94,9 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const [logAscentInput, setLogAscentInput] = useState<LogAscentInput | null>(null);
   const [climbActions, setClimbActions] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const [playlistClimb, setPlaylistClimb] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
-  const { addToQueue } = useQueue();
+  const [queueSheetVisible, setQueueSheetVisible] = useState(false);
+  const { addToQueue, setCurrentClimb, playlistSuggestionSource, sessionId } = useQueue();
+  const { visible: snackbarVisible, nonce: snackbarNonce, dismissSnackbar } = useQueueSnackbar();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
 
   // Climb to open after the boardConfig override has committed. We can't
@@ -157,6 +168,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
 
   const openAddToPlaylist = useCallback((climb: Climb) => {
     const boardConfig = activeBoardConfigRef.current;
+    // TEMP DIAGNOSTIC (Bug 2): confirm the handler fires + board config present.
+    if (__DEV__) console.warn(`[drawer] openAddToPlaylist climb=${climb?.name} hasBoardConfig=${!!boardConfig}`);
     if (!boardConfig) return;
     setPlaylistClimb({ climb, boardConfig });
   }, []);
@@ -196,6 +209,64 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     });
   }, [climbActions]);
 
+  const openQueueSheet = useCallback(() => setQueueSheetVisible(true), []);
+  const closeQueueSheet = useCallback(() => setQueueSheetVisible(false), []);
+
+  // The queue sheet renders climbs against the active board (thumbnails + tick).
+  const queueBoard = useMemo<QueueItemRowBoard | null>(() => {
+    if (!activeBoardConfig) return null;
+    return {
+      boardName: activeBoardConfig.boardName as BoardName,
+      layoutId: activeBoardConfig.layoutId,
+      sizeId: activeBoardConfig.sizeId,
+      setIds: activeBoardConfig.setIds,
+      angle: activeBoardConfig.angle,
+    };
+  }, [activeBoardConfig]);
+
+  // Tap a queue item → make it current and show it in the play drawer.
+  const handleQueueClimbPress = useCallback(
+    (item: ClimbQueueItem) => {
+      setCurrentClimb(item);
+      openPlayDrawer(item.climb, { setAsCurrent: false });
+      setQueueSheetVisible(false);
+    },
+    [setCurrentClimb, openPlayDrawer],
+  );
+
+  // Tap a suggestion → activate it (adds + sets current) and show it.
+  const handleQueueSuggestionPress = useCallback(
+    (climb: QueueClimb) => {
+      const item = climbToQueueItem(climb, { suggested: true });
+      setCurrentClimb(item, { playlistSuggestionSource });
+      openPlayDrawer(climb, { setAsCurrent: false });
+      setQueueSheetVisible(false);
+    },
+    [setCurrentClimb, playlistSuggestionSource, openPlayDrawer],
+  );
+
+  // Tick a history climb → open the log-ascent sheet (stacks above the queue
+  // sheet, which stays open beneath) pre-filled with the active session.
+  const handleQueueTickHistory = useCallback(
+    (item: ClimbQueueItem) => {
+      const boardConfig = activeBoardConfigRef.current;
+      if (!boardConfig) return;
+      setLogAscentInput({
+        climbUuid: item.climb.uuid,
+        boardName: boardConfig.boardName,
+        angle: boardConfig.angle,
+        isMirror: item.climb.mirrored === true,
+        isBenchmark: !!item.climb.benchmark_difficulty,
+        layoutId: boardConfig.layoutId,
+        sizeId: boardConfig.sizeId,
+        setIds: boardConfig.setIds,
+        sessionId,
+        consensusGradeName: item.climb.difficulty,
+      });
+    },
+    [sessionId],
+  );
+
   const value = useMemo<DrawerHostValue>(
     () => ({
       boardConfig: activeBoardConfig,
@@ -204,8 +275,17 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       openClimbActions,
       closeClimbActions,
       openAddToPlaylist,
+      openQueueSheet,
     }),
-    [activeBoardConfig, openPlayDrawer, openLogAscent, openClimbActions, closeClimbActions, openAddToPlaylist],
+    [
+      activeBoardConfig,
+      openPlayDrawer,
+      openLogAscent,
+      openClimbActions,
+      closeClimbActions,
+      openAddToPlaylist,
+      openQueueSheet,
+    ],
   );
 
   return (
@@ -251,6 +331,25 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           onClose={closeAddToPlaylist}
         />
       ) : null}
+      {queueSheetVisible && queueBoard ? (
+        <QueueSheet
+          visible
+          board={queueBoard}
+          onClose={closeQueueSheet}
+          onClimbPress={handleQueueClimbPress}
+          onSuggestionPress={handleQueueSuggestionPress}
+          onTickHistory={handleQueueTickHistory}
+        />
+      ) : null}
+      <QueueAddedSnackbar
+        visible={snackbarVisible}
+        nonce={snackbarNonce}
+        onDismiss={dismissSnackbar}
+        onOpen={() => {
+          dismissSnackbar();
+          openQueueSheet();
+        }}
+      />
     </DrawerHostContext.Provider>
   );
 }

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -14,7 +14,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { randomUUID } from 'expo-crypto';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
-import type { Climb as QueueClimb, ClimbQueueItem } from '@boardsesh/queue';
+import type { Climb as QueueClimb, ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import { PlayDrawer, type PlayDrawerHandle, type PlayDrawerOpenOptions } from '../components/play-drawer';
 import { LogAscentSheet } from '../components/LogAscentSheet';
 import { QueueSheet } from '../components/play-drawer/QueueSheet';
@@ -94,8 +94,13 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const [logAscentInput, setLogAscentInput] = useState<LogAscentInput | null>(null);
   const [climbActions, setClimbActions] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const [playlistClimb, setPlaylistClimb] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
+  // `mounted` controls whether QueueSheet is in the tree (so its suggestion
+  // query only runs while open); `visible` drives the present/dismiss animation.
+  // Splitting them lets a programmatic close play the dismiss animation before
+  // unmounting instead of vanishing instantly.
+  const [queueSheetMounted, setQueueSheetMounted] = useState(false);
   const [queueSheetVisible, setQueueSheetVisible] = useState(false);
-  const { addToQueue, setCurrentClimb, playlistSuggestionSource, sessionId } = useQueue();
+  const { addToQueue, setCurrentClimb, sessionId } = useQueue();
   const { visible: snackbarVisible, nonce: snackbarNonce, dismissSnackbar } = useQueueSnackbar();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
 
@@ -207,8 +212,17 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     });
   }, [climbActions]);
 
-  const openQueueSheet = useCallback(() => setQueueSheetVisible(true), []);
-  const closeQueueSheet = useCallback(() => setQueueSheetVisible(false), []);
+  const openQueueSheet = useCallback(() => {
+    setQueueSheetMounted(true);
+    setQueueSheetVisible(true);
+  }, []);
+  // Request an animated close (flip `visible`; the sheet's dismiss animation then
+  // fires onDismissed → unmount).
+  const requestCloseQueueSheet = useCallback(() => setQueueSheetVisible(false), []);
+  const handleQueueSheetDismissed = useCallback(() => {
+    setQueueSheetVisible(false);
+    setQueueSheetMounted(false);
+  }, []);
 
   // The queue sheet renders climbs against the active board (thumbnails + tick).
   const queueBoard = useMemo<QueueItemRowBoard | null>(() => {
@@ -227,24 +241,28 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     (item: ClimbQueueItem) => {
       setCurrentClimb(item);
       openPlayDrawer(item.climb, { setAsCurrent: false });
-      setQueueSheetVisible(false);
+      requestCloseQueueSheet();
     },
-    [setCurrentClimb, openPlayDrawer],
+    [setCurrentClimb, openPlayDrawer, requestCloseQueueSheet],
   );
 
-  // Tap a suggestion → activate it (adds + sets current) and show it.
+  // Tap a suggestion → activate it with a suggestion source built from the
+  // suggestions list (so the play drawer can keep swiping forward through them)
+  // and show it.
   const handleQueueSuggestionPress = useCallback(
-    (climb: QueueClimb) => {
+    (climb: QueueClimb, source: PlaylistSuggestionSource) => {
       const item = climbToQueueItem(climb, { suggested: true });
-      setCurrentClimb(item, { playlistSuggestionSource });
+      setCurrentClimb(item, { playlistSuggestionSource: source });
       openPlayDrawer(climb, { setAsCurrent: false });
-      setQueueSheetVisible(false);
+      requestCloseQueueSheet();
     },
-    [setCurrentClimb, playlistSuggestionSource, openPlayDrawer],
+    [setCurrentClimb, openPlayDrawer, requestCloseQueueSheet],
   );
 
   // Tick a history climb → open the log-ascent sheet (stacks above the queue
   // sheet, which stays open beneath) pre-filled with the active session.
+  // Deps: only `sessionId` — `activeBoardConfigRef` is a stable ref read at call
+  // time (intentionally not a dep). If that ref ever becomes state, add it here.
   const handleQueueTickHistory = useCallback(
     (item: ClimbQueueItem) => {
       const boardConfig = activeBoardConfigRef.current;
@@ -329,11 +347,12 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           onClose={closeAddToPlaylist}
         />
       ) : null}
-      {queueSheetVisible && queueBoard ? (
+      {queueSheetMounted && queueBoard ? (
         <QueueSheet
-          visible
+          visible={queueSheetVisible}
           board={queueBoard}
-          onClose={closeQueueSheet}
+          onClose={requestCloseQueueSheet}
+          onDismissed={handleQueueSheetDismissed}
           onClimbPress={handleQueueClimbPress}
           onSuggestionPress={handleQueueSuggestionPress}
           onTickHistory={handleQueueTickHistory}

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -223,6 +223,11 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     setQueueSheetVisible(false);
     setQueueSheetMounted(false);
   }, []);
+  // Snackbar "Open": dismiss the snackbar, then open the queue sheet.
+  const handleSnackbarOpen = useCallback(() => {
+    dismissSnackbar();
+    openQueueSheet();
+  }, [dismissSnackbar, openQueueSheet]);
 
   // The queue sheet renders climbs against the active board (thumbnails + tick).
   const queueBoard = useMemo<QueueItemRowBoard | null>(() => {
@@ -362,10 +367,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
         visible={snackbarVisible}
         nonce={snackbarNonce}
         onDismiss={dismissSnackbar}
-        onOpen={() => {
-          dismissSnackbar();
-          openQueueSheet();
-        }}
+        onOpen={handleSnackbarOpen}
       />
     </DrawerHostContext.Provider>
   );

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -51,6 +51,7 @@ import { findPreviousQueueItem, findNextQueueItemWithSuggestions } from '@boards
 import { toClimbQueueItem, type SubscriptionQueueItem } from '../lib/queue-conversion';
 import { climbToQueueItem } from '../lib/climb-to-queue-item';
 import { useToast } from './toast-provider';
+import { useQueueSnackbar } from './queue-snackbar-provider';
 
 export type StartSessionConfig = {
   name?: string;
@@ -67,6 +68,7 @@ type QueueContextValue = {
   setSessionId: (id: string | null) => void;
   addToQueue: (item: ClimbQueueItem) => void;
   removeFromQueue: (uuid: string) => void;
+  reorderQueue: (uuid: string, oldIndex: number, newIndex: number) => void;
   clearQueue: () => void;
   setCurrentClimb: (item: ClimbQueueItem, options?: SetCurrentClimbOptions) => void;
   nextClimb: () => void;
@@ -122,6 +124,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const playlistSuggestionSourceRef = useRef<PlaylistSuggestionSource | null>(null);
   playlistSuggestionSourceRef.current = playlistSuggestionSource;
   const { showToast } = useToast();
+  const { showQueueAddedSnackbar } = useQueueSnackbar();
   const { t } = useTranslation('session');
 
   // JOIN_SESSION cache, keyed by (sessionId, connection epoch). Built once
@@ -359,8 +362,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       mutations.addQueueItem(item).catch((error) => {
         if (__DEV__) console.warn('[queue] addQueueItem sync failed', error);
       });
+      // Surface the "Climb added to queue · Open" snackbar for every add path.
+      showQueueAddedSnackbar();
     },
-    [mutations],
+    [mutations, showQueueAddedSnackbar],
   );
 
   const removeFromQueue = useCallback(
@@ -371,6 +376,18 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       dispatch({ type: 'DELTA_REMOVE_QUEUE_ITEM', payload: { uuid } });
       mutations.removeQueueItem(uuid).catch((error) => {
         if (__DEV__) console.warn('[queue] removeQueueItem sync failed', error);
+      });
+    },
+    [mutations],
+  );
+
+  const reorderQueue = useCallback(
+    (uuid: string, oldIndex: number, newIndex: number) => {
+      // Optimistic local reorder; the reducer re-validates uuid-at-oldIndex so
+      // the server's QueueReordered echo is a safe no-op. Best-effort sync only.
+      dispatch({ type: 'DELTA_REORDER_QUEUE_ITEM', payload: { uuid, oldIndex, newIndex } });
+      mutations.reorderQueueItem(uuid, oldIndex, newIndex).catch((error) => {
+        if (__DEV__) console.warn('[queue] reorderQueueItem sync failed', error);
       });
     },
     [mutations],
@@ -506,6 +523,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       setSessionId,
       addToQueue,
       removeFromQueue,
+      reorderQueue,
       clearQueue,
       setCurrentClimb,
       nextClimb,
@@ -522,6 +540,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       sessionId,
       addToQueue,
       removeFromQueue,
+      reorderQueue,
       clearQueue,
       setCurrentClimb,
       nextClimb,

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -384,13 +384,21 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const reorderQueue = useCallback(
     (uuid: string, oldIndex: number, newIndex: number) => {
       // Optimistic local reorder; the reducer re-validates uuid-at-oldIndex so
-      // the server's QueueReordered echo is a safe no-op. Best-effort sync only.
+      // the server's QueueReordered echo is a safe no-op.
+      const previousQueue = stateRef.current.queue;
+      const previousCurrent = stateRef.current.currentClimbQueueItem;
       dispatch({ type: 'DELTA_REORDER_QUEUE_ITEM', payload: { uuid, oldIndex, newIndex } });
       mutations.reorderQueueItem(uuid, oldIndex, newIndex).catch((error) => {
-        if (__DEV__) console.warn('[queue] reorderQueueItem sync failed', error);
+        if (__DEV__) console.warn('[queue] reorderQueueItem sync failed; rolling back', error);
+        // Unlike add/remove (idempotent, converge on next sync), a failed reorder
+        // would leave this client's order silently diverged from peers. Roll back
+        // to the pre-reorder order — that matches the server, which never applied
+        // the move — and surface the failure.
+        dispatch({ type: 'UPDATE_QUEUE', payload: { queue: previousQueue, currentClimbQueueItem: previousCurrent } });
+        showToast(t('mobile.queue.actionFailed'), 'error');
       });
     },
-    [mutations],
+    [mutations, showToast, t],
   );
 
   const clearQueue = useCallback(() => {

--- a/packages/mobile/src/providers/queue-snackbar-provider.tsx
+++ b/packages/mobile/src/providers/queue-snackbar-provider.tsx
@@ -1,0 +1,44 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+
+/**
+ * Tiny state container for the "Climb added to queue" snackbar. It is mounted
+ * ABOVE QueueProvider so `addToQueue` can trigger it, but it does NOT render the
+ * overlay itself — the overlay lives in DrawerHostProvider (below QueueProvider)
+ * where it can read the queue state for positioning and bind its "Open" button
+ * to `openQueueSheet`. This split avoids a circular provider dependency.
+ */
+type QueueSnackbarContextValue = {
+  /** Show the snackbar (or re-show + reset its timer if already visible). */
+  showQueueAddedSnackbar: () => void;
+  visible: boolean;
+  /** Bumped on every show so the overlay can reset its dismiss timer + replay its entrance. */
+  nonce: number;
+  dismissSnackbar: () => void;
+};
+
+const QueueSnackbarContext = createContext<QueueSnackbarContextValue | null>(null);
+
+export function useQueueSnackbar(): QueueSnackbarContextValue {
+  const context = useContext(QueueSnackbarContext);
+  if (!context) throw new Error('useQueueSnackbar must be used within QueueSnackbarProvider');
+  return context;
+}
+
+export function QueueSnackbarProvider({ children }: { children: ReactNode }) {
+  const [visible, setVisible] = useState(false);
+  const [nonce, setNonce] = useState(0);
+
+  const showQueueAddedSnackbar = useCallback(() => {
+    setNonce((current) => current + 1);
+    setVisible(true);
+  }, []);
+
+  const dismissSnackbar = useCallback(() => setVisible(false), []);
+
+  const value = useMemo(
+    () => ({ showQueueAddedSnackbar, visible, nonce, dismissSnackbar }),
+    [showQueueAddedSnackbar, visible, nonce, dismissSnackbar],
+  );
+
+  return <QueueSnackbarContext.Provider value={value}>{children}</QueueSnackbarContext.Provider>;
+}

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -293,13 +293,19 @@
       "endSessionConfirm": "Are you sure you want to end this session?",
       "climbCount_one": "{{count}} climb",
       "climbCount_other": "{{count}} climbs",
-      "logAscent": "Log ascent"
+      "logAscent": "Log ascent",
+      "dragHandleAria": "Drag to reorder {{name}}"
     },
     "queueSheet": {
       "emptyQueue": "Your queue is empty",
       "toggleHistory": "Toggle history",
       "editQueue": "Edit queue",
       "doneEditing": "Done editing"
+    },
+    "queueSnackbar": {
+      "added": "Climb added to queue",
+      "open": "Open",
+      "openAria": "Open queue"
     },
     "toast": {
       "sessionEnded": "Session ended"

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -293,13 +293,19 @@
       "endSessionConfirm": "¿Estás seguro de que quieres terminar esta sesión?",
       "climbCount_one": "{{count}} bloque",
       "climbCount_other": "{{count}} bloques",
-      "logAscent": "Registrar ascenso"
+      "logAscent": "Registrar ascenso",
+      "dragHandleAria": "Arrastra para reordenar {{name}}"
     },
     "queueSheet": {
       "emptyQueue": "Tu cola está vacía",
       "toggleHistory": "Mostrar historial",
       "editQueue": "Editar cola",
       "doneEditing": "Listo"
+    },
+    "queueSnackbar": {
+      "added": "Bloque añadido a la cola",
+      "open": "Abrir",
+      "openAria": "Abrir cola"
     },
     "toast": {
       "sessionEnded": "Sesión terminada"

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -293,13 +293,19 @@
       "endSessionConfirm": "Êtes-vous sûr de vouloir terminer cette session ?",
       "climbCount_one": "{{count}} bloc",
       "climbCount_other": "{{count}} blocs",
-      "logAscent": "Enregistrer l'ascension"
+      "logAscent": "Enregistrer l'ascension",
+      "dragHandleAria": "Glisser pour réorganiser {{name}}"
     },
     "queueSheet": {
       "emptyQueue": "Votre file est vide",
       "toggleHistory": "Afficher l'historique",
       "editQueue": "Modifier la file",
       "doneEditing": "Terminé"
+    },
+    "queueSnackbar": {
+      "added": "Bloc ajouté à la file",
+      "open": "Ouvrir",
+      "openAria": "Ouvrir la file"
     },
     "toast": {
       "sessionEnded": "Session terminée"

--- a/packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts
+++ b/packages/shared/queue-react/src/__tests__/create-queue-mutations.test.ts
@@ -3,6 +3,7 @@ import type { ClimbQueueItemInput } from '@boardsesh/shared-schema';
 import {
   ADD_QUEUE_ITEM,
   REMOVE_QUEUE_ITEM,
+  REORDER_QUEUE_ITEM,
   SET_CURRENT_CLIMB,
   SET_QUEUE,
   MIRROR_CURRENT_CLIMB,
@@ -59,6 +60,11 @@ describe('web mode (no ensureReady)', () => {
     expect(queriesFor(REMOVE_QUEUE_ITEM)[0][1].variables).toEqual({ uuid: 'x' });
   });
 
+  it('issues REORDER_QUEUE_ITEM with scalar indices', async () => {
+    await make().reorderQueueItem('a', 0, 2);
+    expect(queriesFor(REORDER_QUEUE_ITEM)[0][1].variables).toEqual({ uuid: 'a', oldIndex: 0, newIndex: 2 });
+  });
+
   it('maps the queue and the optional current item for SET_QUEUE', async () => {
     await make().setQueue([item('a'), item('b')], item('c'));
     const vars = queriesFor(SET_QUEUE)[0][1].variables;
@@ -109,6 +115,20 @@ describe('mobile mode (ensureReady)', () => {
     await make({ getSessionId: () => null, ensureReady }).removeQueueItem('x');
     expect(ensureReady).not.toHaveBeenCalled();
     expect(executeMock).not.toHaveBeenCalled();
+  });
+
+  it('no-ops (no create, no execute) for reorderQueueItem when no session', async () => {
+    const ensureReady = vi.fn(async (captured: string | null) => captured);
+    await make({ getSessionId: () => null, ensureReady }).reorderQueueItem('a', 0, 1);
+    expect(ensureReady).not.toHaveBeenCalled();
+    expect(executeMock).not.toHaveBeenCalled();
+  });
+
+  it('issues REORDER_QUEUE_ITEM after ensureReady resolves an existing session', async () => {
+    const ensureReady = vi.fn(async (captured: string | null) => captured);
+    await make({ ensureReady }).reorderQueueItem('a', 2, 0);
+    expect(ensureReady).toHaveBeenCalledWith('S');
+    expect(queriesFor(REORDER_QUEUE_ITEM)[0][1].variables).toEqual({ uuid: 'a', oldIndex: 2, newIndex: 0 });
   });
 
   it('no-ops instead of throwing when ensureReady returns null', async () => {

--- a/packages/shared/queue-react/src/create-queue-mutations.ts
+++ b/packages/shared/queue-react/src/create-queue-mutations.ts
@@ -28,6 +28,7 @@ import { createSetCurrentClimbCoalescer } from '@boardsesh/queue-runtime';
 import {
   ADD_QUEUE_ITEM,
   REMOVE_QUEUE_ITEM,
+  REORDER_QUEUE_ITEM,
   SET_CURRENT_CLIMB,
   MIRROR_CURRENT_CLIMB,
   PUBLISH_PLAYBACK_STATE,
@@ -78,6 +79,14 @@ export type QueueMutationsDeps<TItem> = {
 export type QueueMutationsActions<TItem> = {
   addQueueItem: (item: TItem, position?: number) => Promise<void>;
   removeQueueItem: (uuid: string) => Promise<void>;
+  /**
+   * Move a queued item from `oldIndex` to `newIndex` (positions in the full
+   * queue array). Requires an existing session — never lazily creates one.
+   * The server broadcasts a `QueueReordered` delta; callers optimistically
+   * apply `DELTA_REORDER_QUEUE_ITEM` locally, whose uuid-at-oldIndex check
+   * makes the echoed event a safe no-op.
+   */
+  reorderQueueItem: (uuid: string, oldIndex: number, newIndex: number) => Promise<void>;
   setCurrentClimb: (item: TItem | null, shouldAddToQueue?: boolean, correlationId?: string) => Promise<void>;
   mirrorCurrentClimb: (mirrored: boolean) => Promise<void>;
   /**
@@ -225,6 +234,12 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
       await execute(ready.client, { query: REMOVE_QUEUE_ITEM, variables: { uuid } });
+    },
+
+    reorderQueueItem: async (uuid, oldIndex, newIndex) => {
+      const ready = await resolveCore({ allowCreate: false });
+      if (!ready) return;
+      await execute(ready.client, { query: REORDER_QUEUE_ITEM, variables: { uuid, oldIndex, newIndex } });
     },
 
     setCurrentClimb: async (item, shouldAddToQueue, correlationId) => {


### PR DESCRIPTION
## Spotify-style queue list (mobile)

Stacked on #2487 (base = `mobile-climb-list-readable-thumbnails`), so this diff is just the queue-list feature.

### What's new
- **Snackbar** — "Climb added to queue · **Open**" floats above the persistent queue bar on every add path (swipe-to-queue, actions sheet, similar-climb). **Open** launches the queue sheet from anywhere, even with the play drawer closed.
- **Queue sheet** — last-5 history (dimmed) → current → upcoming → **playlist suggestions** flowing on with no header/divider (the deliberate divergence from web). Rows show climb **thumbnails** via a new shared `ClimbListItemContent` (the search row was refactored onto it, no visual change).
- **History tick** — each history row has a green tick button that opens the log-ascent sheet pre-filled with the active session. This is the group-session "log a climb I already sent" flow that Spotify has no equivalent for.
- **Drag-to-reorder** — always-on ≡ handles on upcoming rows; press-hold to lift and reorder. Custom reanimated-4 hook (`use-queue-drag`) lifts the row + shifts siblings and hard-locks list scroll + sheet pan during a drag so Spotify-style scroll-to-expand never fights it (no drag library — `draggable-flatlist`/`reorderable-list` are incompatible/brittle on reanimated 4).
- **Sync** — add/remove/clear/**reorder** all broadcast to party peers. Reorder uses a new shared `reorderQueueItem` mutation (optimistic `DELTA_REORDER_QUEUE_ITEM`; the server's `QueueReordered` echo is a safe no-op via the reducer's uuid-at-index check).
- **Modal** — `QueueSheet` is now a portalled `BottomSheetModal` (FullWindowOverlay on iOS, `stackBehavior="push"`) hosted in `DrawerHostProvider`; the queue button and snackbar both call `openQueueSheet`.
- **Badge removed** — the broken queue-count badge on the play-drawer queue button is gone.

### Validation
`typecheck:mobile` · `typecheck:shared` · `create-queue-mutations` tests (25, +3 new) · full mobile suite (571) · i18n catalog parity (28, keys in en/es/fr) · `check:mobile-bundle` (android OK).

### Note
The `__DEV__`-only "Bug 2" diagnostics have been **stripped** — the branch is diagnostic-free (verified via `git grep` on HEAD). The `onSwipeableOpen` swipe fix in `ClimbListRow` (a real fix, not a diagnostic) is kept. `AddToPlaylistSheet.tsx`'s diagnostic was never part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
