### PR TITLE
feat(mobile): render SF Symbols on iOS via the shared Icon component

### DIFF
--- a/packages/mobile/src/components/Icon.tsx
+++ b/packages/mobile/src/components/Icon.tsx
@@ -1,4 +1,6 @@
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { SymbolView } from 'expo-symbols';
+import { Platform } from 'react-native';
 import { iconMap, type IconName } from './icon-map';
 
 type IconProps = {
@@ -7,19 +9,19 @@ type IconProps = {
   color?: string | import('react-native').OpaqueColorValue;
 };
 
+// iOS renders native SF Symbols (expo-symbols); Android keeps MaterialCommunityIcons.
+// Both glyph names live in icon-map.ts keyed by the same semantic IconName, so call
+// sites stay platform-agnostic.
 export function Icon({ name, size = 24, color }: IconProps) {
   const mapping = iconMap[name];
 
-  // TODO: Use expo-symbols (SymbolView) on iOS once we have a dev client build.
-  // SF Symbols require native code that doesn't work in Expo Go.
-  // For now, use MaterialCommunityIcons on both platforms.
-  // The Icon component API is stable — swapping the implementation later is a one-file change.
-
-  const iconName = mapping.android;
+  if (Platform.OS === 'ios') {
+    return <SymbolView name={mapping.ios} size={size} tintColor={color} />;
+  }
 
   return (
     <MaterialCommunityIcons
-      name={iconName as React.ComponentProps<typeof MaterialCommunityIcons>['name']}
+      name={mapping.android as React.ComponentProps<typeof MaterialCommunityIcons>['name']}
       size={size}
       color={color}
     />

--- a/packages/mobile/src/components/__tests__/Icon.test.tsx
+++ b/packages/mobile/src/components/__tests__/Icon.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+
+// Controls the platform branch under test.
+const ctrl = vi.hoisted(() => ({ os: 'ios' as string }));
+
+vi.mock('react-native', () => ({
+  Platform: {
+    get OS() {
+      return ctrl.os;
+    },
+  },
+}));
+
+// Stand-ins that surface the glyph name + colour so we can assert which renderer ran.
+vi.mock('expo-symbols', () => ({
+  SymbolView: ({ name, tintColor }: { name: string; tintColor?: string }) =>
+    createElement('div', { 'data-testid': 'symbol-view', 'data-name': name, 'data-tint': tintColor }),
+}));
+
+vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({
+  default: ({ name, color }: { name: string; color?: string }) =>
+    createElement('div', { 'data-testid': 'mci', 'data-name': name, 'data-color': color }),
+}));
+
+import { Icon } from '../Icon';
+import { iconMap } from '../icon-map';
+
+beforeEach(() => {
+  ctrl.os = 'ios';
+});
+
+describe('Icon platform rendering', () => {
+  it('renders an SF Symbol (SymbolView) with the ios glyph on iOS', () => {
+    const { queryByTestId } = render(<Icon name="skip.next" color="#FF0000" />);
+    const symbol = queryByTestId('symbol-view');
+    expect(symbol).not.toBeNull();
+    expect(queryByTestId('mci')).toBeNull();
+    expect(symbol?.getAttribute('data-name')).toBe(iconMap['skip.next'].ios);
+    expect(symbol?.getAttribute('data-tint')).toBe('#FF0000');
+  });
+
+  it('renders MaterialCommunityIcons with the android glyph on Android', () => {
+    ctrl.os = 'android';
+    const { queryByTestId } = render(<Icon name="skip.next" color="#00FF00" />);
+    const mci = queryByTestId('mci');
+    expect(mci).not.toBeNull();
+    expect(queryByTestId('symbol-view')).toBeNull();
+    expect(mci?.getAttribute('data-name')).toBe(iconMap['skip.next'].android);
+    expect(mci?.getAttribute('data-color')).toBe('#00FF00');
+  });
+
+  it('maps every transport glyph to its platform-specific name', () => {
+    for (const transportName of ['play.fill', 'pause', 'skip.previous', 'skip.next', 'end.session'] as const) {
+      ctrl.os = 'ios';
+      const ios = render(<Icon name={transportName} />);
+      expect(ios.queryByTestId('symbol-view')?.getAttribute('data-name')).toBe(iconMap[transportName].ios);
+      ios.unmount();
+
+      ctrl.os = 'android';
+      const android = render(<Icon name={transportName} />);
+      expect(android.queryByTestId('mci')?.getAttribute('data-name')).toBe(iconMap[transportName].android);
+      android.unmount();
+    }
+  });
+});

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -1,5 +1,9 @@
+import type { SymbolViewProps } from 'expo-symbols';
+
 type IconMapping = {
-  ios: string;
+  // SFSymbol union (from sf-symbols-typescript via expo-symbols) — every name is
+  // validated at compile time, so a typo fails `vp run typecheck:mobile`.
+  ios: SymbolViewProps['name'];
   android: string;
 };
 

--- a/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback } from 'react';
-import { View, Pressable, Platform, StyleSheet, type ViewStyle } from 'react-native';
-import { SymbolView } from 'expo-symbols';
+import { View, Pressable, StyleSheet, type ViewStyle } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../Icon';
 import { Badge } from '../Badge';
@@ -285,9 +284,9 @@ type ShareButtonProps = {
   accessibilityLabel: string;
 };
 
-// Renders the native iOS share glyph (square.and.arrow.up) on iOS via expo-symbols.
-// Falls back to the Material Design share icon on Android (via the standard Icon
-// component, which uses MaterialCommunityIcons).
+// The share glyph resolves to the native iOS share symbol (square.and.arrow.up) on
+// iOS and the Material Design share icon on Android — Icon picks per platform from
+// the shared icon-map.
 function ShareButton({ size, onPress, accessibilityLabel }: ShareButtonProps) {
   const { dim, icon } = SIZES[size];
   return (
@@ -301,11 +300,7 @@ function ShareButton({ size, onPress, accessibilityLabel }: ShareButtonProps) {
         pressed && styles.actionButtonPressed,
       ]}
     >
-      {Platform.OS === 'ios' ? (
-        <SymbolView name="square.and.arrow.up" size={icon} tintColor={iosSystemColors.systemGray} />
-      ) : (
-        <Icon name="share" size={icon} color={iosSystemColors.systemGray} />
-      )}
+      <Icon name="share" size={icon} color={iosSystemColors.systemGray} />
     </Pressable>
   );
 }


