### PR TITLE
feat(mobile): grade-first climb search redesign (P0)

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -1,30 +1,30 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
-import { View, Pressable, StyleSheet, RefreshControl, Image, Keyboard } from 'react-native';
+import { View, StyleSheet, RefreshControl, Image, Keyboard } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import type { Climb, BoardName } from '@boardsesh/shared-schema';
-import { toClimbSearchInput } from '@boardsesh/climb-filters';
+import { toClimbSearchInput, DEFAULT_CLIMB_FILTER_STATE } from '@boardsesh/climb-filters';
 import { ClimbListRow } from '../../../src/components/ClimbListRow';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
-import {
-  ClimbFilterSheet,
-  hasActiveFilters,
-  DEFAULT_FILTERS,
-  type ClimbFilters,
-} from '../../../src/components/ClimbFilterSheet';
+import { ClimbFilterSheet, hasActiveFilters, type ClimbFilters } from '../../../src/components/ClimbFilterSheet';
+import { GradePopover } from '../../../src/components/search/GradePopover';
+import { SearchBottomBar } from '../../../src/components/search/SearchBottomBar';
+import { StickyFilterStrip } from '../../../src/components/search/StickyFilterStrip';
+import { countActiveFiltersBeyondGrade } from '../../../src/components/search/active-filter-count';
 import { useDrawerHost } from '../../../src/providers/drawer-host-provider';
 import { useTheme } from '../../../src/providers/theme-provider';
 import { useQueue } from '../../../src/providers/queue-provider';
+import { ClimbSearchProvider, useClimbSearch, type GradeBound } from '../../../src/providers/climb-search-provider';
 import { useBoardProvider } from '@boardsesh/board-react';
 import { randomUUID } from 'expo-crypto';
 import { SearchHeader, type SearchHeaderHandle } from '../../../src/components/SearchHeader';
 import { RecentFilterPills } from '../../../src/components/RecentFilterPills';
-import { BAR_CONTENT_HEIGHT, TAB_BAR_HEIGHT } from '../../../src/components/queue-control/persistent-queue-bar';
-import { useSearchClimbs, useGrades } from '../../../src/lib/graphql/hooks';
+import { TAB_BAR_HEIGHT, BAR_CONTENT_HEIGHT } from '../../../src/theme/layout';
+import { useSearchClimbs, useSearchClimbsCount, useGrades } from '../../../src/lib/graphql/hooks';
 import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../../src/lib/graphql/operations';
 import { getHttpClient } from '../../../src/lib/graphql/client';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
@@ -39,110 +39,122 @@ import {
   clearRecentFilters,
   type RecentFilter,
 } from '../../../src/lib/recent-filter-store';
+import { getLastSearch, saveLastSearch, boardConfigKey } from '../../../src/lib/last-search-store';
 import { getFilterSummary } from '../../../src/lib/filter-summary';
+import { useSearchLayout } from '../../../src/lib/search-layout-preference';
 import { brandColors } from '../../../src/theme/colors';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 
 const PAGE_SIZE = 30;
 const SEARCH_DEBOUNCE_MS = 300;
+// Approximate height of the floating bottom search bar, so the list's last row
+// clears it. Tuned to the bar's content (control row + padding).
+const SEARCH_BAR_HEIGHT = 64;
+// Debounce persisting the per-board last search so rapid grade nudges don't
+// thrash secure-store.
+const SAVE_DEBOUNCE_MS = 600;
 
 export default function ClimbList() {
+  return (
+    <ClimbSearchProvider>
+      <ClimbListInner />
+    </ClimbSearchProvider>
+  );
+}
+
+function ClimbListInner() {
   const navigation = useNavigation();
   const { t } = useTranslation('climbs');
   const { openClimbActions, openAddToPlaylist } = useDrawerHost();
   const { systemColors } = useTheme();
   const { addToQueue, state: queueState } = useQueue();
+  const { filters, name, setFilters, setGrade, setName, replaceSearch } = useClimbSearch();
+  const { layout, loaded: layoutLoaded } = useSearchLayout();
   // The active climb (driving the board / persistent queue bar). We highlight
   // its row so the search → tap → change-active loop is always visible.
-  // Computed once here, not per-row, so a queue change only re-renders the
-  // two affected rows (ClimbListRow is memoized), never the whole list.
   const activeClimbUuid = queueState.currentClimbQueueItem?.climb?.uuid;
+  const hasActiveClimb = !!activeClimbUuid;
   const { getLogbook } = useBoardProvider();
   const searchHeaderRef = useRef<SearchHeaderHandle>(null);
   const insets = useSafeAreaInsets();
-  // Reserve room for the floating queue bar + tab bar so the last row isn't
-  // hidden behind them.
-  const listPaddingBottom = BAR_CONTENT_HEIGHT + TAB_BAR_HEIGHT + insets.bottom;
 
-  const [debouncedSearch, setDebouncedSearch] = useState('');
-  const debouncedSearchRef = useRef('');
+  // Derive the floating bar's position and the list's bottom reservation from
+  // the SAME parts so they can't drift (the last row must clear the bar in the
+  // common active-climb + bottom-bar state). The queue mini-player only renders
+  // when a climb is active, so reserve for it only then.
+  const queueBarReserve = hasActiveClimb ? BAR_CONTENT_HEIGHT + 8 : 0;
+  const searchBarBottom = insets.bottom + TAB_BAR_HEIGHT + 8 + queueBarReserve;
+  const searchBarReserve = layout === 'bottom-bar' ? SEARCH_BAR_HEIGHT + 8 : 0;
+  const listPaddingBottom = insets.bottom + TAB_BAR_HEIGHT + queueBarReserve + searchBarReserve;
+
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isSearchFocused, setIsSearchFocused] = useState(false);
   const [searchTextLength, setSearchTextLength] = useState(0);
-  const [filters, setFilters] = useState<ClimbFilters>(DEFAULT_FILTERS);
   const [showFilters, setShowFilters] = useState(false);
+  const [showGrade, setShowGrade] = useState(false);
   const [recentFilters, setRecentFilters] = useState<RecentFilter[]>([]);
 
-  const filtersActive = hasActiveFilters(filters);
-
-  const handleOpenFilters = useCallback(() => {
-    setShowFilters(true);
+  // The nav header mounts SearchHeader lazily, so an imperative setText right
+  // after an async restore can no-op. Instead we remount the header with the
+  // restored text as `initialValue`, bumping this epoch only on restore /
+  // recent-pill apply (not on keystrokes), so the field always reflects the
+  // committed name.
+  const [headerEpoch, setHeaderEpoch] = useState(0);
+  const headerInitialTextRef = useRef('');
+  const syncHeaderText = useCallback((value: string) => {
+    headerInitialTextRef.current = value;
+    setHeaderEpoch((epoch) => epoch + 1);
   }, []);
 
-  const handleDismissFilters = useCallback(() => {
-    setShowFilters(false);
-  }, []);
+  const handleOpenFilters = useCallback(() => setShowFilters(true), []);
+  const handleDismissFilters = useCallback(() => setShowFilters(false), []);
+  const handleOpenGrade = useCallback(() => setShowGrade(true), []);
+  const handleDismissGrade = useCallback(() => setShowGrade(false), []);
 
-  const handleSearchChange = useCallback((text: string) => {
-    setSearchTextLength(text.length);
+  const handleSearchChange = useCallback(
+    (text: string) => {
+      setSearchTextLength(text.length);
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = setTimeout(() => {
+        setName(text);
+      }, SEARCH_DEBOUNCE_MS);
+    },
+    [setName],
+  );
 
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-    }
-    debounceTimerRef.current = setTimeout(() => {
-      debouncedSearchRef.current = text;
-      setDebouncedSearch(text);
-    }, SEARCH_DEBOUNCE_MS);
-  }, []);
+  const handleSearchFocus = useCallback(() => setIsSearchFocused(true), []);
+  const handleSearchBlur = useCallback(() => setIsSearchFocused(false), []);
 
-  const handleSearchFocus = useCallback(() => {
-    setIsSearchFocused(true);
-  }, []);
-
-  const handleSearchBlur = useCallback(() => {
-    setIsSearchFocused(false);
-  }, []);
-
-  // Set up header once — SearchHeader manages its own text state internally
+  // Set up the header once — SearchHeader (climb-name search) keeps its own
+  // text state. Filters now live in the bottom bar / sticky strip gear, so the
+  // header carries just the name field.
   useEffect(() => {
     navigation.setOptions({
       headerTitle: () => (
         <SearchHeader
+          key={headerEpoch}
           ref={searchHeaderRef}
+          initialValue={headerInitialTextRef.current}
           placeholder={t('search.placeholders.climbs')}
           onChangeText={handleSearchChange}
           onFocus={handleSearchFocus}
           onBlur={handleSearchBlur}
         />
       ),
+      headerRight: undefined,
     });
-  }, [navigation, t, handleSearchChange, handleSearchFocus, handleSearchBlur]);
+  }, [navigation, t, handleSearchChange, handleSearchFocus, handleSearchBlur, headerEpoch]);
 
-  // Separate effect for headerRight since it depends on filtersActive
-  useEffect(() => {
-    navigation.setOptions({
-      headerRight: () => (
-        <Pressable onPress={handleOpenFilters} hitSlop={8} accessibilityRole="button">
-          <Icon name="filter" size={22} color={filtersActive ? brandColors.primary : iosSystemColors.systemGray} />
-        </Pressable>
-      ),
-    });
-  }, [navigation, filtersActive, handleOpenFilters]);
-
-  // Clean up debounce timer on unmount
   useEffect(() => {
     return () => {
-      if (debounceTimerRef.current) {
-        clearTimeout(debounceTimerRef.current);
-      }
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
     };
   }, []);
 
   const { isAuthenticated } = useAuth();
 
   // Load recent filters on mount. Pass auth state so auth-gated fields get
