### PR TITLE
fix(mobile): clear saved climb on angle change + harden create-climb screen

### DIFF
--- a/packages/mobile/src/components/create-climb/CreateClimbSettingsSheet.tsx
+++ b/packages/mobile/src/components/create-climb/CreateClimbSettingsSheet.tsx
@@ -77,8 +77,9 @@ export function CreateClimbSettingsSheet({
     [systemColors],
   );
 
-  if (!visible) return null;
-
+  // Keep the modal mounted and drive it purely via present()/dismiss() in the
+  // effect above. Returning null on !visible would unmount the sheet before the
+  // dismiss effect runs (sheetRef goes null), so the close animation never plays.
   return (
     <ModalSheet ref={sheetRef} snapPoints={['72%']} onDismiss={onDismiss} scrollable>
       <View style={styles.body}>

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen.test.tsx
@@ -1,0 +1,317 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { GraphQLOperationError } from '@boardsesh/graphql-client';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import { useCreateClimbScreen, type CreateClimbBoard } from '../use-create-climb-screen';
+
+// All platform I/O the controller reaches for is mocked here. The shared hold
+// machine (`useCreateClimb`), `climbToQueueItem`, and `isDuplicateClimbError`
+// stay REAL so the orchestration — Set Active uuid/angle, the save state
+// machine, autosave, duplicate handling, draft restore — is exercised end-to-end.
+const mocks = vi.hoisted(() => ({
+  saveClimb: vi.fn(),
+  updateClimb: vi.fn(),
+  setCurrentClimb: vi.fn(),
+  showToast: vi.fn(),
+  routerPush: vi.fn(),
+  refreshAuthState: vi.fn(),
+  loadDraft: vi.fn(),
+  saveDraft: vi.fn(),
+  clearDraft: vi.fn(),
+  uuid: { n: 0 },
+  state: {
+    isAuthenticated: true,
+    profile: { displayName: 'Tester' } as { displayName: string } | null,
+    climb: null as Record<string, unknown> | null,
+    bluetooth: null as unknown,
+  },
+}));
+
+vi.mock('expo-crypto', () => ({ randomUUID: () => `uuid-${++mocks.uuid.n}` }));
+
+vi.mock('expo-router', () => ({ useRouter: () => ({ push: mocks.routerPush }) }));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('@boardsesh/board-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@boardsesh/board-react')>();
+  return {
+    ...actual, // keep the real isDuplicateClimbError
+    useBoardProvider: () => ({
+      isAuthenticated: mocks.state.isAuthenticated,
+      saveClimb: mocks.saveClimb,
+      updateClimb: mocks.updateClimb,
+    }),
+  };
+});
+
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ refreshAuthState: mocks.refreshAuthState }),
+}));
+
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: mocks.state.profile }),
+  useClimb: () => ({ data: mocks.state.climb }),
+}));
+
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueue: () => ({ setCurrentClimb: mocks.setCurrentClimb }),
+}));
+
+vi.mock('../../../providers/bluetooth-provider', () => ({
+  useOptionalBluetoothContext: () => mocks.state.bluetooth,
+}));
+
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: mocks.showToast }),
+}));
+
+vi.mock('../../../lib/create-climb-draft-store', () => ({
+  loadDraft: (...args: unknown[]) => mocks.loadDraft(...args),
+  saveDraft: (...args: unknown[]) => mocks.saveDraft(...args),
+  clearDraft: (...args: unknown[]) => mocks.clearDraft(...args),
+  createClimbDraftKey: (config: CreateClimbBoard) =>
+    `${config.boardName}:${config.layoutId}:${config.sizeId}:${config.angle}`,
+}));
+
+const board25: CreateClimbBoard = { boardName: 'kilter', layoutId: 1, sizeId: 1, setIds: '1', angle: 25 };
+const board40: CreateClimbBoard = { ...board25, angle: 40 };
+
+function renderController(initialBoard: CreateClimbBoard = board25) {
+  return renderHook((props: { board: CreateClimbBoard }) => useCreateClimbScreen(props), {
+    initialProps: { board: initialBoard },
+  });
+}
+
+/** Flush the mount-time draft restore (loadDraft resolves -> restoredRef set). */
+async function flushMount() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** The Climb pushed to the queue by the most recent setCurrentClimb call. */
+function lastQueuedClimb() {
+  const calls = mocks.setCurrentClimb.mock.calls;
+  return (calls[calls.length - 1][0] as ClimbQueueItem).climb;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.uuid.n = 0;
+  mocks.state.isAuthenticated = true;
+  mocks.state.profile = { displayName: 'Tester' };
+  mocks.state.climb = null;
+  mocks.state.bluetooth = null;
+  mocks.saveClimb.mockReset().mockResolvedValue({ uuid: 'c-25', createdAt: null, publishedAt: null });
+  mocks.updateClimb.mockReset().mockResolvedValue({ uuid: 'c-25', createdAt: null, publishedAt: null, isDraft: true });
+  mocks.setCurrentClimb.mockReset();
+  mocks.showToast.mockReset();
+  mocks.routerPush.mockReset();
+  mocks.loadDraft.mockReset().mockResolvedValue(null);
+  mocks.saveDraft.mockReset();
+  mocks.clearDraft.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useCreateClimbScreen', () => {
+  it('regression: Set Active after an angle change carries the new angle and a fresh uuid', async () => {
+    const view = renderController(board25);
+    await flushMount();
+
+    // Paint a valid climb and save it at 25°.
+    act(() => {
+      view.result.current.setName('Angle Test');
+      view.result.current.handlePaint(1);
+    });
+    await act(async () => {
+      await view.result.current.handleSave();
+    });
+    expect(mocks.saveClimb).toHaveBeenCalledTimes(1);
+
+    // Set Active while still at 25° uses the saved climb's uuid.
+    mocks.setCurrentClimb.mockClear();
+    act(() => view.result.current.handleSetActive());
+    expect(lastQueuedClimb()).toMatchObject({ uuid: 'c-25', angle: 25 });
+
+    // Switch the working angle to 40° — same mounted screen, new board prop.
+    view.rerender({ board: board40 });
+    mocks.setCurrentClimb.mockClear();
+    act(() => view.result.current.handleSetActive());
+
+    // The 25° saved identity is dropped: the queue item must NOT reuse c-25,
+    // and it must carry the new 40° angle (no uuid/angle mismatch).
+    const queued = lastQueuedClimb();
+    expect(queued.uuid).not.toBe('c-25');
+    expect(queued.angle).toBe(40);
+  });
+
+  it('Set Active uses a stable preview uuid before save, the saved uuid after, and a fresh one after clear', async () => {
+    const view = renderController();
+    await flushMount();
+
+    act(() => view.result.current.handlePaint(1));
+    act(() => view.result.current.handleSetActive());
+    const previewUuid = lastQueuedClimb().uuid;
+    expect(previewUuid).toMatch(/^uuid-/);
+
+    // Re-tapping reuses the same provisional uuid (same queue slot).
+    act(() => view.result.current.handleSetActive());
+    expect(lastQueuedClimb().uuid).toBe(previewUuid);
+
+    // After save it switches to the saved row's uuid.
+    act(() => view.result.current.setName('Lifecycle'));
+    await act(async () => {
+      await view.result.current.handleSave();
+    });
+    act(() => view.result.current.handleSetActive());
+    expect(lastQueuedClimb().uuid).toBe('c-25');
+
+    // Clear mints a fresh identity; the next Set Active uses neither old uuid.
+    act(() => view.result.current.handleClear());
+    act(() => view.result.current.handlePaint(2));
+    act(() => view.result.current.handleSetActive());
+    const afterClearUuid = lastQueuedClimb().uuid;
+    expect(afterClearUuid).not.toBe('c-25');
+    expect(afterClearUuid).not.toBe(previewUuid);
+  });
+
+  it('routes to login and skips the mutation when unauthenticated', async () => {
+    mocks.state.isAuthenticated = false;
+    const view = renderController();
+    await flushMount();
+
+    await act(async () => {
+      await view.result.current.handleSave();
+    });
+
+    expect(mocks.routerPush).toHaveBeenCalledWith('/auth/login');
+    expect(mocks.saveClimb).not.toHaveBeenCalled();
+  });
+
+  it('asks the screen to open settings when saving without a name', async () => {
+    const view = renderController();
+    await flushMount();
+
+    act(() => view.result.current.handlePaint(1));
+    expect(view.result.current.openSettingsSignal).toBe(0);
+
+    await act(async () => {
+      await view.result.current.handleSave();
+    });
+
+    expect(view.result.current.openSettingsSignal).toBe(1);
+    expect(mocks.saveClimb).not.toHaveBeenCalled();
+  });
+
+  it('runs the save state machine through justSaved and back to ready', async () => {
+    const view = renderController();
+    await flushMount();
+
+    act(() => {
+      view.result.current.setName('Stateful');
+      view.result.current.handlePaint(1);
+    });
+    expect(view.result.current.saveState).toBe('ready');
+
+    await act(async () => {
+      await view.result.current.handleSave();
+    });
+    expect(mocks.saveClimb).toHaveBeenCalledTimes(1);
+    expect(mocks.setCurrentClimb).toHaveBeenCalled();
+    expect(mocks.clearDraft).toHaveBeenCalled();
+    expect(view.result.current.saveState).toBe('justSaved');
+
+    act(() => vi.advanceTimersByTime(3000));
+    expect(view.result.current.saveState).toBe('ready');
+  });
+
+  it('updates the existing row instead of creating a new one within the edit window', async () => {
+    const view = renderController();
+    await flushMount();
+
+    act(() => {
+      view.result.current.setName('Updatable');
+      view.result.current.handlePaint(1);
+    });
+    await act(async () => {
+      await view.result.current.handleSave();
+    });
+    expect(mocks.saveClimb).toHaveBeenCalledTimes(1);
+
+    // Second save with a tracked draft row -> update in place.
+    await act(async () => {
+      await view.result.current.handleSave();
+    });
+    expect(mocks.updateClimb).toHaveBeenCalledTimes(1);
+    expect(mocks.saveClimb).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a duplicate publish inline and other errors as a toast', async () => {
+    const dupError = new GraphQLOperationError([
+      {
+        message: 'duplicate',
+        extensions: { code: 'CLIMB_IS_DUPLICATE', existingClimbUuid: 'c-existing', existingClimbName: 'Existing' },
+      },
+    ]);
+    mocks.saveClimb.mockRejectedValueOnce(dupError);
+
+    const view = renderController();
+    await flushMount();
+
+    act(() => {
+      view.result.current.setName('Dup');
+      view.result.current.handlePaint(1);
+    });
+    await act(async () => {
+      await view.result.current.handleSave();
+    });
+    expect(view.result.current.publishDuplicateError).toEqual({
+      existingClimbUuid: 'c-existing',
+      existingClimbName: 'Existing',
+    });
+    expect(mocks.showToast).not.toHaveBeenCalled();
+
+    // A non-duplicate failure falls back to a toast.
+    mocks.saveClimb.mockRejectedValueOnce(new Error('boom'));
+    await act(async () => {
+      await view.result.current.handleSave();
+    });
+    expect(mocks.showToast).toHaveBeenCalledWith('createClimbForm.alerts.saveFailedFallback', 'error');
+  });
+
+  it('autosaves the working draft after the debounce and clears it on Clear', async () => {
+    const view = renderController();
+    await flushMount();
+
+    act(() => view.result.current.handlePaint(1));
+    act(() => vi.advanceTimersByTime(500));
+    expect(mocks.saveDraft).toHaveBeenCalledWith(
+      'kilter:1:1:25',
+      expect.objectContaining({ isDraft: true }),
+    );
+
+    act(() => view.result.current.handleClear());
+    expect(mocks.clearDraft).toHaveBeenCalledWith('kilter:1:1:25');
+  });
+
+  it('restores a previously saved local draft on mount', async () => {
+    mocks.loadDraft.mockResolvedValueOnce({
+      holdsJson: '{}',
+      name: 'Restored',
+      description: 'From storage',
+      isDraft: false,
+    });
+
+    const view = renderController();
+    await flushMount();
+
+    expect(view.result.current.name).toBe('Restored');
+    expect(view.result.current.description).toBe('From storage');
+    expect(view.result.current.isDraft).toBe(false);
+  });
+});

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -135,6 +135,23 @@ export function useCreateClimbScreen({
     [],
   );
 
+  // A saved climb belongs to the angle it was saved at. The screen stays mounted
+  // across angle changes (the route re-memoises `board`), so a new working angle
+  // means a new climb (same holds, different angle). Drop the saved identity and
+  // mint a fresh preview uuid so Save creates a new row at the new angle and Set
+  // Active carries the right angle — otherwise the queue item would pair the old
+  // uuid with the new angle. Mirrors the per-angle autosave draft key.
+  const lastAngleRef = useRef(board.angle);
+  useEffect(() => {
+    if (lastAngleRef.current === board.angle) return;
+    lastAngleRef.current = board.angle;
+    // Edit identity comes from editClimbUuid (seeded once), not the working angle.
+    if (isEditing) return;
+    setSavedClimb(null);
+    setPublishDuplicateError(null);
+    previewUuidRef.current = randomUUID();
+  }, [board.angle, isEditing]);
+
   // ---- Edit mode: fetch the climb and seed the editor once. ----
   const editVariables = useMemo(
     () =>

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -7,6 +7,13 @@ export default defineConfig({
   define: {
     __DEV__: 'true',
   },
+  // The mobile package pins its own react, while the shared `@boardsesh/*-react`
+  // packages resolve the workspace-root react. A test that renders a shared hook
+  // (e.g. `useCreateClimb`) would otherwise load two React copies and trip
+  // "Invalid hook call". Dedupe collapses them onto a single instance.
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
   test: {
     name: 'mobile',
     globals: true,


### PR DESCRIPTION
Addresses four review findings on the mobile create-climb editor (`packages/mobile/src/components/create-climb/`).

## 1. `savedClimb` / angle mismatch (bug fix)
The screen stays mounted across working-angle changes — the route (`app/(tabs)/climbs/create.tsx`) re-memoises `board`, so a new `angle` flows into the still-mounted hook. After saving at 25° then switching to 40°, `savedClimb` (the 25° row) was still set while `buildProvisionalClimb` read the live `board.angle`. **Set Active** then produced a queue item pairing the old climb uuid with the new angle, so the card showed the wrong angle.

Fix: treat an angle change as a fresh climb identity — clear `savedClimb`, clear any duplicate banner, and mint a new preview uuid when `board.angle` changes (skipped in edit mode, whose identity comes from `editClimbUuid`). This matches the existing model, where the autosave draft key already includes angle (`${boardName}:${layoutId}:${sizeId}:${angle}`).

## 2. Controller hook tests (gap)
The 355-line controller had zero tests. Added `__tests__/use-create-climb-screen.test.tsx` (9 tests) covering: the angle regression above, Set Active uuid lifecycle (stable preview → saved uuid → fresh after clear), unauthenticated routing, open-settings-on-unnamed-save, the save state machine through `justSaved`, update-in-place vs. create, duplicate-inline vs. toast, autosave debounce, and draft restore. The angle test is a true regression guard — it fails (`expected 'c-25' not to be 'c-25'`) without the fix.

## 3. Fragile early-return in `CreateClimbSettingsSheet` (hardening)
`if (!visible) return null` ran after the effect that drives `present()`/`dismiss()`. If `visible` ever flipped to `false` programmatically (e.g. an auto-close after save), the component unmounted before the dismiss effect fired (`sheetRef` already null), so the close animation never played. The `BottomSheetModal` is a true modal (invisible until `present()`), so the sheet now stays mounted and is controlled purely via `present()`/`dismiss()`.

## 4. Stale JSDoc on `CreateClimbScreen` — no change needed
The current file already has a single, accurate JSDoc block describing the routing-aware screen; there was no stale "non-routing single-screen" block to remove.

## Tooling note
The new controller test is the first mobile test to render a shared `@boardsesh/*-react` hook, which surfaced a dual-React resolution between the mobile-pinned `react` and the workspace-root `react`. Added `resolve.dedupe: ['react', 'react-dom']` to `packages/mobile/vite.config.ts`.

## Validation
- `vp run typecheck:mobile` ✓
- `vp test run --project mobile` — 648 tests pass (72 files) ✓
- `vp run check:mobile-bundle` ✓
- Regression test confirmed to fail without the fix, pass with it ✓

https://claude.ai/code/session_01Wn7KCZQNX6nNyUNNDvt6zX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wn7KCZQNX6nNyUNNDvt6zX)_