### PR TITLE
Redesign the mobile climbs search & filter experience (iOS HIG)

### DIFF
--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -52,12 +52,16 @@ vi.mock('expo-router/unstable-native-tabs', () => {
   return { NativeTabs };
 });
 
-import TabLayout from '../_layout';
+import TabLayout, { unstable_settings } from '../_layout';
 
 describe('TabLayout', () => {
   beforeEach(() => {
     cfg.bluetoothConnected = false;
     cfg.sessionId = null;
+  });
+
+  it('lands on the climbs tab by default', () => {
+    expect(unstable_settings.initialRouteName).toBe('climbs');
   });
 
   it('does not render the Record badge when no status is active', () => {

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -10,6 +10,11 @@ import { MaterialTabBar } from '../../src/components/navigation/MaterialTabBar';
 import { useTheme } from '../../src/providers/theme-provider';
 import { brandColors } from '../../src/theme/colors';
 
+// Cold-start on the climbs list (our search surface), not the boards tab — board
+// switching is rare, so the filtered climb list is the home base. Drives the
+// default-selected tab in both the native-tabs and Material `Tabs` variants.
+export const unstable_settings = { initialRouteName: 'climbs' };
+
 type TabIconProps = { focused: boolean; color: ColorValue; size: number };
 
 // Material (MaterialCommunityIcons) glyphs for the JS tab bar, mirroring the
@@ -43,13 +48,6 @@ export default function TabLayout() {
   if (variant === 'material') {
     return (
       <Tabs tabBar={(props) => <MaterialTabBar {...props} />} screenOptions={{ headerShown: false }}>
-        <Tabs.Screen
-          name="boards"
-          options={{
-            title: t('mobile.nav.boards'),
-            tabBarIcon: materialTabIcon('view-dashboard', 'view-dashboard-outline'),
-          }}
-        />
         <Tabs.Screen
           name="climbs"
           options={{ title: t('mobile.nav.climbs'), tabBarIcon: materialTabIcon('magnify', 'magnify') }}
@@ -89,11 +87,6 @@ export default function TabLayout() {
       <NativeTabs.BottomAccessory>
         <QueueBottomAccessory />
       </NativeTabs.BottomAccessory>
-
-      <NativeTabs.Trigger name="boards">
-        <NativeTabs.Trigger.Icon sf="square.grid.2x2" md="dashboard" />
-        <NativeTabs.Trigger.Label>{t('mobile.nav.boards')}</NativeTabs.Trigger.Label>
-      </NativeTabs.Trigger>
 
       <NativeTabs.Trigger name="climbs" role="search">
         <NativeTabs.Trigger.Icon sf="magnifyingglass" md="search" />

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -11,6 +11,7 @@ import {
   mergeBoardFilters,
   countActiveFilters,
   hasActiveBoardFilters,
+  formatFilterSummary,
   DEFAULT_CLIMB_FILTER_STATE,
   DEFAULT_CLIMB_BOARD_FILTER_STATE,
   type ClimbBoardFilterState,
@@ -20,10 +21,10 @@ import { ClimbListRowSkeleton } from '../../../src/components/ClimbListRowSkelet
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
+import { Button } from '../../../src/components/Button';
 import { ClimbFilterSheet, hasActiveFilters, type ClimbFilters } from '../../../src/components/ClimbFilterSheet';
 import { ClimbFilterFab } from '../../../src/components/search/ClimbFilterFab';
 import { ClimbTopChrome } from '../../../src/components/search/ClimbTopChrome';
-import { BoardDetailSheet } from '../../../src/components/board-discovery/BoardDetailSheet';
 import { useDrawerHost } from '../../../src/providers/drawer-host-provider';
 import { useTheme } from '../../../src/providers/theme-provider';
 import { useQueue } from '../../../src/providers/queue-provider';
@@ -35,12 +36,13 @@ import { RecentFilterPills } from '../../../src/components/RecentFilterPills';
 import { useNativeAccessoryActive } from '../../../src/hooks/use-bottom-accessory';
 import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
 import { useGrades } from '../../../src/lib/graphql/hooks';
+import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { useInfiniteSearchClimbs } from '../../../src/lib/graphql/hooks/use-infinite-search-climbs';
 import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../../src/lib/graphql/operations';
 import { getHttpClient } from '../../../src/lib/graphql/client';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
 import { toQueueClimb, toQueueClimbs } from '../../../src/lib/climb-types';
-import { useActiveBoard, useSetActiveBoard } from '../../../src/lib/graphql/use-active-board';
+import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { getBoardRenderData } from '../../../src/lib/board-details';
 import {
@@ -51,6 +53,7 @@ import {
 } from '../../../src/lib/recent-filter-store';
 import { getLastSearch, saveLastSearch, boardConfigKey } from '../../../src/lib/last-search-store';
 import { getFilterSummary } from '../../../src/lib/filter-summary';
+import { getActiveFilterTokens } from '../../../src/lib/filter-tokens';
 import { normalizeSearchName } from '../../../src/lib/search-name';
 import { track } from '../../../src/lib/analytics';
 import { brandColors } from '../../../src/theme/colors';
@@ -103,8 +106,18 @@ function ClimbListInner() {
   const { openClimbActions, openAddToPlaylist } = useDrawerHost();
   const { systemColors, variant } = useTheme();
   const { addToQueue, state: queueState } = useQueue();
-  const { filters, boardFilters, name, setFilters, setBoardFilters, setGrade, setName, replaceSearch } =
-    useClimbSearch();
+  const {
+    filters,
+    boardFilters,
+    name,
+    setFilters,
+    setBoardFilters,
+    setGrade,
+    setName,
+    replaceSearch,
+    patchFilters,
+    patchBoardFilters,
+  } = useClimbSearch();
   // The active climb (driving the board / persistent queue bar). We highlight
   // its row so the search → tap → change-active loop is always visible.
   const activeClimbUuid = queueState.currentClimbQueueItem?.climb?.uuid;
@@ -146,9 +159,6 @@ function ClimbListInner() {
   // The list pads its top by this so the first row rests below the chrome and the
   // rest scroll under it.
   const [searchBarHeight, setSearchBarHeight] = useState(() => insets.top + 60);
-  // Board-detail sheet, opened from the top board capsule.
-  const [showBoardDetail, setShowBoardDetail] = useState(false);
-  const setActiveBoard = useSetActiveBoard();
 
   const blurSearchInputs = useCallback(() => {
     Keyboard.dismiss();
@@ -253,6 +263,7 @@ function ClimbListInner() {
   const gradesRef = useRef(gradesData);
   gradesRef.current = gradesData;
   const grades = useMemo(() => gradesData ?? [], [gradesData]);
+  const { formatGradeByDifficultyId } = useGradeFormat();
 
   const boardConfig = useMemo(
     () => (hasBoardConfig ? { boardName, layoutId, sizeId, setIds, angle } : null),
@@ -535,6 +546,12 @@ function ClimbListInner() {
       .catch(() => {});
   }, []);
 
+  // "Clear all" on the scope row: reset every filter (grade + refinements + board
+  // filters) to defaults, keeping the typed name query.
+  const handleClearAllFilters = useCallback(() => {
+    replaceSearch(DEFAULT_CLIMB_FILTER_STATE, name, DEFAULT_CLIMB_BOARD_FILTER_STATE);
+  }, [replaceSearch, name]);
+
   const handleGradeChange = useCallback(
     (next: GradeBound) => {
       setGrade(next);
@@ -563,6 +580,32 @@ function ClimbListInner() {
     [filters.minGrade, filters.maxGrade],
   );
   const activeFilterCount = useMemo(() => countActiveFilters(filters, boardFilters), [filters, boardFilters]);
+  // Removable active-filter tokens for the scope row beneath the search field.
+  // Each token's `clear` patches just its field back to the default.
+  const filterTokens = useMemo(
+    () =>
+      getActiveFilterTokens({
+        filters,
+        boardFilters,
+        grades,
+        t,
+        formatGradeByDifficultyId,
+        patchFilters,
+        patchBoardFilters,
+        setGrade,
+      }),
+    [filters, boardFilters, grades, t, formatGradeByDifficultyId, patchFilters, patchBoardFilters, setGrade],
+  );
+  // Condensed one-line summary of the active filters for the capsule below the
+  // board name (2 parts max, then "+N more"). Tapping the capsule clears them.
+  const filterSummary = useMemo(() => {
+    if (filterTokens.length === 0) return null;
+    return formatFilterSummary(
+      filterTokens.map((token) => token.label),
+      { more: (count) => t('mobile.search.more', { count }) },
+      2,
+    );
+  }, [filterTokens, t]);
 
   const stackOptions = useMemo(
     () =>
@@ -639,6 +682,16 @@ function ClimbListInner() {
           <Text variant="subheadline" style={styles.emptySubtitle}>
             {t('mobile.emptyState.noBoard.subtitle')}
           </Text>
+          {/* Board selection is a modal now. When BLE serial auto-detect lands it
+              calls useSetActiveBoard(); useActiveBoard() then flips this screen to
+              the climb list with no extra wiring here. */}
+          <Button
+            title={t('mobile.emptyState.noBoard.cta')}
+            onPress={() => router.push('/boards')}
+            variant="filled"
+            size="large"
+            style={styles.emptyCta}
+          />
         </View>
       </>
     );
@@ -712,7 +765,7 @@ function ClimbListInner() {
         searchMode={useNativeSearch ? 'native' : 'custom'}
         canCreate={isAuthenticated && hasBoardConfig}
         onCreate={handleCreateClimb}
-        onOpenBoardDetail={() => setShowBoardDetail(true)}
+        onOpenBoardDetail={() => router.push('/boards')}
         onHeightChange={setSearchBarHeight}
         searchFieldRef={searchHeaderRef}
         searchInitialValue={name}
@@ -721,9 +774,9 @@ function ClimbListInner() {
         onSearchFocus={handleSearchFocus}
         onSearchBlur={handleSearchBlur}
         onCloseGrade={handleDismissGrade}
-        showFilterAction={filterInTopChrome}
         activeFilterCount={activeFilterCount}
         onOpenFilters={handleOpenFilters}
+        filterSummary={filterSummary ? { text: filterSummary, onClear: handleClearAllFilters } : undefined}
       />
 
       {filterInTopChrome ? null : (
@@ -750,16 +803,6 @@ function ClimbListInner() {
           onApply={handleApplyFilters}
         />
       ) : null}
-
-      <BoardDetailSheet
-        board={activeBoard ?? null}
-        visible={showBoardDetail}
-        onClose={() => setShowBoardDetail(false)}
-        onSetActive={(board) => {
-          void setActiveBoard(board);
-          setShowBoardDetail(false);
-        }}
-      />
     </View>
   );
 }
@@ -802,5 +845,8 @@ const styles = StyleSheet.create({
   emptySubtitle: {
     opacity: 0.4,
     textAlign: 'center',
+  },
+  emptyCta: {
+    marginTop: spacing[4],
   },
 });

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -148,7 +148,7 @@ export default function DiscoverLibrary() {
   const handleCreatePress = useCallback(() => {
     if (!createBoard) {
       showToast(t('bottomTabBar.selectBoardForPlaylist'), 'info');
-      router.push('/(tabs)/boards');
+      router.push('/boards');
       return;
     }
     setCreateVisible(true);

--- a/packages/mobile/app/+not-found.tsx
+++ b/packages/mobile/app/+not-found.tsx
@@ -1,5 +1,5 @@
 import { Redirect } from 'expo-router';
 
 export default function NotFound() {
-  return <Redirect href="/(tabs)/boards" />;
+  return <Redirect href="/(tabs)/climbs" />;
 }

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -100,7 +100,7 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
   }, [error]);
 
   const handleGoHome = () => {
-    router.replace('/(tabs)/boards');
+    router.replace('/(tabs)/climbs');
   };
 
   return (
@@ -112,11 +112,11 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
         Something went wrong
       </Text>
       <Text variant="body" style={errorStyles.message}>
-        The app hit an unexpected error. You can try again or head back to your boards.
+        The app hit an unexpected error. You can try again or head back home.
       </Text>
       <View style={errorStyles.buttonRow}>
         <Button title="Try again" onPress={retry} variant="filled" size="large" />
-        <Button title="Go to boards" onPress={handleGoHome} variant="outlined" size="large" />
+        <Button title="Go home" onPress={handleGoHome} variant="outlined" size="large" />
       </View>
     </View>
   );
@@ -252,6 +252,13 @@ function RootLayout() {
                                                   <Stack.Screen name="session/[sessionId]" />
                                                   <Stack.Screen
                                                     name="join/[sessionId]"
+                                                    options={{ presentation: 'modal', headerShown: false }}
+                                                  />
+                                                  {/* Board selection is a modal off the Climbs capsule /
+                                                      no-board CTA — board switching is rare, so it doesn't
+                                                      earn a tab. Its own _layout owns the headers. */}
+                                                  <Stack.Screen
+                                                    name="boards"
                                                     options={{ presentation: 'modal', headerShown: false }}
                                                   />
                                                 </Stack>

--- a/packages/mobile/app/auth/callback.tsx
+++ b/packages/mobile/app/auth/callback.tsx
@@ -32,7 +32,7 @@ export default function AuthCallback() {
         if (result.success) {
           track(SHARED_EVENTS.LoginSucceeded, { flow: 'native' });
           await refreshAuthState();
-          router.replace('/(tabs)/boards');
+          router.replace('/(tabs)/climbs');
         } else {
           track(SHARED_EVENTS.LoginFailed, { flow: 'native', failure_reason: classifyNativeAuthFailureReason(result) });
           setError(result.error);

--- a/packages/mobile/app/boards/_layout.tsx
+++ b/packages/mobile/app/boards/_layout.tsx
@@ -1,6 +1,7 @@
-import { Stack } from 'expo-router';
-import { Platform } from 'react-native';
+import { Stack, router } from 'expo-router';
+import { Platform, Pressable } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { Icon } from '../../src/components/Icon';
 
 export default function BoardsLayout() {
   const { t } = useTranslation('common');
@@ -19,7 +20,24 @@ export default function BoardsLayout() {
         contentStyle: { backgroundColor: 'transparent' },
       }}
     >
-      <Stack.Screen name="index" options={{ title: t('mobile.nav.boards') }} />
+      <Stack.Screen
+        name="index"
+        options={{
+          title: t('mobile.nav.boards'),
+          // A modal now, not a tab: give it an explicit close button (iOS
+          // swipe-to-dismiss alone isn't discoverable for a primary entry point).
+          headerLeft: ({ tintColor }) => (
+            <Pressable
+              onPress={() => router.back()}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel={t('ariaLabels.close')}
+            >
+              <Icon name="close" size={22} color={tintColor} />
+            </Pressable>
+          ),
+        }}
+      />
       {/* Full-screen map; it has its own overlay search field, no nav header. */}
       <Stack.Screen name="search" options={{ headerShown: false, presentation: 'fullScreenModal' }} />
     </Stack>

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -4,25 +4,25 @@ import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import { useMyBoards, usePopularBoardConfigs, useNearbyBoards } from '../../../src/lib/graphql/hooks';
-import { useActiveBoard, useSetActiveBoard } from '../../../src/lib/graphql/use-active-board';
-import { useDeviceLocation } from '../../../src/lib/use-device-location';
-import { useAuth } from '../../../src/providers/auth-provider';
-import { useToast } from '../../../src/providers/toast-provider';
-import { hapticSelection } from '../../../src/lib/haptics';
-import { Text } from '../../../src/components/Text';
-import { Icon } from '../../../src/components/Icon';
-import { Button } from '../../../src/components/Button';
-import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
-import { BoardCarousel } from '../../../src/components/board-discovery/BoardCarousel';
-import { BoardModeCard, type ModeCardState } from '../../../src/components/board-discovery/BoardModeCard';
-import { CustomBoardSheet, type BoardSeed } from '../../../src/components/board-discovery/CustomBoardSheet';
-import { BluetoothQuickstartSheet } from '../../../src/components/board-discovery/BluetoothQuickstartSheet';
-import { userBoardToItem, popularConfigToItem } from '../../../src/components/board-discovery/board-items';
-import type { DiscoveryBoardItem } from '../../../src/components/board-discovery/BoardDiscoveryCard';
-import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
-import { iosSystemColors } from '../../../src/theme/ios-colors';
-import { spacing } from '../../../src/theme/tokens';
+import { useMyBoards, usePopularBoardConfigs, useNearbyBoards } from '../../src/lib/graphql/hooks';
+import { useActiveBoard, useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
+import { useDeviceLocation } from '../../src/lib/use-device-location';
+import { useAuth } from '../../src/providers/auth-provider';
+import { useToast } from '../../src/providers/toast-provider';
+import { hapticSelection } from '../../src/lib/haptics';
+import { Text } from '../../src/components/Text';
+import { Icon } from '../../src/components/Icon';
+import { Button } from '../../src/components/Button';
+import { ActivityIndicator } from '../../src/components/ActivityIndicator';
+import { BoardCarousel } from '../../src/components/board-discovery/BoardCarousel';
+import { BoardModeCard, type ModeCardState } from '../../src/components/board-discovery/BoardModeCard';
+import { CustomBoardSheet, type BoardSeed } from '../../src/components/board-discovery/CustomBoardSheet';
+import { BluetoothQuickstartSheet } from '../../src/components/board-discovery/BluetoothQuickstartSheet';
+import { userBoardToItem, popularConfigToItem } from '../../src/components/board-discovery/board-items';
+import type { DiscoveryBoardItem } from '../../src/components/board-discovery/BoardDiscoveryCard';
+import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
+import { iosSystemColors } from '../../src/theme/ios-colors';
+import { spacing } from '../../src/theme/tokens';
 
 export default function BoardSelection() {
   const { isAuthenticated, refreshAuthState } = useAuth();
@@ -76,7 +76,9 @@ export default function BoardSelection() {
         // only once the write succeeds (a failed write must not strand the user
         // on a board that won't survive the next cold start).
         await setActiveBoard(board);
-        router.navigate('/(tabs)/climbs');
+        // Dismiss the boards modal back onto the Climbs list (replaces with it if
+        // climbs isn't already underneath, e.g. opened from a deep link).
+        router.dismissTo('/(tabs)/climbs');
       } catch {
         showToast(t('mobile.boardSwitchError'), 'error');
       }
@@ -244,7 +246,7 @@ export default function BoardSelection() {
           <BoardModeCard
             icon="search"
             label={t('mobile.discovery.search')}
-            onPress={() => router.push('/(tabs)/boards/search')}
+            onPress={() => router.push('/boards/search')}
           />
         </View>
 

--- a/packages/mobile/app/boards/search.tsx
+++ b/packages/mobile/app/boards/search.tsx
@@ -4,20 +4,20 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import { useSetActiveBoard } from '../../../src/lib/graphql/use-active-board';
-import { useSearchBoardsMap } from '../../../src/lib/graphql/use-search-boards-map';
-import { useDeviceLocation } from '../../../src/lib/use-device-location';
-import { useToast } from '../../../src/providers/toast-provider';
-import { useTheme } from '../../../src/providers/theme-provider';
-import { hapticSelection } from '../../../src/lib/haptics';
-import { Text } from '../../../src/components/Text';
-import { Icon } from '../../../src/components/Icon';
-import { BoardCarousel } from '../../../src/components/board-discovery/BoardCarousel';
-import { BoardDetailSheet } from '../../../src/components/board-discovery/BoardDetailSheet';
-import { userBoardToItem } from '../../../src/components/board-discovery/board-items';
-import type { DiscoveryBoardItem } from '../../../src/components/board-discovery/BoardDiscoveryCard';
-import { brandColors } from '../../../src/theme/colors';
-import { spacing, borderRadius } from '../../../src/theme/tokens';
+import { useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
+import { useSearchBoardsMap } from '../../src/lib/graphql/use-search-boards-map';
+import { useDeviceLocation } from '../../src/lib/use-device-location';
+import { useToast } from '../../src/providers/toast-provider';
+import { useTheme } from '../../src/providers/theme-provider';
+import { hapticSelection } from '../../src/lib/haptics';
+import { Text } from '../../src/components/Text';
+import { Icon } from '../../src/components/Icon';
+import { BoardCarousel } from '../../src/components/board-discovery/BoardCarousel';
+import { BoardDetailSheet } from '../../src/components/board-discovery/BoardDetailSheet';
+import { userBoardToItem } from '../../src/components/board-discovery/board-items';
+import type { DiscoveryBoardItem } from '../../src/components/board-discovery/BoardDiscoveryCard';
+import { brandColors } from '../../src/theme/colors';
+import { spacing, borderRadius } from '../../src/theme/tokens';
 
 // Lazy/guarded expo-maps load: it's a native module, so a JS-only OTA push to a
 // build that predates it would otherwise throw at import. We resolve the
@@ -125,9 +125,10 @@ export default function BoardSearchScreen() {
         // sheet stays open so the error toast has visible context.
         setSelectedUuid(null);
         // router.back() is the same foreground unmount the X button uses —
-        // proven safe for expo-maps — then switch to the climbs tab.
+        // proven safe for expo-maps — closing the search screen first; then
+        // dismiss the boards modal back onto the climbs list.
         router.back();
-        router.navigate('/(tabs)/climbs');
+        router.dismissTo('/(tabs)/climbs');
       } catch {
         showToast(t('mobile.boardSwitchError'), 'error');
       }

--- a/packages/mobile/app/index.tsx
+++ b/packages/mobile/app/index.tsx
@@ -1,14 +1,11 @@
 import { Redirect } from 'expo-router';
-import { useActiveBoard } from '../src/lib/graphql/use-active-board';
 
 /**
- * App launcher route. Pick the default tab only when the user opens the app root;
- * explicit tab routes (join -> Record, deep links, etc.) must keep their target.
+ * App launcher route. Always lands on the Climbs tab — our search surface and
+ * home base. When no board is active yet, the Climbs screen shows a "choose your
+ * board" CTA (board switching is rare, so it lives in a modal, not a tab).
+ * Explicit tab routes (join -> Record, deep links) keep their own target.
  */
 export default function MobileHome() {
-  const { data: activeBoard, isLoading } = useActiveBoard();
-
-  if (isLoading) return null;
-
-  return <Redirect href={activeBoard ? '/(tabs)/climbs' : '/(tabs)/boards'} />;
+  return <Redirect href="/(tabs)/climbs" />;
 }

--- a/packages/mobile/src/components/AscentStatusBadge.tsx
+++ b/packages/mobile/src/components/AscentStatusBadge.tsx
@@ -1,9 +1,8 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { useOptionalBoardProvider } from '@boardsesh/board-react';
 import { Icon } from './Icon';
 import { iosSystemColors } from '../theme/ios-colors';
-import { normalizeAscentStatus, pickHighestAscentStatus, type AscentStatusValue } from '../lib/ascent-status-utils';
+import { useAscentStatus } from '../hooks/use-ascent-status';
 
 type AscentStatusBadgeProps = {
   climbUuid: string;
@@ -24,22 +23,7 @@ const AscentStatusBadge = React.memo(function AscentStatusBadge({
   angle,
   isMirror,
 }: AscentStatusBadgeProps) {
-  const board = useOptionalBoardProvider();
-  const status = useMemo<AscentStatusValue | null>(() => {
-    if (!board) return null;
-    const entries = board.logbook.filter(
-      (entry) =>
-        entry.climb_uuid === climbUuid &&
-        entry.angle === angle &&
-        (isMirror === undefined || entry.is_mirror === isMirror),
-    );
-    if (entries.length === 0) return null;
-    return pickHighestAscentStatus(
-      entries.map((entry) =>
-        normalizeAscentStatus({ status: entry.status, isAscent: entry.is_ascent, tries: entry.tries }),
-      ),
-    );
-  }, [board, climbUuid, angle, isMirror]);
+  const status = useAscentStatus(climbUuid, angle, isMirror);
 
   if (!status) return null;
 

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -5,9 +5,18 @@ import type { BoardName } from '@boardsesh/shared-schema';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { Text } from './Text';
 import { ClimbListThumbnail, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT } from './ClimbListThumbnail';
-import { AscentStatusBadge } from './AscentStatusBadge';
 import { formatSends, formatQuality } from '../lib/format-climb-stats';
 import { useGradeFormat } from '../hooks/use-grade-format';
+import { useAscentStatus } from '../hooks/use-ascent-status';
+import { iosSystemColors } from '../theme/ios-colors';
+import type { AscentStatusValue } from '../lib/ascent-status-utils';
+
+// Scan-line status dot colours — green sent, yellow flash, orange attempted.
+const ASCENT_DOT_COLOR: Record<AscentStatusValue, string> = {
+  send: iosSystemColors.systemGreen,
+  flash: iosSystemColors.systemYellow,
+  attempt: iosSystemColors.systemOrange,
+};
 
 /**
  * Minimal structural climb shape this visual needs. Kept permissive so BOTH the
@@ -57,6 +66,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
 
   const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
   const formattedGrade = formatGrade(climb.difficulty);
+  const ascentStatus = useAscentStatus(climb.uuid, angle);
 
   // Subtitle parts: sends · quality★ · setter (each dropped when absent).
   const subtitleText = useMemo(() => {
@@ -89,7 +99,6 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
           setIds={setIds}
           mirrored={climb.mirrored ?? false}
         />
-        <AscentStatusBadge climbUuid={climb.uuid} angle={angle} />
       </View>
 
       {/* Center: name + subtitle */}
@@ -102,9 +111,10 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
         </Text>
       </View>
 
-      {/* Right: colorized grade */}
+      {/* Right: ascent-status dot + colorized grade — the two scan keys together */}
       <View style={styles.rightSection}>
-        <Text variant="headline" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
+        {ascentStatus ? <View style={[styles.statusDot, { backgroundColor: ASCENT_DOT_COLOR[ascentStatus] }]} /> : null}
+        <Text variant="title3" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
           {formattedGrade ?? climb.difficulty}
         </Text>
       </View>
@@ -135,12 +145,19 @@ const styles = StyleSheet.create({
   },
   rightSection: {
     flexShrink: 0,
-    alignItems: 'flex-end',
-    justifyContent: 'center',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: 6,
+  },
+  statusDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
   },
   gradeText: {
     fontWeight: '700',
-    minWidth: 34,
+    minWidth: 40,
     textAlign: 'right',
   },
 });

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -5,6 +5,7 @@
 
 import { type RefObject, useCallback, useMemo, useState } from 'react';
 import { Keyboard, type LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import { useFocusEffect } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
@@ -21,13 +22,15 @@ import { PressableSurface } from '../PressableSurface';
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
-import { Badge } from '../Badge';
 import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
+import { FilterButton } from './FilterButton';
 
 const CAPSULE_RADIUS = glassSize.capsule / 2;
 const TOP_ACTION_SIZE = glassSize.standard;
 const TOP_TOOLBAR_WIDTH = TOP_ACTION_SIZE * 2;
 const TOP_TOOLBAR_RADIUS = TOP_ACTION_SIZE / 2;
+const SUMMARY_CAPSULE_HEIGHT = glassSize.mini;
+const SUMMARY_CAPSULE_RADIUS = SUMMARY_CAPSULE_HEIGHT / 2;
 
 type ClimbTopChromeProps = {
   searchMode?: 'custom' | 'native';
@@ -42,11 +45,14 @@ type ClimbTopChromeProps = {
   onSearchFocus: () => void;
   onSearchBlur: () => void;
   onCloseGrade: () => void;
-  /** Render the filter affordance in the top-right toolbar (Material variant), next
-   *  to the light/bluetooth button, instead of as the bottom-right FAB. */
-  showFilterAction?: boolean;
+  /** Active-filter count for the Material variant's filter button (rendered to
+   *  the left of the search field — the affordance the native search bar can't
+   *  host). Liquid Glass keeps the bottom filter FAB instead. */
   activeFilterCount?: number;
   onOpenFilters?: () => void;
+  /** Active-filter summary shown as a single capsule below the board name.
+   *  Tapping it clears all filters (no per-chip remove). Absent = no filters. */
+  filterSummary?: { text: string; onClear: () => void };
 };
 
 export function ClimbTopChrome({
@@ -62,15 +68,15 @@ export function ClimbTopChrome({
   onSearchFocus,
   onSearchBlur,
   onCloseGrade,
-  showFilterAction = false,
   activeFilterCount = 0,
   onOpenFilters,
+  filterSummary,
 }: ClimbTopChromeProps) {
   const { t } = useTranslation('climbs');
   const { t: tSettings } = useTranslation('settings');
   const { t: tCommon } = useTranslation('common');
   const { t: tSession } = useTranslation('session');
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors, brandColors, variant } = useTheme();
   const nativeGlass = useNativeGlass();
   const insets = useSafeAreaInsets();
   const { data: activeBoard } = useActiveBoard();
@@ -145,14 +151,22 @@ export function ClimbTopChrome({
   const canOpenAngleSelector = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
   const leftActionCount = (canCreate ? 1 : 0) + (canOpenAngleSelector ? 1 : 0);
 
-  // Right toolbar: filter (Material variant) + light/bluetooth, sharing one surface.
-  const filterActive = activeFilterCount > 0;
-  const showFilter = showFilterAction && onOpenFilters != null;
-  const rightActionCount = (showFilter ? 1 : 0) + (bluetooth ? 1 : 0);
+  // Right toolbar: light/bluetooth only. The filter affordance now lives to the
+  // left of the search field (Material) or as the bottom FAB (Liquid Glass).
+  const rightActionCount = bluetooth ? 1 : 0;
 
   return (
     <>
       <View pointerEvents="box-none" style={[styles.container, { paddingTop: insets.top }]} onLayout={handleLayout}>
+        {/* Scrim: opaque screen background behind the controls, fading to clear at
+            the bottom edge — hides the climb list scrolling up behind the floating
+            islands (the gaps between them otherwise bleed list content = clutter). */}
+        <LinearGradient
+          pointerEvents="none"
+          colors={[systemColors.background, systemColors.background, 'transparent'] as const}
+          locations={[0, 0.7, 1]}
+          style={StyleSheet.absoluteFill}
+        />
         <View pointerEvents="box-none" style={styles.row}>
           <View pointerEvents="box-none" style={styles.leftSlot}>
             {canCreate || canOpenAngleSelector ? (
@@ -226,7 +240,13 @@ export function ClimbTopChrome({
                     pointerEvents="none"
                   />
                   <Icon name="boards" size={14} color={systemColors.secondaryLabel as string} />
-                  <Text variant="footnote" numberOfLines={1} ellipsizeMode="tail" style={styles.capsuleText}>
+                  <Text
+                    variant="caption1"
+                    numberOfLines={1}
+                    ellipsizeMode="tail"
+                    color={systemColors.secondaryLabel as string}
+                    style={styles.capsuleText}
+                  >
                     {boardLabel}
                   </Text>
                 </View>
@@ -251,31 +271,6 @@ export function ClimbTopChrome({
                   style={StyleSheet.absoluteFill}
                   pointerEvents="none"
                 />
-                {showFilter ? (
-                  <PressableSurface
-                    onPress={onOpenFilters}
-                    feedback="opacity"
-                    hitSlop={4}
-                    accessibilityRole="button"
-                    accessibilityLabel={
-                      filterActive
-                        ? t('mobile.search.filterCountAria', { count: activeFilterCount })
-                        : t('mobile.search.filters')
-                    }
-                    style={styles.toolbarAction}
-                  >
-                    <Icon
-                      name="filter"
-                      size={22}
-                      color={filterActive ? brandColors.primary : (systemColors.label as string)}
-                    />
-                    {filterActive ? (
-                      <View pointerEvents="none" style={styles.actionBadge}>
-                        <Badge count={activeFilterCount} color={brandColors.primary} />
-                      </View>
-                    ) : null}
-                  </PressableSurface>
-                ) : null}
                 {bluetooth ? (
                   <PressableSurface
                     onPress={handleBluetoothPress}
@@ -299,9 +294,54 @@ export function ClimbTopChrome({
           </View>
         </View>
 
+        {filterSummary ? (
+          <View pointerEvents="box-none" style={styles.summaryRow}>
+            <PressableSurface
+              onPress={() => {
+                hapticLight();
+                filterSummary.onClear();
+              }}
+              feedback="scale"
+              scaleTo={0.96}
+              accessibilityRole="button"
+              accessibilityLabel={filterSummary.text}
+              accessibilityHint={t('mobile.search.clearAll')}
+              style={styles.summaryPress}
+            >
+              <View
+                style={[
+                  styles.summaryCapsule,
+                  !nativeGlass && shadows.sm,
+                  !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
+                ]}
+              >
+                <GlassSurface
+                  glassEffectStyle="regular"
+                  fallbackColor={systemColors.elevatedSurface}
+                  borderRadius={SUMMARY_CAPSULE_RADIUS}
+                  style={StyleSheet.absoluteFill}
+                  pointerEvents="none"
+                />
+                <Text
+                  variant="caption1"
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                  color={systemColors.label as string}
+                  style={styles.summaryText}
+                >
+                  {filterSummary.text}
+                </Text>
+              </View>
+            </PressableSurface>
+          </View>
+        ) : null}
+
         {usesCustomSearch ? (
           <View pointerEvents="box-none" style={styles.searchStack}>
             <View pointerEvents="box-none" style={styles.searchRow}>
+              {variant === 'material' && onOpenFilters ? (
+                <FilterButton activeFilterCount={activeFilterCount} onPress={onOpenFilters} />
+              ) : null}
               <View pointerEvents="box-none" style={styles.searchSlot}>
                 <SearchHeader
                   ref={searchFieldRef}
@@ -377,7 +417,7 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   capsuleText: {
-    fontWeight: '600',
+    fontWeight: '500',
     flexShrink: 1,
   },
   actionToolbar: {
@@ -393,11 +433,6 @@ const styles = StyleSheet.create({
     height: TOP_ACTION_SIZE,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  actionBadge: {
-    position: 'absolute',
-    top: 5,
-    right: 5,
   },
   angleActionText: {
     fontWeight: '700',
@@ -417,5 +452,28 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     minWidth: 0,
+  },
+  summaryRow: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[1],
+    alignItems: 'center',
+  },
+  summaryPress: {
+    height: SUMMARY_CAPSULE_HEIGHT,
+    maxWidth: 280,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  summaryCapsule: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: SUMMARY_CAPSULE_HEIGHT,
+    borderRadius: SUMMARY_CAPSULE_RADIUS,
+    paddingHorizontal: 12,
+    gap: 5,
+  },
+  summaryText: {
+    fontWeight: '600',
+    flexShrink: 1,
   },
 });

--- a/packages/mobile/src/components/search/FilterButton.tsx
+++ b/packages/mobile/src/components/search/FilterButton.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { GlassIconButton } from '../GlassIconButton';
 import { useTheme } from '../../providers/theme-provider';
 import { withAlpha } from '../../theme/colors';
+import { iosSystemColors } from '../../theme/ios-colors';
 import { glassSize } from '../../theme/layout';
 
 export const FILTER_FAB_SIZE = glassSize.inlinePrimary;
@@ -18,13 +19,21 @@ type FilterButtonProps = {
 
 export function FilterButton({ activeFilterCount, onPress, onLongPress }: FilterButtonProps) {
   const { t } = useTranslation('climbs');
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors, brandColors, variant } = useTheme();
   const active = activeFilterCount > 0;
+  // Liquid Glass paints the active button on a maroon glass tint, so a maroon
+  // glyph is low-contrast — use white there. Material has no tint behind the
+  // glyph, so it keeps maroon (white would vanish on the bare surface).
+  const iconColor = active
+    ? variant === 'material'
+      ? (brandColors.primary as string)
+      : iosSystemColors.white
+    : (systemColors.secondaryLabel as string);
 
   return (
     <GlassIconButton
       iconName="filter"
-      iconColor={active ? brandColors.primary : (systemColors.secondaryLabel as string)}
+      iconColor={iconColor}
       iconSize={20}
       size={FILTER_FAB_SIZE}
       onPress={onPress}

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -50,6 +50,10 @@ vi.mock('react-native-reanimated', () => ({
 }));
 
 vi.mock('expo-router', () => ({ useFocusEffect: () => {} }));
+vi.mock('expo-linear-gradient', () => ({
+  LinearGradient: ({ children }: { children?: ReactNode }) =>
+    createElement('div', { 'data-gradient': 'true' }, children),
+}));
 vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 47, bottom: 0, left: 0, right: 0 }),
 }));

--- a/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import { createElement } from 'react';
+
+const cfg = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
 
 // GlassIconButton → a <button> surfacing the props FilterButton forwards: the
 // badge count, the icon tint, the glass tint, and the accessibility label.
@@ -60,7 +62,12 @@ vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { fill: '#EEE', secondaryLabel: '#999' },
     brandColors: { primary: '#8C4A52' },
+    variant: cfg.variant,
   }),
+}));
+
+vi.mock('../../../theme/ios-colors', () => ({
+  iosSystemColors: { white: '#FFFFFF' },
 }));
 
 // Deterministic colour helper so the active tint/fallback are assertable.
@@ -81,6 +88,10 @@ import { FilterButton } from '../FilterButton';
 const button = (root: HTMLElement) => root.querySelector('[data-icon="filter"]') as HTMLButtonElement;
 
 describe('FilterButton', () => {
+  beforeEach(() => {
+    cfg.variant = 'liquidGlass';
+  });
+
   it('renders the filter glyph and fires onPress', () => {
     const onPress = vi.fn();
     const { container, getByRole } = render(<FilterButton activeFilterCount={0} onPress={onPress} />);
@@ -125,13 +136,20 @@ describe('FilterButton', () => {
     expect(filterButton.getAttribute('data-fallback')).toBe('#EEE');
   });
 
-  it('tints maroon when at least one filter is active', () => {
+  it('uses a white glyph on the maroon glass tint when active (Liquid Glass)', () => {
+    cfg.variant = 'liquidGlass';
     const { container } = render(<FilterButton activeFilterCount={2} onPress={() => {}} />);
     const filterButton = button(container);
-    // Active: icon switches to the brand primary, glass tints/falls back to alpha-mixed maroon.
-    expect(filterButton.getAttribute('data-icon-color')).toBe('#8C4A52');
+    // Active on glass: white glyph reads on the maroon tint; glass tints/falls back to alpha-mixed maroon.
+    expect(filterButton.getAttribute('data-icon-color')).toBe('#FFFFFF');
     expect(filterButton.getAttribute('data-tint')).toBe('#8C4A52@0.18');
     expect(filterButton.getAttribute('data-fallback')).toBe('#8C4A52@0.16');
+  });
+
+  it('keeps the maroon glyph on Material when active (no tint behind it)', () => {
+    cfg.variant = 'material';
+    const { container } = render(<FilterButton activeFilterCount={2} onPress={() => {}} />);
+    expect(button(container).getAttribute('data-icon-color')).toBe('#8C4A52');
   });
 
   it('omits the count from the a11y label when no filters are active', () => {

--- a/packages/mobile/src/components/session-screen/pre-session/BoardSummaryCard.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/BoardSummaryCard.tsx
@@ -25,7 +25,7 @@ export function BoardSummaryCard({ board }: BoardSummaryCardProps) {
   const router = useRouter();
 
   const goToBoards = () => {
-    router.navigate('/(tabs)/boards');
+    router.push('/boards');
   };
 
   if (!board) {

--- a/packages/mobile/src/hooks/use-ascent-status.ts
+++ b/packages/mobile/src/hooks/use-ascent-status.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+import { useOptionalBoardProvider } from '@boardsesh/board-react';
+import { normalizeAscentStatus, pickHighestAscentStatus, type AscentStatusValue } from '../lib/ascent-status-utils';
+
+/**
+ * The user's highest recorded ascent status (flash / send / attempt) for a climb
+ * at a given angle, read from the denormalised logbook via `BoardProvider`.
+ * Returns null when there are no ticks at this angle, or outside a BoardProvider.
+ * Shared by the thumbnail `AscentStatusBadge` and the climb-row scan-line marker.
+ */
+export function useAscentStatus(climbUuid: string, angle: number, isMirror?: boolean): AscentStatusValue | null {
+  const board = useOptionalBoardProvider();
+  return useMemo<AscentStatusValue | null>(() => {
+    if (!board) return null;
+    const entries = board.logbook.filter(
+      (entry) =>
+        entry.climb_uuid === climbUuid &&
+        entry.angle === angle &&
+        (isMirror === undefined || entry.is_mirror === isMirror),
+    );
+    if (entries.length === 0) return null;
+    return pickHighestAscentStatus(
+      entries.map((entry) =>
+        normalizeAscentStatus({ status: entry.status, isAscent: entry.is_ascent, tries: entry.tries }),
+      ),
+    );
+  }, [board, climbUuid, angle, isMirror]);
+}

--- a/packages/mobile/src/lib/__tests__/analytics-screen-path.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-screen-path.test.ts
@@ -15,7 +15,11 @@ describe('normalizeScreenPath', () => {
   });
 
   it('builds a simple tab path', () => {
-    expect(normalizeScreenPath(['(tabs)', 'boards'])).toBe('/boards');
+    expect(normalizeScreenPath(['(tabs)', 'climbs'])).toBe('/climbs');
+  });
+
+  it('builds a top-level modal path (boards is no longer a tab)', () => {
+    expect(normalizeScreenPath(['boards'])).toBe('/boards');
   });
 
   it('keeps nested dynamic segments', () => {

--- a/packages/mobile/src/lib/__tests__/filter-tokens.test.ts
+++ b/packages/mobile/src/lib/__tests__/filter-tokens.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Grade } from '@boardsesh/shared-schema';
+import type { ClimbBoardFilterState } from '@boardsesh/climb-filters';
+import { getActiveFilterTokens, type FilterToken } from '../filter-tokens';
+import { DEFAULT_FILTERS, type ClimbFilters } from '../climb-filter-types';
+
+const mockGrades: Grade[] = [
+  { difficultyId: 5, name: 'V2' },
+  { difficultyId: 10, name: 'V4' },
+  { difficultyId: 15, name: 'V6' },
+];
+
+// Single-scale formatter (the user's preferred V scale), mirroring useGradeFormat.
+const V_BY_ID: Record<number, string> = { 5: 'V2', 10: 'V4', 15: 'V6' };
+const mockFormatGradeById = (id: number | null | undefined) => (id == null ? null : (V_BY_ID[id] ?? null));
+
+const mockT = ((key: string, options?: Record<string, unknown>) => {
+  if (key === 'mobile.search.gradeRange') return `${options?.min}–${options?.max}`;
+  if (key === 'mobile.search.gradeMin') return `${options?.grade}+`;
+  if (key === 'mobile.search.gradeMax') return `Up to ${options?.grade}`;
+  if (key === 'mobile.search.ascents') return `${options?.count}+ ascents`;
+  if (key === 'mobile.search.rating') return `${options?.count}+ stars`;
+  if (key === 'mobile.search.settersCount') return `${options?.count} setters`;
+  if (key === 'search.summary.routesOnly') return 'Routes only';
+  if (key === 'search.summary.bouldersAndRoutes') return 'Boulders & routes';
+  if (key === 'mobile.filter.sort.quality') return 'Quality';
+  if (key === 'mobile.filter.benchmark') return 'Benchmarks only';
+  if (key === 'mobile.filter.status.drafts') return 'Drafts';
+  if (key === 'mobile.filter.tall') return 'Tall climbs only';
+  return key;
+}) as unknown as Parameters<typeof getActiveFilterTokens>[0]['t'];
+
+function build(
+  filters: ClimbFilters,
+  boardFilters: ClimbBoardFilterState = {},
+  grades: Grade[] | undefined = mockGrades,
+) {
+  const patchFilters = vi.fn();
+  const patchBoardFilters = vi.fn();
+  const setGrade = vi.fn();
+  const tokens = getActiveFilterTokens({
+    filters,
+    boardFilters,
+    grades,
+    t: mockT,
+    formatGradeByDifficultyId: mockFormatGradeById,
+    patchFilters,
+    patchBoardFilters,
+    setGrade,
+  });
+  return { tokens, patchFilters, patchBoardFilters, setGrade };
+}
+
+const keys = (tokens: FilterToken[]) => tokens.map((token) => token.key);
+
+describe('getActiveFilterTokens', () => {
+  it('returns no tokens for the default state', () => {
+    expect(build(DEFAULT_FILTERS).tokens).toEqual([]);
+  });
+
+  it('builds a single grade token for a bound and clears it via setGrade', () => {
+    const { tokens, setGrade } = build({ ...DEFAULT_FILTERS, minGrade: 5, maxGrade: 15 });
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]).toMatchObject({ key: 'grade', label: 'V2–V6' });
+    tokens[0].clear();
+    expect(setGrade).toHaveBeenCalledWith({ minGradeId: undefined, maxGradeId: undefined });
+  });
+
+  it('omits the grade token when grades data is unavailable', () => {
+    // Call directly: a default param can't be overridden by an explicit
+    // `undefined`, so the helper's `grades = mockGrades` default would win.
+    const tokens = getActiveFilterTokens({
+      filters: { ...DEFAULT_FILTERS, minGrade: 10 },
+      boardFilters: {},
+      grades: undefined,
+      t: mockT,
+      formatGradeByDifficultyId: mockFormatGradeById,
+      patchFilters: vi.fn(),
+      patchBoardFilters: vi.fn(),
+      setGrade: vi.fn(),
+    });
+    expect(keys(tokens)).not.toContain('grade');
+  });
+
+  it('resets sort to the default on clear', () => {
+    const { tokens, patchFilters } = build({ ...DEFAULT_FILTERS, sortBy: 'quality' });
+    const sort = tokens.find((token) => token.key === 'sort');
+    expect(sort?.label).toBe('Quality');
+    sort?.clear();
+    expect(patchFilters).toHaveBeenCalledWith({ sortBy: DEFAULT_FILTERS.sortBy, sortOrder: DEFAULT_FILTERS.sortOrder });
+  });
+
+  it('builds a setter token labelled by count and clears the setter list', () => {
+    const { tokens, patchFilters } = build({ ...DEFAULT_FILTERS, setter: ['a', 'b'] });
+    const setter = tokens.find((token) => token.key === 'setter');
+    expect(setter?.label).toBe('2 setters');
+    setter?.clear();
+    expect(patchFilters).toHaveBeenCalledWith({ setter: undefined });
+  });
+
+  it('builds a Routes-only climb-type token and clears to boulders-only default', () => {
+    const { tokens, patchFilters } = build({ ...DEFAULT_FILTERS, boulders: false, routes: true });
+    const climbType = tokens.find((token) => token.key === 'climbType');
+    expect(climbType?.label).toBe('Routes only');
+    climbType?.clear();
+    expect(patchFilters).toHaveBeenCalledWith({ boulders: true, routes: false });
+  });
+
+  it('builds a benchmark token from board filters and clears via patchBoardFilters', () => {
+    const { tokens, patchBoardFilters } = build(DEFAULT_FILTERS, { onlyBenchmarks: true });
+    const benchmark = tokens.find((token) => token.key === 'benchmark');
+    expect(benchmark?.label).toBe('Benchmarks only');
+    benchmark?.clear();
+    expect(patchBoardFilters).toHaveBeenCalledWith({ onlyBenchmarks: false });
+  });
+
+  it('orders grade first, then refinements in summary order', () => {
+    const { tokens } = build({
+      ...DEFAULT_FILTERS,
+      minGrade: 5,
+      maxGrade: 15,
+      minAscents: 10,
+      status: 'drafts',
+      routes: true,
+    });
+    expect(keys(tokens)).toEqual(['grade', 'minAscents', 'status', 'climbType']);
+  });
+});

--- a/packages/mobile/src/lib/filter-labels.ts
+++ b/packages/mobile/src/lib/filter-labels.ts
@@ -1,0 +1,42 @@
+// Shared i18n label builders for the climbs filter summary string and the
+// removable filter tokens. Kept in one place so the summary (recent pills) and
+// the active-filter token chips never word a filter differently.
+
+import type { TFunction } from 'i18next';
+import { gradeAccuracyBucket, type FilterSummaryLabels, type SortOption } from '@boardsesh/climb-filters';
+
+export function buildFilterLabels(t: TFunction<'climbs'>): FilterSummaryLabels {
+  return {
+    gradeRange: (min, max) => t('mobile.search.gradeRange', { min, max }),
+    gradeMin: (grade) => t('mobile.search.gradeMin', { grade }),
+    gradeMax: (grade) => t('mobile.search.gradeMax', { grade }),
+    ascents: (count) => t('mobile.search.ascents', { count }),
+    rating: (count) => t('mobile.search.rating', { count }),
+    more: (count) => t('mobile.search.more', { count }),
+    // i18n-keep mobile.search.settersCount
+    setters: (count) => t('mobile.search.settersCount', { count }),
+    // i18n-keep mobile.filter.accuracy.off mobile.filter.accuracy.loose mobile.filter.accuracy.moderate mobile.filter.accuracy.tight
+    gradeAccuracy: (value) => t(`mobile.filter.accuracy.${gradeAccuracyBucket(value)}`),
+    tallOnly: () => t('mobile.filter.tall'),
+    wideOnly: () => t('mobile.filter.wide'),
+    betaOnly: () => t('mobile.filter.betaVideos'),
+    // i18n-keep mobile.filter.status.drafts mobile.filter.status.established mobile.filter.status.projects
+    status: (kind) => t(`mobile.filter.status.${kind}`),
+    hideAttempted: () => t('mobile.filter.progress.hideAttempted'),
+    hideCompleted: () => t('mobile.filter.progress.hideCompleted'),
+    showOnlyAttempted: () => t('mobile.filter.progress.onlyAttempted'),
+    showOnlyCompleted: () => t('mobile.filter.progress.onlyCompleted'),
+  };
+}
+
+export function buildSortLabel(t: TFunction<'climbs'>): (sortBy: string) => string | undefined {
+  const sortLabels: Record<SortOption, string> = {
+    ascents: t('mobile.filter.sort.ascents'),
+    quality: t('mobile.filter.sort.quality'),
+    difficulty: t('mobile.filter.sort.difficulty'),
+    name: t('mobile.filter.sort.name'),
+    popular: t('mobile.filter.sort.popular'),
+    creation: t('mobile.filter.sort.creation'),
+  };
+  return (sortBy: string) => sortLabels[sortBy as SortOption];
+}

--- a/packages/mobile/src/lib/filter-summary.ts
+++ b/packages/mobile/src/lib/filter-summary.ts
@@ -1,49 +1,8 @@
 import type { TFunction } from 'i18next';
 import type { Grade } from '@boardsesh/shared-schema';
-import {
-  getBaseFilterParts,
-  formatFilterSummary,
-  gradeAccuracyBucket,
-  type FilterSummaryLabels,
-  type SortOption,
-} from '@boardsesh/climb-filters';
+import { getBaseFilterParts, formatFilterSummary } from '@boardsesh/climb-filters';
 import { DEFAULT_FILTERS, type ClimbFilters } from './climb-filter-types';
-
-function buildLabels(t: TFunction<'climbs'>): FilterSummaryLabels {
-  return {
-    gradeRange: (min, max) => t('mobile.search.gradeRange', { min, max }),
-    gradeMin: (grade) => t('mobile.search.gradeMin', { grade }),
-    gradeMax: (grade) => t('mobile.search.gradeMax', { grade }),
-    ascents: (count) => t('mobile.search.ascents', { count }),
-    rating: (count) => t('mobile.search.rating', { count }),
-    more: (count) => t('mobile.search.more', { count }),
-    // i18n-keep mobile.search.settersCount
-    setters: (count) => t('mobile.search.settersCount', { count }),
-    // i18n-keep mobile.filter.accuracy.off mobile.filter.accuracy.loose mobile.filter.accuracy.moderate mobile.filter.accuracy.tight
-    gradeAccuracy: (value) => t(`mobile.filter.accuracy.${gradeAccuracyBucket(value)}`),
-    tallOnly: () => t('mobile.filter.tall'),
-    wideOnly: () => t('mobile.filter.wide'),
-    betaOnly: () => t('mobile.filter.betaVideos'),
-    // i18n-keep mobile.filter.status.drafts mobile.filter.status.established mobile.filter.status.projects
-    status: (kind) => t(`mobile.filter.status.${kind}`),
-    hideAttempted: () => t('mobile.filter.progress.hideAttempted'),
-    hideCompleted: () => t('mobile.filter.progress.hideCompleted'),
-    showOnlyAttempted: () => t('mobile.filter.progress.onlyAttempted'),
-    showOnlyCompleted: () => t('mobile.filter.progress.onlyCompleted'),
-  };
-}
-
-function buildSortLabel(t: TFunction<'climbs'>): (sortBy: string) => string | undefined {
-  const sortLabels: Record<SortOption, string> = {
-    ascents: t('mobile.filter.sort.ascents'),
-    quality: t('mobile.filter.sort.quality'),
-    difficulty: t('mobile.filter.sort.difficulty'),
-    name: t('mobile.filter.sort.name'),
-    popular: t('mobile.filter.sort.popular'),
-    creation: t('mobile.filter.sort.creation'),
-  };
-  return (sortBy: string) => sortLabels[sortBy as SortOption];
-}
+import { buildFilterLabels, buildSortLabel } from './filter-labels';
 
 export function getFilterSummary(
   filters: ClimbFilters,
@@ -51,7 +10,7 @@ export function getFilterSummary(
   grades: Grade[] | undefined,
   t: TFunction<'climbs'>,
 ): string {
-  const labels = buildLabels(t);
+  const labels = buildFilterLabels(t);
   const parts = getBaseFilterParts(
     {
       // Only include grade bounds when grades data is available — without it

--- a/packages/mobile/src/lib/filter-tokens.ts
+++ b/packages/mobile/src/lib/filter-tokens.ts
@@ -1,0 +1,210 @@
+// Builds the removable active-filter tokens shown beneath the climbs search
+// field. Each token carries a display label and a `clear` that resets just that
+// one filter back to its default. Labels reuse the same builders as the filter
+// summary string (filter-labels.ts) so a filter is never worded two ways.
+//
+// The typed name query is deliberately NOT a token — it lives in the search
+// field itself, where the field's own clear/cancel handles it.
+//
+// Mobile-only for now: web has no removable-token row and its filter state is a
+// different (URL-param) shape. If web grows one, promote the {key,label,clear}
+// mapping into @boardsesh/climb-filters, parameterized over the state shape.
+
+import type { TFunction } from 'i18next';
+import type { Grade } from '@boardsesh/shared-schema';
+import {
+  getGradeName,
+  applyStatusChange,
+  DEFAULT_CLIMB_FILTER_STATE,
+  type ClimbFilterState,
+  type ClimbBoardFilterState,
+} from '@boardsesh/climb-filters';
+import { buildFilterLabels, buildSortLabel } from './filter-labels';
+import type { GradeBound } from '../providers/climb-search-provider';
+
+export type FilterToken = {
+  /** Stable identity for the React key and tests. */
+  key: string;
+  label: string;
+  /** Reset this single filter to its default. */
+  clear: () => void;
+};
+
+type GetActiveFilterTokensArgs = {
+  filters: ClimbFilterState;
+  boardFilters: ClimbBoardFilterState;
+  grades: Grade[] | undefined;
+  t: TFunction<'climbs'>;
+  /** Formats a difficulty id in the user's chosen single scale (V or font),
+   *  matching how the list rows render grades — keeps the chip from showing the
+   *  dual "7a+/V7" string. Falls back to the dual name when it returns null. */
+  formatGradeByDifficultyId: (difficultyId: number | null | undefined) => string | null;
+  patchFilters: (patch: Partial<ClimbFilterState>) => void;
+  patchBoardFilters: (patch: Partial<ClimbBoardFilterState>) => void;
+  setGrade: (grade: GradeBound) => void;
+};
+
+/**
+ * One token per active filter, in the same field order as the summary string.
+ * Grade is a single token for the whole bound; the name query is excluded.
+ */
+export function getActiveFilterTokens({
+  filters,
+  boardFilters,
+  grades,
+  t,
+  formatGradeByDifficultyId,
+  patchFilters,
+  patchBoardFilters,
+  setGrade,
+}: GetActiveFilterTokensArgs): FilterToken[] {
+  const labels = buildFilterLabels(t);
+  const sortLabel = buildSortLabel(t);
+  const tokens: FilterToken[] = [];
+
+  // Grade — only when grades data has loaded, so the label is a real grade name
+  // rather than the "#42" id fallback.
+  if (grades != null && (filters.minGrade != null || filters.maxGrade != null)) {
+    // Prefer the user's single-scale grade name; fall back to the dual name.
+    const gradeName = (difficultyId: number) =>
+      formatGradeByDifficultyId(difficultyId) ?? getGradeName(difficultyId, grades);
+    let label: string;
+    if (filters.minGrade != null && filters.maxGrade != null) {
+      label = labels.gradeRange(gradeName(filters.minGrade), gradeName(filters.maxGrade));
+    } else if (filters.minGrade != null) {
+      label = labels.gradeMin(gradeName(filters.minGrade));
+    } else {
+      label = labels.gradeMax(gradeName(filters.maxGrade as number));
+    }
+    tokens.push({ key: 'grade', label, clear: () => setGrade({ minGradeId: undefined, maxGradeId: undefined }) });
+  }
+
+  // Sort — when either the field or direction differs from the default.
+  if (
+    filters.sortBy !== DEFAULT_CLIMB_FILTER_STATE.sortBy ||
+    filters.sortOrder !== DEFAULT_CLIMB_FILTER_STATE.sortOrder
+  ) {
+    const label = sortLabel(filters.sortBy);
+    if (label) {
+      tokens.push({
+        key: 'sort',
+        label,
+        clear: () =>
+          patchFilters({
+            sortBy: DEFAULT_CLIMB_FILTER_STATE.sortBy,
+            sortOrder: DEFAULT_CLIMB_FILTER_STATE.sortOrder,
+          }),
+      });
+    }
+  }
+
+  if (filters.minAscents != null) {
+    tokens.push({
+      key: 'minAscents',
+      label: labels.ascents(filters.minAscents),
+      clear: () => patchFilters({ minAscents: undefined }),
+    });
+  }
+
+  if (filters.minRating != null) {
+    tokens.push({
+      key: 'minRating',
+      label: labels.rating(filters.minRating),
+      clear: () => patchFilters({ minRating: undefined }),
+    });
+  }
+
+  if (filters.setter != null && filters.setter.length > 0 && labels.setters) {
+    tokens.push({
+      key: 'setter',
+      label: labels.setters(filters.setter.length),
+      clear: () => patchFilters({ setter: undefined }),
+    });
+  }
+
+  if (filters.gradeAccuracy != null && labels.gradeAccuracy) {
+    tokens.push({
+      key: 'gradeAccuracy',
+      label: labels.gradeAccuracy(filters.gradeAccuracy),
+      clear: () => patchFilters({ gradeAccuracy: undefined }),
+    });
+  }
+
+  if (filters.onlyTallClimbs && labels.tallOnly) {
+    tokens.push({ key: 'tall', label: labels.tallOnly(), clear: () => patchFilters({ onlyTallClimbs: undefined }) });
+  }
+
+  if (filters.onlyWideClimbs && labels.wideOnly) {
+    tokens.push({ key: 'wide', label: labels.wideOnly(), clear: () => patchFilters({ onlyWideClimbs: undefined }) });
+  }
+
+  if (filters.onlyWithBetaVideos && labels.betaOnly) {
+    tokens.push({
+      key: 'beta',
+      label: labels.betaOnly(),
+      clear: () => patchFilters({ onlyWithBetaVideos: undefined }),
+    });
+  }
+
+  // Only drafts/projects produce a token — 'any' is the default and 'established'
+  // is the retired duplicate of the popularity lever (matches the summary).
+  if ((filters.status === 'drafts' || filters.status === 'projects') && labels.status) {
+    tokens.push({
+      key: 'status',
+      label: labels.status(filters.status),
+      clear: () => patchFilters(applyStatusChange(filters, 'any')),
+    });
+  }
+
+  if (filters.hideAttempted && labels.hideAttempted) {
+    tokens.push({
+      key: 'hideAttempted',
+      label: labels.hideAttempted(),
+      clear: () => patchFilters({ hideAttempted: undefined }),
+    });
+  }
+
+  if (filters.hideCompleted && labels.hideCompleted) {
+    tokens.push({
+      key: 'hideCompleted',
+      label: labels.hideCompleted(),
+      clear: () => patchFilters({ hideCompleted: undefined }),
+    });
+  }
+
+  if (filters.showOnlyAttempted && labels.showOnlyAttempted) {
+    tokens.push({
+      key: 'showOnlyAttempted',
+      label: labels.showOnlyAttempted(),
+      clear: () => patchFilters({ showOnlyAttempted: undefined }),
+    });
+  }
+
+  if (filters.showOnlyCompleted && labels.showOnlyCompleted) {
+    tokens.push({
+      key: 'showOnlyCompleted',
+      label: labels.showOnlyCompleted(),
+      clear: () => patchFilters({ showOnlyCompleted: undefined }),
+    });
+  }
+
+  // Climb type — default is boulders-only; a token appears when routes are on or
+  // boulders are off. Clearing returns to the boulders-only default.
+  const bouldersOn = filters.boulders ?? true;
+  const routesOn = filters.routes ?? false;
+  if (bouldersOn !== true || routesOn !== false) {
+    const label = routesOn && !bouldersOn ? t('search.summary.routesOnly') : t('search.summary.bouldersAndRoutes');
+    tokens.push({ key: 'climbType', label, clear: () => patchFilters({ boulders: true, routes: false }) });
+  }
+
+  // Board-renderer filters: only `onlyBenchmarks` is user-settable today.
+  if (boardFilters.onlyBenchmarks) {
+    tokens.push({
+      key: 'benchmark',
+      label: t('mobile.filter.benchmark'),
+      clear: () => patchBoardFilters({ onlyBenchmarks: false }),
+    });
+  }
+
+  return tokens;
+}

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -143,7 +143,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     return <Redirect href="/auth/login" />;
   }
   if (isAuthenticated && inAuthGroup) {
-    return <Redirect href="/(tabs)/boards" />;
+    return <Redirect href="/(tabs)/climbs" />;
   }
 
   return (

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -537,7 +537,8 @@
     "emptyState": {
       "noBoard": {
         "title": "No board selected",
-        "subtitle": "Add a board first to browse climbs"
+        "subtitle": "Add a board first to browse climbs",
+        "cta": "Choose your board"
       },
       "noClimbs": {
         "title": "No climbs found",
@@ -658,7 +659,8 @@
       "filters": "Filters",
       "filterCountAria": "Filters, {{count}} active",
       "filterHint": "Opens all climb filters",
-      "gradeAction": "Set grade range"
+      "gradeAction": "Set grade range",
+      "clearAll": "Clear all"
     },
     "gradeRail": {
       "setFilterAria": "Set grade filter to {{grade}}",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -537,7 +537,8 @@
     "emptyState": {
       "noBoard": {
         "title": "Tabla no seleccionada",
-        "subtitle": "Agrega una tabla primero para explorar bloques"
+        "subtitle": "Agrega una tabla primero para explorar bloques",
+        "cta": "Elige tu tabla"
       },
       "noClimbs": {
         "title": "No se encontraron bloques",
@@ -658,7 +659,8 @@
       "filters": "Filtros",
       "filterCountAria": "Filtros, {{count}} activos",
       "filterHint": "Abre todos los filtros de bloques",
-      "gradeAction": "Ajustar el rango de grado"
+      "gradeAction": "Ajustar el rango de grado",
+      "clearAll": "Borrar todo"
     },
     "gradeRail": {
       "setFilterAria": "Filtrar por grado {{grade}}",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -537,7 +537,8 @@
     "emptyState": {
       "noBoard": {
         "title": "Aucun board sélectionné",
-        "subtitle": "Ajoutez un board pour parcourir les blocs"
+        "subtitle": "Ajoutez un board pour parcourir les blocs",
+        "cta": "Choisir un board"
       },
       "noClimbs": {
         "title": "Aucun bloc trouvé",
@@ -658,7 +659,8 @@
       "filters": "Filtres",
       "filterCountAria": "Filtres, {{count}} actifs",
       "filterHint": "Ouvre tous les filtres de blocs",
-      "gradeAction": "Définir la plage de cotation"
+      "gradeAction": "Définir la plage de cotation",
+      "clearAll": "Tout effacer"
     },
     "gradeRail": {
       "setFilterAria": "Filtrer par cotation {{grade}}",


### PR DESCRIPTION
## What

Reworks the mobile Climbs search & filter experience around one principle from the design exploration: **the Climbs tab is the search surface**, and filtering — not name search — is the dominant interaction.

## Why (data-driven)

- **Board switching is rare** — PostHog (web/Capacitor proxy): ~92% of users use one board in 30 days, 96.6% of sessions resume on the same board. Board selection shouldn't own the primary surface.
- **Filters aren't ubiquitous, but grade dominates** — ~45% of Capacitor-mobile browse sessions apply a filter (~40% browse unfiltered, ~15% name-only); of *filtered* searches, **99.9% set a grade range**. So: keep name search cheap, keep the native search, don't bury search behind filters.

(Mobile RN analytics isn't live yet; the legacy Capacitor app is a webview, so its real mobile usage lands as web events — that's the data source.)

## Changes

- **Land on Climbs** via `unstable_settings.initialRouteName` (both variants).
- **Boards tab → modal**: board selection moves to a modal opened from the board capsule + a no-board CTA; all 9 nav entry points repointed; post-activation uses `router.dismissTo` back onto Climbs. (BLE-serial auto-detect integration point marked.)
- **Active filters → a single summary capsule** below the board name (tap to clear, no per-chip ✕), single-scale grades matching the rows.
- **Scrim** behind the top chrome so the list doesn't bleed through the floating glass islands.
- **Row scan**: louder grade (title3) + a send-status dot on the text line (shared `useAscentStatus` hook).
- **Demoted board capsule**; **white active filter-FAB glyph** on the maroon glass.
- Material variant gets a filter button left of the search field; extracted `filter-tokens` / `filter-labels`.

## Validation

- `vp run typecheck:mobile` ✓
- `vp test --project mobile` — **962 pass** ✓ (new `filter-tokens` test; updated `tab-layout`, `analytics-screen-path`, `filter-button`, `climb-top-chrome`)
- `vp run check:mobile-bundle` ✓

All changes are OTA-safe (no native deps added). **Needs an on-device check on iOS 26 Liquid Glass** — NativeTabs re-layout after removing the Boards trigger, the boards-modal dismissal, and the summary capsule.

## Tried and dropped

- `hideWhenScrolling` to hide the bottom search on scroll — iOS 26 ignores it for the tab-bar-relocated search (confirmed on device); reverted.
- Merging name search into a combined filter drawer — dropped after the data showed >half of sessions browse unfiltered or name-only, so it'd add friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)