### PR TITLE
Render the Material UI variant with react-native-paper (authentic MD3)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -248,6 +248,7 @@
         "react-native-gesture-handler": "~2.31.1",
         "react-native-gifted-charts": "^1.4.77",
         "react-native-pager-view": "^8.0.2",
+        "react-native-paper": "^5.15.3",
         "react-native-qrcode-svg": "^6.3.15",
         "react-native-reanimated": "4.3.1",
         "react-native-safe-area-context": "~5.7.0",
@@ -1026,6 +1027,8 @@
     "@boardsesh/web": ["@boardsesh/web@workspace:packages/web"],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@callstack/react-theme-provider": ["@callstack/react-theme-provider@3.0.9", "", { "dependencies": { "deepmerge": "^3.2.0", "hoist-non-react-statics": "^3.3.0" }, "peerDependencies": { "react": ">=16.3.0" } }, "sha512-tTQ0uDSCL0ypeMa8T/E9wAZRGKWj8kXP7+6RYgPTfOPs9N07C9xM8P02GJ3feETap4Ux5S69D9nteq9mEj86NA=="],
 
     "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
 
@@ -3811,6 +3814,8 @@
 
     "react-native-pager-view": ["react-native-pager-view@8.0.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Y8All2BbjidI4ZIF9kBOIIoldkqrY/2FXapHZMdjwD+ByXhiOWTFenPs5rq9KRN5uAH/gOXtQCqHLxQDNBQRiQ=="],
 
