### PR TITLE
fix(mobile): six create-climb draft/autosave bugs

### DIFF
--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -169,7 +169,9 @@ function ClimbActionsSheet({
       publishedAt: climb.published_at ?? null,
       isDraft: climb.is_draft ?? false,
     };
-    return (climb.is_draft ?? false) || computeCanUpdate(snapshot, boardName);
+    // `computeCanUpdate` already returns true for drafts, so no separate
+    // is_draft guard is needed — keep the draft rule in one place.
+    return computeCanUpdate(snapshot, boardName);
   }, [climb, currentUserId, boardName]);
 
   const snapPoints = useMemo(() => ['40%'], []);

--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { View, StyleSheet, Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { GestureDetector } from 'react-native-gesture-handler';
@@ -62,6 +63,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
   renderHeight,
   overlay,
 }: InteractiveCreateBoardProps) {
+  const { t } = useTranslation('common');
   const { pinchGesture, zoomPanGesture, isZoomed, resetZoom, animatedZoomStyle } = useZoomPanGesture({
     enabled: true,
     containerWidth: renderWidth,
@@ -127,7 +129,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
           {isZoomed ? (
             <Pressable style={styles.resetButton} onPress={resetZoom} hitSlop={8} accessibilityRole="button">
               <Text variant="footnote" style={styles.resetLabel}>
-                Reset zoom
+                {t('board.resetZoom')}
               </Text>
             </Pressable>
           ) : null}

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -236,7 +236,11 @@ export function useCreateClimbScreen({
     // Edit mode operates on an existing climb — never persist it into the
     // per-board new-draft autosave slot, or it resurfaces as a phantom draft.
     if (isEditing) return;
-    const hasContent = Object.keys(litUpHoldsMap).length > 0 || name.trim() !== '' || description.trim() !== '';
+    // Once the WIP has been saved, stop autosaving. `handleSave` clears the
+    // draft and sets `savedClimb`; without this guard the debounced timer would
+    // re-write the just-cleared draft and resurface it as a phantom on reopen.
+    if (savedClimb) return;
+    const hasContent = holdsJson !== '{}' || name.trim() !== '' || description.trim() !== '';
     const handle = setTimeout(() => {
       if (!hasContent) {
         void clearDraft(draftKey);
@@ -245,7 +249,7 @@ export function useCreateClimbScreen({
       void saveDraft(draftKey, { holdsJson, name, description: withNoMatch(description, noMatch), isDraft });
     }, AUTOSAVE_DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [holdsJson, name, description, noMatch, isDraft, draftKey, litUpHoldsMap]);
+  }, [holdsJson, name, description, noMatch, isDraft, draftKey, savedClimb]);
 
   // ---- BLE preview (debounced) while connected. ----
   const sendFramesRef = useRef(bluetooth?.sendFramesToBoard);
@@ -276,6 +280,11 @@ export function useCreateClimbScreen({
 
   const handleClear = useCallback(() => {
     resetHolds();
+    // Treat Clear as a brand-new climb: wipe name/description/draft flag too, or
+    // a Save straight after Clear reuses the old name and skips the name prompt.
+    setName('');
+    setDescription('');
+    setIsDraft(true);
     setSavedClimb(null);
     setPublishDuplicateError(null);
     // Fresh climb identity for the next WIP so its queue item is independent.

--- a/packages/mobile/src/lib/__tests__/create-climb-draft-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/create-climb-draft-store.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// The module pulls in preference-store → AsyncStorage at import time; mock it so
+// the suite loads under Vitest (the native module isn't resolvable here).
+vi.mock('@react-native-async-storage/async-storage', () => {
+  let storage: Record<string, string> = {};
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage[key] = value;
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        delete storage[key];
+      }),
+      __reset: () => {
+        storage = {};
+      },
+    },
+  };
+});
+
+import { createClimbDraftKey } from '../create-climb-draft-store';
+
+describe('createClimbDraftKey', () => {
+  const base = { boardName: 'kilter', layoutId: 1, sizeId: 2, setIds: '10', angle: 40 };
+
+  it('includes every board dimension in the key', () => {
+    expect(createClimbDraftKey(base)).toBe('kilter:1:2:10:40');
+  });
+
+  it('distinguishes hold sets at the same layout/size/angle', () => {
+    // Kilter/Tension share a layout/size/angle across "original" vs "commercial"
+    // (bolt-on) sets. The key must differ so one set's draft never restores hold
+    // IDs that don't exist in the other set.
+    const original = createClimbDraftKey({ ...base, setIds: '10' });
+    const commercial = createClimbDraftKey({ ...base, setIds: '11' });
+    expect(original).not.toBe(commercial);
+  });
+
+  it('distinguishes board, layout, size, and angle', () => {
+    expect(createClimbDraftKey({ ...base, boardName: 'tension' })).not.toBe(createClimbDraftKey(base));
+    expect(createClimbDraftKey({ ...base, layoutId: 99 })).not.toBe(createClimbDraftKey(base));
+    expect(createClimbDraftKey({ ...base, sizeId: 99 })).not.toBe(createClimbDraftKey(base));
+    expect(createClimbDraftKey({ ...base, angle: 25 })).not.toBe(createClimbDraftKey(base));
+  });
+});

--- a/packages/mobile/src/lib/create-climb-draft-store.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.ts
@@ -20,17 +20,21 @@ export type CreateClimbDraft = {
 const KEY_PREFIX = 'boardsesh_create_climb_draft:';
 
 /**
- * Stable per-board key. Matches the brief's
- * `${boardName}:${layoutId}:${sizeId}:${angle}` so two configs that differ in
- * any of those restore independent working drafts.
+ * Stable per-board key of the form
+ * `${boardName}:${layoutId}:${sizeId}:${setIds}:${angle}` so two configs that
+ * differ in any of those restore independent working drafts. `setIds` matters
+ * because Kilter/Tension share a layout/size/angle across "original" vs
+ * "commercial" (bolt-on) hold sets — leaving it out lets a draft from one set
+ * restore hold IDs that don't exist in the current set.
  */
 export function createClimbDraftKey(config: {
   boardName: string;
   layoutId: number;
   sizeId: number;
+  setIds: string;
   angle: number;
 }): string {
-  return `${config.boardName}:${config.layoutId}:${config.sizeId}:${config.angle}`;
+  return `${config.boardName}:${config.layoutId}:${config.sizeId}:${config.setIds}:${config.angle}`;
 }
 
 function storageKey(boardKey: string): string {


### PR DESCRIPTION
A code review of the mobile create-climb editor (#2510) surfaced six issues in its per-board local autosave. This fixes all of them.

## Fixes

**1. Draft key omitted `setIds` (data corruption).** Kilter/Tension share a layout/size/angle across "original" vs "commercial" (bolt-on) hold sets. Without `setIds` in the autosave key, switching sets restored hold IDs that don't exist in the current set — those ghost IDs got a valid state and were serialised back to the server on save, referencing a non-existent hole. `createClimbDraftKey` now includes `setIds`. The single caller already passes the full `CreateClimbBoard` (which carries `setIds`), so no call-site change.

**2. Hardcoded "Reset zoom" string.** `InteractiveCreateBoard` now uses `t('board.resetZoom')` (key already present in `en-US`/`es`/`fr` `common.json`).

**3. Redundant `is_draft` guard in `canEdit`.** `computeCanUpdate` already returns `true` for drafts, so the outer `(climb.is_draft ?? false) ||` was dead and would silently bypass any future draft-specific logic in `computeCanUpdate`. Removed.

**4. Autosave race after save.** `handleSave` cleared the draft then set `savedClimb`, which re-triggered the debounced autosave effect, which re-wrote the just-cleared draft within the 500ms window — resurfacing a phantom draft on next open. The effect now early-returns once `savedClimb` is set.

**5. `handleClear` didn't reset name/description.** "Clear holds" left the previous name/description intact, so Save right after Clear saved an empty climb under the old name without the name prompt. Clear now also resets `name`/`description`/`isDraft`, consistent with resetting `savedClimb` to null. (Confirmed "full reset" behavior with the requester.)

**6. Redundant `litUpHoldsMap` autosave dep.** `holdsJson = JSON.stringify(litUpHoldsMap)` changes in lockstep, so listing both doubled triggers and read `hasContent` from a possibly-stale ref. `hasContent` is now computed from `holdsJson` (`!== '{}'`) and `litUpHoldsMap` dropped from the dep array.

## Notes

Changing the draft-key format orphans any in-flight stored drafts under the old key — acceptable, they simply don't restore (no data loss for saved climbs).

## Validation

- `vp run typecheck:mobile` — passes
- `vp test --project mobile` — 990 passing (incl. new `createClimbDraftKey` unit test)
- `vp run check:mobile-bundle` — Android bundle OK; confirms the new `react-i18next` import resolves

https://claude.ai/code/session_01HUVgNVzjKUzgU36jTfivbJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUVgNVzjKUzgU36jTfivbJ)_