### PR TITLE
feat(mobile): consistent native-glass FABs & capsules + glass PlayDrawer

### DIFF
--- a/packages/mobile/src/components/GlassCluster.tsx
+++ b/packages/mobile/src/components/GlassCluster.tsx
@@ -1,0 +1,45 @@
+import { type ReactNode } from 'react';
+import { View, type StyleProp, type ViewProps, type ViewStyle } from 'react-native';
+import { GlassContainer } from 'expo-glass-effect';
+import { useNativeGlass } from '../hooks/use-native-glass';
+
+type GlassClusterProps = {
+  children?: ReactNode;
+  style?: StyleProp<ViewStyle>;
+  /**
+   * Distance at which sibling glass shapes begin to fuse. Tune per cluster: the
+   * row `gap` is a sensible default so neighbours merge exactly as they meet.
+   */
+  spacing?: number;
+  pointerEvents?: ViewProps['pointerEvents'];
+};
+
+/**
+ * Groups a row of glass controls so iOS 26 Liquid Glass merges them into one
+ * fluid lozenge (`GlassContainer`), the native answer to a custom rounded
+ * container with hand-drawn dividers. Everywhere else — iOS < 26, Android, and
+ * Reduce Transparency — it's a plain `View`, so the children keep their own
+ * shapes and nothing regresses.
+ *
+ * Guardrail (see `glassSize`): only wrap clusters whose members share ONE
+ * height. Mismatched heights merge into an uneven silhouette, so the size-offset
+ * surfaces (the bottom toolbar's hero FAB + shorter capsule) stay separate
+ * bodies instead.
+ */
+export function GlassCluster({ children, style, spacing, pointerEvents }: GlassClusterProps) {
+  const nativeGlass = useNativeGlass();
+
+  if (nativeGlass) {
+    return (
+      <GlassContainer spacing={spacing} style={style} pointerEvents={pointerEvents}>
+        {children}
+      </GlassContainer>
+    );
+  }
+
+  return (
+    <View style={style} pointerEvents={pointerEvents}>
+      {children}
+    </View>
+  );
+}

