### PR TITLE
feat(mobile): create-climb editor (Aurora) — no-SVG board, brush + sheet

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -160,6 +160,7 @@
         "@boardsesh/board-react": "*",
         "@boardsesh/climb-actions": "*",
         "@boardsesh/climb-filters": "*",
+        "@boardsesh/create-climb-react": "*",
         "@boardsesh/graphql": "*",
         "@boardsesh/graphql-client": "*",
         "@boardsesh/i18n": "*",
@@ -325,6 +326,25 @@
       },
       "devDependencies": {
         "typescript": "~6.0.3",
+      },
+    },
+    "packages/shared/create-climb-react": {
+      "name": "@boardsesh/create-climb-react",
+      "version": "1.0.0",
+      "dependencies": {
+        "@boardsesh/board-constants": "*",
+        "@boardsesh/shared-schema": "*",
+      },
+      "devDependencies": {
+        "@testing-library/react": "^16.3.2",
+        "@types/react": "^19",
+        "@vitest/coverage-v8": "^4.1.5",
+        "happy-dom": "^15",
+        "react": "^19",
+        "typescript": "^5.9.3",
+      },
+      "peerDependencies": {
+        "react": "^19",
       },
     },
     "packages/shared/graphql": {
@@ -504,6 +524,7 @@
         "@boardsesh/board-renderer-wasm": "*",
         "@boardsesh/climb-actions": "*",
         "@boardsesh/climb-filters": "*",
+        "@boardsesh/create-climb-react": "*",
         "@boardsesh/crypto": "*",
         "@boardsesh/db": "*",
         "@boardsesh/graphql": "*",
@@ -909,6 +930,8 @@
     "@boardsesh/climb-actions": ["@boardsesh/climb-actions@workspace:packages/shared/climb-actions"],
 
     "@boardsesh/climb-filters": ["@boardsesh/climb-filters@workspace:packages/shared/climb-filters"],
+
+    "@boardsesh/create-climb-react": ["@boardsesh/create-climb-react@workspace:packages/shared/create-climb-react"],
 
     "@boardsesh/crypto": ["@boardsesh/crypto@workspace:packages/crypto"],
 

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -9,6 +9,7 @@ import type { BoardRouteParams, ClimbSearchParams, ClimbRow, ClimbSearchResult }
 type RawSelectResult = {
   uuid: string;
   setter_username: string | null;
+  userId: string | null;
   name: string | null;
   frames: string | null;
   is_draft: boolean | null;
@@ -27,6 +28,7 @@ function mapResultToClimbRow(result: RawSelectResult, params: BoardRouteParams):
   return {
     uuid: result.uuid,
     setter_username: result.setter_username || '',
+    userId: result.userId ?? null,
     name: result.name || '',
     frames: result.frames || '',
     angle: params.angle,
@@ -181,6 +183,7 @@ async function statsDrivenSearch(
   const selectFields = {
     uuid: boardClimbs.uuid,
     setter_username: boardClimbs.setterUsername,
+    userId: boardClimbs.userId,
     name: boardClimbs.name,
     frames: boardClimbs.frames,
     is_draft: boardClimbs.isDraft,
@@ -295,6 +298,7 @@ async function standardSearch(
   const selectFields = {
     uuid: boardClimbs.uuid,
     setter_username: boardClimbs.setterUsername,
+    userId: boardClimbs.userId,
     name: boardClimbs.name,
     frames: boardClimbs.frames,
     is_draft: boardClimbs.isDraft,

--- a/packages/db/src/queries/climbs/types.ts
+++ b/packages/db/src/queries/climbs/types.ts
@@ -174,6 +174,8 @@ export type ClimbSearchResult = {
 export type ClimbRow = {
   uuid: string;
   setter_username: string;
+  /** Owner (creator) user id; null for Aurora-imported climbs. Used for edit-ownership gating. */
+  userId: string | null;
   name: string;
   description: string;
   frames: string;

--- a/packages/mobile/app/(tabs)/climbs/_layout.tsx
+++ b/packages/mobile/app/(tabs)/climbs/_layout.tsx
@@ -32,6 +32,13 @@ export default function ClimbsLayout() {
           presentation: 'modal',
         }}
       />
+      <Stack.Screen
+        name="create"
+        options={{
+          title: t('mobile.nav.createClimb'),
+          presentation: 'modal',
+        }}
+      />
     </Stack>
   );
 }

--- a/packages/mobile/app/(tabs)/climbs/create.tsx
+++ b/packages/mobile/app/(tabs)/climbs/create.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { CreateClimbScreen } from '../../../src/components/create-climb/CreateClimbScreen';
+import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
+import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
+
+type CreateClimbParams = {
+  boardName?: string;
+  layoutId?: string;
+  sizeId?: string;
+  setIds?: string;
+  angle?: string;
+  forkFrames?: string;
+  forkName?: string;
+  forkDescription?: string;
+  editClimbUuid?: string;
+};
+
+/**
+ * Create-climb route. Board config comes from route params (passed by the FAB,
+ * fork/edit entry points); falls back to the user's active board when the
+ * params are absent so the screen can be opened bare.
+ */
+export default function CreateClimbRoute() {
+  const params = useLocalSearchParams<CreateClimbParams>();
+  const { data: activeBoard } = useActiveBoard();
+
+  const board = useMemo(() => {
+    const boardName = (params.boardName ?? activeBoard?.boardType) as BoardName | undefined;
+    const layoutId = params.layoutId ? Number(params.layoutId) : activeBoard?.layoutId;
+    const sizeId = params.sizeId ? Number(params.sizeId) : activeBoard?.sizeId;
+    const setIds = params.setIds ?? activeBoard?.setIds;
+    const angle = params.angle ? Number(params.angle) : activeBoard?.angle;
+    if (!boardName || layoutId == null || sizeId == null || setIds == null || angle == null) {
+      return null;
+    }
+    return { boardName, layoutId, sizeId, setIds, angle };
+  }, [params, activeBoard]);
+
+  if (!board) {
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <CreateClimbScreen
+      board={board}
+      forkFrames={params.forkFrames}
+      forkName={params.forkName}
+      forkDescription={params.forkDescription}
+      editClimbUuid={params.editClimbUuid}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  loading: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { View, StyleSheet, RefreshControl, Image, Keyboard } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useNavigation } from 'expo-router';
+import { useNavigation, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import type { Climb, BoardName } from '@boardsesh/shared-schema';
 import { toClimbSearchInput, DEFAULT_CLIMB_FILTER_STATE } from '@boardsesh/climb-filters';
@@ -11,6 +11,7 @@ import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
 import { ClimbFilterSheet, hasActiveFilters, type ClimbFilters } from '../../../src/components/ClimbFilterSheet';
+import { CreateClimbFab } from '../../../src/components/create-climb/CreateClimbFab';
 import { GradePopover } from '../../../src/components/search/GradePopover';
 import { SearchBottomBar } from '../../../src/components/search/SearchBottomBar';
 import { StickyFilterStrip } from '../../../src/components/search/StickyFilterStrip';
@@ -64,6 +65,7 @@ export default function ClimbList() {
 
 function ClimbListInner() {
   const navigation = useNavigation();
+  const router = useRouter();
   const { t } = useTranslation('climbs');
   const { openClimbActions, openAddToPlaylist } = useDrawerHost();
   const { systemColors } = useTheme();
@@ -564,6 +566,17 @@ function ClimbListInner() {
           boardConfig={boardConfig}
           currentFilters={filters}
           onApply={handleApplyFilters}
+        />
+      ) : null}
+
+      {isAuthenticated && hasBoardConfig ? (
+        <CreateClimbFab
+          onPress={() =>
+            router.push({
+              pathname: '/(tabs)/climbs/create',
+              params: { boardName, layoutId: String(layoutId), sizeId: String(sizeId), setIds, angle: String(angle) },
+            })
+          }
         />
       ) : null}
     </View>

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -16,6 +16,7 @@
     "@boardsesh/board-react": "*",
     "@boardsesh/climb-actions": "*",
     "@boardsesh/climb-filters": "*",
+    "@boardsesh/create-climb-react": "*",
     "@boardsesh/graphql": "*",
     "@boardsesh/graphql-client": "*",
     "@boardsesh/i18n": "*",

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -2,10 +2,12 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { View, StyleSheet } from 'react-native';
 import BottomSheet from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
+import { useRouter } from 'expo-router';
 import * as Clipboard from 'expo-clipboard';
 import * as WebBrowser from 'expo-web-browser';
 import type { Climb } from '@boardsesh/shared-schema';
 import { buildClimbViewPath } from '@boardsesh/play-view';
+import { computeCanUpdate, type SavedClimbSnapshot } from '@boardsesh/create-climb-react';
 import { Sheet } from './Sheet';
 import { ListRow } from './ListRow';
 import { Icon } from './Icon';
@@ -23,6 +25,8 @@ type ClimbActionsSheetProps = {
   sizeId: number;
   setIds: string;
   angle: number;
+  /** Current signed-in user id — gates the owner-only Edit row. */
+  currentUserId?: string | null;
   onAddToQueue?: () => void;
   onToggleFavorite?: () => void;
   /** When provided, shows a "Log a tick" row that opens the LogAscent sheet. */
@@ -45,6 +49,7 @@ function ClimbActionsSheet({
   sizeId,
   setIds,
   angle,
+  currentUserId,
   onAddToQueue,
   onToggleFavorite,
   onTick,
@@ -52,6 +57,7 @@ function ClimbActionsSheet({
 }: ClimbActionsSheetProps) {
   const { t } = useTranslation('climbs');
   const { showToast } = useToast();
+  const router = useRouter();
   const sheetRef = useRef<BottomSheet>(null);
 
   useEffect(() => {
@@ -113,6 +119,55 @@ function ClimbActionsSheet({
     onClose();
   }, [onClose]);
 
+  const handleFork = useCallback(() => {
+    if (!climb) return;
+    onClose();
+    router.push({
+      pathname: '/(tabs)/climbs/create',
+      params: {
+        forkFrames: climb.frames,
+        forkName: climb.name,
+        forkDescription: climb.description ?? '',
+        boardName,
+        layoutId: String(layoutId),
+        sizeId: String(sizeId),
+        setIds,
+        angle: String(angle),
+      },
+    });
+  }, [climb, boardName, layoutId, sizeId, setIds, angle, router, onClose]);
+
+  const handleEdit = useCallback(() => {
+    if (!climb) return;
+    onClose();
+    router.push({
+      pathname: '/(tabs)/climbs/create',
+      params: {
+        editClimbUuid: climb.uuid,
+        boardName,
+        layoutId: String(layoutId),
+        sizeId: String(sizeId),
+        setIds,
+        angle: String(angle),
+      },
+    });
+  }, [climb, boardName, layoutId, sizeId, setIds, angle, router, onClose]);
+
+  // Edit is owner-only, and only while the climb is still a draft OR within
+  // 24h of first publish (the backend enforces the same window). `userId`
+  // is null for Aurora-synced climbs that predate Boardsesh accounts.
+  const canEdit = useMemo(() => {
+    if (!climb || !currentUserId || !climb.userId || climb.userId !== currentUserId) return false;
+    const snapshot: SavedClimbSnapshot = {
+      uuid: climb.uuid,
+      boardType: boardName,
+      createdAt: climb.created_at ?? null,
+      publishedAt: climb.published_at ?? null,
+      isDraft: climb.is_draft ?? false,
+    };
+    return (climb.is_draft ?? false) || computeCanUpdate(snapshot, boardName);
+  }, [climb, currentUserId, boardName]);
+
   const snapPoints = useMemo(() => ['40%'], []);
 
   return (
@@ -142,6 +197,20 @@ function ClimbActionsSheet({
             showSeparator
           />
         )}
+        {canEdit && (
+          <ListRow
+            title={t('mobile.climbActions.edit')}
+            leading={<Icon name="edit" size={22} color={iosSystemColors.systemBlue} />}
+            onPress={handleEdit}
+            showSeparator
+          />
+        )}
+        <ListRow
+          title={t('mobile.climbActions.fork')}
+          leading={<Icon name="branch" size={22} color={iosSystemColors.systemBlue} />}
+          onPress={handleFork}
+          showSeparator
+        />
         <ListRow
           title={t('mobile.climbActions.copyLink')}
           leading={<Icon name="copy" size={22} color={iosSystemColors.systemBlue} />}

--- a/packages/mobile/src/components/create-climb/BrushBar.tsx
+++ b/packages/mobile/src/components/create-climb/BrushBar.tsx
@@ -1,0 +1,281 @@
+import { useMemo } from 'react';
+import { View, Pressable, StyleSheet } from 'react-native';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { useTranslation } from 'react-i18next';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import type { IconName } from '../icon-map';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { useTheme } from '../../providers/theme-provider';
+import { hapticSelection, hapticLight } from '../../lib/haptics';
+import { brandColors } from '../../theme/colors';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { PAINT_ROLES, brushRoleColor, useBrushRoleLabels, type BrushRole } from './brush-roles';
+
+// The save button's visual state, derived by the controller from auth + the
+// saved-climb snapshot + in-flight state.
+export type SaveButtonState = 'ready' | 'saving' | 'justSaved' | 'editLocked' | 'login';
+
+type BrushBarProps = {
+  boardName: BoardName;
+  selectedBrush: BrushRole;
+  onSelectBrush: (role: BrushRole) => void;
+  startingCount: number;
+  finishCount: number;
+  // Secondary controls.
+  saveState: SaveButtonState;
+  onSave: () => void;
+  onClear: () => void;
+  onOpenSettings: () => void;
+  onSetActive: () => void;
+  canSetActive: boolean;
+  /** Heatmap toggle is a placeholder until the heatmap lands; disabled when undefined. */
+  onToggleHeatmap?: () => void;
+  heatmapActive?: boolean;
+};
+
+// Looked up dynamically by role below; mark each resolvable key (one per line,
+// namespace-qualified) so the orphan checker keeps them.
+// i18n-keep climbs.mobile.create.brush.start
+// i18n-keep climbs.mobile.create.brush.hand
+// i18n-keep climbs.mobile.create.brush.finish
+// i18n-keep climbs.mobile.create.brush.foot
+const SAVE_ICON: Record<SaveButtonState, IconName> = {
+  ready: 'square.and.arrow.up.on.square',
+  saving: 'square.and.arrow.up.on.square',
+  justSaved: 'check.small',
+  editLocked: 'lock',
+  login: 'person',
+};
+
+/**
+ * Persistent bottom bar for the create-climb editor: brush role chips + the
+ * eraser on top, a start/finish counter, and the secondary control cluster
+ * (heatmap placeholder, settings, clear, save, set-active). Pure presentational
+ * — all state and callbacks come from the controller via the screen.
+ */
+export function BrushBar({
+  boardName,
+  selectedBrush,
+  onSelectBrush,
+  startingCount,
+  finishCount,
+  saveState,
+  onSave,
+  onClear,
+  onOpenSettings,
+  onSetActive,
+  canSetActive,
+  onToggleHeatmap,
+  heatmapActive = false,
+}: BrushBarProps) {
+  const { t } = useTranslation('climbs');
+  const { systemColors } = useTheme();
+  const roleLabels = useBrushRoleLabels();
+
+  const roleChips = useMemo(
+    () =>
+      PAINT_ROLES.map((role) => ({
+        role,
+        label: roleLabels[role],
+        color: brushRoleColor(boardName, role),
+      })),
+    [boardName, roleLabels],
+  );
+
+  const handleSelect = (role: BrushRole) => {
+    hapticSelection();
+    onSelectBrush(role);
+  };
+
+  return (
+    <View style={[styles.bar, { backgroundColor: systemColors.secondaryBackground }]}>
+      <View style={styles.chipRow}>
+        {roleChips.map(({ role, label, color }) => {
+          const selected = selectedBrush === role;
+          return (
+            <Pressable
+              key={role}
+              onPress={() => handleSelect(role)}
+              accessibilityRole="button"
+              accessibilityLabel={label}
+              accessibilityState={{ selected }}
+              style={[
+                styles.chip,
+                { backgroundColor: systemColors.fill },
+                selected && { borderColor: color, borderWidth: 2 },
+              ]}
+            >
+              <View style={[styles.swatch, { backgroundColor: color }]} />
+              <Text variant="footnote" style={styles.chipLabel} numberOfLines={1}>
+                {label}
+              </Text>
+            </Pressable>
+          );
+        })}
+        <Pressable
+          onPress={() => handleSelect('OFF')}
+          accessibilityRole="button"
+          accessibilityLabel={t('mobile.create.brush.erase')}
+          accessibilityState={{ selected: selectedBrush === 'OFF' }}
+          style={[
+            styles.chip,
+            { backgroundColor: systemColors.fill },
+            selectedBrush === 'OFF' && { borderColor: systemColors.label, borderWidth: 2 },
+          ]}
+        >
+          <Icon name="eraser" size={16} color={systemColors.label as string} />
+          <Text variant="footnote" style={styles.chipLabel} numberOfLines={1}>
+            {t('mobile.create.brush.erase')}
+          </Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.controlRow}>
+        <View style={styles.counters}>
+          <Text variant="footnote" color={systemColors.secondaryLabel}>
+            {t('mobile.create.counts.start', { count: startingCount })}
+          </Text>
+          <Text variant="footnote" color={systemColors.secondaryLabel}>
+            {t('mobile.create.counts.finish', { count: finishCount })}
+          </Text>
+        </View>
+
+        <View style={styles.actions}>
+          <SecondaryButton
+            icon="flame"
+            label={t('mobile.create.actions.heatmap')}
+            onPress={onToggleHeatmap}
+            active={heatmapActive}
+            disabled={!onToggleHeatmap}
+          />
+          <SecondaryButton icon="settings" label={t('mobile.create.actions.settings')} onPress={onOpenSettings} />
+          <SecondaryButton icon="delete" label={t('mobile.create.actions.clear')} onPress={onClear} />
+          <SecondaryButton
+            icon="play.circle"
+            label={t('mobile.create.actions.setActive')}
+            onPress={onSetActive}
+            disabled={!canSetActive}
+          />
+          <Pressable
+            onPress={() => {
+              if (saveState === 'saving' || saveState === 'editLocked') return;
+              hapticLight();
+              onSave();
+            }}
+            accessibilityRole="button"
+            accessibilityLabel={t('mobile.create.actions.save')}
+            disabled={saveState === 'saving' || saveState === 'editLocked'}
+            style={[styles.saveButton, saveState === 'editLocked' && styles.saveButtonDisabled]}
+          >
+            {saveState === 'saving' ? (
+              <ActivityIndicator size="small" color={brandColors.primary} />
+            ) : (
+              <Icon
+                name={SAVE_ICON[saveState]}
+                size={22}
+                color={saveState === 'editLocked' ? (systemColors.tertiaryLabel as string) : brandColors.primary}
+              />
+            )}
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function SecondaryButton({
+  icon,
+  label,
+  onPress,
+  active = false,
+  disabled = false,
+}: {
+  icon: IconName;
+  label: string;
+  onPress?: () => void;
+  active?: boolean;
+  disabled?: boolean;
+}) {
+  const { systemColors } = useTheme();
+  const color = disabled
+    ? (systemColors.tertiaryLabel as string)
+    : active
+      ? brandColors.primary
+      : (systemColors.label as string);
+  return (
+    <Pressable
+      onPress={() => {
+        if (disabled || !onPress) return;
+        hapticLight();
+        onPress();
+      }}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={styles.secondaryButton}
+    >
+      <Icon name={icon} size={22} color={color} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    paddingHorizontal: spacing[3],
+    paddingTop: spacing[2],
+    gap: spacing[2],
+  },
+  chipRow: {
+    flexDirection: 'row',
+    gap: spacing[2],
+  },
+  chip: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[1],
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[2],
+    borderRadius: borderRadius.md,
+    borderColor: 'transparent',
+    borderWidth: 2,
+  },
+  swatch: {
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+  },
+  chipLabel: {
+    fontWeight: '600',
+  },
+  controlRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  counters: {
+    gap: 2,
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  secondaryButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  saveButton: {
+    width: 44,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  saveButtonDisabled: {
+    opacity: 0.6,
+  },
+});

--- a/packages/mobile/src/components/create-climb/CreateClimbFab.tsx
+++ b/packages/mobile/src/components/create-climb/CreateClimbFab.tsx
@@ -1,0 +1,61 @@
+import { Pressable, Platform, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { Icon } from '../Icon';
+import { hapticLight } from '../../lib/haptics';
+import { brandColors } from '../../theme/colors';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing } from '../../theme/tokens';
+import { BAR_CONTENT_HEIGHT, TAB_BAR_HEIGHT } from '../../theme/layout';
+
+/**
+ * Floating "create a climb" button on the climbs list. Anchored bottom-right
+ * and lifted above the persistent queue bar + tab bar (mirrors
+ * CreatePlaylistFab). The parent gates rendering on auth + an active board.
+ */
+export function CreateClimbFab({ onPress }: { onPress: () => void }) {
+  const { t } = useTranslation('climbs');
+  const insets = useSafeAreaInsets();
+  const bottom = BAR_CONTENT_HEIGHT + TAB_BAR_HEIGHT + insets.bottom + spacing[3];
+
+  return (
+    <Pressable
+      onPress={() => {
+        hapticLight();
+        onPress();
+      }}
+      accessibilityRole="button"
+      accessibilityLabel={t('mobile.create.fab.ariaLabel')}
+      style={({ pressed }) => [styles.fab, { bottom }, pressed && styles.pressed]}
+    >
+      <Icon name="plus" size={28} color={iosSystemColors.white} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  fab: {
+    position: 'absolute',
+    right: spacing[4],
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: brandColors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.2,
+        shadowRadius: 8,
+      },
+      android: {
+        elevation: 6,
+      },
+    }),
+  },
+  pressed: {
+    opacity: 0.85,
+  },
+});

--- a/packages/mobile/src/components/create-climb/CreateClimbScreen.tsx
+++ b/packages/mobile/src/components/create-climb/CreateClimbScreen.tsx
@@ -1,0 +1,296 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { View, StyleSheet, KeyboardAvoidingView, Platform, Pressable } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { useTheme } from '../../providers/theme-provider';
+import { getCreateBoardHolds } from '../../lib/create-board-holds';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { brandColors } from '../../theme/colors';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { InteractiveCreateBoard } from './InteractiveCreateBoard';
+import { BrushBar } from './BrushBar';
+import { HoldRoleSheet } from './HoldRoleSheet';
+import { CreateClimbSettingsSheet } from './CreateClimbSettingsSheet';
+import { DraftsSheet } from './DraftsSheet';
+import { useCreateClimbScreen, type CreateClimbBoard } from './use-create-climb-screen';
+
+type CreateClimbScreenProps = {
+  board: CreateClimbBoard;
+  forkFrames?: string;
+  forkName?: string;
+  forkDescription?: string;
+  editClimbUuid?: string;
+};
+
+/**
+ * The create-climb editor screen: the interactive board, the persistent brush
+ * bar, and the long-press / settings / drafts sheets. Composes the controller
+ * hook with the no-SVG board renderer.
+ */
+export function CreateClimbScreen({
+  board,
+  forkFrames,
+  forkName,
+  forkDescription,
+  editClimbUuid,
+}: CreateClimbScreenProps) {
+  const { t } = useTranslation('climbs');
+  const { systemColors } = useTheme();
+  const router = useRouter();
+
+  const controller = useCreateClimbScreen({ board, forkFrames, forkName, forkDescription, editClimbUuid });
+
+  const [longPressHoldId, setLongPressHoldId] = useState<number | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [draftsOpen, setDraftsOpen] = useState(false);
+
+  // The controller asks the screen to open settings (e.g. an unnamed save).
+  useEffect(() => {
+    if (controller.openSettingsSignal > 0) setSettingsOpen(true);
+  }, [controller.openSettingsSignal]);
+
+  const boardHolds = useMemo(
+    () =>
+      getCreateBoardHolds({
+        boardName: board.boardName,
+        layoutId: board.layoutId,
+        sizeId: board.sizeId,
+        setIds: board.setIds.split(',').map(Number),
+      }),
+    [board.boardName, board.layoutId, board.sizeId, board.setIds],
+  );
+
+  const handleLongPress = useCallback((holdId: number) => setLongPressHoldId(holdId), []);
+  const closeHoldRole = useCallback(() => setLongPressHoldId(null), []);
+
+  if (!boardHolds) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: systemColors.background }]} edges={['bottom']}>
+        <View style={styles.centered}>
+          <Icon name="boards" size={48} color={iosSystemColors.systemGray4} />
+          <Text variant="headline" style={styles.centeredTitle}>
+            {t('mobile.create.unavailable.title')}
+          </Text>
+          <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.centeredSubtitle}>
+            {t('mobile.create.unavailable.subtitle')}
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: systemColors.background }]} edges={['bottom']}>
+      <KeyboardAvoidingView style={styles.flex} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        <View style={styles.boardArea}>
+          <InteractiveCreateBoard
+            boardName={board.boardName as BoardName}
+            layoutId={board.layoutId}
+            sizeId={board.sizeId}
+            setIds={board.setIds}
+            boardWidth={boardHolds.boardWidth}
+            boardHeight={boardHolds.boardHeight}
+            holdTargets={boardHolds.holdTargets}
+            litUpHoldsMap={controller.litUpHoldsMap}
+            onPaint={controller.handlePaint}
+            onLongPressHold={handleLongPress}
+            showAllHolds={controller.showAllHolds}
+          />
+        </View>
+
+        {controller.publishDuplicateError ? (
+          <DuplicateBanner
+            name={controller.publishDuplicateError.existingClimbName}
+            onView={
+              controller.publishDuplicateError.existingClimbUuid
+                ? () => {
+                    const uuid = controller.publishDuplicateError?.existingClimbUuid;
+                    if (!uuid) return;
+                    router.push({
+                      pathname: '/(tabs)/climbs/[climbUuid]',
+                      params: {
+                        climbUuid: uuid,
+                        boardName: board.boardName,
+                        layoutId: String(board.layoutId),
+                        sizeId: String(board.sizeId),
+                        setIds: board.setIds,
+                        angle: String(board.angle),
+                      },
+                    });
+                  }
+                : undefined
+            }
+            onDismiss={controller.dismissDuplicateError}
+          />
+        ) : null}
+
+        <View style={styles.barArea}>
+          <Pressable
+            onPress={() => setDraftsOpen(true)}
+            accessibilityRole="button"
+            accessibilityLabel={t('createClimbForm.openDrafts')}
+            style={styles.draftsLink}
+          >
+            <Icon name="history" size={16} color={brandColors.primary} />
+            <Text variant="footnote" color={brandColors.primary}>
+              {t('createClimbForm.openDrafts')}
+            </Text>
+          </Pressable>
+          <BrushBar
+            boardName={board.boardName as BoardName}
+            selectedBrush={controller.selectedBrush}
+            onSelectBrush={controller.setSelectedBrush}
+            startingCount={controller.startingCount}
+            finishCount={controller.finishCount}
+            saveState={controller.saveState}
+            onSave={() => void controller.handleSave()}
+            onClear={controller.handleClear}
+            onOpenSettings={() => setSettingsOpen(true)}
+            onSetActive={controller.handleSetActive}
+            canSetActive={controller.canSetActive}
+          />
+        </View>
+      </KeyboardAvoidingView>
+
+      <HoldRoleSheet
+        holdId={longPressHoldId}
+        boardName={board.boardName as BoardName}
+        litUpHoldsMap={controller.litUpHoldsMap}
+        startingCount={controller.startingCount}
+        finishCount={controller.finishCount}
+        onSelectRole={controller.handleAssignRole}
+        onClose={closeHoldRole}
+      />
+
+      <CreateClimbSettingsSheet
+        visible={settingsOpen}
+        name={controller.name}
+        description={controller.description}
+        isDraft={controller.isDraft}
+        showAllHolds={controller.showAllHolds}
+        onChangeName={controller.setName}
+        onChangeDescription={controller.setDescription}
+        onChangeIsDraft={controller.setIsDraft}
+        onChangeShowAllHolds={controller.setShowAllHolds}
+        bleAvailable={controller.bleAvailable}
+        bleConnected={controller.bleConnected}
+        bleConnecting={controller.bleConnecting}
+        onConnectBoard={controller.handleConnectBoard}
+        onDismiss={() => setSettingsOpen(false)}
+      />
+
+      <DraftsSheet
+        visible={draftsOpen}
+        board={board}
+        onLoadDraft={(climb) => {
+          // Re-enter the screen in edit mode for the picked draft so the
+          // controller re-seeds holds/name/description cleanly from it (rather
+          // than merging into the current working state).
+          setDraftsOpen(false);
+          router.replace({
+            pathname: '/(tabs)/climbs/create',
+            params: {
+              editClimbUuid: climb.uuid,
+              boardName: board.boardName,
+              layoutId: String(board.layoutId),
+              sizeId: String(board.sizeId),
+              setIds: board.setIds,
+              angle: String(board.angle),
+            },
+          });
+        }}
+        onDismiss={() => setDraftsOpen(false)}
+      />
+    </SafeAreaView>
+  );
+}
+
+function DuplicateBanner({
+  name,
+  onView,
+  onDismiss,
+}: {
+  name: string | null;
+  onView?: () => void;
+  onDismiss: () => void;
+}) {
+  const { t } = useTranslation('climbs');
+  const { systemColors } = useTheme();
+  return (
+    <View style={[styles.banner, { backgroundColor: systemColors.secondaryBackground }]}>
+      <View style={styles.bannerText}>
+        <Text variant="footnote">
+          {name
+            ? t('createClimbForm.alerts.publishDuplicateNamed', { name })
+            : t('createClimbForm.alerts.publishDuplicateUnnamed')}
+        </Text>
+        {onView ? (
+          <Pressable onPress={onView} accessibilityRole="button">
+            <Text variant="footnote" color={brandColors.primary}>
+              {t('createClimbForm.alerts.viewMatchingClimb')}
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+      <Pressable onPress={onDismiss} accessibilityRole="button" hitSlop={8}>
+        <Icon name="close" size={16} color={systemColors.secondaryLabel as string} />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  flex: {
+    flex: 1,
+  },
+  boardArea: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing[3],
+  },
+  barArea: {
+    paddingBottom: spacing[2],
+  },
+  draftsLink: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+    alignSelf: 'flex-end',
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+  },
+  banner: {
+    marginHorizontal: spacing[3],
+    marginBottom: spacing[2],
+    padding: spacing[3],
+    borderRadius: borderRadius.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+  },
+  bannerText: {
+    flex: 1,
+    gap: spacing[1],
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[2],
+    paddingHorizontal: spacing[6],
+  },
+  centeredTitle: {
+    marginTop: spacing[2],
+  },
+  centeredSubtitle: {
+    textAlign: 'center',
+  },
+});

--- a/packages/mobile/src/components/create-climb/CreateClimbSettingsSheet.tsx
+++ b/packages/mobile/src/components/create-climb/CreateClimbSettingsSheet.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { View, StyleSheet, type TextStyle } from 'react-native';
+import { BottomSheetModal, BottomSheetTextInput } from '@gorhom/bottom-sheet';
+import { useTranslation } from 'react-i18next';
+import { ModalSheet } from '../ModalSheet';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { SwitchRow } from '../SwitchRow';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { brandColors } from '../../theme/colors';
+import { Button } from '../Button';
+
+const NAME_MAX = 80;
+const DESCRIPTION_MAX = 500;
+
+type CreateClimbSettingsSheetProps = {
+  visible: boolean;
+  name: string;
+  description: string;
+  isDraft: boolean;
+  showAllHolds: boolean;
+  onChangeName: (next: string) => void;
+  onChangeDescription: (next: string) => void;
+  onChangeIsDraft: (next: boolean) => void;
+  onChangeShowAllHolds: (next: boolean) => void;
+  // BLE connect. `bleAvailable` is false when no board is active (no provider).
+  bleAvailable: boolean;
+  bleConnected: boolean;
+  bleConnecting: boolean;
+  onConnectBoard: () => void;
+  onDismiss: () => void;
+};
+
+/**
+ * Gear-sheet for the create-climb editor: climb name + description, the draft
+ * toggle, the show-all-holds discoverability toggle, and a one-tap board (BLE)
+ * connect so the user can light their wall while building.
+ */
+export function CreateClimbSettingsSheet({
+  visible,
+  name,
+  description,
+  isDraft,
+  showAllHolds,
+  onChangeName,
+  onChangeDescription,
+  onChangeIsDraft,
+  onChangeShowAllHolds,
+  bleAvailable,
+  bleConnected,
+  bleConnecting,
+  onConnectBoard,
+  onDismiss,
+}: CreateClimbSettingsSheetProps) {
+  const { t } = useTranslation('climbs');
+  const { systemColors } = useTheme();
+  const sheetRef = useRef<BottomSheetModal>(null);
+
+  useEffect(() => {
+    if (visible) {
+      sheetRef.current?.present();
+    } else {
+      sheetRef.current?.dismiss();
+    }
+  }, [visible]);
+
+  const inputStyle = useMemo<TextStyle>(
+    () => ({
+      backgroundColor: systemColors.fill as string,
+      color: systemColors.label as string,
+      borderRadius: borderRadius.md,
+      paddingHorizontal: spacing[3],
+      paddingVertical: spacing[3],
+      fontSize: 16,
+    }),
+    [systemColors],
+  );
+
+  if (!visible) return null;
+
+  return (
+    <ModalSheet ref={sheetRef} snapPoints={['72%']} onDismiss={onDismiss} scrollable>
+      <View style={styles.body}>
+        <Text variant="title3" style={styles.title}>
+          {t('createClimbForm.settings.title')}
+        </Text>
+
+        <Text variant="footnote" style={styles.label}>
+          {t('createClimbForm.fields.name')}
+        </Text>
+        <BottomSheetTextInput
+          value={name}
+          onChangeText={onChangeName}
+          placeholder={t('createClimbForm.namePlaceholder')}
+          placeholderTextColor={systemColors.tertiaryLabel as string}
+          maxLength={NAME_MAX}
+          style={inputStyle}
+          returnKeyType="done"
+        />
+
+        <Text variant="footnote" style={styles.label}>
+          {t('createClimbForm.fields.description')}
+        </Text>
+        <BottomSheetTextInput
+          value={description}
+          onChangeText={onChangeDescription}
+          placeholder={t('createClimbForm.descriptionPlaceholder')}
+          placeholderTextColor={systemColors.tertiaryLabel as string}
+          maxLength={DESCRIPTION_MAX}
+          multiline
+          style={[inputStyle, styles.multiline]}
+        />
+
+        <View style={styles.switches}>
+          <SwitchRow
+            label={t('mobile.create.settings.draftLabel')}
+            description={t('mobile.create.settings.draftDescription')}
+            value={isDraft}
+            onValueChange={onChangeIsDraft}
+          />
+          <SwitchRow
+            label={t('mobile.create.settings.showAllHoldsLabel')}
+            description={t('mobile.create.settings.showAllHoldsDescription')}
+            value={showAllHolds}
+            onValueChange={onChangeShowAllHolds}
+          />
+        </View>
+
+        <View style={styles.bleSection}>
+          {bleConnected ? (
+            <View style={styles.bleConnected}>
+              <Icon name="bluetooth.connected" size={20} color={brandColors.success} />
+              <Text variant="subheadline" color={systemColors.secondaryLabel}>
+                {t('mobile.create.settings.bleConnected')}
+              </Text>
+            </View>
+          ) : (
+            <Button
+              title={t('mobile.create.settings.connectBoard')}
+              icon="bluetooth"
+              variant="outlined"
+              onPress={onConnectBoard}
+              loading={bleConnecting}
+              disabled={!bleAvailable || bleConnecting}
+            />
+          )}
+          {!bleAvailable ? (
+            <Text variant="footnote" color={systemColors.tertiaryLabel} style={styles.bleHint}>
+              {t('mobile.create.settings.bleUnavailable')}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+    </ModalSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+    paddingBottom: spacing[6],
+    gap: spacing[2],
+  },
+  title: {
+    marginBottom: spacing[2],
+  },
+  label: {
+    marginTop: spacing[2],
+    opacity: 0.6,
+  },
+  multiline: {
+    minHeight: 88,
+    textAlignVertical: 'top',
+  },
+  switches: {
+    marginTop: spacing[3],
+    marginHorizontal: -spacing[4],
+  },
+  bleSection: {
+    marginTop: spacing[4],
+    gap: spacing[2],
+  },
+  bleConnected: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  bleHint: {
+    textAlign: 'center',
+  },
+});

--- a/packages/mobile/src/components/create-climb/DraftsSheet.tsx
+++ b/packages/mobile/src/components/create-climb/DraftsSheet.tsx
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { View, Pressable, StyleSheet, Alert } from 'react-native';
+import { BottomSheetModal, BottomSheetFlatList } from '@gorhom/bottom-sheet';
+import { useTranslation } from 'react-i18next';
+import type { BoardName, Climb, ClimbSearchInput } from '@boardsesh/shared-schema';
+import { ModalSheet } from '../ModalSheet';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { useTheme } from '../../providers/theme-provider';
+import { useToast } from '../../providers/toast-provider';
+import { useSearchClimbs, useDeleteDraftClimb } from '../../lib/graphql/hooks';
+import { hapticLight } from '../../lib/haptics';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { iosSystemColors } from '../../theme/ios-colors';
+
+type BoardConfig = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
+
+type DraftsSheetProps = {
+  visible: boolean;
+  board: BoardConfig;
+  onLoadDraft: (climb: Climb) => void;
+  onDismiss: () => void;
+};
+
+// Count painted holds in an Aurora frames string (`p{id}r{code}` per hold).
+function countHolds(frames: string): number {
+  const matches = frames.match(/p\d+r\d+/g);
+  return matches ? matches.length : 0;
+}
+
+function formatRelativeTime(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const then = Date.parse(iso);
+  if (!Number.isFinite(then)) return '';
+  const seconds = Math.round((Date.now() - then) / 1000);
+  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+  if (seconds < 60) return formatter.format(-seconds, 'second');
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return formatter.format(-minutes, 'minute');
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return formatter.format(-hours, 'hour');
+  const days = Math.round(hours / 24);
+  if (days < 30) return formatter.format(-days, 'day');
+  const months = Math.round(days / 30);
+  if (months < 12) return formatter.format(-months, 'month');
+  return formatter.format(-Math.round(months / 12), 'year');
+}
+
+/**
+ * Lists the climber's saved draft climbs for the active board. Tapping a draft
+ * loads it back into the editor; the trash icon deletes it (with confirm).
+ */
+export function DraftsSheet({ visible, board, onLoadDraft, onDismiss }: DraftsSheetProps) {
+  const { t } = useTranslation('climbs');
+  const { systemColors } = useTheme();
+  const { showToast } = useToast();
+  const sheetRef = useRef<BottomSheetModal>(null);
+  const deleteDraft = useDeleteDraftClimb();
+
+  useEffect(() => {
+    if (visible) {
+      sheetRef.current?.present();
+    } else {
+      sheetRef.current?.dismiss();
+    }
+  }, [visible]);
+
+  const searchInput = useMemo<ClimbSearchInput>(
+    () => ({
+      boardName: board.boardName,
+      layoutId: board.layoutId,
+      sizeId: board.sizeId,
+      setIds: board.setIds,
+      angle: board.angle,
+      page: 1,
+      pageSize: 50,
+      onlyDrafts: true,
+      sortBy: 'creation',
+      sortOrder: 'desc',
+    }),
+    [board],
+  );
+
+  const { data, isLoading, isError } = useSearchClimbs(searchInput, visible);
+  const drafts = data?.climbs ?? [];
+
+  const handleDelete = useCallback(
+    (climb: Climb) => {
+      Alert.alert(t('draftsDrawer.delete.title'), t('draftsDrawer.delete.description'), [
+        { text: t('createClimbForm.dismiss'), style: 'cancel' },
+        {
+          text: t('draftsDrawer.delete.confirm'),
+          style: 'destructive',
+          onPress: () => {
+            deleteDraft.mutate(
+              { uuid: climb.uuid, boardType: board.boardName },
+              {
+                onSuccess: () => showToast(t('draftsDrawer.delete.success'), 'success'),
+                onError: () => showToast(t('draftsDrawer.delete.error'), 'error'),
+              },
+            );
+          },
+        },
+      ]);
+    },
+    [board.boardName, deleteDraft, showToast, t],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: Climb }) => {
+      const holdCount = countHolds(item.frames);
+      const relative = formatRelativeTime(item.created_at);
+      const subtitleParts = [t('mobile.create.drafts.holds', { count: holdCount }), relative].filter(Boolean);
+      return (
+        <View style={styles.row}>
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              onLoadDraft(item);
+            }}
+            accessibilityRole="button"
+            accessibilityLabel={item.name || t('createClimbForm.draftBadge')}
+            style={styles.rowMain}
+          >
+            <Text variant="body" numberOfLines={1}>
+              {item.name || t('createClimbForm.draftBadge')}
+            </Text>
+            <Text variant="footnote" color={systemColors.secondaryLabel} numberOfLines={1}>
+              {subtitleParts.join(' · ')}
+            </Text>
+          </Pressable>
+          <Pressable
+            onPress={() => handleDelete(item)}
+            accessibilityRole="button"
+            accessibilityLabel={t('draftsDrawer.delete.tooltip')}
+            hitSlop={8}
+            style={styles.deleteButton}
+          >
+            <Icon name="delete" size={20} color={iosSystemColors.systemRed} />
+          </Pressable>
+        </View>
+      );
+    },
+    [handleDelete, onLoadDraft, systemColors.secondaryLabel, t],
+  );
+
+  if (!visible) return null;
+
+  return (
+    <ModalSheet ref={sheetRef} snapPoints={['72%']} onDismiss={onDismiss}>
+      <View style={styles.header}>
+        <Text variant="title3">{t('draftsDrawer.title')}</Text>
+        {drafts.length > 0 ? (
+          <Text variant="footnote" color={systemColors.secondaryLabel}>
+            {t('draftsDrawer.count', { count: drafts.length })}
+          </Text>
+        ) : null}
+      </View>
+
+      {isLoading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" />
+        </View>
+      ) : isError ? (
+        <View style={styles.centered}>
+          <Text variant="subheadline" color={systemColors.secondaryLabel}>
+            {t('draftsDrawer.loadError')}
+          </Text>
+        </View>
+      ) : drafts.length === 0 ? (
+        <View style={styles.centered}>
+          <Text variant="headline">{t('draftsDrawer.empty.title')}</Text>
+          <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptySubtitle}>
+            {t('draftsDrawer.empty.subtitle')}
+          </Text>
+        </View>
+      ) : (
+        <BottomSheetFlatList
+          data={drafts}
+          keyExtractor={(item) => item.uuid}
+          renderItem={renderItem}
+          contentContainerStyle={styles.listContent}
+        />
+      )}
+    </ModalSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[2],
+    alignItems: 'center',
+    gap: 2,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing[6],
+    gap: spacing[2],
+  },
+  emptySubtitle: {
+    textAlign: 'center',
+  },
+  listContent: {
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[8],
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing[3],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: iosSystemColors.separator,
+    gap: spacing[2],
+  },
+  rowMain: {
+    flex: 1,
+    gap: 2,
+  },
+  deleteButton: {
+    padding: spacing[2],
+    borderRadius: borderRadius.md,
+  },
+});

