### PR TITLE
feat(mobile): community hold-usage heatmap in the create editor

### DIFF
--- a/packages/backend/src/__tests__/climb-queries.test.ts
+++ b/packages/backend/src/__tests__/climb-queries.test.ts
@@ -6,7 +6,8 @@ import {
   type ParsedBoardRouteParameters,
   type ClimbSearchParams,
 } from '../db/queries/climbs/index';
-import { db } from '../db/client';
+import { db, dbRead } from '../db/client';
+import { getHoldHeatmapData } from '@boardsesh/db/queries';
 import { sql } from 'drizzle-orm';
 
 describe('Climb Query Functions', () => {
@@ -259,6 +260,95 @@ describe('Climb Query Functions', () => {
       // Both should execute without errors (may return null if no data)
       expect(kilterResult === null || typeof kilterResult === 'object').toBe(true);
       expect(tensionResult === null || typeof tensionResult === 'object').toBe(true);
+    });
+  });
+
+  describe('getHoldHeatmapData', () => {
+    // Seed two listed climbs that share hold 700 (HAND in both) plus a unique
+    // hold each, with stats so totalAscents/averageDifficulty are populated.
+    //   - "easy"  (V4-ish, 100 ascents): holds 700 (HAND), 701 (STARTING)
+    //   - "hard"  (V8-ish, 200 ascents): holds 700 (HAND), 702 (FOOT)
+    const HEATMAP_PREFIX = 'heatmap-test-';
+
+    beforeAll(async () => {
+      await db.execute(sql`
+        INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, frames_count, is_draft, is_listed, edge_left, edge_right, edge_bottom, edge_top, created_at, required_set_ids, compatible_size_ids)
+        VALUES
+          (${HEATMAP_PREFIX + 'easy'}, 'kilter', 1, 'test-setter', 'Heatmap Easy', 'p700r12p701r15', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7]),
+          (${HEATMAP_PREFIX + 'hard'}, 'kilter', 1, 'test-setter', 'Heatmap Hard', 'p700r12p702r13', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7])
+        ON CONFLICT DO NOTHING
+      `);
+
+      await db.execute(sql`
+        INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)
+        VALUES
+          ('kilter', ${HEATMAP_PREFIX + 'easy'}, 700, 0, 'HAND'),
+          ('kilter', ${HEATMAP_PREFIX + 'easy'}, 701, 0, 'STARTING'),
+          ('kilter', ${HEATMAP_PREFIX + 'hard'}, 700, 0, 'HAND'),
+          ('kilter', ${HEATMAP_PREFIX + 'hard'}, 702, 0, 'FOOT')
+        ON CONFLICT DO NOTHING
+      `);
+
+      await db.execute(sql`
+        INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, ascensionist_count)
+        VALUES
+          ('kilter', ${HEATMAP_PREFIX + 'easy'}, 40, 13, 100),
+          ('kilter', ${HEATMAP_PREFIX + 'hard'}, 40, 21, 200)
+        ON CONFLICT DO NOTHING
+      `);
+    });
+
+    afterAll(async () => {
+      await db.execute(sql`DELETE FROM board_climb_stats WHERE climb_uuid LIKE ${HEATMAP_PREFIX + '%'}`);
+      await db.execute(sql`DELETE FROM board_climb_holds WHERE climb_uuid LIKE ${HEATMAP_PREFIX + '%'}`);
+      await db.execute(sql`DELETE FROM board_climbs WHERE uuid LIKE ${HEATMAP_PREFIX + '%'}`);
+    });
+
+    it('should aggregate community hold stats for a board config', async () => {
+      const rows = await getHoldHeatmapData(dbRead, testParams, { page: 0, pageSize: 20 });
+      const byHold = new Map(rows.map((row) => [row.holdId, row]));
+
+      // The shared hold is used by both climbs; the unique holds by one each.
+      const shared = byHold.get(700);
+      expect(shared).toBeDefined();
+      expect(shared?.totalUses).toBe(2);
+      expect(shared?.handUses).toBe(2);
+      // totalAscents sums ascensionist_count across both climbs (100 + 200).
+      expect(shared?.totalAscents).toBe(300);
+      // Community-only: no per-user fields without a userId.
+      expect(shared?.userAscents).toBeUndefined();
+      expect(shared?.userAttempts).toBeUndefined();
+
+      const startingHold = byHold.get(701);
+      expect(startingHold?.totalUses).toBe(1);
+      expect(startingHold?.startingUses).toBe(1);
+
+      const footHold = byHold.get(702);
+      expect(footHold?.totalUses).toBe(1);
+      expect(footHold?.footUses).toBe(1);
+    });
+
+    it('should narrow the aggregate when a grade filter excludes climbs', async () => {
+      // Only the "hard" climb (display grade 21) is in 20..22; the shared hold
+      // 700 should now reflect a single climb, and 701 (easy-only) drops out.
+      const rows = await getHoldHeatmapData(dbRead, testParams, {
+        page: 0,
+        pageSize: 20,
+        minGrade: 20,
+        maxGrade: 22,
+      });
+      const byHold = new Map(rows.map((row) => [row.holdId, row]));
+
+      expect(byHold.get(700)?.totalUses).toBe(1);
+      expect(byHold.get(700)?.totalAscents).toBe(200);
+      expect(byHold.get(702)?.totalUses).toBe(1);
+      expect(byHold.has(701)).toBe(false);
+    });
+
+    it('should return an empty array for an invalid size_id', async () => {
+      const rows = await getHoldHeatmapData(dbRead, { ...testParams, size_id: 999999 }, { page: 0, pageSize: 20 });
+      const seededHolds = rows.filter((row) => row.holdId === 700 || row.holdId === 701 || row.holdId === 702);
+      expect(seededHolds).toEqual([]);
     });
   });
 

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -3,6 +3,8 @@ import {
   type CheckMoonBoardClimbDuplicatesInput,
   type ClimbSearchInput,
   type ConnectionContext,
+  type HoldHeatmapInput,
+  type HoldStat,
   type SetterStat,
   type SetterStatsInput,
   type SimilarClimb,
@@ -11,7 +13,7 @@ import {
   USER_SPECIFIC_SEARCH_PARAMS,
 } from '@boardsesh/shared-schema';
 import type { BoardName } from '@boardsesh/board-constants';
-import { getSetterStats } from '@boardsesh/db/queries';
+import { getHoldHeatmapData, getSetterStats } from '@boardsesh/db/queries';
 import { logger } from '../../../utils/logger';
 import {
   type ClimbSearchParams,
@@ -28,6 +30,7 @@ import {
   CheckMoonBoardClimbDuplicatesInputSchema,
   ClimbSearchInputSchema,
   ExternalUUIDSchema,
+  HoldHeatmapInputSchema,
   SetterStatsInputSchema,
   SimilarClimbsInputSchema,
 } from '../../../validation/schemas';
@@ -254,6 +257,75 @@ export const climbQueries = {
     return rows.map((row) => ({
       setterUsername: row.setter_username,
       climbCount: row.climb_count,
+    }));
+  },
+
+  /**
+   * Community hold-usage heatmap for a board configuration. Aggregates how
+   * often each hold is used across matching climbs — community totals only
+   * (never passes a userId, so no personal-progress overlay). MoonBoard has no
+   * hold tables, so it short-circuits to an empty list.
+   */
+  holdHeatmap: async (
+    _: unknown,
+    { input }: { input: HoldHeatmapInput },
+    ctx: ConnectionContext,
+  ): Promise<HoldStat[]> => {
+    // The aggregate scans board_climb_holds for the whole board config before
+    // grouping; 30/min/IP matches setterStats-class read cost and stays well
+    // above the create-editor's interactive cadence (toggled on, then cached
+    // 5 min by React Query on the client).
+    await applyRateLimit(ctx, 30, 'hold-heatmap');
+    const validated = validateInput(HoldHeatmapInputSchema, input, 'input');
+
+    if (!isValidBoardName(validated.boardName)) {
+      throw new Error(`Invalid board name: ${validated.boardName}. Must be one of: ${SUPPORTED_BOARDS.join(', ')}`);
+    }
+
+    // MoonBoard has no board_climb_holds/board_climb_stats rows — return empty
+    // to mirror the web REST heatmap route's MoonBoard short-circuit.
+    if (validated.boardName === 'moonboard') {
+      return [];
+    }
+
+    // Parse setIds from comma-separated string (same pattern as searchClimbs).
+    const setIds = validated.setIds
+      .split(',')
+      .map((id) => parseInt(id.trim(), 10))
+      .filter((id) => !isNaN(id));
+
+    const params: ParsedBoardRouteParameters = {
+      board_name: validated.boardName,
+      layout_id: validated.layoutId,
+      size_id: validated.sizeId,
+      set_ids: setIds,
+      angle: validated.angle,
+    };
+
+    // Map only the community filter subset onto the search params. Personal
+    // progress filters are deliberately omitted — the heatmap is community-only.
+    const searchParams: ClimbSearchParams = {
+      minGrade: validated.minGrade ?? undefined,
+      maxGrade: validated.maxGrade ?? undefined,
+      minAscents: validated.minAscents ?? undefined,
+      minRating: validated.minRating ?? undefined,
+      name: validated.name || undefined,
+      settername: validated.settername && validated.settername.length > 0 ? validated.settername : undefined,
+      onlyClassics: validated.onlyClassics ?? undefined,
+    };
+
+    // No userId → community totals only.
+    const rows = await getHoldHeatmapData(dbRead, params, searchParams);
+
+    return rows.map((row) => ({
+      holdId: row.holdId,
+      totalUses: row.totalUses,
+      startingUses: row.startingUses,
+      handUses: row.handUses,
+      footUses: row.footUses,
+      finishUses: row.finishUses,
+      totalAscents: row.totalAscents,
+      averageDifficulty: row.averageDifficulty,
     }));
   },
 

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -234,6 +234,21 @@ export const SetterStatsInputSchema = z.object({
   search: z.string().max(200).optional(),
 });
 
+export const HoldHeatmapInputSchema = z.object({
+  boardName: BoardNameSchema,
+  layoutId: z.number().int().positive('Layout ID must be positive'),
+  sizeId: z.number().int().positive('Size ID must be positive'),
+  setIds: z.string().min(1, 'Set IDs cannot be empty'),
+  angle: z.number().int().min(0).max(90),
+  minGrade: z.number().int().optional(),
+  maxGrade: z.number().int().optional(),
+  minAscents: z.number().int().min(0).optional(),
+  minRating: z.number().min(0).max(5).optional(),
+  name: z.string().max(200).optional(),
+  settername: z.array(z.string().max(100)).optional(),
+  onlyClassics: z.boolean().optional(),
+});
+
 export const SimilarClimbsInputSchema = z
   .object({
     boardType: BoardNameSchema,

--- a/packages/db/src/queries/climbs/holds-heatmap.ts
+++ b/packages/db/src/queries/climbs/holds-heatmap.ts
@@ -1,0 +1,181 @@
+import { and, sql } from 'drizzle-orm';
+import type { DbInstance } from '../../client/postgres';
+import { executeRows } from '../../client/postgres';
+import { boardClimbs, boardClimbStats, boardClimbHolds, boardseshTicks } from '../../schema/index';
+import { createClimbFilters } from './create-climb-filters';
+import type { BoardRouteParams, ClimbSearchParams } from './types';
+
+/**
+ * One row of aggregate hold-usage data for a board configuration. Drives the
+ * create-climb heatmap (community totals) on web and mobile. The optional
+ * `userAscents`/`userAttempts` fields are only populated when a `userId` is
+ * supplied (web personal-progress overlay) — the mobile path never passes a
+ * userId, so it always gets the community-only shape.
+ */
+export type HoldHeatmapData = {
+  holdId: number;
+  totalUses: number;
+  startingUses: number;
+  totalAscents: number;
+  handUses: number;
+  footUses: number;
+  finishUses: number;
+  averageDifficulty: number | null;
+  userAscents?: number;
+  userAttempts?: number;
+};
+
+/**
+ * Aggregate how often each hold is used across the climbs matching a board
+ * configuration and (optional) search filters. Shared between the web REST
+ * heatmap route + cache and the GraphQL `holdHeatmap` resolver.
+ *
+ * Pass `dbHandle` (the read replica from the caller) so this stays free of any
+ * web/Next coupling — the web wrapper hands in `dbzRead`, the backend hands in
+ * `dbRead`. When `userId` is omitted the result carries community totals only.
+ *
+ * @param dbHandle Drizzle instance (read replica preferred)
+ * @param params Board route parameters
+ * @param searchParams Search/filter parameters (the same shape used by search)
+ * @param userId Optional NextAuth user id for the personal-progress overlay
+ */
+export const getHoldHeatmapData = async (
+  dbHandle: DbInstance,
+  params: BoardRouteParams,
+  searchParams: ClimbSearchParams,
+  userId?: string,
+): Promise<HoldHeatmapData[]> => {
+  // Use the shared filter creator
+  const filters = createClimbFilters(params, searchParams, userId);
+
+  // Check if personal progress filters are active - if so, use user-specific counts
+  const personalProgressFiltersEnabled =
+    searchParams.hideAttempted ||
+    searchParams.hideCompleted ||
+    searchParams.showOnlyAttempted ||
+    searchParams.showOnlyCompleted;
+
+  let holdStats: Record<string, unknown>[];
+
+  if (personalProgressFiltersEnabled && userId) {
+    // When personal progress filters are active, the filters already limit
+    // climbs to the user's attempted/completed ones, so the base query is the
+    // same but the results are user-filtered.
+    holdStats = await dbHandle
+      .select({
+        holdId: boardClimbHolds.holdId,
+        totalUses: sql<number>`COUNT(DISTINCT ${boardClimbHolds.climbUuid})`,
+        totalAscents: sql<number>`COUNT(DISTINCT ${boardClimbHolds.climbUuid})`,
+        startingUses: sql<number>`SUM(CASE WHEN ${boardClimbHolds.holdState} = 'STARTING' THEN 1 ELSE 0 END)`,
+        handUses: sql<number>`SUM(CASE WHEN ${boardClimbHolds.holdState} = 'HAND' THEN 1 ELSE 0 END)`,
+        footUses: sql<number>`SUM(CASE WHEN ${boardClimbHolds.holdState} = 'FOOT' THEN 1 ELSE 0 END)`,
+        finishUses: sql<number>`SUM(CASE WHEN ${boardClimbHolds.holdState} = 'FINISH' THEN 1 ELSE 0 END)`,
+        averageDifficulty: sql<number>`AVG(${boardClimbStats.displayDifficulty})`,
+      })
+      .from(boardClimbHolds)
+      .innerJoin(boardClimbs, and(...filters.getClimbHoldsJoinConditions()))
+      .leftJoin(boardClimbStats, and(...filters.getHoldHeatmapClimbStatsConditions()))
+      .where(
+        and(...filters.getClimbWhereConditions(), ...filters.getSizeConditions(), ...filters.getClimbStatsConditions()),
+      )
+      .groupBy(boardClimbHolds.holdId);
+  } else {
+    // Global community stats when no personal progress filters are active.
+    holdStats = await dbHandle
+      .select({
+        holdId: boardClimbHolds.holdId,
+        totalUses: sql<number>`COUNT(DISTINCT ${boardClimbHolds.climbUuid})`,
+        totalAscents: sql<number>`SUM(${boardClimbStats.ascensionistCount})`,
+        startingUses: sql<number>`SUM(CASE WHEN ${boardClimbHolds.holdState} = 'STARTING' THEN 1 ELSE 0 END)`,
+        handUses: sql<number>`SUM(CASE WHEN ${boardClimbHolds.holdState} = 'HAND' THEN 1 ELSE 0 END)`,
+        footUses: sql<number>`SUM(CASE WHEN ${boardClimbHolds.holdState} = 'FOOT' THEN 1 ELSE 0 END)`,
+        finishUses: sql<number>`SUM(CASE WHEN ${boardClimbHolds.holdState} = 'FINISH' THEN 1 ELSE 0 END)`,
+        averageDifficulty: sql<number>`AVG(${boardClimbStats.displayDifficulty})`,
+      })
+      .from(boardClimbHolds)
+      .innerJoin(boardClimbs, and(...filters.getClimbHoldsJoinConditions()))
+      .leftJoin(boardClimbStats, and(...filters.getHoldHeatmapClimbStatsConditions()))
+      .where(
+        and(...filters.getClimbWhereConditions(), ...filters.getSizeConditions(), ...filters.getClimbStatsConditions()),
+      )
+      .groupBy(boardClimbHolds.holdId);
+  }
+
+  // Add user-specific data only if not already computed in the main query.
+  if (userId && !personalProgressFiltersEnabled) {
+    // Per-hold user ascents/attempts come from boardsesh_ticks (NextAuth userId).
+    const [userAscentsRows, userAttemptsRows] = await Promise.all([
+      executeRows<{ hold_id: number; user_ascents: number }>(
+        dbHandle,
+        sql`
+          SELECT ch.hold_id, COUNT(*) as user_ascents
+          FROM ${boardseshTicks} t
+          JOIN board_climb_holds ch ON t.climb_uuid = ch.climb_uuid AND ch.board_type = ${params.board_name}
+          WHERE t.user_id = ${userId}
+            AND t.board_type = ${params.board_name}
+            AND t.angle = ${params.angle}
+            AND t.status IN ('flash', 'send')
+          GROUP BY ch.hold_id
+        `,
+      ),
+      executeRows<{ hold_id: number; user_attempts: number }>(
+        dbHandle,
+        sql`
+          SELECT ch.hold_id, SUM(t.attempt_count) as user_attempts
+          FROM ${boardseshTicks} t
+          JOIN board_climb_holds ch ON t.climb_uuid = ch.climb_uuid AND ch.board_type = ${params.board_name}
+          WHERE t.user_id = ${userId}
+            AND t.board_type = ${params.board_name}
+            AND t.angle = ${params.angle}
+          GROUP BY ch.hold_id
+        `,
+      ),
+    ]);
+
+    const ascentsMap = new Map<number, number>();
+    const attemptsMap = new Map<number, number>();
+
+    for (const row of userAscentsRows) {
+      ascentsMap.set(Number(row.hold_id), Number(row.user_ascents));
+    }
+    for (const row of userAttemptsRows) {
+      attemptsMap.set(Number(row.hold_id), Number(row.user_attempts));
+    }
+
+    holdStats = holdStats.map((stat) => ({
+      ...stat,
+      userAscents: ascentsMap.get(Number(stat.holdId)) || 0,
+      userAttempts: attemptsMap.get(Number(stat.holdId)) || 0,
+    }));
+  } else if (personalProgressFiltersEnabled && userId) {
+    // The main stats already ARE the user stats, but the frontend still expects
+    // userAscents/userAttempts fields for backward compatibility.
+    holdStats = holdStats.map((stat) => ({
+      ...stat,
+      userAscents: Number(stat.totalAscents) || 0,
+      userAttempts: Number(stat.totalUses) || 0,
+    }));
+  }
+
+  return holdStats.map((stats) => normalizeStats(stats, userId));
+};
+
+function normalizeStats(stats: Record<string, unknown>, userId?: string): HoldHeatmapData {
+  const result: HoldHeatmapData = {
+    holdId: Number(stats.holdId),
+    totalUses: Number(stats.totalUses || 0),
+    totalAscents: Number(stats.totalAscents || 0),
+    startingUses: Number(stats.startingUses || 0),
+    handUses: Number(stats.handUses || 0),
+    footUses: Number(stats.footUses || 0),
+    finishUses: Number(stats.finishUses || 0),
+    averageDifficulty: stats.averageDifficulty ? Number(stats.averageDifficulty) : null,
+  };
+
+  if (userId) {
+    result.userAscents = Number(stats.userAscents || 0);
+    result.userAttempts = Number(stats.userAttempts || 0);
+  }
+
+  return result;
+}

--- a/packages/db/src/queries/climbs/index.ts
+++ b/packages/db/src/queries/climbs/index.ts
@@ -5,5 +5,7 @@ export { getGradeLabel } from './grade-lookup';
 export { populateDenormalizedColumns } from './populate-denormalized-columns';
 export { getSetterStats } from './setter-stats';
 export type { SetterStat } from './setter-stats';
+export { getHoldHeatmapData } from './holds-heatmap';
+export type { HoldHeatmapData } from './holds-heatmap';
 export type { BoardRouteParams, ClimbSearchParams, ClimbSearchInputLike, ClimbRow, ClimbSearchResult } from './types';
 export { mapSearchInputToParams } from './types';

--- a/packages/mobile/src/components/create-climb/CreateClimbScreen.tsx
+++ b/packages/mobile/src/components/create-climb/CreateClimbScreen.tsx
@@ -12,7 +12,9 @@ import { spacing } from '../../theme/tokens';
 import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { BoardImageNative } from '../BoardImageNative';
+import { useHoldHeatmap } from '../../lib/graphql/hooks';
 import { InteractiveCreateBoard } from './InteractiveCreateBoard';
+import { HeatmapOverlay } from './HeatmapOverlay';
 import { BrushBar } from './BrushBar';
 import { HoldRoleSheet } from './HoldRoleSheet';
 import { CreateClimbSettingsSheet } from './CreateClimbSettingsSheet';
@@ -103,6 +105,7 @@ function AuroraCreateClimbScreen({
   const [longPressHoldId, setLongPressHoldId] = useState<number | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [draftsOpen, setDraftsOpen] = useState(false);
+  const [heatmapVisible, setHeatmapVisible] = useState(false);
 
   // The controller asks the screen to open settings (e.g. an unnamed save).
   useEffect(() => {
@@ -111,6 +114,38 @@ function AuroraCreateClimbScreen({
 
   const handleLongPress = useCallback((holdId: number) => setLongPressHoldId(holdId), []);
   const closeHoldRole = useCallback(() => setLongPressHoldId(null), []);
+
+  // Community hold-usage heatmap. Only fetched once the user toggles it on.
+  const { statsByHoldId } = useHoldHeatmap(
+    {
+      boardName: board.boardName,
+      layoutId: board.layoutId,
+      sizeId: board.sizeId,
+      setIds: board.setIds,
+      angle: board.angle,
+    },
+    heatmapVisible,
+  );
+
+  // Skip painted holds so the heat never covers the working climb.
+  const paintedHoldIds = useMemo(
+    () => new Set(Object.keys(controller.litUpHoldsMap).map(Number)),
+    [controller.litUpHoldsMap],
+  );
+
+  const heatmapOverlay = useMemo(
+    () =>
+      heatmapVisible ? (
+        <HeatmapOverlay
+          statsByHoldId={statsByHoldId}
+          holdTargets={boardHolds.holdTargets}
+          boardWidth={boardHolds.boardWidth}
+          boardHeight={boardHolds.boardHeight}
+          paintedHoldIds={paintedHoldIds}
+        />
+      ) : null,
+    [heatmapVisible, statsByHoldId, boardHolds, paintedHoldIds],
+  );
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: systemColors.background }]} edges={['bottom']}>
@@ -135,6 +170,7 @@ function AuroraCreateClimbScreen({
             onPaint={controller.handlePaint}
             onLongPressHold={handleLongPress}
             showAllHolds={controller.showAllHolds}
+            overlay={heatmapOverlay}
           />
         </View>
 
@@ -188,6 +224,8 @@ function AuroraCreateClimbScreen({
             onOpenSettings={() => setSettingsOpen(true)}
             onSetActive={controller.handleSetActive}
             canSetActive={controller.canSetActive}
+            onToggleHeatmap={() => setHeatmapVisible((visible) => !visible)}
+            heatmapActive={heatmapVisible}
           />
         </View>
       </KeyboardAvoidingView>

--- a/packages/mobile/src/components/create-climb/HeatmapOverlay.tsx
+++ b/packages/mobile/src/components/create-climb/HeatmapOverlay.tsx
@@ -1,0 +1,111 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { HoldStat } from '@boardsesh/shared-schema';
+import type { BoardHoldTarget } from '../../lib/create-board-holds';
+
+type HeatmapOverlayProps = {
+  /** Aggregate usage per hold id (community totals). */
+  statsByHoldId: Map<number, HoldStat>;
+  holdTargets: BoardHoldTarget[];
+  boardWidth: number;
+  boardHeight: number;
+  mirrored?: boolean;
+  /** Hold ids the user has already painted — skip them so the overlay never
+   *  covers the working climb. */
+  paintedHoldIds: Set<number>;
+};
+
+// Green → red ramp, low usage (cool) to high usage (hot). Five fixed stops so
+// the colour is deterministic across renders without any HSL math at draw time.
+const RAMP = ['#22c55e', '#a3e635', '#facc15', '#fb923c', '#ef4444'] as const;
+
+const DISC_OPACITY = 0.7;
+// Disc diameter as a multiple of the hold radius — a touch larger than the
+// painted ring so the heat reads as a soft blob rather than a precise marker.
+const DISC_RADIUS_MULTIPLIER = 1.4;
+
+/** Map a normalised intensity (0..1) to a ramp colour. */
+function rampColor(intensity: number): string {
+  const clamped = Math.max(0, Math.min(1, intensity));
+  const index = Math.min(RAMP.length - 1, Math.round(clamped * (RAMP.length - 1)));
+  return RAMP[index];
+}
+
+/**
+ * Non-SVG hold-usage heatmap: one opacity-scaled translucent disc per hold.
+ * Both position and diameter are expressed as percentages of the board box, so
+ * the overlay is fully self-contained — it doesn't need the measured device
+ * width and the discs track the holds at any zoom (the parent applies the zoom
+ * transform). Intensity is `log(1 + uses) / log(1 + maxUses)` so a handful of
+ * mega-popular holds don't flatten the rest of the board to a single colour.
+ * Painted holds are skipped so the overlay never covers the working climb.
+ */
+export const HeatmapOverlay = React.memo(function HeatmapOverlay({
+  statsByHoldId,
+  holdTargets,
+  boardWidth,
+  boardHeight,
+  mirrored = false,
+  paintedHoldIds,
+}: HeatmapOverlayProps) {
+  const discs = useMemo(() => {
+    if (statsByHoldId.size === 0) return [];
+
+    let maxUses = 0;
+    for (const stat of statsByHoldId.values()) {
+      if (stat.totalUses > maxUses) maxUses = stat.totalUses;
+    }
+    if (maxUses <= 0) return [];
+    const logMax = Math.log(1 + maxUses);
+
+    return holdTargets
+      .map((target) => {
+        if (paintedHoldIds.has(target.id)) return null;
+        const stat = statsByHoldId.get(target.id);
+        if (!stat || stat.totalUses <= 0) return null;
+
+        const intensity = logMax > 0 ? Math.log(1 + stat.totalUses) / logMax : 0;
+
+        // Percentage geometry (resolution independent). The container already
+        // carries the board aspect ratio, so width-% and height-% map to the
+        // same on-screen pixels and the disc stays round.
+        const cxPct = (target.cx / boardWidth) * 100;
+        const leftPct = mirrored ? 100 - cxPct : cxPct;
+        const topPct = (target.cy / boardHeight) * 100;
+        const diameterPct = ((target.r * 2 * DISC_RADIUS_MULTIPLIER) / boardWidth) * 100;
+
+        return (
+          <View
+            key={target.id}
+            pointerEvents="none"
+            style={[
+              styles.disc,
+              {
+                left: `${leftPct - diameterPct / 2}%`,
+                top: `${topPct}%`,
+                width: `${diameterPct}%`,
+                aspectRatio: 1,
+                marginTop: `${-diameterPct / 2}%`,
+                borderRadius: 9999,
+                backgroundColor: rampColor(intensity),
+                opacity: DISC_OPACITY,
+              },
+            ]}
+          />
+        );
+      })
+      .filter(Boolean);
+  }, [statsByHoldId, holdTargets, boardWidth, boardHeight, mirrored, paintedHoldIds]);
+
+  return (
+    <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+      {discs}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  disc: {
+    position: 'absolute',
+  },
+});

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -395,3 +395,4 @@ export {
 } from './use-you-data';
 export { useYouProfileData } from './use-you-profile-data';
 export { useVote, useBulkVoteSummaries, useComments, useAddComment } from './use-social';
+export { useHoldHeatmap, type HoldHeatmapParams, type UseHoldHeatmapResult } from './use-hold-heatmap';

--- a/packages/mobile/src/lib/graphql/hooks/use-hold-heatmap.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-hold-heatmap.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { HoldStat } from '@boardsesh/shared-schema';
+import { HOLD_HEATMAP_QUERY, type HoldHeatmapResponse } from '@boardsesh/graphql/operations';
+import { getHttpClient } from '../client';
+
+/** Board configuration the heatmap aggregates over (matches HoldHeatmapInput). */
+export type HoldHeatmapParams = {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
+
+export type UseHoldHeatmapResult = {
+  holdStats: HoldStat[];
+  /** Lookup from hold id → its aggregate row, for O(1) access while rendering. */
+  statsByHoldId: Map<number, HoldStat>;
+  isLoading: boolean;
+};
+
+/**
+ * Community hold-usage heatmap for a board configuration. Community totals only
+ * — never sends a userId. Stays disabled until `enabled` flips (the create
+ * editor only fetches once the user toggles the heatmap on). Cached 5 minutes
+ * since the aggregate barely moves.
+ */
+export function useHoldHeatmap(params: HoldHeatmapParams, enabled: boolean): UseHoldHeatmapResult {
+  const query = useQuery({
+    queryKey: ['holdHeatmap', params.boardName, params.layoutId, params.sizeId, params.setIds, params.angle],
+    queryFn: () =>
+      getHttpClient().request<HoldHeatmapResponse>(HOLD_HEATMAP_QUERY, {
+        input: {
+          boardName: params.boardName,
+          layoutId: params.layoutId,
+          sizeId: params.sizeId,
+          setIds: params.setIds,
+          angle: params.angle,
+        },
+      }),
+    select: (data) => data.holdHeatmap,
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const holdStats = useMemo(() => query.data ?? [], [query.data]);
+  const statsByHoldId = useMemo(() => {
+    const map = new Map<number, HoldStat>();
+    for (const stat of holdStats) map.set(stat.holdId, stat);
+    return map;
+  }, [holdStats]);
+
+  return { holdStats, statsByHoldId, isLoading: query.isLoading };
+}

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -234,6 +234,62 @@ type SetterStat {
 }
 
 """
+Input for the community hold-usage heatmap. Identifies a board configuration
+plus the subset of community filters that materially change the aggregate
+(mirrors the keys the web heatmap cache keys on). Personal-progress filters
+are intentionally absent — the heatmap is community-only.
+"""
+input HoldHeatmapInput {
+  "Board type (e.g., 'kilter', 'tension')"
+  boardName: String!
+  "Layout ID"
+  layoutId: Int!
+  "Size ID"
+  sizeId: Int!
+  "Comma-separated set IDs"
+  setIds: String!
+  "Board angle in degrees"
+  angle: Int!
+  "Only count climbs at or above this display grade"
+  minGrade: Int
+  "Only count climbs at or below this display grade"
+  maxGrade: Int
+  "Only count climbs with at least this many ascents"
+  minAscents: Int
+  "Only count climbs with at least this average rating (whole stars, 1-5)"
+  minRating: Float
+  "Case-insensitive substring filter on climb name"
+  name: String
+  "Restrict to climbs by these setter usernames"
+  settername: [String!]
+  "Restrict to classic/benchmark climbs only"
+  onlyClassics: Boolean
+}
+
+"""
+Aggregate usage of a single hold across the climbs matching a board
+configuration. Community-only — there are no per-user fields.
+"""
+type HoldStat {
+  "Hold (placement) id this row aggregates"
+  holdId: Int!
+  "Distinct climbs that use this hold in any role"
+  totalUses: Int!
+  "Times this hold is used as a starting hold"
+  startingUses: Int!
+  "Times this hold is used as a hand hold"
+  handUses: Int!
+  "Times this hold is used as a foot hold"
+  footUses: Int!
+  "Times this hold is used as a finish hold"
+  finishUses: Int!
+  "Sum of ascents across the climbs that use this hold"
+  totalAscents: Int!
+  "Average display difficulty across the climbs that use this hold (null when none have stats)"
+  averageDifficulty: Float
+}
+
+"""
 User information displayed in queue items.
 """
 type QueueItemUser {
@@ -3571,6 +3627,13 @@ type Query {
   Powers the setter filter autocomplete.
   """
   setterStats(input: SetterStatsInput!): [SetterStat!]!
+
+  """
+  Community hold-usage heatmap for a board configuration: how often each hold
+  is used across matching climbs (community totals only — no per-user stats).
+  Returns an empty list for MoonBoard (no hold tables).
+  """
+  holdHeatmap(input: HoldHeatmapInput!): [HoldStat!]!
 
   """
   Get climb stats history for a climb over the last 12 months.

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1683,6 +1683,63 @@ export type GymMembersInput = {
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
 
+/**
+ * Input for the community hold-usage heatmap. Identifies a board configuration
+ * plus the subset of community filters that materially change the aggregate
+ * (mirrors the keys the web heatmap cache keys on). Personal-progress filters
+ * are intentionally absent — the heatmap is community-only.
+ */
+export type HoldHeatmapInput = {
+  /** Board angle in degrees */
+  angle: Scalars['Int']['input'];
+  /** Board type (e.g., 'kilter', 'tension') */
+  boardName: Scalars['String']['input'];
+  /** Layout ID */
+  layoutId: Scalars['Int']['input'];
+  /** Only count climbs at or below this display grade */
+  maxGrade?: InputMaybe<Scalars['Int']['input']>;
+  /** Only count climbs with at least this many ascents */
+  minAscents?: InputMaybe<Scalars['Int']['input']>;
+  /** Only count climbs at or above this display grade */
+  minGrade?: InputMaybe<Scalars['Int']['input']>;
+  /** Only count climbs with at least this average rating (whole stars, 1-5) */
+  minRating?: InputMaybe<Scalars['Float']['input']>;
+  /** Case-insensitive substring filter on climb name */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** Restrict to classic/benchmark climbs only */
+  onlyClassics?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Comma-separated set IDs */
+  setIds: Scalars['String']['input'];
+  /** Restrict to climbs by these setter usernames */
+  settername?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** Size ID */
+  sizeId: Scalars['Int']['input'];
+};
+
+/**
+ * Aggregate usage of a single hold across the climbs matching a board
+ * configuration. Community-only — there are no per-user fields.
+ */
+export type HoldStat = {
+  __typename?: 'HoldStat';
+  /** Average display difficulty across the climbs that use this hold (null when none have stats) */
+  averageDifficulty?: Maybe<Scalars['Float']['output']>;
+  /** Times this hold is used as a finish hold */
+  finishUses: Scalars['Int']['output'];
+  /** Times this hold is used as a foot hold */
+  footUses: Scalars['Int']['output'];
+  /** Times this hold is used as a hand hold */
+  handUses: Scalars['Int']['output'];
+  /** Hold (placement) id this row aggregates */
+  holdId: Scalars['Int']['output'];
+  /** Times this hold is used as a starting hold */
+  startingUses: Scalars['Int']['output'];
+  /** Sum of ascents across the climbs that use this hold */
+  totalAscents: Scalars['Int']['output'];
+  /** Distinct climbs that use this hold in any role */
+  totalUses: Scalars['Int']['output'];
+};
+
 /** Statistics for a specific board layout. */
 export type LayoutStats = {
   __typename?: 'LayoutStats';
@@ -3075,6 +3132,12 @@ export type Query = {
   /** Get members of a gym. */
   gymMembers: GymMemberConnection;
   /**
+   * Community hold-usage heatmap for a board configuration: how often each hold
+   * is used across matching climbs (community totals only — no per-user stats).
+   * Returns an empty list for MoonBoard (no hold tables).
+   */
+  holdHeatmap: Array<HoldStat>;
+  /**
    * Check if the current user follows a specific user.
    * Requires authentication.
    */
@@ -3473,6 +3536,11 @@ export type QueryGymBySlugArgs = {
 /** Root query type for all read operations. */
 export type QueryGymMembersArgs = {
   input: GymMembersInput;
+};
+
+/** Root query type for all read operations. */
+export type QueryHoldHeatmapArgs = {
+  input: HoldHeatmapInput;
 };
 
 /** Root query type for all read operations. */
@@ -5399,6 +5467,8 @@ export type ResolversTypes = ResolversObject<{
   GymMemberConnection: ResolverTypeWrapper<GymMemberConnection>;
   GymMemberRole: GymMemberRole;
   GymMembersInput: GymMembersInput;
+  HoldHeatmapInput: HoldHeatmapInput;
+  HoldStat: ResolverTypeWrapper<HoldStat>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   JSON: ResolverTypeWrapper<Scalars['JSON']['output']>;
@@ -5656,6 +5726,8 @@ export type ResolversParentTypes = ResolversObject<{
   GymMember: GymMember;
   GymMemberConnection: GymMemberConnection;
   GymMembersInput: GymMembersInput;
+  HoldHeatmapInput: HoldHeatmapInput;
+  HoldStat: HoldStat;
   ID: Scalars['ID']['output'];
   Int: Scalars['Int']['output'];
   JSON: Scalars['JSON']['output'];
@@ -6583,6 +6655,21 @@ export type GymMemberConnectionResolvers<
   hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   members?: Resolver<Array<ResolversTypes['GymMember']>, ParentType, ContextType>;
   totalCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type HoldStatResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['HoldStat'] = ResolversParentTypes['HoldStat'],
+> = ResolversObject<{
+  averageDifficulty?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  finishUses?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  footUses?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  handUses?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  holdId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  startingUses?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  totalAscents?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  totalUses?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -7648,6 +7735,12 @@ export type QueryResolvers<
     ParentType,
     ContextType,
     RequireFields<QueryGymMembersArgs, 'input'>
+  >;
+  holdHeatmap?: Resolver<
+    Array<ResolversTypes['HoldStat']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryHoldHeatmapArgs, 'input'>
   >;
   isFollowing?: Resolver<
     ResolversTypes['Boolean'],
@@ -8745,6 +8838,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   GymConnection?: GymConnectionResolvers<ContextType>;
   GymMember?: GymMemberResolvers<ContextType>;
   GymMemberConnection?: GymMemberConnectionResolvers<ContextType>;
+  HoldStat?: HoldStatResolvers<ContextType>;
   JSON?: GraphQLScalarType;
   LayoutStats?: LayoutStatsResolvers<ContextType>;
   LeaderChanged?: LeaderChangedResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -228,4 +228,60 @@ export const climbTypeDefs = /* GraphQL */ `
     "Number of climbs authored by this setter for the board configuration"
     climbCount: Int!
   }
+
+  """
+  Input for the community hold-usage heatmap. Identifies a board configuration
+  plus the subset of community filters that materially change the aggregate
+  (mirrors the keys the web heatmap cache keys on). Personal-progress filters
+  are intentionally absent — the heatmap is community-only.
+  """
+  input HoldHeatmapInput {
+    "Board type (e.g., 'kilter', 'tension')"
+    boardName: String!
+    "Layout ID"
+    layoutId: Int!
+    "Size ID"
+    sizeId: Int!
+    "Comma-separated set IDs"
+    setIds: String!
+    "Board angle in degrees"
+    angle: Int!
+    "Only count climbs at or above this display grade"
+    minGrade: Int
+    "Only count climbs at or below this display grade"
+    maxGrade: Int
+    "Only count climbs with at least this many ascents"
+    minAscents: Int
+    "Only count climbs with at least this average rating (whole stars, 1-5)"
+    minRating: Float
+    "Case-insensitive substring filter on climb name"
+    name: String
+    "Restrict to climbs by these setter usernames"
+    settername: [String!]
+    "Restrict to classic/benchmark climbs only"
+    onlyClassics: Boolean
+  }
+
+  """
+  Aggregate usage of a single hold across the climbs matching a board
+  configuration. Community-only — there are no per-user fields.
+  """
+  type HoldStat {
+    "Hold (placement) id this row aggregates"
+    holdId: Int!
+    "Distinct climbs that use this hold in any role"
+    totalUses: Int!
+    "Times this hold is used as a starting hold"
+    startingUses: Int!
+    "Times this hold is used as a hand hold"
+    handUses: Int!
+    "Times this hold is used as a foot hold"
+    footUses: Int!
+    "Times this hold is used as a finish hold"
+    finishUses: Int!
+    "Sum of ascents across the climbs that use this hold"
+    totalAscents: Int!
+    "Average display difficulty across the climbs that use this hold (null when none have stats)"
+    averageDifficulty: Float
+  }
 `;

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -88,6 +88,13 @@ export const queriesTypeDefs = /* GraphQL */ `
     setterStats(input: SetterStatsInput!): [SetterStat!]!
 
     """
+    Community hold-usage heatmap for a board configuration: how often each hold
+    is used across matching climbs (community totals only — no per-user stats).
+    Returns an empty list for MoonBoard (no hold tables).
+    """
+    holdHeatmap(input: HoldHeatmapInput!): [HoldStat!]!
+
+    """
     Get climb stats history for a climb over the last 12 months.
     Returns snapshots captured during shared sync for trend analysis.
     """

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -174,6 +174,41 @@ export type SetterStat = {
   climbCount: number;
 };
 
+/**
+ * Input for the community hold-usage heatmap. Board configuration plus the
+ * community filter subset that changes the aggregate. Community-only: no
+ * personal-progress fields.
+ */
+export type HoldHeatmapInput = {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+  minGrade?: number | null;
+  maxGrade?: number | null;
+  minAscents?: number | null;
+  minRating?: number | null;
+  name?: string | null;
+  settername?: string[] | null;
+  onlyClassics?: boolean | null;
+};
+
+/**
+ * Aggregate usage of a single hold across the climbs matching a board
+ * configuration. Community-only (no per-user fields).
+ */
+export type HoldStat = {
+  holdId: number;
+  totalUses: number;
+  startingUses: number;
+  handUses: number;
+  footUses: number;
+  finishUses: number;
+  totalAscents: number;
+  averageDifficulty: number | null;
+};
+
 export type SaveClimbInput = {
   boardType: string;
   layoutId: number;

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1680,6 +1680,63 @@ export type GymMembersInput = {
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
 
+/**
+ * Input for the community hold-usage heatmap. Identifies a board configuration
+ * plus the subset of community filters that materially change the aggregate
+ * (mirrors the keys the web heatmap cache keys on). Personal-progress filters
+ * are intentionally absent — the heatmap is community-only.
+ */
+export type HoldHeatmapInput = {
+  /** Board angle in degrees */
+  angle: Scalars['Int']['input'];
+  /** Board type (e.g., 'kilter', 'tension') */
+  boardName: Scalars['String']['input'];
+  /** Layout ID */
+  layoutId: Scalars['Int']['input'];
+  /** Only count climbs at or below this display grade */
+  maxGrade?: InputMaybe<Scalars['Int']['input']>;
+  /** Only count climbs with at least this many ascents */
+  minAscents?: InputMaybe<Scalars['Int']['input']>;
+  /** Only count climbs at or above this display grade */
+  minGrade?: InputMaybe<Scalars['Int']['input']>;
+  /** Only count climbs with at least this average rating (whole stars, 1-5) */
+  minRating?: InputMaybe<Scalars['Float']['input']>;
+  /** Case-insensitive substring filter on climb name */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** Restrict to classic/benchmark climbs only */
+  onlyClassics?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Comma-separated set IDs */
+  setIds: Scalars['String']['input'];
+  /** Restrict to climbs by these setter usernames */
+  settername?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** Size ID */
+  sizeId: Scalars['Int']['input'];
+};
+
+/**
+ * Aggregate usage of a single hold across the climbs matching a board
+ * configuration. Community-only — there are no per-user fields.
+ */
+export type HoldStat = {
+  __typename?: 'HoldStat';
+  /** Average display difficulty across the climbs that use this hold (null when none have stats) */
+  averageDifficulty?: Maybe<Scalars['Float']['output']>;
+  /** Times this hold is used as a finish hold */
+  finishUses: Scalars['Int']['output'];
+  /** Times this hold is used as a foot hold */
+  footUses: Scalars['Int']['output'];
+  /** Times this hold is used as a hand hold */
+  handUses: Scalars['Int']['output'];
+  /** Hold (placement) id this row aggregates */
+  holdId: Scalars['Int']['output'];
+  /** Times this hold is used as a starting hold */
+  startingUses: Scalars['Int']['output'];
+  /** Sum of ascents across the climbs that use this hold */
+  totalAscents: Scalars['Int']['output'];
+  /** Distinct climbs that use this hold in any role */
+  totalUses: Scalars['Int']['output'];
+};
+
 /** Statistics for a specific board layout. */
 export type LayoutStats = {
   __typename?: 'LayoutStats';
@@ -3072,6 +3129,12 @@ export type Query = {
   /** Get members of a gym. */
   gymMembers: GymMemberConnection;
   /**
+   * Community hold-usage heatmap for a board configuration: how often each hold
+   * is used across matching climbs (community totals only — no per-user stats).
+   * Returns an empty list for MoonBoard (no hold tables).
+   */
+  holdHeatmap: Array<HoldStat>;
+  /**
    * Check if the current user follows a specific user.
    * Requires authentication.
    */
@@ -3470,6 +3533,11 @@ export type QueryGymBySlugArgs = {
 /** Root query type for all read operations. */
 export type QueryGymMembersArgs = {
   input: GymMembersInput;
+};
+
+/** Root query type for all read operations. */
+export type QueryHoldHeatmapArgs = {
+  input: HoldHeatmapInput;
 };
 
 /** Root query type for all read operations. */

--- a/packages/shared/graphql/src/operations/climb-search.ts
+++ b/packages/shared/graphql/src/operations/climb-search.ts
@@ -1,5 +1,5 @@
 import { gql } from 'graphql-request';
-import type { Climb, HoldsFilter, ZoneMatchMode } from '@boardsesh/shared-schema';
+import type { Climb, HoldHeatmapInput, HoldStat, HoldsFilter, ZoneMatchMode } from '@boardsesh/shared-schema';
 
 // Slim fragment for search/list views. Intentionally omits `description` to
 // keep the list payload small — descriptions can be long and no list UI
@@ -109,6 +109,31 @@ export const GET_CLIMB = gql`
     }
   }
 `;
+
+// Community hold-usage heatmap for the create-climb editor. Community totals
+// only — no per-user fields. Returns an empty list for MoonBoard.
+export const HOLD_HEATMAP_QUERY = gql`
+  query HoldHeatmap($input: HoldHeatmapInput!) {
+    holdHeatmap(input: $input) {
+      holdId
+      totalUses
+      startingUses
+      handUses
+      footUses
+      finishUses
+      totalAscents
+      averageDifficulty
+    }
+  }
+`;
+
+export type HoldHeatmapVariables = {
+  input: HoldHeatmapInput;
+};
+
+export type HoldHeatmapResponse = {
+  holdHeatmap: HoldStat[];
+};
 
 // Type for the search input
 export type ClimbSearchInputVariables = {

--- a/packages/web/app/lib/db/queries/climbs/holds-heatmap.ts
+++ b/packages/web/app/lib/db/queries/climbs/holds-heatmap.ts
@@ -1,187 +1,19 @@
-import { and, sql } from 'drizzle-orm';
-import { dbzRead as db, executeRows } from '@/app/lib/db/db';
+import { dbzRead } from '@/app/lib/db/db';
 import type { ParsedBoardRouteParameters, SearchRequestPagination } from '@/app/lib/types';
-import { UNIFIED_TABLES } from '@/lib/db/queries/util/table-select';
-import { createClimbFilters } from '@boardsesh/db/queries';
-import { boardseshTicks } from '@/app/lib/db/schema';
+import { type HoldHeatmapData, getHoldHeatmapData as getSharedHoldHeatmapData } from '@boardsesh/db/queries';
 
-export type HoldHeatmapData = {
-  holdId: number;
-  totalUses: number;
-  startingUses: number;
-  totalAscents: number;
-  handUses: number;
-  footUses: number;
-  finishUses: number;
-  averageDifficulty: number | null;
-  userAscents?: number;
-  userAttempts?: number;
-};
+export type { HoldHeatmapData };
 
+/**
+ * Web wrapper over the shared `getHoldHeatmapData`. Hands the web read-replica
+ * Drizzle handle (`dbzRead`) to the shared query so the REST heatmap route and
+ * the anonymous cache layer keep their existing `(params, searchParams, userId?)`
+ * signature unchanged.
+ */
 export const getHoldHeatmapData = async (
   params: ParsedBoardRouteParameters,
   searchParams: SearchRequestPagination,
   userId?: string,
 ): Promise<HoldHeatmapData[]> => {
-  const { climbs, climbStats, climbHolds } = UNIFIED_TABLES;
-
-  // Use the shared filter creator
-  const filters = createClimbFilters(params, searchParams, userId);
-
-  try {
-    // Check if personal progress filters are active - if so, use user-specific counts
-    const personalProgressFiltersEnabled =
-      searchParams.hideAttempted ||
-      searchParams.hideCompleted ||
-      searchParams.showOnlyAttempted ||
-      searchParams.showOnlyCompleted;
-
-    let holdStats: Record<string, unknown>[];
-
-    if (personalProgressFiltersEnabled && userId) {
-      // When personal progress filters are active, we need to compute user-specific hold statistics
-      // Since the filters already limit climbs to user's attempted/completed ones,
-      // we can use the same base query but the results will be user-filtered
-      const baseQuery = db
-        .select({
-          holdId: climbHolds.holdId,
-          totalUses: sql<number>`COUNT(DISTINCT ${climbHolds.climbUuid})`,
-          totalAscents: sql<number>`COUNT(DISTINCT ${climbHolds.climbUuid})`, // For user mode, this represents user's climb count per hold
-          startingUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'STARTING' THEN 1 ELSE 0 END)`,
-          handUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'HAND' THEN 1 ELSE 0 END)`,
-          footUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FOOT' THEN 1 ELSE 0 END)`,
-          finishUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FINISH' THEN 1 ELSE 0 END)`,
-          averageDifficulty: sql<number>`AVG(${climbStats.displayDifficulty})`,
-        })
-        .from(climbHolds)
-        .innerJoin(climbs, and(...filters.getClimbHoldsJoinConditions()))
-        .leftJoin(climbStats, and(...filters.getHoldHeatmapClimbStatsConditions()))
-        .where(
-          and(
-            ...filters.getClimbWhereConditions(),
-            ...filters.getSizeConditions(),
-            ...filters.getClimbStatsConditions(),
-          ),
-        )
-        .groupBy(climbHolds.holdId);
-
-      holdStats = await baseQuery;
-    } else {
-      // Use global community stats when no personal progress filters are active
-      const baseQuery = db
-        .select({
-          holdId: climbHolds.holdId,
-          totalUses: sql<number>`COUNT(DISTINCT ${climbHolds.climbUuid})`,
-          totalAscents: sql<number>`SUM(${climbStats.ascensionistCount})`,
-          startingUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'STARTING' THEN 1 ELSE 0 END)`,
-          handUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'HAND' THEN 1 ELSE 0 END)`,
-          footUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FOOT' THEN 1 ELSE 0 END)`,
-          finishUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FINISH' THEN 1 ELSE 0 END)`,
-          averageDifficulty: sql<number>`AVG(${climbStats.displayDifficulty})`,
-        })
-        .from(climbHolds)
-        .innerJoin(climbs, and(...filters.getClimbHoldsJoinConditions()))
-        .leftJoin(climbStats, and(...filters.getHoldHeatmapClimbStatsConditions()))
-        .where(
-          and(
-            ...filters.getClimbWhereConditions(),
-            ...filters.getSizeConditions(),
-            ...filters.getClimbStatsConditions(),
-          ),
-        )
-        .groupBy(climbHolds.holdId);
-
-      holdStats = await baseQuery;
-    }
-
-    // Add user-specific data only if not already computed in the main query
-    if (userId && !personalProgressFiltersEnabled) {
-      // Only fetch separate user data if we're not already using user-specific main stats
-      // Uses boardsesh_ticks (NextAuth userId)
-
-      // Query for user ascents and attempts per hold in parallel
-      const [userAscentsQuery, userAttemptsQuery] = await Promise.all([
-        executeRows<{ hold_id: number; user_ascents: number }>(
-          db,
-          sql`
-          SELECT ch.hold_id, COUNT(*) as user_ascents
-          FROM ${boardseshTicks} t
-          JOIN board_climb_holds ch ON t.climb_uuid = ch.climb_uuid AND ch.board_type = ${params.board_name}
-          WHERE t.user_id = ${userId}
-            AND t.board_type = ${params.board_name}
-            AND t.angle = ${params.angle}
-            AND t.status IN ('flash', 'send')
-          GROUP BY ch.hold_id
-        `,
-        ),
-        executeRows<{ hold_id: number; user_attempts: number }>(
-          db,
-          sql`
-          SELECT ch.hold_id, SUM(t.attempt_count) as user_attempts
-          FROM ${boardseshTicks} t
-          JOIN board_climb_holds ch ON t.climb_uuid = ch.climb_uuid AND ch.board_type = ${params.board_name}
-          WHERE t.user_id = ${userId}
-            AND t.board_type = ${params.board_name}
-            AND t.angle = ${params.angle}
-          GROUP BY ch.hold_id
-        `,
-        ),
-      ]);
-
-      // Convert results to Maps for easier lookup
-      const ascentsMap = new Map();
-      const attemptsMap = new Map();
-
-      for (const row of userAscentsQuery) {
-        ascentsMap.set(Number(row.hold_id), Number(row.user_ascents));
-      }
-
-      for (const row of userAttemptsQuery) {
-        attemptsMap.set(Number(row.hold_id), Number(row.user_attempts));
-      }
-
-      // Merge the user data with the hold stats
-      holdStats = holdStats.map((stat) => ({
-        ...stat,
-        userAscents: ascentsMap.get(Number(stat.holdId)) || 0,
-        userAttempts: attemptsMap.get(Number(stat.holdId)) || 0,
-      }));
-    } else if (personalProgressFiltersEnabled && userId) {
-      // When using personal progress filters, the main stats ARE the user stats,
-      // but we still need to provide the userAscents and userAttempts fields
-      // for backward compatibility with the frontend
-      holdStats = holdStats.map((stat) => ({
-        ...stat,
-        userAscents: Number(stat.totalAscents) || 0,
-        userAttempts: Number(stat.totalUses) || 0,
-      }));
-    }
-
-    return holdStats.map((stats) => normalizeStats(stats, userId));
-  } catch (error) {
-    console.error('Error in getHoldHeatmapData:', error);
-    throw error;
-  }
+  return getSharedHoldHeatmapData(dbzRead, params, searchParams, userId);
 };
-
-function normalizeStats(stats: Record<string, unknown>, userId?: string): HoldHeatmapData {
-  // For numeric fields, ensure we're returning a number and handle null/undefined properly
-  const result: HoldHeatmapData = {
-    holdId: Number(stats.holdId),
-    totalUses: Number(stats.totalUses || 0),
-    totalAscents: Number(stats.totalAscents || 0),
-    startingUses: Number(stats.startingUses || 0),
-    handUses: Number(stats.handUses || 0),
-    footUses: Number(stats.footUses || 0),
-    finishUses: Number(stats.finishUses || 0),
-    averageDifficulty: stats.averageDifficulty ? Number(stats.averageDifficulty) : null,
-  };
-
-  // Add user-specific fields if userId was provided
-  if (userId) {
-    result.userAscents = Number(stats.userAscents || 0);
-    result.userAttempts = Number(stats.userAttempts || 0);
-  }
-
-  return result;
-}


### PR DESCRIPTION
**Stacked on #2512** (base = `rn_climb_create_moonboard`, which is stacked on #2510). Merge #2510 → #2512 → this, in order.

## What

Adds a **community hold-usage heatmap** to the create-climb editor (PR 3 of 3) — toggled from the brush-bar flame, it shows how often each hold is used across climbs for the current board config. **Community/global only**; per-user stats are deferred.

## Vertical slice

- **db (shared):** extract `getHoldHeatmapData` from the Next.js app into `@boardsesh/db` (parameterized by a db handle). Web now delegates with its read client — the existing cache + REST heatmap routes are byte-for-byte unchanged in behaviour.
- **backend GraphQL:** `holdHeatmap(input: HoldHeatmapInput!): [HoldStat!]!` — resolver is rate-limited, **community-only** (no per-user ascents/attempts), MoonBoard short-circuits to `[]`; `HoldHeatmapInput`/`HoldStat` schema + zod validator; codegen regenerated (idempotent).
- **mobile:** `useHoldHeatmap` (React Query, only fetched once the toggle is on) + `HeatmapOverlay` — non-SVG, opacity-scaled translucent RN-`View` discs on a log-scaled green→red ramp, aligned to the same hold percentages as the editor's hold layers, hiding already-painted holds. Lives in `InteractiveCreateBoard`'s `overlay` slot inside the zoom transform, so it tracks at any zoom.

## Validation

- `vp run codegen` — idempotent (no CI drift); `vp run typecheck` (full) — green
- `vp test --project backend` `climb-queries` — 24/24 (3 new `getHoldHeatmapData` tests: shared-hold aggregation, grade-filter, invalid size)
- `vp test --project mobile` — 623 · `vp run check:mobile-bundle` — green
- Pre-existing backend daemon/socket flakes in `integration.test.ts` / `graphql-resolvers.test.ts` reproduce on the base branch (not regressions).

## Notes (non-blocking)

- `onlyClassics` in `HoldHeatmapInput` is currently inert (the underlying climb filter is a known no-op, GH #2499) — exposed for parity with the search filter surface; harmless.
- Per-user heatmap stats (the `userId` branch exists in the shared query) are intentionally not wired into the mobile path yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)