### PR TITLE
PR APK: side-by-side "Boardsesh Debug" dev-client build

### DIFF
--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -5,15 +5,16 @@ name: Android PR Build (React Native)
 #   1. Catches what the JS-only checks can't — a broken Expo config plugin, an
 #      app.config.ts mistake, or a Gradle/native-module compile failure — BEFORE
 #      it reaches the push-to-main android-apk-rn.yml release build.
-#   2. Produces a sideloadable APK artifact so anyone can test the branch on a
-#      real device WITHOUT the production keystore.
+#   2. Produces an installable "Boardsesh Debug" APK so anyone can test the
+#      branch on a real device WITHOUT the production keystore.
 #
-# It builds `assembleRelease` (JS bundled → runs standalone), but with the
-# debug-signing FALLBACK in with-android-release-signing.js: this job is NOT in
-# the Production GitHub Environment, so it has no ANDROID_KEYSTORE_* secrets and
-# the plugin signs `release` with the debug key. That makes the APK sideloadable
-# but with a DIFFERENT signature than the production/Play build — uninstall any
-# existing com.boardsesh.app before installing it.
+# It builds `assembleDebug` (debug-signed via the auto-generated debug keystore)
+# with BOARDSESH_DEBUG_BUILD=1, so app.config.ts emits a distinct app name
+# ("Boardsesh Debug") and applicationId (com.boardsesh.app.debug). That installs
+# ALONGSIDE the production com.boardsesh.app app instead of replacing it. The
+# debug variant bundles expo-dev-client, so the APK ships the Metro dev-server
+# switcher: open it and point the PR branch at a local/preview dev server (the
+# JS is not baked in — this build runs against a Metro server, not standalone).
 #
 # ci.yml already runs typecheck:mobile + the mobile vitest project +
 # check:mobile-bundle on PRs, so this doesn't duplicate those. Distinct from the
@@ -100,28 +101,26 @@ jobs:
           # Skip the tailscale probe (already short-circuited on CI, set
           # explicitly so a misconfigured runner never pays the 2s timeout).
           TAILSCALE_HOSTS: ''
+          # Emit the "Boardsesh Debug" flavour: distinct app name +
+          # applicationId (com.boardsesh.app.debug) so it installs alongside the
+          # production app. See app.config.ts.
+          BOARDSESH_DEBUG_BUILD: '1'
         run: bunx expo prebuild --platform android --clean --no-install
 
-      - name: Build debug-signed release APK (compiles all native modules + plugins)
+      - name: Build debug APK (compiles all native modules + plugins, ships dev-client)
         working-directory: packages/mobile/android
-        # No ANDROID_KEYSTORE_* env here → with-android-release-signing falls back
-        # to debug signing. assembleRelease bundles the JS so the APK runs
-        # standalone (a debug APK would expect a Metro dev server).
-        env:
-          # No Production env here → no SENTRY_AUTH_TOKEN; disable the Sentry
-          # source-map upload so the JS-bundle task doesn't fail trying to upload.
-          SENTRY_DISABLE_AUTO_UPLOAD: 'true'
+        # assembleDebug signs with the auto-generated debug keystore and bundles
+        # expo-dev-client, so the APK ships the Metro dev-server switcher. The JS
+        # is NOT baked in — point it at a Metro dev server via the launcher.
         # arm64-v8a only: every modern physical device, ~4× less native compile
         # (board-renderer CMake + RN/Hermes) → faster + far lower peak memory.
-        # The GitHub Release sideload APK uses the same arm64-only path; Play
-        # distribution still goes through the signed AAB in android-apk-rn.yml.
-        run: ./gradlew assembleRelease -PreactNativeArchitectures=arm64-v8a -PboardseshAbiFilters=arm64-v8a --stacktrace
+        run: ./gradlew assembleDebug -PreactNativeArchitectures=arm64-v8a -PboardseshAbiFilters=arm64-v8a --stacktrace
 
