### PR TITLE
Recreate #2524 on main: multiplayer Strava-style mobile session sheet

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -244,6 +244,7 @@
         "react-native-gesture-handler": "~2.31.1",
         "react-native-gifted-charts": "^1.4.77",
         "react-native-pager-view": "^8.0.2",
+        "react-native-qrcode-svg": "^6.3.15",
         "react-native-reanimated": "4.3.1",
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
@@ -2729,6 +2730,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
+
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
@@ -2762,6 +2765,8 @@
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
@@ -3579,6 +3584,8 @@
 
     "p-map": ["p-map@4.0.0", "", { "dependencies": { "aggregate-error": "^3.0.0" } }, "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ=="],
 
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
@@ -3711,6 +3718,8 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
+
     "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
 
     "query-string": ["query-string@7.1.3", "", { "dependencies": { "decode-uri-component": "^0.2.2", "filter-obj": "^1.1.0", "split-on-first": "^1.0.0", "strict-uri-encode": "^2.0.0" } }, "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg=="],
@@ -3780,6 +3789,8 @@
     "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA=="],
 
     "react-native-pager-view": ["react-native-pager-view@8.0.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Y8All2BbjidI4ZIF9kBOIIoldkqrY/2FXapHZMdjwD+ByXhiOWTFenPs5rq9KRN5uAH/gOXtQCqHLxQDNBQRiQ=="],
+
+    "react-native-qrcode-svg": ["react-native-qrcode-svg@6.3.21", "", { "dependencies": { "prop-types": "^15.8.0", "qrcode": "^1.5.4", "text-encoding": "^0.7.0" }, "peerDependencies": { "react": "*", "react-native": ">=0.63.4", "react-native-svg": ">=14.0.0" } }, "sha512-6vcj4rcdpWedvphDR+NSJcudJykNuLgNGFwm2p4xYjR8RdyTzlrELKI5LkO4ANS9cQUbqsfkpippPv64Q2tUtA=="],
 
     "react-native-reanimated": ["react-native-reanimated@4.3.1", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.3.1", "semver": "^7.7.3" }, "peerDependencies": { "react": "*", "react-native": "0.81 - 0.85", "react-native-worklets": "0.8.x" } }, "sha512-KhGsS0YkCA+gusgyzlf9hnqzVPIR398KTpqXyqq/+yYJJPAvyEEPKcxlB0xtOOXSMrR2A9uRKVARVQhZwrOh+Q=="],
 
@@ -3853,6 +3864,8 @@
 
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
+    "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
+
     "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
 
     "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
@@ -3916,6 +3929,8 @@
     "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
+
+    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -4062,6 +4077,8 @@
     "tesseract.js": ["tesseract.js@7.0.0", "", { "dependencies": { "bmp-js": "^0.1.0", "idb-keyval": "^6.2.0", "is-url": "^1.2.4", "node-fetch": "^2.6.9", "opencollective-postinstall": "^2.0.3", "regenerator-runtime": "^0.13.3", "tesseract.js-core": "^7.0.0", "wasm-feature-detect": "^1.8.0", "zlibjs": "^0.3.1" } }, "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA=="],
 
     "tesseract.js-core": ["tesseract.js-core@7.0.0", "", {}, "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw=="],
+
+    "text-encoding": ["text-encoding@0.7.0", "", {}, "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="],
 
     "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
 
@@ -4252,6 +4269,8 @@
     "whatwg-url-minimum": ["whatwg-url-minimum@0.1.2", "", {}, "sha512-XPEm0XFQWNVG292lII1PrRRJl3sItrs7CettZ4ncYxuDVpLyy+NwlGyut2hXI0JswcJUxeCH+CyOJK0ZzAXD6A=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
 
     "which-typed-array": ["which-typed-array@1.1.21", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.9", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw=="],
 
@@ -5101,6 +5120,10 @@
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "qrcode/pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
+
+    "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+
     "react-devtools-core/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
     "react-native/@react-native/normalize-colors": ["@react-native/normalize-colors@0.85.3", "", {}, "sha512-hj0PScZEhIbcOvQV5yMKX3ha4XEIOy/SVE1Rrpp0beW0dpNLOgSC7KDxGewmDnIHK9YdQUXGY9eMEfShUMIaZw=="],
@@ -5393,6 +5416,14 @@
 
     "ora/strip-ansi/ansi-regex": ["ansi-regex@4.1.1", "", {}, "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="],
 
+    "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "qrcode/yargs/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
+
     "restore-cursor/onetime/mimic-fn": ["mimic-fn@1.2.0", "", {}, "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -5427,10 +5458,20 @@
 
     "ora/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
+    "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "qrcode/yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
     "@bacons/apple-targets/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "graphql-config/@graphql-tools/url-loader/@graphql-tools/wrap/@graphql-tools/delegate/@graphql-tools/batch-execute": ["@graphql-tools/batch-execute@10.0.8", "", { "dependencies": { "@graphql-tools/utils": "^11.0.0", "@whatwg-node/promise-helpers": "^1.3.2", "dataloader": "^2.2.3", "tslib": "^2.8.1" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-Kobt37qrVTFhX4HUK5/vPgMXFw/5f97AzmAlfmDBSRh/GnoAmLKCb48FrEI3gdeIwZB2fEhVHJyDqsojldnLQA=="],
 
     "ora/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
+
+    "qrcode/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "qrcode/yargs/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }
 }

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -111,6 +111,13 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       // target's DEVELOPMENT_TEAM build setting. Matches the existing main
       // target value baked into Boardsesh.xcodeproj/project.pbxproj.
       appleTeamId: '9L3HKPZBH3',
+      // Universal Links for the multiplayer join flow:
+      // https://www.boardsesh.com/join/{sessionId} (and the apex domain, since
+      // either can appear in a shared link). The web /join page is the no-app
+      // fallback. The matching apple-app-site-association is served by
+      // packages/web at /.well-known/apple-app-site-association. Changing this
+      // requires a native rebuild (it's baked into the entitlements).
+      associatedDomains: ['applinks:www.boardsesh.com', 'applinks:boardsesh.com'],
       supportsTablet: false,
       // Entitlements for the App Group (shared with the BoardseshWidgets target),
       // shared keychain (so SharedKeychain.swift can read auth + push tokens),
