### PR TITLE
fix(types): add DOM lib to create-climb-react tsconfig

### DIFF
--- a/packages/shared/create-climb-react/tsconfig.json
+++ b/packages/shared/create-climb-react/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## Summary

- `board-constants/hold-states.ts` uses `console.warn`, which TypeScript types in the DOM lib
- The parallel monorepo build (`vp run typecheck`) compiles `board-constants` source under `create-climb-react`'s tsconfig (`lib: ["ES2022"]` only), not through the node_modules symlink path — so `console` isn't in scope
- Adds `"DOM"` to `create-climb-react`'s lib; no runtime behaviour change (`console` is available in all React targets: browser, Node, React Native)

## Test plan

- [x] `vp run typecheck` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)