### PR TITLE
[codex] Fix play drawer header grade spacing

### DIFF
--- a/packages/mobile/src/components/DrawerHeader.tsx
+++ b/packages/mobile/src/components/DrawerHeader.tsx
@@ -1,10 +1,14 @@
-import { memo, useCallback, useState, type ReactNode } from 'react';
+import { memo, useCallback, useEffect, useState, type ReactNode } from 'react';
 import { View, StyleSheet, type LayoutChangeEvent } from 'react-native';
 import { spacing } from '../theme/tokens';
 
 // Default width of the trailing slot (and the matching leading spacer) so the
 // centered column stays optically centered before the trailing element measures.
 const DEFAULT_TRAILING_MIN_WIDTH: number = spacing[12];
+
+export function resolveDrawerHeaderTrailingWidth(layoutWidth: number, minWidth: number): number {
+  return Math.max(minWidth, Math.ceil(layoutWidth));
+}
 
 type DrawerHeaderProps = {
   /** Centered column content (e.g. title + subtitle, or a name input + counts). */
@@ -28,17 +32,24 @@ export const DrawerHeader = memo(function DrawerHeader({
 }: DrawerHeaderProps) {
   const [trailingWidth, setTrailingWidth] = useState(trailingMinWidth);
 
-  const handleTrailingLayout = useCallback((event: LayoutChangeEvent) => {
-    const measured = Math.ceil(event.nativeEvent.layout.width);
-    setTrailingWidth((previous) => (previous === measured ? previous : measured));
-  }, []);
+  useEffect(() => {
+    setTrailingWidth((previous) => (previous === trailingMinWidth ? previous : trailingMinWidth));
+  }, [trailingMinWidth]);
+
+  const handleTrailingLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const measured = resolveDrawerHeaderTrailingWidth(event.nativeEvent.layout.width, trailingMinWidth);
+      setTrailingWidth((previous) => (previous === measured ? previous : measured));
+    },
+    [trailingMinWidth],
+  );
 
   return (
     <View style={styles.container}>
       <View style={styles.headerRow}>
         <View style={[styles.leadingSpacer, { width: trailingWidth }]} />
         <View style={styles.centerColumn}>{center}</View>
-        <View style={[styles.trailing, { minWidth: trailingMinWidth }]} onLayout={handleTrailingLayout}>
+        <View style={[styles.trailing, { minWidth: trailingWidth }]} onLayout={handleTrailingLayout}>
           {trailing}
         </View>
       </View>

--- a/packages/mobile/src/components/DrawerHeader.tsx
+++ b/packages/mobile/src/components/DrawerHeader.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useState, type ReactNode } from 'react';
+import { memo, useCallback, useState, type ReactNode } from 'react';
 import { View, StyleSheet, type LayoutChangeEvent } from 'react-native';
 import { spacing } from '../theme/tokens';
 
@@ -9,6 +9,11 @@ const DEFAULT_TRAILING_MIN_WIDTH: number = spacing[12];
 export function resolveDrawerHeaderTrailingWidth(layoutWidth: number, minWidth: number): number {
   return Math.max(minWidth, Math.ceil(layoutWidth));
 }
+
+type TrailingMeasurement = {
+  minWidth: number;
+  width: number;
+};
 
 type DrawerHeaderProps = {
   /** Centered column content (e.g. title + subtitle, or a name input + counts). */
@@ -30,16 +35,21 @@ export const DrawerHeader = memo(function DrawerHeader({
   trailing,
   trailingMinWidth = DEFAULT_TRAILING_MIN_WIDTH,
 }: DrawerHeaderProps) {
-  const [trailingWidth, setTrailingWidth] = useState(trailingMinWidth);
-
-  useEffect(() => {
-    setTrailingWidth((previous) => (previous === trailingMinWidth ? previous : trailingMinWidth));
-  }, [trailingMinWidth]);
+  const [trailingMeasurement, setTrailingMeasurement] = useState<TrailingMeasurement>({
+    minWidth: trailingMinWidth,
+    width: trailingMinWidth,
+  });
+  const mirroredTrailingWidth =
+    trailingMeasurement.minWidth === trailingMinWidth ? trailingMeasurement.width : trailingMinWidth;
 
   const handleTrailingLayout = useCallback(
     (event: LayoutChangeEvent) => {
       const measured = resolveDrawerHeaderTrailingWidth(event.nativeEvent.layout.width, trailingMinWidth);
-      setTrailingWidth((previous) => (previous === measured ? previous : measured));
+      setTrailingMeasurement((previous) =>
+        previous.minWidth === trailingMinWidth && previous.width === measured
+          ? previous
+          : { minWidth: trailingMinWidth, width: measured },
+      );
     },
     [trailingMinWidth],
   );
@@ -47,9 +57,9 @@ export const DrawerHeader = memo(function DrawerHeader({
   return (
     <View style={styles.container}>
       <View style={styles.headerRow}>
-        <View style={[styles.leadingSpacer, { width: trailingWidth }]} />
+        <View style={[styles.leadingSpacer, { width: mirroredTrailingWidth }]} />
         <View style={styles.centerColumn}>{center}</View>
-        <View style={[styles.trailing, { minWidth: trailingWidth }]} onLayout={handleTrailingLayout}>
+        <View style={[styles.trailing, { minWidth: trailingMinWidth }]} onLayout={handleTrailingLayout}>
           {trailing}
         </View>
       </View>

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -1,23 +1,30 @@
 import { memo, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { getSoftGradeColor } from '@boardsesh/play-view';
 import { formatSends, formatQuality } from '../../lib/format-climb-stats';
 import { Text } from '../Text';
 import { DrawerHeader } from '../DrawerHeader';
 import { ClimbAttributeIcons } from '../ClimbAttributeIcons';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
 
 const MIN_GRADE_COLUMN_WIDTH: number = spacing[12];
 const GRADE_COLUMN_CHARACTER_WIDTH: number = spacing[3];
 
-export function getInitialGradeColumnWidth(displayGrade: string): number {
+// First-render estimate only; DrawerHeader's runtime measurement remains authoritative.
+export function estimateInitialGradeColumnWidth(displayGrade: string): number {
   return Math.max(MIN_GRADE_COLUMN_WIDTH, displayGrade.length * GRADE_COLUMN_CHARACTER_WIDTH);
 }
 
-export function resolvePlayDrawerHeaderGradeColor(displayGrade: string, rawDifficulty?: string): string {
-  return getGradeColor(rawDifficulty ?? displayGrade) ?? DEFAULT_GRADE_COLOR;
+export function resolvePlayDrawerHeaderGradeColor(
+  displayGrade: string,
+  rawDifficulty?: string,
+  darkMode?: boolean,
+): string {
+  return getSoftGradeColor(rawDifficulty ?? displayGrade, darkMode) ?? DEFAULT_GRADE_COLOR;
 }
 
 type PlayDrawerHeaderProps = {
@@ -46,10 +53,11 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   benchmarkDifficulty,
 }: PlayDrawerHeaderProps) {
   const { t } = useTranslation('climbs');
-  const gradeColumnWidth = useMemo(() => getInitialGradeColumnWidth(difficulty), [difficulty]);
+  const { colorScheme } = useTheme();
+  const gradeColumnWidth = useMemo(() => estimateInitialGradeColumnWidth(difficulty), [difficulty]);
   const gradeColor = useMemo(
-    () => resolvePlayDrawerHeaderGradeColor(difficulty, rawDifficulty),
-    [rawDifficulty, difficulty],
+    () => resolvePlayDrawerHeaderGradeColor(difficulty, rawDifficulty, colorScheme === 'dark'),
+    [rawDifficulty, difficulty, colorScheme],
   );
 
   const subtitleParts: string[] = [];

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -7,6 +7,18 @@ import { Text } from '../Text';
 import { DrawerHeader } from '../DrawerHeader';
 import { ClimbAttributeIcons } from '../ClimbAttributeIcons';
 import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing } from '../../theme/tokens';
+
+const MIN_GRADE_COLUMN_WIDTH: number = spacing[12];
+const GRADE_COLUMN_CHARACTER_WIDTH: number = spacing[3];
+
+export function getInitialGradeColumnWidth(displayGrade: string): number {
+  return Math.max(MIN_GRADE_COLUMN_WIDTH, displayGrade.length * GRADE_COLUMN_CHARACTER_WIDTH);
+}
+
+export function resolvePlayDrawerHeaderGradeColor(displayGrade: string, rawDifficulty?: string): string {
+  return getGradeColor(rawDifficulty ?? displayGrade) ?? DEFAULT_GRADE_COLOR;
+}
 
 type PlayDrawerHeaderProps = {
   name: string;
@@ -34,8 +46,9 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   benchmarkDifficulty,
 }: PlayDrawerHeaderProps) {
   const { t } = useTranslation('climbs');
+  const gradeColumnWidth = useMemo(() => getInitialGradeColumnWidth(difficulty), [difficulty]);
   const gradeColor = useMemo(
-    () => getGradeColor(rawDifficulty ?? difficulty) ?? DEFAULT_GRADE_COLOR,
+    () => resolvePlayDrawerHeaderGradeColor(difficulty, rawDifficulty),
     [rawDifficulty, difficulty],
   );
 
@@ -65,6 +78,7 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
           {difficulty}
         </Text>
       }
+      trailingMinWidth={gradeColumnWidth}
     />
   );
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DEFAULT_GRADE_COLOR, getGradeColor } from '@boardsesh/board-constants/grade-colors';
+import { spacing } from '../../../theme/tokens';
+import { resolveDrawerHeaderTrailingWidth } from '../../DrawerHeader';
+import { getInitialGradeColumnWidth, resolvePlayDrawerHeaderGradeColor } from '../PlayDrawerHeader';
+
+vi.mock('react-native', () => ({
+  View: 'View',
+  PlatformColor: (colorName: string): string => colorName,
+  Platform: {
+    OS: 'ios',
+  },
+  StyleSheet: {
+    create: <Styles extends Record<string, unknown>>(styles: Styles): Styles => styles,
+  },
+}));
+
+vi.mock('../../Text', () => ({
+  Text: 'Text',
+}));
+
+describe('resolveDrawerHeaderTrailingWidth', () => {
+  it('clamps measured widths to the minimum grade column width', () => {
+    expect(resolveDrawerHeaderTrailingWidth(spacing[4], spacing[12])).toBe(spacing[12]);
+  });
+
+  it('rounds measured widths up before storing them', () => {
+    expect(resolveDrawerHeaderTrailingWidth(spacing[12] + 0.25, spacing[12])).toBe(spacing[12] + 1);
+  });
+
+  it('keeps measured widths wider than the minimum', () => {
+    expect(resolveDrawerHeaderTrailingWidth(spacing[16], spacing[12])).toBe(spacing[16]);
+  });
+});
+
+describe('getInitialGradeColumnWidth', () => {
+  it('uses the minimum width for compact grade labels', () => {
+    expect(getInitialGradeColumnWidth('V3')).toBe(spacing[12]);
+  });
+
+  it('reserves wider columns for long grade labels before layout fires', () => {
+    expect(getInitialGradeColumnWidth('6c+/V5')).toBeGreaterThan(spacing[12]);
+  });
+});
+
+describe('resolvePlayDrawerHeaderGradeColor', () => {
+  it('uses raw difficulty when the displayed grade is user-formatted', () => {
+    expect(resolvePlayDrawerHeaderGradeColor('V5', '6c+/V5')).toBe(getGradeColor('6c+/V5'));
+  });
+
+  it('falls back to the default grade color when no grade color matches', () => {
+    expect(resolvePlayDrawerHeaderGradeColor('Project')).toBe(DEFAULT_GRADE_COLOR);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header.test.ts
@@ -1,11 +1,53 @@
-import { describe, expect, it, vi } from 'vitest';
-import { DEFAULT_GRADE_COLOR, getGradeColor } from '@boardsesh/board-constants/grade-colors';
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { act, render } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { getSoftGradeColor } from '@boardsesh/play-view';
 import { spacing } from '../../../theme/tokens';
-import { resolveDrawerHeaderTrailingWidth } from '../../DrawerHeader';
-import { getInitialGradeColumnWidth, resolvePlayDrawerHeaderGradeColor } from '../PlayDrawerHeader';
+import { DrawerHeader, resolveDrawerHeaderTrailingWidth } from '../../DrawerHeader';
+import { estimateInitialGradeColumnWidth, resolvePlayDrawerHeaderGradeColor } from '../PlayDrawerHeader';
+
+type MockLayoutEvent = {
+  nativeEvent: {
+    layout: {
+      width: number;
+    };
+  };
+};
+
+type MockViewProps = {
+  children?: ReactNode;
+  onLayout?: (event: MockLayoutEvent) => void;
+  style?: unknown;
+};
+
+const viewMockState = vi.hoisted(() => ({
+  views: [] as Array<Pick<MockViewProps, 'onLayout' | 'style'>>,
+}));
 
 vi.mock('react-native', () => ({
-  View: 'View',
+  View: ({ children, onLayout, style }: MockViewProps) => {
+    viewMockState.views.push({ onLayout, style });
+    const styleList = Array.isArray(style) ? style : [style];
+    const flattenedStyle = Object.assign({}, ...styleList.filter(Boolean)) as {
+      minWidth?: number;
+      width?: number;
+    };
+
+    return createElement(
+      'div',
+      {
+        'data-min-width': flattenedStyle.minWidth == null ? undefined : String(flattenedStyle.minWidth),
+        'data-width': flattenedStyle.width == null ? undefined : String(flattenedStyle.width),
+      },
+      children,
+    );
+  },
+  Appearance: {
+    setColorScheme: vi.fn(),
+  },
+  useColorScheme: () => 'light',
   PlatformColor: (colorName: string): string => colorName,
   Platform: {
     OS: 'ios',
@@ -18,6 +60,44 @@ vi.mock('react-native', () => ({
 vi.mock('../../Text', () => ({
   Text: 'Text',
 }));
+
+vi.mock('../../ClimbAttributeIcons', () => ({
+  ClimbAttributeIcons: () => null,
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ colorScheme: 'light' }),
+}));
+
+beforeEach(() => {
+  viewMockState.views = [];
+});
+
+function getLatestTrailingLayoutHandler(): (event: MockLayoutEvent) => void {
+  const trailingView = [...viewMockState.views].reverse().find((view) => view.onLayout);
+  const layoutHandler = trailingView?.onLayout;
+  expect(layoutHandler).toBeTypeOf('function');
+  if (!layoutHandler) {
+    throw new Error('Expected DrawerHeader trailing View to expose an onLayout handler');
+  }
+  return layoutHandler;
+}
+
+function getNumericAttribute(container: HTMLElement, selector: string, attribute: string): number {
+  const element = container.querySelector(selector);
+  expect(element).not.toBeNull();
+  const rawValue = element?.getAttribute(attribute);
+  expect(rawValue).not.toBeNull();
+  return Number(rawValue);
+}
+
+function getLeadingSpacerWidth(container: HTMLElement): number {
+  return getNumericAttribute(container, '[data-width]', 'data-width');
+}
+
+function getTrailingSlotMinWidth(container: HTMLElement): number {
+  return getNumericAttribute(container, '[data-min-width]:not([data-min-width="0"])', 'data-min-width');
+}
 
 describe('resolveDrawerHeaderTrailingWidth', () => {
   it('clamps measured widths to the minimum grade column width', () => {
@@ -33,19 +113,89 @@ describe('resolveDrawerHeaderTrailingWidth', () => {
   });
 });
 
-describe('getInitialGradeColumnWidth', () => {
+describe('DrawerHeader layout measurement', () => {
+  it('lets the mirrored spacer shrink after a wider trailing measurement', () => {
+    const { container, rerender } = render(
+      createElement(DrawerHeader, {
+        center: 'Moon Dance',
+        trailing: 'V16',
+        trailingMinWidth: spacing[12],
+      }),
+    );
+
+    expect(getLeadingSpacerWidth(container)).toBe(spacing[12]);
+    expect(getTrailingSlotMinWidth(container)).toBe(spacing[12]);
+
+    act(() => {
+      getLatestTrailingLayoutHandler()({ nativeEvent: { layout: { width: spacing[16] } } });
+    });
+
+    expect(getLeadingSpacerWidth(container)).toBe(spacing[16]);
+    expect(getTrailingSlotMinWidth(container)).toBe(spacing[12]);
+
+    viewMockState.views = [];
+    rerender(
+      createElement(DrawerHeader, {
+        center: 'Moon Dance',
+        trailing: 'V3',
+        trailingMinWidth: spacing[12],
+      }),
+    );
+
+    act(() => {
+      getLatestTrailingLayoutHandler()({ nativeEvent: { layout: { width: spacing[12] } } });
+    });
+
+    expect(getLeadingSpacerWidth(container)).toBe(spacing[12]);
+    expect(getTrailingSlotMinWidth(container)).toBe(spacing[12]);
+  });
+
+  it('ignores stale measured width when the minimum width changes', () => {
+    const { container, rerender } = render(
+      createElement(DrawerHeader, {
+        center: 'Moon Dance',
+        trailing: '8B+/V14',
+        trailingMinWidth: spacing[16],
+      }),
+    );
+
+    act(() => {
+      getLatestTrailingLayoutHandler()({ nativeEvent: { layout: { width: spacing[16] + spacing[4] } } });
+    });
+
+    expect(getLeadingSpacerWidth(container)).toBe(spacing[16] + spacing[4]);
+
+    viewMockState.views = [];
+    rerender(
+      createElement(DrawerHeader, {
+        center: 'Moon Dance',
+        trailing: 'V3',
+        trailingMinWidth: spacing[12],
+      }),
+    );
+
+    expect(getLeadingSpacerWidth(container)).toBe(spacing[12]);
+    expect(getTrailingSlotMinWidth(container)).toBe(spacing[12]);
+  });
+});
+
+describe('estimateInitialGradeColumnWidth', () => {
   it('uses the minimum width for compact grade labels', () => {
-    expect(getInitialGradeColumnWidth('V3')).toBe(spacing[12]);
+    expect(estimateInitialGradeColumnWidth('V3')).toBe(spacing[12]);
   });
 
   it('reserves wider columns for long grade labels before layout fires', () => {
-    expect(getInitialGradeColumnWidth('6c+/V5')).toBeGreaterThan(spacing[12]);
+    expect(estimateInitialGradeColumnWidth('6c+/V5')).toBeGreaterThan(spacing[12]);
   });
 });
 
 describe('resolvePlayDrawerHeaderGradeColor', () => {
   it('uses raw difficulty when the displayed grade is user-formatted', () => {
-    expect(resolvePlayDrawerHeaderGradeColor('V5', '6c+/V5')).toBe(getGradeColor('6c+/V5'));
+    expect(resolvePlayDrawerHeaderGradeColor('V5', '6c+/V5')).toBe(getSoftGradeColor('6c+/V5'));
+  });
+
+  it('uses the dark-mode softened grade color when requested', () => {
+    expect(resolvePlayDrawerHeaderGradeColor('V5', '6c+/V5', true)).toBe(getSoftGradeColor('6c+/V5', true));
   });
 
   it('falls back to the default grade color when no grade color matches', () => {


### PR DESCRIPTION
## What changed

- Clamp `DrawerHeader` trailing measurements before mirroring them into the leading spacer.
- Keep the trailing slot's own minimum width at the configured floor so measured widths can grow and shrink without ratcheting stale spacing.
- Let `PlayDrawerHeader` seed the trailing slot width from the displayed grade label so wider grades reserve enough space on first mount.
- Use the softened grade foreground color for better contrast on the play drawer header.
- Add focused mobile coverage for width clamping, mounted grow/shrink behavior, stale minimum changes, initial grade width, and grade color resolution.

## Why

The play drawer title could shift after the first layout event when the rendered grade label was wider than the default spacer. The spacer now starts from a grade-aware width, measured updates keep the same minimum floor defensively, and the trailing slot no longer forces its old measured width back into future measurements.

## Validation

- `vp test run --config vite.config.ts src/components/play-drawer/__tests__/play-drawer-header.test.ts`
- `vp fmt packages/mobile/src/components/DrawerHeader.tsx packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx packages/mobile/src/components/play-drawer/__tests__/play-drawer-header.test.ts --check`
- `vp run typecheck:mobile`

Note: full `vp check` and `vp lint` are currently blocked by unrelated pre-existing repo-wide formatting/lint findings outside this PR's changed files.