+    "react-native-paper": ["react-native-paper@5.15.3", "", { "dependencies": { "@callstack/react-theme-provider": "^3.0.9", "color": "^3.1.2", "use-latest-callback": "^0.2.3" }, "peerDependencies": { "react": "*", "react-native": "*", "react-native-safe-area-context": "*" } }, "sha512-GEyNTmWElIZgnYw09AjjCNupRYzCmP79uAAyGSyCEUZz7KBz1wtJcC0wVUkozR1Rn3PK/td/9LlR6+F1hzmYvA=="],
+
     "react-native-qrcode-svg": ["react-native-qrcode-svg@6.3.21", "", { "dependencies": { "prop-types": "^15.8.0", "qrcode": "^1.5.4", "text-encoding": "^0.7.0" }, "peerDependencies": { "react": "*", "react-native": ">=0.63.4", "react-native-svg": ">=14.0.0" } }, "sha512-6vcj4rcdpWedvphDR+NSJcudJykNuLgNGFwm2p4xYjR8RdyTzlrELKI5LkO4ANS9cQUbqsfkpippPv64Q2tUtA=="],
 
     "react-native-reanimated": ["react-native-reanimated@4.3.1", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.3.1", "semver": "^7.7.3" }, "peerDependencies": { "react": "*", "react-native": "0.81 - 0.85", "react-native-worklets": "0.8.x" } }, "sha512-KhGsS0YkCA+gusgyzlf9hnqzVPIR398KTpqXyqq/+yYJJPAvyEEPKcxlB0xtOOXSMrR2A9uRKVARVQhZwrOh+Q=="],
@@ -4472,6 +4477,8 @@
     "@boardsesh/sync-runtime/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@bramus/specificity/css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "@callstack/react-theme-provider/deepmerge": ["deepmerge@3.3.0", "", {}, "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="],
 
     "@emnapi/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -5143,6 +5150,8 @@
 
     "react-native/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
+    "react-native-paper/color": ["color@3.2.1", "", { "dependencies": { "color-convert": "^1.9.3", "color-string": "^1.6.0" } }, "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA=="],
+
     "react-remove-scroll/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "react-remove-scroll-bar/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -5439,6 +5448,8 @@
 
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
+    "react-native-paper/color/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
+
     "restore-cursor/onetime/mimic-fn": ["mimic-fn@1.2.0", "", {}, "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -5478,6 +5489,8 @@
     "qrcode/yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "react-native-paper/color/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
     "@bacons/apple-targets/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -883,6 +883,28 @@ Glass is for **floating chrome only** — never for content canvases or text-hea
 - A **Light / Dark / System** toggle lives in More → Appearance. `ColorSchemePreferenceProvider` persists the choice and calls `Appearance.setColorScheme(...)`, which overrides the app's native trait collection so `PlatformColor`, the status bar, and the glass all follow in lockstep. `app.config.ts` stays `userInterfaceStyle: 'automatic'` so the override can take effect at runtime.
 - `elevatedSurface` (`tertiarySystemBackground` on iOS) is the token for a raised tile over a secondary/fill surface — e.g. the selected segmented-control pill.
 
+### Material variant (react-native-paper)
+
+The mobile app ships **two visual variants**, switchable in More → **UI style** (Auto / Liquid Glass / Material). Liquid Glass (above) is the preferred, primary UI; **Material** is the default on non-iOS-26 devices and renders authentic Material 3 via `react-native-paper`. The resolved variant is exposed as `useTheme().variant` (`'liquidGlass' | 'material'`) — resolved in `ThemeProvider` from the persisted `uiVariantPreference` (`src/theme/resolve-ui-variant.ts`).
+
+**Our theme stays the source of truth.** `src/theme/paper-theme.ts` `buildPaperTheme(colorScheme, dynamic?)` maps our tokens (`materialSurfaces`, `brandColors`) onto MD3 colour roles and feeds `PaperProvider` (mounted by `src/providers/material-theme-provider.tsx`, under `ThemeProvider`). Paper's MD3 type scale + shapes stay as defaults (system font). The optional `dynamic` palette is the seam for the planned Material You fast-follow (`@pchmn/expo-material3-theme`).
+
+**Per-primitive dispatch convention** — when adding/migrating a primitive, branch on the variant and keep the Liquid Glass body untouched in the `else`:
+
+```tsx
+export function Button(props: ButtonProps) {
+  const { variant: uiVariant } = useTheme();
+  return uiVariant === 'material' ? <ButtonMaterial {...props} /> : <ButtonGlass {...props} />;
+}
+```
+
+The public prop API must stay identical across both branches so call sites never change. `Button.tsx` is the exemplar.
+
+- **Icons:** Paper resolves icons through the app's `@expo/vector-icons` MaterialCommunityIcons (wired via `PaperProvider settings.icon`), so pass the **MDI** name — bridge our semantic `IconName` with `iconMap[name].android` (`src/components/icon-map.ts`).
+- **Paper-backed today:** Button, SegmentedControl→`SegmentedButtons`, SwitchRow→`Switch`, Badge, GlassIconButton→`IconButton`, Card, Toast/QueueAddedSnackbar→`Snackbar`, SearchHeader→`Searchbar`.
+- **Token-skinned but palette-consistent** (they read the same `materialSurfaces` that feeds the Paper theme): `ListRow`, `GradeChip`, `MaterialTabBar`, gorhom sheets, `AccessoryBarSurface`.
+- **Tests:** `react-native-paper` is aliased to a jsdom-safe stub (`test/react-native-paper-stub.tsx`) in `packages/mobile/vite.config.ts` — the same pattern as the posthog stub — so any suite can import a Paper-backed primitive. Component tests that assert Paper props register their own `vi.mock('react-native-paper', …)`, which takes precedence.
+
 ---
 
 ## Anti-Patterns

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -16,6 +16,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { QueryProvider } from '../src/providers/query-provider';
 import { ThemeProvider, useTheme } from '../src/providers/theme-provider';
+import { MaterialThemeProvider } from '../src/providers/material-theme-provider';
 import { AuthProvider } from '../src/providers/auth-provider';
 import { I18nProvider } from '../src/providers/i18n-provider';
 import { BluetoothProvider } from '../src/providers/bluetooth-provider';
@@ -213,18 +214,19 @@ function RootLayout() {
         <I18nProvider>
           <QueryProvider>
             <ThemeProvider>
-              <FeatureFlagsProvider>
-                <AuthProvider onReady={onAuthReady}>
-                  <PartyProfileProvider>
-                    <ConnectionSettingsProvider>
-                      <ToastProvider>
-                        <ClimbActionsDataWrapper>
-                          <QueueSnackbarProvider>
-                            <QueueProvider>
-                              <BoardAdapterWrapper>
-                                <PlaylistsAdapterWrapper>
-                                  <BoardProviderWrapper>
-                                    {/* BottomSheetModalProvider sits inside the board
+              <MaterialThemeProvider>
+                <FeatureFlagsProvider>
+                  <AuthProvider onReady={onAuthReady}>
+                    <PartyProfileProvider>
+                      <ConnectionSettingsProvider>
+                        <ToastProvider>
+                          <ClimbActionsDataWrapper>
+                            <QueueSnackbarProvider>
+                              <QueueProvider>
+                                <BoardAdapterWrapper>
+                                  <PlaylistsAdapterWrapper>
+                                    <BoardProviderWrapper>
+                                      {/* BottomSheetModalProvider sits inside the board
                                     providers (gorhom's BottomSheetModal portals
                                     PlayDrawer → QuickTickBar here, so the host
                                     must be able to see BoardAdapter/BoardProvider
@@ -235,42 +237,43 @@ function RootLayout() {
                                     exist before the picker mounts or gorhom
                                     throws "BottomSheetModalInternalContext
                                     cannot be null". */}
-                                    <BottomSheetModalProvider>
-                                      <BluetoothProviderWrapper>
-                                        <DrawerHostProvider>
-                                          <DeepLinkProvider>
-                                            <ThemedNavigation>
-                                              <Stack screenOptions={{ headerShown: false }} initialRouteName="index">
-                                                <Stack.Screen name="index" />
-                                                <Stack.Screen name="(tabs)" />
-                                                <Stack.Screen
-                                                  name="auth"
-                                                  options={{ headerShown: false, gestureEnabled: false }}
-                                                />
-                                                <Stack.Screen name="session/[sessionId]" />
-                                                <Stack.Screen
-                                                  name="join/[sessionId]"
-                                                  options={{ presentation: 'modal', headerShown: false }}
-                                                />
-                                              </Stack>
-                                            </ThemedNavigation>
-                                            <PersistentQueueBar />
-                                            <AnalyticsScreenTracker />
-                                          </DeepLinkProvider>
-                                        </DrawerHostProvider>
-                                      </BluetoothProviderWrapper>
-                                    </BottomSheetModalProvider>
-                                  </BoardProviderWrapper>
-                                </PlaylistsAdapterWrapper>
-                              </BoardAdapterWrapper>
-                            </QueueProvider>
-                          </QueueSnackbarProvider>
-                        </ClimbActionsDataWrapper>
-                      </ToastProvider>
-                    </ConnectionSettingsProvider>
-                  </PartyProfileProvider>
-                </AuthProvider>
-              </FeatureFlagsProvider>
+                                      <BottomSheetModalProvider>
+                                        <BluetoothProviderWrapper>
+                                          <DrawerHostProvider>
+                                            <DeepLinkProvider>
+                                              <ThemedNavigation>
+                                                <Stack screenOptions={{ headerShown: false }} initialRouteName="index">
+                                                  <Stack.Screen name="index" />
+                                                  <Stack.Screen name="(tabs)" />
+                                                  <Stack.Screen
+                                                    name="auth"
+                                                    options={{ headerShown: false, gestureEnabled: false }}
+                                                  />
+                                                  <Stack.Screen name="session/[sessionId]" />
+                                                  <Stack.Screen
+                                                    name="join/[sessionId]"
+                                                    options={{ presentation: 'modal', headerShown: false }}
+                                                  />
+                                                </Stack>
+                                              </ThemedNavigation>
+                                              <PersistentQueueBar />
+                                              <AnalyticsScreenTracker />
+                                            </DeepLinkProvider>
+                                          </DrawerHostProvider>
+                                        </BluetoothProviderWrapper>
+                                      </BottomSheetModalProvider>
+                                    </BoardProviderWrapper>
+                                  </PlaylistsAdapterWrapper>
+                                </BoardAdapterWrapper>
+                              </QueueProvider>
+                            </QueueSnackbarProvider>
+                          </ClimbActionsDataWrapper>
+                        </ToastProvider>
+                      </ConnectionSettingsProvider>
+                    </PartyProfileProvider>
+                  </AuthProvider>
+                </FeatureFlagsProvider>
+              </MaterialThemeProvider>
             </ThemeProvider>
           </QueryProvider>
         </I18nProvider>

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -82,6 +82,7 @@
     "react-native-gesture-handler": "~2.31.1",
     "react-native-gifted-charts": "^1.4.77",
     "react-native-pager-view": "^8.0.2",
+    "react-native-paper": "^5.15.3",
     "react-native-qrcode-svg": "^6.3.15",
     "react-native-reanimated": "4.3.1",
     "react-native-safe-area-context": "~5.7.0",

--- a/packages/mobile/src/components/Badge.tsx
+++ b/packages/mobile/src/components/Badge.tsx
@@ -1,7 +1,9 @@
 import { View, StyleSheet } from 'react-native';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { Badge as PaperBadge } from 'react-native-paper';
 import { Text } from './Text';
 import { iosSystemColors } from '../theme/ios-colors';
+import { useTheme } from '../providers/theme-provider';
 
 type BadgeProps = {
   count?: number;
@@ -10,7 +12,33 @@ type BadgeProps = {
   size?: 'small' | 'medium';
 };
 
-export function Badge({ count, visible = true, color = iosSystemColors.systemRed, size = 'medium' }: BadgeProps) {
+/**
+ * Badge routes to a Material 3 `Badge` on the Material variant, and to the
+ * existing animated Liquid-Glass dot/count badge on the Liquid Glass variant.
+ * The public prop API is identical for both, so call sites never change.
+ */
+export function Badge(props: BadgeProps) {
+  const { variant: uiVariant } = useTheme();
+  return uiVariant === 'material' ? <BadgeMaterial {...props} /> : <BadgeGlass {...props} />;
+}
+
+function BadgeMaterial({ count, visible = true, color = iosSystemColors.systemRed, size = 'medium' }: BadgeProps) {
+  const isDot = count === undefined || count === 0;
+  const displayCount = count && count > 99 ? '99+' : String(count ?? '');
+
+  // Paper renders a dot when it has no children; pass the count otherwise.
+  // `size` is a numeric diameter in Paper — mirror the glass dot/count sizing.
+  const badgeSize = size === 'small' ? 8 : isDot ? 10 : 18;
+
+  return (
+    <PaperBadge visible={visible} size={badgeSize} style={{ backgroundColor: color }}>
+      {isDot ? undefined : displayCount}
+    </PaperBadge>
+  );
+}
+
+// Liquid Glass badge — the original animated implementation, unchanged.
+function BadgeGlass({ count, visible = true, color = iosSystemColors.systemRed, size = 'medium' }: BadgeProps) {
   if (!visible) return null;
 
   const isDot = count === undefined || count === 0;

--- a/packages/mobile/src/components/Button.tsx
+++ b/packages/mobile/src/components/Button.tsx
@@ -1,8 +1,9 @@
 import { StyleSheet, type ViewStyle } from 'react-native';
+import { Button as PaperButton } from 'react-native-paper';
 import { Text } from './Text';
 import { Icon } from './Icon';
 import { PressableSurface } from './PressableSurface';
-import type { IconName } from './icon-map';
+import { iconMap, type IconName } from './icon-map';
 import { hapticLight } from '../lib/haptics';
 import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
@@ -30,7 +31,19 @@ const sizeConfig = {
   large: { paddingHorizontal: 20, paddingVertical: 14, fontSize: 17, iconSize: 22 },
 } as const;
 
-export function Button({
+/**
+ * Button routes to an authentic Material 3 button on the Material variant, and to
+ * the existing Liquid-Glass/HIG button on the Liquid Glass variant. The public
+ * prop API is identical for both, so call sites never change.
+ */
+export function Button(props: ButtonProps) {
+  const { variant: uiVariant } = useTheme();
+  return uiVariant === 'material' ? <ButtonMaterial {...props} /> : <ButtonGlass {...props} />;
+}
+
+const PAPER_MODE = { filled: 'contained', outlined: 'outlined', text: 'text' } as const;
+
+function ButtonMaterial({
   title,
   onPress,
   variant = 'filled',
@@ -43,8 +56,49 @@ export function Button({
   style,
 }: ButtonProps) {
   const config = sizeConfig[size];
-  // Soft 10dp corner on Liquid Glass, M3 20dp on Material (and Android, which
-  // defaults to the Material variant).
+  const handlePress = () => {
+    if (disabled || loading) return;
+    if (haptic) hapticLight();
+    onPress();
+  };
+
+  return (
+    <PaperButton
+      mode={PAPER_MODE[variant]}
+      onPress={handlePress}
+      disabled={disabled || loading}
+      loading={loading}
+      // Paper resolves the MDI glyph through our icon settings (see
+      // material-theme-provider); map our semantic name to its MDI name.
+      icon={icon ? iconMap[icon].android : undefined}
+      buttonColor={variant === 'filled' ? tintColor : undefined}
+      textColor={variant === 'filled' ? undefined : tintColor}
+      accessibilityLabel={title}
+      // Approximate the small/medium/large ladder on Paper's single-height button.
+      labelStyle={{ fontSize: config.fontSize }}
+      contentStyle={{ paddingVertical: config.paddingVertical }}
+      style={style}
+    >
+      {title}
+    </PaperButton>
+  );
+}
+
+// Liquid Glass / HIG button — the original implementation, unchanged.
+function ButtonGlass({
+  title,
+  onPress,
+  variant = 'filled',
+  size = 'medium',
+  icon,
+  disabled = false,
+  loading = false,
+  haptic = true,
+  tintColor = brandColors.primary,
+  style,
+}: ButtonProps) {
+  const config = sizeConfig[size];
+  // Soft 10dp corner on Liquid Glass.
   const { radii } = useTheme();
 
   const handlePress = () => {

--- a/packages/mobile/src/components/Card.tsx
+++ b/packages/mobile/src/components/Card.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from 'react';
 import { View, StyleSheet, Platform, type ViewStyle } from 'react-native';
+import { Card as PaperCard } from 'react-native-paper';
 import { PressableSurface } from './PressableSurface';
 import { hapticLight } from '../lib/haptics';
 import { useTheme } from '../providers/theme-provider';
@@ -11,7 +12,40 @@ type CardProps = {
   style?: ViewStyle;
 };
 
-export function Card({ children, onPress, haptic = true, style }: CardProps) {
+/**
+ * Card routes to a Material 3 `Card` on the Material variant and to the existing
+ * Liquid Glass surface on the Liquid Glass variant. The public prop API is
+ * identical for both, so call sites never change.
+ */
+export function Card(props: CardProps) {
+  const { variant: uiVariant } = useTheme();
+  return uiVariant === 'material' ? <CardMaterial {...props} /> : <CardGlass {...props} />;
+}
+
+function CardMaterial({ children, onPress, haptic = true, style }: CardProps) {
+  const handlePress = () => {
+    if (haptic) hapticLight();
+    onPress?.();
+  };
+
+  // M3 elevated card. Paper draws its own padding-less surface, so keep the 16dp
+  // content padding the Liquid Glass card uses. Only attach onPress when given,
+  // mirroring the glass branch (no pressable affordance for a static card).
+  return (
+    <PaperCard
+      mode="elevated"
+      onPress={onPress ? handlePress : undefined}
+      accessibilityRole={onPress ? 'button' : undefined}
+      contentStyle={styles.materialContent}
+      style={style}
+    >
+      {children}
+    </PaperCard>
+  );
+}
+
+// Liquid Glass card — the original implementation, unchanged.
+function CardGlass({ children, onPress, haptic = true, style }: CardProps) {
   const { systemColors } = useTheme();
 
   const handlePress = () => {
@@ -53,5 +87,8 @@ const styles = StyleSheet.create({
         elevation: 2,
       },
     }),
+  },
+  materialContent: {
+    padding: 16,
   },
 });

--- a/packages/mobile/src/components/Card.tsx
+++ b/packages/mobile/src/components/Card.tsx
@@ -28,18 +28,18 @@ function CardMaterial({ children, onPress, haptic = true, style }: CardProps) {
     onPress?.();
   };
 
-  // M3 elevated card. Paper draws its own padding-less surface, so keep the 16dp
-  // content padding the Liquid Glass card uses. Only attach onPress when given,
-  // mirroring the glass branch (no pressable affordance for a static card).
+  // M3 elevated card. Paper's Card has no `contentStyle`; padding belongs on
+  // `Card.Content`, which keeps the 16dp the Liquid Glass card uses. Only attach
+  // onPress when given, mirroring the glass branch (no pressable affordance for a
+  // static card).
   return (
     <PaperCard
       mode="elevated"
       onPress={onPress ? handlePress : undefined}
       accessibilityRole={onPress ? 'button' : undefined}
-      contentStyle={styles.materialContent}
       style={style}
     >
-      {children}
+      <PaperCard.Content style={styles.materialContent}>{children}</PaperCard.Content>
     </PaperCard>
   );
 }

--- a/packages/mobile/src/components/GlassIconButton.tsx
+++ b/packages/mobile/src/components/GlassIconButton.tsx
@@ -7,11 +7,12 @@ import {
   View,
 } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { IconButton as PaperIconButton, Badge as PaperBadge } from 'react-native-paper';
 import { GlassSurface } from './GlassSurface';
 import { PressableSurface } from './PressableSurface';
 import { Icon } from './Icon';
 import { Text } from './Text';
-import type { IconName } from './icon-map';
+import { iconMap, type IconName } from './icon-map';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { timing } from '../theme/animations';
@@ -52,6 +53,67 @@ type GlassIconButtonProps = {
 };
 
 /**
+ * Circular icon button shared by the climb-list search row (filter, create) and
+ * the bottom-bar search FAB. Routes to a Material 3 `IconButton` on the Material
+ * variant and to the original Liquid Glass circle on the Liquid Glass variant.
+ * The public prop API is identical for both, so call sites never change.
+ */
+export function GlassIconButton(props: GlassIconButtonProps) {
+  const { variant: uiVariant } = useTheme();
+  return uiVariant === 'material' ? <GlassIconButtonMaterial {...props} /> : <GlassIconButtonGlass {...props} />;
+}
+
+/**
+ * Material 3 icon button. Paper resolves the MDI glyph through our icon settings
+ * (see material-theme-provider), so we hand it the `.android` MDI name. Paper's
+ * `IconButton` renders a single glyph — the Liquid Glass cross-fade morph
+ * (`secondaryIconName` / `active`) has no Material equivalent and is dropped
+ * here; the static `iconName` is shown instead. The count badge is overlaid via
+ * Paper's `Badge` in an outer wrapper so the round target can't crop it.
+ */
+function GlassIconButtonMaterial({
+  iconName,
+  iconColor,
+  iconSize = 22,
+  onPress,
+  onLongPress,
+  accessibilityLabel,
+  accessibilityHint,
+  accessibilityActions,
+  onAccessibilityAction,
+  badgeCount,
+  disabled = false,
+  size = glassSize.standard,
+}: GlassIconButtonProps) {
+  const showBadge = badgeCount != null && badgeCount > 0;
+
+  return (
+    <View style={[styles.wrapper, { width: size, height: size }]}>
+      <PaperIconButton
+        icon={iconMap[iconName].android}
+        iconColor={iconColor as string}
+        size={iconSize}
+        // Match the circular target diameter; Paper's default margin would
+        // otherwise inflate the footprint past the requested `size`.
+        style={[styles.materialButton, { width: size, height: size }]}
+        onPress={onPress}
+        onLongPress={onLongPress}
+        disabled={disabled}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={accessibilityHint}
+        accessibilityActions={accessibilityActions}
+        onAccessibilityAction={onAccessibilityAction}
+      />
+      {showBadge ? (
+        <PaperBadge style={styles.materialBadge} visible>
+          {badgeCount}
+        </PaperBadge>
+      ) : null}
+    </View>
+  );
+}
+
+/**
  * Circular Liquid Glass button — the floating-control affordance shared by the
  * climb-list search row (filter, create) and the bottom-bar search FAB. The glass
  * fills a clipped circle so the iOS < 26 blur fallback doesn't spill past the
@@ -60,7 +122,7 @@ type GlassIconButtonProps = {
  * (spring / ripple), so Android, Reduce Transparency, and cold-start all degrade
  * correctly. With `secondaryIconName`, the glyph cross-fades on `active`.
  */
-export function GlassIconButton({
+function GlassIconButtonGlass({
   iconName,
   iconColor,
   iconSize = 22,
@@ -188,6 +250,14 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  materialButton: {
+    margin: 0,
+  },
+  materialBadge: {
+    position: 'absolute',
+    top: -2,
+    right: -2,
   },
   center: {
     alignItems: 'center',

--- a/packages/mobile/src/components/QueueAddedSnackbar.tsx
+++ b/packages/mobile/src/components/QueueAddedSnackbar.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, View, type ViewStyle } from 'react-native';
 import Animated, { FadeInDown, FadeOutDown } from 'react-native-reanimated';
+import { Snackbar } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import { Text } from './Text';
 import { brandColors } from '../theme/colors';
@@ -23,10 +24,51 @@ type QueueAddedSnackbarProps = {
  * Bottom-anchored "Climb added to queue · Open" snackbar that floats just above
  * the persistent queue bar. Rendered inside DrawerHostProvider so it can read
  * the queue state (to drop lower when the bar is hidden) and bind "Open" to the
- * host's `openQueueSheet`. Unlike the top toast, its overlay is `box-none` so
- * the "Open" button is tappable.
+ * host's `openQueueSheet`. Routes to a Material 3 Paper Snackbar on the Material
+ * variant and to the existing Liquid-Glass pill on the Liquid Glass variant; the
+ * public prop API is identical for both.
  */
-export function QueueAddedSnackbar({
+export function QueueAddedSnackbar(props: QueueAddedSnackbarProps) {
+  const { variant: uiVariant } = useTheme();
+  return uiVariant === 'material' ? <QueueAddedSnackbarMaterial {...props} /> : <QueueAddedSnackbarGlass {...props} />;
+}
+
+function QueueAddedSnackbarMaterial({
+  visible,
+  nonce,
+  onDismiss,
+  onOpen,
+  duration = DEFAULT_DURATION,
+}: QueueAddedSnackbarProps) {
+  const { t } = useTranslation('session');
+  const bottomChrome = useBottomChromeMetrics();
+
+  // Sit above the queue controls when they are showing; otherwise just above the
+  // tab bar/safe area. The nonce forces a remount so the entrance + Paper's own
+  // auto-dismiss timer replay on each show.
+  const bottom = bottomChrome.floatingControlBottom + spacing[2];
+  const wrapperStyle: ViewStyle = { bottom };
+
+  return (
+    <Snackbar
+      key={nonce}
+      visible={visible}
+      onDismiss={onDismiss}
+      duration={duration}
+      wrapperStyle={wrapperStyle}
+      action={{
+        label: t('mobile.queueSnackbar.open'),
+        onPress: onOpen,
+        accessibilityLabel: t('mobile.queueSnackbar.openAria'),
+      }}
+    >
+      {t('mobile.queueSnackbar.added')}
+    </Snackbar>
+  );
+}
+
+// Liquid Glass / HIG snackbar — the original implementation, unchanged.
+function QueueAddedSnackbarGlass({
   visible,
   nonce,
   onDismiss,

--- a/packages/mobile/src/components/SearchHeader.tsx
+++ b/packages/mobile/src/components/SearchHeader.tsx
@@ -96,6 +96,12 @@ export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(fu
         autoCapitalize="none"
         autoCorrect={false}
         accessibilityLabel={placeholder}
+        // Pin both dimensions so the first layout pass is deterministic: `flex: 1`
+        // fills the row slot's width and `minHeight` stops Paper's Surface from
+        // collapsing to 0 before its async content measure (which left the search
+        // bar blank until a tab switch forced a re-layout). minHeight (not height)
+        // so it can still grow to Paper's natural height — no clipping.
+        style={[styles.materialSearchbar, { minHeight: height }]}
       />
     );
   }
@@ -140,6 +146,11 @@ export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(fu
 });
 
 const styles = StyleSheet.create({
+  // Material (Paper Searchbar): fill the row slot's width; minHeight is applied
+  // inline from the `height` prop so the first layout pass can't collapse to 0.
+  materialSearchbar: {
+    flex: 1,
+  },
   capsule: {
     flex: 1,
     height: 44,

--- a/packages/mobile/src/components/SearchHeader.tsx
+++ b/packages/mobile/src/components/SearchHeader.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useImperativeHandle, useRef, useState, useCallback } from 'react';
 import { View, TextInput, Pressable, StyleSheet } from 'react-native';
+import { Searchbar } from 'react-native-paper';
 import { Icon } from './Icon';
 import { GlassSurface } from './GlassSurface';
 import { useTheme } from '../providers/theme-provider';
@@ -44,7 +45,7 @@ export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(fu
   ref,
 ) {
   const inputRef = useRef<TextInput>(null);
-  const { systemColors } = useTheme();
+  const { systemColors, variant: uiVariant } = useTheme();
   const [text, setText] = useState(initialValue);
   const radius = height / 2;
 
@@ -76,6 +77,28 @@ export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(fu
     onSubmit?.(text);
     inputRef.current?.blur();
   }, [onSubmit, text]);
+
+  // Material variant: an authentic MD3 search bar. The imperative handle still
+  // works because Paper's Searchbar forwards its ref to the inner TextInput
+  // (blur/focus) and getText/setText stay backed by our own `text` state.
+  if (uiVariant === 'material') {
+    return (
+      <Searchbar
+        ref={inputRef}
+        value={text}
+        onChangeText={handleChange}
+        onClearIconPress={handleClear}
+        placeholder={placeholder}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onSubmitEditing={handleSubmit}
+        returnKeyType="search"
+        autoCapitalize="none"
+        autoCorrect={false}
+        accessibilityLabel={placeholder}
+      />
+    );
+  }
 
   return (
     <View style={[styles.capsule, { height, borderRadius: radius }]}>

--- a/packages/mobile/src/components/SegmentedControl.tsx
+++ b/packages/mobile/src/components/SegmentedControl.tsx
@@ -1,4 +1,5 @@
 import { View, StyleSheet, type ViewStyle, type ColorValue } from 'react-native';
+import { SegmentedButtons } from 'react-native-paper';
 import { Text } from './Text';
 import { PressableSurface } from './PressableSurface';
 import { hapticSelection } from '../lib/haptics';
@@ -90,7 +91,45 @@ function Segment({
   );
 }
 
-export function SegmentedControl<K extends string = string>({
+/**
+ * SegmentedControl routes to a Material 3 `SegmentedButtons` on the Material
+ * variant, and to the existing Liquid-Glass/HIG segmented control on the Liquid
+ * Glass variant. The public prop API is identical for both, so call sites never
+ * change.
+ */
+export function SegmentedControl<K extends string = string>(props: SegmentedControlProps<K>) {
+  const { variant: uiVariant } = useTheme();
+  return uiVariant === 'material' ? <SegmentedControlMaterial {...props} /> : <SegmentedControlGlass {...props} />;
+}
+
+function SegmentedControlMaterial<K extends string = string>({
+  options,
+  selectedKey,
+  onSelect,
+  disabledKeys,
+  accessibilityLabel,
+}: SegmentedControlProps<K>) {
+  const buttons = options.map((option) => ({
+    value: option.key,
+    label: option.label,
+    disabled: disabledKeys?.has(option.key) ?? false,
+  }));
+
+  const handleValueChange = (nextKey: K) => {
+    if (disabledKeys?.has(nextKey)) return;
+    hapticSelection();
+    onSelect(nextKey);
+  };
+
+  return (
+    <View accessibilityRole="radiogroup" accessibilityLabel={accessibilityLabel}>
+      <SegmentedButtons value={selectedKey} onValueChange={handleValueChange} buttons={buttons} />
+    </View>
+  );
+}
+
+// Liquid Glass / HIG segmented control — the original implementation, unchanged.
+function SegmentedControlGlass<K extends string = string>({
   options,
   selectedKey,
   onSelect,

--- a/packages/mobile/src/components/SwitchRow.tsx
+++ b/packages/mobile/src/components/SwitchRow.tsx
@@ -1,9 +1,11 @@
 import { Pressable, Switch as RNSwitch, View, StyleSheet } from 'react-native';
+import { Switch as PaperSwitch } from 'react-native-paper';
 import { Text } from './Text';
 import { hapticSelection } from '../lib/haptics';
 import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
+import { useTheme } from '../providers/theme-provider';
 
 type SwitchRowProps = {
   label: string;
@@ -14,6 +16,8 @@ type SwitchRowProps = {
 };
 
 export function SwitchRow({ label, description, value, onValueChange, disabled = false }: SwitchRowProps) {
+  const { variant: uiVariant } = useTheme();
+
   const handleToggle = (next: boolean) => {
     if (disabled) return;
     hapticSelection();
@@ -39,13 +43,18 @@ export function SwitchRow({ label, description, value, onValueChange, disabled =
           </Text>
         ) : null}
       </View>
-      <RNSwitch
-        value={value}
-        onValueChange={handleToggle}
-        disabled={disabled}
-        trackColor={{ false: undefined, true: brandColors.primary }}
-        ios_backgroundColor={iosSystemColors.systemGray4 as string}
-      />
+      {uiVariant === 'material' ? (
+        // Paper's Switch picks up the M3 colours from the global PaperProvider theme.
+        <PaperSwitch value={value} onValueChange={handleToggle} disabled={disabled} />
+      ) : (
+        <RNSwitch
+          value={value}
+          onValueChange={handleToggle}
+          disabled={disabled}
+          trackColor={{ false: undefined, true: brandColors.primary }}
+          ios_backgroundColor={iosSystemColors.systemGray4 as string}
+        />
+      )}
     </Pressable>
   );
 }

--- a/packages/mobile/src/components/SwitchRow.tsx
+++ b/packages/mobile/src/components/SwitchRow.tsx
@@ -44,8 +44,15 @@ export function SwitchRow({ label, description, value, onValueChange, disabled =
         ) : null}
       </View>
       {uiVariant === 'material' ? (
-        // Paper's Switch picks up the M3 colours from the global PaperProvider theme.
-        <PaperSwitch value={value} onValueChange={handleToggle} disabled={disabled} />
+        // The outer Pressable owns the toggle for the whole row. Paper's Switch is
+        // a non-interactive visual indicator here (pointerEvents none, no
+        // onValueChange) so a tap on the switch passes through to the row instead
+        // of double-firing the toggle (Paper's Switch wraps its own Pressable,
+        // which doesn't reliably absorb the touch the way the native RN Switch
+        // does on the Liquid Glass path). It picks up M3 colours from PaperProvider.
+        <View pointerEvents="none" accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+          <PaperSwitch value={value} disabled={disabled} />
+        </View>
       ) : (
         <RNSwitch
           value={value}

--- a/packages/mobile/src/components/Toast.tsx
+++ b/packages/mobile/src/components/Toast.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, type ViewStyle } from 'react-native';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { Snackbar } from 'react-native-paper';
 import { useSegments } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Text } from './Text';
@@ -33,19 +34,56 @@ const VARIANT_CONFIG: Record<ToastVariant, { icon: IconName; color: string }> = 
   warning: { icon: 'warning', color: brandColors.warning },
 };
 
+/**
+ * Toast routes to a Material 3 Paper Snackbar on the Material variant, and to the
+ * existing Liquid-Glass/HIG pill on the Liquid Glass variant. The public prop API
+ * is identical for both, so ToastProvider never changes.
+ */
 export function Toast({ toast, onDismiss }: ToastProps) {
+  const { variant: uiVariant } = useTheme();
+  return uiVariant === 'material' ? (
+    <ToastMaterial toast={toast} onDismiss={onDismiss} />
+  ) : (
+    <ToastGlass toast={toast} onDismiss={onDismiss} />
+  );
+}
+
+/**
+ * Reserve the worst-case queue toolbar height on tab screens so a toast never
+ * covers the current-climb controls; off tab screens it sits just above the safe
+ * area. Shared by both variants — ToastProvider sits above QueueProvider, so this
+ * must stay independent from queue context.
+ */
+function useToastBottomOffset() {
   const insets = useSafeAreaInsets();
   const segments = useSegments();
-  const { systemColors, colorScheme } = useTheme();
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const config = VARIANT_CONFIG[toast.variant];
-
-  // ToastProvider sits above QueueProvider, so this must stay independent from
-  // queue context. On tab screens, reserve the worst-case queue toolbar height
-  // so a toast never covers the current-climb controls.
-  const bottomOffset = isTabsRoute(segments)
+  return isTabsRoute(segments)
     ? insets.bottom + TAB_BAR_HEIGHT + TOOLBAR_RESERVE + spacing[2]
     : insets.bottom + spacing[3];
+}
+
+function ToastMaterial({ toast, onDismiss }: ToastProps) {
+  const bottomOffset = useToastBottomOffset();
+
+  // Paper drives its own auto-dismiss timer off `duration` + `onDismiss`, so we
+  // don't run a manual setTimeout on the Material path (it would double-fire).
+  // The glass toast has no tappable affordance, so we omit Paper's trailing
+  // icon-dismiss button to keep the same auto-dismiss-only interaction.
+  const wrapperStyle: ViewStyle = { bottom: bottomOffset };
+
+  return (
+    <Snackbar visible onDismiss={() => onDismiss(toast.id)} duration={toast.duration} wrapperStyle={wrapperStyle}>
+      {toast.message}
+    </Snackbar>
+  );
+}
+
+// Liquid Glass / HIG toast — the original implementation, unchanged.
+function ToastGlass({ toast, onDismiss }: ToastProps) {
+  const { systemColors, colorScheme } = useTheme();
+  const bottomOffset = useToastBottomOffset();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const config = VARIANT_CONFIG[toast.variant];
 
   useEffect(() => {
     timerRef.current = setTimeout(() => onDismiss(toast.id), toast.duration);

--- a/packages/mobile/src/components/__tests__/badge.test.tsx
+++ b/packages/mobile/src/components/__tests__/badge.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Controls the resolved UI variant the Badge branches on.
+const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-view': 'true' }, children),
+}));
+
+// Reanimated Animated.View (Liquid Glass path) → a plain div.
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-animated': 'true' }, children),
+  },
+  FadeIn: { springify: () => ({ damping: () => ({ stiffness: () => ({}) }) }) },
+  FadeOut: { duration: () => ({}) },
+}));
+
+// Paper Badge → <span> exposing the props the test asserts on.
+vi.mock('react-native-paper', () => ({
+  Badge: ({ children, visible, size }: { children?: ReactNode; visible?: boolean; size?: number }) =>
+    createElement(
+      'span',
+      { 'data-paper-badge': 'true', 'data-visible': String(visible), 'data-size': String(size) },
+      children,
+    ),
+}));
+
+vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
+vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: { systemRed: '#FF3B30', white: '#FFFFFF' } }));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ variant: ctrl.variant }),
+}));
+
+import { Badge } from '../Badge';
+
+describe('Badge', () => {
+  it('renders a Paper Badge with the count on the Material variant', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<Badge count={3} />);
+    const paper = container.querySelector('[data-paper-badge]');
+    expect(paper).not.toBeNull();
+    expect(paper?.textContent).toBe('3');
+    expect(container.querySelector('[data-animated]')).toBeNull();
+  });
+
+  it('renders a dot (no count text) when count is zero on the Material variant', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<Badge count={0} />);
+    const paper = container.querySelector('[data-paper-badge]');
+    expect(paper).not.toBeNull();
+    expect(paper?.textContent).toBe('');
+  });
+
+  it('caps the displayed count at 99+ on the Material variant', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<Badge count={150} />);
+    expect(container.querySelector('[data-paper-badge]')?.textContent).toBe('99+');
+  });
+
+  it('renders the animated Liquid Glass badge on the Liquid Glass variant', () => {
+    ctrl.variant = 'liquidGlass';
+    const { container } = render(<Badge count={3} />);
+    expect(container.querySelector('[data-animated]')).not.toBeNull();
+    expect(container.querySelector('[data-paper-badge]')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/__tests__/button.test.tsx
+++ b/packages/mobile/src/components/__tests__/button.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Controls the resolved UI variant the Button branches on.
+const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+// Paper Button → <button> exposing the props the test asserts on.
+vi.mock('react-native-paper', () => ({
+  Button: ({ children, mode, disabled }: { children?: ReactNode; mode?: string; disabled?: boolean }) =>
+    createElement('button', { 'data-paper': 'true', 'data-mode': mode, disabled }, children),
+}));
+
+// Glass-path deps — the PressableSurface fallback renders a plain div.
+vi.mock('../PressableSurface', () => ({
+  PressableSurface: ({ children }: { children?: ReactNode }) =>
+    createElement('div', { 'data-pressable': 'true' }, children),
+}));
+vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
+vi.mock('../Icon', () => ({ Icon: () => createElement('i', null) }));
+vi.mock('../icon-map', () => ({ iconMap: { tick: { ios: 'checkmark', android: 'check' } } }));
+vi.mock('../../lib/haptics', () => ({ hapticLight: vi.fn() }));
+vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#8C4A52' } }));
+vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: { white: '#FFFFFF' } }));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ variant: ctrl.variant, radii: { button: ctrl.variant === 'material' ? 20 : 10 } }),
+}));
+
+import { Button } from '../Button';
+
+describe('Button', () => {
+  it('renders a Paper button on the Material variant', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<Button title="Log" onPress={() => {}} />);
+    const paper = container.querySelector('[data-paper]');
+    expect(paper).not.toBeNull();
+    expect(paper?.getAttribute('data-mode')).toBe('contained'); // filled → contained
+    expect(container.querySelector('[data-pressable]')).toBeNull();
+  });
+
+  it('renders the Liquid Glass (PressableSurface) button on the Liquid Glass variant', () => {
+    ctrl.variant = 'liquidGlass';
+    const { container } = render(<Button title="Log" onPress={() => {}} />);
+    expect(container.querySelector('[data-pressable]')).not.toBeNull();
+    expect(container.querySelector('[data-paper]')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/__tests__/card.test.tsx
+++ b/packages/mobile/src/components/__tests__/card.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Controls the resolved UI variant the Card branches on.
+const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
+
+// Minimal RN surface: View → div, StyleSheet + Platform.select stubs.
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-view': 'true' }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  Platform: { select: (spec: Record<string, unknown>) => spec.ios },
+}));
+
+// Paper Card → <section> exposing the props the material test asserts on.
+vi.mock('react-native-paper', () => ({
+  Card: ({ children, mode, onPress }: { children?: ReactNode; mode?: string; onPress?: () => void }) =>
+    createElement('section', { 'data-paper-card': 'true', 'data-mode': mode, onClick: onPress }, children),
+}));
+
+// Glass-path pressable → a plain <button>.
+vi.mock('../PressableSurface', () => ({
+  PressableSurface: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { 'data-pressable': 'true', onClick: onPress }, children),
+}));
+
+vi.mock('../../lib/haptics', () => ({ hapticLight: vi.fn() }));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ variant: ctrl.variant, systemColors: { secondaryBackground: '#eee' } }),
+}));
+
+import { Card } from '../Card';
+
+describe('Card (Material variant)', () => {
+  it('renders a Paper elevated card', () => {
+    ctrl.variant = 'material';
+    const { container } = render(
+      <Card>
+        <span>Body</span>
+      </Card>,
+    );
+    const paper = container.querySelector('[data-paper-card]');
+    expect(paper).not.toBeNull();
+    expect(paper?.getAttribute('data-mode')).toBe('elevated');
+    expect(container.querySelector('[data-pressable]')).toBeNull();
+    expect(container.textContent).toContain('Body');
+  });
+
+  it('fires onPress when interactive', () => {
+    ctrl.variant = 'material';
+    const onPress = vi.fn();
+    const { container } = render(
+      <Card onPress={onPress}>
+        <span>Tap</span>
+      </Card>,
+    );
+    const paper = container.querySelector('[data-paper-card]');
+    fireEvent.click(paper as Element);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Card (Liquid Glass variant)', () => {
+  it('renders a static View when no onPress is given', () => {
+    ctrl.variant = 'liquidGlass';
+    const { container } = render(
+      <Card>
+        <span>Body</span>
+      </Card>,
+    );
+    expect(container.querySelector('[data-view]')).not.toBeNull();
+    expect(container.querySelector('[data-pressable]')).toBeNull();
+    expect(container.querySelector('[data-paper-card]')).toBeNull();
+  });
+
+  it('renders a PressableSurface and fires onPress when interactive', () => {
+    ctrl.variant = 'liquidGlass';
+    const onPress = vi.fn();
+    const { container } = render(
+      <Card onPress={onPress}>
+        <span>Tap</span>
+      </Card>,
+    );
+    const pressable = container.querySelector('[data-pressable]');
+    expect(pressable).not.toBeNull();
+    expect(container.querySelector('[data-paper-card]')).toBeNull();
+    fireEvent.click(pressable as Element);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/__tests__/card.test.tsx
+++ b/packages/mobile/src/components/__tests__/card.test.tsx
@@ -13,11 +13,15 @@ vi.mock('react-native', () => ({
   Platform: { select: (spec: Record<string, unknown>) => spec.ios },
 }));
 
-// Paper Card → <section> exposing the props the material test asserts on.
-vi.mock('react-native-paper', () => ({
-  Card: ({ children, mode, onPress }: { children?: ReactNode; mode?: string; onPress?: () => void }) =>
-    createElement('section', { 'data-paper-card': 'true', 'data-mode': mode, onClick: onPress }, children),
-}));
+// Paper Card → <section> exposing the props the material test asserts on; Card
+// has a static `.Content` (the component wraps children in <Card.Content>).
+vi.mock('react-native-paper', () => {
+  const Card = ({ children, mode, onPress }: { children?: ReactNode; mode?: string; onPress?: () => void }) =>
+    createElement('section', { 'data-paper-card': 'true', 'data-mode': mode, onClick: onPress }, children);
+  Card.Content = ({ children }: { children?: ReactNode }) =>
+    createElement('div', { 'data-paper-card-content': 'true' }, children);
+  return { Card };
+});
 
 // Glass-path pressable → a plain <button>.
 vi.mock('../PressableSurface', () => ({

--- a/packages/mobile/src/components/__tests__/glass-icon-button.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-icon-button.test.tsx
@@ -1,12 +1,38 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
+
+// Controls the resolved UI variant the button branches on. The glass-path tests
+// below all run on the Liquid Glass variant; a dedicated test flips it to material.
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'material' | 'liquidGlass' }));
 
 // Minimal RN surface: View → div, StyleSheet stubs the helpers the button reads.
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
+}));
+
+// Paper IconButton / Badge → DOM nodes exposing the props the material test asserts on.
+vi.mock('react-native-paper', () => ({
+  IconButton: ({
+    icon,
+    onPress,
+    disabled,
+    accessibilityLabel,
+  }: {
+    icon?: string;
+    onPress?: () => void;
+    disabled?: boolean;
+    accessibilityLabel?: string;
+  }) =>
+    createElement('button', {
+      'data-paper-icon': icon,
+      onClick: onPress,
+      disabled,
+      'data-label': accessibilityLabel,
+    }),
+  Badge: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-paper-badge': 'true' }, children),
 }));
 
 vi.mock('react-native-reanimated', () => ({
@@ -64,7 +90,17 @@ vi.mock('../Text', () => ({
 }));
 
 vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({ brandColors: { primary: '#8C4A52' } }),
+  useTheme: () => ({ variant: ctrl.variant, brandColors: { primary: '#8C4A52' } }),
+}));
+
+// The material branch maps the semantic name to its MDI glyph via iconMap.
+vi.mock('../icon-map', () => ({
+  iconMap: {
+    search: { ios: 'magnifyingglass', android: 'magnify' },
+    filter: { ios: 'line.3.horizontal.decrease', android: 'filter-variant' },
+    tick: { ios: 'checkmark.circle.fill', android: 'check-circle' },
+    close: { ios: 'xmark', android: 'close' },
+  },
 }));
 
 vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: { white: '#FFFFFF' } }));