--- a/packages/mobile/src/components/create-climb/HoldRoleSheet.tsx
+++ b/packages/mobile/src/components/create-climb/HoldRoleSheet.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { View, Pressable, StyleSheet } from 'react-native';
+import BottomSheet from '@gorhom/bottom-sheet';
+import { useTranslation } from 'react-i18next';
+import type { BoardName, HoldState, LitUpHoldsMap } from '@boardsesh/shared-schema';
+import { Sheet } from '../Sheet';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { useTheme } from '../../providers/theme-provider';
+import { hapticSelection } from '../../lib/haptics';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { PAINT_ROLES, brushRoleColor, useBrushRoleLabels, type BrushRole } from './brush-roles';
+
+type HoldRoleSheetProps = {
+  /** The long-pressed hold, or null when the sheet is closed. */
+  holdId: number | null;
+  boardName: BoardName;
+  litUpHoldsMap: LitUpHoldsMap;
+  startingCount: number;
+  finishCount: number;
+  onSelectRole: (holdId: number, role: BrushRole) => void;
+  onClose: () => void;
+};
+
+/**
+ * Long-press role picker for a single hold. Lets the user assign Start / Hand /
+ * Finish / Foot, or clear the hold. Start and Finish are disabled once two are
+ * placed (unless the long-pressed hold already holds that role, so the user can
+ * re-confirm or switch it).
+ */
+export function HoldRoleSheet({
+  holdId,
+  boardName,
+  litUpHoldsMap,
+  startingCount,
+  finishCount,
+  onSelectRole,
+  onClose,
+}: HoldRoleSheetProps) {
+  const { t } = useTranslation('climbs');
+  const { systemColors } = useTheme();
+  const roleLabels = useBrushRoleLabels();
+  const sheetRef = useRef<BottomSheet>(null);
+
+  useEffect(() => {
+    if (holdId != null) {
+      sheetRef.current?.snapToIndex(0);
+    } else {
+      sheetRef.current?.close();
+    }
+  }, [holdId]);
+
+  const currentState: HoldState | undefined = holdId != null ? litUpHoldsMap[holdId]?.state : undefined;
+
+  const snapPoints = useMemo(() => ['38%'], []);
+
+  const handleSelect = (role: BrushRole) => {
+    if (holdId == null) return;
+    hapticSelection();
+    onSelectRole(holdId, role);
+    onClose();
+  };
+
+  return (
+    <Sheet ref={sheetRef} snapPoints={snapPoints} onClose={onClose} enablePanDownToClose fullWindowOverlay>
+      <View style={styles.content}>
+        <Text variant="headline" style={styles.title}>
+          {t('mobile.create.holdRole.title')}
+        </Text>
+        <View style={styles.grid}>
+          {PAINT_ROLES.map((role) => {
+            const isCurrent = currentState === role;
+            const atCap = (role === 'STARTING' && startingCount >= 2) || (role === 'FINISH' && finishCount >= 2);
+            const disabled = atCap && !isCurrent;
+            const color = brushRoleColor(boardName, role);
+            return (
+              <Pressable
+                key={role}
+                onPress={() => handleSelect(role)}
+                disabled={disabled}
+                accessibilityRole="button"
+                accessibilityLabel={roleLabels[role]}
+                accessibilityState={{ selected: isCurrent, disabled }}
+                style={[
+                  styles.cell,
+                  { backgroundColor: systemColors.fill },
+                  isCurrent && { borderColor: color, borderWidth: 2 },
+                  disabled && styles.cellDisabled,
+                ]}
+              >
+                <View style={[styles.swatch, { backgroundColor: color }]} />
+                <Text variant="subheadline" style={styles.cellLabel}>
+                  {roleLabels[role]}
+                </Text>
+              </Pressable>
+            );
+          })}
+          <Pressable
+            onPress={() => handleSelect('OFF')}
+            accessibilityRole="button"
+            accessibilityLabel={t('mobile.create.holdRole.clear')}
+            style={[styles.cell, { backgroundColor: systemColors.fill }]}
+          >
+            <Icon name="eraser" size={20} color={systemColors.label as string} />
+            <Text variant="subheadline" style={styles.cellLabel}>
+              {t('mobile.create.holdRole.clear')}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </Sheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+    gap: spacing[3],
+  },
+  title: {
+    textAlign: 'center',
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+  },
+  cell: {
+    width: '48%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[3],
+    borderRadius: borderRadius.md,
+    borderColor: 'transparent',
+    borderWidth: 2,
+  },
+  cellDisabled: {
+    opacity: 0.4,
+  },
+  swatch: {
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+  },
+  cellLabel: {
+    fontWeight: '600',
+  },
+});

