### PR TITLE
fix(ci): pin @railway/cli to 4.66.0 to unblock backend prod deploy

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -391,7 +391,11 @@ jobs:
 
       - name: Install Railway CLI
         if: needs.check-rollback.outputs.active != 'true'
-        run: npm install -g @railway/cli
+        # Pinned: @railway/cli 4.66.1 added a VolumeInstance.deletedAt field to its
+        # GraphQL queries (railwayapp/cli#928) that Railway's API rejects, breaking
+        # `railway deployment list --json` ("Cannot query field deletedAt on type
+        # VolumeInstance"). 4.66.0 is the last version without it. Bump deliberately.
+        run: npm install -g @railway/cli@4.66.0
 
       # The Railway service Source is the moving GHCR tag :production, which this
       # run just repointed to the freshly built digest. `railway redeploy`


### PR DESCRIPTION
## What broke

The production backend deploy [failed](https://github.com/boardsesh/boardsesh/actions/runs/26861456621/job/79216334481) at the **Trigger Railway redeploy** step. The first command in that step (`railway deployment list --json`) errored with:

```
Cannot query field "deletedAt" on type "VolumeInstance". Did you mean "createdAt"?
##[error]Process completed with exit code 1.
```

## Root cause

`@railway/cli` **4.66.1** was published at `2026-06-03T03:01:30Z` — about **19 minutes before** the failed run at `03:20`. The workflow installed the CLI unpinned (`npm install -g @railway/cli`), so CI grabbed the freshly-broken latest.

4.66.1 shipped [railwayapp/cli#928](https://github.com/railwayapp/cli) (*"feat(volume): show status and scheduled deletion date in volume list"*), which added a `VolumeInstance.deletedAt` field to its GraphQL queries. Railway's production API doesn't expose that field, so any command that pulls in volume info — including `railway deployment list` — fails server-side validation. 4.66.0 (May 30) is the last version without it.

## Fix

Pin the CLI install to `@railway/cli@4.66.0` with a comment explaining why, so the deploy is insulated from this upstream regression. Bump deliberately once Railway resolves the CLI/API mismatch.

This is the only place in the repo that installs the Railway CLI.

https://claude.ai/code/session_01SbDAJ8a9jwS9kfFjUBgbLy

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbDAJ8a9jwS9kfFjUBgbLy)_