### PR TITLE
[codex] fix MoonBoard mobile selector

### DIFF
--- a/packages/mobile/src/components/board-discovery/CustomBoardSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/CustomBoardSheet.tsx
@@ -4,13 +4,13 @@ import type BottomSheet from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { BoardName, UserBoard } from '@boardsesh/shared-schema';
 import { SUPPORTED_BOARDS, ANGLES } from '@boardsesh/board-config';
-import {
-  getAllLayouts,
-  getSizesForLayoutId,
-  getSetsForLayoutAndSize,
-  getDefaultSizeForLayout,
-} from '@boardsesh/board-constants/product-sizes';
 import { useCreateBoard } from '../../lib/graphql/hooks';
+import {
+  getBoardLayouts,
+  getBoardSizesForLayoutId,
+  getBoardSetsForLayoutAndSize,
+  getDefaultBoardSizeForLayout,
+} from '../../lib/custom-board-options';
 import { findOwnedBoardForConfig } from './board-items';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { brandColors } from '../../theme/colors';
@@ -87,10 +87,13 @@ export const CustomBoardSheet = forwardRef<BottomSheet, CustomBoardSheetProps>(f
   }, [seed]);
 
   // Cascading option lists — each derives from the selection above it.
-  const layouts = useMemo(() => getAllLayouts(boardName), [boardName]);
-  const sizes = useMemo(() => (layoutId != null ? getSizesForLayoutId(boardName, layoutId) : []), [boardName, layoutId]);
+  const layouts = useMemo(() => getBoardLayouts(boardName), [boardName]);
+  const sizes = useMemo(
+    () => (layoutId != null ? getBoardSizesForLayoutId(boardName, layoutId) : []),
+    [boardName, layoutId],
+  );
   const sets = useMemo(
-    () => (layoutId != null && sizeId != null ? getSetsForLayoutAndSize(boardName, layoutId, sizeId) : []),
+    () => (layoutId != null && sizeId != null ? getBoardSetsForLayoutAndSize(boardName, layoutId, sizeId) : []),
     [boardName, layoutId, sizeId],
   );
   const angles = ANGLES[boardName] ?? [];
@@ -105,14 +108,14 @@ export const CustomBoardSheet = forwardRef<BottomSheet, CustomBoardSheetProps>(f
   };
   const selectLayout = (next: number) => {
     setLayoutId(next);
-    const defaultSize = getDefaultSizeForLayout(boardName, next);
+    const defaultSize = getDefaultBoardSizeForLayout(boardName, next);
     setSizeId(defaultSize);
-    setSetIds(defaultSize != null ? getSetsForLayoutAndSize(boardName, next, defaultSize).map((s) => s.id) : []);
+    setSetIds(defaultSize != null ? getBoardSetsForLayoutAndSize(boardName, next, defaultSize).map((s) => s.id) : []);
   };
   const selectSize = (next: number) => {
     setSizeId(next);
     // Pre-select all sets for the size (the common case).
-    setSetIds(layoutId != null ? getSetsForLayoutAndSize(boardName, layoutId, next).map((s) => s.id) : []);
+    setSetIds(layoutId != null ? getBoardSetsForLayoutAndSize(boardName, layoutId, next).map((s) => s.id) : []);
   };
   const toggleSet = (id: number) => {
     setSetIds((prev) => (prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]));

--- a/packages/mobile/src/components/create-climb/BrushBar.tsx
+++ b/packages/mobile/src/components/create-climb/BrushBar.tsx
@@ -10,7 +10,7 @@ import { useTheme } from '../../providers/theme-provider';
 import { hapticSelection, hapticLight } from '../../lib/haptics';
 import { brandColors } from '../../theme/colors';
 import { spacing, borderRadius } from '../../theme/tokens';
-import { PAINT_ROLES, brushRoleColor, useBrushRoleLabels, type BrushRole } from './brush-roles';
+import { brushRoleColor, getPaintRoles, useBrushRoleLabels, type BrushRole } from './brush-roles';
 
 // The save button's visual state, derived by the controller from auth + the
 // saved-climb snapshot + in-flight state.
