### PR TITLE
Add Waveshare 2.16 AMOLED thumbnail firmware

### DIFF
--- a/embedded/libs/esp-web-server/src/esp_web_server.cpp
+++ b/embedded/libs/esp-web-server/src/esp_web_server.cpp
@@ -1,5 +1,7 @@
 #include "esp_web_server.h"
 
+#include <config/board_config.h>
+
 // Firmware version macros - provided by build flags or version.h in the project
 #ifndef FIRMWARE_VERSION
 #define FIRMWARE_VERSION "dev"
@@ -223,6 +225,8 @@ void ESPWebServer::handleRoot() {
                 <input type="text" id="backendPath" placeholder="/graphql">
             </div>
         </div>
+        <label>Render URL</label>
+        <input type="text" id="renderBaseUrl" placeholder="https://www.boardsesh.com">
     </div>
 
     <div class="card">
@@ -264,6 +268,7 @@ void ESPWebServer::handleRoot() {
                 document.getElementById('backendHost').value = cfg.backend_host || '';
                 document.getElementById('backendPort').value = cfg.backend_port || 443;
                 document.getElementById('backendPath').value = cfg.backend_path || '/graphql';
+                document.getElementById('renderBaseUrl').value = cfg.render_base_url || 'https://www.boardsesh.com';
                 document.getElementById('proxyEnabled').checked = cfg.proxy_enabled || false;
                 document.getElementById('proxyMac').value = cfg.proxy_mac || '';
                 document.getElementById('proxyMacSection').style.display = cfg.proxy_enabled ? 'block' : 'none';
@@ -342,6 +347,7 @@ void ESPWebServer::handleRoot() {
                 backend_host: document.getElementById('backendHost').value,
                 backend_port: parseInt(document.getElementById('backendPort').value),
                 backend_path: document.getElementById('backendPath').value,
+                render_base_url: document.getElementById('renderBaseUrl').value,
                 proxy_enabled: document.getElementById('proxyEnabled').checked,
                 proxy_mac: document.getElementById('proxyMac').value
             };
@@ -496,6 +502,7 @@ void ESPWebServer::handleGetConfig() {
     doc["backend_host"] = Config.getString("backend_host");
     doc["backend_port"] = Config.getInt("backend_port", 443);
     doc["backend_path"] = Config.getString("backend_path", "/graphql");
+    doc["render_base_url"] = Config.getString("render_base_url", DEFAULT_RENDER_BASE_URL);
     doc["device_name"] = Config.getString("device_name", "Boardsesh Controller");
     doc["brightness"] = Config.getInt("brightness", 128);
     doc["display_brightness"] = Config.getInt("disp_br", 128);
@@ -532,6 +539,9 @@ void ESPWebServer::handleSetConfig() {
     }
     if (doc["backend_path"].is<const char*>()) {
         Config.setString("backend_path", doc["backend_path"]);
+    }
+    if (doc["render_base_url"].is<const char*>()) {
+        Config.setString("render_base_url", doc["render_base_url"]);
     }
     if (doc["device_name"].is<const char*>()) {
         Config.setString("device_name", doc["device_name"]);

--- a/embedded/libs/thumbnail-client/library.json
+++ b/embedded/libs/thumbnail-client/library.json
@@ -1,0 +1,22 @@
+{
+  "name": "thumbnail-client",
+  "version": "1.0.0",
+  "description": "Backend board-render thumbnail URL builder and fetcher for Boardsesh controller firmware",
+  "keywords": ["esp32", "thumbnail", "boardsesh", "board-render"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marcodejongh/boardsesh.git"
+  },
+  "authors": [
+    {
+      "name": "Boardsesh",
+      "email": "hello@boardsesh.com"
+    }
+  ],
+  "license": "MIT",
+  "frameworks": "arduino",
+  "platforms": ["espressif32", "native"],
+  "dependencies": {
+    "log-buffer": "*"
+  }
+}

--- a/embedded/libs/thumbnail-client/src/thumbnail_client.cpp
+++ b/embedded/libs/thumbnail-client/src/thumbnail_client.cpp
@@ -1,0 +1,489 @@
+#include "thumbnail_client.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <config/board_config.h>
+#include <log_buffer.h>
+
+#include <utility>
+
+#ifndef UNIT_TEST
+#include <HTTPClient.h>
+#include <WiFiClient.h>
+#include <WiFiClientSecure.h>
+#endif
+
+namespace {
+
+bool startsWithLiteral(const char* value, const char* prefix) {
+    if (!value || !prefix) return false;
+    return strncmp(value, prefix, strlen(prefix)) == 0;
+}
+
+void stripPathAfterAuthority(char* value) {
+    if (!value) return;
+
+    char* schemeEnd = strstr(value, "://");
+    if (!schemeEnd) return;
+
+    char* authorityStart = schemeEnd + 3;
+    char* pathStart = strchr(authorityStart, '/');
+    if (pathStart) {
+        *pathStart = '\0';
+    }
+}
+
+void copyTrimmed(const char* source, char* dest, size_t destSize) {
+    if (!dest || destSize == 0) return;
+    dest[0] = '\0';
+    if (!source) return;
+
+    const char* start = source;
+    while (*start && isspace(static_cast<unsigned char>(*start))) {
+        start++;
+    }
+
+    const char* end = source + strlen(source);
+    while (end > start && isspace(static_cast<unsigned char>(*(end - 1)))) {
+        end--;
+    }
+
+    size_t len = static_cast<size_t>(end - start);
+    while (len > 0 && start[len - 1] == '/') {
+        len--;
+    }
+
+    if (len >= destSize) {
+        len = destSize - 1;
+    }
+    memcpy(dest, start, len);
+    dest[len] = '\0';
+}
+
+bool copySegment(const char* start, size_t len, char* dest, size_t destSize) {
+    if (!dest || destSize == 0 || len == 0 || len >= destSize) return false;
+    memcpy(dest, start, len);
+    dest[len] = '\0';
+    return true;
+}
+
+bool parseIntegerSegment(const char* value, int& output) {
+    if (!value || value[0] == '\0') return false;
+    char* end = nullptr;
+    long parsed = strtol(value, &end, 10);
+    if (!end || *end != '\0') return false;
+    output = static_cast<int>(parsed);
+    return true;
+}
+
+void sortSetIds(char* setIds) {
+    if (!setIds || setIds[0] == '\0') return;
+
+    static const int MAX_SET_IDS = 16;
+    int parsedSetIds[MAX_SET_IDS];
+    int parsedSetCount = 0;
+
+    const char* cursor = setIds;
+    while (*cursor && parsedSetCount < MAX_SET_IDS) {
+        char* end = nullptr;
+        long parsed = strtol(cursor, &end, 10);
+        if (end == cursor) {
+            return;
+        }
+        parsedSetIds[parsedSetCount++] = static_cast<int>(parsed);
+        cursor = end;
+        if (*cursor == ',') {
+            cursor++;
+        } else if (*cursor != '\0') {
+            return;
+        }
+    }
+
+    if (parsedSetCount == 0) return;
+
+    for (int i = 1; i < parsedSetCount; i++) {
+        int currentSetId = parsedSetIds[i];
+        int sortIndex = i - 1;
+        while (sortIndex >= 0 && parsedSetIds[sortIndex] > currentSetId) {
+            parsedSetIds[sortIndex + 1] = parsedSetIds[sortIndex];
+            sortIndex--;
+        }
+        parsedSetIds[sortIndex + 1] = currentSetId;
+    }
+
+    char sortedSetIds[64];
+    sortedSetIds[0] = '\0';
+    size_t used = 0;
+    for (int i = 0; i < parsedSetCount; i++) {
+        int written = snprintf(sortedSetIds + used, sizeof(sortedSetIds) - used,
+                               "%s%d", i == 0 ? "" : ",", parsedSetIds[i]);
+        if (written < 0 || static_cast<size_t>(written) >= sizeof(sortedSetIds) - used) {
+            return;
+        }
+        used += static_cast<size_t>(written);
+    }
+
+    strncpy(setIds, sortedSetIds, 63);
+    setIds[63] = '\0';
+}
+
+bool isQuerySafe(char value) {
+    unsigned char c = static_cast<unsigned char>(value);
+    return isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~';
+}
+
+void appendQueryPair(String& url, const char* key, const char* value, bool& hasQuery) {
+    url += hasQuery ? "&" : "?";
+    hasQuery = true;
+    url += key;
+    url += "=";
+    url += urlEncodeQueryValue(value);
+}
+
+void clearThumbnail(const RemoteThumbnailDisplayHooks& hooks) {
+    if (hooks.clearThumbnail) {
+        hooks.clearThumbnail(hooks.context);
+    }
+}
+
+void showClimb(const RemoteThumbnailDisplayRequest& request, const RemoteThumbnailDisplayHooks& hooks) {
+    if (!hooks.showClimb) return;
+    hooks.showClimb(hooks.context,
+                    request.climbName,
+                    request.climbGrade ? request.climbGrade : "",
+                    request.gradeColor ? request.gradeColor : "",
+                    request.angle,
+                    request.climbUuid ? request.climbUuid : "",
+                    request.boardTypeName ? request.boardTypeName : "kilter");
+}
+
+void showThumbnailLoading(const RemoteThumbnailDisplayHooks& hooks) {
+    if (hooks.showThumbnailLoading) {
+        hooks.showThumbnailLoading(hooks.context);
+    }
+}
+
+void setThumbnailJpeg(const RemoteThumbnailDisplayHooks& hooks, std::vector<uint8_t>&& data, const char* cacheKey) {
+    if (hooks.setThumbnailJpeg) {
+        hooks.setThumbnailJpeg(hooks.context, std::move(data), cacheKey);
+    }
+}
+
+ThumbnailFetchResult fetchThumbnailJpeg(const RemoteThumbnailDisplayHooks& hooks,
+                                        const char* url,
+                                        std::vector<uint8_t>& output) {
+    if (!hooks.fetchJpeg) {
+        return ThumbnailFetchResult(ThumbnailFetchStatus::NETWORK_ERROR);
+    }
+    return hooks.fetchJpeg(hooks.context, url, output);
+}
+
+#ifndef UNIT_TEST
+bool isHttpsUrl(const char* url) {
+    return startsWithLiteral(url, "https://");
+}
+#endif
+
+}  // namespace
+
+bool parseBoardRenderRoute(const char* boardPath, BoardRenderRoute& route) {
+    memset(&route, 0, sizeof(route));
+    route.layoutId = -1;
+    route.sizeId = -1;
+
+    if (!boardPath || boardPath[0] == '\0') return false;
+
+    const char* cursor = boardPath;
+    while (*cursor == '/') {
+        cursor++;
+    }
+
+    char segments[5][64];
+    memset(segments, 0, sizeof(segments));
+    int segmentCount = 0;
+    const char* segmentStart = cursor;
+
+    while (*cursor && segmentCount < 5) {
+        if (*cursor == '/') {
+            size_t segmentLen = static_cast<size_t>(cursor - segmentStart);
+            if (segmentLen > 0) {
+                if (!copySegment(segmentStart, segmentLen, segments[segmentCount], sizeof(segments[segmentCount]))) {
+                    return false;
+                }
+                segmentCount++;
+            }
+            segmentStart = cursor + 1;
+        }
+        cursor++;
+    }
+
+    if (segmentCount < 5 && cursor > segmentStart) {
+        size_t segmentLen = static_cast<size_t>(cursor - segmentStart);
+        if (!copySegment(segmentStart, segmentLen, segments[segmentCount], sizeof(segments[segmentCount]))) {
+            return false;
+        }
+        segmentCount++;
+    }
+
+    int offset = 0;
+    if (segmentCount >= 5 && strlen(segments[0]) == 2 && islower(segments[0][0]) && islower(segments[0][1])) {
+        offset = 1;
+    }
+
+    if (segmentCount - offset < 4) return false;
+
+    if (!copySegment(segments[offset], strlen(segments[offset]), route.boardName, sizeof(route.boardName))) {
+        return false;
+    }
+    if (!parseIntegerSegment(segments[offset + 1], route.layoutId)) return false;
+    if (!parseIntegerSegment(segments[offset + 2], route.sizeId)) return false;
+    if (!copySegment(segments[offset + 3], strlen(segments[offset + 3]), route.setIds, sizeof(route.setIds))) {
+        return false;
+    }
+    sortSetIds(route.setIds);
+
+    return route.boardName[0] != '\0' && route.setIds[0] != '\0';
+}
+
+String normalizeRenderBaseUrl(const char* baseUrl) {
+    char trimmed[160];
+    copyTrimmed(baseUrl, trimmed, sizeof(trimmed));
+
+    if (trimmed[0] == '\0') {
+        copyTrimmed(DEFAULT_RENDER_BASE_URL, trimmed, sizeof(trimmed));
+    }
+    stripPathAfterAuthority(trimmed);
+
+    if (startsWithLiteral(trimmed, "wss://")) {
+        String normalized = "https://";
+        normalized += trimmed + 6;
+        return normalized;
+    }
+    if (startsWithLiteral(trimmed, "ws://")) {
+        String normalized = "http://";
+        normalized += trimmed + 5;
+        return normalized;
+    }
+    if (startsWithLiteral(trimmed, "https://") || startsWithLiteral(trimmed, "http://")) {
+        return String(trimmed);
+    }
+
+    String normalized = "https://";
+    normalized += trimmed;
+    return normalized;
+}
+
+String urlEncodeQueryValue(const char* value) {
+    static const char HEX_DIGITS[] = "0123456789ABCDEF";
+
+    String encoded;
+    if (!value) return encoded;
+
+    for (const char* cursor = value; *cursor; cursor++) {
+        unsigned char current = static_cast<unsigned char>(*cursor);
+        if (isQuerySafe(*cursor)) {
+            encoded += *cursor;
+        } else {
+            encoded += "%";
+            encoded += HEX_DIGITS[(current >> 4) & 0x0F];
+            encoded += HEX_DIGITS[current & 0x0F];
+        }
+    }
+
+    return encoded;
+}
+
+String buildBoardRenderThumbnailUrl(const char* renderBaseUrl,
+                                    const char* boardPath,
+                                    const char* frames,
+                                    const ThumbnailUrlOptions& options) {
+    BoardRenderRoute route;
+    if (!parseBoardRenderRoute(boardPath, route)) {
+        return "";
+    }
+
+    String url = normalizeRenderBaseUrl(renderBaseUrl);
+    url += "/api/internal/board-render";
+
+    bool hasQuery = false;
+    appendQueryPair(url, "board_name", route.boardName, hasQuery);
+    appendQueryPair(url, "layout_id", String(route.layoutId).c_str(), hasQuery);
+    appendQueryPair(url, "size_id", String(route.sizeId).c_str(), hasQuery);
+    appendQueryPair(url, "set_ids", route.setIds, hasQuery);
+    appendQueryPair(url, "frames", frames ? frames : "", hasQuery);
+    if (options.thumbnail) {
+        appendQueryPair(url, "thumbnail", "1", hasQuery);
+    }
+    if (options.includeBackground) {
+        appendQueryPair(url, "include_background", "1", hasQuery);
+    }
+    appendQueryPair(url, "format", options.format ? options.format : "jpg", hasQuery);
+
+    return url;
+}
+
+const char* thumbnailFetchStatusName(ThumbnailFetchStatus status) {
+    switch (status) {
+        case ThumbnailFetchStatus::OK:
+            return "ok";
+        case ThumbnailFetchStatus::INVALID_URL:
+            return "invalid_url";
+        case ThumbnailFetchStatus::HTTP_ERROR:
+            return "http_error";
+        case ThumbnailFetchStatus::BODY_TOO_LARGE:
+            return "body_too_large";
+        case ThumbnailFetchStatus::EMPTY_BODY:
+            return "empty_body";
+        case ThumbnailFetchStatus::NETWORK_ERROR:
+            return "network_error";
+        case ThumbnailFetchStatus::UNSUPPORTED_IN_TEST:
+            return "unsupported_in_test";
+        default:
+            return "unknown";
+    }
+}
+
+bool thumbnailUrlMatchesCache(const char* thumbnailUrl, const char* currentCacheKey) {
+    return thumbnailUrl && currentCacheKey && thumbnailUrl[0] != '\0' && strcmp(thumbnailUrl, currentCacheKey) == 0;
+}
+
+RemoteThumbnailDisplayResult handleRemoteThumbnailDisplay(const RemoteThumbnailDisplayRequest& request,
+                                                          const RemoteThumbnailDisplayHooks& hooks,
+                                                          String& currentCacheKey) {
+    if (!request.boardPath || request.boardPath[0] == '\0' || !request.frames || request.frames[0] == '\0') {
+        currentCacheKey = "";
+        clearThumbnail(hooks);
+        return RemoteThumbnailDisplayResult::FALLBACK_REQUIRED;
+    }
+
+    String thumbnailUrl = buildBoardRenderThumbnailUrl(request.renderBaseUrl, request.boardPath, request.frames);
+    if (thumbnailUrl.length() == 0) {
+        currentCacheKey = "";
+        clearThumbnail(hooks);
+        return RemoteThumbnailDisplayResult::FALLBACK_REQUIRED;
+    }
+
+    if (thumbnailUrlMatchesCache(thumbnailUrl.c_str(), currentCacheKey.c_str())) {
+        return RemoteThumbnailDisplayResult::CACHE_HIT;
+    }
+
+    Logger.logln("Thumbnail: fetching render preview (%u chars)", (unsigned)thumbnailUrl.length());
+    showClimb(request, hooks);
+    showThumbnailLoading(hooks);
+
+    std::vector<uint8_t> jpegData;
+    ThumbnailFetchResult thumbnailResult = fetchThumbnailJpeg(hooks, thumbnailUrl.c_str(), jpegData);
+    if (thumbnailResult.ok()) {
+        currentCacheKey = thumbnailUrl;
+        Logger.logln("Thumbnail: fetched %u bytes", (unsigned)thumbnailResult.bytesRead);
+        setThumbnailJpeg(hooks, std::move(jpegData), currentCacheKey.c_str());
+        return RemoteThumbnailDisplayResult::FETCHED;
+    }
+
+    currentCacheKey = "";
+    clearThumbnail(hooks);
+    Logger.logln("Thumbnail: fetch failed (%s, http=%d)",
+                 thumbnailFetchStatusName(thumbnailResult.status), thumbnailResult.httpStatus);
+    showClimb(request, hooks);
+    return RemoteThumbnailDisplayResult::FETCH_FAILED;
+}
+
+ThumbnailClient::ThumbnailClient(size_t maxBytes) : _maxBytes(maxBytes) {}
+
+ThumbnailFetchResult ThumbnailClient::fetchJpeg(const char* url, std::vector<uint8_t>& output) {
+    output.clear();
+
+    if (!url || url[0] == '\0') {
+        return ThumbnailFetchResult(ThumbnailFetchStatus::INVALID_URL);
+    }
+
+#ifdef UNIT_TEST
+    return ThumbnailFetchResult(ThumbnailFetchStatus::UNSUPPORTED_IN_TEST);
+#else
+    HTTPClient http;
+    http.setTimeout(THUMBNAIL_HTTP_TIMEOUT_MS);
+    http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+
+    WiFiClient plainClient;
+    WiFiClientSecure secureClient;
+    bool beginOk = false;
+    if (isHttpsUrl(url)) {
+        // Arduino ESP32 does not ship with the public root CA bundle we need here.
+        // HTTPS still encrypts the JPEG request, but the user-configured render host
+        // is not certificate-validated; keep the response size cap and JPEG decoder
+        // choice conservative because this endpoint can be changed in device config.
+        secureClient.setInsecure();
+        beginOk = http.begin(secureClient, url);
+    } else {
+        beginOk = http.begin(plainClient, url);
+    }
+
+    if (!beginOk) {
+        Logger.logln("Thumbnail: invalid render URL: %s", url);
+        return ThumbnailFetchResult(ThumbnailFetchStatus::INVALID_URL);
+    }
+
+    http.addHeader("Connection", "close");
+
+    int httpStatus = http.GET();
+    if (httpStatus != HTTP_CODE_OK) {
+        Logger.logln("Thumbnail: HTTP %d fetching %s", httpStatus, url);
+        http.end();
+        return ThumbnailFetchResult(ThumbnailFetchStatus::HTTP_ERROR, httpStatus);
+    }
+
+    int contentLength = http.getSize();
+    if (contentLength > 0 && static_cast<size_t>(contentLength) > _maxBytes) {
+        Logger.logln("Thumbnail: image too large (%d bytes)", contentLength);
+        http.end();
+        return ThumbnailFetchResult(ThumbnailFetchStatus::BODY_TOO_LARGE, httpStatus);
+    }
+
+    output.reserve(contentLength > 0 ? static_cast<size_t>(contentLength) : 8192);
+    WiFiClient* stream = http.getStreamPtr();
+    uint8_t buffer[512];
+    size_t totalRead = 0;
+    unsigned long lastReadAt = millis();
+
+    while (http.connected() && (contentLength < 0 || totalRead < static_cast<size_t>(contentLength))) {
+        size_t availableBytes = stream->available();
+        if (availableBytes == 0) {
+            if (millis() - lastReadAt > THUMBNAIL_HTTP_TIMEOUT_MS) {
+                Logger.logln("Thumbnail: timed out while reading response");
+                break;
+            }
+            delay(1);
+            continue;
+        }
+
+        size_t readLimit = availableBytes < sizeof(buffer) ? availableBytes : sizeof(buffer);
+        int bytesRead = stream->readBytes(buffer, readLimit);
+        if (bytesRead <= 0) break;
+
+        totalRead += static_cast<size_t>(bytesRead);
+        if (totalRead > _maxBytes) {
+            output.clear();
+            http.end();
+            return ThumbnailFetchResult(ThumbnailFetchStatus::BODY_TOO_LARGE, httpStatus, totalRead);
+        }
+
+        output.insert(output.end(), buffer, buffer + bytesRead);
+        lastReadAt = millis();
+    }
+
+    http.end();
+
+    if (output.empty()) {
+        return ThumbnailFetchResult(ThumbnailFetchStatus::EMPTY_BODY, httpStatus, 0);
+    }
+
+    if (contentLength > 0 && totalRead < static_cast<size_t>(contentLength)) {
+        output.clear();
+        return ThumbnailFetchResult(ThumbnailFetchStatus::NETWORK_ERROR, httpStatus, totalRead);
+    }
+
+    return ThumbnailFetchResult(ThumbnailFetchStatus::OK, httpStatus, output.size());
+#endif
+}

--- a/embedded/libs/thumbnail-client/src/thumbnail_client.h
+++ b/embedded/libs/thumbnail-client/src/thumbnail_client.h
@@ -1,0 +1,108 @@
+#ifndef THUMBNAIL_CLIENT_H
+#define THUMBNAIL_CLIENT_H
+
+#include <Arduino.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <vector>
+
+#define THUMBNAIL_RENDER_BASE_KEY "render_base_url"
+#define THUMBNAIL_MAX_JPEG_BYTES 65536
+#define THUMBNAIL_HTTP_TIMEOUT_MS 4000
+
+struct BoardRenderRoute {
+    char boardName[24];
+    int layoutId;
+    int sizeId;
+    char setIds[64];
+};
+
+struct ThumbnailUrlOptions {
+    bool thumbnail;
+    bool includeBackground;
+    const char* format;
+
+    ThumbnailUrlOptions() : thumbnail(true), includeBackground(true), format("jpg") {}
+};
+
+enum class ThumbnailFetchStatus {
+    OK,
+    INVALID_URL,
+    HTTP_ERROR,
+    BODY_TOO_LARGE,
+    EMPTY_BODY,
+    NETWORK_ERROR,
+    UNSUPPORTED_IN_TEST
+};
+
+struct ThumbnailFetchResult {
+    ThumbnailFetchStatus status;
+    int httpStatus;
+    size_t bytesRead;
+
+    ThumbnailFetchResult(ThumbnailFetchStatus statusValue = ThumbnailFetchStatus::OK,
+                         int httpStatusValue = 0,
+                         size_t bytesReadValue = 0)
+        : status(statusValue), httpStatus(httpStatusValue), bytesRead(bytesReadValue) {}
+
+    bool ok() const { return status == ThumbnailFetchStatus::OK; }
+};
+
+struct RemoteThumbnailDisplayRequest {
+    const char* renderBaseUrl;
+    const char* boardPath;
+    const char* frames;
+    const char* climbName;
+    const char* climbGrade;
+    const char* gradeColor;
+    int angle;
+    const char* climbUuid;
+    const char* boardTypeName;
+};
+
+struct RemoteThumbnailDisplayHooks {
+    void* context;
+    void (*clearThumbnail)(void* context);
+    void (*showClimb)(void* context,
+                      const char* climbName,
+                      const char* climbGrade,
+                      const char* gradeColor,
+                      int angle,
+                      const char* climbUuid,
+                      const char* boardTypeName);
+    void (*showThumbnailLoading)(void* context);
+    void (*setThumbnailJpeg)(void* context, std::vector<uint8_t>&& data, const char* cacheKey);
+    ThumbnailFetchResult (*fetchJpeg)(void* context, const char* url, std::vector<uint8_t>& output);
+};
+
+enum class RemoteThumbnailDisplayResult {
+    FALLBACK_REQUIRED,
+    CACHE_HIT,
+    FETCHED,
+    FETCH_FAILED
+};
+
+bool parseBoardRenderRoute(const char* boardPath, BoardRenderRoute& route);
+String normalizeRenderBaseUrl(const char* baseUrl);
+String urlEncodeQueryValue(const char* value);
+String buildBoardRenderThumbnailUrl(const char* renderBaseUrl,
+                                    const char* boardPath,
+                                    const char* frames,
+                                    const ThumbnailUrlOptions& options = ThumbnailUrlOptions());
+const char* thumbnailFetchStatusName(ThumbnailFetchStatus status);
+bool thumbnailUrlMatchesCache(const char* thumbnailUrl, const char* currentCacheKey);
+RemoteThumbnailDisplayResult handleRemoteThumbnailDisplay(const RemoteThumbnailDisplayRequest& request,
+                                                          const RemoteThumbnailDisplayHooks& hooks,
+                                                          String& currentCacheKey);
+
+class ThumbnailClient {
+  public:
+    explicit ThumbnailClient(size_t maxBytes = THUMBNAIL_MAX_JPEG_BYTES);
+    ThumbnailFetchResult fetchJpeg(const char* url, std::vector<uint8_t>& output);
+
+  private:
+    size_t _maxBytes;
+};
+
+#endif  // THUMBNAIL_CLIENT_H

--- a/embedded/libs/waveshare-amoled-display/library.json
+++ b/embedded/libs/waveshare-amoled-display/library.json
@@ -1,0 +1,25 @@
+{
+  "name": "waveshare-amoled-display",
+  "version": "1.0.0",
+  "description": "Display driver and UI renderer for Waveshare ESP32-S3-Touch-AMOLED-2.16",
+  "keywords": ["esp32", "amoled", "display", "climbing", "boardsesh", "waveshare"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marcodejongh/boardsesh.git"
+  },
+  "authors": [
+    {
+      "name": "Boardsesh",
+      "email": "hello@boardsesh.com"
+    }
+  ],
+  "license": "MIT",
+  "frameworks": "arduino",
+  "platforms": "espressif32",
+  "dependencies": {
+    "display-base": "*",
+    "config-manager": "*",
+    "moononournation/GFX Library for Arduino": "^1.6.4",
+    "bitbank2/JPEGDEC": "^1.8.2"
+  }
+}

--- a/embedded/libs/waveshare-amoled-display/src/waveshare_amoled_display.cpp
+++ b/embedded/libs/waveshare-amoled-display/src/waveshare_amoled_display.cpp
@@ -1,0 +1,340 @@
+#include "waveshare_amoled_display.h"
+
+#include <Wire.h>
+#include <config_manager.h>
+#include <grade_colors.h>
+#include <utility>
+
+WaveshareAmoledDisplay Display;
+
+namespace {
+
+Arduino_GFX* g_jpegGfx = nullptr;
+
+int drawJpegBlock(JPEGDRAW* draw) {
+    if (!g_jpegGfx || !draw) return 0;
+    g_jpegGfx->draw16bitRGBBitmap(draw->x, draw->y, draw->pPixels, draw->iWidth, draw->iHeight);
+    return 1;
+}
+
+const char* safeText(const char* value, const char* fallback = "") {
+    return value && value[0] != '\0' ? value : fallback;
+}
+
+uint16_t statusColor(bool active) {
+    return active ? COLOR_STATUS_OK : COLOR_STATUS_OFF;
+}
+
+}  // namespace
+
+WaveshareAmoledDisplay::WaveshareAmoledDisplay()
+    : _bus(new Arduino_ESP32QSPI(AMOLED_LCD_CS,
+                                 AMOLED_LCD_SCLK,
+                                 AMOLED_LCD_SDIO0,
+                                 AMOLED_LCD_SDIO1,
+                                 AMOLED_LCD_SDIO2,
+                                 AMOLED_LCD_SDIO3)),
+      _gfx(new Arduino_CO5300(_bus,
+                              AMOLED_LCD_RESET,
+                              0,
+                              AMOLED_LCD_WIDTH,
+                              AMOLED_LCD_HEIGHT,
+                              0,
+                              0,
+                              0,
+                              0)),
+      _ready(false),
+      _hasThumbnail(false),
+      _thumbnailLoading(false) {}
+
+WaveshareAmoledDisplay::~WaveshareAmoledDisplay() {
+    delete _gfx;
+    delete _bus;
+}
+
+bool WaveshareAmoledDisplay::begin() {
+    Wire.begin(AMOLED_I2C_SDA, AMOLED_I2C_SCL);
+    _ready = false;
+
+    if (!_gfx || !_gfx->begin()) {
+        return false;
+    }
+
+    _bus->writeC8D8(0x36, 0xA0);
+    _gfx->fillScreen(COLOR_BACKGROUND);
+    _gfx->setBrightness(static_cast<uint8_t>(Config.getInt("disp_br", 180)));
+    _gfx->setTextWrap(false);
+
+    _gfx->fillScreen(0xF800);
+    delay(120);
+    _gfx->fillScreen(0x07E0);
+    delay(120);
+    _gfx->fillScreen(0x001F);
+    delay(120);
+    _gfx->fillScreen(COLOR_BACKGROUND);
+
+    _ready = true;
+    return true;
+}
+
+void WaveshareAmoledDisplay::showConnecting() {
+    if (!_ready) return;
+    _gfx->fillScreen(COLOR_BACKGROUND);
+    drawCenteredText("Boardsesh", 152, 3, COLOR_ACCENT);
+    drawCenteredText("Connecting...", 222, 2, COLOR_TEXT);
+    drawCenteredText("Waiting for WiFi and session", 258, 1, COLOR_TEXT_DIM);
+    drawStatusBar();
+}
+
+void WaveshareAmoledDisplay::showError(const char* message, const char* ipAddress) {
+    if (!_ready) return;
+    _gfx->fillScreen(COLOR_BACKGROUND);
+    drawCenteredText("Error", 150, 3, COLOR_STATUS_ERROR);
+    drawCenteredText(safeText(message, "Something went wrong"), 218, 2, COLOR_TEXT);
+    if (ipAddress && ipAddress[0] != '\0') {
+        drawCenteredText(ipAddress, 260, 1, COLOR_TEXT_DIM);
+    }
+    drawStatusBar();
+}
+
+void WaveshareAmoledDisplay::showConfigPortal(const char* apName, const char* ip) {
+    if (!_ready) return;
+    _gfx->fillScreen(COLOR_BACKGROUND);
+    drawCenteredText("WiFi Setup", 86, 3, COLOR_ACCENT);
+    drawCenteredText("Join this network", 154, 2, COLOR_TEXT);
+    drawCenteredText(safeText(apName, "Boardsesh Setup"), 202, 2, COLOR_STATUS_OK);
+    drawCenteredText("Then open", 282, 2, COLOR_TEXT);
+    drawCenteredText(safeText(ip, "192.168.4.1"), 328, 2, COLOR_ACCENT);
+}
+
+void WaveshareAmoledDisplay::showSetupScreen(const char* apName) {
+    showConfigPortal(apName, "192.168.4.1");
+}
+
+void WaveshareAmoledDisplay::showThumbnailLoading() {
+    if (!_ready) return;
+    _thumbnailJpeg.clear();
+    _thumbnailCacheKey = "";
+    _hasThumbnail = false;
+    _thumbnailLoading = true;
+    refresh();
+}
+
+void WaveshareAmoledDisplay::setThumbnailJpeg(const uint8_t* data, size_t len, const char* cacheKey) {
+    if (!_ready) return;
+    _thumbnailJpeg.clear();
+    _thumbnailCacheKey = cacheKey ? cacheKey : "";
+    _thumbnailLoading = false;
+
+    if (!data || len == 0) {
+        _hasThumbnail = false;
+        refresh();
+        return;
+    }
+
+    _thumbnailJpeg.assign(data, data + len);
+    _hasThumbnail = true;
+    refresh();
+}
+
+void WaveshareAmoledDisplay::setThumbnailJpeg(std::vector<uint8_t>&& data, const char* cacheKey) {
+    if (!_ready) return;
+    _thumbnailJpeg = std::move(data);
+    _thumbnailCacheKey = cacheKey ? cacheKey : "";
+    _thumbnailLoading = false;
+    _hasThumbnail = !_thumbnailJpeg.empty();
+    refresh();
+}
+
+void WaveshareAmoledDisplay::clearThumbnail() {
+    _thumbnailJpeg.clear();
+    _thumbnailCacheKey = "";
+    _hasThumbnail = false;
+    _thumbnailLoading = false;
+}
+
+void WaveshareAmoledDisplay::refresh() {
+    if (!_ready) return;
+    _gfx->fillScreen(COLOR_BACKGROUND);
+    drawStatusBar();
+
+    if (!_hasClimb) {
+        drawCenteredText("No climb selected", 188, 2, COLOR_TEXT);
+        drawCenteredText("Send a climb over Bluetooth", 232, 1, COLOR_TEXT_DIM);
+        drawFooter();
+        return;
+    }
+
+    drawClimbHeader();
+    drawThumbnailFrame();
+    drawFooter();
+}
+
+void WaveshareAmoledDisplay::refreshInfoOnly() {
+    refresh();
+}
+
+void WaveshareAmoledDisplay::onStatusChanged() {
+    if (!_ready) return;
+    drawStatusBar();
+}
+
+void WaveshareAmoledDisplay::drawStatusBar() {
+    _gfx->fillRect(0, 0, SCREEN_WIDTH, AMOLED_STATUS_BAR_HEIGHT, 0x1082);
+    _gfx->drawFastHLine(0, AMOLED_STATUS_BAR_HEIGHT - 1, SCREEN_WIDTH, 0x2945);
+
+    _gfx->setTextSize(1);
+    _gfx->setTextColor(COLOR_TEXT_DIM);
+    _gfx->setCursor(12, 11);
+    _gfx->print("Boardsesh");
+
+    int dotX = SCREEN_WIDTH - 114;
+    _gfx->fillCircle(dotX, 16, 5, statusColor(_wifiConnected));
+    _gfx->setCursor(dotX + 10, 11);
+    _gfx->print("W");
+
+    dotX += 36;
+    _gfx->fillCircle(dotX, 16, 5, statusColor(_backendConnected));
+    _gfx->setCursor(dotX + 10, 11);
+    _gfx->print("B");
+
+    dotX += 36;
+    _gfx->fillCircle(dotX, 16, 5, statusColor(_bleConnected));
+    _gfx->setCursor(dotX + 10, 11);
+    _gfx->print("BLE");
+}
+
+void WaveshareAmoledDisplay::drawClimbHeader() {
+    String displayName = _climbName;
+    if (displayName.length() == 0) {
+        displayName = "Unknown Climb";
+    }
+
+    drawTruncatedText(displayName.c_str(), 18, 44, 2, COLOR_TEXT, 28);
+
+    uint16_t gradeColor = DisplayBase::hexToRgb565(_gradeColor.c_str());
+    int badgeX = SCREEN_WIDTH - 86;
+    _gfx->fillRoundRect(badgeX, 42, 68, 28, 8, gradeColor);
+    _gfx->drawRoundRect(badgeX, 42, 68, 28, 8, 0xFFFF);
+    _gfx->setTextColor(COLOR_BACKGROUND);
+    _gfx->setTextSize(1);
+    const char* grade = _grade.length() > 0 ? _grade.c_str() : "?";
+    int gradeWidth = static_cast<int>(strlen(grade)) * 6;
+    _gfx->setCursor(badgeX + (68 - gradeWidth) / 2, 52);
+    _gfx->print(grade);
+}
+
+void WaveshareAmoledDisplay::drawThumbnailFrame() {
+    int frameX = (SCREEN_WIDTH - AMOLED_PREVIEW_SIZE) / 2;
+    _gfx->fillRoundRect(frameX - 6, AMOLED_PREVIEW_Y - 6,
+                        AMOLED_PREVIEW_SIZE + 12, AMOLED_PREVIEW_SIZE + 12,
+                        10, 0x0841);
+    _gfx->drawRoundRect(frameX - 6, AMOLED_PREVIEW_Y - 6,
+                        AMOLED_PREVIEW_SIZE + 12, AMOLED_PREVIEW_SIZE + 12,
+                        10, 0x4208);
+
+    if (_thumbnailLoading) {
+        drawCenteredText("Loading preview", AMOLED_PREVIEW_Y + 128, 2, COLOR_TEXT_DIM);
+        return;
+    }
+
+    if (!_hasThumbnail || _thumbnailJpeg.empty()) {
+        drawCenteredText("Preview unavailable", AMOLED_PREVIEW_Y + 128, 2, COLOR_TEXT_DIM);
+        return;
+    }
+
+    drawThumbnailImage();
+}
+
+void WaveshareAmoledDisplay::drawThumbnailImage() {
+    JPEGDEC jpeg;
+    if (!jpeg.openRAM(_thumbnailJpeg.data(), static_cast<int>(_thumbnailJpeg.size()), drawJpegBlock)) {
+        drawCenteredText("Preview decode failed", AMOLED_PREVIEW_Y + 128, 1, COLOR_STATUS_ERROR);
+        return;
+    }
+
+    int imageWidth = jpeg.getWidth();
+    int imageHeight = jpeg.getHeight();
+    int imageX = (SCREEN_WIDTH - imageWidth) / 2;
+    int imageY = AMOLED_PREVIEW_Y + (AMOLED_PREVIEW_SIZE - imageHeight) / 2;
+    if (imageY < AMOLED_PREVIEW_Y) {
+        imageY = AMOLED_PREVIEW_Y;
+    }
+
+    g_jpegGfx = _gfx;
+    jpeg.decode(imageX, imageY, 0);
+    jpeg.close();
+    g_jpegGfx = nullptr;
+}
+
+void WaveshareAmoledDisplay::drawFooter() {
+    _gfx->fillRect(0, AMOLED_FOOTER_Y, SCREEN_WIDTH, AMOLED_FOOTER_HEIGHT, 0x0841);
+    _gfx->drawFastHLine(0, AMOLED_FOOTER_Y, SCREEN_WIDTH, 0x2945);
+
+    if (_hasNavigation && _queueTotal > 0) {
+        char positionText[32];
+        snprintf(positionText, sizeof(positionText), "%d / %d", _queueIndex + 1, _queueTotal);
+        drawCenteredText(positionText, AMOLED_FOOTER_Y + 14, 1, COLOR_TEXT_DIM);
+    } else if (_queueCount > 0) {
+        char positionText[32];
+        snprintf(positionText, sizeof(positionText), "%d queued", _queueCount);
+        drawCenteredText(positionText, AMOLED_FOOTER_Y + 14, 1, COLOR_TEXT_DIM);
+    }
+
+    const LocalQueueItem* nextItem = getNextQueueItem();
+    if (nextItem && nextItem->isValid()) {
+        _gfx->setTextSize(1);
+        _gfx->setTextColor(COLOR_TEXT_DIM);
+        _gfx->setCursor(18, AMOLED_FOOTER_Y + 42);
+        _gfx->print("Next:");
+        drawTruncatedText(nextItem->name, 58, AMOLED_FOOTER_Y + 42, 1, COLOR_TEXT, 42);
+    } else if (_hasNavigation && _nextClimb.isValid) {
+        _gfx->setTextSize(1);
+        _gfx->setTextColor(COLOR_TEXT_DIM);
+        _gfx->setCursor(18, AMOLED_FOOTER_Y + 42);
+        _gfx->print("Next:");
+        drawTruncatedText(_nextClimb.name.c_str(), 58, AMOLED_FOOTER_Y + 42, 1, COLOR_TEXT, 42);
+    }
+}
+
+void WaveshareAmoledDisplay::drawCenteredText(const char* text, int y, uint8_t size, uint16_t color) {
+    const char* printable = safeText(text);
+    int textWidth = static_cast<int>(strlen(printable)) * 6 * size;
+    int x = (SCREEN_WIDTH - textWidth) / 2;
+    if (x < 0) x = 0;
+
+    _gfx->setTextSize(size);
+    _gfx->setTextColor(color);
+    _gfx->setCursor(x, y);
+    _gfx->print(printable);
+}
+
+void WaveshareAmoledDisplay::drawTruncatedText(const char* text,
+                                               int x,
+                                               int y,
+                                               uint8_t size,
+                                               uint16_t color,
+                                               int maxChars) {
+    const char* printable = safeText(text);
+    char buffer[80];
+    size_t textLen = strlen(printable);
+    size_t limit = maxChars > 0 ? static_cast<size_t>(maxChars) : sizeof(buffer) - 1;
+    if (limit >= sizeof(buffer)) limit = sizeof(buffer) - 1;
+
+    if (textLen > limit && limit > 3) {
+        memcpy(buffer, printable, limit - 3);
+        buffer[limit - 3] = '.';
+        buffer[limit - 2] = '.';
+        buffer[limit - 1] = '.';
+        buffer[limit] = '\0';
+    } else {
+        size_t copyLen = textLen < sizeof(buffer) - 1 ? textLen : sizeof(buffer) - 1;
+        memcpy(buffer, printable, copyLen);
+        buffer[copyLen] = '\0';
+    }
+
+    _gfx->setTextSize(size);
+    _gfx->setTextColor(color);
+    _gfx->setCursor(x, y);
+    _gfx->print(buffer);
+}

--- a/embedded/libs/waveshare-amoled-display/src/waveshare_amoled_display.h
+++ b/embedded/libs/waveshare-amoled-display/src/waveshare_amoled_display.h
@@ -1,0 +1,79 @@
+#ifndef WAVESHARE_AMOLED_DISPLAY_H
+#define WAVESHARE_AMOLED_DISPLAY_H
+
+#include <Arduino.h>
+#include <Arduino_GFX_Library.h>
+#include <JPEGDEC.h>
+#include <display_base.h>
+
+#include <vector>
+
+// Pin map from the current Waveshare ESP32-S3-Touch-AMOLED-2.16 docs/BSP.
+#define AMOLED_LCD_SDIO0 4
+#define AMOLED_LCD_SDIO1 5
+#define AMOLED_LCD_SDIO2 6
+#define AMOLED_LCD_SDIO3 7
+#define AMOLED_LCD_SCLK  38
+#define AMOLED_LCD_RESET 39
+#define AMOLED_LCD_CS    12
+#define AMOLED_LCD_WIDTH 480
+#define AMOLED_LCD_HEIGHT 480
+
+#define AMOLED_I2C_SDA 15
+#define AMOLED_I2C_SCL 14
+#define AMOLED_TOUCH_INT 11
+#define AMOLED_TOUCH_RST 40
+
+#define AMOLED_STATUS_BAR_HEIGHT 32
+#define AMOLED_PREVIEW_Y 76
+#define AMOLED_PREVIEW_SIZE 286
+#define AMOLED_FOOTER_Y 384
+#define AMOLED_FOOTER_HEIGHT 82
+
+class WaveshareAmoledDisplay : public DisplayBase {
+  public:
+    WaveshareAmoledDisplay();
+    ~WaveshareAmoledDisplay();
+
+    bool begin() override;
+    void showConnecting() override;
+    void showError(const char* message, const char* ipAddress = nullptr) override;
+    void showConfigPortal(const char* apName, const char* ip) override;
+    void showSetupScreen(const char* apName) override;
+    void refresh() override;
+    void refreshInfoOnly() override;
+
+    void showThumbnailLoading();
+    void setThumbnailJpeg(const uint8_t* data, size_t len, const char* cacheKey);
+    void setThumbnailJpeg(std::vector<uint8_t>&& data, const char* cacheKey);
+    void clearThumbnail();
+
+    Arduino_GFX* getDisplay() { return _gfx; }
+
+    static const int SCREEN_WIDTH = AMOLED_LCD_WIDTH;
+    static const int SCREEN_HEIGHT = AMOLED_LCD_HEIGHT;
+
+  protected:
+    void onStatusChanged() override;
+
+  private:
+    Arduino_DataBus* _bus;
+    Arduino_CO5300* _gfx;
+    std::vector<uint8_t> _thumbnailJpeg;
+    String _thumbnailCacheKey;
+    bool _ready;
+    bool _hasThumbnail;
+    bool _thumbnailLoading;
+
+    void drawStatusBar();
+    void drawClimbHeader();
+    void drawThumbnailFrame();
+    void drawThumbnailImage();
+    void drawFooter();
+    void drawCenteredText(const char* text, int y, uint8_t size, uint16_t color);
+    void drawTruncatedText(const char* text, int x, int y, uint8_t size, uint16_t color, int maxChars);
+};
+
+extern WaveshareAmoledDisplay Display;
+
+#endif  // WAVESHARE_AMOLED_DISPLAY_H

--- a/embedded/projects/board-controller/platformio.ini
+++ b/embedded/projects/board-controller/platformio.ini
@@ -8,6 +8,7 @@
 ;   esp32s3dev-proxy - Board controller with BLE proxy
 ;   tdisplay-s3      - T-Display-S3 with display + BLE proxy
 ;   waveshare-7inch  - Waveshare 7" touch LCD with display + BLE proxy
+;   waveshare-amoled-216 - Waveshare ESP32-S3-Touch-AMOLED-2.16 dev board
 ;   esp32dev         - Standard ESP32 (legacy)
 
 [platformio]
@@ -43,6 +44,7 @@ extra_scripts = pre:../../scripts/prebuild.py
 build_flags =
     -D CORE_DEBUG_LEVEL=3
     -D CONFIG_NIMBLE_CPP_ATT_VALUE_INIT_LENGTH=512
+    -Isrc
 
 ; ============================================
 ; ESP32-S3 Development Board (recommended)
@@ -164,6 +166,48 @@ build_flags =
     ; LED pin for Waveshare board
     -D WAVESHARE_LED_PIN=43
     ; Use fewer RMT channels to avoid conflict with display
+    -D FASTLED_RMT_MAX_CHANNELS=2
+
+; ============================================
+; Waveshare ESP32-S3-Touch-AMOLED-2.16 (480x480 QSPI AMOLED)
+; Dev-board firmware with BLE proxy + remote climb thumbnail preview
+; ============================================
+[env:waveshare-amoled-216]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+board_build.mcu = esp32s3
+board_build.f_cpu = 240000000L
+board_build.arduino.memory_type = qio_opi
+board_build.flash_mode = qio
+board_build.psram_type = opi
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+board_build.partitions = partitions_16mb_app.csv
+
+lib_deps =
+    ${env.lib_deps}
+    ble-proxy=symlink://../../libs/ble-proxy
+    climb-history=symlink://../../libs/climb-history
+    display-base=symlink://../../libs/display-base
+    thumbnail-client=symlink://../../libs/thumbnail-client
+    waveshare-amoled-display=symlink://../../libs/waveshare-amoled-display
+    moononournation/GFX Library for Arduino@^1.6.4
+    bitbank2/JPEGDEC@^1.8.2
+
+build_flags =
+    ${env.build_flags}
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+    -D ARDUINO_USB_MODE=1
+    -D ENABLE_BLE_PROXY=1
+    -D ENABLE_WAVESHARE_AMOLED_DISPLAY=1
+    -D ENABLE_REMOTE_THUMBNAIL=1
+    -D FIRMWARE_BUILD_ENV=\"waveshare-amoled-216\"
+    ; PSRAM support (used by WiFi/TLS buffers and decoded image allocations)
+    -D BOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    ; Dev default uses GPIO41/SD_CS; override if the SD socket is needed.
+    -D WAVESHARE_AMOLED_LED_PIN=41
+    ; Use fewer RMT channels to avoid display peripheral conflicts
     -D FASTLED_RMT_MAX_CHANNELS=2
 
 ; ============================================

--- a/embedded/projects/board-controller/src/config/board_config.h
+++ b/embedded/projects/board-controller/src/config/board_config.h
@@ -8,11 +8,13 @@
 
 // LED configuration
 // Note: GPIO 5 conflicts with LCD_RST on T-Display-S3
-// Use TDISPLAY_LED_PIN or WAVESHARE_LED_PIN build flag to override for display builds
+// Use TDISPLAY_LED_PIN, WAVESHARE_LED_PIN, or WAVESHARE_AMOLED_LED_PIN build flag to override for display builds
 #ifdef TDISPLAY_LED_PIN
 #define LED_PIN TDISPLAY_LED_PIN
 #elif defined(WAVESHARE_LED_PIN)
 #define LED_PIN WAVESHARE_LED_PIN
+#elif defined(WAVESHARE_AMOLED_LED_PIN)
+#define LED_PIN WAVESHARE_AMOLED_LED_PIN
 #else
 #define LED_PIN 5  // GPIO pin for LED data (default for non-display builds)
 #endif
@@ -37,6 +39,9 @@
 #define DEFAULT_BACKEND_HOST "ws.boardsesh.com"
 #define DEFAULT_BACKEND_PORT 443
 #define DEFAULT_BACKEND_PATH "/graphql"
+#ifndef DEFAULT_RENDER_BASE_URL
+#define DEFAULT_RENDER_BASE_URL "https://www.boardsesh.com"
+#endif
 
 // Web server
 #define WEB_SERVER_PORT 80

--- a/embedded/projects/board-controller/src/main.cpp
+++ b/embedded/projects/board-controller/src/main.cpp
@@ -24,12 +24,20 @@
 #ifdef ENABLE_BOARD_IMAGE
 #include <board_hold_data.h>
 #endif
+#elif defined(ENABLE_WAVESHARE_AMOLED_DISPLAY)
+#include <waveshare_amoled_display.h>
 #elif defined(ENABLE_DISPLAY)
 #include <lilygo_display.h>
 #endif
 
+#ifdef ENABLE_REMOTE_THUMBNAIL
+#include <thumbnail_client.h>
+
+#include <utility>
+#endif
+
 // Unified macro for code that works with any display
-#if defined(ENABLE_WAVESHARE_DISPLAY) || defined(ENABLE_DISPLAY)
+#if defined(ENABLE_WAVESHARE_DISPLAY) || defined(ENABLE_WAVESHARE_AMOLED_DISPLAY) || defined(ENABLE_DISPLAY)
 #define HAS_DISPLAY 1
 #endif
 
@@ -63,6 +71,11 @@ bool hasCurrentClimb = false;
 // Static buffer for queue sync to avoid heap fragmentation
 // LocalQueueItem is ~88 bytes each, so 150 items = ~13KB
 static LocalQueueItem g_queueSyncBuffer[MAX_QUEUE_SIZE];
+
+#if defined(ENABLE_WAVESHARE_AMOLED_DISPLAY) && defined(ENABLE_REMOTE_THUMBNAIL)
+static ThumbnailClient g_thumbnailClient;
+static String currentThumbnailCacheKey = "";
+#endif
 
 #if defined(ENABLE_WAVESHARE_DISPLAY) && defined(ENABLE_BOARD_IMAGE)
 // Board image config lookup state
@@ -158,6 +171,61 @@ static uint16_t hexToRgb565Fast(const char* hex) {
     // Convert to RGB565: 5 bits red, 6 bits green, 5 bits blue
     return ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
 }
+
+#if defined(ENABLE_WAVESHARE_AMOLED_DISPLAY) && defined(ENABLE_REMOTE_THUMBNAIL)
+// Returns true when this function has left the display in the intended state:
+// fetched thumbnail, preserved duplicate thumbnail, or restored text-only UI
+// after fetch failure. Returns false only when the caller should render fallback UI.
+bool fetchAndDisplayRemoteThumbnail(const char* boardPath,
+                                    const char* frames,
+                                    const char* climbName,
+                                    const char* climbGrade,
+                                    const char* gradeColor,
+                                    int angle,
+                                    const char* climbUuid,
+                                    const char* boardTypeName) {
+    String renderBaseUrl = Config.getString(THUMBNAIL_RENDER_BASE_KEY, DEFAULT_RENDER_BASE_URL);
+    RemoteThumbnailDisplayRequest request = {
+        renderBaseUrl.c_str(),
+        boardPath,
+        frames,
+        climbName,
+        climbGrade,
+        gradeColor,
+        angle,
+        climbUuid,
+        boardTypeName,
+    };
+    RemoteThumbnailDisplayHooks hooks = {
+        nullptr,
+        [](void*) { Display.clearThumbnail(); },
+        [](void*,
+           const char* requestClimbName,
+           const char* requestClimbGrade,
+           const char* requestGradeColor,
+           int requestAngle,
+           const char* requestClimbUuid,
+           const char* requestBoardTypeName) {
+            Display.showClimb(requestClimbName,
+                              requestClimbGrade,
+                              requestGradeColor,
+                              requestAngle,
+                              requestClimbUuid,
+                              requestBoardTypeName);
+        },
+        [](void*) { Display.showThumbnailLoading(); },
+        [](void*, std::vector<uint8_t>&& data, const char* cacheKey) {
+            Display.setThumbnailJpeg(std::move(data), cacheKey);
+        },
+        [](void*, const char* url, std::vector<uint8_t>& output) {
+            return g_thumbnailClient.fetchJpeg(url, output);
+        },
+    };
+
+    RemoteThumbnailDisplayResult result = handleRemoteThumbnailDisplay(request, hooks, currentThumbnailCacheKey);
+    return result != RemoteThumbnailDisplayResult::FALLBACK_REQUIRED;
+}
+#endif
 #endif
 
 // Forward declarations
@@ -239,6 +307,9 @@ void setup() {
 #endif
 #ifdef HAS_DISPLAY
     Logger.logln("Display: Enabled");
+#endif
+#ifdef ENABLE_REMOTE_THUMBNAIL
+    Logger.logln("Remote thumbnails: Enabled");
 #endif
     Logger.logln("=================================");
 
@@ -733,7 +804,11 @@ void onGraphQLStateChange(GraphQLConnectionState state) {
                               "subscription ControllerEvents($sessionId: ID!) { "
                               "controllerEvents(sessionId: $sessionId) { "
                               "... on LedUpdate { __typename commands { position r g b } queueItemUuid climbUuid climbName "
-                              "climbGrade gradeColor boardPath angle clientId "
+                              "climbGrade gradeColor boardPath angle "
+#ifdef ENABLE_REMOTE_THUMBNAIL
+                              "frames "
+#endif
+                              "clientId "
                               "navigation { previousClimbs { name grade gradeColor } "
                               "nextClimb { name grade gradeColor } currentIndex totalCount } } "
                               "... on ControllerQueueSync { __typename queue { uuid climbUuid name grade gradeColor } currentIndex } "
@@ -826,6 +901,7 @@ void handleLedUpdateExtended(JsonObject& data) {
     const char* climbGrade = data["climbGrade"];
     const char* gradeColor = data["gradeColor"];
     const char* boardPath = data["boardPath"];
+    const char* frames = data["frames"];
     int angle = data["angle"] | 0;
 
     JsonArray commands = data["commands"];
@@ -861,6 +937,14 @@ void handleLedUpdateExtended(JsonObject& data) {
             currentGrade = climbGrade ? climbGrade : "?";
             currentGradeColor = gradeColor ? gradeColor : "#888888";
 
+            if (boardPath) {
+                String bp = boardPath;
+                int slashPos = bp.indexOf('/');
+                if (slashPos > 0) {
+                    boardType = bp.substring(0, slashPos);
+                }
+            }
+
             // Parse navigation context if present (allows navigating back to known climbs)
             if (data["navigation"].is<JsonObject>()) {
                 JsonObject nav = data["navigation"];
@@ -889,8 +973,21 @@ void handleLedUpdateExtended(JsonObject& data) {
                 Display.clearNavigationContext();
             }
 
+#if defined(ENABLE_WAVESHARE_AMOLED_DISPLAY) && defined(ENABLE_REMOTE_THUMBNAIL)
+            if (fetchAndDisplayRemoteThumbnail(boardPath,
+                                               frames,
+                                               climbName,
+                                               currentGrade.c_str(),
+                                               currentGradeColor.c_str(),
+                                               angle,
+                                               "",
+                                               boardType.c_str())) {
+                return;
+            }
+#endif
+
             // Show unknown climb on display
-            Display.showClimb(climbName, currentGrade.c_str(), currentGradeColor.c_str(), 0, "", boardType.c_str());
+            Display.showClimb(climbName, currentGrade.c_str(), currentGradeColor.c_str(), angle, "", boardType.c_str());
             return;
         }
 
@@ -905,6 +1002,10 @@ void handleLedUpdateExtended(JsonObject& data) {
         currentClimbName = "";
         currentGrade = "";
         currentGradeColor = "";
+#if defined(ENABLE_WAVESHARE_AMOLED_DISPLAY) && defined(ENABLE_REMOTE_THUMBNAIL)
+        currentThumbnailCacheKey = "";
+        Display.clearThumbnail();
+#endif
 
         Display.showNoClimb();
         return;
@@ -1014,6 +1115,19 @@ void handleLedUpdateExtended(JsonObject& data) {
     } else {
         Display.clearNavigationContext();
     }
+
+#if defined(ENABLE_WAVESHARE_AMOLED_DISPLAY) && defined(ENABLE_REMOTE_THUMBNAIL)
+    if (fetchAndDisplayRemoteThumbnail(boardPath,
+                                       frames,
+                                       climbName,
+                                       climbGrade,
+                                       currentGradeColor.c_str(),
+                                       angle,
+                                       climbUuid,
+                                       boardType.c_str())) {
+        return;
+    }
+#endif
 
     // Update display with gradeColor
     // Note: We always update the display even during rapid navigation.

--- a/embedded/projects/moonboard-dev-server/platformio.ini
+++ b/embedded/projects/moonboard-dev-server/platformio.ini
@@ -25,6 +25,7 @@ lib_deps =
 build_flags =
     -D CORE_DEBUG_LEVEL=3
     -D CONFIG_NIMBLE_CPP_ATT_VALUE_INIT_LENGTH=512
+    -Isrc
 
 [env:esp32s3dev]
 board = esp32-s3-devkitc-1

--- a/embedded/projects/moonboard-dev-server/src/config/board_config.h
+++ b/embedded/projects/moonboard-dev-server/src/config/board_config.h
@@ -14,4 +14,6 @@
 #define DEFAULT_SIZE_ID 1
 #define DEFAULT_SET_IDS "5,6,7,8,9,10"
 
+#define DEFAULT_RENDER_BASE_URL "https://www.boardsesh.com"
+
 #endif

--- a/embedded/scripts/prebuild.py
+++ b/embedded/scripts/prebuild.py
@@ -206,6 +206,16 @@ def check_board_data_codegen():
         print("[Board Data Codegen] Board data is up-to-date")
 
 
+def env_has_define(define_name: str) -> bool:
+    """Return true when the active PlatformIO env has a C/C++ define set."""
+    for define in env.get("CPPDEFINES", []):
+        if define == define_name:
+            return True
+        if isinstance(define, (list, tuple)) and len(define) > 0 and define[0] == define_name:
+            return True
+    return False
+
+
 def before_build(source, target, env):
     """Pre-build hook to check and regenerate types if needed."""
     if _has_codegen_run():
@@ -238,8 +248,11 @@ def before_build(source, target, env):
     else:
         print("[GraphQL Codegen] Types are up-to-date")
 
-    # Also check board data codegen
-    check_board_data_codegen()
+    # Only the local board-image firmware needs generated board image/hold data.
+    if env_has_define("ENABLE_BOARD_IMAGE"):
+        check_board_data_codegen()
+    else:
+        print("[Board Data Codegen] Skipping (ENABLE_BOARD_IMAGE not set)")
 
 
 # Register the pre-build action.
@@ -247,4 +260,3 @@ def before_build(source, target, env):
 # The environment variable deduplication ensures we only run once regardless of which fires first.
 env.AddPreAction("buildprog", before_build)
 env.AddPreAction("$BUILD_DIR/${PROGNAME}.elf", before_build)
-

--- a/embedded/test/lib/thumbnail-client/library.json
+++ b/embedded/test/lib/thumbnail-client/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "thumbnail-client",
+  "version": "1.0.0",
+  "description": "Board-render thumbnail client (test build)",
+  "platforms": ["native", "espressif32"],
+  "dependencies": {
+    "mocks": "*",
+    "log-buffer": "*"
+  },
+  "build": {
+    "flags": ["-std=c++17", "-DUNIT_TEST"]
+  }
+}

--- a/embedded/test/lib/thumbnail-client/src/thumbnail_client.cpp
+++ b/embedded/test/lib/thumbnail-client/src/thumbnail_client.cpp
@@ -1,0 +1,1 @@
+#include "../../../../libs/thumbnail-client/src/thumbnail_client.cpp"

--- a/embedded/test/lib/thumbnail-client/src/thumbnail_client.h
+++ b/embedded/test/lib/thumbnail-client/src/thumbnail_client.h
@@ -1,0 +1,1 @@
+#include "../../../../libs/thumbnail-client/src/thumbnail_client.h"

--- a/embedded/test/platformio.ini
+++ b/embedded/test/platformio.ini
@@ -17,6 +17,7 @@ build_flags =
     -std=c++17
     -D UNIT_TEST
     -D NATIVE_BUILD
+    -I../projects/board-controller/src
 ; Use symlinked libraries in lib/ directory
 lib_deps =
     mocks
@@ -33,6 +34,7 @@ lib_deps =
     climb-history
     grade-colors
     ble-proxy
+    thumbnail-client
 lib_extra_dirs =
     lib
 test_framework = unity

--- a/embedded/test/test_thumbnail_client/test_thumbnail_client.cpp
+++ b/embedded/test/test_thumbnail_client/test_thumbnail_client.cpp
@@ -1,0 +1,244 @@
+#include <thumbnail_client.h>
+#include <unity.h>
+
+#include <vector>
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+struct FakeRemoteThumbnailState {
+    int clearThumbnailCalls;
+    int showClimbCalls;
+    int showThumbnailLoadingCalls;
+    int setThumbnailJpegCalls;
+    int fetchJpegCalls;
+    String lastFetchUrl;
+    String lastCacheKey;
+    ThumbnailFetchResult fetchResult;
+    std::vector<uint8_t> fetchOutput;
+
+    FakeRemoteThumbnailState()
+        : clearThumbnailCalls(0),
+          showClimbCalls(0),
+          showThumbnailLoadingCalls(0),
+          setThumbnailJpegCalls(0),
+          fetchJpegCalls(0),
+          fetchResult(ThumbnailFetchStatus::NETWORK_ERROR) {}
+};
+
+RemoteThumbnailDisplayRequest makeRemoteThumbnailRequest(const char* frames = "p1073r42,p1090r43") {
+    RemoteThumbnailDisplayRequest request = {
+        "https://www.boardsesh.com",
+        "kilter/1/7/20,1/40",
+        frames,
+        "Test Climb",
+        "V5",
+        "#00ff00",
+        40,
+        "climb-uuid",
+        "kilter",
+    };
+    return request;
+}
+
+void fakeClearThumbnail(void* context) {
+    static_cast<FakeRemoteThumbnailState*>(context)->clearThumbnailCalls++;
+}
+
+void fakeShowClimb(void* context,
+                   const char* climbName,
+                   const char* climbGrade,
+                   const char* gradeColor,
+                   int angle,
+                   const char* climbUuid,
+                   const char* boardTypeName) {
+    (void)climbName;
+    (void)climbGrade;
+    (void)gradeColor;
+    (void)angle;
+    (void)climbUuid;
+    (void)boardTypeName;
+    static_cast<FakeRemoteThumbnailState*>(context)->showClimbCalls++;
+}
+
+void fakeShowThumbnailLoading(void* context) {
+    static_cast<FakeRemoteThumbnailState*>(context)->showThumbnailLoadingCalls++;
+}
+
+void fakeSetThumbnailJpeg(void* context, std::vector<uint8_t>&& jpegData, const char* cacheKey) {
+    FakeRemoteThumbnailState* state = static_cast<FakeRemoteThumbnailState*>(context);
+    state->setThumbnailJpegCalls++;
+    state->lastCacheKey = cacheKey ? cacheKey : "";
+    state->fetchOutput = std::move(jpegData);
+}
+
+ThumbnailFetchResult fakeFetchJpeg(void* context, const char* url, std::vector<uint8_t>& output) {
+    FakeRemoteThumbnailState* state = static_cast<FakeRemoteThumbnailState*>(context);
+    state->fetchJpegCalls++;
+    state->lastFetchUrl = url ? url : "";
+    output = state->fetchOutput;
+    return state->fetchResult;
+}
+
+RemoteThumbnailDisplayHooks makeRemoteThumbnailHooks(FakeRemoteThumbnailState& state) {
+    RemoteThumbnailDisplayHooks hooks = {
+        &state,
+        fakeClearThumbnail,
+        fakeShowClimb,
+        fakeShowThumbnailLoading,
+        fakeSetThumbnailJpeg,
+        fakeFetchJpeg,
+    };
+    return hooks;
+}
+
+void test_parse_board_render_route_sorts_set_ids_and_ignores_angle(void) {
+    BoardRenderRoute route;
+    bool parsed = parseBoardRenderRoute("kilter/1/7/20,1/40", route);
+
+    TEST_ASSERT_TRUE(parsed);
+    TEST_ASSERT_EQUAL_STRING("kilter", route.boardName);
+    TEST_ASSERT_EQUAL(1, route.layoutId);
+    TEST_ASSERT_EQUAL(7, route.sizeId);
+    TEST_ASSERT_EQUAL_STRING("1,20", route.setIds);
+}
+
+void test_parse_board_render_route_accepts_locale_prefixed_path(void) {
+    BoardRenderRoute route;
+    bool parsed = parseBoardRenderRoute("/es/tension/2/10/3,1/list", route);
+
+    TEST_ASSERT_TRUE(parsed);
+    TEST_ASSERT_EQUAL_STRING("tension", route.boardName);
+    TEST_ASSERT_EQUAL(2, route.layoutId);
+    TEST_ASSERT_EQUAL(10, route.sizeId);
+    TEST_ASSERT_EQUAL_STRING("1,3", route.setIds);
+}
+
+void test_parse_board_render_route_rejects_missing_segments(void) {
+    BoardRenderRoute route;
+
+    TEST_ASSERT_FALSE(parseBoardRenderRoute("kilter/1/7", route));
+    TEST_ASSERT_FALSE(parseBoardRenderRoute("", route));
+    TEST_ASSERT_FALSE(parseBoardRenderRoute(nullptr, route));
+}
+
+void test_normalize_render_base_url_handles_ws_and_trailing_slashes(void) {
+    TEST_ASSERT_EQUAL_STRING("https://ws.boardsesh.com", normalizeRenderBaseUrl("wss://ws.boardsesh.com/graphql/").c_str());
+    TEST_ASSERT_EQUAL_STRING("http://localhost:3000", normalizeRenderBaseUrl(" http://localhost:3000/ ").c_str());
+    TEST_ASSERT_EQUAL_STRING("https://www.boardsesh.com", normalizeRenderBaseUrl("").c_str());
+    TEST_ASSERT_EQUAL_STRING("https://preview.boardsesh.com", normalizeRenderBaseUrl("preview.boardsesh.com").c_str());
+}
+
+void test_url_encode_query_value_encodes_frames(void) {
+    TEST_ASSERT_EQUAL_STRING("p1r42%2Cp2r43%2Bx%20hold", urlEncodeQueryValue("p1r42,p2r43+x hold").c_str());
+}
+
+void test_build_board_render_thumbnail_url_uses_jpeg_endpoint(void) {
+    String url = buildBoardRenderThumbnailUrl("https://www.boardsesh.com/",
+                                             "kilter/1/7/20,1/40",
+                                             "p1073r42,p1090r43");
+
+    TEST_ASSERT_EQUAL_STRING(
+        "https://www.boardsesh.com/api/internal/board-render?board_name=kilter&layout_id=1&size_id=7&set_ids=1%2C20&frames=p1073r42%2Cp1090r43&thumbnail=1&include_background=1&format=jpg",
+        url.c_str());
+}
+
+void test_build_board_render_thumbnail_url_returns_empty_for_bad_path(void) {
+    TEST_ASSERT_EQUAL_STRING("", buildBoardRenderThumbnailUrl("https://www.boardsesh.com", "kilter/1", "p1r42").c_str());
+}
+
+void test_thumbnail_url_matches_cache_only_for_same_non_empty_url(void) {
+    const char* url =
+        "https://www.boardsesh.com/api/internal/board-render?board_name=kilter&layout_id=1&size_id=7";
+
+    TEST_ASSERT_TRUE(thumbnailUrlMatchesCache(url, url));
+    TEST_ASSERT_FALSE(thumbnailUrlMatchesCache(url, "https://www.boardsesh.com/different.jpg"));
+    TEST_ASSERT_FALSE(thumbnailUrlMatchesCache("", ""));
+    TEST_ASSERT_FALSE(thumbnailUrlMatchesCache(nullptr, url));
+    TEST_ASSERT_FALSE(thumbnailUrlMatchesCache(url, nullptr));
+}
+
+void test_handle_remote_thumbnail_display_cache_hit_does_not_refresh_display(void) {
+    FakeRemoteThumbnailState state;
+    RemoteThumbnailDisplayRequest request = makeRemoteThumbnailRequest();
+    RemoteThumbnailDisplayHooks hooks = makeRemoteThumbnailHooks(state);
+    String currentCacheKey = buildBoardRenderThumbnailUrl(request.renderBaseUrl, request.boardPath, request.frames);
+
+    RemoteThumbnailDisplayResult result = handleRemoteThumbnailDisplay(request, hooks, currentCacheKey);
+
+    TEST_ASSERT_TRUE(result == RemoteThumbnailDisplayResult::CACHE_HIT);
+    TEST_ASSERT_EQUAL(0, state.clearThumbnailCalls);
+    TEST_ASSERT_EQUAL(0, state.showClimbCalls);
+    TEST_ASSERT_EQUAL(0, state.showThumbnailLoadingCalls);
+    TEST_ASSERT_EQUAL(0, state.setThumbnailJpegCalls);
+    TEST_ASSERT_EQUAL(0, state.fetchJpegCalls);
+}
+
+void test_handle_remote_thumbnail_display_failure_restores_text_display(void) {
+    FakeRemoteThumbnailState state;
+    state.fetchResult = ThumbnailFetchResult(ThumbnailFetchStatus::HTTP_ERROR, 503);
+    RemoteThumbnailDisplayRequest request = makeRemoteThumbnailRequest();
+    RemoteThumbnailDisplayHooks hooks = makeRemoteThumbnailHooks(state);
+    String currentCacheKey = "old-thumbnail";
+
+    RemoteThumbnailDisplayResult result = handleRemoteThumbnailDisplay(request, hooks, currentCacheKey);
+
+    TEST_ASSERT_TRUE(result == RemoteThumbnailDisplayResult::FETCH_FAILED);
+    TEST_ASSERT_EQUAL_STRING("", currentCacheKey.c_str());
+    TEST_ASSERT_EQUAL(1, state.fetchJpegCalls);
+    TEST_ASSERT_EQUAL(1, state.clearThumbnailCalls);
+    TEST_ASSERT_EQUAL(2, state.showClimbCalls);
+    TEST_ASSERT_EQUAL(1, state.showThumbnailLoadingCalls);
+    TEST_ASSERT_EQUAL(0, state.setThumbnailJpegCalls);
+}
+
+void test_handle_remote_thumbnail_display_success_sets_thumbnail_without_clear(void) {
+    FakeRemoteThumbnailState state;
+    state.fetchResult = ThumbnailFetchResult(ThumbnailFetchStatus::OK, 200, 3);
+    state.fetchOutput = {0xff, 0xd8, 0xff};
+    RemoteThumbnailDisplayRequest request = makeRemoteThumbnailRequest();
+    RemoteThumbnailDisplayHooks hooks = makeRemoteThumbnailHooks(state);
+    String currentCacheKey = "";
+
+    RemoteThumbnailDisplayResult result = handleRemoteThumbnailDisplay(request, hooks, currentCacheKey);
+
+    TEST_ASSERT_TRUE(result == RemoteThumbnailDisplayResult::FETCHED);
+    TEST_ASSERT_TRUE(currentCacheKey.length() > 0);
+    TEST_ASSERT_EQUAL(1, state.fetchJpegCalls);
+    TEST_ASSERT_EQUAL(0, state.clearThumbnailCalls);
+    TEST_ASSERT_EQUAL(1, state.showClimbCalls);
+    TEST_ASSERT_EQUAL(1, state.showThumbnailLoadingCalls);
+    TEST_ASSERT_EQUAL(1, state.setThumbnailJpegCalls);
+    TEST_ASSERT_EQUAL_STRING(currentCacheKey.c_str(), state.lastCacheKey.c_str());
+}
+
+void test_fetch_jpeg_is_stubbed_in_native_tests(void) {
+    ThumbnailClient client;
+    std::vector<uint8_t> output;
+
+    ThumbnailFetchResult result = client.fetchJpeg("https://www.boardsesh.com/test.jpg", output);
+
+    TEST_ASSERT_EQUAL(ThumbnailFetchStatus::UNSUPPORTED_IN_TEST, result.status);
+    TEST_ASSERT_TRUE(output.empty());
+}
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+
+    UNITY_BEGIN();
+    RUN_TEST(test_parse_board_render_route_sorts_set_ids_and_ignores_angle);
+    RUN_TEST(test_parse_board_render_route_accepts_locale_prefixed_path);
+    RUN_TEST(test_parse_board_render_route_rejects_missing_segments);
+    RUN_TEST(test_normalize_render_base_url_handles_ws_and_trailing_slashes);
+    RUN_TEST(test_url_encode_query_value_encodes_frames);
+    RUN_TEST(test_build_board_render_thumbnail_url_uses_jpeg_endpoint);
+    RUN_TEST(test_build_board_render_thumbnail_url_returns_empty_for_bad_path);
+    RUN_TEST(test_thumbnail_url_matches_cache_only_for_same_non_empty_url);
+    RUN_TEST(test_handle_remote_thumbnail_display_cache_hit_does_not_refresh_display);
+    RUN_TEST(test_handle_remote_thumbnail_display_failure_restores_text_display);
+    RUN_TEST(test_handle_remote_thumbnail_display_success_sets_thumbnail_without_clear);
+    RUN_TEST(test_fetch_jpeg_is_stubbed_in_native_tests);
+    return UNITY_END();
+}

--- a/packages/backend/src/__tests__/controller-thumbnail-frames.test.ts
+++ b/packages/backend/src/__tests__/controller-thumbnail-frames.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { toThumbnailFrames } from '../graphql/resolvers/controller/subscriptions';
+
+describe('controller thumbnail frames', () => {
+  it('preserves single-frame renderer strings', () => {
+    expect(toThumbnailFrames('p1r42p2r43', 'kilter')).toBe('p1r42p2r43');
+  });
+
+  it('collapses multi-frame delta strings to the cumulative final snapshot', () => {
+    expect(toThumbnailFrames('p1r12,p2r13', 'kilter')).toBe('p1r42p2r43');
+  });
+
+  it('removes holds that are off in the final frame', () => {
+    expect(toThumbnailFrames('p1r12p2r13,x2', 'kilter')).toBe('p1r42');
+  });
+});

--- a/packages/backend/src/__tests__/controller.test.ts
+++ b/packages/backend/src/__tests__/controller.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
 import { db } from '../db/client';
 import { esp32Controllers } from '@boardsesh/db/schema/app';
 import { eq, sql } from 'drizzle-orm';
 import { controllerMutations } from '../graphql/resolvers/controller/mutations';
 import { controllerQueries } from '../graphql/resolvers/controller/queries';
-import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { controllerSubscriptions } from '../graphql/resolvers/controller/subscriptions';
+import { pubsub } from '../pubsub';
+import type { ConnectionContext, ControllerEvent } from '@boardsesh/shared-schema';
 
 // Test user ID
 const TEST_USER_ID = 'test-user-controller-tests';
@@ -38,6 +40,27 @@ function createControllerContext(
   };
 }
 
+async function nextControllerEvent(
+  iterator: AsyncIterator<{ controllerEvents: ControllerEvent }>,
+): Promise<{ controllerEvents: ControllerEvent }> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error('Timed out waiting for controller event')), 2000);
+  });
+
+  try {
+    const result = await Promise.race([iterator.next(), timeout]);
+    if (result.done) {
+      throw new Error('Controller event stream ended unexpectedly');
+    }
+    return result.value;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
 describe('Controller Mutations', () => {
   beforeEach(async () => {
     // Create test user if not exists (needed for FK constraint)
@@ -53,6 +76,7 @@ describe('Controller Mutations', () => {
   afterEach(async () => {
     // Clean up test controllers
     await db.execute(sql`DELETE FROM esp32_controllers WHERE user_id = ${TEST_USER_ID}`);
+    vi.restoreAllMocks();
   });
 
   describe('registerController', () => {
@@ -314,6 +338,96 @@ describe('Controller Mutations', () => {
       expect(controller.lastSeenAt).toBeDefined();
     });
   });
+
+  describe('setClimbFromLedPositions', () => {
+    it('publishes raw frames for an unknown BLE climb so controllers can render a thumbnail', async () => {
+      const ctx = createMockContext();
+      const registered = await controllerMutations.registerController(
+        undefined,
+        {
+          input: {
+            boardName: 'kilter',
+            layoutId: 1,
+            sizeId: 10,
+            setIds: '1,2,3',
+          },
+        },
+        ctx,
+      );
+      const publishSpy = vi.spyOn(pubsub, 'publishQueueEvent').mockImplementation(() => {});
+      const controllerCtx = createControllerContext(registered.controllerId, registered.apiKey, {
+        controllerMac: 'AA:BB:CC:DD:EE:FF',
+      });
+      const frames = 'p999991r42,p999992r43';
+
+      const result = await controllerMutations.setClimbFromLedPositions(
+        undefined,
+        { sessionId: TEST_SESSION_ID, frames },
+        controllerCtx,
+      );
+
+      expect(result.matched).toBe(false);
+      expect(publishSpy).toHaveBeenCalledWith(
+        TEST_SESSION_ID,
+        expect.objectContaining({
+          __typename: 'CurrentClimbChanged',
+          item: null,
+          frames,
+          clientId: 'AA:BB:CC:DD:EE:FF',
+        }),
+      );
+    });
+  });
+
+  describe('controllerEvents subscription', () => {
+    it('sends flattened frames for unknown BLE climb thumbnails', async () => {
+      const ctx = createMockContext();
+      const registered = await controllerMutations.registerController(
+        undefined,
+        {
+          input: {
+            boardName: 'kilter',
+            layoutId: 1,
+            sizeId: 10,
+            setIds: '1,2,3',
+          },
+        },
+        ctx,
+      );
+      const controllerCtx = createControllerContext(registered.controllerId, registered.apiKey);
+      const stream = controllerSubscriptions.controllerEvents.subscribe(
+        undefined,
+        { sessionId: TEST_SESSION_ID },
+        controllerCtx,
+      );
+      const iterator = stream[Symbol.asyncIterator]();
+
+      try {
+        await nextControllerEvent(iterator);
+        await nextControllerEvent(iterator);
+
+        pubsub.publishQueueEvent(TEST_SESSION_ID, {
+          __typename: 'CurrentClimbChanged',
+          sequence: 1,
+          stateHash: 'test-state-hash',
+          item: null,
+          frames: 'p1r12,p2r13',
+          clientId: 'AA:BB:CC:DD:EE:FF',
+          correlationId: null,
+        });
+
+        const update = await nextControllerEvent(iterator);
+        expect(update.controllerEvents.__typename).toBe('LedUpdate');
+        if (update.controllerEvents.__typename === 'LedUpdate') {
+          expect(update.controllerEvents.frames).toBe('p1r42p2r43');
+          expect(update.controllerEvents.climbName).toBe('Unknown Climb');
+          expect(update.controllerEvents.clientId).toBe('AA:BB:CC:DD:EE:FF');
+        }
+      } finally {
+        await iterator.return?.(undefined);
+      }
+    });
+  });
 });
 
 describe('Controller Queries', () => {
@@ -377,7 +491,11 @@ describe('Controller Queries', () => {
       const result = await controllerQueries.myControllers(undefined, undefined, ctx);
 
       expect(result).toHaveLength(2);
-      expect(result.map((c) => c.name).sort()).toEqual(['Controller 1', 'Controller 2']);
+      expect(
+        result
+          .map((controller) => controller.name ?? '')
+          .sort((leftName, rightName) => leftName.localeCompare(rightName)),
+      ).toEqual(['Controller 1', 'Controller 2']);
     });
 
     it('should require authentication', async () => {

--- a/packages/backend/src/graphql/resolvers/controller/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/controller/mutations.ts
@@ -193,6 +193,7 @@ export const controllerMutations = {
         sequence: currentState.sequence,
         stateHash: currentState.stateHash,
         item: null, // No queue item for unknown climb
+        frames: framesString,
         clientId: clientIdForEvent, // ESP32 compares this with its MAC
         correlationId: null,
       });

--- a/packages/backend/src/graphql/resolvers/controller/subscriptions.ts
+++ b/packages/backend/src/graphql/resolvers/controller/subscriptions.ts
@@ -18,7 +18,7 @@ import { roomManager } from '../../../services/room-manager';
 import { createAsyncIterator } from '../shared/async-iterators';
 import { getLedPlacements } from '@boardsesh/board-constants/led-placements';
 import { convertLitUpHoldsStringToMap } from '../../../db/queries/util/hold-state';
-import { accumulateFramesToMaps } from '@boardsesh/board-constants/hold-states';
+import { accumulateFramesToMaps, accumulatedMapsToFrameStrings } from '@boardsesh/board-constants/hold-states';
 import { requireControllerAuth } from '../shared/helpers';
 import { getGradeColor } from './grade-colors';
 import { buildNavigationContext, findClimbIndex } from './navigation-helpers';
@@ -106,6 +106,14 @@ function climbToLedCommands(
   return commands;
 }
 
+export function toThumbnailFrames(frames: string | null | undefined, boardName: BoardName): string {
+  if (!frames) return '';
+  if (!frames.includes(',') && !frames.includes('x')) return frames;
+
+  const accumulatedMaps = accumulateFramesToMaps(frames, boardName);
+  return accumulatedMapsToFrameStrings(accumulatedMaps, boardName).at(-1) ?? '';
+}
+
 export const controllerSubscriptions = {
   /**
    * ESP32 controller subscribes to receive LED commands
@@ -148,6 +156,7 @@ export const controllerSubscriptions = {
         climb: { uuid: string; name: string; difficulty: string; angle: number; frames: string } | null | undefined,
         currentItemUuid?: string,
         clientId?: string | null,
+        fallbackFrames?: string | null,
       ): Promise<LedUpdate> => {
         // Get LED placements for this controller's configuration
         const ledPlacements = getLedPlacements(
@@ -166,6 +175,7 @@ export const controllerSubscriptions = {
             __typename: 'LedUpdate',
             commands: [],
             boardPath,
+            frames: toThumbnailFrames(fallbackFrames, controller.boardName as BoardName),
             clientId,
             // If clientId matches controller, this is an unknown BLE climb - show "Unknown Climb"
             climbName: clientId ? 'Unknown Climb' : undefined,
@@ -191,6 +201,7 @@ export const controllerSubscriptions = {
           climbGrade: climb.difficulty,
           gradeColor: getGradeColor(climb.difficulty),
           boardPath,
+          frames: toThumbnailFrames(climb.frames, controller.boardName as BoardName),
           angle: climb.angle,
           navigation,
           clientId,
@@ -229,6 +240,7 @@ export const controllerSubscriptions = {
           if (queueEvent.__typename === 'CurrentClimbChanged' || queueEvent.__typename === 'FullSync') {
             // Extract clientId from the event (null for FullSync or system-initiated changes)
             const eventClientId = queueEvent.__typename === 'CurrentClimbChanged' ? queueEvent.clientId : null;
+            const eventFrames = queueEvent.__typename === 'CurrentClimbChanged' ? queueEvent.frames : null;
 
             const currentItem =
               queueEvent.__typename === 'CurrentClimbChanged'
@@ -244,7 +256,7 @@ export const controllerSubscriptions = {
                   push(ledUpdate);
                 } else {
                   // No climb - could be clearing or unknown climb
-                  const ledUpdate = await buildLedUpdateWithNavigation(null, undefined, eventClientId);
+                  const ledUpdate = await buildLedUpdateWithNavigation(null, undefined, eventClientId, eventFrames);
                   push(ledUpdate);
                 }
               } catch (error) {

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -4895,6 +4895,8 @@ type CurrentClimbChanged {
   stateHash: String!
   "New current climb (null to clear)"
   item: ClimbQueueItem
+  "Raw Aurora frames for an unknown BLE climb when no database match exists"
+  frames: String
   "ID of the client that made this change"
   clientId: ID
   "Correlation ID for request tracking"
@@ -5013,6 +5015,8 @@ type LedUpdate {
   climbGrade: String
   gradeColor: String
   boardPath: String
+  "Compact Aurora frames string for rendering a climb thumbnail."
+  frames: String
   """
   Board angle in degrees. Nullable - null means angle not specified.
   Note: 0 is a valid angle value, so null should be used to indicate "no angle"

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -981,6 +981,8 @@ export type CurrentClimbChanged = {
   clientId?: Maybe<Scalars['ID']['output']>;
   /** Correlation ID for request tracking */
   correlationId?: Maybe<Scalars['ID']['output']>;
+  /** Raw Aurora frames for an unknown BLE climb when no database match exists */
+  frames?: Maybe<Scalars['String']['output']>;
   /** New current climb (null to clear) */
   item?: Maybe<ClimbQueueItem>;
   /** Sequence number of this event */
@@ -1738,6 +1740,8 @@ export type LedUpdate = {
   climbName?: Maybe<Scalars['String']['output']>;
   climbUuid?: Maybe<Scalars['String']['output']>;
   commands: Array<LedCommand>;
+  /** Compact Aurora frames string for rendering a climb thumbnail. */
+  frames?: Maybe<Scalars['String']['output']>;
   gradeColor?: Maybe<Scalars['String']['output']>;
   navigation?: Maybe<QueueNavigationContext>;
   /** Queue item UUID (for reconciling optimistic UI) */
@@ -6265,6 +6269,7 @@ export type CurrentClimbChangedResolvers<
 > = ResolversObject<{
   clientId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   correlationId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  frames?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   item?: Resolver<Maybe<ResolversTypes['ClimbQueueItem']>, ParentType, ContextType>;
   sequence?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -6633,6 +6638,7 @@ export type LedUpdateResolvers<
   climbName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   climbUuid?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   commands?: Resolver<Array<ResolversTypes['LedCommand']>, ParentType, ContextType>;
+  frames?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   gradeColor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   navigation?: Resolver<Maybe<ResolversTypes['QueueNavigationContext']>, ParentType, ContextType>;
   queueItemUuid?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/controller.ts
+++ b/packages/shared-schema/src/schema/controller.ts
@@ -49,6 +49,8 @@ export const controllerTypeDefs = /* GraphQL */ `
     climbGrade: String
     gradeColor: String
     boardPath: String
+    "Compact Aurora frames string for rendering a climb thumbnail."
+    frames: String
     """
     Board angle in degrees. Nullable - null means angle not specified.
     Note: 0 is a valid angle value, so null should be used to indicate "no angle"

--- a/packages/shared-schema/src/schema/events.ts
+++ b/packages/shared-schema/src/schema/events.ts
@@ -218,6 +218,8 @@ export const eventsTypeDefs = /* GraphQL */ `
     stateHash: String!
     "New current climb (null to clear)"
     item: ClimbQueueItem
+    "Raw Aurora frames for an unknown BLE climb when no database match exists"
+    frames: String
     "ID of the client that made this change"
     clientId: ID
     "Correlation ID for request tracking"

--- a/packages/shared-schema/src/types/controller.ts
+++ b/packages/shared-schema/src/types/controller.ts
@@ -34,6 +34,7 @@ export type LedUpdate = {
   climbGrade?: string;
   gradeColor?: string;
   boardPath?: string;
+  frames?: string;
   angle?: number;
   navigation?: QueueNavigationContext | null;
   // ID of client that triggered this update (null if system-initiated)

--- a/packages/shared-schema/src/types/events.ts
+++ b/packages/shared-schema/src/types/events.ts
@@ -57,6 +57,7 @@ export type QueueEvent =
       sequence: number;
       stateHash: string;
       item: ClimbQueueItem | null;
+      frames?: string | null;
       clientId: string | null;
       correlationId: string | null;
     }
@@ -97,6 +98,7 @@ export type SubscriptionQueueEvent =
       sequence: number;
       stateHash: string;
       currentItem: ClimbQueueItem | null;
+      frames?: string | null;
       clientId: string | null;
       correlationId: string | null;
     }

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -978,6 +978,8 @@ export type CurrentClimbChanged = {
   clientId?: Maybe<Scalars['ID']['output']>;
   /** Correlation ID for request tracking */
   correlationId?: Maybe<Scalars['ID']['output']>;
+  /** Raw Aurora frames for an unknown BLE climb when no database match exists */
+  frames?: Maybe<Scalars['String']['output']>;
   /** New current climb (null to clear) */
   item?: Maybe<ClimbQueueItem>;
   /** Sequence number of this event */
@@ -1735,6 +1737,8 @@ export type LedUpdate = {
   climbName?: Maybe<Scalars['String']['output']>;
   climbUuid?: Maybe<Scalars['String']['output']>;
   commands: Array<LedCommand>;
+  /** Compact Aurora frames string for rendering a climb thumbnail. */
+  frames?: Maybe<Scalars['String']['output']>;
   gradeColor?: Maybe<Scalars['String']['output']>;
   navigation?: Maybe<QueueNavigationContext>;
   /** Queue item UUID (for reconciling optimistic UI) */

--- a/packages/web/app/api/internal/board-render/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/board-render/__tests__/route.test.ts
@@ -39,6 +39,7 @@ const mockComposite = vi.fn();
 const mockResize = vi.fn();
 const mockWebpOptions = vi.fn();
 const mockPngOptions = vi.fn();
+const mockJpegOptions = vi.fn();
 const mockSharpInstance = () => {
   const instance = {
     composite: vi.fn((...args: unknown[]) => {
@@ -56,6 +57,10 @@ const mockSharpInstance = () => {
     png: vi.fn((opts: unknown) => {
       mockPngOptions(opts);
       return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0x89, 0x50, 0x4e, 0x47]))) };
+    }),
+    jpeg: vi.fn((opts: unknown) => {
+      mockJpegOptions(opts);
+      return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0xff, 0xd8, 0xff]))) };
     }),
   };
   return instance;
@@ -193,6 +198,16 @@ describe('board-render API route', () => {
     expect(config.frames).toBe('');
   });
 
+  it('accepts quoted Aurora delta frame segments', async () => {
+    const frames = 'p1073r42,"p1090r43,"x1073p1100r44';
+    const response = await GET(makeRequest({ ...validParams, frames }));
+
+    expect(response.status).toBe(200);
+    const configJson = mockRenderOverlay.mock.calls[0][0];
+    const config = JSON.parse(configJson);
+    expect(config.frames).toBe(frames);
+  });
+
   it('returns 400 for invalid board_name', async () => {
     const response = await GET(makeRequest({ ...validParams, board_name: 'invalid' }));
     expect(response.status).toBe(400);
@@ -205,6 +220,8 @@ describe('board-render API route', () => {
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toBe('Invalid format');
+    expect(mockRenderOverlay).not.toHaveBeenCalled();
+    expect(mockJpegOptions).not.toHaveBeenCalled();
   });
 
   it.each(['decoy', 'touchstone', 'grasshopper', 'soill'])('accepts %s as a valid board_name', async (board) => {
@@ -218,6 +235,69 @@ describe('board-render API route', () => {
     const config = JSON.parse(configJson);
     expect(config.thumbnail).toBe(true);
     expect(config.output_width).toBe(200);
+  });
+
+  it('composites backgrounds and returns thumbnail JPEG content for format=jpg', async () => {
+    const response = await GET(makeRequest({ ...validParams, thumbnail: '1', include_background: '1', format: 'jpg' }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('image/jpeg');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=31536000, s-maxage=31536000, immutable');
+    expect(mockComposite).toHaveBeenCalled();
+    expect(mockJpegOptions).toHaveBeenCalledWith({
+      quality: 85,
+      chromaSubsampling: '4:4:4',
+      progressive: false,
+      optimiseScans: false,
+    });
+    expect(mockPngOptions).not.toHaveBeenCalled();
+    expect(mockWebpOptions).not.toHaveBeenCalled();
+
+    const configJson = mockRenderOverlay.mock.calls[0][0];
+    const config = JSON.parse(configJson);
+    expect(config.thumbnail).toBe(true);
+    expect(config.output_width).toBe(200);
+  });
+
+  it('accepts format=jpeg and uses default JPEG options', async () => {
+    const response = await GET(makeRequest({ ...validParams, format: 'jpeg' }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('image/jpeg');
+    expect(mockJpegOptions).toHaveBeenCalledWith({
+      quality: 90,
+      chromaSubsampling: '4:4:4',
+      mozjpeg: true,
+    });
+    expect(mockPngOptions).not.toHaveBeenCalled();
+    expect(mockWebpOptions).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when frames contains invalid syntax', async () => {
+    const response = await GET(makeRequest({ ...validParams, frames: 'p1073r42<script>' }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe('Invalid frames');
+    expect(mockRenderOverlay).not.toHaveBeenCalled();
+  });
+
+  it.each([',', 'p1r42,,p2r43', 'p1r42"p2r43', '"'])(
+    'returns 400 when frames has malformed segment separators: %s',
+    async (frames) => {
+      const response = await GET(makeRequest({ ...validParams, frames }));
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.error).toBe('Invalid frames');
+      expect(mockRenderOverlay).not.toHaveBeenCalled();
+    },
+  );
+
+  it('returns 400 when frames exceeds the request cap', async () => {
+    const response = await GET(makeRequest({ ...validParams, frames: 'p1r42'.repeat(4097) }));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe('Frames string is too large');
+    expect(mockRenderOverlay).not.toHaveBeenCalled();
   });
 
   it('uses native board width when not thumbnail', async () => {
@@ -370,6 +450,10 @@ describe('board-render API route', () => {
         png: vi.fn((opts: unknown) => {
           mockPngOptions(opts);
           return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0x89, 0x50, 0x4e, 0x47]))) };
+        }),
+        jpeg: vi.fn((opts: unknown) => {
+          mockJpegOptions(opts);
+          return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0xff, 0xd8, 0xff]))) };
         }),
       };
       return instance;

--- a/packages/web/app/api/internal/board-render/route.ts
+++ b/packages/web/app/api/internal/board-render/route.ts
@@ -26,8 +26,22 @@ const DEFAULT_PNG_OPTIONS: sharp.PngOptions = {
   adaptiveFiltering: true,
 };
 
+const THUMBNAIL_JPEG_OPTIONS: sharp.JpegOptions = {
+  quality: 85,
+  chromaSubsampling: '4:4:4',
+  progressive: false,
+  optimiseScans: false,
+};
+
+const DEFAULT_JPEG_OPTIONS: sharp.JpegOptions = {
+  quality: 90,
+  chromaSubsampling: '4:4:4',
+  mozjpeg: true,
+};
+
 const OG_BOARD_PADDING_X = 48;
 const OG_BOARD_PADDING_Y = 48;
+const MAX_FRAMES_LENGTH = 16_384;
 
 // Lazily initialized WASM module with promise lock to prevent thundering herd
 let renderOverlay: ((configJson: string) => Uint8Array) | null = null;
@@ -169,6 +183,64 @@ function createOgBackgroundBuffer(boardWidth: number, boardHeight: number): Buff
   );
 }
 
+type OutputFormat = 'webp' | 'png' | 'jpeg';
+
+function normalizeOutputFormat(format: string): OutputFormat | null {
+  if (format === 'jpg') return 'jpeg';
+  if (format === 'webp' || format === 'png' || format === 'jpeg') return format;
+  return null;
+}
+
+function isValidFrameSegment(segment: string): boolean {
+  if (segment.length === 0) return false;
+  let cursor = 0;
+
+  if (segment[cursor] === '"') {
+    cursor++;
+  }
+
+  if (cursor >= segment.length) return false;
+
+  while (cursor < segment.length) {
+    const current = segment[cursor];
+    if (current === 'x') {
+      cursor++;
+      const start = cursor;
+      while (cursor < segment.length && segment[cursor] >= '0' && segment[cursor] <= '9') {
+        cursor++;
+      }
+      if (cursor === start) return false;
+      continue;
+    }
+
+    if (current !== 'p') return false;
+    cursor++;
+    const placementStart = cursor;
+    while (cursor < segment.length && segment[cursor] >= '0' && segment[cursor] <= '9') {
+      cursor++;
+    }
+    if (cursor === placementStart || segment[cursor] !== 'r') return false;
+
+    cursor++;
+    const roleStart = cursor;
+    while (cursor < segment.length && segment[cursor] >= '0' && segment[cursor] <= '9') {
+      cursor++;
+    }
+    if (cursor === roleStart) return false;
+  }
+
+  return true;
+}
+
+function isValidFramesString(frames: string): boolean {
+  if (frames.length === 0) return true;
+  return frames.split(',').every(isValidFrameSegment);
+}
+
+function getJpegOptions(thumbnail: boolean): sharp.JpegOptions {
+  return thumbnail ? THUMBNAIL_JPEG_OPTIONS : DEFAULT_JPEG_OPTIONS;
+}
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
@@ -181,7 +253,7 @@ export async function GET(request: NextRequest) {
     const thumbnail = searchParams.get('thumbnail') === '1';
     const includeBackground = searchParams.get('include_background') === '1';
     const isOgVariant = searchParams.get('variant') === 'og';
-    const format = searchParams.get('format') ?? (isOgVariant ? 'png' : 'webp');
+    const format = normalizeOutputFormat(searchParams.get('format') ?? (isOgVariant ? 'png' : 'webp'));
     // Mirroring is handled client-side via CSS scaleX(-1) to maximize cache hit rate
 
     if (!boardName || !layoutId || !sizeId || !setIds || frames === null) {
@@ -192,8 +264,16 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid board_name' }, { status: 400 });
     }
 
-    if (format !== 'webp' && format !== 'png') {
+    if (format === null) {
       return NextResponse.json({ error: 'Invalid format' }, { status: 400 });
+    }
+
+    if (frames.length > MAX_FRAMES_LENGTH) {
+      return NextResponse.json({ error: 'Frames string is too large' }, { status: 400 });
+    }
+
+    if (!isValidFramesString(frames)) {
+      return NextResponse.json({ error: 'Invalid frames' }, { status: 400 });
     }
 
     const parsedSetIds = setIds
@@ -309,6 +389,9 @@ export async function GET(request: NextRequest) {
               .webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : DEFAULT_WEBP_OPTIONS)
               .toBuffer();
             outputContentType = 'image/webp';
+          } else if (!isOgVariant && format === 'jpeg') {
+            outputBuffer = await compositedImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
+            outputContentType = 'image/jpeg';
           } else {
             imageBuffer = await compositedImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
           }
@@ -321,6 +404,9 @@ export async function GET(request: NextRequest) {
           if (!isOgVariant && format === 'webp') {
             outputBuffer = await overlayImage.webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true }).toBuffer();
             outputContentType = 'image/webp';
+          } else if (!isOgVariant && format === 'jpeg') {
+            outputBuffer = await overlayImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
+            outputContentType = 'image/jpeg';
           } else {
             imageBuffer = await overlayImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
           }
@@ -333,6 +419,9 @@ export async function GET(request: NextRequest) {
         if (!isOgVariant && format === 'webp') {
           outputBuffer = await overlayImage.webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true }).toBuffer();
           outputContentType = 'image/webp';
+        } else if (!isOgVariant && format === 'jpeg') {
+          outputBuffer = await overlayImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
+          outputContentType = 'image/jpeg';
         } else {
           imageBuffer = await overlayImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
         }
@@ -345,6 +434,9 @@ export async function GET(request: NextRequest) {
       if (!isOgVariant && format === 'webp') {
         outputBuffer = await overlayImage.webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true }).toBuffer();
         outputContentType = 'image/webp';
+      } else if (!isOgVariant && format === 'jpeg') {
+        outputBuffer = await overlayImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
+        outputContentType = 'image/jpeg';
       } else {
         imageBuffer = await overlayImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
       }
@@ -354,18 +446,21 @@ export async function GET(request: NextRequest) {
     const encodeT0 = performance.now();
 
     if (outputBuffer === null && isOgVariant && imageBuffer) {
-      outputBuffer = await sharp(createOgBackgroundBuffer(width, height))
-        .composite([
-          {
-            input: imageBuffer,
-            left: Math.round((OG_IMAGE_WIDTH - width) / 2),
-            top: Math.round((OG_IMAGE_HEIGHT - height) / 2),
-            blend: 'over',
-          },
-        ])
-        .png(DEFAULT_PNG_OPTIONS)
-        .toBuffer();
-      outputContentType = 'image/png';
+      const ogImage = sharp(createOgBackgroundBuffer(width, height)).composite([
+        {
+          input: imageBuffer,
+          left: Math.round((OG_IMAGE_WIDTH - width) / 2),
+          top: Math.round((OG_IMAGE_HEIGHT - height) / 2),
+          blend: 'over',
+        },
+      ]);
+      if (format === 'jpeg') {
+        outputBuffer = await ogImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
+        outputContentType = 'image/jpeg';
+      } else {
+        outputBuffer = await ogImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
+        outputContentType = 'image/png';
+      }
     } else if (outputBuffer === null && imageBuffer && format === 'webp') {
       const getWebpOptions = () => {
         if (thumbnail) return THUMBNAIL_WEBP_OPTIONS;
@@ -374,6 +469,9 @@ export async function GET(request: NextRequest) {
       };
       outputBuffer = await sharp(imageBuffer).webp(getWebpOptions()).toBuffer();
       outputContentType = 'image/webp';
+    } else if (outputBuffer === null && imageBuffer && format === 'jpeg') {
+      outputBuffer = await sharp(imageBuffer).jpeg(getJpegOptions(thumbnail)).toBuffer();
+      outputContentType = 'image/jpeg';
     } else if (outputBuffer === null && imageBuffer) {
       outputBuffer = imageBuffer;
       outputContentType = 'image/png';

--- a/packages/web/app/components/board-renderer/__tests__/util.test.ts
+++ b/packages/web/app/components/board-renderer/__tests__/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vite-plus/test';
-import { getImageUrl, buildOverlayUrl, buildOgBoardRenderUrl } from '../util';
+import { getImageUrl, buildBoardRenderUrl, buildOverlayUrl, buildOgBoardRenderUrl } from '../util';
 import type { BoardDetails } from '@/app/lib/types';
 
 describe('getImageUrl', () => {
@@ -102,6 +102,16 @@ describe('buildOverlayUrl', () => {
   it('appends thumbnail=1 when thumbnail is true', () => {
     const url = buildOverlayUrl(boardDetails, 'p1r12', true);
     expect(url).toContain('&thumbnail=1');
+  });
+
+  it('supports JPEG format in board render URLs', () => {
+    const url = buildBoardRenderUrl(boardDetails, 'p1r12', {
+      thumbnail: true,
+      includeBackground: true,
+      format: 'jpg',
+    });
+
+    expect(url).toContain('format=jpg');
   });
 
   it('omits thumbnail param when false', () => {

--- a/packages/web/app/components/board-renderer/util.ts
+++ b/packages/web/app/components/board-renderer/util.ts
@@ -18,7 +18,7 @@ type BuildBoardRenderUrlOptions = {
   thumbnail?: boolean;
   includeBackground?: boolean;
   variant?: 'default' | 'og';
-  format?: 'webp' | 'png';
+  format?: 'webp' | 'png' | 'jpg' | 'jpeg';
 };
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -137,6 +137,17 @@ export default defineConfig({
       codegen: {
         command:
           'bun packages/shared-schema/scripts/print-schema.ts && graphql-codegen && vp fmt packages/shared-schema/src/generated/ packages/shared/graphql/src/generated/',
+        input: [
+          'codegen.ts',
+          'packages/shared-schema/scripts/print-schema.ts',
+          'packages/shared-schema/src/schema/**/*.ts',
+          'packages/shared-schema/src/types/**/*.ts',
+          'packages/shared/graphql/src/**/*.ts',
+          '!packages/shared/graphql/src/generated/**',
+          'packages/web/app/**/*.{ts,tsx}',
+          '!packages/web/app/lib/graphql/**',
+          '!packages/web/**/*.test.{ts,tsx}',
+        ],
       },
 
       // --- Build (topological order via dependsOn) ---


### PR DESCRIPTION
## Summary
- Add a `waveshare-amoled-216` PlatformIO firmware target for the Waveshare ESP32-S3 Touch AMOLED 2.16 board.
- Add embedded thumbnail download/display libraries so the device can fetch a backend-rendered JPEG thumbnail for the active BLE climb.
- Thread BLE frame data through GraphQL/backend events and harden the internal board-render route for JPEG thumbnails.
- Add focused backend, web, and PlatformIO native tests for thumbnail URL generation, remote-thumbnail display orchestration, frame handling, and render validation.

## Follow-up fixes
- Removed production/test thumbnail-client source drift by making the native test shim include the production source.
- Documented the HTTPS `setInsecure()` tradeoff inline and kept conservative JPEG size/decoder behavior.
- Moved render URL defaults into project `board_config.h` files and made shared libs consume those configs.
- Added direct native coverage for cache-hit no-op display behavior, fetch failure fallback display behavior, and successful thumbnail set behavior.
- Replaced disabled codegen caching with explicit schema/document input tracking.
- Covered and fixed `include_background=1&format=jpg` so composited thumbnails are encoded directly as JPEG.

## Validation
- `vp run codegen`
- `vp check --fix vite.config.ts packages/web/app/api/internal/board-render/route.ts packages/web/app/api/internal/board-render/__tests__/route.test.ts`
- `vp test run packages/web/app/api/internal/board-render/__tests__/route.test.ts packages/backend/src/__tests__/controller.test.ts packages/backend/src/__tests__/controller-thumbnail-frames.test.ts`
- `vp test run packages/web/app/api/internal/board-render/__tests__/route.test.ts`
- `vp run typecheck:backend`
- `vp run typecheck:shared`
- `vp run typecheck:web`
- `pio test -e native -f test_thumbnail_client`
- `pio test -e native`
- `pio run -e waveshare-amoled-216`
- `pio run -e esp32s3dev` from `embedded/projects/moonboard-dev-server`
- `git diff --check`

## Notes
- Physical hardware flashing is still pending. The first on-device build is planned for the Waveshare ESP32-S3 Touch AMOLED 2.16 board.
- Full `vp check` still has unrelated pre-existing formatting failures outside this change set, so scoped `vp check --fix` and focused validation above were used for this PR.
- `vp run typecheck:web` still emits the existing Next middleware deprecation, board-render dynamic-path warning, and offline homepage SSR fetch warnings during the dependent web build; it exits successfully.