### PR TITLE
Enable vp check lint for packages/mobile in CI and precommit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,12 +149,12 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           # Match the staged-hook scope in root vite.config.ts: TS/JS files,
-          # excluding generated/, mobile (excluded from vp lint by config), and
-          # embedded firmware sources. xargs -r ensures no-op on empty input.
+          # excluding generated/, board-controller, and embedded firmware sources.
+          # xargs -r ensures no-op on empty input.
           git diff --name-only --diff-filter=ACMR \
             "origin/$BASE_REF...HEAD" \
             -- '*.ts' '*.tsx' '*.js' '*.mjs' '*.cjs' \
-            | grep -vE '(/node_modules/|/generated/|^packages/mobile/|^packages/board-controller/|^embedded/)' \
+            | grep -vE '(/node_modules/|/generated/|^packages/board-controller/|^embedded/)' \
             > changed-lintable.txt || true
           if [ -s changed-lintable.txt ]; then
             xargs -r vp check < changed-lintable.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ React Native + Expo SDK 53, React Native 0.79, Expo Router 5.
 
 ### Mobile vs. web
 
-- **No `vp check` lint** — mobile is excluded. Use `vp run typecheck:mobile`.
+- **Lint via `vp check`** — runs for mobile just like other packages. Use `vp run typecheck:mobile` for type-only checks.
 - **Own i18n provider** at `packages/mobile/src/providers/i18n-provider.tsx`. No web i18n rules apply.
 - **No web dev-server workflow** — use `vp run dev:mobile` (Metro) instead. The QA-notes-into-`/api/internal/dev-metadata` flow is web-only; on mobile the `DevMetadataPanel` (More tab) reads `.boardsesh/qa-notes.md` via env injection.
 - **Styling**: `StyleSheet.create` + theme provider. No MUI, no `style`-prop avoidance rule.