@@ -75,7 +111,11 @@ import { GlassIconButton } from '../GlassIconButton';
 
 const base = { iconColor: '#000', fallbackColor: '#fff', onPress: () => {}, accessibilityLabel: 'Act' };
 
-describe('GlassIconButton', () => {
+describe('GlassIconButton (Liquid Glass variant)', () => {
+  beforeEach(() => {
+    ctrl.variant = 'liquidGlass';
+  });
+
   it('renders the icon and fires onPress', () => {
     const onPress = vi.fn();
     const { getByRole, container } = render(<GlassIconButton {...base} iconName="search" onPress={onPress} />);
@@ -147,5 +187,42 @@ describe('GlassIconButton', () => {
     fireEvent.click(button);
     expect(onPress).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
+  });
+});
+
+describe('GlassIconButton (Material variant)', () => {
+  beforeEach(() => {
+    ctrl.variant = 'material';
+  });
+
+  it('renders a Paper IconButton with the MDI glyph and no glass surface', () => {
+    const { container } = render(<GlassIconButton {...base} iconName="search" />);
+    const paper = container.querySelector('[data-paper-icon]');
+    expect(paper).not.toBeNull();
+    expect(paper?.getAttribute('data-paper-icon')).toBe('magnify'); // search → MDI magnify
+    expect(container.querySelector('[data-glass]')).toBeNull();
+  });
+
+  it('fires onPress and forwards accessibilityLabel + disabled', () => {
+    const onPress = vi.fn();
+    const { getByRole } = render(
+      <GlassIconButton {...base} iconName="search" onPress={onPress} accessibilityLabel="Open search" />,
+    );
+    const button = getByRole('button');
+    expect(button.getAttribute('data-label')).toBe('Open search');
+    fireEvent.click(button);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('overlays a Paper Badge only when badgeCount > 0', () => {
+    const { container, rerender } = render(<GlassIconButton {...base} iconName="filter" badgeCount={3} />);
+    expect(container.querySelector('[data-paper-badge]')?.textContent).toBe('3');
+    rerender(<GlassIconButton {...base} iconName="filter" badgeCount={0} />);
+    expect(container.querySelector('[data-paper-badge]')).toBeNull();
+  });
+
+  it('passes disabled through to the Paper IconButton', () => {
+    const { getByRole } = render(<GlassIconButton {...base} iconName="search" disabled />);
+    expect((getByRole('button') as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/packages/mobile/src/components/__tests__/queue-added-snackbar.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-added-snackbar.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Controls the resolved UI variant the snackbar branches on.
+const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
+
+type ViewMockProps = { children?: ReactNode };
+vi.mock('react-native', () => ({
+  View: ({ children }: ViewMockProps) => createElement('div', { 'data-view': 'true' }, children),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'data-label': accessibilityLabel ?? '' }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {} },
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({ children, accessibilityRole }: { children?: ReactNode; accessibilityRole?: string }) =>
+      createElement('div', { 'data-animated': 'true', 'data-role': accessibilityRole ?? '' }, children),
+  },
+  FadeInDown: { duration: () => ({}) },
+  FadeOutDown: { duration: () => ({}) },
+}));
+
+// Paper Snackbar → div exposing visible/duration/children and the action button.
+type SnackbarAction = { label: string; onPress?: () => void; accessibilityLabel?: string };
+type SnackbarMockProps = {
+  visible?: boolean;
+  duration?: number;
+  onDismiss?: () => void;
+  action?: SnackbarAction;
+  children?: ReactNode;
+};
+vi.mock('react-native-paper', () => ({
+  Snackbar: ({ visible, duration, onDismiss, action, children }: SnackbarMockProps) =>
+    createElement(
+      'div',
+      {
+        'data-paper-snackbar': 'true',
+        'data-visible': visible ? 'true' : 'false',
+        'data-duration': String(duration ?? ''),
+        onClick: onDismiss,
+      },
+      children,
+      action
+        ? createElement(
+            'button',
+            { 'data-action': 'true', 'data-action-label': action.accessibilityLabel ?? '', onClick: action.onPress },
+            action.label,
+          )
+        : null,
+    ),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
+}));
+vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#8C4A52' } }));
+vi.mock('../../theme/tokens', () => ({
+  borderRadius: { lg: 12 },
+  spacing: { 2: 8, 3: 12, 4: 16 },
+  shadowColor: '#000',
+}));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ variant: ctrl.variant, systemColors: { secondaryBackground: '#EEE', label: '#000' } }),
+}));
+vi.mock('../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ floatingControlBottom: 100 }),
+}));
+
+import { QueueAddedSnackbar } from '../QueueAddedSnackbar';
+
+const base = { visible: true, nonce: 1, onDismiss: () => {}, onOpen: () => {} };
+
+describe('QueueAddedSnackbar', () => {
+  it('renders a Paper Snackbar with the Open action on the Material variant', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<QueueAddedSnackbar {...base} />);
+    const snackbar = container.querySelector('[data-paper-snackbar]');
+    expect(snackbar).not.toBeNull();
+    expect(snackbar?.getAttribute('data-visible')).toBe('true');
+    expect(snackbar?.getAttribute('data-duration')).toBe('4000'); // default duration mapped
+    expect(snackbar?.textContent).toContain('mobile.queueSnackbar.added');
+    const action = container.querySelector('[data-action]');
+    expect(action?.textContent).toBe('mobile.queueSnackbar.open');
+    expect(action?.getAttribute('data-action-label')).toBe('mobile.queueSnackbar.openAria');
+    expect(container.querySelector('[data-animated]')).toBeNull();
+  });
+
+  it('maps duration prop and routes the action to onOpen on Material', () => {
+    ctrl.variant = 'material';
+    const onOpen = vi.fn();
+    const { container } = render(<QueueAddedSnackbar {...base} onOpen={onOpen} duration={2500} />);
+    expect(container.querySelector('[data-paper-snackbar]')?.getAttribute('data-duration')).toBe('2500');
+    (container.querySelector('[data-action]') as HTMLElement).click();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the Liquid Glass animated pill on the Liquid Glass variant', () => {
+    ctrl.variant = 'liquidGlass';
+    const onOpen = vi.fn();
+    const { container } = render(<QueueAddedSnackbar {...base} onOpen={onOpen} />);
+    const animated = container.querySelector('[data-animated]');
+    expect(animated).not.toBeNull();
+    expect(animated?.getAttribute('data-role')).toBe('alert');
+    expect(container.textContent).toContain('mobile.queueSnackbar.added');
+    expect(container.querySelector('[data-paper-snackbar]')).toBeNull();
+    // The "Open" Pressable routes to onOpen.
+    const openButton = container.querySelector('[data-label="mobile.queueSnackbar.openAria"]') as HTMLElement;
+    openButton.click();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the glass pill when not visible on Liquid Glass', () => {
+    ctrl.variant = 'liquidGlass';
+    const { container } = render(<QueueAddedSnackbar {...base} visible={false} />);
+    expect(container.querySelector('[data-animated]')).toBeNull();
+  });
+
+  it('auto-dismisses via timer on the Liquid Glass variant', () => {
+    vi.useFakeTimers();
+    ctrl.variant = 'liquidGlass';
+    const onDismiss = vi.fn();
+    render(<QueueAddedSnackbar {...base} onDismiss={onDismiss} duration={1000} />);
+    expect(onDismiss).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});

--- a/packages/mobile/src/components/__tests__/search-header.test.tsx
+++ b/packages/mobile/src/components/__tests__/search-header.test.tsx
@@ -59,6 +59,24 @@ vi.mock('../../theme/ios-colors', () => ({
   iosSystemColors: { systemGray: '#888', white: '#fff' },
 }));
 
+// Paper Searchbar forwards its ref to the inner TextInput; model that so the
+// imperative blur/focus path can be exercised on the Material variant.
+vi.mock('react-native-paper', () => ({
+  Searchbar: forwardRef<
+    HTMLInputElement,
+    { value?: string; placeholder?: string; onChangeText?: (text: string) => void }
+  >(function SearchbarMock({ value, placeholder, onChangeText }, ref) {
+    return createElement('input', {
+      ref,
+      'data-paper': 'searchbar',
+      value,
+      placeholder,
+      onChange: (event: ChangeEvent<HTMLInputElement>) => onChangeText?.(event.currentTarget.value),
+      readOnly: true,
+    });
+  }),
+}));
+
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 
 describe('SearchHeader', () => {
@@ -103,5 +121,27 @@ describe('SearchHeader', () => {
     // Paper owning the inner TextInput.
     act(() => ref.current?.setText('Crimps', { silent: true }));
     expect(ref.current?.getText()).toBe('Crimps');
+  });
+
+  it('forwards blur/focus through the imperative handle on the Material path', () => {
+    ctrl.variant = 'material';
+    const ref = createRef<SearchHeaderHandle>();
+    const { container } = render(
+      <SearchHeader
+        ref={ref}
+        placeholder="Search climbs"
+        onChangeText={() => {}}
+        onFocus={() => {}}
+        onBlur={() => {}}
+      />,
+    );
+    const input = container.querySelector('[data-paper="searchbar"]');
+    expect(input).not.toBeNull();
+
+    // The handle proxies to Paper's forwarded TextInput ref — not a silent no-op.
+    act(() => ref.current?.focus());
+    expect(document.activeElement).toBe(input);
+    act(() => ref.current?.blur());
+    expect(document.activeElement).not.toBe(input);
   });
 });

--- a/packages/mobile/src/components/__tests__/search-header.test.tsx
+++ b/packages/mobile/src/components/__tests__/search-header.test.tsx
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render } from '@testing-library/react';
-import { createElement, forwardRef, type ChangeEvent, type KeyboardEvent, type ReactNode } from 'react';
+import { act, createElement, createRef, forwardRef, type ChangeEvent, type KeyboardEvent, type ReactNode } from 'react';
+
+// Controls the resolved UI variant SearchHeader branches on.
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'material' | 'liquidGlass' }));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -49,17 +52,18 @@ vi.mock('../Icon', () => ({
 }));
 
 vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({ systemColors: { label: '#000', fill: '#eee' } }),
