### PR TITLE
fix(web): restore prod client PostHog analytics (dark since May 31)

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -193,6 +193,14 @@ jobs:
           # any .env file in Next). Same Production-environment secret the
           # migrate job uses.
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          # NEXT_PUBLIC_* must exist at build time — Next inlines it into the
+          # client bundle. Native Vercel builds got this from the project env;
+          # the CI prebuilt build does not, so pass it explicitly (same gap as
+          # DATABASE_URL). Without it, getPosthog() short-circuits and ALL
+          # client-side PostHog analytics goes dark — which is exactly what
+          # happened when prod web moved to CI `vercel build`. Public client key
+          # (phc_…), not a secret, so it's a GitHub Actions variable.
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
         run: vercel build --prod
 
       - name: Package prebuilt output

--- a/packages/web/app/lib/__tests__/analytics.test.ts
+++ b/packages/web/app/lib/__tests__/analytics.test.ts
@@ -10,6 +10,11 @@ const mocks = vi.hoisted(() => ({
     setPersonProperties: vi.fn(),
   },
   vercelTrack: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: mocks.captureMessage,
 }));
 
 vi.mock('@vercel/analytics', () => ({
@@ -70,6 +75,38 @@ describe('analytics wrapper', () => {
       }),
     );
     expect(mocks.posthog.capture).toHaveBeenCalledWith('Climb Opened', { kept: 'yes', count: 2 });
+  });
+
+  it('fails loud once when the PostHog key is missing on a production host', async () => {
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', '');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { track } = await import('../analytics');
+
+    track('Climb Opened');
+    track('Climb Opened');
+
+    // PostHog never initializes, but Vercel analytics is unaffected by the key.
+    expect(mocks.PostHog).not.toHaveBeenCalled();
+    expect(mocks.posthog.capture).not.toHaveBeenCalled();
+    expect(mocks.vercelTrack).toHaveBeenCalledTimes(2);
+
+    // The missing-key alert is emitted exactly once per page load.
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(mocks.captureMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.captureMessage).toHaveBeenCalledWith(expect.stringContaining('NEXT_PUBLIC_POSTHOG_KEY'), 'error');
+
+    consoleError.mockRestore();
+  });
+
+  it('does not warn about a missing key outside production hosts', async () => {
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', '');
+    setWindowLocation('https://boardsesh-preview.vercel.app/b/kilter');
+    const { track } = await import('../analytics');
+
+    track('Preview Event');
+
+    expect(mocks.captureMessage).not.toHaveBeenCalled();
+    expect(mocks.PostHog).not.toHaveBeenCalled();
   });
 
   it('keeps Vercel tracking in previews while PostHog remains production-gated', async () => {

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { track as vercelTrack } from '@vercel/analytics';
 import { PostHog } from 'posthog-js-lite';
 import { analyticsPathname, isAdminAnalyticsUrl } from './analytics-paths';
@@ -24,7 +25,20 @@ function getPosthog(): PostHog | null {
   if (!window.location.hostname.includes('boardsesh.com')) return null;
 
   const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-  if (!apiKey) return null;
+  if (!apiKey) {
+    // We're on a production boardsesh.com host but NEXT_PUBLIC_POSTHOG_KEY was
+    // not inlined into the client bundle at build time, so the SDK can't start
+    // and every client-side event silently goes dark. This exact gap blacked
+    // out product analytics for days after the May 2026 deploy-pipeline move to
+    // CI `vercel build` (the key stopped reaching the build). Fail loud so a
+    // missing key surfaces in minutes, not days. Fires once per page load —
+    // posthogInitAttempted (set above) gates re-entry.
+    const message =
+      'PostHog client key (NEXT_PUBLIC_POSTHOG_KEY) is missing on a production host — client analytics is disabled. Check the web build env.';
+    console.error(`[analytics] ${message}`);
+    Sentry.captureMessage(message, 'error');
+    return null;
+  }
   // Default to the boardsesh backend's PostHog reverse proxy so events look
   // first-party to ad-blockers. NEXT_PUBLIC_POSTHOG_HOST overrides for incident
   // recovery (point straight at us.i.posthog.com if the proxy is down).


### PR DESCRIPTION
## What happened

Client product analytics went **cleanly to zero**, not just degraded. Cliff started mid-day **May 31**, total from **June 1**:

| day | search | queue op | row click | \$pageview | backend Live Activity |
|---|---|---|---|---|---|
| 05-30 | 741 | 784 | 901 | 1525 | 869 |
| 05-31 | 88 | 126 | 154 | 133 | 1048 |
| 06-01→ | **0** | **0** | **0** | **0** | 1289–1414/day |

From June 1 the only surviving events are the four `Live Activity *` ones — all emitted **server-side by the backend, direct to `us.i.posthog.com`**. Every browser SDK event died. This is also why the new search filters show no data.

## Root cause

The **May 30–31 deploy migration** moved prod web from Vercel native git auto-deploy → CI `vercel build --prod` (PRs #2404–2409). The `build-web` job never fed **`NEXT_PUBLIC_POSTHOG_KEY`** into the build. Next.js inlines `NEXT_PUBLIC_*` at build time, so the bundle shipped with the key `undefined` and `getPosthog()` silently returned `null` (`if (!apiKey) return null`) — no events, no error. The same job already special-cases `DATABASE_URL` for exactly this reason; the PostHog key had the identical gap.

Ruled out via live probing: `OPTIONS https://ws.boardsesh.com/api/posthog/e/` → **HTTP 200** with correct CORS (proxy healthy); backend events flow on a separate key; the May 31 CORS commit only *added* permissiveness.

## Changes

- **`production-deploy.yml`** — pass `NEXT_PUBLIC_POSTHOG_KEY: \${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}` into the `build-web` Vercel build step (mirrors the `DATABASE_URL` handling).
- **`analytics.ts`** — fail-loud guardrail: on a `boardsesh.com` host with a missing key, `console.error` + `Sentry.captureMessage(…, 'error')` once per load. A future blackout surfaces in minutes, not days.
- **`analytics.test.ts`** — cover the alert + off-prod silence.

## ⚠️ Required to take effect

1. Set the **`NEXT_PUBLIC_POSTHOG_KEY`** GitHub Actions **Variable** (the public `phc_…` PostHog project key, from Vercel → project env). A Variable, not a Secret — it's public and ships to clients.
2. Merge, then trigger a prod web rebuild (`build-web` only runs on web changes; `workflow_dispatch` works). ~30–60 min after promotion, the four client events resume from 0.

## Validation

`vp run typecheck:web` clean · `vp test --project web` → 10/10 (8 existing + 2 new). Proxy already confirmed healthy, so a successful client POST is the only missing link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)