### PR TITLE
fix(mobile): address route playback review findings (#2496)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -453,7 +453,7 @@
         "happy-dom": "^15",
         "react": "^19",
         "react-dom": "^19",
-        "typescript": "^5.9.3",
+        "typescript": "~6.0.3",
       },
       "peerDependencies": {
         "react": "^19",
@@ -4467,8 +4467,6 @@
     "@boardsesh/moonboard-ocr/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@boardsesh/party-profile/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
-    "@boardsesh/playback-react/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@boardsesh/queue-runtime/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/docs/mobile-play-view-roadmap.md
+++ b/docs/mobile-play-view-roadmap.md
@@ -22,28 +22,29 @@ The authoritative design spec for the play view lives at [`docs/ui/06-play-view.
 
 ## Feature Parity Table
 
-| Feature                                           | Web  | Mobile  | Shared Code                            | Phase |
-| ------------------------------------------------- | ---- | ------- | -------------------------------------- | ----- |
-| Play drawer (bottom sheet shell)                  | Done | Done    | Snap points, state machine             | 1     |
-| Climb header (grade + name + stats)               | Done | Done    | Grade formatting, stat utils           | 1     |
-| Board renderer                                    | Done | Done    | Hold data transforms                   | 1     |
-| Action bar (8 buttons)                            | Done | Done    | Button definitions, action types       | 1     |
-| Tick FAB                                          | Done | Done    | Tick state logic                       | 1     |
-| Queue navigation (prev/next)                      | Done | Done    | Navigation helpers                     | 1     |
-| Board carousel (swipe)                            | Done | Done    | Prefetch logic                         | 2     |
-| Inline tick bar                                   | Done | Done    | QuickTickBar logic                     | 2     |
-| Wake lock                                         | Done | Done    | --                                     | 2     |
-| Queue drawer (nested)                             | Done | Done    | Queue list model (buildQueueListModel) | 3     |
-| Below-fold sections (logbook, similar, community) | Done | Stub    | Section data types                     | 3     |
-| Climb actions sheet                               | Done | Done    | Action definitions                     | 3     |
-| Angle selector                                    | Done | Done    | Angle range utils                      | 3     |
-| Zoom/pan                                          | Done | Planned | Transform math                         | 4     |
-| Double-tap favorite                               | Done | Planned | Favorite toggle logic                  | 4     |
-| Party mode (mini session bar, driver, drift)      | Done | Planned | Session state types                    | 5     |
-| BLE lightbulb integration                         | Done | Planned | Protocol (via @boardsesh/ble-protocol) | 5     |
-| Coachmarks                                        | Done | Planned | Coachmark definitions                  | 6     |
-| Beta videos section                               | Done | Planned | Video data types                       | 6     |
-| Analytics section                                 | Done | Planned | Stat aggregation                       | 6     |
+| Feature                                             | Web  | Mobile  | Shared Code                                   | Phase |
+| --------------------------------------------------- | ---- | ------- | --------------------------------------------- | ----- |
+| Play drawer (bottom sheet shell)                    | Done | Done    | Snap points, state machine                    | 1     |
+| Climb header (grade + name + stats)                 | Done | Done    | Grade formatting, stat utils                  | 1     |
+| Board renderer                                      | Done | Done    | Hold data transforms                          | 1     |
+| Action bar (8 buttons)                              | Done | Done    | Button definitions, action types              | 1     |
+| Tick FAB                                            | Done | Done    | Tick state logic                              | 1     |
+| Queue navigation (prev/next)                        | Done | Done    | Navigation helpers                            | 1     |
+| Board carousel (swipe)                              | Done | Done    | Prefetch logic                                | 2     |
+| Inline tick bar                                     | Done | Done    | QuickTickBar logic                            | 2     |
+| Wake lock                                           | Done | Done    | --                                            | 2     |
+| Queue drawer (nested)                               | Done | Done    | Queue list model (buildQueueListModel)        | 3     |
+| Below-fold sections (logbook, similar, community)   | Done | Stub    | Section data types                            | 3     |
+| Climb actions sheet                                 | Done | Done    | Action definitions                            | 3     |
+| Angle selector                                      | Done | Done    | Angle range utils                             | 3     |
+| Zoom/pan                                            | Done | Planned | Transform math                                | 4     |
+| Double-tap favorite                                 | Done | Planned | Favorite toggle logic                         | 4     |
+| Route/circuit playback (animate, speed, party-sync) | Done | Done    | @boardsesh/playback-react (usePlaybackEngine) | 5     |
+| Party mode (mini session bar, driver, drift)        | Done | Partial | Session state types                           | 5     |
+| BLE lightbulb integration                           | Done | Partial | Protocol (via @boardsesh/ble-protocol)        | 5     |
+| Coachmarks                                          | Done | Planned | Coachmark definitions                         | 6     |
+| Beta videos section                                 | Done | Planned | Video data types                              | 6     |
+| Analytics section                                   | Done | Planned | Stat aggregation                              | 6     |
 
 ## Phase Descriptions
 
@@ -90,6 +91,14 @@ Adds zoom, pan, and gesture shortcuts.
 ### Phase 5: Party Mode
 
 Adds real-time collaborative climbing sessions.
+
+**Shipped (#2496):**
+
+- **Route/circuit playback** -- variable-speed, frame-stepped animation of multi-frame climbs (`framesCount > 1`) in the play drawer, via the shared `@boardsesh/playback-react` engine (`usePlaybackEngine` + `useClimbFrames`). Boulders are unaffected (`isAnimatable` is false).
+- **Playback party-sync** -- `PlaybackStateChanged` is forwarded through the queue provider's `subscribeToQueueEvents` seam (bypassing the reducer) and broadcast via `publishPlaybackState`, so party members see the same frame/speed/play state in real time.
+- **BLE frame mirroring** -- during route playback, the current frame is written to a connected board over BLE through a latest-wins, GATT-safe drain (mobile's `sendFramesToBoard` has no internal mutex).
+
+**Still planned:**
 
 - **Mini session bar** -- persistent bar above the play drawer showing connected users, driver name, and session status
 - **Driver state and lightbulb behavior** -- driver controls which climb is displayed and sends lightbulb commands; non-drivers see the driver's selection in real time

--- a/packages/mobile/src/components/play-drawer/PlaybackControls.tsx
+++ b/packages/mobile/src/components/play-drawer/PlaybackControls.tsx
@@ -173,9 +173,11 @@ function SpeedSlider({
   );
 
   // Keep the thumb synced to the external value while not dragging (peer sync,
-  // commit echoes, resets). The guard avoids fighting the gesture.
+  // commit echoes, resets). Skip until layout gives a real track width — otherwise
+  // `usable` is 0 and the thumb snaps to the left before jumping into place. Read
+  // the SharedValue with `.get()` (Reanimated JS-thread accessor), not `.value`.
   useEffect(() => {
-    if (dragging.value) return;
+    if (usable <= 0 || dragging.get()) return;
     position.value = clamp01((value - MIN_SPEED) / (MAX_SPEED - MIN_SPEED)) * usable;
   }, [value, usable, position, dragging]);
 
@@ -336,7 +338,13 @@ export function PlaybackControls({
     const glide = isPlaying ? Math.max(timing.instant, paceMs / Math.max(speed, 0.01)) : timing.fast;
     progress.value = withTiming(target, { duration: glide });
   }, [frameIndex, frameCount, isPlaying, paceMs, speed, progress]);
-  const progressStyle = useAnimatedStyle(() => ({ transform: [{ scaleX: Math.max(0, progress.value) }] }));
+  // transformOrigin must live in the animated style, not the static StyleSheet —
+  // the latter isn't honoured for the Reanimated-driven scaleX, so the bar would
+  // grow from center instead of left-to-right.
+  const progressStyle = useAnimatedStyle(() => ({
+    transformOrigin: 'left',
+    transform: [{ scaleX: Math.max(0, progress.value) }],
+  }));
 
   const handleMain = useCallback(() => {
     hapticSelection();
@@ -438,7 +446,6 @@ const styles = StyleSheet.create({
     right: 0,
     height: 3,
     backgroundColor: brandColors.primary,
-    transformOrigin: 'left',
   },
   transportRow: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { Climb, BoardName } from '@boardsesh/shared-schema';
+
+// The orchestrator composes three I/O seams — the shared playback engine, the
+// queue provider (party-sync), and the optional Bluetooth context (BLE writes).
+// We mock all three so the test exercises the orchestrator's own logic: the
+// latest-wins GATT-safe drain, the climb-change reset, and party-sync wiring.
+
+type EngineInput = {
+  externalState?: { clientId: string | null } | null;
+  onLocalStateChange?: (state: {
+    frameIndex: number;
+    isPlaying: boolean;
+    speed: number;
+    paceMs: number;
+    anchorTimestamp: number;
+    clientId: string | null;
+  }) => void;
+};
+
+type SendCall = { frame: string; mirrored?: boolean; resolve: (value: boolean) => void };
+
+const mocks = vi.hoisted(() => ({
+  climbFrames: { frames: [] as unknown[], frameStrings: [] as string[], paceMs: 500 },
+  // Mutable engine output — tests drive `currentFrameString` / `isAnimatable`
+  // and rerender to fire the BLE effect.
+  playback: {
+    isAnimatable: true,
+    frameCount: 3,
+    frameIndex: 0,
+    currentFrameString: '',
+    isPlaying: false,
+    speed: 1,
+    play: vi.fn(),
+    pause: vi.fn(),
+    seek: vi.fn(),
+    setSpeed: vi.fn(),
+  },
+  lastEngineInput: { current: null as EngineInput | null },
+  queueListeners: new Set<(event: unknown) => void>(),
+  publishPlaybackState: vi.fn((_input: Record<string, unknown>) => Promise.resolve()),
+  // Stable references — the real queue provider memoises these with useCallback.
+  // An unstable identity would re-run the subscription effect every render and
+  // clear the externally-synced state.
+  subscribeToQueueEvents: null as unknown as (listener: (event: unknown) => void) => () => void,
+  queueValue: null as unknown as { subscribeToQueueEvents: unknown; publishPlaybackState: unknown },
+  bluetooth: {
+    isConnected: true,
+    sendFramesToBoard: vi.fn() as ReturnType<typeof vi.fn>,
+  },
+  sendCalls: [] as SendCall[],
+}));
+
+vi.mock('@boardsesh/playback-react', () => ({
+  useClimbFrames: () => mocks.climbFrames,
+  usePlaybackEngine: (input: EngineInput) => {
+    mocks.lastEngineInput.current = input;
+    return mocks.playback;
+  },
+}));
+
+mocks.subscribeToQueueEvents = (listener: (event: unknown) => void) => {
+  mocks.queueListeners.add(listener);
+  return () => {
+    mocks.queueListeners.delete(listener);
+  };
+};
+mocks.queueValue = {
+  subscribeToQueueEvents: mocks.subscribeToQueueEvents,
+  publishPlaybackState: mocks.publishPlaybackState,
+};
+
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueue: () => mocks.queueValue,
+}));
+
+vi.mock('../../../providers/bluetooth-provider', () => ({
+  useOptionalBluetoothContext: () => mocks.bluetooth,
+}));
+
+import { useMobilePlayback } from '../use-mobile-playback';
+
+const KILTER = 'kilter' as BoardName;
+const climbWith = (uuid: string) => ({ uuid }) as unknown as Climb;
+
+/** Deliver a fake wire event to every active queue-event listener. */
+function emit(event: Record<string, unknown>) {
+  act(() => {
+    for (const listener of mocks.queueListeners) listener(event);
+  });
+}
+
+function playbackEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    __typename: 'PlaybackStateChanged',
+    climbUuid: 'c1',
+    frameIndex: 2,
+    isPlaying: true,
+    speed: 1.5,
+    paceMs: 400,
+    anchorTimestamp: 1700,
+    clientId: 'peer-1',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.climbFrames = { frames: [], frameStrings: ['F0', 'F1', 'F2'], paceMs: 500 };
+  mocks.playback.isAnimatable = true;
+  mocks.playback.frameIndex = 0;
+  mocks.playback.currentFrameString = '';
+  mocks.playback.isPlaying = false;
+  mocks.playback.speed = 1;
+  mocks.lastEngineInput.current = null;
+  mocks.queueListeners.clear();
+  mocks.bluetooth.isConnected = true;
+  mocks.sendCalls = [];
+  // Each write returns a deferred promise so a test can hold a write "in flight".
+  mocks.bluetooth.sendFramesToBoard = vi.fn((frame: string, mirrored?: boolean) => {
+    return new Promise<boolean>((resolve) => {
+      mocks.sendCalls.push({ frame, mirrored, resolve });
+    });
+  });
+});
+
+function renderPlayback(climb: Climb | null) {
+  return renderHook(
+    (props: { climb: Climb | null }) =>
+      useMobilePlayback({
+        climb: props.climb,
+        boardName: KILTER,
+        mirrored: false,
+        isOpen: true,
+      }),
+    { initialProps: { climb } },
+  );
+}
+
+/** Push a new current frame and rerender so the BLE effect re-evaluates. */
+async function setFrame(rerender: (props: { climb: Climb | null }) => void, climb: Climb | null, frame: string) {
+  await act(async () => {
+    mocks.playback.currentFrameString = frame;
+    rerender({ climb });
+  });
+}
+
+describe('useMobilePlayback — BLE drain', () => {
+  it('collapses overlapping frame writes to the latest (GATT-safe)', async () => {
+    const climb = climbWith('c1');
+    const { rerender } = renderPlayback(climb);
+
+    // First frame starts a write that stays in flight.
+    await setFrame(rerender, climb, 'F0');
+    expect(mocks.bluetooth.sendFramesToBoard).toHaveBeenCalledTimes(1);
+    expect(mocks.sendCalls[0].frame).toBe('F0');
+
+    // Two more frames arrive before the write resolves: only the newest is kept,
+    // and no second write is issued while the first is pending.
+    await setFrame(rerender, climb, 'F1');
+    await setFrame(rerender, climb, 'F2');
+    expect(mocks.bluetooth.sendFramesToBoard).toHaveBeenCalledTimes(1);
+
+    // Resolve the in-flight write; the drain flushes the latest pending frame and
+    // skips the superseded one.
+    await act(async () => {
+      mocks.sendCalls[0].resolve(true);
+    });
+    expect(mocks.bluetooth.sendFramesToBoard).toHaveBeenCalledTimes(2);
+    expect(mocks.sendCalls[1].frame).toBe('F2');
+    expect(mocks.bluetooth.sendFramesToBoard.mock.calls.map((call) => call[0])).toEqual(['F0', 'F2']);
+
+    await act(async () => {
+      mocks.sendCalls[1].resolve(true);
+    });
+  });
+
+  it('does not re-send a frame already on the board', async () => {
+    const climb = climbWith('c1');
+    const { rerender } = renderPlayback(climb);
+
+    await setFrame(rerender, climb, 'F0');
+    await act(async () => {
+      mocks.sendCalls[0].resolve(true);
+    });
+    // Same frame string again — nothing to write.
+    await setFrame(rerender, climb, 'F0');
+    expect(mocks.bluetooth.sendFramesToBoard).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-flushes the first frame after a climb change', async () => {
+    const c1 = climbWith('c1');
+    const { rerender } = renderPlayback(c1);
+
+    await setFrame(rerender, c1, 'F0');
+    await act(async () => {
+      mocks.sendCalls[0].resolve(true);
+    });
+    expect(mocks.bluetooth.sendFramesToBoard).toHaveBeenCalledTimes(1);
+
+    // Switch climbs. There's a brief no-frame gap while the next climb's frames
+    // load; the climb-change reset clears the write trackers so the new climb's
+    // first frame flushes even when it matches the last frame of the old climb.
+    const c2 = climbWith('c2');
+    await setFrame(rerender, c2, '');
+    await setFrame(rerender, c2, 'F0');
+    await act(async () => {
+      mocks.sendCalls[1]?.resolve(true);
+    });
+    expect(mocks.bluetooth.sendFramesToBoard).toHaveBeenCalledTimes(2);
+    expect(mocks.sendCalls[1].frame).toBe('F0');
+  });
+
+  it('writes nothing for boulders (isAnimatable false)', async () => {
+    const climb = climbWith('c1');
+    mocks.playback.isAnimatable = false;
+    const { rerender } = renderPlayback(climb);
+
+    await setFrame(rerender, climb, 'F0');
+    expect(mocks.bluetooth.sendFramesToBoard).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing while the board is disconnected', async () => {
+    const climb = climbWith('c1');
+    mocks.bluetooth.isConnected = false;
+    const { rerender } = renderPlayback(climb);
+
+    await setFrame(rerender, climb, 'F0');
+    expect(mocks.bluetooth.sendFramesToBoard).not.toHaveBeenCalled();
+  });
+});
+
+describe('useMobilePlayback — party-sync', () => {
+  beforeEach(() => {
+    // Isolate the subscription wiring from the BLE effect.
+    mocks.bluetooth.isConnected = false;
+  });
+
+  it('applies a matching peer playback event as external engine state', () => {
+    renderPlayback(climbWith('c1'));
+
+    emit(playbackEvent({ climbUuid: 'c1', clientId: 'peer-1' }));
+    expect(mocks.lastEngineInput.current?.externalState?.clientId).toBe('peer-1');
+  });
+
+  it('ignores events for other climbs and non-playback events', () => {
+    renderPlayback(climbWith('c1'));
+
+    emit(playbackEvent({ climbUuid: 'other-climb' }));
+    emit({ __typename: 'QueueItemAdded' });
+    expect(mocks.lastEngineInput.current?.externalState).toBeNull();
+  });
+
+  it('clears peer state when the climb changes', () => {
+    const { rerender } = renderPlayback(climbWith('c1'));
+
+    emit(playbackEvent({ climbUuid: 'c1' }));
+    expect(mocks.lastEngineInput.current?.externalState).not.toBeNull();
+
+    act(() => {
+      rerender({ climb: climbWith('c2') });
+    });
+    expect(mocks.lastEngineInput.current?.externalState).toBeNull();
+  });
+
+  it('publishes local playback state to peers', () => {
+    renderPlayback(climbWith('c1'));
+
+    act(() => {
+      mocks.lastEngineInput.current?.onLocalStateChange?.({
+        frameIndex: 1,
+        isPlaying: true,
+        speed: 2,
+        paceMs: 500,
+        anchorTimestamp: 1700,
+        clientId: 'self',
+      });
+    });
+
+    expect(mocks.publishPlaybackState).toHaveBeenCalledTimes(1);
+    const published = mocks.publishPlaybackState.mock.calls[0][0];
+    expect(published).toMatchObject({ climbUuid: 'c1', frameIndex: 1, isPlaying: true, speed: 2, paceMs: 500 });
+    expect(typeof published.clientId).toBe('string');
+  });
+});

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -438,6 +438,8 @@ export function QueueProvider({ children }: { children: ReactNode }) {
           // model PlaybackStateChanged, but the subscription selects it and the
           // server emits it — SubscriptionQueueEvent is the canonical client
           // union that includes it.
+          // TODO(#2507): add PlaybackStateChanged to SubscriptionWireEnvelope so
+          // this `as unknown as` cast can be removed (don't strip it before then).
           const queueEvent = event as unknown as SubscriptionQueueEvent;
           if (queueEventListenersRef.current.size > 0) {
             for (const listener of queueEventListenersRef.current) {

--- a/packages/shared/playback-react/package.json
+++ b/packages/shared/playback-react/package.json
@@ -39,7 +39,7 @@
     "happy-dom": "^15",
     "react": "^19",
     "react-dom": "^19",
-    "typescript": "^5.9.3"
+    "typescript": "~6.0.3"
   },
   "peerDependencies": {
     "react": "^19"


### PR DESCRIPTION
## What

Follow-up fixes for the review of #2496 (mobile route/circuit playback), which has since merged to `main`. Addresses the animation regression, two slider correctness nits, and the doc/tooling/test gaps. Rebased on latest `main`.

## Fixes

1. ~~`formatAscentCount` dropped~~ — **resolved upstream on `main`** (a `formatSends` helper + `{{formattedCount}}` catalog placeholder, handling k/m abbreviation). Dropped from this PR during the rebase in favour of main's version.

2. **`transformOrigin` regression** — moved `transformOrigin: 'left'` out of the static `StyleSheet` and into the Reanimated `progressStyle`. The static sheet isn't honoured for the Reanimated-driven `scaleX`, so the progress hairline now grows left-to-right instead of from center.

3. **Thumb snaps to 0 on mount** — the SpeedSlider sync effect now skips while `usable === 0` (pre-layout), so the thumb no longer jumps from the left edge when mounting at a non-1× speed (e.g. a party-sync peer joining mid-playback).

4. **Cross-thread SharedValue read** — the same effect reads `dragging.get()` (Reanimated JS-thread accessor) instead of `dragging.value`.

5. **Wire-envelope cast TODO** — added `TODO(#2507)` above the `event as unknown as SubscriptionQueueEvent` cast in `queue-provider`, tracking the missing `PlaybackStateChanged` member on `SubscriptionWireEnvelope`. Tracking issue: #2507 (left open — this PR only adds the marker).

6. **TypeScript version drift** — `@boardsesh/playback-react` devDep bumped `^5.9.3` → `~6.0.3` to match its siblings.

7. **Orchestrator tests** — new `use-mobile-playback` tests with a mocked BLE context and deferred-promise writes covering: latest-wins GATT-safe drain (overlap prevention), climb-change tracker reset, party-sync convergence, and local-state publish.

8. **Roadmap doc** — added a "Route/circuit playback" row (Done/Done) and marked the Party mode + BLE lightbulb rows **Partial** with what actually shipped (playback party-sync + per-frame BLE mirroring).

## Validation (post-rebase)
- `vp run typecheck:mobile` ✓ · `vp run typecheck:shared` ✓
- `vp test --project mobile` — new orchestrator tests (9) ✓
- i18n catalog completeness (28) ✓ (main's `formattedCount` catalog)
- `vp check --fix` (changed files) ✓

Related: #2507

https://claude.ai/code/session_01135uoRbnyVFwUURmPnuMi9