+  useTheme: () => ({ systemColors: { label: '#000', fill: '#eee' }, variant: ctrl.variant }),
 }));
 
 vi.mock('../../theme/ios-colors', () => ({
   iosSystemColors: { systemGray: '#888', white: '#fff' },
 }));
 
-import { SearchHeader } from '../SearchHeader';
+import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 
 describe('SearchHeader', () => {
   it('submits the current text when the keyboard search action fires', () => {
+    ctrl.variant = 'liquidGlass';
     const onSubmit = vi.fn();
     const { getByPlaceholderText } = render(
       <SearchHeader
@@ -76,5 +80,28 @@ describe('SearchHeader', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(onSubmit).toHaveBeenCalledWith('Moonage');
+  });
+
+  it('renders the Material Searchbar and keeps the imperative handle working', () => {
+    ctrl.variant = 'material';
+    const ref = createRef<SearchHeaderHandle>();
+    const { container } = render(
+      <SearchHeader
+        ref={ref}
+        placeholder="Search climbs"
+        onChangeText={() => {}}
+        onFocus={() => {}}
+        onBlur={() => {}}
+      />,
+    );
+
+    // Material path renders the Paper Searchbar (stub), not the glass capsule.
+    expect(container.querySelector('[data-paper="searchbar"]')).not.toBeNull();
+    expect(container.querySelector('[data-glass]')).toBeNull();
+
+    // getText/set({silent}) are backed by local state, so they work regardless of
+    // Paper owning the inner TextInput.
+    act(() => ref.current?.setText('Crimps', { silent: true }));
+    expect(ref.current?.getText()).toBe('Crimps');
   });
 });

--- a/packages/mobile/src/components/__tests__/segmented-control.test.tsx
+++ b/packages/mobile/src/components/__tests__/segmented-control.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Controls the resolved UI variant the SegmentedControl branches on.
+const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
+const hapticSelectionMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-view': 'true' }, children),
+}));
+
+// Paper SegmentedButtons → <div> exposing the props the test asserts on.
+type PaperButton = { value: string; label?: string; disabled?: boolean };
+vi.mock('react-native-paper', () => ({
+  SegmentedButtons: ({
+    value,
+    onValueChange,
+    buttons,
+  }: {
+    value: string;
+    onValueChange: (next: string) => void;
+    buttons: PaperButton[];
+  }) =>
+    createElement(
+      'div',
+      { 'data-paper-segmented': 'true', 'data-value': value },
+      buttons.map((button) =>
+        createElement('button', {
+          key: button.value,
+          'data-segment-value': button.value,
+          'data-disabled': button.disabled ? 'true' : 'false',
+          onClick: () => onValueChange(button.value),
+        }),
+      ),
+    ),
+}));
+
+// Glass-path deps — the PressableSurface fallback renders a plain div.
+vi.mock('../PressableSurface', () => ({
+  PressableSurface: ({ children }: { children?: ReactNode }) =>
+    createElement('div', { 'data-pressable': 'true' }, children),
+}));
+vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
+vi.mock('../../lib/haptics', () => ({ hapticSelection: hapticSelectionMock }));
+vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#8C4A52' } }));
+vi.mock('../../theme/tokens', () => ({ spacing: { 2: 8 } }));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: ctrl.variant,
+    colorScheme: 'light',
+    systemColors: { elevatedSurface: '#fff', label: '#000' },
+    opacity: { disabled: 0.4 },
+  }),
+}));
+
+import { SegmentedControl } from '../SegmentedControl';
+
+const options = [
+  { key: 'a', label: 'Alpha' },
+  { key: 'b', label: 'Beta' },
+] as const;
+
+describe('SegmentedControl', () => {
+  it('renders Paper SegmentedButtons on the Material variant', () => {
+    ctrl.variant = 'material';
+    const { container } = render(
+      <SegmentedControl
+        options={[...options]}
+        selectedKey="a"
+        onSelect={() => {}}
+        trackColor="#eee"
+        accessibilityLabel="Appearance"
+      />,
+    );
+    const paper = container.querySelector('[data-paper-segmented]');
+    expect(paper).not.toBeNull();
+    expect(paper?.getAttribute('data-value')).toBe('a');
+    expect(container.querySelector('[data-pressable]')).toBeNull();
+  });
+
+  it('fires haptics and onSelect on the Material variant', () => {
+    ctrl.variant = 'material';
+    hapticSelectionMock.mockClear();
+    const onSelect = vi.fn();
+    const { container } = render(
+      <SegmentedControl options={[...options]} selectedKey="a" onSelect={onSelect} trackColor="#eee" />,
+    );
+    container.querySelector<HTMLButtonElement>('[data-segment-value="b"]')?.click();
+    expect(hapticSelectionMock).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('b');
+  });
+
+  it('does not select a disabled key on the Material variant', () => {
+    ctrl.variant = 'material';
+    hapticSelectionMock.mockClear();
+    const onSelect = vi.fn();
+    const { container } = render(
+      <SegmentedControl
+        options={[...options]}
+        selectedKey="a"
+        onSelect={onSelect}
+        trackColor="#eee"
+        disabledKeys={new Set(['b'])}
+      />,
+    );
+    const disabled = container.querySelector('[data-segment-value="b"]');
+    expect(disabled?.getAttribute('data-disabled')).toBe('true');
+    disabled?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(hapticSelectionMock).not.toHaveBeenCalled();
+  });
+
+  it('renders the Liquid Glass (PressableSurface) control on the Liquid Glass variant', () => {
+    ctrl.variant = 'liquidGlass';
+    const { container } = render(
+      <SegmentedControl options={[...options]} selectedKey="a" onSelect={() => {}} trackColor="#eee" />,
+    );
+    expect(container.querySelector('[data-pressable]')).not.toBeNull();
+    expect(container.querySelector('[data-paper-segmented]')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/__tests__/switch-row.test.tsx
+++ b/packages/mobile/src/components/__tests__/switch-row.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Controls the resolved UI variant the SwitchRow branches on for its toggle.
+const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
+const hapticSelectionMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-view': 'true' }, children),
+  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('div', { 'data-pressable': 'true', onClick: onPress }, children),
+  // The RN Switch (Liquid Glass path) renders a distinct element.
+  Switch: (props: { value?: boolean; onValueChange?: (next: boolean) => void }) =>
+    createElement('input', {
+      'data-rn-switch': 'true',
+      type: 'checkbox',
+      checked: !!props.value,
+      onChange: () => props.onValueChange?.(!props.value),
+      readOnly: true,
+    }),
+}));
+
+// Paper Switch → <input> exposing the props the test asserts on.
+vi.mock('react-native-paper', () => ({
+  Switch: (props: { value?: boolean; onValueChange?: (next: boolean) => void; disabled?: boolean }) =>
+    createElement('input', {
+      'data-paper-switch': 'true',
+      type: 'checkbox',
+      checked: !!props.value,
+      disabled: props.disabled,
+      onChange: () => props.onValueChange?.(!props.value),
+      readOnly: true,
+    }),
+}));
+
+vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
+vi.mock('../../lib/haptics', () => ({ hapticSelection: hapticSelectionMock }));
+vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#8C4A52' } }));
+vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: { systemGray4: '#ccc' } }));
+vi.mock('../../theme/tokens', () => ({ spacing: { 2: 8, 3: 12, 4: 16 } }));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ variant: ctrl.variant }),
+}));
+
+import { SwitchRow } from '../SwitchRow';
+
+describe('SwitchRow', () => {
+  it('renders the Paper Switch on the Material variant', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<SwitchRow label="Sound" value={false} onValueChange={() => {}} />);
+    expect(container.querySelector('[data-paper-switch]')).not.toBeNull();
+    expect(container.querySelector('[data-rn-switch]')).toBeNull();
+  });
+
+  it('renders the RN Switch on the Liquid Glass variant', () => {
+    ctrl.variant = 'liquidGlass';
+    const { container } = render(<SwitchRow label="Sound" value={false} onValueChange={() => {}} />);
+    expect(container.querySelector('[data-rn-switch]')).not.toBeNull();
+    expect(container.querySelector('[data-paper-switch]')).toBeNull();
+  });
+
+  it('fires haptics and onValueChange when the Paper Switch toggles', () => {
+    ctrl.variant = 'material';
+    hapticSelectionMock.mockClear();
+    const onValueChange = vi.fn();
+    const { container } = render(<SwitchRow label="Sound" value={false} onValueChange={onValueChange} />);
+    const toggle = container.querySelector('[data-paper-switch]');
+    expect(toggle).not.toBeNull();
+    fireEvent.click(toggle as Element);
+    // (In jsdom the click also bubbles to the row Pressable, so handleToggle may
+    //  fire more than once — in RN the Switch captures the touch. We only assert
+    //  the wiring fires, not the exact count.)
+    expect(hapticSelectionMock).toHaveBeenCalled();
+    expect(onValueChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/mobile/src/components/__tests__/switch-row.test.tsx
+++ b/packages/mobile/src/components/__tests__/switch-row.test.tsx
@@ -62,18 +62,30 @@ describe('SwitchRow', () => {
     expect(container.querySelector('[data-paper-switch]')).toBeNull();
   });
 
-  it('fires haptics and onValueChange when the Paper Switch toggles', () => {
+  it('toggles exactly once from the row press on Material (no double-fire)', () => {
     ctrl.variant = 'material';
     hapticSelectionMock.mockClear();
     const onValueChange = vi.fn();
     const { container } = render(<SwitchRow label="Sound" value={false} onValueChange={onValueChange} />);
-    const toggle = container.querySelector('[data-paper-switch]');
-    expect(toggle).not.toBeNull();
-    fireEvent.click(toggle as Element);
-    // (In jsdom the click also bubbles to the row Pressable, so handleToggle may
-    //  fire more than once — in RN the Switch captures the touch. We only assert
-    //  the wiring fires, not the exact count.)
-    expect(hapticSelectionMock).toHaveBeenCalled();
+    // The row Pressable is the sole toggle target; the Paper Switch is a
+    // non-interactive indicator, so a single press fires the toggle once.
+    const row = container.querySelector('[data-pressable]');
+    expect(row).not.toBeNull();
+    fireEvent.click(row as Element);
+    expect(hapticSelectionMock).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenCalledTimes(1);
     expect(onValueChange).toHaveBeenCalledWith(true);
+  });
+
+  it('does not toggle from the Paper Switch itself (it is non-interactive)', () => {
+    ctrl.variant = 'material';
+    hapticSelectionMock.mockClear();
+    const onValueChange = vi.fn();
+    const { container } = render(<SwitchRow label="Sound" value={false} onValueChange={onValueChange} />);
+    const toggle = container.querySelector('[data-paper-switch]') as Element;
+    // SwitchRow no longer wires onValueChange to the Paper Switch, so firing its
+    // change directly is a no-op (the row owns the toggle).
+    fireEvent.change(toggle, { target: { checked: true } });
+    expect(onValueChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/components/__tests__/toast.test.tsx
+++ b/packages/mobile/src/components/__tests__/toast.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Controls the resolved UI variant the Toast branches on.
+const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
+
+type ViewMockProps = { children?: ReactNode };
+vi.mock('react-native', () => ({
+  View: ({ children }: ViewMockProps) => createElement('div', { 'data-view': 'true' }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {} },
+}));
+
+// Reanimated Animated.View → div exposing accessibility props (glass path).
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({ children, accessibilityRole }: { children?: ReactNode; accessibilityRole?: string }) =>
+      createElement('div', { 'data-animated': 'true', 'data-role': accessibilityRole ?? '' }, children),
+  },
+  FadeIn: { duration: () => ({}) },
+  FadeOut: { duration: () => ({}) },
+}));
+
+// Paper Snackbar → div exposing visible/duration/children + onDismiss.
+type SnackbarMockProps = {
+  visible?: boolean;
+  duration?: number;
+  onDismiss?: () => void;
+  children?: ReactNode;
+};
+vi.mock('react-native-paper', () => ({
+  Snackbar: ({ visible, duration, onDismiss, children }: SnackbarMockProps) =>
+    createElement(
+      'div',
+      {
+        'data-paper-snackbar': 'true',
+        'data-visible': visible ? 'true' : 'false',
+        'data-duration': String(duration ?? ''),
+        onClick: onDismiss,
+      },
+      children,
+    ),
+}));
+
+vi.mock('expo-router', () => ({ useSegments: () => ['(tabs)', 'climbs'] }));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+}));
+
+vi.mock('../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
+}));
+vi.mock('../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }) }));
+vi.mock('../../theme/colors', () => ({
+  brandColors: { success: '#34C759', error: '#FF3B30', primary: '#8C4A52', warning: '#FF9500' },
+  withAlpha: (color: string) => color,
+}));
+vi.mock('../../theme/tokens', () => ({ borderRadius: { full: 999 }, spacing: { 2: 8, 3: 12, 4: 16 } }));
+vi.mock('../../theme/layout', () => ({ TAB_BAR_HEIGHT: 49, TOOLBAR_RESERVE: 56 }));
+vi.mock('../../lib/route-segments', () => ({ isTabsRoute: () => true }));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: ctrl.variant,
+    colorScheme: 'light',
+    systemColors: { secondaryBackground: '#EEE', label: '#000' },
+  }),
+}));
+
+import { Toast } from '../Toast';
+
+const toast = { id: 't1', message: 'Saved tick', variant: 'success' as const, duration: 3000 };
+
+describe('Toast', () => {
+  it('renders a Paper Snackbar on the Material variant', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
+    const snackbar = container.querySelector('[data-paper-snackbar]');
+    expect(snackbar).not.toBeNull();
+    expect(snackbar?.getAttribute('data-visible')).toBe('true');
+    expect(snackbar?.getAttribute('data-duration')).toBe('3000'); // duration mapped through
+    expect(snackbar?.textContent).toContain('Saved tick'); // message mapped through
+    // The glass animated pill must not render on Material.
+    expect(container.querySelector('[data-animated]')).toBeNull();
+  });
+
+  it('routes Paper onDismiss to onDismiss(toast.id)', () => {
+    ctrl.variant = 'material';
+    const onDismiss = vi.fn();
+    const { container } = render(<Toast toast={toast} onDismiss={onDismiss} />);
+    (container.querySelector('[data-paper-snackbar]') as HTMLElement).click();
+    expect(onDismiss).toHaveBeenCalledWith('t1');
+  });
+
+  it('renders the Liquid Glass animated pill on the Liquid Glass variant', () => {
+    ctrl.variant = 'liquidGlass';
+    const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
+    const animated = container.querySelector('[data-animated]');
+    expect(animated).not.toBeNull();
+    expect(animated?.getAttribute('data-role')).toBe('alert');
+    expect(container.querySelector('[data-icon="success"]')).not.toBeNull();
+    expect(container.textContent).toContain('Saved tick');
+    expect(container.querySelector('[data-paper-snackbar]')).toBeNull();
+  });
+
+  it('auto-dismisses via timer on the Liquid Glass variant', () => {
+    vi.useFakeTimers();
+    ctrl.variant = 'liquidGlass';
+    const onDismiss = vi.fn();
+    render(<Toast toast={toast} onDismiss={onDismiss} />);
+    expect(onDismiss).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(3000);
+    expect(onDismiss).toHaveBeenCalledWith('t1');
+    vi.useRealTimers();
+  });
+});

