### PR TITLE
fix(mobile): correct angle-change guard, favorite action field, and minor cleanup

### DIFF
--- a/packages/mobile/src/lib/analytics-alias-store.ts
+++ b/packages/mobile/src/lib/analytics-alias-store.ts
@@ -42,8 +42,7 @@ export function createAsyncAliasStore(storage: AsyncKeyValueStorage): {
   }
 
   function persist(): void {
-    const bounded = [...recordedPairs].slice(-MAX_STORED_ALIAS_PAIRS);
-    void storage.setItem(STORAGE_KEY, JSON.stringify(bounded)).catch(() => {
+    void storage.setItem(STORAGE_KEY, JSON.stringify([...recordedPairs])).catch(() => {
       // Best-effort: the in-memory mirror still dedupes for this app session.
     });
   }

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -28,6 +28,7 @@ import { track } from '../lib/analytics';
 import { ClimbActionsSheet } from '../components/ClimbActionsSheet';
 import { AddToPlaylistSheet } from '../components/AddToPlaylistSheet';
 import { useToggleFavorite, useProfile } from '../lib/graphql/hooks';
+import { favoritesStore } from '@boardsesh/climb-actions';
 import { climbToQueueItem } from '../lib/climb-to-queue-item';
 import { useQueue } from './queue-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
@@ -170,8 +171,9 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const handleAngleChange = useCallback(
     (newAngle: number) => {
       const cfg = activeBoardConfigRef.current;
-      if (cfg && newAngle === cfg.angle) return;
       if (boardConfigOverride) {
+        // Guard against the override's current angle, not the base board's.
+        if (newAngle === boardConfigOverride.angle) return;
         // The drawer is showing a climb from a board other than the user's
         // stored active board. Update only the override (so the drawer reflects
         // the change) — do NOT rewrite the stored active board's angle, which
@@ -179,6 +181,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
         // keep the angle write targeting the board actually shown.)
         setBoardConfigOverride((prev) => (prev ? { ...prev, angle: newAngle } : prev));
       } else {
+        if (cfg && newAngle === cfg.angle) return;
         // Fixed-angle boards can't be adjusted — do nothing (the pill is also
         // hidden for them, this is the safety net).
         if (activeBoard?.isAngleAdjustable === false) return;
@@ -245,8 +248,9 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
 
   const handleClimbActionsToggleFavorite = useCallback(() => {
     if (!climbActions) return;
+    const isNowFavorited = !favoritesStore.getIsFavorited(climbActions.climb.uuid);
     track(SHARED_EVENTS.FavoriteToggle, {
-      action: 'toggled',
+      action: isNowFavorited ? 'added' : 'removed',
       climbUuid: climbActions.climb.uuid,
       boardName: climbActions.boardConfig.boardName,
       layoutId: climbActions.boardConfig.layoutId,

--- a/packages/shared/analytics/package.json
+++ b/packages/shared/analytics/package.json
@@ -16,6 +16,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "~6.0.3"
   }
 }

--- a/packages/shared/analytics/package.json
+++ b/packages/shared/analytics/package.json
@@ -16,6 +16,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "typescript": "~6.0.3"
+    "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Summary

- **Angle-change guard bug**: `handleAngleChange` had a single guard at the top comparing `cfg.angle` (from `activeBoardConfigRef`), which could resolve to the base board's stored angle when an override was active. Moved the guard inside each branch — override path now explicitly checks `boardConfigOverride.angle`, so tapping the base board's angle while an override is displayed correctly propagates the change instead of silently no-opping.

- **FavoriteToggle action field**: `handleClimbActionsToggleFavorite` was sending `action: 'toggled'` while every other path (`PlayDrawer`, `FavoritesProvider`) sends `action: 'added' | 'removed'`. Now derives the expected new state from `favoritesStore.getIsFavorited()` before the mutation and tracks the correct value — PostHog queries on `action = 'added'` now cover the ClimbActionsSheet path.

- **TypeScript version in analytics/package.json**: aligned to `^5.9.3` to match the shared-package convention (was `~6.0.3`).

- **Redundant `.slice(-64)` in `analytics-alias-store.ts`**: the `while` loop in `recordAlias` already caps `recordedPairs.size` at 64 before `persist()` is ever called, making the `.slice(-MAX_STORED_ALIAS_PAIRS)` in `persist()` a no-op. Removed it.

## Test plan

- [ ] Open a climb in the play drawer with a board override at a different angle than the base board — verify tapping the base board's angle in the picker actually updates the override angle (no silent no-op)
- [ ] Open a climb via ClimbActionsSheet and toggle favorite — confirm PostHog receives `action: 'added'` or `action: 'removed'` (not `'toggled'`)
- [ ] `vp run typecheck:mobile` passes
- [ ] `vp test --project mobile` passes

https://claude.ai/code/session_01DJUcum55dMDMDSLtaxCB6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJUcum55dMDMDSLtaxCB6A)_