### PR TITLE
[codex] fix android ble permission checks

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/react-native-permissions-test-harness.ts
+++ b/packages/mobile/src/lib/ble/__tests__/react-native-permissions-test-harness.ts
@@ -1,0 +1,32 @@
+import { vi } from 'vitest';
+
+export const reactNativePermissionHarness = {
+  platform: {
+    OS: 'android' as 'android' | 'ios',
+    Version: 31 as number | string,
+  },
+  permissionsAndroid: {
+    PERMISSIONS: {
+      ACCESS_FINE_LOCATION: 'ACCESS_FINE_LOCATION',
+      BLUETOOTH_SCAN: 'BLUETOOTH_SCAN',
+      BLUETOOTH_CONNECT: 'BLUETOOTH_CONNECT',
+      POST_NOTIFICATIONS: 'POST_NOTIFICATIONS',
+    },
+    RESULTS: {
+      GRANTED: 'granted',
+      DENIED: 'denied',
+    },
+    requestMultiple: vi.fn(),
+    request: vi.fn(),
+  },
+};
+
+export function resetReactNativePermissionHarness(): void {
+  reactNativePermissionHarness.platform.OS = 'android';
+  reactNativePermissionHarness.platform.Version = 31;
+  reactNativePermissionHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+    BLUETOOTH_SCAN: 'granted',
+    BLUETOOTH_CONNECT: 'granted',
+  });
+  reactNativePermissionHarness.permissionsAndroid.request.mockResolvedValue('granted');
+}

