### PR TITLE
[codex] Restore mobile climb filter stack

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -32,7 +32,7 @@ import { randomUUID } from 'expo-crypto';
 import { type SearchHeaderHandle } from '../../../src/components/SearchHeader';
 import { RecentFilterPills } from '../../../src/components/RecentFilterPills';
 import { TAB_BAR_HEIGHT, TOOLBAR_RESERVE, TOOLBAR_GAP_ABOVE_TABBAR } from '../../../src/theme/layout';
-import { useSearchClimbs, useGrades } from '../../../src/lib/graphql/hooks';
+import { useSearchClimbs, useSearchClimbsCount, useGrades } from '../../../src/lib/graphql/hooks';
 import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../../src/lib/graphql/operations';
 import { getHttpClient } from '../../../src/lib/graphql/client';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
@@ -280,6 +280,21 @@ function ClimbListInner() {
       ),
     [boardName, layoutId, sizeId, setIds, angle, name, pageNumber, filters, boardFilters],
   );
+
+  const countInput = useMemo(
+    () =>
+      mergeBoardFilters(
+        toClimbSearchInput(
+          filters,
+          { boardName, layoutId, sizeId, setIds, angle },
+          { page: 1, pageSize: PAGE_SIZE },
+          { name },
+        ),
+        boardFilters,
+      ),
+    [boardName, layoutId, sizeId, setIds, angle, name, filters, boardFilters],
+  );
+  const { data: totalCount } = useSearchClimbsCount(countInput, searchReady);
 
   const {
     data: searchResult,
@@ -550,6 +565,7 @@ function ClimbListInner() {
           grades={grades}
           filters={filters}
           boardFilters={boardFilters}
+          count={totalCount}
           activeFilterCount={activeFilterCount}
           onOpenGrade={handleOpenGrade}
           onOpenFilters={handleOpenFilters}
@@ -579,9 +595,14 @@ function ClimbListInner() {
             onSearchBlur={handleSearchBlur}
             bound={gradeBound}
             grades={grades}
+            filters={filters}
+            boardFilters={boardFilters}
+            count={totalCount}
             activeFilterCount={activeFilterCount}
             onOpenGrade={handleOpenGrade}
             onOpenFilters={handleOpenFilters}
+            onPatchFilters={patchFilters}
+            onPatchBoardFilters={patchBoardFilters}
             toolbarBottom={toolbarBottom}
           />
         </>

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -23,6 +23,8 @@ import {
   hasActiveBoardFilters,
   applyStatusChange,
   normalizeRetiredStatus,
+  climbTypeOf,
+  climbTypePatch,
   toClimbSearchInput,
   mergeBoardFilters,
   formatMinAscentsFilterCount,
@@ -31,6 +33,7 @@ import {
   type SortOrder,
   type StatusFilter,
   type GradeAccuracyValue,
+  type ClimbType,
   type ClimbBoardFilterState,
   SORT_OPTIONS,
   GRADE_ACCURACY_VALUES,
@@ -292,29 +295,15 @@ export function ClimbFilterSheet({
     (value: GradeAccuracyValue | 'off') => setFiltersPatch({ gradeAccuracy: value === 'off' ? undefined : value }),
     [setFiltersPatch],
   );
-  // Climb-type toggle (main's #2496 control). A 3-way control means there's no
-  // UI path to "neither", so the never-both-off invariant is structural (see
-  // toClimbSearchInput). "Both" = show everything; boulders-only is the default.
-  const climbTypeKey = useMemo<'boulders' | 'routes' | 'both'>(() => {
-    const bouldersOn = localFilters.boulders ?? true;
-    const routesOn = localFilters.routes ?? false;
-    if (bouldersOn && !routesOn) return 'boulders';
-    if (!bouldersOn && routesOn) return 'routes';
-    return 'both';
-  }, [localFilters.boulders, localFilters.routes]);
   const handleClimbTypeChange = useCallback(
-    (key: string) => {
-      if (key === 'routes') setFiltersPatch({ boulders: false, routes: true });
-      else if (key === 'both') setFiltersPatch({ boulders: true, routes: true });
-      else setFiltersPatch({ boulders: true, routes: false });
-    },
+    (key: string) => setFiltersPatch(climbTypePatch(key as ClimbType)),
     [setFiltersPatch],
   );
   const climbTypeOptions = useMemo(
     () => [
-      { key: 'boulders', label: t('mobile.filter.boulders') },
-      { key: 'routes', label: t('mobile.filter.routes') },
-      { key: 'both', label: t('mobile.filter.both') },
+      { key: 'all', label: t('mobile.filter.climbType.all') },
+      { key: 'boulders', label: t('mobile.filter.climbType.boulders') },
+      { key: 'routes', label: t('mobile.filter.climbType.routes') },
     ],
     [t],
   );
@@ -355,11 +344,12 @@ export function ClimbFilterSheet({
 
   const refineSummary = useMemo(() => {
     const parts: string[] = [];
-    // Boulders-only is the default, so only surface a chip when it differs.
-    const bouldersOn = localFilters.boulders ?? true;
-    const routesOn = localFilters.routes ?? false;
-    if (routesOn && !bouldersOn) parts.push(t('mobile.filter.routes'));
-    else if (routesOn && bouldersOn) parts.push(t('mobile.filter.both'));
+    const climbType = climbTypeOf(localFilters);
+    if (climbType !== 'all') {
+      parts.push(
+        climbType === 'boulders' ? t('mobile.filter.climbType.boulders') : t('mobile.filter.climbType.routes'),
+      );
+    }
     if (localFilters.gradeAccuracy != null) parts.push(accuracyLabels[localFilters.gradeAccuracy]);
     if (localFilters.setter && localFilters.setter.length > 0) {
       parts.push(t('mobile.search.settersCount', { count: localFilters.setter.length }));
@@ -529,11 +519,11 @@ export function ClimbFilterSheet({
             resetKey={sectionResetKey}
           >
             <Text variant="footnote" style={styles.subsectionLabel}>
-              {t('mobile.filter.climbType')}
+              {t('mobile.filter.climbType.label')}
             </Text>
             <SegmentedControl
               options={climbTypeOptions}
-              selectedKey={climbTypeKey}
+              selectedKey={climbTypeOf(localFilters)}
               onSelect={handleClimbTypeChange}
               textVariant="footnote"
               trackColor={trackColor}

--- a/packages/mobile/src/components/search/ClimbSearchBar.tsx
+++ b/packages/mobile/src/components/search/ClimbSearchBar.tsx
@@ -25,6 +25,7 @@ import type { ClimbFilters } from '../../lib/climb-filter-types';
 import type { SearchLayout } from '../../lib/search-layout-preference';
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 import { GlassIconButton } from '../GlassIconButton';
+import { Text } from '../Text';
 import { GradePill } from './GradePill';
 import { FilterButton } from './FilterButton';
 import { ActiveFilterChips } from './ActiveFilterChips';
@@ -43,6 +44,7 @@ type ClimbSearchBarProps = {
   grades: readonly Grade[];
   filters: ClimbFilters;
   boardFilters: ClimbBoardFilterState;
+  count: number | undefined;
   activeFilterCount: number;
   onOpenGrade: () => void;
   onOpenFilters: () => void;
@@ -67,6 +69,7 @@ export function ClimbSearchBar({
   grades,
   filters,
   boardFilters,
+  count,
   activeFilterCount,
   onOpenGrade,
   onOpenFilters,
@@ -116,6 +119,12 @@ export function ClimbSearchBar({
 
         {showControls ? <GradePill bound={bound} grades={grades} onPress={onOpenGrade} maxWidth={132} /> : null}
 
+        {showControls && count != null ? (
+          <Text variant="caption1" color={systemColors.secondaryLabel} numberOfLines={1} style={styles.countText}>
+            {t('mobile.search.climbsCount', { count })}
+          </Text>
+        ) : null}
+
         {showControls ? <FilterButton activeFilterCount={activeFilterCount} onPress={onOpenFilters} /> : null}
       </View>
 
@@ -150,5 +159,8 @@ const styles = StyleSheet.create({
   chipsRow: {
     paddingHorizontal: spacing[4],
     paddingBottom: spacing[2],
+  },
+  countText: {
+    flexShrink: 0,
   },
 });

--- a/packages/mobile/src/components/search/SearchFab.tsx
+++ b/packages/mobile/src/components/search/SearchFab.tsx
@@ -21,17 +21,20 @@ import Animated, {
 import { useTranslation } from 'react-i18next';
 import { useFocusEffect } from 'expo-router';
 import type { Grade } from '@boardsesh/shared-schema';
-import { type GradeBound } from '@boardsesh/climb-filters';
+import { type ClimbBoardFilterState, type GradeBound } from '@boardsesh/climb-filters';
 import { useTheme } from '../../providers/theme-provider';
 import { spacing } from '../../theme/tokens';
 import { TOOLBAR_FAB_SIZE, TOOLBAR_SIDE_MARGIN } from '../../theme/layout';
 import { hapticLight, hapticSelection } from '../../lib/haptics';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { setSearchExpanded } from '../../lib/search-expanded-state';
+import type { ClimbFilters } from '../../lib/climb-filter-types';
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 import { GlassIconButton } from '../GlassIconButton';
+import { Text } from '../Text';
 import { GradePill } from './GradePill';
 import { FilterButton } from './FilterButton';
+import { ActiveFilterChips } from './ActiveFilterChips';
 
 type SearchFabProps = {
   searchFieldRef: RefObject<SearchHeaderHandle | null>;
@@ -44,9 +47,14 @@ type SearchFabProps = {
   onSearchBlur: () => void;
   bound: GradeBound;
   grades: readonly Grade[];
+  filters: ClimbFilters;
+  boardFilters: ClimbBoardFilterState;
+  count: number | undefined;
   activeFilterCount: number;
   onOpenGrade: () => void;
   onOpenFilters: () => void;
+  onPatchFilters: (patch: Partial<ClimbFilters>) => void;
+  onPatchBoardFilters: (patch: Partial<ClimbBoardFilterState>) => void;
   /** Resting bottom for the cluster (clears the tab bar + floating toolbar). */
   toolbarBottom: number;
 };
@@ -61,9 +69,14 @@ export function SearchFab({
   onSearchBlur,
   bound,
   grades,
+  filters,
+  boardFilters,
+  count,
   activeFilterCount,
   onOpenGrade,
   onOpenFilters,
+  onPatchFilters,
+  onPatchBoardFilters,
   toolbarBottom,
 }: SearchFabProps) {
   const { t } = useTranslation('climbs');
@@ -137,6 +150,7 @@ export function SearchFab({
 
   const enter = reduceMotion ? undefined : FadeIn.duration(200);
   const exit = reduceMotion ? undefined : FadeOut.duration(150);
+  const showMetadataRow = expanded && !focused && (count != null || activeFilterCount > 0);
 
   return (
     <>
@@ -150,6 +164,24 @@ export function SearchFab({
       ) : null}
 
       <Animated.View pointerEvents="box-none" style={[styles.cluster, clusterStyle]}>
+        {showMetadataRow ? (
+          <Animated.View entering={enter} exiting={exit} style={styles.metadataRow}>
+            {count != null ? (
+              <Text variant="caption1" color={systemColors.secondaryLabel} numberOfLines={1} style={styles.countText}>
+                {t('mobile.search.climbsCount', { count })}
+              </Text>
+            ) : null}
+            <ActiveFilterChips
+              filters={filters}
+              boardFilters={boardFilters}
+              onPatchFilters={onPatchFilters}
+              onPatchBoardFilters={onPatchBoardFilters}
+              chipHeight={32}
+              style={styles.chips}
+              contentContainerStyle={styles.chipsContent}
+            />
+          </Animated.View>
+        ) : null}
         <View pointerEvents="box-none" style={styles.fabRow}>
           {/* The FAB is pinned LEFT and morphs 🔍→✕; everything speed-dials to its
               right. Collapsed, it carries the active-filter count as a badge. */}
@@ -220,6 +252,22 @@ const styles = StyleSheet.create({
     left: TOOLBAR_SIDE_MARGIN,
     right: TOOLBAR_SIDE_MARGIN,
     zIndex: 19,
+  },
+  metadataRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    marginBottom: spacing[2],
+    marginLeft: TOOLBAR_FAB_SIZE + spacing[2],
+  },
+  countText: {
+    flexShrink: 0,
+  },
+  chips: {
+    flex: 1,
+  },
+  chipsContent: {
+    paddingRight: spacing[2],
   },
   searchSlot: {
     flex: 1,

--- a/packages/mobile/src/components/search/__tests__/active-filter-chips.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/active-filter-chips.test.tsx
@@ -81,7 +81,7 @@ import { ActiveFilterChips } from '../ActiveFilterChips';
 // A base filter state with everything off, so each test opts in to exactly the
 // filters it wants surfaced.
 function makeFilters(over: Partial<ClimbFilters> = {}): ClimbFilters {
-  return { sortBy: 'ascents', sortOrder: 'desc', status: 'any', boulders: true, routes: false, ...over };
+  return { sortBy: 'ascents', sortOrder: 'desc', status: 'any', ...over };
 }
 
 function makeProps(over: Partial<Parameters<typeof ActiveFilterChips>[0]> = {}) {
@@ -167,18 +167,14 @@ describe('ActiveFilterChips', () => {
     expect(onPatchFilters).not.toHaveBeenCalled();
   });
 
-  it('clearing the climb-type chip resets to the boulders default (multi-field patch)', () => {
+  it('clearing the climb-type chip resets to all climbs', () => {
     const onPatchFilters = vi.fn();
-    // routes-only differs from the boulders default, so it surfaces a chip whose
-    // clear payload restores boulders.
     const { container } = render(
-      <ActiveFilterChips
-        {...makeProps({ filters: makeFilters({ boulders: false, routes: true }), onPatchFilters })}
-      />,
+      <ActiveFilterChips {...makeProps({ filters: makeFilters({ boulders: false, routes: true }), onPatchFilters })} />,
     );
-    expect(container.textContent).toContain('mobile.filter.routes');
+    expect(container.textContent).toContain('mobile.filter.climbType.routes');
     fireEvent.click(chips(container)[0]);
-    expect(onPatchFilters).toHaveBeenCalledWith({ boulders: true, routes: false });
+    expect(onPatchFilters).toHaveBeenCalledWith({ boulders: undefined, routes: undefined });
   });
 
   it('defaults the chip height to 30 (radius 15) when chipHeight is omitted', () => {

--- a/packages/mobile/src/components/search/__tests__/search-fab.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/search-fab.test.tsx
@@ -2,8 +2,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import { createElement, forwardRef, type ReactNode, type RefObject } from 'react';
-import type { GradeBound } from '@boardsesh/climb-filters';
+import type { ClimbBoardFilterState, GradeBound } from '@boardsesh/climb-filters';
 import type { SearchHeaderHandle } from '../../SearchHeader';
+import type { ClimbFilters } from '../../../lib/climb-filter-types';
 
 const haptics = vi.hoisted(() => ({ light: vi.fn(), selection: vi.fn() }));
 const signal = vi.hoisted(() => ({ setSearchExpanded: vi.fn() }));
@@ -65,6 +66,12 @@ vi.mock('../../GlassIconButton', () => ({
 
 vi.mock('../GradePill', () => ({ GradePill: () => createElement('div', { 'data-gradepill': 'true' }) }));
 vi.mock('../FilterButton', () => ({ FilterButton: () => createElement('div', { 'data-filterbutton': 'true' }) }));
+vi.mock('../ActiveFilterChips', () => ({
+  ActiveFilterChips: () => createElement('div', { 'data-active-chips': 'true' }),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
+}));
 
 import { SearchFab } from '../SearchFab';
 
@@ -79,9 +86,14 @@ function makeProps(over: Partial<Parameters<typeof SearchFab>[0]> = {}) {
     onSearchBlur: vi.fn(),
     bound: {} as GradeBound,
     grades: [],
+    filters: { sortBy: 'ascents', sortOrder: 'desc', status: 'any' } as ClimbFilters,
+    boardFilters: {} as ClimbBoardFilterState,
+    count: undefined,
     activeFilterCount: 0,
     onOpenGrade: vi.fn(),
     onOpenFilters: vi.fn(),
+    onPatchFilters: vi.fn(),
+    onPatchBoardFilters: vi.fn(),
     toolbarBottom: 100,
     ...over,
   };
@@ -129,5 +141,12 @@ describe('SearchFab', () => {
     expect(fab(container).getAttribute('data-badge')).toBe('4');
     fireEvent.click(fab(container));
     expect(fab(container).getAttribute('data-badge')).toBe('');
+  });
+
+  it('shows the live count and active chips while expanded and idle', () => {
+    const { container } = render(<SearchFab {...makeProps({ activeFilterCount: 2, count: 42 })} />);
+    fireEvent.click(fab(container));
+    expect(container.textContent).toContain('mobile.search.climbsCount');
+    expect(container.querySelector('[data-active-chips]')).not.toBeNull();
   });
 });

--- a/packages/mobile/src/components/search/active-filter-pills.ts
+++ b/packages/mobile/src/components/search/active-filter-pills.ts
@@ -5,7 +5,12 @@
 // dynamic `t()` keys (the i18n linter only allows literal keys). Each pill
 // carries the patch that clears it.
 
-import { formatMinAscentsFilterCount, type ClimbBoardFilterState } from '@boardsesh/climb-filters';
+import {
+  climbTypeOf,
+  climbTypePatch,
+  formatMinAscentsFilterCount,
+  type ClimbBoardFilterState,
+} from '@boardsesh/climb-filters';
 import type { ClimbFilters } from '../../lib/climb-filter-types';
 
 export type ActiveFilterPill = {
@@ -47,14 +52,13 @@ export function buildActiveFilterPills(
   if (boardFilters.onlyBenchmarks) {
     pills.push({ key: 'benchmark', label: t('mobile.filter.benchmark'), clearBoard: { onlyBenchmarks: undefined } });
   }
-  // Climb-type is boulders-only by default; surface a removable pill only when
-  // it differs (routes-only or both). Clearing resets to the boulders default.
-  const bouldersOn = filters.boulders ?? true;
-  const routesOn = filters.routes ?? false;
-  if (routesOn && !bouldersOn) {
-    pills.push({ key: 'climbType', label: t('mobile.filter.routes'), clearFilters: { boulders: true, routes: false } });
-  } else if (routesOn && bouldersOn) {
-    pills.push({ key: 'climbType', label: t('mobile.filter.both'), clearFilters: { boulders: true, routes: false } });
+  const climbType = climbTypeOf(filters);
+  if (climbType !== 'all') {
+    pills.push({
+      key: 'climbType',
+      label: climbType === 'boulders' ? t('mobile.filter.climbType.boulders') : t('mobile.filter.climbType.routes'),
+      clearFilters: climbTypePatch('all'),
+    });
   }
   if (filters.setter && filters.setter.length > 0) {
     pills.push({

--- a/packages/shared/climb-filters/src/__tests__/climb-type-filter.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/climb-type-filter.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vite-plus/test';
 import {
   DEFAULT_CLIMB_FILTER_STATE,
+  climbTypeOf,
+  climbTypePatch,
   hasActiveClimbFilters,
   toClimbSearchInput,
   type ClimbFilterState,
@@ -14,44 +16,51 @@ function inputFor(overrides: Partial<ClimbFilterState>) {
 }
 
 describe('climb-type (boulders/routes) filter', () => {
-  it('defaults to boulders-only', () => {
-    expect(DEFAULT_CLIMB_FILTER_STATE.boulders).toBe(true);
-    expect(DEFAULT_CLIMB_FILTER_STATE.routes).toBe(false);
+  it('defaults to all climbs', () => {
+    expect(DEFAULT_CLIMB_FILTER_STATE.boulders).toBeUndefined();
+    expect(DEFAULT_CLIMB_FILTER_STATE.routes).toBeUndefined();
   });
 
-  it('does not count the boulders-only default as an active filter', () => {
+  it('does not count the all-climbs default as an active filter', () => {
     expect(hasActiveClimbFilters(DEFAULT_CLIMB_FILTER_STATE)).toBe(false);
   });
 
-  it('maps boulders-only to boulders=true with routes omitted', () => {
+  it('maps boulders-only to explicit boulders=true/routes=false', () => {
     const input = inputFor({ boulders: true, routes: false });
     expect(input.boulders).toBe(true);
-    expect(input.routes).toBeUndefined();
+    expect(input.routes).toBe(false);
   });
 
-  it('maps routes-only to routes=true with boulders omitted', () => {
+  it('maps routes-only to explicit boulders=false/routes=true', () => {
     const input = inputFor({ boulders: false, routes: true });
     expect(input.routes).toBe(true);
-    expect(input.boulders).toBeUndefined();
+    expect(input.boulders).toBe(false);
   });
 
-  it('omits both fields when both are selected (no frames_count constraint)', () => {
+  it('preserves explicit both-selected values', () => {
     const input = inputFor({ boulders: true, routes: true });
-    expect(input.boulders).toBeUndefined();
-    expect(input.routes).toBeUndefined();
+    expect(input.boulders).toBe(true);
+    expect(input.routes).toBe(true);
   });
 
-  it('omits both fields when neither is selected (widened to all climbs)', () => {
+  it('preserves explicit neither-selected values', () => {
     const input = inputFor({ boulders: false, routes: false });
-    expect(input.boulders).toBeUndefined();
-    expect(input.routes).toBeUndefined();
+    expect(input.boulders).toBe(false);
+    expect(input.routes).toBe(false);
   });
 
-  it('treats routes-on as an active filter', () => {
+  it('treats explicit routes-only as an active filter', () => {
     expect(hasActiveClimbFilters({ ...DEFAULT_CLIMB_FILTER_STATE, boulders: false, routes: true })).toBe(true);
   });
 
-  it('treats boulders-off as an active filter', () => {
-    expect(hasActiveClimbFilters({ ...DEFAULT_CLIMB_FILTER_STATE, boulders: false, routes: false })).toBe(true);
+  it('treats explicit boulders-only as an active filter', () => {
+    expect(hasActiveClimbFilters({ ...DEFAULT_CLIMB_FILTER_STATE, boulders: true, routes: false })).toBe(true);
+  });
+
+  it('maps UI climb type patches through a single 3-way helper', () => {
+    expect(climbTypeOf(DEFAULT_CLIMB_FILTER_STATE)).toBe('all');
+    expect(climbTypePatch('all')).toEqual({ boulders: undefined, routes: undefined });
+    expect(climbTypePatch('boulders')).toEqual({ boulders: true, routes: false });
+    expect(climbTypePatch('routes')).toEqual({ boulders: false, routes: true });
   });
 });

--- a/packages/shared/climb-filters/src/__tests__/filter-state.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/filter-state.test.ts
@@ -28,8 +28,6 @@ describe('DEFAULT_CLIMB_FILTER_STATE', () => {
       sortBy: 'ascents',
       sortOrder: 'desc',
       status: 'any',
-      boulders: true,
-      routes: false,
     });
   });
 });
@@ -116,8 +114,6 @@ describe('toClimbSearchInput', () => {
       pageSize: 30,
       sortBy: 'ascents',
       sortOrder: 'desc',
-      // Default is boulders-only (routes hidden), matching web.
-      boulders: true,
     });
   });
 

--- a/packages/shared/climb-filters/src/active-filter-count.ts
+++ b/packages/shared/climb-filters/src/active-filter-count.ts
@@ -21,8 +21,7 @@ export function countActiveFiltersBeyondGrade(filters: ClimbFilterState, boardFi
   if (filters.hideCompleted) count += 1;
   if (filters.showOnlyAttempted) count += 1;
   if (filters.showOnlyCompleted) count += 1;
-  // Climb-type defaults to boulders-only; "active" = routes on or boulders off.
-  if ((filters.boulders ?? true) !== true || (filters.routes ?? false) !== false) count += 1;
+  if (filters.boulders != null || filters.routes != null) count += 1;
   if (
     filters.sortBy !== DEFAULT_CLIMB_FILTER_STATE.sortBy ||
     filters.sortOrder !== DEFAULT_CLIMB_FILTER_STATE.sortOrder

--- a/packages/shared/climb-filters/src/filter-state.ts
+++ b/packages/shared/climb-filters/src/filter-state.ts
@@ -35,11 +35,10 @@ export type ClimbFilterState = {
   onlyTallClimbs?: boolean;
   onlyWideClimbs?: boolean;
   onlyWithBetaVideos?: boolean;
-  // Climb-type toggles. Default is boulders-only (routes hidden) — see
-  // DEFAULT_CLIMB_FILTER_STATE. Both-on or both-off means "no preference" and
-  // omits the frames_count constraint. Maps to ClimbSearchInput.boulders/routes,
-  // whose SQL lives in @boardsesh/db create-climb-filters.ts (boulders →
-  // frames_count = 1 or NULL, routes → frames_count > 1).
+  // Climb-type filter. Both undefined = show everything (no frames_count
+  // filter); boulders=true/routes=false = boulders only; boulders=false/
+  // routes=true = routes only. Explicit `false` is meaningful, so callers must
+  // null-check rather than truthy-check.
   boulders?: boolean;
   routes?: boolean;
   status: StatusFilter;
@@ -53,9 +52,6 @@ export const DEFAULT_CLIMB_FILTER_STATE: ClimbFilterState = {
   sortBy: 'ascents',
   sortOrder: 'desc',
   status: 'any',
-  // Match web: show boulders, hide routes until the user opts in.
-  boulders: true,
-  routes: false,
 };
 
 /**
@@ -78,9 +74,8 @@ export function hasActiveClimbFilters(state: ClimbFilterState): boolean {
   if (state.hideCompleted) return true;
   if (state.showOnlyAttempted) return true;
   if (state.showOnlyCompleted) return true;
-  // Default is boulders-only, so "active" means routes turned on or boulders off.
-  if ((state.boulders ?? true) !== true) return true;
-  if ((state.routes ?? false) !== false) return true;
+  if (state.boulders != null) return true;
+  if (state.routes != null) return true;
   return false;
 }
 
@@ -130,6 +125,25 @@ export function normalizeRetiredStatus(state: ClimbFilterState): ClimbFilterStat
   return state.status === 'established' ? { ...state, status: 'any' } : state;
 }
 
+/**
+ * Climb-type as a single 3-way choice for the UI, mapping to the boulders/
+ * routes pair the DB expects: 'all' = no filter, 'boulders' = single-frame,
+ * 'routes' = multi-frame. Avoids the two-switch "at least one on" invariant.
+ */
+export type ClimbType = 'all' | 'boulders' | 'routes';
+
+export function climbTypeOf(state: Pick<ClimbFilterState, 'boulders' | 'routes'>): ClimbType {
+  if (state.boulders === true && state.routes !== true) return 'boulders';
+  if (state.routes === true && state.boulders !== true) return 'routes';
+  return 'all';
+}
+
+export function climbTypePatch(type: ClimbType): Pick<ClimbFilterState, 'boulders' | 'routes'> {
+  if (type === 'boulders') return { boulders: true, routes: false };
+  if (type === 'routes') return { boulders: false, routes: true };
+  return { boulders: undefined, routes: undefined };
+}
+
 export type BoardSearchConfig = {
   boardName: string;
   layoutId: number;
@@ -176,16 +190,8 @@ export function toClimbSearchInput(
   if (state.showOnlyAttempted) input.showOnlyAttempted = true;
   if (state.showOnlyCompleted) input.showOnlyCompleted = true;
 
-  // Climb-type filter: apply only when exactly one of boulders/routes is
-  // selected. Both-on and both-off mean "no preference" → omit entirely (the
-  // backend treats a missing frames_count constraint as all climbs). Mirrors
-  // create-climb-filters.ts and web's never-both-off toggle behaviour.
-  const bouldersOn = state.boulders ?? true;
-  const routesOn = state.routes ?? false;
-  if (bouldersOn !== routesOn) {
-    if (bouldersOn) input.boulders = true;
-    if (routesOn) input.routes = true;
-  }
+  if (state.boulders != null) input.boulders = state.boulders;
+  if (state.routes != null) input.routes = state.routes;
 
   const statusFlags = statusToFlags(state.status);
   if (statusFlags.onlyDrafts) input.onlyDrafts = true;

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -567,10 +567,12 @@
       "savedToast": "Tick saved"
     },
     "filter": {
-      "climbType": "Climb Type",
-      "boulders": "Boulders",
-      "routes": "Routes",
-      "both": "Both",
+      "climbType": {
+        "label": "Type",
+        "all": "All",
+        "boulders": "Boulders",
+        "routes": "Routes"
+      },
       "title": "Filters",
       "sortBy": "Sort by",
       "gradeRange": "Grade range",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -567,10 +567,12 @@
       "savedToast": "Tick guardado"
     },
     "filter": {
-      "climbType": "Tipo",
-      "boulders": "Bloques",
-      "routes": "Rutas",
-      "both": "Ambos",
+      "climbType": {
+        "label": "Tipo",
+        "all": "Todas",
+        "boulders": "Bloques",
+        "routes": "Rutas"
+      },
       "title": "Filtros",
       "sortBy": "Ordenar por",
       "gradeRange": "Rango de grado",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -567,10 +567,12 @@
       "savedToast": "Tick enregistré"
     },
     "filter": {
-      "climbType": "Type",
-      "boulders": "Blocs",
-      "routes": "Voies",
-      "both": "Les deux",
+      "climbType": {
+        "label": "Type",
+        "all": "Tous",
+        "boulders": "Blocs",
+        "routes": "Voies"
+      },
       "title": "Filtres",
       "sortBy": "Trier par",
       "gradeRange": "Plage de cotation",


### PR DESCRIPTION
Fixes #2534.

## What changed

- Restored mobile climb-type filtering as a 3-way All / Boulders / Routes choice, with All as the default and explicit false values preserved in the search input.
- Reconnected live search counts and removable active filter chips into the current mobile search surfaces: the sticky search row, expanded bottom search FAB, and filter sheet.
- Updated mobile filter tests and shared climb-filter tests for the recovered behavior.
- Updated climb-type i18n keys across the existing en-US, es, and fr catalogs.

## Why

The original P1/P2 mobile filter work had mostly landed in newer components, but the remaining behavior still defaulted to boulders-only and the active count/chip affordances were not fully wired into the current search UI. This ports the intended issue behavior onto the active component stack instead of reviving deleted components.

## Validation

- `vp test run packages/shared/climb-filters/src/__tests__/climb-type-filter.test.ts packages/shared/climb-filters/src/__tests__/filter-state.test.ts packages/mobile/src/components/search/__tests__/active-filter-chips.test.tsx packages/mobile/src/components/search/__tests__/search-fab.test.tsx --reporter=agent`
- Scoped `vp check --fix` and scoped `vp check` on the changed files
- `vp run typecheck:climb-filters`
- `vp run typecheck:mobile`
- `vp run check:i18n`

Full `vp check` was also attempted, but it currently reports unrelated pre-existing formatting issues outside this patch. The changed files pass the scoped check.

## QA

The dev server was started with the required QA notes file loaded from `.boardsesh/qa-notes.md`. Startup confirmed `[dev] QA notes: /tmp/boardsesh-2534-mobile-search-filters/.boardsesh/qa-notes.md`.