--- a/packages/mobile/src/components/create-climb/HoldTarget.tsx
+++ b/packages/mobile/src/components/create-climb/HoldTarget.tsx
@@ -1,0 +1,87 @@
+import React, { useMemo } from 'react';
+import { View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { runOnJS } from 'react-native-reanimated';
+
+type HoldTargetProps = {
+  holdId: number;
+  leftPct: number;
+  topPct: number;
+  tapDiameter: number;
+  /** Diameter of the faint discoverability dot, in device px. */
+  dotDiameter: number;
+  showDot: boolean;
+  dotColor: string;
+  onPaint: (holdId: number) => void;
+  onLongPress: (holdId: number) => void;
+};
+
+/**
+ * One hold's transparent tap target plus an optional discoverability dot. A
+ * `GestureDetector` (not Pressable) is used so the per-hold tap/long-press
+ * compose cleanly with the board's ancestor pinch/pan gestures. A quick
+ * stationary touch paints; a 400ms press opens the role sheet; a drag falls
+ * through to the pan gesture (the Tap fails on movement > maxDistance).
+ *
+ * `React.memo` leaf with primitive props — the static tap layer never
+ * re-renders when holds are painted.
+ */
+export const HoldTarget = React.memo(function HoldTarget({
+  holdId,
+  leftPct,
+  topPct,
+  tapDiameter,
+  dotDiameter,
+  showDot,
+  dotColor,
+  onPaint,
+  onLongPress,
+}: HoldTargetProps) {
+  const gesture = useMemo(() => {
+    const tap = Gesture.Tap()
+      .maxDuration(300)
+      .maxDistance(15)
+      .onStart(() => {
+        'worklet';
+        runOnJS(onPaint)(holdId);
+      });
+    const longPress = Gesture.LongPress()
+      .minDuration(400)
+      .onStart(() => {
+        'worklet';
+        runOnJS(onLongPress)(holdId);
+      });
+    // Long-press wins; tap fires only if the long-press fails (released early).
+    return Gesture.Exclusive(longPress, tap);
+  }, [holdId, onPaint, onLongPress]);
+
+  return (
+    <GestureDetector gesture={gesture}>
+      <View
+        style={{
+          position: 'absolute',
+          left: `${leftPct}%`,
+          top: `${topPct}%`,
+          width: tapDiameter,
+          height: tapDiameter,
+          marginLeft: -tapDiameter / 2,
+          marginTop: -tapDiameter / 2,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {showDot ? (
+          <View
+            pointerEvents="none"
+            style={{
+              width: dotDiameter,
+              height: dotDiameter,
+              borderRadius: dotDiameter / 2,
+              backgroundColor: dotColor,
+            }}
+          />
+        ) : null}
+      </View>
+    </GestureDetector>
+  );
+});

--- a/packages/mobile/src/components/create-climb/HoldTargetLayer.tsx
+++ b/packages/mobile/src/components/create-climb/HoldTargetLayer.tsx
@@ -1,0 +1,65 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { BoardHoldTarget } from '../../lib/create-board-holds';
+import { holdGeometry } from './holdLayout';
+import { HoldTarget } from './HoldTarget';
+
+type HoldTargetLayerProps = {
+  holdTargets: BoardHoldTarget[];
+  boardWidth: number;
+  boardHeight: number;
+  measuredWidth: number;
+  mirrored: boolean;
+  /** When true, every hold gets a brighter, larger discoverability dot. */
+  showAllHolds: boolean;
+  onPaint: (holdId: number) => void;
+  onLongPress: (holdId: number) => void;
+};
+
+const FAINT_DOT = 'rgba(255,255,255,0.22)';
+const BRIGHT_DOT = 'rgba(255,255,255,0.55)';
+const FAINT_DOT_DIAMETER = 6;
+
+/**
+ * Static, memoized layer of one tap target per hold. Intentionally independent
+ * of the painted state so it never re-renders when a hold is painted — the
+ * PaintedHoldsLayer draws colored rings on top and visually covers the dot.
+ */
+export const HoldTargetLayer = React.memo(function HoldTargetLayer({
+  holdTargets,
+  boardWidth,
+  boardHeight,
+  measuredWidth,
+  mirrored,
+  showAllHolds,
+  onPaint,
+  onLongPress,
+}: HoldTargetLayerProps) {
+  const targets = useMemo(() => {
+    if (measuredWidth <= 0) return null;
+    return holdTargets.map((hold) => {
+      const geometry = holdGeometry(hold, boardWidth, boardHeight, measuredWidth, mirrored);
+      const dotDiameter = showAllHolds ? Math.max(FAINT_DOT_DIAMETER, geometry.ringDiameter * 0.4) : FAINT_DOT_DIAMETER;
+      return (
+        <HoldTarget
+          key={hold.id}
+          holdId={hold.id}
+          leftPct={geometry.leftPct}
+          topPct={geometry.topPct}
+          tapDiameter={geometry.tapDiameter}
+          dotDiameter={dotDiameter}
+          showDot
+          dotColor={showAllHolds ? BRIGHT_DOT : FAINT_DOT}
+          onPaint={onPaint}
+          onLongPress={onLongPress}
+        />
+      );
+    });
+  }, [holdTargets, boardWidth, boardHeight, measuredWidth, mirrored, showAllHolds, onPaint, onLongPress]);
+
+  return (
+    <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+      {targets}
+    </View>
+  );
+});

--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -1,0 +1,160 @@
+import React, { useCallback, useMemo, useState, type ReactNode } from 'react';
+import { View, StyleSheet, Pressable, type LayoutChangeEvent } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import type { BoardName, LitUpHoldsMap } from '@boardsesh/shared-schema';
+import { BoardImageNative } from '../BoardImageNative';
+import { Text } from '../Text';
+import { useZoomPanGesture } from '../play-drawer/use-zoom-pan-gesture';
+import { overlays } from '../../theme/tokens';
+import type { BoardHoldTarget } from '../../lib/create-board-holds';
+import { HoldTargetLayer } from './HoldTargetLayer';
+import { PaintedHoldsLayer } from './PaintedHoldsLayer';
+
+type InteractiveCreateBoardProps = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  boardWidth: number;
+  boardHeight: number;
+  holdTargets: BoardHoldTarget[];
+  litUpHoldsMap: LitUpHoldsMap;
+  onPaint: (holdId: number) => void;
+  onLongPressHold: (holdId: number) => void;
+  mirrored?: boolean;
+  showAllHolds?: boolean;
+  /** Optional overlay (e.g. heatmap) drawn between the background and the holds. */
+  overlay?: ReactNode;
+};
+
+/**
+ * The no-SVG interactive board editor. The background is the bundled board PNG
+ * (via BoardImageNative with empty frames); painted holds and tap targets are
+ * plain RN Views placed INSIDE the zoom-transformed Animated.View, so RNGH
+ * hit-tests them in board-local space and taps land correctly at any zoom level
+ * with zero manual coordinate math.
+ */
+export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard({
+  boardName,
+  layoutId,
+  sizeId,
+  setIds,
+  boardWidth,
+  boardHeight,
+  holdTargets,
+  litUpHoldsMap,
+  onPaint,
+  onLongPressHold,
+  mirrored = false,
+  showAllHolds = false,
+  overlay,
+}: InteractiveCreateBoardProps) {
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  const { pinchGesture, zoomPanGesture, isZoomed, resetZoom, animatedZoomStyle } = useZoomPanGesture({
+    enabled: true,
+    containerWidth: size.width,
+    containerHeight: size.height,
+  });
+
+  const holdById = useMemo(() => {
+    const map = new Map<number, BoardHoldTarget>();
+    for (const hold of holdTargets) map.set(hold.id, hold);
+    return map;
+  }, [holdTargets]);
+
+  // Pinch (2-finger) and pan (1-finger, no-ops until zoomed) run together. The
+  // per-hold Tap/LongPress detectors are nested children, so a stationary tap
+  // wins (paint) while a drag activates the pan. If a device shows the pan
+  // stealing quick taps while zoomed, add `.activeOffsetX([-8,8]).activeOffsetY([-8,8])`
+  // to zoomPanGesture in use-zoom-pan-gesture.
+  const rootGesture = useMemo(() => Gesture.Simultaneous(pinchGesture, zoomPanGesture), [pinchGesture, zoomPanGesture]);
+
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+    setSize((prev) => (prev.width === width && prev.height === height ? prev : { width, height }));
+  }, []);
+
+  const containerStyle = useMemo(
+    () => [styles.clip, { aspectRatio: boardWidth / boardHeight }],
+    [boardWidth, boardHeight],
+  );
+
+  return (
+    <View style={styles.root}>
+      <GestureDetector gesture={rootGesture}>
+        <View style={containerStyle} onLayout={handleLayout}>
+          <Animated.View style={[styles.board, animatedZoomStyle]}>
+            <BoardImageNative
+              frames=""
+              boardName={boardName}
+              layoutId={layoutId}
+              sizeId={sizeId}
+              setIds={setIds}
+              boardWidth={boardWidth}
+              boardHeight={boardHeight}
+              mirrored={mirrored}
+            />
+            {overlay ? (
+              <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+                {overlay}
+              </View>
+            ) : null}
+            <HoldTargetLayer
+              holdTargets={holdTargets}
+              boardWidth={boardWidth}
+              boardHeight={boardHeight}
+              measuredWidth={size.width}
+              mirrored={mirrored}
+              showAllHolds={showAllHolds}
+              onPaint={onPaint}
+              onLongPress={onLongPressHold}
+            />
+            <PaintedHoldsLayer
+              litUpHoldsMap={litUpHoldsMap}
+              holdById={holdById}
+              boardWidth={boardWidth}
+              boardHeight={boardHeight}
+              measuredWidth={size.width}
+              mirrored={mirrored}
+            />
+          </Animated.View>
+
+          {isZoomed ? (
+            <Pressable style={styles.resetButton} onPress={resetZoom} hitSlop={8} accessibilityRole="button">
+              <Text variant="footnote" style={styles.resetLabel}>
+                Reset zoom
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </GestureDetector>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  root: {
+    width: '100%',
+  },
+  clip: {
+    width: '100%',
+    overflow: 'hidden',
+  },
+  board: {
+    width: '100%',
+  },
+  resetButton: {
+    position: 'absolute',
+    top: 12,
+    right: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    backgroundColor: overlays.scrim,
+  },
+  resetLabel: {
+    color: overlays.onScrim,
+  },
+});

--- a/packages/mobile/src/components/create-climb/PaintedHoldsLayer.tsx
+++ b/packages/mobile/src/components/create-climb/PaintedHoldsLayer.tsx
@@ -1,0 +1,56 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { LitUpHoldsMap } from '@boardsesh/shared-schema';
+import type { BoardHoldTarget } from '../../lib/create-board-holds';
+import { holdGeometry } from './holdLayout';
+import { PaintedRing } from './PaintedRing';
+
+type PaintedHoldsLayerProps = {
+  litUpHoldsMap: LitUpHoldsMap;
+  holdById: Map<number, BoardHoldTarget>;
+  boardWidth: number;
+  boardHeight: number;
+  measuredWidth: number;
+  mirrored: boolean;
+};
+
+/**
+ * Absolute overlay drawing one PaintedRing per painted hold. This is the only
+ * layer that re-renders on a brush tap, and it maps over `litUpHoldsMap` (a
+ * handful of holds) rather than every hold on the board.
+ */
+export const PaintedHoldsLayer = React.memo(function PaintedHoldsLayer({
+  litUpHoldsMap,
+  holdById,
+  boardWidth,
+  boardHeight,
+  measuredWidth,
+  mirrored,
+}: PaintedHoldsLayerProps) {
+  const rings = useMemo(() => {
+    if (measuredWidth <= 0) return [];
+    return Object.entries(litUpHoldsMap)
+      .map(([holdIdStr, hold]) => {
+        const holdId = Number(holdIdStr);
+        const target = holdById.get(holdId);
+        if (!target) return null;
+        const geometry = holdGeometry(target, boardWidth, boardHeight, measuredWidth, mirrored);
+        return (
+          <PaintedRing
+            key={holdId}
+            leftPct={geometry.leftPct}
+            topPct={geometry.topPct}
+            diameter={geometry.ringDiameter}
+            color={hold.displayColor || hold.color}
+          />
+        );
+      })
+      .filter(Boolean);
+  }, [litUpHoldsMap, holdById, boardWidth, boardHeight, measuredWidth, mirrored]);
+
+  return (
+    <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+      {rings}
+    </View>
+  );
+});

--- a/packages/mobile/src/components/create-climb/PaintedRing.tsx
+++ b/packages/mobile/src/components/create-climb/PaintedRing.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { hexWithAlpha } from './holdLayout';
+
+type PaintedRingProps = {
+  leftPct: number;
+  topPct: number;
+  diameter: number;
+  /** Display color of the hold's role (from HOLD_STATE_MAP displayColor). */
+  color: string;
+};
+
+/**
+ * A single painted-hold indicator: a translucent filled ring centred on the
+ * hold. Plain RN View — no SVG — so it repaints instantly when the brush state
+ * changes. `React.memo` with primitive props keeps the painted layer cheap.
+ */
+export const PaintedRing = React.memo(function PaintedRing({ leftPct, topPct, diameter, color }: PaintedRingProps) {
+  return (
+    <View
+      pointerEvents="none"
+      style={[
+        styles.ring,
+        {
+          left: `${leftPct}%`,
+          top: `${topPct}%`,
+          width: diameter,
+          height: diameter,
+          marginLeft: -diameter / 2,
+          marginTop: -diameter / 2,
+          borderRadius: diameter / 2,
+          borderWidth: Math.max(2, diameter * 0.15),
+          borderColor: color,
+          backgroundColor: hexWithAlpha(color, 0.28),
+        },
+      ]}
+    />
+  );
+});
+
+const styles = StyleSheet.create({
+  ring: {
+    position: 'absolute',
+  },
+});

--- a/packages/mobile/src/components/create-climb/brush-roles.ts
+++ b/packages/mobile/src/components/create-climb/brush-roles.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { HOLD_STATE_MAP, STATE_TO_PRIMARY_CODE } from '@boardsesh/board-constants/hold-states';
+import type { BoardName, HoldState } from '@boardsesh/shared-schema';
+
+// The four paintable roles plus the eraser. `'OFF'` clears a hold; the four
+// named roles map straight onto the create-climb hold-state machine's
+// `setHoldState(holdId, role)`.
+export type BrushRole = Extract<HoldState, 'STARTING' | 'HAND' | 'FINISH' | 'FOOT'> | 'OFF';
+
+export const PAINT_ROLES: ReadonlyArray<Exclude<BrushRole, 'OFF'>> = ['STARTING', 'HAND', 'FINISH', 'FOOT'];
+
+/**
+ * The swatch colour for a role on a given board, taken from the board's
+ * canonical role code (the same code the frame string and BLE encoder use).
+ * Falls back to a neutral grey when a board doesn't define the role (e.g. a
+ * Tycho-style colour-only product has no STARTING/FINISH) so the chip stays
+ * visible rather than rendering an undefined colour.
+ */
+export function brushRoleColor(boardName: BoardName, role: Exclude<BrushRole, 'OFF'>): string {
+  const code = STATE_TO_PRIMARY_CODE[boardName]?.[role];
+  if (code === undefined) return '#8E8E93';
+  const info = HOLD_STATE_MAP[boardName]?.[code];
+  if (!info) return '#8E8E93';
+  return info.displayColor || info.color;
+}
+
+/**
+ * Localised labels for the four paint roles, built from static `t()` calls so
+ * the i18n orphan checker can trace every key (a `t(variable)` lookup is
+ * lint-blocked). Shared by the brush bar and the long-press role sheet.
+ */
+export function useBrushRoleLabels(): Record<Exclude<BrushRole, 'OFF'>, string> {
+  const { t } = useTranslation('climbs');
+  return useMemo(
+    () => ({
+      STARTING: t('mobile.create.brush.start'),
+      HAND: t('mobile.create.brush.hand'),
+      FINISH: t('mobile.create.brush.finish'),
+      FOOT: t('mobile.create.brush.foot'),
+    }),
+    [t],
+  );
+}

--- a/packages/mobile/src/components/create-climb/holdLayout.ts
+++ b/packages/mobile/src/components/create-climb/holdLayout.ts
@@ -1,0 +1,56 @@
+import type { BoardHoldTarget } from '../../lib/create-board-holds';
+
+/** Minimum touch target per the iOS HIG / a11y guidance. */
+export const MIN_TAP_DIAMETER = 44;
+
+/**
+ * Append an alpha channel to a `#RGB`/`#RRGGBB` hex color. Returns the input
+ * unchanged for anything else (e.g. the `#FFF` fallback the frame parser emits
+ * for unknown codes) so we never produce an invalid color string.
+ */
+export function hexWithAlpha(hex: string, alpha: number): string {
+  const clamped = Math.max(0, Math.min(1, alpha));
+  const aa = Math.round(clamped * 255)
+    .toString(16)
+    .padStart(2, '0');
+  if (/^#[0-9a-fA-F]{6}$/.test(hex)) return `${hex}${aa}`;
+  if (/^#[0-9a-fA-F]{3}$/.test(hex)) {
+    const [, r, g, b] = hex;
+    return `#${r}${r}${g}${g}${b}${b}${aa}`;
+  }
+  return hex;
+}
+
+export type HoldGeometry = {
+  /** Percentage anchor of the hold centre across the board (resolution-independent). */
+  leftPct: number;
+  topPct: number;
+  /** Painted-ring diameter in device px (centred on the anchor via negative margins). */
+  ringDiameter: number;
+  /** Transparent tap-target diameter in device px (>= MIN_TAP_DIAMETER). */
+  tapDiameter: number;
+};
+
+/**
+ * Compute a hold's on-screen geometry. Positions stay percentage-based — the
+ * viewport box already has the board's aspect ratio, so a mid-session relayout
+ * (rotation, keyboard) self-corrects. Only the diameter needs the measured
+ * device-px scale. `mirrored` flips horizontally for left-handed preview without
+ * touching which hold id is written.
+ */
+export function holdGeometry(
+  hold: BoardHoldTarget,
+  boardWidth: number,
+  boardHeight: number,
+  measuredWidth: number,
+  mirrored: boolean,
+  radiusMultiplier = 1,
+): HoldGeometry {
+  const scale = measuredWidth / boardWidth;
+  const cxPct = (hold.cx / boardWidth) * 100;
+  const leftPct = mirrored ? 100 - cxPct : cxPct;
+  const topPct = (hold.cy / boardHeight) * 100;
+  const ringDiameter = hold.r * 2 * scale * radiusMultiplier;
+  const tapDiameter = Math.max(ringDiameter * 1.6, MIN_TAP_DIAMETER);
+  return { leftPct, topPct, ringDiameter, tapDiameter };
+}

--- a/packages/mobile/src/components/create-climb/index.ts
+++ b/packages/mobile/src/components/create-climb/index.ts
@@ -1,0 +1,8 @@
+export { CreateClimbScreen } from './CreateClimbScreen';
+export { CreateClimbFab } from './CreateClimbFab';
+export { BrushBar, type SaveButtonState } from './BrushBar';
+export { HoldRoleSheet } from './HoldRoleSheet';
+export { CreateClimbSettingsSheet } from './CreateClimbSettingsSheet';
+export { DraftsSheet } from './DraftsSheet';
+export { useCreateClimbScreen, type CreateClimbBoard } from './use-create-climb-screen';
+export { PAINT_ROLES, brushRoleColor, type BrushRole } from './brush-roles';

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -1,0 +1,446 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { randomUUID } from 'expo-crypto';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import type { BoardName, Climb } from '@boardsesh/shared-schema';
+import {
+  useCreateClimb,
+  computeCanUpdate,
+  computeEditLocked,
+  buildInitialHoldsMap,
+  type SavedClimbSnapshot,
+} from '@boardsesh/create-climb-react';
+import { useBoardProvider, isDuplicateClimbError } from '@boardsesh/board-react';
+import { GraphQLOperationError } from '@boardsesh/graphql-client';
+import { useAuth } from '../../providers/auth-provider';
+import { useProfile, useClimb } from '../../lib/graphql/hooks';
+import { useQueue } from '../../providers/queue-provider';
+import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
+import { useToast } from '../../providers/toast-provider';
+import { climbToQueueItem } from '../../lib/climb-to-queue-item';
+import { loadDraft, saveDraft, clearDraft, createClimbDraftKey } from '../../lib/create-climb-draft-store';
+import type { BrushRole } from './brush-roles';
+import type { SaveButtonState } from './BrushBar';
+
+export type CreateClimbBoard = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
+
+type UseCreateClimbScreenArgs = {
+  board: CreateClimbBoard;
+  /** Single-frame holds string to seed a fork from (no savedClimb tracked). */
+  forkFrames?: string;
+  forkName?: string;
+  forkDescription?: string;
+  /** When set, fetch and edit this existing climb in place. */
+  editClimbUuid?: string;
+};
+
+const AUTOSAVE_DEBOUNCE_MS = 500;
+const BLE_PREVIEW_DEBOUNCE_MS = 250;
+const JUST_SAVED_MS = 3000;
+
+/** Duplicate-publish detail surfaced inline so the user can view the match. */
+export type PublishDuplicateError = {
+  existingClimbUuid: string | null;
+  existingClimbName: string | null;
+};
+
+function readDuplicateExtensions(err: unknown): PublishDuplicateError {
+  if (err instanceof GraphQLOperationError) {
+    const extensions = err.extensions as { existingClimbUuid?: unknown; existingClimbName?: unknown } | undefined;
+    return {
+      existingClimbUuid: typeof extensions?.existingClimbUuid === 'string' ? extensions.existingClimbUuid : null,
+      existingClimbName: typeof extensions?.existingClimbName === 'string' ? extensions.existingClimbName : null,
+    };
+  }
+  return { existingClimbUuid: null, existingClimbName: null };
+}
+
+/**
+ * The create-climb screen controller. Composes the shared hold-state machine
+ * with auth, the board provider's save/update mutations, the per-board local
+ * autosave, BLE preview, and the queue, and exposes a save state machine the
+ * BrushBar renders.
+ */
+export function useCreateClimbScreen({
+  board,
+  forkFrames,
+  forkName,
+  forkDescription,
+  editClimbUuid,
+}: UseCreateClimbScreenArgs) {
+  const router = useRouter();
+  const { t } = useTranslation('climbs');
+  const { isAuthenticated, saveClimb, updateClimb } = useBoardProvider();
+  const auth = useAuth();
+  const { data: profile } = useProfile();
+  const { setCurrentClimb } = useQueue();
+  const bluetooth = useOptionalBluetoothContext();
+  const { showToast } = useToast();
+
+  const isForking = !!forkFrames;
+  const isEditing = !!editClimbUuid;
+
+  // Seed the editor from a fork's frames once; an empty start otherwise. Edit
+  // mode seeds asynchronously below (guarded by a ref).
+  const initialHoldsMap = useMemo(
+    () => (isForking && forkFrames ? buildInitialHoldsMap(forkFrames, board.boardName) : {}),
+    // Seed only once from the route param — board.boardName is stable per screen.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const {
+    litUpHoldsMap,
+    setHoldState,
+    generateFramesString,
+    startingCount,
+    finishCount,
+    isValid,
+    resetHolds,
+    loadHolds,
+  } = useCreateClimb(board.boardName, { initialHoldsMap });
+
+  const [selectedBrush, setSelectedBrush] = useState<BrushRole>('HAND');
+  const [name, setName] = useState(isForking && forkName ? `${forkName} fork` : '');
+  const [description, setDescription] = useState(isForking && forkDescription ? forkDescription : '');
+  const [isDraft, setIsDraft] = useState(true);
+  const [showAllHolds, setShowAllHolds] = useState(false);
+
+  const [savedClimb, setSavedClimb] = useState<SavedClimbSnapshot | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [justSaved, setJustSaved] = useState(false);
+  const [publishDuplicateError, setPublishDuplicateError] = useState<PublishDuplicateError | null>(null);
+
+  const draftKey = useMemo(() => createClimbDraftKey(board), [board]);
+  // Skip the local-autosave restore when forking or editing (those seed from
+  // their own source); also skip until the initial restore lands.
+  const skipRestoreRef = useRef(isForking || isEditing);
+  const restoredRef = useRef(false);
+  // Stable provisional queue-item uuid for an unsaved WIP, so re-tapping "Set as
+  // active" updates the same queue slot instead of appending a new item each tap.
+  const previewUuidRef = useRef<string | null>(null);
+  if (!previewUuidRef.current) previewUuidRef.current = randomUUID();
+  // Tracked so the just-saved confirmation timer is cleared on unmount.
+  const justSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (justSavedTimerRef.current) clearTimeout(justSavedTimerRef.current);
+    },
+    [],
+  );
+
+  // ---- Edit mode: fetch the climb and seed the editor once. ----
+  const editVariables = useMemo(
+    () =>
+      isEditing && editClimbUuid
+        ? {
+            boardName: board.boardName,
+            layoutId: board.layoutId,
+            sizeId: board.sizeId,
+            setIds: board.setIds,
+            angle: board.angle,
+            climbUuid: editClimbUuid,
+          }
+        : null,
+    [isEditing, editClimbUuid, board],
+  );
+  const { data: editClimb } = useClimb(editVariables);
+  const editSeededRef = useRef(false);
+  useEffect(() => {
+    if (!editClimb || editSeededRef.current) return;
+    editSeededRef.current = true;
+    loadHolds(buildInitialHoldsMap(editClimb.frames, board.boardName));
+    setName(editClimb.name);
+    setDescription(editClimb.description ?? '');
+    setIsDraft(editClimb.is_draft ?? false);
+    setSavedClimb({
+      uuid: editClimb.uuid,
+      boardType: board.boardName,
+      createdAt: editClimb.created_at ?? null,
+      publishedAt: editClimb.published_at ?? null,
+      isDraft: editClimb.is_draft ?? false,
+    });
+  }, [editClimb, board.boardName, loadHolds]);
+
+  // ---- Local autosave restore on mount. ----
+  useEffect(() => {
+    if (skipRestoreRef.current) {
+      restoredRef.current = true;
+      return;
+    }
+    let cancelled = false;
+    void loadDraft(draftKey).then((draft) => {
+      if (cancelled || !draft) {
+        restoredRef.current = true;
+        return;
+      }
+      try {
+        const parsed = JSON.parse(draft.holdsJson) as Record<number, { state: string }>;
+        loadHolds(parsed as Parameters<typeof loadHolds>[0]);
+      } catch {
+        // Corrupt holds payload — ignore and start clean.
+      }
+      setName(draft.name);
+      setDescription(draft.description);
+      setIsDraft(draft.isDraft);
+      restoredRef.current = true;
+    });
+    return () => {
+      cancelled = true;
+    };
+    // draftKey is stable per screen mount; restore once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ---- Local autosave (debounced). ----
+  const holdsJson = useMemo(() => JSON.stringify(litUpHoldsMap), [litUpHoldsMap]);
+  useEffect(() => {
+    if (!restoredRef.current) return;
+    // Edit mode operates on an existing climb — never persist it into the
+    // per-board new-draft autosave slot, or it resurfaces as a phantom draft.
+    if (isEditing) return;
+    const hasContent = Object.keys(litUpHoldsMap).length > 0 || name.trim() !== '' || description.trim() !== '';
+    const handle = setTimeout(() => {
+      if (!hasContent) {
+        void clearDraft(draftKey);
+        return;
+      }
+      void saveDraft(draftKey, { holdsJson, name, description, isDraft });
+    }, AUTOSAVE_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [holdsJson, name, description, isDraft, draftKey, litUpHoldsMap]);
+
+  // ---- BLE preview (debounced) while connected. ----
+  const sendFramesRef = useRef(bluetooth?.sendFramesToBoard);
+  sendFramesRef.current = bluetooth?.sendFramesToBoard;
+  const bleConnected = bluetooth?.isConnected ?? false;
+  useEffect(() => {
+    if (!bleConnected) return;
+    const handle = setTimeout(() => {
+      void sendFramesRef.current?.(generateFramesString());
+    }, BLE_PREVIEW_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [holdsJson, bleConnected, generateFramesString]);
+
+  // ---- Painting + role assignment. ----
+  const handlePaint = useCallback(
+    (holdId: number) => {
+      setHoldState(holdId, selectedBrush);
+    },
+    [setHoldState, selectedBrush],
+  );
+
+  const handleAssignRole = useCallback(
+    (holdId: number, role: BrushRole) => {
+      setHoldState(holdId, role);
+    },
+    [setHoldState],
+  );
+
+  const handleClear = useCallback(() => {
+    resetHolds();
+    setSavedClimb(null);
+    setPublishDuplicateError(null);
+    // Fresh climb identity for the next WIP so its queue item is independent.
+    previewUuidRef.current = randomUUID();
+    void clearDraft(draftKey);
+  }, [resetHolds, draftKey]);
+
+  // Build a minimal Climb the queue can hold for a not-yet-saved or just-saved
+  // climb. The mutation input (`ClimbInput`) is a strict subset of Climb, so
+  // these placeholder grade fields are never sent to the server — they only
+  // satisfy the type and render neutral values in the queue UI.
+  const buildProvisionalClimb = useCallback(
+    (uuid: string, frames: string): Climb => ({
+      uuid,
+      name: name.trim() || t('createClimbForm.draftBadge'),
+      frames,
+      setter_username: profile?.displayName ?? '',
+      angle: board.angle,
+      ascensionist_count: 0,
+      difficulty: '',
+      quality_average: '0',
+      stars: 0,
+      difficulty_error: '0',
+      benchmark_difficulty: null,
+    }),
+    [name, profile, board.angle, t],
+  );
+
+  // Push the freshly saved climb into the queue as the current climb so the
+  // board (and any connected BLE wall) reflects what was just published.
+  // Known limitation: re-saving a climb that is ALREADY the active queue item
+  // won't refresh its frames via the queue — the reducer short-circuits a
+  // same-uuid local SET_CURRENT_CLIMB. The live BLE preview keeps the local
+  // wall correct; a mobile queue `updateQueueItem` is the follow-up for peers.
+  const syncSavedToQueue = useCallback(
+    (uuid: string, frames: string) => {
+      setCurrentClimb(climbToQueueItem(buildProvisionalClimb(uuid, frames), { uuid }));
+    },
+    [buildProvisionalClimb, setCurrentClimb],
+  );
+
+  // ---- Set Active: build a minimal Climb and push to the queue. ----
+  const handleSetActive = useCallback(() => {
+    const frames = generateFramesString();
+    if (!frames) return;
+    const uuid = savedClimb?.uuid ?? previewUuidRef.current ?? randomUUID();
+    setCurrentClimb(climbToQueueItem(buildProvisionalClimb(uuid, frames), { uuid }));
+  }, [generateFramesString, savedClimb, buildProvisionalClimb, setCurrentClimb]);
+
+  // ---- BLE connect. ----
+  const handleConnectBoard = useCallback(() => {
+    if (!bluetooth) return;
+    void bluetooth.connect(generateFramesString());
+  }, [bluetooth, generateFramesString]);
+
+  // ---- Save state machine. ----
+  const editLocked = computeEditLocked(savedClimb);
+  const canUpdate = computeCanUpdate(savedClimb, board.boardName);
+
+  const saveState: SaveButtonState = useMemo(() => {
+    if (!isAuthenticated) return 'login';
+    if (isSaving) return 'saving';
+    if (justSaved) return 'justSaved';
+    if (editLocked) return 'editLocked';
+    return 'ready';
+  }, [isAuthenticated, isSaving, justSaved, editLocked]);
+
+  // Signal the screen should open the settings sheet (e.g. to fill in a name).
+  const [openSettingsSignal, setOpenSettingsSignal] = useState(0);
+  const requestOpenSettings = useCallback(() => setOpenSettingsSignal((value) => value + 1), []);
+
+  const handleSave = useCallback(async () => {
+    if (!isAuthenticated) {
+      router.push('/auth/login');
+      return;
+    }
+    if (editLocked) return;
+    if (!isValid) return;
+    if (name.trim() === '') {
+      requestOpenSettings();
+      return;
+    }
+
+    setIsSaving(true);
+    setPublishDuplicateError(null);
+    const frames = generateFramesString();
+    try {
+      if (canUpdate && savedClimb) {
+        const result = await updateClimb({
+          uuid: savedClimb.uuid,
+          boardType: board.boardName,
+          name: name.trim(),
+          description,
+          frames,
+          angle: board.angle,
+          isDraft,
+        });
+        setSavedClimb({
+          uuid: result.uuid,
+          boardType: board.boardName,
+          createdAt: result.createdAt ?? savedClimb.createdAt,
+          publishedAt: result.publishedAt ?? savedClimb.publishedAt,
+          isDraft: result.isDraft,
+        });
+        syncSavedToQueue(result.uuid, frames);
+      } else {
+        const result = await saveClimb({
+          layout_id: board.layoutId,
+          name: name.trim(),
+          description,
+          is_draft: isDraft,
+          frames,
+          angle: board.angle,
+        });
+        setSavedClimb({
+          uuid: result.uuid,
+          boardType: board.boardName,
+          createdAt: result.createdAt ?? null,
+          publishedAt: result.publishedAt ?? null,
+          isDraft,
+        });
+        syncSavedToQueue(result.uuid, frames);
+      }
+      await clearDraft(draftKey);
+      setJustSaved(true);
+      if (justSavedTimerRef.current) clearTimeout(justSavedTimerRef.current);
+      justSavedTimerRef.current = setTimeout(() => setJustSaved(false), JUST_SAVED_MS);
+    } catch (err) {
+      if (isDuplicateClimbError(err)) {
+        setPublishDuplicateError(readDuplicateExtensions(err));
+      } else {
+        showToast(t('createClimbForm.alerts.saveFailedFallback'), 'error');
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    isAuthenticated,
+    router,
+    editLocked,
+    isValid,
+    name,
+    canUpdate,
+    savedClimb,
+    generateFramesString,
+    updateClimb,
+    saveClimb,
+    board,
+    description,
+    isDraft,
+    draftKey,
+    requestOpenSettings,
+    syncSavedToQueue,
+    showToast,
+    t,
+  ]);
+
+  const dismissDuplicateError = useCallback(() => setPublishDuplicateError(null), []);
+
+  const canSetActive = isValid;
+
+  return {
+    // editor state
+    litUpHoldsMap,
+    startingCount,
+    finishCount,
+    isValid,
+    selectedBrush,
+    setSelectedBrush,
+    handlePaint,
+    handleAssignRole,
+    handleClear,
+    showAllHolds,
+    setShowAllHolds,
+    // form fields
+    name,
+    setName,
+    description,
+    setDescription,
+    isDraft,
+    setIsDraft,
+    // save
+    saveState,
+    handleSave,
+    canSetActive,
+    handleSetActive,
+    publishDuplicateError,
+    dismissDuplicateError,
+    openSettingsSignal,
+    // ble
+    bleAvailable: !!bluetooth,
+    bleConnected,
+    bleConnecting: bluetooth?.loading ?? false,
+    handleConnectBoard,
+    // auth (re-export so the screen can render a login affordance if needed)
+    isAuthenticated,
+    refreshAuthState: auth.refreshAuthState,
+  };
+}

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -63,6 +63,14 @@ export const iconMap = {
   playlist: { ios: 'folder.badge.plus', android: 'folder-plus-outline' },
   send: { ios: 'paperplane.fill', android: 'send' },
 
+  // Create climb
+  flame: { ios: 'flame', android: 'fire' },
+  lock: { ios: 'lock', android: 'lock-outline' },
+  'play.circle': { ios: 'play.circle', android: 'play-circle-outline' },
+  'square.and.arrow.up.on.square': { ios: 'square.and.arrow.up.on.square', android: 'tray-arrow-up' },
+  eraser: { ios: 'eraser', android: 'eraser' },
+  'hand.raised': { ios: 'hand.raised', android: 'hand-back-right-outline' },
+
   // Status
   info: { ios: 'info.circle', android: 'information-outline' },
   warning: { ios: 'exclamationmark.triangle', android: 'alert-outline' },

--- a/packages/mobile/src/lib/create-board-holds.ts
+++ b/packages/mobile/src/lib/create-board-holds.ts
@@ -1,0 +1,40 @@
+import type { BoardName } from '@boardsesh/shared-schema';
+import { getBoardRenderData } from './board-details';
+
+/**
+ * The minimal per-hold geometry the interactive editor needs to place a tap
+ * target + painted indicator. Both Aurora (`getBoardRenderData`) and MoonBoard
+ * (`getMoonBoardDetails`, added in the MoonBoard PR) already produce
+ * `{id, cx, cy, r}` in board-space pixels, so one editor renders either family.
+ */
+export type BoardHoldTarget = { id: number; cx: number; cy: number; r: number };
+
+export type CreateBoardHolds = {
+  holdTargets: BoardHoldTarget[];
+  boardWidth: number;
+  boardHeight: number;
+  family: 'aurora' | 'moonboard';
+};
+
+/**
+ * Resolve the full set of tappable holds for a board configuration, board-family
+ * agnostic. Aurora boards come from the hole-placement pipeline; the MoonBoard
+ * grid branch is added alongside MoonBoard create support.
+ */
+export function getCreateBoardHolds(cfg: {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: number[];
+}): CreateBoardHolds | null {
+  // MoonBoard uses a separate grid source (getMoonBoardDetails); added in the
+  // MoonBoard PR. For now every supported create board is an Aurora board.
+  const data = getBoardRenderData(cfg);
+  if (!data) return null;
+  return {
+    holdTargets: data.holdsData.map((hold) => ({ id: hold.id, cx: hold.cx, cy: hold.cy, r: hold.r })),
+    boardWidth: data.boardWidth,
+    boardHeight: data.boardHeight,
+    family: 'aurora',
+  };
+}

--- a/packages/mobile/src/lib/create-climb-draft-store.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.ts
@@ -1,0 +1,65 @@
+// Local autosave for the in-progress create-climb form, keyed per board
+// config so switching boards (or angle) restores the right working draft. This
+// is NOT the server-side draft list (that lives in board_climb_stats and is
+// read via SEARCH_CLIMBS `onlyDrafts`); this is a single client-only snapshot
+// of whatever the user is currently painting, so a backgrounded app or an
+// accidental navigation doesn't lose their work-in-progress.
+//
+// Backed by AsyncStorage (non-secret UI state) via the shared preference store.
+
+import { getPreference, setPreference, removePreference } from './preference-store';
+
+export type CreateClimbDraft = {
+  /** JSON.stringify of the editor's LitUpHoldsMap. */
+  holdsJson: string;
+  name: string;
+  description: string;
+  isDraft: boolean;
+};
+
+const KEY_PREFIX = 'boardsesh_create_climb_draft:';
+
+/**
+ * Stable per-board key. Matches the brief's
+ * `${boardName}:${layoutId}:${sizeId}:${angle}` so two configs that differ in
+ * any of those restore independent working drafts.
+ */
+export function createClimbDraftKey(config: {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  angle: number;
+}): string {
+  return `${config.boardName}:${config.layoutId}:${config.sizeId}:${config.angle}`;
+}
+
+function storageKey(boardKey: string): string {
+  return `${KEY_PREFIX}${boardKey}`;
+}
+
+function isCreateClimbDraft(value: unknown): value is CreateClimbDraft {
+  if (value == null || typeof value !== 'object') return false;
+  const candidate = value as Partial<CreateClimbDraft>;
+  return (
+    typeof candidate.holdsJson === 'string' &&
+    typeof candidate.name === 'string' &&
+    typeof candidate.description === 'string' &&
+    typeof candidate.isDraft === 'boolean'
+  );
+}
+
+/** Returns the saved working draft for this board, or null if none/invalid. */
+export async function loadDraft(boardKey: string): Promise<CreateClimbDraft | null> {
+  const stored = await getPreference<unknown>(storageKey(boardKey));
+  return isCreateClimbDraft(stored) ? stored : null;
+}
+
+/** Persists the current working draft for this board (overwrites any prior). */
+export async function saveDraft(boardKey: string, draft: CreateClimbDraft): Promise<void> {
+  await setPreference(storageKey(boardKey), draft);
+}
+
+/** Drops the working draft for this board (after save, clear, or empty form). */
+export async function clearDraft(boardKey: string): Promise<void> {
+  await removePreference(storageKey(boardKey));
+}

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -21,6 +21,11 @@ import {
   CLIMB_STATS_HISTORY,
   type ClimbStatsHistoryResponse,
 } from '@boardsesh/graphql/operations';
+import {
+  DELETE_DRAFT_CLIMB_MUTATION,
+  type DeleteDraftClimbMutationVariables,
+  type DeleteDraftClimbMutationResponse,
+} from '@boardsesh/graphql/operations/new-climb-feed';
 import { getHttpClient } from '../client';
 import {
   GET_PROFILE,
@@ -218,6 +223,29 @@ export function useClimb(variables: GetClimbQueryVariables | null) {
     queryFn: () => getHttpClient().request<GetClimbQueryResponse>(GET_CLIMB, variables!),
     select: (data) => data.climb,
     enabled: !!variables,
+  });
+}
+
+/**
+ * Delete a draft climb. The backend only permits deleting climbs that are
+ * still drafts and owned by the caller. Busts the climb-search caches so the
+ * deleted draft disappears from the drafts list (and any climb list) without a
+ * manual reload.
+ */
+export function useDeleteDraftClimb() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (variables: DeleteDraftClimbMutationVariables) => {
+      const response = await getHttpClient().request<DeleteDraftClimbMutationResponse>(
+        DELETE_DRAFT_CLIMB_MUTATION,
+        variables,
+      );
+      return response.deleteDraftClimb;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
+      void queryClient.invalidateQueries({ queryKey: ['searchClimbsCount'] });
+    },
   });
 }
 

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -65,6 +65,7 @@ const BOARD_FIELDS = `
 const CLIMB_SEARCH_FIELDS = `
   uuid
   setter_username
+  userId
   name
   frames
   angle

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -20,7 +20,7 @@ import { LogAscentSheet } from '../components/LogAscentSheet';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
 import { ClimbActionsSheet } from '../components/ClimbActionsSheet';
 import { AddToPlaylistSheet } from '../components/AddToPlaylistSheet';
-import { useToggleFavorite } from '../lib/graphql/hooks';
+import { useToggleFavorite, useProfile } from '../lib/graphql/hooks';
 import { useQueue } from './queue-provider';
 
 export type BoardConfig = {
@@ -89,6 +89,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const { addToQueue, setSessionBoardPath } = useQueue();
   const setActiveBoard = useSetActiveBoard();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
+  const { data: profile } = useProfile();
 
   // Climb to open after the boardConfig override has committed. We can't
   // open synchronously inside openPlayDrawer when an override is supplied
@@ -278,6 +279,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           sizeId={climbActions.boardConfig.sizeId}
           setIds={climbActions.boardConfig.setIds}
           angle={climbActions.boardConfig.angle}
+          currentUserId={profile?.id ?? null}
           onAddToQueue={handleClimbActionsAddToQueue}
           onToggleFavorite={handleClimbActionsToggleFavorite}
           onTick={handleClimbActionsTick}

--- a/packages/shared/create-climb-react/package.json
+++ b/packages/shared/create-climb-react/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@boardsesh/create-climb-react",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@boardsesh/board-constants": "*",
+    "@boardsesh/shared-schema": "*"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19",
+    "@vitest/coverage-v8": "^4.1.5",
+    "happy-dom": "^15",
+    "react": "^19",
+    "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "react": "^19"
+  }
+}

--- a/packages/shared/create-climb-react/src/__tests__/helpers.test.ts
+++ b/packages/shared/create-climb-react/src/__tests__/helpers.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EDIT_WINDOW_MS, computeCanUpdate, computeEditLocked, buildInitialHoldsMap } from '../helpers';
+
+vi.mock('@boardsesh/board-constants/hold-states', () => ({
+  // Single-frame: `p{id}r{code}`. Multi-frame: comma-separated, later frames win.
+  convertLitUpHoldsStringToMap: (frames: string) => {
+    const result: Record<number, Record<number, { state: string; color: string; displayColor: string }>> = {};
+    frames
+      .split(',')
+      .filter(Boolean)
+      .forEach((frame, index) => {
+        const holds: Record<number, { state: string; color: string; displayColor: string }> = {};
+        for (const match of frame.matchAll(/p(\d+)r(\d+)/g)) {
+          const holdId = Number(match[1]);
+          const code = Number(match[2]);
+          const state = code === 42 ? 'STARTING' : code === 43 ? 'HAND' : 'FINISH';
+          holds[holdId] = { state, color: '#fff', displayColor: '#fff' };
+        }
+        result[index] = holds;
+      });
+    return result;
+  },
+}));
+
+const NOW = Date.parse('2026-06-03T12:00:00.000Z');
+const within = new Date(NOW - 60 * 60 * 1000).toISOString(); // 1h ago
+const expired = new Date(NOW - 48 * 60 * 60 * 1000).toISOString(); // 48h ago
+
+describe('computeCanUpdate', () => {
+  it('returns false with no saved climb', () => {
+    expect(computeCanUpdate(null, 'kilter', NOW)).toBe(false);
+  });
+
+  it('returns false on board mismatch', () => {
+    const saved = { uuid: 'a', boardType: 'tension', createdAt: null, publishedAt: within, isDraft: false };
+    expect(computeCanUpdate(saved, 'kilter', NOW)).toBe(false);
+  });
+
+  it('returns true for a draft regardless of age', () => {
+    const saved = { uuid: 'a', boardType: 'kilter', createdAt: null, publishedAt: null, isDraft: true };
+    expect(computeCanUpdate(saved, 'kilter', NOW)).toBe(true);
+  });
+
+  it('returns true for a climb published within the window', () => {
+    const saved = { uuid: 'a', boardType: 'kilter', createdAt: null, publishedAt: within, isDraft: false };
+    expect(computeCanUpdate(saved, 'kilter', NOW)).toBe(true);
+  });
+
+  it('returns false for a climb published past the window', () => {
+    const saved = { uuid: 'a', boardType: 'kilter', createdAt: null, publishedAt: expired, isDraft: false };
+    expect(computeCanUpdate(saved, 'kilter', NOW)).toBe(false);
+  });
+});
+
+describe('computeEditLocked', () => {
+  it('is false for drafts', () => {
+    const saved = { uuid: 'a', boardType: 'kilter', createdAt: null, publishedAt: null, isDraft: true };
+    expect(computeEditLocked(saved, NOW)).toBe(false);
+  });
+
+  it('is false within the window', () => {
+    const saved = { uuid: 'a', boardType: 'kilter', createdAt: null, publishedAt: within, isDraft: false };
+    expect(computeEditLocked(saved, NOW)).toBe(false);
+  });
+
+  it('is true past the window', () => {
+    const saved = { uuid: 'a', boardType: 'kilter', createdAt: null, publishedAt: expired, isDraft: false };
+    expect(computeEditLocked(saved, NOW)).toBe(true);
+  });
+
+  it('EDIT_WINDOW_MS is 24h', () => {
+    expect(EDIT_WINDOW_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});
+
+describe('buildInitialHoldsMap', () => {
+  it('returns empty for empty frames', () => {
+    expect(buildInitialHoldsMap('', 'kilter')).toEqual({});
+  });
+
+  it('parses a single frame', () => {
+    expect(buildInitialHoldsMap('p100r42p200r43', 'kilter')).toEqual({
+      100: { state: 'STARTING', color: '#fff', displayColor: '#fff' },
+      200: { state: 'HAND', color: '#fff', displayColor: '#fff' },
+    });
+  });
+
+  it('merges multi-frame with later frames overriding', () => {
+    const map = buildInitialHoldsMap('p100r42,p100r43p200r44', 'kilter');
+    expect(map[100].state).toBe('HAND'); // later frame wins
+    expect(map[200].state).toBe('FINISH');
+  });
+});

--- a/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
+++ b/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi } from 'vite-plus/test';
+import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useCreateClimb } from '../use-create-climb';
 
-vi.mock('../../board-renderer/types', () => ({
+vi.mock('@boardsesh/board-constants/hold-states', () => ({
   HOLD_STATE_MAP: {
     kilter: {
       42: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
@@ -302,6 +302,27 @@ describe('useCreateClimb', () => {
       expect(result.current.totalHolds).toBe(2);
       expect(result.current.startingCount).toBe(1);
       expect(result.current.isValid).toBe(true);
+    });
+  });
+
+  describe('loadHolds', () => {
+    it('replaces the entire holds map', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+
+      const next = {
+        200: { state: 'HAND' as const, color: '#00FFFF', displayColor: '#00FFFF' },
+        300: { state: 'FINISH' as const, color: '#FF00FF', displayColor: '#FF00FF' },
+      };
+      act(() => {
+        result.current.loadHolds(next);
+      });
+
+      expect(result.current.litUpHoldsMap).toEqual(next);
+      expect(result.current.litUpHoldsMap[100]).toBeUndefined();
     });
   });
 

--- a/packages/shared/create-climb-react/src/helpers.ts
+++ b/packages/shared/create-climb-react/src/helpers.ts
@@ -1,0 +1,60 @@
+import type { BoardName, LitUpHoldsMap } from '@boardsesh/shared-schema';
+import { convertLitUpHoldsStringToMap } from '@boardsesh/board-constants/hold-states';
+
+/** Window after first publish during which a non-draft climb can still be edited. */
+export const EDIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The minimal record of a saved climb the editor tracks so subsequent saves
+ * can update the same row (vs. creating a new one) and so the edit lock can be
+ * computed. Mirrors the web form's `SavedClimbState`.
+ */
+export type SavedClimbSnapshot = {
+  uuid: string;
+  boardType: string;
+  createdAt: string | null;
+  /** ISO timestamp of first publish; null while the climb is a draft. */
+  publishedAt: string | null;
+  isDraft: boolean;
+};
+
+/**
+ * Can the tracked row be updated in place rather than creating a new one?
+ * Mirrors web `create-climb-form.tsx` `canUpdate`: same board, and either still
+ * a draft (editable indefinitely) or published within the 24h edit window.
+ */
+export function computeCanUpdate(
+  saved: SavedClimbSnapshot | null,
+  boardType: string,
+  now: number = Date.now(),
+): boolean {
+  if (!saved) return false;
+  if (saved.boardType !== boardType) return false;
+  if (saved.isDraft) return true;
+  if (!saved.publishedAt) return false;
+  const publishedMs = Date.parse(saved.publishedAt);
+  return Number.isFinite(publishedMs) && now - publishedMs <= EDIT_WINDOW_MS;
+}
+
+/**
+ * Is the tracked row published and past the 24h window (no further edits)?
+ * Mirrors web `editLocked`. Drafts are never locked.
+ */
+export function computeEditLocked(saved: SavedClimbSnapshot | null, now: number = Date.now()): boolean {
+  if (!saved || saved.isDraft || !saved.publishedAt) return false;
+  const publishedMs = Date.parse(saved.publishedAt);
+  return Number.isFinite(publishedMs) && now - publishedMs > EDIT_WINDOW_MS;
+}
+
+/**
+ * Flatten a (possibly multi-frame) fork/draft frames string into a single
+ * Aurora holds map for seeding the editor. Later frames override earlier ones,
+ * matching the web form's draft-load behaviour.
+ */
+export function buildInitialHoldsMap(frames: string, board: BoardName): LitUpHoldsMap {
+  if (!frames) return {};
+  const framesMap = convertLitUpHoldsStringToMap(frames, board);
+  return Object.entries(framesMap)
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .reduce((acc, [, frame]) => ({ ...acc, ...frame }), {} as LitUpHoldsMap);
+}

--- a/packages/shared/create-climb-react/src/index.ts
+++ b/packages/shared/create-climb-react/src/index.ts
@@ -1,0 +1,13 @@
+// Shared, renderer-agnostic create-climb logic for web + React Native.
+// Pure React + board-constants/shared-schema: no DOM, no react-native, no
+// react-query, no MUI. Hold-state machine + save-decision helpers; platform
+// apps own rendering, persistence, GraphQL transport, and navigation.
+
+export { useCreateClimb } from './use-create-climb';
+export {
+  EDIT_WINDOW_MS,
+  computeCanUpdate,
+  computeEditLocked,
+  buildInitialHoldsMap,
+  type SavedClimbSnapshot,
+} from './helpers';

--- a/packages/shared/create-climb-react/src/use-create-climb.ts
+++ b/packages/shared/create-climb-react/src/use-create-climb.ts
@@ -1,13 +1,18 @@
-'use client';
-
 import { useState, useCallback, useMemo } from 'react';
-import { type LitUpHoldsMap, type HoldState, HOLD_STATE_MAP, STATE_TO_PRIMARY_CODE } from '../board-renderer/types';
-import type { BoardName } from '@/app/lib/types';
+import { HOLD_STATE_MAP, STATE_TO_PRIMARY_CODE } from '@boardsesh/board-constants/hold-states';
+import type { BoardName, HoldState, LitUpHoldsMap } from '@boardsesh/shared-schema';
 
 type UseCreateClimbOptions = {
   initialHoldsMap?: LitUpHoldsMap;
 };
 
+/**
+ * Aurora (Kilter/Tension/etc) hold-state machine for the create-climb editor.
+ * Pure React + board-constants — shared verbatim by the web form and the
+ * React Native editor. Keys holds by numeric id; enforces the max-2
+ * STARTING/FINISH rule; serialises to the Aurora `p{holdId}r{code}` frame
+ * string.
+ */
 export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOptions) {
   const [litUpHoldsMap, setLitUpHoldsMap] = useState<LitUpHoldsMap>(options?.initialHoldsMap ?? {});
 

--- a/packages/shared/create-climb-react/tsconfig.json
+++ b/packages/shared/create-climb-react/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/shared/create-climb-react/vite.config.ts
+++ b/packages/shared/create-climb-react/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'create-climb-react',
+    globals: true,
+    environment: 'happy-dom',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+});

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -666,7 +666,53 @@
       "report": "Report",
       "linkCopied": "Link copied",
       "tick": "Log a tick",
-      "openInApp": "Open in Aurora app"
+      "openInApp": "Open in Aurora app",
+      "fork": "Fork this climb",
+      "edit": "Edit climb"
+    },
+    "create": {
+      "brush": {
+        "start": "Start",
+        "hand": "Hand",
+        "finish": "Finish",
+        "foot": "Foot",
+        "erase": "Erase"
+      },
+      "counts": {
+        "start": "Start: {{count}}/2",
+        "finish": "Finish: {{count}}/2"
+      },
+      "actions": {
+        "heatmap": "Heatmap",
+        "settings": "Settings",
+        "clear": "Clear holds",
+        "setActive": "Set as active climb",
+        "save": "Save climb"
+      },
+      "holdRole": {
+        "title": "Set hold role",
+        "clear": "Clear"
+      },
+      "settings": {
+        "draftLabel": "Save as draft",
+        "draftDescription": "Drafts stay private until you publish them.",
+        "showAllHoldsLabel": "Show all holds",
+        "showAllHoldsDescription": "Highlight every tappable hold on the board.",
+        "connectBoard": "Connect board",
+        "bleConnected": "Board connected",
+        "bleUnavailable": "Pick a board to light it up over Bluetooth."
+      },
+      "drafts": {
+        "holds_one": "{{count}} hold",
+        "holds_other": "{{count}} holds"
+      },
+      "unavailable": {
+        "title": "Can't build here yet",
+        "subtitle": "This board layout is not supported for creating climbs."
+      },
+      "fab": {
+        "ariaLabel": "Create a climb"
+      }
     }
   }
 }

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -29,7 +29,8 @@
       "climbs": "Climbs",
       "climb": "Climb",
       "profile": "Profile",
-      "setters": "Setters"
+      "setters": "Setters",
+      "createClimb": "Create climb"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -666,7 +666,53 @@
       "report": "Reportar",
       "linkCopied": "Enlace copiado",
       "tick": "Registrar un envío",
-      "openInApp": "Abrir en la app Aurora"
+      "openInApp": "Abrir en la app Aurora",
+      "fork": "Bifurcar esta vía",
+      "edit": "Editar vía"
+    },
+    "create": {
+      "brush": {
+        "start": "Inicio",
+        "hand": "Mano",
+        "finish": "Final",
+        "foot": "Pie",
+        "erase": "Borrar"
+      },
+      "counts": {
+        "start": "Inicio: {{count}}/2",
+        "finish": "Final: {{count}}/2"
+      },
+      "actions": {
+        "heatmap": "Mapa de calor",
+        "settings": "Ajustes",
+        "clear": "Borrar presas",
+        "setActive": "Fijar como vía activa",
+        "save": "Guardar vía"
+      },
+      "holdRole": {
+        "title": "Asignar rol de presa",
+        "clear": "Borrar"
+      },
+      "settings": {
+        "draftLabel": "Guardar como borrador",
+        "draftDescription": "Los borradores quedan privados hasta que los publiques.",
+        "showAllHoldsLabel": "Mostrar todas las presas",
+        "showAllHoldsDescription": "Resalta todas las presas pulsables del panel.",
+        "connectBoard": "Conectar panel",
+        "bleConnected": "Panel conectado",
+        "bleUnavailable": "Elige un panel para iluminarlo por Bluetooth."
+      },
+      "drafts": {
+        "holds_one": "{{count}} presa",
+        "holds_other": "{{count}} presas"
+      },
+      "unavailable": {
+        "title": "Aún no se puede crear aquí",
+        "subtitle": "Esta configuración de panel no admite la creación de vías."
+      },
+      "fab": {
+        "ariaLabel": "Crear una vía"
+      }
     }
   }
 }

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -227,7 +227,8 @@
       "climbs": "Bloques",
       "climb": "Bloque",
       "profile": "Perfil",
-      "setters": "Equipadores"
+      "setters": "Equipadores",
+      "createClimb": "Crear vía"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -666,7 +666,53 @@
       "report": "Signaler",
       "linkCopied": "Lien copié",
       "tick": "Enregistrer une croix",
-      "openInApp": "Ouvrir dans l'app Aurora"
+      "openInApp": "Ouvrir dans l'app Aurora",
+      "fork": "Dupliquer cette voie",
+      "edit": "Modifier la voie"
+    },
+    "create": {
+      "brush": {
+        "start": "Départ",
+        "hand": "Main",
+        "finish": "Fin",
+        "foot": "Pied",
+        "erase": "Effacer"
+      },
+      "counts": {
+        "start": "Départ : {{count}}/2",
+        "finish": "Fin : {{count}}/2"
+      },
+      "actions": {
+        "heatmap": "Carte de chaleur",
+        "settings": "Réglages",
+        "clear": "Effacer les prises",
+        "setActive": "Définir comme voie active",
+        "save": "Enregistrer la voie"
+      },
+      "holdRole": {
+        "title": "Définir le rôle de la prise",
+        "clear": "Effacer"
+      },
+      "settings": {
+        "draftLabel": "Enregistrer comme brouillon",
+        "draftDescription": "Les brouillons restent privés jusqu’à publication.",
+        "showAllHoldsLabel": "Afficher toutes les prises",
+        "showAllHoldsDescription": "Met en évidence chaque prise cliquable du panneau.",
+        "connectBoard": "Connecter le panneau",
+        "bleConnected": "Panneau connecté",
+        "bleUnavailable": "Choisissez un panneau pour l’éclairer en Bluetooth."
+      },
+      "drafts": {
+        "holds_one": "{{count}} prise",
+        "holds_other": "{{count}} prises"
+      },
+      "unavailable": {
+        "title": "Création indisponible ici",
+        "subtitle": "Cette configuration de panneau ne permet pas de créer des voies."
+      },
+      "fab": {
+        "ariaLabel": "Créer une voie"
+      }
     }
   }
 }

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -29,7 +29,8 @@
       "climbs": "Blocs",
       "climb": "Bloc",
       "profile": "Profil",
