### PR TITLE
[codex] test MoonBoard mobile follow-up

### DIFF
--- a/packages/mobile/src/components/create-climb/__tests__/brush-roles.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/brush-roles.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { getPaintRoles } from '../brush-roles';
+
+describe('getPaintRoles', () => {
+  it('excludes FOOT for MoonBoard saved-climb roles', () => {
+    expect(getPaintRoles('moonboard')).toEqual(['STARTING', 'HAND', 'FINISH']);
+  });
+
+  it('returns all four paint roles for Kilter', () => {
+    expect(getPaintRoles('kilter')).toEqual(['STARTING', 'HAND', 'FINISH', 'FOOT']);
+  });
+});

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -118,11 +118,12 @@ export function useCreateClimbScreen({
   const [publishDuplicateError, setPublishDuplicateError] = useState<PublishDuplicateError | null>(null);
 
   useEffect(() => {
-    if (selectedBrush === 'OFF') return;
-    const supportedRoles = getPaintRoles(board.boardName);
-    if (supportedRoles.includes(selectedBrush)) return;
-    setSelectedBrush(supportedRoles[0] ?? 'HAND');
-  }, [board.boardName, selectedBrush]);
+    setSelectedBrush((currentBrush) => {
+      if (currentBrush === 'OFF') return currentBrush;
+      const supportedRoles = getPaintRoles(board.boardName);
+      return supportedRoles.includes(currentBrush) ? currentBrush : (supportedRoles[0] ?? 'HAND');
+    });
+  }, [board.boardName]);
 
   const draftKey = useMemo(() => createClimbDraftKey(board), [board]);
   // Skip the local-autosave restore when forking or editing (those seed from

--- a/packages/mobile/src/lib/__tests__/board-details.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-details.test.ts
@@ -129,4 +129,25 @@ describe('getBoardRenderData', () => {
     expect(result).toBeNull();
     expect(mockedGetMoonBoardDetails).not.toHaveBeenCalled();
   });