-  // stripped from pills written by a prior signed-in session — otherwise a
-  // tapped pill would silently no-op on the backend while looking active.
+  // stripped from pills written by a prior signed-in session.
   useEffect(() => {
     getRecentFilters({ isAuthenticated })
       .then(setRecentFilters)
@@ -162,8 +174,66 @@ export default function ClimbList() {
   const { data: gradesData } = useGrades(boardName);
   const gradesRef = useRef(gradesData);
   gradesRef.current = gradesData;
+  const grades = useMemo(() => gradesData ?? [], [gradesData]);
 
-  // Pre-warm board images so they're cached before the user taps into a climb
+  const boardConfig = useMemo(
+    () => (hasBoardConfig ? { boardName, layoutId, sizeId, setIds, angle } : null),
+    [hasBoardConfig, boardName, layoutId, sizeId, setIds, angle],
+  );
+  const boardKey = boardConfig ? boardConfigKey(boardConfig) : null;
+
+  // Per-board memory: restore this board's last search on arrival; a board
+  // never searched before gets the clean default. `restoredKey` is state (not
+  // just a ref) so the search queries can gate on it — that prevents a stale
+  // fetch of the new board filtered by the *previous* board's grade/name while
+  // the async restore is in flight, and the resulting wrong-results flash.
+  const restoredKeyRef = useRef<string | null>(null);
+  const [restoredKey, setRestoredKey] = useState<string | null>(null);
+  useEffect(() => {
+    if (!boardConfig || !boardKey) return;
+    let cancelled = false;
+    restoredKeyRef.current = null;
+    setRestoredKey(null);
+    getLastSearch(boardConfig, { isAuthenticated })
+      .then((saved) => {
+        if (cancelled) return;
+        if (saved) {
+          replaceSearch(saved.filters, saved.searchText);
+          syncHeaderText(saved.searchText);
+        } else {
+          // Never-searched board → clean default band, no grade/filters/name
+          // inherited from the board the climber came from.
+          replaceSearch(DEFAULT_CLIMB_FILTER_STATE, '');
+          syncHeaderText('');
+        }
+        restoredKeyRef.current = boardKey;
+        setRestoredKey(boardKey);
+      })
+      .catch(() => {
+        restoredKeyRef.current = boardKey;
+        setRestoredKey(boardKey);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // Restore is keyed on the board only — re-running on filter changes would
+    // clobber the user's edits. replaceSearch/syncHeaderText are stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [boardKey, isAuthenticated]);
+
+  // Search is "ready" once this board's restore has landed — gate queries on it.
+  const searchReady = hasBoardConfig && restoredKey === boardKey;
+
+  // Persist the current search for this board once the restore for it landed.
+  useEffect(() => {
+    if (!boardConfig || restoredKeyRef.current !== boardKey) return;
+    const handle = setTimeout(() => {
+      void saveLastSearch(boardConfig, filters, name);
+    }, SAVE_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [filters, name, boardConfig, boardKey]);
+
+  // Pre-warm board images so they're cached before the user taps into a climb.
   useEffect(() => {
     if (!activeBoard) return;
     const parsedSetIds = activeBoard.setIds.split(',').map(Number);
@@ -180,16 +250,14 @@ export default function ClimbList() {
     }
   }, [activeBoard]);
 
-  // Track pagination
+  // Pagination + accumulation for infinite scroll.
   const [pageNumber, setPageNumber] = useState(1);
-  // Accumulate climbs across pages for infinite scroll
   const [accumulatedClimbs, setAccumulatedClimbs] = useState<Climb[]>([]);
 
-  // Clear accumulated climbs and reset page when search or filters change
   useEffect(() => {
     setAccumulatedClimbs([]);
     setPageNumber(1);
-  }, [debouncedSearch, filters]);
+  }, [name, filters]);
 
   const searchInput = useMemo(
     () =>
@@ -197,32 +265,41 @@ export default function ClimbList() {
         filters,
         { boardName, layoutId, sizeId, setIds, angle },
         { page: pageNumber, pageSize: PAGE_SIZE },
-        { name: debouncedSearch },
+        { name },
       ),
-    [boardName, layoutId, sizeId, setIds, angle, debouncedSearch, pageNumber, filters],
+    [boardName, layoutId, sizeId, setIds, angle, name, pageNumber, filters],
   );
+
+  // Page-independent input for the result count so the count query key stays
+  // stable while the user scrolls (totalCount is the same across pages).
+  const countInput = useMemo(
+    () =>
+      toClimbSearchInput(
+        filters,
+        { boardName, layoutId, sizeId, setIds, angle },
+        { page: 1, pageSize: PAGE_SIZE },
+        { name },
+      ),
+    [boardName, layoutId, sizeId, setIds, angle, name, filters],
+  );
+  const { data: totalCount } = useSearchClimbsCount(countInput, searchReady);
 
   const {
     data: searchResult,
     isLoading: isClimbsLoading,
     isRefetching,
     refetch,
-  } = useSearchClimbs(searchInput, hasBoardConfig);
+  } = useSearchClimbs(searchInput, searchReady);
   const hasMore = searchResult?.hasMore ?? false;
   const isLoadingMoreRef = useRef(false);
 
   useEffect(() => {
     if (!searchResult?.climbs) return;
-
     isLoadingMoreRef.current = false;
-
     setAccumulatedClimbs((previous) => accumulateClimbs(previous, searchResult.climbs, pageNumber));
   }, [searchResult?.climbs, pageNumber]);
 
-  // Feed the visible climb UUIDs into the shared logbook so the ascent badge
-  // can render flash/send/attempt without baking per-user counts into the
-  // (CDN-cacheable) search query. `getLogbook` is a noop when the user is
-  // anonymous or the active board hasn't resolved yet.
+  // Feed visible UUIDs into the shared logbook for the ascent badge.
   useEffect(() => {
     if (accumulatedClimbs.length === 0) return;
     void getLogbook(accumulatedClimbs.map((climb) => climb.uuid));
@@ -241,21 +318,15 @@ export default function ClimbList() {
     }
   }, [hasMore, isClimbsLoading, isRefetching]);
 
-  const boardConfig = useMemo(
-    () => (hasBoardConfig ? { boardName, layoutId, sizeId, setIds, angle } : null),
-    [hasBoardConfig, boardName, layoutId, sizeId, setIds, angle],
-  );
-
   // Page the same search query the list uses so the play-drawer swipe can walk
-  // climbs beyond what's loaded in the list (capped by the shared refresh
-  // helper). Activation pages are 0-based; the search query is 1-based.
+  // climbs beyond what's loaded. Activation pages are 0-based; search is 1-based.
   const fetchSearchPage = useCallback(
     async ({ page, pageSize }: { page: number; pageSize: number }) => {
       const input = toClimbSearchInput(
         filters,
         { boardName, layoutId, sizeId, setIds, angle },
         { page: page + 1, pageSize },
-        { name: debouncedSearch },
+        { name },
       );
       const response = await getHttpClient().request<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input });
       return {
@@ -263,12 +334,9 @@ export default function ClimbList() {
         hasMore: response.searchClimbs.hasMore,
       };
     },
-    [filters, boardName, layoutId, sizeId, setIds, angle, debouncedSearch],
+    [filters, boardName, layoutId, sizeId, setIds, angle, name],
   );
 
-  // Tapping a climb seeds a suggestion source from the search results, anchored
-  // at the tapped climb, so the play-drawer swipe continues through the climbs
-  // listed after it — mirroring the playlist flow.
   const allQueueClimbs = useMemo(() => toQueueClimbs(accumulatedClimbs), [accumulatedClimbs]);
 
   const activateClimbListClimb = usePlaylistActivation({
@@ -297,7 +365,7 @@ export default function ClimbList() {
       setFilters(newFilters);
       setShowFilters(false);
 
-      const currentSearch = debouncedSearchRef.current;
+      const currentSearch = name;
       if (hasActiveFilters(newFilters) || currentSearch.length > 0) {
         const label = getFilterSummary(newFilters, currentSearch, gradesRef.current, t);
         addRecentFilter(label, newFilters, currentSearch)
@@ -306,22 +374,21 @@ export default function ClimbList() {
           .catch(() => {});
       }
     },
-    [t, isAuthenticated],
+    [t, isAuthenticated, name, setFilters],
   );
 
-  const handleApplyRecentFilter = useCallback((pillFilters: ClimbFilters, pillSearchText: string) => {
-    setFilters(pillFilters);
-    debouncedSearchRef.current = pillSearchText;
-    setDebouncedSearch(pillSearchText);
-    setSearchTextLength(pillSearchText.length);
-    searchHeaderRef.current?.setText(pillSearchText);
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-    }
-    Keyboard.dismiss();
-    searchHeaderRef.current?.blur();
-    setIsSearchFocused(false);
-  }, []);
+  const handleApplyRecentFilter = useCallback(
+    (pillFilters: ClimbFilters, pillSearchText: string) => {
+      replaceSearch(pillFilters, pillSearchText);
+      setSearchTextLength(pillSearchText.length);
+      syncHeaderText(pillSearchText);
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      Keyboard.dismiss();
+      searchHeaderRef.current?.blur();
+      setIsSearchFocused(false);
+    },
+    [replaceSearch, syncHeaderText],
+  );
 
   const handleClearRecentFilters = useCallback(() => {
     clearRecentFilters()
@@ -329,9 +396,24 @@ export default function ClimbList() {
       .catch(() => {});
   }, []);
 
-  const showRecentPills = isSearchFocused && searchTextLength === 0 && recentFilters.length > 0;
+  const handleGradeChange = useCallback(
+    (next: GradeBound) => {
+      setGrade(next);
+    },
+    [setGrade],
+  );
 
-  const isInitialLoading = isBoardLoading || (isClimbsLoading && accumulatedClimbs.length === 0);
+  const showRecentPills = isSearchFocused && searchTextLength === 0 && recentFilters.length > 0;
+  // Show the spinner (not a premature "no climbs" empty state) while a board is
+  // resolving or its per-board restore hasn't landed yet.
+  const isInitialLoading =
+    isBoardLoading || (hasBoardConfig && !searchReady) || (isClimbsLoading && accumulatedClimbs.length === 0);
+
+  const gradeBound = useMemo<GradeBound>(
+    () => ({ minGradeId: filters.minGrade, maxGradeId: filters.maxGrade }),
+    [filters.minGrade, filters.maxGrade],
+  );
+  const activeFilterCount = useMemo(() => countActiveFiltersBeyondGrade(filters), [filters]);
 
   const renderClimbItem = useCallback(
     ({ item: climb }: { item: Climb }) => (
@@ -389,6 +471,17 @@ export default function ClimbList() {
 
   return (
     <View style={[styles.container, { backgroundColor: systemColors.background }]}>
+      {layoutLoaded && layout === 'sticky-strip' ? (
+        <StickyFilterStrip
+          bound={gradeBound}
+          grades={grades}
+          count={totalCount}
+          activeFilterCount={activeFilterCount}
+          onOpenGrade={handleOpenGrade}
+          onOpenFilters={handleOpenFilters}
+        />
+      ) : null}
+
       <FlashList
         data={accumulatedClimbs}
         renderItem={renderClimbItem}
@@ -406,7 +499,7 @@ export default function ClimbList() {
             <RecentFilterPills
               recentFilters={recentFilters}
               currentFilters={filters}
-              currentSearchText={debouncedSearch}
+              currentSearchText={name}
               onApply={handleApplyRecentFilter}
               onClear={handleClearRecentFilters}
             />
@@ -424,19 +517,42 @@ export default function ClimbList() {
             <View style={styles.emptyContainer}>
               <Icon name="search" size={48} color={iosSystemColors.systemGray4} />
               <Text variant="headline" style={styles.emptyTitle}>
-                {debouncedSearch.length > 0
-                  ? t('mobile.emptyState.noMatches.title')
-                  : t('mobile.emptyState.noClimbs.title')}
+                {name.length > 0 ? t('mobile.emptyState.noMatches.title') : t('mobile.emptyState.noClimbs.title')}
               </Text>
               <Text variant="subheadline" style={styles.emptySubtitle}>
-                {debouncedSearch.length > 0
-                  ? t('mobile.emptyState.noMatches.description', { query: debouncedSearch })
+                {name.length > 0
+                  ? t('mobile.emptyState.noMatches.description', { query: name })
                   : t('mobile.emptyState.noClimbs.subtitle')}
               </Text>
             </View>
           ) : null
         }
       />
+
+      {layoutLoaded && layout === 'bottom-bar' ? (
+        <SearchBottomBar
+          bound={gradeBound}
+          grades={grades}
+          count={totalCount}
+          activeFilterCount={activeFilterCount}
+          onOpenGrade={handleOpenGrade}
+          onOpenFilters={handleOpenFilters}
+          bottomOffset={searchBarBottom}
+        />
+      ) : null}
+
+      {showGrade ? (
+        // sendDifficultyIds is omitted for now → the rail centers on the V5–V7
+        // band default; logbook-personalized "my grade" centering is wired in a
+        // later phase once the screen sources the climber's recent send grades.
+        <GradePopover
+          boardName={boardName}
+          grade={gradeBound}
+          onChange={handleGradeChange}
+          onDismiss={handleDismissGrade}
+        />
+      ) : null}
+
       {showFilters ? (
         <ClimbFilterSheet
           onDismiss={handleDismissFilters}

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -14,6 +14,7 @@ import { ListRow } from '../../../src/components/ListRow';
 import { SectionHeader } from '../../../src/components/SectionHeader';
 import { SegmentedControl } from '../../../src/components/SegmentedControl';
 import { isPreviewBuild } from '../../../src/lib/eas-api';
+import { useSearchLayout, type SearchLayout } from '../../../src/lib/search-layout-preference';
 
 export default function MoreScreen() {
   const { systemColors, borderRadius, themeOverride, setThemeOverride } = useTheme();
@@ -21,11 +22,17 @@ export default function MoreScreen() {
   const { t: tProfile } = useTranslation('profile');
   const { signOut } = useAuth();
   const { data: profile } = useProfile();
+  const { layout: searchLayout, setLayout: setSearchLayout } = useSearchLayout();
 
   const appearanceOptions: { key: ThemeOverride; label: string }[] = [
     { key: 'system', label: t('mobile.more.appearance.system') },
     { key: 'light', label: t('mobile.more.appearance.light') },
     { key: 'dark', label: t('mobile.more.appearance.dark') },
+  ];
+
+  const searchLayoutOptions: { key: SearchLayout; label: string }[] = [
+    { key: 'bottom-bar', label: t('mobile.more.searchLayout.bottomBar') },
+    { key: 'sticky-strip', label: t('mobile.more.searchLayout.stickyStrip') },
   ];
 
   return (
@@ -52,6 +59,32 @@ export default function MoreScreen() {
             trackColor={systemColors.fill}
             accessibilityLabel={t('mobile.more.appearance.title')}
           />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <SectionHeader title={t('mobile.more.searchLayout.title')} />
+        <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: systemColors.secondaryBackground,
+              borderRadius: borderRadius.lg,
+              marginHorizontal: spacing[4],
+              padding: spacing[3],
+            },
+          ]}
+        >
+          <SegmentedControl
+            options={searchLayoutOptions}
+            selectedKey={searchLayout}
+            onSelect={setSearchLayout}
+            trackColor={systemColors.fill}
+            accessibilityLabel={t('mobile.more.searchLayout.title')}
+          />
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.settingHint}>
+            {t('mobile.more.searchLayout.description')}
+          </Text>
         </View>
       </View>
       {__DEV__ ? (
@@ -129,6 +162,9 @@ const styles = StyleSheet.create({
   },
   card: {
     overflow: 'hidden',
+  },
+  settingHint: {
+    marginTop: spacing[2],
   },
   accountEmail: {
     paddingHorizontal: spacing[4],

--- a/packages/mobile/src/components/SearchHeader.tsx
+++ b/packages/mobile/src/components/SearchHeader.tsx
@@ -17,15 +17,18 @@ type SearchHeaderProps = {
   onChangeText: (text: string) => void;
   onFocus: () => void;
   onBlur: () => void;
+  /** Seeds the field on mount — used to reflect a restored per-board search
+   *  without an imperative setText race against the lazily-mounted header. */
+  initialValue?: string;
 };
 
 export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(function SearchHeader(
-  { placeholder, onChangeText, onFocus, onBlur },
+  { placeholder, onChangeText, onFocus, onBlur, initialValue = '' },
   ref,
 ) {
   const inputRef = useRef<TextInput>(null);
   const { systemColors } = useTheme();
-  const [text, setText] = useState('');
+  const [text, setText] = useState(initialValue);
 
   useImperativeHandle(ref, () => ({
     blur: () => inputRef.current?.blur(),

--- a/packages/mobile/src/components/search/ClimbSearchControls.tsx
+++ b/packages/mobile/src/components/search/ClimbSearchControls.tsx
@@ -1,0 +1,165 @@
+// The shared control row used by both search layouts (bottom bar + sticky
+// strip): the grade pill (primary), the live result count, and the filters
+// gear with an active-count badge. Layout-agnostic — the wrappers position it.
+
+import { useMemo } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { Grade } from '@boardsesh/shared-schema';
+import { isAnyGrade, type GradeBound } from '@boardsesh/climb-filters';
+import { getGradeColor } from '@boardsesh/board-constants/grade-colors';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { useTheme } from '../../providers/theme-provider';
+import { useGradeFormat } from '../../hooks/use-grade-format';
+import { spacing } from '../../theme/tokens';
+import { brandColors } from '../../theme/colors';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { formatGradePillLabel } from './grade-pill-label';
+
+type ClimbSearchControlsProps = {
+  bound: GradeBound;
+  grades: readonly Grade[];
+  /** Result count for the active filter set; undefined while loading. */
+  count: number | undefined;
+  activeFilterCount: number;
+  onOpenGrade: () => void;
+  onOpenFilters: () => void;
+};
+
+function tintFromHex(hexColor: string | undefined): string | undefined {
+  if (hexColor && /^#[0-9a-fA-F]{6}$/.test(hexColor)) return `${hexColor}24`;
+  return undefined;
+}
+
+export function ClimbSearchControls({
+  bound,
+  grades,
+  count,
+  activeFilterCount,
+  onOpenGrade,
+  onOpenFilters,
+}: ClimbSearchControlsProps) {
+  const { t } = useTranslation('climbs');
+  const { systemColors } = useTheme();
+  const { formatGrade } = useGradeFormat();
+
+  const gradeLabel = useMemo(
+    () => formatGradePillLabel(bound, grades, formatGrade, t),
+    [bound, grades, formatGrade, t],
+  );
+
+  const accentHex = useMemo(() => {
+    const id = bound.minGradeId ?? bound.maxGradeId;
+    if (id == null) return undefined;
+    const grade = grades.find((entry) => entry.difficultyId === id);
+    return grade ? (getGradeColor(grade.name) ?? undefined) : undefined;
+  }, [bound, grades]);
+
+  const gradeActive = !isAnyGrade(bound);
+  const pillBackground = gradeActive ? (tintFromHex(accentHex) ?? systemColors.fill) : systemColors.fill;
+  const pillBorder = gradeActive ? (accentHex ?? brandColors.primary) : iosSystemColors.separator;
+
+  return (
+    <View style={styles.row}>
+      <Pressable
+        onPress={onOpenGrade}
+        accessibilityRole="button"
+        accessibilityLabel={`${t('mobile.search.grade')}, ${gradeLabel}`}
+        style={[styles.gradePill, { backgroundColor: pillBackground as string, borderColor: pillBorder }]}
+      >
+        {gradeActive && accentHex ? <View style={[styles.gradeDot, { backgroundColor: accentHex }]} /> : null}
+        <Text variant="subheadline" style={styles.gradeText} numberOfLines={1}>
+          {gradeLabel}
+        </Text>
+        <Icon name="chevron.down" size={13} color={systemColors.secondaryLabel as string} />
+      </Pressable>
+
+      <View style={styles.spacer}>
+        {count != null ? (
+          <Text variant="footnote" color={systemColors.secondaryLabel} numberOfLines={1}>
+            {t('mobile.search.climbsCount', { count })}
+          </Text>
+        ) : null}
+      </View>
+
+      <Pressable
+        onPress={onOpenFilters}
+        accessibilityRole="button"
+        accessibilityLabel={
+          activeFilterCount > 0 ? `${t('mobile.search.filters')}, ${activeFilterCount}` : t('mobile.search.filters')
+        }
+        hitSlop={8}
+        style={styles.gearButton}
+      >
+        <Icon
+          name="filter"
+          size={22}
+          color={activeFilterCount > 0 ? brandColors.primary : (systemColors.secondaryLabel as string)}
+        />
+        {activeFilterCount > 0 ? (
+          <View style={styles.badge}>
+            <Text variant="caption2" color={iosSystemColors.white} style={styles.badgeText}>
+              {activeFilterCount}
+            </Text>
+          </View>
+        ) : null}
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  gradePill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    borderRadius: 18,
+    borderWidth: 1,
+    maxWidth: '60%',
+  },
+  gradeDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  gradeText: {
+    fontWeight: '600',
+    flexShrink: 1,
+  },
+  spacer: {
+    flex: 1,
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+  },
+  gearButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badge: {
+    position: 'absolute',
+    top: 2,
+    right: 0,
+    minWidth: 16,
+    height: 16,
+    borderRadius: 8,
+    paddingHorizontal: 4,
+    backgroundColor: brandColors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeText: {
+    fontWeight: '700',
+    fontSize: 10,
+    lineHeight: 14,
+  },
+});

--- a/packages/mobile/src/components/search/GradePopover.tsx
+++ b/packages/mobile/src/components/search/GradePopover.tsx
@@ -1,0 +1,327 @@
+// The grade front door. Grade is 68% of searches and the most-touched control
+// in the app, so this is the spine of the search UX:
+//   • single tap on a chip = pick that grade and auto-dismiss (the 60% fast path)
+//   • a quick second tap extends to a range (the 33% case), keeping the sheet open
+//   • the "Any" chip clears
+// A low sheet (not the 90% filter mega-sheet) keeps it one-handed. Tap rules are
+// the shared, web-identical state machine in @boardsesh/climb-filters.
+
+import { useCallback, useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react';
+import { Platform, Pressable, ScrollView, StyleSheet, View, type ViewStyle } from 'react-native';
+import {
+  BottomSheetBackdrop,
+  BottomSheetModal,
+  BottomSheetView,
+  type BottomSheetBackdropProps,
+} from '@gorhom/bottom-sheet';
+import { FullWindowOverlay } from 'react-native-screens';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import {
+  RANGE_EXTEND_WINDOW_MS,
+  clearGradeBound,
+  computeGradeTap,
+  isAnyGrade,
+  isGradeEndpoint,
+  isGradeInRange,
+  isRangeGrade,
+  isSingleGrade,
+  type GradeBound,
+} from '@boardsesh/climb-filters';
+import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { useTheme } from '../../providers/theme-provider';
+import { useGrades } from '../../lib/graphql/hooks';
+import { useGradeFormat } from '../../hooks/use-grade-format';
+import { gradeRailCenter } from '../../lib/grade-seed';
+import { hapticSelection } from '../../lib/haptics';
+import { spacing } from '../../theme/tokens';
+import { brandColors } from '../../theme/colors';
+import { iosSystemColors } from '../../theme/ios-colors';
+
+// After a single-grade tap the sheet lingers so a second tap can extend to a
+// range, then auto-dismisses (the one-tap fast path). Scrolling the rail (the
+// climber is still deciding) cancels the pending dismiss, so a deliberate
+// browse → tap is never cut off mid-decision.
+const AUTO_DISMISS_MS = 900;
+const CLEAR_DISMISS_MS = 300;
+
+type GradePopoverProps = {
+  boardName: string;
+  grade: GradeBound;
+  /** Recent send difficulty ids, used to center the rail on "my grade". */
+  sendDifficultyIds?: number[];
+  onChange: (next: GradeBound) => void;
+  onDismiss: () => void;
+};
+
+function PopoverContainer({ children }: PropsWithChildren) {
+  return <FullWindowOverlay>{children}</FullWindowOverlay>;
+}
+const modalContainerComponent = Platform.OS === 'ios' ? PopoverContainer : undefined;
+
+/** Translucent tint for in-range (non-endpoint) chips from a 6-digit hex. */
+function withAlpha(hexColor: string): string {
+  return /^#[0-9a-fA-F]{6}$/.test(hexColor) ? `${hexColor}2E` : hexColor;
+}
+
+export function GradePopover({ boardName, grade, sendDifficultyIds = [], onChange, onDismiss }: GradePopoverProps) {
+  const { t } = useTranslation('climbs');
+  const { systemColors } = useTheme();
+  const { formatGrade } = useGradeFormat();
+  const insets = useSafeAreaInsets();
+  const sheetRef = useRef<BottomSheetModal>(null);
+  const scrollRef = useRef<ScrollView>(null);
+  const { data: gradesData } = useGrades(boardName);
+
+  const grades = useMemo(() => [...(gradesData ?? [])].sort((a, b) => a.difficultyId - b.difficultyId), [gradesData]);
+  const gradeIds = useMemo(() => grades.map((entry) => entry.difficultyId), [grades]);
+
+  const [bound, setBound] = useState<GradeBound>(grade);
+  const lastSingleAtRef = useRef<number | undefined>(isSingleGrade(grade) ? Date.now() : undefined);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const snapPoints = useMemo(() => ['42%'], []);
+
+  useEffect(() => {
+    sheetRef.current?.present();
+    return () => {
+      if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
+    };
+  }, []);
+
+  const clearDismissTimer = useCallback(() => {
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleDismiss = useCallback(
+    (delay: number) => {
+      clearDismissTimer();
+      dismissTimerRef.current = setTimeout(() => {
+        sheetRef.current?.dismiss();
+      }, delay);
+    },
+    [clearDismissTimer],
+  );
+
+  // Center the rail on the current selection, else "my grade", else the band
+  // center — once, after grades load and the row has measured its children.
+  const chipLayouts = useRef<Record<number, { x: number; width: number }>>({});
+  const [railWidth, setRailWidth] = useState(0);
+  const didCenterRef = useRef(false);
+  const centerId = useMemo(
+    () => gradeRailCenter(bound, grades, sendDifficultyIds),
+    // Only the initial center matters; recomputing as `bound` changes would
+    // fight the user's scroll. Depend on grades/sends, not bound.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [grades, sendDifficultyIds],
+  );
+
+  const maybeCenter = useCallback(() => {
+    if (didCenterRef.current || railWidth === 0 || centerId == null) return;
+    const layout = chipLayouts.current[centerId];
+    if (!layout) return;
+    didCenterRef.current = true;
+    const target = Math.max(0, layout.x + layout.width / 2 - railWidth / 2);
+    scrollRef.current?.scrollTo({ x: target, animated: false });
+  }, [railWidth, centerId]);
+
+  const apply = useCallback(
+    (next: GradeBound) => {
+      setBound(next);
+      onChange(next);
+      lastSingleAtRef.current = isSingleGrade(next) ? Date.now() : undefined;
+    },
+    [onChange],
+  );
+
+  const handleTapGrade = useCallback(
+    (gradeId: number) => {
+      hapticSelection();
+      clearDismissTimer();
+      const withinWindow =
+        lastSingleAtRef.current !== undefined && Date.now() - lastSingleAtRef.current < RANGE_EXTEND_WINDOW_MS;
+      const result = computeGradeTap(bound, gradeIds, gradeId, withinWindow);
+      apply(result.next);
+      // Range building keeps the sheet open (the user is mid-gesture); a single
+      // grade or a clear is the terminal fast-path action, so dismiss shortly.
+      if (!isRangeGrade(result.next)) {
+        scheduleDismiss(AUTO_DISMISS_MS);
+      }
+    },
+    [bound, gradeIds, apply, clearDismissTimer, scheduleDismiss],
+  );
+
+  const handleClear = useCallback(() => {
+    hapticSelection();
+    apply(clearGradeBound());
+    scheduleDismiss(CLEAR_DISMISS_MS);
+  }, [apply, scheduleDismiss]);
+
+  const handleDone = useCallback(() => {
+    clearDismissTimer();
+    sheetRef.current?.dismiss();
+  }, [clearDismissTimer]);
+
+  const renderBackdrop = useCallback(
+    (backdropProps: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop {...backdropProps} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.35} />
+    ),
+    [],
+  );
+
+  const anySelected = isAnyGrade(bound);
+  const showDone = isRangeGrade(bound);
+
+  const backgroundStyle: ViewStyle = {
+    backgroundColor: systemColors.secondaryBackground as string,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+  };
+
+  return (
+    <BottomSheetModal
+      ref={sheetRef}
+      name="grade-popover"
+      index={0}
+      snapPoints={snapPoints}
+      enableDynamicSizing={false}
+      stackBehavior="push"
+      containerComponent={modalContainerComponent}
+      enablePanDownToClose
+      backdropComponent={renderBackdrop}
+      onDismiss={onDismiss}
+      handleIndicatorStyle={styles.indicator}
+      backgroundStyle={backgroundStyle}
+    >
+      <BottomSheetView style={[styles.content, { paddingBottom: insets.bottom + spacing[3] }]}>
+        <View style={styles.header}>
+          <Text variant="title3">{t('mobile.search.grade')}</Text>
+          {showDone ? (
+            <Pressable onPress={handleDone} hitSlop={8} accessibilityRole="button">
+              <Text variant="subheadline" color={brandColors.primary}>
+                {t('mobile.filter.done')}
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+
+        <ScrollView
+          ref={scrollRef}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.rail}
+          onScrollBeginDrag={clearDismissTimer}
+          onLayout={(event) => {
+            setRailWidth(event.nativeEvent.layout.width);
+            maybeCenter();
+          }}
+        >
+          <Pressable
+            onPress={handleClear}
+            accessibilityRole="button"
+            accessibilityState={{ selected: anySelected }}
+            accessibilityLabel={t('mobile.search.gradeClear')}
+            style={[
+              styles.chip,
+              {
+                borderColor: anySelected ? brandColors.primary : iosSystemColors.separator,
+                backgroundColor: anySelected ? brandColors.primary : 'transparent',
+              },
+            ]}
+          >
+            <Text variant="footnote" color={anySelected ? iosSystemColors.white : undefined} style={styles.chipText}>
+              {t('mobile.search.gradeClear')}
+            </Text>
+          </Pressable>
+
+          {grades.map((entry) => {
+            const color = getGradeColor(entry.name) ?? DEFAULT_GRADE_COLOR;
+            const endpoint = isGradeEndpoint(bound, entry.difficultyId);
+            const inside = !endpoint && isGradeInRange(bound, entry.difficultyId);
+            const label = formatGrade(entry.name) ?? entry.name;
+            const backgroundColor = endpoint ? color : inside ? withAlpha(color) : 'transparent';
+            const borderColor = endpoint || inside ? color : iosSystemColors.separator;
+            return (
+              <Pressable
+                key={entry.difficultyId}
+                onPress={() => handleTapGrade(entry.difficultyId)}
+                onLayout={(event) => {
+                  const { x, width } = event.nativeEvent.layout;
+                  chipLayouts.current[entry.difficultyId] = { x, width };
+                  maybeCenter();
+                }}
+                accessibilityRole="button"
+                accessibilityState={{ selected: endpoint }}
+                accessibilityLabel={label}
+                style={[styles.chip, { backgroundColor, borderColor }]}
+              >
+                <Text variant="footnote" color={endpoint ? iosSystemColors.white : undefined} style={styles.chipText}>
+                  {label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+
+        <View style={styles.hintRow}>
+          <Icon name="search" size={13} color={iosSystemColors.systemGray} />
+          <Text variant="caption1" color={systemColors.secondaryLabel} style={styles.hint}>
+            {t('mobile.search.gradeHint')}
+          </Text>
+        </View>
+      </BottomSheetView>
+    </BottomSheetModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  indicator: {
+    backgroundColor: iosSystemColors.separator,
+    width: 36,
+    height: 5,
+    borderRadius: 3,
+  },
+  content: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+    gap: spacing[3],
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: 28,
+  },
+  rail: {
+    flexDirection: 'row',
+    gap: spacing[2],
+    paddingVertical: spacing[2],
+    paddingRight: spacing[4],
+  },
+  chip: {
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    borderRadius: 18,
+    borderWidth: 1,
+    minWidth: 48,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  chipText: {
+    fontWeight: '600',
+    fontVariant: ['tabular-nums'],
+  },
+  hintRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  hint: {
+    flex: 1,
+  },
+});

--- a/packages/mobile/src/components/search/SearchBottomBar.tsx
+++ b/packages/mobile/src/components/search/SearchBottomBar.tsx
@@ -1,0 +1,65 @@
+// Bottom-bar search layout: a floating card pinned in the thumb zone above the
+// queue bar / tab bar. Grade lives where the hand already rests (the two RN-UX
+// judges' pick). The climber can switch to the sticky-strip layout in Settings.
+
+import { useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated, { FadeIn, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import type { Grade } from '@boardsesh/shared-schema';
+import type { GradeBound } from '@boardsesh/climb-filters';
+import { useTheme } from '../../providers/theme-provider';
+import { shadowColor } from '../../theme/tokens';
+import { ClimbSearchControls } from './ClimbSearchControls';
+
+type SearchBottomBarProps = {
+  bound: GradeBound;
+  grades: readonly Grade[];
+  count: number | undefined;
+  activeFilterCount: number;
+  onOpenGrade: () => void;
+  onOpenFilters: () => void;
+  /** Distance from the bottom of the screen (clears the queue + tab bars). */
+  bottomOffset: number;
+};
+
+export function SearchBottomBar({ bottomOffset, ...controls }: SearchBottomBarProps) {
+  const { systemColors } = useTheme();
+
+  // Slide the bar up/down in sync with the queue bar fading in/out, rather than
+  // snapping by ~64px when a climb becomes/stops being active.
+  const offset = useSharedValue(bottomOffset);
+  useEffect(() => {
+    offset.value = withTiming(bottomOffset, { duration: 200 });
+  }, [bottomOffset, offset]);
+  const animatedStyle = useAnimatedStyle(() => ({ bottom: offset.value }));
+
+  return (
+    <Animated.View
+      entering={FadeIn.duration(180)}
+      style={[styles.bar, { backgroundColor: systemColors.elevatedSurface as string }, animatedStyle]}
+    >
+      <View style={styles.inner}>
+        <ClimbSearchControls {...controls} />
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    position: 'absolute',
+    left: 8,
+    right: 8,
+    borderRadius: 14,
+    overflow: 'hidden',
+    shadowColor,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.18,
+    shadowRadius: 10,
+    elevation: 6,
+  },
+  inner: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+});

--- a/packages/mobile/src/components/search/StickyFilterStrip.tsx
+++ b/packages/mobile/src/components/search/StickyFilterStrip.tsx
@@ -1,0 +1,39 @@
+// Sticky-strip search layout: grade + count + filters in a flat strip directly
+// under the nav header. No collision with the queue bar; the climber can switch
+// to the bottom-bar layout in Settings.
+
+import { StyleSheet, View } from 'react-native';
+import type { Grade } from '@boardsesh/shared-schema';
+import type { GradeBound } from '@boardsesh/climb-filters';
+import { useTheme } from '../../providers/theme-provider';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing } from '../../theme/tokens';
+import { ClimbSearchControls } from './ClimbSearchControls';
+
+type StickyFilterStripProps = {
+  bound: GradeBound;
+  grades: readonly Grade[];
+  count: number | undefined;
+  activeFilterCount: number;
+  onOpenGrade: () => void;
+  onOpenFilters: () => void;
+};
+
+export function StickyFilterStrip(props: StickyFilterStripProps) {
+  const { systemColors } = useTheme();
+
+  return (
+    <View style={[styles.strip, { backgroundColor: systemColors.background as string }]}>
+      <ClimbSearchControls {...props} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  strip: {
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: iosSystemColors.separator,
+  },
+});

--- a/packages/mobile/src/components/search/active-filter-count.ts
+++ b/packages/mobile/src/components/search/active-filter-count.ts
@@ -1,0 +1,31 @@
+import { DEFAULT_CLIMB_FILTER_STATE } from '@boardsesh/climb-filters';
+import type { ClimbFilters } from '../../lib/climb-filter-types';
+
+/**
+ * Count of active filters *beyond grade* — grade has its own pill, so the gear
+ * badge should mean "extra refinements are on". Sort counts as one when it
+ * differs from the default. (P1 will surface these as removable pills; for now
+ * this drives the badge.)
+ */
+export function countActiveFiltersBeyondGrade(filters: ClimbFilters): number {
+  let count = 0;
+  if (filters.setter && filters.setter.length > 0) count += 1;
+  if (filters.minAscents != null) count += 1;
+  if (filters.minRating != null) count += 1;
+  if (filters.gradeAccuracy != null) count += 1;
+  if (filters.status !== DEFAULT_CLIMB_FILTER_STATE.status) count += 1;
+  if (filters.onlyTallClimbs) count += 1;
+  if (filters.onlyWideClimbs) count += 1;
+  if (filters.onlyWithBetaVideos) count += 1;
+  if (filters.hideAttempted) count += 1;
+  if (filters.hideCompleted) count += 1;
+  if (filters.showOnlyAttempted) count += 1;
+  if (filters.showOnlyCompleted) count += 1;
+  if (
+    filters.sortBy !== DEFAULT_CLIMB_FILTER_STATE.sortBy ||
+    filters.sortOrder !== DEFAULT_CLIMB_FILTER_STATE.sortOrder
+  ) {
+    count += 1;
+  }
+  return count;
+}

--- a/packages/mobile/src/components/search/grade-pill-label.ts
+++ b/packages/mobile/src/components/search/grade-pill-label.ts
@@ -1,0 +1,32 @@
+import type { Grade } from '@boardsesh/shared-schema';
+import type { GradeBound } from '@boardsesh/climb-filters';
+
+type TFunc = (key: string, options?: Record<string, unknown>) => string;
+type FormatGrade = (difficulty: string | null | undefined) => string | null;
+
+/**
+ * Human label for the grade pill in the search bar / sticky strip:
+ * "Any grade" · "V6" · "V4–V8" · "V4+" · "Up to V8". Mirrors web's grade
+ * summary so the two platforms read the same.
+ */
+export function formatGradePillLabel(
+  bound: GradeBound,
+  grades: readonly Grade[],
+  formatGrade: FormatGrade,
+  t: TFunc,
+): string {
+  const { minGradeId, maxGradeId } = bound;
+  if (minGradeId == null && maxGradeId == null) return t('mobile.search.anyGrade');
+
+  const label = (difficultyId: number): string => {
+    const grade = grades.find((entry) => entry.difficultyId === difficultyId);
+    return (grade ? (formatGrade(grade.name) ?? grade.name) : undefined) ?? '?';
+  };
+
+  if (minGradeId != null && maxGradeId != null) {
+    if (minGradeId === maxGradeId) return label(minGradeId);
+    return t('mobile.search.gradeRange', { min: label(minGradeId), max: label(maxGradeId) });
+  }
+  if (minGradeId != null) return t('mobile.search.gradeMin', { grade: label(minGradeId) });
+  return t('mobile.search.gradeMax', { grade: label(maxGradeId as number) });
+}

--- a/packages/mobile/src/lib/__tests__/grade-seed.test.ts
+++ b/packages/mobile/src/lib/__tests__/grade-seed.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { Grade } from '@boardsesh/shared-schema';
+import { defaultGradeCenter, gradeRailCenter, selectModalSendGrade } from '../grade-seed';
+
+function grade(difficultyId: number): Grade {
+  return { difficultyId, name: `V${difficultyId}` } as Grade;
+}
+
+const GRADES: Grade[] = Array.from({ length: 11 }, (_, index) => grade(10 + index)); // ids 10..20
+
+describe('selectModalSendGrade', () => {
+  it('returns undefined for no sends', () => {
+    expect(selectModalSendGrade([])).toBeUndefined();
+  });
+
+  it('returns the most-frequent difficulty id', () => {
+    expect(selectModalSendGrade([22, 22, 22, 20, 23])).toBe(22);
+  });
+
+  it('breaks ties toward the harder grade', () => {
+    expect(selectModalSendGrade([20, 20, 22, 22])).toBe(22);
+  });
+});
+
+describe('defaultGradeCenter', () => {
+  it('returns undefined for an empty band', () => {
+    expect(defaultGradeCenter([])).toBeUndefined();
+  });
+
+  it('lands in the upper-middle of the band', () => {
+    // 11 grades (ids 10..20), index round(10*0.6)=6 -> id 16.
+    expect(defaultGradeCenter(GRADES)).toBe(16);
+  });
+});
+
+describe('gradeRailCenter', () => {
+  it('prefers the current min selection', () => {
+    expect(gradeRailCenter({ minGradeId: 18, maxGradeId: 20 }, GRADES, [12])).toBe(18);
+  });
+
+  it('falls back to max when only max is set', () => {
+    expect(gradeRailCenter({ minGradeId: undefined, maxGradeId: 19 }, GRADES, [12])).toBe(19);
+  });
+
+  it('uses the modal send grade when nothing is selected', () => {
+    expect(gradeRailCenter({ minGradeId: undefined, maxGradeId: undefined }, GRADES, [14, 14, 17])).toBe(14);
+  });
+
+  it('falls back to the default band center with no selection and no sends', () => {
+    expect(gradeRailCenter({ minGradeId: undefined, maxGradeId: undefined }, GRADES, [])).toBe(16);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/last-search-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/last-search-store.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BoardSearchConfig } from '@boardsesh/climb-filters';
+import type { ClimbFilters } from '../climb-filter-types';
+
+vi.mock('expo-secure-store', () => {
+  let storage: Record<string, string> = {};
+  return {
+    getItemAsync: vi.fn(async (key: string) => storage[key] ?? null),
+    setItemAsync: vi.fn(async (key: string, value: string) => {
+      storage[key] = value;
+    }),
+    deleteItemAsync: vi.fn(async (key: string) => {
+      delete storage[key];
+    }),
+    __reset: () => {
+      storage = {};
+    },
+    __raw: () => storage,
+  };
+});
+
+const STORE_KEY = 'boardsesh_last_search_by_board';
+
+const kilterBoard: BoardSearchConfig = {
+  boardName: 'kilter',
+  layoutId: 1,
+  sizeId: 7,
+  setIds: '1,20',
+  angle: 40,
+};
+
+const tensionBoard: BoardSearchConfig = {
+  boardName: 'tension',
+  layoutId: 9,
+  sizeId: 3,
+  setIds: '5',
+  angle: 30,
+};
+
+const defaultFilters: ClimbFilters = {
+  sortBy: 'ascents',
+  sortOrder: 'desc',
+  status: 'any',
+};
+
+const activeFilters: ClimbFilters = {
+  sortBy: 'quality',
+  sortOrder: 'desc',
+  status: 'any',
+  minGrade: 15,
+};
+
+async function resetStore() {
+  const store = await import('expo-secure-store');
+  (store as unknown as { __reset: () => void }).__reset();
+}
+
+async function rawStorage(): Promise<Record<string, string>> {
+  const store = await import('expo-secure-store');
+  return (store as unknown as { __raw: () => Record<string, string> }).__raw();
+}
+
+async function seedRaw(map: unknown) {
+  const store = await import('expo-secure-store');
+  await store.setItemAsync(STORE_KEY, JSON.stringify(map));
+}
+
+describe('boardConfigKey', () => {
+  it('produces distinct keys for different board configs', async () => {
+    const { boardConfigKey } = await import('../last-search-store');
+    expect(boardConfigKey(kilterBoard)).not.toBe(boardConfigKey(tensionBoard));
+  });
+
+  it('produces identical keys for identical configs', async () => {
+    const { boardConfigKey } = await import('../last-search-store');
+    expect(boardConfigKey(kilterBoard)).toBe(boardConfigKey({ ...kilterBoard }));
+  });
+
+  it('differentiates configs that differ only by angle', async () => {
+    const { boardConfigKey } = await import('../last-search-store');
+    expect(boardConfigKey(kilterBoard)).not.toBe(boardConfigKey({ ...kilterBoard, angle: 45 }));
+  });
+});
+
+describe('saveLastSearch / getLastSearch', () => {
+  beforeEach(resetStore);
+
+  it('round-trips a saved search for a board', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, activeFilters, 'crimps');
+    const restored = await getLastSearch(kilterBoard);
+    expect(restored?.filters).toEqual(activeFilters);
+    expect(restored?.searchText).toBe('crimps');
+    expect(typeof restored?.updatedAt).toBe('number');
+  });
+
+  it('returns null for a board that has never been searched', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, activeFilters, 'crimps');
+    expect(await getLastSearch(tensionBoard)).toBeNull();
+  });
+
+  it('returns null when storage is empty', async () => {
+    const { getLastSearch } = await import('../last-search-store');
+    expect(await getLastSearch(kilterBoard)).toBeNull();
+  });
+
+  it('keeps two different board configs isolated', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, activeFilters, 'crimps');
+    await saveLastSearch(tensionBoard, { ...defaultFilters, sortBy: 'name' }, 'slopers');
+
+    const kilter = await getLastSearch(kilterBoard);
+    const tension = await getLastSearch(tensionBoard);
+    expect(kilter?.searchText).toBe('crimps');
+    expect(kilter?.filters.minGrade).toBe(15);
+    expect(tension?.searchText).toBe('slopers');
+    expect(tension?.filters.sortBy).toBe('name');
+  });
+
+  it('overwrites the previous search for the same board', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, activeFilters, 'crimps');
+    await saveLastSearch(kilterBoard, { ...defaultFilters, sortBy: 'quality' }, 'jugs');
+    const restored = await getLastSearch(kilterBoard);
+    expect(restored?.searchText).toBe('jugs');
+    expect(restored?.filters.minGrade).toBeUndefined();
+  });
+});
+
+describe('saveLastSearch no-op on default/empty', () => {
+  beforeEach(resetStore);
+
+  it('does not persist when filters are default and search text is empty', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, defaultFilters, '');
+    expect(await getLastSearch(kilterBoard)).toBeNull();
+    expect(Object.keys(await rawStorage())).not.toContain(STORE_KEY);
+  });
+
+  it('does not persist when filters are default and search text is whitespace only', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, defaultFilters, '   ');
+    expect(await getLastSearch(kilterBoard)).toBeNull();
+  });
+
+  it('persists when only search text is set', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, defaultFilters, 'overhang');
+    expect((await getLastSearch(kilterBoard))?.searchText).toBe('overhang');
+  });
+
+  it('persists when only filters are active', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, activeFilters, '');
+    expect((await getLastSearch(kilterBoard))?.filters.minGrade).toBe(15);
+  });
+
+  it('deletes the saved entry when the search is reset to the clean default', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, activeFilters, 'crimps');
+    expect(await getLastSearch(kilterBoard)).not.toBeNull();
+    // Clearing back to default must erase the entry, not leave a stale one.
+    await saveLastSearch(kilterBoard, defaultFilters, '');
+    expect(await getLastSearch(kilterBoard)).toBeNull();
+  });
+
+  it('clearing one board leaves other boards untouched', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, activeFilters, 'crimps');
+    await saveLastSearch(tensionBoard, activeFilters, 'slopers');
+    await saveLastSearch(kilterBoard, defaultFilters, '');
+    expect(await getLastSearch(kilterBoard)).toBeNull();
+    expect((await getLastSearch(tensionBoard))?.searchText).toBe('slopers');
+  });
+});
+
+describe('getLastSearch defensive validation', () => {
+  beforeEach(resetStore);
+
+  it('returns null when the stored value is not an object map', async () => {
+    const { getLastSearch } = await import('../last-search-store');
+    await seedRaw([1, 2, 3]);
+    expect(await getLastSearch(kilterBoard)).toBeNull();
+  });
+
+  it('drops malformed entries with an unknown sortBy', async () => {
+    const { boardConfigKey, getLastSearch } = await import('../last-search-store');
+    await seedRaw({
+      [boardConfigKey(kilterBoard)]: {
+        filters: { sortBy: 'newest', sortOrder: 'desc', status: 'any' },
+        searchText: 'x',
+        updatedAt: 1,
+      },
+    });
+    expect(await getLastSearch(kilterBoard)).toBeNull();
+  });
+
+  it('drops malformed entries with an unknown status', async () => {
+    const { boardConfigKey, getLastSearch } = await import('../last-search-store');
+    await seedRaw({
+      [boardConfigKey(kilterBoard)]: {
+        filters: { sortBy: 'ascents', sortOrder: 'desc', status: 'mystery' },
+        searchText: 'x',
+        updatedAt: 1,
+      },
+    });
+    expect(await getLastSearch(kilterBoard)).toBeNull();
+  });
+
+  it('drops entries missing searchText or updatedAt', async () => {
+    const { boardConfigKey, getLastSearch } = await import('../last-search-store');
+    await seedRaw({
+      [boardConfigKey(kilterBoard)]: {
+        filters: { sortBy: 'ascents', sortOrder: 'desc', status: 'any' },
+      },
+    });
+    expect(await getLastSearch(kilterBoard)).toBeNull();
+  });
+
+  it('normalizes a missing status (legacy entry) to "any"', async () => {
+    const { boardConfigKey, getLastSearch } = await import('../last-search-store');
+    await seedRaw({
+      [boardConfigKey(kilterBoard)]: {
+        filters: { sortBy: 'ascents', sortOrder: 'desc', minGrade: 10 },
+        searchText: 'x',
+        updatedAt: 1,
+      },
+    });
+    const restored = await getLastSearch(kilterBoard);
+    expect(restored?.filters.status).toBe('any');
+    expect(restored?.filters.minGrade).toBe(10);
+  });
+
+  it('keeps valid entries while dropping malformed siblings', async () => {
+    const { boardConfigKey, getLastSearch } = await import('../last-search-store');
+    await seedRaw({
+      [boardConfigKey(kilterBoard)]: {
+        filters: { sortBy: 'bogus', sortOrder: 'desc', status: 'any' },
+        searchText: 'x',
+        updatedAt: 1,
+      },
+      [boardConfigKey(tensionBoard)]: {
+        filters: { sortBy: 'ascents', sortOrder: 'desc', status: 'any' },
+        searchText: 'good',
+        updatedAt: 2,
+      },
+    });
+    expect(await getLastSearch(kilterBoard)).toBeNull();
+    expect((await getLastSearch(tensionBoard))?.searchText).toBe('good');
+  });
+});
+
+describe('getLastSearch auth-gated stripping', () => {
+  beforeEach(resetStore);
+
+  it('strips auth-gated fields when isAuthenticated=false', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, { ...activeFilters, hideAttempted: true, showOnlyCompleted: true }, 'crimps');
+    const restored = await getLastSearch(kilterBoard, { isAuthenticated: false });
+    expect(restored?.filters).not.toHaveProperty('hideAttempted');
+    expect(restored?.filters).not.toHaveProperty('showOnlyCompleted');
+    expect(restored?.filters.minGrade).toBe(15);
+  });
+
+  it('keeps auth-gated fields when isAuthenticated=true', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, { ...activeFilters, hideAttempted: true }, 'crimps');
+    const restored = await getLastSearch(kilterBoard, { isAuthenticated: true });
+    expect(restored?.filters.hideAttempted).toBe(true);
+  });
+});
+
+describe('map cap eviction', () => {
+  beforeEach(resetStore);
+
+  it('keeps only the 20 most-recently-updated boards', async () => {
+    const { saveLastSearch, getLastSearch, boardConfigKey } = await import('../last-search-store');
+    // Force a strictly increasing clock so eviction order is deterministic
+    // even when saves land within the same real millisecond.
+    let clock = 1000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => (clock += 1));
+    // Persist 25 distinct boards; updatedAt increases with each save.
+    const boards: BoardSearchConfig[] = [];
+    for (let index = 0; index < 25; index += 1) {
+      const board: BoardSearchConfig = { ...kilterBoard, angle: index };
+      boards.push(board);
+      await saveLastSearch(board, activeFilters, `q${index}`);
+    }
+    nowSpy.mockRestore();
+
+    const stored: unknown = JSON.parse((await rawStorage())[STORE_KEY]);
+    expect(Object.keys(stored as Record<string, unknown>)).toHaveLength(20);
+
+    // The 5 oldest boards (angles 0-4) should be evicted.
+    expect(await getLastSearch(boards[0])).toBeNull();
+    expect(await getLastSearch(boards[4])).toBeNull();
+    // The newest boards survive.
+    expect((await getLastSearch(boards[24]))?.searchText).toBe('q24');
+    expect((await getLastSearch(boards[5]))?.searchText).toBe('q5');
+    expect(boardConfigKey(boards[24])).toContain('|24');
+  });
+});
+
+describe('clearLastSearch / clearAllLastSearches', () => {
+  beforeEach(resetStore);
+
+  it('clears only the targeted board', async () => {
+    const { saveLastSearch, getLastSearch, clearLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, activeFilters, 'crimps');
+    await saveLastSearch(tensionBoard, activeFilters, 'slopers');
+    await clearLastSearch(kilterBoard);
+    expect(await getLastSearch(kilterBoard)).toBeNull();
+    expect((await getLastSearch(tensionBoard))?.searchText).toBe('slopers');
+  });
+
+  it('is a no-op clearing a board that was never saved', async () => {
+    const { saveLastSearch, getLastSearch, clearLastSearch } = await import('../last-search-store');
+    await saveLastSearch(tensionBoard, activeFilters, 'slopers');
+    await clearLastSearch(kilterBoard);
+    expect((await getLastSearch(tensionBoard))?.searchText).toBe('slopers');
+  });
+
+  it('clears every board', async () => {
+    const { saveLastSearch, getLastSearch, clearAllLastSearches } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, activeFilters, 'crimps');
+    await saveLastSearch(tensionBoard, activeFilters, 'slopers');
+    await clearAllLastSearches();
+    expect(await getLastSearch(kilterBoard)).toBeNull();
+    expect(await getLastSearch(tensionBoard)).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/grade-seed.ts
+++ b/packages/mobile/src/lib/grade-seed.ts
@@ -1,0 +1,54 @@
+// Decides which grade the grade rail should center on when it opens. The
+// search analytics show grade is the #1 lever and the active band peaks at
+// V5–V7, but a climber's own level is the real center of gravity — so prefer
+// the climber's modal recent send grade, falling back to the upper-middle of
+// the board's grade band (a board-agnostic proxy for that V5–V7 peak; no
+// hardcoded Kilter difficulty ids).
+//
+// Pure functions only, so they're trivially testable and could be promoted to
+// a shared package if web wants the same personalization.
+
+import type { Grade } from '@boardsesh/shared-schema';
+
+export type GradeSelection = { minGradeId: number | undefined; maxGradeId: number | undefined };
+
+/** Most-frequent difficulty id across the climber's recent sends, or undefined. */
+export function selectModalSendGrade(sendDifficultyIds: readonly number[]): number | undefined {
+  if (sendDifficultyIds.length === 0) return undefined;
+  const counts = new Map<number, number>();
+  for (const id of sendDifficultyIds) {
+    counts.set(id, (counts.get(id) ?? 0) + 1);
+  }
+  let best: number | undefined;
+  let bestCount = -1;
+  for (const [id, count] of counts) {
+    // Ties resolve to the harder grade (higher id) — climbers aim up, not down.
+    if (count > bestCount || (count === bestCount && best !== undefined && id > best)) {
+      best = id;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+/** Default rail center when the climber has no usable send history. */
+export function defaultGradeCenter(grades: readonly Grade[]): number | undefined {
+  if (grades.length === 0) return undefined;
+  const index = Math.min(grades.length - 1, Math.max(0, Math.round((grades.length - 1) * 0.6)));
+  return grades[index]?.difficultyId;
+}
+
+/**
+ * The difficulty id the grade rail should scroll to / highlight: the current
+ * selection if any, else the climber's modal send grade, else the default band
+ * center.
+ */
+export function gradeRailCenter(
+  selected: GradeSelection,
+  grades: readonly Grade[],
+  sendDifficultyIds: readonly number[] = [],
+): number | undefined {
+  if (selected.minGradeId != null) return selected.minGradeId;
+  if (selected.maxGradeId != null) return selected.maxGradeId;
+  return selectModalSendGrade(sendDifficultyIds) ?? defaultGradeCenter(grades);
+}

--- a/packages/mobile/src/lib/last-search-store.ts
+++ b/packages/mobile/src/lib/last-search-store.ts
@@ -1,0 +1,171 @@
+import * as SecureStore from 'expo-secure-store';
+import {
+  SORT_OPTIONS,
+  STATUS_FILTER_VALUES,
+  hasActiveClimbFilters,
+  type BoardSearchConfig,
+} from '@boardsesh/climb-filters';
+import type { ClimbFilters } from './climb-filter-types';
+import { AUTH_GATED_FIELDS } from './recent-filter-store';
+
+export type LastSearch = {
+  filters: ClimbFilters;
+  searchText: string;
+  updatedAt: number;
+};
+
+// One secure-store key holds a JSON map of boardConfigKey -> LastSearch so we
+// can remember the last applied search per board config. Capped to bound
+// growth when a user hops across many board configs.
+const LAST_SEARCH_KEY = 'boardsesh_last_search_by_board';
+const MAX_BOARDS = 20;
+
+type LastSearchMap = Record<string, LastSearch>;
+
+/**
+ * Stable key from a resolved board config
+ * (`boardName|layoutId|sizeId|setIds|angle`). Two configs that differ in any
+ * field get distinct keys, so each board restores its own last search.
+ */
+export function boardConfigKey(board: BoardSearchConfig): string {
+  return `${board.boardName}|${board.layoutId}|${board.sizeId}|${board.setIds}|${board.angle}`;
+}
+
+function isValidLastSearch(entry: unknown): entry is LastSearch {
+  if (entry == null || typeof entry !== 'object') return false;
+  const candidate = entry as {
+    filters?: { sortBy?: unknown; status?: unknown };
+    searchText?: unknown;
+    updatedAt?: unknown;
+  };
+  if (typeof candidate.searchText !== 'string') return false;
+  if (typeof candidate.updatedAt !== 'number') return false;
+  const filters = candidate.filters;
+  if (filters == null) return false;
+  if (typeof filters.sortBy !== 'string' || !(SORT_OPTIONS as readonly string[]).includes(filters.sortBy)) {
+    return false;
+  }
+  // Missing status is normalized later (older app versions wrote entries before
+  // the field existed); an unknown status value is dropped.
+  if (filters.status != null && !(STATUS_FILTER_VALUES as readonly string[]).includes(filters.status as string)) {
+    return false;
+  }
+  return true;
+}
+
+// Backfill `status` for entries written before the field existed. Without this
+// a missing status renders as "active" since `hasActiveClimbFilters` treats
+// `undefined !== 'any'` as a change.
+function normalizeEntry(entry: LastSearch): LastSearch {
+  if (entry.filters.status == null) {
+    return { ...entry, filters: { ...entry.filters, status: 'any' } };
+  }
+  return entry;
+}
+
+function stripAuthGatedFields(filters: ClimbFilters): ClimbFilters {
+  const sanitized = { ...filters };
+  for (const field of AUTH_GATED_FIELDS) {
+    delete sanitized[field];
+  }
+  return sanitized;
+}
+
+async function readMap(): Promise<LastSearchMap> {
+  try {
+    const value = await SecureStore.getItemAsync(LAST_SEARCH_KEY);
+    if (!value) return {};
+    const parsed: unknown = JSON.parse(value);
+    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const result: LastSearchMap = {};
+    for (const [key, entry] of Object.entries(parsed)) {
+      if (isValidLastSearch(entry)) {
+        result[key] = normalizeEntry(entry);
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+// Keep the map bounded to the most-recently-updated boards.
+function capMap(map: LastSearchMap): LastSearchMap {
+  const keys = Object.keys(map);
+  if (keys.length <= MAX_BOARDS) return map;
+  const keep = keys.sort((a, b) => map[b].updatedAt - map[a].updatedAt).slice(0, MAX_BOARDS);
+  const capped: LastSearchMap = {};
+  for (const key of keep) {
+    capped[key] = map[key];
+  }
+  return capped;
+}
+
+/**
+ * Returns the saved last search for this board, or `null` if the board has
+ * never been searched. Pass `isAuthenticated = false` to strip auth-gated
+ * filters so a search saved while signed in doesn't silently no-op on the
+ * backend for a signed-out user.
+ */
+export async function getLastSearch(
+  board: BoardSearchConfig,
+  options?: { isAuthenticated?: boolean },
+): Promise<LastSearch | null> {
+  const map = await readMap();
+  const entry = map[boardConfigKey(board)];
+  if (entry == null) return null;
+  if (options?.isAuthenticated === false) {
+    return { ...entry, filters: stripAuthGatedFields(entry.filters) };
+  }
+  return entry;
+}
+
+/**
+ * Persists the current search for this board. When the search is back at the
+ * clean default (no active filters AND empty name) any saved entry for the
+ * board is *deleted* — so a climber who clears their search and returns later
+ * gets the clean default instead of a resurrected stale search.
+ */
+export async function saveLastSearch(
+  board: BoardSearchConfig,
+  filters: ClimbFilters,
+  searchText: string,
+): Promise<void> {
+  try {
+    const key = boardConfigKey(board);
+    if (!hasActiveClimbFilters(filters) && searchText.trim() === '') {
+      const map = await readMap();
+      if (key in map) {
+        delete map[key];
+        await SecureStore.setItemAsync(LAST_SEARCH_KEY, JSON.stringify(map));
+      }
+      return;
+    }
+    const map = await readMap();
+    map[key] = { filters, searchText, updatedAt: Date.now() };
+    const capped = capMap(map);
+    await SecureStore.setItemAsync(LAST_SEARCH_KEY, JSON.stringify(capped));
+  } catch {
+    // Storage failure is non-critical.
+  }
+}
+
+export async function clearLastSearch(board: BoardSearchConfig): Promise<void> {
+  try {
+    const map = await readMap();
+    const key = boardConfigKey(board);
+    if (!(key in map)) return;
+    delete map[key];
+    await SecureStore.setItemAsync(LAST_SEARCH_KEY, JSON.stringify(map));
+  } catch {
+    // Storage failure is non-critical.
+  }
+}
+
+export async function clearAllLastSearches(): Promise<void> {
+  try {
+    await SecureStore.deleteItemAsync(LAST_SEARCH_KEY);
+  } catch {
+    // Storage failure is non-critical.
+  }
+}

--- a/packages/mobile/src/lib/recent-filter-store.ts
+++ b/packages/mobile/src/lib/recent-filter-store.ts
@@ -20,7 +20,7 @@ const MAX_ITEMS = 10;
 // pills while signed out we strip these so a recent search from a previous
 // signed-in session doesn't silently no-op (UI would show the pill as
 // "active" but the list would be unfiltered).
-const AUTH_GATED_FIELDS = [
+export const AUTH_GATED_FIELDS = [
   'hideAttempted',
   'hideCompleted',
   'showOnlyAttempted',

--- a/packages/mobile/src/lib/search-layout-preference.ts
+++ b/packages/mobile/src/lib/search-layout-preference.ts
@@ -1,0 +1,93 @@
+// User-selectable layout for the climbs search screen. We ship two real
+// layouts and let the climber pick — this is the rollout mechanism for the
+// TestFlight cohort to try both and tell us which they prefer, instead of a
+// hidden flag.
+//
+//  - `bottom-bar`   — grade pill + filter pills + result count pinned in the
+//                     thumb zone above the queue bar.
+//  - `sticky-strip` — grade + filters in a sticky strip under the nav header.
+//
+// Backed by the non-secret AsyncStorage preference store. A module-level
+// listener set keeps the climbs screen and the More-tab setting in sync
+// without threading a provider through the tree.
+
+import { useCallback, useEffect, useState } from 'react';
+import { getPreference, setPreference } from './preference-store';
+
+export const SEARCH_LAYOUTS = ['bottom-bar', 'sticky-strip'] as const;
+export type SearchLayout = (typeof SEARCH_LAYOUTS)[number];
+
+export const DEFAULT_SEARCH_LAYOUT: SearchLayout = 'bottom-bar';
+
+const STORAGE_KEY = 'search-layout';
+
+let current: SearchLayout = DEFAULT_SEARCH_LAYOUT;
+let hasLoaded = false;
+const listeners = new Set<(layout: SearchLayout) => void>();
+
+function isSearchLayout(value: unknown): value is SearchLayout {
+  return typeof value === 'string' && (SEARCH_LAYOUTS as readonly string[]).includes(value);
+}
+
+function notify(): void {
+  for (const listener of listeners) listener(current);
+}
+
+/**
+ * Read the persisted layout into the module cache and notify subscribers.
+ * Falls back to the default for a missing/invalid value. Safe to call
+ * repeatedly — later callers just re-broadcast the cached value.
+ */
+export async function loadSearchLayout(): Promise<SearchLayout> {
+  const stored = await getPreference<SearchLayout>(STORAGE_KEY);
+  current = isSearchLayout(stored) ? stored : DEFAULT_SEARCH_LAYOUT;
+  hasLoaded = true;
+  notify();
+  return current;
+}
+
+/** Persist the chosen layout and broadcast it to every mounted consumer. */
+export async function setSearchLayoutPreference(layout: SearchLayout): Promise<void> {
+  current = layout;
+  hasLoaded = true;
+  notify();
+  await setPreference(STORAGE_KEY, layout);
+}
+
+/**
+ * Subscribe to the current search layout. Triggers a one-time load on first
+ * mount; updates live when the setting changes anywhere in the app.
+ */
+export function useSearchLayout(): {
+  layout: SearchLayout;
+  loaded: boolean;
+  setLayout: (layout: SearchLayout) => void;
+} {
+  const [layout, setLayoutState] = useState<SearchLayout>(current);
+  const [loaded, setLoaded] = useState<boolean>(hasLoaded);
+
+  useEffect(() => {
+    const listener = (next: SearchLayout) => {
+      setLayoutState(next);
+      setLoaded(true);
+    };
+    listeners.add(listener);
+    if (!hasLoaded) {
+      void loadSearchLayout();
+    } else {
+      // Sync this fresh subscriber to the cached value (it may have changed
+      // between module init and mount).
+      setLayoutState(current);
+      setLoaded(true);
+    }
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  const setLayout = useCallback((next: SearchLayout) => {
+    void setSearchLayoutPreference(next);
+  }, []);
+
+  return { layout, loaded, setLayout };
+}

--- a/packages/mobile/src/providers/climb-search-provider.tsx
+++ b/packages/mobile/src/providers/climb-search-provider.tsx
@@ -1,0 +1,119 @@
+// Single source of truth for the climbs search screen's filter + name + view
+// state. Replaces the per-screen useState soup so the grade popover, the
+// search bar / sticky strip, the filter sheet, and the results list all read
+// and write one place. Mirrors web's UISearchParamsProvider in spirit
+// (immediate local apply; the screen owns debouncing the GraphQL query and
+// persisting per-board memory).
+//
+// Pure in-memory state only — no storage or network here. Per-board
+// restoration and result counting are wired by the climbs screen so this
+// provider stays trivially testable and renderer-agnostic.
+
+import { createContext, useCallback, useContext, useMemo, useReducer, type PropsWithChildren } from 'react';
+import { DEFAULT_CLIMB_FILTER_STATE } from '@boardsesh/climb-filters';
+import type { ClimbFilters } from '../lib/climb-filter-types';
+
+export type SearchViewMode = 'list' | 'grid';
+
+/** Lower/upper grade bounds as difficulty ids; undefined = unbounded side. */
+export type GradeBound = { minGradeId: number | undefined; maxGradeId: number | undefined };
+
+export type ClimbSearchState = {
+  filters: ClimbFilters;
+  /** Committed (already-debounced) name term used for the query. */
+  name: string;
+  viewMode: SearchViewMode;
+};
+
+const DEFAULT_STATE: ClimbSearchState = {
+  filters: DEFAULT_CLIMB_FILTER_STATE,
+  name: '',
+  viewMode: 'list',
+};
+
+type Action =
+  | { type: 'setFilters'; filters: ClimbFilters }
+  | { type: 'patchFilters'; patch: Partial<ClimbFilters> }
+  | { type: 'setGrade'; grade: GradeBound }
+  | { type: 'setName'; name: string }
+  | { type: 'replaceSearch'; filters: ClimbFilters; name: string }
+  | { type: 'setViewMode'; viewMode: SearchViewMode }
+  | { type: 'reset' };
+
+function reducer(state: ClimbSearchState, action: Action): ClimbSearchState {
+  switch (action.type) {
+    case 'setFilters':
+      return { ...state, filters: action.filters };
+    case 'patchFilters':
+      return { ...state, filters: { ...state.filters, ...action.patch } };
+    case 'setGrade':
+      return {
+        ...state,
+        filters: { ...state.filters, minGrade: action.grade.minGradeId, maxGrade: action.grade.maxGradeId },
+      };
+    case 'setName':
+      return { ...state, name: action.name };
+    case 'replaceSearch':
+      return { ...state, filters: action.filters, name: action.name };
+    case 'setViewMode':
+      return { ...state, viewMode: action.viewMode };
+    case 'reset':
+      return { ...DEFAULT_STATE };
+    default:
+      return state;
+  }
+}
+
+export type ClimbSearchContextValue = ClimbSearchState & {
+  setFilters: (filters: ClimbFilters) => void;
+  patchFilters: (patch: Partial<ClimbFilters>) => void;
+  setGrade: (grade: GradeBound) => void;
+  setName: (name: string) => void;
+  /** Apply a saved filter+name pair atomically (recent pill, per-board restore). */
+  replaceSearch: (filters: ClimbFilters, name: string) => void;
+  setViewMode: (viewMode: SearchViewMode) => void;
+  reset: () => void;
+};
+
+const ClimbSearchContext = createContext<ClimbSearchContextValue | null>(null);
+
+export function ClimbSearchProvider({ children, initial }: PropsWithChildren<{ initial?: Partial<ClimbSearchState> }>) {
+  const [state, dispatch] = useReducer(reducer, { ...DEFAULT_STATE, ...initial });
+
+  // Actions get STABLE identities (dispatch is stable) so consumers like the
+  // climbs screen's debounced name handler don't churn the nav header on every
+  // keystroke/grade tap. State spreads in separately.
+  const actions = useMemo(
+    () => ({
+      setFilters: (filters: ClimbFilters) => dispatch({ type: 'setFilters', filters }),
+      patchFilters: (patch: Partial<ClimbFilters>) => dispatch({ type: 'patchFilters', patch }),
+      setGrade: (grade: GradeBound) => dispatch({ type: 'setGrade', grade }),
+      setName: (name: string) => dispatch({ type: 'setName', name }),
+      replaceSearch: (filters: ClimbFilters, name: string) => dispatch({ type: 'replaceSearch', filters, name }),
+      setViewMode: (viewMode: SearchViewMode) => dispatch({ type: 'setViewMode', viewMode }),
+      reset: () => dispatch({ type: 'reset' }),
+    }),
+    [],
+  );
+
+  const value = useMemo<ClimbSearchContextValue>(() => ({ ...state, ...actions }), [state, actions]);
+
+  return <ClimbSearchContext.Provider value={value}>{children}</ClimbSearchContext.Provider>;
+}
+
+export function useClimbSearch(): ClimbSearchContextValue {
+  const value = useContext(ClimbSearchContext);
+  if (!value) {
+    throw new Error('useClimbSearch must be used within a ClimbSearchProvider');
+  }
+  return value;
+}
+
+/** Non-throwing variant for components that may render outside the provider. */
+export function useOptionalClimbSearch(): ClimbSearchContextValue | null {
+  return useContext(ClimbSearchContext);
+}
+
+// Re-export the callback so test/setup code can build a default state without
+// importing the shared package directly.
+export const DEFAULT_CLIMB_SEARCH_STATE = DEFAULT_STATE;

--- a/packages/shared/climb-filters/src/__tests__/grade-range.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/grade-range.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RANGE_EXTEND_WINDOW_MS,
+  isAnyGrade,
+  isSingleGrade,
+  isRangeGrade,
+  clearGradeBound,
+  isGradeInRange,
+  isGradeEndpoint,
+  computeGradeTap,
+  type GradeBound,
+} from '../grade-range';
+
+// Ascending difficulty_ids, mirroring how the picker feeds them. Gaps between
+// ids are intentional so index-neighbor logic (rule 4 trim) can't be confused
+// with id arithmetic.
+const gradeIds = [10, 12, 14, 16, 18, 20];
+
+const any: GradeBound = { minGradeId: undefined, maxGradeId: undefined };
+
+describe('RANGE_EXTEND_WINDOW_MS', () => {
+  it('matches the documented 3000ms window', () => {
+    expect(RANGE_EXTEND_WINDOW_MS).toBe(3000);
+  });
+});
+
+describe('grade-bound predicates', () => {
+  it('isAnyGrade is true only when both bounds are undefined', () => {
+    expect(isAnyGrade({ minGradeId: undefined, maxGradeId: undefined })).toBe(true);
+    expect(isAnyGrade({ minGradeId: 12, maxGradeId: 12 })).toBe(false);
+    expect(isAnyGrade({ minGradeId: 12, maxGradeId: undefined })).toBe(false);
+    expect(isAnyGrade({ minGradeId: undefined, maxGradeId: 12 })).toBe(false);
+  });
+
+  it('isSingleGrade is true only when both bounds are set and equal', () => {
+    expect(isSingleGrade({ minGradeId: 14, maxGradeId: 14 })).toBe(true);
+    expect(isSingleGrade({ minGradeId: 14, maxGradeId: 16 })).toBe(false);
+    expect(isSingleGrade({ minGradeId: undefined, maxGradeId: undefined })).toBe(false);
+    expect(isSingleGrade({ minGradeId: 14, maxGradeId: undefined })).toBe(false);
+  });
+
+  it('isRangeGrade is true only when both bounds are set and unequal', () => {
+    expect(isRangeGrade({ minGradeId: 12, maxGradeId: 18 })).toBe(true);
+    expect(isRangeGrade({ minGradeId: 12, maxGradeId: 12 })).toBe(false);
+    expect(isRangeGrade({ minGradeId: undefined, maxGradeId: undefined })).toBe(false);
+    expect(isRangeGrade({ minGradeId: undefined, maxGradeId: 12 })).toBe(false);
+  });
+
+  it('clearGradeBound returns both-undefined', () => {
+    expect(clearGradeBound()).toEqual({ minGradeId: undefined, maxGradeId: undefined });
+    expect(isAnyGrade(clearGradeBound())).toBe(true);
+  });
+
+  it('isGradeInRange is inclusive and false unless both bounds are set', () => {
+    const range: GradeBound = { minGradeId: 12, maxGradeId: 18 };
+    expect(isGradeInRange(range, 12)).toBe(true); // lower endpoint
+    expect(isGradeInRange(range, 18)).toBe(true); // upper endpoint
+    expect(isGradeInRange(range, 14)).toBe(true); // interior
+    expect(isGradeInRange(range, 10)).toBe(false); // below
+    expect(isGradeInRange(range, 20)).toBe(false); // above
+    expect(isGradeInRange({ minGradeId: undefined, maxGradeId: 18 }, 14)).toBe(false);
+    expect(isGradeInRange({ minGradeId: 12, maxGradeId: undefined }, 14)).toBe(false);
+    expect(isGradeInRange(any, 14)).toBe(false);
+  });
+
+  it('isGradeEndpoint matches either endpoint only', () => {
+    const range: GradeBound = { minGradeId: 12, maxGradeId: 18 };
+    expect(isGradeEndpoint(range, 12)).toBe(true);
+    expect(isGradeEndpoint(range, 18)).toBe(true);
+    expect(isGradeEndpoint(range, 14)).toBe(false);
+    expect(isGradeEndpoint(range, 20)).toBe(false);
+  });
+});
+
+describe('computeGradeTap — rule 1: Any -> single', () => {
+  it('collapses Any to a single grade regardless of window flag', () => {
+    expect(computeGradeTap(any, gradeIds, 14, false)).toEqual({
+      next: { minGradeId: 14, maxGradeId: 14 },
+    });
+    expect(computeGradeTap(any, gradeIds, 14, true)).toEqual({
+      next: { minGradeId: 14, maxGradeId: 14 },
+    });
+  });
+
+  it('emits no meta on Any -> single', () => {
+    expect(computeGradeTap(any, gradeIds, 10, false).meta).toBeUndefined();
+  });
+});
+
+describe('computeGradeTap — rule 2: single -> clear', () => {
+  it('tapping the same single grade clears to Any', () => {
+    const single: GradeBound = { minGradeId: 14, maxGradeId: 14 };
+    expect(computeGradeTap(single, gradeIds, 14, false)).toEqual({
+      next: { minGradeId: undefined, maxGradeId: undefined },
+    });
+    // Window flag must not change clear behaviour.
+    expect(computeGradeTap(single, gradeIds, 14, true)).toEqual({
+      next: { minGradeId: undefined, maxGradeId: undefined },
+    });
+  });
+
+  it('emits no meta on clear', () => {
+    const single: GradeBound = { minGradeId: 14, maxGradeId: 14 };
+    expect(computeGradeTap(single, gradeIds, 14, false).meta).toBeUndefined();
+  });
+});
+
+describe('computeGradeTap — rule 3: single + different chip', () => {
+  it('within window: extends to range [min,max] (tapping higher)', () => {
+    const single: GradeBound = { minGradeId: 12, maxGradeId: 12 };
+    expect(computeGradeTap(single, gradeIds, 18, true)).toEqual({
+      next: { minGradeId: 12, maxGradeId: 18 },
+      meta: { extendedRangeWithinWindow: true },
+    });
+  });
+
+  it('within window: extends to range, normalising order (tapping lower)', () => {
+    const single: GradeBound = { minGradeId: 18, maxGradeId: 18 };
+    expect(computeGradeTap(single, gradeIds, 12, true)).toEqual({
+      next: { minGradeId: 12, maxGradeId: 18 },
+      meta: { extendedRangeWithinWindow: true },
+    });
+  });
+
+  it('outside window: switches single grade with meta false', () => {
+    const single: GradeBound = { minGradeId: 12, maxGradeId: 12 };
+    expect(computeGradeTap(single, gradeIds, 18, false)).toEqual({
+      next: { minGradeId: 18, maxGradeId: 18 },
+      meta: { extendedRangeWithinWindow: false },
+    });
+  });
+});
+
+describe('computeGradeTap — rule 4: range endpoint trim', () => {
+  it('tapping the lower endpoint trims it inward by one grade index', () => {
+    const range: GradeBound = { minGradeId: 12, maxGradeId: 18 };
+    // index of 12 is 1; next index is 2 -> id 14, still <= 18.
+    expect(computeGradeTap(range, gradeIds, 12, false)).toEqual({
+      next: { minGradeId: 14, maxGradeId: 18 },
+    });
+  });
+
+  it('tapping the upper endpoint trims it inward by one grade index', () => {
+    const range: GradeBound = { minGradeId: 12, maxGradeId: 18 };
+    // index of 18 is 4; prev index is 3 -> id 16, still >= 12.
+    expect(computeGradeTap(range, gradeIds, 18, false)).toEqual({
+      next: { minGradeId: 12, maxGradeId: 16 },
+    });
+  });
+
+  it('lower-endpoint trim that would invert collapses to the surviving (max) endpoint', () => {
+    // Adjacent two-grade range: trimming the lower endpoint would push min past
+    // max, so settle on max as a single grade.
+    const range: GradeBound = { minGradeId: 12, maxGradeId: 14 };
+    expect(computeGradeTap(range, gradeIds, 12, false)).toEqual({
+      next: { minGradeId: 14, maxGradeId: 14 },
+    });
+  });
+
+  it('upper-endpoint trim that would invert collapses to the surviving (min) endpoint', () => {
+    const range: GradeBound = { minGradeId: 12, maxGradeId: 14 };
+    expect(computeGradeTap(range, gradeIds, 14, false)).toEqual({
+      next: { minGradeId: 12, maxGradeId: 12 },
+    });
+  });
+
+  it('lower-endpoint trim at the top of the grades array collapses to max', () => {
+    // min is the second-to-last grade, max is the last grade. Trimming min
+    // inward lands on max -> single.
+    const range: GradeBound = { minGradeId: 18, maxGradeId: 20 };
+    expect(computeGradeTap(range, gradeIds, 18, false)).toEqual({
+      next: { minGradeId: 20, maxGradeId: 20 },
+    });
+  });
+
+  it('endpoint trim ignores the window flag', () => {
+    const range: GradeBound = { minGradeId: 12, maxGradeId: 18 };
+    expect(computeGradeTap(range, gradeIds, 12, true)).toEqual({
+      next: { minGradeId: 14, maxGradeId: 18 },
+    });
+  });
+
+  it('emits no meta on endpoint trim', () => {
+    const range: GradeBound = { minGradeId: 12, maxGradeId: 18 };
+    expect(computeGradeTap(range, gradeIds, 12, false).meta).toBeUndefined();
+  });
+});
+
+describe('computeGradeTap — rule 5: range interior collapse', () => {
+  it('tapping an interior chip collapses to that single grade', () => {
+    const range: GradeBound = { minGradeId: 12, maxGradeId: 18 };
+    expect(computeGradeTap(range, gradeIds, 14, false)).toEqual({
+      next: { minGradeId: 14, maxGradeId: 14 },
+    });
+    expect(computeGradeTap(range, gradeIds, 16, false).meta).toBeUndefined();
+  });
+});
+
+describe('computeGradeTap — rule 6: range outside collapse', () => {
+  it('tapping a chip below the range collapses to that single grade', () => {
+    const range: GradeBound = { minGradeId: 12, maxGradeId: 18 };
+    expect(computeGradeTap(range, gradeIds, 10, false)).toEqual({
+      next: { minGradeId: 10, maxGradeId: 10 },
+    });
+  });
+
+  it('tapping a chip above the range collapses to that single grade', () => {
+    const range: GradeBound = { minGradeId: 12, maxGradeId: 18 };
+    expect(computeGradeTap(range, gradeIds, 20, false)).toEqual({
+      next: { minGradeId: 20, maxGradeId: 20 },
+    });
+  });
+
+  it('outside-collapse ignores the window flag and emits no meta', () => {
+    const range: GradeBound = { minGradeId: 12, maxGradeId: 18 };
+    expect(computeGradeTap(range, gradeIds, 20, true)).toEqual({
+      next: { minGradeId: 20, maxGradeId: 20 },
+    });
+  });
+});

--- a/packages/shared/climb-filters/src/grade-range.ts
+++ b/packages/shared/climb-filters/src/grade-range.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure grade-range tap rules shared by the web GradeRangePicker and the mobile
+ * GradePopover. The bounds are `{ minGradeId, maxGradeId }`:
+ *   - both undefined = "Any" (filter cleared)
+ *   - equal = single grade
+ *   - unequal = range
+ * The grade ids fed in MUST be ascending difficulty_ids.
+ */
+
+/**
+ * Tapping a different chip while a single grade is selected only extends to a
+ * range when the second tap lands within this window. Past it, the tap is
+ * treated as a single-grade switch instead — matches user intent (rapid taps =
+ * "I'm building a range", slow taps over a session = "I'm switching grades").
+ */
+export const RANGE_EXTEND_WINDOW_MS = 3000;
+
+export type GradeBound = { minGradeId: number | undefined; maxGradeId: number | undefined };
+
+/**
+ * Optional metadata emitted with a tap result. Lets the call site fold
+ * picker-internal context into analytics without the rule logic knowing about
+ * the analytics layer.
+ */
+export type GradeTapMeta = {
+  /**
+   * Set only when the user tapped a different chip from the currently-selected
+   * single grade. `true` = the second tap landed inside the
+   * RANGE_EXTEND_WINDOW_MS window from the first tap and was treated as range
+   * extension. `false` = the window had expired so we switched single grade
+   * (avoiding an accidental range). Undefined for all other rules.
+   */
+  extendedRangeWithinWindow?: boolean;
+};
+
+export type GradeTapResult = { next: GradeBound; meta?: GradeTapMeta };
+
+/** Both bounds undefined = "Any" (filter cleared). */
+export function isAnyGrade(bound: GradeBound): boolean {
+  return bound.minGradeId === undefined && bound.maxGradeId === undefined;
+}
+
+/** Both bounds set and equal = a single grade is selected. */
+export function isSingleGrade(bound: GradeBound): boolean {
+  return bound.minGradeId !== undefined && bound.maxGradeId !== undefined && bound.minGradeId === bound.maxGradeId;
+}
+
+/** Both bounds set and unequal = a true range is selected. */
+export function isRangeGrade(bound: GradeBound): boolean {
+  return bound.minGradeId !== undefined && bound.maxGradeId !== undefined && bound.minGradeId !== bound.maxGradeId;
+}
+
+/** The cleared ("Any") bound. */
+export function clearGradeBound(): GradeBound {
+  return { minGradeId: undefined, maxGradeId: undefined };
+}
+
+/** Whether a grade id falls within the inclusive bounds (false unless both set). */
+export function isGradeInRange(bound: GradeBound, gradeId: number): boolean {
+  if (bound.minGradeId === undefined || bound.maxGradeId === undefined) return false;
+  return gradeId >= bound.minGradeId && gradeId <= bound.maxGradeId;
+}
+
+/** Whether a grade id is exactly one of the two endpoints. */
+export function isGradeEndpoint(bound: GradeBound, gradeId: number): boolean {
+  return gradeId === bound.minGradeId || gradeId === bound.maxGradeId;
+}
+
+/**
+ * Pure reducer for one chip tap. `gradeIds` MUST be ascending difficulty_ids.
+ * `withinExtendWindow` = caller's timer says the tap is inside
+ * RANGE_EXTEND_WINDOW_MS of the last fresh single-grade selection. Implements
+ * rules 1-6 + clear-on-resame:
+ *   1. From Any -> single. 2. Tap the same single grade -> Any (clear).
+ *   3. From single, tap a different chip: within window -> range [min,max];
+ *      else -> switch single.
+ *   4. From range, tap an endpoint -> trim inward (collapse to surviving
+ *      endpoint if it inverts).
+ *   5. From range, tap interior -> collapse to that single grade.
+ *   6. From range, tap outside -> collapse to that single grade.
+ */
+export function computeGradeTap(
+  current: GradeBound,
+  gradeIds: number[],
+  tappedGradeId: number,
+  withinExtendWindow: boolean,
+): GradeTapResult {
+  const { minGradeId, maxGradeId } = current;
+
+  if (isRangeGrade(current) && minGradeId !== undefined && maxGradeId !== undefined) {
+    // Rule 4: tapping an endpoint of a range trims it. The other endpoint is
+    // preserved; the tapped endpoint moves inward by one grade (still within
+    // the range). If the trim collapses min > max, settle on the surviving
+    // endpoint as a single grade.
+    if (tappedGradeId === minGradeId) {
+      const minIdx = gradeIds.findIndex((id) => id === minGradeId);
+      const nextMinIdx = minIdx + 1;
+      if (nextMinIdx < gradeIds.length && gradeIds[nextMinIdx] <= maxGradeId) {
+        const newMin = gradeIds[nextMinIdx];
+        return { next: { minGradeId: newMin, maxGradeId } };
+      }
+      // Trim would invert; collapse to the surviving (max) endpoint.
+      return { next: { minGradeId: maxGradeId, maxGradeId } };
+    }
+    if (tappedGradeId === maxGradeId) {
+      const maxIdx = gradeIds.findIndex((id) => id === maxGradeId);
+      const nextMaxIdx = maxIdx - 1;
+      if (nextMaxIdx >= 0 && gradeIds[nextMaxIdx] >= minGradeId) {
+        const newMax = gradeIds[nextMaxIdx];
+        return { next: { minGradeId, maxGradeId: newMax } };
+      }
+      return { next: { minGradeId, maxGradeId: minGradeId } };
+    }
+    // Rules 5 & 6: interior or outside — collapse to the tapped grade.
+    return { next: { minGradeId: tappedGradeId, maxGradeId: tappedGradeId } };
+  }
+
+  if (isSingleGrade(current)) {
+    if (minGradeId === tappedGradeId) {
+      // Rule 2: tap the same single grade -> Any (clear).
+      return { next: clearGradeBound() };
+    }
+    // Rule 3 is time-gated: rapid taps after a fresh single-grade pick build a
+    // range; slow taps switch single grade. Avoids accidentally creating a
+    // range during the user's primary single-grade workflow (warm-up V4, then
+    // climb V6 30s later — V6 should *replace*, not extend).
+    if (withinExtendWindow) {
+      const otherId = minGradeId as number;
+      const lo = Math.min(otherId, tappedGradeId);
+      const hi = Math.max(otherId, tappedGradeId);
+      return { next: { minGradeId: lo, maxGradeId: hi }, meta: { extendedRangeWithinWindow: true } };
+    }
+    return {
+      next: { minGradeId: tappedGradeId, maxGradeId: tappedGradeId },
+      meta: { extendedRangeWithinWindow: false },
+    };
+  }
+
+  // Rule 1: "Any" or any other state — collapse to single grade.
+  return { next: { minGradeId: tappedGradeId, maxGradeId: tappedGradeId } };
+}

--- a/packages/shared/climb-filters/src/index.ts
+++ b/packages/shared/climb-filters/src/index.ts
@@ -1,4 +1,5 @@
 export * from './grade-lookup';
+export * from './grade-range';
 export * from './filter-normalization';
 export * from './filter-summary';
 export * from './filter-state';

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -642,7 +642,12 @@
       "settersCount_one": "{{count}} setter",
       "settersCount_other": "{{count}} setters",
       "climbsCount_one": "{{count}} climb",
-      "climbsCount_other": "{{count}} climbs"
+      "climbsCount_other": "{{count}} climbs",
+      "grade": "Grade",
+      "anyGrade": "Any grade",
+      "gradeClear": "Any",
+      "gradeHint": "Tap a grade · tap a second for a range",
+      "filters": "Filters"
     },
     "climbRow": {
       "addToQueue": "Add to queue",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -16,6 +16,12 @@
         "system": "System",
         "light": "Light",
         "dark": "Dark"
+      },
+      "searchLayout": {
+        "title": "Search layout",
+        "description": "Where the grade and filters sit on the climbs screen.",
+        "bottomBar": "Bottom bar",
+        "stickyStrip": "Top strip"
       }
     },
     "nav": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -642,7 +642,12 @@
       "settersCount_one": "{{count}} equipador",
       "settersCount_other": "{{count}} equipadores",
       "climbsCount_one": "{{count}} vía",
-      "climbsCount_other": "{{count}} vías"
+      "climbsCount_other": "{{count}} vías",
+      "grade": "Grado",
+      "anyGrade": "Cualquier grado",
+      "gradeClear": "Cualquiera",
+      "gradeHint": "Toca un grado · toca otro para un rango",
+      "filters": "Filtros"
     },
     "climbRow": {
       "addToQueue": "Añadir a la cola",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -214,6 +214,12 @@
         "system": "Sistema",
         "light": "Claro",
         "dark": "Oscuro"
+      },
+      "searchLayout": {
+        "title": "Diseño de búsqueda",
+        "description": "Dónde se sitúan el grado y los filtros en la pantalla de bloques.",
+        "bottomBar": "Barra inferior",
+        "stickyStrip": "Barra superior"
       }
     },
     "nav": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -642,7 +642,12 @@
       "settersCount_one": "{{count}} ouvreur",
       "settersCount_other": "{{count}} ouvreurs",
       "climbsCount_one": "{{count}} voie",
-      "climbsCount_other": "{{count}} voies"
+      "climbsCount_other": "{{count}} voies",
+      "grade": "Niveau",
+      "anyGrade": "Tout niveau",
+      "gradeClear": "Tous",
+      "gradeHint": "Touchez un niveau · un second pour une plage",
+      "filters": "Filtres"
     },
     "climbRow": {
       "addToQueue": "Ajouter à la file",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -16,6 +16,12 @@
         "system": "Système",
         "light": "Clair",
         "dark": "Sombre"
+      },
+      "searchLayout": {
+        "title": "Disposition de recherche",
+        "description": "Où se trouvent le niveau et les filtres sur l'écran des blocs.",
+        "bottomBar": "Barre inférieure",
+        "stickyStrip": "Barre supérieure"
       }
     },
     "nav": {

--- a/packages/web/app/components/grade-picker/grade-range-picker.tsx
+++ b/packages/web/app/components/grade-picker/grade-range-picker.tsx
@@ -10,6 +10,16 @@ import {
   useScrollIndicators,
   useStopHorizontalTouchPropagation,
 } from '@/app/components/logbook/tick-controls';
+import {
+  RANGE_EXTEND_WINDOW_MS,
+  computeGradeTap,
+  isAnyGrade,
+  isSingleGrade,
+  isRangeGrade,
+  isGradeInRange,
+  isGradeEndpoint,
+  type GradeBound,
+} from '@boardsesh/climb-filters';
 import type { BoulderGrade } from '@/app/lib/board-data';
 import baseStyles from './inline-grade-picker.module.css';
 import styles from './grade-range-picker.module.css';
@@ -45,15 +55,6 @@ export type GradeRangePickerProps = {
 };
 
 /**
- * Tapping a different chip while a single grade is selected only extends to
- * a range when the second tap lands within this window. Past it, the tap is
- * treated as a single-grade switch instead — matches user intent (rapid
- * taps = "I'm building a range", slow taps over a session = "I'm switching
- * grades").
- */
-const RANGE_EXTEND_WINDOW_MS = 3000;
-
-/**
  * In dark mode `getGradeColor` returns a pale text-readable variant. Pull the
  * hue and re-render at lower lightness so a filled band reads against the
  * dark surface. Light mode passes through.
@@ -81,19 +82,20 @@ export const GradeRangePicker: React.FC<GradeRangePickerProps> = ({
   useStopHorizontalTouchPropagation(containerRef);
   const { canScrollLeft, canScrollRight } = useScrollIndicators(containerRef);
 
-  const isAny = minGradeId === undefined && maxGradeId === undefined;
-  const isSingleGrade = minGradeId !== undefined && maxGradeId !== undefined && minGradeId === maxGradeId;
-  const isRange = minGradeId !== undefined && maxGradeId !== undefined && minGradeId !== maxGradeId;
+  const bound: GradeBound = { minGradeId, maxGradeId };
+  const isAny = isAnyGrade(bound);
+  const isSingle = isSingleGrade(bound);
+  const isRange = isRangeGrade(bound);
 
   // Timestamp of the most recent transition INTO a single-grade state.
   // Re-stamps on every bounds change so each fresh single-grade selection
   // starts its own 3-second extension window. Cleared when state is not a
   // single grade so we don't accidentally extend from a stale window after
   // the user explored a range and came back.
-  const singleGradeSelectedAtRef = useRef<number | undefined>(isSingleGrade ? Date.now() : undefined);
+  const singleGradeSelectedAtRef = useRef<number | undefined>(isSingle ? Date.now() : undefined);
   useEffect(() => {
-    singleGradeSelectedAtRef.current = isSingleGrade ? Date.now() : undefined;
-  }, [minGradeId, maxGradeId, isSingleGrade]);
+    singleGradeSelectedAtRef.current = isSingle ? Date.now() : undefined;
+  }, [minGradeId, maxGradeId, isSingle]);
 
   const lowGrade = minGradeId !== undefined ? grades.find((g) => g.difficulty_id === minGradeId) : undefined;
   const highGrade = maxGradeId !== undefined ? grades.find((g) => g.difficulty_id === maxGradeId) : undefined;
@@ -180,74 +182,26 @@ export const GradeRangePicker: React.FC<GradeRangePickerProps> = ({
   //   5. From a range, tap an *interior* chip → "V_X only" (collapse).
   //   6. From a range, tap a chip outside the range → "V_X only" (collapse).
   // No long-press, no double-tap. Range is built by tapping two chips in
-  // sequence; switching single grade from a range is one tap.
+  // sequence; switching single grade from a range is one tap. The bounds math
+  // lives in @boardsesh/climb-filters/computeGradeTap; this component owns the
+  // timer, the within-window decision, and re-emitting through onChange.
   const handleChipTap = useCallback(
     (gradeId: number) => {
-      if (isRange && minGradeId !== undefined && maxGradeId !== undefined) {
-        // Rule 4: tapping an endpoint of a range trims it. The other
-        // endpoint is preserved; the tapped endpoint moves inward by one
-        // grade (still within the range). If the trim collapses min > max,
-        // settle on the surviving endpoint as a single grade.
-        if (gradeId === minGradeId) {
-          const minIdx = grades.findIndex((g) => g.difficulty_id === minGradeId);
-          const nextMinIdx = minIdx + 1;
-          if (nextMinIdx < grades.length && grades[nextMinIdx].difficulty_id <= maxGradeId) {
-            const newMin = grades[nextMinIdx].difficulty_id;
-            onChange({ minGradeId: newMin, maxGradeId });
-            return;
-          }
-          // Trim would invert; collapse to the surviving (max) endpoint.
-          onChange({ minGradeId: maxGradeId, maxGradeId });
-          return;
-        }
-        if (gradeId === maxGradeId) {
-          const maxIdx = grades.findIndex((g) => g.difficulty_id === maxGradeId);
-          const nextMaxIdx = maxIdx - 1;
-          if (nextMaxIdx >= 0 && grades[nextMaxIdx].difficulty_id >= minGradeId) {
-            const newMax = grades[nextMaxIdx].difficulty_id;
-            onChange({ minGradeId, maxGradeId: newMax });
-            return;
-          }
-          onChange({ minGradeId, maxGradeId: minGradeId });
-          return;
-        }
-        // Rules 5 & 6: interior or outside — collapse to the tapped grade.
-        onChange({ minGradeId: gradeId, maxGradeId: gradeId });
-        return;
-      }
-      if (isSingleGrade) {
-        if (minGradeId === gradeId) {
-          handleClear();
-          return;
-        }
-        // Rule 3 is time-gated: rapid taps after a fresh single-grade pick
-        // build a range; slow taps switch single grade. Avoids accidentally
-        // creating a range during the user's primary single-grade workflow
-        // (warm-up V4, then climb V6 30s later — V6 should *replace*, not
-        // extend).
-        const selectedAt = singleGradeSelectedAtRef.current;
-        const withinWindow = selectedAt !== undefined && Date.now() - selectedAt < RANGE_EXTEND_WINDOW_MS;
-        if (withinWindow) {
-          const otherId = minGradeId as number;
-          const lo = Math.min(otherId, gradeId);
-          const hi = Math.max(otherId, gradeId);
-          onChange({ minGradeId: lo, maxGradeId: hi }, { extendedRangeWithinWindow: true });
-        } else {
-          onChange({ minGradeId: gradeId, maxGradeId: gradeId }, { extendedRangeWithinWindow: false });
-        }
-        return;
-      }
-      // "Any" or any other state — collapse to single grade.
-      onChange({ minGradeId: gradeId, maxGradeId: gradeId });
+      // Rule 3 is time-gated: rapid taps after a fresh single-grade pick build
+      // a range; slow taps switch single grade. Avoids accidentally creating a
+      // range during the user's primary single-grade workflow (warm-up V4,
+      // then climb V6 30s later — V6 should *replace*, not extend).
+      const selectedAt = singleGradeSelectedAtRef.current;
+      const withinWindow = selectedAt !== undefined && Date.now() - selectedAt < RANGE_EXTEND_WINDOW_MS;
+      const gradeIds = grades.map((grade) => grade.difficulty_id);
+      const { next, meta } = computeGradeTap({ minGradeId, maxGradeId }, gradeIds, gradeId, withinWindow);
+      onChange(next, meta);
     },
-    [isRange, isSingleGrade, minGradeId, maxGradeId, grades, onChange, handleClear],
+    [minGradeId, maxGradeId, grades, onChange],
   );
 
-  const inRange = (gradeId: number): boolean => {
-    if (minGradeId === undefined || maxGradeId === undefined) return false;
-    return gradeId >= minGradeId && gradeId <= maxGradeId;
-  };
-  const isEndpoint = (gradeId: number): boolean => gradeId === minGradeId || gradeId === maxGradeId;
+  const inRange = (gradeId: number): boolean => isGradeInRange(bound, gradeId);
+  const isEndpoint = (gradeId: number): boolean => isGradeEndpoint(bound, gradeId);
 
   return (
     <div className={styles.wrapper}>


### PR DESCRIPTION
## What & why

P0 of the mobile climb-search redesign. We ran an expert design team against the PostHog search-usage findings (`posthog_dash/docs/search-usage-findings.md`, n=12,708 searches / 628 climbers) and restructured the climbs screen around how people actually search: **grade is 68% of searches and the most-touched control in the app**, name text is 36%, and 89% of searches use ≤2 filters.

This is an *optimize-for* change, not a *cut* — all capabilities stay; their altitude changes.

## Highlights

- **Grade front door** — `GradePopover`, a low bottom-sheet grade rail. **Single tap picks a grade and auto-dismisses** (the 60% single-grade fast path); a quick second tap builds a range; "Any" clears. Rail centers on the V5–V7 band. Driven by a shared, **web-identical** tap-state machine extracted to `@boardsesh/climb-filters` (`computeGradeTap`); web's `grade-range-picker` was re-pointed to it (no behavior change).
- **Two layouts behind a user setting** — a new **Search layout** setting (More tab, persisted) switches between `SearchBottomBar` (floating, thumb zone) and `StickyFilterStrip` (under header). This is the rollout mechanism for the TestFlight cohort to try both and give feedback. Both render a shared `ClimbSearchControls` (grade pill + live result count + filters gear with active-count badge).
- **Live result count** — via the existing `SEARCH_CLIMBS_COUNT` op (page-independent key).
- **Per-board search memory** — each board config restores its own last search; a never-searched board gets a clean default; clearing the search deletes the stored entry.
- **`ClimbSearchProvider`** (context + reducer) replaces the screen's local state soup; action identities are stable so the nav header doesn't churn per keystroke.

All existing climb-row behavior is preserved: swipe-to-queue, long-press actions, add-to-playlist, play-drawer activation/paging, image prefetch, logbook ascent badges, pull-to-refresh, infinite scroll, recent-filter pills.

## Shared-package work (extract, don't duplicate)

- New `grade-range.ts` in `@boardsesh/climb-filters` (pure tap-rule state machine + predicates), with tests; web re-pointed.
- New mobile `last-search-store.ts` (per-board, secure-store) and `grade-seed.ts` (pure rail-centering), with tests.

## Validation

typecheck (mobile + shared) · mobile tests **620** · climb-filters **114** · web **4794** (incl. the web re-point + i18n parity) · i18n hardcoded + orphan checks · Metro bundle (`check:mobile-bundle`).

Two QA workflows ran (5-lens design panel → judges → synthesis; then a 2-reviewer adversarial review of the diff). All actionable findings fixed: per-board clear-on-reset, board-switch query gating (no stale-results flash / double fetch), header text sync on restore, bottom-bar padding so the last row clears the bar, a11y labels, and a longer/interruptible grade-dismiss window.

## Follow-ups (later phases per the approved plan)

P1 tiered filter sheet + Hide-sent + popularity consolidation + benchmark (mobile) + removable filter pills · P2 grid view + boulder/route · P3 holds tap-to-include · P4 zone + heatmap. "My grade" logbook personalization of the rail center is a wired seam (currently band-default). Separate issue to file: web `onlyClassics`/`onlyBenchmarks` is a no-op at the DB layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)