### PR TITLE
fix(db): route-only search returns empty list — use LEFT-JOIN path

### DIFF
--- a/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
@@ -7,6 +7,7 @@ const baseInput = {
   sortOrder: 'desc' as const,
   isDraftsQuery: false,
   projectsOnly: false,
+  routesOnly: false,
   page: 0,
   hasStatsFilters: false,
 };
@@ -15,6 +16,12 @@ void describe('chooseSearchPath', () => {
   void describe('the hot path: ascents DESC, page 0, no stats filters', () => {
     void it('uses stats-driven-with-fallback so projects appear at the bottom of narrow-filter pages', () => {
       assert.equal(chooseSearchPath(baseInput), 'stats-driven-with-fallback');
+    });
+  });
+
+  void describe('routes-only filter', () => {
+    void it('uses standard-only so unclimbed routes (no stats row) still appear in the list', () => {
+      assert.equal(chooseSearchPath({ ...baseInput, routesOnly: true }), 'standard-only');
     });
   });
 

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -75,6 +75,8 @@ export const searchClimbs = async (
     sortOrder,
     isDraftsQuery,
     projectsOnly: !!searchParams.projectsOnly,
+    // Routes-only (frames_count > 1, boulders off) — see chooseSearchPath.
+    routesOnly: !!searchParams.routes && !searchParams.boulders,
     page,
     hasStatsFilters,
   });
@@ -130,6 +132,7 @@ export type SearchPath = 'standard-only' | 'stats-driven-only' | 'stats-driven-w
  *   - non-ascents-DESC sort → standard-only (only ascents-DESC has the index-driven plan)
  *   - drafts query          → standard-only (drafts have no stats rows)
  *   - projectsOnly          → standard-only (the user explicitly wants stats-less climbs)
+ *   - routesOnly            → standard-only (routes are few + often unclimbed; the stats path drops them)
  *   - page === 0 && !hasStatsFilters → stats-driven-with-fallback
  *   - otherwise             → stats-driven-only
  */
@@ -138,12 +141,19 @@ export function chooseSearchPath(input: {
   sortOrder: 'asc' | 'desc';
   isDraftsQuery: boolean;
   projectsOnly: boolean;
+  routesOnly: boolean;
   page: number;
   hasStatsFilters: boolean;
 }): SearchPath {
   if (input.sortBy !== 'ascents' || input.sortOrder !== 'desc') return 'standard-only';
   if (input.isDraftsQuery) return 'standard-only';
   if (input.projectsOnly) return 'standard-only';
+  // Routes (frames_count > 1) are a small, frequently-unclimbed set. The
+  // stats-driven path INNER JOINs board_climb_stats at the angle, which drops
+  // routes with no stats row — the count query still counts them, so the list
+  // comes back empty while the count says e.g. 66. Force the LEFT JOIN path so
+  // unclimbed routes surface; the tiny routes dataset makes the index plan moot.
+  if (input.routesOnly) return 'standard-only';
   if (input.page === 0 && !input.hasStatsFilters) return 'stats-driven-with-fallback';
   return 'stats-driven-only';
 }


### PR DESCRIPTION
## What

A **routes-only** search (the Routes filter) returned an **empty list** even though the result count was correct (e.g. shows "66"). Reproduced on a Kilter **homewall** whose routes are largely unclimbed; routes showed fine on a 12×12 OG board (popular, climbed routes).

## Why

The default `ascents`-DESC sort uses the **stats-driven path** in `searchClimbs`: `FROM board_climb_stats INNER JOIN board_climbs` at the selected angle. That INNER JOIN drops climbs with **no stats row at that angle**. Routes (`frames_count > 1`) are a small, frequently-unclimbed set, so most have no stats row → they're dropped from the list. The **count** query uses `createClimbFilters` *without* the stats join, so it still counts them — hence count = 66 while the list = 0. The existing page-0 fallback to the LEFT-JOIN path only fires when the stats-driven path returns a *partial* page, so it doesn't reliably cover this.

(Confirmed in the dev DB: Kilter homewall 10×12 has 68 routes compatible with the size, but only ~37 have a stats row at 40° — the rest are silently excluded from the list.)

## Fix

Route the **routes-only** case (`routes && !boulders`) to `standardSearch` (LEFT JOIN `board_climb_stats`) so unclimbed routes surface, sorted `ascents DESC NULLS LAST`. Routes are a tiny dataset, so the index-driven stats plan isn't needed here. `chooseSearchPath` gains a `routesOnly` input; +1 unit test.

This is a shared query, so it fixes the **web** route filter now, and **mobile** once #2496 (mobile route playback + filter) lands.

## Validation

- `@boardsesh/db`: 97 tests pass, incl. the new `chooseSearchPath` routes-only case.
- `vp run typecheck` (full) ✓ · lint/format ✓.

Followup to #2232 (route/circuit support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
