### PR TITLE
[codex] Add Material You dynamic color to mobile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,7 @@ Multiple worktrees can publish independent previews. Testers install the "previe
 
 One-time: `vp run mobile:preview-build` produces an installable `.ipa`/`.apk`. Testers install it (iOS ad-hoc, Android APK).
 
-Four preview channels (`preview-1` ... `preview-4`), one per test device. Publish: `vp run mobile:publish` (defaults to current git branch; pass `--branch`, `--message`, `--platform ios` to override). Point a channel at a branch: `bunx eas-cli@16 channel:edit preview-N --branch <branch>`.
+Four preview channels (`preview-1` ... `preview-4`), one per test device. Publish: `vp run mobile:publish` (defaults to current git branch; pass `--branch`, `--message`, `--platform ios` to override). Point a channel at a branch: `bun x -p eas-cli@16 eas channel:edit preview-N --branch <branch>`.
 
 CI: `mobile-eas-update.yml` auto-publishes on every push to a non-main branch touching `packages/mobile/` or shared packages, and comments on the PR. `EXPO_TOKEN` secret required.
 

--- a/bun.lock
+++ b/bun.lock
@@ -200,6 +200,7 @@
         "@boardsesh/shared-schema": "*",
         "@expo/vector-icons": "^15.1.1",
         "@gorhom/bottom-sheet": "^5.2.14",
+        "@pchmn/expo-material3-theme": "^1.4.0",
         "@react-native-async-storage/async-storage": "^3.1.0",
         "@react-native-community/blur": "^4.4.1",
         "@sentry/cli": "2.53.0",
@@ -1401,6 +1402,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@material/material-color-utilities": ["@material/material-color-utilities@0.3.0", "", {}, "sha512-ztmtTd6xwnuh2/xu+Vb01btgV8SQWYCaK56CkRK8gEkWe5TuDyBcYJ0wgkMRn+2VcE9KUmhvkz+N9GHrqw/C0g=="],
+
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
@@ -1580,6 +1583,8 @@
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
     "@parse/node-apn": ["@parse/node-apn@8.1.0", "", { "dependencies": { "debug": "4.4.3", "jsonwebtoken": "9.0.3", "node-forge": "1.4.0", "verror": "1.10.1" } }, "sha512-LowcdkKPDikbbzIr3zwEdoFW5wfEbbTzpYQeen3S8kKLePG0AQK586Li+OLC7bonyLmlk//Yk3smHZOLSV6TZA=="],