--- a/packages/mobile/app/boards/search.tsx
+++ b/packages/mobile/app/boards/search.tsx
@@ -28,6 +28,7 @@ type MapModule = typeof import('expo-maps');
 let expoMaps: MapModule | null = null;
 try {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
+  // oxlint-disable-next-line import/no-commonjs
   expoMaps = require('expo-maps') as MapModule;
 } catch {
   expoMaps = null;

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -350,6 +350,7 @@ function getNativeModule() {
   if (moduleLoadAttempted) return renderModule;
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
+    // oxlint-disable-next-line import/no-commonjs
     const loaded = require('../../modules/board-renderer/src/index') as typeof renderModule;
     // The wrapper exposes `boardRendererNative` which is null when the
     // native binary isn't loaded. Treat that as "no native renderer

--- a/packages/mobile/src/lib/__tests__/android-bluetooth-feature-plugin.test.ts
+++ b/packages/mobile/src/lib/__tests__/android-bluetooth-feature-plugin.test.ts
@@ -4,21 +4,21 @@ import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 
-interface UsesFeature {
+type UsesFeature = {
   $: Record<string, string>;
-}
+};
 
-interface AndroidManifestShape {
+type AndroidManifestShape = {
   manifest: {
     'uses-feature'?: UsesFeature[];
     'uses-permission'?: UsesFeature[];
   };
-}
+};
 
-interface BluetoothFeaturePlugin {
+type BluetoothFeaturePlugin = {
   addBluetoothLeFeature(androidManifest: AndroidManifestShape): AndroidManifestShape;
   FEATURE_NAME: string;
-}
+};
 
 const plugin = require('../../../plugins/with-android-bluetooth-feature.js') as BluetoothFeaturePlugin;
 

--- a/packages/mobile/src/lib/__tests__/android-release-signing-plugin.test.ts
+++ b/packages/mobile/src/lib/__tests__/android-release-signing-plugin.test.ts
@@ -4,11 +4,11 @@ import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 
-interface AndroidReleaseSigningPlugin {
+type AndroidReleaseSigningPlugin = {
   applyAndroidReleaseSigning(contents: string): string;
   MARKER: string;
   RELEASE_SIGNING_CONFIG_LINE: string;
-}
+};
 
 const plugin = require('../../../plugins/with-android-release-signing.js') as AndroidReleaseSigningPlugin;
 

--- a/packages/mobile/src/lib/__tests__/android-session-service-plugin.test.ts
+++ b/packages/mobile/src/lib/__tests__/android-session-service-plugin.test.ts
@@ -4,11 +4,11 @@ import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 
-interface ManifestElement {
+type ManifestElement = {
   $: Record<string, string>;
-}
+};
 
-interface AndroidManifestShape {
+type AndroidManifestShape = {
   manifest: {
     application?: Array<{
       $: Record<string, string>;
@@ -16,13 +16,13 @@ interface AndroidManifestShape {
       receiver?: ManifestElement[];
     }>;
   };
-}
+};
 
-interface SessionServicePlugin {
+type SessionServicePlugin = {
   addSessionService(manifest: AndroidManifestShape): AndroidManifestShape;
   SERVICE_NAME: string;
   RECEIVER_NAME: string;
-}
+};
 
 const plugin = require('../../../plugins/with-android-session-service.js') as SessionServicePlugin;
 

--- a/packages/mobile/src/lib/__tests__/dev-networking-plugin.test.ts
+++ b/packages/mobile/src/lib/__tests__/dev-networking-plugin.test.ts
@@ -4,11 +4,11 @@ import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 
-interface DevNetworkingPlugin {
+type DevNetworkingPlugin = {
   applyBoardseshDevNetworkingInfoPlist(infoPlist: Record<string, unknown>): Record<string, unknown>;
   TAILSCALE_ATS_EXCEPTION: Record<string, unknown>;
   TAILSCALE_DOMAIN: string;
-}
+};
 
 const devNetworkingPlugin = require('../../../plugins/with-boardsesh-dev-networking.js') as DevNetworkingPlugin;
 

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -49,7 +49,7 @@ export function getAnalyticsClient(): PostHog | null {
 }
 
 const analytics = createAnalytics(getClient, {
-  onDebug: __DEV__ ? (name, properties) => console.log('[analytics]', name, properties ?? {}) : undefined,
+  onDebug: __DEV__ ? (name, properties) => console.info('[analytics]', name, properties ?? {}) : undefined,
 });
 
 export const { track, identify, setPersonProperties, alias, reset } = analytics;
@@ -59,6 +59,6 @@ export const { track, identify, setPersonProperties, alias, reset } = analytics;
 // calls this from a route-change effect. `screen()` emits the native $screen
 // event PostHog's mobile insights key off.
 export function trackScreen(path: string): void {
-  if (__DEV__) console.log('[analytics] $screen', path);
+  if (__DEV__) console.info('[analytics] $screen', path);
   void getClient()?.screen(path);
 }

--- a/packages/mobile/src/lib/board-backgrounds-manifest.ts
+++ b/packages/mobile/src/lib/board-backgrounds-manifest.ts
@@ -10,6 +10,7 @@
 // This keeps the canonical asset set in one place (the web package).
 
 /* eslint-disable @typescript-eslint/no-require-imports */
+// oxlint-disable import/no-commonjs
 export const BOARD_BACKGROUND_ASSETS: Record<string, number> = {
   'decoy/product_sizes_layouts_sets/1.webp': require('../../../web/public/images/decoy/product_sizes_layouts_sets/1.webp'),
   'decoy/product_sizes_layouts_sets/10.webp': require('../../../web/public/images/decoy/product_sizes_layouts_sets/10.webp'),

--- a/packages/mobile/src/lib/live-activity/__tests__/widget-build-settings.test.ts
+++ b/packages/mobile/src/lib/live-activity/__tests__/widget-build-settings.test.ts
@@ -4,33 +4,33 @@ import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 
-interface WidgetTargetConfig {
+type WidgetTargetConfig = {
   deploymentTarget: string;
   xcodeProjectSettings?: unknown;
-}
+};
 
-interface CapturingTarget {
+type CapturingTarget = {
   isa: 'PBXNativeTarget';
   props: {
     name: string;
     productName: string;
   };
   setBuildSetting(settingName: string, settingValue: string): void;
-}
+};
 
-interface CapturingProject {
+type CapturingProject = {
   rootObject: {
     props: {
       targets: CapturingTarget[];
     };
   };
-}
+};
 
-interface WidgetBuildSettingsPlugin {
+type WidgetBuildSettingsPlugin = {
   configureBoardseshWidgetTarget(project: CapturingProject): void;
   WIDGET_DEPLOYMENT_TARGET: string;
   WIDGET_SWIFT_FLAGS: string;
-}
+};
 
 const widgetTargetConfig = require('../../../../targets/BoardseshWidgets/expo-target.config.js') as WidgetTargetConfig;
 const widgetBuildSettingsPlugin =

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     ignore: ['design/**', '**/generated/**', '**/board-controller/**'],
   },
   lint: {
-    ignorePatterns: ['**/board-controller/**', 'mobile/**', 'packages/mobile/**'],
+    ignorePatterns: ['**/board-controller/**'],
     options: {
       typeAware: true,
       typeCheck: true,


### PR DESCRIPTION
## Summary

- Removes `packages/mobile/**` from `lint.ignorePatterns` in `vite.config.ts` so mobile TypeScript files go through the same oxlint + oxfmt pass as every other package
- Removes `^packages/mobile/` from the CI lint step's grep filter so changed mobile files are linted in PRs
- The precommit staged hook already covers `*.{ts,tsx}` — removing the ignorePatterns exclusion activates it for mobile with no additional changes
- Unit tests for mobile were already running in `test-default` (mobile is in `test.projects` and absent from `INFRA_PROJECTS`)

Pre-existing violations fixed alongside the config change:
- `console.log` → `console.info` in `analytics.ts` (`__DEV__`-guarded debug callbacks)
- `// oxlint-disable-next-line import/no-commonjs` on dynamic native `require()` calls in `search.tsx` and `use-native-climb-render.ts`
- `// oxlint-disable import/no-commonjs` on the auto-generated `board-backgrounds-manifest.ts` (mirrors existing `eslint-disable`)
- `interface` → `type` in 6 Expo config plugin test files

## Test plan

- [ ] CI lint job processes mobile files (no longer filtered out in the `grep -vE` exclusion)
- [ ] CI `test-default` job continues to run mobile tests (no change required)
- [ ] Staging a mobile `.ts` file and committing fires `vp check --fix` via the precommit hook

https://claude.ai/code/session_013NN1jQyfSN16GuMoSnBNFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013NN1jQyfSN16GuMoSnBNFZ)_