### PR TITLE
Review fixes for the queue FAB + search redesign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,13 @@ jobs:
       # push-to-main. Runs before the heavier Metro bundle so it fails fast.
       - name: Check native build-phase deps resolve
         run: vp run check:mobile-native-deps
+      # A Bun patch is keyed by an exact version, so an Expo/RN bump can silently
+      # drop it: install only warns, and typecheck + the Metro bundle stay green
+      # while a native-only behavior (e.g. the iOS 26 tab-bar minimize tracking
+      # the climbs FlashList) regresses all the way into TestFlight. Assert the
+      # patched source is actually present on this cheap Linux runner.
+      - name: Check native patches are applied
+        run: vp run check:mobile-patches
       - name: Download built packages
         uses: actions/download-artifact@v4
         with:

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -26,6 +26,10 @@ export default function TabLayout() {
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
 
   return (
+    // `minimizeBehavior="onScrollDown"` relies on UIKit finding the climbs
+    // FlashList's nested scroll view, which it can't by default — that fallback
+    // lives in patches/react-native-screens@4.25.2.patch. `vp run check:mobile-patches`
+    // (CI) fails the build if that patch ever stops applying after a dep bump.
     <NativeTabs minimizeBehavior="onScrollDown">
       <NativeTabs.BottomAccessory>
         <QueueBottomAccessory />

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -10,7 +10,6 @@ import {
   toClimbSearchInput,
   mergeBoardFilters,
   countActiveFilters,
-  countActiveFiltersBeyondGrade,
   hasActiveBoardFilters,
   DEFAULT_CLIMB_FILTER_STATE,
   DEFAULT_CLIMB_BOARD_FILTER_STATE,
@@ -422,7 +421,10 @@ function ClimbListInner() {
       sizeId,
       setIds,
       angle,
-      activeFilterCount: countActiveFiltersBeyondGrade(filters, boardFilters),
+      // Grade-inclusive, matching the filter button's badge — a set grade is an
+      // active filter, so the analytics count and the UI never disagree (and a
+      // grade-only search reports 1, not 0).
+      activeFilterCount: countActiveFilters(filters, boardFilters),
     });
   }, [firstSearchPage, name, filters, boardFilters, boardName, layoutId, sizeId, setIds, angle]);
 

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -175,7 +175,12 @@ function ClimbListInner() {
     setSearchTextLength(text.length);
     const customSearch = searchHeaderRef.current;
     const nativeSearch = nativeSearchRef.current;
-    customSearch?.setText(text);
+    // Seed the displayed text only — never re-enter onChangeText, which would
+    // re-arm the input debounce and redundantly re-commit the term. Callers
+    // commit `name` through the search provider (replaceSearch / setName); this
+    // just mirrors it into the field. (The native bar's setText likewise does
+    // not fire its change handler.)
+    customSearch?.setText(text, { silent: true });
     nativeSearch?.setText(text);
     return customSearch != null || nativeSearch != null;
   }, []);

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -9,6 +9,7 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import {
   toClimbSearchInput,
   mergeBoardFilters,
+  countActiveFilters,
   countActiveFiltersBeyondGrade,
   hasActiveBoardFilters,
   DEFAULT_CLIMB_FILTER_STATE,
@@ -79,10 +80,6 @@ type NativeSearchChange = string | { nativeEvent?: { text?: string } };
 
 function readNativeSearchText(change: NativeSearchChange): string {
   return typeof change === 'string' ? change : (change.nativeEvent?.text ?? '');
-}
-
-function gradeFilterActive(filters: ClimbFilters): boolean {
-  return filters.minGrade != null || filters.maxGrade != null;
 }
 
 function queryLengthBucket(query: string): 'none' | 'short' | 'medium' | 'long' {
@@ -558,10 +555,7 @@ function ClimbListInner() {
     () => ({ minGradeId: filters.minGrade, maxGradeId: filters.maxGrade }),
     [filters.minGrade, filters.maxGrade],
   );
-  const activeFilterCount = useMemo(
-    () => countActiveFiltersBeyondGrade(filters, boardFilters) + (gradeFilterActive(filters) ? 1 : 0),
-    [filters, boardFilters],
-  );
+  const activeFilterCount = useMemo(() => countActiveFilters(filters, boardFilters), [filters, boardFilters]);
 
   const stackOptions = useMemo(
     () =>

--- a/packages/mobile/src/components/GlassIconButton.tsx
+++ b/packages/mobile/src/components/GlassIconButton.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useRef } from 'react';
-import { type ColorValue, StyleSheet, View } from 'react-native';
+import {
+  type AccessibilityActionEvent,
+  type AccessibilityActionInfo,
+  type ColorValue,
+  StyleSheet,
+  View,
+} from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { GlassSurface } from './GlassSurface';
 import { PressableSurface } from './PressableSurface';
@@ -22,6 +28,10 @@ type GlassIconButtonProps = {
   /** Hint describing what activation does — useful when the button morphs in
    *  place (e.g. search ↔ close) rather than navigating. */
   accessibilityHint?: string;
+  /** Custom assistive-tech actions (e.g. a grade shortcut VoiceOver / Switch
+   *  Control can reach, mirroring an otherwise-invisible long-press). */
+  accessibilityActions?: ReadonlyArray<AccessibilityActionInfo>;
+  onAccessibilityAction?: (event: AccessibilityActionEvent) => void;
   /** Translucent tint composited on the glass (iOS). Omit for a neutral surface. */
   tintColor?: string;
   /** Solid colour used on Android, Reduce Transparency, and the cold-start frame. */
@@ -58,6 +68,8 @@ export function GlassIconButton({
   onLongPress,
   accessibilityLabel,
   accessibilityHint,
+  accessibilityActions,
+  onAccessibilityAction,
   tintColor,
   fallbackColor,
   badgeCount,
@@ -131,6 +143,8 @@ export function GlassIconButton({
         accessibilityRole="button"
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint}
+        accessibilityActions={accessibilityActions}
+        onAccessibilityAction={onAccessibilityAction}
         style={[styles.button, { width: size, height: size, borderRadius: size / 2 }]}
       >
         <GlassSurface

--- a/packages/mobile/src/components/PressableSurface.tsx
+++ b/packages/mobile/src/components/PressableSurface.tsx
@@ -2,6 +2,8 @@ import { type ReactNode } from 'react';
 import {
   Pressable,
   Platform,
+  type AccessibilityActionEvent,
+  type AccessibilityActionInfo,
   type AccessibilityRole,
   type AccessibilityState,
   type GestureResponderEvent,
@@ -46,6 +48,9 @@ type PressableSurfaceProps = {
   accessibilityLabel?: string;
   accessibilityHint?: string;
   accessibilityState?: AccessibilityState;
+  /** Custom assistive-tech actions (e.g. a long-press equivalent VoiceOver / Switch Control can reach). */
+  accessibilityActions?: ReadonlyArray<AccessibilityActionInfo>;
+  onAccessibilityAction?: (event: AccessibilityActionEvent) => void;
   style?: StyleProp<ViewStyle>;
 };
 
@@ -75,6 +80,8 @@ export function PressableSurface({
   accessibilityLabel,
   accessibilityHint,
   accessibilityState,
+  accessibilityActions,
+  onAccessibilityAction,
   style,
 }: PressableSurfaceProps) {
   // `pressed` is 0 at rest, 1 while held. Resolved into a scale or opacity in
@@ -124,6 +131,8 @@ export function PressableSurface({
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint}
         accessibilityState={accessibilityState}
+        accessibilityActions={accessibilityActions}
+        onAccessibilityAction={onAccessibilityAction}
         style={style}
       >
         {children}
@@ -144,6 +153,8 @@ export function PressableSurface({
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}
       accessibilityState={accessibilityState}
+      accessibilityActions={accessibilityActions}
+      onAccessibilityAction={onAccessibilityAction}
       style={[animatedStyle, style]}
     >
       {children}

--- a/packages/mobile/src/components/SearchHeader.tsx
+++ b/packages/mobile/src/components/SearchHeader.tsx
@@ -9,7 +9,14 @@ export type SearchHeaderHandle = {
   blur: () => void;
   focus: () => void;
   getText: () => string;
-  setText: (text: string) => void;
+  /**
+   * Set the field text imperatively. Pass `{ silent: true }` for programmatic
+   * seeding (board restore / per-board sync / recent-pill apply) to update only
+   * the displayed value WITHOUT re-entering `onChangeText` — which would re-arm
+   * the caller's input debounce and redundantly re-commit the term (and could
+   * outlive a fast board switch).
+   */
+  setText: (text: string, options?: { silent?: boolean }) => void;
 };
 
 type SearchHeaderProps = {
@@ -45,9 +52,9 @@ export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(fu
     blur: () => inputRef.current?.blur(),
     focus: () => inputRef.current?.focus(),
     getText: () => text,
-    setText: (newText: string) => {
+    setText: (newText: string, options?: { silent?: boolean }) => {
       setText(newText);
-      onChangeText(newText);
+      if (!options?.silent) onChangeText(newText);
     },
   }));
 

--- a/packages/mobile/src/components/grade/GradeRail.tsx
+++ b/packages/mobile/src/components/grade/GradeRail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ElementRef, type ReactNode } from 'react';
-import { AccessibilityInfo, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 import { Gesture, GestureDetector, ScrollView } from 'react-native-gesture-handler';
 import { runOnJS } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
@@ -26,7 +26,6 @@ import { hapticSelection } from '../../lib/haptics';
 import { brandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { GradeChip } from './GradeChip';
-import { readableTextColor } from './grade-chip-colors';
 
 const CLEAR_DISMISS_MS = 300;
 
@@ -63,7 +62,7 @@ type GradeRangeRailProps = {
   sendDifficultyIds?: readonly number[];
   onChange: (next: GradeBound) => void;
   /**
-   * Asked to dismiss itself (swipe, Done, completed range, or cleared
+   * Asked to dismiss itself (swipe the handle down, completed range, or cleared
    * selection). Only ever called when `dismissible` is true, so an inline,
    * always-open rail (e.g. inside the filter sheet) can omit it.
    */
@@ -95,14 +94,11 @@ export function GradeRangeRail({
   // closure on the timer.
   const onRequestCloseRef = useRef(onRequestClose);
   const [railWidth, setRailWidth] = useState(0);
-  const [screenReaderEnabled, setScreenReaderEnabled] = useState<boolean | null>(null);
   const didCenterRef = useRef(false);
 
   const grades = useMemo(() => sortedGrades(unsortedGrades), [unsortedGrades]);
   const gradeIds = useMemo(() => grades.map((grade) => grade.difficultyId), [grades]);
   const centerId = useMemo(() => gradeRailCenter(bound, grades, sendDifficultyIds), [bound, grades, sendDifficultyIds]);
-  const showDone = dismissible && (isRangeGrade(bound) || (screenReaderEnabled === true && !isAnyGrade(bound)));
-  const showTopRow = showTitle || showDone;
 
   const clearDismissTimer = useCallback(() => {
     if (dismissTimerRef.current) {
@@ -121,22 +117,6 @@ export function GradeRangeRail({
   }, [clearDismissTimer]);
 
   useEffect(() => clearDismissTimer, [clearDismissTimer]);
-
-  useEffect(() => {
-    let mounted = true;
-    AccessibilityInfo.isScreenReaderEnabled()
-      .then((enabled) => {
-        if (mounted) setScreenReaderEnabled(enabled);
-      })
-      .catch(() => {
-        if (mounted) setScreenReaderEnabled(false);
-      });
-    const subscription = AccessibilityInfo.addEventListener('screenReaderChanged', setScreenReaderEnabled);
-    return () => {
-      mounted = false;
-      subscription.remove();
-    };
-  }, []);
 
   const scheduleDismiss = useCallback(
     (delay: number) => {
@@ -184,7 +164,7 @@ export function GradeRangeRail({
       // existing range, and crucially clearing a grade (tapping the already-
       // selected one). That clear case is how a user starts a fresh range from a
       // prior selection, so closing there would cut them off mid-build. To
-      // dismiss without finishing a range, swipe the handle down or tap Done.
+      // dismiss without finishing a range, swipe the handle down.
       const completedRange = isSingleGrade(bound) && isRangeGrade(result.next);
       if (dismissible && completedRange) {
         scheduleDismiss(CLEAR_DISMISS_MS);
@@ -219,28 +199,11 @@ export function GradeRangeRail({
           </PressableSurface>
         </GestureDetector>
       ) : null}
-      {showTopRow ? (
-        <View style={[styles.topRow, !showTitle && styles.topRowEnd]}>
-          {showTitle ? (
-            <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.title}>
-              {t('mobile.filter.gradeRange')}
-            </Text>
-          ) : null}
-          {showDone ? (
-            <PressableSurface
-              onPress={() => {
-                handleRequestClose();
-              }}
-              feedback="opacity"
-              accessibilityRole="button"
-              accessibilityLabel={t('mobile.filter.done')}
-              style={styles.doneButton}
-            >
-              <Text variant="subheadline" color={readableTextColor(brandColors.primary)} style={styles.doneText}>
-                {t('mobile.filter.done')}
-              </Text>
-            </PressableSurface>
-          ) : null}
+      {showTitle ? (
+        <View style={styles.topRow}>
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.title}>
+            {t('mobile.filter.gradeRange')}
+          </Text>
         </View>
       ) : null}
       <ScrollView
@@ -412,20 +375,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
   },
-  topRowEnd: {
-    justifyContent: 'flex-end',
-  },
   title: {
-    fontWeight: '600',
-  },
-  doneButton: {
-    minHeight: 44,
-    borderRadius: 22,
-    backgroundColor: brandColors.primary,
-    justifyContent: 'center',
-    paddingHorizontal: spacing[3],
-  },
-  doneText: {
     fontWeight: '600',
   },
   railContent: {

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -10,11 +10,12 @@ import { View, StyleSheet, type ColorValue, type LayoutChangeEvent } from 'react
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { runOnJS, useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
-import { computePeekOffset } from '@boardsesh/play-view';
+import { computePeekOffset, computeNavigationStateWithSuggestions } from '@boardsesh/play-view';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { shadows } from '../../theme/tokens';
 import { TOOLBAR_CAPSULE_HEIGHT, TOOLBAR_CAPSULE_MAX_WIDTH } from '../../theme/layout';
+import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { useNativeGlass } from '../../hooks/use-native-glass';
@@ -46,11 +47,23 @@ type ClimbLabelProps = {
 function ClimbLabel({ display, labelColor, formattedGrade, gradeColor }: ClimbLabelProps) {
   return (
     <View style={styles.labelInner}>
-      <Text variant="subheadline" color={labelColor} numberOfLines={1} ellipsizeMode="tail" style={styles.name}>
+      <Text
+        variant="subheadline"
+        color={labelColor}
+        numberOfLines={1}
+        ellipsizeMode="tail"
+        maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+        style={styles.name}
+      >
         {display.name ?? ''}
       </Text>
       {formattedGrade ? (
-        <Text variant="headline" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
+        <Text
+          variant="headline"
+          numberOfLines={1}
+          maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+          style={[styles.gradeText, { color: gradeColor }]}
+        >
           {formattedGrade}
         </Text>
       ) : null}
@@ -84,7 +97,7 @@ export function ClimbCapsule({
   endActionSize = 0,
   height = TOOLBAR_CAPSULE_HEIGHT,
 }: ClimbCapsuleProps) {
-  const { state, nextClimb, previousClimb } = useQueue();
+  const { state, nextClimb, previousClimb, playlistSuggestionSource } = useQueue();
   const { openPlayDrawer } = useDrawerHost();
   const { systemColors } = useTheme();
   const { t } = useTranslation('session');
@@ -96,15 +109,15 @@ export function ClimbCapsule({
 
   const { currentClimbQueueItem, queue } = state;
 
-  const currentIndex = useMemo(() => {
-    if (!currentClimbQueueItem) return -1;
-    return queue.findIndex(({ uuid }) => uuid === currentClimbQueueItem.uuid);
-  }, [queue, currentClimbQueueItem]);
-
-  const canPrevious = currentIndex > 0;
-  const canNext = currentIndex >= 0 && currentIndex < queue.length - 1;
-  const previousItem = canPrevious ? queue[currentIndex - 1] : null;
-  const nextItem = canNext ? queue[currentIndex + 1] : null;
+  // Suggestion-aware so the capsule carousel matches the play drawer: at the
+  // queue tail of an active playlist, `nextItem` falls through to the next
+  // playlist climb (a transient "peek") instead of stopping. canPrevious/prevItem
+  // stay queue-only — there is no backward suggestion fall-through.
+  const { canPrevious, canNext, nextItem, prevItem } = useMemo(
+    () => computeNavigationStateWithSuggestions(queue, currentClimbQueueItem, playlistSuggestionSource),
+    [queue, currentClimbQueueItem, playlistSuggestionSource],
+  );
+  const previousItem = prevItem;
 
   const handleNext = useCallback(() => {
     hapticSelection();

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -5,7 +5,7 @@ import Animated, { runOnJS, useAnimatedStyle, useDerivedValue } from 'react-nati
 import { useTranslation } from 'react-i18next';
 import type { BoardName } from '@boardsesh/shared-schema';
 import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
-import { computePeekOffset } from '@boardsesh/play-view';
+import { computePeekOffset, computeNavigationStateWithSuggestions } from '@boardsesh/play-view';
 import { getBoardRenderData } from '../../lib/board-details';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
@@ -15,6 +15,7 @@ import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-pro
 import { hapticLight, hapticSelection } from '../../lib/haptics';
 import { spacing } from '../../theme/tokens';
 import { glassSize } from '../../theme/layout';
+import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { Text } from '../Text';
 import { BoardRenderer } from '../board-renderer/BoardRenderer';
 import { useCarouselGesture } from '../play-drawer/use-carousel-gesture';
@@ -108,11 +109,24 @@ function ClimbLabel({ climb, labelColor, formattedGrade, showThumbnail, boardCon
   return (
     <View style={styles.labelInner}>
       {showThumbnail ? <AccessoryClimbThumbnail climb={climb} boardConfig={boardConfig} /> : null}
-      <Text variant="subheadline" color={labelColor} numberOfLines={1} ellipsizeMode="tail" style={styles.name}>
+      <Text
+        variant="subheadline"
+        color={labelColor}
+        numberOfLines={1}
+        ellipsizeMode="tail"
+        maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+        style={styles.name}
+      >
         {climb.name}
       </Text>
       {formattedGrade ? (
-        <Text variant="subheadline" color={labelColor} numberOfLines={1} style={styles.gradeText}>
+        <Text
+          variant="subheadline"
+          color={labelColor}
+          numberOfLines={1}
+          maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+          style={styles.gradeText}
+        >
           {formattedGrade}
         </Text>
       ) : null}
@@ -125,7 +139,12 @@ function climbFromItem(item: ClimbQueueItem | null | undefined): Climb | null {
 }
 
 export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryClimbRowProps) {
-  const { state, nextClimb: navigateNextClimb, previousClimb: navigatePreviousClimb } = useQueue();
+  const {
+    state,
+    nextClimb: navigateNextClimb,
+    previousClimb: navigatePreviousClimb,
+    playlistSuggestionSource,
+  } = useQueue();
   const { boardConfig, openPlayDrawer } = useDrawerHost();
   const { systemColors } = useTheme();
   const { t } = useTranslation('session');
@@ -136,15 +155,16 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
   const { currentClimbQueueItem, queue } = state;
   const currentClimb = climbFromItem(currentClimbQueueItem);
 
-  const currentIndex = useMemo(() => {
-    if (!currentClimbQueueItem) return -1;
-    return queue.findIndex(({ uuid }) => uuid === currentClimbQueueItem.uuid);
-  }, [queue, currentClimbQueueItem]);
-
-  const canPrevious = currentIndex > 0;
-  const canNext = currentIndex >= 0 && currentIndex < queue.length - 1;
-  const previousClimb = climbFromItem(canPrevious ? queue[currentIndex - 1] : null);
-  const nextQueueClimb = climbFromItem(canNext ? queue[currentIndex + 1] : null);
+  // Suggestion-aware so the carousel matches the play drawer: at the queue tail
+  // of an active playlist, `nextItem` falls through to the next playlist climb
+  // (a transient "peek") instead of dead-ending. canPrevious/prevItem stay
+  // queue-only — there is no backward suggestion fall-through.
+  const { canPrevious, canNext, nextItem, prevItem } = useMemo(
+    () => computeNavigationStateWithSuggestions(queue, currentClimbQueueItem, playlistSuggestionSource),
+    [queue, currentClimbQueueItem, playlistSuggestionSource],
+  );
+  const previousClimb = climbFromItem(prevItem);
+  const nextQueueClimb = climbFromItem(nextItem);
   const showThumbnail = placement === 'regular' && boardConfig !== null;
 
   const handleNext = useCallback(() => {

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -15,6 +15,18 @@ const queue = vi.hoisted(() => ({
 }));
 const drawer = vi.hoisted(() => ({ openPlayDrawer: vi.fn() }));
 
+// Injectable navigation result so tests drive the suggestion-aware canNext/nextItem
+// the capsule reads from computeNavigationStateWithSuggestions.
+const nav = vi.hoisted(() => ({
+  result: {
+    canNext: false,
+    canPrevious: false,
+    nextItem: null as ClimbQueueItem | null,
+    prevItem: null as ClimbQueueItem | null,
+    remainingCount: 0,
+  },
+}));
+
 // --- RN surface: View → div ---------------------------------------------------
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -47,7 +59,10 @@ vi.mock('react-native-gesture-handler', () => {
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
-vi.mock('@boardsesh/play-view', () => ({ computePeekOffset: () => 0 }));
+vi.mock('@boardsesh/play-view', () => ({
+  computePeekOffset: () => 0,
+  computeNavigationStateWithSuggestions: () => nav.result,
+}));
 
 // getGradeColor returns a distinct hue for V6 so we can assert the grade text
 // carries the grade colour (not a generic white-on-pill style).
@@ -148,6 +163,7 @@ function makeItem(climb: Climb): ClimbQueueItem {
 
 describe('ClimbCapsule', () => {
   beforeEach(() => {
+    nav.result = { canNext: false, canPrevious: false, nextItem: null, prevItem: null, remainingCount: 0 };
     queue.state.currentClimbQueueItem = null;
     queue.state.queue = [];
     drawer.openPlayDrawer.mockClear();
@@ -246,5 +262,25 @@ describe('ClimbCapsule', () => {
     render(<ClimbCapsule />);
     // No tap fired → no call yet. (Documents the jsdom gesture limitation.)
     expect(drawer.openPlayDrawer).not.toHaveBeenCalled();
+  });
+
+  it('peeks the suggestion-aware next climb past the queue tail', () => {
+    const item = makeItem(makeClimb({ uuid: 'current', name: 'Current Route' }));
+    queue.state.currentClimbQueueItem = item;
+    queue.state.queue = [item];
+    // Only one climb queued, yet navigation reports a next item — a playlist
+    // suggestion peek. The capsule must render it instead of stopping at the tail.
+    nav.result = {
+      canNext: true,
+      canPrevious: false,
+      nextItem: makeItem(makeClimb({ uuid: 'peek', name: 'Suggested Next', difficulty: 'V7' })),
+      prevItem: null,
+      remainingCount: 0,
+    };
+
+    const { container } = render(<ClimbCapsule />);
+
+    expect(container.textContent).toContain('Current Route');
+    expect(container.textContent).toContain('Suggested Next');
   });
 });

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -24,6 +24,18 @@ const boardRender = vi.hoisted(() => ({
   boardHeight: 1920,
 }));
 
+// Injectable navigation result so tests can drive the suggestion-aware
+// canNext/nextItem the component reads from computeNavigationStateWithSuggestions.
+const nav = vi.hoisted(() => ({
+  result: {
+    canNext: false,
+    canPrevious: false,
+    nextItem: null as ClimbQueueItem | null,
+    prevItem: null as ClimbQueueItem | null,
+    remainingCount: 0,
+  },
+}));
+
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
   PlatformColor: (name: string) => name,
@@ -32,11 +44,13 @@ vi.mock('react-native', () => ({
     style,
     accessibilityRole,
     accessibilityLabel,
+    accessibilityActions,
   }: {
     children?: ReactNode;
     style?: unknown;
     accessibilityRole?: string;
     accessibilityLabel?: string;
+    accessibilityActions?: ReadonlyArray<{ name: string; label?: string }>;
   }) => {
     const readStyleValue = (styleKey: string): unknown => {
       const styles = Array.isArray(style) ? style : [style];
@@ -72,6 +86,9 @@ vi.mock('react-native', () => ({
         'data-overflow': overflow == null ? '' : String(overflow),
         'data-role': accessibilityRole ?? '',
         'data-label': accessibilityLabel ?? '',
+        'data-actions': Array.isArray(accessibilityActions)
+          ? accessibilityActions.map((action) => action.name).join(',')
+          : '',
       },
       children,
     );
@@ -100,7 +117,10 @@ vi.mock('react-native-gesture-handler', () => {
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
-vi.mock('@boardsesh/play-view', () => ({ computePeekOffset: () => 0 }));
+vi.mock('@boardsesh/play-view', () => ({
+  computePeekOffset: () => 0,
+  computeNavigationStateWithSuggestions: () => nav.result,
+}));
 
 type TextMockProps = {
   children?: ReactNode;
@@ -265,6 +285,7 @@ function expectNumericAttribute(element: HTMLElement, attributeName: string, exp
 
 describe('NativeAccessoryClimbRow', () => {
   beforeEach(() => {
+    nav.result = { canNext: false, canPrevious: false, nextItem: null, prevItem: null, remainingCount: 0 };
     const currentItem = makeItem(makeClimb());
     queue.state.currentClimbQueueItem = currentItem;
     queue.state.queue = [currentItem];
@@ -371,5 +392,36 @@ describe('NativeAccessoryClimbRow', () => {
 
     expect(tick).not.toBeNull();
     expect(tick?.closest('[data-gesture="true"]')).toBeNull();
+  });
+
+  it('surfaces the suggestion-aware next item as a peek and a "next" accessibility action', () => {
+    const currentItem = makeItem(makeClimb({ uuid: 'current', name: 'Current Climb' }));
+    queue.state.currentClimbQueueItem = currentItem;
+    queue.state.queue = [currentItem];
+    // Navigation reports a next item even though only one climb is queued — i.e.
+    // a playlist suggestion peek past the tail. The carousel must reflect it
+    // rather than dead-ending, and expose a VoiceOver "next" action.
+    nav.result = {
+      canNext: true,
+      canPrevious: false,
+      nextItem: makeItem(makeClimb({ uuid: 'peek', name: 'Playlist Next', difficulty: 'V9' })),
+      prevItem: null,
+      remainingCount: 0,
+    };
+
+    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+
+    expect(container.textContent).toContain('Current Climb');
+    expect(container.textContent).toContain('Playlist Next');
+    const swipeTarget = container.querySelector('[data-role="button"]');
+    expect(swipeTarget?.getAttribute('data-actions')).toContain('next');
+  });
+
+  it('exposes no "next" action and no peek at the navigation tail', () => {
+    // Default nav.result (set in beforeEach) reports no next/previous item.
+    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+
+    const swipeTarget = container.querySelector('[data-role="button"]');
+    expect(swipeTarget?.getAttribute('data-actions')).toBe('');
   });
 });

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -65,16 +65,18 @@ describe('PersistentQueueBar', () => {
     expect(container.querySelector('[data-capsule]')).toBeNull();
   });
 
-  it('on the Climbs tab: shows the capsule and standalone tick fallback', () => {
+  it('shows the capsule and standalone tick when a climb is current', () => {
     const { container } = render(<PersistentQueueBar />);
     expect(container.querySelector('[data-capsule]')).not.toBeNull();
     expect(container.querySelector('[data-tick]')).not.toBeNull();
   });
 
-  it('off the Climbs tab: capsule only, no tick (regardless of layout)', () => {
+  it('shows the tick on every tab — parity with the always-on native accessory', () => {
+    // Even off the Climbs tab the fallback keeps the tick so an ascent can be
+    // logged from anywhere, matching the iOS 26 bottom accessory.
     cfg.onClimbsTab = false;
     const { container } = render(<PersistentQueueBar />);
     expect(container.querySelector('[data-capsule]')).not.toBeNull();
-    expect(container.querySelector('[data-tick]')).toBeNull();
+    expect(container.querySelector('[data-tick]')).not.toBeNull();
   });
 });

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -5,8 +5,9 @@
  * Just the global climb capsule now, floating above the tab bar (iOS-Photos
  * style, no opaque card):
  *   [ grade · climb name ]            [ ✓ tick ]
- *     ↑ tap = PlayDrawer                ↑ Climbs tab only, when the native
- *       swipe = prev/next                 bottom accessory is unavailable
+ *     ↑ tap = PlayDrawer                ↑ log ascent — shown on every tab so the
+ *       swipe = prev/next                 fallback matches the always-on iOS 26
+ *                                         bottom accessory (current climb + tick)
  *
  * The native iOS 26 bottom accessory owns this same current climb + tick pair.
  * On that path this JS fallback returns null so the tab bar minimization behavior
@@ -15,8 +16,6 @@
 
 import { View, StyleSheet } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
-import { useSegments } from 'expo-router';
-import { isClimbsTabRoute } from '../../lib/route-segments';
 import { timing } from '../../theme/animations';
 import {
   TOOLBAR_RESERVE,
@@ -43,7 +42,6 @@ export function PersistentQueueBar() {
   const bottomChrome = useBottomChromeMetrics();
 
   const currentClimb = state.currentClimbQueueItem?.climb;
-  const onClimbsTab = isClimbsTabRoute(useSegments());
 
   if (!bottomChrome.jsQueueToolbarVisible) return null;
   if (!currentClimb) return null;
@@ -60,7 +58,7 @@ export function PersistentQueueBar() {
           <ClimbCapsule />
         </View>
         <View style={styles.heroSlot} pointerEvents="box-none">
-          {onClimbsTab ? <LogAscentFab climb={currentClimb} /> : null}
+          <LogAscentFab climb={currentClimb} />
         </View>
       </Animated.View>
     </Animated.View>
@@ -86,14 +84,14 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  // Left gutter: balances the capsule so it reads centered between the screen
-  // edge and the standalone tick.
+  // Left gutter spacer: balances the capsule so it reads centered between the
+  // screen edge and the standalone tick (which now shows on every tab).
   sideSlot: {
     width: TOOLBAR_FAB_SIZE,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  // Standalone log-ascent tick (hero size) on the Climbs tab.
+  // Standalone log-ascent tick (hero size), shown on every tab.
   heroSlot: {
     width: glassSize.hero,
     alignItems: 'center',

--- a/packages/mobile/src/components/search/FilterButton.tsx
+++ b/packages/mobile/src/components/search/FilterButton.tsx
@@ -33,6 +33,17 @@ export function FilterButton({ activeFilterCount, onPress, onLongPress }: Filter
       }
       accessibilityHint={onLongPress ? t('mobile.search.filterHint') : undefined}
       onLongPress={onLongPress}
+      // The long-press opens the grade rail, but a raw long-press is invisible
+      // to VoiceOver / Switch Control. Expose it as a named action so assistive
+      // tech can reach grade selection too (the Filters sheet stays the fallback).
+      accessibilityActions={onLongPress ? [{ name: 'grade', label: t('mobile.search.gradeAction') }] : undefined}
+      onAccessibilityAction={
+        onLongPress
+          ? (event) => {
+              if (event.nativeEvent.actionName === 'grade') onLongPress();
+            }
+          : undefined
+      }
       tintColor={active ? withAlpha(brandColors.primary, 0.18) : undefined}
       fallbackColor={active ? withAlpha(brandColors.primary, 0.16) : systemColors.fill}
       badgeCount={activeFilterCount}

--- a/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
@@ -14,6 +14,8 @@ type GlassMockProps = {
   onLongPress?: () => void;
   accessibilityLabel?: string;
   accessibilityHint?: string;
+  accessibilityActions?: ReadonlyArray<{ name: string; label?: string }>;
+  onAccessibilityAction?: (event: { nativeEvent: { actionName: string } }) => void;
   tintColor?: string;
   fallbackColor?: string;
   badgeCount?: number;
@@ -28,6 +30,8 @@ vi.mock('../../GlassIconButton', () => ({
     onLongPress,
     accessibilityLabel,
     accessibilityHint,
+    accessibilityActions,
+    onAccessibilityAction,
     tintColor,
     fallbackColor,
     badgeCount,
@@ -35,12 +39,17 @@ vi.mock('../../GlassIconButton', () => ({
     createElement('button', {
       onClick: onPress,
       onDoubleClick: onLongPress,
+      // Simulate VoiceOver / Switch Control invoking the named "grade" action.
+      onContextMenu: () => onAccessibilityAction?.({ nativeEvent: { actionName: 'grade' } }),
       'data-icon': iconName,
       'data-icon-color': iconColor ?? '',
       'data-icon-size': iconSize == null ? '' : String(iconSize),
       'data-size': size == null ? '' : String(size),
       'data-label': accessibilityLabel ?? '',
       'data-hint': accessibilityHint ?? '',
+      'data-actions': Array.isArray(accessibilityActions)
+        ? accessibilityActions.map((action) => action.name).join(',')
+        : '',
       'data-tint': tintColor ?? '',
       'data-fallback': fallbackColor ?? '',
       'data-badge': badgeCount == null ? '' : String(badgeCount),
@@ -138,5 +147,21 @@ describe('FilterButton', () => {
   it('adds the long-press hint when quick grade search is available', () => {
     const { container } = render(<FilterButton activeFilterCount={0} onPress={() => {}} onLongPress={() => {}} />);
     expect(button(container).getAttribute('data-hint')).toBe('mobile.search.filterHint');
+  });
+
+  it('exposes a grade accessibility action that assistive tech can trigger', () => {
+    // A raw long-press is invisible to VoiceOver / Switch Control, so grade must
+    // also be reachable as a named action that runs the same handler.
+    const onLongPress = vi.fn();
+    const { getByRole } = render(<FilterButton activeFilterCount={0} onPress={() => {}} onLongPress={onLongPress} />);
+    const filterButton = getByRole('button');
+    expect(filterButton.getAttribute('data-actions')).toContain('grade');
+    fireEvent.contextMenu(filterButton);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes no custom actions when grade quick-access is unavailable', () => {
+    const { container } = render(<FilterButton activeFilterCount={0} onPress={() => {}} />);
+    expect(button(container).getAttribute('data-actions')).toBe('');
   });
 });

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { computeBottomChromeMetrics } from '../bottom-chrome-metrics';
+import { TAB_BAR_HEIGHT, TOOLBAR_GAP_ABOVE_TABBAR, TOOLBAR_RESERVE, glassSize } from '../../theme/layout';
+
+// Assert the arbitration in terms of the layout constants (not magic numbers) so
+// this stays correct when the glass-size ladder is retuned.
+const NATIVE_ACCESSORY_RESERVE = glassSize.standard + TOOLBAR_GAP_ABOVE_TABBAR;
+
+describe('computeBottomChromeMetrics', () => {
+  it('reserves nothing extra outside the tabs group', () => {
+    const metrics = computeBottomChromeMetrics({
+      insetsBottom: 34,
+      insideTabs: false,
+      hasCurrentClimb: false,
+      nativeAccessoryMounted: false,
+    });
+    expect(metrics.tabBarHeight).toBe(0);
+    expect(metrics.tabBarBottom).toBe(34);
+    expect(metrics.scrollBottomPadding).toBe(34);
+    expect(metrics.floatingControlBottom).toBe(34);
+    expect(metrics.jsQueueToolbarVisible).toBe(false);
+    expect(metrics.nativeAccessoryVisible).toBe(false);
+  });
+
+  it('reserves the JS toolbar when a climb is set and the native accessory is unavailable', () => {
+    const metrics = computeBottomChromeMetrics({
+      insetsBottom: 0,
+      insideTabs: true,
+      hasCurrentClimb: true,
+      nativeAccessoryMounted: false,
+    });
+    expect(metrics.jsQueueToolbarVisible).toBe(true);
+    expect(metrics.jsQueueReserve).toBe(TOOLBAR_RESERVE);
+    expect(metrics.scrollBottomPadding).toBe(TAB_BAR_HEIGHT + TOOLBAR_RESERVE);
+    expect(metrics.floatingControlBottom).toBe(TAB_BAR_HEIGHT + TOOLBAR_RESERVE);
+  });
+
+  it('does not pad scroll content for the UIKit-owned native accessory', () => {
+    const metrics = computeBottomChromeMetrics({
+      insetsBottom: 0,
+      insideTabs: true,
+      hasCurrentClimb: true,
+      nativeAccessoryMounted: true,
+    });
+    expect(metrics.nativeAccessoryVisible).toBe(true);
+    expect(metrics.jsQueueToolbarVisible).toBe(false);
+    expect(metrics.jsQueueReserve).toBe(0);
+    // UIKit adds the accessory inset itself, so scroll padding is just the tab bar.
+    expect(metrics.scrollBottomPadding).toBe(TAB_BAR_HEIGHT);
+    // But floating controls must still clear the accessory.
+    expect(metrics.nativeAccessoryReserve).toBe(NATIVE_ACCESSORY_RESERVE);
+    expect(metrics.floatingControlBottom).toBe(TAB_BAR_HEIGHT + NATIVE_ACCESSORY_RESERVE);
+  });
+
+  it('keeps the tab bar but no toolbar reserve when no climb is set, even if the accessory is mounted', () => {
+    const metrics = computeBottomChromeMetrics({
+      insetsBottom: 34,
+      insideTabs: true,
+      hasCurrentClimb: false,
+      nativeAccessoryMounted: true,
+    });
+    expect(metrics.jsQueueToolbarVisible).toBe(false);
+    expect(metrics.nativeAccessoryVisible).toBe(false); // mounted, but no climb to show
+    expect(metrics.scrollBottomPadding).toBe(34 + TAB_BAR_HEIGHT);
+    expect(metrics.floatingControlBottom).toBe(34 + TAB_BAR_HEIGHT);
+  });
+
+  it('never reports both the JS toolbar and the native accessory as visible at once', () => {
+    for (const hasCurrentClimb of [true, false]) {
+      for (const nativeAccessoryMounted of [true, false]) {
+        const metrics = computeBottomChromeMetrics({
+          insetsBottom: 0,
+          insideTabs: true,
+          hasCurrentClimb,
+          nativeAccessoryMounted,
+        });
+        expect(metrics.jsQueueToolbarVisible && metrics.nativeAccessoryVisible).toBe(false);
+      }
+    }
+  });
+});

--- a/packages/mobile/src/hooks/bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/bottom-chrome-metrics.ts
@@ -1,0 +1,73 @@
+import { TAB_BAR_HEIGHT, TOOLBAR_GAP_ABOVE_TABBAR, TOOLBAR_RESERVE, glassSize } from '../theme/layout';
+
+/**
+ * Inputs the React hook gathers (safe-area insets, route, queue, capability)
+ * reduced to the primitives the math needs. Kept separate from
+ * {@link import('./use-bottom-chrome-metrics').useBottomChromeMetrics} so the
+ * arbitration is a pure, unit-tested function: it decides whether the last list
+ * row, the queue-added snackbar, and the filter FAB clear the tab bar /
+ * accessory — a class of bug that is invisible in code review and only shows on
+ * device. (Replaces the unit-tested pure `queueSnackbarBottomOffset` that was
+ * folded into the hook.)
+ */
+export type BottomChromeInputs = {
+  /** Bottom safe-area inset. */
+  insetsBottom: number;
+  /** Whether the current route is inside the (tabs) group (tab bar present). */
+  insideTabs: boolean;
+  /** Whether a climb is currently set (drives the toolbar / accessory). */
+  hasCurrentClimb: boolean;
+  /** Whether the iOS 26 native bottom accessory is mounted (it replaces the JS toolbar). */
+  nativeAccessoryMounted: boolean;
+};
+
+export type BottomChromeMetrics = {
+  hasCurrentClimb: boolean;
+  insideTabs: boolean;
+  nativeAccessoryMounted: boolean;
+  nativeAccessoryVisible: boolean;
+  jsQueueToolbarVisible: boolean;
+  tabBarHeight: number;
+  tabBarBottom: number;
+  jsQueueReserve: number;
+  nativeAccessoryReserve: number;
+  /** Bottom padding for scroll views so the last row clears the tab bar + JS toolbar. */
+  scrollBottomPadding: number;
+  /** Bottom offset for floating controls (FABs, snackbar) so they clear all chrome. */
+  floatingControlBottom: number;
+};
+
+/**
+ * Pure bottom-chrome arbitration. `nativeAccessoryVisible` and
+ * `jsQueueToolbarVisible` are mutually exclusive (the JS toolbar only mounts
+ * when the native accessory does not). The native accessory is UIKit-owned and
+ * adds its own content inset, so `scrollBottomPadding` reserves only for the JS
+ * toolbar; `floatingControlBottom` takes the max of the two reserves so floating
+ * controls clear whichever chrome is present.
+ */
+export function computeBottomChromeMetrics({
+  insetsBottom,
+  insideTabs,
+  hasCurrentClimb,
+  nativeAccessoryMounted,
+}: BottomChromeInputs): BottomChromeMetrics {
+  const nativeAccessoryVisible = nativeAccessoryMounted && hasCurrentClimb;
+  const jsQueueToolbarVisible = hasCurrentClimb && !nativeAccessoryMounted;
+  const tabBarHeight = insideTabs ? TAB_BAR_HEIGHT : 0;
+  const jsQueueReserve = jsQueueToolbarVisible ? TOOLBAR_RESERVE : 0;
+  const nativeAccessoryReserve = nativeAccessoryVisible ? glassSize.standard + TOOLBAR_GAP_ABOVE_TABBAR : 0;
+
+  return {
+    hasCurrentClimb,
+    insideTabs,
+    nativeAccessoryMounted,
+    nativeAccessoryVisible,
+    jsQueueToolbarVisible,
+    tabBarHeight,
+    tabBarBottom: insetsBottom + tabBarHeight,
+    jsQueueReserve,
+    nativeAccessoryReserve,
+    scrollBottomPadding: insetsBottom + tabBarHeight + jsQueueReserve,
+    floatingControlBottom: insetsBottom + tabBarHeight + Math.max(jsQueueReserve, nativeAccessoryReserve),
+  };
+}

--- a/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
@@ -2,10 +2,15 @@ import { useMemo } from 'react';
 import { useSegments } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useQueue } from '../providers/queue-provider';
-import { TAB_BAR_HEIGHT, TOOLBAR_GAP_ABOVE_TABBAR, TOOLBAR_RESERVE, glassSize } from '../theme/layout';
 import { isTabsRoute } from '../lib/route-segments';
 import { isBottomAccessoryAvailable } from './use-bottom-accessory';
+import { computeBottomChromeMetrics } from './bottom-chrome-metrics';
 
+/**
+ * Reserves and offsets for chrome that floats over scrollable content (the
+ * persistent queue toolbar / iOS 26 bottom accessory). Gathers the React inputs
+ * and delegates the arithmetic to the pure {@link computeBottomChromeMetrics}.
+ */
 export function useBottomChromeMetrics() {
   const insets = useSafeAreaInsets();
   const segments = useSegments();
@@ -14,36 +19,15 @@ export function useBottomChromeMetrics() {
   const hasCurrentClimb = state.currentClimbQueueItem?.climb != null;
   const insideTabs = isTabsRoute(segments);
   const nativeAccessoryMounted = insideTabs && isBottomAccessoryAvailable();
-  const nativeAccessoryVisible = nativeAccessoryMounted && hasCurrentClimb;
-  const jsQueueToolbarVisible = hasCurrentClimb && !nativeAccessoryMounted;
-  const tabBarHeight = insideTabs ? TAB_BAR_HEIGHT : 0;
-  const jsQueueReserve = jsQueueToolbarVisible ? TOOLBAR_RESERVE : 0;
-  const nativeAccessoryReserve = nativeAccessoryVisible ? glassSize.standard + TOOLBAR_GAP_ABOVE_TABBAR : 0;
 
   return useMemo(
-    () => ({
-      hasCurrentClimb,
-      insideTabs,
-      nativeAccessoryMounted,
-      nativeAccessoryVisible,
-      jsQueueToolbarVisible,
-      tabBarHeight,
-      tabBarBottom: insets.bottom + tabBarHeight,
-      jsQueueReserve,
-      nativeAccessoryReserve,
-      scrollBottomPadding: insets.bottom + tabBarHeight + jsQueueReserve,
-      floatingControlBottom: insets.bottom + tabBarHeight + Math.max(jsQueueReserve, nativeAccessoryReserve),
-    }),
-    [
-      hasCurrentClimb,
-      insets.bottom,
-      insideTabs,
-      jsQueueReserve,
-      jsQueueToolbarVisible,
-      nativeAccessoryMounted,
-      nativeAccessoryReserve,
-      nativeAccessoryVisible,
-      tabBarHeight,
-    ],
+    () =>
+      computeBottomChromeMetrics({
+        insetsBottom: insets.bottom,
+        insideTabs,
+        hasCurrentClimb,
+        nativeAccessoryMounted,
+      }),
+    [insets.bottom, insideTabs, hasCurrentClimb, nativeAccessoryMounted],
   );
 }

--- a/packages/mobile/src/theme/layout.ts
+++ b/packages/mobile/src/theme/layout.ts
@@ -1,9 +1,9 @@
 /**
  * Shared layout metrics for chrome that floats over scrollable content.
  *
- * The persistent climb toolbar — a glass capsule (current climb), joined on the
- * Climbs tab by a standalone log-ascent tick when the native bottom accessory is
- * unavailable — floats above the tab bar while a climb is active. Screens
+ * The persistent climb toolbar — a glass capsule (current climb) joined by a
+ * standalone log-ascent tick when the native bottom accessory is unavailable —
+ * floats above the tab bar while a climb is active. Screens
  * reserve it via `useBottomChromeMetrics()` so native-accessory screens do not
  * keep padding for a JS toolbar that is not mounted. Owned here (rather than
  * inside queue-control) so any screen can pad correctly without importing those

--- a/packages/mobile/src/theme/typography.ts
+++ b/packages/mobile/src/theme/typography.ts
@@ -70,3 +70,13 @@ export const textStyles = {
 } as const satisfies Record<string, TypeStyle>;
 
 export type TextVariant = keyof typeof textStyles;
+
+/**
+ * Max Dynamic Type multiplier for labels inside fixed-height glass chrome — the
+ * queue capsule and the iOS 26 bottom-accessory / now-playing-style rows, whose
+ * height is pinned to the `glassSize` ladder. The global `Text` default (1.5×)
+ * clips the single-line climb name + grade against those rigid heights, so cap
+ * them at 1.2× — still meaningfully larger for low-vision users, but it fits the
+ * platter. Surfaces that can grow with their content keep the 1.5× default.
+ */
+export const CHROME_LABEL_MAX_FONT_SCALE = 1.2;

--- a/packages/shared/climb-filters/src/__tests__/active-filter-count.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/active-filter-count.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { countActiveFilters, countActiveFiltersBeyondGrade, isGradeFilterActive } from '../active-filter-count';
+import { DEFAULT_CLIMB_FILTER_STATE } from '../filter-state';
+
+describe('isGradeFilterActive', () => {
+  it('is false for the default state', () => {
+    expect(isGradeFilterActive(DEFAULT_CLIMB_FILTER_STATE)).toBe(false);
+  });
+
+  it('is true when either grade endpoint is set', () => {
+    expect(isGradeFilterActive({ ...DEFAULT_CLIMB_FILTER_STATE, minGrade: 10 })).toBe(true);
+    expect(isGradeFilterActive({ ...DEFAULT_CLIMB_FILTER_STATE, maxGrade: 20 })).toBe(true);
+  });
+});
+
+describe('countActiveFilters', () => {
+  it('is 0 for the default state with no grade', () => {
+    expect(countActiveFilters(DEFAULT_CLIMB_FILTER_STATE)).toBe(0);
+  });
+
+  it('counts an active grade bound as exactly one (single, min-only, max-only, range)', () => {
+    expect(countActiveFilters({ ...DEFAULT_CLIMB_FILTER_STATE, minGrade: 10 })).toBe(1);
+    expect(countActiveFilters({ ...DEFAULT_CLIMB_FILTER_STATE, maxGrade: 20 })).toBe(1);
+    expect(countActiveFilters({ ...DEFAULT_CLIMB_FILTER_STATE, minGrade: 10, maxGrade: 20 })).toBe(1);
+  });
+
+  it('adds grade on top of beyond-grade filters', () => {
+    const filters = { ...DEFAULT_CLIMB_FILTER_STATE, minGrade: 10, minAscents: 5 };
+    expect(countActiveFiltersBeyondGrade(filters)).toBe(1);
+    expect(countActiveFilters(filters)).toBe(2);
+  });
+
+  it('equals the beyond-grade count when no grade is set', () => {
+    const filters = { ...DEFAULT_CLIMB_FILTER_STATE, onlyTallClimbs: true };
+    expect(countActiveFilters(filters)).toBe(countActiveFiltersBeyondGrade(filters));
+  });
+
+  it('includes board filters alongside grade', () => {
+    const filters = { ...DEFAULT_CLIMB_FILTER_STATE, minGrade: 10 };
+    expect(countActiveFilters(filters, { onlyBenchmarks: true })).toBe(2);
+  });
+});

--- a/packages/shared/climb-filters/src/active-filter-count.ts
+++ b/packages/shared/climb-filters/src/active-filter-count.ts
@@ -37,3 +37,19 @@ export function countActiveFiltersBeyondGrade(filters: ClimbFilterState, boardFi
   }
   return count;
 }
+
+/** True when a grade bound is set (either endpoint), matching hasActiveClimbFilters. */
+export function isGradeFilterActive(filters: ClimbFilterState): boolean {
+  return filters.minGrade != null || filters.maxGrade != null;
+}
+
+/**
+ * Total active-filter count INCLUDING grade — for a badge that should reflect
+ * every active refinement, grade included (e.g. the climbs filter FAB). Grade
+ * counts as one when either bound is set. Shared so web and mobile can't
+ * disagree on what the badge counts. Use {@link countActiveFiltersBeyondGrade}
+ * instead when grade has its own visible control and should be excluded.
+ */
+export function countActiveFilters(filters: ClimbFilterState, boardFilters?: ClimbBoardFilterState): number {
+  return countActiveFiltersBeyondGrade(filters, boardFilters) + (isGradeFilterActive(filters) ? 1 : 0);
+}

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -657,7 +657,8 @@
       "gradeClear": "Any",
       "filters": "Filters",
       "filterCountAria": "Filters, {{count}} active",
-      "filterHint": "Tap for filters. Hold for grade."
+      "filterHint": "Opens all climb filters",
+      "gradeAction": "Set grade range"
     },
     "gradeRail": {
       "setFilterAria": "Set grade filter to {{grade}}",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -657,7 +657,8 @@
       "gradeClear": "Cualquiera",
       "filters": "Filtros",
       "filterCountAria": "Filtros, {{count}} activos",
-      "filterHint": "Toca para filtrar. Mantén pulsado para elegir grado."
+      "filterHint": "Abre todos los filtros de bloques",
+      "gradeAction": "Ajustar el rango de grado"
     },
     "gradeRail": {
       "setFilterAria": "Filtrar por grado {{grade}}",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -657,7 +657,8 @@
       "gradeClear": "Tous",
       "filters": "Filtres",
       "filterCountAria": "Filtres, {{count}} actifs",
-      "filterHint": "Touchez pour filtrer. Maintenez pour choisir la cotation."
+      "filterHint": "Ouvre tous les filtres de blocs",
+      "gradeAction": "Définir la plage de cotation"
     },
     "gradeRail": {
       "setFilterAria": "Filtrer par cotation {{grade}}",

--- a/scripts/__tests__/mobile-patches-check.test.ts
+++ b/scripts/__tests__/mobile-patches-check.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { checkPatchesApplied, versionFromKey, type PatchCheckEnv, type PatchRule } from '../mobile-patches-check';
+
+const PKG = 'react-native-screens';
+const FILE = 'ios/helpers/scroll-view/RNSScrollViewFinder.mm';
+const KEY = 'react-native-screens@4.25.2';
+const SENTINELS = ['rnscreens_contentScrollViewForEdge', 'findScrollViewDeepFirstFrom'];
+const RULES: PatchRule[] = [{ package: PKG, file: FILE, sentinels: SENTINELS, patchedKey: KEY }];
+
+const PATCHED_SOURCE = `
++ (nullable UIScrollView *)findScrollViewDeepFirstFrom:(nullable UIView *)view { /* ... */ }
+- (nullable UIScrollView *)rnscreens_contentScrollViewForEdge:(NSDirectionalRectEdge)edge { /* ... */ }
+`;
+
+/**
+ * Build a fake env from explicit maps so tests never touch a real node_modules
+ * tree. A missing key throws, mirroring an unresolvable package / absent file.
+ */
+function makeEnv(opts: {
+  patchedDependencies?: Record<string, string>;
+  versions?: Record<string, string>;
+  files?: Record<string, string>;
+}): PatchCheckEnv {
+  return {
+    patchedDependencies: opts.patchedDependencies ?? { [KEY]: `patches/${KEY}.patch` },
+    readInstalledVersion(pkg) {
+      const version = opts.versions?.[pkg];
+      if (!version) throw new Error(`Cannot find module '${pkg}/package.json'`);
+      return version;
+    },
+    readInstalledFile(pkg, fileSubpath) {
+      const hit = opts.files?.[`${pkg}::${fileSubpath}`];
+      if (hit === undefined) throw new Error(`ENOENT: ${pkg}/${fileSubpath}`);
+      return hit;
+    },
+  };
+}
+
+describe('checkPatchesApplied', () => {
+  it('passes when configured, version matches, and all sentinels are present', () => {
+    const env = makeEnv({
+      versions: { [PKG]: '4.25.2' },
+      files: { [`${PKG}::${FILE}`]: PATCHED_SOURCE },
+    });
+
+    const result = checkPatchesApplied(RULES, env);
+
+    expect(result.checked).toBe(1);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('fails when the patch is no longer configured in patchedDependencies', () => {
+    const env = makeEnv({
+      patchedDependencies: {},
+      versions: { [PKG]: '4.25.2' },
+      files: { [`${PKG}::${FILE}`]: PATCHED_SOURCE },
+    });
+
+    const result = checkPatchesApplied(RULES, env);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('patch no longer configured');
+  });
+
+  it('fails on version drift — the install would be unpatched', () => {
+    const env = makeEnv({
+      versions: { [PKG]: '4.25.3' },
+      // Even if the file somehow still had the sentinels, drift is reported first.
+      files: { [`${PKG}::${FILE}`]: PATCHED_SOURCE },
+    });
+
+    const result = checkPatchesApplied(RULES, env);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('version drift');
+    expect(result.errors[0]).toContain('4.25.3');
+    expect(result.errors[0]).toContain('4.25.2');
+  });
+
+  it('fails when the version matches but the sentinel is missing (patch silently dropped)', () => {
+    const env = makeEnv({
+      versions: { [PKG]: '4.25.2' },
+      files: { [`${PKG}::${FILE}`]: '// upstream source with no swizzle\n' },
+    });
+
+    const result = checkPatchesApplied(RULES, env);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('patch NOT applied');
+    expect(result.errors[0]).toContain('rnscreens_contentScrollViewForEdge');
+    expect(result.errors[0]).toContain('findScrollViewDeepFirstFrom');
+  });
+
+  it('fails when only some sentinels are present', () => {
+    const env = makeEnv({
+      versions: { [PKG]: '4.25.2' },
+      files: { [`${PKG}::${FILE}`]: '- (id)rnscreens_contentScrollViewForEdge:(int)e { }\n' },
+    });
+
+    const result = checkPatchesApplied(RULES, env);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('findScrollViewDeepFirstFrom');
+    expect(result.errors[0]).not.toContain('"rnscreens_contentScrollViewForEdge"');
+  });
+
+  it('fails when the package is not resolvable from packages/mobile', () => {
+    const env = makeEnv({ versions: {}, files: {} });
+
+    const result = checkPatchesApplied(RULES, env);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('not resolvable from packages/mobile');
+  });
+
+  it('fails when the patched file is absent', () => {
+    const env = makeEnv({ versions: { [PKG]: '4.25.2' }, files: {} });
+
+    const result = checkPatchesApplied(RULES, env);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('cannot read patched file');
+  });
+});
+
+describe('versionFromKey', () => {
+  it('extracts the version from an unscoped key', () => {
+    expect(versionFromKey('react-native-screens@4.25.2')).toBe('4.25.2');
+  });
+
+  it('extracts the version from a scoped key', () => {
+    expect(versionFromKey('@sentry/cli@2.53.0')).toBe('2.53.0');
+  });
+
+  it('returns empty string when no version segment is present', () => {
+    expect(versionFromKey('react-native-screens')).toBe('');
+  });
+});

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -1,0 +1,196 @@
+/// <reference types="node" />
+
+/**
+ * Guards against a silently-dropped Bun patch on a native module.
+ *
+ * `patchedDependencies` in the root package.json keys each patch by an EXACT
+ * version string (e.g. "react-native-screens@4.25.2"). The moment the resolved
+ * version drifts off that key — an Expo SDK bump, `bun update`, or a transitive
+ * floor raise from expo-router — Bun installs the dependency UNPATCHED and only
+ * emits a warning. The app still installs, typechecks, and bundles; the only
+ * symptom is a missing NATIVE behavior at runtime that no JS check can see.
+ *
+ * For react-native-screens specifically, the patch adds a
+ * `-[UIViewController contentScrollViewForEdge:]` fallback (the
+ * `rnscreens_contentScrollViewForEdge` swizzle + `findScrollViewDeepFirstFrom`
+ * deep search) so the iOS 26 tab-bar minimize tracks the climbs FlashList. Drop
+ * the patch and the tab bar just stops minimizing — invisible to typecheck, the
+ * Metro bundle, and every existing test, all the way into TestFlight.
+ *
+ * This check resolves the COPY packages/mobile actually uses (the same one
+ * CocoaPods compiles) and asserts the patch's sentinel symbols are present in
+ * the installed source. It fails the PR on a cheap Linux runner the instant a
+ * patch stops applying — no Xcode required.
+ *
+ * Usage: vp run check:mobile-patches
+ */
+
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export interface PatchRule {
+  /** The patched package — must be a direct dependency of packages/mobile. */
+  package: string;
+  /** Path, within the installed package, to the source file the patch edits. */
+  file: string;
+  /** Symbols the patch introduces; ALL must be present in the installed file. */
+  sentinels: readonly string[];
+  /** The exact `patchedDependencies` key expected in the root package.json. */
+  patchedKey: string;
+}
+
+/**
+ * Rules are maintained by hand — one per patched native module whose absence is
+ * invisible to JS-level checks. Add a rule when you `bun patch` a package whose
+ * effect is native-only (the JS side would catch a missing JS patch on its own).
+ */
+export const RULES: readonly PatchRule[] = [
+  {
+    package: 'react-native-screens',
+    file: 'ios/helpers/scroll-view/RNSScrollViewFinder.mm',
+    sentinels: ['rnscreens_contentScrollViewForEdge', 'findScrollViewDeepFirstFrom'],
+    patchedKey: 'react-native-screens@4.25.2',
+  },
+];
+
+/**
+ * I/O abstracted so {@link checkPatchesApplied} can be unit-tested without a
+ * real node_modules tree. The real implementation is {@link createNodeEnv}.
+ */
+export interface PatchCheckEnv {
+  /** The root package.json `patchedDependencies` map. */
+  patchedDependencies: Record<string, string>;
+  /** Installed `version` of `pkg` as resolved from packages/mobile. Throws if unresolvable. */
+  readInstalledVersion(pkg: string): string;
+  /** Read `fileSubpath` from the installed `pkg` (resolved from packages/mobile). Throws if pkg unresolvable or file absent. */
+  readInstalledFile(pkg: string, fileSubpath: string): string;
+}
+
+export interface CheckResult {
+  /** Number of rules that were checked. */
+  checked: number;
+  /** Human-readable failure messages; empty means the check passed. */
+  errors: string[];
+}
+
+/** "react-native-screens@4.25.2" -> "4.25.2"; "@scope/name@1.2.3" -> "1.2.3". */
+export function versionFromKey(patchedKey: string): string {
+  const at = patchedKey.lastIndexOf('@');
+  return at > 0 ? patchedKey.slice(at + 1) : '';
+}
+
+/**
+ * Pure check: verify every patch rule against the installed tree via `env`.
+ * All filesystem/resolution access goes through `env`, so tests inject a fake.
+ */
+export function checkPatchesApplied(rules: readonly PatchRule[], env: PatchCheckEnv): CheckResult {
+  const errors: string[] = [];
+  let checked = 0;
+
+  for (const rule of rules) {
+    checked += 1;
+
+    // (1) The patch must still be configured at all.
+    if (!Object.prototype.hasOwnProperty.call(env.patchedDependencies, rule.patchedKey)) {
+      errors.push(
+        `${rule.package}: patch no longer configured — expected key "${rule.patchedKey}" in the root ` +
+          `package.json "patchedDependencies". If you intentionally removed it, also delete the rule in ` +
+          `scripts/mobile-patches-check.ts and patches/${rule.patchedKey}.patch.`,
+      );
+      continue;
+    }
+
+    // (2) The configured key must match the installed version — Bun applies a
+    //     patch only to its exact key, so any drift means an UNPATCHED install.
+    const expectedVersion = versionFromKey(rule.patchedKey);
+    let installedVersion: string;
+    try {
+      installedVersion = env.readInstalledVersion(rule.package);
+    } catch (error) {
+      errors.push(`${rule.package}: not resolvable from packages/mobile (${(error as Error).message}).`);
+      continue;
+    }
+    if (expectedVersion && installedVersion !== expectedVersion) {
+      errors.push(
+        `${rule.package}: version drift — installed ${installedVersion}, but "patchedDependencies" targets ` +
+          `${expectedVersion}. Bun keys patches by exact version, so this install is UNPATCHED. Regenerate the ` +
+          `patch for ${installedVersion} (\`bun patch ${rule.package}\`), update the key + patches/ filename, ` +
+          `then re-run this check.`,
+      );
+      continue;
+    }
+
+    // (3) The patch's sentinel symbols must be present in the installed source.
+    let source: string;
+    try {
+      source = env.readInstalledFile(rule.package, rule.file);
+    } catch (error) {
+      errors.push(`${rule.package}: cannot read patched file ${rule.file} (${(error as Error).message}).`);
+      continue;
+    }
+    const missing = rule.sentinels.filter((sentinel) => !source.includes(sentinel));
+    if (missing.length > 0) {
+      errors.push(
+        `${rule.package}: patch NOT applied — ${rule.file} is missing ${missing.map((s) => `"${s}"`).join(', ')}. ` +
+          `Run \`bun install\` to re-apply patches/${rule.patchedKey}.patch; if it no longer applies cleanly, ` +
+          `regenerate it with \`bun patch ${rule.package}\`.`,
+      );
+    }
+  }
+
+  return { checked, errors };
+}
+
+/** Real-filesystem env used when the script runs for real. */
+export function createNodeEnv(mobilePackageJson: string, patchedDependencies: Record<string, string>): PatchCheckEnv {
+  const requireFromMobile = createRequire(mobilePackageJson);
+  const resolvePackageJson = (pkg: string) => requireFromMobile.resolve(`${pkg}/package.json`);
+  return {
+    patchedDependencies,
+    readInstalledVersion(pkg) {
+      const { version } = JSON.parse(readFileSync(resolvePackageJson(pkg), 'utf8')) as { version?: string };
+      if (!version) throw new Error(`no "version" field in ${pkg}/package.json`);
+      return version;
+    },
+    readInstalledFile(pkg, fileSubpath) {
+      return readFileSync(resolve(dirname(resolvePackageJson(pkg)), fileSubpath), 'utf8');
+    },
+  };
+}
+
+/** Wire the real filesystem and run the check. Returns the process exit code. */
+export function main(): number {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  const mobilePackageJson = resolve(repoRoot, 'packages', 'mobile', 'package.json');
+
+  let patchedDependencies: Record<string, string>;
+  try {
+    const rootPkg = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8')) as {
+      patchedDependencies?: Record<string, string>;
+    };
+    patchedDependencies = rootPkg.patchedDependencies ?? {};
+  } catch (error) {
+    console.error(`[mobile-patches] FAILED — cannot read root package.json: ${(error as Error).message}`);
+    return 1;
+  }
+
+  const env = createNodeEnv(mobilePackageJson, patchedDependencies);
+  const { checked, errors } = checkPatchesApplied(RULES, env);
+
+  if (errors.length > 0) {
+    console.error('[mobile-patches] FAILED — native patch(es) not applied:');
+    for (const error of errors) console.error(`  ✗ ${error}`);
+    return 1;
+  }
+
+  console.log(`[mobile-patches] OK — ${checked} native patch(es) applied.`);
+  return 0;
+}
+
+// Run only when executed directly (tsx scripts/mobile-patches-check.ts), not
+// when imported by tests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -349,6 +349,10 @@ export default defineConfig({
         command: 'tsx scripts/mobile-native-deps-check.ts',
         cache: false,
       },
+      'check:mobile-patches': {
+        command: 'tsx scripts/mobile-patches-check.ts',
+        cache: false,
+      },
       'check:mobile-bundle': {
         command: 'bash scripts/mobile-bundle-check.sh',
         cache: false,


### PR DESCRIPTION
Remediation from a multi-reviewer pass (3 code reviewers + a 2-person design team) on the native-tab queue accessory + climbs search redesign (originally #2554, now merged to main). **Rebased on latest `main`**, so this PR's diff is just the review fixes.

## Commits

- **`f0f206b` Phase A — ship-blockers**
  - **react-native-screens patch apply-guard** in CI (`scripts/mobile-patches-check.ts` + test, run after `check:mobile-native-deps`). A Bun patch is keyed by exact version, so an Expo/RN bump silently drops it and the iOS 26 tab-bar minimize regresses with nothing catching it.
  - **Dynamic Type cap** on the fixed-height glass chrome so the climb name/grade don't clip at large accessibility text.
  - **Suggestion-aware queue carousel** — `canNext/canPrevious` from `computeNavigationStateWithSuggestions`, so a playlist no longer dead-ends at the queue tail (+ tail-peek tests).
  - **SearchHeader silent setter** — programmatic seeding (board restore / sync / recent pill) no longer re-arms the input debounce or re-commits the term.
  - **Grade as a real `accessibilityAction`** on the filter button (VoiceOver / Switch Control can't reach a raw long-press) + hint copy fixed across locales.
- **`c617d72` Phase B — tick parity** — dropped the Climbs-tab-only gate so the JS fallback shows the log-ascent tick on every tab, matching the always-on iOS 26 accessory (+ test).
- **`18b3426` Phase D — reuse + testability** — shared `countActiveFilters` (grade-inclusive) in `@boardsesh/climb-filters` (+ tests); extracted the pure `computeBottomChromeMetrics` from the hook (+ test), restoring the coverage lost when `queueSnackbarBottomOffset` was inlined.
- **`ab5181b` Fast grade rail** — removed the redundant Done button from the filter-button grade rail (it has an accessible drag handle, tap-outside, and auto-dismiss). Found in device testing.

## Validation (Linux)
`typecheck:mobile`, `vp test --project mobile`, `climb-filters` + i18n catalog-parity + patch-guard tests, and `check:mobile-bundle` (iOS + Android) — all green. Verified live on a device via Metro (app bundles + runs; tabs/search/grade exercised).

## Deferred to a device-paired follow-up (not in this PR)
These need an on-device build to get right and were intentionally not done blind:
- Visible "grade" cue / active band on the filter FAB (the a11y action is in; the visible cue is next).
- Record-tab dedup of the floating accessory vs the inline session; live-session-vs-Bluetooth badge disambiguation; return-to-session affordance.
- Native swizzle hardening (gate/bound the `contentScrollViewForEdge` swizzle, idempotent vs double `+load`); the `useBottomChromeMetrics` re-render fan-out; the shared `useQueueClimbCarousel` extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)