--- a/packages/mobile/src/components/navigation/MaterialTabBar.tsx
+++ b/packages/mobile/src/components/navigation/MaterialTabBar.tsx
@@ -17,9 +17,11 @@ import { TAB_BAR_HEIGHT } from '../../theme/layout';
  */
 export function MaterialTabBar({ state, descriptors, navigation, insets }: BottomTabBarProps) {
   const { systemColors } = useTheme();
-  const activeColor = brandColors.primary;
+  // Softened active state (closer to M3, which tints the indicator gently rather
+  // than using full primary): a lighter maroon pill + a muted maroon icon/label.
+  const activeColor = withAlpha(brandColors.primary, 0.8);
   const inactiveColor = systemColors.secondaryLabel;
-  const indicatorColor = withAlpha(brandColors.primary, 0.16);
+  const indicatorColor = withAlpha(brandColors.primary, 0.1);
 
   return (
     <View

--- a/packages/mobile/src/providers/material-theme-provider.tsx
+++ b/packages/mobile/src/providers/material-theme-provider.tsx
@@ -1,0 +1,40 @@
+import { useMemo, type ReactNode } from 'react';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { PaperProvider } from 'react-native-paper';
+import { useTheme } from './theme-provider';
+import { buildPaperTheme } from '../theme/paper-theme';
+
+type PaperIconProps = { name: string; color?: string; size: number };
+
+// Route react-native-paper's icons to the @expo/vector-icons MaterialCommunityIcons
+// font the app already bundles (Paper uses MDI names by default), so we don't
+// ship a second icon font.
+function paperIcon({ name, color, size }: PaperIconProps) {
+  return (
+    <MaterialCommunityIcons
+      name={name as React.ComponentProps<typeof MaterialCommunityIcons>['name']}
+      color={color}
+      size={size}
+    />
+  );
+}
+
+const paperSettings = { icon: paperIcon };
+
+/**
+ * Mounts react-native-paper's PaperProvider with an MD3 theme derived from our
+ * tokens (see buildPaperTheme). Sits inside ThemeProvider so it tracks the
+ * resolved light/dark scheme; the Material variant's primitives read this theme,
+ * while the Liquid Glass variant ignores it entirely. Mounted unconditionally —
+ * it's cheap and keeps the provider tree stable across a variant switch.
+ */
+export function MaterialThemeProvider({ children }: { children: ReactNode }) {
+  const { colorScheme } = useTheme();
+  const paperTheme = useMemo(() => buildPaperTheme(colorScheme), [colorScheme]);
+
+  return (
+    <PaperProvider theme={paperTheme} settings={paperSettings}>
+      {children}
+    </PaperProvider>
+  );
+}

--- a/packages/mobile/src/theme/__tests__/paper-theme.test.ts
+++ b/packages/mobile/src/theme/__tests__/paper-theme.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+
+// colors.ts touches Platform/PlatformColor at import; Android skips the iOS branch.
+vi.mock('react-native', () => ({ Platform: { OS: 'android' }, PlatformColor: (name: string) => name }));
+// react-native-paper imports react-native at load; stub the MD3 base themes.
+vi.mock('react-native-paper', () => ({
+  MD3LightTheme: { dark: false, colors: { primary: 'base', elevation: {} } },
+  MD3DarkTheme: { dark: true, colors: { primary: 'base', elevation: {} } },
+}));
+
+import { buildPaperTheme } from '../paper-theme';
+
+describe('buildPaperTheme', () => {
+  it('maps the brand + material surfaces onto MD3 roles (light)', () => {
+    const theme = buildPaperTheme('light');
+    expect(theme.colors.primary).toBe('#8C4A52');
+    expect(theme.colors.onPrimary).toBe('#FFFFFF');
+    expect(theme.colors.background).toBe('#F4ECEC'); // materialSurfaces.light.background
+    expect(theme.colors.surface).toBe('#FFFFFF'); // secondaryBackground
+    expect(theme.colors.error).toBe('#B8524C');
+    expect(theme.colors.elevation.level2).toBe('#FFFFFF'); // elevatedSurface (light)
+  });
+
+  it('uses the dark tonal surfaces for the dark scheme', () => {
+    const theme = buildPaperTheme('dark');
+    expect(theme.colors.background).toBe('#141011');
+    expect(theme.colors.surface).toBe('#1F1A1B');
+  });
+
+  it('passes a provided dynamic palette straight through (Material You hook)', () => {
+    const dynamic = { primary: '#123456' } as unknown as Parameters<typeof buildPaperTheme>[1];
+    const theme = buildPaperTheme('light', dynamic);
+    expect(theme.colors.primary).toBe('#123456');
+  });
+});

--- a/packages/mobile/src/theme/paper-theme.ts
+++ b/packages/mobile/src/theme/paper-theme.ts
@@ -1,0 +1,67 @@
+import { MD3DarkTheme, MD3LightTheme, type MD3Theme } from 'react-native-paper';
+import { brandColors, materialSurfaces, withAlpha } from './colors';
+
+type ColorScheme = 'light' | 'dark';
+
+/**
+ * Build a react-native-paper Material 3 theme from our existing design tokens, so
+ * the Material UI variant renders authentic MD3 components tinted to the
+ * Boardsesh brand (maroon #8C4A52) and consistent with our `materialSurfaces`
+ * ladder. Our theme stays the source of truth — this is the downstream Paper
+ * consumer; the Liquid Glass variant never touches it.
+ *
+ * Type scale + component shapes are left as Paper's MD3 defaults (system font:
+ * Roboto on Android, San Francisco on iOS) — that IS the native Material look.
+ * Only the colour roles are mapped from our tokens.
+ *
+ * The optional `dynamic` palette is the hook for the Material You fast-follow
+ * (@pchmn/expo-material3-theme); unused today, callers pass `undefined`.
+ */
+export function buildPaperTheme(colorScheme: ColorScheme, dynamic?: MD3Theme['colors']): MD3Theme {
+  const base = colorScheme === 'dark' ? MD3DarkTheme : MD3LightTheme;
+  if (dynamic) {
+    return { ...base, colors: { ...base.colors, ...dynamic } };
+  }
+
+  const surfaces = materialSurfaces[colorScheme];
+  const isDark = colorScheme === 'dark';
+  const onSurface = surfaces.label as string;
+  const onSurfaceVariant = surfaces.secondaryLabel as string;
+
+  return {
+    ...base,
+    colors: {
+      ...base.colors,
+      primary: brandColors.primary,
+      onPrimary: '#FFFFFF',
+      primaryContainer: withAlpha(brandColors.primary, isDark ? 0.32 : 0.14),
+      onPrimaryContainer: onSurface,
+      secondary: brandColors.primary,
+      onSecondary: '#FFFFFF',
+      secondaryContainer: withAlpha(brandColors.primary, isDark ? 0.28 : 0.16),
+      onSecondaryContainer: onSurface,
+      tertiary: brandColors.success,
+      onTertiary: '#FFFFFF',
+      background: surfaces.background as string,
+      onBackground: onSurface,
+      surface: surfaces.secondaryBackground as string,
+      onSurface,
+      surfaceVariant: surfaces.tertiaryBackground as string,
+      onSurfaceVariant,
+      outline: surfaces.separator as string,
+      outlineVariant: surfaces.separator as string,
+      error: brandColors.error,
+      onError: '#FFFFFF',
+      // Surface-tint ladder: map Paper's elevation levels onto our tonal surfaces
+      // so elevated Paper components match the rest of the Material chrome.
+      elevation: {
+        level0: 'transparent',
+        level1: surfaces.secondaryBackground as string,
+        level2: surfaces.elevatedSurface as string,
+        level3: surfaces.elevatedSurface as string,
+        level4: surfaces.elevatedSurface as string,
+        level5: surfaces.elevatedSurface as string,
+      },
+    },
+  };
+}

--- a/packages/mobile/test/react-native-paper-stub.tsx
+++ b/packages/mobile/test/react-native-paper-stub.tsx
@@ -1,0 +1,36 @@
+// Test stub for react-native-paper. The real entry pulls in untransformed
+// RN-native source (and react-native-vector-icons) that throws a SyntaxError
+// under vitest's node env — the same problem the posthog stub solves. This keeps
+// react-native-paper importable in every suite (integration tests that render a
+// Paper-using primitive without their own mock). Component-specific tests that
+// assert Paper props still register their own `vi.mock('react-native-paper', …)`,
+// which takes precedence over this alias for that file.
+import { createElement, type ReactNode } from 'react';
+
+type StubProps = Record<string, unknown> & { children?: ReactNode };
+
+const stub =
+  (name: string) =>
+  ({ children }: StubProps) =>
+    createElement('div', { 'data-paper': name }, children);
+
+export const PaperProvider = ({ children }: StubProps) => createElement('div', { 'data-paper': 'provider' }, children);
+export const Button = stub('button');
+export const IconButton = stub('icon-button');
+export const Switch = stub('switch');
+export const Badge = stub('badge');
+export const Snackbar = stub('snackbar');
+export const Searchbar = stub('searchbar');
+export const SegmentedButtons = stub('segmented-buttons');
+export const ActivityIndicator = stub('activity-indicator');
+export const TouchableRipple = stub('touchable-ripple');
+
+const CardStub = stub('card');
+export const Card = Object.assign(CardStub, {
+  Content: stub('card-content'),
+  Title: stub('card-title'),
+  Actions: stub('card-actions'),
+});
+
+export const MD3LightTheme = { dark: false, roundness: 5, colors: { elevation: {} }, fonts: {} };
+export const MD3DarkTheme = { dark: true, roundness: 5, colors: { elevation: {} }, fonts: {} };

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
       // `src/lib/analytics`. Analytics is a no-op in tests (isAnalyticsEnabled is
       // false), so a lightweight stub satisfies the static imports safely.
       'posthog-react-native': fileURLToPath(new URL('./test/posthog-react-native-stub.ts', import.meta.url)),
+      // react-native-paper's real entry throws a SyntaxError under vitest's node
+      // env (untransformed RN-native source + react-native-vector-icons). Stub it
+      // so any suite can import a Paper-backed primitive; component tests that
+      // assert Paper props register their own vi.mock which takes precedence.
+      'react-native-paper': fileURLToPath(new URL('./test/react-native-paper-stub.tsx', import.meta.url)),
     },
     // .tsx test files can opt into a jsdom environment per file via the
     // `// @vitest-environment jsdom` pragma — needed to render React


### PR DESCRIPTION
## What

Upgrades the **`material` UI variant**'s primitives from the hand-rolled token skin (#2568) to **authentic Material Design 3 via `react-native-paper`** (5.15.3). The Liquid Glass variant — the preferred iOS 26 UI — is **byte-identical**.

## Why

Our main competitor is a Flutter app that doesn't look native — Flutter draws every pixel on its own canvas. React Native renders *real* native views (native scroll, text, ripple, momentum), and Paper layers authentic MD3 on top — so RN + Paper reads as more native than the competitor. A genuinely native-feeling Material option is a selling point.

## How (our theme stays the source of truth)

- **`src/theme/paper-theme.ts`** `buildPaperTheme()` maps our tokens (`materialSurfaces`, `brandColors`) onto MD3 colour roles; Paper's MD3 type scale + shapes stay as defaults (system font: Roboto on Android, SF on iOS). A `dynamic` param is the seam for the Material You fast-follow.
- **`src/providers/material-theme-provider.tsx`** mounts `PaperProvider` under `ThemeProvider`; its `settings.icon` reuses the app's `@expo/vector-icons` MaterialCommunityIcons so we don't ship a second icon font.
- **Per-primitive pattern** (exemplar `Button.tsx`): `variant === 'material' ? <Paper…/> : <existing glass body verbatim/>`. Public prop APIs are unchanged → **zero call-site changes**, and the glass path only ever lives in the untouched `else` branch.

## Migrated to Paper (material branch)

Button, SegmentedControl→`SegmentedButtons`, SwitchRow→`Switch`, Badge, GlassIconButton→`IconButton` (so the filter / log-ascent / create FABs go MD3), Card, Toast→`Snackbar`, QueueAddedSnackbar→`Snackbar`, SearchHeader→`Searchbar` (the `SearchHeaderHandle` imperative ref is preserved — Paper owns the inner `TextInput`; `getText`/`setText({silent})` stay backed by local state).

## Kept token-skinned but palette-consistent

ListRow, GradeChip, the `MaterialTabBar`, gorhom sheets, and `AccessoryBarSurface` read the same `materialSurfaces` palette that feeds the Paper theme, so they match Paper components without taking a Paper dependency (their APIs don't map cleanly to `List.Item`/`Chip`/`BottomNavigation`).

## Liquid Glass untouched

Every migration is an internal branch; the glass body is moved verbatim into the `else`. The glass regression tests (`glass-surface`, `theme-provider`) stay green unchanged. On iOS 26 `auto` resolves to Liquid Glass, so Paper ships **off by default on the preferred platform**.

## Tests

- `react-native-paper` aliased to a jsdom-safe stub in `vite.config.ts` (same pattern as the existing `posthog-react-native` stub), so any suite can import a Paper-backed primitive; component tests register their own `vi.mock` which takes precedence.
- New: `paper-theme` builder unit test + per-primitive material↔glass render tests.

## Validation

- `vp run typecheck:mobile` — clean
- `vp test --project mobile` — **952 passing**
- `vp run check:mobile-bundle` — iOS 10.2 MB / Android 10.4 MB (~0.4 MB for Paper; no duplicate-React), verified Paper bundles on RN 0.85 / React 19 / New Architecture
- `vp run check:mobile-native-deps` — OK (Paper ships no iOS build-phase plugin)

Visual QA on device (the macOS-only simulator/screenshot gates can't run in CI here) is still needed — Material variant on Android + iOS-Material, and a no-op-diff confirmation of the iOS 26 Liquid Glass path.

## Out of scope (fast-follows)

- **Material You dynamic color** via `@pchmn/expo-material3-theme` → feeds `buildPaperTheme`'s `dynamic` param; needs a fresh native build (not OTA).
- Android nav-bar edge-to-edge (`react-native-edge-to-edge`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)