### PR TITLE
Add Material UI variant alongside the iOS 26 liquid glass UI (mobile)

### DIFF
--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -1,29 +1,84 @@
+import type { ColorValue } from 'react-native';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
+import { Tabs } from 'expo-router';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useTranslation } from 'react-i18next';
 import { useBluetoothConnectedStatus } from '../../src/lib/ble/bluetooth-status-store';
 import { useQueue } from '../../src/providers/queue-provider';
 import { QueueBottomAccessory } from '../../src/components/queue-control/QueueBottomAccessory';
+import { MaterialTabBar } from '../../src/components/navigation/MaterialTabBar';
+import { useTheme } from '../../src/providers/theme-provider';
 import { brandColors } from '../../src/theme/colors';
 
+type TabIconProps = { focused: boolean; color: ColorValue; size: number };
+
+// Material (MaterialCommunityIcons) glyphs for the JS tab bar, mirroring the
+// SF Symbols / md hints used by the native tab bar. Rendered on all platforms in
+// the Material variant so it reads as Material even on iOS.
+const materialTabIcon =
+  (active: string, inactive: string) =>
+  ({ focused, color, size }: TabIconProps) => (
+    <MaterialCommunityIcons name={(focused ? active : inactive) as never} color={color} size={size} />
+  );
+
 /**
- * Native bottom tabs (`expo-router/unstable-native-tabs`). On iOS 26 this renders
- * the system Liquid Glass tab bar and folds into a leading home button on scroll
- * (`minimizeBehavior="onScrollDown"`). The bottom accessory now owns only the
- * current climb + tick, so its single native platter is the intended background.
- * The Climbs tab opts into the native search role, which lets iOS place search
- * in the separated bottom-right tab affordance.
+ * Bottom tabs. The Liquid Glass variant uses the system Liquid Glass tab bar
+ * (`expo-router/unstable-native-tabs`) with a native `BottomAccessory` platter
+ * for the current climb + tick. The Material variant uses a JS `Tabs` navigator
+ * with the Material 3 `MaterialTabBar`; its climb/tick chrome rides the floating
+ * `PersistentQueueBar` (the native accessory is Liquid-Glass-only).
  */
 export default function TabLayout() {
   const { t } = useTranslation('common');
   const { t: tPlaylists } = useTranslation('playlists');
   const { t: tSession } = useTranslation('session');
+  const { variant } = useTheme();
 
   // Record-tab status cue: a badge when a board is connected over Bluetooth or a
-  // session is live (the custom tab bar's green dot + blink have no native
-  // equivalent under NativeTabs).
+  // session is live.
   const isBluetoothConnected = useBluetoothConnectedStatus();
   const { sessionId } = useQueue();
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
+
+  if (variant === 'material') {
+    return (
+      <Tabs tabBar={(props) => <MaterialTabBar {...props} />} screenOptions={{ headerShown: false }}>
+        <Tabs.Screen
+          name="boards"
+          options={{
+            title: t('mobile.nav.boards'),
+            tabBarIcon: materialTabIcon('view-dashboard', 'view-dashboard-outline'),
+          }}
+        />
+        <Tabs.Screen
+          name="climbs"
+          options={{ title: t('mobile.nav.climbs'), tabBarIcon: materialTabIcon('magnify', 'magnify') }}
+        />
+        <Tabs.Screen
+          name="record"
+          options={{
+            title: tSession('mobile.session.recordTab'),
+            tabBarIcon: materialTabIcon('record-circle', 'record-circle-outline'),
+            tabBarBadge: showRecordBadge ? '' : undefined,
+          }}
+        />
+        <Tabs.Screen
+          name="discover"
+          options={{
+            title: tPlaylists('bottomTabBar.discover'),
+            tabBarIcon: materialTabIcon('bookmark-multiple', 'bookmark-multiple-outline'),
+          }}
+        />
+        <Tabs.Screen
+          name="profile"
+          options={{
+            title: t('mobile.nav.profile'),
+            tabBarIcon: materialTabIcon('account-circle', 'account-circle-outline'),
+          }}
+        />
+      </Tabs>
+    );
+  }
 
   return (
     // `minimizeBehavior="onScrollDown"` relies on UIKit finding the climbs

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -101,7 +101,7 @@ function ClimbListInner() {
   const router = useRouter();
   const { t } = useTranslation('climbs');
   const { openClimbActions, openAddToPlaylist } = useDrawerHost();
-  const { systemColors } = useTheme();
+  const { systemColors, variant } = useTheme();
   const { addToQueue, state: queueState } = useQueue();
   const { filters, boardFilters, name, setFilters, setBoardFilters, setGrade, setName, replaceSearch } =
     useClimbSearch();
@@ -130,6 +130,11 @@ function ClimbListInner() {
     filterFabMinimumBottom,
     bottomChrome.floatingControlBottom + spacing[2] - filterFabNativeAccessoryDrop,
   );
+
+  // On the Material variant the filter lives in the top-right toolbar (next to
+  // the light/bluetooth button) inside ClimbTopChrome, so the bottom filter FAB
+  // is not rendered here.
+  const filterInTopChrome = variant === 'material';
 
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isSearchFocused, setIsSearchFocused] = useState(false);
@@ -716,19 +721,24 @@ function ClimbListInner() {
         onSearchFocus={handleSearchFocus}
         onSearchBlur={handleSearchBlur}
         onCloseGrade={handleDismissGrade}
+        showFilterAction={filterInTopChrome}
+        activeFilterCount={activeFilterCount}
+        onOpenFilters={handleOpenFilters}
       />
 
-      <ClimbFilterFab
-        activeFilterCount={activeFilterCount}
-        bottom={filterFabBottom}
-        bound={gradeBound}
-        grades={grades}
-        gradeRailVisible={showGrade}
-        onOpenFilters={handleOpenFilters}
-        onOpenGrade={handleOpenGrade}
-        onCloseGrade={handleDismissGrade}
-        onGradeChange={handleGradeChange}
-      />
+      {filterInTopChrome ? null : (
+        <ClimbFilterFab
+          activeFilterCount={activeFilterCount}
+          bottom={filterFabBottom}
+          bound={gradeBound}
+          grades={grades}
+          gradeRailVisible={showGrade}
+          onOpenFilters={handleOpenFilters}
+          onOpenGrade={handleOpenGrade}
+          onCloseGrade={handleDismissGrade}
+          onGradeChange={handleGradeChange}
+        />
+      )}
 
       {showFilters ? (
         <ClimbFilterSheet

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -32,7 +32,7 @@ import { useBoardProvider } from '@boardsesh/board-react';
 import { randomUUID } from 'expo-crypto';
 import { type SearchHeaderHandle } from '../../../src/components/SearchHeader';
 import { RecentFilterPills } from '../../../src/components/RecentFilterPills';
-import { isBottomAccessoryAvailable } from '../../../src/hooks/use-bottom-accessory';
+import { useNativeAccessoryActive } from '../../../src/hooks/use-bottom-accessory';
 import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
 import { useGrades } from '../../../src/lib/graphql/hooks';
 import { useInfiniteSearchClimbs } from '../../../src/lib/graphql/hooks/use-infinite-search-climbs';
@@ -119,7 +119,7 @@ function ClimbListInner() {
   // presents this screen's headerSearchBarOptions controller in the bottom tab
   // bar's search role — there is no header search bar. Fallback devices keep the
   // custom search field inside the top chrome.
-  const useNativeSearch = isBottomAccessoryAvailable();
+  const useNativeSearch = useNativeAccessoryActive();
 
   const listPaddingBottom = bottomChrome.scrollBottomPadding;
   const filterFabNativeAccessoryDrop = bottomChrome.nativeAccessoryVisible ? glassSize.standard * 2 : 0;

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -2,7 +2,7 @@ import { router } from 'expo-router';
 import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { GradeDisplayFormat } from '@boardsesh/play-view';
-import type { ThemeOverride } from '@boardsesh/key-value-storage';
+import type { ThemeOverride, UiVariantPreference } from '@boardsesh/key-value-storage';
 import { useTheme } from '../../../src/providers/theme-provider';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useProfile } from '../../../src/lib/graphql/hooks';
@@ -16,20 +16,31 @@ import { SectionHeader } from '../../../src/components/SectionHeader';
 import { SegmentedControl } from '../../../src/components/SegmentedControl';
 import { isPreviewBuild } from '../../../src/lib/eas-api';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
+import { useGlassCapability } from '../../../src/hooks/use-glass-capability';
 
 export default function MoreScreen() {
-  const { systemColors, borderRadius, themeOverride, setThemeOverride } = useTheme();
+  const { systemColors, borderRadius, themeOverride, setThemeOverride, uiVariantPreference, setUiVariant } = useTheme();
   const { t } = useTranslation('common');
   const { t: tProfile } = useTranslation('profile');
   const { signOut } = useAuth();
   const { data: profile } = useProfile();
   const { gradeFormat, setGradeFormat } = useGradeFormat();
+  const glassCapable = useGlassCapability();
 
   const appearanceOptions: { key: ThemeOverride; label: string }[] = [
     { key: 'system', label: t('mobile.more.appearance.system') },
     { key: 'light', label: t('mobile.more.appearance.light') },
     { key: 'dark', label: t('mobile.more.appearance.dark') },
   ];
+
+  const uiStyleOptions: { key: UiVariantPreference; label: string }[] = [
+    { key: 'auto', label: t('mobile.more.uiStyle.auto') },
+    { key: 'liquidGlass', label: t('mobile.more.uiStyle.liquidGlass') },
+    { key: 'material', label: t('mobile.more.uiStyle.material') },
+  ];
+  // Liquid Glass can't render on Android / iOS < 26, so show it disabled there
+  // rather than hide it — more honest than a no-op control.
+  const disabledUiStyles = glassCapable ? undefined : new Set<UiVariantPreference>(['liquidGlass']);
 
   const gradeFormatOptions: { key: GradeDisplayFormat; label: string }[] = [
     { key: 'v-grade', label: t('mobile.more.gradeFormat.vGrade') },
@@ -61,6 +72,33 @@ export default function MoreScreen() {
             trackColor={systemColors.fill}
             accessibilityLabel={t('mobile.more.appearance.title')}
           />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <SectionHeader title={t('mobile.more.uiStyle.title')} />
+        <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: systemColors.secondaryBackground,
+              borderRadius: borderRadius.lg,
+              marginHorizontal: spacing[4],
+              padding: spacing[3],
+            },
+          ]}
+        >
+          <SegmentedControl
+            options={uiStyleOptions}
+            selectedKey={uiVariantPreference}
+            onSelect={(key) => void setUiVariant(key)}
+            disabledKeys={disabledUiStyles}
+            trackColor={systemColors.fill}
+            accessibilityLabel={t('mobile.more.uiStyle.title')}
+          />
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.settingHint}>
+            {glassCapable ? t('mobile.more.uiStyle.description') : t('mobile.more.uiStyle.glassUnavailable')}
+          </Text>
         </View>
       </View>
 

--- a/packages/mobile/src/components/Button.tsx
+++ b/packages/mobile/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import { Platform, StyleSheet, type ViewStyle } from 'react-native';
+import { StyleSheet, type ViewStyle } from 'react-native';
 import { Text } from './Text';
 import { Icon } from './Icon';
 import { PressableSurface } from './PressableSurface';
@@ -6,7 +6,7 @@ import type { IconName } from './icon-map';
 import { hapticLight } from '../lib/haptics';
 import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
-import { material } from '../theme/tokens';
+import { useTheme } from '../providers/theme-provider';
 
 type ButtonVariant = 'filled' | 'outlined' | 'text';
 type ButtonSize = 'small' | 'medium' | 'large';
@@ -30,9 +30,6 @@ const sizeConfig = {
   large: { paddingHorizontal: 20, paddingVertical: 14, fontSize: 17, iconSize: 22 },
 } as const;
 
-// M3 corner radius on Android, the existing iOS radius elsewhere.
-const BUTTON_RADIUS = Platform.select({ android: material.button.radius, default: 10 });
-
 export function Button({
   title,
   onPress,
@@ -46,6 +43,9 @@ export function Button({
   style,
 }: ButtonProps) {
   const config = sizeConfig[size];
+  // Soft 10dp corner on Liquid Glass, M3 20dp on Material (and Android, which
+  // defaults to the Material variant).
+  const { radii } = useTheme();
 
   const handlePress = () => {
     if (disabled || loading) return;
@@ -60,7 +60,7 @@ export function Button({
     gap: 6,
     paddingHorizontal: config.paddingHorizontal,
     paddingVertical: config.paddingVertical,
-    borderRadius: BUTTON_RADIUS,
+    borderRadius: radii.button,
     opacity: disabled ? 0.5 : 1,
     ...(variant === 'filled' && { backgroundColor: tintColor }),
     ...(variant === 'outlined' && { borderWidth: 1, borderColor: tintColor }),

--- a/packages/mobile/src/components/GlassSurface.tsx
+++ b/packages/mobile/src/components/GlassSurface.tsx
@@ -18,9 +18,11 @@ type GlassSurfaceProps = {
    */
   tintColor?: string;
   /**
-   * Solid background used on Android and when Reduce Transparency is enabled.
-   * Defaults to the theme's secondary background. Pass an opaque tint here when
-   * a surface wants its tint to survive on the no-glass path.
+   * Fill layered over the surface on the no-glass paths (Material / Android /
+   * Reduce Transparency). It composites on top of an opaque secondary-background
+   * base, so a translucent token (e.g. `systemColors.fill`) reads as a tint —
+   * not a see-through hole — and an opaque value fully covers the base. Omit it
+   * to get the plain secondary-background surface.
    */
   fallbackColor?: ColorValue;
   /**
@@ -72,16 +74,26 @@ export function GlassSurface({
   const mode = useEffectiveSurfaceMode();
   const isDark = colorScheme === 'dark';
 
-  const solidColor = fallbackColor ?? systemColors.secondaryBackground;
+  // The no-glass paths always start from an opaque base so the surface never
+  // shows the screen through it (a `fallbackColor` may be a translucent token
+  // like `fill`, meant as a tint over a surface, not a standalone background —
+  // and a see-through surface would also defeat Reduce Transparency).
+  const baseColor = systemColors.secondaryBackground;
   const radius = borderRadius != null ? { borderRadius } : null;
   // The blur/solid paths have no native shape, so clip them to the radius here.
   const clippedRadius = borderRadius != null ? { borderRadius, overflow: 'hidden' as const } : null;
 
   // Solid: Reduce Transparency (a11y) on any platform, or Android forced onto
-  // the Liquid Glass variant. Flat fill, no elevation.
+  // the Liquid Glass variant. Opaque base + the fallback/tint layered on top.
   if (mode === 'solid') {
     return (
-      <View style={[style, clippedRadius, { backgroundColor: solidColor }]} pointerEvents={pointerEvents}>
+      <View style={[style, clippedRadius, { backgroundColor: baseColor }]} pointerEvents={pointerEvents}>
+        {fallbackColor ? (
+          <View pointerEvents="none" style={[StyleSheet.absoluteFill, { backgroundColor: fallbackColor }]} />
+        ) : null}
+        {tintColor ? (
+          <View pointerEvents="none" style={[StyleSheet.absoluteFill, { backgroundColor: tintColor }]} />
+        ) : null}
         {children}
       </View>
     );
@@ -89,11 +101,14 @@ export function GlassSurface({
 
   // Material: opaque M3 tonal surface. Background + radius + shadow live on the
   // same view (no `overflow: 'hidden'`, which would clip the iOS shadow) so the
-  // surface casts a real elevation shadow with rounded corners. A tint is
-  // composited as a translucent overlay, matching the blur path.
+  // surface casts a real elevation shadow with rounded corners. The fallback and
+  // tint composite over the opaque base, matching the blur path.
   if (mode === 'material') {
     return (
-      <View style={[style, radius, shadows.sm, { backgroundColor: solidColor }]} pointerEvents={pointerEvents}>
+      <View style={[style, radius, shadows.sm, { backgroundColor: baseColor }]} pointerEvents={pointerEvents}>
+        {fallbackColor ? (
+          <View pointerEvents="none" style={[StyleSheet.absoluteFill, radius, { backgroundColor: fallbackColor }]} />
+        ) : null}
         {tintColor ? (
           <View pointerEvents="none" style={[StyleSheet.absoluteFill, radius, { backgroundColor: tintColor }]} />
         ) : null}

--- a/packages/mobile/src/components/GlassSurface.tsx
+++ b/packages/mobile/src/components/GlassSurface.tsx
@@ -1,18 +1,11 @@
 import { type ReactNode } from 'react';
-import {
-  Platform,
-  StyleSheet,
-  View,
-  type ColorValue,
-  type StyleProp,
-  type ViewProps,
-  type ViewStyle,
-} from 'react-native';
+import { StyleSheet, View, type ColorValue, type StyleProp, type ViewProps, type ViewStyle } from 'react-native';
 import { BlurView } from '@react-native-community/blur';
-import { GlassView, isGlassEffectAPIAvailable, isLiquidGlassAvailable, type GlassStyle } from 'expo-glass-effect';
+import { GlassView, type GlassStyle } from 'expo-glass-effect';
 import { useTheme } from '../providers/theme-provider';
 import { iosDarkColors, iosLightColors } from '../theme/ios-colors';
-import { useReduceTransparency } from '../hooks/use-reduce-transparency';
+import { shadows } from '../theme/tokens';
+import { useEffectiveSurfaceMode } from '../hooks/use-effective-surface-mode';
 
 type GlassSurfaceProps = {
   children?: ReactNode;
@@ -52,13 +45,14 @@ type GlassSurfaceProps = {
 };
 
 /**
- * One background primitive for every translucent surface. Picks the best
- * available material for the device and degrades cleanly:
+ * One background primitive for every translucent / tonal surface. Picks the
+ * right material for the device, variant and a11y settings via
+ * `useEffectiveSurfaceMode()`, and renders cleanly for each:
  *
- *   iOS 26+            → expo-glass-effect GlassView (true Liquid Glass)
- *   iOS < 26           → @react-native-community/blur frosted blur
- *   Android            → solid themed surface
- *   Reduce Transparency → solid themed surface (any platform)
+ *   glass    → expo-glass-effect GlassView (iOS 26 Liquid Glass — preferred)
+ *   blur     → @react-native-community/blur frosted blur (iOS < 26 fallback)
+ *   material → opaque Material 3 tonal surface + elevation shadow
+ *   solid    → flat themed surface (Reduce Transparency, or Android on glass)
  *
  * It fills its parent like gorhom's `backgroundComponent`; consumers stack
  * content on top either as children or as siblings.
@@ -75,7 +69,7 @@ export function GlassSurface({
   pointerEvents,
 }: GlassSurfaceProps) {
   const { systemColors, colorScheme } = useTheme();
-  const reduceTransparency = useReduceTransparency();
+  const mode = useEffectiveSurfaceMode();
   const isDark = colorScheme === 'dark';
 
   const solidColor = fallbackColor ?? systemColors.secondaryBackground;
@@ -83,8 +77,9 @@ export function GlassSurface({
   // The blur/solid paths have no native shape, so clip them to the radius here.
   const clippedRadius = borderRadius != null ? { borderRadius, overflow: 'hidden' as const } : null;
 
-  // Honour Reduce Transparency strictly — no glass, no blur.
-  if (reduceTransparency) {
+  // Solid: Reduce Transparency (a11y) on any platform, or Android forced onto
+  // the Liquid Glass variant. Flat fill, no elevation.
+  if (mode === 'solid') {
     return (
       <View style={[style, clippedRadius, { backgroundColor: solidColor }]} pointerEvents={pointerEvents}>
         {children}
@@ -92,10 +87,25 @@ export function GlassSurface({
     );
   }
 
-  // iOS 26+: real Liquid Glass. The radius goes on the GlassView itself so the
-  // native glass renders a rounded shape with its own clean edge (no parent clip
-  // or RN border, which would seam at the cardinal points of a circle).
-  if (Platform.OS === 'ios' && isLiquidGlassAvailable() && isGlassEffectAPIAvailable()) {
+  // Material: opaque M3 tonal surface. Background + radius + shadow live on the
+  // same view (no `overflow: 'hidden'`, which would clip the iOS shadow) so the
+  // surface casts a real elevation shadow with rounded corners. A tint is
+  // composited as a translucent overlay, matching the blur path.
+  if (mode === 'material') {
+    return (
+      <View style={[style, radius, shadows.sm, { backgroundColor: solidColor }]} pointerEvents={pointerEvents}>
+        {tintColor ? (
+          <View pointerEvents="none" style={[StyleSheet.absoluteFill, radius, { backgroundColor: tintColor }]} />
+        ) : null}
+        {children}
+      </View>
+    );
+  }
+
+  // Glass: real iOS 26 Liquid Glass. The radius goes on the GlassView itself so
+  // the native glass renders a rounded shape with its own clean edge (no parent
+  // clip or RN border, which would seam at the cardinal points of a circle).
+  if (mode === 'glass') {
     return (
       <View style={style} pointerEvents={pointerEvents}>
         <GlassView
@@ -110,29 +120,20 @@ export function GlassSurface({
     );
   }
 
-  // iOS < 26: frosted blur approximation (matches the existing tab-bar look).
-  if (Platform.OS === 'ios') {
-    return (
-      <View style={[style, clippedRadius]} pointerEvents={pointerEvents}>
-        <BlurView
-          blurType={isDark ? 'dark' : 'light'}
-          blurAmount={blurAmount}
-          reducedTransparencyFallbackColor={
-            isDark ? iosDarkColors.secondaryBackground : iosLightColors.secondaryBackground
-          }
-          style={StyleSheet.absoluteFill}
-        />
-        {tintColor ? (
-          <View pointerEvents="none" style={[StyleSheet.absoluteFill, { backgroundColor: tintColor }]} />
-        ) : null}
-        {children}
-      </View>
-    );
-  }
-
-  // Android: solid themed surface (or an opaque tint via fallbackColor).
+  // Blur: iOS < 26 frosted approximation (matches the pre-Liquid-Glass tab bar).
   return (
-    <View style={[style, clippedRadius, { backgroundColor: solidColor }]} pointerEvents={pointerEvents}>
+    <View style={[style, clippedRadius]} pointerEvents={pointerEvents}>
+      <BlurView
+        blurType={isDark ? 'dark' : 'light'}
+        blurAmount={blurAmount}
+        reducedTransparencyFallbackColor={
+          isDark ? iosDarkColors.secondaryBackground : iosLightColors.secondaryBackground
+        }
+        style={StyleSheet.absoluteFill}
+      />
+      {tintColor ? (
+        <View pointerEvents="none" style={[StyleSheet.absoluteFill, { backgroundColor: tintColor }]} />
+      ) : null}
       {children}
     </View>
   );

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -17,7 +17,7 @@ import {
 import { FullWindowOverlay } from 'react-native-screens';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { hapticMedium } from '../lib/haptics';
-import { sheetAndroid, sheetStyles, spacing } from '../theme/tokens';
+import { sheetStyles, spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 
 // iOS renders the modal in a native window overlay so it sits above the queue
@@ -54,7 +54,7 @@ export const ModalSheet = forwardRef<BottomSheetModal, ModalSheetProps>(function
   },
   ref,
 ) {
-  const { systemColors } = useTheme();
+  const { systemColors, sheet } = useTheme();
   const insets = useSafeAreaInsets();
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);
 
@@ -64,11 +64,11 @@ export const ModalSheet = forwardRef<BottomSheetModal, ModalSheetProps>(function
         {...props}
         disappearsOnIndex={-1}
         appearsOnIndex={0}
-        opacity={sheetAndroid.scrimOpacity}
+        opacity={sheet.scrimOpacity}
         pressBehavior="close"
       />
     ),
-    [],
+    [sheet.scrimOpacity],
   );
 
   const handleChange = useCallback(
@@ -81,7 +81,7 @@ export const ModalSheet = forwardRef<BottomSheetModal, ModalSheetProps>(function
 
   const backgroundStyle = {
     ...sheetStyles.background,
-    ...sheetAndroid.corners,
+    ...sheet.corners,
     backgroundColor: systemColors.secondaryBackground,
   };
 
@@ -109,7 +109,7 @@ export const ModalSheet = forwardRef<BottomSheetModal, ModalSheetProps>(function
       enablePanDownToClose={enablePanDownToClose}
       backdropComponent={renderBackdrop}
       backgroundStyle={backgroundStyle}
-      handleIndicatorStyle={sheetAndroid.handleStyle}
+      handleIndicatorStyle={sheet.handleStyle}
       containerComponent={modalContainerComponent}
       onChange={handleChange}
       onDismiss={onDismiss}

--- a/packages/mobile/src/components/SegmentedControl.tsx
+++ b/packages/mobile/src/components/SegmentedControl.tsx
@@ -19,6 +19,8 @@ type SegmentedControlProps<K extends string> = {
   textVariant?: 'subheadline' | 'footnote';
   /** Background color for the segmented control track. */
   trackColor: ColorValue;
+  /** Keys that render dimmed and non-selectable (e.g. Liquid Glass on a device that can't show it). */
+  disabledKeys?: ReadonlySet<K>;
   /** Accessibility label naming the group (e.g. "Appearance"), so VoiceOver announces what the segments control. */
   accessibilityLabel?: string;
 };
@@ -26,15 +28,17 @@ type SegmentedControlProps<K extends string> = {
 function Segment({
   label,
   selected,
+  disabled,
   onPress,
   textVariant,
 }: {
   label: string;
   selected: boolean;
+  disabled: boolean;
   onPress: () => void;
   textVariant: 'subheadline' | 'footnote';
 }) {
-  const { systemColors, colorScheme } = useTheme();
+  const { systemColors, colorScheme, opacity } = useTheme();
   const isDark = colorScheme === 'dark';
 
   // Selected pill is a raised tile over the track — elevatedSurface reads as a
@@ -45,6 +49,7 @@ function Segment({
     alignItems: 'center',
     justifyContent: 'center',
     borderRadius: 7,
+    ...(disabled && { opacity: opacity.disabled }),
     ...(selected && {
       backgroundColor: systemColors.elevatedSurface,
       shadowColor: '#000',
@@ -62,13 +67,15 @@ function Segment({
   return (
     <PressableSurface
       onPress={() => {
+        if (disabled) return;
         hapticSelection();
         onPress();
       }}
+      disabled={disabled}
       feedback="scale"
       scaleTo={0.95}
       accessibilityRole="radio"
-      accessibilityState={{ selected }}
+      accessibilityState={{ selected, disabled }}
       accessibilityLabel={label}
       style={segmentStyle}
     >
@@ -89,6 +96,7 @@ export function SegmentedControl<K extends string = string>({
   onSelect,
   textVariant = 'subheadline',
   trackColor,
+  disabledKeys,
   accessibilityLabel,
 }: SegmentedControlProps<K>) {
   const containerStyle = {
@@ -105,6 +113,7 @@ export function SegmentedControl<K extends string = string>({
           key={option.key}
           label={option.label}
           selected={selectedKey === option.key}
+          disabled={disabledKeys?.has(option.key) ?? false}
           onPress={() => onSelect(option.key)}
           textVariant={textVariant}
         />

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -9,7 +9,7 @@ import BottomSheet, {
 import { FullWindowOverlay } from 'react-native-screens';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { hapticMedium } from '../lib/haptics';
-import { sheetAndroid, sheetStyles, spacing } from '../theme/tokens';
+import { sheetStyles, spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 
 // On iOS a plain BottomSheet renders inside the screen's view tree, so it sits
@@ -67,15 +67,15 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
   },
   ref,
 ) {
-  const { systemColors } = useTheme();
+  const { systemColors, sheet: sheetChrome } = useTheme();
   const insets = useSafeAreaInsets();
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
-      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} opacity={sheetAndroid.scrimOpacity} />
+      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} opacity={sheetChrome.scrimOpacity} />
     ),
-    [],
+    [sheetChrome.scrimOpacity],
   );
 
   const handleChange = useCallback(
@@ -88,7 +88,7 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
 
   const backgroundStyle = {
     ...sheetStyles.background,
-    ...sheetAndroid.corners,
+    ...sheetChrome.corners,
     backgroundColor: systemColors.secondaryBackground,
   };
 
@@ -121,7 +121,7 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
       backgroundStyle={backgroundStyle}
       onChange={handleChange}
       onClose={onClose}
-      handleIndicatorStyle={sheetAndroid.handleStyle}
+      handleIndicatorStyle={sheetChrome.handleStyle}
       style={styles.sheet}
     >
       {footer ? (

--- a/packages/mobile/src/components/__tests__/glass-surface.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-surface.test.tsx
@@ -4,7 +4,13 @@ import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
 // Controls the rendering branch under test.
-const ctrl = vi.hoisted(() => ({ os: 'ios' as string, glass: true, glassApi: true, rt: false }));
+const ctrl = vi.hoisted(() => ({
+  os: 'ios' as string,
+  glass: true,
+  glassApi: true,
+  rt: false,
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
+}));
 
 // Minimal RN surface. View renders a <div> exposing its background colour and
 // pointerEvents so the solid path and tint overlays are inspectable.
@@ -42,13 +48,21 @@ vi.mock('../../hooks/use-reduce-transparency', () => ({
 }));
 
 vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({ systemColors: { secondaryBackground: '#1C1C1E' }, colorScheme: 'dark' }),
+  useTheme: () => ({
+    systemColors: { secondaryBackground: '#1C1C1E', elevatedSurface: '#2C2C2E' },
+    colorScheme: 'dark',
+    variant: ctrl.variant,
+  }),
 }));
 
 vi.mock('../../theme/ios-colors', () => ({
   iosDarkColors: { secondaryBackground: '#1C1C1E' },
   iosLightColors: { secondaryBackground: '#F2F2F7' },
 }));
+
+// Real tokens.ts pulls in PlatformColor via ios-colors; the material branch only
+// needs shadows.sm, so stub it.
+vi.mock('../../theme/tokens', () => ({ shadows: { sm: {} } }));
 
 import { GlassSurface } from '../GlassSurface';
 
@@ -57,6 +71,7 @@ beforeEach(() => {
   ctrl.glass = true;
   ctrl.glassApi = true;
   ctrl.rt = false;
+  ctrl.variant = 'liquidGlass';
 });
 
 describe('GlassSurface fallback hierarchy', () => {
@@ -90,6 +105,22 @@ describe('GlassSurface fallback hierarchy', () => {
 
   it('Reduce Transparency takes priority over Liquid Glass — solid surface', () => {
     ctrl.rt = true; // even though iOS 26 + glass are available
+    const { queryByTestId } = render(<GlassSurface />);
+    expect(queryByTestId('glass-view')).toBeNull();
+    expect(queryByTestId('blur-view')).toBeNull();
+  });
+
+  it('renders an opaque Material surface on the Material variant — even on iOS 26 hardware', () => {
+    ctrl.variant = 'material'; // glass is available, but the user chose Material
+    const { queryByTestId, container } = render(<GlassSurface />);
+    expect(queryByTestId('glass-view')).toBeNull();
+    expect(queryByTestId('blur-view')).toBeNull();
+    expect(container.querySelector('[data-bg="#1C1C1E"]')).not.toBeNull();
+  });
+
+  it('Reduce Transparency still wins over the Material variant — solid surface', () => {
+    ctrl.variant = 'material';
+    ctrl.rt = true;
     const { queryByTestId } = render(<GlassSurface />);
     expect(queryByTestId('glass-view')).toBeNull();
     expect(queryByTestId('blur-view')).toBeNull();

--- a/packages/mobile/src/components/__tests__/glass-surface.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-surface.test.tsx
@@ -118,6 +118,24 @@ describe('GlassSurface fallback hierarchy', () => {
     expect(container.querySelector('[data-bg="#1C1C1E"]')).not.toBeNull();
   });
 
+  it('composites a translucent fallbackColor over an opaque base (no see-through) on Material', () => {
+    // The climbs search bar passes the faint `fill` token as its fallback; it
+    // must not punch a hole through the surface on the no-glass paths.
+    ctrl.variant = 'material';
+    const { container } = render(<GlassSurface fallbackColor="rgba(1, 2, 3, 0.1)" />);
+    // Opaque secondary-background base is present...
+    expect(container.querySelector('[data-bg="#1C1C1E"]')).not.toBeNull();
+    // ...with the translucent fill layered on top as a tint.
+    expect(container.querySelector('[data-bg="rgba(1, 2, 3, 0.1)"]')).not.toBeNull();
+  });
+
+  it('composites a translucent fallbackColor over an opaque base on the solid path too', () => {
+    ctrl.rt = true; // solid path
+    const { container } = render(<GlassSurface fallbackColor="rgba(1, 2, 3, 0.1)" />);
+    expect(container.querySelector('[data-bg="#1C1C1E"]')).not.toBeNull();
+    expect(container.querySelector('[data-bg="rgba(1, 2, 3, 0.1)"]')).not.toBeNull();
+  });
+
   it('Reduce Transparency still wins over the Material variant — solid surface', () => {
     ctrl.variant = 'material';
     ctrl.rt = true;

--- a/packages/mobile/src/components/navigation/MaterialTabBar.tsx
+++ b/packages/mobile/src/components/navigation/MaterialTabBar.tsx
@@ -1,0 +1,120 @@
+import { Platform, StyleSheet, View } from 'react-native';
+import type { BottomTabBarProps } from 'expo-router/tabs';
+import { Text } from '../Text';
+import { PressableSurface } from '../PressableSurface';
+import { useTheme } from '../../providers/theme-provider';
+import { brandColors, withAlpha } from '../../theme/colors';
+import { material } from '../../theme/tokens';
+import { TAB_BAR_HEIGHT } from '../../theme/layout';
+
+/**
+ * Material 3 bottom navigation bar — the JS tab bar for the Material UI variant
+ * (the Liquid Glass variant uses the native `NativeTabs` instead). Built from the
+ * existing design tokens so it reads as the same product: an opaque elevated
+ * surface, a tonal active-indicator pill behind the focused icon, label below,
+ * and a status dot for the Record tab. Icons/labels/badges come from each
+ * screen's React Navigation options, so this stays a generic custom tab bar.
+ */
+export function MaterialTabBar({ state, descriptors, navigation, insets }: BottomTabBarProps) {
+  const { systemColors } = useTheme();
+  const activeColor = brandColors.primary;
+  const inactiveColor = systemColors.secondaryLabel;
+  const indicatorColor = withAlpha(brandColors.primary, 0.16);
+
+  return (
+    <View
+      style={[
+        styles.bar,
+        {
+          backgroundColor: systemColors.elevatedSurface,
+          borderTopColor: systemColors.separator,
+          paddingBottom: insets.bottom,
+          height: TAB_BAR_HEIGHT + insets.bottom,
+        },
+      ]}
+    >
+      {state.routes.map((route, index) => {
+        const { options } = descriptors[route.key];
+        const focused = state.index === index;
+        const label = typeof options.title === 'string' ? options.title : route.name;
+        const color = focused ? activeColor : inactiveColor;
+
+        const onPress = () => {
+          const event = navigation.emit({ type: 'tabPress', target: route.key, canPreventDefault: true });
+          if (!focused && !event.defaultPrevented) {
+            navigation.navigate(route.name);
+          }
+        };
+        const onLongPress = () => {
+          navigation.emit({ type: 'tabLongPress', target: route.key });
+        };
+
+        return (
+          <PressableSurface
+            key={route.key}
+            onPress={onPress}
+            onLongPress={onLongPress}
+            feedback="none"
+            rippleColor={brandColors.primary}
+            rippleBorderless
+            accessibilityRole="tab"
+            accessibilityState={{ selected: focused }}
+            accessibilityLabel={label}
+            style={styles.item}
+          >
+            <View style={[styles.indicator, focused && { backgroundColor: indicatorColor }]}>
+              {options.tabBarIcon?.({ focused, color, size: 24 })}
+              {options.tabBarBadge != null ? (
+                <View
+                  style={[
+                    styles.badge,
+                    { backgroundColor: brandColors.success, borderColor: systemColors.elevatedSurface },
+                  ]}
+                />
+              ) : null}
+            </View>
+            <Text variant="caption2" color={color} numberOfLines={1}>
+              {label}
+            </Text>
+          </PressableSurface>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: 'row',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    ...Platform.select({
+      android: { elevation: material.navBar.surfaceElevation },
+      ios: { shadowColor: '#000', shadowOffset: { width: 0, height: -2 }, shadowOpacity: 0.08, shadowRadius: 8 },
+      default: {},
+    }),
+  },
+  item: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: 6,
+    gap: 4,
+  },
+  // M3 active-indicator pill — fixed size, tonal fill only when focused.
+  indicator: {
+    width: material.navBar.activeIndicatorWidth,
+    height: material.navBar.activeIndicatorHeight,
+    borderRadius: material.navBar.activeIndicatorRadius,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badge: {
+    position: 'absolute',
+    top: 2,
+    right: 10,
+    width: 9,
+    height: 9,
+    borderRadius: 5,
+    borderWidth: 1.5,
+  },
+});

--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -47,7 +47,7 @@ export function QueueSheet({
 }: QueueSheetProps) {
   const { t } = useTranslation('session');
   const insets = useSafeAreaInsets();
-  const { systemColors } = useTheme();
+  const { systemColors, sheet } = useTheme();
   const sheetRef = useRef<BottomSheetModal>(null);
 
   const { state, removeFromQueue, clearQueue, reorderQueue, playlistSuggestionSource } = useQueue();
@@ -138,12 +138,22 @@ export function QueueSheet({
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
-      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.4} pressBehavior="close" />
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        opacity={sheet.scrimOpacity}
+        pressBehavior="close"
+      />
     ),
-    [],
+    [sheet.scrimOpacity],
   );
 
-  const backgroundStyle = { ...sheetStyles.background, backgroundColor: systemColors.secondaryBackground };
+  const backgroundStyle = {
+    ...sheetStyles.background,
+    ...sheet.corners,
+    backgroundColor: systemColors.secondaryBackground,
+  };
 
   const viewOnlyMode = queue.length === 0;
 
@@ -163,7 +173,7 @@ export function QueueSheet({
       backdropComponent={renderBackdrop}
       containerComponent={modalContainerComponent}
       onDismiss={handleDismissed}
-      handleIndicatorStyle={sheetStyles.indicator}
+      handleIndicatorStyle={sheet.handleStyle}
       backgroundStyle={backgroundStyle}
       style={styles.sheet}
     >

--- a/packages/mobile/src/components/queue-control/AccessoryBarSurface.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryBarSurface.tsx
@@ -1,0 +1,72 @@
+import { type ReactNode } from 'react';
+import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import { GlassSurface } from '../GlassSurface';
+import { useTheme } from '../../providers/theme-provider';
+import { useEffectiveSurfaceMode } from '../../hooks/use-effective-surface-mode';
+import { shadows } from '../../theme/tokens';
+
+type AccessoryBarSurfaceProps = {
+  /** Surface height; the default radius is a full pill (`height / 2`). */
+  height: number;
+  borderRadius?: number;
+  style?: StyleProp<ViewStyle>;
+  children: ReactNode;
+};
+
+/**
+ * The variant-aware background for a floating "active context" pill (the climb
+ * capsule today, a workout timer later). It owns ONLY the surface + height so the
+ * occupant content stays variant-agnostic:
+ *
+ *   glass    → Liquid Glass pill (native edge — no border/shadow)
+ *   material → opaque M3 tonal pill + elevation (no border)
+ *   blur/solid → frosted/solid fill + hairline border + separation shadow
+ *
+ * Reduce Transparency is handled inside `GlassSurface`/`useEffectiveSurfaceMode`
+ * (it resolves to the solid branch here), so a11y stays correct without this
+ * component knowing about it.
+ */
+export function AccessoryBarSurface({ height, borderRadius, style, children }: AccessoryBarSurfaceProps) {
+  const mode = useEffectiveSurfaceMode();
+  const { systemColors } = useTheme();
+  const radius = borderRadius ?? height / 2;
+  const shape: ViewStyle = { height, borderRadius: radius };
+
+  // Native Liquid Glass draws its own refractive edge + lift.
+  if (mode === 'glass') {
+    return (
+      <View style={[shape, style]}>
+        <GlassSurface
+          glassEffectStyle="regular"
+          borderRadius={radius}
+          style={StyleSheet.absoluteFill}
+          pointerEvents="none"
+        />
+        {children}
+      </View>
+    );
+  }
+
+  // Material: opaque M3 tonal surface + elevation; no border (elevation separates).
+  if (mode === 'material') {
+    return (
+      <View style={[shape, { backgroundColor: systemColors.elevatedSurface }, shadows.sm, style]}>{children}</View>
+    );
+  }
+
+  // Blur / solid fallback: the surface has no intrinsic edge, so add the hairline
+  // border and separation shadow.
+  return (
+    <View
+      style={[shape, shadows.sm, { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator }, style]}
+    >
+      <GlassSurface
+        fallbackColor={systemColors.elevatedSurface}
+        borderRadius={radius}
+        style={StyleSheet.absoluteFill}
+        pointerEvents="none"
+      />
+      {children}
+    </View>
+  );
+}

--- a/packages/mobile/src/components/queue-control/AccessoryClimbThumbnail.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryClimbThumbnail.tsx
@@ -1,0 +1,79 @@
+import { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { BoardName } from '@boardsesh/shared-schema';
+import type { Climb } from '@boardsesh/queue';
+import { getBoardRenderData } from '../../lib/board-details';
+import { type BoardConfig } from '../../providers/drawer-host-provider';
+import { BoardRenderer } from '../board-renderer/BoardRenderer';
+
+/** Square slot size for the accessory-bar board thumbnail. */
+export const ACCESSORY_THUMBNAIL_SLOT_SIZE = 40;
+const ACCESSORY_THUMBNAIL_ART_MAX_SIZE = 40;
+const ACCESSORY_THUMBNAIL_ART_RADIUS = 10;
+
+function getAccessoryThumbnailBoardSize(boardWidth: number, boardHeight: number) {
+  const boardAspectRatio = boardWidth / boardHeight;
+  if (!Number.isFinite(boardAspectRatio) || boardAspectRatio <= 0) {
+    return { width: ACCESSORY_THUMBNAIL_ART_MAX_SIZE, height: ACCESSORY_THUMBNAIL_ART_MAX_SIZE };
+  }
+  if (boardAspectRatio >= 1) {
+    return { width: ACCESSORY_THUMBNAIL_ART_MAX_SIZE, height: ACCESSORY_THUMBNAIL_ART_MAX_SIZE / boardAspectRatio };
+  }
+  return { width: ACCESSORY_THUMBNAIL_ART_MAX_SIZE * boardAspectRatio, height: ACCESSORY_THUMBNAIL_ART_MAX_SIZE };
+}
+
+/**
+ * The small board render shown beside the climb name in the accessory bar (the
+ * floating capsule and the iOS 26 native accessory). Renders nothing if the
+ * board config or render data isn't available.
+ */
+export function AccessoryClimbThumbnail({ climb, boardConfig }: { climb: Climb; boardConfig: BoardConfig | null }) {
+  const boardRenderData = useMemo(() => {
+    if (!boardConfig) return null;
+    const setIdValues = boardConfig.setIds
+      .split(',')
+      .map((setIdText) => Number(setIdText))
+      .filter((setIdValue) => Number.isFinite(setIdValue));
+    if (setIdValues.length === 0) return null;
+    return getBoardRenderData({
+      boardName: boardConfig.boardName as BoardName,
+      layoutId: boardConfig.layoutId,
+      sizeId: boardConfig.sizeId,
+      setIds: setIdValues,
+    });
+  }, [boardConfig]);
+
+  if (!boardRenderData) return null;
+
+  const thumbnailBoardStyle = {
+    ...getAccessoryThumbnailBoardSize(boardRenderData.boardWidth, boardRenderData.boardHeight),
+    borderRadius: ACCESSORY_THUMBNAIL_ART_RADIUS,
+    overflow: 'hidden' as const,
+  };
+
+  return (
+    <View style={styles.thumbnailSlot}>
+      <BoardRenderer
+        frames={climb.frames}
+        boardName={boardConfig?.boardName as BoardName}
+        boardWidth={boardRenderData.boardWidth}
+        boardHeight={boardRenderData.boardHeight}
+        imageUrls={boardRenderData.imageUrls}
+        holdsData={boardRenderData.holdsData}
+        mirrored={climb.mirrored === true}
+        fillContainer
+        style={thumbnailBoardStyle}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  thumbnailSlot: {
+    width: ACCESSORY_THUMBNAIL_SLOT_SIZE,
+    height: ACCESSORY_THUMBNAIL_SLOT_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+});

--- a/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
+++ b/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
@@ -35,6 +35,11 @@ type ActiveContextBarProps = {
   trailing?: ReactNode;
   /** Width of the trailing slot (defaults to the hero size). */
   trailingWidth?: number;
+  /** Render the primary edge-to-edge (no leading/trailing slots) — the Material
+   *  full-width bar, where the trailing action lives inside the primary. */
+  fillPrimary?: boolean;
+  /** Lift above the tab bar (defaults to TOOLBAR_GAP_ABOVE_TABBAR). */
+  gapAboveTabBar?: number;
 };
 
 export function ActiveContextBar({
@@ -42,6 +47,8 @@ export function ActiveContextBar({
   primary,
   trailing,
   trailingWidth = glassSize.hero,
+  fillPrimary = false,
+  gapAboveTabBar = TOOLBAR_GAP_ABOVE_TABBAR,
 }: ActiveContextBarProps) {
   const reduceMotion = useReduceMotion();
   const bottomChrome = useBottomChromeMetrics();
@@ -50,19 +57,25 @@ export function ActiveContextBar({
     <Animated.View
       entering={reduceMotion ? undefined : FadeIn.duration(timing.normal)}
       pointerEvents="box-none"
-      style={[styles.toolbar, { bottom: bottomChrome.tabBarBottom + TOOLBAR_GAP_ABOVE_TABBAR }]}
+      style={[styles.toolbar, { bottom: bottomChrome.tabBarBottom + gapAboveTabBar }]}
     >
-      <Animated.View style={styles.row} pointerEvents="box-none" importantForAccessibility="auto">
-        <View style={styles.sideSlot} pointerEvents={leading ? 'box-none' : 'none'}>
-          {leading}
-        </View>
-        <View style={styles.centerSlot} pointerEvents="box-none">
+      {fillPrimary ? (
+        <View style={styles.fillRow} pointerEvents="box-none" importantForAccessibility="auto">
           {primary}
         </View>
-        <View style={[styles.heroSlot, { width: trailingWidth }]} pointerEvents="box-none">
-          {trailing}
-        </View>
-      </Animated.View>
+      ) : (
+        <Animated.View style={styles.row} pointerEvents="box-none" importantForAccessibility="auto">
+          <View style={styles.sideSlot} pointerEvents={leading ? 'box-none' : 'none'}>
+            {leading}
+          </View>
+          <View style={styles.centerSlot} pointerEvents="box-none">
+            {primary}
+          </View>
+          <View style={[styles.heroSlot, { width: trailingWidth }]} pointerEvents="box-none">
+            {trailing}
+          </View>
+        </Animated.View>
+      )}
     </Animated.View>
   );
 }
@@ -79,6 +92,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: TOOLBAR_GAP,
+  },
+  // Full-width primary (Material bar): the single occupant spans the toolbar.
+  fillRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
   },
   centerSlot: {
     flex: 1,

--- a/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
+++ b/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
@@ -1,0 +1,100 @@
+/**
+ * ActiveContextBar — the content-agnostic floating bar that sits above the tab
+ * bar. It owns ONLY the layout (absolute lift above the tab bar, the
+ * leading / primary / trailing slot rhythm, fade-in) — not what fills it. Today
+ * the primary slot holds the climb capsule; a later workout rep-timer drops into
+ * the same slot with no changes here.
+ *
+ *   [ leading ]      [        primary        ]      [ trailing ]
+ *     gutter/widget     climb capsule / timer         hero action (tick)
+ *
+ * Visibility is the caller's call (it knows whether there's a climb / timer to
+ * show); this component only positions whatever it's given.
+ */
+
+import { type ReactNode } from 'react';
+import { View, StyleSheet } from 'react-native';
+import Animated, { FadeIn } from 'react-native-reanimated';
+import { timing } from '../../theme/animations';
+import {
+  TOOLBAR_SIDE_MARGIN,
+  TOOLBAR_GAP,
+  TOOLBAR_FAB_SIZE,
+  TOOLBAR_GAP_ABOVE_TABBAR,
+  glassSize,
+} from '../../theme/layout';
+import { useReduceMotion } from '../../hooks/use-reduce-motion';
+import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+
+type ActiveContextBarProps = {
+  /** Optional leading widget; defaults to an empty gutter that balances the bar. */
+  leading?: ReactNode;
+  /** The main occupant (climb capsule today, timer later). */
+  primary: ReactNode;
+  /** Optional trailing hero action (e.g. the log-ascent tick). */
+  trailing?: ReactNode;
+  /** Width of the trailing slot (defaults to the hero size). */
+  trailingWidth?: number;
+};
+
+export function ActiveContextBar({
+  leading,
+  primary,
+  trailing,
+  trailingWidth = glassSize.hero,
+}: ActiveContextBarProps) {
+  const reduceMotion = useReduceMotion();
+  const bottomChrome = useBottomChromeMetrics();
+
+  return (
+    <Animated.View
+      entering={reduceMotion ? undefined : FadeIn.duration(timing.normal)}
+      pointerEvents="box-none"
+      style={[styles.toolbar, { bottom: bottomChrome.tabBarBottom + TOOLBAR_GAP_ABOVE_TABBAR }]}
+    >
+      <Animated.View style={styles.row} pointerEvents="box-none" importantForAccessibility="auto">
+        <View style={styles.sideSlot} pointerEvents={leading ? 'box-none' : 'none'}>
+          {leading}
+        </View>
+        <View style={styles.centerSlot} pointerEvents="box-none">
+          {primary}
+        </View>
+        <View style={[styles.heroSlot, { width: trailingWidth }]} pointerEvents="box-none">
+          {trailing}
+        </View>
+      </Animated.View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  toolbar: {
+    position: 'absolute',
+    left: TOOLBAR_SIDE_MARGIN,
+    right: TOOLBAR_SIDE_MARGIN,
+    // `bottom` is set inline from the safe-area inset + tab-bar height so the
+    // islands float just above the tab bar.
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: TOOLBAR_GAP,
+  },
+  centerSlot: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  // Left gutter: balances the primary slot so it reads centered between the
+  // screen edge and the trailing action.
+  sideSlot: {
+    width: TOOLBAR_FAB_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  heroSlot: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -1,31 +1,23 @@
-// The toolbar's center element: a frosted-glass pill showing the current climb's
-// name with the grade colorized on the right — the same treatment as the climb
-// list rows. Tap opens the PlayDrawer; horizontal swipe steps the queue
-// (prev/next) with the neighbouring climb peeking in — the same carousel feel as
-// the play drawer. A faint grade wash tints the glass. Extracted from the old
-// queue bar so the swipe/peek + drawer wiring is shared.
+// The toolbar's center element: a floating pill showing the current climb's name
+// with the grade colorized on the right — the same treatment as the climb list
+// rows. Tap opens the PlayDrawer; horizontal swipe steps the queue (prev/next)
+// with the neighbouring climb peeking in. The pill's background adapts to the UI
+// variant (Liquid Glass / Material / fallback) via AccessoryBarSurface; the
+// swipe/peek/tap behaviour is shared with the native accessory via useQueueCarousel.
 
-import { type ReactNode, useCallback, useMemo, useState } from 'react';
-import { View, StyleSheet, type ColorValue, type LayoutChangeEvent } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, { runOnJS, useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
-import { useTranslation } from 'react-i18next';
-import { computePeekOffset, computeNavigationStateWithSuggestions } from '@boardsesh/play-view';
+import { useMemo } from 'react';
+import { View, StyleSheet, type ColorValue } from 'react-native';
+import { GestureDetector } from 'react-native-gesture-handler';
+import Animated from 'react-native-reanimated';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { ClimbQueueItem } from '@boardsesh/queue';
-import { shadows } from '../../theme/tokens';
 import { TOOLBAR_CAPSULE_HEIGHT, TOOLBAR_CAPSULE_MAX_WIDTH } from '../../theme/layout';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { useGradeFormat } from '../../hooks/use-grade-format';
-import { useReduceMotion } from '../../hooks/use-reduce-motion';
-import { useNativeGlass } from '../../hooks/use-native-glass';
 import { Text } from '../Text';
-import { GlassSurface } from '../GlassSurface';
 import { useTheme } from '../../providers/theme-provider';
-import { useQueue } from '../../providers/queue-provider';
-import { useDrawerHost } from '../../providers/drawer-host-provider';
-import { hapticLight, hapticSelection } from '../../lib/haptics';
-import { useCarouselGesture } from '../play-drawer/use-carousel-gesture';
+import { AccessoryBarSurface } from './AccessoryBarSurface';
+import { useQueueCarousel } from './use-queue-carousel';
 
 type ClimbDisplay = {
   difficulty: string | null | undefined;
@@ -72,182 +64,49 @@ function ClimbLabel({ display, labelColor, formattedGrade, gradeColor }: ClimbLa
 }
 
 type ClimbCapsuleProps = {
-  /**
-   * Render without the capsule's own glass pill / border / shadow. Used inside
-   * the iOS 26 tab-bar bottom accessory, which is itself a Liquid Glass platter —
-   * a second glass surface there would read as glass-on-glass. Keeps the label
-   * + swipe/tap gestures; just drops the background chrome.
-   */
-  bare?: boolean;
-  /**
-   * Let the capsule fill its parent. Used by the native bottom accessory where
-   * UIKit's platter is wider than the standalone floating capsule cap.
-   */
-  fillWidth?: boolean;
-  /** Optional right-side action rendered inside the capsule chrome. */
-  endAction?: ReactNode;
-  endActionSize?: number;
   height?: number;
 };
 
-export function ClimbCapsule({
-  bare = false,
-  fillWidth = false,
-  endAction,
-  endActionSize = 0,
-  height = TOOLBAR_CAPSULE_HEIGHT,
-}: ClimbCapsuleProps) {
-  const { state, nextClimb, previousClimb, playlistSuggestionSource } = useQueue();
-  const { openPlayDrawer } = useDrawerHost();
+export function ClimbCapsule({ height = TOOLBAR_CAPSULE_HEIGHT }: ClimbCapsuleProps) {
   const { systemColors } = useTheme();
-  const { t } = useTranslation('session');
   const { formatGrade } = useGradeFormat();
-  const reduceMotion = useReduceMotion();
-  const nativeGlass = useNativeGlass();
+  const {
+    onLayout,
+    composedGesture,
+    currentLabelStyle,
+    nextPeekStyle,
+    prevPeekStyle,
+    currentItem,
+    previousItem,
+    nextItem,
+    handleNext,
+    handlePrevious,
+    swipeAccessibilityActions,
+  } = useQueueCarousel();
 
-  const [width, setWidth] = useState(0);
-
-  const { currentClimbQueueItem, queue } = state;
-
-  // Suggestion-aware so the capsule carousel matches the play drawer: at the
-  // queue tail of an active playlist, `nextItem` falls through to the next
-  // playlist climb (a transient "peek") instead of stopping. canPrevious/prevItem
-  // stay queue-only — there is no backward suggestion fall-through.
-  const { canPrevious, canNext, nextItem, prevItem } = useMemo(
-    () => computeNavigationStateWithSuggestions(queue, currentClimbQueueItem, playlistSuggestionSource),
-    [queue, currentClimbQueueItem, playlistSuggestionSource],
-  );
-  const previousItem = prevItem;
-
-  const handleNext = useCallback(() => {
-    hapticSelection();
-    nextClimb();
-  }, [nextClimb]);
-
-  const handlePrevious = useCallback(() => {
-    hapticSelection();
-    previousClimb();
-  }, [previousClimb]);
-
-  const { gesture: panGesture, translateX } = useCarouselGesture({
-    onSwipeNext: handleNext,
-    onSwipePrevious: handlePrevious,
-    canSwipeNext: canNext,
-    canSwipePrevious: canPrevious,
-    boardWidth: width,
-    enabled: width > 0,
-    reduceMotion,
-  });
-
-  const handleOpenPlay = useCallback(() => {
-    if (!currentClimbQueueItem?.climb) return;
-    hapticLight();
-    // Opening the drawer for the already-current climb; opting out of
-    // setAsCurrent avoids duplicating it at the end of the queue.
-    openPlayDrawer(currentClimbQueueItem.climb, { setAsCurrent: false });
-  }, [openPlayDrawer, currentClimbQueueItem]);
-
-  const tapGesture = useMemo(
-    () =>
-      Gesture.Tap()
-        .maxDuration(250)
-        .onEnd(() => {
-          'worklet';
-          runOnJS(handleOpenPlay)();
-        }),
-    [handleOpenPlay],
-  );
-
-  // Swipe up to open the drawer — a quick alternative to tapping (like dragging a
-  // now-playing chip up to full screen). Activates only on upward movement and
-  // bails on horizontal travel, so the prev/next carousel keeps the sideways
-  // swipes. Opens on a decisive drag or a fast upward flick.
-  const swipeUpGesture = useMemo(
-    () =>
-      Gesture.Pan()
-        .activeOffsetY(-12)
-        .failOffsetX([-20, 20])
-        .onEnd((event) => {
-          'worklet';
-          if (event.translationY < -40 || event.velocityY < -600) {
-            runOnJS(handleOpenPlay)();
-          }
-        }),
-    [handleOpenPlay],
-  );
-
-  const composedGesture = useMemo(
-    () => Gesture.Race(panGesture, swipeUpGesture, tapGesture),
-    [panGesture, swipeUpGesture, tapGesture],
-  );
-
-  const onLayout = useCallback((event: LayoutChangeEvent) => {
-    setWidth(event.nativeEvent.layout.width);
-  }, []);
-
-  const currentLabelStyle = useAnimatedStyle(() => ({ transform: [{ translateX: translateX.value }] }));
-  const nextPeekX = useDerivedValue(() =>
-    computePeekOffset({ direction: 'next', swipeOffset: translateX.value, viewportWidth: width }),
-  );
-  const prevPeekX = useDerivedValue(() =>
-    computePeekOffset({ direction: 'prev', swipeOffset: translateX.value, viewportWidth: width }),
-  );
-  const nextPeekStyle = useAnimatedStyle(() => ({ transform: [{ translateX: nextPeekX.value }] }));
-  const prevPeekStyle = useAnimatedStyle(() => ({ transform: [{ translateX: prevPeekX.value }] }));
-
-  const currentDisplay = climbDisplay(currentClimbQueueItem);
+  const currentDisplay = climbDisplay(currentItem);
   const previousDisplay = climbDisplay(previousItem);
   const nextDisplay = climbDisplay(nextItem);
 
+  const grades = useMemo(() => {
+    const color = (display: ClimbDisplay | null) =>
+      display ? (getGradeColor(display.difficulty) ?? DEFAULT_GRADE_COLOR) : DEFAULT_GRADE_COLOR;
+    return {
+      current: currentDisplay ? formatGrade(currentDisplay.difficulty) : null,
+      previous: previousDisplay ? formatGrade(previousDisplay.difficulty) : null,
+      next: nextDisplay ? formatGrade(nextDisplay.difficulty) : null,
+      currentColor: color(currentDisplay),
+      previousColor: color(previousDisplay),
+      nextColor: color(nextDisplay),
+    };
+  }, [currentDisplay, previousDisplay, nextDisplay, formatGrade]);
+
   if (!currentDisplay) return null;
 
-  // Swipe is invisible to VoiceOver — expose prev/next as custom actions on the
-  // capsule (rotor / two-finger swipe), gated on the same edge guards.
-  const swipeAccessibilityActions = [
-    ...(canPrevious ? [{ name: 'previous', label: t('mobile.queue.previousClimb') }] : []),
-    ...(canNext ? [{ name: 'next', label: t('mobile.queue.nextClimb') }] : []),
-  ];
-
-  const currentFormatted = formatGrade(currentDisplay.difficulty);
-  const previousFormatted = previousDisplay ? formatGrade(previousDisplay.difficulty) : null;
-  const nextFormatted = nextDisplay ? formatGrade(nextDisplay.difficulty) : null;
-
-  const currentGradeColor = getGradeColor(currentDisplay.difficulty) ?? DEFAULT_GRADE_COLOR;
-  const previousGradeColor = previousDisplay
-    ? (getGradeColor(previousDisplay.difficulty) ?? DEFAULT_GRADE_COLOR)
-    : DEFAULT_GRADE_COLOR;
-  const nextGradeColor = nextDisplay
-    ? (getGradeColor(nextDisplay.difficulty) ?? DEFAULT_GRADE_COLOR)
-    : DEFAULT_GRADE_COLOR;
-  const endActionReservedWidth = endAction ? endActionSize + 8 : 0;
-  const labelSlotRight = 16 + endActionReservedWidth;
   const capsuleRadius = height / 2;
 
   return (
-    <View
-      style={[
-        styles.capsule,
-        { height, borderRadius: capsuleRadius },
-        fillWidth ? styles.fillWidthCapsule : null,
-        // Native Liquid Glass draws its own edge + lift; the hairline border and
-        // shadow are only needed on the blur/solid fallback. `bare` (inside the
-        // native accessory's own glass platter) drops all background chrome.
-        !bare && !nativeGlass && shadows.sm,
-        !bare && !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
-      ]}
-    >
-      {/* Neutral frosted glass — no grade-hued wash. The colorized grade text
-          carries the grade; the capsule background stays a plain glass surface.
-          Omitted in `bare` mode (the accessory platter is the glass). */}
-      {bare ? null : (
-        <GlassSurface
-          glassEffectStyle="regular"
-          fallbackColor={systemColors.elevatedSurface}
-          borderRadius={capsuleRadius}
-          style={StyleSheet.absoluteFill}
-          pointerEvents="none"
-        />
-      )}
+    <AccessoryBarSurface height={height} borderRadius={capsuleRadius} style={styles.capsule}>
       <GestureDetector gesture={composedGesture}>
         <View
           style={[styles.swipeArea, { height, borderRadius: capsuleRadius }]}
@@ -260,12 +119,12 @@ export function ClimbCapsule({
             else if (event.nativeEvent.actionName === 'previous') handlePrevious();
           }}
         >
-          <Animated.View style={[styles.labelSlot, { right: labelSlotRight }, currentLabelStyle]}>
+          <Animated.View style={[styles.labelSlot, currentLabelStyle]}>
             <ClimbLabel
               display={currentDisplay}
               labelColor={systemColors.label}
-              formattedGrade={currentFormatted}
-              gradeColor={currentGradeColor}
+              formattedGrade={grades.current}
+              gradeColor={grades.currentColor}
             />
           </Animated.View>
           {nextDisplay ? (
@@ -273,8 +132,8 @@ export function ClimbCapsule({
               <ClimbLabel
                 display={nextDisplay}
                 labelColor={systemColors.label}
-                formattedGrade={nextFormatted}
-                gradeColor={nextGradeColor}
+                formattedGrade={grades.next}
+                gradeColor={grades.nextColor}
               />
             </Animated.View>
           ) : null}
@@ -283,15 +142,14 @@ export function ClimbCapsule({
               <ClimbLabel
                 display={previousDisplay}
                 labelColor={systemColors.label}
-                formattedGrade={previousFormatted}
-                gradeColor={previousGradeColor}
+                formattedGrade={grades.previous}
+                gradeColor={grades.previousColor}
               />
             </Animated.View>
           ) : null}
         </View>
       </GestureDetector>
-      {endAction ? <View style={[styles.endActionSlot, { width: endActionSize, height }]}>{endAction}</View> : null}
-    </View>
+    </AccessoryBarSurface>
   );
 }
 
@@ -299,10 +157,6 @@ const styles = StyleSheet.create({
   capsule: {
     flex: 1,
     maxWidth: TOOLBAR_CAPSULE_MAX_WIDTH,
-  },
-  fillWidthCapsule: {
-    width: '100%',
-    maxWidth: '100%',
   },
   swipeArea: {
     flex: 1,
@@ -314,13 +168,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 16,
     right: 16,
-    justifyContent: 'center',
-  },
-  endActionSlot: {
-    position: 'absolute',
-    top: 0,
-    right: 8,
-    alignItems: 'center',
     justifyContent: 'center',
   },
   peekSlot: {

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -5,40 +5,35 @@
 // variant (Liquid Glass / Material / fallback) via AccessoryBarSurface; the
 // swipe/peek/tap behaviour is shared with the native accessory via useQueueCarousel.
 
-import { useMemo } from 'react';
+import { useMemo, type ReactNode } from 'react';
 import { View, StyleSheet, type ColorValue } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
-import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { Climb } from '@boardsesh/queue';
 import { TOOLBAR_CAPSULE_HEIGHT, TOOLBAR_CAPSULE_MAX_WIDTH } from '../../theme/layout';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { Text } from '../Text';
 import { useTheme } from '../../providers/theme-provider';
+import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
 import { AccessoryBarSurface } from './AccessoryBarSurface';
+import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useQueueCarousel } from './use-queue-carousel';
 
-type ClimbDisplay = {
-  difficulty: string | null | undefined;
-  name: string | undefined;
-};
-
-function climbDisplay(item: ClimbQueueItem | null | undefined): ClimbDisplay | null {
-  if (!item?.climb) return null;
-  return { difficulty: item.climb.difficulty, name: item.climb.name };
-}
-
 type ClimbLabelProps = {
-  display: ClimbDisplay;
+  climb: Climb;
   labelColor: ColorValue;
   formattedGrade: string | null;
   gradeColor: string;
+  showThumbnail: boolean;
+  boardConfig: BoardConfig | null;
 };
 
-function ClimbLabel({ display, labelColor, formattedGrade, gradeColor }: ClimbLabelProps) {
+function ClimbLabel({ climb, labelColor, formattedGrade, gradeColor, showThumbnail, boardConfig }: ClimbLabelProps) {
   return (
     <View style={styles.labelInner}>
+      {showThumbnail ? <AccessoryClimbThumbnail climb={climb} boardConfig={boardConfig} /> : null}
       <Text
         variant="subheadline"
         color={labelColor}
@@ -47,7 +42,7 @@ function ClimbLabel({ display, labelColor, formattedGrade, gradeColor }: ClimbLa
         maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
         style={styles.name}
       >
-        {display.name ?? ''}
+        {climb.name}
       </Text>
       {formattedGrade ? (
         <Text
@@ -65,10 +60,21 @@ function ClimbLabel({ display, labelColor, formattedGrade, gradeColor }: ClimbLa
 
 type ClimbCapsuleProps = {
   height?: number;
+  /** Span the full available width instead of the centered 260px cap (Material bar). */
+  fillWidth?: boolean;
+  /** Action floated inside the capsule on the right, outside the swipe target (e.g. the tick). */
+  endAction?: ReactNode;
+  endActionSize?: number;
 };
 
-export function ClimbCapsule({ height = TOOLBAR_CAPSULE_HEIGHT }: ClimbCapsuleProps) {
+export function ClimbCapsule({
+  height = TOOLBAR_CAPSULE_HEIGHT,
+  fillWidth = false,
+  endAction,
+  endActionSize = 0,
+}: ClimbCapsuleProps) {
   const { systemColors } = useTheme();
+  const { boardConfig } = useDrawerHost();
   const { formatGrade } = useGradeFormat();
   const {
     onLayout,
@@ -84,71 +90,87 @@ export function ClimbCapsule({ height = TOOLBAR_CAPSULE_HEIGHT }: ClimbCapsulePr
     swipeAccessibilityActions,
   } = useQueueCarousel();
 
-  const currentDisplay = climbDisplay(currentItem);
-  const previousDisplay = climbDisplay(previousItem);
-  const nextDisplay = climbDisplay(nextItem);
+  const currentClimb = currentItem?.climb ?? null;
+  const previousClimb = previousItem?.climb ?? null;
+  const nextClimb = nextItem?.climb ?? null;
+  // Board art needs the active board config; matches the iOS 26 native accessory.
+  const showThumbnail = boardConfig != null;
 
   const grades = useMemo(() => {
-    const color = (display: ClimbDisplay | null) =>
-      display ? (getGradeColor(display.difficulty) ?? DEFAULT_GRADE_COLOR) : DEFAULT_GRADE_COLOR;
+    const color = (climb: Climb | null) =>
+      climb ? (getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR) : DEFAULT_GRADE_COLOR;
     return {
-      current: currentDisplay ? formatGrade(currentDisplay.difficulty) : null,
-      previous: previousDisplay ? formatGrade(previousDisplay.difficulty) : null,
-      next: nextDisplay ? formatGrade(nextDisplay.difficulty) : null,
-      currentColor: color(currentDisplay),
-      previousColor: color(previousDisplay),
-      nextColor: color(nextDisplay),
+      current: currentClimb ? formatGrade(currentClimb.difficulty) : null,
+      previous: previousClimb ? formatGrade(previousClimb.difficulty) : null,
+      next: nextClimb ? formatGrade(nextClimb.difficulty) : null,
+      currentColor: color(currentClimb),
+      previousColor: color(previousClimb),
+      nextColor: color(nextClimb),
     };
-  }, [currentDisplay, previousDisplay, nextDisplay, formatGrade]);
+  }, [currentClimb, previousClimb, nextClimb, formatGrade]);
 
-  if (!currentDisplay) return null;
+  if (!currentClimb) return null;
 
   const capsuleRadius = height / 2;
+  // Reserve room on the right so the name/grade never slide under the inline tick.
+  const endActionReservedWidth = endAction ? endActionSize + 8 : 0;
+  const labelRight = 16 + endActionReservedWidth;
 
   return (
-    <AccessoryBarSurface height={height} borderRadius={capsuleRadius} style={styles.capsule}>
+    <AccessoryBarSurface
+      height={height}
+      borderRadius={capsuleRadius}
+      style={[styles.capsule, fillWidth ? null : styles.capsuleCap]}
+    >
       <GestureDetector gesture={composedGesture}>
         <View
           style={[styles.swipeArea, { height, borderRadius: capsuleRadius }]}
           onLayout={onLayout}
           accessibilityRole="button"
-          accessibilityLabel={currentDisplay.name}
+          accessibilityLabel={currentClimb.name}
           accessibilityActions={swipeAccessibilityActions}
           onAccessibilityAction={(event) => {
             if (event.nativeEvent.actionName === 'next') handleNext();
             else if (event.nativeEvent.actionName === 'previous') handlePrevious();
           }}
         >
-          <Animated.View style={[styles.labelSlot, currentLabelStyle]}>
+          <Animated.View style={[styles.labelSlot, { right: labelRight }, currentLabelStyle]}>
             <ClimbLabel
-              display={currentDisplay}
+              climb={currentClimb}
               labelColor={systemColors.label}
               formattedGrade={grades.current}
               gradeColor={grades.currentColor}
+              showThumbnail={showThumbnail}
+              boardConfig={boardConfig}
             />
           </Animated.View>
-          {nextDisplay ? (
-            <Animated.View style={[styles.peekSlot, nextPeekStyle]} pointerEvents="none">
+          {nextClimb ? (
+            <Animated.View style={[styles.peekSlot, { right: labelRight }, nextPeekStyle]} pointerEvents="none">
               <ClimbLabel
-                display={nextDisplay}
+                climb={nextClimb}
                 labelColor={systemColors.label}
                 formattedGrade={grades.next}
                 gradeColor={grades.nextColor}
+                showThumbnail={showThumbnail}
+                boardConfig={boardConfig}
               />
             </Animated.View>
           ) : null}
-          {previousDisplay ? (
-            <Animated.View style={[styles.peekSlot, prevPeekStyle]} pointerEvents="none">
+          {previousClimb ? (
+            <Animated.View style={[styles.peekSlot, { right: labelRight }, prevPeekStyle]} pointerEvents="none">
               <ClimbLabel
-                display={previousDisplay}
+                climb={previousClimb}
                 labelColor={systemColors.label}
                 formattedGrade={grades.previous}
                 gradeColor={grades.previousColor}
+                showThumbnail={showThumbnail}
+                boardConfig={boardConfig}
               />
             </Animated.View>
           ) : null}
         </View>
       </GestureDetector>
+      {endAction ? <View style={[styles.endActionSlot, { width: endActionSize, height }]}>{endAction}</View> : null}
     </AccessoryBarSurface>
   );
 }
@@ -156,6 +178,9 @@ export function ClimbCapsule({ height = TOOLBAR_CAPSULE_HEIGHT }: ClimbCapsulePr
 const styles = StyleSheet.create({
   capsule: {
     flex: 1,
+  },
+  // Centered-pill cap; omitted on the full-width Material bar.
+  capsuleCap: {
     maxWidth: TOOLBAR_CAPSULE_MAX_WIDTH,
   },
   swipeArea: {
@@ -174,6 +199,13 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 16,
     right: 16,
+    justifyContent: 'center',
+  },
+  endActionSlot: {
+    position: 'absolute',
+    top: 0,
+    right: 8,
+    alignItems: 'center',
     justifyContent: 'center',
   },
   labelInner: {

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -1,10 +1,7 @@
-import { useMemo } from 'react';
 import { StyleSheet, View, type ColorValue } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
-import type { BoardName } from '@boardsesh/shared-schema';
 import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
-import { getBoardRenderData } from '../../lib/board-details';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useTheme } from '../../providers/theme-provider';
 import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
@@ -12,7 +9,7 @@ import { spacing } from '../../theme/tokens';
 import { glassSize } from '../../theme/layout';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { Text } from '../Text';
-import { BoardRenderer } from '../board-renderer/BoardRenderer';
+import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useQueueCarousel } from './use-queue-carousel';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
 
@@ -25,9 +22,6 @@ type NativeAccessoryClimbRowProps = {
 
 const ACCESSORY_LEADING_INSET = spacing[1];
 const ACCESSORY_TRAILING_INSET = spacing[3];
-const ACCESSORY_THUMBNAIL_SLOT_SIZE = 40;
-const ACCESSORY_THUMBNAIL_ART_MAX_SIZE = 40;
-const ACCESSORY_THUMBNAIL_ART_RADIUS = 10;
 
 type ClimbLabelProps = {
   climb: Climb;
@@ -36,69 +30,6 @@ type ClimbLabelProps = {
   showThumbnail: boolean;
   boardConfig: BoardConfig | null;
 };
-
-function getAccessoryThumbnailBoardSize(boardWidth: number, boardHeight: number) {
-  const boardAspectRatio = boardWidth / boardHeight;
-  if (!Number.isFinite(boardAspectRatio) || boardAspectRatio <= 0) {
-    return {
-      width: ACCESSORY_THUMBNAIL_ART_MAX_SIZE,
-      height: ACCESSORY_THUMBNAIL_ART_MAX_SIZE,
-    };
-  }
-
-  if (boardAspectRatio >= 1) {
-    return {
-      width: ACCESSORY_THUMBNAIL_ART_MAX_SIZE,
-      height: ACCESSORY_THUMBNAIL_ART_MAX_SIZE / boardAspectRatio,
-    };
-  }
-
-  return {
-    width: ACCESSORY_THUMBNAIL_ART_MAX_SIZE * boardAspectRatio,
-    height: ACCESSORY_THUMBNAIL_ART_MAX_SIZE,
-  };
-}
-
-function AccessoryClimbThumbnail({ climb, boardConfig }: { climb: Climb; boardConfig: BoardConfig | null }) {
-  const boardRenderData = useMemo(() => {
-    if (!boardConfig) return null;
-    const setIdValues = boardConfig.setIds
-      .split(',')
-      .map((setIdText) => Number(setIdText))
-      .filter((setIdValue) => Number.isFinite(setIdValue));
-    if (setIdValues.length === 0) return null;
-    return getBoardRenderData({
-      boardName: boardConfig.boardName as BoardName,
-      layoutId: boardConfig.layoutId,
-      sizeId: boardConfig.sizeId,
-      setIds: setIdValues,
-    });
-  }, [boardConfig]);
-
-  if (!boardRenderData) return null;
-
-  const thumbnailBoardStyle = {
-    ...getAccessoryThumbnailBoardSize(boardRenderData.boardWidth, boardRenderData.boardHeight),
-    borderRadius: ACCESSORY_THUMBNAIL_ART_RADIUS,
-    overflow: 'hidden' as const,
-  };
-
-  return (
-    <View style={styles.thumbnailSlot}>
-      <BoardRenderer
-        frames={climb.frames}
-        boardName={boardConfig?.boardName as BoardName}
-        boardWidth={boardRenderData.boardWidth}
-        boardHeight={boardRenderData.boardHeight}
-        imageUrls={boardRenderData.imageUrls}
-        holdsData={boardRenderData.holdsData}
-        mirrored={climb.mirrored === true}
-        fillContainer
-        style={thumbnailBoardStyle}
-      />
-    </View>
-  );
-}
 
 function ClimbLabel({ climb, labelColor, formattedGrade, showThumbnail, boardConfig }: ClimbLabelProps) {
   return (
@@ -257,13 +188,6 @@ const styles = StyleSheet.create({
     gap: spacing[2],
     paddingLeft: spacing[2],
     paddingRight: spacing[1],
-  },
-  thumbnailSlot: {
-    width: ACCESSORY_THUMBNAIL_SLOT_SIZE,
-    height: ACCESSORY_THUMBNAIL_SLOT_SIZE,
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
   },
   name: {
     flex: 1,

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -1,24 +1,19 @@
-import { useCallback, useMemo, useState } from 'react';
-import { StyleSheet, View, type ColorValue, type LayoutChangeEvent } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, { runOnJS, useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
-import { useTranslation } from 'react-i18next';
+import { useMemo } from 'react';
+import { StyleSheet, View, type ColorValue } from 'react-native';
+import { GestureDetector } from 'react-native-gesture-handler';
+import Animated from 'react-native-reanimated';
 import type { BoardName } from '@boardsesh/shared-schema';
 import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
-import { computePeekOffset, computeNavigationStateWithSuggestions } from '@boardsesh/play-view';
 import { getBoardRenderData } from '../../lib/board-details';
 import { useGradeFormat } from '../../hooks/use-grade-format';
-import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { useTheme } from '../../providers/theme-provider';
-import { useQueue } from '../../providers/queue-provider';
 import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
-import { hapticLight, hapticSelection } from '../../lib/haptics';
 import { spacing } from '../../theme/tokens';
 import { glassSize } from '../../theme/layout';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { Text } from '../Text';
 import { BoardRenderer } from '../board-renderer/BoardRenderer';
-import { useCarouselGesture } from '../play-drawer/use-carousel-gesture';
+import { useQueueCarousel } from './use-queue-carousel';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
 
 type AccessoryPlacement = 'regular' | 'inline';
@@ -138,110 +133,35 @@ function climbFromItem(item: ClimbQueueItem | null | undefined): Climb | null {
   return item?.climb ?? null;
 }
 
+/**
+ * Content for the iOS 26 tab-bar bottom accessory (Liquid Glass variant only).
+ * UIKit supplies the glass platter, so this stays bare: current climb + tick,
+ * with the same swipe/peek carousel as the floating capsule (shared via
+ * useQueueCarousel). Its plain grade + board thumbnail are tuned for the platter,
+ * so they intentionally differ from the floating capsule's colorized grade.
+ */
 export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryClimbRowProps) {
-  const {
-    state,
-    nextClimb: navigateNextClimb,
-    previousClimb: navigatePreviousClimb,
-    playlistSuggestionSource,
-  } = useQueue();
-  const { boardConfig, openPlayDrawer } = useDrawerHost();
+  const { boardConfig } = useDrawerHost();
   const { systemColors } = useTheme();
-  const { t } = useTranslation('session');
   const { formatGrade } = useGradeFormat();
-  const reduceMotion = useReduceMotion();
-  const [clipWidth, setClipWidth] = useState(0);
+  const {
+    onLayout,
+    composedGesture,
+    currentLabelStyle,
+    nextPeekStyle,
+    prevPeekStyle,
+    currentItem,
+    previousItem,
+    nextItem,
+    handleNext,
+    handlePrevious,
+    swipeAccessibilityActions,
+  } = useQueueCarousel();
 
-  const { currentClimbQueueItem, queue } = state;
-  const currentClimb = climbFromItem(currentClimbQueueItem);
-
-  // Suggestion-aware so the carousel matches the play drawer: at the queue tail
-  // of an active playlist, `nextItem` falls through to the next playlist climb
-  // (a transient "peek") instead of dead-ending. canPrevious/prevItem stay
-  // queue-only — there is no backward suggestion fall-through.
-  const { canPrevious, canNext, nextItem, prevItem } = useMemo(
-    () => computeNavigationStateWithSuggestions(queue, currentClimbQueueItem, playlistSuggestionSource),
-    [queue, currentClimbQueueItem, playlistSuggestionSource],
-  );
-  const previousClimb = climbFromItem(prevItem);
+  const currentClimb = climbFromItem(currentItem);
+  const previousClimb = climbFromItem(previousItem);
   const nextQueueClimb = climbFromItem(nextItem);
   const showThumbnail = placement === 'regular' && boardConfig !== null;
-
-  const handleNext = useCallback(() => {
-    hapticSelection();
-    navigateNextClimb();
-  }, [navigateNextClimb]);
-
-  const handlePrevious = useCallback(() => {
-    hapticSelection();
-    navigatePreviousClimb();
-  }, [navigatePreviousClimb]);
-
-  const handleOpenPlay = useCallback(() => {
-    if (!currentClimb) return;
-    hapticLight();
-    openPlayDrawer(currentClimb, { setAsCurrent: false });
-  }, [openPlayDrawer, currentClimb]);
-
-  const { gesture: panGesture, translateX } = useCarouselGesture({
-    onSwipeNext: handleNext,
-    onSwipePrevious: handlePrevious,
-    canSwipeNext: canNext,
-    canSwipePrevious: canPrevious,
-    boardWidth: clipWidth,
-    enabled: clipWidth > 0,
-    reduceMotion,
-  });
-
-  const tapGesture = useMemo(
-    () =>
-      Gesture.Tap()
-        .maxDuration(250)
-        .onEnd(() => {
-          'worklet';
-          runOnJS(handleOpenPlay)();
-        }),
-    [handleOpenPlay],
-  );
-
-  const swipeUpGesture = useMemo(
-    () =>
-      Gesture.Pan()
-        .activeOffsetY(-12)
-        .failOffsetX([-20, 20])
-        .onEnd((event) => {
-          'worklet';
-          if (event.translationY < -40 || event.velocityY < -600) {
-            runOnJS(handleOpenPlay)();
-          }
-        }),
-    [handleOpenPlay],
-  );
-
-  const composedGesture = useMemo(
-    () => Gesture.Race(panGesture, swipeUpGesture, tapGesture),
-    [panGesture, swipeUpGesture, tapGesture],
-  );
-
-  const onClipLayout = useCallback((event: LayoutChangeEvent) => {
-    setClipWidth(event.nativeEvent.layout.width);
-  }, []);
-
-  const currentLabelStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: translateX.value }],
-  }));
-  const nextPeekX = useDerivedValue(() =>
-    computePeekOffset({ direction: 'next', swipeOffset: translateX.value, viewportWidth: clipWidth }),
-  );
-  const previousPeekX = useDerivedValue(() =>
-    computePeekOffset({ direction: 'prev', swipeOffset: translateX.value, viewportWidth: clipWidth }),
-  );
-  const nextPeekStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: nextPeekX.value }],
-  }));
-  const previousPeekStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: previousPeekX.value }],
-  }));
 
   if (!currentClimb) return null;
 
@@ -249,17 +169,13 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
   const currentFormattedGrade = formatGrade(currentClimb.difficulty);
   const previousFormattedGrade = previousClimb ? formatGrade(previousClimb.difficulty) : null;
   const nextFormattedGrade = nextQueueClimb ? formatGrade(nextQueueClimb.difficulty) : null;
-  const swipeAccessibilityActions = [
-    ...(canPrevious ? [{ name: 'previous', label: t('mobile.queue.previousClimb') }] : []),
-    ...(canNext ? [{ name: 'next', label: t('mobile.queue.nextClimb') }] : []),
-  ];
 
   return (
     <View style={[styles.row, { width, height: rowHeight }]}>
       <GestureDetector gesture={composedGesture}>
         <View
           style={styles.swipeClip}
-          onLayout={onClipLayout}
+          onLayout={onLayout}
           accessibilityRole="button"
           accessibilityLabel={currentClimb.name}
           accessibilityActions={swipeAccessibilityActions}
@@ -289,7 +205,7 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
             </Animated.View>
           ) : null}
           {previousClimb ? (
-            <Animated.View style={[styles.peekSlot, previousPeekStyle]} pointerEvents="none">
+            <Animated.View style={[styles.peekSlot, prevPeekStyle]} pointerEvents="none">
               <ClimbLabel
                 climb={previousClimb}
                 labelColor={systemColors.label}

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -130,6 +130,10 @@ vi.mock('../../../theme/colors', () => ({ withAlpha: (color: string) => `${color
 vi.mock('../../../theme/layout', () => ({ TOOLBAR_CAPSULE_HEIGHT: 52, TOOLBAR_CAPSULE_MAX_WIDTH: 260 }));
 vi.mock('../../../theme/tokens', () => ({ shadows: { sm: {} } }));
 vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
+// AccessoryBarSurface (the capsule background) resolves the surface via this —
+// force the glass branch so the GlassSurface mock renders and `[data-glass]`
+// assertions hold.
+vi.mock('../../../hooks/use-effective-surface-mode', () => ({ useEffectiveSurfaceMode: () => 'glass' }));
 
 // useCarouselGesture is mocked: in jsdom we cannot drive the RNGH worklets, so
 // the hook just returns an inert gesture + a translateX shared value.
@@ -232,22 +236,6 @@ describe('ClimbCapsule', () => {
     const { container } = render(<ClimbCapsule />);
     // No tint passed to the glass — the capsule background is plain frosted glass.
     expect(container.querySelector('[data-glass]')?.getAttribute('data-tint')).toBe('');
-  });
-
-  it('reserves the right edge for an inline action outside the capsule gesture target', () => {
-    const item = makeItem(makeClimb({ difficulty: 'V6', name: 'Inline Tick' }));
-    queue.state.currentClimbQueueItem = item;
-    queue.state.queue = [item];
-
-    const { container } = render(<ClimbCapsule endAction={<button data-inline-action="tick" />} endActionSize={44} />);
-
-    expect(container.textContent).toContain('Inline Tick');
-    expect(container.querySelector('[data-inline-action="tick"]')).not.toBeNull();
-    const gradeNode = Array.from(container.querySelectorAll('[data-text]')).find((node) =>
-      (node.textContent ?? '').includes('6C'),
-    );
-    expect(gradeNode?.getAttribute('data-color')).toBe('#FF0000');
-    expect(container.querySelector('[data-inline-action="tick"]')?.closest('[data-gesture]')).toBeNull();
   });
 
   it('wires openPlayDrawer with setAsCurrent:false (drawer-open behavior; tap worklet not driven in jsdom)', () => {

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -111,8 +111,12 @@ vi.mock('../../../providers/queue-provider', () => ({
 }));
 
 vi.mock('../../../providers/drawer-host-provider', () => ({
-  useDrawerHost: () => ({ openPlayDrawer: drawer.openPlayDrawer }),
+  useDrawerHost: () => ({ openPlayDrawer: drawer.openPlayDrawer, boardConfig: null }),
 }));
+
+// The board thumbnail pulls in BoardRenderer/board-details (native deps); the
+// capsule only renders it when boardConfig is set (null here), so stub it out.
+vi.mock('../AccessoryClimbThumbnail', () => ({ AccessoryClimbThumbnail: () => null }));
 
 // formatGrade prefixes so the displayed grade is distinguishable from the raw
 // difficulty key used for colour lookup.

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -43,8 +43,11 @@ vi.mock('../../../theme/layout', () => ({
   TOOLBAR_GAP: 8,
   TOOLBAR_FAB_SIZE: 56,
   TOOLBAR_GAP_ABOVE_TABBAR: 10,
-  glassSize: { hero: 64 },
+  glassSize: { hero: 64, inline: 44 },
 }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4 } }));
+// Default to the Liquid Glass layout (centered capsule + standalone hero tick).
+vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ variant: 'liquidGlass' }) }));
 // The floating bar renders only where the native bottom accessory doesn't
 // (Material variant / iOS < 26 / Android) — force that path so the capsule/tick
 // assertions hold. `useNativeAccessoryActive` is what use-bottom-chrome-metrics
@@ -55,6 +58,9 @@ vi.mock('../../../hooks/use-bottom-accessory', () => ({
 }));
 vi.mock('../ClimbCapsule', () => ({ ClimbCapsule: () => createElement('div', { 'data-capsule': 'true' }) }));
 vi.mock('../LogAscentFab', () => ({ LogAscentFab: () => createElement('div', { 'data-tick': 'true' }) }));
+vi.mock('../LogAscentToolbarButton', () => ({
+  LogAscentToolbarButton: () => createElement('div', { 'data-tick-inline': 'true' }),
+}));
 
 import { PersistentQueueBar } from '../persistent-queue-bar';
 

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -45,9 +45,14 @@ vi.mock('../../../theme/layout', () => ({
   TOOLBAR_GAP_ABOVE_TABBAR: 10,
   glassSize: { hero: 64 },
 }));
-// Legacy bar renders only where the native bottom accessory doesn't (Android /
-// iOS < 26) — force that path so the capsule/tick assertions hold.
-vi.mock('../../../hooks/use-bottom-accessory', () => ({ isBottomAccessoryAvailable: () => false }));
+// The floating bar renders only where the native bottom accessory doesn't
+// (Material variant / iOS < 26 / Android) — force that path so the capsule/tick
+// assertions hold. `useNativeAccessoryActive` is what use-bottom-chrome-metrics
+// reads now (variant-aware); the capability function stays for other callers.
+vi.mock('../../../hooks/use-bottom-accessory', () => ({
+  isBottomAccessoryAvailable: () => false,
+  useNativeAccessoryActive: () => false,
+}));
 vi.mock('../ClimbCapsule', () => ({ ClimbCapsule: () => createElement('div', { 'data-capsule': 'true' }) }));
 vi.mock('../LogAscentFab', () => ({ LogAscentFab: () => createElement('div', { 'data-tick': 'true' }) }));
 

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -2,33 +2,24 @@
  * PersistentQueueBar — the floating climb toolbar that mounts at the app root
  * and is visible on every screen while a current climb is set.
  *
- * Just the global climb capsule now, floating above the tab bar (iOS-Photos
- * style, no opaque card):
+ * It is a thin adapter: it decides *whether* the climb bar should show (a current
+ * climb exists and the native iOS 26 bottom accessory isn't already owning it),
+ * then hands the climb capsule + log-ascent tick to the content-agnostic
+ * {@link ActiveContextBar} for layout:
+ *
  *   [ grade · climb name ]            [ ✓ tick ]
  *     ↑ tap = PlayDrawer                ↑ log ascent — shown on every tab so the
  *       swipe = prev/next                 fallback matches the always-on iOS 26
  *                                         bottom accessory (current climb + tick)
  *
- * The native iOS 26 bottom accessory owns this same current climb + tick pair.
- * On that path this JS fallback returns null so the tab bar minimization behavior
- * comes from UIKit.
+ * On the Liquid Glass variant on iOS 26 the native bottom accessory owns this
+ * same pair, so `jsQueueToolbarVisible` is false here and this returns null.
  */
 
-import { View, StyleSheet } from 'react-native';
-import Animated, { FadeIn } from 'react-native-reanimated';
-import { timing } from '../../theme/animations';
-import {
-  TOOLBAR_RESERVE,
-  TOOLBAR_SIDE_MARGIN,
-  TOOLBAR_GAP,
-  TOOLBAR_FAB_SIZE,
-  TOOLBAR_GAP_ABOVE_TABBAR,
-  TAB_BAR_HEIGHT,
-  glassSize,
-} from '../../theme/layout';
+import { TOOLBAR_RESERVE, TAB_BAR_HEIGHT } from '../../theme/layout';
 import { useQueue } from '../../providers/queue-provider';
-import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
 import { LogAscentFab } from './LogAscentFab';
 
@@ -38,7 +29,6 @@ export { TOOLBAR_RESERVE, TAB_BAR_HEIGHT };
 
 export function PersistentQueueBar() {
   const { state } = useQueue();
-  const reduceMotion = useReduceMotion();
   const bottomChrome = useBottomChromeMetrics();
 
   const currentClimb = state.currentClimbQueueItem?.climb;
@@ -46,55 +36,5 @@ export function PersistentQueueBar() {
   if (!bottomChrome.jsQueueToolbarVisible) return null;
   if (!currentClimb) return null;
 
-  return (
-    <Animated.View
-      entering={reduceMotion ? undefined : FadeIn.duration(timing.normal)}
-      pointerEvents="box-none"
-      style={[styles.toolbar, { bottom: bottomChrome.tabBarBottom + TOOLBAR_GAP_ABOVE_TABBAR }]}
-    >
-      <Animated.View style={styles.row} pointerEvents="box-none" importantForAccessibility="auto">
-        <View style={styles.sideSlot} pointerEvents="none" />
-        <View style={styles.centerSlot} pointerEvents="box-none">
-          <ClimbCapsule />
-        </View>
-        <View style={styles.heroSlot} pointerEvents="box-none">
-          <LogAscentFab climb={currentClimb} />
-        </View>
-      </Animated.View>
-    </Animated.View>
-  );
+  return <ActiveContextBar primary={<ClimbCapsule />} trailing={<LogAscentFab climb={currentClimb} />} />;
 }
-
-const styles = StyleSheet.create({
-  toolbar: {
-    position: 'absolute',
-    left: TOOLBAR_SIDE_MARGIN,
-    right: TOOLBAR_SIDE_MARGIN,
-    // `bottom` is set inline from the safe-area inset + tab-bar height so the
-    // islands float just above the tab bar.
-  },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: TOOLBAR_GAP,
-  },
-  centerSlot: {
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  // Left gutter spacer: balances the capsule so it reads centered between the
-  // screen edge and the standalone tick (which now shows on every tab).
-  sideSlot: {
-    width: TOOLBAR_FAB_SIZE,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  // Standalone log-ascent tick (hero size), shown on every tab.
-  heroSlot: {
-    width: glassSize.hero,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -4,24 +4,27 @@
  *
  * It is a thin adapter: it decides *whether* the climb bar should show (a current
  * climb exists and the native iOS 26 bottom accessory isn't already owning it),
- * then hands the climb capsule + log-ascent tick to the content-agnostic
- * {@link ActiveContextBar} for layout:
+ * then lays it out per variant via {@link ActiveContextBar}:
  *
- *   [ grade · climb name ]            [ ✓ tick ]
- *     ↑ tap = PlayDrawer                ↑ log ascent — shown on every tab so the
- *       swipe = prev/next                 fallback matches the always-on iOS 26
- *                                         bottom accessory (current climb + tick)
+ *   Liquid Glass / fallback   [ grade · name ]        [ ✓ tick ]
+ *     centered capsule + standalone hero tick (tap = PlayDrawer, swipe = prev/next)
+ *
+ *   Material                  [ ▢ grade · name              ✓ ]
+ *     one full-width capsule with the tick inside, sitting close to the tab bar
  *
  * On the Liquid Glass variant on iOS 26 the native bottom accessory owns this
- * same pair, so `jsQueueToolbarVisible` is false here and this returns null.
+ * pair, so `jsQueueToolbarVisible` is false here and this returns null.
  */
 
-import { TOOLBAR_RESERVE, TAB_BAR_HEIGHT } from '../../theme/layout';
+import { TOOLBAR_RESERVE, TAB_BAR_HEIGHT, glassSize } from '../../theme/layout';
+import { spacing } from '../../theme/tokens';
 import { useQueue } from '../../providers/queue-provider';
+import { useTheme } from '../../providers/theme-provider';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
 import { LogAscentFab } from './LogAscentFab';
+import { LogAscentToolbarButton } from './LogAscentToolbarButton';
 
 // Re-export so layout consumers that already import toolbar metrics from this
 // module don't need to know which file owns them. Source of truth: theme/layout.
@@ -29,12 +32,29 @@ export { TOOLBAR_RESERVE, TAB_BAR_HEIGHT };
 
 export function PersistentQueueBar() {
   const { state } = useQueue();
+  const { variant } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
 
   const currentClimb = state.currentClimbQueueItem?.climb;
 
   if (!bottomChrome.jsQueueToolbarVisible) return null;
   if (!currentClimb) return null;
+
+  if (variant === 'material') {
+    return (
+      <ActiveContextBar
+        fillPrimary
+        gapAboveTabBar={spacing[1]}
+        primary={
+          <ClimbCapsule
+            fillWidth
+            endAction={<LogAscentToolbarButton climb={currentClimb} size={glassSize.inline} />}
+            endActionSize={glassSize.inline}
+          />
+        }
+      />
+    );
+  }
 
   return <ActiveContextBar primary={<ClimbCapsule />} trailing={<LogAscentFab climb={currentClimb} />} />;
 }

--- a/packages/mobile/src/components/queue-control/use-queue-carousel.ts
+++ b/packages/mobile/src/components/queue-control/use-queue-carousel.ts
@@ -1,0 +1,158 @@
+import { useCallback, useMemo, useState } from 'react';
+import { type LayoutChangeEvent } from 'react-native';
+import { Gesture, type ComposedGesture } from 'react-native-gesture-handler';
+import { runOnJS, useAnimatedStyle, useDerivedValue, type AnimatedStyle } from 'react-native-reanimated';
+import { useTranslation } from 'react-i18next';
+import { computePeekOffset, computeNavigationStateWithSuggestions } from '@boardsesh/play-view';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import { useReduceMotion } from '../../hooks/use-reduce-motion';
+import { useQueue } from '../../providers/queue-provider';
+import { useDrawerHost } from '../../providers/drawer-host-provider';
+import { hapticLight, hapticSelection } from '../../lib/haptics';
+import { useCarouselGesture } from '../play-drawer/use-carousel-gesture';
+
+type AccessibilityAction = { name: string; label: string };
+
+/**
+ * The shared "current climb" carousel behind the floating queue capsule
+ * (`ClimbCapsule`) and the iOS 26 native bottom accessory
+ * (`NativeAccessoryClimbRow`). Both surfaces show name + grade with the same
+ * swipe-to-step / swipe-up-to-open / tap-to-open interaction and the neighbouring
+ * climb peeking in — this hook owns all of that (queue navigation, gesture
+ * composition, peek animation, a11y actions) so the two presentational wrappers
+ * keep only their own labels and chrome.
+ */
+export type QueueCarousel = {
+  /** Measure the swipe viewport so the peek offsets are width-relative. */
+  onLayout: (event: LayoutChangeEvent) => void;
+  /** Tap (open) ∪ swipe-up (open) ∪ horizontal pan (prev/next). */
+  composedGesture: ComposedGesture;
+  currentLabelStyle: AnimatedStyle;
+  nextPeekStyle: AnimatedStyle;
+  prevPeekStyle: AnimatedStyle;
+  currentItem: ClimbQueueItem | null | undefined;
+  previousItem: ClimbQueueItem | null | undefined;
+  nextItem: ClimbQueueItem | null | undefined;
+  canPrevious: boolean;
+  canNext: boolean;
+  handleNext: () => void;
+  handlePrevious: () => void;
+  /** Prev/next exposed as a11y actions (swipe is invisible to VoiceOver). */
+  swipeAccessibilityActions: AccessibilityAction[];
+};
+
+export function useQueueCarousel(): QueueCarousel {
+  const { state, nextClimb, previousClimb, playlistSuggestionSource } = useQueue();
+  const { openPlayDrawer } = useDrawerHost();
+  const { t } = useTranslation('session');
+  const reduceMotion = useReduceMotion();
+
+  const [width, setWidth] = useState(0);
+  const { currentClimbQueueItem, queue } = state;
+
+  // Suggestion-aware so the capsule carousel matches the play drawer: at the
+  // queue tail of an active playlist, `nextItem` falls through to the next
+  // playlist climb (a transient "peek") instead of stopping. canPrevious/prevItem
+  // stay queue-only — there is no backward suggestion fall-through.
+  const { canPrevious, canNext, nextItem, prevItem } = useMemo(
+    () => computeNavigationStateWithSuggestions(queue, currentClimbQueueItem, playlistSuggestionSource),
+    [queue, currentClimbQueueItem, playlistSuggestionSource],
+  );
+
+  const handleNext = useCallback(() => {
+    hapticSelection();
+    nextClimb();
+  }, [nextClimb]);
+
+  const handlePrevious = useCallback(() => {
+    hapticSelection();
+    previousClimb();
+  }, [previousClimb]);
+
+  const handleOpenPlay = useCallback(() => {
+    if (!currentClimbQueueItem?.climb) return;
+    hapticLight();
+    // Opening the drawer for the already-current climb; opting out of
+    // setAsCurrent avoids duplicating it at the end of the queue.
+    openPlayDrawer(currentClimbQueueItem.climb, { setAsCurrent: false });
+  }, [openPlayDrawer, currentClimbQueueItem]);
+
+  const { gesture: panGesture, translateX } = useCarouselGesture({
+    onSwipeNext: handleNext,
+    onSwipePrevious: handlePrevious,
+    canSwipeNext: canNext,
+    canSwipePrevious: canPrevious,
+    boardWidth: width,
+    enabled: width > 0,
+    reduceMotion,
+  });
+
+  const tapGesture = useMemo(
+    () =>
+      Gesture.Tap()
+        .maxDuration(250)
+        .onEnd(() => {
+          'worklet';
+          runOnJS(handleOpenPlay)();
+        }),
+    [handleOpenPlay],
+  );
+
+  // Swipe up to open the drawer — a quick alternative to tapping (like dragging a
+  // now-playing chip up to full screen). Activates only on upward movement and
+  // bails on horizontal travel, so the prev/next carousel keeps the sideways
+  // swipes. Opens on a decisive drag or a fast upward flick.
+  const swipeUpGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .activeOffsetY(-12)
+        .failOffsetX([-20, 20])
+        .onEnd((event) => {
+          'worklet';
+          if (event.translationY < -40 || event.velocityY < -600) {
+            runOnJS(handleOpenPlay)();
+          }
+        }),
+    [handleOpenPlay],
+  );
+
+  const composedGesture = useMemo(
+    () => Gesture.Race(panGesture, swipeUpGesture, tapGesture),
+    [panGesture, swipeUpGesture, tapGesture],
+  );
+
+  const onLayout = useCallback((event: LayoutChangeEvent) => {
+    setWidth(event.nativeEvent.layout.width);
+  }, []);
+
+  const currentLabelStyle = useAnimatedStyle(() => ({ transform: [{ translateX: translateX.value }] }));
+  const nextPeekX = useDerivedValue(() =>
+    computePeekOffset({ direction: 'next', swipeOffset: translateX.value, viewportWidth: width }),
+  );
+  const prevPeekX = useDerivedValue(() =>
+    computePeekOffset({ direction: 'prev', swipeOffset: translateX.value, viewportWidth: width }),
+  );
+  const nextPeekStyle = useAnimatedStyle(() => ({ transform: [{ translateX: nextPeekX.value }] }));
+  const prevPeekStyle = useAnimatedStyle(() => ({ transform: [{ translateX: prevPeekX.value }] }));
+
+  const swipeAccessibilityActions: AccessibilityAction[] = [
+    ...(canPrevious ? [{ name: 'previous', label: t('mobile.queue.previousClimb') }] : []),
+    ...(canNext ? [{ name: 'next', label: t('mobile.queue.nextClimb') }] : []),
+  ];
+
+  return {
+    onLayout,
+    composedGesture,
+    currentLabelStyle,
+    nextPeekStyle,
+    prevPeekStyle,
+    currentItem: currentClimbQueueItem,
+    previousItem: prevItem,
+    nextItem,
+    canPrevious,
+    canNext,
+    handleNext,
+    handlePrevious,
+    swipeAccessibilityActions,
+  };
+}

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -21,6 +21,7 @@ import { PressableSurface } from '../PressableSurface';
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
+import { Badge } from '../Badge';
 import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
 
 const CAPSULE_RADIUS = glassSize.capsule / 2;
@@ -41,6 +42,11 @@ type ClimbTopChromeProps = {
   onSearchFocus: () => void;
   onSearchBlur: () => void;
   onCloseGrade: () => void;
+  /** Render the filter affordance in the top-right toolbar (Material variant), next
+   *  to the light/bluetooth button, instead of as the bottom-right FAB. */
+  showFilterAction?: boolean;
+  activeFilterCount?: number;
+  onOpenFilters?: () => void;
 };
 
 export function ClimbTopChrome({
@@ -56,6 +62,9 @@ export function ClimbTopChrome({
   onSearchFocus,
   onSearchBlur,
   onCloseGrade,
+  showFilterAction = false,
+  activeFilterCount = 0,
+  onOpenFilters,
 }: ClimbTopChromeProps) {
   const { t } = useTranslation('climbs');
   const { t: tSettings } = useTranslation('settings');
@@ -135,6 +144,11 @@ export function ClimbTopChrome({
 
   const canOpenAngleSelector = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
   const leftActionCount = (canCreate ? 1 : 0) + (canOpenAngleSelector ? 1 : 0);
+
+  // Right toolbar: filter (Material variant) + light/bluetooth, sharing one surface.
+  const filterActive = activeFilterCount > 0;
+  const showFilter = showFilterAction && onOpenFilters != null;
+  const rightActionCount = (showFilter ? 1 : 0) + (bluetooth ? 1 : 0);
 
   return (
     <>
@@ -221,11 +235,11 @@ export function ClimbTopChrome({
           </View>
 
           <View pointerEvents="box-none" style={styles.rightSlot}>
-            {bluetooth ? (
+            {rightActionCount > 0 ? (
               <View
                 style={[
                   styles.actionToolbar,
-                  { width: TOP_ACTION_SIZE },
+                  { width: TOP_ACTION_SIZE * rightActionCount },
                   !nativeGlass && shadows.sm,
                   !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
                 ]}
@@ -237,22 +251,49 @@ export function ClimbTopChrome({
                   style={StyleSheet.absoluteFill}
                   pointerEvents="none"
                 />
-                <PressableSurface
-                  onPress={handleBluetoothPress}
-                  feedback="opacity"
-                  hitSlop={4}
-                  accessibilityRole="button"
-                  accessibilityLabel={
-                    bluetoothConnected ? tCommon('lightControl.disconnect') : tSettings('ble.connectBoard')
-                  }
-                  style={styles.toolbarAction}
-                >
-                  <Icon
-                    name={bluetoothConnected ? 'lightbulb.fill' : 'lightbulb'}
-                    size={23}
-                    color={bluetoothConnected ? brandColors.warning : (systemColors.label as string)}
-                  />
-                </PressableSurface>
+                {showFilter ? (
+                  <PressableSurface
+                    onPress={onOpenFilters}
+                    feedback="opacity"
+                    hitSlop={4}
+                    accessibilityRole="button"
+                    accessibilityLabel={
+                      filterActive
+                        ? t('mobile.search.filterCountAria', { count: activeFilterCount })
+                        : t('mobile.search.filters')
+                    }
+                    style={styles.toolbarAction}
+                  >
+                    <Icon
+                      name="filter"
+                      size={22}
+                      color={filterActive ? brandColors.primary : (systemColors.label as string)}
+                    />
+                    {filterActive ? (
+                      <View pointerEvents="none" style={styles.actionBadge}>
+                        <Badge count={activeFilterCount} color={brandColors.primary} />
+                      </View>
+                    ) : null}
+                  </PressableSurface>
+                ) : null}
+                {bluetooth ? (
+                  <PressableSurface
+                    onPress={handleBluetoothPress}
+                    feedback="opacity"
+                    hitSlop={4}
+                    accessibilityRole="button"
+                    accessibilityLabel={
+                      bluetoothConnected ? tCommon('lightControl.disconnect') : tSettings('ble.connectBoard')
+                    }
+                    style={styles.toolbarAction}
+                  >
+                    <Icon
+                      name={bluetoothConnected ? 'lightbulb.fill' : 'lightbulb'}
+                      size={23}
+                      color={bluetoothConnected ? brandColors.warning : (systemColors.label as string)}
+                    />
+                  </PressableSurface>
+                ) : null}
               </View>
             ) : null}
           </View>
@@ -352,6 +393,11 @@ const styles = StyleSheet.create({
     height: TOP_ACTION_SIZE,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  actionBadge: {
+    position: 'absolute',
+    top: 5,
+    right: 5,
   },
   angleActionText: {
     fontWeight: '700',

--- a/packages/mobile/src/hooks/use-bottom-accessory.ts
+++ b/packages/mobile/src/hooks/use-bottom-accessory.ts
@@ -1,13 +1,24 @@
 import { Platform } from 'react-native';
 import { isLiquidGlassAvailable } from 'expo-glass-effect';
+import { useTheme } from '../providers/theme-provider';
 
 /**
- * Whether the app should use `NativeTabs.BottomAccessory` for the current climb
- * controls. Search lives in the top chrome, so the native accessory can now use
- * UIKit's single platter and inline/minimized behavior without nesting another
- * search/tick capsule inside it.
+ * Whether the device *can* host `NativeTabs.BottomAccessory` — the pure
+ * capability check (iOS 26 + RN ≥ 0.82). The native accessory is tied to the
+ * system Liquid Glass tab bar, so it only exists on that path.
  */
 export function isBottomAccessoryAvailable(): boolean {
   const reactNativeMinor = Platform.constants.reactNativeVersion?.minor ?? 0;
   return Platform.OS === 'ios' && reactNativeMinor >= 82 && isLiquidGlassAvailable();
+}
+
+/**
+ * Whether the native bottom accessory is actually in use right now: the device
+ * supports it AND the user is on the Liquid Glass variant. On the Material
+ * variant the JS tab bar replaces `NativeTabs`, so the current climb + tick ride
+ * the floating `PersistentQueueBar` instead and this returns false.
+ */
+export function useNativeAccessoryActive(): boolean {
+  const { variant } = useTheme();
+  return variant === 'liquidGlass' && isBottomAccessoryAvailable();
 }

--- a/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
@@ -3,7 +3,7 @@ import { useSegments } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useQueue } from '../providers/queue-provider';
 import { isTabsRoute } from '../lib/route-segments';
-import { isBottomAccessoryAvailable } from './use-bottom-accessory';
+import { useNativeAccessoryActive } from './use-bottom-accessory';
 import { computeBottomChromeMetrics } from './bottom-chrome-metrics';
 
 /**
@@ -18,7 +18,8 @@ export function useBottomChromeMetrics() {
 
   const hasCurrentClimb = state.currentClimbQueueItem?.climb != null;
   const insideTabs = isTabsRoute(segments);
-  const nativeAccessoryMounted = insideTabs && isBottomAccessoryAvailable();
+  const nativeAccessoryActive = useNativeAccessoryActive();
+  const nativeAccessoryMounted = insideTabs && nativeAccessoryActive;
 
   return useMemo(
     () =>

--- a/packages/mobile/src/hooks/use-effective-surface-mode.ts
+++ b/packages/mobile/src/hooks/use-effective-surface-mode.ts
@@ -1,0 +1,30 @@
+import { Platform } from 'react-native';
+import { useTheme } from '../providers/theme-provider';
+import { useReduceTransparency } from './use-reduce-transparency';
+import { useGlassCapability } from './use-glass-capability';
+
+/**
+ * How a translucent surface should actually render on this device, for this
+ * user, right now. One ordered decision so every consumer agrees:
+ *
+ *   solid    — Reduce Transparency on (a11y wins, any platform/variant)
+ *   material — the Material variant (opaque M3 tonal surface), even on iOS 26
+ *   glass    — iOS 26 Liquid Glass (the preferred path)
+ *   blur     — iOS < 26 frosted blur (the Liquid Glass fallback)
+ *   solid    — anything else (e.g. Android forced onto Liquid Glass)
+ *
+ * `GlassSurface` switches on this; `useNativeGlass()` is `mode === 'glass'`.
+ */
+export type SurfaceMode = 'glass' | 'blur' | 'material' | 'solid';
+
+export function useEffectiveSurfaceMode(): SurfaceMode {
+  const { variant } = useTheme();
+  const reduceTransparency = useReduceTransparency();
+  const glassCapable = useGlassCapability();
+
+  if (reduceTransparency) return 'solid';
+  if (variant === 'material') return 'material';
+  if (glassCapable) return 'glass';
+  if (Platform.OS === 'ios') return 'blur';
+  return 'solid';
+}

--- a/packages/mobile/src/hooks/use-glass-capability.ts
+++ b/packages/mobile/src/hooks/use-glass-capability.ts
@@ -1,0 +1,16 @@
+import { Platform } from 'react-native';
+import { isGlassEffectAPIAvailable, isLiquidGlassAvailable } from 'expo-glass-effect';
+
+/**
+ * Whether the device can render real iOS 26 Liquid Glass. This is the pure
+ * *capability* check — it deliberately excludes Reduce Transparency, which is an
+ * orthogonal render-mode concern handled in `GlassSurface`/`useEffectiveSurfaceMode`.
+ *
+ * Used to resolve the `'auto'` UI-variant preference and to gate the Settings
+ * "Liquid Glass" option. The native answer is stable per process, so this is a
+ * plain synchronous check exposed as a hook for naming consistency — letting the
+ * first paint pick the correct variant without awaiting async storage.
+ */
+export function useGlassCapability(): boolean {
+  return Platform.OS === 'ios' && isLiquidGlassAvailable() && isGlassEffectAPIAvailable();
+}

--- a/packages/mobile/src/hooks/use-native-glass.ts
+++ b/packages/mobile/src/hooks/use-native-glass.ts
@@ -1,18 +1,17 @@
-import { Platform } from 'react-native';
-import { isGlassEffectAPIAvailable, isLiquidGlassAvailable } from 'expo-glass-effect';
-import { useReduceTransparency } from './use-reduce-transparency';
+import { useEffectiveSurfaceMode } from './use-effective-surface-mode';
 
 /**
  * Whether the real iOS 26 Liquid Glass path is active — i.e. `GlassSurface`
- * renders a native `GlassView` rather than the blur/solid fallback. Native glass
- * draws its own refractive edge, so on this path components should drop their
- * hand-drawn hairline borders and separation shadows (those belong to the
- * fallback, where the blur has no intrinsic edge). Mirrors the branch logic in
- * `GlassSurface`, kept in one place so the chrome stays in agreement.
+ * renders a native `GlassView` rather than the blur/material/solid fallback.
+ * Native glass draws its own refractive edge, so on this path components drop
+ * their hand-drawn hairline borders and separation shadows (those belong to the
+ * other paths, where the surface has no intrinsic edge). Because this is false
+ * for the Material variant, chrome automatically re-adds its border + elevation
+ * in Material mode, which is exactly what a flat M3 surface wants.
+ *
+ * Thin wrapper over `useEffectiveSurfaceMode()` so the chrome and `GlassSurface`
+ * always agree on the active path.
  */
 export function useNativeGlass(): boolean {
-  const reduceTransparency = useReduceTransparency();
-  return (
-    Platform.OS === 'ios' && !reduceTransparency && isLiquidGlassAvailable() && isGlassEffectAPIAvailable()
-  );
+  return useEffectiveSurfaceMode() === 'glass';
 }

--- a/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
@@ -32,8 +32,15 @@ vi.mock('react-native', () => ({
   Appearance: { setColorScheme: vi.fn() },
 }));
 
+// useGlassCapability imports these; under jsdom (Platform.OS='android') the
+// capability is false regardless, but the import must resolve.
+vi.mock('expo-glass-effect', () => ({
+  isLiquidGlassAvailable: () => false,
+  isGlassEffectAPIAvailable: () => false,
+}));
+
 import { ThemeProvider, useTheme } from '../theme-provider';
-import { THEME_OVERRIDE_KEY } from '@boardsesh/key-value-storage';
+import { THEME_OVERRIDE_KEY, UI_VARIANT_KEY } from '@boardsesh/key-value-storage';
 
 const wrapper = ({ children }: { children: ReactNode }) => <ThemeProvider>{children}</ThemeProvider>;
 
@@ -130,6 +137,49 @@ describe('ThemeProvider', () => {
       });
 
       expect(result.current.themeOverride).toBe('dark');
+    });
+  });
+
+  describe('uiVariant', () => {
+    it("defaults to the Material variant on a non-glass device ('auto' → material)", async () => {
+      const { result } = renderHook(() => useTheme(), { wrapper });
+      await waitFor(() => expect(getMock).toHaveBeenCalledWith(UI_VARIANT_KEY));
+      expect(result.current.uiVariantPreference).toBe('auto');
+      expect(result.current.variant).toBe('material');
+      // Material maps M3 tonal surfaces + the 20dp button radius.
+      expect(result.current.radii.button).toBe(20);
+      expect(result.current.systemColors.background).toBe('#F4ECEC');
+    });
+
+    it('setUiVariant persists to SecureStore and flips the resolved variant + tokens', async () => {
+      const { result } = renderHook(() => useTheme(), { wrapper });
+      await waitFor(() => expect(getMock).toHaveBeenCalledWith(UI_VARIANT_KEY));
+
+      await act(async () => {
+        await result.current.setUiVariant('liquidGlass');
+      });
+
+      expect(result.current.uiVariantPreference).toBe('liquidGlass');
+      expect(result.current.variant).toBe('liquidGlass');
+      // Liquid Glass keeps the soft 10dp button radius and the (Android) system
+      // surface — not the Material tonal map.
+      expect(result.current.radii.button).toBe(10);
+      expect(result.current.systemColors.background).toBe('#FFFFFF');
+      expect(setMock).toHaveBeenCalledWith(UI_VARIANT_KEY, 'liquidGlass');
+    });
+
+    it('hydrates a stored variant preference on mount', async () => {
+      getMock.mockImplementation((key: string) => Promise.resolve(key === UI_VARIANT_KEY ? 'liquidGlass' : null));
+      const { result } = renderHook(() => useTheme(), { wrapper });
+      await waitFor(() => expect(result.current.uiVariantPreference).toBe('liquidGlass'));
+      expect(result.current.variant).toBe('liquidGlass');
+    });
+
+    it('ignores a stored value that is not a UiVariantPreference', async () => {
+      getMock.mockImplementation((key: string) => Promise.resolve(key === UI_VARIANT_KEY ? 'frosted' : null));
+      const { result } = renderHook(() => useTheme(), { wrapper });
+      await waitFor(() => expect(getMock).toHaveBeenCalledWith(UI_VARIANT_KEY));
+      expect(result.current.uiVariantPreference).toBe('auto');
     });
   });
 

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -1,10 +1,28 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { Appearance, Platform, useColorScheme, type ColorValue } from 'react-native';
-import { THEME_OVERRIDE_KEY, isThemeOverride, type ThemeOverride } from '@boardsesh/key-value-storage';
-import { iosSystemColors, brandColors, androidFallbackColors } from '../theme/colors';
+import {
+  THEME_OVERRIDE_KEY,
+  isThemeOverride,
+  type ThemeOverride,
+  UI_VARIANT_KEY,
+  isUiVariantPreference,
+  type UiVariantPreference,
+} from '@boardsesh/key-value-storage';
+import { iosSystemColors, brandColors, androidFallbackColors, materialSurfaces } from '../theme/colors';
 import { textStyles, type TextVariant } from '../theme/typography';
-import { spacing, borderRadius, shadows, opacity } from '../theme/tokens';
+import {
+  spacing,
+  borderRadius,
+  shadows,
+  opacity,
+  radiiByVariant,
+  sheetChromeByVariant,
+  type Radii,
+  type SheetChrome,
+} from '../theme/tokens';
 import { springs, timing } from '../theme/animations';
+import { resolveUiVariant, type UiVariant } from '../theme/resolve-ui-variant';
+import { useGlassCapability } from '../hooks/use-glass-capability';
 import { secureStorePreferences } from '../lib/preferences/secure-store-adapter';
 
 type ColorScheme = 'light' | 'dark';
@@ -39,6 +57,15 @@ type Theme = {
   timing: typeof timing;
   themeOverride: ThemeOverride;
   setThemeOverride: (next: ThemeOverride) => Promise<void>;
+  /** Resolved visual variant the app renders in ('auto' already resolved). */
+  variant: UiVariant;
+  /** The user's raw stored preference, including 'auto'. Drives the settings UI. */
+  uiVariantPreference: UiVariantPreference;
+  setUiVariant: (next: UiVariantPreference) => Promise<void>;
+  /** Semantic corner radii for the current variant (control/card/sheet). */
+  radii: Radii;
+  /** Bottom-sheet chrome (scrim/handle/corners) for the current variant. */
+  sheet: SheetChrome;
 };
 
 const ThemeContext = createContext<Theme | null>(null);
@@ -52,7 +79,14 @@ const ThemeContext = createContext<Theme | null>(null);
  * On Android, PlatformColor is not used — we pick from the
  * androidFallbackColors light/dark map.
  */
-function resolveSystemColors(colorScheme: ColorScheme): ResolvedSystemColors {
+function resolveSystemColors(colorScheme: ColorScheme, variant: UiVariant): ResolvedSystemColors {
+  // Material variant: M3 tonal surfaces on every platform — including iOS 26
+  // hardware when the user explicitly chose Material. Drawn opaque (no glass),
+  // so we don't use PlatformColor here.
+  if (variant === 'material') {
+    return { ...materialSurfaces[colorScheme] };
+  }
+
   if (Platform.OS === 'ios' && iosSystemColors) {
     // PlatformColor values adapt automatically on iOS — return as-is.
     return iosSystemColors as ResolvedSystemColors;
@@ -86,10 +120,15 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   // resolved scheme switches to the saved override (if any) without a visible
   // flash when the OS already matches the override.
   const [themeOverride, setThemeOverrideState] = useState<ThemeOverride>('system');
+  // `'auto'` until SecureStore hydrates — same value as a brand-new user, so the
+  // first paint resolves to the platform default (Liquid Glass on iOS 26,
+  // Material elsewhere) via the synchronous capability check, no flash.
+  const [uiVariantPreference, setUiVariantPreferenceState] = useState<UiVariantPreference>('auto');
   // Guards the hydration effect against stomping a user choice that lands
   // before the SecureStore read resolves (a tap on a settings toggle can
   // beat the keychain read on a cold launch).
   const hasUserChosenRef = useRef(false);
+  const hasUserChosenVariantRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -103,6 +142,15 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         // Storage read can fail if SecureStore is unavailable (rare). Stay on
         // the 'system' default rather than crashing — the user's override is
         // lost for this session but the app remains usable.
+      });
+    secureStorePreferences
+      .get<UiVariantPreference>(UI_VARIANT_KEY)
+      .then((value) => {
+        if (cancelled || hasUserChosenVariantRef.current) return;
+        if (isUiVariantPreference(value)) setUiVariantPreferenceState(value);
+      })
+      .catch(() => {
+        // Same rationale as the theme override read — stay on 'auto'.
       });
     return () => {
       cancelled = true;
@@ -139,8 +187,28 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     }
   }, []);
 
+  const setUiVariant = useCallback(async (next: UiVariantPreference) => {
+    hasUserChosenVariantRef.current = true;
+    setUiVariantPreferenceState(next);
+    try {
+      await secureStorePreferences.set(UI_VARIANT_KEY, next);
+    } catch (error) {
+      // See setThemeOverride — keep the in-memory pick on write failure.
+      // eslint-disable-next-line no-console
+      console.warn('[theme-provider] Failed to persist UI variant', error);
+    }
+  }, []);
+
+  // Synchronous native check — lets the first paint resolve 'auto' to the right
+  // variant without waiting on the async SecureStore read.
+  const glassCapable = useGlassCapability();
+  const variant = useMemo<UiVariant>(
+    () => resolveUiVariant(uiVariantPreference, glassCapable),
+    [uiVariantPreference, glassCapable],
+  );
+
   const theme = useMemo<Theme>(() => {
-    const resolvedSystemColors = resolveSystemColors(colorScheme);
+    const resolvedSystemColors = resolveSystemColors(colorScheme, variant);
 
     return {
       colorScheme,
@@ -155,8 +223,13 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       timing,
       themeOverride,
       setThemeOverride,
+      variant,
+      uiVariantPreference,
+      setUiVariant,
+      radii: radiiByVariant[variant],
+      sheet: sheetChromeByVariant[variant],
     };
-  }, [colorScheme, themeOverride, setThemeOverride]);
+  }, [colorScheme, variant, themeOverride, setThemeOverride, uiVariantPreference, setUiVariant]);
 
   // React 19 context provider syntax (Expo SDK 53+ / React 19)
   return <ThemeContext value={theme}>{children}</ThemeContext>;
@@ -182,4 +255,4 @@ export function useOptionalTheme(): Theme | null {
   return useContext(ThemeContext);
 }
 
-export type { Theme, ColorScheme, ResolvedSystemColors, TextVariant };
+export type { Theme, ColorScheme, ResolvedSystemColors, TextVariant, UiVariant };

--- a/packages/mobile/src/theme/__tests__/resolve-ui-variant.test.ts
+++ b/packages/mobile/src/theme/__tests__/resolve-ui-variant.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolveUiVariant } from '../resolve-ui-variant';
+
+describe('resolveUiVariant', () => {
+  it("follows capability on 'auto': glass when capable, Material otherwise", () => {
+    expect(resolveUiVariant('auto', true)).toBe('liquidGlass');
+    expect(resolveUiVariant('auto', false)).toBe('material');
+  });
+
+  it('honours an explicit Liquid Glass choice even when capable', () => {
+    expect(resolveUiVariant('liquidGlass', true)).toBe('liquidGlass');
+  });
+
+  it('honours an explicit Liquid Glass choice even on incapable hardware', () => {
+    // Forced glass on a non-capable device still resolves to the glass *variant*;
+    // GlassSurface degrades the actual rendering to solid.
+    expect(resolveUiVariant('liquidGlass', false)).toBe('liquidGlass');
+  });
+
+  it('honours an explicit Material choice even on iOS 26 hardware', () => {
+    expect(resolveUiVariant('material', true)).toBe('material');
+    expect(resolveUiVariant('material', false)).toBe('material');
+  });
+});

--- a/packages/mobile/src/theme/colors.ts
+++ b/packages/mobile/src/theme/colors.ts
@@ -69,9 +69,54 @@ export const androidFallbackColors = {
   },
 } as const;
 
+/**
+ * Material 3 tonal surfaces for the Material UI variant, keyed by color scheme.
+ * Same shape as `androidFallbackColors` so the ThemeProvider can return them
+ * directly as the resolved system colors on ANY platform when the user is on the
+ * Material variant (including iOS 26 hardware where they chose Material).
+ *
+ * Neutrals are warmed toward the maroon brand tint (#8C4A52) so Material reads as
+ * the same product as Liquid Glass rather than a generic M3 theme. The Material
+ * feel comes from elevation shadows, ripple, the nav active-indicator pill, and
+ * bounded radii — not from a different palette. Labels keep the iOS-derived
+ * neutral values so text contrast matches the glass variant exactly.
+ */
+export const materialSurfaces = {
+  light: {
+    // M3 base surface — warm-tinted so cards/elevation read against it.
+    background: '#F4ECEC',
+    // Cards and sheets sit a step up from the base (surface container low).
+    secondaryBackground: '#FFFFFF',
+    tertiaryBackground: '#FFFFFF',
+    groupedBackground: '#F4ECEC',
+    // Raised tile (selected segmented pill, elevated bar) — surface + elevation.
+    elevatedSurface: '#FFFFFF',
+    label: '#000000',
+    secondaryLabel: 'rgba(60, 60, 67, 0.6)',
+    tertiaryLabel: 'rgba(60, 60, 67, 0.3)',
+    // M3 outline-variant.
+    separator: 'rgba(60, 60, 67, 0.18)',
+    // Faint maroon track for segmented controls / fills.
+    fill: 'rgba(140, 74, 82, 0.1)',
+  },
+  dark: {
+    background: '#141011',
+    secondaryBackground: '#1F1A1B',
+    tertiaryBackground: '#2A2425',
+    groupedBackground: '#141011',
+    elevatedSurface: '#2A2425',
+    label: '#FFFFFF',
+    secondaryLabel: 'rgba(235, 235, 245, 0.6)',
+    tertiaryLabel: 'rgba(235, 235, 245, 0.3)',
+    separator: 'rgba(235, 235, 245, 0.18)',
+    fill: 'rgba(235, 220, 222, 0.12)',
+  },
+} as const;
+
 export type SystemColorKey = keyof typeof androidFallbackColors.light;
 export type BrandColors = typeof brandColors;
 export type AndroidFallbackColors = typeof androidFallbackColors;
+export type MaterialSurfaces = typeof materialSurfaces;
 
 /**
  * Apply an alpha (0–1) to a colour. Handles `#RGB` and `#RRGGBB` hex by

--- a/packages/mobile/src/theme/resolve-ui-variant.ts
+++ b/packages/mobile/src/theme/resolve-ui-variant.ts
@@ -1,0 +1,26 @@
+import type { UiVariantPreference } from '@boardsesh/key-value-storage';
+
+/**
+ * The resolved visual variant the whole app renders in. Unlike the stored
+ * `UiVariantPreference` ('auto' | 'liquidGlass' | 'material'), this is the
+ * concrete choice after `'auto'` has been resolved against device capability —
+ * it is never `'auto'`.
+ *
+ *   liquidGlass — the iOS 26 Liquid Glass UI (preferred, primary)
+ *   material    — the Material 3 UI (default off iOS 26)
+ */
+export type UiVariant = 'liquidGlass' | 'material';
+
+/**
+ * Resolve the effective variant from the user's preference and whether the
+ * device can render Liquid Glass. An explicit choice always wins; `'auto'`
+ * follows capability (glass on iOS 26, Material everywhere else).
+ *
+ * Pure and synchronous so the first paint can pick the right variant without
+ * waiting on async storage — `glassCapable` is a synchronous native check.
+ */
+export function resolveUiVariant(preference: UiVariantPreference, glassCapable: boolean): UiVariant {
+  if (preference === 'liquidGlass') return 'liquidGlass';
+  if (preference === 'material') return 'material';
+  return glassCapable ? 'liquidGlass' : 'material';
+}

--- a/packages/mobile/src/theme/tokens.ts
+++ b/packages/mobile/src/theme/tokens.ts
@@ -6,7 +6,6 @@
  * Animation tokens have moved to ./animations.ts
  */
 
-import { Platform } from 'react-native';
 import { iosSystemColors } from './ios-colors';
 import { withAlpha } from './colors';
 
@@ -144,20 +143,42 @@ export function androidRipple(color: string, borderless = false): { color: strin
 }
 
 /**
- * Bottom-sheet chrome resolved per platform: Android gets the Material 3 metrics
- * (28dp corners, slimmer handle, lighter scrim), iOS keeps the softer existing
- * look. Shared by Sheet and ModalSheet so the two never drift.
+ * Corner radii that genuinely differ between the two variants, resolved via
+ * `theme.radii`. Pills/capsules stay fully rounded and cards stay `lg` in BOTH
+ * variants (the variants differ in surface/elevation, not those silhouettes), so
+ * they're not here — only the button corner varies (soft 10dp on Liquid Glass,
+ * M3 20dp on Material). Sheet corners live in `sheetChromeByVariant` below.
  */
-export const sheetAndroid = {
-  scrimOpacity: Platform.OS === 'android' ? material.sheet.scrimOpacity : 0.4,
-  handleStyle:
-    Platform.OS === 'android'
-      ? { ...sheetStyles.indicator, width: material.sheet.handleWidth, height: material.sheet.handleHeight }
-      : sheetStyles.indicator,
-  corners:
-    Platform.OS === 'android'
-      ? { borderTopLeftRadius: material.sheet.cornerRadius, borderTopRightRadius: material.sheet.cornerRadius }
-      : null,
+export const radiiByVariant = {
+  liquidGlass: {
+    button: 10,
+  },
+  material: {
+    button: material.button.radius,
+  },
+} as const;
+
+/**
+ * Bottom-sheet chrome resolved per UI variant (supersedes the old
+ * `Platform.OS`-keyed `sheetAndroid` so an iOS-26 user on Material gets M3 sheet
+ * metrics too). Liquid Glass keeps the softer existing look; Material uses the
+ * M3 metrics (28dp corners, slimmer handle, lighter scrim). Consumed by Sheet,
+ * ModalSheet and PlayDrawer via `theme.sheet` so the three never drift.
+ */
+export const sheetChromeByVariant = {
+  liquidGlass: {
+    scrimOpacity: 0.4,
+    handleStyle: sheetStyles.indicator,
+    corners: null as { borderTopLeftRadius: number; borderTopRightRadius: number } | null,
+  },
+  material: {
+    scrimOpacity: material.sheet.scrimOpacity,
+    handleStyle: { ...sheetStyles.indicator, width: material.sheet.handleWidth, height: material.sheet.handleHeight },
+    corners: {
+      borderTopLeftRadius: material.sheet.cornerRadius,
+      borderTopRightRadius: material.sheet.cornerRadius,
+    } as { borderTopLeftRadius: number; borderTopRightRadius: number } | null,
+  },
 } as const;
 
 export type Spacing = typeof spacing;
@@ -165,3 +186,5 @@ export type BorderRadius = typeof borderRadius;
 export type Shadows = typeof shadows;
 export type Opacity = typeof opacity;
 export type Material = typeof material;
+export type Radii = (typeof radiiByVariant)[keyof typeof radiiByVariant];
+export type SheetChrome = (typeof sheetChromeByVariant)[keyof typeof sheetChromeByVariant];

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -17,6 +17,14 @@
         "light": "Light",
         "dark": "Dark"
       },
+      "uiStyle": {
+        "title": "UI style",
+        "auto": "Auto",
+        "liquidGlass": "Liquid Glass",
+        "material": "Material",
+        "description": "Auto picks Liquid Glass where your device can render it, Material everywhere else.",
+        "glassUnavailable": "Liquid Glass needs iOS 26. Your device runs Material."
+      },
       "gradeFormat": {
         "title": "Grade format",
         "description": "Choose how climb grades read across the app.",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -215,6 +215,14 @@
         "light": "Claro",
         "dark": "Oscuro"
       },
+      "uiStyle": {
+        "title": "Estilo de interfaz",
+        "auto": "Automático",
+        "liquidGlass": "Liquid Glass",
+        "material": "Material",
+        "description": "Automático usa Liquid Glass donde tu dispositivo puede mostrarlo y Material en el resto.",
+        "glassUnavailable": "Liquid Glass requiere iOS 26. Tu dispositivo usa Material."
+      },
       "gradeFormat": {
         "title": "Formato de grado",
         "description": "Elige cómo se muestran los grados en la app.",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -17,6 +17,14 @@
         "light": "Clair",
         "dark": "Sombre"
       },
+      "uiStyle": {
+        "title": "Style d'interface",
+        "auto": "Automatique",
+        "liquidGlass": "Liquid Glass",
+        "material": "Material",
+        "description": "Automatique choisit Liquid Glass quand ton appareil peut l'afficher, Material partout ailleurs.",
+        "glassUnavailable": "Liquid Glass nécessite iOS 26. Ton appareil utilise Material."
+      },
       "gradeFormat": {
         "title": "Format de cotation",
         "description": "Choisis comment les cotations s'affichent dans l'app.",

--- a/packages/shared/key-value-storage/src/__tests__/ui-variant.test.ts
+++ b/packages/shared/key-value-storage/src/__tests__/ui-variant.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { UI_VARIANT_KEY, isUiVariantPreference } from '../ui-variant';
+
+describe('ui-variant', () => {
+  it('exposes a stable storage key', () => {
+    expect(UI_VARIANT_KEY).toBe('ui_variant');
+  });
+
+  it("uses only characters that satisfy expo-secure-store's regex", () => {
+    // SecureStore rejects keys outside [\w.-]+ — see theme.ts.
+    expect(UI_VARIANT_KEY).toMatch(/^[\w.-]+$/);
+  });
+
+  it('accepts the three valid preferences', () => {
+    expect(isUiVariantPreference('auto')).toBe(true);
+    expect(isUiVariantPreference('liquidGlass')).toBe(true);
+    expect(isUiVariantPreference('material')).toBe(true);
+  });
+
+  it('rejects everything else', () => {
+    expect(isUiVariantPreference('Auto')).toBe(false);
+    expect(isUiVariantPreference('glass')).toBe(false);
+    expect(isUiVariantPreference('')).toBe(false);
+    expect(isUiVariantPreference(null)).toBe(false);
+    expect(isUiVariantPreference(undefined)).toBe(false);
+    expect(isUiVariantPreference(0)).toBe(false);
+  });
+});

--- a/packages/shared/key-value-storage/src/index.ts
+++ b/packages/shared/key-value-storage/src/index.ts
@@ -8,3 +8,4 @@
 
 export type { KeyValueStorage } from './storage';
 export { THEME_OVERRIDE_KEY, isThemeOverride, type ThemeOverride } from './theme';
+export { UI_VARIANT_KEY, isUiVariantPreference, type UiVariantPreference } from './ui-variant';

--- a/packages/shared/key-value-storage/src/ui-variant.ts
+++ b/packages/shared/key-value-storage/src/ui-variant.ts
@@ -1,0 +1,17 @@
+// UI variant preference: the user's explicit choice of visual style on top of
+// the platform default. `'auto'` (or absent) follows device capability —
+// Liquid Glass where the OS can render it (iOS 26), Material everywhere else.
+// `'liquidGlass'` and `'material'` force a skin regardless of the platform.
+//
+// Mobile persists this via SecureStore alongside the theme override, so the key
+// uses only [\w.-] to satisfy expo-secure-store's validator (see theme.ts).
+// Lives here next to THEME_OVERRIDE_KEY so a future server-side preference sync
+// reads/writes the same slot.
+
+export const UI_VARIANT_KEY = 'ui_variant';
+
+export type UiVariantPreference = 'auto' | 'liquidGlass' | 'material';
+
+export function isUiVariantPreference(value: unknown): value is UiVariantPreference {
+  return value === 'auto' || value === 'liquidGlass' || value === 'material';
+}


### PR DESCRIPTION
## What

Adds a second visual variant — **Material 3** — to `packages/mobile`, alongside the existing iOS 26 **Liquid Glass** UI. Switchable in Settings; **defaults to Material on devices that aren't iOS 26** (Android + iOS < 26). Liquid Glass stays the primary, preferred UI and is **behaviorally unchanged** for an iOS 26 user who never opens the setting.

## How it works

- **One resolved `variant` in `ThemeProvider`.** A persisted `UI_VARIANT_KEY` preference (`'auto' | 'liquidGlass' | 'material'`) is resolved against device capability (`resolveUiVariant`), mirroring the existing `themeOverride` machinery (SecureStore, hydration race-guard, `console.warn` on write failure). `'auto'` → Liquid Glass on iOS 26, Material elsewhere — so the platform default needs zero stored state.
- **`GlassSurface` absorbs Material.** A single `useEffectiveSurfaceMode()` resolves to `glass | blur | material | solid` (Reduce Transparency still wins first). `GlassSurface` gains a `material` branch (opaque M3 tonal surface + elevation). `useNativeGlass()` is now `mode === 'glass'`, so the handful of chrome components that gate borders/shadows on it adapt for free.
- **Variant-keyed tokens resolved in the theme** (`materialSurfaces`, `radiiByVariant`, `sheetChromeByVariant`) so the component layer stays free of `if (variant)`. Spacing/size ladder, springs/timing and the type scale stay shared across variants — Material follows the liquid-glass design philosophy, it isn't a generic M3 clone.
- **JS Material 3 tab bar.** On the Material variant `(tabs)/_layout` renders `expo-router`'s `<Tabs>` with a custom `MaterialTabBar` (active-indicator pill, ripple, record badge) instead of the native Liquid Glass `NativeTabs`.
- **Timer-ready accessory bar.** The queue bar is refactored into a content-agnostic `ActiveContextBar` (leading/primary/trailing slots) + a variant-aware `AccessoryBarSurface` background, with the carousel logic extracted into a shared `useQueueCarousel` hook (deduping `ClimbCapsule` ↔ `NativeAccessoryClimbRow`). This sets the bar up to host a workout **rep timer** (time-between-ticks) in a later version with no container changes.
- **Settings switcher** (Auto / Liquid Glass / Material) in the More screen, with Liquid Glass shown-but-disabled on devices that can't render it; i18n keys for en-US/es/fr.

## Liquid Glass is untouched
For an iOS 26 user who doesn't change the setting: `GlassSurface` glass/blur/solid branches, the native `NativeTabs` + bottom-accessory, `ClimbCapsule`'s glass pill + colorized grade, and the native accessory's plain-grade/thumbnail/tick all render exactly as before. Sheet chrome is unchanged per platform.

## Validation
- `vp run typecheck:mobile` — clean
- `vp test --project mobile` — 916 passing (incl. new `resolve-ui-variant`, `ui-variant`, and Material/regression cases in `glass-surface` + `theme-provider`)
- `vp run check:mobile-bundle` — iOS + Android bundles OK
- i18n catalog completeness (en-US/es/fr parity) passing

## Notes for review
- Per discussion, on iOS 26 a user who picks Material gets the full JS Material tab bar (not the native glass one).
- `NativeAccessoryClimbRow` was kept (not merged into `ClimbCapsule`) to avoid risking the prized liquid-glass native accessory's layout, which can't be visually verified on Linux CI — the genuine duplication (carousel logic) was extracted into `useQueueCarousel` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)