### PR TITLE
[codex] Fix PostHog production analytics

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -201,6 +201,12 @@ jobs:
           # happened when prod web moved to CI `vercel build`. Public client key
           # (phc_…), not a secret, so it's a GitHub Actions variable.
           NEXT_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+          # Keep the production client fallback pointed at the backend service.
+          # Without this, Next can inline the tracked local .env.local value
+          # (ws://localhost:8080/graphql) during CI builds. Runtime host
+          # derivation now protects boardsesh.com, but this keeps every caller
+          # that still reads the baked env on the right backend.
+          NEXT_PUBLIC_WS_URL: ${{ vars.NEXT_PUBLIC_WS_URL || 'wss://ws.boardsesh.com/graphql' }}
         run: vercel build --prod
 
       - name: Package prebuilt output

--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -126,7 +126,7 @@ APNS_BUNDLE_ID=com.boardsesh.app    # Must match your iOS app's bundle ID
 APNS_PRODUCTION=true                 # true = production APNs (matches the app's aps-environment=production entitlement)
 
 # Optional server-side product analytics for Live Activity usage
-POSTHOG_PROJECT_KEY=phc_...          # Backend PostHog project key
+POSTHOG_PROJECT_KEY=phc_...          # Backend PostHog project key (preferred; falls back to NEXT_PUBLIC_POSTHOG_KEY)
 POSTHOG_HOST=https://us.i.posthog.com
 POSTHOG_ENVIRONMENT=production       # Defaults to SENTRY_ENVIRONMENT, then NODE_ENV, then development
 ```
@@ -139,7 +139,7 @@ When the backend starts, you should see:
 
 If you see `[APNs] Missing one or more required env vars...`, double-check the values.
 
-If `POSTHOG_PROJECT_KEY` is unset, Live Activity product analytics are skipped and APNs delivery still works.
+If both `POSTHOG_PROJECT_KEY` and `NEXT_PUBLIC_POSTHOG_KEY` are unset, Live Activity product analytics are skipped and APNs delivery still works.
 
 ## iOS Build Configuration
 

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -301,7 +301,7 @@ This ensures `BoardSessionBridge` only calls `activateSession()` when the actual
 
 ## Backend URL Resolution
 
-The WebSocket backend URL is resolved at runtime by `packages/web/app/lib/backend-url.ts` rather than relying solely on the build-time `NEXT_PUBLIC_WS_URL` environment variable. This is necessary because branch deploy previews serve a single build from multiple domains, and a hard-coded URL only works for one of them.
+The WebSocket backend URL is resolved at runtime by `packages/web/app/lib/backend-url.ts` rather than relying solely on the build-time `NEXT_PUBLIC_WS_URL` environment variable. This is necessary because production and branch deploy previews can serve a build whose baked fallback is missing or points at local development.
 
 ### Preview Domain Pattern
 
@@ -322,8 +322,8 @@ The runtime resolver maps the frontend hostname to the backend:
 
 `getBackendWsUrl()` checks these sources in order and returns the first match:
 
-1. **Host-derived URL** -- if the page hostname matches `{N}.preview.boardsesh.com`, the backend URL is derived automatically. No build-time config needed.
-2. **`NEXT_PUBLIC_WS_URL` build-time fallback** -- the standard env var baked into the Next.js client bundle at build time. Used for production (`boardsesh.com`) and any hostname that doesn't match a known pattern.
+1. **Host-derived URL** -- if the page hostname is `boardsesh.com` / `www.boardsesh.com` or matches `{N}.preview.boardsesh.com`, the backend URL is derived automatically. No build-time config needed.
+2. **`NEXT_PUBLIC_WS_URL` build-time fallback** -- the standard env var baked into the Next.js client bundle at build time. Used for any hostname that doesn't match a known pattern.
 
 On the server side (SSR), only the build-time env var is used.
 
@@ -1654,7 +1654,7 @@ ActivityKit on every device that registered a token for this session
 
 ### Server-Side Analytics
 
-Live Activity actions that happen outside the web view are captured server-side through PostHog when `POSTHOG_PROJECT_KEY` is configured. `POSTHOG_HOST` defaults to `https://us.i.posthog.com`, and `POSTHOG_ENVIRONMENT` can override the event `environment` property. If `POSTHOG_ENVIRONMENT` is unset, the backend falls back to `SENTRY_ENVIRONMENT`, then `NODE_ENV`, then `development`. Server events are sent directly rather than through the browser `/api/posthog/*` proxy.
+Live Activity actions that happen outside the web view are captured server-side through PostHog when `POSTHOG_PROJECT_KEY` is configured. The backend can also fall back to `NEXT_PUBLIC_POSTHOG_KEY` for compatibility with the web build env, but `POSTHOG_PROJECT_KEY` is the preferred runtime variable. `POSTHOG_HOST` defaults to `https://us.i.posthog.com`, and `POSTHOG_ENVIRONMENT` can override the event `environment` property. If `POSTHOG_ENVIRONMENT` is unset, the backend falls back to `SENTRY_ENVIRONMENT`, then `NODE_ENV`, then `development`. Server events are sent directly rather than through the browser `/api/posthog/*` proxy.
 
 Event taxonomy:
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -46,7 +46,7 @@ Environment variables:
 | --------------------- | ----------------------------------------------------------------- | -------------------------------------------------------- |
 | `PORT`                | `8080`                                                            | WebSocket server port                                    |
 | `DATABASE_URL`        | `postgresql://postgres:postgres@localhost:5432/boardsesh_backend` | PostgreSQL connection string                             |
