### PR TITLE
[codex] fix android material header and grade rail

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useMemo, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useMemo, useState, type ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
 // Navigation theme comes from expo-router's vendored React Navigation. Expo
 // SDK 56's expo-router is not compatible with a separately-installed
@@ -46,10 +46,11 @@ import { brandColors } from '../src/theme/colors';
 import { iosDarkColors } from '../src/theme/ios-colors';
 import { spacing } from '../src/theme/tokens';
 import { wrapWithSentry, reportError } from '../src/lib/sentry';
+import { loadRequiredFonts } from '../src/lib/required-fonts';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
 
-SplashScreen.preventAutoHideAsync();
+void SplashScreen.preventAutoHideAsync();
 
 const layoutStyles = StyleSheet.create({
   root: { flex: 1 },
@@ -201,9 +202,31 @@ function ThemedNavigation({ children }: { children: ReactNode }) {
 }
 
 function RootLayout() {
-  const onAuthReady = useCallback(() => {
-    SplashScreen.hideAsync();
+  const [authReady, setAuthReady] = useState(false);
+  const [fontsReady, setFontsReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadRequiredFonts()
+      .catch((error: unknown) => {
+        reportError(error);
+      })
+      .finally(() => {
+        if (!cancelled) setFontsReady(true);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
+
+  const onAuthReady = useCallback(() => {
+    setAuthReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!authReady || !fontsReady) return;
+    void SplashScreen.hideAsync();
+  }, [authReady, fontsReady]);
 
   return (
     <GestureHandlerRootView style={layoutStyles.root}>

--- a/packages/mobile/src/components/SearchHeader.tsx
+++ b/packages/mobile/src/components/SearchHeader.tsx
@@ -83,26 +83,29 @@ export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(fu
   // (blur/focus) and getText/setText stay backed by our own `text` state.
   if (uiVariant === 'material') {
     return (
-      <Searchbar
-        ref={inputRef}
-        value={text}
-        onChangeText={handleChange}
-        onClearIconPress={handleClear}
-        placeholder={placeholder}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        onSubmitEditing={handleSubmit}
-        returnKeyType="search"
-        autoCapitalize="none"
-        autoCorrect={false}
-        accessibilityLabel={placeholder}
-        // Pin both dimensions so the first layout pass is deterministic: `flex: 1`
-        // fills the row slot's width and `minHeight` stops Paper's Surface from
-        // collapsing to 0 before its async content measure (which left the search
-        // bar blank until a tab switch forced a re-layout). minHeight (not height)
-        // so it can still grow to Paper's natural height — no clipping.
-        style={[styles.materialSearchbar, { minHeight: height }]}
-      />
+      <View style={[styles.materialFrame, { height, borderRadius: radius }]}>
+        <Searchbar
+          ref={inputRef}
+          value={text}
+          onChangeText={handleChange}
+          onClearIconPress={handleClear}
+          placeholder={placeholder}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onSubmitEditing={handleSubmit}
+          returnKeyType="search"
+          autoCapitalize="none"
+          autoCorrect={false}
+          accessibilityLabel={placeholder}
+          elevation={0}
+          inputStyle={styles.materialInput}
+          // Pin the full footprint on first mount. Paper's Searchbar contains a
+          // Surface + TextInput stack; on Android it can draw only the tonal
+          // surface for one frame if its parent hands it an unconstrained flex
+          // slot. The wrapper owns the slot, and the Searchbar fills it.
+          style={[styles.materialSearchbar, { height, borderRadius: radius }]}
+        />
+      </View>
     );
   }
 
@@ -148,8 +151,21 @@ export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(fu
 const styles = StyleSheet.create({
   // Material (Paper Searchbar): fill the row slot's width; minHeight is applied
   // inline from the `height` prop so the first layout pass can't collapse to 0.
+  materialFrame: {
+    flex: 1,
+    minWidth: 0,
+    overflow: 'hidden',
+    justifyContent: 'center',
+  },
   materialSearchbar: {
     flex: 1,
+    width: '100%',
+    margin: 0,
+  },
+  materialInput: {
+    minHeight: 0,
+    paddingVertical: 0,
+    textAlignVertical: 'center',
   },
   capsule: {
     flex: 1,

--- a/packages/mobile/src/components/__tests__/search-header.test.tsx
+++ b/packages/mobile/src/components/__tests__/search-header.test.tsx
@@ -61,14 +61,35 @@ vi.mock('../../theme/ios-colors', () => ({
 
 // Paper Searchbar forwards its ref to the inner TextInput; model that so the
 // imperative blur/focus path can be exercised on the Material variant.
+function readStyleField(style: unknown, field: string): string {
+  const styleItems = Array.isArray(style) ? style : [style];
+  const matchingStyle = styleItems.find(
+    (item): item is Record<string, unknown> => typeof item === 'object' && item !== null && field in item,
+  );
+  const fieldValue = matchingStyle?.[field];
+  if (typeof fieldValue === 'number' || typeof fieldValue === 'string') return String(fieldValue);
+  return '';
+}
+
 vi.mock('react-native-paper', () => ({
   Searchbar: forwardRef<
     HTMLInputElement,
-    { value?: string; placeholder?: string; onChangeText?: (text: string) => void }
-  >(function SearchbarMock({ value, placeholder, onChangeText }, ref) {
+    {
+      value?: string;
+      placeholder?: string;
+      onChangeText?: (text: string) => void;
+      style?: unknown;
+      inputStyle?: unknown;
+      elevation?: number;
+    }
+  >(function SearchbarMock({ value, placeholder, onChangeText, style, inputStyle, elevation }, ref) {
     return createElement('input', {
       ref,
       'data-paper': 'searchbar',
+      'data-height': readStyleField(style, 'height'),
+      'data-radius': readStyleField(style, 'borderRadius'),
+      'data-elevation': String(elevation ?? ''),
+      'data-has-input-style': inputStyle ? 'true' : 'false',
       value,
       placeholder,
       onChange: (event: ChangeEvent<HTMLInputElement>) => onChangeText?.(event.currentTarget.value),
@@ -114,8 +135,13 @@ describe('SearchHeader', () => {
     );
 
     // Material path renders the Paper Searchbar (stub), not the glass capsule.
-    expect(container.querySelector('[data-paper="searchbar"]')).not.toBeNull();
+    const searchbar = container.querySelector('[data-paper="searchbar"]');
+    expect(searchbar).not.toBeNull();
     expect(container.querySelector('[data-glass]')).toBeNull();
+    expect(searchbar?.getAttribute('data-height')).toBe('44');
+    expect(searchbar?.getAttribute('data-radius')).toBe('22');
+    expect(searchbar?.getAttribute('data-elevation')).toBe('0');
+    expect(searchbar?.getAttribute('data-has-input-style')).toBe('true');
 
     // getText/set({silent}) are backed by local state, so they work regardless of
     // Paper owning the inner TextInput.

--- a/packages/mobile/src/components/grade/GradeRail.tsx
+++ b/packages/mobile/src/components/grade/GradeRail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ElementRef, type ReactNode } from 'react';
-import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 import { Gesture, GestureDetector, ScrollView } from 'react-native-gesture-handler';
 import { runOnJS } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
@@ -39,7 +39,7 @@ type RailFrameProps = {
 function RailFrame({ children, style }: RailFrameProps) {
   const { systemColors } = useTheme();
   return (
-    <View style={[styles.frame, style]}>
+    <View collapsable={false} style={[styles.frame, style]}>
       <GlassSurface
         glassEffectStyle="regular"
         fallbackColor={systemColors.secondaryBackground}
@@ -209,8 +209,10 @@ export function GradeRangeRail({
       <ScrollView
         ref={scrollRef}
         horizontal
+        nestedScrollEnabled={Platform.OS === 'android'}
         showsHorizontalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
+        style={styles.railScroll}
         contentContainerStyle={styles.railContent}
         onScrollBeginDrag={clearDismissTimer}
         onLayout={(event) => {
@@ -355,6 +357,7 @@ const styles = StyleSheet.create({
   frame: {
     overflow: 'hidden',
     borderRadius: 24,
+    minHeight: 62,
     paddingTop: 2,
     paddingBottom: spacing[2],
   },
@@ -382,8 +385,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[2],
+    minHeight: 52,
     paddingHorizontal: spacing[3],
     paddingVertical: spacing[1],
+  },
+  railScroll: {
+    flexGrow: 0,
+    minHeight: 52,
   },
   singleSelectContent: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/grade/__tests__/grade-range-rail.test.tsx
+++ b/packages/mobile/src/components/grade/__tests__/grade-range-rail.test.tsx
@@ -14,6 +14,7 @@ const accessibilityInfo = vi.hoisted(() => ({
 type LayoutEvent = { nativeEvent: { layout: { x: number; width: number; height: number; y: number } } };
 
 vi.mock('react-native', () => ({
+  Platform: { OS: 'android' },
   AccessibilityInfo: {
     isScreenReaderEnabled: accessibilityInfo.screenReaderEnabled,
     addEventListener: accessibilityInfo.addEventListener,
@@ -44,11 +45,20 @@ vi.mock('react-native-gesture-handler', () => ({
   },
   GestureDetector: ({ children }: { children?: ReactNode }) =>
     createElement('div', { 'data-gesture': 'true' }, children),
-  ScrollView: ({ children, onLayout }: { children?: ReactNode; onLayout?: (event: LayoutEvent) => void }) =>
+  ScrollView: ({
+    children,
+    nestedScrollEnabled,
+    onLayout,
+  }: {
+    children?: ReactNode;
+    nestedScrollEnabled?: boolean;
+    onLayout?: (event: LayoutEvent) => void;
+  }) =>
     createElement(
       'div',
       {
         'data-scroll': 'true',
+        'data-nested-scroll': nestedScrollEnabled ? 'true' : 'false',
         onClick: onLayout
           ? () => onLayout({ nativeEvent: { layout: { x: 0, width: 320, height: 44, y: 0 } } })
           : undefined,
@@ -142,7 +152,7 @@ vi.mock('../../../lib/haptics', () => ({ hapticSelection: haptics.selection }));
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, options?: Record<string, unknown>) => {
-      if (key.includes('Aria') && options?.grade) return `${key}:${options.grade}`;
+      if (key.includes('Aria') && typeof options?.grade === 'string') return `${key}:${options.grade}`;
       return key;
     },
   }),
@@ -230,7 +240,7 @@ describe('GradeRangeRail', () => {
     });
     // First tap: single grade selected, rail stays open
     fireEvent.click(getByText('V4'));
-    act(() => vi.advanceTimersByTime(0));
+    void act(() => vi.advanceTimersByTime(0));
     expect(onRequestClose).not.toHaveBeenCalled();
 
     // Rerender with the new bound — same onRequestClose ref
@@ -245,7 +255,7 @@ describe('GradeRangeRail', () => {
 
     // Second tap within window: range formed → close
     fireEvent.click(getByText('V6'));
-    act(() => vi.advanceTimersByTime(300));
+    void act(() => vi.advanceTimersByTime(300));
     expect(onRequestClose).toHaveBeenCalled();
   });
 
@@ -265,7 +275,7 @@ describe('GradeRangeRail', () => {
     // Tap V5 again (it's already selected) → deselects to "any". The rail must
     // stay open so the user can build a new range from here, not close.
     fireEvent.click(getByText('V5'));
-    act(() => vi.advanceTimersByTime(10000));
+    void act(() => vi.advanceTimersByTime(10000));
     expect(onRequestClose).not.toHaveBeenCalled();
   });
 
@@ -284,7 +294,7 @@ describe('GradeRangeRail', () => {
     });
     // Tap V4 (min endpoint of existing range) → trims to V5-V6 — still a range, rail stays open
     fireEvent.click(getByText('V4'));
-    act(() => vi.advanceTimersByTime(10000));
+    void act(() => vi.advanceTimersByTime(10000));
     expect(onRequestClose).not.toHaveBeenCalled();
   });
 
@@ -296,6 +306,21 @@ describe('GradeRangeRail', () => {
       vi.advanceTimersByTime(3000);
     });
     expect(onRequestClose).not.toHaveBeenCalled();
+  });
+
+  it('keeps the inline filter rail visible while grades are pending on Android', () => {
+    const { getByText, container } = render(
+      <GradeRangeRail
+        grades={[]}
+        bound={{ minGradeId: undefined, maxGradeId: undefined }}
+        onChange={vi.fn()}
+        dismissible={false}
+        showTitle
+      />,
+    );
+    expect(getByText('mobile.filter.gradeRange')).toBeTruthy();
+    expect(getByText('mobile.search.gradeClear')).toBeTruthy();
+    expect(container.querySelector('[data-scroll="true"]')?.getAttribute('data-nested-scroll')).toBe('true');
   });
 });
 

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -20,6 +20,7 @@ const ctrl = vi.hoisted(() => ({
   board: null as BoardLabelFields | null,
   bluetooth: null as BluetoothCtx,
   setActiveBoard: vi.fn(),
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
 }));
 const haptics = vi.hoisted(() => ({ light: vi.fn(), selection: vi.fn() }));
 
@@ -80,6 +81,7 @@ vi.mock('../../../providers/theme-provider', () => ({
       elevatedSurface: '#fff',
     },
     brandColors: { primary: '#6D28D9', warning: '#FF9500' },
+    variant: ctrl.variant,
   }),
 }));
 
@@ -264,6 +266,7 @@ describe('ClimbTopChrome', () => {
   beforeEach(() => {
     ctrl.board = null;
     ctrl.bluetooth = null;
+    ctrl.variant = 'liquidGlass';
     ctrl.setActiveBoard.mockClear();
     haptics.light.mockClear();
     haptics.selection.mockClear();
@@ -344,6 +347,13 @@ describe('ClimbTopChrome', () => {
     expect(lightbulb(container)).toBeNull();
     expect(container.querySelector('[data-search-field]')).not.toBeNull();
     expect(container.querySelector('[data-pressable^="mobile.search.filters"]')).toBeNull();
+  });
+
+  it('renders the Material filter affordance next to the custom search field', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<ClimbTopChrome {...makeProps({ onOpenFilters: vi.fn() })} />);
+    expect(container.querySelector('[data-search-field]')).not.toBeNull();
+    expect(container.querySelector('[data-paper="icon-button"]')).not.toBeNull();
   });
 
   it('native search mode leaves text search in the stack header and does not render filter chrome', () => {

--- a/packages/mobile/src/lib/__tests__/required-fonts.test.ts
+++ b/packages/mobile/src/lib/__tests__/required-fonts.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const iconFont = vi.hoisted(() => ({ loadFont: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({
+  default: { loadFont: iconFont.loadFont },
+}));
+
+import { loadRequiredFonts } from '../required-fonts';
+
+describe('loadRequiredFonts', () => {
+  it('preloads the MaterialCommunityIcons font before first app paint', async () => {
+    await loadRequiredFonts();
+    expect(iconFont.loadFont).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/lib/required-fonts.ts
+++ b/packages/mobile/src/lib/required-fonts.ts
@@ -1,0 +1,10 @@
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+
+/**
+ * Fonts that must be available before the first visible Android Material frame.
+ * Expo vector icons render an empty Text node until their font loads; gating the
+ * splash avoids blank toolbar/search icons that only repaint after navigation.
+ */
+export async function loadRequiredFonts(): Promise<void> {
+  await MaterialCommunityIcons.loadFont();
+}


### PR DESCRIPTION
## What changed

- Preload `MaterialCommunityIcons` before hiding the mobile splash screen so Android Material chrome does not first paint with blank icon/text surfaces.
- Give the Material climbs `SearchHeader` a fixed first-render frame around Paper's `Searchbar`.
- Give the shared grade rail an Android-safe bottom-sheet layout with explicit min height and nested horizontal scrolling.
- Add focused mobile tests for required font loading, Material search header layout, Material top-chrome filter rendering, and Android grade rail visibility.

## Why

On Android, the Material climbs header could render as grey blocks on cold start until a tab switch forced the icon/search controls to repaint. The grade filter inside the filter drawer could also disappear because the new shared grade rail did not have a strong enough layout contract when mounted inside a Gorhom bottom-sheet scroll view.

## Validation

- `vp test run --project mobile`
- `vp run typecheck:mobile`
- `vp run check:mobile-bundle`
- targeted `vp check` on all touched files