### PR TITLE
Fix Android sheet scroll and safe-area button issues

### DIFF
--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useMemo, useRef, useState, useEffect, type PropsWithChildren } from 'react';
-import { View, Pressable, ScrollView, StyleSheet, Platform, type ViewStyle } from 'react-native';
+import { View, Pressable, StyleSheet, Platform, type ViewStyle } from 'react-native';
+// react-native-gesture-handler's ScrollView (not the bare RN one) for the
+// horizontal sort-by chip rail: nested inside the sheet's vertical
+// BottomSheetScrollView, a plain RN ScrollView won't scroll on Android because
+// the parent scroll/pan gestures capture the touch. The gesture-handler
+// scrollable coordinates nested scrolling correctly.
+import { ScrollView } from 'react-native-gesture-handler';
 import {
   BottomSheetBackdrop,
   BottomSheetModal,

--- a/packages/mobile/src/components/EndSessionSheet.tsx
+++ b/packages/mobile/src/components/EndSessionSheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import BottomSheet, { BottomSheetBackdrop, BottomSheetView, type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -36,8 +36,6 @@ export function EndSessionSheet({ visible, onDismiss, onConfirm, isEnding, climb
     }
   }, [mounted]);
 
-  const snapPoints = useMemo(() => ['35%'], []);
-
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />,
     [],
@@ -53,7 +51,10 @@ export function EndSessionSheet({ visible, onDismiss, onConfirm, isEnding, climb
   return (
     <BottomSheet
       ref={sheetRef}
-      snapPoints={snapPoints}
+      // Size to content rather than a fixed snap point — with safe-area bottom
+      // padding added (up to ~34pt on gesture-nav phones), a fixed '35%' could
+      // crowd or clip the buttons on shorter devices.
+      enableDynamicSizing
       enablePanDownToClose
       onClose={handleClose}
       backdropComponent={renderBackdrop}
@@ -89,7 +90,7 @@ export function EndSessionSheet({ visible, onDismiss, onConfirm, isEnding, climb
 
 const styles = StyleSheet.create({
   content: {
-    flex: 1,
+    // No flex:1 — enableDynamicSizing measures the content's intrinsic height.
     alignItems: 'center',
     paddingHorizontal: spacing[6],
     paddingTop: spacing[4],

--- a/packages/mobile/src/components/EndSessionSheet.tsx
+++ b/packages/mobile/src/components/EndSessionSheet.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import BottomSheet, { BottomSheetBackdrop, BottomSheetView, type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { Text } from './Text';
 import { Button } from './Button';
@@ -19,6 +20,7 @@ type EndSessionSheetProps = {
 export function EndSessionSheet({ visible, onDismiss, onConfirm, isEnding, climbCount }: EndSessionSheetProps) {
   const { t } = useTranslation('session');
   const { systemColors } = useTheme();
+  const insets = useSafeAreaInsets();
   const sheetRef = useRef<BottomSheet>(null);
   const [mounted, setMounted] = useState(false);
 
@@ -58,7 +60,7 @@ export function EndSessionSheet({ visible, onDismiss, onConfirm, isEnding, climb
       backgroundStyle={{ backgroundColor: systemColors.secondaryBackground }}
       handleIndicatorStyle={sheetStyles.indicator}
     >
-      <BottomSheetView style={styles.content}>
+      <BottomSheetView style={[styles.content, { paddingBottom: insets.bottom + spacing[3] }]}>
         <Icon name="end.session" size={40} color={systemColors.secondaryLabel} />
 
         <Text variant="title2" style={styles.title}>

--- a/packages/mobile/src/components/__tests__/end-session-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/end-session-sheet.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, forwardRef, useImperativeHandle, type ReactNode, type Ref } from 'react';
+
+// Pulls `paddingBottom` out of a style that may be a single object or an array
+// of layers (the component passes `[styles.content, { paddingBottom }]`).
+function readPaddingBottom(style: unknown): number | undefined {
+  const layers = Array.isArray(style) ? style : [style];
+  for (const layer of layers) {
+    if (layer && typeof layer === 'object' && 'paddingBottom' in layer) {
+      return (layer as { paddingBottom?: number }).paddingBottom;
+    }
+  }
+  return undefined;
+}
+
+const sheet = vi.hoisted(() => ({ expand: vi.fn() }));
+
+type ViewMockProps = { children?: ReactNode };
+vi.mock('react-native', () => ({
+  View: ({ children }: ViewMockProps) => createElement('div', {}, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+// BottomSheet → div exposing the dynamic-sizing / snap-point props so a test can
+// assert the sheet is content-sized, with an imperative `expand` for the effect.
+type SheetMockProps = {
+  children?: ReactNode;
+  enableDynamicSizing?: boolean;
+  snapPoints?: (string | number)[];
+};
+type SheetViewMockProps = { children?: ReactNode; style?: unknown };
+vi.mock('@gorhom/bottom-sheet', () => ({
+  default: forwardRef(({ children, enableDynamicSizing, snapPoints }: SheetMockProps, ref: Ref<unknown>) => {
+    useImperativeHandle(ref, () => ({ expand: sheet.expand }));
+    return createElement(
+      'div',
+      {
+        'data-sheet': 'true',
+        'data-dynamic': enableDynamicSizing ? 'true' : 'false',
+        'data-snappoints': snapPoints ? JSON.stringify(snapPoints) : '',
+      },
+      children,
+    );
+  }),
+  BottomSheetView: ({ children, style }: SheetViewMockProps) =>
+    createElement('div', { 'data-sheet-view': 'true', 'data-pb': String(readPaddingBottom(style) ?? '') }, children),
+  BottomSheetBackdrop: () => createElement('div', { 'data-backdrop': 'true' }),
+}));
+
+// Gesture-nav phone: a non-zero bottom inset is the case the dynamic-sizing fix
+// guards against (button row crowded under the home indicator).
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { count?: number }) => (opts?.count != null ? `${key}:${opts.count}` : key),
+  }),
+}));
+
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryBackground: '#fff', secondaryLabel: '#888' } }),
+}));
+
+type TextMockProps = { children?: ReactNode };
+vi.mock('../Text', () => ({
+  Text: ({ children }: TextMockProps) => createElement('span', { 'data-text': 'true' }, children),
+}));
+
+type ButtonMockProps = { title: string; onPress?: () => void; variant?: string; loading?: boolean };
+vi.mock('../Button', () => ({
+  Button: ({ title, onPress, variant, loading }: ButtonMockProps) =>
+    createElement('button', {
+      onClick: onPress,
+      'data-button': title,
+      'data-variant': variant ?? 'filled',
+      'data-loading': loading ? 'true' : 'false',
+    }),
+}));
+
+vi.mock('../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+
+vi.mock('../../theme/tokens', () => ({
+  spacing: { 3: 12, 4: 16, 6: 24 },
+  sheetStyles: { indicator: {} },
+}));
+
+import { EndSessionSheet } from '../EndSessionSheet';
+
+function makeProps(over: Partial<Parameters<typeof EndSessionSheet>[0]> = {}) {
+  return {
+    visible: true,
+    onDismiss: vi.fn(),
+    onConfirm: vi.fn(),
+    isEnding: false,
+    climbCount: 3,
+    ...over,
+  };
+}
+
+const button = (root: HTMLElement, title: string) =>
+  root.querySelector(`[data-button="${title}"]`) as HTMLButtonElement | null;
+
+describe('EndSessionSheet', () => {
+  beforeEach(() => {
+    sheet.expand.mockClear();
+  });
+
+  it('renders nothing until it has been made visible', () => {
+    const { container } = render(<EndSessionSheet {...makeProps({ visible: false })} />);
+    expect(container.querySelector('[data-sheet]')).toBeNull();
+  });
+
+  it('shows the confirmation copy, climb count, and both actions when visible', () => {
+    const { container } = render(<EndSessionSheet {...makeProps({ climbCount: 5 })} />);
+    expect(container.querySelector('[data-icon="end.session"]')).not.toBeNull();
+    // climbCount flows through the interpolated count key.
+    expect(container.textContent).toContain('mobile.queue.climbCount:5');
+    expect(button(container, 'summary.done')).not.toBeNull();
+    expect(button(container, 'mobile.queue.endSession')).not.toBeNull();
+  });
+
+  it('sizes to content instead of a fixed snap point', () => {
+    const { container } = render(<EndSessionSheet {...makeProps()} />);
+    const sheetEl = container.querySelector('[data-sheet]') as HTMLElement;
+    expect(sheetEl.getAttribute('data-dynamic')).toBe('true');
+    expect(sheetEl.getAttribute('data-snappoints')).toBe('');
+  });
+
+  it('pads the content past the safe-area bottom inset (34) plus spacing[3] (12)', () => {
+    const { container } = render(<EndSessionSheet {...makeProps()} />);
+    const view = container.querySelector('[data-sheet-view]') as HTMLElement;
+    expect(view.getAttribute('data-pb')).toBe('46');
+  });
+
+  it('fires onConfirm when End session is pressed', () => {
+    const onConfirm = vi.fn();
+    const { container } = render(<EndSessionSheet {...makeProps({ onConfirm })} />);
+    fireEvent.click(button(container, 'mobile.queue.endSession')!);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onDismiss when Done is pressed', () => {
+    const onDismiss = vi.fn();
+    const { container } = render(<EndSessionSheet {...makeProps({ onDismiss })} />);
+    fireEvent.click(button(container, 'summary.done')!);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects the ending state on the confirm button', () => {
+    const { container } = render(<EndSessionSheet {...makeProps({ isEnding: true })} />);
+    expect(button(container, 'mobile.queue.endSession')?.getAttribute('data-loading')).toBe('true');
+  });
+});

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { View, Pressable, StyleSheet, type TextStyle } from 'react-native';
 import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import {
   createInitialTickState,
@@ -63,6 +64,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
   const { t: tClimbs } = useTranslation('climbs');
   const { systemColors } = useTheme();
   const { showToast } = useToast();
+  const insets = useSafeAreaInsets();
   const saveTick = useSaveTick(toBoardName(boardName));
   const { data: grades } = useGrades(boardName);
 
@@ -198,7 +200,9 @@ export const QuickTickBar = React.memo(function QuickTickBar({
   const saveLabel = ascentType === 'flash' ? t('playView.tickBar.flashSaveLabel') : t('playView.tickBar.sendSaveLabel');
 
   return (
-    <View style={styles.container}>
+    // The save row sits at the very bottom of LogAscentSheet, so the bottom
+    // padding must clear the Android system nav bar / home indicator.
+    <View style={[styles.container, { paddingBottom: insets.bottom + spacing[3] }]}>
       <View style={styles.row}>
         <Text variant="footnote" color={iosSystemColors.systemGray} style={styles.rowLabel}>
           {t('playView.tickBar.gradeLabel')}
@@ -324,7 +328,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
 const styles = StyleSheet.create({
   container: {
     paddingTop: spacing[1],
-    paddingBottom: spacing[3],
+    // paddingBottom applied inline (safe-area aware) — see render.
   },
   row: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -328,7 +328,6 @@ export const QuickTickBar = React.memo(function QuickTickBar({
 const styles = StyleSheet.create({
   container: {
     paddingTop: spacing[1],
-    // paddingBottom applied inline (safe-area aware) — see render.
   },
   row: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/search/GradePopover.tsx
+++ b/packages/mobile/src/components/search/GradePopover.tsx
@@ -6,8 +6,9 @@
 // A low sheet (not the 90% filter mega-sheet) keeps it one-handed. Tap rules are
 // the shared, web-identical state machine in @boardsesh/climb-filters.
 
-import { useCallback, useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react';
-import { Platform, Pressable, ScrollView, StyleSheet, View, type ViewStyle } from 'react-native';
+import { useCallback, useEffect, useMemo, useRef, useState, type ElementRef, type PropsWithChildren } from 'react';
+import { Platform, Pressable, StyleSheet, View, type ViewStyle } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
 import {
   BottomSheetBackdrop,
   BottomSheetModal,
@@ -72,7 +73,7 @@ export function GradePopover({ boardName, grade, sendDifficultyIds = [], onChang
   const { formatGrade } = useGradeFormat();
   const insets = useSafeAreaInsets();
   const sheetRef = useRef<BottomSheetModal>(null);
-  const scrollRef = useRef<ScrollView>(null);
+  const scrollRef = useRef<ElementRef<typeof ScrollView>>(null);
   const { data: gradesData } = useGrades(boardName);
 
   const grades = useMemo(() => [...(gradesData ?? [])].sort((a, b) => a.difficultyId - b.difficultyId), [gradesData]);
@@ -210,6 +211,10 @@ export function GradePopover({ boardName, grade, sendDifficultyIds = [], onChang
           ) : null}
         </View>
 
+        {/* react-native-gesture-handler's ScrollView (not the bare RN one) — a
+            plain ScrollView inside a gorhom sheet has its touches captured by
+            the sheet's pan handler on Android, so the rail never scrolls. The
+            gesture-handler scrollable coordinates with the sheet's pan gesture. */}
         <ScrollView
           ref={scrollRef}
           horizontal


### PR DESCRIPTION
## What

Fixes two Android-specific bottom-sheet bugs in the mobile app, both reported from a device with on-screen 3-button navigation.

### 1. Horizontal rails won't scroll inside sheets

The grade selector rail (`GradePopover`) and the **Sort by** chip rail in the climb filter sheet (`ClimbFilterSheet`) couldn't be scrolled on Android. Both used a plain React Native `ScrollView`. Inside a `@gorhom/bottom-sheet`, the sheet's pan/scroll gestures capture the touch stream on Android, so a bare RN `ScrollView` never receives the move events — as a direct sheet child (grade rail) or nested inside the vertical `BottomSheetScrollView` (sort-by rail).

Switched both to `react-native-gesture-handler`'s `ScrollView`, which is a `NativeViewGestureHandler`-backed scrollable that coordinates with the sheet's gestures. This is the established fix for horizontal scrollers inside gorhom sheets.

### 2. Sheet action buttons render under the system nav bar

The **End session** sheet (`EndSessionSheet`) and the log-ascent save row (`QuickTickBar`, rendered at the bottom of `LogAscentSheet`) applied no safe-area bottom padding, so their buttons sat behind the Android system nav buttons. Added `paddingBottom: insets.bottom + spacing[3]`, matching the pattern the shared `Sheet`/`ModalSheet` footers already use.

## Files

- `packages/mobile/src/components/search/GradePopover.tsx` — grade rail → RNGH `ScrollView`
- `packages/mobile/src/components/ClimbFilterSheet.tsx` — sort-by rail → RNGH `ScrollView`
- `packages/mobile/src/components/EndSessionSheet.tsx` — safe-area bottom padding
- `packages/mobile/src/components/play-drawer/QuickTickBar.tsx` — safe-area bottom padding

## Validation

- `vp run typecheck:mobile` — pass
- `vp test --project mobile` — 748 tests pass
- `vp run check:mobile-bundle` — Android Metro bundle builds clean

No Android emulator in this environment, so the scroll/safe-area behaviour needs an on-device check via an EAS preview: confirm the grade rail and Sort by rail scroll horizontally, and that the End session / log-ascent buttons sit fully above the system nav bar.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XSNAyzTSmsmdb9Wh4dXy5M)_