### PR TITLE
Restore toast variant semantics on the Material path

### DIFF
--- a/packages/mobile/src/components/GlassIconButton.tsx
+++ b/packages/mobile/src/components/GlassIconButton.tsx
@@ -91,6 +91,11 @@ function GlassIconButtonMaterial({
     <View style={[styles.wrapper, { width: size, height: size }]}>
       <PaperIconButton
         icon={iconMap[iconName].android}
+        // Paper types iconColor as `string`. In the Material branch our themed
+        // colours resolve from materialSurfaces (hex/rgba strings on every
+        // platform), so no PlatformColor opaque ref reaches here; even if one
+        // did, Paper forwards it to MaterialCommunityIcons' `color`, which
+        // accepts ColorValue at runtime. The cast just satisfies Paper's type.
         iconColor={iconColor as string}
         size={iconSize}
         // Match the circular target diameter; Paper's default margin would

--- a/packages/mobile/src/components/QueueAddedSnackbar.tsx
+++ b/packages/mobile/src/components/QueueAddedSnackbar.tsx
@@ -45,7 +45,9 @@ function QueueAddedSnackbarMaterial({
 
   // Sit above the queue controls when they are showing; otherwise just above the
   // tab bar/safe area. The nonce forces a remount so the entrance + Paper's own
-  // auto-dismiss timer replay on each show.
+  // auto-dismiss timer replay on each show. Paper's wrapper is
+  // pointerEvents="box-none", so taps outside the pill reach content behind it —
+  // matching the glass path's absoluteFill/box-none wrapper.
   const bottom = bottomChrome.floatingControlBottom + spacing[2];
   const wrapperStyle: ViewStyle = { bottom };
 

--- a/packages/mobile/src/components/SegmentedControl.tsx
+++ b/packages/mobile/src/components/SegmentedControl.tsx
@@ -115,8 +115,9 @@ function SegmentedControlMaterial<K extends string = string>({
     disabled: disabledKeys?.has(option.key) ?? false,
   }));
 
+  // Paper never fires onValueChange for a button rendered disabled, so disabled
+  // keys can't reach here — no re-check needed.
   const handleValueChange = (nextKey: K) => {
-    if (disabledKeys?.has(nextKey)) return;
     hapticSelection();
     onSelect(nextKey);
   };

--- a/packages/mobile/src/components/Toast.tsx
+++ b/packages/mobile/src/components/Toast.tsx
@@ -7,7 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Text } from './Text';
 import { Icon } from './Icon';
 import type { IconName } from './icon-map';
-import { brandColors, withAlpha } from '../theme/colors';
+import { brandColors, blendOpaque, withAlpha } from '../theme/colors';
 import { borderRadius, spacing } from '../theme/tokens';
 import { TAB_BAR_HEIGHT, TOOLBAR_RESERVE } from '../theme/layout';
 import { isTabsRoute } from '../lib/route-segments';
@@ -63,17 +63,42 @@ function useToastBottomOffset() {
 }
 
 function ToastMaterial({ toast, onDismiss }: ToastProps) {
+  const { systemColors, colorScheme } = useTheme();
   const bottomOffset = useToastBottomOffset();
+  const config = VARIANT_CONFIG[toast.variant];
 
   // Paper drives its own auto-dismiss timer off `duration` + `onDismiss`, so we
   // don't run a manual setTimeout on the Material path (it would double-fire).
   // The glass toast has no tappable affordance, so we omit Paper's trailing
-  // icon-dismiss button to keep the same auto-dismiss-only interaction.
+  // icon-dismiss button to keep the same auto-dismiss-only interaction. Paper's
+  // wrapper is pointerEvents="box-none", so taps outside the pill reach content
+  // behind it — matching the glass path's absoluteFill/box-none wrapper.
   const wrapperStyle: ViewStyle = { bottom: bottomOffset };
 
+  // Carry the same variant cue as the glass pill: an opaque brand-hued wash over
+  // the surface (legible while floating over content) plus a leading icon and
+  // brand-coloured label. Passing our own content node lets us own the icon and
+  // text colour rather than inheriting Paper's inverse-surface text colour.
+  const backgroundColor = blendOpaque(
+    config.color,
+    systemColors.secondaryBackground as string,
+    colorScheme === 'dark' ? 0.24 : 0.15,
+  );
+
   return (
-    <Snackbar visible onDismiss={() => onDismiss(toast.id)} duration={toast.duration} wrapperStyle={wrapperStyle}>
-      {toast.message}
+    <Snackbar
+      visible
+      onDismiss={() => onDismiss(toast.id)}
+      duration={toast.duration}
+      wrapperStyle={wrapperStyle}
+      style={{ backgroundColor }}
+    >
+      <View style={styles.materialContent} accessibilityRole="alert" accessibilityLiveRegion="assertive">
+        <Icon name={config.icon} size={18} color={config.color} />
+        <Text variant="subheadline" color={config.color} style={styles.message} numberOfLines={2}>
+          {toast.message}
+        </Text>
+      </View>
     </Snackbar>
   );
 }
@@ -135,5 +160,10 @@ const styles = StyleSheet.create({
   },
   message: {
     flexShrink: 1,
+  },
+  materialContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
   },
 });