+
+  it('warns and returns null when MoonBoard details cannot be resolved', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockedGetMoonBoardDetails.mockImplementation(() => {
+      throw new Error('layout missing');
+    });
+
+    try {
+      expect(
+        getBoardRenderData({
+          boardName: 'moonboard',
+          layoutId: 999,
+          sizeId: 1,
+          setIds: [8],
+        }),
+      ).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith('[board-details] MoonBoard render data unavailable:', 'layout missing');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/packages/mobile/src/lib/__tests__/create-board-holds.test.ts
+++ b/packages/mobile/src/lib/__tests__/create-board-holds.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../board-details', () => ({
+  getBoardRenderData: vi.fn(),
+}));
+
+import { getBoardRenderData } from '../board-details';
+import { getCreateBoardHolds } from '../create-board-holds';
+
+const mockedGetBoardRenderData = vi.mocked(getBoardRenderData);
+
+describe('getCreateBoardHolds', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns MoonBoard hold targets and family from render data', () => {
+    mockedGetBoardRenderData.mockReturnValue({
+      boardWidth: 650,
+      boardHeight: 1000,
+      imageUrls: ['https://example.com/images/moonboard/moonboard-bg.png'],
+      holdsData: [
+        { id: 1, mirroredHoldId: null, cx: 68, cy: 950, r: 12 },
+        { id: 198, mirroredHoldId: null, cx: 618, cy: 50, r: 12 },
+      ],
+    });
+
+    expect(
+      getCreateBoardHolds({
+        boardName: 'moonboard',
+        layoutId: 3,
+        sizeId: 1,
+        setIds: [8],
+      }),
+    ).toEqual({
+      holdTargets: [
+        { id: 1, cx: 68, cy: 950, r: 12 },
+        { id: 198, cx: 618, cy: 50, r: 12 },
+      ],
+      boardWidth: 650,
+      boardHeight: 1000,
+      family: 'moonboard',
+    });
+  });
+
+  it('returns null when render data is unavailable', () => {
+    mockedGetBoardRenderData.mockReturnValue(null);
+
+    expect(
+      getCreateBoardHolds({
+        boardName: 'moonboard',
+        layoutId: 999,
+        sizeId: 1,
+        setIds: [8],
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/custom-board-options.test.ts
+++ b/packages/mobile/src/lib/__tests__/custom-board-options.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { getAllLayouts } from '@boardsesh/board-constants/product-sizes';
 import {
   getBoardLayouts,
   getBoardSetsForLayoutAndSize,
@@ -7,6 +8,10 @@ import {
 } from '../custom-board-options';
 
 describe('custom board options', () => {
+  it('delegates non-MoonBoard layouts to product-size constants', () => {
+    expect(getBoardLayouts('kilter')).toEqual(getAllLayouts('kilter'));
+  });
+
   it('returns MoonBoard layouts for the custom board selector', () => {
     const layouts = getBoardLayouts('moonboard');
     expect(layouts.map((layout) => layout.name)).toEqual([

--- a/packages/mobile/src/lib/board-details.ts
+++ b/packages/mobile/src/lib/board-details.ts
@@ -96,7 +96,12 @@ function getMoonBoardRenderData(params: {
       imageUrls,
       holdsData,
     };
-  } catch {
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[board-details] MoonBoard render data unavailable:',
+      error instanceof Error ? error.message : String(error),
+    );
     return null;
   }
 }

--- a/packages/mobile/src/lib/custom-board-options.ts
+++ b/packages/mobile/src/lib/custom-board-options.ts
@@ -9,7 +9,13 @@ import {
   type ProductSizeData,
   type SetData,
 } from '@boardsesh/board-constants/product-sizes';
-import { MOONBOARD_LAYOUTS, MOONBOARD_SETS, MOONBOARD_SIZE, type MoonBoardLayoutKey } from '@boardsesh/board-config';
+import {
+  getLayoutById,
+  MOONBOARD_LAYOUTS,
+  MOONBOARD_SETS,
+  MOONBOARD_SIZE,
+  type MoonBoardLayoutKey,
+} from '@boardsesh/board-config';
 
 const MOONBOARD_PRODUCT_SIZE: ProductSizeData = {
   id: MOONBOARD_SIZE.id,
@@ -22,14 +28,8 @@ const MOONBOARD_PRODUCT_SIZE: ProductSizeData = {
   productId: MOONBOARD_SIZE.id,
 };
 
-function getMoonBoardLayoutEntry(
-  layoutId: number,
-): [MoonBoardLayoutKey, (typeof MOONBOARD_LAYOUTS)[MoonBoardLayoutKey]] | null {
-  return (
-    (Object.entries(MOONBOARD_LAYOUTS).find(([, layout]) => layout.id === layoutId) as
-      | [MoonBoardLayoutKey, (typeof MOONBOARD_LAYOUTS)[MoonBoardLayoutKey]]
-      | undefined) ?? null
-  );
+function getMoonBoardLayoutKey(layoutId: number): MoonBoardLayoutKey | null {
+  return (getLayoutById(layoutId)?.[0] as MoonBoardLayoutKey | undefined) ?? null;
 }
 
 export function getBoardLayouts(boardName: BoardName): LayoutData[] {
@@ -46,7 +46,7 @@ export function getBoardLayouts(boardName: BoardName): LayoutData[] {
 
 export function getBoardSizesForLayoutId(boardName: BoardName, layoutId: number): ProductSizeData[] {
   if (boardName === 'moonboard') {
-    return getMoonBoardLayoutEntry(layoutId) ? [MOONBOARD_PRODUCT_SIZE] : [];
+    return getMoonBoardLayoutKey(layoutId) ? [MOONBOARD_PRODUCT_SIZE] : [];
   }
 
   return getSizesForLayoutId(boardName, layoutId);
@@ -54,9 +54,9 @@ export function getBoardSizesForLayoutId(boardName: BoardName, layoutId: number)
 
 export function getBoardSetsForLayoutAndSize(boardName: BoardName, layoutId: number, sizeId: number): SetData[] {
   if (boardName === 'moonboard') {
-    const layoutEntry = getMoonBoardLayoutEntry(layoutId);
-    if (!layoutEntry || sizeId !== MOONBOARD_SIZE.id) return [];
-    return MOONBOARD_SETS[layoutEntry[0]].map((set) => ({ id: set.id, name: set.name }));
+    const layoutKey = getMoonBoardLayoutKey(layoutId);
+    if (!layoutKey || sizeId !== MOONBOARD_SIZE.id) return [];
+    return MOONBOARD_SETS[layoutKey].map((set) => ({ id: set.id, name: set.name }));
   }
 
   return getSetsForLayoutAndSize(boardName, layoutId, sizeId);
@@ -64,7 +64,7 @@ export function getBoardSetsForLayoutAndSize(boardName: BoardName, layoutId: num
 
 export function getDefaultBoardSizeForLayout(boardName: BoardName, layoutId: number): number | null {
   if (boardName === 'moonboard') {
-    return getMoonBoardLayoutEntry(layoutId) ? MOONBOARD_SIZE.id : null;
+    return getMoonBoardLayoutKey(layoutId) ? MOONBOARD_SIZE.id : null;
   }
 
   return getDefaultSizeForLayout(boardName, layoutId);

--- a/packages/shared/create-climb-react/src/use-create-climb.ts
+++ b/packages/shared/create-climb-react/src/use-create-climb.ts
@@ -21,6 +21,9 @@ function filterSupportedHoldsMap(boardName: BoardName, holdsMap: LitUpHoldsMap):
  * string.
  */
 export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOptions) {
+  // The editor mounts once per board route today, so this initial sanitizer only
+  // needs the mount-time board. If a future caller swaps boardName mid-mount,
+  // remount this hook or re-sanitize litUpHoldsMap on board change.
   const [litUpHoldsMap, setLitUpHoldsMap] = useState<LitUpHoldsMap>(() =>
     filterSupportedHoldsMap(boardName, options?.initialHoldsMap ?? {}),
   );


### PR DESCRIPTION
## Summary

- Add missing coverage for MoonBoard mobile follow-up behavior: paint roles, create-board hold targets/family, and non-MoonBoard custom board option delegation.
- Tighten the follow-up code paths by clamping the selected brush only when the board changes, reusing `getLayoutById`, and logging MoonBoard render-data adapter failures before returning `null`.
- Document the stable-board-name assumption in the shared create-climb hook lazy initializer.

## Validation

- `vp test --project mobile -- src/components/create-climb/__tests__/brush-roles.test.ts src/lib/__tests__/create-board-holds.test.ts src/lib/__tests__/custom-board-options.test.ts src/lib/__tests__/board-details.test.ts`
- `vp run typecheck:create-climb-react`
- `vp run typecheck:mobile`

Known base issue:

- `vp run check:i18n:orphans` currently fails on existing `packages/shared/i18n/locales/en-US/session.json` keys `mobile.similarClimbs.sends_one` and `mobile.similarClimbs.sends_other`; this branch does not touch those keys.