### PR TITLE
feat(mobile): boulder/route climb-type filter (P2)

### DIFF
--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -17,6 +17,8 @@ import {
   hasActiveClimbFilters,
   applyStatusChange,
   normalizeRetiredStatus,
+  climbTypeOf,
+  climbTypePatch,
   toClimbSearchInput,
   mergeBoardFilters,
   formatMinAscentsFilterCount,
@@ -25,6 +27,7 @@ import {
   type SortOrder,
   type StatusFilter,
   type GradeAccuracyValue,
+  type ClimbType,
   type ClimbBoardFilterState,
   SORT_OPTIONS,
   GRADE_ACCURACY_VALUES,
@@ -329,6 +332,18 @@ export function ClimbFilterSheet({
     (value: GradeAccuracyValue | 'off') => setFiltersPatch({ gradeAccuracy: value === 'off' ? undefined : value }),
     [setFiltersPatch],
   );
+  const handleClimbTypeChange = useCallback(
+    (value: string) => setFiltersPatch(climbTypePatch(value as ClimbType)),
+    [setFiltersPatch],
+  );
+  const climbTypeOptions = useMemo(
+    () => [
+      { key: 'all', label: t('mobile.filter.climbType.all') },
+      { key: 'boulders', label: t('mobile.filter.climbType.boulders') },
+      { key: 'routes', label: t('mobile.filter.climbType.routes') },
+    ],
+    [t],
+  );
 
   const handleApply = useCallback(() => {
     onApply(localFilters, localBoardFilters);
@@ -366,6 +381,12 @@ export function ClimbFilterSheet({
 
   const refineSummary = useMemo(() => {
     const parts: string[] = [];
+    const climbType = climbTypeOf(localFilters);
+    if (climbType !== 'all') {
+      parts.push(
+        climbType === 'boulders' ? t('mobile.filter.climbType.boulders') : t('mobile.filter.climbType.routes'),
+      );
+    }
     if (localFilters.gradeAccuracy != null) parts.push(accuracyLabels[localFilters.gradeAccuracy]);
     if (localFilters.setter && localFilters.setter.length > 0) {
       parts.push(t('mobile.search.settersCount', { count: localFilters.setter.length }));
@@ -373,14 +394,7 @@ export function ClimbFilterSheet({
     if (localFilters.onlyTallClimbs) parts.push(t('mobile.filter.tall'));
     if (localFilters.onlyWideClimbs) parts.push(t('mobile.filter.wide'));
     return parts.join(' · ') || null;
-  }, [
-    localFilters.gradeAccuracy,
-    localFilters.setter,
-    localFilters.onlyTallClimbs,
-    localFilters.onlyWideClimbs,
-    accuracyLabels,
-    t,
-  ]);
+  }, [localFilters, accuracyLabels, t]);
 
   const advancedSummary = useMemo(() => {
     const parts: string[] = [];
@@ -538,6 +552,18 @@ export function ClimbFilterSheet({
             summary={refineSummary}
             resetKey={sectionResetKey}
           >
+            <Text variant="footnote" style={styles.subsectionLabel}>
+              {t('mobile.filter.climbType.label')}
+            </Text>
+            <SegmentedControl
+              options={climbTypeOptions}
+              selectedKey={climbTypeOf(localFilters)}
+              onSelect={handleClimbTypeChange}
+              textVariant="footnote"
+              trackColor={trackColor}
+            />
+
+            <View style={styles.subsectionGap} />
             <Pressable
               onPress={openSetters}
               accessibilityRole="button"

--- a/packages/mobile/src/components/search/active-filter-pills.ts
+++ b/packages/mobile/src/components/search/active-filter-pills.ts
@@ -5,7 +5,12 @@
 // dynamic `t()` keys (the i18n linter only allows literal keys). Each pill
 // carries the patch that clears it.
 
-import { formatMinAscentsFilterCount, type ClimbBoardFilterState } from '@boardsesh/climb-filters';
+import {
+  climbTypeOf,
+  climbTypePatch,
+  formatMinAscentsFilterCount,
+  type ClimbBoardFilterState,
+} from '@boardsesh/climb-filters';
 import type { ClimbFilters } from '../../lib/climb-filter-types';
 
 export type ActiveFilterPill = {
@@ -46,6 +51,14 @@ export function buildActiveFilterPills(
   }
   if (boardFilters.onlyBenchmarks) {
     pills.push({ key: 'benchmark', label: t('mobile.filter.benchmark'), clearBoard: { onlyBenchmarks: undefined } });
+  }
+  const climbType = climbTypeOf(filters);
+  if (climbType !== 'all') {
+    pills.push({
+      key: 'climbType',
+      label: climbType === 'boulders' ? t('mobile.filter.climbType.boulders') : t('mobile.filter.climbType.routes'),
+      clearFilters: climbTypePatch('all'),
+    });
   }
   if (filters.setter && filters.setter.length > 0) {
     pills.push({

--- a/packages/mobile/src/providers/climb-search-provider.tsx
+++ b/packages/mobile/src/providers/climb-search-provider.tsx
@@ -17,8 +17,6 @@ import {
 } from '@boardsesh/climb-filters';
 import type { ClimbFilters } from '../lib/climb-filter-types';
 
-export type SearchViewMode = 'list' | 'grid';
-
 /** Lower/upper grade bounds as difficulty ids; undefined = unbounded side. */
 export type GradeBound = { minGradeId: number | undefined; maxGradeId: number | undefined };
 
@@ -28,14 +26,12 @@ export type ClimbSearchState = {
   boardFilters: ClimbBoardFilterState;
   /** Committed (already-debounced) name term used for the query. */
   name: string;
-  viewMode: SearchViewMode;
 };
 
 const DEFAULT_STATE: ClimbSearchState = {
   filters: DEFAULT_CLIMB_FILTER_STATE,
   boardFilters: DEFAULT_CLIMB_BOARD_FILTER_STATE,
   name: '',
-  viewMode: 'list',
 };
 
 type Action =
@@ -46,7 +42,6 @@ type Action =
   | { type: 'patchBoardFilters'; patch: Partial<ClimbBoardFilterState> }
   | { type: 'setName'; name: string }
   | { type: 'replaceSearch'; filters: ClimbFilters; boardFilters: ClimbBoardFilterState; name: string }
-  | { type: 'setViewMode'; viewMode: SearchViewMode }
   | { type: 'reset' };
 
 function reducer(state: ClimbSearchState, action: Action): ClimbSearchState {
@@ -68,8 +63,6 @@ function reducer(state: ClimbSearchState, action: Action): ClimbSearchState {
       return { ...state, name: action.name };
     case 'replaceSearch':
       return { ...state, filters: action.filters, boardFilters: action.boardFilters, name: action.name };
-    case 'setViewMode':
-      return { ...state, viewMode: action.viewMode };
     case 'reset':
       return { ...DEFAULT_STATE };
     default:
@@ -86,7 +79,6 @@ export type ClimbSearchContextValue = ClimbSearchState & {
   setName: (name: string) => void;
   /** Apply a saved filter+name (+board filters) set atomically (recent pill, per-board restore). */
   replaceSearch: (filters: ClimbFilters, name: string, boardFilters?: ClimbBoardFilterState) => void;
-  setViewMode: (viewMode: SearchViewMode) => void;
   reset: () => void;
 };
 
@@ -111,7 +103,6 @@ export function ClimbSearchProvider({ children, initial }: PropsWithChildren<{ i
         name: string,
         boardFilters: ClimbBoardFilterState = DEFAULT_CLIMB_BOARD_FILTER_STATE,
       ) => dispatch({ type: 'replaceSearch', filters, name, boardFilters }),
-      setViewMode: (viewMode: SearchViewMode) => dispatch({ type: 'setViewMode', viewMode }),
       reset: () => dispatch({ type: 'reset' }),
     }),
     [],

--- a/packages/shared/climb-filters/src/__tests__/climb-type.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/climb-type.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  climbTypeOf,
+  climbTypePatch,
+  hasActiveClimbFilters,
+  toClimbSearchInput,
+  DEFAULT_CLIMB_FILTER_STATE,
+  type BoardSearchConfig,
+} from '../filter-state';
+
+const board: BoardSearchConfig = { boardName: 'kilter', layoutId: 1, sizeId: 7, setIds: '1,20', angle: 40 };
+const page = { page: 0, pageSize: 30 };
+
+describe('climbTypeOf / climbTypePatch', () => {
+  it('maps the default (both undefined) to "all"', () => {
+    expect(climbTypeOf({})).toBe('all');
+    expect(climbTypePatch('all')).toEqual({ boulders: undefined, routes: undefined });
+  });
+
+  it('round-trips boulders and routes', () => {
+    expect(climbTypeOf(climbTypePatch('boulders'))).toBe('boulders');
+    expect(climbTypeOf(climbTypePatch('routes'))).toBe('routes');
+    expect(climbTypePatch('boulders')).toEqual({ boulders: true, routes: false });
+    expect(climbTypePatch('routes')).toEqual({ boulders: false, routes: true });
+  });
+
+  it('treats both-true as "all"', () => {
+    expect(climbTypeOf({ boulders: true, routes: true })).toBe('all');
+  });
+});
+
+describe('boulders/routes in filter state', () => {
+  it('hasActiveClimbFilters is true for any explicit climb type (including routes-only false boulders)', () => {
+    expect(hasActiveClimbFilters({ ...DEFAULT_CLIMB_FILTER_STATE, boulders: true, routes: false })).toBe(true);
+    expect(hasActiveClimbFilters({ ...DEFAULT_CLIMB_FILTER_STATE, boulders: false, routes: true })).toBe(true);
+    expect(hasActiveClimbFilters(DEFAULT_CLIMB_FILTER_STATE)).toBe(false);
+  });
+
+  it('toClimbSearchInput passes explicit false (routes-only) through', () => {
+    const input = toClimbSearchInput({ ...DEFAULT_CLIMB_FILTER_STATE, boulders: false, routes: true }, board, page);
+    expect(input.boulders).toBe(false);
+    expect(input.routes).toBe(true);
+  });
+
+  it('toClimbSearchInput omits climb type when unset (all)', () => {
+    const input = toClimbSearchInput(DEFAULT_CLIMB_FILTER_STATE, board, page);
+    expect(input.boulders).toBeUndefined();
+    expect(input.routes).toBeUndefined();
+  });
+});

--- a/packages/shared/climb-filters/src/active-filter-count.ts
+++ b/packages/shared/climb-filters/src/active-filter-count.ts
@@ -21,6 +21,7 @@ export function countActiveFiltersBeyondGrade(filters: ClimbFilterState, boardFi
   if (filters.hideCompleted) count += 1;
   if (filters.showOnlyAttempted) count += 1;
   if (filters.showOnlyCompleted) count += 1;
+  if (filters.boulders != null || filters.routes != null) count += 1;
   if (
     filters.sortBy !== DEFAULT_CLIMB_FILTER_STATE.sortBy ||
     filters.sortOrder !== DEFAULT_CLIMB_FILTER_STATE.sortOrder

--- a/packages/shared/climb-filters/src/filter-state.ts
+++ b/packages/shared/climb-filters/src/filter-state.ts
@@ -40,6 +40,12 @@ export type ClimbFilterState = {
   hideCompleted?: boolean;
   showOnlyAttempted?: boolean;
   showOnlyCompleted?: boolean;
+  // Climb-type filter. Both undefined = show everything (no frames_count
+  // filter); boulders=true/routes=false = boulders only; boulders=false/
+  // routes=true = routes only. Explicit `false` is meaningful, so callers must
+  // null-check rather than truthy-check.
+  boulders?: boolean;
+  routes?: boolean;
 };
 
 export const DEFAULT_CLIMB_FILTER_STATE: ClimbFilterState = {
@@ -68,6 +74,8 @@ export function hasActiveClimbFilters(state: ClimbFilterState): boolean {
   if (state.hideCompleted) return true;
   if (state.showOnlyAttempted) return true;
   if (state.showOnlyCompleted) return true;
+  if (state.boulders != null) return true;
+  if (state.routes != null) return true;
   return false;
 }
 
@@ -117,6 +125,25 @@ export function normalizeRetiredStatus(state: ClimbFilterState): ClimbFilterStat
   return state.status === 'established' ? { ...state, status: 'any' } : state;
 }
 
+/**
+ * Climb-type as a single 3-way choice for the UI, mapping to the boulders/
+ * routes pair the DB expects: 'all' = no filter, 'boulders' = single-frame,
+ * 'routes' = multi-frame. Avoids the two-switch "at least one on" invariant.
+ */
+export type ClimbType = 'all' | 'boulders' | 'routes';
+
+export function climbTypeOf(state: Pick<ClimbFilterState, 'boulders' | 'routes'>): ClimbType {
+  if (state.boulders === true && state.routes !== true) return 'boulders';
+  if (state.routes === true && state.boulders !== true) return 'routes';
+  return 'all';
+}
+
+export function climbTypePatch(type: ClimbType): Pick<ClimbFilterState, 'boulders' | 'routes'> {
+  if (type === 'boulders') return { boulders: true, routes: false };
+  if (type === 'routes') return { boulders: false, routes: true };
+  return { boulders: undefined, routes: undefined };
+}
+
 export type BoardSearchConfig = {
   boardName: string;
   layoutId: number;
@@ -162,6 +189,8 @@ export function toClimbSearchInput(
   if (state.hideCompleted) input.hideCompleted = true;
   if (state.showOnlyAttempted) input.showOnlyAttempted = true;
   if (state.showOnlyCompleted) input.showOnlyCompleted = true;
+  if (state.boulders != null) input.boulders = state.boulders;
+  if (state.routes != null) input.routes = state.routes;
 
   const statusFlags = statusToFlags(state.status);
   if (statusFlags.onlyDrafts) input.onlyDrafts = true;

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -586,6 +586,12 @@
       "established2plus": "Established 2+",
       "benchmark": "Benchmarks only",
       "benchmarkDescription": "Setter-flagged benchmark climbs",
+      "climbType": {
+        "label": "Type",
+        "all": "All",
+        "boulders": "Boulders",
+        "routes": "Routes"
+      },
       "showCount_one": "Show {{count}} climb",
       "showCount_other": "Show {{count}} climbs",
       "sort": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -586,6 +586,12 @@
       "established2plus": "Establecido 2+",
       "benchmark": "Solo benchmarks",
       "benchmarkDescription": "Vías marcadas como benchmark por el equipador",
+      "climbType": {
+        "label": "Tipo",
+        "all": "Todas",
+        "boulders": "Bloques",
+        "routes": "Vías"
+      },
       "showCount_one": "Ver {{count}} vía",
       "showCount_other": "Ver {{count}} vías",
       "sort": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -586,6 +586,12 @@
       "established2plus": "Établies 2+",
       "benchmark": "Benchmarks uniquement",
       "benchmarkDescription": "Voies marquées benchmark par l'ouvreur",
+      "climbType": {
+        "label": "Type",
+        "all": "Toutes",
+        "boulders": "Blocs",
+        "routes": "Voies"
+      },
       "showCount_one": "Voir {{count}} voie",
       "showCount_other": "Voir {{count}} voies",
       "sort": {


### PR DESCRIPTION
## What & why

P2 of the mobile climb-search redesign — **stacked on P1 (#2500)**. (Review against the diff vs #2500; retarget to `main` as the stack merges.)

**Grid view was dropped on purpose.** The analytics strongly prefer list (606 vs 256) and list is the design default, so bringing grid to mobile isn't worth it. P2 is therefore the **boulder/route toggle** plus a small dead-code cleanup.

## Highlights

- **Climb type filter** — a 3-way "Type" segmented control (All / Boulders / Routes) in the filter sheet's REFINE tier. Maps to the `boulders`/`routes` pair the DB already expects (All = no constraint, Boulders = `frames_count = 1`, Routes = `frames_count > 1`), via a small shared `climbTypeOf`/`climbTypePatch` helper — no two-switch "at least one on" invariant to get wrong. Shows in the section summary and as a removable bar pill.
- **Shared/state plumbing** — `boulders`/`routes` added to `ClimbFilterState` + `toClimbSearchInput` (null-checked so routes-only's explicit `false` reaches the DB) + `hasActiveClimbFilters` + the shared active-filter count. No backend work — the DB + GraphQL already support these fields.
- **Cleanup** — removed the speculative `viewMode`/`setViewMode`/`SearchViewMode` from `ClimbSearchProvider` (added in P0 anticipating grid, now dead).

## Validation

typecheck (shared + mobile) · tests (climb-filters **132**, mobile **624**) · i18n hardcoded + orphans + 3-locale parity · Metro bundle. One QA pass — no bugs.

Noted (not changed): the backend Zod schema sets `boulders: .default(true)` / `routes: .default(false)`. It's inert today (the resolver maps raw input, not the parsed output, so mobile's "All" correctly returns everything), but it's a latent foot-gun if the resolver ever switches to parsed output — worth a defensive cleanup in a separate backend change.

## Roadmap left

P3 holds tap-to-include (the `ClimbBoardFilterState` type already reserves `holdsFilter`/`zoneBox`/`zoneMode`/`setterId`) · P4 zone + heatmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)