### PR TITLE
Share Instagram/TikTok beta reels into Boardsesh to attach to a climb (mobile)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -229,6 +229,7 @@
         "expo-modules-core": "~56.0.13",
         "expo-router": "~56.2.8",
         "expo-secure-store": "~56.0.4",
+        "expo-share-intent": "^7.0.0",
         "expo-splash-screen": "~56.0.10",
         "expo-status-bar": "~56.0.4",
         "expo-symbols": "~56.0.5",
@@ -2963,6 +2964,8 @@
     "expo-secure-store": ["expo-secure-store@56.0.4", "", { "peerDependencies": { "expo": "*" } }, "sha512-hjEi/gmpdFFJ9lYbdp3k3p/WchV7Gi0Qt8jt/m/0WJadqQrskafHAlDxbZkII1cN3Yd7zp9Lvkeq3UfGhSwirQ=="],
 
     "expo-server": ["expo-server@56.0.4", "", {}, "sha512-4dJ57KuAwDl7eQGD6aG9kTzBIftWAfHH1+6Zxy7NcPCBrKYis3/H5enGUz1asH8HHhONXfJ5BdJqfEWAEAgWxA=="],
+
+    "expo-share-intent": ["expo-share-intent@7.0.0", "", { "dependencies": { "@expo/config-plugins": "~56.0.8", "expo-constants": "~56.0.10", "expo-linking": "~56.0.11" }, "peerDependencies": { "expo": "^56", "react": "*", "react-native": "*" } }, "sha512-9fVw0ObAdJMj9YlN/zkBwMKWlQakjP5xa2pf81V44sK+49GJyVT38NBJv+RtEGSK5CH2SUJHHdJ062HZG5a/AQ=="],
 
     "expo-splash-screen": ["expo-splash-screen@56.0.10", "", { "dependencies": { "@expo/config-plugins": "~56.0.8", "@expo/image-utils": "^0.10.1", "xml2js": "0.6.0" }, "peerDependencies": { "expo": "*" } }, "sha512-vDIlo8hzt9HlCZQ0kSY66v83D1WEXOJbVMeyPDfXDu9tbDdPMNUyDpi4WGJXikAjxnAKfbt5Mv5NnEbxINy+VA=="],
 

--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -632,3 +632,102 @@ describe('recentBetaLinks Redis cache', () => {
     expect(redisDelMock).not.toHaveBeenCalled();
   });
 });
