### PR TITLE
[codex] Polish mobile grade labels

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -560,7 +560,7 @@ const styles = StyleSheet.create({
   closeButton: {
     position: 'absolute',
     top: 8,
-    right: 8,
+    left: 8,
     zIndex: 2,
     width: 44,
     height: 44,

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -44,57 +44,51 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
 
   return (
     <View style={styles.container}>
-      {/* Grade */}
-      <View style={styles.gradeColumn}>
-        <View style={[styles.gradePill, { backgroundColor: gradeColor }]}>
-          <Text variant="footnote" color={iosSystemColors.white} style={styles.gradeText}>
-            {difficulty}
+      <View style={styles.headerRow}>
+        <View style={styles.leadingSpacer} />
+        <View style={styles.centerColumn}>
+          <Text variant="body" style={styles.nameText} numberOfLines={1}>
+            {name}
+          </Text>
+          <Text variant="caption1" style={styles.subtitleText} numberOfLines={1}>
+            {subtitleParts.join(' · ')}
           </Text>
         </View>
-      </View>
-
-      {/* Name + details */}
-      <View style={styles.centerColumn}>
-        <Text variant="body" style={styles.nameText} numberOfLines={1}>
-          {name}
-        </Text>
-        <Text variant="caption1" style={styles.subtitleText} numberOfLines={1}>
-          {subtitleParts.join(' · ')}
+        <Text variant="headline" style={[styles.gradeText, { color: gradeColor }]} numberOfLines={1}>
+          {difficulty}
         </Text>
       </View>
-
-      {/* Spacer for symmetry */}
-      <View style={styles.spacer} />
     </View>
   );
 });
 
 const styles = StyleSheet.create({
   container: {
-    flexDirection: 'row',
-    alignItems: 'center',
     paddingHorizontal: spacing[4],
     paddingVertical: spacing[3],
     minHeight: 56,
+    justifyContent: 'center',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
     gap: spacing[3],
   },
-  gradeColumn: {
+  leadingSpacer: {
     flexShrink: 0,
     minWidth: 48,
-    alignItems: 'center',
-  },
-  gradePill: {
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 8,
-  },
-  gradeText: {
-    fontWeight: '700',
   },
   centerColumn: {
     flex: 1,
     minWidth: 0,
     alignItems: 'center',
+  },
+  gradeText: {
+    flexShrink: 0,
+    minWidth: 48,
+    fontVariant: ['tabular-nums'],
+    fontWeight: '700',
+    textAlign: 'right',
   },
   nameText: {
     fontWeight: '700',
@@ -104,9 +98,5 @@ const styles = StyleSheet.create({
     color: iosSystemColors.systemGray,
     marginTop: 2,
     textAlign: 'center',
-  },
-  spacer: {
-    flexShrink: 0,
-    minWidth: 48,
   },
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -1,10 +1,12 @@
-import { memo, useMemo } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { memo, useCallback, useMemo, useState } from 'react';
+import { View, StyleSheet, type LayoutChangeEvent } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { Text } from '../Text';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
+
+const MIN_GRADE_COLUMN_WIDTH: number = spacing[12];
 
 type PlayDrawerHeaderProps = {
   name: string;
@@ -29,10 +31,16 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   setterUsername,
 }: PlayDrawerHeaderProps) {
   const { t } = useTranslation('climbs');
+  const [gradeColumnWidth, setGradeColumnWidth] = useState(MIN_GRADE_COLUMN_WIDTH);
   const gradeColor = useMemo(
     () => getGradeColor(rawDifficulty ?? difficulty) ?? DEFAULT_GRADE_COLOR,
     [rawDifficulty, difficulty],
   );
+
+  const handleGradeLayout = useCallback((event: LayoutChangeEvent) => {
+    const measuredWidth = Math.ceil(event.nativeEvent.layout.width);
+    setGradeColumnWidth((previousWidth) => (previousWidth === measuredWidth ? previousWidth : measuredWidth));
+  }, []);
 
   const qualityNum = parseFloat(qualityAverage);
   const qualityDisplay = stars > 0 ? stars.toFixed(1) : qualityNum > 0 ? qualityNum.toFixed(1) : null;
@@ -45,7 +53,7 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   return (
     <View style={styles.container}>
       <View style={styles.headerRow}>
-        <View style={styles.leadingSpacer} />
+        <View style={[styles.leadingSpacer, { width: gradeColumnWidth }]} />
         <View style={styles.centerColumn}>
           <Text variant="body" style={styles.nameText} numberOfLines={1}>
             {name}
@@ -54,7 +62,12 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
             {subtitleParts.join(' · ')}
           </Text>
         </View>
-        <Text variant="headline" style={[styles.gradeText, { color: gradeColor }]} numberOfLines={1}>
+        <Text
+          variant="headline"
+          style={[styles.gradeText, { color: gradeColor }]}
+          numberOfLines={1}
+          onLayout={handleGradeLayout}
+        >
           {difficulty}
         </Text>
       </View>
@@ -76,7 +89,6 @@ const styles = StyleSheet.create({
   },
   leadingSpacer: {
     flexShrink: 0,
-    minWidth: 48,
   },
   centerColumn: {
     flex: 1,
@@ -85,7 +97,7 @@ const styles = StyleSheet.create({
   },
   gradeText: {
     flexShrink: 0,
-    minWidth: 48,
+    minWidth: MIN_GRADE_COLUMN_WIDTH,
     fontVariant: ['tabular-nums'],
     fontWeight: '700',
     textAlign: 'right',

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -3,7 +3,7 @@
  * root and is visible on every screen while a current climb is set.
  *
  * Layout (condensed for mobile, no thumbnail per design):
- *   [grade] climb name…              [✓ tick] [BT] [⏻ end]
+ *   climb name…              grade   [✓ tick] [BT] [⏻ end]
  *      ↑ tap opens PlayDrawer    ↑ horizontal swipe = prev/next
  *
  * The horizontal swipe mirrors the play-drawer carousel pattern
@@ -58,22 +58,20 @@ type ClimbLabelProps = {
   display: ClimbDisplay;
   labelColor: ColorValue;
   formattedGrade: string | null;
-  chipBackground: string;
+  gradeColor: string;
 };
 
-function ClimbLabel({ display, labelColor, formattedGrade, chipBackground }: ClimbLabelProps) {
+function ClimbLabel({ display, labelColor, formattedGrade, gradeColor }: ClimbLabelProps) {
   return (
     <View style={styles.labelInner}>
-      {formattedGrade ? (
-        <View style={[styles.gradePill, { backgroundColor: chipBackground }]}>
-          <Text variant="caption1" color={iosSystemColors.white} style={styles.gradeText}>
-            {formattedGrade}
-          </Text>
-        </View>
-      ) : null}
       <Text variant="subheadline" color={labelColor} numberOfLines={1} ellipsizeMode="tail" style={styles.name}>
         {display.name ?? ''}
       </Text>
+      {formattedGrade ? (
+        <Text variant="headline" color={gradeColor} numberOfLines={1} style={styles.gradeText}>
+          {formattedGrade}
+        </Text>
+      ) : null}
     </View>
   );
 }
@@ -221,14 +219,14 @@ export function PersistentQueueBar() {
   const previousFormatted = previousDisplay ? format(previousDisplay.difficulty) : null;
   const nextFormatted = nextDisplay ? format(nextDisplay.difficulty) : null;
 
-  // Vivid grade color (`getGradeColor` raw hex) for the chip, matching the
-  // PlayDrawer header pill. Falls back to the default neutral grade color when
-  // the difficulty is unrecognised.
-  const currentChipColor = getGradeColor(currentDisplay.difficulty) ?? DEFAULT_GRADE_COLOR;
-  const previousChipColor = previousDisplay
+  // Vivid grade color (`getGradeColor` raw hex) for the trailing grade text,
+  // matching climb list rows. Falls back to the default neutral grade color
+  // when the difficulty is unrecognised.
+  const currentGradeColor = getGradeColor(currentDisplay.difficulty) ?? DEFAULT_GRADE_COLOR;
+  const previousGradeColor = previousDisplay
     ? (getGradeColor(previousDisplay.difficulty) ?? DEFAULT_GRADE_COLOR)
     : DEFAULT_GRADE_COLOR;
-  const nextChipColor = nextDisplay
+  const nextGradeColor = nextDisplay
     ? (getGradeColor(nextDisplay.difficulty) ?? DEFAULT_GRADE_COLOR)
     : DEFAULT_GRADE_COLOR;
 
@@ -261,7 +259,7 @@ export function PersistentQueueBar() {
                   display={currentDisplay}
                   labelColor={systemColors.label}
                   formattedGrade={currentFormatted}
-                  chipBackground={currentChipColor}
+                  gradeColor={currentGradeColor}
                 />
               </Animated.View>
               {nextDisplay ? (
@@ -270,7 +268,7 @@ export function PersistentQueueBar() {
                     display={nextDisplay}
                     labelColor={systemColors.label}
                     formattedGrade={nextFormatted}
-                    chipBackground={nextChipColor}
+                    gradeColor={nextGradeColor}
                   />
                 </Animated.View>
               ) : null}
@@ -280,7 +278,7 @@ export function PersistentQueueBar() {
                     display={previousDisplay}
                     labelColor={systemColors.label}
                     formattedGrade={previousFormatted}
-                    chipBackground={previousChipColor}
+                    gradeColor={previousGradeColor}
                   />
                 </Animated.View>
               ) : null}
@@ -379,21 +377,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 8,
   },
-  gradePill: {
+  gradeText: {
     // Reserve a 3-char slot ("V10") so the climb name doesn't shift
     // horizontally as the user swipes between climbs with different
     // grade widths. 4-char grades like "V10+" still expand slightly.
     minWidth: 40,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 6,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  gradeText: {
     fontVariant: ['tabular-nums'],
-    fontWeight: '600',
-    textAlign: 'center',
+    fontWeight: '700',
+    textAlign: 'right',
   },
   name: {
     flex: 1,

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -20,7 +20,6 @@ import { useTranslation } from 'react-i18next';
 import { computePeekOffset, getGradeTintColor } from '@boardsesh/play-view';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { ClimbQueueItem } from '@boardsesh/queue';
-import { iosSystemColors } from '../../theme/ios-colors';
 import { shadowColor } from '../../theme/tokens';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { Text } from '../Text';


### PR DESCRIPTION
## Summary

- Replace filled grade pills in the mobile queue bar and Play Drawer header with colorized grade text.
- Keep the Play Drawer climb title and byline centered while moving the close chevron to the left so it no longer overlaps the right-side grade.
- Preserve stable grade sizing with tabular numbers while matching the existing climb list grade treatment.

## Validation

- `vp run typecheck:mobile`
- `vp test --project mobile`

## Notes

`gh auth status` reports the local `gh` token is invalid, so this PR was opened through the GitHub connector after pushing with Git over SSH.