+
+    "@pchmn/expo-material3-theme": ["@pchmn/expo-material3-theme@1.4.0", "", { "dependencies": { "@material/material-color-utilities": "^0.3.0", "color": "^4.2.3" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-XNt0gpZX5argOQ7JiFnNdiXHpHjmpwJoMQrlnd1kpb8ly/IWZN2hh011incmfZXV2Xs+p6Uo1BGDKv8hW4MQTQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 

--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -920,7 +920,9 @@ Glass is for **floating chrome only** — never for content canvases or text-hea
 
 The mobile app ships **two visual variants**, switchable in More → **UI style** (Auto / Liquid Glass / Material). Liquid Glass (above) is the preferred, primary UI; **Material** is the default on non-iOS-26 devices and renders authentic Material 3 via `react-native-paper`. The resolved variant is exposed as `useTheme().variant` (`'liquidGlass' | 'material'`) — resolved in `ThemeProvider` from the persisted `uiVariantPreference` (`src/theme/resolve-ui-variant.ts`).
 
-**Our theme stays the source of truth.** `src/theme/paper-theme.ts` `buildPaperTheme(colorScheme, dynamic?)` maps our tokens (`materialSurfaces`, `brandColors`) onto MD3 colour roles and feeds `PaperProvider` (mounted by `src/providers/material-theme-provider.tsx`, under `ThemeProvider`). Paper's MD3 type scale + shapes stay as defaults (system font). The optional `dynamic` palette is the seam for the planned Material You fast-follow (`@pchmn/expo-material3-theme`).
+**Our theme stays the source of truth.** `src/theme/paper-theme.ts` `buildPaperTheme(colorScheme, dynamic?)` maps our tokens (`materialSurfaces`, `brandColors`) onto MD3 colour roles and feeds `PaperProvider` (mounted by `src/providers/material-theme-provider.tsx`, under `ThemeProvider`). Paper's MD3 type scale + shapes stay as defaults (system font). On Android 12+ in the Material variant, `@pchmn/expo-material3-theme` supplies the device Material You palette; unsupported devices keep the static "Velvet Send" violet Material map.
+
+**Material You must reach both theme paths.** `ThemeProvider` gates dynamic color to `variant === 'material' && isDynamicThemeSupported`, passes that palette to Paper, and converts it into the `systemColors` shape used by token-skinned surfaces. Do not feed dynamic color only to Paper; the tab bar, gorhom sheets, accessory bar, `ListRow`, `GradeChip`, and `GlassSurface` material branch must stay palette-consistent.
 
 **Per-primitive dispatch convention** — when adding/migrating a primitive, branch on the variant and keep the Liquid Glass body untouched in the `else`:
 
@@ -935,7 +937,8 @@ The public prop API must stay identical across both branches so call sites never
 
 - **Icons:** Paper resolves icons through the app's `@expo/vector-icons` MaterialCommunityIcons (wired via `PaperProvider settings.icon`), so pass the **MDI** name — bridge our semantic `IconName` with `iconMap[name].android` (`src/components/icon-map.ts`).
 - **Paper-backed today:** Button, SegmentedControl→`SegmentedButtons`, SwitchRow→`Switch`, Badge, GlassIconButton→`IconButton`, Card, Toast/QueueAddedSnackbar→`Snackbar`, SearchHeader→`Searchbar`.
-- **Token-skinned but palette-consistent** (they read the same `materialSurfaces` that feeds the Paper theme): `ListRow`, `GradeChip`, `MaterialTabBar`, gorhom sheets, `AccessoryBarSurface`.
+- **Token-skinned but palette-consistent** (they read the same static or dynamic Material surface ladder that feeds the Paper theme): `ListRow`, `GradeChip`, `MaterialTabBar`, gorhom sheets, `AccessoryBarSurface`.
+- **Native build note:** `@pchmn/expo-material3-theme` is an Android native module. Adding or updating it needs a fresh `vp run mobile:preview-build`; OTA-only updates are not enough for testers who do not already have the module in their installed shell.
 - **Tests:** `react-native-paper` is aliased to a jsdom-safe stub (`test/react-native-paper-stub.tsx`) in `packages/mobile/vite.config.ts` — the same pattern as the posthog stub — so any suite can import a Paper-backed primitive. Component tests that assert Paper props register their own `vi.mock('react-native-paper', …)`, which takes precedence.
 
 ---

--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -892,12 +892,12 @@ The Expo app (`packages/mobile/`) is a separate implementation from the web CSS 
 
 `packages/mobile/src/components/GlassSurface.tsx` is the single primitive for every translucent surface. It resolves the best material per device:
 
-| Condition                                   | Material                                              |
-| ------------------------------------------- | ----------------------------------------------------- |
-| iOS 26+ (Liquid Glass available)            | `expo-glass-effect` `GlassView`                       |
-| iOS < 26                                    | `@react-native-community/blur` `BlurView` (frosted)   |
-| Android                                     | Solid themed surface (`systemColors.secondaryBackground`) |
-| Reduce Transparency on (any platform)       | Solid themed surface                                  |
+| Condition                             | Material                                                  |
+| ------------------------------------- | --------------------------------------------------------- |
+| iOS 26+ (Liquid Glass available)      | `expo-glass-effect` `GlassView`                           |
+| iOS < 26                              | `@react-native-community/blur` `BlurView` (frosted)       |
+| Android                               | Solid themed surface (`systemColors.secondaryBackground`) |
+| Reduce Transparency on (any platform) | Solid themed surface                                      |
 
 Props: `glassEffectStyle` (`'regular'` for frosted chrome, `'clear'` for content-forward), `tintColor` (translucent hue composited onto the glass), `fallbackColor` (solid path).
 
@@ -922,7 +922,7 @@ The mobile app ships **two visual variants**, switchable in More → **UI style*
 
 **Our theme stays the source of truth.** `src/theme/paper-theme.ts` `buildPaperTheme(colorScheme, dynamic?)` maps our tokens (`materialSurfaces`, `brandColors`) onto MD3 colour roles and feeds `PaperProvider` (mounted by `src/providers/material-theme-provider.tsx`, under `ThemeProvider`). Paper's MD3 type scale + shapes stay as defaults (system font). On Android 12+ in the Material variant, `@pchmn/expo-material3-theme` supplies the device Material You palette; unsupported devices keep the static "Velvet Send" violet Material map.
 
-**Material You must reach both theme paths.** `ThemeProvider` gates dynamic color to `variant === 'material' && isDynamicThemeSupported`, passes that palette to Paper, and converts it into the `systemColors` shape used by token-skinned surfaces. Do not feed dynamic color only to Paper; the tab bar, gorhom sheets, accessory bar, `ListRow`, `GradeChip`, and `GlassSurface` material branch must stay palette-consistent.
+**Material You must reach both theme paths.** `ThemeProvider` gates dynamic color to `variant === 'material'`, `isDynamicThemeSupported`, and a real device palette. If the native module returns its generated maroon fallback, `dynamicMaterialColors` stays undefined and the static Material map is used. Do not feed dynamic color only to Paper; the tab bar, gorhom sheets, accessory bar, `ListRow`, `GradeChip`, and `GlassSurface` material branch must stay palette-consistent.
 
 **Per-primitive dispatch convention** — when adding/migrating a primitive, branch on the variant and keep the Liquid Glass body untouched in the `else`:
 

--- a/packages/mobile/modules/board-renderer/src/index.ts
+++ b/packages/mobile/modules/board-renderer/src/index.ts
@@ -74,7 +74,7 @@ export async function renderHoldsOverlay(configJson: string, cacheKey: string): 
   //   WHEN:  safe to delete once every active EAS preview channel
   //          (`preview-1` through `preview-4`) has been rebuilt onto a
   //          binary that exports `renderHoldsOverlay`.
-  //   HOW:   run `bunx eas-cli@16 channel:view preview-N` for N=1..4 and
+  //   HOW:   run `bun x -p eas-cli@16 eas channel:view preview-N` for N=1..4 and
   //          confirm each channel's runtime version maps to a build SHA
   //          that postdates the overlay-only commit. Easiest path: run
   //          `vp run mobile:preview-build` for all four channels, then

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -34,6 +34,7 @@
     "@boardsesh/shared-schema": "*",
     "@expo/vector-icons": "^15.1.1",
     "@gorhom/bottom-sheet": "^5.2.14",
+    "@pchmn/expo-material3-theme": "^1.4.0",
     "@react-native-async-storage/async-storage": "^3.1.0",
     "@react-native-community/blur": "^4.4.1",
     "@sentry/cli": "2.53.0",

--- a/packages/mobile/src/components/PressableSurface.tsx
+++ b/packages/mobile/src/components/PressableSurface.tsx
@@ -14,7 +14,8 @@ import {
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { springs } from '../theme/animations';
 import { androidRipple } from '../theme/tokens';
-import { brandColors } from '../theme/colors';
+import { brandColors as staticBrandColors } from '../theme/colors';
+import { useOptionalTheme } from '../providers/theme-provider';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
@@ -84,6 +85,8 @@ export function PressableSurface({
   onAccessibilityAction,
   style,
 }: PressableSurfaceProps) {
+  const theme = useOptionalTheme();
+  const defaultRippleColor = theme?.brandColors.tint ?? staticBrandColors.tint;
   // `pressed` is 0 at rest, 1 while held. Resolved into a scale or opacity in
   // the worklet so the same shared value drives either feedback mode.
   const pressed = useSharedValue(0);
@@ -125,7 +128,7 @@ export function PressableSurface({
         onLongPress={onLongPress}
         onLayout={onLayout}
         disabled={disabled}
-        android_ripple={androidRipple(rippleColor ?? brandColors.tint, rippleBorderless)}
+        android_ripple={androidRipple(rippleColor ?? defaultRippleColor, rippleBorderless)}
         hitSlop={hitSlop}
         accessibilityRole={accessibilityRole}
         accessibilityLabel={accessibilityLabel}

--- a/packages/mobile/src/components/__tests__/button.test.tsx
+++ b/packages/mobile/src/components/__tests__/button.test.tsx
@@ -1,10 +1,13 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
 // Controls the resolved UI variant the Button branches on.
-const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
+const ctrl = vi.hoisted(() => ({
+  variant: 'material' as 'material' | 'liquidGlass',
+  primary: '#3366AA',
+}));
 
 vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: unknown) => styles },
@@ -12,8 +15,30 @@ vi.mock('react-native', () => ({
 
 // Paper Button → <button> exposing the props the test asserts on.
 vi.mock('react-native-paper', () => ({
-  Button: ({ children, mode, disabled }: { children?: ReactNode; mode?: string; disabled?: boolean }) =>
-    createElement('button', { 'data-paper': 'true', 'data-mode': mode, disabled }, children),
+  Button: ({
+    children,
+    mode,
+    disabled,
+    buttonColor,
+    textColor,
+  }: {
+    children?: ReactNode;
+    mode?: string;
+    disabled?: boolean;
+    buttonColor?: string;
+    textColor?: string;
+  }) =>
+    createElement(
+      'button',
+      {
+        'data-paper': 'true',
+        'data-mode': mode,
+        'data-button-color': buttonColor,
+        'data-text-color': textColor,
+        disabled,
+      },
+      children,
+    ),
 }));
 
 // Glass-path deps — the PressableSurface fallback renders a plain div.
@@ -30,21 +55,37 @@ vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: { white: '#FFFFFF' }
 vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({
     variant: ctrl.variant,
+    brandColors: { primary: ctrl.primary, primaryFill: ctrl.primary, onPrimary: '#FFFFFF', accent: '#FF8A3D' },
     radii: { button: ctrl.variant === 'material' ? 20 : 10 },
-    brandColors: { primary: '#6D28D9', primaryFill: '#6D28D9', onPrimary: '#FFFFFF', accent: '#FF8A3D' },
   }),
 }));
 
 import { Button } from '../Button';
 
 describe('Button', () => {
-  it('renders a Paper button on the Material variant', () => {
+  beforeEach(() => {
     ctrl.variant = 'material';
+    ctrl.primary = '#3366AA';
+  });
+
+  it('renders a Paper button on the Material variant', () => {
     const { container } = render(<Button title="Log" onPress={() => {}} />);
     const paper = container.querySelector('[data-paper]');
     expect(paper).not.toBeNull();
     expect(paper?.getAttribute('data-mode')).toBe('contained'); // filled → contained
     expect(container.querySelector('[data-pressable]')).toBeNull();
+  });
+
+  it('uses the resolved theme primary for untinted Material buttons', () => {
+    const { container } = render(<Button title="Log" onPress={() => {}} />);
+    const paper = container.querySelector('[data-paper]');
+    expect(paper?.getAttribute('data-button-color')).toBe('#3366AA');
+  });
+
+  it('honours an explicit Material button tint', () => {
+    const { container } = render(<Button title="Log" onPress={() => {}} tintColor="#FF3B30" variant="outlined" />);
+    const paper = container.querySelector('[data-paper]');
+    expect(paper?.getAttribute('data-text-color')).toBe('#FF3B30');
   });
 
   it('renders the Liquid Glass (PressableSurface) button on the Liquid Glass variant', () => {

--- a/packages/mobile/src/components/__tests__/pressable-surface.test.tsx
+++ b/packages/mobile/src/components/__tests__/pressable-surface.test.tsx
@@ -4,7 +4,10 @@ import { render, fireEvent } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
 // Controls the rendering branch under test.
-const ctrl = vi.hoisted(() => ({ os: 'ios' as string }));
+const ctrl = vi.hoisted(() => ({
+  os: 'ios' as string,
+  theme: null as { brandColors: { tint: string } } | null,
+}));
 
 // Minimal RN surface: Pressable becomes a <button> that exposes whether it
 // received an android_ripple config and forwards onPress as onClick.
@@ -52,6 +55,10 @@ vi.mock('../../theme/colors', () => ({
   brandColors: { tint: '#6D28D9' },
 }));
 
+vi.mock('../../providers/theme-provider', () => ({
+  useOptionalTheme: () => ctrl.theme,
+}));
+
 vi.mock('../../theme/animations', () => ({
   springs: { snappy: {} },
 }));
@@ -60,6 +67,7 @@ import { PressableSurface } from '../PressableSurface';
 
 beforeEach(() => {
   ctrl.os = 'ios';
+  ctrl.theme = null;
 });
 
 describe('PressableSurface', () => {
@@ -69,10 +77,17 @@ describe('PressableSurface', () => {
     expect(container.querySelector('[data-has-ripple="true"]')).not.toBeNull();
   });
 
-  it('defaults the Android ripple to the brand tint', () => {
+  it('falls back to the static brand tint outside a theme provider', () => {
     ctrl.os = 'android';
     const { container } = render(<PressableSurface>x</PressableSurface>);
     expect(container.querySelector('[data-ripple-color="#6D28D9"]')).not.toBeNull();
+  });
+
+  it('uses the resolved theme tint for default Android ripples', () => {
+    ctrl.os = 'android';
+    ctrl.theme = { brandColors: { tint: '#3366AA' } };
+    const { container } = render(<PressableSurface>x</PressableSurface>);
+    expect(container.querySelector('[data-ripple-color="#3366AA"]')).not.toBeNull();
   });
 
   it('honours an explicit rippleColor on Android', () => {

--- a/packages/mobile/src/components/grade/GradeChip.tsx
+++ b/packages/mobile/src/components/grade/GradeChip.tsx
@@ -10,7 +10,7 @@ import {
 import { Text } from '../Text';
 import { PressableSurface } from '../PressableSurface';
 import { useTheme } from '../../providers/theme-provider';
-import { brandColors, withAlpha } from '../../theme/colors';
+import { brandColors as staticBrandColors, withAlpha } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { readableTextColor } from './grade-chip-colors';
 
@@ -39,7 +39,7 @@ export function GradeChip({
   onLayout,
   style,
 }: GradeChipProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors = staticBrandColors } = useTheme();
   const accentColor = gradeColor ?? brandColors.primary;
   const selected = tone === 'selected';
   const ranged = tone === 'range';

--- a/packages/mobile/src/components/grade/GradeChip.tsx
+++ b/packages/mobile/src/components/grade/GradeChip.tsx
@@ -10,7 +10,7 @@ import {
 import { Text } from '../Text';
 import { PressableSurface } from '../PressableSurface';
 import { useTheme } from '../../providers/theme-provider';
-import { brandColors as staticBrandColors, withAlpha } from '../../theme/colors';
+import { withAlpha } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { readableTextColor } from './grade-chip-colors';
 
@@ -39,7 +39,7 @@ export function GradeChip({
   onLayout,
   style,
 }: GradeChipProps) {
-  const { systemColors, brandColors = staticBrandColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const accentColor = gradeColor ?? brandColors.primary;
   const selected = tone === 'selected';
   const ranged = tone === 'range';

--- a/packages/mobile/src/components/grade/GradeRail.tsx
+++ b/packages/mobile/src/components/grade/GradeRail.tsx
@@ -23,7 +23,6 @@ import { useTheme } from '../../providers/theme-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { gradeRailCenter } from '../../lib/grade-seed';
 import { hapticSelection } from '../../lib/haptics';
-import { brandColors as staticBrandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { GradeChip } from './GradeChip';
 
@@ -83,7 +82,7 @@ export function GradeRangeRail({
   style,
 }: GradeRangeRailProps) {
   const { t } = useTranslation('climbs');
-  const { systemColors, brandColors = staticBrandColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { formatGrade } = useGradeFormat();
   const scrollRef = useRef<ElementRef<typeof ScrollView>>(null);
   const chipLayoutsRef = useRef<Record<number, ChipLayout>>({});

--- a/packages/mobile/src/components/grade/GradeRail.tsx
+++ b/packages/mobile/src/components/grade/GradeRail.tsx
@@ -23,7 +23,7 @@ import { useTheme } from '../../providers/theme-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { gradeRailCenter } from '../../lib/grade-seed';
 import { hapticSelection } from '../../lib/haptics';
-import { brandColors } from '../../theme/colors';
+import { brandColors as staticBrandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { GradeChip } from './GradeChip';
 
@@ -83,7 +83,7 @@ export function GradeRangeRail({
   style,
 }: GradeRangeRailProps) {
   const { t } = useTranslation('climbs');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors = staticBrandColors } = useTheme();
   const { formatGrade } = useGradeFormat();
   const scrollRef = useRef<ElementRef<typeof ScrollView>>(null);
   const chipLayoutsRef = useRef<Record<number, ChipLayout>>({});

--- a/packages/mobile/src/components/grade/__tests__/grade-chip.test.tsx
+++ b/packages/mobile/src/components/grade/__tests__/grade-chip.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const theme = vi.hoisted(() => ({
+  primary: '#3366AA',
+}));
+
+type StyleObject = {
+  backgroundColor?: string;
+  borderColor?: string;
+};
+
+function flattenStyle(style: unknown): StyleObject {
+  const styleItems = Array.isArray(style) ? style : [style];
+  return styleItems.reduce<StyleObject>((mergedStyle, styleItem) => {
+    if (styleItem && typeof styleItem === 'object') {
+      return { ...mergedStyle, ...(styleItem as StyleObject) };
+    }
+    return mergedStyle;
+  }, {});
+}
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({
+    children,
+    rippleColor,
+    style,
+  }: {
+    children?: ReactNode;
+    rippleColor?: string;
+    style?: unknown;
+  }) => {
+    const flattenedStyle = flattenStyle(style);
+    return createElement(
+      'button',
+      {
+        'data-ripple-color': rippleColor,
+        'data-background-color': flattenedStyle.backgroundColor,
+        'data-border-color': flattenedStyle.borderColor,
+      },
+      children,
+    );
+  },
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children, color }: { children?: ReactNode; color?: string }) =>
+    createElement('span', { 'data-text-color': color }, children),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { fill: '#EEEEEE' },
+    brandColors: { primary: theme.primary },
+  }),
+}));
+
+vi.mock('../../../theme/colors', () => ({
+  withAlpha: (color: string, alpha: number) => `${color}@${alpha}`,
+}));
+
+vi.mock('../../../theme/tokens', () => ({ spacing: { 3: 12 } }));
+
+import { GradeChip } from '../GradeChip';
+
+describe('GradeChip', () => {
+  beforeEach(() => {
+    theme.primary = '#3366AA';
+  });
+
+  it('uses the resolved theme primary when no grade color is supplied', () => {
+    const { getByRole } = render(
+      <GradeChip label="Any" tone="selected" onPress={() => {}} accessibilityLabel="Any grade" />,
+    );
+
+    const chip = getByRole('button');
+    expect(chip.getAttribute('data-ripple-color')).toBe('#3366AA');
+    expect(chip.getAttribute('data-background-color')).toBe('#3366AA');
+    expect(chip.getAttribute('data-border-color')).toBe('#3366AA');
+  });
+
+  it('uses the resolved theme primary for tonal range states', () => {
+    const { getByRole } = render(
+      <GradeChip label="Any" tone="range" onPress={() => {}} accessibilityLabel="Any grade" />,
+    );
+
+    const chip = getByRole('button');
+    expect(chip.getAttribute('data-ripple-color')).toBe('#3366AA');
+    expect(chip.getAttribute('data-background-color')).toBe('#3366AA@0.18');
+    expect(chip.getAttribute('data-border-color')).toBe('#3366AA@0.75');
+  });
+});

--- a/packages/mobile/src/components/grade/__tests__/grade-range-rail.test.tsx
+++ b/packages/mobile/src/components/grade/__tests__/grade-range-rail.test.tsx
@@ -10,6 +10,7 @@ const accessibilityInfo = vi.hoisted(() => ({
   screenReaderEnabled: vi.fn(() => Promise.resolve(false)),
   addEventListener: vi.fn(() => ({ remove: vi.fn() })),
 }));
+const theme = vi.hoisted(() => ({ primary: '#6D28D9' }));
 
 type LayoutEvent = { nativeEvent: { layout: { x: number; width: number; height: number; y: number } } };
 
@@ -67,12 +68,14 @@ vi.mock('react-native-reanimated', () => ({
 vi.mock('../GradeChip', () => ({
   GradeChip: ({
     label,
+    gradeColor,
     onPress,
     accessibilityLabel,
     accessibilityState,
     onLayout,
   }: {
     label: string;
+    gradeColor?: string;
     onPress: () => void;
     accessibilityLabel: string;
     accessibilityState?: { selected?: boolean };
@@ -86,6 +89,7 @@ vi.mock('../GradeChip', () => ({
           onPress();
         },
         'data-label': accessibilityLabel,
+        'data-grade-color': gradeColor,
         'data-selected': accessibilityState?.selected ? 'true' : 'false',
       },
       label,
@@ -123,6 +127,7 @@ vi.mock('../../../providers/theme-provider', () => ({
       secondaryBackground: '#fff',
       secondaryLabel: '#666',
     },
+    brandColors: { primary: theme.primary },
   }),
 }));
 
@@ -171,6 +176,7 @@ describe('GradeRangeRail', () => {
     accessibilityInfo.screenReaderEnabled.mockReset();
     accessibilityInfo.screenReaderEnabled.mockResolvedValue(false);
     accessibilityInfo.addEventListener.mockClear();
+    theme.primary = '#6D28D9';
   });
 
   afterEach(() => {
@@ -296,6 +302,13 @@ describe('GradeRangeRail', () => {
       vi.advanceTimersByTime(3000);
     });
     expect(onRequestClose).not.toHaveBeenCalled();
+  });
+
+  it('passes the resolved theme primary to the clear chip', () => {
+    theme.primary = '#3366AA';
+    const { getByText } = renderRail({ minGradeId: undefined, maxGradeId: undefined });
+
+    expect(getByText('mobile.search.gradeClear').getAttribute('data-grade-color')).toBe('#3366AA');
   });
 });
 

--- a/packages/mobile/src/providers/__tests__/material-theme-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/material-theme-provider.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { Material3Scheme } from '@pchmn/expo-material3-theme';
+
+const dynamicMaterialColors = vi.hoisted(() => ({ primary: '#3366AA' }) as unknown as Material3Scheme);
+
+type BuildPaperThemeMock = (colorScheme: string, dynamicPalette?: Material3Scheme) => { colors: { primary: string } };
+
+const buildPaperThemeMock = vi.hoisted(() =>
+  vi.fn<BuildPaperThemeMock>(() => ({ colors: { primary: '#3366AA' } })),
+);
+
+vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({
+  default: () => createElement('span', { 'data-icon': 'material-community' }),
+}));
+
+vi.mock('react-native-paper', () => ({
+  PaperProvider: ({ children }: { children: ReactNode }) => createElement('div', { 'data-paper': 'provider' }, children),
+}));
+
+vi.mock('../theme-provider', () => ({
+  useTheme: () => ({ colorScheme: 'dark', dynamicMaterialColors }),
+}));
+
+vi.mock('../../theme/paper-theme', () => ({
+  buildPaperTheme: (colorScheme: string, dynamicPalette?: Material3Scheme) =>
+    buildPaperThemeMock(colorScheme, dynamicPalette),
+}));
+
+import { MaterialThemeProvider } from '../material-theme-provider';
+
+describe('MaterialThemeProvider', () => {
+  it('passes dynamic Material colors into the Paper theme builder', () => {
+    render(
+      <MaterialThemeProvider>
+        <span>child</span>
+      </MaterialThemeProvider>,
+    );
+
+    expect(buildPaperThemeMock).toHaveBeenCalledWith('dark', dynamicMaterialColors);
+  });
+});

--- a/packages/mobile/src/providers/__tests__/material-theme-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/material-theme-provider.test.tsx
@@ -8,16 +8,15 @@ const dynamicMaterialColors = vi.hoisted(() => ({ primary: '#3366AA' }) as unkno
 
 type BuildPaperThemeMock = (colorScheme: string, dynamicPalette?: Material3Scheme) => { colors: { primary: string } };
 
-const buildPaperThemeMock = vi.hoisted(() =>
-  vi.fn<BuildPaperThemeMock>(() => ({ colors: { primary: '#3366AA' } })),
-);
+const buildPaperThemeMock = vi.hoisted(() => vi.fn<BuildPaperThemeMock>(() => ({ colors: { primary: '#3366AA' } })));
 
 vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({
   default: () => createElement('span', { 'data-icon': 'material-community' }),
 }));
 
 vi.mock('react-native-paper', () => ({
-  PaperProvider: ({ children }: { children: ReactNode }) => createElement('div', { 'data-paper': 'provider' }, children),
+  PaperProvider: ({ children }: { children: ReactNode }) =>
+    createElement('div', { 'data-paper': 'provider' }, children),
 }));
 
 vi.mock('../theme-provider', () => ({

--- a/packages/mobile/src/providers/__tests__/theme-provider-dynamic-fallback.test.tsx
+++ b/packages/mobile/src/providers/__tests__/theme-provider-dynamic-fallback.test.tsx
@@ -7,6 +7,7 @@ import { UI_VARIANT_KEY } from '@boardsesh/key-value-storage';
 
 const getMock = vi.fn();
 const useColorSchemeMock = vi.fn();
+const appStateAddEventListenerMock = vi.hoisted(() => vi.fn(() => ({ remove: vi.fn() })));
 
 vi.mock('../../lib/preferences/secure-store-adapter', () => ({
   secureStorePreferences: {
@@ -21,6 +22,7 @@ vi.mock('react-native', () => ({
   useColorScheme: () => useColorSchemeMock(),
   PlatformColor: (name: string) => name,
   Appearance: { setColorScheme: vi.fn() },
+  AppState: { addEventListener: appStateAddEventListenerMock },
 }));
 
 vi.mock('expo-glass-effect', () => ({
@@ -74,6 +76,7 @@ describe('ThemeProvider supported Material fallback', () => {
   beforeEach(() => {
     getMock.mockReset();
     useColorSchemeMock.mockReset();
+    appStateAddEventListenerMock.mockClear();
     getMock.mockResolvedValue(null);
     useColorSchemeMock.mockReturnValue('light');
   });

--- a/packages/mobile/src/providers/__tests__/theme-provider-dynamic-fallback.test.tsx
+++ b/packages/mobile/src/providers/__tests__/theme-provider-dynamic-fallback.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { Material3Theme } from '@pchmn/expo-material3-theme';
+import { UI_VARIANT_KEY } from '@boardsesh/key-value-storage';
+
+const getMock = vi.fn();
+const useColorSchemeMock = vi.fn();
+
+vi.mock('../../lib/preferences/secure-store-adapter', () => ({
+  secureStorePreferences: {
+    get: (key: string) => getMock(key),
+    set: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android', Version: 35 },
+  useColorScheme: () => useColorSchemeMock(),
+  PlatformColor: (name: string) => name,
+  Appearance: { setColorScheme: vi.fn() },
+}));
+
+vi.mock('expo-glass-effect', () => ({
+  isLiquidGlassAvailable: () => false,
+  isGlassEffectAPIAvailable: () => false,
+}));
+
+const fallbackMaterialTheme = vi.hoisted(
+  () =>
+    ({
+      light: {
+        primary: '#6D28D9',
+        onPrimary: '#FFFFFF',
+        background: '#F3EFFA',
+        onSurface: '#000000',
+        onSurfaceVariant: 'rgba(60, 60, 67, 0.6)',
+        outlineVariant: 'rgba(60, 60, 67, 0.18)',
+        surfaceContainerLow: '#FFFFFF',
+        surfaceContainer: '#FFFFFF',
+        elevation: { level2: '#FFFFFF' },
+      },
+      dark: {
+        primary: '#7C3AED',
+        onPrimary: '#FFFFFF',
+        background: '#15101E',
+        onSurface: '#FFFFFF',
+        onSurfaceVariant: 'rgba(235, 235, 245, 0.6)',
+        outlineVariant: 'rgba(235, 235, 245, 0.18)',
+        surfaceContainerLow: '#221A33',
+        surfaceContainer: '#2A2142',
+        elevation: { level2: '#2A2142' },
+      },
+    }) as unknown as Material3Theme,
+);
+
+vi.mock('@pchmn/expo-material3-theme', () => ({
+  isDynamicThemeSupported: true,
+  createMaterial3Theme: () => fallbackMaterialTheme,
+  useMaterial3Theme: () => ({
+    theme: fallbackMaterialTheme,
+    updateTheme: () => undefined,
+    resetTheme: () => undefined,
+  }),
+}));
+
+import { ThemeProvider, useTheme } from '../theme-provider';
+
+const wrapper = ({ children }: { children: ReactNode }) => <ThemeProvider>{children}</ThemeProvider>;
+
+describe('ThemeProvider supported Material fallback', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    useColorSchemeMock.mockReset();
+    getMock.mockResolvedValue(null);
+    useColorSchemeMock.mockReturnValue('light');
+  });
+
+  it('keeps static Material colours when the native module returns only its fallback palette', async () => {
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    await waitFor(() => expect(getMock).toHaveBeenCalledWith(UI_VARIANT_KEY));
+
+    expect(result.current.variant).toBe('material');
+    expect(result.current.systemColors.background).toBe('#F3EFFA');
+    expect(result.current.systemColors.fill).toBe('rgba(109, 40, 217, 0.14)');
+    expect(result.current.brandColors.primary).toBe('#6D28D9');
+    expect(result.current.dynamicMaterialColors).toBeUndefined();
+  });
+});

--- a/packages/mobile/src/providers/__tests__/theme-provider-dynamic-material.test.tsx
+++ b/packages/mobile/src/providers/__tests__/theme-provider-dynamic-material.test.tsx
@@ -8,6 +8,8 @@ import { THEME_OVERRIDE_KEY, UI_VARIANT_KEY } from '@boardsesh/key-value-storage
 const getMock = vi.fn();
 const setMock = vi.fn();
 const useColorSchemeMock = vi.fn();
+const resetMaterial3ThemeMock = vi.hoisted(() => vi.fn());
+const appStateChangeListeners = vi.hoisted(() => [] as Array<(state: string) => void>);
 
 vi.mock('../../lib/preferences/secure-store-adapter', () => ({
   secureStorePreferences: {
@@ -22,6 +24,12 @@ vi.mock('react-native', () => ({
   useColorScheme: () => useColorSchemeMock(),
   PlatformColor: (name: string) => name,
   Appearance: { setColorScheme: vi.fn() },
+  AppState: {
+    addEventListener: (_eventName: string, listener: (state: string) => void) => {
+      appStateChangeListeners.push(listener);
+      return { remove: vi.fn() };
+    },
+  },
 }));
 
 vi.mock('expo-glass-effect', () => ({
@@ -91,7 +99,7 @@ vi.mock('@pchmn/expo-material3-theme', () => ({
   useMaterial3Theme: () => ({
     theme: dynamicMaterialTheme,
     updateTheme: () => undefined,
-    resetTheme: () => undefined,
+    resetTheme: resetMaterial3ThemeMock,
   }),
 }));
 
@@ -104,6 +112,8 @@ describe('ThemeProvider dynamic Material color', () => {
     getMock.mockReset();
     setMock.mockReset();
     useColorSchemeMock.mockReset();
+    resetMaterial3ThemeMock.mockReset();
+    appStateChangeListeners.length = 0;
     getMock.mockResolvedValue(null);
     setMock.mockResolvedValue(undefined);
     useColorSchemeMock.mockReturnValue('light');
@@ -134,6 +144,18 @@ describe('ThemeProvider dynamic Material color', () => {
     expect(result.current.systemColors.fill).toBe('rgba(168, 199, 250, 0.18)');
     expect(result.current.brandColors.primary).toBe('#A8C7FA');
     expect(result.current.brandColors.onPrimary).toBe('#071426');
+  });
+
+  it('refreshes the native dynamic palette when Android returns active', async () => {
+    renderHook(() => useTheme(), { wrapper });
+
+    await waitFor(() => expect(appStateChangeListeners).toHaveLength(1));
+
+    appStateChangeListeners[0]?.('background');
+    expect(resetMaterial3ThemeMock).not.toHaveBeenCalled();
+
+    appStateChangeListeners[0]?.('active');
+    expect(resetMaterial3ThemeMock).toHaveBeenCalledTimes(1);
   });
 
   it('ignores dynamic Material colors when the resolved variant is Liquid Glass', async () => {

--- a/packages/mobile/src/providers/__tests__/theme-provider-dynamic-material.test.tsx
+++ b/packages/mobile/src/providers/__tests__/theme-provider-dynamic-material.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { Material3Theme } from '@pchmn/expo-material3-theme';
+import { THEME_OVERRIDE_KEY, UI_VARIANT_KEY } from '@boardsesh/key-value-storage';
+
+const getMock = vi.fn();
+const setMock = vi.fn();
+const useColorSchemeMock = vi.fn();
+
+vi.mock('../../lib/preferences/secure-store-adapter', () => ({
+  secureStorePreferences: {
+    get: (key: string) => getMock(key),
+    set: (key: string, storedPreference: unknown) => setMock(key, storedPreference),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android', Version: 35 },
+  useColorScheme: () => useColorSchemeMock(),
+  PlatformColor: (name: string) => name,
+  Appearance: { setColorScheme: vi.fn() },
+}));
+
+vi.mock('expo-glass-effect', () => ({
+  isLiquidGlassAvailable: () => false,
+  isGlassEffectAPIAvailable: () => false,
+}));
+
+const dynamicMaterialTheme = vi.hoisted(
+  () =>
+    ({
+      light: {
+        primary: '#3366AA',
+        onPrimary: '#FFFFFF',
+        background: '#FBF8FF',
+        onSurface: '#191C20',
+        onSurfaceVariant: '#42474E',
+        outlineVariant: '#C2C7CF',
+        surfaceContainerLow: '#F5F2FA',
+        surfaceContainer: '#EFECF4',
+        elevation: { level2: '#ECEFF8' },
+      },
+      dark: {
+        primary: '#A8C7FA',
+        onPrimary: '#071426',
+        background: '#101418',
+        onSurface: '#E1E2E8',
+        onSurfaceVariant: '#C2C7CF',
+        outlineVariant: '#42474E',
+        surfaceContainerLow: '#1A1C20',
+        surfaceContainer: '#1E2024',
+        elevation: { level2: '#242832' },
+      },
+    }) as unknown as Material3Theme,
+);
+
+const fallbackMaterialTheme = vi.hoisted(
+  () =>
+    ({
+      light: {
+        primary: '#6D28D9',
+        onPrimary: '#FFFFFF',
+        background: '#F3EFFA',
+        onSurface: '#000000',
+        onSurfaceVariant: 'rgba(60, 60, 67, 0.6)',
+        outlineVariant: 'rgba(60, 60, 67, 0.18)',
+        surfaceContainerLow: '#FFFFFF',
+        surfaceContainer: '#FFFFFF',
+        elevation: { level2: '#FFFFFF' },
+      },
+      dark: {
+        primary: '#7C3AED',
+        onPrimary: '#FFFFFF',
+        background: '#15101E',
+        onSurface: '#FFFFFF',
+        onSurfaceVariant: 'rgba(235, 235, 245, 0.6)',
+        outlineVariant: 'rgba(235, 235, 245, 0.18)',
+        surfaceContainerLow: '#221A33',
+        surfaceContainer: '#2A2142',
+        elevation: { level2: '#2A2142' },
+      },
+    }) as unknown as Material3Theme,
+);
+
+vi.mock('@pchmn/expo-material3-theme', () => ({
+  isDynamicThemeSupported: true,
+  createMaterial3Theme: () => fallbackMaterialTheme,
+  useMaterial3Theme: () => ({
+    theme: dynamicMaterialTheme,
+    updateTheme: () => undefined,
+    resetTheme: () => undefined,
+  }),
+}));
+
+import { ThemeProvider, useTheme } from '../theme-provider';
+
+const wrapper = ({ children }: { children: ReactNode }) => <ThemeProvider>{children}</ThemeProvider>;
+
+describe('ThemeProvider dynamic Material color', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    setMock.mockReset();
+    useColorSchemeMock.mockReset();
+    getMock.mockResolvedValue(null);
+    setMock.mockResolvedValue(undefined);
+    useColorSchemeMock.mockReturnValue('light');
+  });
+
+  it('uses the Android 12+ dynamic palette for the Material variant', async () => {
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    await waitFor(() => expect(getMock).toHaveBeenCalledWith(UI_VARIANT_KEY));
+
+    expect(result.current.variant).toBe('material');
+    expect(result.current.systemColors.background).toBe('#FBF8FF');
+    expect(result.current.systemColors.secondaryBackground).toBe('#F5F2FA');
+    expect(result.current.systemColors.elevatedSurface).toBe('#ECEFF8');
+    expect(result.current.systemColors.fill).toBe('rgba(51, 102, 170, 0.12)');
+    expect(result.current.brandColors.primary).toBe('#3366AA');
+    expect(result.current.dynamicMaterialColors?.primary).toBe('#3366AA');
+  });
+
+  it('composes dynamic Material colors with the appearance override', async () => {
+    getMock.mockImplementation((key: string) => Promise.resolve(key === THEME_OVERRIDE_KEY ? 'dark' : null));
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    await waitFor(() => expect(result.current.themeOverride).toBe('dark'));
+
+    expect(result.current.colorScheme).toBe('dark');
+    expect(result.current.systemColors.background).toBe('#101418');
+    expect(result.current.systemColors.fill).toBe('rgba(168, 199, 250, 0.18)');
+    expect(result.current.brandColors.primary).toBe('#A8C7FA');
+    expect(result.current.brandColors.onPrimary).toBe('#071426');
+  });
+
+  it('ignores dynamic Material colors when the resolved variant is Liquid Glass', async () => {
+    getMock.mockImplementation((key: string) => Promise.resolve(key === UI_VARIANT_KEY ? 'liquidGlass' : null));
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    await waitFor(() => expect(result.current.uiVariantPreference).toBe('liquidGlass'));
+
+    expect(result.current.variant).toBe('liquidGlass');
+    expect(result.current.systemColors.background).toBe('#F4F1FB');
+    expect(result.current.brandColors.primary).toBe('#6D28D9');
+    expect(result.current.dynamicMaterialColors).toBeUndefined();
+  });
+});

--- a/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
@@ -23,6 +23,7 @@ vi.mock('../../lib/preferences/secure-store-adapter', () => ({
 // module doesn't blow up. PlatformColor is still mocked as a passthrough for
 // belt-and-braces in case some other module reaches for it.
 const useColorSchemeMock = vi.fn();
+const appStateAddEventListenerMock = vi.hoisted(() => vi.fn(() => ({ remove: vi.fn() })));
 vi.mock('react-native', () => ({
   Platform: { OS: 'android' },
   useColorScheme: () => useColorSchemeMock(),
@@ -30,6 +31,7 @@ vi.mock('react-native', () => ({
   // The provider drives Appearance.setColorScheme so the override flips native
   // iOS colours; mock it so the effect doesn't blow up under jsdom.
   Appearance: { setColorScheme: vi.fn() },
+  AppState: { addEventListener: appStateAddEventListenerMock },
 }));
 
 // useGlassCapability imports these; under jsdom (Platform.OS='android') the
@@ -50,6 +52,7 @@ describe('ThemeProvider', () => {
     setMock.mockReset();
     removeMock.mockReset();
     useColorSchemeMock.mockReset();
+    appStateAddEventListenerMock.mockClear();
     // Defaults: no stored preference, OS in light mode.
     getMock.mockResolvedValue(null);
     setMock.mockResolvedValue(undefined);

--- a/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
@@ -149,6 +149,8 @@ describe('ThemeProvider', () => {
       // Material maps M3 tonal surfaces + the 20dp button radius.
       expect(result.current.radii.button).toBe(20);
       expect(result.current.systemColors.background).toBe('#F3EFFA');
+      expect(result.current.brandColors.primary).toBe('#6D28D9');
+      expect(result.current.dynamicMaterialColors).toBeUndefined();
     });
 
     it('setUiVariant persists to SecureStore and flips the resolved variant + tokens', async () => {

--- a/packages/mobile/src/providers/material-theme-provider.tsx
+++ b/packages/mobile/src/providers/material-theme-provider.tsx
@@ -29,8 +29,11 @@ const paperSettings = { icon: paperIcon };
  * it's cheap and keeps the provider tree stable across a variant switch.
  */
 export function MaterialThemeProvider({ children }: { children: ReactNode }) {
-  const { colorScheme } = useTheme();
-  const paperTheme = useMemo(() => buildPaperTheme(colorScheme), [colorScheme]);
+  const { colorScheme, dynamicMaterialColors } = useTheme();
+  const paperTheme = useMemo(
+    () => buildPaperTheme(colorScheme, dynamicMaterialColors),
+    [colorScheme, dynamicMaterialColors],
+  );
 
   return (
     <PaperProvider theme={paperTheme} settings={paperSettings}>

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { Appearance, Platform, useColorScheme, type OpaqueColorValue } from 'react-native';
+import { AppState, Appearance, Platform, useColorScheme, type OpaqueColorValue } from 'react-native';
 import {
   createMaterial3Theme,
   isDynamicThemeSupported,
@@ -156,7 +156,7 @@ function hasDeviceDynamicPalette(colorScheme: ColorScheme, materialColors: Mater
 
 export function ThemeProvider({ children }: ThemeProviderProps) {
   const deviceColorScheme = useColorScheme();
-  const { theme: material3Theme } = useMaterial3Theme(materialThemeOptions);
+  const { theme: material3Theme, resetTheme: resetMaterial3Theme } = useMaterial3Theme(materialThemeOptions);
   // `'system'` until SecureStore hydrates — same value as a brand-new user, so
   // the first paint matches the OS preference. Once hydration completes the
   // resolved scheme switches to the saved override (if any) without a visible
@@ -207,6 +207,18 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   useEffect(() => {
     Appearance.setColorScheme(themeOverride === 'system' ? 'unspecified' : themeOverride);
   }, [themeOverride]);
+
+  useEffect(() => {
+    if (Platform.OS !== 'android' || !isDynamicThemeSupported) return;
+
+    const subscription = AppState.addEventListener('change', (nextAppState) => {
+      if (nextAppState === 'active') resetMaterial3Theme();
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [resetMaterial3Theme]);
 
   const colorScheme: ColorScheme = useMemo(() => {
     if (themeOverride === 'light') return 'light';

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -1,6 +1,12 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { Appearance, Platform, useColorScheme, type OpaqueColorValue } from 'react-native';
 import {
+  createMaterial3Theme,
+  isDynamicThemeSupported,
+  useMaterial3Theme,
+  type Material3Scheme,
+} from '@pchmn/expo-material3-theme';
+import {
   THEME_OVERRIDE_KEY,
   isThemeOverride,
   type ThemeOverride,
@@ -11,9 +17,11 @@ import {
 import {
   iosSystemColors,
   brandColors,
-  brandColorsDark,
   androidFallbackColors,
   materialSurfaces,
+  materialSurfacesFromDynamicPalette,
+  brandColorsFromDynamicPalette,
+  type BrandColors,
 } from '../theme/colors';
 import { textStyles, type TextVariant } from '../theme/typography';
 import {
@@ -32,12 +40,6 @@ import { useGlassCapability } from '../hooks/use-glass-capability';
 import { secureStorePreferences } from '../lib/preferences/secure-store-adapter';
 
 type ColorScheme = 'light' | 'dark';
-
-/**
- * Resolved brand colours for the current colour scheme. `brandColors` (light) and
- * `brandColorsDark` share the same keys, so either set satisfies this shape.
- */
-type ResolvedBrandColors = typeof brandColors | typeof brandColorsDark;
 
 /**
  * Resolved system colors for the current color scheme.
@@ -61,7 +63,9 @@ type ResolvedSystemColors = {
 type Theme = {
   colorScheme: ColorScheme;
   systemColors: ResolvedSystemColors;
-  brandColors: ResolvedBrandColors;
+  brandColors: BrandColors;
+  /** Device-provided MD3 palette when Material You dynamic color is active. */
+  dynamicMaterialColors?: Material3Scheme;
   textStyles: typeof textStyles;
   spacing: typeof spacing;
   borderRadius: typeof borderRadius;
@@ -93,12 +97,18 @@ const ThemeContext = createContext<Theme | null>(null);
  * On Android, PlatformColor is not used — we pick from the
  * androidFallbackColors light/dark map.
  */
-function resolveSystemColors(colorScheme: ColorScheme, variant: UiVariant): ResolvedSystemColors {
+function resolveSystemColors(
+  colorScheme: ColorScheme,
+  variant: UiVariant,
+  dynamicMaterialColors?: Material3Scheme,
+): ResolvedSystemColors {
   // Material variant: M3 tonal surfaces on every platform — including iOS 26
   // hardware when the user explicitly chose Material. Drawn opaque (no glass),
   // so we don't use PlatformColor here.
   if (variant === 'material') {
-    return { ...materialSurfaces[colorScheme] };
+    return dynamicMaterialColors
+      ? materialSurfacesFromDynamicPalette(colorScheme, dynamicMaterialColors)
+      : { ...materialSurfaces[colorScheme] };
   }
 
   if (Platform.OS === 'ios' && iosSystemColors) {
@@ -123,20 +133,30 @@ function resolveSystemColors(colorScheme: ColorScheme, variant: UiVariant): Reso
   };
 }
 
-/**
- * Pick the brand colour set for the current scheme. The dark set lifts the violet
- * tint and brightens semantic tones so brand foregrounds stay legible on near-black.
- */
-function resolveBrandColors(colorScheme: ColorScheme): ResolvedBrandColors {
-  return colorScheme === 'dark' ? brandColorsDark : brandColors;
-}
-
 type ThemeProviderProps = {
   children: ReactNode;
 };
 
+const materialThemeOptions = { fallbackSourceColor: brandColors.primaryFill };
+const staticFallbackMaterialTheme = createMaterial3Theme(brandColors.primaryFill);
+
+function hasDeviceDynamicPalette(colorScheme: ColorScheme, materialColors: Material3Scheme): boolean {
+  const fallbackColors = staticFallbackMaterialTheme[colorScheme];
+
+  return (
+    materialColors.primary !== fallbackColors.primary ||
+    materialColors.background !== fallbackColors.background ||
+    materialColors.surfaceContainerLow !== fallbackColors.surfaceContainerLow ||
+    materialColors.surfaceContainer !== fallbackColors.surfaceContainer ||
+    materialColors.elevation.level2 !== fallbackColors.elevation.level2 ||
+    materialColors.onSurface !== fallbackColors.onSurface ||
+    materialColors.outlineVariant !== fallbackColors.outlineVariant
+  );
+}
+
 export function ThemeProvider({ children }: ThemeProviderProps) {
   const deviceColorScheme = useColorScheme();
+  const { theme: material3Theme } = useMaterial3Theme(materialThemeOptions);
   // `'system'` until SecureStore hydrates — same value as a brand-new user, so
   // the first paint matches the OS preference. Once hydration completes the
   // resolved scheme switches to the saved override (if any) without a visible
@@ -230,12 +250,21 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   );
 
   const theme = useMemo<Theme>(() => {
-    const resolvedSystemColors = resolveSystemColors(colorScheme, variant);
+    const candidateDynamicMaterialColors = material3Theme[colorScheme];
+    const dynamicMaterialColors =
+      variant === 'material' &&
+      isDynamicThemeSupported &&
+      hasDeviceDynamicPalette(colorScheme, candidateDynamicMaterialColors)
+        ? candidateDynamicMaterialColors
+        : undefined;
+    const resolvedSystemColors = resolveSystemColors(colorScheme, variant, dynamicMaterialColors);
+    const resolvedBrandColors = brandColorsFromDynamicPalette(colorScheme, dynamicMaterialColors);
 
     return {
       colorScheme,
       systemColors: resolvedSystemColors,
-      brandColors: resolveBrandColors(colorScheme),
+      brandColors: resolvedBrandColors,
+      dynamicMaterialColors,
       textStyles,
       spacing,
       borderRadius,
@@ -251,7 +280,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       radii: radiiByVariant[variant],
       sheet: sheetChromeByVariant[variant],
     };
-  }, [colorScheme, variant, themeOverride, setThemeOverride, uiVariantPreference, setUiVariant]);
+  }, [colorScheme, material3Theme, variant, themeOverride, setThemeOverride, uiVariantPreference, setUiVariant]);
 
   // React 19 context provider syntax (Expo SDK 53+ / React 19)
   return <ThemeContext value={theme}>{children}</ThemeContext>;

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -143,6 +143,12 @@ const staticFallbackMaterialTheme = createMaterial3Theme(brandColors.primaryFill
 function hasDeviceDynamicPalette(colorScheme: ColorScheme, materialColors: Material3Scheme): boolean {
   const fallbackColors = staticFallbackMaterialTheme[colorScheme];
 
+  // `@pchmn/expo-material3-theme` returns a generated theme from our fallback
+  // source color when the platform has no real wallpaper palette. There is no
+  // explicit "dynamic palette was used" flag, so compare several independent
+  // MD3 roles against the generated fallback. Using multiple roles makes this
+  // less sensitive to one role matching by coincidence; keep this in sync with
+  // the fields that drive both Paper and token-skinned Material surfaces.
   return (
     materialColors.primary !== fallbackColors.primary ||
     materialColors.background !== fallbackColors.background ||

--- a/packages/mobile/src/theme/__tests__/material-dynamic-colors.test.ts
+++ b/packages/mobile/src/theme/__tests__/material-dynamic-colors.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Material3Scheme } from '@pchmn/expo-material3-theme';
+
+vi.mock('react-native', () => ({ Platform: { OS: 'android' }, PlatformColor: (name: string) => name }));
+
+import {
+  brandColors,
+  brandColorsDark,
+  brandColorsFromDynamicPalette,
+  materialSurfacesFromDynamicPalette,
+} from '../colors';
+
+const dynamicLightPalette = {
+  primary: '#3366AA',
+  onPrimary: '#FFFFFF',
+  background: '#FBF8FF',
+  onSurface: '#191C20',
+  onSurfaceVariant: '#42474E',
+  outlineVariant: '#C2C7CF',
+  surfaceContainerLow: '#F5F2FA',
+  surfaceContainer: '#EFECF4',
+  elevation: { level2: '#ECEFF8' },
+} as unknown as Material3Scheme;
+
+describe('dynamic Material surfaces', () => {
+  it('maps an MD3 dynamic light palette into the app systemColors shape', () => {
+    const surfaces = materialSurfacesFromDynamicPalette('light', dynamicLightPalette);
+
+    expect(surfaces.background).toBe('#FBF8FF');
+    expect(surfaces.secondaryBackground).toBe('#F5F2FA');
+    expect(surfaces.tertiaryBackground).toBe('#EFECF4');
+    expect(surfaces.elevatedSurface).toBe('#ECEFF8');
+    expect(surfaces.label).toBe('#191C20');
+    expect(surfaces.secondaryLabel).toBe('#42474E');
+    expect(surfaces.tertiaryLabel).toBe('rgba(25, 28, 32, 0.38)');
+    expect(surfaces.separator).toBe('#C2C7CF');
+    expect(surfaces.fill).toBe('rgba(51, 102, 170, 0.12)');
+  });
+
+  it('uses a stronger primary fill in dark mode', () => {
+    const surfaces = materialSurfacesFromDynamicPalette('dark', dynamicLightPalette);
+
+    expect(surfaces.fill).toBe('rgba(51, 102, 170, 0.18)');
+  });
+
+  it('keeps status colours static while switching Material accent colours', () => {
+    const resolvedBrandColors = brandColorsFromDynamicPalette('light', dynamicLightPalette);
+
+    expect(resolvedBrandColors.primary).toBe('#3366AA');
+    expect(resolvedBrandColors.tint).toBe('#3366AA');
+    expect(resolvedBrandColors.primaryFill).toBe('#3366AA');
+    expect(resolvedBrandColors.onPrimary).toBe('#FFFFFF');
+    expect(resolvedBrandColors.success).toBe(brandColors.success);
+    expect(resolvedBrandColors.warning).toBe(brandColors.warning);
+    expect(resolvedBrandColors.error).toBe(brandColors.error);
+  });
+
+  it('returns the scheme-aware static brand map when no dynamic palette is active', () => {
+    expect(brandColorsFromDynamicPalette('light')).toBe(brandColors);
+    expect(brandColorsFromDynamicPalette('dark')).toBe(brandColorsDark);
+  });
+});

--- a/packages/mobile/src/theme/__tests__/paper-theme.test.ts
+++ b/packages/mobile/src/theme/__tests__/paper-theme.test.ts
@@ -28,9 +28,29 @@ describe('buildPaperTheme', () => {
     expect(theme.colors.surface).toBe('#221A33');
   });
 
-  it('passes a provided dynamic palette straight through (Material You hook)', () => {
-    const dynamic = { primary: '#123456' } as unknown as Parameters<typeof buildPaperTheme>[1];
+  it('passes a provided dynamic palette straight through for Paper colors and surfaces', () => {
+    const dynamic = {
+      primary: '#123456',
+      background: '#F8FAFF',
+      surface: '#F1F4FB',
+      surfaceVariant: '#E4E9F2',
+      outlineVariant: '#C2CAD6',
+      elevation: {
+        level0: 'transparent',
+        level1: '#EEF2FA',
+        level2: '#E8EEF8',
+        level3: '#E2EAF5',
+        level4: '#DDE5F1',
+        level5: '#D7E1EE',
+      },
+    } as unknown as Parameters<typeof buildPaperTheme>[1];
     const theme = buildPaperTheme('light', dynamic);
+
     expect(theme.colors.primary).toBe('#123456');
+    expect(theme.colors.background).toBe('#F8FAFF');
+    expect(theme.colors.surface).toBe('#F1F4FB');
+    expect(theme.colors.surfaceVariant).toBe('#E4E9F2');
+    expect(theme.colors.outlineVariant).toBe('#C2CAD6');
+    expect(theme.colors.elevation.level2).toBe('#E8EEF8');
   });
 });

--- a/packages/mobile/src/theme/colors.ts
+++ b/packages/mobile/src/theme/colors.ts
@@ -1,4 +1,5 @@
 import { Platform, PlatformColor, type OpaqueColorValue } from 'react-native';
+import type { Material3Scheme } from '@pchmn/expo-material3-theme';
 
 /**
  * iOS semantic system colors via PlatformColor.
@@ -153,9 +154,12 @@ export const materialSurfaces = {
 } as const;
 
 export type SystemColorKey = keyof typeof androidFallbackColors.light;
-export type BrandColors = typeof brandColors;
+export type MaterialColorScheme = keyof typeof materialSurfaces;
+export type BrandColorKey = keyof typeof brandColors;
+export type BrandColors = Record<BrandColorKey, string>;
 export type AndroidFallbackColors = typeof androidFallbackColors;
 export type MaterialSurfaces = typeof materialSurfaces;
+export type MaterialSurfaceTokens = Record<SystemColorKey, string>;
 
 /**
  * Normalise a `#RGB`/`#RRGGBB` hex string to a 6-digit hex (no `#`), or return
@@ -224,4 +228,52 @@ export function blendOpaque(foreground: string, background: string, alpha: numbe
   }
   const mix = (channel: 0 | 1 | 2) => fg[channel] * alpha + bg[channel] * (1 - alpha);
   return `#${toHexByte(mix(0))}${toHexByte(mix(1))}${toHexByte(mix(2))}`;
+}
+
+/**
+ * Convert a Material You / MD3 palette into the same semantic surface ladder
+ * the token-skinned mobile components already consume through
+ * `useTheme().systemColors`.
+ */
+export function materialSurfacesFromDynamicPalette(
+  colorScheme: MaterialColorScheme,
+  dynamicPalette: Material3Scheme,
+): MaterialSurfaceTokens {
+  const isDark = colorScheme === 'dark';
+
+  return {
+    background: dynamicPalette.background,
+    secondaryBackground: dynamicPalette.surfaceContainerLow,
+    tertiaryBackground: dynamicPalette.surfaceContainer,
+    groupedBackground: dynamicPalette.background,
+    elevatedSurface: dynamicPalette.elevation.level2,
+    label: dynamicPalette.onSurface,
+    secondaryLabel: dynamicPalette.onSurfaceVariant,
+    tertiaryLabel: withAlpha(dynamicPalette.onSurface, 0.38),
+    separator: dynamicPalette.outlineVariant,
+    fill: withAlpha(dynamicPalette.primary, isDark ? 0.18 : 0.12),
+  };
+}
+
+/**
+ * Keep semantic status colours stable, but let Material-only accent chrome
+ * follow the device's dynamic primary colour.
+ */
+export function brandColorsFromDynamicPalette(
+  colorScheme: MaterialColorScheme,
+  dynamicPalette?: Material3Scheme,
+): BrandColors {
+  const fallbackBrandColors = colorScheme === 'dark' ? brandColorsDark : brandColors;
+
+  if (!dynamicPalette) {
+    return fallbackBrandColors;
+  }
+
+  return {
+    ...fallbackBrandColors,
+    tint: dynamicPalette.primary,
+    primary: dynamicPalette.primary,
+    primaryFill: dynamicPalette.primary,
+    onPrimary: dynamicPalette.onPrimary,
+  };
 }

--- a/packages/mobile/src/theme/paper-theme.ts
+++ b/packages/mobile/src/theme/paper-theme.ts
@@ -14,8 +14,9 @@ type ColorScheme = 'light' | 'dark';
  * Roboto on Android, San Francisco on iOS) — that IS the native Material look.
  * Only the colour roles are mapped from our tokens.
  *
- * The optional `dynamic` palette is the hook for the Material You fast-follow
- * (@pchmn/expo-material3-theme); unused today, callers pass `undefined`.
+ * The optional `dynamic` palette is the Android 12+ Material You palette from
+ * @pchmn/expo-material3-theme. Callers pass `undefined` for static fallback
+ * Material and every Liquid Glass path.
  */
 export function buildPaperTheme(colorScheme: ColorScheme, dynamic?: MD3Theme['colors']): MD3Theme {
   const base = colorScheme === 'dark' ? MD3DarkTheme : MD3LightTheme;

--- a/packages/mobile/test/expo-material3-theme-stub.ts
+++ b/packages/mobile/test/expo-material3-theme-stub.ts
@@ -1,0 +1,55 @@
+type StubMaterial3Scheme = {
+  primary: string;
+  onPrimary: string;
+  background: string;
+  onSurface: string;
+  onSurfaceVariant: string;
+  outlineVariant: string;
+  surfaceContainerLow: string;
+  surfaceContainer: string;
+  elevation: { level2: string };
+};
+
+type StubMaterial3Theme = {
+  light: StubMaterial3Scheme;
+  dark: StubMaterial3Scheme;
+};
+
+const fallbackTheme: StubMaterial3Theme = {
+  light: {
+    primary: '#6D28D9',
+    onPrimary: '#FFFFFF',
+    background: '#F3EFFA',
+    onSurface: '#000000',
+    onSurfaceVariant: 'rgba(60, 60, 67, 0.6)',
+    outlineVariant: 'rgba(60, 60, 67, 0.18)',
+    surfaceContainerLow: '#FFFFFF',
+    surfaceContainer: '#FFFFFF',
+    elevation: { level2: '#FFFFFF' },
+  },
+  dark: {
+    primary: '#7C3AED',
+    onPrimary: '#FFFFFF',
+    background: '#15101E',
+    onSurface: '#FFFFFF',
+    onSurfaceVariant: 'rgba(235, 235, 245, 0.6)',
+    outlineVariant: 'rgba(235, 235, 245, 0.18)',
+    surfaceContainerLow: '#221A33',
+    surfaceContainer: '#2A2142',
+    elevation: { level2: '#2A2142' },
+  },
+};
+
+export const isDynamicThemeSupported = false;
+
+export function useMaterial3Theme() {
+  return {
+    theme: fallbackTheme,
+    updateTheme: () => undefined,
+    resetTheme: () => undefined,
+  };
+}
+
+export function createMaterial3Theme() {
+  return fallbackTheme;
+}

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -19,6 +19,12 @@ export default defineConfig({
       // `src/lib/analytics`. Analytics is a no-op in tests (isAnalyticsEnabled is
       // false), so a lightweight stub satisfies the static imports safely.
       'posthog-react-native': fileURLToPath(new URL('./test/posthog-react-native-stub.ts', import.meta.url)),
+      // @pchmn/expo-material3-theme is an Android native module. Stub it for
+      // generic unit tests; theme-specific tests can vi.mock the package with a
+      // dynamic palette before importing ThemeProvider.
+      '@pchmn/expo-material3-theme': fileURLToPath(
+        new URL('./test/expo-material3-theme-stub.ts', import.meta.url),
+      ),
       // react-native-paper's real entry throws a SyntaxError under vitest's node
       // env (untransformed RN-native source + react-native-vector-icons). Stub it
       // so any suite can import a Paper-backed primitive; component tests that

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -22,9 +22,7 @@ export default defineConfig({
       // @pchmn/expo-material3-theme is an Android native module. Stub it for
       // generic unit tests; theme-specific tests can vi.mock the package with a
       // dynamic palette before importing ThemeProvider.
-      '@pchmn/expo-material3-theme': fileURLToPath(
-        new URL('./test/expo-material3-theme-stub.ts', import.meta.url),
-      ),
+      '@pchmn/expo-material3-theme': fileURLToPath(new URL('./test/expo-material3-theme-stub.ts', import.meta.url)),
       // react-native-paper's real entry throws a SyntaxError under vitest's node
       // env (untransformed RN-native source + react-native-vector-icons). Stub it
       // so any suite can import a Paper-backed primitive; component tests that

--- a/scripts/mobile-dev-client-build.ts
+++ b/scripts/mobile-dev-client-build.ts
@@ -12,7 +12,18 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
-const EAS_ARGS = ['eas-cli@16', 'build', '--profile', 'development-device', '--platform', 'ios', '--non-interactive'];
+const EAS_ARGS = [
+  'x',
+  '-p',
+  'eas-cli@16',
+  'eas',
+  'build',
+  '--profile',
+  'development-device',
+  '--platform',
+  'ios',
+  '--non-interactive',
+];
 
 console.log('[mobile:dev-client-build] Profile:  development-device');
 console.log('[mobile:dev-client-build] Platform: ios');
@@ -22,10 +33,10 @@ console.log('');
 console.log('[mobile:dev-client-build] Install this build on the iPhone used for local Metro testing.');
 console.log('[mobile:dev-client-build] After install, switch servers in More -> Metro Bundler.');
 console.log('');
-console.log(`[mobile:dev-client-build] Running: bunx ${EAS_ARGS.join(' ')}`);
+console.log(`[mobile:dev-client-build] Running: bun ${EAS_ARGS.join(' ')}`);
 console.log('');
 
-const result = spawnSync('bunx', EAS_ARGS, {
+const result = spawnSync('bun', EAS_ARGS, {
   cwd: MOBILE_DIR,
   stdio: 'inherit',
   env: { ...process.env },
@@ -35,7 +46,7 @@ if (result.status !== 0) {
   console.error('');
   console.error('[mobile:dev-client-build] Build submission failed.');
   if (result.status === 1) {
-    console.error('[mobile:dev-client-build] Make sure you are logged in: bunx eas login');
+    console.error('[mobile:dev-client-build] Make sure you are logged in: bun x -p eas-cli@16 eas login');
   }
   process.exit(result.status ?? 1);
 }

--- a/scripts/mobile-preview-build.ts
+++ b/scripts/mobile-preview-build.ts
@@ -55,12 +55,23 @@ console.log('[mobile:preview-build] This build is the "shell" that testers insta
 console.log('[mobile:preview-build] After install, they receive JS updates via `vp run mobile:publish`.');
 console.log('');
 
-const easArgs = ['eas-cli@16', 'build', '--profile', 'preview', '--platform', platform, '--non-interactive'];
+const easArgs = [
+  'x',
+  '-p',
+  'eas-cli@16',
+  'eas',
+  'build',
+  '--profile',
+  'preview',
+  '--platform',
+  platform,
+  '--non-interactive',
+];
 
-console.log(`[mobile:preview-build] Running: bunx ${easArgs.join(' ')}`);
+console.log(`[mobile:preview-build] Running: bun ${easArgs.join(' ')}`);
 console.log('');
 
-const result = spawnSync('bunx', easArgs, {
+const result = spawnSync('bun', easArgs, {
   cwd: MOBILE_DIR,
   stdio: 'inherit',
   env: { ...process.env },
@@ -70,7 +81,7 @@ if (result.status !== 0) {
   console.error('');
   console.error('[mobile:preview-build] Build submission failed.');
   if (result.status === 1) {
-    console.error('[mobile:preview-build] Make sure you are logged in: bunx eas login');
+    console.error('[mobile:preview-build] Make sure you are logged in: bun x -p eas-cli@16 eas login');
   }
   process.exit(result.status ?? 1);
 }
@@ -78,4 +89,4 @@ if (result.status !== 0) {
 console.log('');
 console.log('[mobile:preview-build] Build submitted to EAS.');
 console.log('[mobile:preview-build] Once complete, share the install link from the EAS dashboard');
-console.log('[mobile:preview-build] or run: bunx eas build:list --profile preview --status finished');
+console.log('[mobile:preview-build] or run: bun x -p eas-cli@16 eas build:list --profile preview --status finished');

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -122,7 +122,10 @@ console.log(`[mobile:publish] Platform: ${platform}`);
 console.log('');
 
 const easArgs = [
+  'x',
+  '-p',
   'eas-cli@16',
+  'eas',
   'update',
   '--branch',
   sanitizedBranch,
@@ -133,10 +136,10 @@ const easArgs = [
   '--non-interactive',
 ];
 
-console.log(`[mobile:publish] Running: bunx ${easArgs.join(' ')}`);
+console.log(`[mobile:publish] Running: bun ${easArgs.join(' ')}`);
 console.log('');
 
-const result = spawnSync('bunx', easArgs, {
+const result = spawnSync('bun', easArgs, {
   cwd: MOBILE_DIR,
   stdio: 'inherit',
   env: { ...process.env },
@@ -146,8 +149,8 @@ if (result.status !== 0) {
   console.error('');
   console.error('[mobile:publish] Update failed.');
   if (result.status === 1) {
-    console.error('[mobile:publish] Make sure you are logged in: bunx eas login');
-    console.error('[mobile:publish] And the project is linked: bunx eas init (from packages/mobile/)');
+    console.error('[mobile:publish] Make sure you are logged in: bun x -p eas-cli@16 eas login');
+    console.error('[mobile:publish] And the project is linked: bun x -p eas-cli@16 eas init (from packages/mobile/)');
   }
   process.exit(result.status ?? 1);
 }
@@ -157,4 +160,4 @@ console.log(`[mobile:publish] Published to branch "${sanitizedBranch}".`);
 console.log(`[mobile:publish] Testers on the "preview" build will receive this update.`);
 console.log('');
 console.log(`[mobile:publish] To point a preview build at this branch:`);
-console.log(`  bunx eas-cli@16 channel:edit preview --branch ${sanitizedBranch}`);
+console.log(`  bun x -p eas-cli@16 eas channel:edit preview --branch ${sanitizedBranch}`);


### PR DESCRIPTION
## What

Adds Android 12+ Material You dynamic color to the mobile Material UI variant.

## Why

After the react-native-paper Material variant landed, Paper components could accept a dynamic MD3 palette, but the token-skinned Material chrome still needed the same palette so the app did not look half dynamic and half static-brand.

## How

- Adds `@pchmn/expo-material3-theme` for Android dynamic MD3 palettes.
- Gates dynamic color to the resolved `material` variant and a real device dynamic palette.
- Feeds the dynamic palette into `buildPaperTheme` for Paper components.
- Converts the same palette into the app `systemColors` shape for token-skinned surfaces.
- Routes Material tab bar, grade controls, default Material button tint/fill, and default Android ripple tint through contextual theme accents.
- Refreshes the native dynamic palette when Android returns to the active app state, so wallpaper changes can apply without a JS reload.
- Keeps unsupported devices, generated fallback palettes, and Liquid Glass on the static "Velvet Send" violet brand paths.
- Aligns mobile EAS helpers and docs on `bun x -p eas-cli@16 eas ...`.
- Documents the fallback-palette detection heuristic and covers GradeChip/GradeRail dynamic accents with unit tests.

## Validation

- `vp run typecheck:mobile`
- `vp test --project mobile` — 148 files / 1130 tests passed
- `vp run check:mobile-native-deps`
- `vp run check:mobile-bundle` — iOS 10.4 MB, Android 10.6 MB
- `vp run mobile:preview-build` reached EAS, but this environment is not authenticated with Expo and has no `EXPO_TOKEN`, so no build was submitted.

Note: `vp check` is currently blocked by unrelated pre-existing formatting issues in 22 files; none are in this PR diff.

## Device QA Needed

- Fresh preview build install on Android 12+.
- Verify wallpaper changes recolor Paper components and token-skinned Material surfaces.
- Verify older Android and iOS stay on the static violet brand Material map.
- Verify light/dark and appearance override still compose.