### PR TITLE
[codex] document wall confirm and widget drift guardrails

### DIFF
--- a/packages/mobile/modules/live-activity/README.md
+++ b/packages/mobile/modules/live-activity/README.md
@@ -44,6 +44,7 @@ the files listed below have **byte-identical copies** in both folders:
 - `ClimbSessionAttributes.swift`
 - `SharedConstants.swift`
 - `SharedKeychain.swift`
+- `TakeControlIntent.swift`
 - `WidgetNetworking.swift`
 
 When you change one, change the other. The

--- a/packages/shared/play-view/src/wall-confirm-fallback.ts
+++ b/packages/shared/play-view/src/wall-confirm-fallback.ts
@@ -1,11 +1,13 @@
 /**
  * Shared controller for the wall-confirm fallback flow used by web and mobile.
  *
- * When a user claims the wall, both platforms wait briefly for a
- * WallConfirmedClimb event. If no confirm arrives, this controller decides
- * whether to skip fallback, auto-connect to the last board, or open the board
- * picker. Platform-specific BLE, native-shell, and event-bus dependencies are
- * injected so the timer/listener logic stays in one place.
+ * This logic was extracted from the original web hook and made
+ * platform-neutral for React Native by injecting BLE, native-shell, timer, and
+ * event-bus dependencies. When a user claims the wall, both platforms wait
+ * briefly for a WallConfirmedClimb event. If no confirm arrives, this
+ * controller decides whether to skip fallback, auto-connect to the last board,
+ * or open the board picker so web and mobile do not each carry their own
+ * timer/listener/fallback implementation.
  */
 export const WALL_CONFIRM_TIMEOUT_MS = 2000;
 


### PR DESCRIPTION
## Summary

- Clarify that the shared wall-confirm fallback controller was extracted from the web hook and made platform-neutral through injected dependencies.
- Add `TakeControlIntent.swift` to the Live Activity README's duplicated widget Swift file list so the docs match the existing drift test guardrail.

## Validation

- `vp test run packages/shared/queue-runtime/src/__tests__/wall-control-optimistic.test.ts packages/shared/play-view/src/__tests__/wall-confirm-fallback.test.ts packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx packages/mobile/src/components/play-drawer/__tests__/use-wall-confirm-fallback.test.tsx packages/web/app/components/play-view/__tests__/use-wall-confirm-fallback.test.tsx packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts`
- `vp run typecheck`
- `vp fmt --check packages/shared/play-view/src/wall-confirm-fallback.ts packages/mobile/modules/live-activity/README.md`

Note: `vp check` was run and hit unrelated pre-existing formatting issues outside these two edited files.