-| `POSTHOG_PROJECT_KEY` | unset                                                             | Enables backend PostHog events for Live Activity usage   |
+| `POSTHOG_PROJECT_KEY` | `NEXT_PUBLIC_POSTHOG_KEY`, then unset                             | Enables backend PostHog events for Live Activity usage   |
 | `POSTHOG_HOST`        | `https://us.i.posthog.com`                                        | PostHog ingestion host                                   |
 | `POSTHOG_ENVIRONMENT` | `SENTRY_ENVIRONMENT`, then `NODE_ENV`, then `development`         | Event environment property for backend PostHog analytics |
 

--- a/packages/backend/src/__tests__/analytics-posthog.test.ts
+++ b/packages/backend/src/__tests__/analytics-posthog.test.ts
@@ -41,7 +41,7 @@ describe('backend PostHog analytics helper', () => {
     vi.restoreAllMocks();
   });
 
-  it('does not initialize or capture without POSTHOG_PROJECT_KEY', async () => {
+  it('does not initialize or capture without a PostHog project key', async () => {
     const { captureBackendEvent } = await loadPosthogModule();
 
     const captured = captureBackendEvent('Live Activity Started', {
@@ -53,7 +53,7 @@ describe('backend PostHog analytics helper', () => {
     expect(posthogMocks.PostHog).not.toHaveBeenCalled();
     expect(posthogMocks.capture).not.toHaveBeenCalled();
     expect(loggerMock.warn).toHaveBeenCalledWith(
-      '[PostHog] POSTHOG_PROJECT_KEY is not set; backend analytics disabled',
+      '[PostHog] POSTHOG_PROJECT_KEY/NEXT_PUBLIC_POSTHOG_KEY is not set; backend analytics disabled',
     );
   });
 
@@ -107,6 +107,23 @@ describe('backend PostHog analytics helper', () => {
     vi.stubEnv('POSTHOG_PROJECT_KEY', 'ph_project');
     expect(captureBackendEvent('Live Activity Started', { distinctId: 'user-1' })).toBe(true);
     expect(posthogMocks.PostHog).toHaveBeenCalledOnce();
+  });
+
+  it('can use NEXT_PUBLIC_POSTHOG_KEY when the backend-specific key is missing', async () => {
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', 'ph_public_project');
+    const { captureBackendEvent } = await loadPosthogModule();
+
+    expect(captureBackendEvent('Live Activity Started', { distinctId: 'user-1' })).toBe(true);
+
+    expect(posthogMocks.PostHog).toHaveBeenCalledWith(
+      'ph_public_project',
+      expect.objectContaining({
+        host: 'https://us.i.posthog.com',
+      }),
+    );
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      '[PostHog] Using NEXT_PUBLIC_POSTHOG_KEY for backend analytics; prefer POSTHOG_PROJECT_KEY',
+    );
   });
 
   it('can disable PostHog person profiles for aggregate events', async () => {

--- a/packages/backend/src/services/analytics/posthog.ts
+++ b/packages/backend/src/services/analytics/posthog.ts
@@ -28,6 +28,27 @@ let initAttempted = false;
 let missingProjectKeyLogged = false;
 const loggedQueuedEvents = new Set<BackendAnalyticsEvent>();
 
+function readOptionalEnv(envName: string): string | null {
+  const rawValue = process.env[envName];
+  if (!rawValue) return null;
+
+  const trimmedValue = rawValue.trim();
+  return trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function getProjectKeyConfig(): {
+  projectKey: string;
+  envName: 'POSTHOG_PROJECT_KEY' | 'NEXT_PUBLIC_POSTHOG_KEY';
+} | null {
+  const backendProjectKey = readOptionalEnv('POSTHOG_PROJECT_KEY');
+  if (backendProjectKey) return { projectKey: backendProjectKey, envName: 'POSTHOG_PROJECT_KEY' };
+
+  const publicProjectKey = readOptionalEnv('NEXT_PUBLIC_POSTHOG_KEY');
+  if (publicProjectKey) return { projectKey: publicProjectKey, envName: 'NEXT_PUBLIC_POSTHOG_KEY' };
+
+  return null;
+}
+
 function sanitizeProperties(properties: AnalyticsProperties | undefined): SanitizedAnalyticsProperties {
   const sanitized: SanitizedAnalyticsProperties = {};
   if (!properties) return sanitized;
@@ -44,19 +65,23 @@ function sanitizeProperties(properties: AnalyticsProperties | undefined): Saniti
 function getPosthogClient(): PostHog | null {
   if (posthogClient) return posthogClient;
 
-  const projectKey = process.env.POSTHOG_PROJECT_KEY;
-  if (!projectKey) {
+  const projectKeyConfig = getProjectKeyConfig();
+  if (!projectKeyConfig) {
     if (!missingProjectKeyLogged) {
       missingProjectKeyLogged = true;
-      logger.warn('[PostHog] POSTHOG_PROJECT_KEY is not set; backend analytics disabled');
+      logger.warn('[PostHog] POSTHOG_PROJECT_KEY/NEXT_PUBLIC_POSTHOG_KEY is not set; backend analytics disabled');
     }
     return null;
   }
   if (initAttempted) return null;
   initAttempted = true;
 
-  const host = process.env.POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST;
-  const client = new PostHog(projectKey, {
+  const host = readOptionalEnv('POSTHOG_HOST') ?? DEFAULT_POSTHOG_HOST;
+  if (projectKeyConfig.envName === 'NEXT_PUBLIC_POSTHOG_KEY') {
+    logger.warn('[PostHog] Using NEXT_PUBLIC_POSTHOG_KEY for backend analytics; prefer POSTHOG_PROJECT_KEY');
+  }
+
+  const client = new PostHog(projectKeyConfig.projectKey, {
     host,
     flushAt: POSTHOG_FLUSH_AT,
     flushInterval: POSTHOG_FLUSH_INTERVAL_MS,
@@ -73,7 +98,12 @@ function getPosthogClient(): PostHog | null {
 }
 
 function getAnalyticsEnvironment(): string {
-  return process.env.POSTHOG_ENVIRONMENT ?? process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV ?? 'development';
+  return (
+    readOptionalEnv('POSTHOG_ENVIRONMENT') ??
+    readOptionalEnv('SENTRY_ENVIRONMENT') ??
+    readOptionalEnv('NODE_ENV') ??
+    'development'
+  );
 }
 
 export function captureBackendEvent(eventName: BackendAnalyticsEvent, options: CaptureBackendEventOptions): boolean {

--- a/packages/web/app/lib/__tests__/analytics.test.ts
+++ b/packages/web/app/lib/__tests__/analytics.test.ts
@@ -98,6 +98,47 @@ describe('analytics wrapper', () => {
     consoleError.mockRestore();
   });
 
+  it('derives the production backend proxy host when no explicit PostHog host is configured', async () => {
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_HOST', '');
+    vi.stubEnv('NEXT_PUBLIC_WS_URL', '');
+    const { track } = await import('../analytics');
+
+    track('Climb Opened');
+
+    expect(mocks.PostHog).toHaveBeenCalledWith(
+      'ph_test_key',
+      expect.objectContaining({
+        host: 'https://ws.boardsesh.com/api/posthog',
+      }),
+    );
+    expect(mocks.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('falls back to direct PostHog ingestion when the proxy URL cannot be derived', async () => {
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_HOST', '');
+    vi.stubEnv('NEXT_PUBLIC_WS_URL', '');
+    setWindowLocation('https://app.boardsesh.com/b/kilter');
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { track } = await import('../analytics');
+
+    track('Climb Opened');
+
+    expect(mocks.PostHog).toHaveBeenCalledWith(
+      'ph_test_key',
+      expect.objectContaining({
+        host: 'https://us.i.posthog.com',
+      }),
+    );
+    expect(mocks.posthog.capture).toHaveBeenCalledWith('Climb Opened', undefined);
+    expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('PostHog proxy URL could not be derived'));
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('PostHog proxy URL could not be derived'),
+      'warning',
+    );
+
+    consoleWarn.mockRestore();
+  });
+
   it('does not warn about a missing key outside production hosts', async () => {
     vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', '');
     setWindowLocation('https://boardsesh-preview.vercel.app/b/kilter');

--- a/packages/web/app/lib/__tests__/backend-url.test.ts
+++ b/packages/web/app/lib/__tests__/backend-url.test.ts
@@ -18,8 +18,12 @@ describe('deriveWsUrlFromHost', () => {
     expect(deriveWsUrlFromHost('localhost', true)).toBeNull();
   });
 
-  it('should return null for bare boardsesh.com', () => {
-    expect(deriveWsUrlFromHost('boardsesh.com', true)).toBeNull();
+  it('should derive wss URL for production domain', () => {
+    expect(deriveWsUrlFromHost('boardsesh.com', true)).toBe('wss://ws.boardsesh.com/graphql');
+  });
+
+  it('should derive wss URL for www production domain', () => {
+    expect(deriveWsUrlFromHost('www.boardsesh.com', true)).toBe('wss://ws.boardsesh.com/graphql');
   });
 
   it('should return null for non-numeric prefix', () => {
@@ -81,6 +85,24 @@ describe('getBackendWsUrl (client runtime local-network fallback)', () => {
 
     const { getBackendWsUrl } = await import('../backend-url');
     expect(getBackendWsUrl()).toBe('wss://backend.example.com/graphql');
+  });
+
+  it('derives production backend before using the local fallback', async () => {
+    process.env.NEXT_PUBLIC_WS_URL = 'ws://localhost:8080/graphql';
+
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      value: {
+        location: {
+          hostname: 'boardsesh.com',
+          protocol: 'https:',
+        },
+      },
+    });
+
+    const { getBackendWsUrl, getBackendHttpUrl } = await import('../backend-url');
+    expect(getBackendWsUrl()).toBe('wss://ws.boardsesh.com/graphql');
+    expect(getBackendHttpUrl()).toBe('https://ws.boardsesh.com');
   });
 });
 

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -11,9 +11,18 @@ type AllowedPropertyValues = string | number | boolean | null | undefined;
 type EventProperties = Record<string, AllowedPropertyValues>;
 type FlagsDataInput = Parameters<typeof vercelTrack>[2];
 
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
 let posthogClient: PostHog | null = null;
 let posthogInitAttempted = false;
 const shouldDebugAnalytics = process.env.NEXT_PUBLIC_ANALYTICS_DEBUG === '1';
+
+function readOptionalEnv(envName: string): string | null {
+  const rawValue = process.env[envName];
+  if (!rawValue) return null;
+
+  const trimmedValue = rawValue.trim();
+  return trimmedValue.length > 0 ? trimmedValue : null;
+}
 
 function getPosthog(): PostHog | null {
   if (typeof window === 'undefined') return null;
@@ -25,7 +34,7 @@ function getPosthog(): PostHog | null {
   // out of the prod PostHog project.
   if (!window.location.hostname.includes('boardsesh.com')) return null;
 
-  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  const apiKey = readOptionalEnv('NEXT_PUBLIC_POSTHOG_KEY');
   if (!apiKey) {
     // We're on a production boardsesh.com host but NEXT_PUBLIC_POSTHOG_KEY was
     // not inlined into the client bundle at build time, so the SDK can't start
@@ -44,8 +53,14 @@ function getPosthog(): PostHog | null {
   // first-party to ad-blockers. NEXT_PUBLIC_POSTHOG_HOST overrides for incident
   // recovery (point straight at us.i.posthog.com if the proxy is down).
   const backendUrl = getBackendHttpUrl();
-  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? (backendUrl ? `${backendUrl}/api/posthog` : null);
-  if (!host) return null;
+  const configuredHost = readOptionalEnv('NEXT_PUBLIC_POSTHOG_HOST');
+  const host = configuredHost ?? (backendUrl ? `${backendUrl}/api/posthog` : DEFAULT_POSTHOG_HOST);
+  if (!configuredHost && !backendUrl) {
+    const message =
+      'PostHog proxy URL could not be derived on a production host; using direct PostHog ingestion. Check NEXT_PUBLIC_WS_URL or NEXT_PUBLIC_POSTHOG_HOST in the web build env.';
+    console.warn(`[analytics] ${message}`);
+    Sentry.captureMessage(message, 'warning');
+  }
 
   posthogClient = new PostHog(apiKey, {
     host,

--- a/packages/web/app/lib/backend-url.ts
+++ b/packages/web/app/lib/backend-url.ts
@@ -10,7 +10,7 @@
  * the current hostname, so every access path reaches the right backend.
  *
  * Resolution order (client-side):
- * 1. Host-derived URL for preview domains ({N}.preview.boardsesh.com)
+ * 1. Host-derived URL for production and preview domains
  * 2. NEXT_PUBLIC_WS_URL build-time fallback
  */
 
@@ -18,6 +18,7 @@
  * Derive the WS backend URL from the current page hostname.
  *
  * Maps preview frontend hostnames to their corresponding backend:
+ *   boardsesh.com → wss://ws.boardsesh.com/graphql
  *   42.preview.boardsesh.com → wss://42.ws.preview.boardsesh.com/graphql
  *
  * Returns null when the hostname doesn't match a known pattern (callers
@@ -27,6 +28,10 @@
  */
 export function deriveWsUrlFromHost(hostname: string, secure: boolean): string | null {
   const protocol = secure ? 'wss' : 'ws';
+
+  if (hostname === 'boardsesh.com' || hostname === 'www.boardsesh.com') {
+    return `${protocol}://ws.boardsesh.com/graphql`;
+  }
 
   // Match {N}.preview.boardsesh.com → {N}.ws.preview.boardsesh.com
   const previewMatch = hostname.match(/^(\d+)\.preview\.boardsesh\.com$/);


### PR DESCRIPTION
## Summary

Fixes the production PostHog outage path introduced by moving production builds/deploys to GitHub Actions.

## What changed

- Derive the production backend URL from `boardsesh.com` / `www.boardsesh.com` at runtime, so web analytics defaults to `https://ws.boardsesh.com/api/posthog` instead of a baked local fallback.
- Keep client PostHog flowing even if the proxy URL cannot be derived by falling back to direct PostHog ingestion and reporting a Sentry warning.
- Allow backend server-side PostHog events to use `POSTHOG_PROJECT_KEY` first, with `NEXT_PUBLIC_POSTHOG_KEY` as a compatibility fallback.
- Pass `NEXT_PUBLIC_WS_URL` into the production CI web build, defaulting to `wss://ws.boardsesh.com/graphql`.
- Add regression tests and update the backend/live-activity/websocket docs.

## Root cause

The CI build path restored `NEXT_PUBLIC_POSTHOG_KEY`, but PostHog still depended on backend URL/env plumbing that could be missing or locally inlined after the GitHub Actions build move. That left client events able to no-op silently and backend events dependent on only the backend-specific key name.

## Validation

- `vp test run packages/web/app/lib/__tests__/analytics.test.ts packages/web/app/lib/__tests__/backend-url.test.ts packages/backend/src/__tests__/analytics-posthog.test.ts --reporter=agent`
- `vp run check:service-deploy-inputs`
- `vp run typecheck:web`
- `vp run typecheck:backend`
- Targeted `vp lint` on changed TypeScript files
- `git diff --check`

## Notes

Full `vp check` is currently blocked by pre-existing unrelated formatting issues in 21 files outside this patch; changed files were formatted with `vp fmt`.