--- a/packages/mobile/src/components/GlassIconButton.tsx
+++ b/packages/mobile/src/components/GlassIconButton.tsx
@@ -9,6 +9,7 @@ import type { IconName } from './icon-map';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { timing } from '../theme/animations';
+import { glassSize } from '../theme/layout';
 import { useReduceMotion } from '../hooks/use-reduce-motion';
 
 type GlassIconButtonProps = {
@@ -27,7 +28,8 @@ type GlassIconButtonProps = {
   /** Count badge (top-right). Rendered only when > 0. */
   badgeCount?: number;
   disabled?: boolean;
-  /** Diameter of the circular target (default 44 — the HIG minimum). */
+  /** Diameter of the circular target (default `glassSize.standard` — the standard
+   *  floating FAB; pass `glassSize.hero` for a surface's defining action). */
   size?: number;
   /**
    * Optional second glyph the button morphs to (e.g. search ↔ close). When set,
@@ -58,7 +60,7 @@ export function GlassIconButton({
   fallbackColor,
   badgeCount,
   disabled = false,
-  size = 44,
+  size = glassSize.standard,
   secondaryIconName,
   active = false,
 }: GlassIconButtonProps) {

--- a/packages/mobile/src/components/GlassSurface.tsx
+++ b/packages/mobile/src/components/GlassSurface.tsx
@@ -40,6 +40,14 @@ type GlassSurfaceProps = {
   borderRadius?: number;
   /** Blur strength for the iOS < 26 fallback. */
   blurAmount?: number;
+  /**
+   * Let the native Liquid Glass react to touches with Apple's own press/highlight
+   * (iOS 26 only — ignored on the blur/solid fallback, where the consumer's
+   * PressableSurface supplies the feedback). Only takes effect when the GlassView
+   * is the touch target; a `pointerEvents="none"` glass behind content won't see
+   * the touch.
+   */
+  isInteractive?: boolean;
   pointerEvents?: ViewProps['pointerEvents'];
 };
 
@@ -63,6 +71,7 @@ export function GlassSurface({
   fallbackColor,
   borderRadius,
   blurAmount = 20,
+  isInteractive = false,
   pointerEvents,
 }: GlassSurfaceProps) {
   const { systemColors, colorScheme } = useTheme();
@@ -92,6 +101,7 @@ export function GlassSurface({
         <GlassView
           glassEffectStyle={glassEffectStyle}
           tintColor={tintColor}
+          isInteractive={isInteractive}
           colorScheme={isDark ? 'dark' : 'light'}
           style={[StyleSheet.absoluteFill, radius]}
         />

--- a/packages/mobile/src/components/drawer-action-bar/DrawerActionBar.tsx
+++ b/packages/mobile/src/components/drawer-action-bar/DrawerActionBar.tsx
@@ -3,16 +3,21 @@ import { Icon } from '../Icon';
 import type { IconName } from '../icon-map';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
+import { glassSize } from '../../theme/layout';
 
 // Shared building blocks for the Play Drawer and Create Drawer action bars: the
 // circular icon button, its size scale, and the two-row container/row styles.
 // Both bars import these so the layout grammar never drifts between them.
+//
+// These bars sit INSIDE a sheet, not floating over content, so they ride the
+// inline size tier (`inlinePrimary`/`inline`) — distinct from the floating
+// chrome's hero/standard tier, and both at or above the 44pt touch floor.
 
 export type ButtonSize = 'lg' | 'sm';
 
 export const SIZES: Record<ButtonSize, { dim: number; icon: number }> = {
-  lg: { dim: 56, icon: 28 },
-  sm: { dim: 40, icon: 22 },
+  lg: { dim: glassSize.inlinePrimary, icon: 28 },
+  sm: { dim: glassSize.inline, icon: 22 },
 };
 
 type ActionButtonProps = {

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -8,6 +8,7 @@ import {
   BottomSheetHandle,
   BottomSheetScrollView,
   type BottomSheetBackdropProps,
+  type BottomSheetBackgroundProps,
   type BottomSheetHandleProps,
 } from '@gorhom/bottom-sheet';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
@@ -25,6 +26,7 @@ import { DeferredSections } from './DeferredSections';
 import { AngleSelectorSheet } from './AngleSelectorSheet';
 import { ClimbActionsSheet } from '../ClimbActionsSheet';
 import { BleControlSheet } from '../ble/BleControlSheet';
+import { GlassSurface } from '../GlassSurface';
 import { Icon } from '../Icon';
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
@@ -334,7 +336,21 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     [],
   );
 
-  const backgroundStyle = { ...sheetStyles.background, backgroundColor: systemColors.secondaryBackground };
+  // Frosted-glass sheet background — the same Liquid-Glass language as the session
+  // overlay (SessionScreenHost), so the drawer reads as part of the same chrome as
+  // it rises. `style` from gorhom positions the fill; sheetStyles.background rounds
+  // the top, and overflow clips the blur fallback to those corners.
+  const renderBackground = useCallback(
+    ({ style, pointerEvents }: BottomSheetBackgroundProps) => (
+      <GlassSurface
+        glassEffectStyle="regular"
+        fallbackColor={systemColors.secondaryBackground}
+        style={[style, sheetStyles.background, styles.glassBackground]}
+        pointerEvents={pointerEvents}
+      />
+    ),
+    [systemColors.secondaryBackground],
+  );
 
   // Custom handle component wraps gorhom's default in a View whose onLayout
   // reports the actual handle height (depends on indicator style + paddings).
@@ -393,9 +409,9 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         enableContentPanningGesture={!subDrawerOpen}
         enableHandlePanningGesture={!subDrawerOpen}
         backdropComponent={renderBackdrop}
+        backgroundComponent={renderBackground}
         handleComponent={HandleComponent}
         onDismiss={handleClose}
-        backgroundStyle={backgroundStyle}
       >
         <BottomSheetScrollView
           style={styles.content}
@@ -578,6 +594,9 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
 const styles = StyleSheet.create({
   content: {
     flex: 1,
+  },
+  glassBackground: {
+    overflow: 'hidden',
   },
   closeButton: {
     position: 'absolute',

--- a/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
@@ -7,7 +7,7 @@ import { BleLightbulbButton } from '../ble/BleLightbulbButton';
 import { ActionButton, SIZES, type ButtonSize, drawerActionBarStyles } from '../drawer-action-bar/DrawerActionBar';
 import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
-import { shadows } from '../../theme/tokens';
+import { glassSize } from '../../theme/layout';
 import { hapticMedium } from '../../lib/haptics';
 
 type PlayDrawerActionBarProps = {
@@ -172,11 +172,10 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
             onPress={handleAngleSelector}
             accessibilityRole="button"
             accessibilityLabel={t('mobile.angleSelector.title')}
-            style={({ pressed }) => [
-              styles.anglePill,
-              { height: SIZES.sm.dim, borderRadius: SIZES.sm.dim / 2 },
-              pressed && drawerActionBarStyles.actionButtonPressed,
-            ]}
+            // A label-only mini pill (32pt); hit-slop lifts the tap target back to
+            // the 44pt floor without growing the visual chip.
+            hitSlop={8}
+            style={({ pressed }) => [styles.anglePill, pressed && drawerActionBarStyles.actionButtonPressed]}
           >
             <Text variant="caption1" style={styles.angleText}>
               {currentAngle}°
@@ -269,12 +268,14 @@ function TickButton({ size, ascentCount, onPress, onLongPress, accessibilityLabe
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel}
       style={({ pressed }) => [
-        styles.tickButton,
+        drawerActionBarStyles.actionButton,
         { width: dim, height: dim, borderRadius: dim / 2 },
-        pressed && styles.tickButtonPressed,
+        pressed && drawerActionBarStyles.actionButtonPressed,
       ]}
     >
-      <Icon name="tick.outline" size={icon} color={iosSystemColors.white} />
+      {/* The primary log action: a green glyph on the glass sheet (colour on the
+          icon, not a fill) — its hue and the count badge mark it as the hero. */}
+      <Icon name="tick.outline" size={icon} color={brandColors.success} />
       {ascentCount > 0 && (
         <View style={styles.countBadge}>
           <Text variant="caption2" color={iosSystemColors.white} style={styles.countText}>
@@ -287,25 +288,19 @@ function TickButton({ size, ascentCount, onPress, onLongPress, accessibilityLabe
 }
 
 const styles = StyleSheet.create({
+  // A neutral, label-only outlined capsule (no colour fill) — the mini inline tier.
   anglePill: {
-    paddingHorizontal: 14,
+    height: glassSize.mini,
+    borderRadius: glassSize.mini / 2,
+    paddingHorizontal: 12,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: `${iosSystemColors.systemGray}1F`,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: iosSystemColors.separator,
   },
   angleText: {
     fontWeight: '600',
     color: iosSystemColors.systemGray,
-  },
-  tickButton: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: brandColors.success,
-    ...shadows.md,
-  },
-  tickButtonPressed: {
-    opacity: 0.9,
-    transform: [{ scale: 0.92 }],
   },
   countBadge: {
     position: 'absolute',

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-action-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-action-bar.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Minimal RN surface. Pressable exposes its a11y label + hitSlop so the angle
+// pill's restored 44pt touch target is inspectable.
+type PressMockProps = {
+  children?: ReactNode;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+  hitSlop?: number;
+};
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children, onPress, accessibilityLabel, hitSlop }: PressMockProps) =>
+    createElement(
+      'button',
+      { onClick: onPress, 'data-label': accessibilityLabel, 'data-hitslop': hitSlop == null ? '' : String(hitSlop) },
+      children,
+    ),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+// Icon → expose name + colour so the tick glyph's green (colour-on-glyph, not a
+// fill) is assertable. Paths are relative to THIS test file (one level under the
+// source in __tests__), so they carry an extra `../`.
+vi.mock('../../Icon', () => ({
+  Icon: ({ name, color }: { name?: string; color?: string }) =>
+    createElement('span', { 'data-icon': name, 'data-color': color }),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../ble/BleLightbulbButton', () => ({
+  BleLightbulbButton: () => createElement('div', { 'data-ble': 'true' }),
+}));
+vi.mock('../../drawer-action-bar/DrawerActionBar', () => ({
+  SIZES: { lg: { dim: 48, icon: 28 }, sm: { dim: 44, icon: 22 } },
+  ActionButton: ({ iconName }: { iconName?: string }) => createElement('div', { 'data-action': iconName }),
+  drawerActionBarStyles: {
+    container: {},
+    rowPrimary: {},
+    primarySlot: {},
+    rowSecondary: {},
+    spacer: {},
+    actionButton: {},
+    actionButtonPressed: {},
+  },
+}));
+vi.mock('../../../theme/colors', () => ({ brandColors: { primary: '#8C4A52', success: '#6B9080' } }));
+vi.mock('../../../theme/ios-colors', () => ({
+  iosSystemColors: { white: '#FFFFFF', systemGray: '#8E8E93', systemRed: '#FF3B30', separator: '#ccc' },
+}));
+vi.mock('../../../theme/layout', () => ({ glassSize: { mini: 32 } }));
+vi.mock('../../../lib/haptics', () => ({ hapticMedium: vi.fn() }));
+
+import { PlayDrawerActionBar } from '../PlayDrawerActionBar';
+
+const baseProps = {
+  canSwipePrevious: true,
+  canSwipeNext: true,
+  isMirrored: false,
+  supportsMirroring: true,
+  isFavorited: false,
+  remainingQueueCount: 3,
+  lightbulbActive: false,
+  ascentCount: 2,
+  currentAngle: 40,
+  onPrevClick: vi.fn(),
+  onNextClick: vi.fn(),
+  onMirror: vi.fn(),
+  onToggleFavorite: vi.fn(),
+  onLightbulb: vi.fn(),
+  onOpenActions: vi.fn(),
+  onOpenQueue: vi.fn(),
+  onShare: vi.fn(),
+  onTickPress: vi.fn(),
+  onTickLongPress: vi.fn(),
+  onOpenAngleSelector: vi.fn(),
+};
+
+describe('PlayDrawerActionBar', () => {
+  it('renders the tick as a green glyph (colour on the icon, not a solid fill)', () => {
+    const { container } = render(createElement(PlayDrawerActionBar, baseProps));
+    const tick = container.querySelector('[data-icon="tick.outline"]') as HTMLElement;
+
+    expect(tick).toBeTruthy();
+    expect(tick.getAttribute('data-color')).toBe('#6B9080');
+    // The old solid-white-on-green tick is gone — no white tick glyph remains.
+    expect(container.querySelector('[data-icon="tick.outline"][data-color="#FFFFFF"]')).toBeNull();
+  });
+
+  it('keeps the 32pt angle pill tappable at the 44pt floor via hit-slop', () => {
+    const { container } = render(createElement(PlayDrawerActionBar, baseProps));
+    const anglePill = container.querySelector('[data-label="mobile.angleSelector.title"]') as HTMLElement;
+
+    expect(anglePill).toBeTruthy();
+    expect(anglePill.textContent).toContain('40°');
+    expect(Number(anglePill.getAttribute('data-hitslop'))).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/packages/mobile/src/components/playlist/CreatePlaylistFab.tsx
+++ b/packages/mobile/src/components/playlist/CreatePlaylistFab.tsx
@@ -1,35 +1,41 @@
-import { Pressable, Platform, StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
-import { Icon } from '../Icon';
+import { GlassIconButton } from '../GlassIconButton';
+import { useTheme } from '../../providers/theme-provider';
 import { hapticLight } from '../../lib/haptics';
-import { brandColors } from '../../theme/colors';
-import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
+import { glassSize } from '../../theme/layout';
 import { TOOLBAR_RESERVE, TAB_BAR_HEIGHT } from '../queue-control/persistent-queue-bar';
 
 /**
- * Floating "create playlist" button on the Discover library (mirrors web's
- * `Fab`). Anchored bottom-right, lifted above the persistent queue bar + tab
- * bar so it never sits under them. The parent gates rendering on auth.
+ * Floating "create playlist" button on the Discover library — the single defining
+ * action of that screen, so it takes the glass `hero` size. Neutral Liquid Glass
+ * with a maroon plus glyph (colour on the icon, not a fill), matching the search /
+ * log-ascent FABs. Anchored bottom-right, lifted above the persistent queue bar +
+ * tab bar so it never sits under them. The parent gates rendering on auth.
  */
 export function CreatePlaylistFab({ onPress }: { onPress: () => void }) {
   const { t } = useTranslation('playlists');
+  const { systemColors, brandColors } = useTheme();
   const insets = useSafeAreaInsets();
   const bottom = TOOLBAR_RESERVE + TAB_BAR_HEIGHT + insets.bottom + spacing[3];
 
   return (
-    <Pressable
-      onPress={() => {
-        hapticLight();
-        onPress();
-      }}
-      accessibilityRole="button"
-      accessibilityLabel={t('library.createFab.ariaLabel')}
-      style={({ pressed }) => [styles.fab, { bottom }, pressed && styles.pressed]}
-    >
-      <Icon name="plus" size={28} color={iosSystemColors.white} />
-    </Pressable>
+    <View style={[styles.fab, { bottom }]}>
+      <GlassIconButton
+        iconName="plus"
+        iconColor={brandColors.primary}
+        iconSize={28}
+        size={glassSize.hero}
+        onPress={() => {
+          hapticLight();
+          onPress();
+        }}
+        accessibilityLabel={t('library.createFab.ariaLabel')}
+        fallbackColor={systemColors.fill}
+      />
+    </View>
   );
 }
 
@@ -37,25 +43,5 @@ const styles = StyleSheet.create({
   fab: {
     position: 'absolute',
     right: spacing[4],
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    backgroundColor: brandColors.primary,
-    alignItems: 'center',
-    justifyContent: 'center',
-    ...Platform.select({
-      ios: {
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: 4 },
-        shadowOpacity: 0.2,
-        shadowRadius: 8,
-      },
-      android: {
-        elevation: 6,
-      },
-    }),
-  },
-  pressed: {
-    opacity: 0.85,
   },
 });

--- a/packages/mobile/src/components/playlist/__tests__/create-playlist-fab.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/create-playlist-fab.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const haptics = vi.hoisted(() => ({ light: vi.fn() }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ bottom: 0 }) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { fill: '#eee' }, brandColors: { primary: '#8C4A52' } }),
+}));
+vi.mock('../../../lib/haptics', () => ({ hapticLight: haptics.light }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 3: 12, 4: 16 } }));
+vi.mock('../../../theme/layout', () => ({ glassSize: { hero: 64 } }));
+// Only TOOLBAR_RESERVE/TAB_BAR_HEIGHT are needed; mock to avoid pulling the
+// whole queue bar (and its providers) into this unit.
+vi.mock('../../queue-control/persistent-queue-bar', () => ({ TOOLBAR_RESERVE: 74, TAB_BAR_HEIGHT: 49 }));
+
+// GlassIconButton → a button exposing the glass props we assert on. Its mere
+// presence proves the FAB is glass rather than the old solid-maroon Pressable.
+type GlassMockProps = {
+  iconName?: string;
+  iconColor?: string;
+  size?: number;
+  fallbackColor?: string;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+};
+vi.mock('../../GlassIconButton', () => ({
+  GlassIconButton: ({ iconName, iconColor, size, fallbackColor, onPress, accessibilityLabel }: GlassMockProps) =>
+    createElement('button', {
+      'data-glass': 'true',
+      'data-icon': iconName,
+      'data-icon-color': iconColor,
+      'data-size': String(size),
+      'data-fallback': fallbackColor,
+      'data-label': accessibilityLabel,
+      onClick: onPress,
+    }),
+}));
+
+import { CreatePlaylistFab } from '../CreatePlaylistFab';
+
+describe('CreatePlaylistFab', () => {
+  it('renders a glass FAB — a hero-sized plus with a maroon glyph, no solid fill', () => {
+    const { container } = render(createElement(CreatePlaylistFab, { onPress: vi.fn() }));
+    const button = container.querySelector('[data-glass="true"]') as HTMLElement;
+
+    expect(button).toBeTruthy();
+    expect(button.getAttribute('data-icon')).toBe('plus');
+    // Colour rides the glyph (maroon), not a background fill.
+    expect(button.getAttribute('data-icon-color')).toBe('#8C4A52');
+    expect(button.getAttribute('data-size')).toBe('64');
+    // Neutral solid fallback (Android / Reduce Transparency), not the brand maroon.
+    expect(button.getAttribute('data-fallback')).toBe('#eee');
+  });
+
+  it('fires haptics + onPress when tapped', () => {
+    const onPress = vi.fn();
+    const { container } = render(createElement(CreatePlaylistFab, { onPress }));
+    fireEvent.click(container.querySelector('[data-glass="true"]') as HTMLElement);
+
+    expect(haptics.light).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -13,11 +13,12 @@ import { useTranslation } from 'react-i18next';
 import { computePeekOffset } from '@boardsesh/play-view';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { ClimbQueueItem } from '@boardsesh/queue';
-import { shadows } from '../../theme/tokens';
+import { shadows, glassMaterial } from '../../theme/tokens';
 import { withAlpha } from '../../theme/colors';
 import { TOOLBAR_CAPSULE_HEIGHT, TOOLBAR_CAPSULE_MAX_WIDTH } from '../../theme/layout';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
+import { useNativeGlass } from '../../hooks/use-native-glass';
 import { Text } from '../Text';
 import { GlassSurface } from '../GlassSurface';
 import { useTheme } from '../../providers/theme-provider';
@@ -67,6 +68,7 @@ export function ClimbCapsule() {
   const { t } = useTranslation('session');
   const { formatGrade } = useGradeFormat();
   const reduceMotion = useReduceMotion();
+  const nativeGlass = useNativeGlass();
 
   const [width, setWidth] = useState(0);
 
@@ -188,12 +190,21 @@ export function ClimbCapsule() {
   const gradeWash = withAlpha(getGradeColor(currentDisplay.difficulty) ?? DEFAULT_GRADE_COLOR, 0.16);
 
   return (
-    <View style={[styles.capsule, { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator }]}>
+    <View
+      style={[
+        styles.capsule,
+        // Native Liquid Glass draws its own edge + lift; the hairline border and
+        // shadow are only needed on the blur/solid fallback.
+        !nativeGlass && shadows.sm,
+        !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
+      ]}
+    >
       <GlassSurface
         glassEffectStyle="regular"
         tintColor={gradeWash}
         fallbackColor={systemColors.elevatedSurface}
         borderRadius={CAPSULE_RADIUS}
+        blurAmount={glassMaterial.thin}
         style={StyleSheet.absoluteFill}
         pointerEvents="none"
       />
@@ -249,7 +260,6 @@ const styles = StyleSheet.create({
     maxWidth: TOOLBAR_CAPSULE_MAX_WIDTH,
     height: TOOLBAR_CAPSULE_HEIGHT,
     borderRadius: CAPSULE_RADIUS,
-    ...shadows.sm,
   },
   swipeArea: {
     flex: 1,

--- a/packages/mobile/src/components/queue-control/LogAscentFab.tsx
+++ b/packages/mobile/src/components/queue-control/LogAscentFab.tsx
@@ -18,14 +18,14 @@ import { withAlpha } from '../../theme/colors';
 import { springs } from '../../theme/animations';
 import { hapticSelection } from '../../lib/haptics';
 import { countSentAscents } from '../../lib/ascent-status-utils';
-import { TOOLBAR_FAB_SIZE } from '../../theme/layout';
+import { glassSize } from '../../theme/layout';
 
 type LogAscentFabProps = {
   climb: Climb;
   size?: number;
 };
 
-export function LogAscentFab({ climb, size = TOOLBAR_FAB_SIZE }: LogAscentFabProps) {
+export function LogAscentFab({ climb, size = glassSize.hero }: LogAscentFabProps) {
   const { t } = useTranslation('session');
   const { systemColors, brandColors } = useTheme();
   const { boardConfig, openLogAscent } = useDrawerHost();

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -109,8 +109,9 @@ vi.mock('../../../hooks/use-reduce-motion', () => ({ useReduceMotion: () => fals
 vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn(), hapticSelection: vi.fn() }));
 
 vi.mock('../../../theme/colors', () => ({ withAlpha: (color: string) => `${color}29` }));
-vi.mock('../../../theme/layout', () => ({ TOOLBAR_CAPSULE_HEIGHT: 56, TOOLBAR_CAPSULE_MAX_WIDTH: 260 }));
-vi.mock('../../../theme/tokens', () => ({ shadows: { sm: {} } }));
+vi.mock('../../../theme/layout', () => ({ TOOLBAR_CAPSULE_HEIGHT: 52, TOOLBAR_CAPSULE_MAX_WIDTH: 260 }));
+vi.mock('../../../theme/tokens', () => ({ shadows: { sm: {} }, glassMaterial: { regular: 20, thin: 13 } }));
+vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
 
 // useCarouselGesture is mocked: in jsdom we cannot drive the RNGH worklets, so
 // the hook just returns an inert gesture + a translateX shared value.

--- a/packages/mobile/src/components/queue-control/__tests__/log-ascent-fab.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/log-ascent-fab.test.tsx
@@ -79,7 +79,7 @@ vi.mock('../../../theme/colors', () => ({
 }));
 vi.mock('../../../theme/animations', () => ({ springs: { bouncy: {}, snappy: {} } }));
 vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
-vi.mock('../../../theme/layout', () => ({ TOOLBAR_FAB_SIZE: 56 }));
+vi.mock('../../../theme/layout', () => ({ glassSize: { hero: 64, standard: 56 } }));
 
 // NB: ../../lib/ascent-status-utils is intentionally NOT mocked — the real,
 // pure countSentAscents drives the logged/green state from the logbook fixture.

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -29,6 +29,7 @@ import {
   TOOLBAR_GAP,
   TOOLBAR_FAB_SIZE,
   TOOLBAR_GAP_ABOVE_TABBAR,
+  glassSize,
 } from '../../theme/layout';
 import { useQueue } from '../../providers/queue-provider';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
@@ -81,7 +82,7 @@ export function PersistentQueueBar() {
         <View style={styles.centerSlot} pointerEvents="box-none">
           <ClimbCapsule />
         </View>
-        <View style={styles.sideSlot} pointerEvents="box-none">
+        <View style={styles.heroSlot} pointerEvents="box-none">
           {onClimbsTab ? <LogAscentFab climb={currentClimb} /> : null}
         </View>
       </Animated.View>
@@ -102,8 +103,17 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: TOOLBAR_GAP,
   },
+  // Left gutter: reserves room for the Climbs-tab search FAB (standard size) so
+  // the capsule never centers under where it floats in.
   sideSlot: {
     width: TOOLBAR_FAB_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  // Right slot holds the hero log-ascent FAB — a touch larger than the search
+  // gutter, which gives the row its deliberate, playful asymmetry.
+  heroSlot: {
+    width: glassSize.hero,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -13,14 +13,18 @@ import { formatBoardDisplayName } from '@boardsesh/board-config';
 import { useTheme } from '../../providers/theme-provider';
 import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
-import { spacing, shadows } from '../../theme/tokens';
+import { spacing, shadows, glassMaterial } from '../../theme/tokens';
 import { withAlpha } from '../../theme/colors';
+import { glassSize } from '../../theme/layout';
 import { hapticLight } from '../../lib/haptics';
+import { useNativeGlass } from '../../hooks/use-native-glass';
 import { GlassSurface } from '../GlassSurface';
 import { GlassIconButton } from '../GlassIconButton';
 import { PressableSurface } from '../PressableSurface';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
+
+const CAPSULE_RADIUS = glassSize.capsule / 2;
 
 type ClimbTopChromeProps = {
   canCreate: boolean;
@@ -34,6 +38,7 @@ export function ClimbTopChrome({ canCreate, onCreate, onOpenBoardDetail, onHeigh
   const { t: tSettings } = useTranslation('settings');
   const { t: tCommon } = useTranslation('common');
   const { systemColors, brandColors } = useTheme();
+  const nativeGlass = useNativeGlass();
   const insets = useSafeAreaInsets();
   const { data: activeBoard } = useActiveBoard();
   const bluetooth = useOptionalBluetoothContext();
@@ -78,6 +83,7 @@ export function ClimbTopChrome({ canCreate, onCreate, onOpenBoardDetail, onHeigh
             <GlassIconButton
               iconName="plus"
               iconColor={systemColors.label as string}
+              size={glassSize.standard}
               onPress={onCreate}
               accessibilityLabel={t('mobile.create.fab.ariaLabel')}
               fallbackColor={systemColors.fill}
@@ -98,13 +104,17 @@ export function ClimbTopChrome({ canCreate, onCreate, onOpenBoardDetail, onHeigh
               <View
                 style={[
                   styles.capsuleGlass,
-                  { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
+                  // Native Liquid Glass renders its own edge + lift; keep the
+                  // hairline border + shadow only on the blur/solid fallback.
+                  !nativeGlass && shadows.sm,
+                  !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
                 ]}
               >
                 <GlassSurface
-                  glassEffectStyle="clear"
+                  glassEffectStyle="regular"
                   fallbackColor={systemColors.elevatedSurface}
-                  borderRadius={22}
+                  borderRadius={CAPSULE_RADIUS}
+                  blurAmount={glassMaterial.thin}
                   style={StyleSheet.absoluteFill}
                   pointerEvents="none"
                 />
@@ -123,6 +133,7 @@ export function ClimbTopChrome({ canCreate, onCreate, onOpenBoardDetail, onHeigh
             <GlassIconButton
               iconName={bluetoothConnected ? 'lightbulb.fill' : 'lightbulb'}
               iconColor={bluetoothConnected ? brandColors.warning : (systemColors.label as string)}
+              size={glassSize.standard}
               onPress={handleBluetoothPress}
               accessibilityLabel={
                 bluetoothConnected ? tCommon('lightControl.disconnect') : tSettings('ble.connectBoard')
@@ -150,10 +161,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: spacing[4],
     paddingVertical: spacing[2],
-    minHeight: 44,
+    minHeight: glassSize.standard,
   },
   sideSlot: {
-    width: 44,
+    width: glassSize.standard,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -162,7 +173,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   capsulePress: {
-    height: 44,
+    height: glassSize.capsule,
     maxWidth: 180,
     alignItems: 'center',
     justifyContent: 'center',
@@ -170,11 +181,10 @@ const styles = StyleSheet.create({
   capsuleGlass: {
     flexDirection: 'row',
     alignItems: 'center',
-    height: 44,
-    borderRadius: 22,
+    height: glassSize.capsule,
+    borderRadius: CAPSULE_RADIUS,
     paddingHorizontal: 14,
     gap: 6,
-    ...shadows.sm,
   },
   capsuleText: {
     fontWeight: '600',

--- a/packages/mobile/src/components/search/FilterButton.tsx
+++ b/packages/mobile/src/components/search/FilterButton.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { GlassIconButton } from '../GlassIconButton';
 import { useTheme } from '../../providers/theme-provider';
 import { withAlpha } from '../../theme/colors';
+import { glassSize } from '../../theme/layout';
 
 type FilterButtonProps = {
   activeFilterCount: number;
@@ -21,6 +22,7 @@ export function FilterButton({ activeFilterCount, onPress }: FilterButtonProps) 
     <GlassIconButton
       iconName="filter"
       iconColor={active ? brandColors.primary : (systemColors.secondaryLabel as string)}
+      size={glassSize.standard}
       onPress={onPress}
       accessibilityLabel={
         active ? `${t('mobile.search.filters')}, ${activeFilterCount}` : t('mobile.search.filters')

--- a/packages/mobile/src/components/search/GradePill.tsx
+++ b/packages/mobile/src/components/search/GradePill.tsx
@@ -16,7 +16,11 @@ import { PressableSurface } from '../PressableSurface';
 import { useTheme } from '../../providers/theme-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { withAlpha } from '../../theme/colors';
+import { glassMaterial } from '../../theme/tokens';
+import { glassSize } from '../../theme/layout';
 import { formatGradePillLabel } from './grade-pill-label';
+
+const PILL_RADIUS = glassSize.standard / 2;
 
 type GradePillProps = {
   bound: GradeBound;
@@ -61,7 +65,8 @@ export function GradePill({ bound, grades, onPress, maxWidth }: GradePillProps) 
         glassEffectStyle="regular"
         tintColor={tintColor}
         fallbackColor={fallbackColor}
-        borderRadius={22}
+        borderRadius={PILL_RADIUS}
+        blurAmount={glassMaterial.thin}
         style={StyleSheet.absoluteFill}
         pointerEvents="none"
       />
@@ -77,8 +82,8 @@ export function GradePill({ bound, grades, onPress, maxWidth }: GradePillProps) 
 
 const styles = StyleSheet.create({
   pill: {
-    height: 44,
-    borderRadius: 22,
+    height: glassSize.standard,
+    borderRadius: PILL_RADIUS,
     overflow: 'hidden',
     justifyContent: 'center',
   },
@@ -87,7 +92,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 4,
     paddingHorizontal: 14,
-    height: 44,
+    height: glassSize.standard,
   },
   gradeText: {
     fontWeight: '600',

--- a/packages/mobile/src/components/search/SearchFab.tsx
+++ b/packages/mobile/src/components/search/SearchFab.tsx
@@ -9,7 +9,7 @@
 // badge. Controls are individual glass elements over the list (no glass-on-glass).
 
 import { type RefObject, useCallback, useEffect, useState } from 'react';
-import { Keyboard, Pressable, StyleSheet, View } from 'react-native';
+import { Keyboard, Pressable, StyleSheet } from 'react-native';
 import Animated, {
   FadeIn,
   FadeOut,
@@ -30,6 +30,7 @@ import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { setSearchExpanded } from '../../lib/search-expanded-state';
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 import { GlassIconButton } from '../GlassIconButton';
+import { GlassCluster } from '../GlassCluster';
 import { GradePill } from './GradePill';
 import { FilterButton } from './FilterButton';
 
@@ -150,7 +151,7 @@ export function SearchFab({
       ) : null}
 
       <Animated.View pointerEvents="box-none" style={[styles.cluster, clusterStyle]}>
-        <View pointerEvents="box-none" style={styles.fabRow}>
+        <GlassCluster pointerEvents="box-none" style={styles.fabRow} spacing={spacing[2]}>
           {/* The FAB is pinned LEFT and morphs 🔍→✕; everything speed-dials to its
               right. Collapsed, it carries the active-filter count as a badge. */}
           <GlassIconButton
@@ -200,7 +201,7 @@ export function SearchFab({
               />
             </Animated.View>
           ) : null}
-        </View>
+        </GlassCluster>
       </Animated.View>
     </>
   );

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -78,11 +78,15 @@ vi.mock('../../../providers/bluetooth-provider', () => ({
 vi.mock('../../../theme/tokens', () => ({
   spacing: { 2: 8, 4: 16 },
   shadows: { sm: {} },
+  glassMaterial: { regular: 20, thin: 13 },
 }));
 
 vi.mock('../../../theme/colors', () => ({
   withAlpha: (color: string, alpha: number) => `${color}@${alpha}`,
 }));
+
+// Drive the fallback (non-native-glass) branch so the capsule's hairline/shadow render.
+vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
 
 vi.mock('../../../lib/haptics', () => ({ hapticLight: haptics.light }));
 

--- a/packages/mobile/src/components/search/__tests__/grade-pill.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/grade-pill.test.tsx
@@ -68,6 +68,9 @@ vi.mock('@boardsesh/board-constants/grade-colors', () => ({
   getGradeColor: (name: string) => (name === 'V6' ? '#FF0000' : null),
 }));
 
+vi.mock('../../../theme/tokens', () => ({ glassMaterial: { regular: 20, thin: 13 } }));
+vi.mock('../../../theme/layout', () => ({ glassSize: { standard: 56 } }));
+
 // Real-ish bound predicate: "any" iff both ids are undefined (mirrors source).
 vi.mock('@boardsesh/climb-filters', () => ({
   isAnyGrade: (bound: GradeBound) => bound.minGradeId === undefined && bound.maxGradeId === undefined,

--- a/packages/mobile/src/components/search/__tests__/search-fab.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/search-fab.test.tsx
@@ -65,6 +65,9 @@ vi.mock('../../GlassIconButton', () => ({
 
 vi.mock('../GradePill', () => ({ GradePill: () => createElement('div', { 'data-gradepill': 'true' }) }));
 vi.mock('../FilterButton', () => ({ FilterButton: () => createElement('div', { 'data-filterbutton': 'true' }) }));
+vi.mock('../../GlassCluster', () => ({
+  GlassCluster: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
 
 import { SearchFab } from '../SearchFab';
 

--- a/packages/mobile/src/hooks/use-native-glass.ts
+++ b/packages/mobile/src/hooks/use-native-glass.ts
@@ -1,0 +1,18 @@
+import { Platform } from 'react-native';
+import { isGlassEffectAPIAvailable, isLiquidGlassAvailable } from 'expo-glass-effect';
+import { useReduceTransparency } from './use-reduce-transparency';
+
+/**
+ * Whether the real iOS 26 Liquid Glass path is active — i.e. `GlassSurface`
+ * renders a native `GlassView` rather than the blur/solid fallback. Native glass
+ * draws its own refractive edge, so on this path components should drop their
+ * hand-drawn hairline borders and separation shadows (those belong to the
+ * fallback, where the blur has no intrinsic edge). Mirrors the branch logic in
+ * `GlassSurface`, kept in one place so the chrome stays in agreement.
+ */
+export function useNativeGlass(): boolean {
+  const reduceTransparency = useReduceTransparency();
+  return (
+    Platform.OS === 'ios' && !reduceTransparency && isLiquidGlassAvailable() && isGlassEffectAPIAvailable()
+  );
+}

--- a/packages/mobile/src/theme/layout.ts
+++ b/packages/mobile/src/theme/layout.ts
@@ -13,14 +13,39 @@
 /** Bottom tab bar height (excludes the safe-area inset). */
 export const TAB_BAR_HEIGHT = 49;
 
-/** Diameter of the floating toolbar's circular FABs (search, log-ascent).
- *  Larger than the 44pt HIG minimum — a primary, thumb-friendly action sized
- *  like the iOS Photos / Material FAB so it reads as the obvious target. */
-export const TOOLBAR_FAB_SIZE = 56;
+/**
+ * One height ladder for every glass FAB / capsule / pill, so the floating chrome
+ * reads as a single, deliberately-sized system rather than a pile of ad-hoc
+ * diameters. Liquid Glass earns expressiveness from a single hero bump plus a
+ * 4pt capsule offset — not from many sizes — so the ladder is capped and every
+ * interactive tier stays at or above the 44pt touch floor.
+ *
+ *   hero          one defining action per floating surface (log-ascent, create)
+ *   standard      default floating FAB
+ *   capsule       standalone floating capsule — 4pt under its sibling FABs
+ *   inlinePrimary primary action inside a sheet (PlayDrawer)
+ *   inline        standard inline control + touch-target floor
+ *   mini          label-only pill (angle); carries 44pt hit-slop when tappable
+ *
+ * Guardrail: the hero bump and the capsule offset are for STANDALONE glass
+ * bodies. Anything merged inside a GlassContainer shares one height.
+ */
+export const glassSize = {
+  hero: 64,
+  standard: 56,
+  capsule: 52,
+  inlinePrimary: 48,
+  inline: 44,
+  mini: 32,
+} as const;
 
-/** Height of the centered climb capsule. Matches the FAB diameter so the three
- *  floating elements share one optical baseline. */
-export const TOOLBAR_CAPSULE_HEIGHT = 56;
+/** Diameter of the floating toolbar's standard circular FABs (search).
+ *  The log-ascent hero FAB is `glassSize.hero`; see `glassSize`. */
+export const TOOLBAR_FAB_SIZE = glassSize.standard;
+
+/** Height of the centered climb capsule — one step under the flanking FABs so it
+ *  reads as context, not an action (the playful tell). See `glassSize`. */
+export const TOOLBAR_CAPSULE_HEIGHT = glassSize.capsule;
 
 /** Max width of the centered climb capsule so it never collides with the side
  *  FABs and stays Photos-style centered on wide phones. */
@@ -37,5 +62,6 @@ export const TOOLBAR_GAP = 8;
 export const TOOLBAR_GAP_ABOVE_TABBAR = 10;
 
 /** Bottom padding screens reserve (above the tab bar + safe-area inset) so the
- *  last scrollable row clears the floating toolbar. */
-export const TOOLBAR_RESERVE = TOOLBAR_CAPSULE_HEIGHT + TOOLBAR_GAP_ABOVE_TABBAR;
+ *  last scrollable row clears the floating toolbar. Keyed off the tallest island
+ *  (the hero log-ascent FAB), not the shorter capsule, so nothing hides under it. */
+export const TOOLBAR_RESERVE = glassSize.hero + TOOLBAR_GAP_ABOVE_TABBAR;

--- a/packages/mobile/src/theme/tokens.ts
+++ b/packages/mobile/src/theme/tokens.ts
@@ -79,6 +79,18 @@ export const opacity = {
 } as const;
 
 /**
+ * Glass material strength, expressed as the iOS<26 `blurAmount` fallback. Native
+ * Liquid Glass (`GlassView`) only exposes `regular`/`clear`, so the material
+ * split lives on the blur path: actionable FABs read with the frostier `regular`
+ * material; informational text capsules use the lighter `thin` material so the
+ * content behind them stays legible.
+ */
+export const glassMaterial = {
+  regular: 20,
+  thin: 13,
+} as const;
+
+/**
  * Floating-overlay tokens. Intentionally fixed across light/dark — these are
  * for chips/buttons that overlay arbitrary content (board images, photos) and
  * need stable contrast regardless of the user's color scheme.


### PR DESCRIPTION
## What & why

The RN rewrite's floating chrome grew in two waves that disagreed on height, material, and colour — most visibly the **top board-name capsule cluster sat at 44pt while the bottom toolbar sat at 56pt**, plus a solid-maroon create FAB and a solid-green tick in the play drawer. This unifies everything onto **one native Liquid-Glass system** with a deliberate, slightly playful size ladder, **no solid colour fills** (colour rides icons/text/native tint only), and gives the **PlayDrawer a glass background** like the session overlay.

Direction came from the product owner + an iOS-design-expert consult: keep two size tiers (don't flatten), let a hero/standard/capsule offset add playfulness, and **use native iOS components over custom UI**.

## Changes

**Size ladder** — new `glassSize` tokens in `theme/layout.ts`:
| tier | pt | where |
|---|---|---|
| hero | 64 | `CreatePlaylistFab`, `LogAscentFab` (a surface's defining action) |
| standard | 56 | floating FABs (search, filter, create/lightbulb) |
| capsule | 52 | standalone floating capsules — 4pt under the FABs (the playful tell) |
| inlinePrimary / inline / mini | 48 / 44 / 32 | PlayDrawer action bar (distinct inline tier) |

- **Top chrome** (`ClimbTopChrome`): board capsule 44→52 (`clear`→`regular`+thin material), flanking FABs 44→56 — fixes the mismatch with the bottom toolbar.
- **`CreatePlaylistFab`**: solid maroon circle → glass hero (64) with a maroon plus *glyph*.
- **Search row**: `GradePill`/`FilterButton` 44→56; the expanded row merges natively via a new **`GlassCluster`** (expo-glass-effect `GlassContainer`), plain `View` on the fallback.
- **`ClimbCapsule`**: 56→52 + thin material; custom hairline/shadow dropped on the native-glass path via a new shared `useNativeGlass()` hook.
- **PlayDrawer action bar**: onto the inline tier (48/44); `TickButton` loses its solid green for a green *glyph*; angle pill → 32pt label with 44pt hit-slop.
- **PlayDrawer**: gets a glass `backgroundComponent`, matching `SessionScreenHost`.

**Native-first**: material thin/regular split via native `glassEffectStyle`/`tintColor`, no custom borders/shadows on the iOS 26 path, `GlassContainer` cluster-merging, SF Symbols throughout. The blur/solid fallback (iOS<26 / Android / Reduce Transparency) is preserved via `GlassSurface`.

## Validation

- `vp run typecheck:mobile` — clean
- `vp test --project mobile` — **792 passed** (6 tests updated, 2 added: `CreatePlaylistFab`, `PlayDrawerActionBar`)
- `vp run check:mobile-bundle` — **iOS 8.7 MB + Android 8.9 MB OK**

> Note: the thin/regular material split and `GlassContainer` merging only render their full effect on real **iOS 26** hardware (the blur fallback approximates them) — worth a look on a device/preview build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)