### PR TITLE
[codex] Fix Android BLE availability race

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -10,6 +10,7 @@ const mockBleManager = vi.hoisted(() => ({
   connectToDevice: vi.fn(),
   cancelDeviceConnection: vi.fn(),
   onDeviceDisconnected: vi.fn(),
+  onStateChange: vi.fn(),
 }));
 
 // ── Module mocks ────────────────────────────────────────────────────────
@@ -57,6 +58,7 @@ function createMockDevicePicker(): DevicePickerFn {
 describe('RNBleAdapter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockBleManager.onStateChange.mockReturnValue({ remove: vi.fn() });
   });
 
   describe('isAvailable', () => {
@@ -80,12 +82,43 @@ describe('RNBleAdapter', () => {
     });
 
     it('returns false when bluetooth state is Unknown', async () => {
-      mockBleManager.state.mockResolvedValue(State.Unknown);
-      const adapter = new RNBleAdapter(createMockDevicePicker());
+      vi.useFakeTimers();
+      try {
+        mockBleManager.state.mockResolvedValue(State.Unknown);
+        const adapter = new RNBleAdapter(createMockDevicePicker());
 
-      const available = await adapter.isAvailable();
+        const availablePromise = adapter.isAvailable();
+        await vi.advanceTimersByTimeAsync(2_500);
+        const available = await availablePromise;
 
-      expect(available).toBe(false);
+        expect(available).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('waits for transient bluetooth state to become PoweredOn', async () => {
+      vi.useFakeTimers();
+      try {
+        const stateListeners: Array<(state: State) => void> = [];
+        const removeListener = vi.fn();
+        mockBleManager.state.mockResolvedValue(State.Unknown);
+        mockBleManager.onStateChange.mockImplementation((listener: (state: State) => void) => {
+          stateListeners.push(listener);
+          return { remove: removeListener };
+        });
+        const adapter = new RNBleAdapter(createMockDevicePicker());
+
+        const availablePromise = adapter.isAvailable();
+        await Promise.resolve();
+        expect(stateListeners).toHaveLength(1);
+        stateListeners[0](State.PoweredOn);
+
+        await expect(availablePromise).resolves.toBe(true);
+        expect(removeListener).toHaveBeenCalledOnce();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('returns false when state() throws', async () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
@@ -8,6 +8,7 @@ import {
 
 const mockBleManager = vi.hoisted(() => ({
   state: vi.fn(),
+  onStateChange: vi.fn(),
   startDeviceScan: vi.fn(),
   stopDeviceScan: vi.fn(),
 }));
@@ -21,7 +22,14 @@ vi.mock('react-native', async () => {
 });
 
 vi.mock('react-native-ble-plx', () => ({
-  State: { PoweredOn: 'PoweredOn', PoweredOff: 'PoweredOff' },
+  State: {
+    PoweredOn: 'PoweredOn',
+    PoweredOff: 'PoweredOff',
+    Unknown: 'Unknown',
+    Resetting: 'Resetting',
+    Unauthorized: 'Unauthorized',
+    Unsupported: 'Unsupported',
+  },
 }));
 
 vi.mock('../ble-manager', () => ({ bleManager: mockBleManager }));
@@ -47,6 +55,7 @@ describe('useBoardScan', () => {
     vi.useFakeTimers();
     resetReactNativePermissionHarness();
     mockBleManager.state.mockResolvedValue('PoweredOn');
+    mockBleManager.onStateChange.mockReturnValue({ remove: vi.fn() });
   });
 
   afterEach(() => {
@@ -62,6 +71,76 @@ describe('useBoardScan', () => {
     });
 
     expect(result.current.status).toBe('unavailable');
+    expect(mockBleManager.startDeviceScan).not.toHaveBeenCalled();
+  });
+
+  it('waits for transient Bluetooth state before scanning', async () => {
+    mockBleManager.state.mockResolvedValue('Unknown');
+    const stateListeners: Array<(state: string) => void> = [];
+    mockBleManager.onStateChange.mockImplementation((listener: (state: string) => void) => {
+      stateListeners.push(listener);
+      return { remove: vi.fn() };
+    });
+    const { result } = renderHook(() => useBoardScan());
+
+    await act(async () => {
+      const startPromise = result.current.start();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(stateListeners).toHaveLength(1);
+      stateListeners[0]('PoweredOn');
+      await startPromise;
+    });
+
+    expect(result.current.status).toBe('scanning');
+    expect(mockBleManager.startDeviceScan).toHaveBeenCalled();
+  });
+
+  it('does not start scanning after reset during Bluetooth readiness wait', async () => {
+    mockBleManager.state.mockResolvedValue('Unknown');
+    const stateListeners: Array<(state: string) => void> = [];
+    mockBleManager.onStateChange.mockImplementation((listener: (state: string) => void) => {
+      stateListeners.push(listener);
+      return { remove: vi.fn() };
+    });
+    const { result } = renderHook(() => useBoardScan());
+
+    await act(async () => {
+      const startPromise = result.current.start();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(stateListeners).toHaveLength(1);
+      result.current.reset();
+      stateListeners[0]('PoweredOn');
+      await startPromise;
+    });
+
+    expect(result.current.status).toBe('idle');
+    expect(mockBleManager.startDeviceScan).not.toHaveBeenCalled();
+  });
+
+  it('does not start scanning after unmount during Bluetooth readiness wait', async () => {
+    mockBleManager.state.mockResolvedValue('Unknown');
+    const stateListeners: Array<(state: string) => void> = [];
+    mockBleManager.onStateChange.mockImplementation((listener: (state: string) => void) => {
+      stateListeners.push(listener);
+      return { remove: vi.fn() };
+    });
+    const { result, unmount } = renderHook(() => useBoardScan());
+
+    await act(async () => {
+      const startPromise = result.current.start();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(stateListeners).toHaveLength(1);
+      unmount();
+      stateListeners[0]('PoweredOn');
+      await startPromise;
+    });
+
     expect(mockBleManager.startDeviceScan).not.toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -1,4 +1,4 @@
-import { type Device, type Characteristic, State } from 'react-native-ble-plx';
+import { type Device, type Characteristic } from 'react-native-ble-plx';
 import {
   AURORA_ADVERTISED_SERVICE_UUID,
   UART_SERVICE_UUID,
@@ -8,6 +8,7 @@ import {
   parseSerialNumber,
 } from '@boardsesh/ble-protocol';
 import { bleManager } from './ble-manager';
+import { waitForBlePoweredOn } from './availability';
 import type { BluetoothAdapter, BleConnection, DevicePickerFn, DiscoveredDevice } from './types';
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
 
@@ -24,12 +25,7 @@ export class RNBleAdapter implements BluetoothAdapter {
   constructor(private readonly devicePicker: DevicePickerFn) {}
 
   async isAvailable(): Promise<boolean> {
-    try {
-      const state = await bleManager.state();
-      return state === State.PoweredOn;
-    } catch {
-      return false;
-    }
+    return waitForBlePoweredOn();
   }
 
   // The scan/select flow (silent serial auto-select → grace-window picker

--- a/packages/mobile/src/lib/ble/availability.ts
+++ b/packages/mobile/src/lib/ble/availability.ts
@@ -1,0 +1,69 @@
+import { State } from 'react-native-ble-plx';
+import { bleManager } from './ble-manager';
+
+const DEFAULT_BLE_POWERED_ON_TIMEOUT_MS = 2_500;
+
+type BleStateSubscription = {
+  remove(): void;
+};
+
+function isTransientBleState(state: State): boolean {
+  return state === State.Unknown || state === State.Resetting || state === State.Unauthorized;
+}
+
+export async function waitForBlePoweredOn(timeoutMs = DEFAULT_BLE_POWERED_ON_TIMEOUT_MS): Promise<boolean> {
+  let currentState: State;
+  try {
+    currentState = await bleManager.state();
+  } catch {
+    return false;
+  }
+
+  if (currentState === State.PoweredOn) {
+    return true;
+  }
+
+  if (!isTransientBleState(currentState)) {
+    return false;
+  }
+
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let subscription: BleStateSubscription | null = null;
+    let removeAfterSubscribe = false;
+
+    const finish = (available: boolean) => {
+      if (settled) return;
+      settled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      if (subscription) {
+        subscription.remove();
+      } else {
+        removeAfterSubscribe = true;
+      }
+      resolve(available);
+    };
+
+    timeoutId = setTimeout(() => finish(false), timeoutMs);
+
+    try {
+      subscription = bleManager.onStateChange((nextState) => {
+        if (nextState === State.PoweredOn) {
+          finish(true);
+          return;
+        }
+
+        if (!isTransientBleState(nextState)) {
+          finish(false);
+        }
+      }, true);
+
+      if (removeAfterSubscribe) {
+        subscription.remove();
+      }
+    } catch {
+      finish(false);
+    }
+  });
+}

--- a/packages/mobile/src/lib/ble/use-board-scan.ts
+++ b/packages/mobile/src/lib/ble/use-board-scan.ts
@@ -6,9 +6,9 @@
 // opened here; connecting happens later when the user enters play mode.
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { State } from 'react-native-ble-plx';
 import { AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID, parseSerialNumber } from '@boardsesh/ble-protocol';
 import { bleManager } from './ble-manager';
+import { waitForBlePoweredOn } from './availability';
 import { requestBleRuntimePermissions } from './use-ble-permissions';
 
 const SCAN_TIMEOUT_MS = 15_000;
@@ -29,6 +29,7 @@ export function useBoardScan(): BoardScan {
   const [serials, setSerials] = useState<string[]>([]);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scanningRef = useRef(false);
+  const scanAttemptRef = useRef(0);
   // A device event can land in the BLE callback just after unmount; gate the
   // state writes so we don't setState on an unmounted component.
   const mountedRef = useRef(true);
@@ -47,19 +48,22 @@ export function useBoardScan(): BoardScan {
   const start = useCallback(async () => {
     if (scanningRef.current) return;
 
+    const scanAttempt = scanAttemptRef.current + 1;
+    scanAttemptRef.current = scanAttempt;
+    const isCurrentScanAttempt = () => mountedRef.current && scanAttemptRef.current === scanAttempt;
+
     const permissionsGranted = await requestBleRuntimePermissions();
+    if (!isCurrentScanAttempt()) return;
+
     if (!permissionsGranted) {
       setStatus('unavailable');
       return;
     }
 
-    let powered = false;
-    try {
-      powered = (await bleManager.state()) === State.PoweredOn;
-    } catch {
-      powered = false;
-    }
-    if (!powered) {
+    const bluetoothPoweredOn = await waitForBlePoweredOn();
+    if (!isCurrentScanAttempt()) return;
+
+    if (!bluetoothPoweredOn) {
       setStatus('unavailable');
       return;
     }
@@ -70,7 +74,7 @@ export function useBoardScan(): BoardScan {
     scanningRef.current = true;
 
     bleManager.startDeviceScan([AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID], null, (error, device) => {
-      if (!mountedRef.current) return;
+      if (!isCurrentScanAttempt()) return;
       if (error) {
         stop();
         setStatus('unavailable');
@@ -85,12 +89,14 @@ export function useBoardScan(): BoardScan {
     });
 
     timeoutRef.current = setTimeout(() => {
+      if (!isCurrentScanAttempt()) return;
       stop();
       setStatus('done');
     }, SCAN_TIMEOUT_MS);
   }, [stop]);
 
   const reset = useCallback(() => {
+    scanAttemptRef.current += 1;
     stop();
     setSerials([]);
     setStatus('idle');
@@ -101,6 +107,7 @@ export function useBoardScan(): BoardScan {
   useEffect(() => {
     return () => {
       mountedRef.current = false;
+      scanAttemptRef.current += 1;
       stop();
     };
   }, [stop]);


### PR DESCRIPTION
## Summary

Fixes the first-attempt Android BLE connect failure where `react-native-ble-plx` can briefly report a transient state such as `Unknown` immediately after Nearby Devices permission is granted.

## Changes

- Add a shared BLE availability helper that waits briefly for `PoweredOn` during transient states.
- Use that helper in the direct board connect adapter and the scan-only board quickstart path.
- Add regression tests for delayed `Unknown -> PoweredOn` availability before connect/scan.

## Validation

- `vp test run packages/mobile/src/lib/ble/__tests__/adapter.test.ts packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts packages/mobile/src/lib/ble/__tests__/use-ble-permissions.test.ts --reporter=dot`
- `vp run typecheck:mobile`
- `vp fmt --check packages/mobile/src/lib/ble/availability.ts packages/mobile/src/lib/ble/adapter.ts packages/mobile/src/lib/ble/use-board-scan.ts packages/mobile/src/lib/ble/__tests__/adapter.test.ts packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts`
- `vp run check:i18n:orphans`