+
+describe('betaLinkPreview resolver', () => {
+  // requireAuthenticated + applyRateLimit run for real here (helpers isn't
+  // mocked); the redis mock defaults to disconnected so applyRateLimit falls
+  // back to the in-memory limiter and never needs a real Redis.
+  const ctx = (isAuthenticated: boolean) =>
+    ({ isAuthenticated, userId: 'user-1', connectionId: 'conn-1', clientIp: '127.0.0.1' }) as unknown as Parameters<
+      typeof betaLinkQueries.betaLinkPreview
+    >[2];
+
+  beforeEach(() => {
+    fetchInstagramMetaMock.mockReset();
+    fetchTikTokMetaMock.mockReset();
+    redisConnectedMock.mockReset();
+    redisConnectedMock.mockReturnValue(false);
+  });
+
+  it('returns thumbnail + caption for an authenticated Instagram preview', async () => {
+    fetchInstagramMetaMock.mockResolvedValueOnce({
+      status: 'ok',
+      thumbnail: 'https://scontent.cdninstagram.com/raw.jpg',
+      username: 'climber',
+      caption: 'Sent Purple Nurple 🧗',
+    });
+
+    const result = await betaLinkQueries.betaLinkPreview(
+      undefined,
+      { link: 'https://www.instagram.com/reel/ABC123/' },
+      ctx(true),
+    );
+
+    expect(result).toEqual({
+      link: 'https://www.instagram.com/reel/ABC123/',
+      thumbnail: 'https://scontent.cdninstagram.com/raw.jpg',
+      username: 'climber',
+      caption: 'Sent Purple Nurple 🧗',
+    });
+  });
+
+  it('throws when unauthenticated and never calls out to Instagram', async () => {
+    await expect(
+      betaLinkQueries.betaLinkPreview(undefined, { link: 'https://www.instagram.com/reel/ABC123/' }, ctx(false)),
+    ).rejects.toThrow(/auth/i);
+    expect(fetchInstagramMetaMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null fields (no error, no outbound call) for a non-IG/TikTok URL', async () => {
+    const result = await betaLinkQueries.betaLinkPreview(
+      undefined,
+      { link: 'https://example.com/whatever' },
+      ctx(true),
+    );
+
+    expect(result).toEqual({
+      link: 'https://example.com/whatever',
+      thumbnail: null,
+      username: null,
+      caption: null,
+    });
+    expect(fetchInstagramMetaMock).not.toHaveBeenCalled();
+    expect(fetchTikTokMetaMock).not.toHaveBeenCalled();
+  });
+
+  it('previews TikTok (thumbnail + username; caption stays null)', async () => {
+    fetchTikTokMetaMock.mockResolvedValueOnce({
+      status: 'ok',
+      thumbnail: 'https://p16-common-sign.tiktokcdn.com/x.jpg',
+      username: 'climber',
+    });
+    const url = 'https://www.tiktok.com/@climber/video/9999999999';
+
+    const result = await betaLinkQueries.betaLinkPreview(undefined, { link: url }, ctx(true));
+
+    expect(result).toMatchObject({
+      link: url,
+      thumbnail: 'https://p16-common-sign.tiktokcdn.com/x.jpg',
+      username: 'climber',
+      caption: null,
+    });
+    expect(fetchInstagramMetaMock).not.toHaveBeenCalled();
+  });
+
+  it('best-effort: an unavailable IG post yields null media fields, not an error', async () => {
+    fetchInstagramMetaMock.mockResolvedValueOnce({ status: 'gone' });
+
+    const result = await betaLinkQueries.betaLinkPreview(
+      undefined,
+      { link: 'https://www.instagram.com/p/GONE/' },
+      ctx(true),
+    );
+
+    expect(result).toMatchObject({
+      link: 'https://www.instagram.com/p/GONE/',
+      thumbnail: null,
+      username: null,
+      caption: null,
+    });
+  });
+});

--- a/packages/backend/src/__tests__/instagram-beta-validation.test.ts
+++ b/packages/backend/src/__tests__/instagram-beta-validation.test.ts
@@ -23,6 +23,7 @@ describe('validateInstagramBetaLink', () => {
       status: 'ok',
       thumbnail: 'https://cdn.example.com/photo.jpg',
       username: 'camgibbs',
+      caption: null,
     });
 
     await expect(validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/')).resolves.toEqual({
@@ -41,6 +42,7 @@ describe('validateInstagramBetaLink', () => {
       status: 'ok',
       thumbnail: 'https://cdn.example.com/photo.jpg',
       username: 'someone',
+      caption: null,
     });
 
     await expect(validateInstagramBetaLink('https://www.instagram.com/reel/DLM2nf9S1h6/')).resolves.toMatchObject({
@@ -80,6 +82,7 @@ describe('validateInstagramBetaLink', () => {
       status: 'ok',
       thumbnail: '',
       username: null,
+      caption: null,
     });
 
     await expect(validateInstagramBetaLink('https://www.instagram.com/p/CU-NOpdL8Kf/')).resolves.toEqual({

--- a/packages/backend/src/__tests__/instagram-meta.test.ts
+++ b/packages/backend/src/__tests__/instagram-meta.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
 import {
   clearInstagramMetaCache,
+  extractInstagramCaption,
   fetchInstagramMeta,
   getInstagramMediaId,
   INSTAGRAM_META_TTL_MS,
@@ -72,6 +73,7 @@ describe('fetchInstagramMeta', () => {
       status: 'ok',
       thumbnail: 'https://scontent.cdninstagram.com/p1080x1080/photo.jpg',
       username: 'testclimber',
+      caption: null,
     });
   });
 
@@ -329,6 +331,7 @@ describe('fetchInstagramMeta', () => {
       status: 'ok',
       thumbnail: 'https://scontent.cdninstagram.com/photo.jpg',
       username: null,
+      caption: null,
     });
   });
 
@@ -380,5 +383,36 @@ describe('fetchInstagramMeta', () => {
     const result = await fetchInstagramMeta(SAMPLE_URL);
     // readBodyWithCap throws -> fetchInstagramMeta maps to transient_error.
     expect(result).toEqual({ status: 'transient_error' });
+  });
+});
+
+describe('extractInstagramCaption', () => {
+  it('parses the edge_media_to_caption JSON node', () => {
+    const html = `<html><script>{"edge_media_to_caption":{"edges":[{"node":{"text":"Sent Purple Nurple at 40\\u00b0 \\ud83e\\uddd7"}}]}}</script></html>`;
+    expect(extractInstagramCaption(html, 'someuser')).toBe('Sent Purple Nurple at 40° 🧗');
+  });
+
+  it('parses the rendered .Caption div, dropping the leading username, despite nested divs', () => {
+    const html = `
+      <div class="Caption">
+        <a class="CaptionUsername" href="/climber/"><div class="CaptionUsernameInner">climber</div></a>
+        First ascent of <b>The Crimp Master</b>! Felt solid.
+        <div class="CaptionComments">View all 12 comments</div>
+      </div>`;
+    expect(extractInstagramCaption(html, 'climber')).toBe('First ascent of The Crimp Master ! Felt solid.');
+  });
+
+  it('falls back to og:description and strips the like/comment prefix and quotes', () => {
+    const html = `<meta property="og:description" content="1,234 likes, 56 comments - climber on Instagram: &quot;Flashed Yellow Brick Road&quot;" />`;
+    expect(extractInstagramCaption(html, 'climber')).toBe('Flashed Yellow Brick Road');
+  });
+
+  it('ignores accessibility_caption when there is no real caption', () => {
+    const html = `<html><script>{"accessibility_caption":"Photo by climber on January 01, 2026."}</script></html>`;
+    expect(extractInstagramCaption(html, 'climber')).toBeNull();
+  });
+
+  it('returns null when nothing parseable is present', () => {
+    expect(extractInstagramCaption('<html><body>no caption here</body></html>', null)).toBeNull();
   });
 });

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -14,6 +14,8 @@ import {
 } from '../../../lib/beta-link-thumbnails';
 import { redisClientManager } from '../../../redis/client';
 import { logger } from '../../../utils/logger';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { applyRateLimit, requireAuthenticated } from '../shared/helpers';
 
 type BetaLinkResult = {
   climbUuid: string;
@@ -30,6 +32,13 @@ type RecentBetaLinkResult = {
   climbName: string | null;
   boardType: string;
   layoutId: number | null;
+};
+
+type BetaLinkPreviewResult = {
+  link: string;
+  thumbnail: string | null;
+  username: string | null;
+  caption: string | null;
 };
 
 const RECENT_BETA_LINKS_MAX_LIMIT = 50;
@@ -420,6 +429,51 @@ export const betaLinkQueries = {
     const enriched = await Promise.all(rows.map((row) => limit(() => enrichRowSafe(row))));
 
     return enriched.filter((r): r is BetaLinkResult => r !== null);
+  },
+
+  // Live, unsaved preview of a shared Instagram/TikTok URL for the mobile share
+  // flow. Returns the thumbnail/caption so the client can show the post and
+  // auto-match the climb from the caption before attaching. Best-effort: a
+  // private/unavailable post (or a non-IG/TikTok URL) yields null fields rather
+  // than an error, so the user can still attach manually. Auth + the same 30/min
+  // limit as beta-link writes guard the outbound IG/TikTok fetch. Thumbnail is
+  // the platform CDN URL (not S3-cached) — it's a throwaway preview, not yet a
+  // persisted beta link. Caption is Instagram-only for now.
+  betaLinkPreview: async (
+    _: unknown,
+    { link }: { link: string },
+    ctx: ConnectionContext,
+  ): Promise<BetaLinkPreviewResult> => {
+    requireAuthenticated(ctx);
+    await applyRateLimit(ctx, 30, 'beta-link-preview');
+
+    const preview: BetaLinkPreviewResult = {
+      link,
+      thumbnail: null,
+      username: null,
+      caption: null,
+    };
+
+    if (isInstagramUrl(link)) {
+      const meta = await fetchInstagramMeta(link);
+      if (meta.status === 'ok') {
+        preview.thumbnail = meta.thumbnail;
+        preview.username = meta.username;
+        preview.caption = meta.caption;
+      }
+      return preview;
+    }
+
+    if (isTikTokUrl(link)) {
+      const meta = await fetchTikTokMeta(link);
+      if (meta.status === 'ok') {
+        preview.thumbnail = meta.thumbnail;
+        preview.username = meta.username;
+      }
+      return preview;
+    }
+
+    return preview;
   },
 
   // Powers the home-screen "Fresh beta" slider. We deliberately read only

--- a/packages/backend/src/lib/instagram-meta.ts
+++ b/packages/backend/src/lib/instagram-meta.ts
@@ -92,7 +92,7 @@ const CIRCUIT_THRESHOLD = 10;
 const CIRCUIT_COOLDOWN_MS = 5 * 60 * 1000;
 
 export type InstagramMetaResult =
-  | { status: 'ok'; thumbnail: string; username: string | null }
+  | { status: 'ok'; thumbnail: string; username: string | null; caption: string | null }
   | { status: 'gone' }
   | { status: 'transient_error' };
 
@@ -100,9 +100,13 @@ export type InstagramMetaResult =
 // count toward the circuit breaker. Body-cap rejections don't — they're a
 // local defense, not an IG-availability signal.
 type UncachedResult =
-  | { status: 'ok'; thumbnail: string; username: string | null }
+  | { status: 'ok'; thumbnail: string; username: string | null; caption: string | null }
   | { status: 'gone' }
   | { status: 'transient_error'; tripBreaker: boolean };
+
+// Cap the caption we keep. Matching a climb only needs the name, and the UI
+// preview truncates anyway — this guards against a pathological multi-KB body.
+const MAX_CAPTION_LENGTH = 2000;
 
 function decodeHtmlEntities(s: string): string {
   return s
@@ -121,6 +125,97 @@ function decodeJsonString(s: string): string {
   } catch {
     return s;
   }
+}
+
+/**
+ * Grab the inner HTML of the first `<div class="<className>">` while respecting
+ * nested `<div>`s — the captioned embed wraps the username in a nested div, so a
+ * non-greedy regex to the first `</div>` truncates the caption. Walks div
+ * open/close tags to find the matching close. Returns null if not found.
+ */
+function extractDivContentByClass(html: string, className: string): string | null {
+  const classMatch = new RegExp(`class=["']${className}["']`, 'i').exec(html);
+  if (!classMatch) return null;
+  const openTagEnd = html.indexOf('>', classMatch.index);
+  if (openTagEnd === -1) return null;
+  const contentStart = openTagEnd + 1;
+  const divTag = /<(\/?)div\b[^>]*>/gi;
+  divTag.lastIndex = contentStart;
+  let depth = 1;
+  let match: RegExpExecArray | null;
+  while ((match = divTag.exec(html)) !== null) {
+    depth += match[1] ? -1 : 1;
+    if (depth === 0) return html.slice(contentStart, match.index);
+  }
+  return null;
+}
+
+/**
+ * Best-effort caption extraction from the /embed/captioned/ page. Caption is a
+ * convenience for auto-matching the climb on share — never required, so any
+ * parse miss returns null and the user picks the climb manually. Tries the
+ * structured JSON (cleanest), then the rendered `.Caption` div (the whole point
+ * of the captioned variant), then the og:description meta.
+ */
+export function extractInstagramCaption(html: string, username: string | null): string | null {
+  const cap = (text: string): string | null => {
+    const trimmed = text.trim();
+    return trimmed ? trimmed.slice(0, MAX_CAPTION_LENGTH) : null;
+  };
+
+  const fromEdge = html.match(
+    /"edge_media_to_caption"\s*:\s*\{\s*"edges"\s*:\s*\[\s*\{\s*"node"\s*:\s*\{\s*"text"\s*:\s*"((?:\\.|[^"\\])*)"/,
+  );
+  if (fromEdge) {
+    const text = cap(decodeJsonString(fromEdge[1]));
+    if (text) return text;
+  }
+
+  // Require a `{`/`,` before the key so we don't latch onto "accessibility_caption".
+  const fromCaptionField = html.match(/[,{]\s*"caption"\s*:\s*"((?:\\.|[^"\\])*)"/);
+  if (fromCaptionField) {
+    const text = cap(decodeJsonString(fromCaptionField[1]));
+    if (text) return text;
+  }
+
+  const captionDiv = extractDivContentByClass(html, 'Caption');
+  if (captionDiv) {
+    // The caption div nests a "View all N comments" block (.CaptionComments)
+    // and sometimes a timestamp after the caption text — cut them off.
+    const commentsIdx = captionDiv.search(/class=["']Caption(?:Comments|Time)["']/i);
+    const captionOnly =
+      commentsIdx === -1
+        ? captionDiv
+        : captionDiv.slice(
+            0,
+            captionDiv.lastIndexOf('<div', commentsIdx) === -1
+              ? commentsIdx
+              : captionDiv.lastIndexOf('<div', commentsIdx),
+          );
+    let text = decodeHtmlEntities(captionOnly.replace(/<[^>]+>/g, ' '))
+      .replace(/\s+/g, ' ')
+      .trim();
+    // The CaptionUsername link renders the poster's handle as the first token.
+    if (username && text.toLowerCase().startsWith(username.toLowerCase())) {
+      text = text.slice(username.length).trim();
+    }
+    const capped = cap(text);
+    if (capped) return capped;
+  }
+
+  const ogDescription = html.match(/property=["']og:description["']\s+content=["']([^"']*)["']/i)?.[1];
+  if (ogDescription) {
+    const decoded = decodeHtmlEntities(ogDescription).trim();
+    // IG formats this as: `1,234 likes, 56 comments - username on Instagram: "caption"`.
+    const stripped = decoded
+      .replace(/^[\d,.]+\s+likes?,\s+[\d,.]+\s+comments?\s+-\s+.*?\son\sInstagram[^:]*:\s*/i, '')
+      .replace(/^["“]([\s\S]*)["”]$/, '$1')
+      .trim();
+    const text = cap(stripped || decoded);
+    if (text) return text;
+  }
+
+  return null;
 }
 
 /**
@@ -240,7 +335,9 @@ async function fetchInstagramMetaUncached(url: string): Promise<UncachedResult> 
   // shouldn't end up in boardBetaLinks.foreign_username.
   const username = sanitizeInstagramUsername(rawUsername);
 
-  return { status: 'ok', thumbnail, username };
+  const caption = extractInstagramCaption(html, username);
+
+  return { status: 'ok', thumbnail, username, caption };
 }
 
 export async function fetchInstagramMeta(url: string): Promise<InstagramMetaResult> {

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -213,6 +213,17 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
         : {}),
     },
     plugins: [
+      // MUST stay FIRST — do not move it after expo-share-intent. @expo/config-
+      // plugins composes withEntitlementsPlist mods so they execute in REVERSE
+      // registration order (the earliest-registered plugin's callback runs
+      // LAST). So registering this first is exactly what makes it run last and
+      // observe the final merged array after expo-share-intent has prepended its
+      // App Group. Verified against the installed @expo/config-plugins: with this
+      // plugin first the chain runs [share-intent, dedup] → one group; moving it
+      // after expo-share-intent runs [dedup, share-intent] → the duplicate
+      // survives. Same ordering rule the BoardseshWidgets build-settings plugin
+      // relies on below.
+      './plugins/with-share-intent-app-group-dedup',
       'expo-router',
       'expo-secure-store',
       'expo-localization',
@@ -245,6 +256,32 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       'expo-updates',
       'expo-web-browser',
       'react-native-ble-plx',
+      // Makes Boardsesh a share target so a beta video link shared from
+      // Instagram/TikTok (the OS share sheet) opens the app. iOS gets a no-UI
+      // Share Extension that redirects into the host app; Android gets an
+      // ACTION_SEND text intent filter. Restricted to links/text only (no
+      // image/movie/file activation rules) so it never appears for raw media.
+      // iosAppGroupIdentifier reuses the existing group.com.boardsesh.app (also
+      // the plugin default of group.<bundleId>) shared with the widget target;
+      // ./plugins/with-share-intent-app-group-dedup collapses the duplicate the
+      // plugin otherwise leaves in the main app's entitlements. Registered
+      // before @bacons/apple-targets — the share extension and the widget are
+      // independent Xcode targets, but EAS managed credentials must extend
+      // provisioning profiles for both com.boardsesh.app.share-extension and
+      // com.boardsesh.app.widgets on the next native build (NOT deliverable via
+      // OTA). androidIntentFilters only accepts text/* | image/* | video/* | */*.
+      [
+        'expo-share-intent',
+        {
+          iosActivationRules: {
+            NSExtensionActivationSupportsWebURLWithMaxCount: 1,
+            NSExtensionActivationSupportsText: true,
+          },
+          iosShareExtensionName: 'Boardsesh',
+          iosAppGroupIdentifier: 'group.com.boardsesh.app',
+          androidIntentFilters: ['text/*'],
+        },
+      ],
       // Signs the Android `release` build type with our keystore when the
       // ANDROID_KEYSTORE_* env vars are set (CI), falling back to debug signing
       // for local `expo prebuild`. Lets the android-apk-rn workflow produce a

--- a/packages/mobile/app/+native-intent.ts
+++ b/packages/mobile/app/+native-intent.ts
@@ -1,0 +1,22 @@
+import { getShareExtensionKey } from 'expo-share-intent';
+
+// Expo Router's redirect hook for OS-level deep links. The iOS Share Extension
+// (expo-share-intent) opens the app via a synthetic `com.boardsesh.app://...
+// dataUrl=<key>` URL; without this redirect Expo Router treats that as an
+// unmatched route and shows +not-found. Send it to the home route — the
+// ShareTargetProvider then reads the shared link from the native module and
+// routes on to /share-beta after auth + URL validation. Android delivers shares
+// through an ACTION_SEND intent (no deep-link path), so it falls through here
+// unchanged and the provider handles it the same way.
+export function redirectSystemPath({ path }: { path: string; initial: boolean }): string {
+  try {
+    if (path.includes(`dataUrl=${getShareExtensionKey()}`)) {
+      return '/';
+    }
+  } catch {
+    // getShareExtensionKey() can throw off-native (web, tests, module not
+    // loaded). Fall through to the no-op `return path` so ordinary deep links
+    // (join/universal links) still reach their destination — never reroute them.
+  }
+  return path;
+}

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -25,6 +25,7 @@ import { QueueProvider } from '../src/providers/queue-provider';
 import { QueueSnackbarProvider } from '../src/providers/queue-snackbar-provider';
 import { DrawerHostProvider } from '../src/providers/drawer-host-provider';
 import { DeepLinkProvider } from '../src/providers/deep-link-provider';
+import { ShareTargetProvider } from '../src/providers/share-target-provider';
 import { FeatureFlagsProvider } from '../src/providers/feature-flags-provider';
 import { PartyProfileProvider } from '../src/providers/party-profile-provider';
 import { ConnectionSettingsProvider } from '../src/providers/connection-settings-provider';
@@ -241,30 +242,39 @@ function RootLayout() {
                                         <BluetoothProviderWrapper>
                                           <DrawerHostProvider>
                                             <DeepLinkProvider>
-                                              <ThemedNavigation>
-                                                <Stack screenOptions={{ headerShown: false }} initialRouteName="index">
-                                                  <Stack.Screen name="index" />
-                                                  <Stack.Screen name="(tabs)" />
-                                                  <Stack.Screen
-                                                    name="auth"
-                                                    options={{ headerShown: false, gestureEnabled: false }}
-                                                  />
-                                                  <Stack.Screen name="session/[sessionId]" />
-                                                  <Stack.Screen
-                                                    name="join/[sessionId]"
-                                                    options={{ presentation: 'modal', headerShown: false }}
-                                                  />
-                                                  {/* Board selection is a modal off the Climbs capsule /
+                                              <ShareTargetProvider>
+                                                <ThemedNavigation>
+                                                  <Stack
+                                                    screenOptions={{ headerShown: false }}
+                                                    initialRouteName="index"
+                                                  >
+                                                    <Stack.Screen name="index" />
+                                                    <Stack.Screen name="(tabs)" />
+                                                    <Stack.Screen
+                                                      name="auth"
+                                                      options={{ headerShown: false, gestureEnabled: false }}
+                                                    />
+                                                    <Stack.Screen name="session/[sessionId]" />
+                                                    <Stack.Screen
+                                                      name="join/[sessionId]"
+                                                      options={{ presentation: 'modal', headerShown: false }}
+                                                    />
+                                                    <Stack.Screen
+                                                      name="share-beta"
+                                                      options={{ presentation: 'modal', headerShown: false }}
+                                                    />
+                                                    {/* Board selection is a modal off the Climbs capsule /
                                                       no-board CTA — board switching is rare, so it doesn't
                                                       earn a tab. Its own _layout owns the headers. */}
-                                                  <Stack.Screen
-                                                    name="boards"
-                                                    options={{ presentation: 'modal', headerShown: false }}
-                                                  />
-                                                </Stack>
-                                              </ThemedNavigation>
-                                              <PersistentQueueBar />
-                                              <AnalyticsScreenTracker />
+                                                    <Stack.Screen
+                                                      name="boards"
+                                                      options={{ presentation: 'modal', headerShown: false }}
+                                                    />
+                                                  </Stack>
+                                                </ThemedNavigation>
+                                                <PersistentQueueBar />
+                                                <AnalyticsScreenTracker />
+                                              </ShareTargetProvider>
                                             </DeepLinkProvider>
                                           </DrawerHostProvider>
                                         </BluetoothProviderWrapper>

--- a/packages/mobile/app/share-beta.tsx
+++ b/packages/mobile/app/share-beta.tsx
@@ -1,0 +1,317 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { StyleSheet, View, TextInput, Pressable } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { FlashList } from '@shopify/flash-list';
+import { Image } from 'expo-image';
+import * as Haptics from 'expo-haptics';
+import type { AscentFeedItem } from '@boardsesh/graphql/operations';
+import { Text } from '../src/components/Text';
+import { Button } from '../src/components/Button';
+import { Icon } from '../src/components/Icon';
+import { ActivityIndicator } from '../src/components/ActivityIndicator';
+import { LogbookRow } from '../src/components/you/LogbookRow';
+import { useTheme } from '../src/providers/theme-provider';
+import { useAuth } from '../src/providers/auth-provider';
+import { useToast } from '../src/providers/toast-provider';
+import { useProfile, useUserAscentsFeed, useAttachBetaLink, useBetaLinkPreview } from '../src/lib/graphql/hooks';
+import { partitionAscentsForShare } from '../src/lib/match-ascents-to-caption';
+import { extractGraphqlMessage } from '../src/lib/graphql/extract-error-message';
+import { spacing, borderRadius } from '../src/theme/tokens';
+import { iosSystemColors } from '../src/theme/ios-colors';
+import { brandColors } from '../src/theme/colors';
+
+// Keep the ascents query from refiring on every keystroke; commit the search
+// term after a short pause.
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Modal opened by the share target (ShareTargetProvider) after a beta video link
+ * is shared into Boardsesh from Instagram / TikTok. Lists the user's recent
+ * ascents (with a name search over their logged climbs) and attaches the shared
+ * link to the climb they pick, via the existing attachBetaLink mutation. The link
+ * arrives as a route param so this screen is decoupled from the native module.
+ */
+export default function ShareBetaScreen() {
+  const { link } = useLocalSearchParams<{ link: string }>();
+  const { t } = useTranslation('session');
+  const { systemColors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { isAuthenticated } = useAuth();
+  const { showToast } = useToast();
+  const { data: profile } = useProfile();
+  const attach = useAttachBetaLink();
+
+  // Best-effort: fetch the reel's thumbnail + caption so we can preview the post
+  // and auto-match the climb. Never blocks the manual picker.
+  const preview = useBetaLinkPreview(link);
+  const caption = preview.data?.caption ?? null;
+  const thumbnail = preview.data?.thumbnail ?? null;
+
+  const [searchText, setSearchText] = useState('');
+  const [committedQuery, setCommittedQuery] = useState('');
+  useEffect(() => {
+    const handle = setTimeout(() => setCommittedQuery(searchText.trim()), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [searchText]);
+
+  // Nothing to attach (shouldn't happen — the provider validates first); just
+  // dismiss rather than show a dead screen.
+  useEffect(() => {
+    if (!link) router.back();
+  }, [link, router]);
+
+  // statusMode 'both' so projects/attempts show too (people post beta of climbs
+  // they're still working). climbName filters the user's *logged* climbs when
+  // searching; the row shape is identical either way.
+  const feedInput = useMemo(
+    () =>
+      committedQuery ? ({ statusMode: 'both', climbName: committedQuery } as const) : ({ statusMode: 'both' } as const),
+    [committedQuery],
+  );
+  const feed = useUserAscentsFeed(profile?.id, feedInput);
+  // Memoized so the identity is stable while the query data is unchanged —
+  // keeps the caption→suggestion partition below from recomputing every render.
+  const items = useMemo(() => feed.data?.pages.flatMap((page) => page.userAscentsFeed.items) ?? [], [feed.data]);
+
+  const handleEndReached = useCallback(() => {
+    if (feed.hasNextPage && !feed.isFetchingNextPage) void feed.fetchNextPage();
+  }, [feed]);
+
+  const handleAttach = useCallback(
+    (ascent: AscentFeedItem) => {
+      if (!link || attach.isPending) return;
+      attach.mutate(
+        { boardType: ascent.boardType, climbUuid: ascent.climbUuid, link, angle: ascent.angle },
+        {
+          onSuccess: () => {
+            void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+            showToast(t('mobile.betaVideos.attachSuccess'), 'success');
+            router.back();
+          },
+          onError: (error: unknown) => {
+            // Surface the backend message verbatim — it carries the useful
+            // guidance ("post isn't available", "already attached to <climb>",
+            // "temporarily blocking us"). Keep the modal open so the user can
+            // pick a different climb or retry.
+            void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+            showToast(extractGraphqlMessage(error) ?? t('mobile.betaVideos.attachError'), 'error');
+          },
+        },
+      );
+    },
+    [attach, link, router, showToast, t],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: AscentFeedItem }) => <LogbookRow ascent={item} onPress={handleAttach} />,
+    [handleAttach],
+  );
+
+  // Auto-match the climb from the reel caption, partitioning the list into a
+  // "Suggested" group + the rest. Memoized (matcher is pure) so typing/preview
+  // state changes don't re-normalize every climb name. Hidden while searching.
+  const isSearching = committedQuery.length > 0;
+  const { suggestions, listData } = useMemo(
+    () => partitionAscentsForShare(caption, items, isSearching),
+    [caption, items, isSearching],
+  );
+  const showSuggestions = suggestions.length > 0;
+
+  const containerStyle = [styles.container, { backgroundColor: systemColors.background, paddingTop: insets.top }];
+
+  // Defense in depth — the provider stashes shares until login, so this is rare.
+  if (!isAuthenticated) {
+    return (
+      <View style={containerStyle}>
+        <View style={styles.centered}>
+          <Icon name="person" size={40} color={systemColors.secondaryLabel} />
+          <Text variant="title3" style={styles.centeredText}>
+            {t('mobile.betaVideos.shareSignIn')}
+          </Text>
+          <Button
+            title={t('mobile.betaVideos.shareSignInButton')}
+            variant="filled"
+            size="large"
+            onPress={() => router.replace('/auth/login')}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={containerStyle}>
+      <View style={styles.header}>
+        <Pressable
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel={t('mobile.betaVideos.shareClose')}
+          hitSlop={spacing[2]}
+          style={styles.closeButton}
+        >
+          <Icon name="close" size={22} color={systemColors.secondaryLabel} />
+        </Pressable>
+        <Text variant="headline">{t('mobile.betaVideos.shareTargetTitle')}</Text>
+        <View style={styles.closeButton} />
+      </View>
+
+      <View style={[styles.linkCard, { backgroundColor: systemColors.secondaryBackground }]}>
+        {thumbnail ? (
+          <Image source={{ uri: thumbnail }} style={styles.thumb} contentFit="cover" transition={150} />
+        ) : (
+          <View style={[styles.thumb, styles.thumbFallback]}>
+            <Icon name="video" size={20} color={brandColors.primary} />
+          </View>
+        )}
+        <View style={styles.linkText}>
+          <Text variant="subheadline" color={systemColors.label} numberOfLines={2}>
+            {caption ?? link}
+          </Text>
+          {preview.isLoading && (
+            <Text variant="caption2" color={systemColors.tertiaryLabel}>
+              {t('mobile.betaVideos.shareReadingCaption')}
+            </Text>
+          )}
+        </View>
+      </View>
+
+      <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.prompt}>
+        {t('mobile.betaVideos.shareTargetPrompt')}
+      </Text>
+
+      <TextInput
+        value={searchText}
+        onChangeText={setSearchText}
+        placeholder={t('mobile.betaVideos.shareSearchPlaceholder')}
+        placeholderTextColor={iosSystemColors.systemGray}
+        autoCapitalize="none"
+        autoCorrect={false}
+        returnKeyType="search"
+        style={[styles.input, { color: systemColors.label, borderColor: systemColors.separator }]}
+      />
+
+      <View style={styles.listWrapper} pointerEvents={attach.isPending ? 'none' : 'auto'}>
+        {!profile?.id || feed.isPending ? (
+          <View style={styles.centered}>
+            <ActivityIndicator size="large" />
+          </View>
+        ) : (
+          <FlashList
+            data={listData}
+            renderItem={renderItem}
+            keyExtractor={(item) => item.uuid}
+            keyboardShouldPersistTaps="handled"
+            onEndReached={handleEndReached}
+            onEndReachedThreshold={0.5}
+            contentContainerStyle={{ paddingBottom: insets.bottom + spacing[6] }}
+            ListHeaderComponent={
+              showSuggestions ? (
+                <View style={styles.suggestedSection}>
+                  <Text variant="footnote" color={brandColors.primary} style={styles.sectionLabel}>
+                    {t('mobile.betaVideos.shareSuggestedTitle')}
+                  </Text>
+                  {suggestions.map((ascent) => (
+                    <LogbookRow key={ascent.uuid} ascent={ascent} onPress={handleAttach} />
+                  ))}
+                  {listData.length > 0 && (
+                    <Text variant="footnote" color={systemColors.tertiaryLabel} style={styles.sectionLabel}>
+                      {t('mobile.betaVideos.shareOtherAscents')}
+                    </Text>
+                  )}
+                </View>
+              ) : null
+            }
+            ListFooterComponent={
+              feed.isFetchingNextPage ? (
+                <View style={styles.footer}>
+                  <ActivityIndicator size="small" />
+                </View>
+              ) : null
+            }
+            ListEmptyComponent={
+              showSuggestions ? null : (
+                <View style={styles.empty}>
+                  <Icon name="tick.outline" size={44} color={systemColors.tertiaryLabel} />
+                  <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptyText}>
+                    {isSearching ? t('mobile.betaVideos.shareNoResults') : t('mobile.betaVideos.shareNoAscents')}
+                  </Text>
+                </View>
+              )
+            }
+          />
+        )}
+      </View>
+
+      {attach.isPending && (
+        <View style={styles.overlay} pointerEvents="auto">
+          <ActivityIndicator size="large" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+  },
+  closeButton: { width: 32, height: 32, alignItems: 'center', justifyContent: 'center' },
+  linkCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    marginHorizontal: spacing[4],
+    padding: spacing[3],
+    borderRadius: borderRadius.md,
+  },
+  thumb: { width: 44, height: 44, borderRadius: borderRadius.sm },
+  thumbFallback: { alignItems: 'center', justifyContent: 'center' },
+  linkText: { flex: 1, gap: 2 },
+  suggestedSection: { gap: spacing[1] },
+  sectionLabel: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[1],
+    fontWeight: '600',
+  },
+  prompt: { paddingHorizontal: spacing[4], marginTop: spacing[4], marginBottom: spacing[2] },
+  input: {
+    marginHorizontal: spacing[4],
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    fontSize: 16,
+    marginBottom: spacing[2],
+  },
+  listWrapper: { flex: 1 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: spacing[4], padding: spacing[6] },
+  centeredText: { textAlign: 'center' },
+  footer: { paddingVertical: spacing[5], alignItems: 'center' },
+  empty: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: 96,
+    paddingHorizontal: spacing[8],
+    gap: spacing[3],
+  },
+  emptyText: { textAlign: 'center' },
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0,0,0,0.15)',
+  },
+});

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -63,6 +63,7 @@
     "expo-modules-core": "~56.0.13",
     "expo-router": "~56.2.8",
     "expo-secure-store": "~56.0.4",
+    "expo-share-intent": "^7.0.0",
     "expo-splash-screen": "~56.0.10",
     "expo-status-bar": "~56.0.4",
     "expo-symbols": "~56.0.5",

--- a/packages/mobile/plugins/with-share-intent-app-group-dedup.js
+++ b/packages/mobile/plugins/with-share-intent-app-group-dedup.js
@@ -1,0 +1,43 @@
+const { createRunOncePlugin, withEntitlementsPlist } = require('expo/config-plugins');
+
+// app.config.ts declares group.com.boardsesh.app in ios.entitlements (the single
+// source of truth — the BoardseshWidgets Live Activity target and the shared
+// keychain both depend on it). expo-share-intent's own withIosAppEntitlements
+// *prepends* the same App Group to the main app's application-groups array
+// without deduping (node_modules/expo-share-intent/plugin/build/ios/
+// withIosAppEntitlements.js), so the merged array ends up holding
+// group.com.boardsesh.app twice. A duplicated app-group entry is the kind of
+// thing codesign/EAS credential validation can choke on, so we collapse it.
+//
+// Must run AFTER expo-share-intent's entitlements mod. Expo executes user mods
+// in reverse registration order (the earliest plugin in the array runs last —
+// see @expo/config-plugins withMod), so this plugin is registered FIRST in
+// app.config.ts's plugins array to guarantee it runs last and sees the final,
+// merged array.
+const APP_GROUP_KEY = 'com.apple.security.application-groups';
+
+/**
+ * Collapse the application-groups entitlement to unique values, preserving
+ * order. Pure transform over the parsed entitlements object for testability.
+ *
+ * @param {Record<string, unknown>} entitlements
+ * @returns {Record<string, unknown>}
+ */
+function dedupeApplicationGroups(entitlements) {
+  const groups = entitlements[APP_GROUP_KEY];
+  if (Array.isArray(groups)) {
+    entitlements[APP_GROUP_KEY] = Array.from(new Set(groups));
+  }
+  return entitlements;
+}
+
+function withShareIntentAppGroupDedup(config) {
+  return withEntitlementsPlist(config, (modConfig) => {
+    modConfig.modResults = dedupeApplicationGroups(modConfig.modResults);
+    return modConfig;
+  });
+}
+
+module.exports = createRunOncePlugin(withShareIntentAppGroupDedup, 'with-share-intent-app-group-dedup', '1.0.0');
+module.exports.dedupeApplicationGroups = dedupeApplicationGroups;
+module.exports.APP_GROUP_KEY = APP_GROUP_KEY;

--- a/packages/mobile/src/components/play-drawer/BetaVideoAddSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/BetaVideoAddSheet.tsx
@@ -7,6 +7,7 @@ import { isBetaVideoUrl } from '@boardsesh/shared-schema';
 import { Sheet } from '../Sheet';
 import { Text } from '../Text';
 import { useAttachBetaLink } from '../../lib/graphql/hooks';
+import { extractGraphqlMessage } from '../../lib/graphql/extract-error-message';
 import { useToast } from '../../providers/toast-provider';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { brandColors } from '../../theme/colors';
@@ -128,18 +129,6 @@ export const BetaVideoAddSheet = forwardRef<BetaVideoAddSheetHandle, Props>(func
     </Sheet>
   );
 });
-
-// graphql-request throws ClientError-shaped errors with response.errors[].
-// Surface the first server message if present; otherwise fall back to the
-// generic toast string so we never leak fetch internals to users.
-function extractGraphqlMessage(error: unknown): string | null {
-  if (error && typeof error === 'object' && 'response' in error) {
-    const response = (error as { response?: { errors?: { message?: string }[] } }).response;
-    const first = response?.errors?.[0]?.message;
-    if (typeof first === 'string' && first.length > 0) return first;
-  }
-  return null;
-}
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/mobile/src/lib/__tests__/match-ascents-to-caption.test.ts
+++ b/packages/mobile/src/lib/__tests__/match-ascents-to-caption.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import type { AscentFeedItem } from '@boardsesh/graphql/operations';
+import { matchAscentsToCaption, partitionAscentsForShare } from '../match-ascents-to-caption';
+
+function makeAscent(climbName: string, climbUuid = climbName.toLowerCase().replace(/\s+/g, '-')): AscentFeedItem {
+  return {
+    uuid: `tick-${climbUuid}`,
+    climbUuid,
+    climbName,
+    setterUsername: null,
+    boardType: 'kilter',
+    layoutId: 1,
+    angle: 40,
+    isMirror: false,
+    status: 'send',
+    attemptCount: 1,
+    quality: null,
+    difficulty: null,
+    difficultyName: null,
+    consensusDifficulty: null,
+    consensusDifficultyName: null,
+    qualityAverage: null,
+    isBenchmark: false,
+    isNoMatch: false,
+    comment: '',
+    climbedAt: '2026-06-07T00:00:00.000Z',
+    frames: null,
+  };
+}
+
+describe('matchAscentsToCaption', () => {
+  it('matches a climb whose name appears in the caption', () => {
+    const ascents = [makeAscent('Purple Nurple'), makeAscent('The Crimp Master')];
+    const result = matchAscentsToCaption('Finally sent Purple Nurple today!', ascents);
+    expect(result.map((a) => a.climbName)).toEqual(['Purple Nurple']);
+  });
+
+  it('ignores diacritics, emoji, and punctuation on both sides', () => {
+    const ascents = [makeAscent('Café Crux')];
+    const result = matchAscentsToCaption('cafe crux 🔥 @ 40°!!!', ascents);
+    expect(result.map((a) => a.climbName)).toEqual(['Café Crux']);
+  });
+
+  it('matches whole names on word boundaries, not partial words', () => {
+    const ascents = [makeAscent('Crimp'), makeAscent('Crimpy McCrimpface')];
+    const result = matchAscentsToCaption('huge send on Crimpy McCrimpface', ascents);
+    // "Crimp" must NOT match inside "Crimpy".
+    expect(result.map((a) => a.climbName)).toEqual(['Crimpy McCrimpface']);
+  });
+
+  it('ranks the longer (more specific) match first', () => {
+    const ascents = [makeAscent('Slab'), makeAscent('Slab Master')];
+    const result = matchAscentsToCaption('Slab Master is the best', ascents);
+    expect(result.map((a) => a.climbName)).toEqual(['Slab Master', 'Slab']);
+  });
+
+  it('skips very short climb names to avoid false positives', () => {
+    const ascents = [makeAscent('Up')];
+    expect(matchAscentsToCaption('send Up there', ascents)).toEqual([]);
+  });
+
+  it('de-dupes by climb when the same climb was logged more than once', () => {
+    const ascents = [makeAscent('Purple Nurple', 'pn-1'), makeAscent('Purple Nurple', 'pn-1')];
+    const result = matchAscentsToCaption('Purple Nurple again', ascents);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns nothing for an empty or missing caption', () => {
+    const ascents = [makeAscent('Purple Nurple')];
+    expect(matchAscentsToCaption('', ascents)).toEqual([]);
+    expect(matchAscentsToCaption(null, ascents)).toEqual([]);
+    expect(matchAscentsToCaption(undefined, ascents)).toEqual([]);
+  });
+});
+
+describe('partitionAscentsForShare', () => {
+  it('pulls a caption-matched climb into suggestions and out of the main list', () => {
+    const ascents = [makeAscent('Purple Nurple', 'pn'), makeAscent('The Crimp Master', 'cm')];
+    const { suggestions, listData } = partitionAscentsForShare('Sent Purple Nurple!', ascents, false);
+    expect(suggestions.map((a) => a.climbUuid)).toEqual(['pn']);
+    expect(listData.map((a) => a.climbUuid)).toEqual(['cm']);
+  });
+
+  it('shows no suggestions and the full list while searching', () => {
+    const ascents = [makeAscent('Purple Nurple', 'pn'), makeAscent('The Crimp Master', 'cm')];
+    const { suggestions, listData } = partitionAscentsForShare('Sent Purple Nurple!', ascents, true);
+    expect(suggestions).toEqual([]);
+    expect(listData).toBe(ascents);
+  });
+
+  it('returns the full list unchanged when nothing matches', () => {
+    const ascents = [makeAscent('Purple Nurple', 'pn')];
+    expect(partitionAscentsForShare('a generic caption', ascents, false)).toEqual({
+      suggestions: [],
+      listData: ascents,
+    });
+    expect(partitionAscentsForShare(null, ascents, false)).toEqual({ suggestions: [], listData: ascents });
+  });
+});

--- a/packages/mobile/src/lib/__tests__/native-intent.test.ts
+++ b/packages/mobile/src/lib/__tests__/native-intent.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getShareExtensionKeyMock = vi.fn();
+vi.mock('expo-share-intent', () => ({
+  getShareExtensionKey: () => getShareExtensionKeyMock(),
+}));
+
+import { redirectSystemPath } from '../../../app/+native-intent';
+
+const JOIN_LINK = '/join/123e4567-e89b-12d3-a456-426614174000';
+
+describe('redirectSystemPath', () => {
+  beforeEach(() => {
+    getShareExtensionKeyMock.mockReset();
+  });
+
+  it('redirects the share-extension deep link to the home route', () => {
+    getShareExtensionKeyMock.mockReturnValue('SHAREKEY');
+    expect(redirectSystemPath({ path: 'com.boardsesh.app://share?dataUrl=SHAREKEY', initial: true })).toBe('/');
+  });
+
+  it('leaves ordinary deep links untouched', () => {
+    getShareExtensionKeyMock.mockReturnValue('SHAREKEY');
+    expect(redirectSystemPath({ path: JOIN_LINK, initial: true })).toBe(JOIN_LINK);
+  });
+
+  it('falls through to the original path (never reroutes) when getShareExtensionKey throws', () => {
+    // Off-native (web, tests, module not loaded) getShareExtensionKey can throw.
+    getShareExtensionKeyMock.mockImplementation(() => {
+      throw new Error('native module not loaded');
+    });
+    expect(redirectSystemPath({ path: JOIN_LINK, initial: true })).toBe(JOIN_LINK);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/share-intent-app-group-dedup-plugin.test.ts
+++ b/packages/mobile/src/lib/__tests__/share-intent-app-group-dedup-plugin.test.ts
@@ -1,0 +1,103 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+interface DedupPlugin {
+  dedupeApplicationGroups(entitlements: Record<string, unknown>): Record<string, unknown>;
+  APP_GROUP_KEY: string;
+}
+
+const plugin = require('../../../plugins/with-share-intent-app-group-dedup.js') as DedupPlugin;
+
+describe('with-share-intent-app-group-dedup', () => {
+  it('collapses the duplicate App Group expo-share-intent prepends', () => {
+    // What the merged entitlements look like after expo-share-intent prepends
+    // our group to the one already declared in ios.entitlements.
+    const entitlements = {
+      [plugin.APP_GROUP_KEY]: ['group.com.boardsesh.app', 'group.com.boardsesh.app'],
+    };
+
+    const result = plugin.dedupeApplicationGroups(entitlements);
+
+    expect(result[plugin.APP_GROUP_KEY]).toEqual(['group.com.boardsesh.app']);
+  });
+
+  it('preserves order and keeps distinct groups', () => {
+    const entitlements = {
+      [plugin.APP_GROUP_KEY]: ['group.com.boardsesh.app', 'group.com.boardsesh.other', 'group.com.boardsesh.app'],
+    };
+
+    const result = plugin.dedupeApplicationGroups(entitlements);
+
+    expect(result[plugin.APP_GROUP_KEY]).toEqual(['group.com.boardsesh.app', 'group.com.boardsesh.other']);
+  });
+
+  it('leaves entitlements without an application-groups array untouched', () => {
+    const entitlements = { 'aps-environment': 'production' };
+
+    const result = plugin.dedupeApplicationGroups(entitlements);
+
+    expect(result).toEqual({ 'aps-environment': 'production' });
+  });
+});
+
+describe('with-share-intent-app-group-dedup ordering (real mod chain)', () => {
+  // Run the entitlements mod chain through the real @expo/config-plugins
+  // composition to prove the dedup actually wins given the registration order in
+  // app.config.ts — not just that the pure transform works in isolation.
+  const { withEntitlementsPlist } = require('expo/config-plugins');
+
+  // Mirrors expo-share-intent's withIosAppEntitlements, which PREPENDS the App
+  // Group to the main app's application-groups without deduping (see
+  // node_modules/expo-share-intent/plugin/build/ios/withIosAppEntitlements.js).
+  const withPrependAppGroup = (config: unknown) =>
+    withEntitlementsPlist(config, (modConfig: { modResults: Record<string, unknown> }) => {
+      const existing = modConfig.modResults[plugin.APP_GROUP_KEY];
+      modConfig.modResults[plugin.APP_GROUP_KEY] = [
+        'group.com.boardsesh.app',
+        ...(Array.isArray(existing) ? existing : []),
+      ];
+      return modConfig;
+    });
+
+  const withDedup = (config: unknown) =>
+    withEntitlementsPlist(config, (modConfig: { modResults: Record<string, unknown> }) => {
+      modConfig.modResults = plugin.dedupeApplicationGroups(modConfig.modResults);
+      return modConfig;
+    });
+
+  async function runEntitlements(config: unknown): Promise<Record<string, unknown>> {
+    const mod = (
+      config as { mods: { ios: { entitlements: (c: unknown) => Promise<{ modResults: Record<string, unknown> }> } } }
+    ).mods.ios.entitlements;
+    // Seed modResults the way the base provider does from ios.entitlements.
+    const result = await mod({
+      ...(config as object),
+      modResults: { [plugin.APP_GROUP_KEY]: ['group.com.boardsesh.app'] },
+      modRequest: { projectRoot: '/tmp', platform: 'ios', modName: 'entitlements', introspect: true },
+    });
+    return result.modResults;
+  }
+
+  it('yields a single App Group when dedup is registered FIRST (app.config order)', async () => {
+    // Expo composes withEntitlementsPlist mods to run in reverse registration
+    // order, so registering dedup first makes it run LAST — after the prepend.
+    let config: unknown = { name: 'x', slug: 'x', mods: {} };
+    config = withDedup(config); // registered first
+    config = withPrependAppGroup(config); // registered after (mimics expo-share-intent)
+
+    expect(await runEntitlements(config)).toEqual({ [plugin.APP_GROUP_KEY]: ['group.com.boardsesh.app'] });
+  });
+
+  it('would leave the duplicate in the reverse order — pins WHY dedup must be first', async () => {
+    let config: unknown = { name: 'x', slug: 'x', mods: {} };
+    config = withPrependAppGroup(config); // registered first → runs last
+    config = withDedup(config); // registered after → runs first, before the prepend
+
+    expect(await runEntitlements(config)).toEqual({
+      [plugin.APP_GROUP_KEY]: ['group.com.boardsesh.app', 'group.com.boardsesh.app'],
+    });
+  });
+});

--- a/packages/mobile/src/lib/graphql/extract-error-message.ts
+++ b/packages/mobile/src/lib/graphql/extract-error-message.ts
@@ -1,0 +1,14 @@
+// graphql-request throws ClientError-shaped errors carrying response.errors[].
+// Surface the first server message when present so backend guidance reaches the
+// user verbatim (e.g. "This Instagram post isn't available", "already attached
+// to <other climb>", "Instagram is temporarily blocking us"); otherwise return
+// null so the caller can fall back to a generic toast string. Never leaks fetch
+// internals.
+export function extractGraphqlMessage(error: unknown): string | null {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const response = (error as { response?: { errors?: { message?: string }[] } }).response;
+    const first = response?.errors?.[0]?.message;
+    if (typeof first === 'string' && first.length > 0) return first;
+  }
+  return null;
+}

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-beta-link-preview.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-beta-link-preview.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const requestMock = vi.fn();
+vi.mock('../../client', () => ({
+  getHttpClient: () => ({ request: requestMock }),
+}));
+
+import { useBetaLinkPreview } from '../use-beta-link-preview';
+
+function wrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useBetaLinkPreview', () => {
+  beforeEach(() => {
+    requestMock.mockReset();
+  });
+
+  it('does not fetch when there is no link (enabled gating)', () => {
+    const { result } = renderHook(() => useBetaLinkPreview(undefined), { wrapper: wrapper() });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it('unwraps betaLinkPreview from the response', async () => {
+    const preview = {
+      link: 'https://www.instagram.com/reel/abc/',
+      thumbnail: 'https://cdn.example.com/x.jpg',
+      username: 'climber',
+      caption: 'Sent it 🧗',
+    };
+    requestMock.mockResolvedValueOnce({ betaLinkPreview: preview });
+
+    const { result } = renderHook(() => useBetaLinkPreview('https://www.instagram.com/reel/abc/'), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data).toEqual(preview);
+    expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -397,6 +397,7 @@ export function useAttachBetaLink() {
 // Re-export feature-specific hooks that live alongside this barrel so the
 // import surface from this directory stays a single path.
 export { useInfiniteSearchClimbs } from './use-infinite-search-climbs';
+export { useBetaLinkPreview } from './use-beta-link-preview';
 export { useMobileClimbActionsData } from './use-mobile-climb-actions-data';
 export {
   useAllBoardsTicks,

--- a/packages/mobile/src/lib/graphql/hooks/use-beta-link-preview.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-beta-link-preview.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  BETA_LINK_PREVIEW,
+  type BetaLinkPreviewQueryResponse,
+  type BetaLinkPreviewQueryVariables,
+} from '@boardsesh/graphql/operations/beta-links';
+import { getHttpClient } from '../client';
+
+/**
+ * Live preview of a shared Instagram/TikTok URL (thumbnail + caption) for the
+ * share flow, so the screen can auto-match the climb from the caption. Best
+ * effort — `retry: false` because a transient IG block shouldn't hammer the
+ * endpoint, and the screen falls back to the manual picker when this is empty.
+ *
+ * Standalone (not in the hooks barrel) so it stays importable without pulling
+ * react-native into unit tests.
+ */
+export function useBetaLinkPreview(link: string | undefined) {
+  return useQuery({
+    queryKey: ['betaLinkPreview', link],
+    queryFn: () =>
+      getHttpClient().request<BetaLinkPreviewQueryResponse, BetaLinkPreviewQueryVariables>(BETA_LINK_PREVIEW, {
+        link: link!,
+      }),
+    select: (data) => data.betaLinkPreview,
+    enabled: !!link,
+    staleTime: 10 * 60 * 1000,
+    retry: false,
+  });
+}

--- a/packages/mobile/src/lib/match-ascents-to-caption.ts
+++ b/packages/mobile/src/lib/match-ascents-to-caption.ts
@@ -1,0 +1,76 @@
+import type { AscentFeedItem } from '@boardsesh/graphql/operations';
+
+// Climb names shorter than this (after normalization) match too much random
+// caption text to be trustworthy, so we skip them and let the user pick
+// manually. Tunable; 4 keeps out "up", "yes", "g2"-style names.
+const MIN_MATCHABLE_NAME_LENGTH = 4;
+
+/**
+ * Lowercase, strip diacritics, and reduce to single-spaced alphanumerics so a
+ * caption like "Sent *Purple Nurple* 🔥 @ 40°" and a climb name "Purple Nurple"
+ * compare cleanly.
+ */
+function normalizeForMatch(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Find which of the user's recent ascents the shared reel is about by looking
+ * for their climb names inside the post caption. Matches whole names on word
+ * boundaries (so "Crimp" doesn't match "Crimpy McCrimpface"), de-dupes by climb,
+ * and ranks longer (more specific) names first — the strongest match leads.
+ *
+ * Returns [] when there's no caption or no confident hit, in which case the
+ * screen falls back to the plain recent-ascents list. Pure + side-effect free
+ * for unit testing.
+ */
+export function matchAscentsToCaption(caption: string | null | undefined, ascents: AscentFeedItem[]): AscentFeedItem[] {
+  if (!caption) return [];
+  const haystack = ` ${normalizeForMatch(caption)} `;
+  if (haystack.trim().length === 0) return [];
+
+  const seen = new Set<string>();
+  const scored: { ascent: AscentFeedItem; score: number }[] = [];
+
+  for (const ascent of ascents) {
+    const name = normalizeForMatch(ascent.climbName);
+    if (name.length < MIN_MATCHABLE_NAME_LENGTH) continue;
+    if (!haystack.includes(` ${name} `)) continue;
+    if (seen.has(ascent.climbUuid)) continue;
+    seen.add(ascent.climbUuid);
+    scored.push({ ascent, score: name.length });
+  }
+
+  return scored.sort((a, b) => b.score - a.score).map((entry) => entry.ascent);
+}
+
+export type ShareBetaList = {
+  suggestions: AscentFeedItem[];
+  listData: AscentFeedItem[];
+};
+
+/**
+ * Split the recent-ascents list for the share-beta picker into caption-matched
+ * "suggestions" and the remaining "other ascents", with the matched climbs
+ * pulled out of the main list so they aren't shown twice. While the user is
+ * actively searching we hand control back to them — no suggestions, the full
+ * (already name-filtered) list flows through. Pure for unit testing.
+ */
+export function partitionAscentsForShare(
+  caption: string | null | undefined,
+  ascents: AscentFeedItem[],
+  isSearching: boolean,
+): ShareBetaList {
+  const suggestions = isSearching ? [] : matchAscentsToCaption(caption, ascents);
+  if (suggestions.length === 0) {
+    return { suggestions, listData: ascents };
+  }
+  const suggestedUuids = new Set(suggestions.map((ascent) => ascent.climbUuid));
+  return { suggestions, listData: ascents.filter((ascent) => !suggestedUuids.has(ascent.climbUuid)) };
+}

--- a/packages/mobile/src/providers/__tests__/share-target-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/share-target-provider.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+// Controllable share-intent state. Mutate fields per test; the mocked hook reads
+// them at call time.
+const shareState: { hasShareIntent: boolean; shareIntent: { webUrl: string | null; text: string | null } } = {
+  hasShareIntent: false,
+  shareIntent: { webUrl: null, text: null },
+};
+const resetShareIntentMock = vi.fn();
+vi.mock('expo-share-intent', () => ({
+  useShareIntent: () => ({ ...shareState, resetShareIntent: resetShareIntentMock }),
+}));
+
+const navigateMock = vi.fn();
+vi.mock('expo-router', () => ({
+  useRouter: () => ({ navigate: navigateMock }),
+}));
+
+// In-memory AsyncStorage stand-in.
+const storage = new Map<string, string>();
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn(async (key: string) => storage.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: string) => {
+      storage.set(key, value);
+    }),
+    removeItem: vi.fn(async (key: string) => {
+      storage.delete(key);
+    }),
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const authState = { isAuthenticated: true };
+vi.mock('../auth-provider', () => ({
+  useAuth: () => authState,
+}));
+
+const showToastMock = vi.fn();
+vi.mock('../toast-provider', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+// Treat Instagram/TikTok URLs as valid beta links; everything else invalid.
+vi.mock('@boardsesh/shared-schema', () => ({
+  isBetaVideoUrl: (url: string) => /instagram\.com|tiktok\.com/.test(url),
+}));
+
+import { ShareTargetProvider, extractSharedLink } from '../share-target-provider';
+
+const INSTAGRAM_LINK = 'https://instagram.com/reel/abc123';
+const PENDING_SHARE_KEY = 'boardsesh_pending_share_link';
+
+function renderProvider() {
+  return render(<ShareTargetProvider>{null}</ShareTargetProvider>);
+}
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  resetShareIntentMock.mockReset();
+  showToastMock.mockReset();
+  storage.clear();
+  shareState.hasShareIntent = false;
+  shareState.shareIntent = { webUrl: null, text: null };
+  authState.isAuthenticated = true;
+});
+
+describe('extractSharedLink', () => {
+  it('prefers the structured webUrl', () => {
+    expect(extractSharedLink({ webUrl: '  https://instagram.com/reel/x  ', text: 'ignored' })).toBe(
+      'https://instagram.com/reel/x',
+    );
+  });
+
+  it('pulls the first URL out of caption text when there is no webUrl', () => {
+    expect(extractSharedLink({ webUrl: null, text: 'nice send https://instagram.com/reel/y 🔥' })).toBe(
+      'https://instagram.com/reel/y',
+    );
+  });
+
+  it('falls back from an empty webUrl to a URL in the text', () => {
+    expect(extractSharedLink({ webUrl: '', text: 'see https://tiktok.com/@me/video/1' })).toBe(
+      'https://tiktok.com/@me/video/1',
+    );
+  });
+
+  it('strips an emoji glued directly onto the URL', () => {
+    expect(extractSharedLink({ webUrl: null, text: 'crushed it https://www.instagram.com/reel/abc123🔥' })).toBe(
+      'https://www.instagram.com/reel/abc123',
+    );
+  });
+
+  it('strips wrapping brackets and trailing sentence punctuation', () => {
+    expect(extractSharedLink({ webUrl: null, text: '(https://www.instagram.com/reel/abc123).' })).toBe(
+      'https://www.instagram.com/reel/abc123',
+    );
+  });
+
+  it('preserves a canonical trailing slash', () => {
+    expect(extractSharedLink({ webUrl: null, text: 'see https://www.instagram.com/reel/abc123/ now' })).toBe(
+      'https://www.instagram.com/reel/abc123/',
+    );
+  });
+
+  it('returns null when there is no URL', () => {
+    expect(extractSharedLink({ webUrl: null, text: 'just words' })).toBeNull();
+    expect(extractSharedLink(null)).toBeNull();
+  });
+});
+
+describe('ShareTargetProvider', () => {
+  it('routes a shared beta link to the picker when authenticated', async () => {
+    authState.isAuthenticated = true;
+    shareState.hasShareIntent = true;
+    shareState.shareIntent = { webUrl: INSTAGRAM_LINK, text: null };
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith({ pathname: '/share-beta', params: { link: INSTAGRAM_LINK } });
+    });
+    expect(resetShareIntentMock).toHaveBeenCalled();
+    expect(storage.has(PENDING_SHARE_KEY)).toBe(false);
+  });
+
+  it('stashes a shared link for replay when signed out', async () => {
+    authState.isAuthenticated = false;
+    shareState.hasShareIntent = true;
+    shareState.shareIntent = { webUrl: INSTAGRAM_LINK, text: null };
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(storage.get(PENDING_SHARE_KEY)).toBe(INSTAGRAM_LINK);
+    });
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-beta URL with a toast and does not route', async () => {
+    authState.isAuthenticated = true;
+    shareState.hasShareIntent = true;
+    shareState.shareIntent = { webUrl: 'https://example.com/whatever', text: null };
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith('mobile.betaVideos.urlInvalid', 'error');
+    });
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(storage.has(PENDING_SHARE_KEY)).toBe(false);
+  });
+
+  it('replays a stashed link once authenticated and clears the stash', async () => {
+    storage.set(PENDING_SHARE_KEY, INSTAGRAM_LINK);
+    authState.isAuthenticated = true;
+    shareState.hasShareIntent = false;
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith({ pathname: '/share-beta', params: { link: INSTAGRAM_LINK } });
+    });
+    expect(storage.has(PENDING_SHARE_KEY)).toBe(false);
+  });
+});

--- a/packages/mobile/src/providers/share-target-provider.tsx
+++ b/packages/mobile/src/providers/share-target-provider.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, type ReactNode } from 'react';
+import { useRouter } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useShareIntent, type ShareIntent } from 'expo-share-intent';
+import { useTranslation } from 'react-i18next';
+import { isBetaVideoUrl } from '@boardsesh/shared-schema';
+import { useAuth } from './auth-provider';
+import { useToast } from './toast-provider';
+
+// Stash for a beta link shared before sign-in. Mirrors DeepLinkProvider's
+// PENDING_JOIN_KEY: the auth gate redirects an unauthenticated launch to
+// /auth/login (and the OAuth round-trip backgrounds the app), so we persist the
+// link and replay it once auth flips true. resetOnBackground is off too, but the
+// stash is the durable path across the login redirect.
+const PENDING_SHARE_KEY = 'boardsesh_pending_share_link';
+
+/**
+ * Pull the first http(s) URL out of a shared payload. The OS share sheet usually
+ * hands us a clean `webUrl`, but some apps share a caption + link as plain text
+ * ("nice send https://instagram.com/reel/..."), and isBetaVideoUrl is anchored
+ * ^...$ so it rejects surrounding words. Prefer the structured webUrl, then the
+ * first URL token inside the text. Exported for unit testing.
+ */
+export function extractSharedLink(shareIntent: Pick<ShareIntent, 'webUrl' | 'text'> | null): string | null {
+  if (!shareIntent) return null;
+  const webUrl = shareIntent.webUrl?.trim();
+  if (webUrl) return webUrl;
+  // Stop the URL before whitespace and closing wrappers ("(url)", "<url>",
+  // "url"), then strip trailing sentence punctuation / emoji glued to the URL
+  // ("...reel/abc🔥", "...reel/abc."). Without this, those trailing chars fail
+  // the anchored isBetaVideoUrl check and a valid link gets rejected. A trailing
+  // "/" (canonical IG/TikTok form) and query/fragment chars are preserved.
+  const match = shareIntent.text?.match(/https?:\/\/[^\s)\]}>"'«»]+/u);
+  if (!match) return null;
+  const trimmed = match[0].replace(/[\s\p{S}.,;:!?…]+$/u, '');
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Share-target receiver for the beta-video flow. Reads links shared into the app
+ * from another app's share sheet (Instagram / TikTok) via expo-share-intent and
+ * routes to the /share-beta picker. Attaching happens on that screen — this
+ * provider never writes.
+ *
+ * Auth survival mirrors DeepLinkProvider: a link that arrives while signed out is
+ * stashed in AsyncStorage and replayed once `useAuth().isAuthenticated` flips
+ * true. Non-beta URLs are rejected with a toast and never routed.
+ */
+export function ShareTargetProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const { isAuthenticated } = useAuth();
+  const { t } = useTranslation('session');
+  const { showToast } = useToast();
+  // resetOnBackground defaults to true; turn it off so the OAuth round-trip
+  // (which backgrounds the app) can't wipe a share before we've consumed it.
+  const { hasShareIntent, shareIntent, resetShareIntent } = useShareIntent({ resetOnBackground: false });
+
+  // Latest auth state for the async handlers, so the receive effect can read it
+  // without resubscribing on every auth change.
+  const isAuthenticatedRef = useRef(isAuthenticated);
+  isAuthenticatedRef.current = isAuthenticated;
+
+  const navigateToShare = useCallback(
+    (link: string) => {
+      // navigate (not push): reuses the modal if it's already open for the same
+      // link instead of stacking duplicates, and still opens it in the
+      // post-login replay case.
+      router.navigate({ pathname: '/share-beta', params: { link } });
+    },
+    [router],
+  );
+
+  const handleLink = useCallback(
+    async (link: string) => {
+      if (isAuthenticatedRef.current) {
+        navigateToShare(link);
+        return;
+      }
+      // Signed out: stash it for replay after login. The auth gate is about to
+      // redirect to /auth/login.
+      try {
+        await AsyncStorage.setItem(PENDING_SHARE_KEY, link);
+      } catch (error) {
+        if (__DEV__) console.warn('[share-target] failed to stash pending share', error);
+      }
+    },
+    [navigateToShare],
+  );
+
+  // React to an incoming share. Capture the link, then reset the native module
+  // so the same share isn't re-processed; resetting also flips hasShareIntent
+  // false, so this effect short-circuits on the next run rather than looping.
+  useEffect(() => {
+    if (!hasShareIntent) return;
+    const link = extractSharedLink(shareIntent);
+    resetShareIntent();
+    if (!link) return;
+    if (!isBetaVideoUrl(link)) {
+      showToast(t('mobile.betaVideos.urlInvalid'), 'error');
+      return;
+    }
+    void handleLink(link);
+  }, [hasShareIntent, shareIntent, resetShareIntent, handleLink, showToast, t]);
+
+  // Replay a pending share once authenticated (post-login, or a link received
+  // while signed out). Clears the stash on consume so it fires exactly once.
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const pendingLink = await AsyncStorage.getItem(PENDING_SHARE_KEY);
+        if (cancelled || !pendingLink) return;
+        await AsyncStorage.removeItem(PENDING_SHARE_KEY);
+        if (isBetaVideoUrl(pendingLink)) navigateToShare(pendingLink);
+      } catch (error) {
+        if (__DEV__) console.warn('[share-target] failed to consume pending share', error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, navigateToShare]);
+
+  return <>{children}</>;
+}

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -3485,6 +3485,20 @@ type RecentBetaLink {
 }
 
 """
+Live, unsaved metadata for a shared Instagram/TikTok URL — used by the mobile
+share flow to preview the post and auto-match the climb from the caption
+before anything is attached. Best-effort: any field can be null if the post is
+private/unavailable or the platform doesn't expose it (caption is currently
+Instagram-only). Never throws — the user can still attach manually.
+"""
+type BetaLinkPreview {
+  link: String!
+  thumbnail: String
+  username: String
+  caption: String
+}
+
+"""
 Root query type for all read operations.
 """
 type Query {
@@ -4065,6 +4079,14 @@ type Query {
   Returns only rows whose thumbnails are cached in our S3.
   """
   userBetaLinks(userId: String!, limit: Int = 50): [RecentBetaLink!]!
+
+  """
+  Live preview metadata for a shared Instagram/TikTok URL, before it's
+  attached. Powers the mobile share flow: shows the post thumbnail/caption and
+  lets the client auto-match the climb from the caption. Best-effort — returns
+  null fields rather than throwing when the post is unavailable.
+  """
+  betaLinkPreview(link: String!): BetaLinkPreview!
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -324,6 +324,21 @@ export type BetaLink = {
   thumbnail?: Maybe<Scalars['String']['output']>;
 };
 
+/**
+ * Live, unsaved metadata for a shared Instagram/TikTok URL — used by the mobile
+ * share flow to preview the post and auto-match the climb from the caption
+ * before anything is attached. Best-effort: any field can be null if the post is
+ * private/unavailable or the platform doesn't expose it (caption is currently
+ * Instagram-only). Never throws — the user can still attach manually.
+ */
+export type BetaLinkPreview = {
+  __typename?: 'BetaLinkPreview';
+  caption?: Maybe<Scalars['String']['output']>;
+  link: Scalars['String']['output'];
+  thumbnail?: Maybe<Scalars['String']['output']>;
+  username?: Maybe<Scalars['String']['output']>;
+};
+
 /** Board leaderboard result. */
 export type BoardLeaderboard = {
   __typename?: 'BoardLeaderboard';
@@ -2963,6 +2978,13 @@ export type Query = {
    */
   auroraCredentials: Array<AuroraCredentialStatus>;
   /**
+   * Live preview metadata for a shared Instagram/TikTok URL, before it's
+   * attached. Powers the mobile share flow: shows the post thumbnail/caption and
+   * lets the client auto-match the climb from the caption. Best-effort — returns
+   * null fields rather than throwing when the post is unavailable.
+   */
+  betaLinkPreview: BetaLinkPreview;
+  /**
    * Get external (Instagram, TikTok) beta links for a climb.
    * Live-checks each post and omits any that have been deleted or made private.
    * Caches thumbnails to our S3 bucket on first read.
@@ -3301,6 +3323,11 @@ export type QueryAnglesArgs = {
 /** Root query type for all read operations. */
 export type QueryAuroraCredentialArgs = {
   boardType: Scalars['String']['input'];
+};
+
+/** Root query type for all read operations. */
+export type QueryBetaLinkPreviewArgs = {
+  link: Scalars['String']['input'];
 };
 
 /** Root query type for all read operations. */
@@ -5302,6 +5329,7 @@ export type ResolversTypes = ResolversObject<{
   AuroraCredential: ResolverTypeWrapper<AuroraCredential>;
   AuroraCredentialStatus: ResolverTypeWrapper<AuroraCredentialStatus>;
   BetaLink: ResolverTypeWrapper<BetaLink>;
+  BetaLinkPreview: ResolverTypeWrapper<BetaLinkPreview>;
   BoardLeaderboard: ResolverTypeWrapper<BoardLeaderboard>;
   BoardLeaderboardEntry: ResolverTypeWrapper<BoardLeaderboardEntry>;
   BoardLeaderboardInput: BoardLeaderboardInput;
@@ -5563,6 +5591,7 @@ export type ResolversParentTypes = ResolversObject<{
   AuroraCredential: AuroraCredential;
   AuroraCredentialStatus: AuroraCredentialStatus;
   BetaLink: BetaLink;
+  BetaLinkPreview: BetaLinkPreview;
   BoardLeaderboard: BoardLeaderboard;
   BoardLeaderboardEntry: BoardLeaderboardEntry;
   BoardLeaderboardInput: BoardLeaderboardInput;
@@ -5928,6 +5957,17 @@ export type BetaLinkResolvers<
   isListed?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   link?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   thumbnail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type BetaLinkPreviewResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['BetaLinkPreview'] = ResolversParentTypes['BetaLinkPreview'],
+> = ResolversObject<{
+  caption?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  link?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  thumbnail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -7466,6 +7506,12 @@ export type QueryResolvers<
     RequireFields<QueryAuroraCredentialArgs, 'boardType'>
   >;
   auroraCredentials?: Resolver<Array<ResolversTypes['AuroraCredentialStatus']>, ParentType, ContextType>;
+  betaLinkPreview?: Resolver<
+    ResolversTypes['BetaLinkPreview'],
+    ParentType,
+    ContextType,
+    RequireFields<QueryBetaLinkPreviewArgs, 'link'>
+  >;
   betaLinks?: Resolver<
     Array<ResolversTypes['BetaLink']>,
     ParentType,
@@ -8695,6 +8741,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   AuroraCredential?: AuroraCredentialResolvers<ContextType>;
   AuroraCredentialStatus?: AuroraCredentialStatusResolvers<ContextType>;
   BetaLink?: BetaLinkResolvers<ContextType>;
+  BetaLinkPreview?: BetaLinkPreviewResolvers<ContextType>;
   BoardLeaderboard?: BoardLeaderboardResolvers<ContextType>;
   BoardLeaderboardEntry?: BoardLeaderboardEntryResolvers<ContextType>;
   BoardSerialConfig?: BoardSerialConfigResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/beta-links.ts
+++ b/packages/shared-schema/src/schema/beta-links.ts
@@ -23,4 +23,18 @@ export const betaLinksTypeDefs = /* GraphQL */ `
     boardType: String!
     layoutId: Int
   }
+
+  """
+  Live, unsaved metadata for a shared Instagram/TikTok URL — used by the mobile
+  share flow to preview the post and auto-match the climb from the caption
+  before anything is attached. Best-effort: any field can be null if the post is
+  private/unavailable or the platform doesn't expose it (caption is currently
+  Instagram-only). Never throws — the user can still attach manually.
+  """
+  type BetaLinkPreview {
+    link: String!
+    thumbnail: String
+    username: String
+    caption: String
+  }
 `;

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -580,5 +580,13 @@ export const queriesTypeDefs = /* GraphQL */ `
     Returns only rows whose thumbnails are cached in our S3.
     """
     userBetaLinks(userId: String!, limit: Int = 50): [RecentBetaLink!]!
+
+    """
+    Live preview metadata for a shared Instagram/TikTok URL, before it's
+    attached. Powers the mobile share flow: shows the post thumbnail/caption and
+    lets the client auto-match the climb from the caption. Best-effort — returns
+    null fields rather than throwing when the post is unavailable.
+    """
+    betaLinkPreview(link: String!): BetaLinkPreview!
   }
 `;

--- a/packages/shared/graphql/src/generated/gql.ts
+++ b/packages/shared/graphql/src/generated/gql.ts
@@ -20,6 +20,7 @@ type Documents = {
   '\n  mutation AttachBetaLink($input: AttachBetaLinkInput!) {\n    attachBetaLink(input: $input)\n  }\n': typeof types.AttachBetaLinkDocument;
   '\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n': typeof types.GetRecentBetaLinksDocument;
   '\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n': typeof types.GetUserBetaLinksDocument;
+  '\n  query BetaLinkPreview($link: String!) {\n    betaLinkPreview(link: $link) {\n      link\n      thumbnail\n      username\n      caption\n    }\n  }\n': typeof types.BetaLinkPreviewDocument;
   '\n  query ClimbStatsHistory($boardName: String!, $climbUuid: ID!) {\n    climbStatsHistory(boardName: $boardName, climbUuid: $climbUuid) {\n      angle\n      ascensionistCount\n      qualityAverage\n      difficultyAverage\n      displayDifficulty\n      createdAt\n    }\n  }\n': typeof types.ClimbStatsHistoryDocument;
   '\n  query GetGlobalCommentFeed($input: GlobalCommentFeedInput) {\n    globalCommentFeed(input: $input) {\n      comments {\n        uuid\n        userId\n        userDisplayName\n        userAvatarUrl\n        entityType\n        entityId\n        parentCommentUuid\n        body\n        isDeleted\n        replyCount\n        upvotes\n        downvotes\n        voteScore\n        userVote\n        createdAt\n        updatedAt\n      }\n      totalCount\n      hasMore\n      cursor\n    }\n  }\n': typeof types.GetGlobalCommentFeedDocument;
   '\n  query GetComments($input: CommentsInput!) {\n    comments(input: $input) {\n      comments {\n        uuid\n        userId\n        userDisplayName\n        userAvatarUrl\n        entityType\n        entityId\n        parentCommentUuid\n        body\n        isDeleted\n        replyCount\n        upvotes\n        downvotes\n        voteScore\n        userVote\n        createdAt\n        updatedAt\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.GetCommentsDocument;
@@ -135,6 +136,8 @@ const documents: Documents = {
     types.GetRecentBetaLinksDocument,
   '\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n':
     types.GetUserBetaLinksDocument,
+  '\n  query BetaLinkPreview($link: String!) {\n    betaLinkPreview(link: $link) {\n      link\n      thumbnail\n      username\n      caption\n    }\n  }\n':
+    types.BetaLinkPreviewDocument,
   '\n  query ClimbStatsHistory($boardName: String!, $climbUuid: ID!) {\n    climbStatsHistory(boardName: $boardName, climbUuid: $climbUuid) {\n      angle\n      ascensionistCount\n      qualityAverage\n      difficultyAverage\n      displayDifficulty\n      createdAt\n    }\n  }\n':
     types.ClimbStatsHistoryDocument,
   '\n  query GetGlobalCommentFeed($input: GlobalCommentFeedInput) {\n    globalCommentFeed(input: $input) {\n      comments {\n        uuid\n        userId\n        userDisplayName\n        userAvatarUrl\n        entityType\n        entityId\n        parentCommentUuid\n        body\n        isDeleted\n        replyCount\n        upvotes\n        downvotes\n        voteScore\n        userVote\n        createdAt\n        updatedAt\n      }\n      totalCount\n      hasMore\n      cursor\n    }\n  }\n':
@@ -384,6 +387,12 @@ export function graphql(
 export function graphql(
   source: '\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n',
 ): (typeof documents)['\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n'];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query BetaLinkPreview($link: String!) {\n    betaLinkPreview(link: $link) {\n      link\n      thumbnail\n      username\n      caption\n    }\n  }\n',
+): (typeof documents)['\n  query BetaLinkPreview($link: String!) {\n    betaLinkPreview(link: $link) {\n      link\n      thumbnail\n      username\n      caption\n    }\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -321,6 +321,21 @@ export type BetaLink = {
   thumbnail?: Maybe<Scalars['String']['output']>;
 };
 
+/**
+ * Live, unsaved metadata for a shared Instagram/TikTok URL — used by the mobile
+ * share flow to preview the post and auto-match the climb from the caption
+ * before anything is attached. Best-effort: any field can be null if the post is
+ * private/unavailable or the platform doesn't expose it (caption is currently
+ * Instagram-only). Never throws — the user can still attach manually.
+ */
+export type BetaLinkPreview = {
+  __typename?: 'BetaLinkPreview';
+  caption?: Maybe<Scalars['String']['output']>;
+  link: Scalars['String']['output'];
+  thumbnail?: Maybe<Scalars['String']['output']>;
+  username?: Maybe<Scalars['String']['output']>;
+};
+
 /** Board leaderboard result. */
 export type BoardLeaderboard = {
   __typename?: 'BoardLeaderboard';
@@ -2960,6 +2975,13 @@ export type Query = {
    */
   auroraCredentials: Array<AuroraCredentialStatus>;
   /**
+   * Live preview metadata for a shared Instagram/TikTok URL, before it's
+   * attached. Powers the mobile share flow: shows the post thumbnail/caption and
+   * lets the client auto-match the climb from the caption. Best-effort — returns
+   * null fields rather than throwing when the post is unavailable.
+   */
+  betaLinkPreview: BetaLinkPreview;
+  /**
    * Get external (Instagram, TikTok) beta links for a climb.
    * Live-checks each post and omits any that have been deleted or made private.
    * Caches thumbnails to our S3 bucket on first read.
@@ -3298,6 +3320,11 @@ export type QueryAnglesArgs = {
 /** Root query type for all read operations. */
 export type QueryAuroraCredentialArgs = {
   boardType: Scalars['String']['input'];
+};
+
+/** Root query type for all read operations. */
+export type QueryBetaLinkPreviewArgs = {
+  link: Scalars['String']['input'];
 };
 
 /** Root query type for all read operations. */
@@ -5268,6 +5295,21 @@ export type GetUserBetaLinksQuery = {
       createdAt?: string | null;
     };
   }>;
+};
+
+export type BetaLinkPreviewQueryVariables = Exact<{
+  link: Scalars['String']['input'];
+}>;
+
+export type BetaLinkPreviewQuery = {
+  __typename?: 'Query';
+  betaLinkPreview: {
+    __typename?: 'BetaLinkPreview';
+    link: string;
+    thumbnail?: string | null;
+    username?: string | null;
+    caption?: string | null;
+  };
 };
 
 export type ClimbStatsHistoryQueryVariables = Exact<{
@@ -7631,6 +7673,48 @@ export const GetUserBetaLinksDocument = {
     },
   ],
 } as unknown as DocumentNode<GetUserBetaLinksQuery, GetUserBetaLinksQueryVariables>;
+export const BetaLinkPreviewDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'BetaLinkPreview' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'link' } },
+          type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'betaLinkPreview' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'link' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'link' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'link' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'thumbnail' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'username' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'caption' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<BetaLinkPreviewQuery, BetaLinkPreviewQueryVariables>;
 export const ClimbStatsHistoryDocument = {
   kind: 'Document',
   definitions: [

--- a/packages/shared/graphql/src/operations/beta-links.ts
+++ b/packages/shared/graphql/src/operations/beta-links.ts
@@ -64,3 +64,24 @@ export const GET_USER_BETA_LINKS = gql`
     }
   }
 `;
+
+export const BETA_LINK_PREVIEW = gql`
+  query BetaLinkPreview($link: String!) {
+    betaLinkPreview(link: $link) {
+      link
+      thumbnail
+      username
+      caption
+    }
+  }
+`;
+
+export type BetaLinkPreviewRow = {
+  link: string;
+  thumbnail: string | null;
+  username: string | null;
+  caption: string | null;
+};
+
+export type BetaLinkPreviewQueryVariables = { link: string };
+export type BetaLinkPreviewQueryResponse = { betaLinkPreview: BetaLinkPreviewRow };

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -275,7 +275,18 @@
       "cardLabelWithUser": "Beta video by @{{username}}",
       "cardLabel": "Beta video",
       "openError": "Couldn't open this link",
-      "urlInvalid": "Needs to be an Instagram or TikTok URL"
+      "urlInvalid": "Needs to be an Instagram or TikTok URL",
+      "shareTargetTitle": "Attach your beta",
+      "shareTargetPrompt": "Tap the climb you sent it on",
+      "shareSearchPlaceholder": "Search your logged climbs",
+      "shareNoAscents": "Log a climb first, then pin your beta to it",
+      "shareNoResults": "No logged climbs match that",
+      "shareSignIn": "Sign in to attach your beta",
+      "shareSignInButton": "Sign in",
+      "shareClose": "Close",
+      "shareReadingCaption": "Reading the caption…",
+      "shareSuggestedTitle": "Matched from the caption",
+      "shareOtherAscents": "Your other ascents"
     },
     "angleSelector": {
       "title": "Choose Angle",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -275,7 +275,18 @@
       "cardLabelWithUser": "Video beta de @{{username}}",
       "cardLabel": "Video beta",
       "openError": "No se pudo abrir este enlace",
-      "urlInvalid": "Debe ser una URL de Instagram o TikTok"
+      "urlInvalid": "Debe ser una URL de Instagram o TikTok",
+      "shareTargetTitle": "Adjunta tu beta",
+      "shareTargetPrompt": "Toca el bloque que escalaste",
+      "shareSearchPlaceholder": "Busca en tus bloques registrados",
+      "shareNoAscents": "Registra un bloque primero y luego adjunta tu beta",
+      "shareNoResults": "Ningún bloque registrado coincide",
+      "shareSignIn": "Inicia sesión para adjuntar tu beta",
+      "shareSignInButton": "Iniciar sesión",
+      "shareClose": "Cerrar",
+      "shareReadingCaption": "Leyendo la descripción…",
+      "shareSuggestedTitle": "Encontrado en la descripción",
+      "shareOtherAscents": "Tus otros ascensos"
     },
     "angleSelector": {
       "title": "Elegir ángulo",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -275,7 +275,18 @@
       "cardLabelWithUser": "Video beta de @{{username}}",
       "cardLabel": "Video beta",
       "openError": "Impossible d ouvrir ce lien",
-      "urlInvalid": "Doit etre une URL Instagram ou TikTok"
+      "urlInvalid": "Doit etre une URL Instagram ou TikTok",
+      "shareTargetTitle": "Joindre ta beta",
+      "shareTargetPrompt": "Touche le bloc que tu as grimpe",
+      "shareSearchPlaceholder": "Cherche dans tes blocs enregistres",
+      "shareNoAscents": "Enregistre un bloc d abord, puis joins ta beta",
+      "shareNoResults": "Aucun bloc enregistre ne correspond",
+      "shareSignIn": "Connecte-toi pour joindre ta beta",
+      "shareSignInButton": "Se connecter",
+      "shareClose": "Fermer",
+      "shareReadingCaption": "Lecture de la description...",
+      "shareSuggestedTitle": "Trouve dans la description",
+      "shareOtherAscents": "Tes autres ascensions"
     },
     "angleSelector": {
       "title": "Choisir l'angle",


### PR DESCRIPTION
## What & why

Today a climber posts a beta reel on Instagram/TikTok, then has to switch to Boardsesh, find the climb, and paste the link. This makes Boardsesh a **share target**: from the OS share sheet on a reel, tap **Boardsesh** and pin it to a climb in a tap or two. **Mobile only.**

The data layer already existed (`attachBetaLink`, `board_beta_links`, IG/TikTok URL validation, dedup, thumbnails) — this is mostly the native share-target plumbing, a pick-an-ascent screen, and caption-based auto-matching.

## Share target + picker
- **`expo-share-intent`** (v7): iOS no-UI share extension that redirects into the host app + Android `ACTION_SEND` text filter. Restricted to links/text (no raw media).
- **`ShareTargetProvider`** mirrors the existing `DeepLinkProvider`: validates the shared link (`isBetaVideoUrl`), routes to `/share-beta`, and stashes to AsyncStorage so a share survives the sign-in round-trip. `app/+native-intent.ts` keeps Expo Router off `+not-found`.
- **`/share-beta`** modal lists recent ascents (incl. attempts/projects) with a name search over logged climbs; tapping attaches via the existing `attachBetaLink`, surfacing backend errors verbatim and keeping the sheet open to retry.
- **`with-share-intent-app-group-dedup`** plugin collapses the duplicate App Group `expo-share-intent` prepends (we reuse the existing `group.com.boardsesh.app` shared with the Live Activity widget).

## Caption auto-match
- Parse the reel caption from Instagram's already-fetched `/embed/captioned/` page (`extractInstagramCaption`).
- New **`betaLinkPreview(link)`** query (auth + 30/min rate limit, best-effort — returns null fields, never throws) returns the post thumbnail + caption.
- **`matchAscentsToCaption`** surfaces the matching climb in a "Matched from the caption" group above the picker.

Everything is best-effort: any fetch/parse/match miss degrades silently to the manual picker.

## Notes
- ⚠️ **Requires a fresh native build** (new iOS extension target + entitlements + Android intent filter) — not deliverable via OTA. Cut a preview build for testers.
- Caption matching is **Instagram-only** for now (TikTok captions are a small follow-up via oEmbed `title`) and matches against the user's loaded recent ascents.
- No silent auto-attach — the backend's cross-climb dedup is fatal, so it stays one-tap confirm.

## Validation
Full `typecheck` (all packages, codegen regenerated) · backend tests (34) · mobile tests (936, incl. new matcher/provider/plugin tests) · `check:mobile-bundle` (Android) · `check:mobile-native-deps` · i18n orphans + catalog completeness · format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