### PR DESCRIPTION
## What

The mobile transport controls (and the rest of the icon set) rendered `MaterialCommunityIcons` on both platforms, so iOS showed Material glyphs instead of native SF Symbols. Rather than swap just the transport glyphs piecemeal, this cashes in the standing `Icon.tsx` TODO and migrates the **whole** icon set in one go.

`Icon` now branches on `Platform.OS`:
- **iOS** → `expo-symbols` `SymbolView` using the icon-map's `ios` glyph (drops MaterialCommunityIcons from the iOS bundle entirely)
- **Android** → `MaterialCommunityIcons` using the `android` glyph (unchanged)

The public `Icon` API (`name` / `size` / `color`) is untouched, so no call sites change.

## Compile-time safety

`icon-map.ts`'s `ios` field is now typed as the SFSymbol union (`SymbolViewProps['name']` from `sf-symbols-typescript` via `expo-symbols`) instead of `string`. Every one of the 116 SF Symbol names is now validated by `vp run typecheck:mobile` — a typo fails the build instead of rendering a blank glyph on device. All 116 existing names passed the stricter type as-is.

## Cleanup

`ShareButton` in `PlayDrawerActionBar.tsx` hand-rolled its own `Platform.OS === 'ios' ? SymbolView : Icon` branch — now redundant since `Icon` does it. Collapsed to a single `<Icon name="share" .../>` and dropped the now-unused `expo-symbols` and `Platform` imports.

## Scope

- **Android stays on MaterialCommunityIcons** — SF Symbols are iOS-only and have no native Android equivalent. Bundling an SF-Symbol-alike set for Android is a much larger, separately-scoped effort.
- **No speed pill.** The Podcasts-style tap-to-cycle speed pill is out of scope; there's no playback-speed control in the mobile app yet.
- **No new native build.** `SymbolView` already shipped in the preview build (it was used by `ShareButton`), so this is JS-only and rides OTA.

## Verification

- `vp run typecheck:mobile` — passes (validates all 116 SF Symbol names)
- `vp test --project mobile` — 623 tests pass, including a new `Icon.test.tsx` that asserts `Icon` renders `SymbolView` with the `ios` glyph on iOS and `MaterialCommunityIcons` with the `android` glyph on Android
- `vp run check:mobile-bundle` — Metro bundle builds clean (the `expo-symbols` import resolves)

Visual confirmation of SF Symbols rendering in the play-drawer transport row needs a device/simulator (macOS or OTA preview) — not reproducible on the Linux CI box.

https://claude.ai/code/session_012Zr4B4bCMKrGxdoFV4vJKb

---
_Generated by [Claude Code](https://claude.ai/code/session_012Zr4B4bCMKrGxdoFV4vJKb)_