@@ -145,6 +152,24 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
     },
     android: {
       package: 'com.boardsesh.app',
+      // App Links for the multiplayer join flow:
+      // https://www.boardsesh.com/join/{sessionId} (and the apex domain).
+      // autoVerify lets Android open the link directly in the app once the
+      // Digital Asset Links file (served by packages/web at
+      // /.well-known/assetlinks.json) verifies the package signature. The web
+      // /join page is the no-app fallback. Changing this requires a native
+      // rebuild (it's baked into AndroidManifest.xml).
+      intentFilters: [
+        {
+          action: 'VIEW',
+          autoVerify: true,
+          data: [
+            { scheme: 'https', host: 'www.boardsesh.com', pathPrefix: '/join' },
+            { scheme: 'https', host: 'boardsesh.com', pathPrefix: '/join' },
+          ],
+          category: ['BROWSABLE', 'DEFAULT'],
+        },
+      ],
       // Keep the legacy predictive back gesture OFF. Enabling it
       // (android.predictiveBackGestureEnabled: true) currently breaks
       // cross-screen back navigation with Expo Router + react-native-screens —

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -23,6 +23,7 @@ import { ToastProvider } from '../src/providers/toast-provider';
 import { QueueProvider } from '../src/providers/queue-provider';
 import { DrawerHostProvider } from '../src/providers/drawer-host-provider';
 import { SessionScreenProvider } from '../src/providers/session-screen-provider';
+import { DeepLinkProvider } from '../src/providers/deep-link-provider';
 import { SessionScreenHost } from '../src/components/session-screen/SessionScreenHost';
 import { FeatureFlagsProvider } from '../src/providers/feature-flags-provider';
 import { PartyProfileProvider } from '../src/providers/party-profile-provider';
@@ -232,17 +233,24 @@ function RootLayout() {
                                   <BluetoothProviderWrapper>
                                     <SessionScreenProvider>
                                       <DrawerHostProvider>
-                                        <ThemedNavigation>
-                                          <Stack screenOptions={{ headerShown: false }} initialRouteName="(tabs)">
-                                            <Stack.Screen name="(tabs)" />
-                                            <Stack.Screen
-                                              name="auth"
-                                              options={{ headerShown: false, gestureEnabled: false }}
-                                            />
-                                          </Stack>
-                                        </ThemedNavigation>
-                                        <PersistentQueueBar />
-                                        <SessionScreenHost />
+                                        <DeepLinkProvider>
+                                          <ThemedNavigation>
+                                            <Stack screenOptions={{ headerShown: false }} initialRouteName="(tabs)">
+                                              <Stack.Screen name="(tabs)" />
+                                              <Stack.Screen
+                                                name="auth"
+                                                options={{ headerShown: false, gestureEnabled: false }}
+                                              />
+                                              <Stack.Screen name="session/[sessionId]" />
+                                              <Stack.Screen
+                                                name="join/[sessionId]"
+                                                options={{ presentation: 'modal', headerShown: false }}
+                                              />
+                                            </Stack>
+                                          </ThemedNavigation>
+                                          <PersistentQueueBar />
+                                          <SessionScreenHost />
+                                        </DeepLinkProvider>
                                       </DrawerHostProvider>
                                     </SessionScreenProvider>
                                   </BluetoothProviderWrapper>

--- a/packages/mobile/app/join/[sessionId].tsx
+++ b/packages/mobile/app/join/[sessionId].tsx
@@ -64,7 +64,9 @@ export default function JoinSessionScreen() {
       // owned-board reuse path run instead.
       let ownedBoards = myBoards.data?.boards;
       if (!ownedBoards) {
-        ownedBoards = (await myBoards.refetch()).data?.boards ?? [];
+        // cancelRefetch:false reuses an in-flight fetch instead of firing a
+        // redundant request if the boards query is already loading.
+        ownedBoards = (await myBoards.refetch({ cancelRefetch: false })).data?.boards ?? [];
       }
       const userBoard = await resolveBoardForSession(session.boardPath, {
         ownedBoards,

--- a/packages/mobile/app/join/[sessionId].tsx
+++ b/packages/mobile/app/join/[sessionId].tsx
@@ -1,0 +1,267 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Alert, StyleSheet, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { parseBoardPath, formatBoardDisplayName } from '@boardsesh/board-config';
+import { Text } from '../../src/components/Text';
+import { Button } from '../../src/components/Button';
+import { Card } from '../../src/components/Card';
+import { Avatar } from '../../src/components/Avatar';
+import { ActivityIndicator } from '../../src/components/ActivityIndicator';
+import { Icon } from '../../src/components/Icon';
+import { useTheme } from '../../src/providers/theme-provider';
+import { useAuth } from '../../src/providers/auth-provider';
+import { useQueue } from '../../src/providers/queue-provider';
+import { useSessionScreen } from '../../src/providers/session-screen-provider';
+import { useToast } from '../../src/providers/toast-provider';
+import { useSessionPreview, useMyBoards, useCreateBoard } from '../../src/lib/graphql/hooks';
+import { resolveBoardForSession } from '../../src/lib/board-path-to-user-board';
+import { spacing, borderRadius } from '../../src/theme/tokens';
+import { brandColors } from '../../src/theme/colors';
+
+/** Human board label for the confirmation card, e.g. "Kilter · 40°". */
+function boardLabelFromPath(boardPath: string): string {
+  const parsed = parseBoardPath(boardPath);
+  if (!parsed) return boardPath;
+  const name = formatBoardDisplayName(parsed.boardName);
+  return parsed.angle != null ? `${name} · ${parsed.angle}°` : name;
+}
+
+export default function JoinSessionScreen() {
+  const { sessionId } = useLocalSearchParams<{ sessionId: string }>();
+  const { t } = useTranslation('session');
+  const { systemColors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { isAuthenticated } = useAuth();
+  const { showToast } = useToast();
+
+  const { sessionId: activeSessionId, joinSession, clearSession } = useQueue();
+  const sessionScreen = useSessionScreen();
+
+  const preview = useSessionPreview(sessionId);
+  const myBoards = useMyBoards(undefined, { enabled: isAuthenticated });
+  const createBoard = useCreateBoard();
+
+  const [isJoining, setIsJoining] = useState(false);
+
+  const session = preview.data;
+  const hostName = useMemo(
+    () => session?.users.find((sessionUser) => sessionUser.isLeader)?.username ?? t('mobileJoin.hostFallback'),
+    [session, t],
+  );
+
+  const performJoin = useCallback(async () => {
+    if (!session) return;
+    setIsJoining(true);
+    try {
+      // Make sure the user's boards have loaded before resolving. On a cold
+      // deep-link open the preview can resolve before myBoards; an empty list
+      // makes resolveBoardForSession create a board the user already owns, which
+      // the backend rejects ("You already have a board with this configuration")
+      // and surfaces as a generic join error. Awaiting the boards lets the
+      // owned-board reuse path run instead.
+      let ownedBoards = myBoards.data?.boards;
+      if (!ownedBoards) {
+        ownedBoards = (await myBoards.refetch()).data?.boards ?? [];
+      }
+      const userBoard = await resolveBoardForSession(session.boardPath, {
+        ownedBoards,
+        createBoard: (input) => createBoard.mutateAsync(input),
+      });
+      await joinSession(session.id, { boardPath: session.boardPath, userBoard });
+      sessionScreen.open();
+      router.back();
+    } catch (error) {
+      if (__DEV__) console.warn('[join] failed to join session', error);
+      showToast(t('mobileJoin.joinError'), 'error');
+      setIsJoining(false);
+    }
+  }, [session, myBoards, createBoard, joinSession, sessionScreen, router, showToast, t]);
+
+  const handleJoinPress = useCallback(() => {
+    if (!session) return;
+    // Already in a different session — confirm the switch before clearing it.
+    if (activeSessionId && activeSessionId !== session.id) {
+      Alert.alert(t('mobileJoin.switchTitle'), t('mobileJoin.switchBody'), [
+        { text: t('mobileJoin.cancel'), style: 'cancel' },
+        {
+          text: t('mobileJoin.join'),
+          style: 'destructive',
+          onPress: () => {
+            void (async () => {
+              await clearSession();
+              await performJoin();
+            })();
+          },
+        },
+      ]);
+      return;
+    }
+    void performJoin();
+  }, [session, activeSessionId, clearSession, performJoin, t]);
+
+  const containerStyle = [styles.container, { backgroundColor: systemColors.background, paddingTop: insets.top }];
+
+  // Not signed in — surface a sign-in CTA (the auth gate also handles this; this
+  // is defense in depth so the modal never shows a dead confirmation card).
+  if (!isAuthenticated) {
+    return (
+      <View style={containerStyle}>
+        <View style={styles.centered}>
+          <Icon name="person" size={40} color={systemColors.secondaryLabel} />
+          <Text variant="title3" style={styles.centeredTitle}>
+            {t('mobileJoin.signInToJoin')}
+          </Text>
+          <Button
+            title={t('mobileJoin.signInToJoin')}
+            variant="filled"
+            size="large"
+            onPress={() => router.replace('/auth/login')}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  // Loading the preview.
+  if (preview.isLoading) {
+    return (
+      <View style={containerStyle}>
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" />
+          <Text variant="subheadline" color={systemColors.secondaryLabel}>
+            {t('mobileJoin.loading')}
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  // Errored — offer a retry.
+  if (preview.isError) {
+    return (
+      <View style={containerStyle}>
+        <View style={styles.centered}>
+          <Icon name="warning" size={40} color={brandColors.warning} />
+          <Text variant="title3" style={styles.centeredTitle}>
+            {t('mobileJoin.error')}
+          </Text>
+          <Button title={t('mobileJoin.retry')} variant="filled" size="large" onPress={() => void preview.refetch()} />
+          <Button title={t('mobileJoin.cancel')} variant="text" onPress={() => router.back()} />
+        </View>
+      </View>
+    );
+  }
+
+  // Not found (session query resolved to null).
+  if (!session) {
+    return (
+      <View style={containerStyle}>
+        <View style={styles.centered}>
+          <Icon name="search" size={40} color={systemColors.secondaryLabel} />
+          <Text variant="title3" style={styles.centeredTitle}>
+            {t('mobileJoin.notFound')}
+          </Text>
+          <Button title={t('mobileJoin.cancel')} variant="filled" size="large" onPress={() => router.back()} />
+        </View>
+      </View>
+    );
+  }
+
+  // Ended.
+  if (session.endedAt != null) {
+    return (
+      <View style={containerStyle}>
+        <View style={styles.centered}>
+          <Icon name="clock" size={40} color={systemColors.secondaryLabel} />
+          <Text variant="title3" style={styles.centeredTitle}>
+            {t('mobileJoin.ended')}
+          </Text>
+          <Button title={t('mobileJoin.cancel')} variant="filled" size="large" onPress={() => router.back()} />
+        </View>
+      </View>
+    );
+  }
+
+  // Loaded + active — confirmation card.
+  return (
+    <View style={[containerStyle, styles.confirmContainer]}>
+      <Card style={styles.card}>
+        <Text variant="title2" style={styles.cardTitle}>
+          {t('mobileJoin.confirmTitle', { host: hostName })}
+        </Text>
+        <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.boardLabel}>
+          {t('mobileJoin.boardLabel', { board: boardLabelFromPath(session.boardPath), count: session.users.length })}
+        </Text>
+
+        <View style={styles.avatarRow}>
+          {session.users.slice(0, 6).map((sessionUser) => (
+            <Avatar key={sessionUser.id} uri={sessionUser.avatarUrl} name={sessionUser.username} size={40} />
+          ))}
+        </View>
+
+        <View style={styles.buttonColumn}>
+          <Button
+            title={t('mobileJoin.join')}
+            variant="filled"
+            size="large"
+            loading={isJoining}
+            disabled={isJoining}
+            onPress={handleJoinPress}
+          />
+          <Button
+            title={t('mobileJoin.cancel')}
+            variant="text"
+            size="large"
+            disabled={isJoining}
+            onPress={() => router.back()}
+          />
+        </View>
+      </Card>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  confirmContainer: {
+    justifyContent: 'center',
+    padding: spacing[4],
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[4],
+    padding: spacing[6],
+  },
+  centeredTitle: {
+    textAlign: 'center',
+  },
+  card: {
+    padding: spacing[5],
+    borderRadius: borderRadius.xl,
+    gap: spacing[3],
+  },
+  cardTitle: {
+    textAlign: 'center',
+  },
+  boardLabel: {
+    textAlign: 'center',
+  },
+  avatarRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: spacing[2],
+    marginVertical: spacing[2],
+  },
+  buttonColumn: {
+    gap: spacing[2],
+    marginTop: spacing[2],
+  },
+});

--- a/packages/mobile/app/session/[sessionId].tsx
+++ b/packages/mobile/app/session/[sessionId].tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { View, Pressable, StyleSheet } from 'react-native';
+import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { FlashList } from '@shopify/flash-list';
+import { useTranslation } from 'react-i18next';
+import type BottomSheet from '@gorhom/bottom-sheet';
+import type { SessionDetailTick, SessionFeedParticipant, SocialEntityType } from '@boardsesh/shared-schema';
+import { formatTickAbsoluteTime } from '@boardsesh/profile-stats';
+import { Text } from '../../src/components/Text';
+import { Icon } from '../../src/components/Icon';
+import { ActivityIndicator } from '../../src/components/ActivityIndicator';
+import { SectionHeader } from '../../src/components/SectionHeader';
+import { FeedSocialRow } from '../../src/components/you/FeedSocialRow';
+import { CommentSheet } from '../../src/components/you/CommentSheet';
+import { SessionDetailHero } from '../../src/components/session/SessionDetailHero';
+import { SessionStatTiles } from '../../src/components/session/SessionStatTiles';
+import { SessionAnalyticsSection } from '../../src/components/session/SessionAnalyticsSection';
+import { SessionParticipantBreakdown } from '../../src/components/session/SessionParticipantBreakdown';
+import { SessionTickRow } from '../../src/components/session/SessionTickRow';
+import { SessionEditSheet } from '../../src/components/session/SessionEditSheet';
+import { useSessionDetail, useProfile } from '../../src/lib/graphql/hooks';
+import { navigateToSessionClimb } from '../../src/lib/session-tick-mapping';
+import { TOOLBAR_RESERVE } from '../../src/theme/layout';
+import { spacing } from '../../src/theme/tokens';
+import { useTheme } from '../../src/providers/theme-provider';
+
+export default function SessionDetailScreen() {
+  const { sessionId } = useLocalSearchParams<{ sessionId: string }>();
+  const { t } = useTranslation('session');
+  const { systemColors } = useTheme();
+  const navigation = useNavigation();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const paddingBottom = TOOLBAR_RESERVE + insets.bottom + spacing[6];
+
+  const { data: session, isPending } = useSessionDetail(sessionId);
+  const { data: profile } = useProfile();
+
+  const editSheetRef = useRef<BottomSheet | null>(null);
+  const commentSheetRef = useRef<BottomSheet | null>(null);
+  const [commentTarget, setCommentTarget] = useState<{ entityId: string; entityType: SocialEntityType } | null>(null);
+
+  // Session name, falling back to a generated "<date>" label when unnamed.
+  const title = useMemo(() => {
+    if (!session) return '';
+    if (session.sessionName) return session.sessionName;
+    return formatTickAbsoluteTime(session.lastTickAt, 'MMM D, YYYY');
+  }, [session]);
+
+  const isMultiUser = (session?.participants.length ?? 0) > 1;
+  const participantById = useMemo(() => {
+    const map = new Map<string, SessionFeedParticipant>();
+    for (const participant of session?.participants ?? []) map.set(participant.userId, participant);
+    return map;
+  }, [session]);
+
+  const isOwnedInferred =
+    !!session && session.sessionType === 'inferred' && !!profile?.id && session.ownerUserId === profile.id;
+
+  const openComments = useCallback((entityId: string, entityType: SocialEntityType) => {
+    setCommentTarget({ entityId, entityType });
+    commentSheetRef.current?.snapToIndex(0);
+  }, []);
+
+  const handleOpenSessionComments = useCallback((id: string) => openComments(id, 'session'), [openComments]);
+  const handleOpenTickComments = useCallback((tickUuid: string) => openComments(tickUuid, 'tick'), [openComments]);
+
+  const handleTickPress = useCallback(
+    (tick: SessionDetailTick) => navigateToSessionClimb(router, tick),
+    [router],
+  );
+
+  // Header: title + edit overflow for an owned inferred session.
+  useEffect(() => {
+    navigation.setOptions({
+      headerShown: true,
+      title: title || t('mobileDetail.title'),
+      headerRight: () =>
+        isOwnedInferred ? (
+          <Pressable
+            onPress={() => editSheetRef.current?.snapToIndex(0)}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={t('mobileDetail.editTitle')}
+          >
+            <Icon name="more.actions" size={22} color={systemColors.label} />
+          </Pressable>
+        ) : null,
+    });
+  }, [navigation, title, isOwnedInferred, systemColors, t]);
+
+  if (isPending) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (!session) {
+    return (
+      <View style={styles.centered}>
+        <Icon name="history" size={48} color={systemColors.tertiaryLabel} />
+        <Text variant="headline" color={systemColors.secondaryLabel} style={styles.notFound}>
+          {t('mobileDetail.notFound')}
+        </Text>
+      </View>
+    );
+  }
+
+  const header = (
+    <View>
+      <SessionDetailHero session={session} title={title} />
+      <SessionStatTiles
+        sends={session.totalSends}
+        flashes={session.totalFlashes}
+        attempts={session.totalAttempts}
+        hardestGrade={session.hardestGrade}
+      />
+
+      <SessionAnalyticsSection ticks={session.ticks} />
+
+      <SessionParticipantBreakdown participants={session.participants} />
+
+      <View style={styles.social}>
+        <FeedSocialRow
+          entityId={session.sessionId}
+          upvotes={session.upvotes}
+          userVote={null}
+          commentCount={session.commentCount}
+          onOpenComments={handleOpenSessionComments}
+        />
+      </View>
+
+      <SectionHeader title={t('detail.climbsCount', { count: session.ticks.length })} />
+    </View>
+  );
+
+  return (
+    <View style={styles.flex}>
+      <FlashList
+        data={session.ticks}
+        renderItem={({ item }) => (
+          <SessionTickRow
+            tick={item}
+            isMultiUser={isMultiUser}
+            participant={participantById.get(item.userId)}
+            onPress={handleTickPress}
+            onOpenComments={handleOpenTickComments}
+          />
+        )}
+        keyExtractor={(tick) => tick.uuid}
+        ListHeaderComponent={header}
+        contentContainerStyle={{ paddingBottom }}
+      />
+
+      <SessionEditSheet sheetRef={editSheetRef} session={session} onClose={() => undefined} />
+      <CommentSheet
+        sheetRef={commentSheetRef}
+        entityId={commentTarget?.entityId ?? null}
+        entityType={commentTarget?.entityType ?? 'session'}
+        onClose={() => setCommentTarget(null)}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: spacing[3], paddingHorizontal: spacing[8] },
+  notFound: { textAlign: 'center' },
+  social: { paddingHorizontal: spacing[4], marginTop: spacing[2] },
+});

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -78,6 +78,7 @@
     "react-native-gesture-handler": "~2.31.1",
     "react-native-gifted-charts": "^1.4.77",
     "react-native-pager-view": "^8.0.2",
+    "react-native-qrcode-svg": "^6.3.15",
     "react-native-reanimated": "4.3.1",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",

--- a/packages/mobile/src/components/session-screen/InviteSheet.tsx
+++ b/packages/mobile/src/components/session-screen/InviteSheet.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Share, StyleSheet, View } from 'react-native';
+import BottomSheet, { BottomSheetBackdrop, BottomSheetView, type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import * as Clipboard from 'expo-clipboard';
+import QRCode from 'react-native-qrcode-svg';
+import { Text } from '../Text';
+import { Button } from '../Button';
+import { useTheme } from '../../providers/theme-provider';
+import { useToast } from '../../providers/toast-provider';
+import { hapticSelection } from '../../lib/haptics';
+import { spacing, borderRadius, sheetStyles } from '../../theme/tokens';
+import { buildSessionShareUrl } from '../../lib/session-share';
+
+type InviteSheetProps = {
+  visible: boolean;
+  onDismiss: () => void;
+  sessionId: string;
+};
+
+const QR_SIZE = 200;
+// QR codes need a light background to scan reliably, even in dark mode — this is
+// the one place a hardcoded white is correct (it's the scannable surface, not
+// themeable chrome).
+const QR_TILE_BACKGROUND = '#FFFFFF';
+
+export function InviteSheet({ visible, onDismiss, sessionId }: InviteSheetProps) {
+  const { t } = useTranslation('session');
+  const { systemColors } = useTheme();
+  const { showToast } = useToast();
+  const insets = useSafeAreaInsets();
+  const sheetRef = useRef<BottomSheet>(null);
+  const [mounted, setMounted] = useState(false);
+
+  const shareUrl = useMemo(() => buildSessionShareUrl(sessionId), [sessionId]);
+
+  useEffect(() => {
+    if (visible) {
+      setMounted(true);
+    }
+  }, [visible]);
+
+  useEffect(() => {
+    if (mounted) {
+      sheetRef.current?.expand();
+    }
+  }, [mounted]);
+
+  const snapPoints = useMemo(() => ['60%'], []);
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />,
+    [],
+  );
+
+  const handleClose = useCallback(() => {
+    setMounted(false);
+    onDismiss();
+  }, [onDismiss]);
+
+  const handleCopyLink = useCallback(() => {
+    hapticSelection();
+    void Clipboard.setStringAsync(shareUrl).then(() => {
+      showToast(t('mobile.session.inviteCopied'), 'success');
+    });
+  }, [shareUrl, showToast, t]);
+
+  const handleShare = useCallback(() => {
+    hapticSelection();
+    void Share.share({ message: shareUrl, url: shareUrl });
+  }, [shareUrl]);
+
+  if (!mounted) return null;
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      snapPoints={snapPoints}
+      enablePanDownToClose
+      onClose={handleClose}
+      backdropComponent={renderBackdrop}
+      backgroundStyle={{ backgroundColor: systemColors.secondaryBackground }}
+      handleIndicatorStyle={sheetStyles.indicator}
+    >
+      <BottomSheetView style={[styles.content, { paddingBottom: insets.bottom + spacing[4] }]}>
+        <Text variant="title2" style={styles.title}>
+          {t('mobile.session.inviteTitle')}
+        </Text>
+        <Text variant="body" color={systemColors.secondaryLabel} style={styles.subtitle}>
+          {t('mobile.session.inviteSubtitle')}
+        </Text>
+
+        <View style={styles.qrTile}>
+          <QRCode value={shareUrl} size={QR_SIZE} backgroundColor={QR_TILE_BACKGROUND} />
+        </View>
+
+        <View style={styles.buttonRow}>
+          <Button
+            title={t('mobile.session.inviteCopyLink')}
+            icon="copy"
+            variant="outlined"
+            onPress={handleCopyLink}
+            style={styles.button}
+          />
+          <Button
+            title={t('mobile.session.inviteShare')}
+            icon="share"
+            onPress={handleShare}
+            style={styles.button}
+          />
+        </View>
+      </BottomSheetView>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    paddingHorizontal: spacing[6],
+    paddingTop: spacing[4],
+    gap: spacing[3],
+  },
+  title: {
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  subtitle: {
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  qrTile: {
+    backgroundColor: QR_TILE_BACKGROUND,
+    padding: spacing[4],
+    borderRadius: borderRadius.lg,
+    marginVertical: spacing[2],
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: spacing[3],
+    width: '100%',
+  },
+  button: {
+    flex: 1,
+  },
+});

--- a/packages/mobile/src/components/session-screen/SessionScreen.tsx
+++ b/packages/mobile/src/components/session-screen/SessionScreen.tsx
@@ -1,12 +1,17 @@
+import { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { PanGesture } from 'react-native-gesture-handler';
 import { useQueue } from '../../providers/queue-provider';
 import { SessionScreenHeader } from './SessionScreenHeader';
 import { PreSessionView } from './pre-session/PreSessionView';
 import { InSessionView } from './in-session/InSessionView';
+import { InviteSheet } from './InviteSheet';
 
 type SessionScreenProps = {
   onClose: () => void;
+  /** Swipe-down-to-dismiss gesture, attached to the header by the host. */
+  headerGesture: PanGesture;
 };
 
 /**
@@ -14,16 +19,29 @@ type SessionScreenProps = {
  * configuration form and the in-session live view based on whether the
  * QueueContext currently holds an active sessionId.
  */
-export function SessionScreen({ onClose }: SessionScreenProps) {
-  const { sessionId } = useQueue();
+export function SessionScreen({ onClose, headerGesture }: SessionScreenProps) {
+  const { sessionId, sessionUsers } = useQueue();
   const insets = useSafeAreaInsets();
+  const [showInvite, setShowInvite] = useState(false);
 
   const sessionActive = sessionId !== null;
+  // Teach the share affordance while solo; once a friend joins, the label drops
+  // and the share glyph stands on its own.
+  const soloInvite = sessionActive && sessionUsers.length <= 1;
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
-      <SessionScreenHeader onClose={onClose} sessionActive={sessionActive} />
+      <SessionScreenHeader
+        onClose={onClose}
+        sessionActive={sessionActive}
+        onShare={sessionActive ? () => setShowInvite(true) : undefined}
+        inviteHint={soloInvite}
+        dragGesture={headerGesture}
+      />
       <View style={styles.body}>{sessionActive ? <InSessionView /> : <PreSessionView />}</View>
+      {sessionId ? (
+        <InviteSheet visible={showInvite} onDismiss={() => setShowInvite(false)} sessionId={sessionId} />
+      ) : null}
     </View>
   );
 }

--- a/packages/mobile/src/components/session-screen/SessionScreen.tsx
+++ b/packages/mobile/src/components/session-screen/SessionScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { PanGesture } from 'react-native-gesture-handler';
+import type { SharedValue } from 'react-native-reanimated';
 import { useQueue } from '../../providers/queue-provider';
 import { SessionScreenHeader } from './SessionScreenHeader';
 import { PreSessionView } from './pre-session/PreSessionView';
@@ -12,6 +13,9 @@ type SessionScreenProps = {
   onClose: () => void;
   /** Swipe-down-to-dismiss gesture, attached to the header by the host. */
   headerGesture: PanGesture;
+  /** Host overlay offset (0 = presented) — the in-session body's pull-to-dismiss drives it. */
+  translateY: SharedValue<number>;
+  screenHeight: number;
 };
 
 /**
@@ -19,7 +23,7 @@ type SessionScreenProps = {
  * configuration form and the in-session live view based on whether the
  * QueueContext currently holds an active sessionId.
  */
-export function SessionScreen({ onClose, headerGesture }: SessionScreenProps) {
+export function SessionScreen({ onClose, headerGesture, translateY, screenHeight }: SessionScreenProps) {
   const { sessionId, sessionUsers } = useQueue();
   const insets = useSafeAreaInsets();
   const [showInvite, setShowInvite] = useState(false);
@@ -38,7 +42,9 @@ export function SessionScreen({ onClose, headerGesture }: SessionScreenProps) {
         inviteHint={soloInvite}
         dragGesture={headerGesture}
       />
-      <View style={styles.body}>{sessionActive ? <InSessionView /> : <PreSessionView />}</View>
+      <View style={styles.body}>
+        {sessionActive ? <InSessionView translateY={translateY} screenHeight={screenHeight} /> : <PreSessionView />}
+      </View>
       {sessionId ? (
         <InviteSheet visible={showInvite} onDismiss={() => setShowInvite(false)} sessionId={sessionId} />
       ) : null}

--- a/packages/mobile/src/components/session-screen/SessionScreenHeader.tsx
+++ b/packages/mobile/src/components/session-screen/SessionScreenHeader.tsx
@@ -1,27 +1,48 @@
 import { Pressable, StyleSheet, View } from 'react-native';
+import { GestureDetector, type PanGesture } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { useTheme } from '../../providers/theme-provider';
+import { brandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 
 type SessionScreenHeaderProps = {
   onClose: () => void;
   sessionActive: boolean;
+  /** When set, a share button floats at the trailing edge to invite climbers. */
+  onShare?: () => void;
+  /**
+   * Show a short "Invite" label beside the share glyph to teach the affordance.
+   * Set while the climber is solo; collapses to the icon alone once a friend
+   * joins (a clear contextual label, the HIG-preferred alternative to a coachmark).
+   */
+  inviteHint?: boolean;
+  /** Swipe-down-to-dismiss gesture (the header doubles as the drag handle). */
+  dragGesture: PanGesture;
 };
 
 /**
  * Compact header strip for the session overlay. Left: chevron-down to minimize
  * (session stays alive — the tab icon then blinks). Center: contextual title.
+ * Right: a share button to invite climbers while a session is live. The whole
+ * strip is also a drag handle — swipe it down to dismiss the overlay.
  */
-export function SessionScreenHeader({ onClose, sessionActive }: SessionScreenHeaderProps) {
+export function SessionScreenHeader({
+  onClose,
+  sessionActive,
+  onShare,
+  inviteHint,
+  dragGesture,
+}: SessionScreenHeaderProps) {
   const { t } = useTranslation('session');
   const { systemColors } = useTheme();
 
   const title = sessionActive ? t('mobile.session.headerActive') : t('mobile.session.headerStart');
 
   return (
-    <View style={styles.row}>
+    <GestureDetector gesture={dragGesture}>
+      <View style={styles.row}>
       <Pressable
         onPress={onClose}
         hitSlop={12}
@@ -34,8 +55,26 @@ export function SessionScreenHeader({ onClose, sessionActive }: SessionScreenHea
       <Text variant="title3" color={systemColors.label} style={styles.title} numberOfLines={1}>
         {title}
       </Text>
-      <View style={styles.iconButton} />
-    </View>
+      {onShare ? (
+          <Pressable
+            onPress={onShare}
+            hitSlop={12}
+            accessibilityRole="button"
+            accessibilityLabel={t('mobile.session.invite')}
+            style={styles.shareButton}
+          >
+            {inviteHint ? (
+              <Text variant="subheadline" color={brandColors.primary} style={styles.shareLabel}>
+                {t('mobile.session.inviteAction')}
+              </Text>
+            ) : null}
+            <Icon name="share" size={22} color={brandColors.primary} />
+          </Pressable>
+        ) : (
+          <View style={styles.iconButton} />
+        )}
+      </View>
+    </GestureDetector>
   );
 }
 
@@ -57,5 +96,17 @@ const styles = StyleSheet.create({
     height: 40,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  shareButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: spacing[1],
+    minWidth: 40,
+    height: 40,
+    paddingLeft: spacing[2],
+  },
+  shareLabel: {
+    fontWeight: '600',
   },
 });

--- a/packages/mobile/src/components/session-screen/SessionScreenHost.tsx
+++ b/packages/mobile/src/components/session-screen/SessionScreenHost.tsx
@@ -108,7 +108,12 @@ export function SessionScreenHost() {
       <Animated.View style={[StyleSheet.absoluteFill, animatedStyle]}>
         <View style={StyleSheet.absoluteFill}>
           <GlassSurface glassEffectStyle="regular" style={StyleSheet.absoluteFill} />
-          <SessionScreen onClose={close} headerGesture={headerGesture} />
+          <SessionScreen
+            onClose={close}
+            headerGesture={headerGesture}
+            translateY={translateY}
+            screenHeight={screenHeight}
+          />
         </View>
       </Animated.View>
     </View>

--- a/packages/mobile/src/components/session-screen/SessionScreenHost.tsx
+++ b/packages/mobile/src/components/session-screen/SessionScreenHost.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { StyleSheet, View, useColorScheme, useWindowDimensions } from 'react-native';
 import Animated, {
   Easing,
@@ -8,11 +8,17 @@ import Animated, {
   withSpring,
   withTiming,
 } from 'react-native-reanimated';
+import { Gesture } from 'react-native-gesture-handler';
 import { StatusBar } from 'expo-status-bar';
 import { useSessionScreen } from '../../providers/session-screen-provider';
 import { GlassSurface } from '../GlassSurface';
 import { SessionScreen } from './SessionScreen';
 import { springs } from '../../theme/animations';
+
+// Drag down past this fraction of the screen (or flick faster than this) to
+// dismiss; otherwise the overlay springs back to fully presented.
+const DISMISS_DISTANCE_FRACTION = 0.2;
+const DISMISS_VELOCITY = 800;
 
 /**
  * Full-screen Strava-style overlay that hosts the Session screen. Mounted once
@@ -66,6 +72,31 @@ export function SessionScreenHost() {
     };
   });
 
+  // Swipe-down-to-dismiss, attached to the header (so it never fights the
+  // in-session body scroll). Drives the same translateY the open/close
+  // animation uses; on release we either dismiss (which lets the close effect
+  // finish the exit) or spring back to fully presented.
+  const dragStartY = useSharedValue(0);
+  const headerGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .activeOffsetY(10)
+        .onStart(() => {
+          dragStartY.value = translateY.value;
+        })
+        .onUpdate((event) => {
+          translateY.value = Math.max(0, dragStartY.value + event.translationY);
+        })
+        .onEnd((event) => {
+          if (translateY.value > screenHeight * DISMISS_DISTANCE_FRACTION || event.velocityY > DISMISS_VELOCITY) {
+            runOnJS(close)();
+          } else {
+            translateY.value = withSpring(0, springs.gentle);
+          }
+        }),
+    [screenHeight, close, translateY, dragStartY],
+  );
+
   if (!isOpen && !mounted) {
     return null;
   }
@@ -77,7 +108,7 @@ export function SessionScreenHost() {
       <Animated.View style={[StyleSheet.absoluteFill, animatedStyle]}>
         <View style={StyleSheet.absoluteFill}>
           <GlassSurface glassEffectStyle="regular" style={StyleSheet.absoluteFill} />
-          <SessionScreen onClose={close} />
+          <SessionScreen onClose={close} headerGesture={headerGesture} />
         </View>
       </Animated.View>
     </View>

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -129,6 +129,13 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
     [sessionUsers, participantId],
   );
 
+  // The driver is tracked by participant id (SessionUser.id); resolve it to the
+  // DB user id the leaderboard rows key on so the driver badge actually lights.
+  const driverUserId = useMemo(
+    () => sessionUsers.find((user) => user.id === driverParticipantId)?.userId ?? null,
+    [sessionUsers, driverParticipantId],
+  );
+
   // Swipe-down-to-dismiss from the body. Drag the sheet only when the inner
   // scroll is at the top and the pull is downward; otherwise the scroll handles
   // it (the two run simultaneously). Drives the host's translateY, and on
@@ -208,11 +215,7 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
               gradeDistribution={gradeDistribution}
             />
 
-            <SessionLeaderboard
-              participants={participants}
-              driverParticipantId={driverParticipantId}
-              selfUserId={selfUserId}
-            />
+            <SessionLeaderboard participants={participants} driverUserId={driverUserId} selfUserId={selfUserId} />
           </Animated.ScrollView>
         </GestureDetector>
 

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -1,50 +1,116 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import type { ClimbQueueItem } from '@boardsesh/queue';
-import { Text } from '../../Text';
+import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '../../Button';
-import { QueueItemRow } from '../../QueueItemRow';
 import { EndSessionSheet } from '../../EndSessionSheet';
 import { useTheme } from '../../../providers/theme-provider';
 import { useQueue } from '../../../providers/queue-provider';
 import { useSessionScreen } from '../../../providers/session-screen-provider';
-import { useSessionSummary } from '../../../lib/graphql/hooks';
-import { spacing, borderRadius } from '../../../theme/tokens';
-import { SessionStatsHeader } from './SessionStatsHeader';
-
-const SUMMARY_POLL_INTERVAL_MS = 15_000;
+import type { SessionDetailTick } from '@boardsesh/shared-schema';
+import { useSessionDetail, useSessionSummary } from '../../../lib/graphql/hooks';
+import { gradeSortValue } from '../../you/profile-chart-colors';
+import { spacing } from '../../../theme/tokens';
+import { SessionAnalytics, type HardestSend } from './SessionAnalytics';
+import { SessionLeaderboard } from './SessionLeaderboard';
+import { SessionPresenceRow } from './SessionPresenceRow';
 
 export function InSessionView() {
   const { t } = useTranslation('session');
   const { systemColors } = useTheme();
   const insets = useSafeAreaInsets();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { close } = useSessionScreen();
-  const { state, sessionId, setCurrentClimb, removeFromQueue, endSession } = useQueue();
+  const { state, sessionId, liveStats, sessionUsers, driverParticipantId, participantId, endSession } = useQueue();
 
-  // Live summary: same query as the post-session view, just polled while the
-  // overlay is open so the live tiles stay current as the user logs ticks.
+  // Seed the live view from the full session detail (rich grade split, flashes,
+  // per-participant flashes, and the tick list we mine for the hardest climb's
+  // NAME). `liveStats` (pushed over the session subscription ~2s after a tick)
+  // overlays the seed so aggregates update without polling.
+  const detailQuery = useSessionDetail(sessionId ?? undefined);
+  const detail = detailQuery.data;
+
+  // Only trust a live push that belongs to the CURRENT session. After a direct
+  // A→B session switch the provider resets liveStats, but this guards the window
+  // (and any late A push) so we never attribute the previous session's numbers
+  // to this one.
+  const live = liveStats && liveStats.sessionId === sessionId ? liveStats : null;
+
+  // startedAt isn't carried by the live push, so the ticking timer reads it from
+  // a single (non-polled) summary query.
   const summaryQuery = useSessionSummary(sessionId);
-  const refetchSummary = summaryQuery.refetch;
+  const startedAt = summaryQuery.data?.startedAt ?? null;
+
+  // A new hardest grade arriving over the live push won't carry the climb NAME
+  // (the push has aggregates only). Refresh the detail so detail.ticks gains the
+  // tick whose climbName we surface in the celebration card.
+  const liveHardestGrade = live?.hardestGrade ?? null;
   useEffect(() => {
-    if (!sessionId) return;
-    const id = setInterval(() => {
-      void refetchSummary();
-    }, SUMMARY_POLL_INTERVAL_MS);
-    return () => clearInterval(id);
-  }, [sessionId, refetchSummary]);
+    if (!sessionId || !liveHardestGrade) return;
+    void queryClient.invalidateQueries({ queryKey: ['sessionDetail', sessionId] });
+  }, [sessionId, liveHardestGrade, queryClient]);
+
+  // Live push takes precedence over the seed for every aggregate.
+  const sends = live?.totalSends ?? detail?.totalSends ?? 0;
+  const flashes = live?.totalFlashes ?? detail?.totalFlashes ?? 0;
+  const gradeDistribution = live?.gradeDistribution ?? detail?.gradeDistribution ?? [];
+  const participants = live?.participants ?? detail?.participants ?? [];
+  const hardestGrade = live?.hardestGrade ?? detail?.hardestGrade ?? null;
+
+  const isMultiUser = participants.length > 1;
+
+  // Hardest send(s) to celebrate. Solo: the session's single hardest (grade from
+  // the aggregate, climb name mined from the tick list). Party: each climber's
+  // own hardest send, hardest first, so everyone's effort shows with their face.
+  const hardestSends = useMemo<HardestSend[]>(() => {
+    const sends = (detail?.ticks ?? []).filter((tick) => tick.status !== 'attempt');
+    if (!isMultiUser) {
+      if (!hardestGrade) return [];
+      let bestName: string | null = null;
+      let bestDifficulty = -Infinity;
+      for (const tick of sends) {
+        const difficulty = tick.difficulty ?? -Infinity;
+        if (difficulty > bestDifficulty) {
+          bestDifficulty = difficulty;
+          bestName = tick.climbName ?? null;
+        }
+      }
+      return [{ grade: hardestGrade, climbName: bestName }];
+    }
+    const bestByUser = new Map<string, SessionDetailTick>();
+    for (const tick of sends) {
+      const current = bestByUser.get(tick.userId);
+      if (!current || (tick.difficulty ?? -Infinity) > (current.difficulty ?? -Infinity)) {
+        bestByUser.set(tick.userId, tick);
+      }
+    }
+    return [...bestByUser.entries()]
+      .map(([userId, tick]) => {
+        const participant = participants.find((entry) => entry.userId === userId);
+        return {
+          userId,
+          displayName: participant?.displayName ?? null,
+          avatarUrl: participant?.avatarUrl ?? null,
+          grade: tick.difficultyName ?? '',
+          climbName: tick.climbName,
+        };
+      })
+      .filter((entry) => entry.grade)
+      .sort((a, b) => gradeSortValue(b.grade) - gradeSortValue(a.grade));
+  }, [detail?.ticks, participants, isMultiUser, hardestGrade]);
+
+  // Our own database user id (for the "you" highlight in the leaderboard).
+  // Undefined when we can't resolve it — the leaderboard handles that.
+  const selfUserId = useMemo(
+    () => sessionUsers.find((user) => user.id === participantId)?.userId ?? null,
+    [sessionUsers, participantId],
+  );
 
   const [showEndSession, setShowEndSession] = useState(false);
   const [isEnding, setIsEnding] = useState(false);
-
-  const { queue, currentClimbQueueItem } = state;
-  const currentUuid = currentClimbQueueItem?.uuid;
-
-  const handlePressItem = useCallback((item: ClimbQueueItem) => setCurrentClimb(item), [setCurrentClimb]);
-  const handleRemoveItem = useCallback((uuid: string) => removeFromQueue(uuid), [removeFromQueue]);
 
   const handleConfirmEnd = useCallback(async () => {
     setIsEnding(true);
@@ -66,31 +132,26 @@ export function InSessionView() {
         contentContainerStyle={[styles.content, { paddingBottom: 100 + insets.bottom }]}
         showsVerticalScrollIndicator={false}
       >
-        <SessionStatsHeader summary={summaryQuery.data ?? null} />
+        <SessionPresenceRow
+          users={sessionUsers}
+          driverParticipantId={driverParticipantId}
+          selfParticipantId={participantId}
+        />
 
-        <View style={styles.queueSection}>
-          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
-            {t('mobile.session.inQueueTitle')}
-          </Text>
-          {queue.length === 0 ? (
-            <View style={[styles.emptyCard, { backgroundColor: systemColors.secondaryBackground }]}>
-              <Text variant="body" color={systemColors.secondaryLabel}>
-                {t('mobile.session.inQueueEmpty')}
-              </Text>
-            </View>
-          ) : (
-            queue.map((item, index) => (
-              <QueueItemRow
-                key={item.uuid}
-                item={item}
-                position={index + 1}
-                isCurrentClimb={currentUuid === item.uuid}
-                onPress={handlePressItem}
-                onRemove={handleRemoveItem}
-              />
-            ))
-          )}
-        </View>
+        <SessionAnalytics
+          sends={sends}
+          flashes={flashes}
+          hardestGrade={hardestGrade}
+          hardestSends={hardestSends}
+          startedAt={startedAt}
+          gradeDistribution={gradeDistribution}
+        />
+
+        <SessionLeaderboard
+          participants={participants}
+          driverParticipantId={driverParticipantId}
+          selfUserId={selfUserId}
+        />
       </ScrollView>
 
       <View
@@ -109,7 +170,7 @@ export function InSessionView() {
         onDismiss={() => setShowEndSession(false)}
         onConfirm={() => void handleConfirmEnd()}
         isEnding={isEnding}
-        climbCount={queue.length}
+        climbCount={state.queue.length}
       />
     </View>
   );
@@ -126,18 +187,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[4],
     paddingTop: spacing[2],
     gap: spacing[5],
-  },
-  queueSection: {
-    gap: spacing[2],
-  },
-  sectionLabel: {
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  emptyCard: {
-    padding: spacing[4],
-    borderRadius: borderRadius.lg,
-    alignItems: 'center',
   },
   footer: {
     paddingHorizontal: spacing[4],

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
@@ -17,11 +17,16 @@ import { EndSessionSheet } from '../../EndSessionSheet';
 import { useTheme } from '../../../providers/theme-provider';
 import { useQueue } from '../../../providers/queue-provider';
 import { useSessionScreen } from '../../../providers/session-screen-provider';
-import type { SessionDetailTick } from '@boardsesh/shared-schema';
+import type { SessionDetailTick, SessionFeedParticipant } from '@boardsesh/shared-schema';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import { useSessionDetail, useSessionSummary } from '../../../lib/graphql/hooks';
+import { navigateToSessionClimb } from '../../../lib/session-tick-mapping';
 import { gradeSortValue } from '../../you/profile-chart-colors';
 import { spacing } from '../../../theme/tokens';
 import { springs } from '../../../theme/animations';
+import { SectionHeader } from '../../SectionHeader';
+import { SessionTickRow } from '../../session/SessionTickRow';
+import { CommentSheet } from '../../you/CommentSheet';
 import { SessionAnalytics, type HardestSend } from './SessionAnalytics';
 import { SessionLeaderboard } from './SessionLeaderboard';
 import { SessionPresenceRow } from './SessionPresenceRow';
@@ -81,6 +86,13 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
   const hardestGrade = live?.hardestGrade ?? detail?.hardestGrade ?? null;
 
   const isMultiUser = participants.length > 1;
+
+  // Lookup for the per-tick leading avatar in multi-user sessions.
+  const participantById = useMemo(() => {
+    const map = new Map<string, SessionFeedParticipant>();
+    for (const participant of participants) map.set(participant.userId, participant);
+    return map;
+  }, [participants]);
 
   // Hardest send(s) to celebrate. Solo: the session's single hardest (grade from
   // the aggregate, climb name mined from the tick list). Party: each climber's
@@ -173,6 +185,25 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
   const [showEndSession, setShowEndSession] = useState(false);
   const [isEnding, setIsEnding] = useState(false);
 
+  // Comment thread for a tapped climb's tick (opened from a row's social row).
+  const commentSheetRef = useRef<BottomSheet | null>(null);
+  const [commentTickUuid, setCommentTickUuid] = useState<string | null>(null);
+
+  const handleTickPress = useCallback(
+    (tick: SessionDetailTick) => {
+      // The session overlay sits above the tab navigator; drop it before pushing
+      // the climb route so the climb lands on a visible screen.
+      close();
+      navigateToSessionClimb(router, tick);
+    },
+    [close, router],
+  );
+
+  const handleOpenTickComments = useCallback((tickUuid: string) => {
+    setCommentTickUuid(tickUuid);
+    commentSheetRef.current?.snapToIndex(0);
+  }, []);
+
   const handleConfirmEnd = useCallback(async () => {
     setIsEnding(true);
     const summary = await endSession();
@@ -216,6 +247,22 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
             />
 
             <SessionLeaderboard participants={participants} driverUserId={driverUserId} selfUserId={selfUserId} />
+
+            {detail && detail.ticks.length > 0 ? (
+              <View style={styles.climbs}>
+                <SectionHeader title={t('detail.climbsCount', { count: detail.ticks.length })} />
+                {detail.ticks.map((tick) => (
+                  <SessionTickRow
+                    key={tick.uuid}
+                    tick={tick}
+                    isMultiUser={isMultiUser}
+                    participant={participantById.get(tick.userId)}
+                    onPress={handleTickPress}
+                    onOpenComments={handleOpenTickComments}
+                  />
+                ))}
+              </View>
+            ) : null}
           </Animated.ScrollView>
         </GestureDetector>
 
@@ -240,6 +287,13 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
           isEnding={isEnding}
           climbCount={state.queue.length}
         />
+
+        <CommentSheet
+          sheetRef={commentSheetRef}
+          entityId={commentTickUuid}
+          entityType="tick"
+          onClose={() => setCommentTickUuid(null)}
+        />
       </View>
     </GestureDetector>
   );
@@ -260,5 +314,11 @@ const styles = StyleSheet.create({
   footer: {
     paddingHorizontal: spacing[4],
     paddingTop: spacing[3],
+  },
+  // Pull the climbs list out of the content's horizontal padding so the
+  // full-bleed SectionHeader / SessionTickRow rows match the session-detail
+  // screen (their own 16px inset + edge-to-edge separators).
+  climbs: {
+    marginHorizontal: -spacing[4],
   },
 });

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  runOnJS,
+  useAnimatedScrollHandler,
+  useSharedValue,
+  withSpring,
+  type SharedValue,
+} from 'react-native-reanimated';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
@@ -13,11 +21,23 @@ import type { SessionDetailTick } from '@boardsesh/shared-schema';
 import { useSessionDetail, useSessionSummary } from '../../../lib/graphql/hooks';
 import { gradeSortValue } from '../../you/profile-chart-colors';
 import { spacing } from '../../../theme/tokens';
+import { springs } from '../../../theme/animations';
 import { SessionAnalytics, type HardestSend } from './SessionAnalytics';
 import { SessionLeaderboard } from './SessionLeaderboard';
 import { SessionPresenceRow } from './SessionPresenceRow';
 
-export function InSessionView() {
+// Drag the sheet down past this fraction of the screen (or flick faster) to
+// dismiss; otherwise it springs back. Mirrors the host's open/close thresholds.
+const DISMISS_DISTANCE_FRACTION = 0.18;
+const DISMISS_VELOCITY = 800;
+
+type InSessionViewProps = {
+  /** Host overlay offset (0 = presented). The body pull-to-dismiss drives it. */
+  translateY: SharedValue<number>;
+  screenHeight: number;
+};
+
+export function InSessionView({ translateY, screenHeight }: InSessionViewProps) {
   const { t } = useTranslation('session');
   const { systemColors } = useTheme();
   const insets = useSafeAreaInsets();
@@ -109,6 +129,40 @@ export function InSessionView() {
     [sessionUsers, participantId],
   );
 
+  // Swipe-down-to-dismiss from the body. Drag the sheet only when the inner
+  // scroll is at the top and the pull is downward; otherwise the scroll handles
+  // it (the two run simultaneously). Drives the host's translateY, and on
+  // release either dismisses (close) or springs back to fully presented.
+  const scrollOffset = useSharedValue(0);
+  const startedAtTop = useSharedValue(true);
+  const scrollHandler = useAnimatedScrollHandler((event) => {
+    scrollOffset.value = event.contentOffset.y;
+  });
+  const scrollGesture = useMemo(() => Gesture.Native(), []);
+  const dismissGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .activeOffsetY(12)
+        .onStart(() => {
+          startedAtTop.value = scrollOffset.value <= 0;
+        })
+        .onUpdate((event) => {
+          if (startedAtTop.value && event.translationY > 0) {
+            translateY.value = event.translationY;
+          }
+        })
+        .onEnd((event) => {
+          if (!startedAtTop.value) return;
+          if (translateY.value > screenHeight * DISMISS_DISTANCE_FRACTION || event.velocityY > DISMISS_VELOCITY) {
+            runOnJS(close)();
+          } else {
+            translateY.value = withSpring(0, springs.gentle);
+          }
+        })
+        .simultaneousWithExternalGesture(scrollGesture),
+    [translateY, screenHeight, close, scrollOffset, startedAtTop, scrollGesture],
+  );
+
   const [showEndSession, setShowEndSession] = useState(false);
   const [isEnding, setIsEnding] = useState(false);
 
@@ -126,37 +180,48 @@ export function InSessionView() {
   }, [endSession, close, router]);
 
   return (
-    <View style={styles.container}>
-      <ScrollView
-        style={styles.scroll}
-        contentContainerStyle={[styles.content, { paddingBottom: 100 + insets.bottom }]}
-        showsVerticalScrollIndicator={false}
-      >
-        <SessionPresenceRow
-          users={sessionUsers}
-          driverParticipantId={driverParticipantId}
-          selfParticipantId={participantId}
-        />
+    <GestureDetector gesture={dismissGesture}>
+      <View style={styles.container}>
+        <GestureDetector gesture={scrollGesture}>
+          <Animated.ScrollView
+            style={styles.scroll}
+            contentContainerStyle={[styles.content, { paddingBottom: 100 + insets.bottom }]}
+            showsVerticalScrollIndicator={false}
+            onScroll={scrollHandler}
+            scrollEventThrottle={16}
+            // No bounce: a downward pull at the top should move the sheet (our
+            // pan), not bounce the scroll view underneath it.
+            bounces={false}
+          >
+            <SessionPresenceRow
+              users={sessionUsers}
+              driverParticipantId={driverParticipantId}
+              selfParticipantId={participantId}
+            />
 
-        <SessionAnalytics
-          sends={sends}
-          flashes={flashes}
-          hardestGrade={hardestGrade}
-          hardestSends={hardestSends}
-          startedAt={startedAt}
-          gradeDistribution={gradeDistribution}
-        />
+            <SessionAnalytics
+              sends={sends}
+              flashes={flashes}
+              hardestGrade={hardestGrade}
+              hardestSends={hardestSends}
+              startedAt={startedAt}
+              gradeDistribution={gradeDistribution}
+            />
 
-        <SessionLeaderboard
-          participants={participants}
-          driverParticipantId={driverParticipantId}
-          selfUserId={selfUserId}
-        />
-      </ScrollView>
+            <SessionLeaderboard
+              participants={participants}
+              driverParticipantId={driverParticipantId}
+              selfUserId={selfUserId}
+            />
+          </Animated.ScrollView>
+        </GestureDetector>
 
-      <View
-        style={[styles.footer, { backgroundColor: systemColors.background, paddingBottom: insets.bottom + spacing[3] }]}
-      >
+        <View
+          style={[
+            styles.footer,
+            { backgroundColor: systemColors.background, paddingBottom: insets.bottom + spacing[3] },
+          ]}
+        >
         <Button
           title={t('mobile.session.inEndSession')}
           onPress={() => setShowEndSession(true)}
@@ -165,14 +230,15 @@ export function InSessionView() {
         />
       </View>
 
-      <EndSessionSheet
-        visible={showEndSession}
-        onDismiss={() => setShowEndSession(false)}
-        onConfirm={() => void handleConfirmEnd()}
-        isEnding={isEnding}
-        climbCount={state.queue.length}
-      />
-    </View>
+        <EndSessionSheet
+          visible={showEndSession}
+          onDismiss={() => setShowEndSession(false)}
+          onConfirm={() => void handleConfirmEnd()}
+          isEnding={isEnding}
+          climbCount={state.queue.length}
+        />
+      </View>
+    </GestureDetector>
   );
 }
 

--- a/packages/mobile/src/components/session-screen/in-session/SessionAnalytics.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/SessionAnalytics.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useRef } from 'react';
+import { StyleSheet, View, type ColorValue } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { SessionGradeDistributionItem } from '@boardsesh/shared-schema';
+import { Text } from '../../Text';
+import { Icon } from '../../Icon';
+import { type IconName } from '../../icon-map';
+import { Avatar } from '../../Avatar';
+import { useTheme } from '../../../providers/theme-provider';
+import { gradeBadgeColor } from '../../you/profile-chart-colors';
+import { brandColors } from '../../../theme/colors';
+import { spacing, borderRadius } from '../../../theme/tokens';
+import { hapticSuccess } from '../../../lib/haptics';
+import { SessionGradeChart } from './SessionGradeChart';
+import { SessionTimer } from './SessionTimer';
+
+/** One climber's hardest send. `userId` set only for multi-climber parties (so
+ *  the solo case renders without an avatar). */
+export type HardestSend = {
+  userId?: string;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  grade: string;
+  climbName?: string | null;
+};
+
+type SessionAnalyticsProps = {
+  sends: number;
+  flashes: number;
+  /** Aggregate session-hardest grade — drives the celebration haptic. */
+  hardestGrade: string | null;
+  /** Hardest send(s) to display: one entry solo, one per climber in a party. */
+  hardestSends: HardestSend[];
+  /** Session start time for the live duration cell (null until summary loads). */
+  startedAt: string | null;
+  gradeDistribution: SessionGradeDistributionItem[];
+};
+
+/**
+ * Analytics block for the live in-session view: a row of stat cells
+ * (Sent / Flashed / Attempted / Duration), a hardest-send celebration, and the
+ * grade-distribution chart. Replaces the old SessionStatsHeader. Fires a single
+ * tasteful success haptic the first time a new hardest grade lands.
+ */
+export function SessionAnalytics({
+  sends,
+  flashes,
+  hardestGrade,
+  hardestSends,
+  startedAt,
+  gradeDistribution,
+}: SessionAnalyticsProps) {
+  const { t } = useTranslation('session');
+  const { systemColors } = useTheme();
+
+  // Celebrate a fresh hardest grade once. Seeded with the initial grade so the
+  // first render (which may already carry a hardest) doesn't buzz; only a later
+  // change to a different grade fires the haptic.
+  const lastHardestGrade = useRef<string | null>(hardestGrade);
+  useEffect(() => {
+    if (hardestGrade && hardestGrade !== lastHardestGrade.current) {
+      hapticSuccess();
+    }
+    lastHardestGrade.current = hardestGrade;
+  }, [hardestGrade]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.statsRow}>
+        <StatTile
+          value={sends}
+          label={t('mobile.session.inStatsSends')}
+          icon="tick"
+          tint={brandColors.success}
+          background={systemColors.secondaryBackground}
+          labelColor={systemColors.secondaryLabel}
+        />
+        <StatTile
+          value={flashes}
+          label={t('mobile.session.inStatsFlashes')}
+          icon="flash"
+          tint={brandColors.warning}
+          background={systemColors.secondaryBackground}
+          labelColor={systemColors.secondaryLabel}
+        />
+        <View style={[styles.statCard, { backgroundColor: systemColors.secondaryBackground }]}>
+          <Icon name="clock" size={18} color={systemColors.secondaryLabel} />
+          {startedAt ? (
+            <SessionTimer startedAt={startedAt} />
+          ) : (
+            <Text variant="title2" style={styles.statValue}>
+              —
+            </Text>
+          )}
+          <Text variant="caption1" color={systemColors.secondaryLabel}>
+            {t('mobile.session.inStatsDuration')}
+          </Text>
+        </View>
+      </View>
+
+      {hardestSends.length > 0 ? (
+        <View style={[styles.hardestCard, { backgroundColor: systemColors.secondaryBackground }]}>
+          <Text variant="caption1" color={systemColors.secondaryLabel}>
+            {t(hardestSends.length > 1 ? 'mobile.session.inStatsHardestEach' : 'mobile.session.inStatsHardest')}
+          </Text>
+          {hardestSends.map((send, index) => (
+            <View key={send.userId ?? `solo-${index}`} style={styles.hardestRow}>
+              {send.userId ? <Avatar uri={send.avatarUrl} name={send.displayName} size={28} /> : null}
+              {/* Grade as bold coloured text — no pill, per the chip cleanup. */}
+              <Text variant="title3" color={gradeBadgeColor(send.grade)} style={styles.hardestGrade}>
+                {send.grade}
+              </Text>
+              {send.climbName ? (
+                <Text variant="body" numberOfLines={1} style={styles.hardestName}>
+                  {send.climbName}
+                </Text>
+              ) : null}
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      {gradeDistribution.length > 0 ? (
+        <View style={styles.section}>
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
+            {t('mobile.session.inStatsGrades')}
+          </Text>
+          <SessionGradeChart distribution={gradeDistribution} />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+type StatTileProps = {
+  value: number;
+  label: string;
+  icon: IconName;
+  tint: ColorValue;
+  background: ColorValue;
+  labelColor: ColorValue;
+};
+
+function StatTile({ value, label, icon, tint, background, labelColor }: StatTileProps) {
+  return (
+    <View style={[styles.statCard, { backgroundColor: background }]}>
+      <Icon name={icon} size={18} color={tint} />
+      <Text variant="title2" style={styles.statValue}>
+        {value}
+      </Text>
+      <Text variant="caption1" color={labelColor}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing[3],
+  },
+  statsRow: {
+    flexDirection: 'row',
+    gap: spacing[2],
+  },
+  statCard: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: spacing[3],
+    borderRadius: borderRadius.lg,
+    gap: spacing[1],
+  },
+  statValue: {
+    fontWeight: '700',
+  },
+  hardestCard: {
+    padding: spacing[3],
+    borderRadius: borderRadius.lg,
+    gap: spacing[2],
+  },
+  hardestRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+  },
+  hardestGrade: {
+    fontWeight: '700',
+    minWidth: 44,
+  },
+  hardestName: {
+    flex: 1,
+  },
+  section: {
+    gap: spacing[2],
+  },
+  sectionLabel: {
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+});

--- a/packages/mobile/src/components/session-screen/in-session/SessionGradeChart.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/SessionGradeChart.tsx
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import type { SessionGradeDistributionItem } from '@boardsesh/shared-schema';
+import { StackedBarChart } from '../../you/YouCharts';
+import { buildSessionGradeBars } from '../../you/profile-chart-colors';
+
+type SessionGradeChartProps = {
+  distribution: SessionGradeDistributionItem[];
+};
+
+/**
+ * Grade distribution for the live in-session view. Reuses the same vivid
+ * grade-coloured bars as the activity feed (SessionFeedCard): each grade bar is
+ * the total ascents for that grade drawn in the grade's own colour, so the
+ * chart reads as a colourful grade pyramid. Returns null when there's nothing
+ * logged yet.
+ */
+export function SessionGradeChart({ distribution }: SessionGradeChartProps) {
+  const bars = useMemo(() => buildSessionGradeBars(distribution), [distribution]);
+
+  if (!bars) return null;
+
+  return <StackedBarChart bars={bars} colorBy="grade" height={120} />;
+}

--- a/packages/mobile/src/components/session-screen/in-session/SessionLeaderboard.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/SessionLeaderboard.tsx
@@ -14,7 +14,9 @@ import { spacing, borderRadius } from '../../../theme/tokens';
 
 type SessionLeaderboardProps = {
   participants: SessionFeedParticipant[];
-  driverParticipantId?: string | null;
+  /** DB user id of the driver (resolved from the participant roster upstream) —
+   *  the same id space as `participant.userId`, so it actually matches. */
+  driverUserId?: string | null;
   selfUserId?: string | null;
 };
 
@@ -24,7 +26,7 @@ type SessionLeaderboardProps = {
  * Hidden when fewer than two climbers have logged anything (no leaderboard of
  * one).
  */
-export function SessionLeaderboard({ participants, driverParticipantId, selfUserId }: SessionLeaderboardProps) {
+export function SessionLeaderboard({ participants, driverUserId, selfUserId }: SessionLeaderboardProps) {
   const { t } = useTranslation('session');
   const { systemColors } = useTheme();
 
@@ -40,11 +42,10 @@ export function SessionLeaderboard({ participants, driverParticipantId, selfUser
       <SectionHeader title={t('mobile.session.inLeaderboardTitle')} />
       <View style={[styles.list, { backgroundColor: systemColors.secondaryBackground }]}>
         {ranked.map((participant, index) => {
-          // The leaderboard keys on userId, but the driver is tracked by
-          // participant id; we can only highlight the driver when the two ids
-          // line up. selfUserId likewise drives the "you" tint.
+          // Both ids are DB user ids (driverUserId is resolved from the roster
+          // upstream), so they match a participant's userId directly.
           const isSelf = !!selfUserId && participant.userId === selfUserId;
-          const isDriver = !!driverParticipantId && participant.userId === driverParticipantId;
+          const isDriver = !!driverUserId && participant.userId === driverUserId;
           return (
             <View
               key={participant.userId}

--- a/packages/mobile/src/components/session-screen/in-session/SessionLeaderboard.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/SessionLeaderboard.tsx
@@ -1,0 +1,149 @@
+import { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { SessionFeedParticipant } from '@boardsesh/shared-schema';
+import { Text } from '../../Text';
+import { Icon } from '../../Icon';
+import { type IconName } from '../../icon-map';
+import { Avatar } from '../../Avatar';
+import { SectionHeader } from '../../SectionHeader';
+import { useTheme } from '../../../providers/theme-provider';
+import { brandColors, withAlpha } from '../../../theme/colors';
+import { iosSystemColors } from '../../../theme/ios-colors';
+import { spacing, borderRadius } from '../../../theme/tokens';
+
+type SessionLeaderboardProps = {
+  participants: SessionFeedParticipant[];
+  driverParticipantId?: string | null;
+  selfUserId?: string | null;
+};
+
+/**
+ * Ranked roster — the social heart of the live view. Climbers sort by sends,
+ * then flashes; the driver gets a lightbulb badge and your own row is tinted.
+ * Hidden when fewer than two climbers have logged anything (no leaderboard of
+ * one).
+ */
+export function SessionLeaderboard({ participants, driverParticipantId, selfUserId }: SessionLeaderboardProps) {
+  const { t } = useTranslation('session');
+  const { systemColors } = useTheme();
+
+  const ranked = useMemo(
+    () => [...participants].sort((a, b) => b.sends - a.sends || b.flashes - a.flashes),
+    [participants],
+  );
+
+  if (ranked.length <= 1) return null;
+
+  return (
+    <View>
+      <SectionHeader title={t('mobile.session.inLeaderboardTitle')} />
+      <View style={[styles.list, { backgroundColor: systemColors.secondaryBackground }]}>
+        {ranked.map((participant, index) => {
+          // The leaderboard keys on userId, but the driver is tracked by
+          // participant id; we can only highlight the driver when the two ids
+          // line up. selfUserId likewise drives the "you" tint.
+          const isSelf = !!selfUserId && participant.userId === selfUserId;
+          const isDriver = !!driverParticipantId && participant.userId === driverParticipantId;
+          return (
+            <View
+              key={participant.userId}
+              style={[
+                styles.row,
+                index > 0 ? { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: systemColors.separator } : null,
+                isSelf ? { backgroundColor: withAlpha(brandColors.primary, 0.1) } : null,
+              ]}
+            >
+              <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.rank}>
+                {index + 1}
+              </Text>
+              <Avatar uri={participant.avatarUrl} name={participant.displayName} size={32} />
+              <View style={styles.nameColumn}>
+                <Text variant="subheadline" style={styles.name} numberOfLines={1}>
+                  {participant.displayName ?? t('mobile.session.inLeaderboardClimber')}
+                </Text>
+                {isDriver ? (
+                  <View style={styles.driverRow}>
+                    <Icon name="lightbulb.fill" size={11} color={brandColors.warning} />
+                    <Text variant="caption2" color={systemColors.secondaryLabel}>
+                      {t('mobile.session.inDriverLabel')}
+                    </Text>
+                  </View>
+                ) : null}
+              </View>
+              <View style={styles.chips}>
+                {participant.sends > 0 ? (
+                  <Chip icon="tick" label={`${participant.sends}`} tint={brandColors.success} />
+                ) : null}
+                {participant.flashes > 0 ? (
+                  <Chip icon="flash" label={`${participant.flashes}`} tint={brandColors.warning} />
+                ) : null}
+                {participant.attempts > 0 ? (
+                  <Chip icon="circle" label={`${participant.attempts}`} tint={iosSystemColors.systemGray} />
+                ) : null}
+              </View>
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+function Chip({ icon, label, tint }: { icon: IconName; label: string; tint: string }) {
+  return (
+    <View style={[styles.chip, { backgroundColor: withAlpha(tint, 0.15) }]}>
+      <Icon name={icon} size={12} color={tint} />
+      <Text variant="caption1" color={tint} style={styles.chipLabel}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  list: {
+    borderRadius: borderRadius.lg,
+    overflow: 'hidden',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+  },
+  rank: {
+    width: 20,
+    textAlign: 'center',
+    fontWeight: '700',
+  },
+  nameColumn: {
+    flex: 1,
+    gap: 2,
+  },
+  name: {
+    fontWeight: '600',
+  },
+  driverRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  chips: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: spacing[2],
+    paddingVertical: 3,
+    borderRadius: borderRadius.full,
+  },
+  chipLabel: {
+    fontWeight: '600',
+  },
+});

--- a/packages/mobile/src/components/session-screen/in-session/SessionPresenceRow.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/SessionPresenceRow.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { SessionUser } from '@boardsesh/shared-schema';
+import { Text } from '../../Text';
+import { Icon } from '../../Icon';
+import { AvatarGroup } from '../../you/AvatarGroup';
+import { useTheme } from '../../../providers/theme-provider';
+import { brandColors } from '../../../theme/colors';
+import { spacing, opacity } from '../../../theme/tokens';
+
+type SessionPresenceRowProps = {
+  users: SessionUser[];
+  driverParticipantId?: string | null;
+  selfParticipantId?: string | null;
+};
+
+/**
+ * Compact "who's connected right now" row: overlapping avatars + a live count +
+ * a driver indicator. Connected climbers lead the avatar cluster; if everyone is
+ * mid-reconnect the cluster dims to read as offline. Renders nothing when the
+ * roster is empty.
+ */
+export function SessionPresenceRow({ users, driverParticipantId, selfParticipantId }: SessionPresenceRowProps) {
+  const { t } = useTranslation('session');
+  const { systemColors } = useTheme();
+
+  // Connected climbers first so the visible (non-overflow) avatars favour the
+  // people actually present. The AvatarGroup participant shape carries no
+  // connection state, so dimming is expressed at the cluster level.
+  const ordered = useMemo(() => {
+    const connected = users.filter((user) => user.connectionState === 'CONNECTED');
+    const reconnecting = users.filter((user) => user.connectionState !== 'CONNECTED');
+    return [...connected, ...reconnecting];
+  }, [users]);
+
+  const participants = useMemo(
+    () =>
+      ordered.map((user) => ({
+        userId: user.id,
+        displayName: user.username,
+        avatarUrl: user.avatarUrl,
+      })),
+    [ordered],
+  );
+
+  if (users.length === 0) return null;
+
+  const allReconnecting = users.every((user) => user.connectionState !== 'CONNECTED');
+  const driver = driverParticipantId
+    ? users.find((user) => user.id === driverParticipantId)
+    : undefined;
+  const driverIsSelf = !!driver && driver.id === selfParticipantId;
+
+  return (
+    <View style={styles.container}>
+      <View style={[styles.avatars, allReconnecting ? { opacity: opacity.subtle } : null]}>
+        <AvatarGroup participants={participants} size={32} max={4} />
+      </View>
+      <View style={styles.text}>
+        <Text variant="subheadline" style={styles.count}>
+          {t('mobile.session.inPresenceCount', { count: users.length })}
+        </Text>
+        {driver ? (
+          <View style={styles.driverRow}>
+            <Icon name="lightbulb.fill" size={12} color={brandColors.warning} />
+            <Text variant="caption1" color={systemColors.secondaryLabel} numberOfLines={1}>
+              {driverIsSelf ? t('mobile.session.inDriverLabel') : driver.username}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+  },
+  avatars: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  text: {
+    flex: 1,
+    gap: 2,
+  },
+  count: {
+    fontWeight: '600',
+  },
+  driverRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+});

--- a/packages/mobile/src/components/session/SessionAnalyticsSection.tsx
+++ b/packages/mobile/src/components/session/SessionAnalyticsSection.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { deriveProfileViewModel } from '@boardsesh/profile-stats';
+import type { SessionDetailTick } from '@boardsesh/shared-schema';
+import { Card } from '../Card';
+import { SectionHeader } from '../SectionHeader';
+import { StackedBarChart, GroupedBarChart, type ChartLegendItem } from '../you/YouCharts';
+import { layoutChartColor, flashRedpointColor } from '../you/profile-chart-colors';
+import { sessionTicksToLogbook } from '../../lib/session-tick-mapping';
+import { useGradeFormat } from '../../hooks/use-grade-format';
+import { spacing } from '../../theme/tokens';
+
+/**
+ * Rich per-session breakdown: maps the session's ticks into the shared
+ * `deriveProfileViewModel` aggregation (timeframe 'all', all boards) and renders
+ * the grade-distribution + flash-vs-redpoint charts, mirroring the Progress tab.
+ * Renders nothing when there are no ticks.
+ */
+export function SessionAnalyticsSection({ ticks }: { ticks: SessionDetailTick[] }) {
+  const { t } = useTranslation('profile');
+  // Match the grade format the Progress tab / useYouProfileData uses so a
+  // session's charts read identically to the profile's.
+  const { gradeFormat } = useGradeFormat();
+
+  const viewModel = useMemo(() => {
+    if (ticks.length === 0) return null;
+    return deriveProfileViewModel({
+      allBoardsTicks: sessionTicksToLogbook(ticks),
+      selectedBoard: 'all',
+      timeframe: 'all',
+      fromDate: '',
+      toDate: '',
+      gradeFormat,
+      profileStats: null,
+    });
+  }, [ticks, gradeFormat]);
+
+  const gradeDistLegend = useMemo<ChartLegendItem[] | undefined>(
+    () => viewModel?.aggregatedStackedBars?.legend.map((entry) => ({ label: entry.label, color: layoutChartColor(entry.key) })),
+    [viewModel],
+  );
+  const flashRedpointLegend = useMemo<ChartLegendItem[] | undefined>(
+    () =>
+      viewModel?.aggregatedFlashRedpointBars?.[0]?.values.map((value) => ({
+        label: value.label,
+        color: flashRedpointColor(value.key),
+      })),
+    [viewModel],
+  );
+
+  if (!viewModel) return null;
+
+  return (
+    <View>
+      <SectionHeader title={t('stats.gradeDistribution')} />
+      <Card style={styles.chartCard}>
+        <StackedBarChart bars={viewModel.aggregatedStackedBars?.bars ?? null} colorBy="layout" legend={gradeDistLegend} />
+      </Card>
+
+      {viewModel.aggregatedFlashRedpointBars && (
+        <>
+          <SectionHeader title={t('stats.flashVsRedpoint')} />
+          <Card style={styles.chartCard}>
+            <GroupedBarChart bars={viewModel.aggregatedFlashRedpointBars} legend={flashRedpointLegend} />
+          </Card>
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  chartCard: { marginHorizontal: spacing[4] },
+});

--- a/packages/mobile/src/components/session/SessionDetailHero.tsx
+++ b/packages/mobile/src/components/session/SessionDetailHero.tsx
@@ -1,0 +1,80 @@
+import { View, StyleSheet } from 'react-native';
+import type { SessionDetail } from '@boardsesh/shared-schema';
+import { formatTickAbsoluteTime } from '@boardsesh/profile-stats';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { AvatarGroup } from '../you/AvatarGroup';
+import { spacing } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
+
+function formatDuration(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+type SessionDetailHeroProps = {
+  session: SessionDetail;
+  /** Pre-resolved display name (session name or a generated fallback). */
+  title: string;
+};
+
+/** Hero block for the session-detail screen: avatars, name, date, board, duration, goal. */
+export function SessionDetailHero({ session, title }: SessionDetailHeroProps) {
+  const { systemColors } = useTheme();
+
+  const absoluteDate = formatTickAbsoluteTime(session.lastTickAt, 'MMM D, YYYY · h:mm A');
+
+  return (
+    <View style={styles.container}>
+      <AvatarGroup participants={session.participants} size={44} />
+      <Text variant="title2" style={styles.title}>
+        {title}
+      </Text>
+      <Text variant="subheadline" color={systemColors.secondaryLabel}>
+        {absoluteDate}
+      </Text>
+
+      {session.boardTypes.length > 0 && (
+        <Text variant="footnote" color={systemColors.tertiaryLabel} style={styles.boards}>
+          {session.boardTypes.join(' · ')}
+        </Text>
+      )}
+
+      <View style={styles.metaRow}>
+        {session.durationMinutes != null && session.durationMinutes > 0 && (
+          <View style={styles.metaItem}>
+            <Icon name="clock" size={14} color={systemColors.secondaryLabel} />
+            <Text variant="footnote" color={systemColors.secondaryLabel}>
+              {formatDuration(session.durationMinutes)}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      {session.goal ? (
+        <View style={styles.goal}>
+          <Icon name="flag" size={14} color={systemColors.secondaryLabel} />
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.goalText}>
+            {session.goal}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[4],
+    gap: spacing[1],
+  },
+  title: { fontWeight: '700', marginTop: spacing[2] },
+  boards: { marginTop: spacing[1] },
+  metaRow: { flexDirection: 'row', alignItems: 'center', gap: spacing[4], marginTop: spacing[2] },
+  metaItem: { flexDirection: 'row', alignItems: 'center', gap: spacing[1] },
+  goal: { flexDirection: 'row', alignItems: 'flex-start', gap: spacing[2], marginTop: spacing[2] },
+  goalText: { flex: 1 },
+});

--- a/packages/mobile/src/components/session/SessionEditSheet.tsx
+++ b/packages/mobile/src/components/session/SessionEditSheet.tsx
@@ -1,0 +1,115 @@
+import { type RefObject, useEffect, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import BottomSheet, { BottomSheetTextInput } from '@gorhom/bottom-sheet';
+import { useTranslation } from 'react-i18next';
+import type { SessionDetail } from '@boardsesh/shared-schema';
+import { Text } from '../Text';
+import { Sheet } from '../Sheet';
+import { Button } from '../Button';
+import { SectionHeader } from '../SectionHeader';
+import { useUpdateInferredSession } from '../../lib/graphql/hooks';
+import { hapticSuccess, hapticError } from '../../lib/haptics';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
+import { useToast } from '../../providers/toast-provider';
+
+type SessionEditSheetProps = {
+  sheetRef: RefObject<BottomSheet | null>;
+  session: SessionDetail | null;
+  onClose: () => void;
+};
+
+/** Rename / edit the goal of an inferred session the viewer owns. */
+export function SessionEditSheet({ sheetRef, session, onClose }: SessionEditSheetProps) {
+  const { t } = useTranslation('session');
+  const { systemColors } = useTheme();
+  const { showToast } = useToast();
+  const updateSession = useUpdateInferredSession(session?.sessionId ?? '');
+
+  const [name, setName] = useState('');
+  const [goal, setGoal] = useState('');
+
+  // Re-seed whenever a different session opens the sheet.
+  useEffect(() => {
+    if (!session) return;
+    setName(session.sessionName ?? '');
+    setGoal(session.goal ?? '');
+  }, [session]);
+
+  const save = () => {
+    if (!session || updateSession.isPending) return;
+    updateSession.mutate(
+      { name: name.trim(), description: goal.trim() },
+      {
+        onSuccess: () => {
+          hapticSuccess();
+          showToast(t('mobileDetail.updated'), 'success');
+          sheetRef.current?.close();
+        },
+        onError: () => {
+          hapticError();
+          showToast(t('mobileDetail.updateError'), 'error');
+        },
+      },
+    );
+  };
+
+  return (
+    <Sheet
+      ref={sheetRef}
+      snapPoints={['55%']}
+      scrollable
+      fullWindowOverlay
+      onClose={onClose}
+      contentContainerStyle={styles.content}
+      keyboardBehavior="interactive"
+      keyboardBlurBehavior="restore"
+      android_keyboardInputMode="adjustResize"
+      footer={
+        <Button title={t('mobileDetail.save')} onPress={save} loading={updateSession.isPending} disabled={!session} />
+      }
+    >
+      <Text variant="title3" style={styles.title}>
+        {t('mobileDetail.editTitle')}
+      </Text>
+
+      <SectionHeader title={t('mobileDetail.nameLabel')} />
+      <View style={styles.field}>
+        <BottomSheetTextInput
+          style={[styles.input, { backgroundColor: systemColors.fill, color: systemColors.label }]}
+          placeholderTextColor={systemColors.tertiaryLabel}
+          value={name}
+          onChangeText={setName}
+        />
+      </View>
+
+      <SectionHeader title={t('mobileDetail.goalLabel')} />
+      <View style={styles.field}>
+        <BottomSheetTextInput
+          style={[styles.input, styles.multiline, { backgroundColor: systemColors.fill, color: systemColors.label }]}
+          placeholderTextColor={systemColors.tertiaryLabel}
+          value={goal}
+          onChangeText={setGoal}
+          multiline
+        />
+      </View>
+    </Sheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: { paddingBottom: spacing[6] },
+  title: { paddingHorizontal: spacing[4], paddingTop: spacing[2] },
+  field: { paddingHorizontal: spacing[4] },
+  input: {
+    minHeight: 44,
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    fontSize: 16,
+  },
+  multiline: {
+    minHeight: 88,
+    textAlignVertical: 'top',
+  },
+});

--- a/packages/mobile/src/components/session/SessionParticipantBreakdown.tsx
+++ b/packages/mobile/src/components/session/SessionParticipantBreakdown.tsx
@@ -1,0 +1,72 @@
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { SessionFeedParticipant } from '@boardsesh/shared-schema';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { type IconName } from '../icon-map';
+import { Avatar } from '../Avatar';
+import { ListRow } from '../ListRow';
+import { SectionHeader } from '../SectionHeader';
+import { brandColors, withAlpha } from '../../theme/colors';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
+
+/** Per-climber sends/flashes/attempts breakdown. Renders nothing for solo sessions. */
+export function SessionParticipantBreakdown({ participants }: { participants: SessionFeedParticipant[] }) {
+  const { t } = useTranslation('session');
+  const { t: tYou } = useTranslation('you');
+
+  if (participants.length <= 1) return null;
+
+  return (
+    <View>
+      <SectionHeader title={t('mobileDetail.participants')} />
+      {participants.map((participant) => (
+        <ListRow
+          key={participant.userId}
+          title={participant.displayName ?? tYou('mobile.unknownName')}
+          leading={<Avatar uri={participant.avatarUrl} name={participant.displayName} size={32} />}
+          showSeparator
+          trailing={
+            <View style={styles.chips}>
+              {participant.sends > 0 && (
+                <Chip icon="tick" label={`${participant.sends}`} tint={brandColors.success} />
+              )}
+              {participant.flashes > 0 && (
+                <Chip icon="flash" label={`${participant.flashes}`} tint={brandColors.warning} />
+              )}
+              {participant.attempts > 0 && (
+                <Chip icon="circle" label={`${participant.attempts}`} tint={iosSystemColors.systemGray} />
+              )}
+            </View>
+          }
+        />
+      ))}
+    </View>
+  );
+}
+
+function Chip({ icon, label, tint }: { icon: IconName; label: string; tint: string }) {
+  return (
+    <View style={[styles.chip, { backgroundColor: withAlpha(tint, 0.15) }]}>
+      <Icon name={icon} size={11} color={tint} />
+      <Text variant="caption1" color={tint} style={styles.chipLabel}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  chips: { flexDirection: 'row', alignItems: 'center', gap: spacing[1] },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    borderRadius: borderRadius.full,
+  },
+  chipLabel: { fontWeight: '600' },
+});

--- a/packages/mobile/src/components/session/SessionStatTiles.tsx
+++ b/packages/mobile/src/components/session/SessionStatTiles.tsx
@@ -1,0 +1,93 @@
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { getGradeTextColor } from '@boardsesh/play-view';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { type IconName } from '../icon-map';
+import { Card } from '../Card';
+import { gradeBadgeColor } from '../you/profile-chart-colors';
+import { brandColors } from '../../theme/colors';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
+
+type SessionStatTilesProps = {
+  sends: number;
+  flashes: number;
+  attempts: number;
+  hardestGrade?: string | null;
+};
+
+/** Sends / Flashes / Attempts / Hardest tiles for the session-detail header. */
+export function SessionStatTiles({ sends, flashes, attempts, hardestGrade }: SessionStatTilesProps) {
+  const { t } = useTranslation('you');
+  const { t: tFeed } = useTranslation('feed');
+
+  return (
+    <Card style={styles.card}>
+      <View style={styles.tiles}>
+        <StatTile value={sends} label={t('mobile.sessions.weekly.sends')} icon="tick" tint={brandColors.success} />
+        <StatTile
+          value={flashes}
+          label={t('mobile.sessions.weekly.flashes')}
+          icon="flash"
+          tint={brandColors.warning}
+        />
+        <StatTile
+          value={attempts}
+          label={t('mobile.sessions.weekly.attempts')}
+          icon="circle"
+          tint={iosSystemColors.systemGray}
+        />
+        {hardestGrade ? <GradeTile grade={hardestGrade} label={tFeed('sessionFeedCard.hardest')} /> : null}
+      </View>
+    </Card>
+  );
+}
+
+function StatTile({ value, label, icon, tint }: { value: number; label: string; icon: IconName; tint: string }) {
+  const { systemColors } = useTheme();
+  return (
+    <View style={[styles.tile, { backgroundColor: systemColors.fill }]}>
+      <View style={styles.valueRow}>
+        <Icon name={icon} size={14} color={tint} />
+        <Text variant="title3" color={tint}>
+          {value}
+        </Text>
+      </View>
+      <Text variant="caption1" color={systemColors.secondaryLabel} numberOfLines={1}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+function GradeTile({ grade, label }: { grade: string; label: string }) {
+  const background = gradeBadgeColor(grade);
+  const textColor = getGradeTextColor(background);
+  return (
+    <View style={[styles.tile, { backgroundColor: background }]}>
+      <Text variant="title3" color={textColor}>
+        {grade}
+      </Text>
+      <Text variant="caption1" color={textColor} style={styles.gradeLabel} numberOfLines={1}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: { marginHorizontal: spacing[4], marginTop: spacing[4] },
+  tiles: { flexDirection: 'row', gap: spacing[2] },
+  tile: {
+    flex: 1,
+    borderRadius: borderRadius.md,
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[2],
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  valueRow: { flexDirection: 'row', alignItems: 'center', gap: spacing[1] },
+  gradeLabel: { opacity: 0.85 },
+});

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -1,0 +1,143 @@
+import { memo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { SessionDetailTick, SessionFeedParticipant } from '@boardsesh/shared-schema';
+import { getGradeTextColor } from '@boardsesh/play-view';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { type IconName } from '../icon-map';
+import { ListRow } from '../ListRow';
+import { Avatar } from '../Avatar';
+import { FeedSocialRow } from '../you/FeedSocialRow';
+import { gradeBadgeColor } from '../you/profile-chart-colors';
+import { brandColors } from '../../theme/colors';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+type TickStatusMeta = { icon: IconName; color: string };
+
+function statusMeta(status: string): TickStatusMeta {
+  if (status === 'flash') return { icon: 'flash', color: brandColors.warning };
+  if (status === 'send') return { icon: 'tick', color: brandColors.success };
+  return { icon: 'circle', color: iosSystemColors.systemGray };
+}
+
+type TFunc = (key: string, options?: Record<string, unknown>) => string;
+
+function ordinalSuffix(n: number, t: TFunc): string {
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 13) return t('detail.ordinalDefault', { n });
+  switch (n % 10) {
+    case 1:
+      return t('detail.ordinalFirst', { n });
+    case 2:
+      return t('detail.ordinalSecond', { n });
+    case 3:
+      return t('detail.ordinalThird', { n });
+    default:
+      return t('detail.ordinalDefault', { n });
+  }
+}
+
+/** Attempt subtitle, mirroring web's `formatAttemptText`. */
+function formatAttemptText(tick: SessionDetailTick, t: TFunc): string | null {
+  if (tick.status === 'flash') return null;
+  const sessionAttempts = tick.attemptCount;
+  const total = tick.totalAttempts;
+
+  if (tick.status === 'send') {
+    const parts = [t('detail.attemptOnNth', { ordinal: ordinalSuffix(sessionAttempts, t) })];
+    if (total != null && total > sessionAttempts) parts.push(t('detail.totalAttempts', { count: total }));
+    return parts.join(', ');
+  }
+
+  const parts = [t('detail.attemptCount', { count: sessionAttempts })];
+  if (total != null && total > sessionAttempts) parts.push(t('detail.totalAttempts', { count: total }));
+  return parts.join(', ');
+}
+
+type SessionTickRowProps = {
+  tick: SessionDetailTick;
+  isMultiUser: boolean;
+  /** Participant who logged the tick, for the leading avatar in multi-user sessions. */
+  participant?: SessionFeedParticipant;
+  onPress: (tick: SessionDetailTick) => void;
+  onOpenComments: (tickUuid: string) => void;
+};
+
+export const SessionTickRow = memo(function SessionTickRow({
+  tick,
+  isMultiUser,
+  participant,
+  onPress,
+  onOpenComments,
+}: SessionTickRowProps) {
+  const { t } = useTranslation('session');
+
+  const meta = statusMeta(tick.status);
+  const attemptText = formatAttemptText(tick, t);
+  const subtitleParts = [attemptText, tick.comment ?? null].filter((part): part is string => !!part);
+  const subtitle = subtitleParts.length > 0 ? subtitleParts.join(' · ') : undefined;
+
+  return (
+    <ListRow
+      title={tick.climbName ?? t('detail.unknownClimb')}
+      subtitle={subtitle}
+      onPress={() => onPress(tick)}
+      leading={
+        isMultiUser ? (
+          <Avatar uri={participant?.avatarUrl} name={participant?.displayName} size={28} />
+        ) : (
+          <View style={[styles.badge, { backgroundColor: meta.color }]}>
+            <Icon name={meta.icon} size={14} color={iosSystemColors.white} />
+          </View>
+        )
+      }
+      trailing={
+        <View style={styles.trailing}>
+          {tick.difficultyName ? (
+            <View style={[styles.gradePill, { backgroundColor: gradeBadgeColor(tick.difficultyName) }]}>
+              <Text
+                variant="caption1"
+                color={getGradeTextColor(gradeBadgeColor(tick.difficultyName))}
+                style={styles.gradeText}
+              >
+                {tick.difficultyName}
+              </Text>
+            </View>
+          ) : null}
+          <FeedSocialRow
+            entityId={tick.uuid}
+            entityType="tick"
+            upvotes={tick.upvotes}
+            userVote={null}
+            commentCount={0}
+            onOpenComments={onOpenComments}
+            compact
+          />
+        </View>
+      }
+    />
+  );
+});
+
+const styles = StyleSheet.create({
+  badge: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  trailing: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  gradePill: {
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    borderRadius: borderRadius.sm,
+  },
+  gradeText: { fontWeight: '700' },
+});

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -111,7 +111,6 @@ export const SessionTickRow = memo(function SessionTickRow({
             entityType="tick"
             upvotes={tick.upvotes}
             userVote={null}
-            commentCount={0}
             onOpenComments={onOpenComments}
             compact
           />

--- a/packages/mobile/src/components/you/CommentSheet.tsx
+++ b/packages/mobile/src/components/you/CommentSheet.tsx
@@ -2,6 +2,7 @@ import { type RefObject, useState } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
 import BottomSheet, { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
+import type { SocialEntityType } from '@boardsesh/shared-schema';
 import { Text } from '../Text';
 import { Avatar } from '../Avatar';
 import { Icon } from '../Icon';
@@ -16,25 +17,28 @@ import { useTheme } from '../../providers/theme-provider';
 
 type CommentSheetProps = {
   sheetRef: RefObject<BottomSheet | null>;
-  sessionId: string | null;
+  /** The commented entity (a session or a tick); `null` while closed. */
+  entityId: string | null;
+  /** Defaults to `'session'` so existing session call sites stay unchanged. */
+  entityType?: SocialEntityType;
   onClose: () => void;
 };
 
-/** Comment thread for a session, with an inline composer. */
-export function CommentSheet({ sheetRef, sessionId, onClose }: CommentSheetProps) {
+/** Comment thread for a social entity (session or tick), with an inline composer. */
+export function CommentSheet({ sheetRef, entityId, entityType = 'session', onClose }: CommentSheetProps) {
   const { t } = useTranslation('you');
   const { systemColors } = useTheme();
   const [draft, setDraft] = useState('');
 
-  const commentsQuery = useComments('session', sessionId ?? undefined, !!sessionId);
+  const commentsQuery = useComments(entityType, entityId ?? undefined, !!entityId);
   const addComment = useAddComment();
   const comments = commentsQuery.data?.comments ?? [];
 
   const submit = () => {
     const body = draft.trim();
-    if (!body || !sessionId) return;
+    if (!body || !entityId) return;
     hapticLight();
-    addComment.mutate({ entityType: 'session', entityId: sessionId, body });
+    addComment.mutate({ entityType, entityId, body });
     setDraft('');
   };
 
@@ -77,7 +81,7 @@ export function CommentSheet({ sheetRef, sessionId, onClose }: CommentSheetProps
       <Text variant="title3" style={styles.title}>
         {t('mobile.comments.title')}
       </Text>
-      {commentsQuery.isPending && sessionId ? (
+      {commentsQuery.isPending && entityId ? (
         <View style={styles.centered}>
           <ActivityIndicator />
         </View>

--- a/packages/mobile/src/components/you/FeedSectionLabel.tsx
+++ b/packages/mobile/src/components/you/FeedSectionLabel.tsx
@@ -1,0 +1,32 @@
+import { View, Platform, StyleSheet } from 'react-native';
+import { Text } from '../Text';
+import { spacing } from '../../theme/tokens';
+
+/**
+ * Sticky-style section label for the grouped sessions feed (Today / This week /
+ * Earlier). Mirrors `SectionHeader`'s uppercase iOS treatment but with the
+ * card-aligned horizontal inset the feed uses.
+ */
+export function FeedSectionLabel({ label }: { label: string }) {
+  const displayLabel = Platform.OS === 'ios' ? label.toUpperCase() : label;
+  return (
+    <View style={styles.container}>
+      <Text variant="footnote" style={styles.text}>
+        {displayLabel}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[5],
+    paddingBottom: spacing[1],
+  },
+  text: {
+    opacity: 0.6,
+    letterSpacing: 0.5,
+    fontWeight: '600',
+  },
+});

--- a/packages/mobile/src/components/you/FeedSocialRow.tsx
+++ b/packages/mobile/src/components/you/FeedSocialRow.tsx
@@ -17,7 +17,10 @@ type FeedSocialRowProps = {
   upvotes: number;
   /** Server vote for the viewer: 1 = upvoted, else not. */
   userVote: number | null;
-  commentCount: number;
+  /** Comment count to badge. Omit when the count isn't known (e.g. per-tick
+   *  rows, where the detail query doesn't return it) — the icon shows without
+   *  a number rather than a misleading 0. */
+  commentCount?: number;
   onOpenComments: (entityId: string) => void;
   /** Compact spacing for inline (per-tick) placement. */
   compact?: boolean;
@@ -67,7 +70,7 @@ export function FeedSocialRow({
       </Pressable>
       <Pressable style={styles.button} onPress={() => onOpenComments(entityId)} accessibilityRole="button" hitSlop={6}>
         <Icon name="comment" size={iconSize} color={systemColors.secondaryLabel} />
-        {commentCount > 0 && (
+        {commentCount != null && commentCount > 0 && (
           <Text variant="footnote" color={systemColors.secondaryLabel}>
             {commentCount}
           </Text>

--- a/packages/mobile/src/components/you/FeedSocialRow.tsx
+++ b/packages/mobile/src/components/you/FeedSocialRow.tsx
@@ -1,4 +1,5 @@
 import { View, Pressable, StyleSheet } from 'react-native';
+import type { SocialEntityType } from '@boardsesh/shared-schema';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { useOptimisticVote } from './use-optimistic-vote';
@@ -8,19 +9,34 @@ import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 
 type FeedSocialRowProps = {
-  sessionId: string;
+  /** The voted/commented entity (a session or a tick). */
+  entityId: string;
+  /** Defaults to `'session'` so existing session cards stay unchanged. */
+  entityType?: SocialEntityType;
   /** Server upvote count (from the bulk vote summary, else the feed item). */
   upvotes: number;
   /** Server vote for the viewer: 1 = upvoted, else not. */
   userVote: number | null;
   commentCount: number;
-  onOpenComments: (sessionId: string) => void;
+  onOpenComments: (entityId: string) => void;
+  /** Compact spacing for inline (per-tick) placement. */
+  compact?: boolean;
 };
 
-/** Vote + comment row for a session feed card. */
-export function FeedSocialRow({ sessionId, upvotes, userVote, commentCount, onOpenComments }: FeedSocialRowProps) {
+/** Vote + comment row for a feed entity (session card or tick row). */
+export function FeedSocialRow({
+  entityId,
+  entityType = 'session',
+  upvotes,
+  userVote,
+  commentCount,
+  onOpenComments,
+  compact = false,
+}: FeedSocialRowProps) {
   const { systemColors } = useTheme();
-  const { voted, count, toggle, isPending } = useOptimisticVote(sessionId, upvotes, userVote);
+  const { voted, count, toggle, isPending } = useOptimisticVote(entityId, upvotes, userVote, entityType);
+
+  const iconSize = compact ? 16 : 18;
 
   const handleVote = () => {
     if (isPending) return; // guard double-tap (toggle no-ops too)
@@ -29,7 +45,7 @@ export function FeedSocialRow({ sessionId, upvotes, userVote, commentCount, onOp
   };
 
   return (
-    <View style={styles.row}>
+    <View style={[styles.row, compact && styles.rowCompact]}>
       <Pressable
         style={styles.button}
         onPress={handleVote}
@@ -40,7 +56,7 @@ export function FeedSocialRow({ sessionId, upvotes, userVote, commentCount, onOp
       >
         <Icon
           name={voted ? 'favorite.fill' : 'favorite'}
-          size={18}
+          size={iconSize}
           color={voted ? brandColors.error : systemColors.secondaryLabel}
         />
         {count > 0 && (
@@ -49,8 +65,8 @@ export function FeedSocialRow({ sessionId, upvotes, userVote, commentCount, onOp
           </Text>
         )}
       </Pressable>
-      <Pressable style={styles.button} onPress={() => onOpenComments(sessionId)} accessibilityRole="button" hitSlop={6}>
-        <Icon name="comment" size={18} color={systemColors.secondaryLabel} />
+      <Pressable style={styles.button} onPress={() => onOpenComments(entityId)} accessibilityRole="button" hitSlop={6}>
+        <Icon name="comment" size={iconSize} color={systemColors.secondaryLabel} />
         {commentCount > 0 && (
           <Text variant="footnote" color={systemColors.secondaryLabel}>
             {commentCount}
@@ -67,6 +83,11 @@ const styles = StyleSheet.create({
     gap: spacing[6],
     marginTop: spacing[3],
     paddingTop: spacing[3],
+  },
+  rowCompact: {
+    gap: spacing[4],
+    marginTop: 0,
+    paddingTop: 0,
   },
   button: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/you/SessionFeedCard.tsx
+++ b/packages/mobile/src/components/you/SessionFeedCard.tsx
@@ -11,7 +11,7 @@ import { Card } from '../Card';
 import { AvatarGroup } from './AvatarGroup';
 import { FeedSocialRow } from './FeedSocialRow';
 import { StackedBarChart } from './YouCharts';
-import { gradeBadgeColor } from './profile-chart-colors';
+import { gradeBadgeColor, buildSessionGradeBars } from './profile-chart-colors';
 import { brandColors, withAlpha } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
@@ -22,6 +22,7 @@ type SessionFeedCardProps = {
   /** Per-viewer vote summary (count + userVote) for this session, if loaded. */
   voteSummary?: { upvotes: number; userVote: number | null };
   onOpenComments: (sessionId: string) => void;
+  onPress: (sessionId: string) => void;
 };
 
 function formatDuration(minutes: number): string {
@@ -35,6 +36,7 @@ export const SessionFeedCard = memo(function SessionFeedCard({
   session,
   voteSummary,
   onOpenComments,
+  onPress,
 }: SessionFeedCardProps) {
   const { t } = useTranslation('feed');
   const { systemColors } = useTheme();
@@ -44,83 +46,90 @@ export const SessionFeedCard = memo(function SessionFeedCard({
     .filter((name): name is string => !!name)
     .join(', ');
 
-  const gradeBars = useMemo(
-    () =>
-      session.gradeDistribution.length > 0
-        ? session.gradeDistribution.map((item) => ({
-            key: item.grade,
-            label: item.grade,
-            segments: [{ value: item.flash + item.send, key: item.grade, label: item.grade }],
-          }))
-        : null,
-    [session.gradeDistribution],
-  );
+  const gradeBars = useMemo(() => buildSessionGradeBars(session.gradeDistribution), [session.gradeDistribution]);
 
   return (
-    <Card style={styles.card} haptic={false}>
-      <View style={styles.header}>
-        <AvatarGroup participants={session.participants} size={32} />
-        <View style={styles.headerText}>
-          <Text variant="subheadline" style={styles.names} numberOfLines={1}>
-            {names || t('sessionFeedCard.climbCount', { count: session.tickCount })}
-          </Text>
-          <View style={styles.meta}>
-            <Text variant="caption1" color={systemColors.tertiaryLabel}>
-              {formatTickRelativeTime(session.lastTickAt)}
+    <View style={styles.wrapper}>
+      {/* Only the summary region navigates; the social row sits below as a
+          sibling so vote/comment taps never trigger navigation. */}
+      <Card onPress={() => onPress(session.sessionId)}>
+        <View style={styles.header}>
+          <AvatarGroup participants={session.participants} size={32} />
+          <View style={styles.headerText}>
+            <Text variant="subheadline" style={styles.names} numberOfLines={1}>
+              {names || t('sessionFeedCard.climbCount', { count: session.tickCount })}
             </Text>
-            {session.durationMinutes != null && session.durationMinutes > 0 && (
-              <View style={styles.metaItem}>
-                <Icon name="clock" size={11} color={systemColors.tertiaryLabel} />
-                <Text variant="caption1" color={systemColors.tertiaryLabel}>
-                  {formatDuration(session.durationMinutes)}
-                </Text>
-              </View>
-            )}
+            <View style={styles.meta}>
+              <Text variant="caption1" color={systemColors.tertiaryLabel}>
+                {formatTickRelativeTime(session.lastTickAt)}
+              </Text>
+              {session.durationMinutes != null && session.durationMinutes > 0 && (
+                <View style={styles.metaItem}>
+                  <Icon name="clock" size={11} color={systemColors.tertiaryLabel} />
+                  <Text variant="caption1" color={systemColors.tertiaryLabel}>
+                    {formatDuration(session.durationMinutes)}
+                  </Text>
+                </View>
+              )}
+            </View>
           </View>
+          {session.hardestGrade ? <HardestBadge grade={session.hardestGrade} label={t('sessionFeedCard.hardest')} /> : null}
         </View>
-      </View>
 
-      {session.goal ? (
-        <View style={styles.goal}>
-          <Icon name="flag" size={13} color={systemColors.secondaryLabel} />
-          <Text variant="footnote" color={systemColors.secondaryLabel} numberOfLines={2}>
-            {session.goal}
+        {session.goal ? (
+          <View style={styles.goal}>
+            <Icon name="flag" size={13} color={systemColors.secondaryLabel} />
+            <Text variant="footnote" color={systemColors.secondaryLabel} numberOfLines={2}>
+              {session.goal}
+            </Text>
+          </View>
+        ) : null}
+
+        {/* Hero stat: total sends, the headline number of the session. */}
+        <View style={styles.hero}>
+          <Text variant="title2" color={brandColors.success}>
+            {session.totalSends}
+          </Text>
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.heroLabel}>
+            {t('sessionFeedCard.sendsLabel')}
           </Text>
         </View>
-      ) : null}
 
-      <View style={styles.chips}>
-        {session.totalFlashes > 0 && <Chip icon="flash" label={`${session.totalFlashes}`} tint={brandColors.warning} />}
-        {session.totalSends > 0 && <Chip icon="tick" label={`${session.totalSends}`} tint={brandColors.success} />}
-        {session.totalAttempts > 0 && (
-          <Chip icon="circle" label={`${session.totalAttempts}`} tint={iosSystemColors.systemGray} />
-        )}
-        {session.hardestGrade ? <GradeChip grade={session.hardestGrade} /> : null}
-      </View>
-
-      {gradeBars && (
-        <View style={styles.chart}>
-          <StackedBarChart bars={gradeBars} colorBy="grade" height={84} />
+        <View style={styles.chips}>
+          {session.totalFlashes > 0 && (
+            <Chip icon="flash" label={`${session.totalFlashes}`} tint={brandColors.warning} />
+          )}
+          {session.totalAttempts > 0 && (
+            <Chip icon="circle" label={`${session.totalAttempts}`} tint={iosSystemColors.systemGray} />
+          )}
         </View>
-      )}
 
-      <View style={styles.boardRow}>
-        <Text variant="caption1" color={systemColors.tertiaryLabel} numberOfLines={1} style={styles.flex}>
-          {session.boardTypes.join(' · ')}
-        </Text>
-        <Text variant="caption1" color={systemColors.tertiaryLabel}>
-          {t('sessionFeedCard.climbCount', { count: session.tickCount })}
-        </Text>
+        {gradeBars && (
+          <View style={styles.chart}>
+            <StackedBarChart bars={gradeBars} colorBy="grade" height={84} />
+          </View>
+        )}
+
+        <View style={styles.boardRow}>
+          <Text variant="caption1" color={systemColors.tertiaryLabel} numberOfLines={1} style={styles.flex}>
+            {session.boardTypes.join(' · ')}
+          </Text>
+          <Text variant="caption1" color={systemColors.tertiaryLabel}>
+            {t('sessionFeedCard.climbCount', { count: session.tickCount })}
+          </Text>
+        </View>
+      </Card>
+
+      <View style={styles.social}>
+        <FeedSocialRow
+          entityId={session.sessionId}
+          upvotes={voteSummary?.upvotes ?? session.upvotes}
+          userVote={voteSummary?.userVote ?? null}
+          commentCount={session.commentCount}
+          onOpenComments={onOpenComments}
+        />
       </View>
-
-      <FeedSocialRow
-        sessionId={session.sessionId}
-        upvotes={voteSummary?.upvotes ?? session.upvotes}
-        userVote={voteSummary?.userVote ?? null}
-        commentCount={session.commentCount}
-        onOpenComments={onOpenComments}
-      />
-    </Card>
+    </View>
   );
 });
 
@@ -135,27 +144,46 @@ function Chip({ icon, label, tint }: { icon: IconName; label: string; tint: stri
   );
 }
 
-function GradeChip({ grade }: { grade: string }) {
+function HardestBadge({ grade, label }: { grade: string; label: string }) {
+  const { systemColors } = useTheme();
   const background = gradeBadgeColor(grade);
   const textColor = getGradeTextColor(background);
   return (
-    <View style={[styles.chip, { backgroundColor: background }]}>
-      <Text variant="caption1" color={textColor} style={styles.chipLabel}>
-        {grade}
+    <View style={styles.hardest}>
+      <View style={[styles.hardestPill, { backgroundColor: background }]}>
+        <Icon name="flame" size={12} color={textColor} />
+        <Text variant="footnote" color={textColor} style={styles.hardestGrade}>
+          {grade}
+        </Text>
+      </View>
+      <Text variant="caption2" color={systemColors.tertiaryLabel}>
+        {label}
       </Text>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  card: { marginHorizontal: spacing[4], marginTop: spacing[3] },
+  wrapper: { marginHorizontal: spacing[4], marginTop: spacing[3] },
   header: { flexDirection: 'row', alignItems: 'center', gap: spacing[3] },
   headerText: { flex: 1 },
   names: { fontWeight: '600' },
   meta: { flexDirection: 'row', alignItems: 'center', gap: spacing[3], marginTop: 2 },
   metaItem: { flexDirection: 'row', alignItems: 'center', gap: 3 },
+  hardest: { alignItems: 'center', gap: 2 },
+  hardestPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: spacing[2],
+    paddingVertical: 3,
+    borderRadius: borderRadius.full,
+  },
+  hardestGrade: { fontWeight: '700' },
   goal: { flexDirection: 'row', alignItems: 'center', gap: spacing[2], marginTop: spacing[3] },
-  chips: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing[2], marginTop: spacing[3] },
+  hero: { flexDirection: 'row', alignItems: 'baseline', gap: spacing[2], marginTop: spacing[3] },
+  heroLabel: { textTransform: 'lowercase' },
+  chips: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing[2], marginTop: spacing[2] },
   chip: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -168,4 +196,5 @@ const styles = StyleSheet.create({
   chart: { marginTop: spacing[3] },
   boardRow: { flexDirection: 'row', alignItems: 'center', marginTop: spacing[3], gap: spacing[2] },
   flex: { flex: 1 },
+  social: { paddingHorizontal: spacing[1] },
 });

--- a/packages/mobile/src/components/you/SessionsFeedHeader.tsx
+++ b/packages/mobile/src/components/you/SessionsFeedHeader.tsx
@@ -1,0 +1,110 @@
+import { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { SessionFeedItem } from '@boardsesh/shared-schema';
+import { parseTickTime } from '@boardsesh/profile-stats';
+import { Text } from '../Text';
+import { Card } from '../Card';
+import { brandColors } from '../../theme/colors';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+type WeeklyRollup = {
+  sessions: number;
+  sends: number;
+  flashes: number;
+  streakWeeks: number;
+};
+
+/**
+ * Compute the "this week" rollup + week-streak purely from the already-loaded
+ * feed pages — no extra query. `now` is injected so the calculation is
+ * deterministic and testable. Streak = number of consecutive ISO-ish weeks
+ * (trailing 7-day windows back from `now`) that contain at least one session.
+ */
+function computeRollup(sessions: SessionFeedItem[], now: number): WeeklyRollup {
+  const weekAgo = now - WEEK_MS;
+  let weeklySessions = 0;
+  let weeklySends = 0;
+  let weeklyFlashes = 0;
+  for (const session of sessions) {
+    if (parseTickTime(session.lastTickAt).valueOf() >= weekAgo) {
+      weeklySessions += 1;
+      weeklySends += session.totalSends;
+      weeklyFlashes += session.totalFlashes;
+    }
+  }
+
+  // Streak: walk back week-by-week from `now`; stop at the first empty week.
+  const weekIndexes = new Set<number>();
+  for (const session of sessions) {
+    const ageMs = now - parseTickTime(session.lastTickAt).valueOf();
+    if (ageMs < 0) continue;
+    weekIndexes.add(Math.floor(ageMs / WEEK_MS));
+  }
+  let streakWeeks = 0;
+  while (weekIndexes.has(streakWeeks)) streakWeeks += 1;
+
+  return { sessions: weeklySessions, sends: weeklySends, flashes: weeklyFlashes, streakWeeks };
+}
+
+export function SessionsFeedHeader({ sessions, now }: { sessions: SessionFeedItem[]; now: number }) {
+  const { t } = useTranslation('you');
+  const { systemColors } = useTheme();
+
+  const rollup = useMemo(() => computeRollup(sessions, now), [sessions, now]);
+
+  // Nothing logged in the trailing week → skip the rollup entirely so the feed
+  // doesn't lead with a wall of zeros.
+  if (rollup.sessions === 0) return null;
+
+  return (
+    <Card style={styles.card}>
+      <Text variant="subheadline" style={styles.headline}>
+        {rollup.streakWeeks > 1
+          ? t('mobile.sessions.streak', { count: rollup.streakWeeks })
+          : t('mobile.sessions.weeklySends', { count: rollup.sends })}
+      </Text>
+      <View style={styles.tiles}>
+        <View style={[styles.tile, { backgroundColor: systemColors.fill }]}>
+          <Text variant="title2">{rollup.sessions}</Text>
+          <Text variant="caption1" color={systemColors.secondaryLabel}>
+            {t('mobile.sessions.weekly.sessions')}
+          </Text>
+        </View>
+        <View style={[styles.tile, { backgroundColor: systemColors.fill }]}>
+          <Text variant="title2" color={brandColors.success}>
+            {rollup.sends}
+          </Text>
+          <Text variant="caption1" color={systemColors.secondaryLabel}>
+            {t('mobile.sessions.weekly.sends')}
+          </Text>
+        </View>
+        <View style={[styles.tile, { backgroundColor: systemColors.fill }]}>
+          <Text variant="title2" color={brandColors.warning}>
+            {rollup.flashes}
+          </Text>
+          <Text variant="caption1" color={systemColors.secondaryLabel}>
+            {t('mobile.sessions.weekly.flashes')}
+          </Text>
+        </View>
+      </View>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: { marginHorizontal: spacing[4], marginTop: spacing[4] },
+  headline: { fontWeight: '600', marginBottom: spacing[3] },
+  tiles: { flexDirection: 'row', gap: spacing[2] },
+  tile: {
+    flex: 1,
+    borderRadius: borderRadius.md,
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[2],
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+});

--- a/packages/mobile/src/components/you/SessionsTab.tsx
+++ b/packages/mobile/src/components/you/SessionsTab.tsx
@@ -1,24 +1,43 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { View, RefreshControl, StyleSheet } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
+import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import type { SessionFeedItem } from '@boardsesh/shared-schema';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
+import { Button } from '../Button';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { SessionFeedCard } from './SessionFeedCard';
+import { SessionsFeedHeader } from './SessionsFeedHeader';
+import { FeedSectionLabel } from './FeedSectionLabel';
 import { CommentSheet } from './CommentSheet';
+import { bucketSessionsByRecency, type FeedRecencyBucket } from '../../lib/feed-time-buckets';
 import { useSessionGroupedFeed, useBulkVoteSummaries } from '../../lib/graphql/hooks';
 import { TOOLBAR_RESERVE, TAB_BAR_HEIGHT } from '../../theme/layout';
 import { brandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
+import { useSessionScreen } from '../../providers/session-screen-provider';
+
+type FeedRow = { type: 'header'; bucket: FeedRecencyBucket } | { type: 'session'; item: SessionFeedItem };
+
+type TFunc = (key: string) => string;
+
+// String-literal `t(...)` per call so the catalog keys stay statically greppable.
+function sectionLabel(bucket: FeedRecencyBucket, t: TFunc): string {
+  if (bucket === 'today') return t('mobile.sessions.sectionToday');
+  if (bucket === 'thisWeek') return t('mobile.sessions.sectionThisWeek');
+  return t('mobile.sessions.sectionEarlier');
+}
 
 export function SessionsTab({ userId }: { userId: string | undefined }) {
   const { t } = useTranslation('you');
   const { systemColors } = useTheme();
+  const router = useRouter();
+  const { open: openSessionScreen } = useSessionScreen();
   const insets = useSafeAreaInsets();
   const paddingBottom = TOOLBAR_RESERVE + TAB_BAR_HEIGHT + insets.bottom + spacing[4];
 
@@ -30,6 +49,22 @@ export function SessionsTab({ userId }: { userId: string | undefined }) {
     () => feed.data?.pages.flatMap((page) => page.sessionGroupedFeed.sessions) ?? [],
     [feed.data],
   );
+
+  // One clock captured per mount (stable across renders) so the rollup header
+  // and the section bucketing agree and neither rebuckets on every render.
+  const [now] = useState(() => Date.now());
+
+  // Flatten the recency groups into header + session rows for a single
+  // virtualized list (FlashList has no built-in section support).
+  const rows = useMemo<FeedRow[]>(() => {
+    const groups = bucketSessionsByRecency(sessions, now);
+    const flattened: FeedRow[] = [];
+    for (const group of groups) {
+      flattened.push({ type: 'header', bucket: group.bucket });
+      for (const item of group.sessions) flattened.push({ type: 'session', item });
+    }
+    return flattened;
+  }, [sessions, now]);
 
   // Per-viewer vote state for the visible sessions (the feed item carries
   // counts but not the viewer's own vote). Refetches as more pages load.
@@ -48,19 +83,32 @@ export function SessionsTab({ userId }: { userId: string | undefined }) {
     commentSheetRef.current?.snapToIndex(0);
   }, []);
 
+  const handleOpenSession = useCallback(
+    (sessionId: string) => {
+      router.push({ pathname: '/session/[sessionId]', params: { sessionId } });
+    },
+    [router],
+  );
+
   const handleEndReached = useCallback(() => {
     if (feed.hasNextPage && !feed.isFetchingNextPage) void feed.fetchNextPage();
   }, [feed]);
 
   const renderItem = useCallback(
-    ({ item }: { item: SessionFeedItem }) => (
-      <SessionFeedCard
-        session={item}
-        voteSummary={summaryMap.get(item.sessionId)}
-        onOpenComments={handleOpenComments}
-      />
-    ),
-    [handleOpenComments, summaryMap],
+    ({ item: row }: { item: FeedRow }) => {
+      if (row.type === 'header') {
+        return <FeedSectionLabel label={sectionLabel(row.bucket, t)} />;
+      }
+      return (
+        <SessionFeedCard
+          session={row.item}
+          voteSummary={summaryMap.get(row.item.sessionId)}
+          onOpenComments={handleOpenComments}
+          onPress={handleOpenSession}
+        />
+      );
+    },
+    [handleOpenComments, handleOpenSession, summaryMap, t],
   );
 
   if (!userId || feed.isPending) {
@@ -74,13 +122,15 @@ export function SessionsTab({ userId }: { userId: string | undefined }) {
   return (
     <View style={styles.flex}>
       <FlashList
-        data={sessions}
+        data={rows}
         extraData={summaryMap}
         renderItem={renderItem}
-        keyExtractor={(item) => item.sessionId}
+        getItemType={(row) => row.type}
+        keyExtractor={(row) => (row.type === 'header' ? `header-${row.bucket}` : row.item.sessionId)}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         contentContainerStyle={{ paddingBottom }}
+        ListHeaderComponent={sessions.length > 0 ? <SessionsFeedHeader sessions={sessions} now={now} /> : null}
         refreshControl={
           <RefreshControl
             refreshing={feed.isRefetching}
@@ -99,12 +149,25 @@ export function SessionsTab({ userId }: { userId: string | undefined }) {
           <View style={styles.empty}>
             <Icon name="history" size={48} color={systemColors.tertiaryLabel} />
             <Text variant="headline" style={styles.emptyTitle}>
-              {t('mobile.sessions.empty')}
+              {t('mobile.sessions.emptyTitle')}
             </Text>
+            <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptyBody}>
+              {t('mobile.sessions.emptyBody')}
+            </Text>
+            <View style={styles.emptyCta}>
+              {/* The Record tab opens the session overlay (mounted at the root),
+                  so open it directly rather than navigating to the blank /record
+                  screen — a programmatic push wouldn't trigger BlurTabBar. */}
+              <Button title={t('mobile.sessions.emptyCta')} onPress={openSessionScreen} />
+            </View>
           </View>
         }
       />
-      <CommentSheet sheetRef={commentSheetRef} sessionId={commentSessionId} onClose={() => setCommentSessionId(null)} />
+      <CommentSheet
+        sheetRef={commentSheetRef}
+        entityId={commentSessionId}
+        onClose={() => setCommentSessionId(null)}
+      />
     </View>
   );
 }
@@ -120,5 +183,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[8],
     gap: spacing[2],
   },
-  emptyTitle: { opacity: 0.6, marginTop: spacing[3], textAlign: 'center' },
+  emptyTitle: { marginTop: spacing[3], textAlign: 'center' },
+  emptyBody: { textAlign: 'center' },
+  emptyCta: { marginTop: spacing[4] },
 });

--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState, type ReactNode } from 'react';
 import { View, StyleSheet, type LayoutChangeEvent } from 'react-native';
 import { BarChart, LineChart } from 'react-native-gifted-charts';
-import type { RawBar, RawGroupedBar, RawVPointsTimeline } from '@boardsesh/profile-stats';
+import type { RawGroupedBar, RawVPointsTimeline } from '@boardsesh/profile-stats';
 import { Text } from '../Text';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { useTheme } from '../../providers/theme-provider';
-import { gradeChartColor, layoutChartColor, flashRedpointColor } from './profile-chart-colors';
+import { gradeChartColor, layoutChartColor, flashRedpointColor, type ColoredBar } from './profile-chart-colors';
 
 const MAX_X_LABELS = 12;
 const AXIS_LABEL_SIZE = 10;
@@ -82,8 +82,13 @@ function ChartFrame({ height, loading, emptyLabel, isEmpty, children }: FramePro
 }
 
 type StackedBarsProps = {
-  bars: RawBar[] | null;
-  /** 'grade' colors segments by grade label; 'layout' by layoutKey. */
+  bars: ColoredBar[] | null;
+  /**
+   * Fallback colour resolution when a segment has no explicit `color`:
+   * 'grade' colours by grade label, 'layout' by layoutKey. A segment that
+   * carries its own `color` (e.g. the gold flash cap on session grade bars)
+   * overrides this.
+   */
   colorBy: 'grade' | 'layout';
   height?: number;
   loading?: boolean;
@@ -117,7 +122,8 @@ export function StackedBarChart({
           .filter((segment) => segment.value > 0)
           .map((segment) => ({
             value: segment.value,
-            color: colorBy === 'grade' ? gradeChartColor(segment.key) : layoutChartColor(segment.key),
+            // An explicit segment colour wins; otherwise fall back to colorBy.
+            color: segment.color ?? (colorBy === 'grade' ? gradeChartColor(segment.key) : layoutChartColor(segment.key)),
           }));
         const stacks = filled.length > 0 ? filled : [{ value: 0, color: 'transparent' }];
         // Round only the stack's outer corners (bottom of the bottom segment,

--- a/packages/mobile/src/components/you/profile-chart-colors.ts
+++ b/packages/mobile/src/components/you/profile-chart-colors.ts
@@ -1,5 +1,15 @@
-import { V_GRADE_COLORS, FONT_GRADE_COLORS } from '@boardsesh/board-constants/grade-colors';
+import { V_GRADE_COLORS, FONT_GRADE_COLORS, getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import type { RawBar, RawBarSegment } from '@boardsesh/profile-stats';
+import type { SessionGradeDistributionItem } from '@boardsesh/shared-schema';
 import { brandColors, withAlpha } from '../../theme/colors';
+
+/**
+ * A stacked-bar segment that may carry its own colour, overriding the chart's
+ * `colorBy` resolution. Used for session grade bars (vivid grade colour for
+ * sends + a gold flash cap). Plain `RawBar`s (no colour) remain valid.
+ */
+export type ColoredBarSegment = RawBarSegment & { color?: string };
+export type ColoredBar = Omit<RawBar, 'segments'> & { segments: ColoredBarSegment[] };
 
 // Mobile color resolution for the renderer-agnostic chart data emitted by
 // @boardsesh/profile-stats. Mirrors the web adapter's palette so the two
@@ -67,9 +77,53 @@ export function flashRedpointColor(seriesKey: 'flash' | 'redpoint'): string {
   return seriesKey === 'flash' ? withAlpha(brandColors.success, 0.85) : withAlpha(brandColors.error, 0.85);
 }
 
-/** Solid grade color (un-softened) for badges/chips. */
+/**
+ * Solid (vivid) grade color for badges, bars and grade text. Routes through
+ * board-constants' `getGradeColor`, which extracts the V- or font-grade token
+ * from a label — so combined board names like "6B+/V4" resolve to a real colour
+ * instead of the grey fallback the naive map lookup produced.
+ */
 export function gradeBadgeColor(gradeLabel: string | null | undefined): string {
-  if (!gradeLabel) return '#808080';
-  const normalized = gradeLabel.replace(/\+$/, '');
-  return V_GRADE_COLORS[normalized] ?? FONT_GRADE_COLORS[gradeLabel.toLowerCase()] ?? '#808080';
+  return getGradeColor(gradeLabel) ?? DEFAULT_GRADE_COLOR;
+}
+
+/**
+ * Sortable rank for a grade label so chart X-axes read easy→hard. Extracts the
+ * V-number when present (combined Aurora labels always carry one), else maps a
+ * font grade; unknown labels sort last.
+ */
+export function gradeSortValue(gradeLabel: string): number {
+  const vMatch = gradeLabel.match(/V(\d+)/i);
+  if (vMatch) return Number(vMatch[1]);
+  const fontMatch = gradeLabel.match(/(\d)([abc])(\+?)/i);
+  if (fontMatch) {
+    const number = Number(fontMatch[1]);
+    const letter = fontMatch[2].toLowerCase().charCodeAt(0) - 96; // a=1, b=2, c=3
+    // Offset past the V range so a pure-font session still sorts ascending.
+    return 100 + number * 10 + letter * 2 + (fontMatch[3] ? 1 : 0);
+  }
+  return Number.MAX_SAFE_INTEGER;
+}
+
+/**
+ * Build grade-distribution bars for a session view. Each grade bar is the total
+ * ascents (flash + send) for that grade, drawn in the grade's own vivid colour —
+ * a colourful grade pyramid. Grades with no ascents are dropped; returns null
+ * when the whole distribution is empty. Pass straight to `StackedBarChart` (the
+ * segment carries an explicit colour, so `colorBy` is ignored for these bars).
+ */
+export function buildSessionGradeBars(distribution: SessionGradeDistributionItem[]): ColoredBar[] | null {
+  const bars: ColoredBar[] = [];
+  // Order the X-axis easy→hard regardless of the order the backend returns.
+  const ordered = [...distribution].sort((a, b) => gradeSortValue(a.grade) - gradeSortValue(b.grade));
+  for (const item of ordered) {
+    const total = item.flash + item.send;
+    if (total <= 0) continue;
+    bars.push({
+      key: item.grade,
+      label: item.grade,
+      segments: [{ value: total, key: item.grade, label: item.grade, color: gradeBadgeColor(item.grade) }],
+    });
+  }
+  return bars.length > 0 ? bars : null;
 }

--- a/packages/mobile/src/components/you/use-optimistic-vote.ts
+++ b/packages/mobile/src/components/you/use-optimistic-vote.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import type { SocialEntityType } from '@boardsesh/shared-schema';
 import { useVote } from '../../lib/graphql/hooks';
 
 export type OptimisticVote = {
@@ -13,16 +14,20 @@ export type OptimisticVote = {
 };
 
 /**
- * Optimistic upvote state for a feed entity (currently sessions). Layers a local
+ * Optimistic upvote state for a feed entity (sessions or ticks). Layers a local
  * override over the server count / `userVote` so the UI flips instantly,
  * reconciles to the server summary on success, rolls back on error, and resets
  * when the row is recycled onto a different entity — FlashList reuses component
  * instances, so without the reset one card's vote would bleed onto another.
+ *
+ * `entityType` defaults to `'session'` so existing session call sites stay
+ * unchanged; tick rows pass `'tick'` to reuse the same vote pipeline.
  */
 export function useOptimisticVote(
-  sessionId: string,
+  entityId: string,
   serverUpvotes: number,
   serverUserVote: number | null,
+  entityType: SocialEntityType = 'session',
 ): OptimisticVote {
   // Destructure the stable `mutate` + the `isPending` flag rather than depend on
   // the whole useMutation result — that object is a fresh reference every render,
@@ -31,8 +36,8 @@ export function useOptimisticVote(
   const { mutate: voteMutate, isPending: voteIsPending } = useVote();
   const [optimistic, setOptimistic] = useState<{ count: number; voted: boolean } | null>(null);
 
-  // Recycled onto a different session → drop the previous card's optimistic state.
-  useEffect(() => setOptimistic(null), [sessionId]);
+  // Recycled onto a different entity → drop the previous row's optimistic state.
+  useEffect(() => setOptimistic(null), [entityId]);
 
   const voted = optimistic ? optimistic.voted : serverUserVote === 1;
   const count = optimistic ? optimistic.count : serverUpvotes;
@@ -42,13 +47,13 @@ export function useOptimisticVote(
     const nextVoted = !voted;
     setOptimistic({ count: count + (nextVoted ? 1 : -1), voted: nextVoted });
     voteMutate(
-      { entityType: 'session', entityId: sessionId, value: nextVoted ? 1 : 0 },
+      { entityType, entityId, value: nextVoted ? 1 : 0 },
       {
         onSuccess: (summary) => setOptimistic({ count: summary.upvotes, voted: summary.userVote === 1 }),
         onError: () => setOptimistic(null),
       },
     );
-  }, [voteMutate, voteIsPending, voted, count, sessionId]);
+  }, [voteMutate, voteIsPending, voted, count, entityId, entityType]);
 
   return { voted, count, toggle, isPending: voteIsPending };
 }

--- a/packages/mobile/src/lib/__tests__/board-path-to-user-board.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-path-to-user-board.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { CreateBoardInput, UserBoard } from '@boardsesh/shared-schema';
+import {
+  parseBoardConfigFromPath,
+  findOwnedBoardForSession,
+  buildCreateBoardInput,
+  resolveBoardForSession,
+} from '../board-path-to-user-board';
+
+function makeBoard(overrides: Partial<UserBoard> = {}): UserBoard {
+  return {
+    uuid: 'board-uuid',
+    boardType: 'kilter',
+    layoutId: 8,
+    sizeId: 17,
+    setIds: '27,28',
+    name: 'Kilter',
+    angle: 40,
+    isOwned: true,
+    isAngleAdjustable: true,
+    ...overrides,
+  } as unknown as UserBoard;
+}
+
+describe('parseBoardConfigFromPath', () => {
+  it('parses a full board path into a config tuple', () => {
+    expect(parseBoardConfigFromPath('kilter/8/17/27,28/40')).toEqual({
+      boardType: 'kilter',
+      layoutId: 8,
+      sizeId: 17,
+      setIds: '27,28',
+      angle: 40,
+    });
+  });
+
+  it('tolerates a locale prefix and leading slash', () => {
+    expect(parseBoardConfigFromPath('/es/tension/9/8/7,6/25')).toEqual({
+      boardType: 'tension',
+      layoutId: 9,
+      sizeId: 8,
+      setIds: '7,6',
+      angle: 25,
+    });
+  });
+
+  it('returns null when the path has no angle', () => {
+    expect(parseBoardConfigFromPath('kilter/8/17/27,28')).toBeNull();
+  });
+
+  it('returns null for an unparseable path', () => {
+    expect(parseBoardConfigFromPath('not-a-board-path')).toBeNull();
+  });
+});
+
+describe('findOwnedBoardForSession', () => {
+  const config = { boardType: 'kilter', layoutId: 8, sizeId: 17, setIds: '27,28', angle: 30 };
+
+  it('reuses an exact-config owned board, overriding the angle from the session', () => {
+    const owned = makeBoard({ angle: 40 });
+    const result = findOwnedBoardForSession([owned], config);
+    expect(result).toMatchObject({ uuid: 'board-uuid', angle: 30 });
+    // Must not mutate the cached board in place.
+    expect(owned.angle).toBe(40);
+  });
+
+  it('returns the same reference when the angle already matches', () => {
+    const owned = makeBoard({ angle: 30 });
+    const result = findOwnedBoardForSession([owned], config);
+    expect(result).toBe(owned);
+  });
+
+  it('returns undefined when no owned board matches the config', () => {
+    const owned = makeBoard({ boardType: 'tension' });
+    expect(findOwnedBoardForSession([owned], config)).toBeUndefined();
+  });
+
+  it('does not match on set-id differences', () => {
+    const owned = makeBoard({ setIds: '27' });
+    expect(findOwnedBoardForSession([owned], config)).toBeUndefined();
+  });
+});
+
+describe('buildCreateBoardInput', () => {
+  it('builds an unowned create input with a derived board name', () => {
+    const input: CreateBoardInput = buildCreateBoardInput({
+      boardType: 'moonboard',
+      layoutId: 1,
+      sizeId: 2,
+      setIds: '3',
+      angle: 25,
+    });
+    expect(input).toEqual({
+      boardType: 'moonboard',
+      layoutId: 1,
+      sizeId: 2,
+      setIds: '3',
+      angle: 25,
+      isOwned: false,
+      name: 'MoonBoard',
+    });
+  });
+});
+
+describe('resolveBoardForSession', () => {
+  it('reuses an owned board without creating one', async () => {
+    const owned = makeBoard({ angle: 40 });
+    const createBoard = vi.fn();
+    const result = await resolveBoardForSession('kilter/8/17/27,28/30', {
+      ownedBoards: [owned],
+      createBoard,
+    });
+    expect(result).toMatchObject({ uuid: 'board-uuid', angle: 30 });
+    expect(createBoard).not.toHaveBeenCalled();
+  });
+
+  it('creates a board when none is owned', async () => {
+    const created = makeBoard({ uuid: 'fresh-uuid', isOwned: false, angle: 30 });
+    const createBoard = vi.fn().mockResolvedValue(created);
+    const result = await resolveBoardForSession('kilter/8/17/27,28/30', {
+      ownedBoards: [],
+      createBoard,
+    });
+    expect(createBoard).toHaveBeenCalledWith({
+      boardType: 'kilter',
+      layoutId: 8,
+      sizeId: 17,
+      setIds: '27,28',
+      angle: 30,
+      isOwned: false,
+      name: 'Kilter',
+    });
+    expect(result).toBe(created);
+  });
+
+  it('throws on an unparseable board path', async () => {
+    await expect(
+      resolveBoardForSession('garbage', { ownedBoards: [], createBoard: vi.fn() }),
+    ).rejects.toThrow(/Cannot resolve a board/);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/feed-time-buckets.test.ts
+++ b/packages/mobile/src/lib/__tests__/feed-time-buckets.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { bucketSessionsByRecency } from '../feed-time-buckets';
+
+// Fixed clock: 2026-06-04T12:00:00Z. The helper buckets off the local calendar
+// day, but these timestamps are spaced far enough apart that they land in the
+// intended bucket regardless of the test runner's timezone.
+const NOW = Date.parse('2026-06-04T12:00:00.000Z');
+
+function session(id: string, lastTickAt: string) {
+  return { sessionId: id, lastTickAt };
+}
+
+describe('bucketSessionsByRecency', () => {
+  it('splits sessions into today / this week / earlier', () => {
+    const groups = bucketSessionsByRecency(
+      [
+        session('today', '2026-06-04T09:00:00.000Z'),
+        session('threeDaysAgo', '2026-06-01T09:00:00.000Z'),
+        session('lastMonth', '2026-05-01T09:00:00.000Z'),
+      ],
+      NOW,
+    );
+    expect(groups.map((group) => group.bucket)).toEqual(['today', 'thisWeek', 'earlier']);
+    expect(groups[0].sessions[0].sessionId).toBe('today');
+    expect(groups[1].sessions[0].sessionId).toBe('threeDaysAgo');
+    expect(groups[2].sessions[0].sessionId).toBe('lastMonth');
+  });
+
+  it('drops empty buckets and keeps the most-recent-first order', () => {
+    // Both timestamps are well over a week before NOW (2026-06-04), so they
+    // collapse into a single "earlier" group.
+    const groups = bucketSessionsByRecency(
+      [session('older', '2026-05-01T09:00:00.000Z'), session('newer', '2026-05-15T09:00:00.000Z')],
+      NOW,
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].bucket).toBe('earlier');
+    expect(groups[0].sessions.map((s) => s.sessionId)).toEqual(['newer', 'older']);
+  });
+
+  it('treats a session exactly 7 days old as this week, not earlier', () => {
+    const sevenDaysAgo = new Date(NOW - 7 * 24 * 60 * 60 * 1000).toISOString();
+    const groups = bucketSessionsByRecency([session('boundary', sevenDaysAgo)], NOW);
+    expect(groups[0].bucket).toBe('thisWeek');
+  });
+
+  it('sorts within a bucket newest-first regardless of input order', () => {
+    const groups = bucketSessionsByRecency(
+      [
+        session('b', '2026-06-02T09:00:00.000Z'),
+        session('a', '2026-06-03T09:00:00.000Z'),
+        session('c', '2026-06-01T09:00:00.000Z'),
+      ],
+      NOW,
+    );
+    expect(groups[0].bucket).toBe('thisWeek');
+    expect(groups[0].sessions.map((s) => s.sessionId)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns an empty array for no sessions', () => {
+    expect(bucketSessionsByRecency([], NOW)).toEqual([]);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/session-tick-mapping.test.ts
+++ b/packages/mobile/src/lib/__tests__/session-tick-mapping.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SessionDetailTick } from '@boardsesh/shared-schema';
+
+vi.mock('../playlists/board-details-for-playlist', () => ({
+  getBoardConfigForPlaylist: vi.fn(),
+}));
+
+import { getBoardConfigForPlaylist } from '../playlists/board-details-for-playlist';
+import { sessionTicksToLogbook, navigateToSessionClimb } from '../session-tick-mapping';
+
+const mockedGetBoardConfig = vi.mocked(getBoardConfigForPlaylist);
+
+function makeTick(overrides: Partial<SessionDetailTick> = {}): SessionDetailTick {
+  return {
+    uuid: 'tick-1',
+    userId: 'user-1',
+    climbUuid: 'climb-1',
+    climbName: 'Test Climb',
+    boardType: 'kilter',
+    layoutId: 1,
+    angle: 40,
+    status: 'send',
+    attemptCount: 2,
+    difficulty: 12,
+    difficultyName: 'V4',
+    quality: null,
+    isMirror: false,
+    isBenchmark: false,
+    isNoMatch: false,
+    comment: null,
+    frames: null,
+    setterUsername: null,
+    climbedAt: '2026-06-01T10:00:00.000Z',
+    upvotes: 0,
+    totalAttempts: 5,
+    ...overrides,
+  };
+}
+
+describe('sessionTicksToLogbook', () => {
+  it('buckets ticks by board type', () => {
+    const result = sessionTicksToLogbook([
+      makeTick({ uuid: 'a', boardType: 'kilter' }),
+      makeTick({ uuid: 'b', boardType: 'tension' }),
+      makeTick({ uuid: 'c', boardType: 'kilter' }),
+    ]);
+    expect(Object.keys(result).sort()).toEqual(['kilter', 'tension']);
+    expect(result.kilter).toHaveLength(2);
+    expect(result.tension).toHaveLength(1);
+  });
+
+  it('maps tick fields onto LogbookEntry, mirroring difficulty into effectiveDifficulty', () => {
+    const [entry] = sessionTicksToLogbook([makeTick({ difficulty: 12, attemptCount: 3, angle: 40 })]).kilter;
+    expect(entry).toMatchObject({
+      climbed_at: '2026-06-01T10:00:00.000Z',
+      difficulty: 12,
+      effectiveDifficulty: 12,
+      tries: 3,
+      angle: 40,
+      status: 'send',
+      layoutId: 1,
+      boardType: 'kilter',
+      climbUuid: 'climb-1',
+    });
+  });
+
+  it('normalises unknown statuses to attempt and clamps tries to at least 1', () => {
+    const [entry] = sessionTicksToLogbook([makeTick({ status: 'repeat', attemptCount: 0 })]).kilter;
+    expect(entry.status).toBe('attempt');
+    expect(entry.tries).toBe(1);
+  });
+
+  it('coalesces a null difficulty to null on both grade fields', () => {
+    const [entry] = sessionTicksToLogbook([makeTick({ difficulty: null })]).kilter;
+    expect(entry.difficulty).toBeNull();
+    expect(entry.effectiveDifficulty).toBeNull();
+  });
+
+  it('returns an empty object for no ticks', () => {
+    expect(sessionTicksToLogbook([])).toEqual({});
+  });
+});
+
+describe('navigateToSessionClimb', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('pushes the climb-detail route with stringified board params', () => {
+    mockedGetBoardConfig.mockReturnValue({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: [1, 20, 33],
+    });
+    const push = vi.fn();
+    navigateToSessionClimb({ push } as never, makeTick({ climbUuid: 'climb-9', angle: 50 }));
+    expect(push).toHaveBeenCalledWith({
+      pathname: '/(tabs)/climbs/[climbUuid]',
+      params: {
+        climbUuid: 'climb-9',
+        boardName: 'kilter',
+        layoutId: '1',
+        sizeId: '10',
+        setIds: '1,20,33',
+        angle: '50',
+      },
+    });
+  });
+
+  it('does not navigate when the board config cannot resolve (e.g. MoonBoard)', () => {
+    mockedGetBoardConfig.mockReturnValue(null);
+    const push = vi.fn();
+    navigateToSessionClimb({ push } as never, makeTick({ boardType: 'moonboard' }));
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/board-path-to-user-board.ts
+++ b/packages/mobile/src/lib/board-path-to-user-board.ts
@@ -1,0 +1,105 @@
+// Resolves a session's `boardPath` string into a full `UserBoard` ready to be
+// set as the active board when joining a party session.
+//
+// A `boardPath` (e.g. `kilter/8/17/27,28/40`) is just a config tuple — it has
+// no uuid/slug, but `setActiveBoard` (and the BLE wrapper, BoardProvider, etc.)
+// need a real UserBoard. Resolution mirrors the custom-board create flow
+// (CustomBoardSheet): reuse a board the user already owns that matches the
+// config, otherwise persist a new one via CREATE_BOARD so the server hands back
+// a full UserBoard (uuid/slug/isAngleAdjustable).
+//
+// The pure logic (parse + owned-reuse + the create-input it would build) is
+// factored out so it can be unit-tested without React/GraphQL. The join screen
+// wires the real `useMyBoards` data + `useCreateBoard` mutation into `deps`.
+
+import type { CreateBoardInput, UserBoard } from '@boardsesh/shared-schema';
+import { parseBoardPath, formatBoardDisplayName } from '@boardsesh/board-config';
+import { findOwnedBoardForConfig } from '../components/board-discovery/board-items';
+
+/** A board config parsed out of a session boardPath, with a concrete angle. */
+export type ResolvedBoardConfig = {
+  boardType: string;
+  layoutId: number;
+  sizeId: number;
+  /** Comma-separated set ids, as stored on UserBoard. */
+  setIds: string;
+  angle: number;
+};
+
+export type ResolveBoardDeps = {
+  /** The boards the signed-in user already owns (from `useMyBoards`). */
+  ownedBoards: UserBoard[];
+  /** Persists a new board server-side and returns the full UserBoard. */
+  createBoard: (input: CreateBoardInput) => Promise<UserBoard>;
+};
+
+/**
+ * Parse a session boardPath into a config tuple. Returns `null` when the path
+ * isn't a valid board path or has no angle — a party board is always at a
+ * concrete angle, so a missing angle means we can't resolve a usable board.
+ */
+export function parseBoardConfigFromPath(boardPath: string): ResolvedBoardConfig | null {
+  const parsed = parseBoardPath(boardPath);
+  if (!parsed || parsed.angle == null) return null;
+  return {
+    boardType: parsed.boardName,
+    layoutId: parsed.layoutId,
+    sizeId: parsed.sizeId,
+    setIds: parsed.setIds,
+    angle: parsed.angle,
+  };
+}
+
+/**
+ * Find a board the user already owns matching `config` (ignoring angle). When
+ * found, returns it with the path's angle applied — a session can be on any
+ * angle, and we never want to leave the joiner on the board's last-used angle.
+ */
+export function findOwnedBoardForSession(
+  ownedBoards: UserBoard[],
+  config: ResolvedBoardConfig,
+): UserBoard | undefined {
+  const owned = findOwnedBoardForConfig(ownedBoards, {
+    boardType: config.boardType,
+    layoutId: config.layoutId,
+    sizeId: config.sizeId,
+    setIds: config.setIds,
+  });
+  if (!owned) return undefined;
+  return owned.angle === config.angle ? owned : { ...owned, angle: config.angle };
+}
+
+/**
+ * Build the CREATE_BOARD input for a session config when the user owns no
+ * matching board. `isOwned: false` — joining someone else's session shouldn't
+ * claim the board as your own gear; it's a board you're climbing on right now.
+ */
+export function buildCreateBoardInput(config: ResolvedBoardConfig): CreateBoardInput {
+  return {
+    boardType: config.boardType,
+    layoutId: config.layoutId,
+    sizeId: config.sizeId,
+    setIds: config.setIds,
+    angle: config.angle,
+    isOwned: false,
+    name: formatBoardDisplayName(config.boardType),
+  };
+}
+
+/**
+ * Resolve a session `boardPath` into a full `UserBoard`:
+ * 1. Parse the path → config (throws on an unparseable / angle-less path).
+ * 2. Reuse a matching owned board (angle overridden from the path), or
+ * 3. Create a new board via `deps.createBoard`.
+ */
+export async function resolveBoardForSession(boardPath: string, deps: ResolveBoardDeps): Promise<UserBoard> {
+  const config = parseBoardConfigFromPath(boardPath);
+  if (!config) {
+    throw new Error(`Cannot resolve a board from session boardPath: ${boardPath}`);
+  }
+
+  const owned = findOwnedBoardForSession(deps.ownedBoards, config);
+  if (owned) return owned;
+
+  return deps.createBoard(buildCreateBoardInput(config));
+}

--- a/packages/mobile/src/lib/feed-time-buckets.ts
+++ b/packages/mobile/src/lib/feed-time-buckets.ts
@@ -1,0 +1,46 @@
+import { parseTickTime, tickTimeMs } from '@boardsesh/profile-stats';
+
+export type FeedRecencyBucket = 'today' | 'thisWeek' | 'earlier';
+
+/** Minimal shape needed to bucket a session by recency. */
+type RecencySession = { lastTickAt: string };
+
+export type FeedSessionGroup<TSession extends RecencySession> = {
+  bucket: FeedRecencyBucket;
+  sessions: TSession[];
+};
+
+// Bucket order is fixed (most recent first); empty buckets are dropped.
+const BUCKET_ORDER: FeedRecencyBucket[] = ['today', 'thisWeek', 'earlier'];
+
+/**
+ * Group sessions into Today / This week / Earlier buckets by their `lastTickAt`,
+ * sorted most-recent-first within each bucket and across buckets. Pure: `now` is
+ * injected (never `Date.now()` internally) so callers and tests control the
+ * clock. "Today" is the same local calendar day as `now`; "This week" is within
+ * the trailing 7 days but not today; everything older is "Earlier".
+ */
+export function bucketSessionsByRecency<TSession extends RecencySession>(
+  sessions: TSession[],
+  now: number,
+): FeedSessionGroup<TSession>[] {
+  const startOfToday = parseTickTime(new Date(now).toISOString()).startOf('day').valueOf();
+  const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000;
+
+  const grouped: Record<FeedRecencyBucket, TSession[]> = { today: [], thisWeek: [], earlier: [] };
+
+  // Sort a copy newest-first so each bucket comes out ordered without re-sorting.
+  const sorted = [...sessions].sort((left, right) => tickTimeMs(right.lastTickAt) - tickTimeMs(left.lastTickAt));
+
+  for (const session of sorted) {
+    const at = tickTimeMs(session.lastTickAt);
+    if (at >= startOfToday) grouped.today.push(session);
+    else if (at >= sevenDaysAgo) grouped.thisWeek.push(session);
+    else grouped.earlier.push(session);
+  }
+
+  return BUCKET_ORDER.filter((bucket) => grouped[bucket].length > 0).map((bucket) => ({
+    bucket,
+    sessions: grouped[bucket],
+  }));
+}

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -398,3 +398,4 @@ export {
 } from './use-you-data';
 export { useYouProfileData } from './use-you-profile-data';
 export { useVote, useBulkVoteSummaries, useComments, useAddComment } from './use-social';
+export { useSessionDetail, useUpdateInferredSession, useSessionPreview } from './use-session-detail';

--- a/packages/mobile/src/lib/graphql/hooks/use-session-detail.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-session-detail.ts
@@ -1,0 +1,72 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  GET_SESSION_DETAIL,
+  UPDATE_INFERRED_SESSION,
+  type GetSessionDetailQueryResponse,
+} from '@boardsesh/graphql/operations';
+import type { SessionDetail, UpdateInferredSessionInput } from '@boardsesh/shared-schema';
+import { GET_SESSION, type GetSessionQueryResponse, type SessionPreview } from '../operations';
+import { getHttpClient } from '../client';
+
+const SESSION_DETAIL_STALE_TIME_MS = 30 * 1000;
+
+/**
+ * Full detail for a single past session (the Strava-style activity view):
+ * aggregate stats, participant breakdown, grade distribution, and the full
+ * per-climb tick list. Backed by the shared `GET_SESSION_DETAIL` operation,
+ * which is reused unchanged from web.
+ */
+export function useSessionDetail(sessionId: string | undefined) {
+  return useQuery({
+    queryKey: ['sessionDetail', sessionId],
+    queryFn: () =>
+      getHttpClient()
+        .request<GetSessionDetailQueryResponse>(GET_SESSION_DETAIL, { sessionId })
+        .then((response) => response.sessionDetail),
+    enabled: !!sessionId,
+    staleTime: SESSION_DETAIL_STALE_TIME_MS,
+  });
+}
+
+type UpdateInferredSessionResponse = {
+  updateInferredSession: SessionDetail;
+};
+
+/**
+ * Rename / edit the goal of an inferred session the user owns. Patches the
+ * cached detail and invalidates the session feed so both surfaces reflect the
+ * edit. Web maps the user-facing "goal" onto the `description` input field.
+ */
+export function useUpdateInferredSession(sessionId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: Omit<UpdateInferredSessionInput, 'sessionId'>) =>
+      getHttpClient()
+        .request<UpdateInferredSessionResponse>(UPDATE_INFERRED_SESSION, { input: { sessionId, ...input } })
+        .then((response) => response.updateInferredSession),
+    onSuccess: (updated) => {
+      queryClient.setQueryData<SessionDetail | null>(['sessionDetail', sessionId], (prev) =>
+        prev ? { ...prev, ...updated } : updated,
+      );
+      void queryClient.invalidateQueries({ queryKey: ['sessionGroupedFeed'] });
+    },
+  });
+}
+
+/**
+ * Read-only session preview for the join-confirmation screen: host, board,
+ * participant roster, and whether the session has ended. Does NOT join the
+ * session — see `QueueProvider.joinSession`.
+ */
+export function useSessionPreview(sessionId: string | undefined) {
+  return useQuery<SessionPreview | null>({
+    queryKey: ['sessionPreview', sessionId],
+    queryFn: () =>
+      getHttpClient()
+        .request<GetSessionQueryResponse>(GET_SESSION, { sessionId })
+        .then((response) => response.session),
+    enabled: !!sessionId,
+    // Preview reflects live presence; keep it fresh while the screen is open.
+    staleTime: 10 * 1000,
+  });
+}

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -18,6 +18,9 @@ import type {
   PublicUserProfile,
   FollowConnection,
   TickStatus,
+  SessionUser,
+  SessionFeedParticipant,
+  SessionGradeDistributionItem,
 } from '@boardsesh/shared-schema';
 
 // ============================================
@@ -540,6 +543,53 @@ export type GetNearbySessionsQueryResponse = {
   nearbySessions: DiscoverableSessionItem[];
 };
 
+// Read-only session preview, used by the join-confirmation screen to show the
+// host, board, and participant count before the user commits to joining. The
+// `session` query does not join the session — joining happens via JOIN_SESSION
+// once the user confirms (see QueueProvider.joinSession).
+export const GET_SESSION = gql`
+  query GetSession($sessionId: ID!) {
+    session(sessionId: $sessionId) {
+      id
+      name
+      boardPath
+      color
+      goal
+      startedAt
+      endedAt
+      driverParticipantId
+      users {
+        id
+        username
+        isLeader
+        avatarUrl
+        userId
+        connectionState
+      }
+    }
+  }
+`;
+
+export type GetSessionQueryVariables = {
+  sessionId: string;
+};
+
+export type SessionPreview = {
+  id: string;
+  name: string | null;
+  boardPath: string;
+  color: string | null;
+  goal: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  driverParticipantId: string | null;
+  users: SessionUser[];
+};
+
+export type GetSessionQueryResponse = {
+  session: SessionPreview | null;
+};
+
 // ============================================
 // Tick Queries & Mutations
 // ============================================
@@ -823,9 +873,55 @@ export const SESSION_UPDATES_SUBSCRIPTION = `
         boardPath
         changedByParticipantId
       }
+      ... on SessionStatsUpdated {
+        sessionId
+        totalSends
+        totalFlashes
+        totalAttempts
+        tickCount
+        participants {
+          userId
+          displayName
+          avatarUrl
+          sends
+          flashes
+          attempts
+        }
+        gradeDistribution {
+          grade
+          flash
+          send
+          attempt
+        }
+        boardTypes
+        hardestGrade
+        durationMinutes
+        goal
+      }
     }
   }
 `;
+
+/**
+ * Aggregate live-session stats pushed over `sessionUpdates` (the
+ * `SessionStatsUpdated` event). Mirrors the feed/detail stat shape so the
+ * in-session analytics view can render flashes + the flash/send/attempt grade
+ * split without a separate poll. Ticks are intentionally omitted (the live view
+ * shows aggregates only).
+ */
+export type SessionLiveStatsEvent = {
+  sessionId: string;
+  totalSends: number;
+  totalFlashes: number;
+  totalAttempts: number;
+  tickCount: number;
+  participants: SessionFeedParticipant[];
+  gradeDistribution: SessionGradeDistributionItem[];
+  boardTypes: string[];
+  hardestGrade?: string | null;
+  durationMinutes?: number | null;
+  goal?: string | null;
+};
 
 // Envelope for the session-updates subscription. Fields specific to events the
 // mobile app reacts to are optional so a plain `__typename` + field check
@@ -833,8 +929,28 @@ export const SESSION_UPDATES_SUBSCRIPTION = `
 // fall through the guard. Extend as more event handling lands.
 export type SessionUpdateEvent = {
   __typename: string;
+  // SessionBoardPathChanged
   boardPath?: string;
   changedByParticipantId?: string | null;
+  // UserJoined / UserPresenceChanged
+  user?: SessionUser;
+  // UserLeft
+  userId?: string;
+  // DriverChanged
+  driverParticipantId?: string | null;
+  previousDriverParticipantId?: string | null;
+  // SessionStatsUpdated (aggregate fields — see SessionLiveStatsEvent)
+  sessionId?: string;
+  totalSends?: number;
+  totalFlashes?: number;
+  totalAttempts?: number;
+  tickCount?: number;
+  participants?: SessionFeedParticipant[];
+  gradeDistribution?: SessionGradeDistributionItem[];
+  boardTypes?: string[];
+  hardestGrade?: string | null;
+  durationMinutes?: number | null;
+  goal?: string | null;
 };
 
 // Fields the queue UI needs from each climb in a subscription payload.

--- a/packages/mobile/src/lib/session-share.ts
+++ b/packages/mobile/src/lib/session-share.ts
@@ -1,0 +1,9 @@
+// Canonical https join URL — also the QR payload. Universal Links route this to
+// the app (when installed); the web /join page is the fallback. Keep the host in
+// sync with the Universal Links config (apex vs www) — see C/web side.
+const JOIN_BASE_URL = 'https://www.boardsesh.com/join';
+
+/** Build the shareable https join URL for a session (QR payload + copy/share). */
+export function buildSessionShareUrl(sessionId: string): string {
+  return `${JOIN_BASE_URL}/${encodeURIComponent(sessionId)}`;
+}

--- a/packages/mobile/src/lib/session-tick-mapping.ts
+++ b/packages/mobile/src/lib/session-tick-mapping.ts
@@ -1,0 +1,66 @@
+import { type useRouter } from 'expo-router';
+import type { LogbookEntry } from '@boardsesh/profile-stats';
+import type { SessionDetailTick } from '@boardsesh/shared-schema';
+import { getBoardConfigForPlaylist } from './playlists/board-details-for-playlist';
+
+type Router = ReturnType<typeof useRouter>;
+
+/**
+ * Normalise a session's per-climb ticks into the `LogbookEntry` shape the shared
+ * `deriveProfileViewModel` aggregation consumes, bucketed by board type (the
+ * derive step keys every chart off `Record<boardType, LogbookEntry[]>`).
+ *
+ * `SessionDetailTick.status` is a free-form string off the GraphQL record, so we
+ * narrow it to the three statuses the stats layer understands; anything else
+ * (shouldn't happen in practice) falls through as an attempt.
+ */
+export function sessionTicksToLogbook(ticks: SessionDetailTick[]): Record<string, LogbookEntry[]> {
+  const byBoard: Record<string, LogbookEntry[]> = {};
+  for (const tick of ticks) {
+    const boardType = tick.boardType;
+    const entry: LogbookEntry = {
+      climbed_at: tick.climbedAt,
+      difficulty: tick.difficulty ?? null,
+      // Session ticks carry no consensus override, so the user difficulty doubles
+      // as the effective grade for bucketing.
+      effectiveDifficulty: tick.difficulty ?? null,
+      tries: Math.max(1, tick.attemptCount),
+      angle: tick.angle,
+      status: normaliseStatus(tick.status),
+      layoutId: tick.layoutId ?? null,
+      boardType,
+      climbUuid: tick.climbUuid,
+    };
+    (byBoard[boardType] ??= []).push(entry);
+  }
+  return byBoard;
+}
+
+function normaliseStatus(status: string): LogbookEntry['status'] {
+  if (status === 'flash') return 'flash';
+  if (status === 'send') return 'send';
+  return 'attempt';
+}
+
+/**
+ * Navigate to the climb-detail route for a session tick. `SessionDetailTick`
+ * only carries `boardType` + `layoutId`, so we resolve the renderable size/sets
+ * via `getBoardConfigForPlaylist` (same path the playlist tiles use). Returns
+ * early — without navigating — for boards the bundled config can't resolve
+ * (e.g. MoonBoard), matching the playlist behaviour of falling back cleanly.
+ */
+export function navigateToSessionClimb(router: Router, tick: SessionDetailTick): void {
+  const config = getBoardConfigForPlaylist(tick.boardType, tick.layoutId);
+  if (!config) return;
+  router.push({
+    pathname: '/(tabs)/climbs/[climbUuid]',
+    params: {
+      climbUuid: tick.climbUuid,
+      boardName: config.boardName,
+      layoutId: String(config.layoutId),
+      sizeId: String(config.sizeId),
+      setIds: config.setIds.join(','),
+      angle: String(tick.angle),
+    },
+  });
+}

--- a/packages/mobile/src/providers/deep-link-provider.tsx
+++ b/packages/mobile/src/providers/deep-link-provider.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useRef, type ReactNode } from 'react';
+import * as Linking from 'expo-linking';
+import { useRouter } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useAuth } from './auth-provider';
+
+// Stash for a join that arrived before the user was signed in. The auth gate
+// (auth-provider) redirects an unauthenticated cold-start to /auth/login and
+// swallows the deep link's intended route, so we persist the target sessionId
+// and replay it once auth flips to authenticated.
+const PENDING_JOIN_KEY = 'boardsesh_pending_join_session_id';
+
+// Loose UUID-ish guard: 8-4-4-4-12 hex, the shape our session ids take. Rejects
+// obvious garbage (`http`, `..`, empty) before we push a route that would just
+// render "Session not found". Case-insensitive — ids are lowercase but a shared
+// link could be upper/mixed.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidSessionId(value: string | null | undefined): value is string {
+  return typeof value === 'string' && UUID_RE.test(value.trim());
+}
+
+/**
+ * Pull a sessionId out of a Boardsesh join link. Handles every shape we accept:
+ * the Universal/App Link `https://www.boardsesh.com/join/{id}`, the custom
+ * scheme `com.boardsesh.app://join/{id}` (where `join` lands in `hostname`),
+ * a leading locale segment (`/es/join/{id}`), and stray leading/trailing
+ * slashes. Returns null when the URL isn't a join link or the id is malformed.
+ */
+export function parseJoinSessionId(url: string): string | null {
+  let parsed: Linking.ParsedURL;
+  try {
+    parsed = Linking.parse(url);
+  } catch {
+    return null;
+  }
+
+  // Reassemble the full path. For https links `hostname` is the domain and the
+  // route lives entirely in `path` (`join/{id}`). For the custom scheme
+  // `com.boardsesh.app://join/{id}` the first segment (`join`) is parsed into
+  // `hostname` with the id in `path` — so we only fold `hostname` in when it
+  // isn't a web domain (contains a dot).
+  const segments: string[] = [];
+  if (parsed.hostname && !parsed.hostname.includes('.')) {
+    segments.push(parsed.hostname);
+  }
+  if (parsed.path) {
+    segments.push(...parsed.path.split('/'));
+  }
+
+  const cleaned = segments
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+
+  // Drop a leading two-letter locale segment (`es`, `fr`). No route prefix is
+  // two letters, so this can't swallow a real segment.
+  if (cleaned.length > 0 && /^[a-z]{2}$/.test(cleaned[0])) {
+    cleaned.shift();
+  }
+
+  if (cleaned.length < 2 || cleaned[0] !== 'join') return null;
+  const sessionId = cleaned[1];
+  return isValidSessionId(sessionId) ? sessionId : null;
+}
+
+/**
+ * Deep-link receiver for the multiplayer join flow. Listens for join links
+ * (cold start via `getInitialURL`, warm via the `url` event) and routes to the
+ * join-confirmation modal. Joining itself happens on the modal's confirm — this
+ * provider never joins.
+ *
+ * Auth survival: a link that arrives while signed out is stashed in AsyncStorage
+ * and replayed once `useAuth().isAuthenticated` flips true (the auth gate routes
+ * the cold-start to login first). Clears the stash on consume.
+ */
+export function DeepLinkProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const { isAuthenticated } = useAuth();
+
+  // Latest auth state for the async link handlers, so the listener effect can
+  // stay mounted across auth changes without re-subscribing.
+  const isAuthenticatedRef = useRef(isAuthenticated);
+  isAuthenticatedRef.current = isAuthenticated;
+
+  const navigateToJoin = useCallback(
+    (sessionId: string) => {
+      // navigate (not push): Expo Router's built-in linking already routes a
+      // tapped/launched join link to this modal when authenticated. navigate
+      // reuses that existing instance (same route + params) instead of stacking
+      // a duplicate, while still opening the modal in the post-login replay case
+      // where the original route was swallowed by the auth-gate redirect.
+      router.navigate({ pathname: '/join/[sessionId]', params: { sessionId } });
+    },
+    [router],
+  );
+
+  const handleSessionId = useCallback(
+    async (sessionId: string) => {
+      if (isAuthenticatedRef.current) {
+        navigateToJoin(sessionId);
+        return;
+      }
+      // Signed out: stash it so we can replay after login. The auth gate is
+      // about to redirect to /auth/login.
+      try {
+        await AsyncStorage.setItem(PENDING_JOIN_KEY, sessionId);
+      } catch (error) {
+        if (__DEV__) console.warn('[deep-link] failed to stash pending join', error);
+      }
+    },
+    [navigateToJoin],
+  );
+
+  const handleUrl = useCallback(
+    (url: string | null) => {
+      if (!url) return;
+      const sessionId = parseJoinSessionId(url);
+      if (sessionId) void handleSessionId(sessionId);
+    },
+    [handleSessionId],
+  );
+
+  // Cold start + warm links.
+  useEffect(() => {
+    let cancelled = false;
+    void Linking.getInitialURL().then((url) => {
+      if (!cancelled) handleUrl(url);
+    });
+    const subscription = Linking.addEventListener('url', ({ url }) => handleUrl(url));
+    return () => {
+      cancelled = true;
+      subscription.remove();
+    };
+  }, [handleUrl]);
+
+  // Replay a pending join once the user is authenticated (post-login, or a link
+  // received while signed out that we stashed above). Clears the stash on
+  // consume so it fires exactly once.
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const pendingSessionId = await AsyncStorage.getItem(PENDING_JOIN_KEY);
+        if (cancelled || !pendingSessionId) return;
+        await AsyncStorage.removeItem(PENDING_JOIN_KEY);
+        if (isValidSessionId(pendingSessionId)) {
+          navigateToJoin(pendingSessionId);
+        }
+      } catch (error) {
+        if (__DEV__) console.warn('[deep-link] failed to consume pending join', error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, navigateToJoin]);
+
+  return <>{children}</>;
+}

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -33,7 +33,7 @@ import {
   type SubscriptionWireEnvelope,
 } from '@boardsesh/queue-runtime';
 import { useQueueMutations, type PublishPlaybackStateInput } from '@boardsesh/queue-react';
-import type { SessionSummary, SubscriptionQueueEvent } from '@boardsesh/shared-schema';
+import type { SessionSummary, SubscriptionQueueEvent, SessionUser, UserBoard } from '@boardsesh/shared-schema';
 import { execute } from '@boardsesh/graphql-client';
 import { buildBoardPath, parseBoardPath } from '@boardsesh/board-config';
 import { JOIN_SESSION } from '@boardsesh/graphql/operations/queue-session';
@@ -48,6 +48,7 @@ import {
   type CreateSessionMutationResponse,
   type EndSessionMutationResponse,
   type SessionUpdateEvent,
+  type SessionLiveStatsEvent,
   type GetClimbQueryResponse,
 } from '../lib/graphql/operations';
 import { getStoredActiveBoard } from '../lib/active-board-store';
@@ -71,6 +72,21 @@ type QueueContextValue = {
   dispatch: React.Dispatch<QueueAction>;
   sessionId: string | null;
   setSessionId: (id: string | null) => void;
+  /**
+   * Live aggregate stats for the active session, pushed over `sessionUpdates`
+   * (the `SessionStatsUpdated` event) as ticks are logged. Null until the first
+   * push arrives (or when there's no session).
+   */
+  liveStats: SessionLiveStatsEvent | null;
+  /**
+   * Connected participants in the active session. Seeded from the JOIN_SESSION
+   * response and kept current via UserJoined/UserLeft/UserPresenceChanged.
+   */
+  sessionUsers: SessionUser[];
+  /** Participant id of the member currently driving the wall, if any. */
+  driverParticipantId: string | null;
+  /** Our own participant id for the active session (marks "you" in rosters). */
+  participantId: string | null;
   addToQueue: (item: ClimbQueueItem) => void;
   removeFromQueue: (uuid: string) => void;
   clearQueue: () => void;
@@ -91,6 +107,15 @@ type QueueContextValue = {
    * mutation failed. No-op (returns existing id) when a session is live.
    */
   startSession: (config?: StartSessionConfig) => Promise<string | null>;
+  /**
+   * Join an existing session created by someone else (party mode). Switches the
+   * active board to the session's board, sets + persists the sessionId, and
+   * relies on the session effect to run JOIN_SESSION + open the realtime
+   * subscriptions. No-ops if already in this session. Differs from
+   * `startSession`, which *reads* the active board to create a new session;
+   * `joinSession` *writes* the active board from the session's boardPath.
+   */
+  joinSession: (sessionId: string, opts: { boardPath: string; userBoard: UserBoard }) => Promise<void>;
   /**
    * Broadcast the session's boardPath so every party member follows the same
    * angle/board. Best-effort; a true no-op in solo (never creates a session).
@@ -127,6 +152,13 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(queueReducer, defaultSearchParams, initialState);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const sessionIdRef = useRef<string | null>(null);
+  // Live session analytics + presence. liveStats is pushed over `sessionUpdates`
+  // (SessionStatsUpdated); the roster is seeded from JOIN_SESSION and kept
+  // current via UserJoined/UserLeft/UserPresenceChanged/DriverChanged.
+  const [liveStats, setLiveStats] = useState<SessionLiveStatsEvent | null>(null);
+  const [sessionUsers, setSessionUsers] = useState<SessionUser[]>([]);
+  const [driverParticipantId, setDriverParticipantId] = useState<string | null>(null);
+  const [participantId, setParticipantId] = useState<string | null>(null);
   // Our own participant id, captured from the JOIN_SESSION response. Used to
   // suppress the echo of our own SessionBoardPathChanged broadcasts (the server
   // stamps `changedByParticipantId` with the originator's participant id).
@@ -176,14 +208,28 @@ export function QueueProvider({ children }: { children: ReactNode }) {
           );
         },
         execute: async ({ sessionId: sid, boardPath }) => {
-          const result = await execute<{ joinSession?: { participantId?: string | null } }>(getWsClient(), {
+          const result = await execute<{
+            joinSession?: {
+              participantId?: string | null;
+              driverParticipantId?: string | null;
+              users?: SessionUser[] | null;
+            };
+          }>(getWsClient(), {
             query: JOIN_SESSION,
             variables: { sessionId: sid, boardPath },
           });
+          const joined = result?.joinSession;
           // Remember our participant id so we can ignore the echo of our own
           // board-path broadcasts. Only overwrite on a concrete value.
-          const joinedParticipantId = result?.joinSession?.participantId;
-          if (joinedParticipantId) participantIdRef.current = joinedParticipantId;
+          if (joined?.participantId) {
+            participantIdRef.current = joined.participantId;
+            setParticipantId(joined.participantId);
+          }
+          // Seed the live presence roster + driver from the join response. The
+          // UserJoined/UserLeft/DriverChanged events that follow are deltas;
+          // this is the initial snapshot of who's already in the session.
+          if (joined?.users) setSessionUsers(joined.users);
+          setDriverParticipantId(joined?.driverParticipantId ?? null);
           return result;
         },
       }),
@@ -251,6 +297,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       unsubscribeRef.current?.();
       unsubscribeRef.current = null;
       participantIdRef.current = null;
+      setParticipantId(null);
+      setLiveStats(null);
+      setSessionUsers([]);
+      setDriverParticipantId(null);
       joinTracker.reset();
       return;
     }
@@ -341,7 +391,49 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       {
         next: ({ data }) => {
           const event = data?.sessionUpdates;
-          if (!event || event.__typename !== 'SessionBoardPathChanged' || !event.boardPath) return;
+          if (!event) return;
+
+          // Live analytics push: flashes + flash/send/attempt grade split +
+          // per-participant breakdown. Drives the in-session analytics view and
+          // leaderboard without polling.
+          if (event.__typename === 'SessionStatsUpdated') {
+            setLiveStats({
+              sessionId: event.sessionId ?? sessionId,
+              totalSends: event.totalSends ?? 0,
+              totalFlashes: event.totalFlashes ?? 0,
+              totalAttempts: event.totalAttempts ?? 0,
+              tickCount: event.tickCount ?? 0,
+              participants: event.participants ?? [],
+              gradeDistribution: event.gradeDistribution ?? [],
+              boardTypes: event.boardTypes ?? [],
+              hardestGrade: event.hardestGrade ?? null,
+              durationMinutes: event.durationMinutes ?? null,
+              goal: event.goal ?? null,
+            });
+            return;
+          }
+
+          // Presence roster maintenance (deltas on top of the JOIN_SESSION seed).
+          if ((event.__typename === 'UserJoined' || event.__typename === 'UserPresenceChanged') && event.user) {
+            const incoming = event.user;
+            setSessionUsers((prev) => {
+              const next = prev.filter((existing) => existing.id !== incoming.id);
+              next.push(incoming);
+              return next;
+            });
+            return;
+          }
+          if (event.__typename === 'UserLeft' && event.userId) {
+            const leftId = event.userId;
+            setSessionUsers((prev) => prev.filter((existing) => existing.id !== leftId));
+            return;
+          }
+          if (event.__typename === 'DriverChanged') {
+            setDriverParticipantId(event.driverParticipantId ?? null);
+            return;
+          }
+
+          if (event.__typename !== 'SessionBoardPathChanged' || !event.boardPath) return;
           // Echo of our own change — we already applied it locally before
           // broadcasting. A null local participant id (peer event before our
           // JOIN_SESSION resolved) can't be the originator, so we apply it.
@@ -382,6 +474,16 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       unsubConnected();
       unsubClosed();
       unsubscribeRef.current = null;
+      // Reset live analytics/presence on EVERY session change (not only on
+      // teardown to null). A direct A→B switch (joinSession) flips sessionId
+      // without an intermediate null, so without this the previous session's
+      // liveStats/roster would leak into the joined session until B's first
+      // push. The new session re-seeds the roster from its JOIN_SESSION response.
+      setLiveStats(null);
+      setSessionUsers([]);
+      setDriverParticipantId(null);
+      setParticipantId(null);
+      participantIdRef.current = null;
       joinTracker.reset();
     };
   }, [sessionId, coordinator, ensureJoined, joinTracker]);
@@ -708,6 +810,23 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     }
   }, [clearSession, showToast, t]);
 
+  const joinSession = useCallback(
+    async (sessionToJoin: string, opts: { boardPath: string; userBoard: UserBoard }) => {
+      // Idempotent against double-tap / re-entrant deep links.
+      if (sessionIdRef.current === sessionToJoin) return;
+      // Switch the active board to the session's board FIRST (and persist it) so
+      // the session effect's JOIN_SESSION reads the correct boardPath and the
+      // whole tree (BLE wrapper, BoardProvider, climb list, play drawer) renders
+      // on the joined board. Unlike startSession (which reads the active board to
+      // build the new session's path), joinSession writes it from the session.
+      await setActiveBoard(opts.userBoard);
+      sessionIdRef.current = sessionToJoin;
+      setSessionId(sessionToJoin);
+      await setStoredSessionId(sessionToJoin);
+    },
+    [setActiveBoard],
+  );
+
   const publishPlaybackState = useCallback(
     (input: PublishPlaybackStateInput) => mutations.publishPlaybackState(input),
     [mutations],
@@ -719,6 +838,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       dispatch,
       sessionId,
       setSessionId,
+      liveStats,
+      sessionUsers,
+      driverParticipantId,
+      participantId,
       addToQueue,
       removeFromQueue,
       clearQueue,
@@ -731,6 +854,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       clearSession,
       endSession,
       startSession: createSessionWithConfig,
+      joinSession,
       setSessionBoardPath,
       subscribeToQueueEvents,
       publishPlaybackState,
@@ -738,6 +862,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     [
       state,
       sessionId,
+      liveStats,
+      sessionUsers,
+      driverParticipantId,
+      participantId,
       addToQueue,
       removeFromQueue,
       clearQueue,
@@ -750,6 +878,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       clearSession,
       endSession,
       createSessionWithConfig,
+      joinSession,
       setSessionBoardPath,
       subscribeToQueueEvents,
       publishPlaybackState,

--- a/packages/shared/i18n/locales/en-US/feed.json
+++ b/packages/shared/i18n/locales/en-US/feed.json
@@ -120,7 +120,9 @@
   },
   "sessionFeedCard": {
     "climbCount_one": "{{count}} climb",
-    "climbCount_other": "{{count}} climbs"
+    "climbCount_other": "{{count}} climbs",
+    "hardest": "Hardest",
+    "sendsLabel": "sends"
   },
   "sessionSummary": {
     "completed": "Session completed"

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -248,9 +248,7 @@
     "similarClimbs": {
       "title": "Similar Climbs",
       "empty": "No similar climbs found",
-      "retry": "Try again",
-      "sends_one": "{{count}} send",
-      "sends_other": "{{count}} sends"
+      "retry": "Try again"
     },
     "community": {
       "title": "Community",
@@ -337,8 +335,6 @@
       "inStatsDuration": "Duration",
       "inStatsHardest": "Hardest send",
       "inStatsGrades": "Grade distribution",
-      "inQueueTitle": "Queue",
-      "inQueueEmpty": "Queue is empty — browse climbs to add.",
       "inEndSession": "End session",
       "notification": {
         "channelName": "Active climbing session",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -340,7 +340,20 @@
         "contentTitleFallback": "Climbing session",
         "previous": "Previous",
         "next": "Next"
-      }
+      },
+      "inStatsFlashes": "Flashes",
+      "inLeaderboardTitle": "Who's climbing",
+      "inLeaderboardClimber": "Climber",
+      "inPresenceCount": "{{count}} climbing",
+      "inDriverLabel": "Driving",
+      "invite": "Invite climbers",
+      "inviteTitle": "Invite to this session",
+      "inviteSubtitle": "Scan to join, or share the link",
+      "inviteCopyLink": "Copy link",
+      "inviteCopied": "Link copied",
+      "inviteShare": "Share",
+      "inStatsHardestEach": "Hardest sends",
+      "inviteAction": "Invite"
     }
   },
   "playView": {
@@ -408,5 +421,32 @@
       "starRating_one": "{{count}} star",
       "starRating_other": "{{count}} stars"
     }
+  },
+  "mobileDetail": {
+    "notFound": "Session not found",
+    "editTitle": "Edit session",
+    "nameLabel": "Name",
+    "goalLabel": "Goal",
+    "save": "Save",
+    "participants": "Climbers",
+    "updated": "Session updated",
+    "updateError": "Couldn't update session",
+    "title": "Session"
+  },
+  "mobileJoin": {
+    "loading": "Loading session…",
+    "notFound": "Session not found",
+    "ended": "This session has ended",
+    "error": "Couldn't load this session",
+    "retry": "Try again",
+    "confirmTitle": "Join {{host}}'s session?",
+    "boardLabel": "{{board}} · {{count}} climbing",
+    "join": "Join session",
+    "cancel": "Cancel",
+    "switchTitle": "Leave your current session?",
+    "switchBody": "You'll leave your active session to join this one.",
+    "signInToJoin": "Sign in to join",
+    "joinError": "Couldn't join the session",
+    "hostFallback": "a climber"
   }
 }

--- a/packages/shared/i18n/locales/en-US/you.json
+++ b/packages/shared/i18n/locales/en-US/you.json
@@ -26,7 +26,21 @@
     "unknownName": "Climber",
     "cancel": "Cancel",
     "sessions": {
-      "empty": "No sessions logged yet — go climb something."
+      "empty": "No sessions logged yet — go climb something.",
+      "weeklySends": "{{count}} sends this week",
+      "weekly": {
+        "sessions": "Sessions",
+        "sends": "Sends",
+        "flashes": "Flashes",
+        "attempts": "Attempts"
+      },
+      "streak": "{{count}} week streak",
+      "sectionToday": "Today",
+      "sectionThisWeek": "This week",
+      "sectionEarlier": "Earlier",
+      "emptyTitle": "No sessions yet",
+      "emptyBody": "Start a session and your climbs land here.",
+      "emptyCta": "Start a session"
     },
     "progress": {
       "empty": "Nothing logged yet — your stats show up once you start ticking climbs."

--- a/packages/shared/i18n/locales/en-US/you.json
+++ b/packages/shared/i18n/locales/en-US/you.json
@@ -26,7 +26,6 @@
     "unknownName": "Climber",
     "cancel": "Cancel",
     "sessions": {
-      "empty": "No sessions logged yet — go climb something.",
       "weeklySends": "{{count}} sends this week",
       "weekly": {
         "sessions": "Sessions",

--- a/packages/shared/i18n/locales/es/feed.json
+++ b/packages/shared/i18n/locales/es/feed.json
@@ -120,7 +120,9 @@
   },
   "sessionFeedCard": {
     "climbCount_one": "{{count}} bloque",
-    "climbCount_other": "{{count}} bloques"
+    "climbCount_other": "{{count}} bloques",
+    "hardest": "Más difícil",
+    "sendsLabel": "encadenes"
   },
   "sessionSummary": {
     "completed": "Sesión completada"

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -248,9 +248,7 @@
     "similarClimbs": {
       "title": "Escaladas similares",
       "empty": "No se encontraron escaladas similares",
-      "retry": "Reintentar",
-      "sends_one": "{{count}} envío",
-      "sends_other": "{{count}} envíos"
+      "retry": "Reintentar"
     },
     "community": {
       "title": "Comunidad",
@@ -337,8 +335,6 @@
       "inStatsDuration": "Duración",
       "inStatsHardest": "Encadene más duro",
       "inStatsGrades": "Distribución de grados",
-      "inQueueTitle": "Cola",
-      "inQueueEmpty": "Cola vacía — explora vías para añadir.",
       "inEndSession": "Terminar sesión",
       "notification": {
         "channelName": "Sesión de escalada activa",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -340,7 +340,20 @@
         "contentTitleFallback": "Sesión de escalada",
         "previous": "Anterior",
         "next": "Siguiente"
-      }
+      },
+      "inStatsFlashes": "Flashes",
+      "inLeaderboardTitle": "Quién escala",
+      "inLeaderboardClimber": "Escalador",
+      "inPresenceCount": "{{count}} escalando",
+      "inDriverLabel": "Al mando",
+      "invite": "Invitar escaladores",
+      "inviteTitle": "Invitar a esta sesión",
+      "inviteSubtitle": "Escanea para unirte o comparte el enlace",
+      "inviteCopyLink": "Copiar enlace",
+      "inviteCopied": "Enlace copiado",
+      "inviteShare": "Compartir",
+      "inStatsHardestEach": "Más difíciles",
+      "inviteAction": "Invitar"
     }
   },
   "playView": {
@@ -408,5 +421,32 @@
       "starRating_one": "{{count}} estrella",
       "starRating_other": "{{count}} estrellas"
     }
+  },
+  "mobileDetail": {
+    "notFound": "Sesión no encontrada",
+    "editTitle": "Editar sesión",
+    "nameLabel": "Nombre",
+    "goalLabel": "Objetivo",
+    "save": "Guardar",
+    "participants": "Escaladores",
+    "updated": "Sesión actualizada",
+    "updateError": "No se pudo actualizar la sesión",
+    "title": "Sesión"
+  },
+  "mobileJoin": {
+    "loading": "Cargando sesión…",
+    "notFound": "Sesión no encontrada",
+    "ended": "Esta sesión ha terminado",
+    "error": "No se pudo cargar esta sesión",
+    "retry": "Reintentar",
+    "confirmTitle": "¿Unirte a la sesión de {{host}}?",
+    "boardLabel": "{{board}} · {{count}} escalando",
+    "join": "Unirse a la sesión",
+    "cancel": "Cancelar",
+    "switchTitle": "¿Salir de tu sesión actual?",
+    "switchBody": "Saldrás de tu sesión activa para unirte a esta.",
+    "signInToJoin": "Inicia sesión para unirte",
+    "joinError": "No se pudo unir a la sesión",
+    "hostFallback": "un escalador"
   }
 }

--- a/packages/shared/i18n/locales/es/you.json
+++ b/packages/shared/i18n/locales/es/you.json
@@ -26,7 +26,21 @@
     "unknownName": "Escalador",
     "cancel": "Cancelar",
     "sessions": {
-      "empty": "Aún no hay sesiones — ve a escalar algo."
+      "empty": "Aún no hay sesiones — ve a escalar algo.",
+      "weeklySends": "{{count}} encadenes esta semana",
+      "weekly": {
+        "sessions": "Sesiones",
+        "sends": "Encadenes",
+        "flashes": "Flashes",
+        "attempts": "Intentos"
+      },
+      "streak": "Racha de {{count}} semanas",
+      "sectionToday": "Hoy",
+      "sectionThisWeek": "Esta semana",
+      "sectionEarlier": "Anterior",
+      "emptyTitle": "Aún no hay sesiones",
+      "emptyBody": "Inicia una sesión y tus vías aparecerán aquí.",
+      "emptyCta": "Empezar una sesión"
     },
     "progress": {
       "empty": "Nada registrado todavía — tus estadísticas aparecen cuando empieces a registrar vías."

--- a/packages/shared/i18n/locales/es/you.json
+++ b/packages/shared/i18n/locales/es/you.json
@@ -26,7 +26,6 @@
     "unknownName": "Escalador",
     "cancel": "Cancelar",
     "sessions": {
-      "empty": "Aún no hay sesiones — ve a escalar algo.",
       "weeklySends": "{{count}} encadenes esta semana",
       "weekly": {
         "sessions": "Sesiones",

--- a/packages/shared/i18n/locales/fr/feed.json
+++ b/packages/shared/i18n/locales/fr/feed.json
@@ -120,7 +120,9 @@
   },
   "sessionFeedCard": {
     "climbCount_one": "{{count}} bloc",
-    "climbCount_other": "{{count}} blocs"
+    "climbCount_other": "{{count}} blocs",
+    "hardest": "Plus dur",
+    "sendsLabel": "réussites"
   },
   "sessionSummary": {
     "completed": "Session terminée"

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -248,9 +248,7 @@
     "similarClimbs": {
       "title": "Voies similaires",
       "empty": "Aucune voie similaire trouvee",
-      "retry": "Reessayer",
-      "sends_one": "{{count}} envoi",
-      "sends_other": "{{count}} envois"
+      "retry": "Reessayer"
     },
     "community": {
       "title": "Communaute",
@@ -337,8 +335,6 @@
       "inStatsDuration": "Durée",
       "inStatsHardest": "Plus dure enchaînée",
       "inStatsGrades": "Répartition par cotation",
-      "inQueueTitle": "File",
-      "inQueueEmpty": "File vide — parcours des voies pour ajouter.",
       "inEndSession": "Terminer la session",
       "notification": {
         "channelName": "Session d'escalade active",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -340,7 +340,20 @@
         "contentTitleFallback": "Session d'escalade",
         "previous": "Précédent",
         "next": "Suivant"
-      }
+      },
+      "inStatsFlashes": "Flashs",
+      "inLeaderboardTitle": "Qui grimpe",
+      "inLeaderboardClimber": "Grimpeur",
+      "inPresenceCount": "{{count}} en train de grimper",
+      "inDriverLabel": "Aux commandes",
+      "invite": "Inviter des grimpeurs",
+      "inviteTitle": "Inviter à cette session",
+      "inviteSubtitle": "Scannez pour rejoindre ou partagez le lien",
+      "inviteCopyLink": "Copier le lien",
+      "inviteCopied": "Lien copié",
+      "inviteShare": "Partager",
+      "inStatsHardestEach": "Les plus durs",
+      "inviteAction": "Inviter"
     }
   },
   "playView": {
@@ -408,5 +421,32 @@
       "starRating_one": "{{count}} etoile",
       "starRating_other": "{{count}} etoiles"
     }
+  },
+  "mobileDetail": {
+    "notFound": "Session introuvable",
+    "editTitle": "Modifier la session",
+    "nameLabel": "Nom",
+    "goalLabel": "Objectif",
+    "save": "Enregistrer",
+    "participants": "Grimpeurs",
+    "updated": "Session mise à jour",
+    "updateError": "Impossible de mettre à jour la session",
+    "title": "Session"
+  },
+  "mobileJoin": {
+    "loading": "Chargement de la session…",
+    "notFound": "Session introuvable",
+    "ended": "Cette session est terminée",
+    "error": "Impossible de charger cette session",
+    "retry": "Réessayer",
+    "confirmTitle": "Rejoindre la session de {{host}} ?",
+    "boardLabel": "{{board}} · {{count}} en train de grimper",
+    "join": "Rejoindre la session",
+    "cancel": "Annuler",
+    "switchTitle": "Quitter votre session actuelle ?",
+    "switchBody": "Vous quitterez votre session active pour rejoindre celle-ci.",
+    "signInToJoin": "Connectez-vous pour rejoindre",
+    "joinError": "Impossible de rejoindre la session",
+    "hostFallback": "un grimpeur"
   }
 }

--- a/packages/shared/i18n/locales/fr/you.json
+++ b/packages/shared/i18n/locales/fr/you.json
@@ -26,7 +26,6 @@
     "unknownName": "Grimpeur",
     "cancel": "Annuler",
     "sessions": {
-      "empty": "Aucune session enregistrée — va grimper.",
       "weeklySends": "{{count}} réussites cette semaine",
       "weekly": {
         "sessions": "Sessions",

--- a/packages/shared/i18n/locales/fr/you.json
+++ b/packages/shared/i18n/locales/fr/you.json
@@ -26,7 +26,21 @@
     "unknownName": "Grimpeur",
     "cancel": "Annuler",
     "sessions": {
-      "empty": "Aucune session enregistrée — va grimper."
+      "empty": "Aucune session enregistrée — va grimper.",
+      "weeklySends": "{{count}} réussites cette semaine",
+      "weekly": {
+        "sessions": "Sessions",
+        "sends": "Réussites",
+        "flashes": "Flashs",
+        "attempts": "Essais"
+      },
+      "streak": "Série de {{count}} semaines",
+      "sectionToday": "Aujourd'hui",
+      "sectionThisWeek": "Cette semaine",
+      "sectionEarlier": "Plus tôt",
+      "emptyTitle": "Pas encore de sessions",
+      "emptyBody": "Démarrez une session et vos voies apparaîtront ici.",
+      "emptyCta": "Démarrer une session"
     },
     "progress": {
       "empty": "Rien d'enregistré pour l'instant — tes stats apparaissent dès que tu coches des voies."


### PR DESCRIPTION
## Why

PR #2524 ("Make mobile sessions a multiplayer, Strava-style experience") was merged into the **wrong base** (`mobile/climbs-glass-search-hig`) and never reached `main`. As a result the entire session-sheet redesign is missing from `main` and from the current TestFlight build — the live session sheet still renders the upcoming queue, the header has an empty slot where the share/invite button should be, and there's no swipe-to-dismiss.

This recreates #2524 on top of current `main` by merging `origin/rn-sessions-experience` and reconciling it against the queue-recovery (#2525) and glass-toolbar work that *did* land, plus one follow-up: surfacing the per-climb attempted/sent history on the live sheet itself.

## What this restores (from #2524)

**Live session sheet**
- Queue dropped from the sheet (it lives in the play drawer); the sheet is now a live analytics surface.
- Presence row, sends/flashes/duration stat tiles, hardest-send celebration, grade-distribution chart, per-climber leaderboard — pushed over the existing `SessionStatsUpdated` event (no polling).
- Header **share/invite button** (QR + copy-link + native share) and **swipe-the-body-down to dismiss**.

**Profile sessions + session detail**
- New `/session/[sessionId]` screen (`GET_SESSION_DETAIL`): stats, grade pyramid, participant breakdown, and the **per-climb attempted/sent tick list** (`SessionTickRow`, tap → climb), rename/goal.
- Richer profile sessions feed (weekly header, time-bucket grouping, tappable cards).

**Multiplayer join (Universal/App Links)**
- `deep-link-provider`, `join/[sessionId]`, `boardPath → UserBoard` resolution, and a public `joinSession` on `QueueProvider`.
- Note: Universal Links need a native rebuild to route into the app; the JS join flow is OTA-safe.

## Follow-up on top of #2524

**Attempted/sent history on the live sheet** — the in-session sheet now also shows a "Climbs (n)" section below the leaderboard, reusing `SessionTickRow` driven by the already-fetched `sessionDetail.ticks`. Tapping a row drops the overlay and opens the climb; the comment button opens a `CommentSheet` (same as the detail screen). This answers the original ask: the queue surface there now renders the history of attempted and sent climbs, using the same row look.

## Conflict resolution

- `_layout.tsx` — unioned HEAD's `QueueSnackbarProvider` (queue recovery) with #2524's `DeepLinkProvider` + the `session/[sessionId]` and `join/[sessionId]` routes.
- `InSessionView.tsx` — took #2524's version (queue dropped; presence + analytics + leaderboard + swipe-to-dismiss).
- `queue-provider.tsx`, graphql hooks, and `session.json` (en/es/fr) auto-merged into clean unions: `reorderQueue` + queue snackbar are kept alongside `liveStats` / `joinSession` / presence.
- Dropped 4 orphaned i18n keys the merge surfaced (`session.inQueueTitle/inQueueEmpty` after the queue removal; `similarClimbs.sends_one/_other` retired on main) so `check:i18n:orphans` passes.

## Validation

- `vp run typecheck:mobile` ✅
- `vp test --project mobile` — 783 passed ✅
- `vp run check:mobile-bundle` — android bundle OK ✅
- `vp run check:i18n` + `check:i18n:orphans` ✅ · locale parity ✅

Draft because Universal Links need a native rebuild to route into the app (the bundled JS rides OTA).