--- a/packages/mobile/src/components/Toast.tsx
+++ b/packages/mobile/src/components/Toast.tsx
@@ -79,6 +79,10 @@ function ToastMaterial({ toast, onDismiss }: ToastProps) {
   // the surface (legible while floating over content) plus a leading icon and
   // brand-coloured label. Passing our own content node lets us own the icon and
   // text colour rather than inheriting Paper's inverse-surface text colour.
+  // `secondaryBackground as string`: on the Material path themed colours resolve
+  // from materialSurfaces (hex strings on every platform), never a PlatformColor
+  // opaque ref; blendOpaque also returns its background unchanged for non-hex
+  // input, so the cast is safe.
   const backgroundColor = blendOpaque(
     config.color,
     systemColors.secondaryBackground as string,
@@ -93,6 +97,10 @@ function ToastMaterial({ toast, onDismiss }: ToastProps) {
       wrapperStyle={wrapperStyle}
       style={{ backgroundColor }}
     >
+      {/* role + assertive live region sit on our content node, not the Snackbar
+          root (Paper owns that and sets its own polite region). The glass path
+          puts them on its container; here the content View is the equivalent
+          announced node, so TalkBack reads the message assertively either way. */}
       <View style={styles.materialContent} accessibilityRole="alert" accessibilityLiveRegion="assertive">
         <Icon name={config.icon} size={18} color={config.color} />
         <Text variant="subheadline" color={config.color} style={styles.message} numberOfLines={2}>

--- a/packages/mobile/src/components/__tests__/segmented-control.test.tsx
+++ b/packages/mobile/src/components/__tests__/segmented-control.test.tsx
@@ -32,7 +32,8 @@ vi.mock('react-native-paper', () => ({
           key: button.value,
           'data-segment-value': button.value,
           'data-disabled': button.disabled ? 'true' : 'false',
-          onClick: () => onValueChange(button.value),
+          // Real Paper never fires onValueChange for a disabled button.
+          onClick: button.disabled ? undefined : () => onValueChange(button.value),
         }),
       ),
     ),

--- a/packages/mobile/src/components/__tests__/toast.test.tsx
+++ b/packages/mobile/src/components/__tests__/toast.test.tsx
@@ -6,9 +6,10 @@ import { createElement, type ReactNode } from 'react';
 // Controls the resolved UI variant the Toast branches on.
 const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
 
-type ViewMockProps = { children?: ReactNode };
+type ViewMockProps = { children?: ReactNode; accessibilityRole?: string };
 vi.mock('react-native', () => ({
-  View: ({ children }: ViewMockProps) => createElement('div', { 'data-view': 'true' }, children),
+  View: ({ children, accessibilityRole }: ViewMockProps) =>
+    createElement('div', { 'data-view': 'true', 'data-role': accessibilityRole ?? '' }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {} },
 }));
 
@@ -28,15 +29,17 @@ type SnackbarMockProps = {
   duration?: number;
   onDismiss?: () => void;
   children?: ReactNode;
+  style?: { backgroundColor?: string };
 };
 vi.mock('react-native-paper', () => ({
-  Snackbar: ({ visible, duration, onDismiss, children }: SnackbarMockProps) =>
+  Snackbar: ({ visible, duration, onDismiss, children, style }: SnackbarMockProps) =>
     createElement(
       'div',
       {
         'data-paper-snackbar': 'true',
         'data-visible': visible ? 'true' : 'false',
         'data-duration': String(duration ?? ''),
+        'data-bg': style?.backgroundColor ?? '',
         onClick: onDismiss,
       },
       children,
@@ -55,6 +58,7 @@ vi.mock('../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement(
 vi.mock('../../theme/colors', () => ({
   brandColors: { success: '#34C759', error: '#FF3B30', primary: '#8C4A52', warning: '#FF9500' },
   withAlpha: (color: string) => color,
+  blendOpaque: (_foreground: string, background: string) => background,
 }));
 vi.mock('../../theme/tokens', () => ({ borderRadius: { full: 999 }, spacing: { 2: 8, 3: 12, 4: 16 } }));
 vi.mock('../../theme/layout', () => ({ TAB_BAR_HEIGHT: 49, TOOLBAR_RESERVE: 56 }));
@@ -80,6 +84,10 @@ describe('Toast', () => {
     expect(snackbar?.getAttribute('data-visible')).toBe('true');
     expect(snackbar?.getAttribute('data-duration')).toBe('3000'); // duration mapped through
     expect(snackbar?.textContent).toContain('Saved tick'); // message mapped through
+    // Variant cue carries through: leading icon, brand-tinted surface, alert role.
+    expect(container.querySelector('[data-icon="success"]')).not.toBeNull();
+    expect(snackbar?.getAttribute('data-bg')).toBe('#EEE'); // blendOpaque → base surface (mocked)
+    expect(container.querySelector('[data-view][data-role="alert"]')).not.toBeNull();
     // The glass animated pill must not render on Material.
     expect(container.querySelector('[data-animated]')).toBeNull();
   });

--- a/packages/mobile/src/components/__tests__/toast.test.tsx
+++ b/packages/mobile/src/components/__tests__/toast.test.tsx
@@ -58,7 +58,9 @@ vi.mock('../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement(
 vi.mock('../../theme/colors', () => ({
   brandColors: { success: '#34C759', error: '#FF3B30', primary: '#8C4A52', warning: '#FF9500' },
   withAlpha: (color: string) => color,
-  blendOpaque: (_foreground: string, background: string) => background,
+  // Encode both args so tests can assert the variant colour (foreground) and the
+  // surface (background) both reach blendOpaque — i.e. the colour-selection logic.
+  blendOpaque: (foreground: string, background: string) => `${foreground}|${background}`,
 }));
 vi.mock('../../theme/tokens', () => ({ borderRadius: { full: 999 }, spacing: { 2: 8, 3: 12, 4: 16 } }));
 vi.mock('../../theme/layout', () => ({ TAB_BAR_HEIGHT: 49, TOOLBAR_RESERVE: 56 }));
@@ -86,10 +88,27 @@ describe('Toast', () => {
     expect(snackbar?.textContent).toContain('Saved tick'); // message mapped through
     // Variant cue carries through: leading icon, brand-tinted surface, alert role.
     expect(container.querySelector('[data-icon="success"]')).not.toBeNull();
-    expect(snackbar?.getAttribute('data-bg')).toBe('#EEE'); // blendOpaque → base surface (mocked)
+    // blendOpaque(config.color, secondaryBackground): success → brand success hue.
+    expect(snackbar?.getAttribute('data-bg')).toBe('#34C759|#EEE');
     expect(container.querySelector('[data-view][data-role="alert"]')).not.toBeNull();
     // The glass animated pill must not render on Material.
     expect(container.querySelector('[data-animated]')).toBeNull();
+  });
+
+  it('selects the matching icon + tint per variant on the Material variant', () => {
+    ctrl.variant = 'material';
+    const cases = [
+      { variant: 'error' as const, icon: 'error', color: '#FF3B30' },
+      { variant: 'warning' as const, icon: 'warning', color: '#FF9500' },
+      { variant: 'info' as const, icon: 'info', color: '#8C4A52' },
+    ];
+    for (const { variant, icon, color } of cases) {
+      const { container } = render(
+        <Toast toast={{ id: variant, message: 'msg', variant, duration: 3000 }} onDismiss={() => {}} />,
+      );
+      expect(container.querySelector(`[data-icon="${icon}"]`)).not.toBeNull();
+      expect(container.querySelector('[data-paper-snackbar]')?.getAttribute('data-bg')).toBe(`${color}|#EEE`);
+    }
   });
 
   it('routes Paper onDismiss to onDismiss(toast.id)', () => {

--- a/packages/mobile/src/theme/__tests__/colors.test.ts
+++ b/packages/mobile/src/theme/__tests__/colors.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+
+// colors.ts touches Platform/PlatformColor at import; Android skips the iOS branch.
+vi.mock('react-native', () => ({ Platform: { OS: 'android' }, PlatformColor: (name: string) => name }));
+
+import { blendOpaque, withAlpha } from '../colors';
+
+describe('withAlpha', () => {
+  it('emits rgba() for hex input', () => {
+    expect(withAlpha('#8C4A52', 0.15)).toBe('rgba(140, 74, 82, 0.15)');
+  });
+
+  it('returns non-hex input unchanged', () => {
+    expect(withAlpha('rgba(1, 2, 3, 0.4)', 0.2)).toBe('rgba(1, 2, 3, 0.4)');
+  });
+});
+
+describe('blendOpaque', () => {
+  it('composites foreground over background at alpha as opaque hex', () => {
+    // 15% of pure red over white → light pink, fully opaque.
+    expect(blendOpaque('#FF0000', '#FFFFFF', 0.15)).toBe('#ffd9d9');
+  });
+
+  it('alpha 0 returns the background, alpha 1 returns the foreground', () => {
+    expect(blendOpaque('#123456', '#ffffff', 0)).toBe('#ffffff');
+    expect(blendOpaque('#123456', '#ffffff', 1)).toBe('#123456');
+  });
+
+  it('expands 3-digit hex before blending', () => {
+    expect(blendOpaque('#000', '#fff', 0.5)).toBe('#808080');
+  });
+
+  it('returns the background unchanged when an input is not hex', () => {
+    expect(blendOpaque('rgba(0,0,0,1)', '#1F1A1B', 0.2)).toBe('#1F1A1B');
+  });
+});

--- a/packages/mobile/src/theme/colors.ts
+++ b/packages/mobile/src/theme/colors.ts
@@ -119,6 +119,18 @@ export type AndroidFallbackColors = typeof androidFallbackColors;
 export type MaterialSurfaces = typeof materialSurfaces;
 
 /**
+ * Normalise a `#RGB`/`#RRGGBB` hex string to a 6-digit hex (no `#`), or return
+ * `null` for any other format (already-`rgba()`, named colour, PlatformColor).
+ * Shared by `withAlpha` and `parseHex` so the expansion/validation rule can't
+ * drift between them.
+ */
+function expandHex(color: string): string | null {
+  const hex = color.replace('#', '');
+  const full = hex.length === 3 ? hex.replace(/(.)/g, '$1$1') : hex;
+  return full.length === 6 && !/[^0-9a-fA-F]/.test(full) ? full : null;
+}
+
+/**
  * Apply an alpha (0–1) to a colour. Handles `#RGB` and `#RRGGBB` hex by
  * emitting an `rgba()` string; any other format (already-`rgba()`, named
  * colour, PlatformColor) is returned unchanged so this never produces an
@@ -126,9 +138,8 @@ export type MaterialSurfaces = typeof materialSurfaces;
  * only works for 6-digit hex.
  */
 export function withAlpha(color: string, alpha: number): string {
-  const hex = color.replace('#', '');
-  const full = hex.length === 3 ? hex.replace(/(.)/g, '$1$1') : hex;
-  if (full.length !== 6 || /[^0-9a-fA-F]/.test(full)) {
+  const full = expandHex(color);
+  if (!full) {
     if (__DEV__) {
       // eslint-disable-next-line no-console
       console.warn(`[withAlpha] expected a hex colour, got "${color}" — returning it unchanged (alpha not applied)`);
@@ -142,9 +153,8 @@ export function withAlpha(color: string, alpha: number): string {
 }
 
 function parseHex(color: string): [number, number, number] | null {
-  const hex = color.replace('#', '');
-  const full = hex.length === 3 ? hex.replace(/(.)/g, '$1$1') : hex;
-  if (full.length !== 6 || /[^0-9a-fA-F]/.test(full)) return null;
+  const full = expandHex(color);
+  if (!full) return null;
   return [parseInt(full.slice(0, 2), 16), parseInt(full.slice(2, 4), 16), parseInt(full.slice(4, 6), 16)];
 }
 
@@ -165,7 +175,7 @@ export function blendOpaque(foreground: string, background: string, alpha: numbe
   const fg = parseHex(foreground);
   const bg = parseHex(background);
   if (!fg || !bg) {
-    if (__DEV__ && (!fg || !bg)) {
+    if (__DEV__) {
       // eslint-disable-next-line no-console
       console.warn(
         `[blendOpaque] expected hex colours, got foreground "${foreground}" / background "${background}" — returning background unchanged`,

--- a/packages/mobile/src/theme/colors.ts
+++ b/packages/mobile/src/theme/colors.ts
@@ -140,3 +140,39 @@ export function withAlpha(color: string, alpha: number): string {
   const b = parseInt(full.slice(4, 6), 16);
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
+
+function parseHex(color: string): [number, number, number] | null {
+  const hex = color.replace('#', '');
+  const full = hex.length === 3 ? hex.replace(/(.)/g, '$1$1') : hex;
+  if (full.length !== 6 || /[^0-9a-fA-F]/.test(full)) return null;
+  return [parseInt(full.slice(0, 2), 16), parseInt(full.slice(2, 4), 16), parseInt(full.slice(4, 6), 16)];
+}
+
+function toHexByte(value: number): string {
+  return Math.round(value).toString(16).padStart(2, '0');
+}
+
+/**
+ * Alpha-composite `foreground` over `background` at `alpha` (0–1) and return an
+ * opaque `#RRGGBB`. Unlike `withAlpha` (which yields a translucent `rgba()`),
+ * this is for surfaces that float over arbitrary content and must stay opaque —
+ * e.g. a variant-tinted toast pill that washes its brand hue over a neutral
+ * surface yet can't let the content behind bleed through. Both inputs must be
+ * `#RGB`/`#RRGGBB` hex; any other format returns `background` unchanged so this
+ * never emits an invalid colour.
+ */
+export function blendOpaque(foreground: string, background: string, alpha: number): string {
+  const fg = parseHex(foreground);
+  const bg = parseHex(background);
+  if (!fg || !bg) {
+    if (__DEV__ && (!fg || !bg)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[blendOpaque] expected hex colours, got foreground "${foreground}" / background "${background}" — returning background unchanged`,
+      );
+    }
+    return background;
+  }
+  const mix = (channel: 0 | 1 | 2) => fg[channel] * alpha + bg[channel] * (1 - alpha);
+  return `#${toHexByte(mix(0))}${toHexByte(mix(1))}${toHexByte(mix(2))}`;
+}


### PR DESCRIPTION
## What

A review of the Material (react-native-paper) migration flagged four issues in the Paper-backed mobile primitives. This addresses all four, with the toast getting full parity with the Liquid Glass path.

### 1. Toast variant semantics (the main one)

`ToastMaterial` rendered every variant (success / error / info / warning) as an identical plain Snackbar — no icon, no colour, no `accessibilityRole`, and `VARIANT_CONFIG` went entirely unused. It now carries the same cue as the glass pill:

- **Leading variant icon** (`config.icon` in `config.color`) and a brand-coloured label, passed as the Snackbar's children node so we own the icon/text colour instead of inheriting Paper's inverse-surface colour.
- **Brand-hued tint** via a new `blendOpaque()` helper in `theme/colors.ts` that alpha-composites the variant colour over the surface and returns an **opaque** `#RRGGBB` (the pill floats over content, so `withAlpha`'s translucent output would bleed). Same 15% / 24% (dark) wash ratios the glass path uses.
- **`accessibilityRole="alert"` + assertive live region** on the content row.

### 2. SegmentedControl redundant guard

Dropped the dead `disabledKeys?.has(nextKey)` re-check in `SegmentedControlMaterial.handleValueChange` — Paper never fires `onValueChange` for a button rendered `disabled`. The test's Paper mock was firing it anyway (which is why the guard looked load-bearing); the mock now mirrors real Paper, so the "does not select a disabled key" test validates Paper's behaviour rather than the removed guard.

### 3. GlassIconButton `iconColor` cast

Kept `iconColor as string` but documented the invariant: in the Material branch, themed colours resolve from `materialSurfaces` (hex/rgba strings on every platform), so no `PlatformColor` opaque ref reaches here — and even if one did, Paper forwards it to MaterialCommunityIcons' `color`, which accepts `ColorValue` at runtime. The cast only satisfies Paper's `string` type.

### 4. Snackbar touch passthrough

No code change: Paper's Snackbar wrapper is `pointerEvents="box-none"`, so taps outside the pill reach content behind it — the same guarantee the glass path gets from its explicit `absoluteFill` + `box-none` wrapper. Documented in `ToastMaterial` and `QueueAddedSnackbarMaterial`; touch passthrough isn't assertable in jsdom, so it's flagged for on-device QA.

## Tests

- `colors.test.ts` (new) — unit coverage for `blendOpaque` (compositing, alpha 0/1 bounds, 3-digit hex expansion, non-hex fallback).
- `toast.test.tsx` — asserts the Material path renders the variant icon, a tinted Snackbar background, and the alert role.
- `segmented-control.test.tsx` — Paper mock no longer fires `onValueChange` for disabled buttons.

## Validation

- `vp test --project mobile` — 960 passed
- `vp run typecheck:mobile` — clean
- `vp run check:mobile-bundle` — android bundle OK (10.4 MB)

On-device QA still pending (macOS-only): each toast variant shows a distinct icon + tint with a single screen-reader announcement, and taps pass through to content behind a visible toast / "Climb added" snackbar.

https://claude.ai/code/session_01Apa7D8hk8LDMWzxPbAet6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01Apa7D8hk8LDMWzxPbAet6A)_