### PR TITLE
Add missing tests: resolveBoardReturnTo, filter labels, PlaylistDetailView

### DIFF
--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -1,0 +1,342 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { Climb } from '@boardsesh/queue';
+
+const ctrl = vi.hoisted(() => ({ back: vi.fn() }));
+
+// ── React Native ──────────────────────────────────────────────────────────────
+vi.mock('react-native', () => ({
+  View: ({
+    children,
+    pointerEvents,
+    style,
+    onLayout,
+  }: {
+    children?: ReactNode;
+    pointerEvents?: string;
+    style?: unknown;
+    onLayout?: (e: unknown) => void;
+  }) => {
+    const attrs: Record<string, unknown> = {};
+    if (pointerEvents) attrs['data-pointer-events'] = pointerEvents;
+    if (onLayout) attrs['data-has-layout'] = 'true';
+    return createElement('div', attrs, children);
+  },
+  StyleSheet: {
+    create: (s: Record<string, unknown>) => s,
+    absoluteFill: {},
+    hairlineWidth: 1,
+  },
+}));
+
+// ── Reanimated ────────────────────────────────────────────────────────────────
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+      createElement('div', { 'data-animated-view': 'true' }, children),
+  },
+  useAnimatedStyle: () => ({}),
+  useSharedValue: (v: number) => ({ value: v }),
+  // useAnimatedReaction runs on a worklet thread — no-op in jsdom; the
+  // component initialises `collapsed` to false via useState, which is what the
+  // tests assert against.
+  useAnimatedReaction: () => undefined,
+  runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+  interpolate: (v: number) => v,
+  Extrapolation: { CLAMP: 'CLAMP' },
+}));
+
+// ── Expo / third-party ────────────────────────────────────────────────────────
+vi.mock('expo-linear-gradient', () => ({
+  LinearGradient: ({
+    colors,
+    children,
+  }: {
+    colors: string[];
+    children?: ReactNode;
+  }) => createElement('div', { 'data-gradient': JSON.stringify(colors) }, children ?? null),
+}));
+
+vi.mock('@shopify/flash-list', () => ({
+  FlashList: ({
+    data,
+    ListHeaderComponent,
+    ListEmptyComponent,
+    ListFooterComponent,
+    onEndReached,
+  }: {
+    data?: unknown[];
+    ListHeaderComponent?: ReactNode;
+    ListEmptyComponent?: ReactNode;
+    ListFooterComponent?: ReactNode;
+    onEndReached?: () => void;
+  }) =>
+    createElement(
+      'div',
+      { 'data-list': 'true', onClick: onEndReached },
+      ListHeaderComponent ?? null,
+      data?.length === 0 ? ListEmptyComponent ?? null : null,
+      ListFooterComponent ?? null,
+    ),
+}));
+
+vi.mock('expo-router', () => ({ useRouter: () => ({ back: ctrl.back }) }));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 44, bottom: 0, left: 0, right: 0 }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, opts?: Record<string, unknown>) => key }),
+}));
+
+// ── Theme / providers ─────────────────────────────────────────────────────────
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { label: '#000000', fill: '#eeeeee' } }),
+}));
+
+vi.mock('../../../providers/drawer-host-provider', () => ({
+  useDrawerHost: () => ({ boardConfig: null }),
+}));
+
+vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+}));
+
+vi.mock('../../../theme/layout', () => ({ glassSize: { standard: 48, capsule: 36, hero: 56 } }));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 4: 16, 5: 20, 12: 48 },
+  borderRadius: { xl: 24 },
+}));
+vi.mock('../../../theme/colors', () => ({
+  withAlpha: (color: string, alpha: number) => `${color}|${alpha}`,
+}));
+vi.mock('../../../theme/ios-colors', () => ({
+  iosSystemColors: { white: '#ffffff', systemGray4: '#aeaeb2' },
+}));
+
+// ── Leaf components ───────────────────────────────────────────────────────────
+vi.mock('../../Text', () => ({
+  Text: ({ children, variant }: { children?: ReactNode; variant?: string }) =>
+    createElement('span', { 'data-variant': variant ?? '' }, children),
+}));
+
+vi.mock('../../Icon', () => ({
+  Icon: ({ name, size }: { name: string; size?: number }) =>
+    createElement('span', { 'data-icon': name, 'data-size': size }),
+}));
+
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: ({ size }: { size?: string }) =>
+    createElement('div', { 'data-spinner': size ?? 'default' }),
+}));
+
+vi.mock('../../ClimbListRow', () => ({ ClimbListRow: () => null }));
+
+vi.mock('../../GlassIconButton', () => ({
+  GlassIconButton: ({
+    iconName,
+    onPress,
+    accessibilityLabel,
+  }: {
+    iconName: string;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { 'data-icon': iconName, onClick: onPress, 'aria-label': accessibilityLabel }),
+}));
+
+vi.mock('../PlaylistBoardBackdrop', () => ({
+  PlaylistBoardBackdrop: ({ boardType }: { boardType: string }) =>
+    createElement('div', { 'data-backdrop': boardType }),
+}));
+
+// Use real playlist-gradient and playlist-colors (pure TS, no RN imports).
+
+// ── Subject ───────────────────────────────────────────────────────────────────
+import { PlaylistDetailView, type PlaylistDetailViewProps } from '../PlaylistDetailView';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const CLIMB: Climb = {
+  uuid: 'abc-123',
+  name: 'Test Route',
+  setter_username: 'tester',
+  frames: '',
+  angle: 40,
+  ascensionist_count: 5,
+  difficulty: '10',
+  quality_average: '3.0',
+  stars: 3,
+  difficulty_error: '0',
+  benchmark_difficulty: null,
+};
+
+function makeProps(overrides: Partial<PlaylistDetailViewProps> = {}): PlaylistDetailViewProps {
+  return {
+    hero: {
+      name: 'My Playlist',
+      climbCount: 12,
+      color: '#8C4A52',
+    },
+    climbs: [],
+    isLoading: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+    onActivateClimb: vi.fn(),
+    emptyMessage: 'No climbs yet',
+    ...overrides,
+  };
+}
+
+describe('PlaylistDetailView', () => {
+  beforeEach(() => {
+    ctrl.back.mockClear();
+  });
+
+  // ── Navigation ──────────────────────────────────────────────────────────────
+
+  it('always renders the back FAB', () => {
+    const { container } = render(<PlaylistDetailView {...makeProps()} />);
+    const btn = container.querySelector('[data-icon="back"]');
+    expect(btn).not.toBeNull();
+  });
+
+  it('clicking the back FAB calls router.back', () => {
+    const { container } = render(<PlaylistDetailView {...makeProps()} />);
+    fireEvent.click(container.querySelector('[data-icon="back"]') as HTMLElement);
+    expect(ctrl.back).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Action threading ────────────────────────────────────────────────────────
+
+  it('calls actions(false) initially and renders the returned node', () => {
+    const actions = vi.fn((collapsed: boolean) =>
+      createElement('span', { 'data-action-collapsed': String(collapsed) }, 'action'),
+    );
+    const { container } = render(<PlaylistDetailView {...makeProps({ actions })} />);
+    expect(actions).toHaveBeenCalledWith(false);
+    expect(container.querySelector('[data-action-collapsed="false"]')).not.toBeNull();
+  });
+
+  it('renders no actions container when actions prop is omitted', () => {
+    const { container } = render(<PlaylistDetailView {...makeProps()} />);
+    // Only the back FAB button should be present; no extra data-icon= elements
+    const allButtons = container.querySelectorAll('button[data-icon]');
+    expect(allButtons).toHaveLength(1);
+  });
+
+  // ── Hero content ────────────────────────────────────────────────────────────
+
+  it('renders the playlist name in the collapsed header bar', () => {
+    const { getAllByText } = render(<PlaylistDetailView {...makeProps()} />);
+    // The name appears both in the hero banner and the collapsed header bar
+    const nodes = getAllByText('My Playlist');
+    expect(nodes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders the emoji icon when hero.icon is set', () => {
+    const { getByText } = render(<PlaylistDetailView {...makeProps({ hero: { name: 'P', climbCount: 0, icon: '🏔️' } })} />);
+    expect(getByText('🏔️')).not.toBeNull();
+  });
+
+  it('falls back to the tag icon when hero.icon is absent', () => {
+    const { container } = render(<PlaylistDetailView {...makeProps()} />);
+    expect(container.querySelector('[data-icon="tag"]')).not.toBeNull();
+  });
+
+  it('renders description when provided', () => {
+    const { getByText } = render(
+      <PlaylistDetailView {...makeProps({ hero: { name: 'P', climbCount: 0, description: 'A great playlist' } })} />,
+    );
+    expect(getByText('A great playlist')).not.toBeNull();
+  });
+
+  it('renders subtitle when provided', () => {
+    const { getByText } = render(
+      <PlaylistDetailView {...makeProps({ hero: { name: 'P', climbCount: 0, subtitle: 'by Setter A' } })} />,
+    );
+    expect(getByText('by Setter A')).not.toBeNull();
+  });
+
+  it('renders follower label when provided', () => {
+    const { getByText } = render(
+      <PlaylistDetailView {...makeProps({ hero: { name: 'P', climbCount: 0, followerLabel: '42 followers' } })} />,
+    );
+    expect(getByText('42 followers')).not.toBeNull();
+  });
+
+  // ── Loading / empty states ──────────────────────────────────────────────────
+
+  it('shows large loading spinner when isLoading=true and climbs is empty', () => {
+    const { container } = render(<PlaylistDetailView {...makeProps({ isLoading: true, climbs: [] })} />);
+    expect(container.querySelector('[data-spinner="large"]')).not.toBeNull();
+  });
+
+  it('shows empty message and playlist icon when not loading and climbs is empty', () => {
+    const { getByText, container } = render(
+      <PlaylistDetailView {...makeProps({ isLoading: false, climbs: [] })} />,
+    );
+    expect(getByText('No climbs yet')).not.toBeNull();
+    expect(container.querySelector('[data-icon="playlist"]')).not.toBeNull();
+  });
+
+  it('shows a small footer spinner when isFetchingNextPage=true', () => {
+    const { container } = render(
+      <PlaylistDetailView {...makeProps({ isFetchingNextPage: true, climbs: [CLIMB] })} />,
+    );
+    expect(container.querySelector('[data-spinner="small"]')).not.toBeNull();
+  });
+
+  it('shows no footer spinner when isFetchingNextPage=false', () => {
+    const { container } = render(
+      <PlaylistDetailView {...makeProps({ isFetchingNextPage: false, climbs: [CLIMB] })} />,
+    );
+    expect(container.querySelector('[data-spinner="small"]')).toBeNull();
+  });
+
+  // ── Board backdrop ──────────────────────────────────────────────────────────
+
+  it('renders PlaylistBoardBackdrop when showBoardBackdrop and boardType are set', () => {
+    const { container } = render(
+      <PlaylistDetailView
+        {...makeProps({ hero: { name: 'P', climbCount: 0, showBoardBackdrop: true, boardType: 'kilter' } })}
+      />,
+    );
+    expect(container.querySelector('[data-backdrop="kilter"]')).not.toBeNull();
+  });
+
+  it('does not render backdrop when showBoardBackdrop is false', () => {
+    const { container } = render(
+      <PlaylistDetailView
+        {...makeProps({ hero: { name: 'P', climbCount: 0, showBoardBackdrop: false, boardType: 'kilter' } })}
+      />,
+    );
+    expect(container.querySelector('[data-backdrop]')).toBeNull();
+  });
+
+  it('uses translucent gradient colors when board backdrop is enabled', () => {
+    const { container } = render(
+      <PlaylistDetailView
+        {...makeProps({ hero: { name: 'P', climbCount: 0, showBoardBackdrop: true, boardType: 'kilter', color: '#8C4A52' } })}
+      />,
+    );
+    const gradients = container.querySelectorAll('[data-gradient]');
+    // The first gradient is the colour wash — its colors should be the withAlpha strings
+    const firstGradientColors: string[] = JSON.parse(gradients[0]?.getAttribute('data-gradient') ?? '[]');
+    expect(firstGradientColors.every((c) => c.includes('|0.82'))).toBe(true);
+  });
+
+  it('uses opaque gradient colors when board backdrop is disabled', () => {
+    const { container } = render(
+      <PlaylistDetailView
+        {...makeProps({ hero: { name: 'P', climbCount: 0, showBoardBackdrop: false, color: '#8C4A52' } })}
+      />,
+    );
+    const gradients = container.querySelectorAll('[data-gradient]');
+    const firstGradientColors: string[] = JSON.parse(gradients[0]?.getAttribute('data-gradient') ?? '[]');
+    // No alpha suffix means opaque colors from buildHeroGradient
+    expect(firstGradientColors.every((c) => !c.includes('|0.82'))).toBe(true);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/filter-labels.test.ts
+++ b/packages/mobile/src/lib/__tests__/filter-labels.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import type { TFunction } from 'i18next';
+import { buildFilterLabels, buildSortLabel } from '../filter-labels';
+
+// Mirrors the pattern from filter-summary.test.ts: the mock t returns the key
+// (with interpolated placeholders for readable assertions) or a formatted string
+// for parametric keys.
+const mockT = ((key: string, opts?: Record<string, unknown>) => {
+  if (key === 'mobile.search.gradeRange') return `${opts?.min}–${opts?.max}`;
+  if (key === 'mobile.search.gradeMin') return `${opts?.grade}+`;
+  if (key === 'mobile.search.gradeMax') return `up to ${opts?.grade}`;
+  if (key === 'mobile.search.ascents') return `${opts?.count}+ ascents`;
+  if (key === 'mobile.search.rating') return `${opts?.count}+ stars`;
+  if (key === 'mobile.search.more') return `+${opts?.count} more`;
+  if (key === 'mobile.search.settersCount') return `${opts?.count} setters`;
+  return key;
+}) as unknown as TFunction<'climbs'>;
+
+describe('buildFilterLabels', () => {
+  const labels = buildFilterLabels(mockT);
+
+  it('gradeRange passes both bounds', () => {
+    expect(labels.gradeRange('V0', 'V8')).toBe('V0–V8');
+  });
+
+  it('gradeMin passes the grade arg', () => {
+    expect(labels.gradeMin('V4')).toBe('V4+');
+  });
+
+  it('gradeMax passes the grade arg', () => {
+    expect(labels.gradeMax('V6')).toBe('up to V6');
+  });
+
+  it('ascents passes count', () => {
+    expect(labels.ascents(10)).toBe('10+ ascents');
+  });
+
+  it('rating passes count', () => {
+    expect(labels.rating(3)).toBe('3+ stars');
+  });
+
+  it('more passes count', () => {
+    expect(labels.more(2)).toBe('+2 more');
+  });
+
+  it('setters uses mobile.search.settersCount (not mobile.search.setters)', () => {
+    // The key rename is the silent-typo risk the doc comment warns about.
+    expect(labels.setters(5)).toBe('5 setters');
+  });
+
+  it('gradeAccuracy resolves the bucket suffix — off', () => {
+    // gradeAccuracyBucket('0') === 'off'
+    expect(labels.gradeAccuracy('0')).toBe('mobile.filter.accuracy.off');
+  });
+
+  it('gradeAccuracy resolves the bucket suffix — loose', () => {
+    expect(labels.gradeAccuracy('0.2')).toBe('mobile.filter.accuracy.loose');
+  });
+
+  it('gradeAccuracy resolves the bucket suffix — moderate', () => {
+    expect(labels.gradeAccuracy('0.1')).toBe('mobile.filter.accuracy.moderate');
+  });
+
+  it('gradeAccuracy resolves the bucket suffix — tight', () => {
+    expect(labels.gradeAccuracy('0.05')).toBe('mobile.filter.accuracy.tight');
+  });
+
+  it('tallOnly uses mobile.filter.tall', () => {
+    expect(labels.tallOnly()).toBe('mobile.filter.tall');
+  });
+
+  it('wideOnly uses mobile.filter.wide', () => {
+    expect(labels.wideOnly()).toBe('mobile.filter.wide');
+  });
+
+  it('betaOnly uses mobile.filter.betaVideos', () => {
+    expect(labels.betaOnly()).toBe('mobile.filter.betaVideos');
+  });
+
+  it('status appends the kind suffix', () => {
+    expect(labels.status('drafts')).toBe('mobile.filter.status.drafts');
+    expect(labels.status('established')).toBe('mobile.filter.status.established');
+    expect(labels.status('projects')).toBe('mobile.filter.status.projects');
+  });
+
+  it('hideAttempted uses mobile.filter.progress.hideAttempted', () => {
+    expect(labels.hideAttempted()).toBe('mobile.filter.progress.hideAttempted');
+  });
+
+  it('hideCompleted uses mobile.filter.progress.hideCompleted', () => {
+    expect(labels.hideCompleted()).toBe('mobile.filter.progress.hideCompleted');
+  });
+
+  it('showOnlyAttempted uses mobile.filter.progress.onlyAttempted', () => {
+    expect(labels.showOnlyAttempted()).toBe('mobile.filter.progress.onlyAttempted');
+  });
+
+  it('showOnlyCompleted uses mobile.filter.progress.onlyCompleted', () => {
+    expect(labels.showOnlyCompleted()).toBe('mobile.filter.progress.onlyCompleted');
+  });
+
+  it('returns all required keys (no missing fields)', () => {
+    // Ensures Required<FilterSummaryLabels> is fully populated.
+    const keys: Array<keyof ReturnType<typeof buildFilterLabels>> = [
+      'gradeRange', 'gradeMin', 'gradeMax', 'ascents', 'rating', 'more',
+      'setters', 'gradeAccuracy', 'tallOnly', 'wideOnly', 'betaOnly',
+      'status', 'hideAttempted', 'hideCompleted', 'showOnlyAttempted', 'showOnlyCompleted',
+    ];
+    for (const key of keys) {
+      expect(typeof labels[key]).toBe('function');
+    }
+  });
+});
+
+describe('buildSortLabel', () => {
+  const sortLabel = buildSortLabel(mockT);
+
+  it('maps every valid SortOption to its i18n key', () => {
+    expect(sortLabel('ascents')).toBe('mobile.filter.sort.ascents');
+    expect(sortLabel('quality')).toBe('mobile.filter.sort.quality');
+    expect(sortLabel('difficulty')).toBe('mobile.filter.sort.difficulty');
+    expect(sortLabel('name')).toBe('mobile.filter.sort.name');
+    expect(sortLabel('popular')).toBe('mobile.filter.sort.popular');
+    expect(sortLabel('creation')).toBe('mobile.filter.sort.creation');
+  });
+
+  it('returns undefined for an unknown sort string', () => {
+    expect(sortLabel('unknown_sort')).toBeUndefined();
+  });
+});

--- a/packages/mobile/src/lib/boards/__tests__/board-return-to.test.ts
+++ b/packages/mobile/src/lib/boards/__tests__/board-return-to.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { resolveBoardReturnTo } from '../board-return-to';
+
+describe('resolveBoardReturnTo', () => {
+  it('defaults to climbs for undefined', () => {
+    expect(resolveBoardReturnTo(undefined)).toBe('/(tabs)/climbs');
+  });
+
+  it('returns discover for the exact allow-listed discover route', () => {
+    expect(resolveBoardReturnTo('/(tabs)/discover')).toBe('/(tabs)/discover');
+  });
+
+  it('returns climbs for the climbs route (already the default)', () => {
+    expect(resolveBoardReturnTo('/(tabs)/climbs')).toBe('/(tabs)/climbs');
+  });
+
+  it('returns climbs for an arbitrary unknown route', () => {
+    expect(resolveBoardReturnTo('/settings')).toBe('/(tabs)/climbs');
+    expect(resolveBoardReturnTo('/evil')).toBe('/(tabs)/climbs');
+  });
+
+  it('returns climbs for an empty string', () => {
+    expect(resolveBoardReturnTo('')).toBe('/(tabs)/climbs');
+  });
+
+  it('does not allow path-traversal variants of the discover route', () => {
+    expect(resolveBoardReturnTo('/(tabs)/discover/../settings')).toBe('/(tabs)/climbs');
+    expect(resolveBoardReturnTo('/(tabs)/discover/')).toBe('/(tabs)/climbs');
+    expect(resolveBoardReturnTo(' /(tabs)/discover')).toBe('/(tabs)/climbs');
+  });
+});


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`board-return-to.test.ts`** — 6 tests covering the navigation allow-list: `undefined` defaults to climbs, the one allow-listed alternative (`/(tabs)/discover`) passes through, arbitrary strings and path-traversal variants all fall back to climbs
- **`filter-labels.test.ts`** — 24 tests pinning every i18n key wired by `buildFilterLabels` (all 16 required fields, including the `settersCount` rename that a typo would silently break) and `buildSortLabel` (all 6 sort options + unknown → `undefined`)
- **`playlist-detail-view.test.tsx`** — 18 tests covering: back FAB always renders, `actions` prop called with `collapsed=false` and rendered, loading/empty/pagination states, board backdrop toggle, gradient opacity (opaque vs translucent with backdrop), hero content variants (emoji icon, fallback icon, description, subtitle, follower label)

CI confirmation: `mobile` is included in the positive `--project=` list derived by `scripts/ci-test-default-projects.ts` from root `vite.config.ts`. No CI config changes needed.

## Test plan

- [ ] CI passes all three new test files under `--project=mobile`
- [ ] `board-return-to.test.ts`: all 6 assertions green
- [ ] `filter-labels.test.ts`: all 24 assertions green (gradeAccuracy bucket mapping, settersCount key, progress keys)
- [ ] `playlist-detail-view.test.tsx`: all 18 assertions green (back FAB, actions threading, loading/empty/footer states, backdrop, gradient)

https://claude.ai/code/session_01X1Bs6gQc5QpiouxmrvMHrY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1Bs6gQc5QpiouxmrvMHrY)_