### PR TITLE
[codex] Fix Android board renderer FFI linking

### DIFF
--- a/packages/mobile/modules/board-renderer/android/src/main/cpp/CMakeLists.txt
+++ b/packages/mobile/modules/board-renderer/android/src/main/cpp/CMakeLists.txt
@@ -2,10 +2,8 @@ cmake_minimum_required(VERSION 3.22)
 project(board_renderer_jni)
 
 add_library(board_renderer_jni SHARED jni_bridge.cpp)
-target_link_libraries(board_renderer_jni board_renderer_ffi log)
 
-# Link pre-built Rust library
-add_library(board_renderer_ffi SHARED IMPORTED)
-set_target_properties(board_renderer_ffi PROPERTIES
-    IMPORTED_LOCATION ${CMAKE_SOURCE_DIR}/../jniLibs/${ANDROID_ABI}/libboard_renderer_ffi.so
-)
+# Link by library name so Android records DT_NEEDED as
+# libboard_renderer_ffi.so, not this machine's absolute source path.
+target_link_directories(board_renderer_jni PRIVATE ${CMAKE_SOURCE_DIR}/../jniLibs/${ANDROID_ABI})
+target_link_libraries(board_renderer_jni PRIVATE board_renderer_ffi log)


### PR DESCRIPTION
## Summary

Fixes Android board-renderer native loading by linking the JNI bridge against `libboard_renderer_ffi.so` by library name instead of importing the prebuilt Rust library as an absolute source-path target.

The old CMake setup caused `libboard_renderer_jni.so` to record a `DT_NEEDED` entry pointing at the local build machine path, so Android could not load the dependency from the APK at runtime.

## Validation

- Built the Android app from source and installed it on the `Boardsesh_API_35` emulator.
- Verified `llvm-readelf -d` now reports `NEEDED Shared library: [libboard_renderer_ffi.so]` for `libboard_renderer_jni.so`.
- Cleared logcat, relaunched the app, and confirmed the previous `UnsatisfiedLinkError`, `NoClassDefFoundError`, and `useNativeClimbRender render failed` renderer-load messages no longer appeared.