-      - name: Upload sideloadable APK
+      - name: Upload installable APK
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: boardsesh-rn-android-pr-${{ github.event.pull_request.number || github.run_number }}
-          path: packages/mobile/android/app/build/outputs/apk/release/*.apk
+          path: packages/mobile/android/app/build/outputs/apk/debug/*.apk
           retention-days: 14
           if-no-files-found: warn

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -4,6 +4,17 @@ import type { ExpoConfig, ConfigContext } from 'expo/config';
 const DEFAULT_EAS_PROJECT_ID = '87499648-655e-4fb8-9856-65da37e55fb1';
 const EAS_PROJECT_ID = process.env.EXPO_PUBLIC_EAS_PROJECT_ID ?? DEFAULT_EAS_PROJECT_ID;
 
+// Side-by-side "debug" flavour. When BOARDSESH_DEBUG_BUILD=1 (set by the PR APK
+// workflow, android-pr-rn.yml), prebuild emits a distinct app name + applicationId
+// /bundleIdentifier so the build installs ALONGSIDE the production app instead of
+// replacing it (the scheme stays shared on purpose — see below). Paired with an
+// `assembleDebug` build, that gives a throwaway "Boardsesh Debug" install with the
+// expo-dev-client Metro server switcher for pointing a PR branch at a local/preview
+// dev server.
+const IS_DEBUG_BUILD = process.env.BOARDSESH_DEBUG_BUILD === '1';
+const APP_NAME = IS_DEBUG_BUILD ? 'Boardsesh Debug' : 'Boardsesh';
+const APP_ID = IS_DEBUG_BUILD ? 'com.boardsesh.app.debug' : 'com.boardsesh.app';
+
 function resolveDevMetadata(): {
   branchName: string | null;
   qaNotes: string | null;
@@ -81,10 +92,14 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
 
   return {
     ...config,
-    name: 'Boardsesh',
+    name: APP_NAME,
     slug: 'boardsesh',
     owner: 'boardsesh',
     version: '2.0.0',
+    // Deliberately NOT suffixed for the debug flavour: this scheme is the OAuth
+    // redirect URI registered with Aurora (com.boardsesh.app://auth/callback in
+    // src/lib/auth.ts). The side-by-side install is keyed off applicationId, not
+    // the scheme, so keeping it shared keeps login working in the debug build.
     scheme: 'com.boardsesh.app',
     orientation: 'portrait',
     icon: './assets/icon.png',
@@ -106,7 +121,7 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
         }
       : {}),
     ios: {
-      bundleIdentifier: 'com.boardsesh.app',
+      bundleIdentifier: APP_ID,
       // Required by @bacons/apple-targets to assign the widget extension
       // target's DEVELOPMENT_TEAM build setting. Matches the existing main
       // target value baked into Boardsesh.xcodeproj/project.pbxproj.
@@ -151,7 +166,7 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       },
     },
     android: {
-      package: 'com.boardsesh.app',
+      package: APP_ID,
       // App Links for the multiplayer join flow:
       // https://www.boardsesh.com/join/{sessionId} (and the apex domain).
       // autoVerify lets Android open the link directly in the app once the


### PR DESCRIPTION
## What

Turn the per-PR Android APK into a side-by-side **"Boardsesh Debug"** build with the Metro dev-server switcher, so it installs *alongside* the production app instead of replacing it.

## Why

You can't currently have the PR test build and the production install on the same device — same `applicationId`, so one replaces the other. And the PR APK bundled JS to run standalone, with no way to point it at a Metro dev server.

## Changes

**`packages/mobile/app.config.ts`** — new `BOARDSESH_DEBUG_BUILD=1` flavour switch (off everywhere else, so existing EAS/iOS/production builds are untouched):
- `name` → `Boardsesh Debug`
- `android.package` / `ios.bundleIdentifier` → `com.boardsesh.app.debug` — distinct `applicationId` lets it coexist with the production `com.boardsesh.app` install.
- `scheme` deliberately **unchanged** (`com.boardsesh.app`): it's the Aurora OAuth redirect URI (`com.boardsesh.app://auth/callback` in `src/lib/auth.ts`). Side-by-side install is keyed off `applicationId`, not the scheme, so login keeps working.

**`.github/workflows/android-pr-rn.yml`** — the PR APK job now:
- sets `BOARDSESH_DEBUG_BUILD=1` during `expo prebuild`,
- builds `assembleDebug` instead of `assembleRelease`. The debug variant bundles `expo-dev-client` (already a dependency), which is what ships the **Metro dev-server switcher**. The JS is not baked in — open the app and point it at a local/preview dev server via the launcher.
- uploads the APK from `apk/debug/`.

The job still compiles every native module + Expo config plugin, so it keeps catching prebuild/Gradle/native-module regressions before they hit the push-to-main release build.

## Validation

- `vp run typecheck:mobile` — passes.

The new APK itself is produced by this PR's CI run (the android-pr-rn workflow).

https://claude.ai/code/session_01A1qSZKRWiD2gTA57iPdXkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1qSZKRWiD2gTA57iPdXkG)_