-      "setters": "Ouvreurs"
+      "setters": "Ouvreurs",
+      "createClimb": "Créer une voie"
     }
   },
   "lightControl": {

--- a/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import CreateClimbForm from '../create-climb-form';
 import { useBoardProvider } from '../../board-provider/board-provider-context';
-import { useCreateClimb } from '../use-create-climb';
+import { useCreateClimb } from '@boardsesh/create-climb-react';
 import { useMoonBoardCreateClimb } from '../use-moonboard-create-climb';
 import { useOptionalBluetoothContext } from '../../board-bluetooth-control/bluetooth-context';
 import type { BoardDetails, Climb } from '@/app/lib/types';
@@ -69,7 +69,7 @@ vi.mock('../../board-bluetooth-control/bluetooth-context', () => ({
   useOptionalBluetoothContext: vi.fn(() => ({ isConnected: false, sendFramesToBoard: mockSendFramesToBoard })),
 }));
 
-vi.mock('../use-create-climb', () => ({
+vi.mock('@boardsesh/create-climb-react', () => ({
   useCreateClimb: vi.fn(() => ({
     litUpHoldsMap: mockAuroraCreateState.litUpHoldsMap,
     setHoldState: mockSetAuroraHoldState,

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -40,7 +40,7 @@ import MoonBoardRenderer from '../moonboard-renderer/moonboard-renderer';
 import ZoomableBoard from '../board-renderer/zoomable-board';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import { useBoardProvider } from '../board-provider/board-provider-context';
-import { useCreateClimb } from './use-create-climb';
+import { useCreateClimb } from '@boardsesh/create-climb-react';
 import { useMoonBoardCreateClimb } from './use-moonboard-create-climb';
 import { useOptionalBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
 import type { MoonBoardClimbDuplicateMatch, UpdateClimbInput } from '@boardsesh/shared-schema';

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -34,6 +34,7 @@
     "@boardsesh/board-react": "*",
     "@boardsesh/board-renderer-wasm": "*",
     "@boardsesh/climb-actions": "*",
+    "@boardsesh/create-climb-react": "*",
     "@boardsesh/climb-filters": "*",
     "@boardsesh/crypto": "*",
     "@boardsesh/db": "*",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
       './packages/shared/ble-protocol/vite.config.ts',
       './packages/shared/board-config/vite.config.ts',
       './packages/shared/board-react/vite.config.ts',
+      './packages/shared/create-climb-react/vite.config.ts',
       './packages/shared/queue/vite.config.ts',
       './packages/shared/queue-runtime/vite.config.ts',
       './packages/shared/queue-react/vite.config.ts',
@@ -231,6 +232,9 @@ export default defineConfig({
       'typecheck:board-react': {
         command: 'bun run --filter=@boardsesh/board-react typecheck',
       },
+      'typecheck:create-climb-react': {
+        command: 'bun run --filter=@boardsesh/create-climb-react typecheck',
+      },
       'typecheck:party-profile': {
         command: 'bun run --filter=@boardsesh/party-profile typecheck',
       },
@@ -287,6 +291,7 @@ export default defineConfig({
           'typecheck:queue-react',
           'typecheck:playlists-react',
           'typecheck:board-react',
+          'typecheck:create-climb-react',
           'typecheck:party-profile',
           'typecheck:climb-actions',
           'typecheck:key-value-storage',


### PR DESCRIPTION
## What

Adds the **create-climb screen** to the React Native app (`packages/mobile`) for **Aurora boards** (Kilter / Tension / decoy / touchstone / grasshopper / soill). Feature parity with the web create-climb form, plus a brush-first UX, and **no `react-native-svg`** for the interactive board.

This is **PR 1 of 3** (stacked): MoonBoard support and the hold-usage heatmap follow as separate PRs branched off this one.

## How it works (no-SVG board)

The interactive board renders the bundled board background PNG (via `BoardImageNative` with empty frames) and draws every hold as an absolutely-positioned RN `View` / `GestureDetector` placed **inside** the zoom-transformed `Animated.View`. RNGH hit-tests transformed subviews in board-local space, so a tap lands on the right hold at any zoom level with **zero manual screen→board coordinate math**. Painting repaints instantly (plain Views) — no per-tap native re-render. Pinch-zoom reuses the existing `useZoomPanGesture`.

- **Brush + sheet interaction:** a persistent brush bar (Start / Hand / Finish / Foot / Erase) is the primary fast path — pick a brush, tap holds to paint. Long-press a hold opens the per-hold role sheet (web parity).
- **Save flow:** `saveClimb`/`updateClimb` via the already-shared `@boardsesh/board-react` GraphQL mutations; name-required → settings sheet; 24h edit-lock; just-saved confirmation; inline duplicate banner with "view existing climb".
- **Autosave** to AsyncStorage (per board), **drafts** list + delete, **Set Active** → party queue, **BLE live preview** while connected.
- **Entry points:** FAB on the climbs list, plus **Fork** and owner-gated **Edit** in the climb actions sheet.

## Shared extraction (extract-don't-duplicate)

New `@boardsesh/create-climb-react` package holds the renderer-agnostic hold-state machine (`useCreateClimb`) + save-decision helpers (`computeCanUpdate`, `computeEditLocked`, `buildInitialHoldsMap`). Web's `create-climb-form.tsx` now imports from it; the duplicated web hook was deleted.

`userId` is added to `searchClimbs` results (db + GraphQL fragment) so the Edit action can gate on ownership from the list.

## Validation

- `vp run typecheck` — green (full monorepo incl. web build)
- `vp test --project mobile` — 623 pass · `@boardsesh/create-climb-react` — 33 pass · web create-climb — 105 pass · backend `climb-queries` — 21 pass
- `vp run check:mobile-bundle` — green (iOS + Android)
- i18n parity (en-US / es / fr) intact; format + lint clean

## Notes / follow-ups

- MoonBoard is out of scope here (`getCreateBoardHolds` returns null → friendly empty state); lands in PR 2.
- Re-saving a climb that is *already* the active queue item won't refresh its frames via the queue (reducer short-circuits same-uuid local updates); the live BLE preview keeps the local wall correct. A mobile-queue `updateQueueItem` is the follow-up for party peers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)