### PR TITLE
Recolor mobile design system to "Velvet Send" violet brand

### DIFF
--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -20,6 +20,8 @@ Boardsesh follows a **modern, mobile-first aesthetic** inspired by apps like Spo
 
 All tokens live in `packages/web/app/theme/theme-config.ts` and are exposed as CSS custom properties in `packages/web/app/components/index.css`.
 
+> **Web vs. mobile.** The tables in this section are the **web** palette (maroon/sage). The React Native app (`packages/mobile`) uses a separate, logo-cohesive **"Velvet Send"** violet palette — see [Mobile palette — "Velvet Send"](#mobile-palette--velvet-send-packagesmobile). The two are intentionally independent; only the climbing **grade colours** are shared (`@boardsesh/board-constants`).
+
 ### Colors
 
 | Token                  | Value     | CSS Variable            | Usage                                           |
@@ -161,6 +163,37 @@ Base unit: **4px**. All spacing uses this scale.
 | `zIndex.tooltip`  | `1060` |
 
 ---
+
+## Mobile palette — "Velvet Send" (`packages/mobile`)
+
+The React Native app is recolored onto a **violet brand** anchored on the logo (built from the V11–V16 grade purples). Tokens live in `packages/mobile/src/theme/colors.ts` as `brandColors` (light) + `brandColorsDark` (dark overrides). They are resolved per colour scheme by the ThemeProvider and exposed as **`useTheme().brandColors`** — components must read brand colours from the theme wherever the scheme matters, **not** from the static import. Material-variant components additionally read these via `buildPaperTheme` (`paper-theme.ts`).
+
+### Brand & semantic
+
+| Role          | Light     | Dark      | Usage                                                            |
+| ------------- | --------- | --------- | --------------------------------------------------------------- |
+| `primary`/`tint` | `#6D28D9` | `#A78BFA` | Foreground brand: text, icons, links, borders, accent bars      |
+| `primaryFill` | `#6D28D9` | `#7C3AED` | Filled surface/button background (pair with `onPrimary`)         |
+| `onPrimary`   | `#FFFFFF` | `#FFFFFF` | Text/icon on `primaryFill`                                       |
+| `accent`      | `#FF8A3D` | `#FF8A3D` | Amber spark for highlights — **fill-only, always dark text**     |
+| `success`     | `#047857` | `#34D399` | Sends, positive confirmation                                    |
+| `warning`     | `#B45309` | `#FBBF24` | Flashes, caution                                                |
+| `error`       | `#C81E1E` | `#F87171` | Destructive, removals                                           |
+
+Contrast (WCAG): white-on-`#6D28D9` 7.10:1 · `#A78BFA` tint ≥6.12:1 across the dark ladder · white-on-`#7C3AED` 5.70:1 · black-on-`#FF8A3D` 8.95:1 (white-on-amber fails, so accent is fill-only).
+
+> **Scheme-aware rule.** Use `useTheme().brandColors.primary` for any brand **foreground** so dark mode lifts to `#A78BFA`. The static `brandColors` import is only safe for **fills** that carry white/`onPrimary` text (e.g. filled buttons, swipe-action panels), where the value is legible in both schemes. A number of legacy static foreground sites are not yet ported — tracked as a follow-up.
+
+### Neutrals
+
+- **Liquid Glass variant** (iOS): neutrals come from `PlatformColor` (system materials, auto-adapting). **Android fallback** is a violet-tinted set in `androidFallbackColors` (light bg `#F4F1FB` / dark bg `#0F0B16`, label `#16111F` / `#F5F2FB`, opaque secondary labels for AA).
+- **Material 3 variant** (any platform): `materialSurfaces` — violet-tinted tonal surfaces (light bg `#F3EFFA`, surface `#FFFFFF`, fill `rgba(109,40,217,0.14)`; dark bg `#15101E`, surface `#221A33`, elevated `#2A2142`).
+
+### Grade colours (shared with web + backend)
+
+The yellow→red→purple grade arc in `@boardsesh/board-constants/grade-colors.ts` was refreshed (V0 `#FFD400` → V10 `#7E1C8E`); the V11–V16 logo purples are unchanged. Luminance descends monotonically except the documented V10→V11 step (the logo purple is brighter than its grape neighbour) — guarded by a test in `board-constants/src/__tests__/grade-colors.test.ts`. Grade-pill text is auto-picked for contrast (`readableTextColor`), so refreshed hexes stay AA without per-pill colours.
+
+> Climbing **hold** colours (`hold-states.ts`) are board data, fully decoupled from the theme — the recolor never affects rendered holds.
 
 ## Color Usage Rules
 

--- a/packages/backend/src/__tests__/grade-colors.test.ts
+++ b/packages/backend/src/__tests__/grade-colors.test.ts
@@ -6,15 +6,15 @@ const DEFAULT_GRADE_COLOR = '#808080';
 describe('Grade Color Utilities', () => {
   describe('getVGradeColor', () => {
     it('should return correct color for V0', () => {
-      expect(getVGradeColor('V0')).toBe('#FFEB3B');
+      expect(getVGradeColor('V0')).toBe('#FFD400');
     });
 
     it('should return correct color for V5', () => {
-      expect(getVGradeColor('V5')).toBe('#F44336');
+      expect(getVGradeColor('V5')).toBe('#F03E3E');
     });
 
     it('should return correct color for V10', () => {
-      expect(getVGradeColor('V10')).toBe('#A11B4A');
+      expect(getVGradeColor('V10')).toBe('#7E1C8E');
     });
 
     it('should return correct color for V17', () => {
@@ -22,8 +22,8 @@ describe('Grade Color Utilities', () => {
     });
 
     it('should be case insensitive', () => {
-      expect(getVGradeColor('v3')).toBe('#FF7043');
-      expect(getVGradeColor('v10')).toBe('#A11B4A');
+      expect(getVGradeColor('v3')).toBe('#FF6D2E');
+      expect(getVGradeColor('v10')).toBe('#7E1C8E');
     });
 
     it('should return default color for invalid V-grade', () => {
@@ -47,19 +47,19 @@ describe('Grade Color Utilities', () => {
 
   describe('getFontGradeColor', () => {
     it('should return correct color for 4a (V0 equivalent)', () => {
-      expect(getFontGradeColor('4a')).toBe('#FFEB3B');
+      expect(getFontGradeColor('4a')).toBe('#FFD400');
     });
 
     it('should return correct color for 6a', () => {
-      expect(getFontGradeColor('6a')).toBe('#FF7043');
+      expect(getFontGradeColor('6a')).toBe('#FF6D2E');
     });
 
     it('should return correct color for 6a+', () => {
-      expect(getFontGradeColor('6a+')).toBe('#FF7043');
+      expect(getFontGradeColor('6a+')).toBe('#FF6D2E');
     });
 
     it('should return correct color for 7b+', () => {
-      expect(getFontGradeColor('7b+')).toBe('#C62828');
+      expect(getFontGradeColor('7b+')).toBe('#B81A5A');
     });
 
     it('should return correct color for 8c+', () => {
@@ -67,8 +67,8 @@ describe('Grade Color Utilities', () => {
     });
 
     it('should be case insensitive', () => {
-      expect(getFontGradeColor('6A')).toBe('#FF7043');
-      expect(getFontGradeColor('7B+')).toBe('#C62828');
+      expect(getFontGradeColor('6A')).toBe('#FF6D2E');
+      expect(getFontGradeColor('7B+')).toBe('#B81A5A');
     });
 
     it('should return default color for invalid Font grade', () => {
@@ -91,33 +91,33 @@ describe('Grade Color Utilities', () => {
 
   describe('getGradeColor', () => {
     it('should extract V-grade from mixed format "6a/V3"', () => {
-      expect(getGradeColor('6a/V3')).toBe('#FF7043'); // V3 color
+      expect(getGradeColor('6a/V3')).toBe('#FF6D2E'); // V3 color
     });
 
     it('should extract V-grade from mixed format "7b/V8"', () => {
-      expect(getGradeColor('7b/V8')).toBe('#C62828'); // V8 color
+      expect(getGradeColor('7b/V8')).toBe('#B81A5A'); // V8 color
     });
 
     it('should prefer V-grade over Font grade', () => {
       // If both are present, V-grade takes precedence
-      expect(getGradeColor('6a/V5')).toBe('#F44336'); // V5 color, not 6a color
+      expect(getGradeColor('6a/V5')).toBe('#F03E3E'); // V5 color, not 6a color
     });
 
     it('should handle standalone V-grade', () => {
-      expect(getGradeColor('V4')).toBe('#FF5722');
+      expect(getGradeColor('V4')).toBe('#FF5026');
     });
 
     it('should fall back to Font grade when no V-grade present', () => {
-      expect(getGradeColor('6a')).toBe('#FF7043');
-      expect(getGradeColor('7a+')).toBe('#D32F2F');
+      expect(getGradeColor('6a')).toBe('#FF6D2E');
+      expect(getGradeColor('7a+')).toBe('#CF1F3C');
     });
 
     it('should be case insensitive for V-grade extraction', () => {
-      expect(getGradeColor('6a/v3')).toBe('#FF7043');
+      expect(getGradeColor('6a/v3')).toBe('#FF6D2E');
     });
 
     it('should be case insensitive for Font grade extraction', () => {
-      expect(getGradeColor('6A')).toBe('#FF7043');
+      expect(getGradeColor('6A')).toBe('#FF6D2E');
     });
 
     it('should return default color for invalid difficulty string', () => {
@@ -138,11 +138,11 @@ describe('Grade Color Utilities', () => {
     });
 
     it('should handle V-grade embedded in longer strings', () => {
-      expect(getGradeColor('Grade: V7 (Hard)')).toBe('#D32F2F');
+      expect(getGradeColor('Grade: V7 (Hard)')).toBe('#CF1F3C');
     });
 
     it('should handle Font grade embedded in longer strings', () => {
-      expect(getGradeColor('Grade: 7a (Hard)')).toBe('#E53935');
+      expect(getGradeColor('Grade: 7a (Hard)')).toBe('#E22A2A');
     });
   });
 });

--- a/packages/backend/src/__tests__/navigation-helpers.test.ts
+++ b/packages/backend/src/__tests__/navigation-helpers.test.ts
@@ -49,7 +49,7 @@ describe('Navigation Helper Utilities', () => {
 
       expect(result.name).toBe('Boulder Problem');
       expect(result.grade).toBe('V5');
-      expect(result.gradeColor).toBe('#F44336'); // V5 color
+      expect(result.gradeColor).toBe('#F03E3E'); // V5 color
     });
 
     it('should use getGradeColor for mixed grade formats', () => {
@@ -61,7 +61,7 @@ describe('Navigation Helper Utilities', () => {
 
       const result = buildNavigationItem(queueItem);
 
-      expect(result.gradeColor).toBe('#E53935'); // V6 color
+      expect(result.gradeColor).toBe('#E22A2A'); // V6 color
     });
 
     it('should return default gray color for null difficulty', () => {

--- a/packages/board-constants/src/__tests__/grade-colors.test.ts
+++ b/packages/board-constants/src/__tests__/grade-colors.test.ts
@@ -52,17 +52,17 @@ describe('FONT_GRADE_COLORS', () => {
 
 describe('getVGradeColor', () => {
   it('returns correct color for known grades', () => {
-    expect(getVGradeColor('V0')).toBe('#FFEB3B');
-    expect(getVGradeColor('V5')).toBe('#F44336');
+    expect(getVGradeColor('V0')).toBe('#FFD400');
+    expect(getVGradeColor('V5')).toBe('#F03E3E');
     expect(getVGradeColor('V17')).toBe('#2A0054');
   });
 
   it('is case-insensitive', () => {
-    expect(getVGradeColor('v3')).toBe('#FF7043');
+    expect(getVGradeColor('v3')).toBe('#FF6D2E');
   });
 
   it('strips trailing + from V-grade', () => {
-    expect(getVGradeColor('V5+')).toBe('#F44336');
+    expect(getVGradeColor('V5+')).toBe('#F03E3E');
   });
 
   it('returns undefined for null/undefined/unknown', () => {
@@ -74,12 +74,12 @@ describe('getVGradeColor', () => {
 
 describe('getFontGradeColor', () => {
   it('returns correct color for known grades', () => {
-    expect(getFontGradeColor('6a')).toBe('#FF7043');
-    expect(getFontGradeColor('7b+')).toBe('#C62828');
+    expect(getFontGradeColor('6a')).toBe('#FF6D2E');
+    expect(getFontGradeColor('7b+')).toBe('#B81A5A');
   });
 
   it('is case-insensitive', () => {
-    expect(getFontGradeColor('6A')).toBe('#FF7043');
+    expect(getFontGradeColor('6A')).toBe('#FF6D2E');
   });
 
   it('returns undefined for null/undefined/unknown', () => {
@@ -90,11 +90,11 @@ describe('getFontGradeColor', () => {
 
 describe('getGradeColor', () => {
   it('extracts V-grade from combined string', () => {
-    expect(getGradeColor('6a/V3')).toBe('#FF7043');
+    expect(getGradeColor('6a/V3')).toBe('#FF6D2E');
   });
 
   it('falls back to font grade when no V-grade', () => {
-    expect(getGradeColor('7a')).toBe('#E53935');
+    expect(getGradeColor('7a')).toBe('#E22A2A');
   });
 
   it('returns undefined for null/undefined/unrecognized', () => {

--- a/packages/board-constants/src/__tests__/grade-colors.test.ts
+++ b/packages/board-constants/src/__tests__/grade-colors.test.ts
@@ -108,3 +108,41 @@ describe('DEFAULT_GRADE_COLOR', () => {
     expect(DEFAULT_GRADE_COLOR).toBe('#808080');
   });
 });
+
+// WCAG relative luminance of a #RRGGBB hex (0 = black, 1 = white).
+function relativeLuminance(hex: string): number {
+  const channel = (int: number) => {
+    const c = int / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+// The arc is designed to descend in luminance (easy/bright -> hard/dark) so a
+// pill reads as "harder = darker". The ONE intentional exception is V10 -> V11,
+// where V11 is the fixed brighter logo purple. These guards stop a future palette
+// tweak from silently flattening or re-ordering the ramp.
+describe('grade arc luminance shape', () => {
+  it('descends monotonically across the warm ramp V0–V10', () => {
+    for (let i = 0; i < 10; i++) {
+      const lighter = relativeLuminance(V_GRADE_COLORS[`V${i}`]);
+      const darker = relativeLuminance(V_GRADE_COLORS[`V${i + 1}`]);
+      expect(lighter, `V${i} should be lighter than V${i + 1}`).toBeGreaterThan(darker);
+    }
+  });
+
+  it('descends monotonically across the logo purples V11–V17', () => {
+    for (let i = 11; i < 17; i++) {
+      const lighter = relativeLuminance(V_GRADE_COLORS[`V${i}`]);
+      const darker = relativeLuminance(V_GRADE_COLORS[`V${i + 1}`]);
+      expect(lighter, `V${i} should be lighter than V${i + 1}`).toBeGreaterThan(darker);
+    }
+  });
+
+  it('keeps the single documented V10→V11 inversion (logo purple brighter than its grape neighbour)', () => {
+    expect(relativeLuminance(V_GRADE_COLORS.V11)).toBeGreaterThan(relativeLuminance(V_GRADE_COLORS.V10));
+  });
+});

--- a/packages/board-constants/src/grade-colors.ts
+++ b/packages/board-constants/src/grade-colors.ts
@@ -1,57 +1,62 @@
 /**
- * Grade color scheme based on thecrag.com grade coloring.
+ * Grade color scheme — a punchier yellow→red→purple arc that ends on the
+ * Boardsesh logo's V11–V16 purples (kept byte-for-byte).
  *
  * Color progression from yellow (easy) to purple (hard):
- * - V0: Yellow
+ * - V0: Golden yellow
  * - V1-V2: Orange
- * - V3-V4: Dark orange/red-orange
+ * - V3-V4: Red-orange
  * - V5-V6: Red
- * - V7-V10: Dark red/crimson
- * - V11+: Purple/magenta
+ * - V7-V10: Crimson → magenta → grape (bridge into the logo purples)
+ * - V11+: Purple (logo range — unchanged)
+ *
+ * Luminance descends monotonically except the single V10→V11 step, which is
+ * inherent: the fixed logo purple V11 is brighter than its grape neighbours. The
+ * per-pill text colour is auto-picked by contrast (black on V0–V6, white on V7+).
  */
 
 // V-grade to hex color mapping
 export const V_GRADE_COLORS: Record<string, string> = {
-  V0: '#FFEB3B', // Yellow
-  V1: '#FFC107', // Amber/Yellow-orange
-  V2: '#FF9800', // Orange
-  V3: '#FF7043', // Deep orange
-  V4: '#FF5722', // Red-orange
-  V5: '#F44336', // Red
-  V6: '#E53935', // Red (slightly darker)
-  V7: '#D32F2F', // Dark red
-  V8: '#C62828', // Darker red
-  V9: '#B71C1C', // Deep red
-  V10: '#A11B4A', // Red-purple transition
-  V11: '#9C27B0', // Purple
-  V12: '#7B1FA2', // Dark purple
-  V13: '#6A1B9A', // Darker purple
-  V14: '#5C1A87', // Deep purple
-  V15: '#4A148C', // Very deep purple
-  V16: '#38006B', // Near black purple
+  V0: '#FFD400', // Golden yellow
+  V1: '#FFB300', // Amber
+  V2: '#FF9100', // Orange
+  V3: '#FF6D2E', // Deep orange
+  V4: '#FF5026', // Red-orange
+  V5: '#F03E3E', // Red
+  V6: '#E22A2A', // Red (slightly darker)
+  V7: '#CF1F3C', // Crimson
+  V8: '#B81A5A', // Raspberry
+  V9: '#9E1A78', // Magenta-purple
+  V10: '#7E1C8E', // Grape (bridge into the logo purples)
+  V11: '#9C27B0', // Purple (logo)
+  V12: '#7B1FA2', // Dark purple (logo)
+  V13: '#6A1B9A', // Darker purple (logo)
+  V14: '#5C1A87', // Deep purple (logo)
+  V15: '#4A148C', // Very deep purple (logo)
+  V16: '#38006B', // Near black purple (logo)
   V17: '#2A0054', // Darkest purple
 };
 
 // Font grade to hex color mapping (uses same color as corresponding V-grade)
 export const FONT_GRADE_COLORS: Record<string, string> = {
-  '4a': '#FFEB3B', // V0
-  '4b': '#FFEB3B', // V0
-  '4c': '#FFEB3B', // V0
-  '5a': '#FFC107', // V1
-  '5b': '#FFC107', // V1
-  '5c': '#FF9800', // V2
-  '6a': '#FF7043', // V3
-  '6a+': '#FF7043', // V3
-  '6b': '#FF5722', // V4
-  '6b+': '#FF5722', // V4
-  '6c': '#F44336', // V5
-  '6c+': '#F44336', // V5
-  '7a': '#E53935', // V6
-  '7a+': '#D32F2F', // V7
-  '7b': '#C62828', // V8
-  '7b+': '#C62828', // V8
-  '7c': '#B71C1C', // V9
-  '7c+': '#A11B4A', // V10
+  '4a': '#FFD400', // V0
+  '4b': '#FFD400', // V0
+  '4c': '#FFD400', // V0
+  '5a': '#FFB300', // V1
+  '5b': '#FFB300', // V1
+  '5c': '#FF9100', // V2
+  '6a': '#FF6D2E', // V3
+  '6a+': '#FF6D2E', // V3
+  '6b': '#FF5026', // V4
+  '6b+': '#FF5026', // V4
+  '6c': '#F03E3E', // V5
+  '6c+': '#F03E3E', // V5
+  '7a': '#E22A2A', // V6
+  '7a+': '#CF1F3C', // V7
+  '7b': '#B81A5A', // V8
+  '7b+': '#B81A5A', // V8
+  '7c': '#9E1A78', // V9
+  '7c+': '#7E1C8E', // V10
   '8a': '#9C27B0', // V11
   '8a+': '#7B1FA2', // V12
   '8b': '#6A1B9A', // V13

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -25,7 +25,7 @@ vi.mock('../../../src/components/queue-control/QueueBottomAccessory', () => ({
 }));
 
 vi.mock('../../../src/theme/colors', () => ({
-  brandColors: { success: '#6B9080' },
+  brandColors: { success: '#047857' },
 }));
 
 vi.mock('expo-router/unstable-native-tabs', () => {

--- a/packages/mobile/src/components/ActivityIndicator.tsx
+++ b/packages/mobile/src/components/ActivityIndicator.tsx
@@ -1,10 +1,15 @@
 import { ActivityIndicator as RNActivityIndicator, type ActivityIndicatorProps } from 'react-native';
 import { brandColors } from '../theme/colors';
+import { useOptionalTheme } from '../providers/theme-provider';
 
 type Props = Omit<ActivityIndicatorProps, 'color'> & {
   color?: string;
 };
 
-export function ActivityIndicator({ color = brandColors.primary, ...props }: Props) {
-  return <RNActivityIndicator color={color} {...props} />;
+export function ActivityIndicator({ color, ...props }: Props) {
+  // Scheme-aware brand tint (lifts to #A78BFA in dark); falls back to the static
+  // light value when rendered before the ThemeProvider mounts.
+  const theme = useOptionalTheme();
+  const resolvedColor = color ?? theme?.brandColors.primary ?? brandColors.primary;
+  return <RNActivityIndicator color={resolvedColor} {...props} />;
 }

--- a/packages/mobile/src/components/Button.tsx
+++ b/packages/mobile/src/components/Button.tsx
@@ -5,8 +5,6 @@ import { Icon } from './Icon';
 import { PressableSurface } from './PressableSurface';
 import { iconMap, type IconName } from './icon-map';
 import { hapticLight } from '../lib/haptics';
-import { brandColors } from '../theme/colors';
-import { iosSystemColors } from '../theme/ios-colors';
 import { useTheme } from '../providers/theme-provider';
 
 type ButtonVariant = 'filled' | 'outlined' | 'text';
@@ -52,9 +50,13 @@ function ButtonMaterial({
   disabled = false,
   loading = false,
   haptic = true,
-  tintColor = brandColors.primary,
+  tintColor,
   style,
 }: ButtonProps) {
+  const { brandColors: brand } = useTheme();
+  // Filled buttons sit on a brand FILL; outlined/text use the legible brand TINT.
+  const fillColor = tintColor ?? brand.primaryFill;
+  const accentColor = tintColor ?? brand.primary;
   const config = sizeConfig[size];
   const handlePress = () => {
     if (disabled || loading) return;
@@ -71,8 +73,8 @@ function ButtonMaterial({
       // Paper resolves the MDI glyph through our icon settings (see
       // material-theme-provider); map our semantic name to its MDI name.
       icon={icon ? iconMap[icon].android : undefined}
-      buttonColor={variant === 'filled' ? tintColor : undefined}
-      textColor={variant === 'filled' ? undefined : tintColor}
+      buttonColor={variant === 'filled' ? fillColor : undefined}
+      textColor={variant === 'filled' ? undefined : accentColor}
       accessibilityLabel={title}
       // Approximate the small/medium/large ladder on Paper's single-height button.
       labelStyle={{ fontSize: config.fontSize }}
@@ -94,12 +96,17 @@ function ButtonGlass({
   disabled = false,
   loading = false,
   haptic = true,
-  tintColor = brandColors.primary,
+  tintColor,
   style,
 }: ButtonProps) {
   const config = sizeConfig[size];
-  // Soft 10dp corner on Liquid Glass.
-  const { radii } = useTheme();
+  // Soft 10dp corner on Liquid Glass; brand colours resolve per colour scheme.
+  const { radii, brandColors: brand } = useTheme();
+  // Filled buttons sit on a brand FILL with on-primary text; outlined/text use the
+  // legible brand TINT for both border and label.
+  const fillColor = tintColor ?? brand.primaryFill;
+  const accentColor = tintColor ?? brand.primary;
+  const onFillColor = brand.onPrimary;
 
   const handlePress = () => {
     if (disabled || loading) return;
@@ -116,13 +123,13 @@ function ButtonGlass({
     paddingVertical: config.paddingVertical,
     borderRadius: radii.button,
     opacity: disabled ? 0.5 : 1,
-    ...(variant === 'filled' && { backgroundColor: tintColor }),
-    ...(variant === 'outlined' && { borderWidth: 1, borderColor: tintColor }),
+    ...(variant === 'filled' && { backgroundColor: fillColor }),
+    ...(variant === 'outlined' && { borderWidth: 1, borderColor: accentColor }),
   };
 
-  const textColor = variant === 'filled' ? iosSystemColors.white : tintColor;
-  // M3 ripple: onPrimary (white) over a filled button, the tint over outlined/text.
-  const rippleColor = variant === 'filled' ? iosSystemColors.white : tintColor;
+  const textColor = variant === 'filled' ? onFillColor : accentColor;
+  // M3 ripple: on-primary over a filled button, the tint over outlined/text.
+  const rippleColor = variant === 'filled' ? onFillColor : accentColor;
 
   return (
     <PressableSurface

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -399,7 +399,7 @@ export function ClimbFilterSheet({
   const applyLabel =
     previewCount != null ? t('mobile.filter.showCount', { count: previewCount }) : t('mobile.filter.apply');
   // Reset stays a quiet secondary accent until there's actually something to
-  // reset — so the header isn't a second always-on maroon next to Apply.
+  // reset — so the header isn't a second always-on violet next to Apply.
   const anyActive = hasActiveClimbFilters(localFilters) || hasActiveBoardFilters(localBoardFilters);
 
   return (

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -19,6 +19,7 @@ import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { brandColors } from '../theme/colors';
 import { spacing } from '../theme/tokens';
+import { selectedRowColors } from './climb-list-row-colors';
 
 // Swipe tuning. Each side reveals a panel up to ACTION_REVEAL wide; dragging
 // past COMMIT_THRESHOLD and RELEASING commits the action (Spotify-style swipe-
@@ -130,7 +131,10 @@ const ClimbListRow = React.memo(function ClimbListRow({
   selected,
   unsupported,
 }: ClimbListRowProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors: brand } = useTheme();
+  // Active-row highlight colours, derived from the scheme-aware brand so the wash
+  // + accent stay visible in dark (lifted #A78BFA) as well as light.
+  const highlight = useMemo(() => selectedRowColors(brand.primary), [brand.primary]);
 
   const swipeableRef = useRef<SwipeableMethods>(null);
 
@@ -272,9 +276,13 @@ const ClimbListRow = React.memo(function ClimbListRow({
             accessibilityLabel={climb.name}
             accessibilityState={{ selected: !!selected }}
           >
-            {/* Active-climb highlight: rose wash + left accent bar */}
-            {selected ? <View style={styles.selectedFill} pointerEvents="none" /> : null}
-            {selected ? <View style={styles.selectedAccent} pointerEvents="none" /> : null}
+            {/* Active-climb highlight: violet wash + left accent bar */}
+            {selected ? (
+              <View style={[styles.selectedFill, { backgroundColor: highlight.fill }]} pointerEvents="none" />
+            ) : null}
+            {selected ? (
+              <View style={[styles.selectedAccent, { backgroundColor: highlight.accent }]} pointerEvents="none" />
+            ) : null}
 
             <ClimbListItemContent
               climb={climb}
@@ -311,9 +319,10 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
     gap: spacing[3],
   },
-  // Active-climb wash. Brand violet (#6D28D9) — kept distinct from the grade
-  // colour on the right of the row. Behind the content (crisp text). Bumped
-  // from 0.14 → 0.18 so it reads on near-black OLED, where the accent bar
+  // Active-climb wash + left accent bar. The COLOUR is applied inline from the
+  // scheme-aware brand (see `highlight` / selectedRowColors) so dark mode uses the
+  // lifted #A78BFA tint instead of the near-invisible dark fill — only layout
+  // lives here. The 0.18 wash alpha reads on near-black OLED, where the accent bar
   // scrolls off during a swipe and the wash is the only state cue left.
   selectedFill: {
     position: 'absolute',
@@ -321,7 +330,6 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
-    backgroundColor: 'rgba(109, 40, 217, 0.18)',
   },
   selectedAccent: {
     position: 'absolute',
@@ -329,7 +337,6 @@ const styles = StyleSheet.create({
     top: 0,
     bottom: 0,
     width: 5,
-    backgroundColor: brandColors.primary,
   },
   separator: {
     height: StyleSheet.hairlineWidth,
@@ -342,6 +349,9 @@ const styles = StyleSheet.create({
   // Pin each icon to the OUTER edge of its panel (queue = right/screen edge,
   // playlist = left/screen edge) so it appears as soon as the panel starts
   // revealing, instead of needing half the panel out to see a centred icon.
+  // These are full-bleed panels with WHITE icons, so they use the static brand
+  // FILL (white-legible in both schemes); the lifted dark-mode tints would fail
+  // white-on-fill contrast, so they intentionally don't vary by colour scheme.
   queueAction: {
     backgroundColor: brandColors.success,
     alignItems: 'flex-start',

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -311,7 +311,7 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
     gap: spacing[3],
   },
-  // Active-climb wash. Brand rose (#8C4A52) — kept distinct from the grade
+  // Active-climb wash. Brand violet (#6D28D9) — kept distinct from the grade
   // colour on the right of the row. Behind the content (crisp text). Bumped
   // from 0.14 → 0.18 so it reads on near-black OLED, where the accent bar
   // scrolls off during a swipe and the wash is the only state cue left.
@@ -321,7 +321,7 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
-    backgroundColor: 'rgba(140, 74, 82, 0.18)',
+    backgroundColor: 'rgba(109, 40, 217, 0.18)',
   },
   selectedAccent: {
     position: 'absolute',

--- a/packages/mobile/src/components/RadioGroup.tsx
+++ b/packages/mobile/src/components/RadioGroup.tsx
@@ -3,7 +3,6 @@ import { Text } from './Text';
 import { Icon } from './Icon';
 import { hapticSelection } from '../lib/haptics';
 import { useTheme } from '../providers/theme-provider';
-import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
 
@@ -21,7 +20,7 @@ type RadioGroupProps<T extends string> = {
 };
 
 export function RadioGroup<T extends string>({ options, value, onChange }: RadioGroupProps<T>) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   return (
     <View style={[styles.container, { backgroundColor: systemColors.secondaryBackground as string }]}>
       {options.map((option, index) => {

--- a/packages/mobile/src/components/SegmentedControl.tsx
+++ b/packages/mobile/src/components/SegmentedControl.tsx
@@ -3,7 +3,6 @@ import { SegmentedButtons } from 'react-native-paper';
 import { Text } from './Text';
 import { PressableSurface } from './PressableSurface';
 import { hapticSelection } from '../lib/haptics';
-import { brandColors } from '../theme/colors';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 
@@ -39,7 +38,7 @@ function Segment({
   onPress: () => void;
   textVariant: 'subheadline' | 'footnote';
 }) {
-  const { systemColors, colorScheme, opacity } = useTheme();
+  const { systemColors, colorScheme, opacity, brandColors } = useTheme();
   const isDark = colorScheme === 'dark';
 
   // Selected pill is a raised tile over the track — elevatedSurface reads as a
@@ -61,8 +60,9 @@ function Segment({
     }),
   };
 
-  // Maroon brand accent reads well on the light pill; on the dark pill it's too
-  // low-contrast, so fall back to the high-contrast label colour there.
+  // Violet brand accent reads well on the light pill (#6D28D9 on white = 7.10:1);
+  // on the dark pill it's too low-contrast, so fall back to the high-contrast
+  // label colour there.
   const selectedTextColor = isDark ? systemColors.label : brandColors.primary;
 
   return (

--- a/packages/mobile/src/components/SwitchRow.tsx
+++ b/packages/mobile/src/components/SwitchRow.tsx
@@ -2,7 +2,6 @@ import { Pressable, Switch as RNSwitch, View, StyleSheet } from 'react-native';
 import { Switch as PaperSwitch } from 'react-native-paper';
 import { Text } from './Text';
 import { hapticSelection } from '../lib/haptics';
-import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
@@ -16,7 +15,7 @@ type SwitchRowProps = {
 };
 
 export function SwitchRow({ label, description, value, onValueChange, disabled = false }: SwitchRowProps) {
-  const { variant: uiVariant } = useTheme();
+  const { variant: uiVariant, brandColors } = useTheme();
 
   const handleToggle = (next: boolean) => {
     if (disabled) return;
@@ -58,7 +57,11 @@ export function SwitchRow({ label, description, value, onValueChange, disabled =
           value={value}
           onValueChange={handleToggle}
           disabled={disabled}
-          trackColor={{ false: undefined, true: brandColors.primary }}
+          // Filled track behind a white thumb — use the scheme-aware brand FILL so
+          // dark mode gets the brighter #7C3AED (white thumb 5.70:1). The lighter
+          // track also reduces the contrast of iOS's native track-edge highlight,
+          // which is what reads as a "white rim" on a dark, saturated switch.
+          trackColor={{ false: undefined, true: brandColors.primaryFill }}
           ios_backgroundColor={iosSystemColors.systemGray4 as string}
         />
       )}

--- a/packages/mobile/src/components/__tests__/button.test.tsx
+++ b/packages/mobile/src/components/__tests__/button.test.tsx
@@ -25,10 +25,14 @@ vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => cr
 vi.mock('../Icon', () => ({ Icon: () => createElement('i', null) }));
 vi.mock('../icon-map', () => ({ iconMap: { tick: { ios: 'checkmark', android: 'check' } } }));
 vi.mock('../../lib/haptics', () => ({ hapticLight: vi.fn() }));
-vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#8C4A52' } }));
+vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#6D28D9' } }));
 vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: { white: '#FFFFFF' } }));
 vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({ variant: ctrl.variant, radii: { button: ctrl.variant === 'material' ? 20 : 10 } }),
+  useTheme: () => ({
+    variant: ctrl.variant,
+    radii: { button: ctrl.variant === 'material' ? 20 : 10 },
+    brandColors: { primary: '#6D28D9', primaryFill: '#6D28D9', onPrimary: '#FFFFFF', accent: '#FF8A3D' },
+  }),
 }));
 
 import { Button } from '../Button';

--- a/packages/mobile/src/components/__tests__/climb-list-row-colors.test.ts
+++ b/packages/mobile/src/components/__tests__/climb-list-row-colors.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// theme/colors touches Platform/PlatformColor at import; stub for the test env.
+vi.mock('react-native', () => ({ Platform: { OS: 'android' }, PlatformColor: (name: string) => name }));
+
+import { selectedRowColors } from '../climb-list-row-colors';
+
+describe('selectedRowColors', () => {
+  it('derives the active-row wash + accent from the light brand primary', () => {
+    // Light scheme: brandColors.primary = #6D28D9 -> rgb(109, 40, 217).
+    expect(selectedRowColors('#6D28D9')).toEqual({
+      fill: 'rgba(109, 40, 217, 0.18)',
+      accent: '#6D28D9',
+    });
+  });
+
+  it('uses the lifted tint in dark so the highlight stays visible on near-black', () => {
+    // Dark scheme: brandColorsDark.primary = #A78BFA -> rgb(167, 139, 250). The
+    // wash/accent MUST differ from the light scheme, or dark rows lose the cue.
+    expect(selectedRowColors('#A78BFA')).toEqual({
+      fill: 'rgba(167, 139, 250, 0.18)',
+      accent: '#A78BFA',
+    });
+  });
+
+  it('produces a different wash per scheme (regression guard for the static-style bug)', () => {
+    expect(selectedRowColors('#6D28D9').fill).not.toBe(selectedRowColors('#A78BFA').fill);
+  });
+});

--- a/packages/mobile/src/components/__tests__/glass-icon-button.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-icon-button.test.tsx
@@ -90,7 +90,7 @@ vi.mock('../Text', () => ({
 }));
 
 vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({ variant: ctrl.variant, brandColors: { primary: '#8C4A52' } }),
+  useTheme: () => ({ variant: ctrl.variant, brandColors: { primary: '#6D28D9' } }),
 }));
 
 // The material branch maps the semantic name to its MDI glyph via iconMap.

--- a/packages/mobile/src/components/__tests__/pressable-surface.test.tsx
+++ b/packages/mobile/src/components/__tests__/pressable-surface.test.tsx
@@ -49,7 +49,7 @@ vi.mock('../../theme/tokens', () => ({
 }));
 
 vi.mock('../../theme/colors', () => ({
-  brandColors: { tint: '#8C4A52' },
+  brandColors: { tint: '#6D28D9' },
 }));
 
 vi.mock('../../theme/animations', () => ({
@@ -72,7 +72,7 @@ describe('PressableSurface', () => {
   it('defaults the Android ripple to the brand tint', () => {
     ctrl.os = 'android';
     const { container } = render(<PressableSurface>x</PressableSurface>);
-    expect(container.querySelector('[data-ripple-color="#8C4A52"]')).not.toBeNull();
+    expect(container.querySelector('[data-ripple-color="#6D28D9"]')).not.toBeNull();
   });
 
   it('honours an explicit rippleColor on Android', () => {

--- a/packages/mobile/src/components/__tests__/queue-added-snackbar.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-added-snackbar.test.tsx
@@ -69,7 +69,7 @@ vi.mock('react-i18next', () => ({
 vi.mock('../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
 }));
-vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#8C4A52' } }));
+vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#6D28D9' } }));
 vi.mock('../../theme/tokens', () => ({
   borderRadius: { lg: 12 },
   spacing: { 2: 8, 3: 12, 4: 16 },

--- a/packages/mobile/src/components/__tests__/segmented-control.test.tsx
+++ b/packages/mobile/src/components/__tests__/segmented-control.test.tsx
@@ -45,7 +45,7 @@ vi.mock('../PressableSurface', () => ({
 }));
 vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
 vi.mock('../../lib/haptics', () => ({ hapticSelection: hapticSelectionMock }));
-vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#8C4A52' } }));
+vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#6D28D9' } }));
 vi.mock('../../theme/tokens', () => ({ spacing: { 2: 8 } }));
 vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({
@@ -53,6 +53,7 @@ vi.mock('../../providers/theme-provider', () => ({
     colorScheme: 'light',
     systemColors: { elevatedSurface: '#fff', label: '#000' },
     opacity: { disabled: 0.4 },
+    brandColors: { primary: '#6D28D9' },
   }),
 }));
 

--- a/packages/mobile/src/components/__tests__/switch-row.test.tsx
+++ b/packages/mobile/src/components/__tests__/switch-row.test.tsx
@@ -38,7 +38,7 @@ vi.mock('react-native-paper', () => ({
 
 vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
 vi.mock('../../lib/haptics', () => ({ hapticSelection: hapticSelectionMock }));
-vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#8C4A52' } }));
+vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#6D28D9' } }));
 vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: { systemGray4: '#ccc' } }));
 vi.mock('../../theme/tokens', () => ({ spacing: { 2: 8, 3: 12, 4: 16 } }));
 vi.mock('../../providers/theme-provider', () => ({

--- a/packages/mobile/src/components/__tests__/switch-row.test.tsx
+++ b/packages/mobile/src/components/__tests__/switch-row.test.tsx
@@ -38,11 +38,10 @@ vi.mock('react-native-paper', () => ({
 
 vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
 vi.mock('../../lib/haptics', () => ({ hapticSelection: hapticSelectionMock }));
-vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#6D28D9' } }));
 vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: { systemGray4: '#ccc' } }));
 vi.mock('../../theme/tokens', () => ({ spacing: { 2: 8, 3: 12, 4: 16 } }));
 vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({ variant: ctrl.variant }),
+  useTheme: () => ({ variant: ctrl.variant, brandColors: { primaryFill: '#7C3AED' } }),
 }));
 
 import { SwitchRow } from '../SwitchRow';

--- a/packages/mobile/src/components/__tests__/toast.test.tsx
+++ b/packages/mobile/src/components/__tests__/toast.test.tsx
@@ -100,7 +100,7 @@ describe('Toast', () => {
     const cases = [
       { variant: 'error' as const, icon: 'error', color: '#FF3B30' },
       { variant: 'warning' as const, icon: 'warning', color: '#FF9500' },
-      { variant: 'info' as const, icon: 'info', color: '#8C4A52' },
+      { variant: 'info' as const, icon: 'info', color: '#6D28D9' },
     ];
     for (const { variant, icon, color } of cases) {
       const { container } = render(

--- a/packages/mobile/src/components/__tests__/toast.test.tsx
+++ b/packages/mobile/src/components/__tests__/toast.test.tsx
@@ -53,7 +53,7 @@ vi.mock('../Text', () => ({
 }));
 vi.mock('../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }) }));
 vi.mock('../../theme/colors', () => ({
-  brandColors: { success: '#34C759', error: '#FF3B30', primary: '#8C4A52', warning: '#FF9500' },
+  brandColors: { success: '#34C759', error: '#FF3B30', primary: '#6D28D9', warning: '#FF9500' },
   withAlpha: (color: string) => color,
 }));
 vi.mock('../../theme/tokens', () => ({ borderRadius: { full: 999 }, spacing: { 2: 8, 3: 12, 4: 16 } }));

--- a/packages/mobile/src/components/climb-list-row-colors.ts
+++ b/packages/mobile/src/components/climb-list-row-colors.ts
@@ -1,0 +1,18 @@
+import { withAlpha } from '../theme/colors';
+
+/**
+ * Highlight colours for the active (selected) climb row, derived from the
+ * scheme-aware brand primary. Pass `useTheme().brandColors.primary` so the wash
+ * + accent track the colour scheme: in dark the resolved primary is the lifted
+ * `#A78BFA` tint, not the dark `#6D28D9` fill (which is near-invisible on a
+ * near-black row). Kept as a pure function so the per-scheme behaviour is unit
+ * testable without rendering the (reanimated + swipeable) row.
+ */
+export function selectedRowColors(brandPrimary: string): { fill: string; accent: string } {
+  return {
+    // Subtle wash behind the row content.
+    fill: withAlpha(brandPrimary, 0.18),
+    // Solid left accent bar.
+    accent: brandPrimary,
+  };
+}

--- a/packages/mobile/src/components/grade/__tests__/grade-chip-colors.test.ts
+++ b/packages/mobile/src/components/grade/__tests__/grade-chip-colors.test.ts
@@ -3,17 +3,17 @@ import { contrastRatio, readableTextColor, readableDarkText, readableLightText }
 
 describe('grade chip color helpers', () => {
   it('uses dark text on light grade colors', () => {
-    expect(readableTextColor('#FFEB3B')).toBe(readableDarkText);
-    expect(readableTextColor('#F44336')).toBe(readableDarkText);
+    expect(readableTextColor('#FFD400')).toBe(readableDarkText);
+    expect(readableTextColor('#F03E3E')).toBe(readableDarkText);
   });
 
   it('uses light text on dark grade colors', () => {
-    expect(readableTextColor('#A11B4A')).toBe(readableLightText);
+    expect(readableTextColor('#7E1C8E')).toBe(readableLightText);
     expect(readableTextColor('#2A0054')).toBe(readableLightText);
   });
 
   it('chooses a color with at least AA contrast for known grade colors', () => {
-    for (const gradeColor of ['#FFEB3B', '#F44336', '#E53935', '#A11B4A', '#2A0054']) {
+    for (const gradeColor of ['#FFD400', '#F03E3E', '#E22A2A', '#7E1C8E', '#2A0054']) {
       const selectedTextColor = readableTextColor(gradeColor);
       expect(contrastRatio(gradeColor, selectedTextColor)).toBeGreaterThanOrEqual(4.5);
     }

--- a/packages/mobile/src/components/grade/__tests__/grade-range-rail.test.tsx
+++ b/packages/mobile/src/components/grade/__tests__/grade-range-rail.test.tsx
@@ -127,7 +127,7 @@ vi.mock('../../../providers/theme-provider', () => ({
 }));
 
 vi.mock('../../../theme/colors', () => ({
-  brandColors: { primary: '#8C4A52' },
+  brandColors: { primary: '#6D28D9' },
   withAlpha: (color: string, alpha: number) => `${color}@${alpha}`,
 }));
 

--- a/packages/mobile/src/components/navigation/MaterialTabBar.tsx
+++ b/packages/mobile/src/components/navigation/MaterialTabBar.tsx
@@ -3,7 +3,7 @@ import type { BottomTabBarProps } from 'expo-router/tabs';
 import { Text } from '../Text';
 import { PressableSurface } from '../PressableSurface';
 import { useTheme } from '../../providers/theme-provider';
-import { brandColors, withAlpha } from '../../theme/colors';
+import { withAlpha } from '../../theme/colors';
 import { material } from '../../theme/tokens';
 import { TAB_BAR_HEIGHT } from '../../theme/layout';
 
@@ -16,9 +16,11 @@ import { TAB_BAR_HEIGHT } from '../../theme/layout';
  * screen's React Navigation options, so this stays a generic custom tab bar.
  */
 export function MaterialTabBar({ state, descriptors, navigation, insets }: BottomTabBarProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   // Softened active state (closer to M3, which tints the indicator gently rather
-  // than using full primary): a lighter maroon pill + a muted maroon icon/label.
+  // than using full primary): a lighter violet pill + a muted violet icon/label.
+  // Brand colours resolve per scheme (lifted #A78BFA in dark), so the active tab
+  // stays legible on the dark Material bar instead of dimming to the dark fill.
   const activeColor = withAlpha(brandColors.primary, 0.8);
   const inactiveColor = systemColors.secondaryLabel;
   const indicatorColor = withAlpha(brandColors.primary, 0.1);

--- a/packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx
+++ b/packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx
@@ -95,12 +95,18 @@ vi.mock('../../../providers/theme-provider', () => ({
       separator: '#3A3A3C',
       secondaryLabel: '#8E8E93',
     },
+    // MaterialTabBar now reads the scheme-aware brand from the theme (lifted
+    // tint in dark) rather than the static import.
+    brandColors: { primary: '#FF3B30', success: '#6B9080' },
   }),
 }));
 
 vi.mock('../../../theme/colors', () => ({
   brandColors: { primary: '#FF3B30', success: '#6B9080' },
-  withAlpha: (color: string, alpha: number) => `${color}${Math.round(alpha * 255).toString(16).padStart(2, '0')}`,
+  withAlpha: (color: string, alpha: number) =>
+    `${color}${Math.round(alpha * 255)
+      .toString(16)
+      .padStart(2, '0')}`,
 }));
 
 vi.mock('../../../theme/tokens', () => ({
@@ -141,7 +147,7 @@ function makeProps(overrides: {
           title: overrides.title ?? route.name,
           tabBarIcon:
             overrides.tabBarIcon !== undefined
-              ? overrides.tabBarIcon ?? undefined
+              ? (overrides.tabBarIcon ?? undefined)
               : i === 0
                 ? ({ focused }: { focused: boolean }) =>
                     createElement('span', { 'data-icon': 'true', 'data-focused': String(focused) })
@@ -180,13 +186,17 @@ describe('MaterialTabBar', () => {
   describe('badge rendering', () => {
     it('renders a badge dot when tabBarBadge is set', () => {
       const props = makeProps({ tabBarBadge: '' });
-      const { queryByTestId } = render(<MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />);
+      const { queryByTestId } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
       expect(queryByTestId('badge')).not.toBeNull();
     });
 
     it('does not render a badge when tabBarBadge is undefined', () => {
       const props = makeProps({ tabBarBadge: undefined });
-      const { queryByTestId } = render(<MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />);
+      const { queryByTestId } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
       expect(queryByTestId('badge')).toBeNull();
     });
   });
@@ -194,7 +204,9 @@ describe('MaterialTabBar', () => {
   describe('navigation callbacks', () => {
     it('emits tabPress and navigates when an inactive tab is pressed', () => {
       const props = makeProps({ activeIndex: 0 });
-      const { getAllByRole } = render(<MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />);
+      const { getAllByRole } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
       const tabs = getAllByRole('tab');
       // Press the second tab (index 1, inactive)
       fireEvent.click(tabs[1]);
@@ -208,7 +220,9 @@ describe('MaterialTabBar', () => {
 
     it('does not navigate when the already-focused tab is pressed', () => {
       const props = makeProps({ activeIndex: 0 });
-      const { getAllByRole } = render(<MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />);
+      const { getAllByRole } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
       const tabs = getAllByRole('tab');
       // Press the first tab (already focused)
       fireEvent.click(tabs[0]);
@@ -222,7 +236,9 @@ describe('MaterialTabBar', () => {
 
     it('emits tabLongPress on long press', () => {
       const props = makeProps({ activeIndex: 0 });
-      const { getAllByRole } = render(<MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />);
+      const { getAllByRole } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
       const tabs = getAllByRole('tab');
       fireEvent.contextMenu(tabs[1]);
       expect(props.navigation.emit).toHaveBeenCalledWith({
@@ -235,21 +251,27 @@ describe('MaterialTabBar', () => {
   describe('accessibility state', () => {
     it('marks the focused tab as selected', () => {
       const props = makeProps({ activeIndex: 0 });
-      const { getAllByRole } = render(<MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />);
+      const { getAllByRole } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
       const tabs = getAllByRole('tab');
       expect(tabs[0].getAttribute('aria-selected')).toBe('true');
     });
 
     it('marks unfocused tabs as not selected', () => {
       const props = makeProps({ activeIndex: 0 });
-      const { getAllByRole } = render(<MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />);
+      const { getAllByRole } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
       const tabs = getAllByRole('tab');
       expect(tabs[1].getAttribute('aria-selected')).toBe('false');
     });
 
     it('uses the title as the accessibility label', () => {
       const props = makeProps({ activeIndex: 0, title: 'Home' });
-      const { getAllByRole } = render(<MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />);
+      const { getAllByRole } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
       const tabs = getAllByRole('tab');
       expect(tabs[0].getAttribute('aria-label')).toBe('Home');
     });

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-action-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-action-bar.test.tsx
@@ -64,7 +64,7 @@ vi.mock('../../drawer-action-bar/DrawerActionBar', () => ({
     actionButtonPressed: {},
   },
 }));
-vi.mock('../../../theme/colors', () => ({ brandColors: { primary: '#8C4A52', success: '#6B9080' } }));
+vi.mock('../../../theme/colors', () => ({ brandColors: { primary: '#6D28D9', success: '#047857' } }));
 vi.mock('../../../theme/ios-colors', () => ({
   iosSystemColors: { white: '#FFFFFF', systemGray: '#8E8E93', systemRed: '#FF3B30', separator: '#ccc' },
 }));
@@ -102,7 +102,7 @@ describe('PlayDrawerActionBar', () => {
     const tick = container.querySelector('[data-icon="tick.outline"]') as HTMLElement;
 
     expect(tick).toBeTruthy();
-    expect(tick.getAttribute('data-color')).toBe('#6B9080');
+    expect(tick.getAttribute('data-color')).toBe('#047857');
     // The old solid-white-on-green tick is gone — no white tick glyph remains.
     expect(container.querySelector('[data-icon="tick.outline"][data-color="#FFFFFF"]')).toBeNull();
   });

--- a/packages/mobile/src/components/playlist/__tests__/playlist-gradient.test.ts
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-gradient.test.ts
@@ -44,7 +44,7 @@ describe('buildHeroGradient', () => {
     expect(gradient.locations).toEqual([0, 0.55, 1]);
   });
 
-  it('falls back to the brand maroon for missing or invalid colours', () => {
+  it('falls back to the brand violet for missing or invalid colours', () => {
     expect(buildHeroGradient(undefined).colors[1]).toBe(PLAYLIST_COLORS[0]);
     expect(buildHeroGradient('not-a-colour').colors[1]).toBe(PLAYLIST_COLORS[0]);
   });

--- a/packages/mobile/src/components/playlist/__tests__/playlist-gradient.test.ts
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-gradient.test.ts
@@ -11,12 +11,12 @@ function channelSum(hex: string): number {
 
 describe('shiftLightness', () => {
   it('returns a valid 6-digit hex', () => {
-    expect(shiftLightness('#8C4A52', 14)).toMatch(HEX);
-    expect(shiftLightness('#8C4A52', -20)).toMatch(HEX);
+    expect(shiftLightness('#6D28D9', 14)).toMatch(HEX);
+    expect(shiftLightness('#6D28D9', -20)).toMatch(HEX);
   });
 
   it('lifts toward white for a positive delta and deepens for a negative one', () => {
-    const base = '#8C4A52';
+    const base = '#6D28D9';
     expect(channelSum(shiftLightness(base, 14))).toBeGreaterThan(channelSum(base));
     expect(channelSum(shiftLightness(base, -20))).toBeLessThan(channelSum(base));
   });
@@ -38,9 +38,9 @@ describe('shiftLightness', () => {
 
 describe('buildHeroGradient', () => {
   it('builds a 3-stop gradient with the true colour in the middle', () => {
-    const gradient = buildHeroGradient('#8C4A52');
+    const gradient = buildHeroGradient('#6D28D9');
     expect(gradient.colors).toHaveLength(3);
-    expect(gradient.colors[1]).toBe('#8C4A52');
+    expect(gradient.colors[1]).toBe('#6D28D9');
     expect(gradient.locations).toEqual([0, 0.55, 1]);
   });
 

--- a/packages/mobile/src/components/playlist/playlist-colors.ts
+++ b/packages/mobile/src/components/playlist/playlist-colors.ts
@@ -1,15 +1,17 @@
-// Cycling fallback palette mirroring web's `PLAYLIST_COLORS`
-// (playlist-preview-square.tsx). Used as the preview tint when a playlist has
-// no valid `color`, and as the swatch options in the create/edit form.
+// Cycling swatch palette for playlists. Used as the preview tint when a playlist
+// has no valid `color`, and as the swatch options in the create/edit form. Leads
+// with the violet brand + amber accent, then a varied set so playlists stay
+// distinguishable. Mobile-specific (intentionally diverges from web's list, which
+// keeps the old maroon-led order).
 export const PLAYLIST_COLORS = [
-  '#8C4A52', // primary
-  '#5fb27a', // accentGreen
-  '#9C27B0', // purple
-  '#C4943C', // warning
-  '#EC4899', // pink
-  '#6B9080', // success
-  '#d65a4f', // accentRose
-  '#FBBF24', // amber
+  '#6D28D9', // brand violet
+  '#FF8A3D', // amber accent
+  '#047857', // emerald
+  '#2563EB', // blue
+  '#DB2777', // pink
+  '#0891B2', // cyan
+  '#CA8A04', // gold
+  '#DC2626', // red
 ] as const;
 
 const HEX_PATTERN = /^#([0-9A-Fa-f]{3}){1,2}$/;

--- a/packages/mobile/src/components/playlist/playlist-gradient.ts
+++ b/packages/mobile/src/components/playlist/playlist-gradient.ts
@@ -84,7 +84,7 @@ export type HeroGradient = {
 /**
  * A 3-stop diagonal gradient from one playlist colour: a lifted top-left, the
  * true colour through the middle, and a deepened bottom-right (where the title
- * sits, so white text keeps contrast). Falls back to the brand maroon when the
+ * sits, so white text keeps contrast). Falls back to the brand violet when the
  * colour is missing/invalid, so the hero always has a deterministic banner.
  */
 export function buildHeroGradient(baseHex: string | undefined): HeroGradient {

--- a/packages/mobile/src/components/search/FilterButton.tsx
+++ b/packages/mobile/src/components/search/FilterButton.tsx
@@ -1,5 +1,5 @@
 // The filters affordance shared by the top search row and the bottom card: a
-// Liquid Glass circle that tints maroon and shows a count badge when filters are
+// Liquid Glass circle that tints violet and shows a count badge when filters are
 // active. Tapping opens the full filter sheet.
 
 import { useTranslation } from 'react-i18next';
@@ -21,9 +21,9 @@ export function FilterButton({ activeFilterCount, onPress, onLongPress }: Filter
   const { t } = useTranslation('climbs');
   const { systemColors, brandColors, variant } = useTheme();
   const active = activeFilterCount > 0;
-  // Liquid Glass paints the active button on a maroon glass tint, so a maroon
+  // Liquid Glass paints the active button on a violet glass tint, so a violet
   // glyph is low-contrast — use white there. Material has no tint behind the
-  // glyph, so it keeps maroon (white would vanish on the bare surface).
+  // glyph, so it keeps the violet (white would vanish on the bare surface).
   const iconColor = active
     ? variant === 'material'
       ? (brandColors.primary as string)

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -79,7 +79,7 @@ vi.mock('../../../providers/theme-provider', () => ({
       separator: '#ccc',
       elevatedSurface: '#fff',
     },
-    brandColors: { primary: '#8C4A52', warning: '#FF9500' },
+    brandColors: { primary: '#6D28D9', warning: '#FF9500' },
   }),
 }));
 

--- a/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
@@ -61,7 +61,7 @@ vi.mock('../../GlassIconButton', () => ({
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { fill: '#EEE', secondaryLabel: '#999' },
-    brandColors: { primary: '#8C4A52' },
+    brandColors: { primary: '#6D28D9' },
     variant: cfg.variant,
   }),
 }));
@@ -142,14 +142,14 @@ describe('FilterButton', () => {
     const filterButton = button(container);
     // Active on glass: white glyph reads on the maroon tint; glass tints/falls back to alpha-mixed maroon.
     expect(filterButton.getAttribute('data-icon-color')).toBe('#FFFFFF');
-    expect(filterButton.getAttribute('data-tint')).toBe('#8C4A52@0.18');
-    expect(filterButton.getAttribute('data-fallback')).toBe('#8C4A52@0.16');
+    expect(filterButton.getAttribute('data-tint')).toBe('#6D28D9@0.18');
+    expect(filterButton.getAttribute('data-fallback')).toBe('#6D28D9@0.16');
   });
 
   it('keeps the maroon glyph on Material when active (no tint behind it)', () => {
     cfg.variant = 'material';
     const { container } = render(<FilterButton activeFilterCount={2} onPress={() => {}} />);
-    expect(button(container).getAttribute('data-icon-color')).toBe('#8C4A52');
+    expect(button(container).getAttribute('data-icon-color')).toBe('#6D28D9');
   });
 
   it('omits the count from the a11y label when no filters are active', () => {

--- a/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
@@ -136,17 +136,17 @@ describe('FilterButton', () => {
     expect(filterButton.getAttribute('data-fallback')).toBe('#EEE');
   });
 
-  it('uses a white glyph on the maroon glass tint when active (Liquid Glass)', () => {
+  it('uses a white glyph on the violet glass tint when active (Liquid Glass)', () => {
     cfg.variant = 'liquidGlass';
     const { container } = render(<FilterButton activeFilterCount={2} onPress={() => {}} />);
     const filterButton = button(container);
-    // Active on glass: white glyph reads on the maroon tint; glass tints/falls back to alpha-mixed maroon.
+    // Active on glass: white glyph reads on the violet tint; glass tints/falls back to alpha-mixed violet.
     expect(filterButton.getAttribute('data-icon-color')).toBe('#FFFFFF');
     expect(filterButton.getAttribute('data-tint')).toBe('#6D28D9@0.18');
     expect(filterButton.getAttribute('data-fallback')).toBe('#6D28D9@0.16');
   });
 
-  it('keeps the maroon glyph on Material when active (no tint behind it)', () => {
+  it('keeps the violet glyph on Material when active (no tint behind it)', () => {
     cfg.variant = 'material';
     const { container } = render(<FilterButton activeFilterCount={2} onPress={() => {}} />);
     expect(button(container).getAttribute('data-icon-color')).toBe('#6D28D9');

--- a/packages/mobile/src/components/session/SessionAnalyticsSection.tsx
+++ b/packages/mobile/src/components/session/SessionAnalyticsSection.tsx
@@ -9,6 +9,7 @@ import { StackedBarChart, GroupedBarChart, type ChartLegendItem } from '../you/Y
 import { layoutChartColor, flashRedpointColor } from '../you/profile-chart-colors';
 import { sessionTicksToLogbook } from '../../lib/session-tick-mapping';
 import { useGradeFormat } from '../../hooks/use-grade-format';
+import { useTheme } from '../../providers/theme-provider';
 import { spacing } from '../../theme/tokens';
 
 /**
@@ -19,6 +20,7 @@ import { spacing } from '../../theme/tokens';
  */
 export function SessionAnalyticsSection({ ticks }: { ticks: SessionDetailTick[] }) {
   const { t } = useTranslation('profile');
+  const { colorScheme } = useTheme();
   // Match the grade format the Progress tab / useYouProfileData uses so a
   // session's charts read identically to the profile's.
   const { gradeFormat } = useGradeFormat();
@@ -48,9 +50,9 @@ export function SessionAnalyticsSection({ ticks }: { ticks: SessionDetailTick[] 
     () =>
       viewModel?.aggregatedFlashRedpointBars?.[0]?.values.map((value) => ({
         label: value.label,
-        color: flashRedpointColor(value.key),
+        color: flashRedpointColor(value.key, colorScheme),
       })),
-    [viewModel],
+    [viewModel, colorScheme],
   );
 
   if (!viewModel) return null;

--- a/packages/mobile/src/components/you/ProgressTab.tsx
+++ b/packages/mobile/src/components/you/ProgressTab.tsx
@@ -20,7 +20,7 @@ type YouData = ReturnType<typeof useYouProfileData>;
 export function ProgressTab({ data }: { data: YouData }) {
   const { t } = useTranslation('profile');
   const { t: tYou } = useTranslation('you');
-  const { systemColors } = useTheme();
+  const { systemColors, colorScheme } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[6];
 
@@ -38,9 +38,9 @@ export function ProgressTab({ data }: { data: YouData }) {
     () =>
       data.aggregatedFlashRedpointBars?.[0]?.values.map((value) => ({
         label: value.label,
-        color: flashRedpointColor(value.key),
+        color: flashRedpointColor(value.key, colorScheme),
       })),
-    [data.aggregatedFlashRedpointBars],
+    [data.aggregatedFlashRedpointBars, colorScheme],
   );
 
   if (data.loading) {

--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -192,7 +192,7 @@ type GroupedBarsProps = {
  * wider gap separating groups, and the grade label centered under each pair.
  */
 export function GroupedBarChart({ bars, height = 150, loading, emptyLabel, legend }: GroupedBarsProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, colorScheme } = useTheme();
   const isEmpty = !bars || bars.length === 0;
   const groupGap = 14;
   const innerGap = 2;
@@ -210,7 +210,7 @@ export function GroupedBarChart({ bars, height = 150, loading, emptyLabel, legen
           const data = list.flatMap((bar) =>
             bar.values.map((value, valueIndex) => ({
               value: value.value,
-              frontColor: flashRedpointColor(value.key),
+              frontColor: flashRedpointColor(value.key, colorScheme),
               spacing: valueIndex === 0 ? innerGap : groupGap,
               label: valueIndex === 0 ? bar.label : undefined,
               labelWidth: barWidth * 2 + innerGap,

--- a/packages/mobile/src/components/you/profile-chart-colors.ts
+++ b/packages/mobile/src/components/you/profile-chart-colors.ts
@@ -6,7 +6,7 @@ import {
 } from '@boardsesh/board-constants/grade-colors';
 import type { RawBar, RawBarSegment } from '@boardsesh/profile-stats';
 import type { SessionGradeDistributionItem } from '@boardsesh/shared-schema';
-import { brandColors, withAlpha } from '../../theme/colors';
+import { brandColors, brandColorsDark, withAlpha } from '../../theme/colors';
 import { gradeSortValue } from './grade-sort-value';
 
 export { gradeSortValue } from './grade-sort-value';
@@ -82,9 +82,15 @@ export function gradeChartColor(gradeKey: string): string {
   return `hsla(${hDeg}, ${sMuted}%, ${lMuted}%, 0.75)`;
 }
 
-/** Flash = sage success, Redpoint = brick error — matches the web stats chart. */
-export function flashRedpointColor(seriesKey: 'flash' | 'redpoint'): string {
-  return seriesKey === 'flash' ? withAlpha(brandColors.success, 0.85) : withAlpha(brandColors.error, 0.85);
+/**
+ * Flash = emerald success, Redpoint = red error. Resolves the brand semantic tone
+ * for the current colour scheme so the bars stay vivid on dark chart surfaces
+ * (brighter #34D399 / #F87171 in dark). Pass the chart's `colorScheme` so a bar
+ * fill and its legend swatch always match.
+ */
+export function flashRedpointColor(seriesKey: 'flash' | 'redpoint', colorScheme: 'light' | 'dark' = 'light'): string {
+  const brand = colorScheme === 'dark' ? brandColorsDark : brandColors;
+  return seriesKey === 'flash' ? withAlpha(brand.success, 0.85) : withAlpha(brand.error, 0.85);
 }
 
 /**

--- a/packages/mobile/src/lib/smart-playlists.ts
+++ b/packages/mobile/src/lib/smart-playlists.ts
@@ -42,7 +42,7 @@ export const SMART_PLAYLISTS: SmartPlaylistPresentation[] = [
     type: 'PROJECTS',
     slug: 'projects',
     icon: '🎯',
-    color: '#d65a4f', // themeTokens.colors.accentRose
+    color: '#2563EB', // blue — distinct from the amber/purple/pink presets
     titleI18nKey: 'library.smart.projects.title',
     descriptionI18nKey: 'library.smart.projects.description',
   },

--- a/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
@@ -148,7 +148,7 @@ describe('ThemeProvider', () => {
       expect(result.current.variant).toBe('material');
       // Material maps M3 tonal surfaces + the 20dp button radius.
       expect(result.current.radii.button).toBe(20);
-      expect(result.current.systemColors.background).toBe('#F4ECEC');
+      expect(result.current.systemColors.background).toBe('#F3EFFA');
     });
 
     it('setUiVariant persists to SecureStore and flips the resolved variant + tokens', async () => {
@@ -164,7 +164,7 @@ describe('ThemeProvider', () => {
       // Liquid Glass keeps the soft 10dp button radius and the (Android) system
       // surface — not the Material tonal map.
       expect(result.current.radii.button).toBe(10);
-      expect(result.current.systemColors.background).toBe('#FFFFFF');
+      expect(result.current.systemColors.background).toBe('#F4F1FB');
       expect(setMock).toHaveBeenCalledWith(UI_VARIANT_KEY, 'liquidGlass');
     });
 

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -8,7 +8,13 @@ import {
   isUiVariantPreference,
   type UiVariantPreference,
 } from '@boardsesh/key-value-storage';
-import { iosSystemColors, brandColors, androidFallbackColors, materialSurfaces } from '../theme/colors';
+import {
+  iosSystemColors,
+  brandColors,
+  brandColorsDark,
+  androidFallbackColors,
+  materialSurfaces,
+} from '../theme/colors';
 import { textStyles, type TextVariant } from '../theme/typography';
 import {
   spacing,
@@ -26,6 +32,12 @@ import { useGlassCapability } from '../hooks/use-glass-capability';
 import { secureStorePreferences } from '../lib/preferences/secure-store-adapter';
 
 type ColorScheme = 'light' | 'dark';
+
+/**
+ * Resolved brand colours for the current colour scheme. `brandColors` (light) and
+ * `brandColorsDark` share the same keys, so either set satisfies this shape.
+ */
+type ResolvedBrandColors = typeof brandColors | typeof brandColorsDark;
 
 /**
  * Resolved system colors for the current color scheme.
@@ -47,7 +59,7 @@ type ResolvedSystemColors = {
 type Theme = {
   colorScheme: ColorScheme;
   systemColors: ResolvedSystemColors;
-  brandColors: typeof brandColors;
+  brandColors: ResolvedBrandColors;
   textStyles: typeof textStyles;
   spacing: typeof spacing;
   borderRadius: typeof borderRadius;
@@ -107,6 +119,14 @@ function resolveSystemColors(colorScheme: ColorScheme, variant: UiVariant): Reso
     separator: fallback.separator,
     fill: fallback.fill,
   };
+}
+
+/**
+ * Pick the brand colour set for the current scheme. The dark set lifts the violet
+ * tint and brightens semantic tones so brand foregrounds stay legible on near-black.
+ */
+function resolveBrandColors(colorScheme: ColorScheme): ResolvedBrandColors {
+  return colorScheme === 'dark' ? brandColorsDark : brandColors;
 }
 
 type ThemeProviderProps = {
@@ -213,7 +233,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     return {
       colorScheme,
       systemColors: resolvedSystemColors,
-      brandColors,
+      brandColors: resolveBrandColors(colorScheme),
       textStyles,
       spacing,
       borderRadius,

--- a/packages/mobile/src/theme/__tests__/paper-theme.test.ts
+++ b/packages/mobile/src/theme/__tests__/paper-theme.test.ts
@@ -14,18 +14,18 @@ import { buildPaperTheme } from '../paper-theme';
 describe('buildPaperTheme', () => {
   it('maps the brand + material surfaces onto MD3 roles (light)', () => {
     const theme = buildPaperTheme('light');
-    expect(theme.colors.primary).toBe('#8C4A52');
+    expect(theme.colors.primary).toBe('#6D28D9');
     expect(theme.colors.onPrimary).toBe('#FFFFFF');
-    expect(theme.colors.background).toBe('#F4ECEC'); // materialSurfaces.light.background
+    expect(theme.colors.background).toBe('#F3EFFA'); // materialSurfaces.light.background
     expect(theme.colors.surface).toBe('#FFFFFF'); // secondaryBackground
-    expect(theme.colors.error).toBe('#B8524C');
+    expect(theme.colors.error).toBe('#C81E1E');
     expect(theme.colors.elevation.level2).toBe('#FFFFFF'); // elevatedSurface (light)
   });
 
   it('uses the dark tonal surfaces for the dark scheme', () => {
     const theme = buildPaperTheme('dark');
-    expect(theme.colors.background).toBe('#141011');
-    expect(theme.colors.surface).toBe('#1F1A1B');
+    expect(theme.colors.background).toBe('#15101E');
+    expect(theme.colors.surface).toBe('#221A33');
   });
 
   it('passes a provided dynamic palette straight through (Material You hook)', () => {

--- a/packages/mobile/src/theme/colors.ts
+++ b/packages/mobile/src/theme/colors.ts
@@ -28,14 +28,51 @@ export const iosSystemColors: Record<string, ColorValue> | null =
     : null;
 
 /**
- * Brand colors are the same on all platforms and in all color schemes.
+ * Brand colors — "Velvet Send" system, anchored on the logo's V11–V16 purples.
+ *
+ * `brandColors` holds the LIGHT-scheme values (and the scheme-agnostic anchors);
+ * `brandColorsDark` overrides the few roles that need a different value in dark
+ * mode so they stay legible. The ThemeProvider resolves the right set per scheme
+ * and exposes it as `useTheme().brandColors` — components should read brand
+ * colours from the theme (not these constants) wherever the colour scheme matters.
+ *
+ * Role split:
+ * - `primary`/`tint`: brand colour for FOREGROUND use (text, icons, links, borders).
+ * - `primaryFill`: brand colour for a FILLED surface/button background.
+ * - `onPrimary`: text/icon colour sitting on `primaryFill`.
+ * - `accent`: warm amber spark for highlights — FILL-ONLY, always pair with dark text.
+ *
+ * Contrast (WCAG, light): white-on-primary #6D28D9 = 7.10:1; black-on-accent = 8.95:1.
  */
 export const brandColors = {
-  tint: '#8C4A52',
-  primary: '#8C4A52',
-  success: '#6B9080',
-  warning: '#C4943C',
-  error: '#B8524C',
+  tint: '#6D28D9',
+  primary: '#6D28D9',
+  primaryFill: '#6D28D9',
+  onPrimary: '#FFFFFF',
+  accent: '#FF8A3D',
+  success: '#047857',
+  warning: '#B45309',
+  error: '#C81E1E',
+} as const;
+
+/**
+ * Dark-scheme brand overrides. The dark violet primary is too low-contrast as a
+ * foreground on near-black, so the tint lifts to #A78BFA; filled buttons use a
+ * brighter #7C3AED so white text still clears AA (5.70:1). Semantic tones brighten
+ * for legibility on dark surfaces. Same keys as `brandColors`.
+ *
+ * Contrast (WCAG, dark): #A78BFA tint ≥6.12:1 across the dark surface ladder;
+ * white-on-#7C3AED = 5.70:1.
+ */
+export const brandColorsDark = {
+  tint: '#A78BFA',
+  primary: '#A78BFA',
+  primaryFill: '#7C3AED',
+  onPrimary: '#FFFFFF',
+  accent: '#FF8A3D',
+  success: '#34D399',
+  warning: '#FBBF24',
+  error: '#F87171',
 } as const;
 
 /**
@@ -44,28 +81,29 @@ export const brandColors = {
  */
 export const androidFallbackColors = {
   light: {
-    background: '#FFFFFF',
-    secondaryBackground: '#F2F2F7',
+    background: '#F4F1FB',
+    secondaryBackground: '#FFFFFF',
     tertiaryBackground: '#FFFFFF',
-    groupedBackground: '#F2F2F7',
+    groupedBackground: '#F4F1FB',
     elevatedSurface: '#FFFFFF',
-    label: '#000000',
-    secondaryLabel: 'rgba(60, 60, 67, 0.6)',
-    tertiaryLabel: 'rgba(60, 60, 67, 0.3)',
-    separator: 'rgba(60, 60, 67, 0.29)',
-    fill: 'rgba(120, 120, 128, 0.2)',
+    label: '#16111F',
+    // Opaque (not 0.6-alpha) so secondary text clears WCAG AA: #5B5563 = 6.44:1 on bg.
+    secondaryLabel: '#5B5563',
+    tertiaryLabel: '#8E8898',
+    separator: 'rgba(60, 55, 75, 0.18)',
+    fill: 'rgba(109, 40, 217, 0.1)',
   },
   dark: {
-    background: '#000000',
-    secondaryBackground: '#1C1C1E',
-    tertiaryBackground: '#2C2C2E',
-    groupedBackground: '#000000',
-    elevatedSurface: '#2C2C2E',
-    label: '#FFFFFF',
-    secondaryLabel: 'rgba(235, 235, 245, 0.6)',
-    tertiaryLabel: 'rgba(235, 235, 245, 0.3)',
-    separator: 'rgba(84, 84, 88, 0.6)',
-    fill: 'rgba(120, 120, 128, 0.36)',
+    background: '#0F0B16',
+    secondaryBackground: '#181225',
+    tertiaryBackground: '#221A32',
+    groupedBackground: '#0F0B16',
+    elevatedSurface: '#221A32',
+    label: '#F5F2FB',
+    secondaryLabel: '#A9A2B6',
+    tertiaryLabel: '#6E687C',
+    separator: 'rgba(180, 168, 205, 0.2)',
+    fill: 'rgba(199, 184, 232, 0.12)',
   },
 } as const;
 
@@ -75,41 +113,42 @@ export const androidFallbackColors = {
  * directly as the resolved system colors on ANY platform when the user is on the
  * Material variant (including iOS 26 hardware where they chose Material).
  *
- * Neutrals are warmed toward the maroon brand tint (#8C4A52) so Material reads as
- * the same product as Liquid Glass rather than a generic M3 theme. The Material
- * feel comes from elevation shadows, ripple, the nav active-indicator pill, and
- * bounded radii — not from a different palette. Labels keep the iOS-derived
- * neutral values so text contrast matches the glass variant exactly.
+ * Neutrals are tinted toward the violet brand (#6D28D9) so Material reads as the
+ * same product as Liquid Glass rather than a generic M3 theme. The Material feel
+ * comes from elevation shadows, ripple, the nav active-indicator pill, and bounded
+ * radii — not from a different palette. Labels use opaque values so text contrast
+ * clears WCAG AA and matches the glass variant.
  */
 export const materialSurfaces = {
   light: {
-    // M3 base surface — warm-tinted so cards/elevation read against it.
-    background: '#F4ECEC',
+    // M3 base surface — violet-tinted so cards/elevation read against it.
+    background: '#F3EFFA',
     // Cards and sheets sit a step up from the base (surface container low).
     secondaryBackground: '#FFFFFF',
     tertiaryBackground: '#FFFFFF',
-    groupedBackground: '#F4ECEC',
+    groupedBackground: '#F3EFFA',
     // Raised tile (selected segmented pill, elevated bar) — surface + elevation.
     elevatedSurface: '#FFFFFF',
-    label: '#000000',
-    secondaryLabel: 'rgba(60, 60, 67, 0.6)',
-    tertiaryLabel: 'rgba(60, 60, 67, 0.3)',
+    label: '#16111F',
+    secondaryLabel: '#5B5563',
+    tertiaryLabel: '#8E8898',
     // M3 outline-variant.
-    separator: 'rgba(60, 60, 67, 0.18)',
-    // Faint maroon track for segmented controls / fills.
-    fill: 'rgba(140, 74, 82, 0.1)',
+    separator: 'rgba(60, 55, 75, 0.18)',
+    // Faint violet track for segmented controls / fills (bumped to 0.14 so selected
+    // pills read on white).
+    fill: 'rgba(109, 40, 217, 0.14)',
   },
   dark: {
-    background: '#141011',
-    secondaryBackground: '#1F1A1B',
-    tertiaryBackground: '#2A2425',
-    groupedBackground: '#141011',
-    elevatedSurface: '#2A2425',
-    label: '#FFFFFF',
-    secondaryLabel: 'rgba(235, 235, 245, 0.6)',
-    tertiaryLabel: 'rgba(235, 235, 245, 0.3)',
-    separator: 'rgba(235, 235, 245, 0.18)',
-    fill: 'rgba(235, 220, 222, 0.12)',
+    background: '#15101E',
+    secondaryBackground: '#221A33',
+    tertiaryBackground: '#2A2142',
+    groupedBackground: '#15101E',
+    elevatedSurface: '#2A2142',
+    label: '#F5F2FB',
+    secondaryLabel: '#A9A2B6',
+    tertiaryLabel: '#6E687C',
+    separator: 'rgba(180, 168, 205, 0.18)',
+    fill: 'rgba(199, 184, 232, 0.14)',
   },
 } as const;
 

--- a/packages/mobile/src/theme/ios-colors.ts
+++ b/packages/mobile/src/theme/ios-colors.ts
@@ -4,7 +4,7 @@ import { brandColors } from './colors';
 /**
  * The interactive-accent blue. iOS keeps Apple's #007AFF; Android resolves it to
  * the brand tint so the active tab, links, and "edit / copy / open" affordances
- * read as Boardsesh maroon rather than an out-of-place iOS blue. This is the one
+ * read as Boardsesh violet rather than an out-of-place iOS blue. This is the one
  * value in `iosSystemColors` that genuinely leaks an iOS aesthetic onto Android
  * (it's used as a *tint*, not a fixed status colour); resolving it here fixes
  * every static (StyleSheet / default-prop) consumer at once without a wide
@@ -29,7 +29,7 @@ export const iosSystemColors = {
   systemGreen: '#34C759',
   /** iOS systemYellow — caution, moderate indicators */
   systemYellow: '#FFCC00',
-  /** Interactive accent — iOS systemBlue (#007AFF); brand maroon on Android. */
+  /** Interactive accent — iOS systemBlue (#007AFF); brand violet on Android. */
   systemBlue: ACCENT_TINT,
   /** iOS systemOrange — moderate warnings, attempted indicators */
   systemOrange: '#FF9500',

--- a/packages/mobile/src/theme/paper-theme.ts
+++ b/packages/mobile/src/theme/paper-theme.ts
@@ -41,9 +41,12 @@ export function buildPaperTheme(colorScheme: ColorScheme, dynamic?: MD3Theme['co
       onSecondary: brand.onPrimary,
       secondaryContainer: withAlpha(brand.primaryFill, isDark ? 0.28 : 0.16),
       onSecondaryContainer: onSurface,
-      // Amber accent is the M3 tertiary role — fill-only, so it carries dark text.
+      // Amber accent is the M3 tertiary role — fill-only, so it carries dark text
+      // in BOTH schemes (white fails on amber). Pin to the light-scheme label
+      // token (the dark ink) rather than the per-scheme `onSurface`, which would
+      // be near-white in dark and illegible on the accent.
       tertiary: brand.accent,
-      onTertiary: '#16111F',
+      onTertiary: materialSurfaces.light.label as string,
       background: surfaces.background as string,
       onBackground: onSurface,
       surface: surfaces.secondaryBackground as string,

--- a/packages/mobile/src/theme/paper-theme.ts
+++ b/packages/mobile/src/theme/paper-theme.ts
@@ -1,12 +1,12 @@
 import { MD3DarkTheme, MD3LightTheme, type MD3Theme } from 'react-native-paper';
-import { brandColors, materialSurfaces, withAlpha } from './colors';
+import { brandColors, brandColorsDark, materialSurfaces, withAlpha } from './colors';
 
 type ColorScheme = 'light' | 'dark';
 
 /**
  * Build a react-native-paper Material 3 theme from our existing design tokens, so
  * the Material UI variant renders authentic MD3 components tinted to the
- * Boardsesh brand (maroon #8C4A52) and consistent with our `materialSurfaces`
+ * Boardsesh brand (violet #6D28D9) and consistent with our `materialSurfaces`
  * ladder. Our theme stays the source of truth — this is the downstream Paper
  * consumer; the Liquid Glass variant never touches it.
  *
@@ -25,6 +25,7 @@ export function buildPaperTheme(colorScheme: ColorScheme, dynamic?: MD3Theme['co
 
   const surfaces = materialSurfaces[colorScheme];
   const isDark = colorScheme === 'dark';
+  const brand = isDark ? brandColorsDark : brandColors;
   const onSurface = surfaces.label as string;
   const onSurfaceVariant = surfaces.secondaryLabel as string;
 
@@ -32,16 +33,17 @@ export function buildPaperTheme(colorScheme: ColorScheme, dynamic?: MD3Theme['co
     ...base,
     colors: {
       ...base.colors,
-      primary: brandColors.primary,
-      onPrimary: '#FFFFFF',
-      primaryContainer: withAlpha(brandColors.primary, isDark ? 0.32 : 0.14),
+      primary: brand.primaryFill,
+      onPrimary: brand.onPrimary,
+      primaryContainer: withAlpha(brand.primaryFill, isDark ? 0.32 : 0.14),
       onPrimaryContainer: onSurface,
-      secondary: brandColors.primary,
-      onSecondary: '#FFFFFF',
-      secondaryContainer: withAlpha(brandColors.primary, isDark ? 0.28 : 0.16),
+      secondary: brand.primaryFill,
+      onSecondary: brand.onPrimary,
+      secondaryContainer: withAlpha(brand.primaryFill, isDark ? 0.28 : 0.16),
       onSecondaryContainer: onSurface,
-      tertiary: brandColors.success,
-      onTertiary: '#FFFFFF',
+      // Amber accent is the M3 tertiary role — fill-only, so it carries dark text.
+      tertiary: brand.accent,
+      onTertiary: '#16111F',
       background: surfaces.background as string,
       onBackground: onSurface,
       surface: surfaces.secondaryBackground as string,
@@ -50,7 +52,7 @@ export function buildPaperTheme(colorScheme: ColorScheme, dynamic?: MD3Theme['co
       onSurfaceVariant,
       outline: surfaces.separator as string,
       outlineVariant: surfaces.separator as string,
-      error: brandColors.error,
+      error: brand.error,
       onError: '#FFFFFF',
       // Surface-tint ladder: map Paper's elevation levels onto our tonal surfaces
       // so elevated Paper components match the rest of the Material chrome.

--- a/packages/web/app/lib/__tests__/grade-colors.test.ts
+++ b/packages/web/app/lib/__tests__/grade-colors.test.ts
@@ -15,9 +15,9 @@ import {
 describe('Grade Colors', () => {
   describe('getVGradeColor', () => {
     it('returns correct color for known V-grades', () => {
-      expect(getVGradeColor('V0')).toBe('#FFEB3B');
-      expect(getVGradeColor('V5')).toBe('#F44336');
-      expect(getVGradeColor('V10')).toBe('#A11B4A');
+      expect(getVGradeColor('V0')).toBe('#FFD400');
+      expect(getVGradeColor('V5')).toBe('#F03E3E');
+      expect(getVGradeColor('V10')).toBe('#7E1C8E');
       expect(getVGradeColor('V17')).toBe('#2A0054');
     });
 
@@ -46,8 +46,8 @@ describe('Grade Colors', () => {
 
   describe('getFontGradeColor', () => {
     it('returns correct color for known Font grades', () => {
-      expect(getFontGradeColor('6a')).toBe('#FF7043');
-      expect(getFontGradeColor('7b+')).toBe('#C62828');
+      expect(getFontGradeColor('6a')).toBe('#FF6D2E');
+      expect(getFontGradeColor('7b+')).toBe('#B81A5A');
     });
 
     it('is case-insensitive', () => {
@@ -118,14 +118,14 @@ describe('Grade Colors', () => {
     });
 
     it('correctly parses a real grade color', () => {
-      // V0 = #FFEB3B -> rgb(255, 235, 59)
-      expect(getGradeColorWithOpacity('#FFEB3B', 0.8)).toBe('rgba(255, 235, 59, 0.8)');
+      // V0 = #FFD400 -> rgb(255, 212, 0)
+      expect(getGradeColorWithOpacity('#FFD400', 0.8)).toBe('rgba(255, 212, 0, 0.8)');
     });
   });
 
   describe('isLightColor', () => {
     it('returns true for light colors (yellow)', () => {
-      expect(isLightColor('#FFEB3B')).toBe(true); // V0 yellow
+      expect(isLightColor('#FFD400')).toBe(true); // V0 golden yellow
     });
 
     it('returns true for white', () => {
@@ -141,14 +141,14 @@ describe('Grade Colors', () => {
     });
 
     it('returns false for dark red', () => {
-      expect(isLightColor('#B71C1C')).toBe(false); // V9 deep red
+      expect(isLightColor('#9E1A78')).toBe(false); // V9 magenta-purple
     });
   });
 
   describe('getGradeTextColor', () => {
     it('returns black (#000000) for light backgrounds', () => {
-      expect(getGradeTextColor('#FFEB3B')).toBe('#000000'); // V0 yellow
-      expect(getGradeTextColor('#FFC107')).toBe('#000000'); // V1 amber
+      expect(getGradeTextColor('#FFD400')).toBe('#000000'); // V0 golden yellow
+      expect(getGradeTextColor('#FFB300')).toBe('#000000'); // V1 amber
     });
 
     it('returns white (#FFFFFF) for dark backgrounds', () => {


### PR DESCRIPTION
## What & why

The mobile app adopted a content-first HIG / iOS 26 Liquid Glass strategy, but the inherited brand — muted maroon `#8C4A52` + sage `#6B9080` — read as dated and didn't pop. It also had no relationship to the Boardsesh logo, which is built from the **V11–V16 grade purples** (`#9C27B0`→`#38006B`).

This re-anchors the **mobile** design system on a logo-cohesive **violet `#6D28D9`** + warm **amber accent `#FF8A3D`** ("Velvet Send"). The palette was generated and adversarially critiqued by a multi-agent design pass; every text/button pair was recomputed against WCAG AA using the repo's own `contrastRatio()`. The web brand is unchanged.

## The palette

| Role | Light | Dark |
|---|---|---|
| Primary (text/icon/links) | `#6D28D9` | `#A78BFA` |
| Primary fill (filled buttons) | `#6D28D9` | `#7C3AED` |
| Accent (fill + dark text) | `#FF8A3D` | `#FF8A3D` |
| Success / Warning / Error | `#047857` / `#B45309` / `#C81E1E` | `#34D399` / `#FBBF24` / `#F87171` |

WCAG AA verified: white-on-primary 7.10:1 · dark tint `#A78BFA` ≥6.12:1 across the dark surface ladder · white-on-`#7C3AED` (dark fill) 5.70:1 · amber accent is fill-only with dark text.

## Changes

- **Brand tokens & surfaces** (`packages/mobile/src/theme/colors.ts`): new `brandColors` (light) + `brandColorsDark`; `theme.brandColors` now resolves per colour scheme. Material 3 tonal surfaces and Android-glass neutrals retinted maroon→violet; Paper theme rewired (`paper-theme.ts`).
- **Scheme-aware consumers**: Button, RadioGroup, SegmentedControl, ActivityIndicator, and the You-page flash/redpoint charts read the resolved brand so dark mode gets the `#A78BFA` tint. Playlist swatches, smart-playlist colors and the active-row wash recolored.
- **Grade arc** (`@boardsesh/board-constants/grade-colors.ts`): punchier V0→V10 (`#FFD400`→`#7E1C8E`), V11–V16 logo purples kept byte-for-byte. **Shared with web + backend**, so web grade pills update too (they already auto-pick legible text). Grade-hex assertions updated in board-constants, backend, web and mobile test suites.
- **Hold colors untouched** — board data in `board-constants/hold-states.ts`, fully decoupled from the theme.

## Validation

- `vp run typecheck` (web + backend + shared + mobile) ✅
- `vp test --project mobile` — **990 passed** ✅
- grade-color suites (board-constants, backend ×2, web, shared play-view, mobile grade-chip) — **162 passed** ✅
- `vp run check:mobile-bundle` ✅ (10.4 MB) · pre-commit `vp check --fix` + i18n checks ✅

## Follow-up (not in this PR)

~80 call sites still import the static `brandColors`, so in **dark mode** they render the light violet `#6D28D9` as a foreground (low-ish contrast on near-black). This is **parity with the previous maroon** (no regression), not a full fix — a focused scheme-aware sweep lifting those to `#A78BFA` is the next step, best paired with on-device dark-mode QA. **Tracked in #2583.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