--- a/packages/mobile/src/lib/ble/__tests__/use-ble-permissions.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-ble-permissions.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockBleManager = vi.hoisted(() => ({
+  state: vi.fn(),
+  onStateChange: vi.fn(),
+}));
+
+const reactNativeHarness = vi.hoisted(() => ({
+  platform: {
+    OS: 'android' as 'android' | 'ios',
+    Version: 31 as number | string,
+  },
+  permissionsAndroid: {
+    PERMISSIONS: {
+      ACCESS_FINE_LOCATION: 'ACCESS_FINE_LOCATION',
+      BLUETOOTH_SCAN: 'BLUETOOTH_SCAN',
+      BLUETOOTH_CONNECT: 'BLUETOOTH_CONNECT',
+      POST_NOTIFICATIONS: 'POST_NOTIFICATIONS',
+    },
+    RESULTS: {
+      GRANTED: 'granted',
+      DENIED: 'denied',
+    },
+    requestMultiple: vi.fn(),
+    request: vi.fn(),
+  },
+}));
+
+vi.mock('react-native', () => ({
+  Platform: reactNativeHarness.platform,
+  PermissionsAndroid: reactNativeHarness.permissionsAndroid,
+}));
+
+vi.mock('react-native-ble-plx', () => ({
+  State: {
+    PoweredOn: 'PoweredOn',
+    PoweredOff: 'PoweredOff',
+    Unknown: 'Unknown',
+  },
+}));
+
+vi.mock('../ble-manager', () => ({
+  bleManager: mockBleManager,
+}));
+
+import { requestBleRuntimePermissions } from '../use-ble-permissions';
+
+describe('requestBleRuntimePermissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reactNativeHarness.platform.OS = 'android';
+    reactNativeHarness.platform.Version = 31;
+    reactNativeHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+      BLUETOOTH_SCAN: 'granted',
+      BLUETOOTH_CONNECT: 'granted',
+    });
+    reactNativeHarness.permissionsAndroid.request.mockResolvedValue('granted');
+    mockBleManager.state.mockResolvedValue('PoweredOn');
+  });
+
+  it('requests Android 12+ scan and connect permissions', async () => {
+    const permissionsGranted = await requestBleRuntimePermissions();
+
+    expect(permissionsGranted).toBe(true);
+    expect(reactNativeHarness.permissionsAndroid.requestMultiple).toHaveBeenCalledWith([
+      'BLUETOOTH_SCAN',
+      'BLUETOOTH_CONNECT',
+    ]);
+    expect(mockBleManager.state).not.toHaveBeenCalled();
+  });
+
+  it('requests fine location on Android 11 and below', async () => {
+    reactNativeHarness.platform.Version = 30;
+    reactNativeHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+      ACCESS_FINE_LOCATION: 'granted',
+    });
+
+    const permissionsGranted = await requestBleRuntimePermissions();
+
+    expect(permissionsGranted).toBe(true);
+    expect(reactNativeHarness.permissionsAndroid.requestMultiple).toHaveBeenCalledWith(['ACCESS_FINE_LOCATION']);
+  });
+
+  it('returns false when a required Android permission is denied', async () => {
+    reactNativeHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+      BLUETOOTH_SCAN: 'granted',
+      BLUETOOTH_CONNECT: 'denied',
+    });
+
+    const permissionsGranted = await requestBleRuntimePermissions();
+
+    expect(permissionsGranted).toBe(false);
+  });
+
+  it('requests Android notification permission without making it part of the BLE gate', async () => {
+    reactNativeHarness.platform.Version = 33;
+    reactNativeHarness.permissionsAndroid.request.mockResolvedValue('denied');
+
+    const permissionsGranted = await requestBleRuntimePermissions({ requestNotificationPermission: true });
+
+    expect(permissionsGranted).toBe(true);
+    expect(reactNativeHarness.permissionsAndroid.request).toHaveBeenCalledWith('POST_NOTIFICATIONS');
+  });
+
+  it('checks CoreBluetooth state on iOS instead of Android runtime permissions', async () => {
+    reactNativeHarness.platform.OS = 'ios';
+    mockBleManager.state.mockResolvedValue('PoweredOn');
+
+    const permissionsGranted = await requestBleRuntimePermissions();
+
+    expect(permissionsGranted).toBe(true);
+    expect(mockBleManager.state).toHaveBeenCalledOnce();
+    expect(reactNativeHarness.permissionsAndroid.requestMultiple).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/ble/__tests__/use-ble-permissions.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-ble-permissions.test.ts
@@ -1,35 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  reactNativePermissionHarness,
+  resetReactNativePermissionHarness,
+} from './react-native-permissions-test-harness';
 
 const mockBleManager = vi.hoisted(() => ({
   state: vi.fn(),
   onStateChange: vi.fn(),
 }));
 
-const reactNativeHarness = vi.hoisted(() => ({
-  platform: {
-    OS: 'android' as 'android' | 'ios',
-    Version: 31 as number | string,
-  },
-  permissionsAndroid: {
-    PERMISSIONS: {
-      ACCESS_FINE_LOCATION: 'ACCESS_FINE_LOCATION',
-      BLUETOOTH_SCAN: 'BLUETOOTH_SCAN',
-      BLUETOOTH_CONNECT: 'BLUETOOTH_CONNECT',
-      POST_NOTIFICATIONS: 'POST_NOTIFICATIONS',
-    },
-    RESULTS: {
-      GRANTED: 'granted',
-      DENIED: 'denied',
-    },
-    requestMultiple: vi.fn(),
-    request: vi.fn(),
-  },
-}));
-
-vi.mock('react-native', () => ({
-  Platform: reactNativeHarness.platform,
-  PermissionsAndroid: reactNativeHarness.permissionsAndroid,
-}));
+vi.mock('react-native', async () => {
+  const { reactNativePermissionHarness: harness } = await import('./react-native-permissions-test-harness');
+  return {
+    Platform: harness.platform,
+    PermissionsAndroid: harness.permissionsAndroid,
+  };
+});
 
 vi.mock('react-native-ble-plx', () => ({
   State: {
@@ -48,13 +34,7 @@ import { requestBleRuntimePermissions } from '../use-ble-permissions';
 describe('requestBleRuntimePermissions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    reactNativeHarness.platform.OS = 'android';
-    reactNativeHarness.platform.Version = 31;
-    reactNativeHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
-      BLUETOOTH_SCAN: 'granted',
-      BLUETOOTH_CONNECT: 'granted',
-    });
-    reactNativeHarness.permissionsAndroid.request.mockResolvedValue('granted');
+    resetReactNativePermissionHarness();
     mockBleManager.state.mockResolvedValue('PoweredOn');
   });
 
@@ -62,7 +42,7 @@ describe('requestBleRuntimePermissions', () => {
     const permissionsGranted = await requestBleRuntimePermissions();
 
     expect(permissionsGranted).toBe(true);
-    expect(reactNativeHarness.permissionsAndroid.requestMultiple).toHaveBeenCalledWith([
+    expect(reactNativePermissionHarness.permissionsAndroid.requestMultiple).toHaveBeenCalledWith([
       'BLUETOOTH_SCAN',
       'BLUETOOTH_CONNECT',
     ]);
@@ -70,19 +50,21 @@ describe('requestBleRuntimePermissions', () => {
   });
 
   it('requests fine location on Android 11 and below', async () => {
-    reactNativeHarness.platform.Version = 30;
-    reactNativeHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+    reactNativePermissionHarness.platform.Version = 30;
+    reactNativePermissionHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
       ACCESS_FINE_LOCATION: 'granted',
     });
 
     const permissionsGranted = await requestBleRuntimePermissions();
 
     expect(permissionsGranted).toBe(true);
-    expect(reactNativeHarness.permissionsAndroid.requestMultiple).toHaveBeenCalledWith(['ACCESS_FINE_LOCATION']);
+    expect(reactNativePermissionHarness.permissionsAndroid.requestMultiple).toHaveBeenCalledWith([
+      'ACCESS_FINE_LOCATION',
+    ]);
   });
 
   it('returns false when a required Android permission is denied', async () => {
-    reactNativeHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+    reactNativePermissionHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
       BLUETOOTH_SCAN: 'granted',
       BLUETOOTH_CONNECT: 'denied',
     });
@@ -93,23 +75,23 @@ describe('requestBleRuntimePermissions', () => {
   });
 
   it('requests Android notification permission without making it part of the BLE gate', async () => {
-    reactNativeHarness.platform.Version = 33;
-    reactNativeHarness.permissionsAndroid.request.mockResolvedValue('denied');
+    reactNativePermissionHarness.platform.Version = 33;
+    reactNativePermissionHarness.permissionsAndroid.request.mockResolvedValue('denied');
 
     const permissionsGranted = await requestBleRuntimePermissions({ requestNotificationPermission: true });
 
     expect(permissionsGranted).toBe(true);
-    expect(reactNativeHarness.permissionsAndroid.request).toHaveBeenCalledWith('POST_NOTIFICATIONS');
+    expect(reactNativePermissionHarness.permissionsAndroid.request).toHaveBeenCalledWith('POST_NOTIFICATIONS');
   });
 
-  it('checks CoreBluetooth state on iOS instead of Android runtime permissions', async () => {
-    reactNativeHarness.platform.OS = 'ios';
-    mockBleManager.state.mockResolvedValue('PoweredOn');
+  it('does not check hardware state for iOS runtime permissions', async () => {
+    reactNativePermissionHarness.platform.OS = 'ios';
+    mockBleManager.state.mockResolvedValue('PoweredOff');
 
     const permissionsGranted = await requestBleRuntimePermissions();
 
     expect(permissionsGranted).toBe(true);
-    expect(mockBleManager.state).toHaveBeenCalledOnce();
-    expect(reactNativeHarness.permissionsAndroid.requestMultiple).not.toHaveBeenCalled();
+    expect(mockBleManager.state).not.toHaveBeenCalled();
+    expect(reactNativePermissionHarness.permissionsAndroid.requestMultiple).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -3,8 +3,48 @@ import type { HoldPlacement } from '../../../components/board-renderer/types';
 
 // ── Mock native modules that use-board-bluetooth.ts imports transitively ──
 
+const reactNativeHarness = vi.hoisted(() => ({
+  platform: {
+    OS: 'android' as 'android' | 'ios',
+    Version: 31,
+  },
+  permissionsAndroid: {
+    PERMISSIONS: {
+      ACCESS_FINE_LOCATION: 'ACCESS_FINE_LOCATION',
+      BLUETOOTH_SCAN: 'BLUETOOTH_SCAN',
+      BLUETOOTH_CONNECT: 'BLUETOOTH_CONNECT',
+      POST_NOTIFICATIONS: 'POST_NOTIFICATIONS',
+    },
+    RESULTS: {
+      GRANTED: 'granted',
+      DENIED: 'denied',
+    },
+    requestMultiple: vi.fn(),
+    request: vi.fn(),
+  },
+}));
+
+const mockBleManager = vi.hoisted(() => ({
+  state: vi.fn().mockResolvedValue('PoweredOn'),
+  onStateChange: vi.fn(),
+}));
+
 vi.mock('react-native', () => ({
   Alert: { alert: vi.fn() },
+  Platform: reactNativeHarness.platform,
+  PermissionsAndroid: reactNativeHarness.permissionsAndroid,
+}));
+
+vi.mock('react-native-ble-plx', () => ({
+  State: {
+    PoweredOn: 'PoweredOn',
+    PoweredOff: 'PoweredOff',
+    Unknown: 'Unknown',
+  },
+}));
+
+vi.mock('../ble-manager', () => ({
+  bleManager: mockBleManager,
 }));
 
 vi.mock('expo-keep-awake', () => ({

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1,39 +1,28 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { Alert } from 'react-native';
 import type { HoldPlacement } from '../../../components/board-renderer/types';
+import {
+  reactNativePermissionHarness,
+  resetReactNativePermissionHarness,
+} from './react-native-permissions-test-harness';
 
 // ── Mock native modules that use-board-bluetooth.ts imports transitively ──
-
-const reactNativeHarness = vi.hoisted(() => ({
-  platform: {
-    OS: 'android' as 'android' | 'ios',
-    Version: 31,
-  },
-  permissionsAndroid: {
-    PERMISSIONS: {
-      ACCESS_FINE_LOCATION: 'ACCESS_FINE_LOCATION',
-      BLUETOOTH_SCAN: 'BLUETOOTH_SCAN',
-      BLUETOOTH_CONNECT: 'BLUETOOTH_CONNECT',
-      POST_NOTIFICATIONS: 'POST_NOTIFICATIONS',
-    },
-    RESULTS: {
-      GRANTED: 'granted',
-      DENIED: 'denied',
-    },
-    requestMultiple: vi.fn(),
-    request: vi.fn(),
-  },
-}));
 
 const mockBleManager = vi.hoisted(() => ({
   state: vi.fn().mockResolvedValue('PoweredOn'),
   onStateChange: vi.fn(),
 }));
 
-vi.mock('react-native', () => ({
-  Alert: { alert: vi.fn() },
-  Platform: reactNativeHarness.platform,
-  PermissionsAndroid: reactNativeHarness.permissionsAndroid,
-}));
+vi.mock('react-native', async () => {
+  const { reactNativePermissionHarness: harness } = await import('./react-native-permissions-test-harness');
+  return {
+    Alert: { alert: vi.fn() },
+    Platform: harness.platform,
+    PermissionsAndroid: harness.permissionsAndroid,
+  };
+});
 
 vi.mock('react-native-ble-plx', () => ({
   State: {
@@ -63,6 +52,12 @@ vi.mock('@boardsesh/ble-protocol/moonboard', () => ({
   getMoonboardBluetoothPacket: mockGetMoonboardBluetoothPacket,
 }));
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
 vi.mock('../adapter', () => ({
   RNBleAdapter: vi.fn(),
 }));
@@ -77,7 +72,8 @@ vi.mock('../adapter-factory', () => ({
   isNativeIosBleAdapter: vi.fn().mockReturnValue(false),
 }));
 
-import { convertToMirroredFramesString, dispatchMoonboardPacket } from '../use-board-bluetooth';
+import { createBluetoothAdapter } from '../adapter-factory';
+import { convertToMirroredFramesString, dispatchMoonboardPacket, useBoardBluetooth } from '../use-board-bluetooth';
 
 // ── Factory helper ─────────────────────────────────────────────────────────
 
@@ -86,6 +82,37 @@ function makePlacement(id: number, mirroredHoldId: number | null): HoldPlacement
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
+
+describe('useBoardBluetooth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetReactNativePermissionHarness();
+    mockBleManager.state.mockResolvedValue('PoweredOn');
+  });
+
+  it('shows permission copy and stops before adapter availability when Android BLE permission is denied', async () => {
+    reactNativePermissionHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+      BLUETOOTH_SCAN: 'denied',
+      BLUETOOTH_CONNECT: 'granted',
+    });
+    const { result } = renderHook(() =>
+      useBoardBluetooth({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+      }),
+    );
+
+    let connected = true;
+    await act(async () => {
+      connected = await result.current.connect();
+    });
+
+    expect(connected).toBe(false);
+    expect(Alert.alert).toHaveBeenCalledWith('ble.permissionRequired', 'ble.errorPermissionDenied');
+    expect(createBluetoothAdapter).not.toHaveBeenCalled();
+  });
+});
 
 describe('convertToMirroredFramesString', () => {
   it('correctly maps hold IDs to mirrored IDs', () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
@@ -8,6 +8,32 @@ const mockBleManager = vi.hoisted(() => ({
   stopDeviceScan: vi.fn(),
 }));
 
+const reactNativeHarness = vi.hoisted(() => ({
+  platform: {
+    OS: 'android' as 'android' | 'ios',
+    Version: 31 as number | string,
+  },
+  permissionsAndroid: {
+    PERMISSIONS: {
+      ACCESS_FINE_LOCATION: 'ACCESS_FINE_LOCATION',
+      BLUETOOTH_SCAN: 'BLUETOOTH_SCAN',
+      BLUETOOTH_CONNECT: 'BLUETOOTH_CONNECT',
+      POST_NOTIFICATIONS: 'POST_NOTIFICATIONS',
+    },
+    RESULTS: {
+      GRANTED: 'granted',
+      DENIED: 'denied',
+    },
+    requestMultiple: vi.fn(),
+    request: vi.fn(),
+  },
+}));
+
+vi.mock('react-native', () => ({
+  Platform: reactNativeHarness.platform,
+  PermissionsAndroid: reactNativeHarness.permissionsAndroid,
+}));
+
 vi.mock('react-native-ble-plx', () => ({
   State: { PoweredOn: 'PoweredOn', PoweredOff: 'PoweredOff' },
 }));
@@ -33,6 +59,13 @@ describe('useBoardScan', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    reactNativeHarness.platform.OS = 'android';
+    reactNativeHarness.platform.Version = 31;
+    reactNativeHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+      BLUETOOTH_SCAN: 'granted',
+      BLUETOOTH_CONNECT: 'granted',
+    });
+    reactNativeHarness.permissionsAndroid.request.mockResolvedValue('granted');
     mockBleManager.state.mockResolvedValue('PoweredOn');
   });
 
@@ -49,6 +82,39 @@ describe('useBoardScan', () => {
     });
 
     expect(result.current.status).toBe('unavailable');
+    expect(mockBleManager.startDeviceScan).not.toHaveBeenCalled();
+  });
+
+  it('requests Android BLE permissions before checking Bluetooth state', async () => {
+    const { result } = renderHook(() => useBoardScan());
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(reactNativeHarness.permissionsAndroid.requestMultiple).toHaveBeenCalledWith([
+      'BLUETOOTH_SCAN',
+      'BLUETOOTH_CONNECT',
+    ]);
+    expect(reactNativeHarness.permissionsAndroid.requestMultiple.mock.invocationCallOrder[0]).toBeLessThan(
+      mockBleManager.state.mock.invocationCallOrder[0],
+    );
+    expect(result.current.status).toBe('scanning');
+  });
+
+  it('reports unavailable when Android BLE permissions are denied', async () => {
+    reactNativeHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+      BLUETOOTH_SCAN: 'denied',
+      BLUETOOTH_CONNECT: 'granted',
+    });
+    const { result } = renderHook(() => useBoardScan());
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(result.current.status).toBe('unavailable');
+    expect(mockBleManager.state).not.toHaveBeenCalled();
     expect(mockBleManager.startDeviceScan).not.toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
+import {
+  reactNativePermissionHarness,
+  resetReactNativePermissionHarness,
+} from './react-native-permissions-test-harness';
 
 const mockBleManager = vi.hoisted(() => ({
   state: vi.fn(),
@@ -8,31 +12,13 @@ const mockBleManager = vi.hoisted(() => ({
   stopDeviceScan: vi.fn(),
 }));
 
-const reactNativeHarness = vi.hoisted(() => ({
-  platform: {
-    OS: 'android' as 'android' | 'ios',
-    Version: 31 as number | string,
-  },
-  permissionsAndroid: {
-    PERMISSIONS: {
-      ACCESS_FINE_LOCATION: 'ACCESS_FINE_LOCATION',
-      BLUETOOTH_SCAN: 'BLUETOOTH_SCAN',
-      BLUETOOTH_CONNECT: 'BLUETOOTH_CONNECT',
-      POST_NOTIFICATIONS: 'POST_NOTIFICATIONS',
-    },
-    RESULTS: {
-      GRANTED: 'granted',
-      DENIED: 'denied',
-    },
-    requestMultiple: vi.fn(),
-    request: vi.fn(),
-  },
-}));
-
-vi.mock('react-native', () => ({
-  Platform: reactNativeHarness.platform,
-  PermissionsAndroid: reactNativeHarness.permissionsAndroid,
-}));
+vi.mock('react-native', async () => {
+  const { reactNativePermissionHarness: harness } = await import('./react-native-permissions-test-harness');
+  return {
+    Platform: harness.platform,
+    PermissionsAndroid: harness.permissionsAndroid,
+  };
+});
 
 vi.mock('react-native-ble-plx', () => ({
   State: { PoweredOn: 'PoweredOn', PoweredOff: 'PoweredOff' },
@@ -59,13 +45,7 @@ describe('useBoardScan', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    reactNativeHarness.platform.OS = 'android';
-    reactNativeHarness.platform.Version = 31;
-    reactNativeHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
-      BLUETOOTH_SCAN: 'granted',
-      BLUETOOTH_CONNECT: 'granted',
-    });
-    reactNativeHarness.permissionsAndroid.request.mockResolvedValue('granted');
+    resetReactNativePermissionHarness();
     mockBleManager.state.mockResolvedValue('PoweredOn');
   });
 
@@ -92,18 +72,18 @@ describe('useBoardScan', () => {
       await result.current.start();
     });
 
-    expect(reactNativeHarness.permissionsAndroid.requestMultiple).toHaveBeenCalledWith([
+    expect(reactNativePermissionHarness.permissionsAndroid.requestMultiple).toHaveBeenCalledWith([
       'BLUETOOTH_SCAN',
       'BLUETOOTH_CONNECT',
     ]);
-    expect(reactNativeHarness.permissionsAndroid.requestMultiple.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(reactNativePermissionHarness.permissionsAndroid.requestMultiple.mock.invocationCallOrder[0]).toBeLessThan(
       mockBleManager.state.mock.invocationCallOrder[0],
     );
     expect(result.current.status).toBe('scanning');
   });
 
   it('reports unavailable when Android BLE permissions are denied', async () => {
-    reactNativeHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+    reactNativePermissionHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
       BLUETOOTH_SCAN: 'denied',
       BLUETOOTH_CONNECT: 'granted',
     });

--- a/packages/mobile/src/lib/ble/use-ble-permissions.ts
+++ b/packages/mobile/src/lib/ble/use-ble-permissions.ts
@@ -3,11 +3,80 @@ import { Platform, PermissionsAndroid } from 'react-native';
 import { State } from 'react-native-ble-plx';
 import { bleManager } from './ble-manager';
 
+type AndroidPermission = (typeof PermissionsAndroid.PERMISSIONS)[keyof typeof PermissionsAndroid.PERMISSIONS];
+
 type BlePermissionsResult = {
   bleState: State;
   isAvailable: boolean;
   requestPermissions: () => Promise<boolean>;
 };
+
+type BleRuntimePermissionOptions = {
+  requestNotificationPermission?: boolean;
+};
+
+function androidApiLevel(): number {
+  if (typeof Platform.Version === 'number') {
+    return Platform.Version;
+  }
+
+  const parsedVersion = Number.parseInt(String(Platform.Version), 10);
+  return Number.isNaN(parsedVersion) ? 0 : parsedVersion;
+}
+
+async function requestOptionalNotificationPermission(): Promise<void> {
+  if (Platform.OS !== 'android' || androidApiLevel() < 33) return;
+
+  try {
+    await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS);
+  } catch {
+    // Notification permission is optional for BLE continuity - ignore failures.
+  }
+}
+
+export async function requestBleRuntimePermissions({
+  requestNotificationPermission = false,
+}: BleRuntimePermissionOptions = {}): Promise<boolean> {
+  if (Platform.OS === 'ios') {
+    // iOS handles BLE permissions via Info.plist entries; the system prompts
+    // automatically on first scan. No runtime permission request needed.
+    try {
+      const state = await bleManager.state();
+      return state === State.PoweredOn;
+    } catch {
+      return false;
+    }
+  }
+
+  if (Platform.OS !== 'android') {
+    return true;
+  }
+
+  const requiredPermissions: AndroidPermission[] =
+    androidApiLevel() >= 31
+      ? [PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN, PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT]
+      : [PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION];
+
+  try {
+    const permissionResults = await PermissionsAndroid.requestMultiple(requiredPermissions);
+    const requiredPermissionsGranted = requiredPermissions.every(
+      (permission) => permissionResults[permission] === PermissionsAndroid.RESULTS.GRANTED,
+    );
+
+    if (requestNotificationPermission) {
+      // POST_NOTIFICATIONS (Android 13+) lets the session foreground-service show
+      // its ongoing notification with Previous/Next controls. Requested at
+      // connect time, but decoupled from the BLE gate: a denial only hides the
+      // notification; the foreground service still runs and keeps the board
+      // connection alive in the background.
+      await requestOptionalNotificationPermission();
+    }
+
+    return requiredPermissionsGranted;
+  } catch {
+    return false;
+  }
+}
 
 export function useBlePermissions(): BlePermissionsResult {
   const [bleState, setBleState] = useState<State>(State.Unknown);
@@ -21,40 +90,7 @@ export function useBlePermissions(): BlePermissionsResult {
   }, []);
 
   const requestPermissions = useCallback(async (): Promise<boolean> => {
-    if (Platform.OS === 'ios') {
-      // iOS handles BLE permissions via Info.plist entries; the system prompts
-      // automatically on first scan. No runtime permission request needed.
-      const state = await bleManager.state();
-      return state === State.PoweredOn;
-    }
-
-    // Android: request runtime BLE permissions
-    const permissions: Array<(typeof PermissionsAndroid.PERMISSIONS)[keyof typeof PermissionsAndroid.PERMISSIONS]> = [];
-
-    if (typeof Platform.Version === 'number' && Platform.Version >= 31) {
-      permissions.push(PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN, PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT);
-    } else {
-      permissions.push(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION);
-    }
-
-    const results = await PermissionsAndroid.requestMultiple(permissions);
-    const allGranted = Object.values(results).every((result) => result === PermissionsAndroid.RESULTS.GRANTED);
-
-    // POST_NOTIFICATIONS (Android 13+) lets the session foreground-service show
-    // its ongoing notification with Previous/Next controls. Requested here — at
-    // connect time, the contextual moment a session becomes possible — but kept
-    // DECOUPLED from the BLE gate: a denial only hides the notification; the
-    // foreground service still runs and keeps the board connection alive in the
-    // background, so it must never block connecting.
-    if (typeof Platform.Version === 'number' && Platform.Version >= 33) {
-      try {
-        await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS);
-      } catch {
-        // Notification permission is optional for BLE continuity — ignore failures.
-      }
-    }
-
-    return allGranted;
+    return requestBleRuntimePermissions({ requestNotificationPermission: true });
   }, []);
 
   return {

--- a/packages/mobile/src/lib/ble/use-ble-permissions.ts
+++ b/packages/mobile/src/lib/ble/use-ble-permissions.ts
@@ -39,13 +39,9 @@ export async function requestBleRuntimePermissions({
 }: BleRuntimePermissionOptions = {}): Promise<boolean> {
   if (Platform.OS === 'ios') {
     // iOS handles BLE permissions via Info.plist entries; the system prompts
-    // automatically on first scan. No runtime permission request needed.
-    try {
-      const state = await bleManager.state();
-      return state === State.PoweredOn;
-    } catch {
-      return false;
-    }
+    // automatically on first scan. No runtime permission request needed, and
+    // radio state is checked separately by scan/connect availability guards.
+    return true;
   }
 
   if (Platform.OS !== 'android') {

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -12,6 +12,7 @@ import { getMoonboardBluetoothPacket } from '@boardsesh/ble-protocol/moonboard';
 import { isDisconnectionError } from '@boardsesh/ble-protocol/connection-error';
 import type { AuroraBoardName } from '@boardsesh/shared-schema';
 import { createBluetoothAdapter, isNativeIosBleAdapter } from './adapter-factory';
+import { requestBleRuntimePermissions } from './use-ble-permissions';
 import type { BluetoothAdapter, DevicePickerFn, DiscoveredDevice } from './types';
 import type { HoldPlacement } from '../../components/board-renderer/types';
 
@@ -277,6 +278,12 @@ export function useBoardBluetooth({
       setLoading(true);
 
       try {
+        const permissionsGranted = await requestBleRuntimePermissions({ requestNotificationPermission: true });
+        if (!permissionsGranted) {
+          Alert.alert(t('ble.notAvailable'), t('ble.notAvailable'));
+          return false;
+        }
+
         const adapter = createBluetoothAdapter(devicePicker);
 
         const available = await adapter.isAvailable();

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -280,7 +280,7 @@ export function useBoardBluetooth({
       try {
         const permissionsGranted = await requestBleRuntimePermissions({ requestNotificationPermission: true });
         if (!permissionsGranted) {
-          Alert.alert(t('ble.notAvailable'), t('ble.notAvailable'));
+          Alert.alert(t('ble.permissionRequired'), t('ble.errorPermissionDenied'));
           return false;
         }
 

--- a/packages/mobile/src/lib/ble/use-board-scan.ts
+++ b/packages/mobile/src/lib/ble/use-board-scan.ts
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { State } from 'react-native-ble-plx';
 import { AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID, parseSerialNumber } from '@boardsesh/ble-protocol';
 import { bleManager } from './ble-manager';
+import { requestBleRuntimePermissions } from './use-ble-permissions';
 
 const SCAN_TIMEOUT_MS = 15_000;
 
@@ -45,6 +46,12 @@ export function useBoardScan(): BoardScan {
 
   const start = useCallback(async () => {
     if (scanningRef.current) return;
+
+    const permissionsGranted = await requestBleRuntimePermissions();
+    if (!permissionsGranted) {
+      setStatus('unavailable');
+      return;
+    }
 
     let powered = false;
     try {

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -373,6 +373,8 @@
     "relightBoard": "Re-light board",
     "holdForControls": "Hold for board controls",
     "notAvailable": "Bluetooth is not available",
+    "permissionRequired": "Bluetooth permission required",
+    "errorPermissionDenied": "Allow Bluetooth permissions to connect a board.",
     "errorLedMissing": "Could not send to board — LED data missing for this board configuration.",
     "errorIncompatible": "This climb is for a different board configuration.",
     "errorConnectionFailed": "Could not connect to the board. Make sure it is powered on and nearby."

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -373,6 +373,8 @@
     "relightBoard": "Reiluminar tablero",
     "holdForControls": "Mantén pulsado para los controles",
     "notAvailable": "Bluetooth no está disponible",
+    "permissionRequired": "Permiso de Bluetooth necesario",
+    "errorPermissionDenied": "Permite los permisos de Bluetooth para conectar un tablero.",
     "errorLedMissing": "No se pudo enviar al tablero — faltan datos LED para esta configuración.",
     "errorIncompatible": "Este boulder es para una configuración de tablero diferente.",
     "errorConnectionFailed": "No se pudo conectar al tablero. Asegúrate de que esté encendido y cerca."

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -373,6 +373,8 @@
     "relightBoard": "Rallumer le panneau",
     "holdForControls": "Maintenir pour les commandes",
     "notAvailable": "Le Bluetooth n'est pas disponible",
+    "permissionRequired": "Autorisation Bluetooth requise",
+    "errorPermissionDenied": "Autorisez le Bluetooth pour connecter un panneau.",
     "errorLedMissing": "Impossible d'envoyer au panneau — données LED manquantes pour cette configuration.",
     "errorIncompatible": "Ce bloc est pour une configuration de panneau différente.",
     "errorConnectionFailed": "Impossible de se connecter au panneau. Vérifiez qu'il est allumé et à proximité."


### PR DESCRIPTION
## What changed

- Added a shared mobile BLE runtime permission helper.
- Request Android BLE permissions before quickstart scanning and before board connect availability checks.
- Kept Android 13 notification permission optional so denial does not block BLE.
- Added tests for Android 12+, Android 11 and below, denied permissions, optional notification permission, iOS behavior, and scan ordering.

## Why

Android was checking BLE state or starting scans before requesting runtime permissions. On Android 12+, missing `BLUETOOTH_SCAN` / `BLUETOOTH_CONNECT` grants can make BLE surface as unavailable even when the device supports Bluetooth.

## Validation

- `vp test run --project mobile`
- `vp run typecheck:mobile`
