### PR TITLE
Fix party-profile UUID generation on mobile (Hermes)

### DIFF
--- a/packages/mobile/src/providers/__tests__/party-profile-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/party-profile-provider.test.tsx
@@ -22,6 +22,14 @@ vi.mock('expo-secure-store', () => {
   };
 });
 
+// The provider injects expo-crypto's randomUUID into ensureProfile (Hermes has
+// no global crypto.randomUUID). Mock the native module so the suite stays in the
+// node/jsdom env, and so a created profile's id is deterministic — see the mount
+// test below, which asserts the id comes from this injected generator.
+vi.mock('expo-crypto', () => ({
+  randomUUID: () => 'test-uuid',
+}));
+
 // AuthProvider transitively imports expo-router; stub the consumed surface
 // so we can test PartyProfileProvider in isolation.
 vi.mock('../auth-provider', () => ({
@@ -73,7 +81,11 @@ describe('PartyProfileProvider', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.profile).not.toBeNull();
-    expect(typeof result.current.profile?.id).toBe('string');
+    // The id must come from the injected expo-crypto generator, not the shared
+    // default. If the `randomUUID` arg is dropped, the provider falls back to
+    // jsdom's real crypto.randomUUID (a genuine UUID, not 'test-uuid') and this
+    // fails — guarding against the Hermes "crypto.randomUUID unavailable" bug.
+    expect(result.current.profile?.id).toBe('test-uuid');
     expect(result.current.hasProfile).toBe(true);
   });
 

--- a/packages/mobile/src/providers/party-profile-provider.tsx
+++ b/packages/mobile/src/providers/party-profile-provider.tsx
@@ -14,6 +14,7 @@
 // in this single provider; the issue lays out the cleaner split.
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { randomUUID } from 'expo-crypto';
 import { ensureProfile, type PartyProfile } from '@boardsesh/party-profile';
 import { reconcileAnalyticsIdentity } from '@boardsesh/analytics';
 import { partyProfileStorage } from '../lib/party-profile-store';
@@ -46,7 +47,9 @@ export function PartyProfileProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let mounted = true;
-    ensureProfile(partyProfileStorage)
+    // Inject expo-crypto's randomUUID: Hermes has no global crypto.randomUUID,
+    // so the shared default generator throws. Mirrors web, which injects uuid v4.
+    ensureProfile(partyProfileStorage, randomUUID)
       .then((loaded) => {
         if (mounted) setProfile(loaded);
       })
@@ -93,7 +96,7 @@ export function PartyProfileProvider({ children }: { children: ReactNode }) {
 
   const refreshProfile = useCallback(async () => {
     try {
-      const loaded = await ensureProfile(partyProfileStorage);
+      const loaded = await ensureProfile(partyProfileStorage, randomUUID);
       setProfile(loaded);
     } catch (err) {
       if (__DEV__) console.warn('[party-profile] refresh failed', err);


### PR DESCRIPTION
## Problem

Every mobile launch logged:

```
WARN  [party-profile] load failed [Error: crypto.randomUUID unavailable — party profile cannot generate an id]
```

The party profile is a per-device anonymous identity — a stable UUID in `expo-secure-store` that seeds the WebSocket party display name and anchors the anonymous PostHog `distinct_id` before login. When its id can't be generated the profile never loads: no stable party-session peer identity, and pre-login analytics events lose their anchor for later identity reconciliation.

## Root cause

The shared `ensureProfile()` defaults to a `defaultGenerateId()` that reads `globalThis.crypto.randomUUID()`. That global isn't present in React Native's Hermes runtime, so it throws. The throw is **intentional** — the shared default is designed to fail loud and let each platform inject its own generator rather than silently hand out non-UUID ids.

- Web already injects its generator (`uuid` v4) in `party-profile-db.ts`, so web is unaffected.
- Mobile called `ensureProfile(partyProfileStorage)` with no generator, falling through to the broken default.

## Fix

Inject `expo-crypto`'s `randomUUID` (already a mobile dep, used in 7+ files) at both mobile call sites — mount and `refreshProfile` — mirroring web. `expo-crypto.randomUUID()` returns a v4 UUID, so id format parity with web holds. The shared `defaultGenerateId` is left untouched; the contract is per-platform injection.

## Why tests didn't catch it

The provider test runs under `@vitest-environment jsdom`, where `crypto.randomUUID` *does* exist — so the default generator succeeded in tests while failing on-device. This PR mocks `expo-crypto` (matching the existing pattern in `drawer-host-provider.test.tsx` / `queue-provider-session-updates.test.tsx`) and asserts the created profile's id comes from the injected generator (`'test-uuid'`). Drop the generator arg and the test now fails — a real regression guard.

## Verification

- `vp run typecheck:mobile` ✅
- `vp test --project mobile` → 6/6 pass (incl. the new regression assertion) ✅
- `vp run check:mobile-bundle` → iOS + Android bundles compile ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)