@@ -72,15 +72,16 @@ export function BrushBar({
   const { t } = useTranslation('climbs');
   const { systemColors } = useTheme();
   const roleLabels = useBrushRoleLabels();
+  const paintRoles = useMemo(() => getPaintRoles(boardName), [boardName]);
 
   const roleChips = useMemo(
     () =>
-      PAINT_ROLES.map((role) => ({
+      paintRoles.map((role) => ({
         role,
         label: roleLabels[role],
         color: brushRoleColor(boardName, role),
       })),
-    [boardName, roleLabels],
+    [boardName, paintRoles, roleLabels],
   );
 
   const handleSelect = (role: BrushRole) => {

--- a/packages/mobile/src/components/create-climb/HoldRoleSheet.tsx
+++ b/packages/mobile/src/components/create-climb/HoldRoleSheet.tsx
@@ -9,7 +9,7 @@ import { Icon } from '../Icon';
 import { useTheme } from '../../providers/theme-provider';
 import { hapticSelection } from '../../lib/haptics';
 import { spacing, borderRadius } from '../../theme/tokens';
-import { PAINT_ROLES, brushRoleColor, useBrushRoleLabels, type BrushRole } from './brush-roles';
+import { brushRoleColor, getPaintRoles, useBrushRoleLabels, type BrushRole } from './brush-roles';
 
 type HoldRoleSheetProps = {
   /** The long-pressed hold, or null when the sheet is closed. */
@@ -53,6 +53,7 @@ export function HoldRoleSheet({
   const currentState: HoldState | undefined = holdId != null ? litUpHoldsMap[holdId]?.state : undefined;
 
   const snapPoints = useMemo(() => ['38%'], []);
+  const paintRoles = useMemo(() => getPaintRoles(boardName), [boardName]);
 
   const handleSelect = (role: BrushRole) => {
     if (holdId == null) return;
@@ -68,7 +69,7 @@ export function HoldRoleSheet({
           {t('mobile.create.holdRole.title')}
         </Text>
         <View style={styles.grid}>
-          {PAINT_ROLES.map((role) => {
+          {paintRoles.map((role) => {
             const isCurrent = currentState === role;
             const atCap = (role === 'STARTING' && startingCount >= 2) || (role === 'FINISH' && finishCount >= 2);
             const disabled = atCap && !isCurrent;

--- a/packages/mobile/src/components/create-climb/brush-roles.ts
+++ b/packages/mobile/src/components/create-climb/brush-roles.ts
@@ -10,6 +10,11 @@ export type BrushRole = Extract<HoldState, 'STARTING' | 'HAND' | 'FINISH' | 'FOO
 
 export const PAINT_ROLES: ReadonlyArray<Exclude<BrushRole, 'OFF'>> = ['STARTING', 'HAND', 'FINISH', 'FOOT'];
 
+export function getPaintRoles(boardName: BoardName): ReadonlyArray<Exclude<BrushRole, 'OFF'>> {
+  const supportedRoles = STATE_TO_PRIMARY_CODE[boardName];
+  return PAINT_ROLES.filter((role) => supportedRoles[role] !== undefined);
+}
+
 /**
  * The swatch colour for a role on a given board, taken from the board's
  * canonical role code (the same code the frame string and BLE encoder use).

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -19,7 +19,7 @@ import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider'
 import { useToast } from '../../providers/toast-provider';
 import { climbToQueueItem } from '../../lib/climb-to-queue-item';
 import { loadDraft, saveDraft, clearDraft, createClimbDraftKey } from '../../lib/create-climb-draft-store';
-import type { BrushRole } from './brush-roles';
+import { getPaintRoles, type BrushRole } from './brush-roles';
 import type { SaveButtonState } from './BrushBar';
 
 export type CreateClimbBoard = {
@@ -116,6 +116,13 @@ export function useCreateClimbScreen({
   const [isSaving, setIsSaving] = useState(false);
   const [justSaved, setJustSaved] = useState(false);
   const [publishDuplicateError, setPublishDuplicateError] = useState<PublishDuplicateError | null>(null);
+
+  useEffect(() => {
+    if (selectedBrush === 'OFF') return;
+    const supportedRoles = getPaintRoles(board.boardName);
+    if (supportedRoles.includes(selectedBrush)) return;
+    setSelectedBrush(supportedRoles[0] ?? 'HAND');
+  }, [board.boardName, selectedBrush]);
 
   const draftKey = useMemo(() => createClimbDraftKey(board), [board]);
   // Skip the local-autosave restore when forking or editing (those seed from

--- a/packages/mobile/src/lib/__tests__/board-details.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-details.test.ts
@@ -12,6 +12,8 @@ vi.mock('@boardsesh/board-config', () => ({
     tension: {},
     moonboard: {},
   },
+  MOONBOARD_SIZE: { id: 1 },
+  getMoonBoardDetails: vi.fn(),
 }));
 
 vi.mock('../env', () => ({
@@ -19,10 +21,11 @@ vi.mock('../env', () => ({
 }));
 
 import { getImageFilename } from '@boardsesh/board-constants/product-sizes';
-import { BOARD_IMAGE_DIMENSIONS } from '@boardsesh/board-config';
-import { getBoardAspectRatio } from '../board-details';
+import { BOARD_IMAGE_DIMENSIONS, getMoonBoardDetails } from '@boardsesh/board-config';
+import { getBoardAspectRatio, getBoardRenderData } from '../board-details';
 
 const mockedGetImageFilename = vi.mocked(getImageFilename);
+const mockedGetMoonBoardDetails = vi.mocked(getMoonBoardDetails);
 
 const baseParams = {
   boardName: 'kilter' as const,
@@ -58,5 +61,72 @@ describe('getBoardAspectRatio', () => {
     BOARD_IMAGE_DIMENSIONS.kilter = { 'board.png': { width: 1200, height: 800 } };
     const result = getBoardAspectRatio({ ...baseParams, setIds: [1] });
     expect(result).toBeCloseTo(1200 / 800);
+  });
+
+  it('uses MoonBoard render details for the MoonBoard aspect ratio', () => {
+    mockedGetMoonBoardDetails.mockReturnValue({
+      boardWidth: 650,
+      boardHeight: 1000,
+      imageUrls: [],
+      holdsData: [],
+      images_to_holds: { 'moonboard-bg.png': [] },
+    } as unknown as ReturnType<typeof getMoonBoardDetails>);
+
+    const result = getBoardAspectRatio({
+      boardName: 'moonboard',
+      layoutId: 3,
+      sizeId: 1,
+      setIds: [8],
+    });
+
+    expect(result).toBeCloseTo(650 / 1000);
+  });
+});
+
+describe('getBoardRenderData', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('builds MoonBoard render data from the shared MoonBoard config', () => {
+    mockedGetMoonBoardDetails.mockReturnValue({
+      boardWidth: 650,
+      boardHeight: 1000,
+      imageUrls: [],
+      holdsData: [{ id: 1, mirroredHoldId: null, cx: 100, cy: 200, r: 12 }],
+      images_to_holds: {
+        'moonboard-bg.png': [],
+        'moonboard2024/woodenholds.png': [],
+      },
+    } as unknown as ReturnType<typeof getMoonBoardDetails>);
+
+    const result = getBoardRenderData({
+      boardName: 'moonboard',
+      layoutId: 3,
+      sizeId: 1,
+      setIds: [8],
+    });
+
+    expect(result).toEqual({
+      boardWidth: 650,
+      boardHeight: 1000,
+      imageUrls: [
+        'https://example.com/images/moonboard/moonboard-bg.png',
+        'https://example.com/images/moonboard/moonboard2024/woodenholds.png',
+      ],
+      holdsData: [{ id: 1, mirroredHoldId: null, cx: 100, cy: 200, r: 12 }],
+    });
+  });
+
+  it('returns null for an invalid MoonBoard size', () => {
+    const result = getBoardRenderData({
+      boardName: 'moonboard',
+      layoutId: 3,
+      sizeId: 999,
+      setIds: [8],
+    });
+
+    expect(result).toBeNull();
+    expect(mockedGetMoonBoardDetails).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/lib/__tests__/custom-board-options.test.ts
+++ b/packages/mobile/src/lib/__tests__/custom-board-options.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getBoardLayouts,
+  getBoardSetsForLayoutAndSize,
+  getBoardSizesForLayoutId,
+  getDefaultBoardSizeForLayout,
+} from '../custom-board-options';
+
+describe('custom board options', () => {
+  it('returns MoonBoard layouts for the custom board selector', () => {
+    const layouts = getBoardLayouts('moonboard');
+    expect(layouts.map((layout) => layout.name)).toEqual([
+      'MoonBoard 2010',
+      'MoonBoard 2016',
+      'MoonBoard 2024',
+      'MoonBoard Masters 2017',
+      'MoonBoard Masters 2019',
+      'Mini MoonBoard 2020',
+    ]);
+  });
+
+  it('returns the MoonBoard standard size for known layouts', () => {
+    expect(getDefaultBoardSizeForLayout('moonboard', 3)).toBe(1);
+    expect(getBoardSizesForLayoutId('moonboard', 3)).toEqual([
+      {
+        id: 1,
+        name: 'Standard',
+        description: '11x18 Grid',
+        edgeLeft: 0,
+        edgeRight: 11,
+        edgeBottom: 0,
+        edgeTop: 18,
+        productId: 1,
+      },
+    ]);
+  });
+
+  it('returns MoonBoard sets for a known layout and size', () => {
+    const sets = getBoardSetsForLayoutAndSize('moonboard', 3, 1);
+    expect(sets.map((set) => set.name)).toEqual([
+      'Hold Set D',
+      'Hold Set E',
+      'Hold Set F',
+      'Wooden Holds',
+      'Wooden Holds B',
+      'Wooden Holds C',
+    ]);
+  });
+
+  it('returns no MoonBoard options for unknown layout or size combinations', () => {
+    expect(getDefaultBoardSizeForLayout('moonboard', 999)).toBeNull();
+    expect(getBoardSizesForLayoutId('moonboard', 999)).toEqual([]);
+    expect(getBoardSetsForLayoutAndSize('moonboard', 3, 999)).toEqual([]);
+  });
+});

--- a/packages/mobile/src/lib/board-details.ts
+++ b/packages/mobile/src/lib/board-details.ts
@@ -1,5 +1,5 @@
 import { getProductSize, getImageFilename, getHolePlacements } from '@boardsesh/board-constants/product-sizes';
-import { BOARD_IMAGE_DIMENSIONS } from '@boardsesh/board-config';
+import { BOARD_IMAGE_DIMENSIONS, MOONBOARD_SIZE, getMoonBoardDetails } from '@boardsesh/board-config';
 import type { BoardName } from '@boardsesh/shared-schema';
 import type { HoldPlacement } from '../components/board-renderer/types';
 import { WEB_BASE_URL } from './env';
@@ -22,6 +22,10 @@ export function getBoardRenderData(params: {
   setIds: number[];
 }): BoardRenderData | null {
   const { boardName, layoutId, sizeId, setIds } = params;
+
+  if (boardName === 'moonboard') {
+    return getMoonBoardRenderData({ layoutId, sizeId, setIds });
+  }
 
   const sizeData = getProductSize(boardName, sizeId);
   if (!sizeData) return null;
@@ -65,6 +69,38 @@ export function getBoardRenderData(params: {
   return { boardWidth, boardHeight, imageUrls, holdsData };
 }
 
+function getMoonBoardRenderData(params: {
+  layoutId: number;
+  sizeId: number;
+  setIds: number[];
+}): BoardRenderData | null {
+  const { layoutId, sizeId, setIds } = params;
+  if (sizeId !== MOONBOARD_SIZE.id) return null;
+
+  try {
+    const details = getMoonBoardDetails({ layout_id: layoutId, set_ids: setIds });
+    const imageUrls = Object.keys(details.images_to_holds).map(
+      (filename) => `${WEB_BASE_URL}/images/moonboard/${filename}`,
+    );
+    const holdsData: HoldPlacement[] = details.holdsData.map((hold) => ({
+      id: hold.id,
+      mirroredHoldId: hold.mirroredHoldId,
+      cx: hold.cx,
+      cy: hold.cy,
+      r: hold.r,
+    }));
+
+    return {
+      boardWidth: details.boardWidth,
+      boardHeight: details.boardHeight,
+      imageUrls,
+      holdsData,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export function getBoardAspectRatio(params: {
   boardName: BoardName;
   layoutId: number;
@@ -72,6 +108,11 @@ export function getBoardAspectRatio(params: {
   setIds: number[];
 }): number {
   const { boardName, layoutId, sizeId, setIds } = params;
+
+  if (boardName === 'moonboard') {
+    const renderData = getBoardRenderData(params);
+    return renderData ? renderData.boardWidth / renderData.boardHeight : 1080 / 1920;
+  }
 
   for (const setId of setIds) {
     const imageFilename = getImageFilename(boardName, layoutId, sizeId, setId);

--- a/packages/mobile/src/lib/create-board-holds.ts
+++ b/packages/mobile/src/lib/create-board-holds.ts
@@ -18,8 +18,8 @@ export type CreateBoardHolds = {
 
 /**
  * Resolve the full set of tappable holds for a board configuration, board-family
- * agnostic. Aurora boards come from the hole-placement pipeline; the MoonBoard
- * grid branch is added alongside MoonBoard create support.
+ * agnostic. Aurora boards come from the hole-placement pipeline; MoonBoard comes
+ * from the grid-backed render data branch.
  */
 export function getCreateBoardHolds(cfg: {
   boardName: BoardName;
@@ -27,14 +27,12 @@ export function getCreateBoardHolds(cfg: {
   sizeId: number;
   setIds: number[];
 }): CreateBoardHolds | null {
-  // MoonBoard uses a separate grid source (getMoonBoardDetails); added in the
-  // MoonBoard PR. For now every supported create board is an Aurora board.
   const data = getBoardRenderData(cfg);
   if (!data) return null;
   return {
     holdTargets: data.holdsData.map((hold) => ({ id: hold.id, cx: hold.cx, cy: hold.cy, r: hold.r })),
     boardWidth: data.boardWidth,
     boardHeight: data.boardHeight,
-    family: 'aurora',
+    family: cfg.boardName === 'moonboard' ? 'moonboard' : 'aurora',
   };
 }

--- a/packages/mobile/src/lib/custom-board-options.ts
+++ b/packages/mobile/src/lib/custom-board-options.ts
@@ -1,0 +1,71 @@
+import type { BoardName } from '@boardsesh/shared-schema';
+import { MOONBOARD_GRID } from '@boardsesh/board-constants/moonboard';
+import {
+  getAllLayouts,
+  getDefaultSizeForLayout,
+  getSetsForLayoutAndSize,
+  getSizesForLayoutId,
+  type LayoutData,
+  type ProductSizeData,
+  type SetData,
+} from '@boardsesh/board-constants/product-sizes';
+import { MOONBOARD_LAYOUTS, MOONBOARD_SETS, MOONBOARD_SIZE, type MoonBoardLayoutKey } from '@boardsesh/board-config';
+
+const MOONBOARD_PRODUCT_SIZE: ProductSizeData = {
+  id: MOONBOARD_SIZE.id,
+  name: MOONBOARD_SIZE.name,
+  description: MOONBOARD_SIZE.description,
+  edgeLeft: 0,
+  edgeRight: MOONBOARD_GRID.numColumns,
+  edgeBottom: 0,
+  edgeTop: MOONBOARD_GRID.numRows,
+  productId: MOONBOARD_SIZE.id,
+};
+
+function getMoonBoardLayoutEntry(
+  layoutId: number,
+): [MoonBoardLayoutKey, (typeof MOONBOARD_LAYOUTS)[MoonBoardLayoutKey]] | null {
+  return (
+    (Object.entries(MOONBOARD_LAYOUTS).find(([, layout]) => layout.id === layoutId) as
+      | [MoonBoardLayoutKey, (typeof MOONBOARD_LAYOUTS)[MoonBoardLayoutKey]]
+      | undefined) ?? null
+  );
+}
+
+export function getBoardLayouts(boardName: BoardName): LayoutData[] {
+  if (boardName === 'moonboard') {
+    return Object.values(MOONBOARD_LAYOUTS).map((layout) => ({
+      id: layout.id,
+      name: layout.name,
+      productId: MOONBOARD_PRODUCT_SIZE.productId,
+    }));
+  }
+
+  return getAllLayouts(boardName);
+}
+
+export function getBoardSizesForLayoutId(boardName: BoardName, layoutId: number): ProductSizeData[] {
+  if (boardName === 'moonboard') {
+    return getMoonBoardLayoutEntry(layoutId) ? [MOONBOARD_PRODUCT_SIZE] : [];
+  }
+
+  return getSizesForLayoutId(boardName, layoutId);
+}
+
+export function getBoardSetsForLayoutAndSize(boardName: BoardName, layoutId: number, sizeId: number): SetData[] {
+  if (boardName === 'moonboard') {
+    const layoutEntry = getMoonBoardLayoutEntry(layoutId);
+    if (!layoutEntry || sizeId !== MOONBOARD_SIZE.id) return [];
+    return MOONBOARD_SETS[layoutEntry[0]].map((set) => ({ id: set.id, name: set.name }));
+  }
+
+  return getSetsForLayoutAndSize(boardName, layoutId, sizeId);
+}
+
+export function getDefaultBoardSizeForLayout(boardName: BoardName, layoutId: number): number | null {
+  if (boardName === 'moonboard') {
+    return getMoonBoardLayoutEntry(layoutId) ? MOONBOARD_SIZE.id : null;
+  }
+
+  return getDefaultSizeForLayout(boardName, layoutId);
+}

--- a/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
+++ b/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
@@ -303,6 +303,20 @@ describe('useCreateClimb', () => {
       expect(result.current.startingCount).toBe(1);
       expect(result.current.isValid).toBe(true);
     });
+
+    it('drops initial holds whose state cannot be saved for the board', () => {
+      const initialHoldsMap = {
+        100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' },
+        200: { state: 'FOOT' as const, color: '#FFA500', displayColor: '#FFA500' },
+      };
+
+      const { result } = renderHook(() => useCreateClimb('moonboard', { initialHoldsMap }));
+
+      expect(result.current.litUpHoldsMap).toEqual({
+        100: { state: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
+      });
+      expect(result.current.generateFramesString()).toBe('p100r42');
+    });
   });
 
   describe('loadHolds', () => {
@@ -323,6 +337,22 @@ describe('useCreateClimb', () => {
 
       expect(result.current.litUpHoldsMap).toEqual(next);
       expect(result.current.litUpHoldsMap[100]).toBeUndefined();
+    });
+
+    it('drops loaded holds whose state cannot be saved for the board', () => {
+      const { result } = renderHook(() => useCreateClimb('moonboard'));
+
+      act(() => {
+        result.current.loadHolds({
+          100: { state: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
+          200: { state: 'FOOT', color: '#FFA500', displayColor: '#FFA500' },
+        });
+      });
+
+      expect(result.current.litUpHoldsMap).toEqual({
+        100: { state: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
+      });
+      expect(result.current.generateFramesString()).toBe('p100r43');
     });
   });
 

--- a/packages/shared/create-climb-react/src/use-create-climb.ts
+++ b/packages/shared/create-climb-react/src/use-create-climb.ts
@@ -6,6 +6,13 @@ type UseCreateClimbOptions = {
   initialHoldsMap?: LitUpHoldsMap;
 };
 
+function filterSupportedHoldsMap(boardName: BoardName, holdsMap: LitUpHoldsMap): LitUpHoldsMap {
+  const stateToCode = STATE_TO_PRIMARY_CODE[boardName];
+  return Object.fromEntries(
+    Object.entries(holdsMap).filter(([, hold]) => hold.state !== 'OFF' && stateToCode[hold.state] !== undefined),
+  ) as LitUpHoldsMap;
+}
+
 /**
  * Aurora (Kilter/Tension/etc) hold-state machine for the create-climb editor.
  * Pure React + board-constants — shared verbatim by the web form and the
@@ -14,7 +21,9 @@ type UseCreateClimbOptions = {
  * string.
  */
 export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOptions) {
-  const [litUpHoldsMap, setLitUpHoldsMap] = useState<LitUpHoldsMap>(options?.initialHoldsMap ?? {});
+  const [litUpHoldsMap, setLitUpHoldsMap] = useState<LitUpHoldsMap>(() =>
+    filterSupportedHoldsMap(boardName, options?.initialHoldsMap ?? {}),
+  );
 
   // Derived state: count holds by type
   const startingCount = useMemo(
@@ -88,9 +97,9 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
     const stateToCode = STATE_TO_PRIMARY_CODE[boardName];
     return Object.entries(litUpHoldsMap)
       .filter(([, hold]) => hold.state !== 'OFF')
-      .map(([holdId, hold]) => {
+      .flatMap(([holdId, hold]) => {
         const code = stateToCode[hold.state];
-        return `p${holdId}r${code}`;
+        return code === undefined ? [] : [`p${holdId}r${code}`];
       })
       .join('');
   }, [litUpHoldsMap, boardName]);
@@ -101,9 +110,12 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
   }, []);
 
   // Replace the entire holds map in one shot (used when loading a draft back into the form).
-  const loadHolds = useCallback((next: LitUpHoldsMap) => {
-    setLitUpHoldsMap(next);
-  }, []);
+  const loadHolds = useCallback(
+    (next: LitUpHoldsMap) => {
+      setLitUpHoldsMap(filterSupportedHoldsMap(boardName, next));
+    },
+    [boardName],
+  );
 
   return {
     litUpHoldsMap,


### PR DESCRIPTION
## Summary

Fixes MoonBoard setup selection in the React Native app by routing the custom board selector through MoonBoard's handwritten layout, size, and set config instead of the generated Aurora product-size tables.

Also wires MoonBoard render data into the mobile board-detail path so selected MoonBoard configs can render backgrounds and grid holds, and hardens the create-climb editor so unsupported roles like MoonBoard `FOOT` are hidden, clamped, and filtered before frame serialization.

## Root Cause

MoonBoard exists in shared board config, but the RN custom board selector used `@boardsesh/board-constants/product-sizes` helpers for layouts and sets. Those generated tables are Aurora-backed and have empty MoonBoard layout/set maps, so selecting MoonBoard produced no layouts. Downstream render/create paths hit the same gap and returned no board data.

## Validation

- `vp test --project mobile -- src/lib/__tests__/custom-board-options.test.ts src/lib/__tests__/board-details.test.ts`
- `vp test --project create-climb-react -- src/__tests__/use-create-climb.test.ts`
- `vp run typecheck:create-climb-react`
- `vp run typecheck:mobile`
- `vp run check:i18n:orphans`
- Built and installed the Android RN dev client on `Boardsesh_API_35` with `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home ANDROID_HOME=$HOME/Library/Android/sdk bunx expo run:android --port 8082`