### PR TITLE
Add chevron close button to all mobile sheets

### DIFF
--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -34,6 +34,7 @@ import { CollapsibleSection } from './CollapsibleSection';
 import { RadioGroup, type RadioOption } from './RadioGroup';
 import { SwitchRow } from './SwitchRow';
 import { Icon } from './Icon';
+import { SheetHandle } from './SheetHandle';
 import { useTheme } from '../providers/theme-provider';
 import { useGrades } from '../lib/graphql/hooks';
 import { useAuth } from '../providers/auth-provider';
@@ -385,6 +386,8 @@ export function ClimbFilterSheet({ onDismiss, boardConfig, currentFilters, onApp
     [],
   );
 
+  const renderHandle = useCallback(() => <SheetHandle onClose={() => sheetRef.current?.dismiss()} />, []);
+
   const openSetters = useCallback(() => {
     if (!boardConfig) return;
     router.push({
@@ -422,7 +425,7 @@ export function ClimbFilterSheet({ onDismiss, boardConfig, currentFilters, onApp
       enablePanDownToClose
       backdropComponent={renderBackdrop}
       onDismiss={onDismiss}
-      handleIndicatorStyle={styles.indicator}
+      handleComponent={renderHandle}
       backgroundStyle={backgroundStyle}
     >
       <View style={styles.header}>
@@ -663,12 +666,6 @@ export function ClimbFilterSheet({ onDismiss, boardConfig, currentFilters, onApp
 }
 
 const styles = StyleSheet.create({
-  indicator: {
-    backgroundColor: iosSystemColors.separator,
-    width: 36,
-    height: 5,
-    borderRadius: 3,
-  },
   scrollView: {
     flex: 1,
   },

--- a/packages/mobile/src/components/EndSessionSheet.tsx
+++ b/packages/mobile/src/components/EndSessionSheet.tsx
@@ -5,8 +5,9 @@ import { useTranslation } from 'react-i18next';
 import { Text } from './Text';
 import { Button } from './Button';
 import { Icon } from './Icon';
+import { SheetHandle } from './SheetHandle';
 import { useTheme } from '../providers/theme-provider';
-import { spacing, sheetStyles } from '../theme/tokens';
+import { spacing } from '../theme/tokens';
 
 type EndSessionSheetProps = {
   visible: boolean;
@@ -46,6 +47,8 @@ export function EndSessionSheet({ visible, onDismiss, onConfirm, isEnding, climb
     onDismiss();
   }, [onDismiss]);
 
+  const renderHandle = useCallback(() => <SheetHandle onClose={() => sheetRef.current?.close()} />, []);
+
   if (!mounted) return null;
 
   return (
@@ -56,7 +59,7 @@ export function EndSessionSheet({ visible, onDismiss, onConfirm, isEnding, climb
       onClose={handleClose}
       backdropComponent={renderBackdrop}
       backgroundStyle={{ backgroundColor: systemColors.secondaryBackground }}
-      handleIndicatorStyle={sheetStyles.indicator}
+      handleComponent={renderHandle}
     >
       <BottomSheetView style={styles.content}>
         <Icon name="end.session" size={40} color={systemColors.secondaryLabel} />

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -7,7 +7,7 @@
 // a portal above the play drawer's own modal. `FullWindowOverlay` on iOS
 // lifts the sheet above the tab bar — same pattern as DevicePickerSheet.
 import { useCallback, useEffect, useMemo, useRef, type PropsWithChildren } from 'react';
-import { Platform, Pressable, StyleSheet, View, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, type ViewStyle } from 'react-native';
 import {
   BottomSheetModal,
   BottomSheetBackdrop,
@@ -15,11 +15,8 @@ import {
   type BottomSheetBackdropProps,
 } from '@gorhom/bottom-sheet';
 import { FullWindowOverlay } from 'react-native-screens';
-import { useTranslation } from 'react-i18next';
 import { useTheme } from '../providers/theme-provider';
-import { iosSystemColors } from '../theme/ios-colors';
-import { spacing } from '../theme/tokens';
-import { Icon } from './Icon';
+import { SheetHandle } from './SheetHandle';
 import { QuickTickBar } from './play-drawer/QuickTickBar';
 
 type LogAscentSheetProps = {
@@ -67,7 +64,6 @@ export function LogAscentSheet({
   // nothing happens).
   const isPresentedRef = useRef(false);
   const { systemColors } = useTheme();
-  const { t } = useTranslation('session');
 
   useEffect(() => {
     if (visible && !isPresentedRef.current) {
@@ -98,6 +94,8 @@ export function LogAscentSheet({
     [],
   );
 
+  const renderHandle = useCallback(() => <SheetHandle onClose={onDismiss} />, [onDismiss]);
+
   const backgroundStyle: ViewStyle = {
     backgroundColor: systemColors.secondaryBackground as string,
     borderTopLeftRadius: 16,
@@ -115,28 +113,13 @@ export function LogAscentSheet({
       enablePanDownToClose
       onDismiss={handleSheetDismiss}
       backdropComponent={renderBackdrop}
-      handleIndicatorStyle={styles.indicator}
+      handleComponent={renderHandle}
       backgroundStyle={backgroundStyle}
       keyboardBehavior="extend"
       keyboardBlurBehavior="restore"
       android_keyboardInputMode="adjustResize"
     >
       <BottomSheetView style={styles.content}>
-        <View style={styles.closeButtonRow}>
-          <Pressable
-            onPress={onDismiss}
-            accessibilityRole="button"
-            accessibilityLabel={t('playView.tickBar.closeAria')}
-            hitSlop={8}
-            style={({ pressed }) => [
-              styles.closeButton,
-              { backgroundColor: systemColors.fill as string },
-              pressed && styles.closeButtonPressed,
-            ]}
-          >
-            <Icon name="chevron.down" size={18} color={systemColors.secondaryLabel} />
-          </Pressable>
-        </View>
         <QuickTickBar
           climbUuid={climbUuid}
           boardName={boardName}
@@ -156,29 +139,7 @@ export function LogAscentSheet({
 }
 
 const styles = StyleSheet.create({
-  indicator: {
-    backgroundColor: iosSystemColors.separator,
-    width: 36,
-    height: 5,
-    borderRadius: 3,
-  },
   content: {
     flex: 1,
-  },
-  closeButtonRow: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    paddingHorizontal: spacing[4],
-    paddingTop: spacing[1],
-  },
-  closeButton: {
-    width: 30,
-    height: 30,
-    borderRadius: 15,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  closeButtonPressed: {
-    opacity: 0.7,
   },
 });

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -5,7 +5,7 @@
 // `LogAscentSheet`) so the sheet portals over the bar. Same prop surface as
 // `Sheet`, driven imperatively via ref (`present()` / `dismiss()`).
 
-import { forwardRef, useCallback, useMemo, type ReactNode } from 'react';
+import { forwardRef, useCallback, useMemo, useRef, type ReactNode } from 'react';
 import { Platform, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 import {
   BottomSheetModal,
@@ -20,6 +20,7 @@ import { hapticMedium } from '../lib/haptics';
 import { sheetStyles, spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
+import { SheetHandle } from './SheetHandle';
 
 // iOS renders the modal in a native window overlay so it sits above the queue
 // bar; Android's modal portal already covers it.
@@ -59,6 +60,21 @@ export const ModalSheet = forwardRef<BottomSheetModal, ModalSheetProps>(function
   const insets = useSafeAreaInsets();
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);
 
+  // Keep our own handle to the modal instance so the chevron close button can
+  // drive `dismiss()`, while still forwarding the instance to the parent's ref.
+  const innerRef = useRef<BottomSheetModal | null>(null);
+  const setRefs = useCallback(
+    (instance: BottomSheetModal | null) => {
+      innerRef.current = instance;
+      if (typeof ref === 'function') ref(instance);
+      else if (ref) ref.current = instance;
+    },
+    [ref],
+  );
+
+  const handleClose = useCallback(() => innerRef.current?.dismiss(), []);
+  const renderHandle = useCallback(() => <SheetHandle onClose={handleClose} />, [handleClose]);
+
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
       <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.4} pressBehavior="close" />
@@ -89,14 +105,14 @@ export const ModalSheet = forwardRef<BottomSheetModal, ModalSheetProps>(function
 
   return (
     <BottomSheetModal
-      ref={ref}
+      ref={setRefs}
       index={0}
       snapPoints={enableDynamicSizing ? undefined : snapPoints}
       enableDynamicSizing={enableDynamicSizing}
       enablePanDownToClose={enablePanDownToClose}
       backdropComponent={renderBackdrop}
       backgroundStyle={backgroundStyle}
-      handleIndicatorStyle={sheetStyles.indicator}
+      handleComponent={renderHandle}
       containerComponent={modalContainerComponent}
       onChange={handleChange}
       onDismiss={onDismiss}

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useMemo, type ReactNode } from 'react';
+import { forwardRef, useCallback, useMemo, useRef, type ReactNode } from 'react';
 import { Platform, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 import BottomSheet, {
   BottomSheetBackdrop,
@@ -12,6 +12,7 @@ import { hapticMedium } from '../lib/haptics';
 import { sheetStyles, spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
+import { SheetHandle } from './SheetHandle';
 
 // On iOS a plain BottomSheet renders inside the screen's view tree, so it sits
 // behind root-level chrome (the floating tab bar + persistent queue bar).
@@ -72,6 +73,21 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
   const insets = useSafeAreaInsets();
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);
 
+  // Keep our own handle to the sheet instance so the chevron close button can
+  // drive `close()`, while still forwarding the instance to the parent's ref.
+  const innerRef = useRef<BottomSheet | null>(null);
+  const setRefs = useCallback(
+    (instance: BottomSheet | null) => {
+      innerRef.current = instance;
+      if (typeof ref === 'function') ref(instance);
+      else if (ref) ref.current = instance;
+    },
+    [ref],
+  );
+
+  const handleClose = useCallback(() => innerRef.current?.close(), []);
+  const renderHandle = useCallback(() => <SheetHandle onClose={handleClose} />, [handleClose]);
+
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
       <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.4} />
@@ -102,7 +118,7 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
 
   const sheet = (
     <BottomSheet
-      ref={ref}
+      ref={setRefs}
       index={-1}
       snapPoints={enableDynamicSizing ? undefined : snapPoints}
       enableDynamicSizing={enableDynamicSizing}
@@ -114,7 +130,7 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
       backgroundStyle={backgroundStyle}
       onChange={handleChange}
       onClose={onClose}
-      handleIndicatorStyle={sheetStyles.indicator}
+      handleComponent={renderHandle}
       style={styles.sheet}
     >
       {footer ? (

--- a/packages/mobile/src/components/SheetHandle.tsx
+++ b/packages/mobile/src/components/SheetHandle.tsx
@@ -1,0 +1,75 @@
+import { memo } from 'react';
+import { Pressable, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Icon } from './Icon';
+import { useTheme } from '../providers/theme-provider';
+import { sheetStyles, spacing } from '../theme/tokens';
+
+type SheetCloseButtonProps = {
+  onClose: () => void;
+  style?: StyleProp<ViewStyle>;
+};
+
+// Chevron close button pinned to the top-right corner of a sheet. Standalone so
+// drawers with their own bespoke handle (e.g. PlayDrawer) can drop it in
+// without adopting the whole SheetHandle.
+export const SheetCloseButton = memo(function SheetCloseButton({ onClose, style }: SheetCloseButtonProps) {
+  const { systemColors } = useTheme();
+  const { t } = useTranslation('common');
+
+  return (
+    <Pressable
+      onPress={onClose}
+      accessibilityRole="button"
+      accessibilityLabel={t('ariaLabels.close')}
+      hitSlop={8}
+      style={({ pressed }) => [
+        styles.closeButton,
+        { backgroundColor: systemColors.fill as string },
+        style,
+        pressed && styles.closeButtonPressed,
+      ]}
+    >
+      <Icon name="chevron.down" size={18} color={systemColors.secondaryLabel} />
+    </Pressable>
+  );
+});
+
+type SheetHandleProps = {
+  onClose: () => void;
+};
+
+// Shared bottom-sheet handle. Renders gorhom's grabber pill centered (the drag
+// handle) plus a chevron close button pinned to the top-right corner, so every
+// sheet exposes both affordances in the same spot. Pass it to a gorhom sheet
+// via `handleComponent` — gorhom feeds animated props we don't need, so the
+// wrapper ignores them.
+export const SheetHandle = memo(function SheetHandle({ onClose }: SheetHandleProps) {
+  return (
+    <View style={styles.handle}>
+      <View style={sheetStyles.indicator} />
+      <SheetCloseButton onClose={onClose} />
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  handle: {
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 3,
+    right: spacing[4],
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeButtonPressed: {
+    opacity: 0.7,
+  },
+});

--- a/packages/mobile/src/components/ble/DevicePickerSheet.tsx
+++ b/packages/mobile/src/components/ble/DevicePickerSheet.tsx
@@ -14,6 +14,7 @@ import { parseBoardTypeFromDeviceName } from '@boardsesh/ble-protocol';
 import type { DiscoveredDevice } from '../../lib/ble/types';
 import { Text } from '../Text';
 import { Button } from '../Button';
+import { SheetHandle } from '../SheetHandle';
 import { DeviceCard } from './DeviceCard';
 import { useTheme } from '../../providers/theme-provider';
 import { spacing } from '../../theme/tokens';
@@ -53,6 +54,8 @@ export function DevicePickerSheet({ devices, onSelect, onDismiss, isScanning }: 
     [],
   );
 
+  const renderHandle = useCallback(() => <SheetHandle onClose={() => sheetRef.current?.dismiss()} />, []);
+
   const renderDeviceItem = useCallback(
     ({ item }: { item: DiscoveredDevice }) => {
       const boardType = parseBoardTypeFromDeviceName(item.name);
@@ -87,7 +90,7 @@ export function DevicePickerSheet({ devices, onSelect, onDismiss, isScanning }: 
       enablePanDownToClose
       backdropComponent={renderBackdrop}
       onDismiss={onDismiss}
-      handleIndicatorStyle={styles.indicator}
+      handleComponent={renderHandle}
       backgroundStyle={backgroundStyle}
     >
       <BottomSheetView style={styles.header}>
@@ -136,12 +139,6 @@ export function DevicePickerSheet({ devices, onSelect, onDismiss, isScanning }: 
 }
 
 const styles = StyleSheet.create({
-  indicator: {
-    backgroundColor: iosSystemColors.separator,
-    width: 36,
-    height: 5,
-    borderRadius: 3,
-  },
   header: {
     paddingHorizontal: spacing[4],
     paddingBottom: spacing[3],

--- a/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
@@ -17,6 +17,7 @@ import { useGradeFormat } from '../../hooks/use-grade-format';
 import { buildAngleStatsMap, type AngleStats } from './community-utils';
 import { AngleBoardDiagram } from './AngleBoardDiagram';
 import { AngleSlider } from './AngleSlider';
+import { SheetHandle } from '../SheetHandle';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { brandColors } from '../../theme/colors';
 import { spacing, sheetStyles } from '../../theme/tokens';
@@ -108,6 +109,8 @@ export const AngleSelectorSheet = memo(function AngleSelectorSheet({
     [],
   );
 
+  const renderHandle = useCallback(() => <SheetHandle onClose={() => sheetRef.current?.dismiss()} />, []);
+
   const backgroundStyle = { ...sheetStyles.background, backgroundColor: systemColors.secondaryBackground };
 
   return (
@@ -121,7 +124,7 @@ export const AngleSelectorSheet = memo(function AngleSelectorSheet({
       enablePanDownToClose
       onDismiss={handleDismiss}
       backdropComponent={renderBackdrop}
-      handleIndicatorStyle={sheetStyles.indicator}
+      handleComponent={renderHandle}
       backgroundStyle={backgroundStyle}
     >
       <BottomSheetView style={[styles.container, { paddingBottom: insets.bottom + spacing[4] }]}>

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -23,6 +23,7 @@ import { DeferredSections } from './DeferredSections';
 import { QueueSheet } from './QueueSheet';
 import { AngleSelectorSheet } from './AngleSelectorSheet';
 import { ClimbActionsSheet } from '../ClimbActionsSheet';
+import { SheetCloseButton } from '../SheetHandle';
 import { Icon } from '../Icon';
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
@@ -306,6 +307,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     () => (props: BottomSheetHandleProps) => (
       <View onLayout={handleHandleLayout}>
         <BottomSheetHandle {...props} indicatorStyle={sheetStyles.indicator} />
+        <SheetCloseButton onClose={() => sheetRef.current?.dismiss()} />
       </View>
     ),
     [handleHandleLayout],

--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { QueueSheetHeader } from './QueueSheetHeader';
 import { QueueList } from './QueueList';
+import { SheetHandle } from '../SheetHandle';
 import { Text } from '../Text';
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
@@ -125,6 +126,8 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
     [],
   );
 
+  const renderHandle = useCallback(() => <SheetHandle onClose={() => sheetRef.current?.close()} />, []);
+
   const backgroundStyle = { ...sheetStyles.background, backgroundColor: systemColors.secondaryBackground };
 
   const viewOnlyMode = queue.length === 0;
@@ -138,7 +141,7 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
       backdropComponent={renderBackdrop}
       onChange={handleSheetChange}
       onClose={handleClose}
-      handleIndicatorStyle={sheetStyles.indicator}
+      handleComponent={renderHandle}
       backgroundStyle={backgroundStyle}
       style={styles.sheet}
     >
@@ -150,7 +153,6 @@ export function QueueSheet({ visible, onClose, onClimbPress }: QueueSheetProps) 
         viewOnlyMode={viewOnlyMode}
         onToggleEditMode={handleToggleEditMode}
         onToggleHistory={handleToggleHistory}
-        onClose={handleClose}
         onClearAll={handleClearAll}
       />
 

--- a/packages/mobile/src/components/play-drawer/QueueSheetHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheetHeader.tsx
@@ -16,7 +16,6 @@ type QueueSheetHeaderProps = {
   viewOnlyMode: boolean;
   onToggleEditMode: () => void;
   onToggleHistory: () => void;
-  onClose: () => void;
   onClearAll: () => void;
 };
 
@@ -28,7 +27,6 @@ export const QueueSheetHeader = memo(function QueueSheetHeader({
   viewOnlyMode,
   onToggleEditMode,
   onToggleHistory,
-  onClose,
   onClearAll,
 }: QueueSheetHeaderProps) {
   const { t } = useTranslation('session');
@@ -113,16 +111,6 @@ export const QueueSheetHeader = memo(function QueueSheetHeader({
             <Icon name="edit" size={20} color={iosSystemColors.systemGray} />
           </Pressable>
         )}
-
-        <Pressable
-          onPress={onClose}
-          accessibilityRole="button"
-          accessibilityLabel={t('playView.closeAria')}
-          hitSlop={8}
-          style={styles.headerButton}
-        >
-          <Icon name="close" size={18} color={iosSystemColors.systemGray} />
-        </Pressable>
       </View>
     </View>
   );


### PR DESCRIPTION
## What

Every bottom sheet in `packages/mobile` now exposes the same two affordances in the same spot: a **drag handle** and an explicit **close button** — a chevron pinned to the top-right corner.

Before this, only `LogAscentSheet` had an explicit close button (and it lived inside the content, not the corner). Every other sheet relied solely on pan-down / backdrop-tap to dismiss.

## How

- **New `SheetHandle`** (`packages/mobile/src/components/SheetHandle.tsx`): renders gorhom's grabber pill (the drag handle) centered, plus a chevron close button pinned top-right. Also exports a standalone **`SheetCloseButton`** for drawers that keep their own bespoke handle.
- **Base wrappers** `Sheet` and `ModalSheet` now pass `SheetHandle` via `handleComponent`, so every sheet built on them gets the chevron + handle automatically. A merged ref lets the button drive `close()` / `dismiss()` while still forwarding the instance to the parent.
- **Raw gorhom sheets** wired individually: `EndSessionSheet`, `QueueSheet`, `LogAscentSheet`, `ClimbFilterSheet`, `AngleSelectorSheet`, `DevicePickerSheet`, and the `PlayDrawer` measured handle.
- **Cleanup**: `LogAscentSheet` drops its bespoke close-button row in favour of the shared handle; `QueueSheetHeader` drops its now-redundant close `X`. Per-file duplicate `indicator` styles removed in favour of the shared one.

## Sheets covered

Via base wrappers: `ClimbActionsSheet`, `AddToPlaylistSheet`, `BoardDetailSheet`, `BluetoothQuickstartSheet`, `CommentSheet`, `YouFilterSheet`, `LogbookEditSheet`, `CustomBoardSheet`, `BetaVideoAddSheet`, `PlaylistFormSheet`, `DevServerSwitcherScreen` info sheet. Direct: the seven listed above.

The close-button accessibility label reuses the existing `common:ariaLabels.close` catalog key (no new strings).

## Validation

- `vp run typecheck:mobile` — passes
- `vp test --project mobile` — 585 tests pass
- `vp run check:mobile-bundle` — iOS + Android bundles OK

https://claude.ai/code/session_01TbZJzRgv7SNL9pBfDxDVpp