### PR TITLE
fix(mobile): sync queue items to server (ClimbInput) + break PlayDrawer require cycle

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -24,7 +24,6 @@ import { AngleSelectorSheet } from './AngleSelectorSheet';
 import { ClimbActionsSheet } from '../ClimbActionsSheet';
 import { Icon } from '../Icon';
 import { useQueue } from '../../providers/queue-provider';
-import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useToast } from '../../providers/toast-provider';
@@ -66,10 +65,13 @@ export type PlayDrawerHandle = {
 type PlayDrawerProps = {
   boardConfig: BoardConfig;
   onAngleChange?: (angle: number) => void;
+  /** Open the queue list sheet (provided by DrawerHostProvider; passed as a prop
+   *  rather than read via useDrawerHost to avoid a host↔PlayDrawer require cycle). */
+  onOpenQueue: () => void;
 };
 
 export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function PlayDrawer(
-  { boardConfig, onAngleChange },
+  { boardConfig, onAngleChange, onOpenQueue },
   ref,
 ) {
   const { t } = useTranslation('session');
@@ -113,7 +115,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
 
   const { state, setCurrentClimb, nextClimb, previousClimb, playlistSuggestionSource, sessionId, addToQueue } =
     useQueue();
-  const { openQueueSheet } = useDrawerHost();
   const bluetooth = useOptionalBluetoothContext();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
   const { formatGrade } = useGradeFormat();
@@ -237,8 +238,8 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   }, []);
 
   const handleOpenQueue = useCallback(() => {
-    openQueueSheet();
-  }, [openQueueSheet]);
+    onOpenQueue();
+  }, [onOpenQueue]);
 
   const handleOpenAngleSelector = useCallback(() => {
     setActiveSubDrawer('angleSelector');

--- a/packages/mobile/src/lib/climb-to-queue-item.ts
+++ b/packages/mobile/src/lib/climb-to-queue-item.ts
@@ -1,6 +1,43 @@
 import { randomUUID } from 'expo-crypto';
-import type { Climb } from '@boardsesh/shared-schema';
+import type { Climb, ClimbInput } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem } from '@boardsesh/queue';
+
+/**
+ * Map a `Climb` to the GraphQL `ClimbInput` for queue mutations. `ClimbInput` is
+ * a strict subset of `Climb` — sending extra fields (notably `created_at`, which
+ * search results carry but `ClimbInput` does not define) makes the server reject
+ * the whole mutation ("Field \"created_at\" is not defined by type
+ * \"ClimbInput\""), which silently breaks queue sync to party peers. TypeScript
+ * won't catch the excess fields on a plain assignment, so build the input
+ * explicitly here and let the `ClimbInput` return type pin the shape. Use this at
+ * every wire boundary (add / setCurrent / setQueue) so it can't be bypassed by an
+ * item built from a raw climb (e.g. `addToQueue({ uuid, climb })`).
+ */
+export function toClimbInput(climb: Climb): ClimbInput {
+  return {
+    uuid: climb.uuid,
+    setter_username: climb.setter_username,
+    userId: climb.userId,
+    name: climb.name,
+    description: climb.description,
+    frames: climb.frames,
+    angle: climb.angle,
+    ascensionist_count: climb.ascensionist_count,
+    difficulty: climb.difficulty,
+    quality_average: climb.quality_average,
+    stars: climb.stars,
+    difficulty_error: climb.difficulty_error,
+    mirrored: climb.mirrored,
+    benchmark_difficulty: climb.benchmark_difficulty,
+    is_no_match: climb.is_no_match,
+    is_draft: climb.is_draft,
+    published_at: climb.published_at,
+    userAscents: climb.userAscents,
+    userAttempts: climb.userAttempts,
+    framesCount: climb.framesCount,
+    framesPace: climb.framesPace,
+  };
+}
 
 /**
  * Build a ClimbQueueItem from a Climb returned by SEARCH_CLIMBS / climb-detail

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -312,7 +312,9 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   return (
     <DrawerHostContext.Provider value={value}>
       {children}
-      {activeBoardConfig ? <PlayDrawer ref={playDrawerRef} boardConfig={activeBoardConfig} /> : null}
+      {activeBoardConfig ? (
+        <PlayDrawer ref={playDrawerRef} boardConfig={activeBoardConfig} onOpenQueue={openQueueSheet} />
+      ) : null}
       {logAscentInput ? (
         <LogAscentSheet
           visible

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -49,7 +49,7 @@ import { getStoredActiveBoard } from '../lib/active-board-store';
 import { getStoredSessionId, setStoredSessionId, clearStoredSessionId } from '../lib/session-store';
 import { findPreviousQueueItem, findNextQueueItemWithSuggestions } from '@boardsesh/play-view';
 import { toClimbQueueItem, type SubscriptionQueueItem } from '../lib/queue-conversion';
-import { climbToQueueItem } from '../lib/climb-to-queue-item';
+import { climbToQueueItem, toClimbInput } from '../lib/climb-to-queue-item';
 import { useToast } from './toast-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
 
@@ -333,7 +333,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const mutations = useQueueMutations<ClimbQueueItem>({
     getClient: () => getWsClient(),
     getSessionId: () => sessionIdRef.current,
-    toQueueItemInput: (item) => ({ uuid: item.uuid, climb: item.climb }),
+    // Strip the climb to ClimbInput fields — sending the raw search climb (with
+    // created_at) makes the server reject the mutation and silently breaks queue
+    // sync to peers. See toClimbInput.
+    toQueueItemInput: (item) => ({ uuid: item.uuid, climb: toClimbInput(item.climb) }),
     ensureReady: async (capturedSessionId) => {
       const sessionId = capturedSessionId ?? (await ensureSessionRef.current());
       if (!sessionId) return null;


### PR DESCRIPTION
## Queue sync fix + require-cycle cleanup (follow-up to #2490)

Two issues surfaced from the dev-server log during #2490 QA, deferred to this follow-up.

### 1. Queue items never synced to the server (party-mode regression)
Mobile queue mutations sent `item.climb` verbatim. The GraphQL `ClimbInput` is a strict subset of `Climb` with **no `created_at`**, so the server rejected every mutation built from a raw search climb:

```
[queue] addQueueItem sync failed … Field "created_at" is not defined by type "ClimbInput"
```

`climbToQueueItem` already strips the climb, but `addToQueue({ uuid, climb })` (swipe-to-queue, climb-actions) passes the raw climb. The errors are best-effort/`__DEV__`-only, so they were swallowed — the queue never reached party peers, and a server FullSync (empty server queue) could wipe the optimistic local queue. **Suspected root cause of the "open queue list → swipe-to-suggested stops" regression.**

Fix: a central `toClimbInput(climb)` that builds the exact `ClimbInput` shape, used at the provider's `toQueueItemInput` wire boundary so every path (add / setCurrent / setQueue) is stripped regardless of how the item was built. Also preserves `mirrored`/`is_draft` that `climbToQueueItem` dropped.

### 2. `drawer-host-provider ↔ PlayDrawer` require cycle
RN warned: `Require cycle: drawer-host-provider → play-drawer → PlayDrawer → drawer-host-provider` ("can result in uninitialized values"). PlayDrawer imported `useDrawerHost` only for `openQueueSheet`. Fix: pass `onOpenQueue` as a prop from `DrawerHostProvider`; PlayDrawer no longer imports the host. Verified the bundle check no longer prints the cycle warning.

### Validation
`vp run typecheck:mobile` · `vp test --project mobile` (594) · `vp run check:mobile-bundle` (iOS + Android OK, no require-cycle warning).

Please re-test the swipe-to-suggested flow after opening the queue list — this should resolve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
