### PR TITLE
Mobile: port static brandColors foregrounds to scheme-aware useTheme() (#2583)

### DIFF
--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -170,19 +170,21 @@ The React Native app is recolored onto a **violet brand** anchored on the logo (
 
 ### Brand & semantic
 
-| Role          | Light     | Dark      | Usage                                                            |
-| ------------- | --------- | --------- | --------------------------------------------------------------- |
-| `primary`/`tint` | `#6D28D9` | `#A78BFA` | Foreground brand: text, icons, links, borders, accent bars      |
-| `primaryFill` | `#6D28D9` | `#7C3AED` | Filled surface/button background (pair with `onPrimary`)         |
-| `onPrimary`   | `#FFFFFF` | `#FFFFFF` | Text/icon on `primaryFill`                                       |
-| `accent`      | `#FF8A3D` | `#FF8A3D` | Amber spark for highlights — **fill-only, always dark text**     |
-| `success`     | `#047857` | `#34D399` | Sends, positive confirmation                                    |
-| `warning`     | `#B45309` | `#FBBF24` | Flashes, caution                                                |
-| `error`       | `#C81E1E` | `#F87171` | Destructive, removals                                           |
+| Role             | Light     | Dark      | Usage                                                        |
+| ---------------- | --------- | --------- | ------------------------------------------------------------ |
+| `primary`/`tint` | `#6D28D9` | `#A78BFA` | Foreground brand: text, icons, links, borders, accent bars   |
+| `primaryFill`    | `#6D28D9` | `#7C3AED` | Filled surface/button background (pair with `onPrimary`)     |
+| `onPrimary`      | `#FFFFFF` | `#FFFFFF` | Text/icon on `primaryFill`                                   |
+| `accent`         | `#FF8A3D` | `#FF8A3D` | Amber spark for highlights — **fill-only, always dark text** |
+| `success`        | `#047857` | `#34D399` | Sends, positive confirmation                                 |
+| `warning`        | `#B45309` | `#FBBF24` | Flashes, caution                                             |
+| `error`          | `#C81E1E` | `#F87171` | Destructive, removals                                        |
 
 Contrast (WCAG): white-on-`#6D28D9` 7.10:1 · `#A78BFA` tint ≥6.12:1 across the dark ladder · white-on-`#7C3AED` 5.70:1 · black-on-`#FF8A3D` 8.95:1 (white-on-amber fails, so accent is fill-only).
 
-> **Scheme-aware rule.** Use `useTheme().brandColors.primary` for any brand **foreground** so dark mode lifts to `#A78BFA`. The static `brandColors` import is only safe for **fills** that carry white/`onPrimary` text (e.g. filled buttons, swipe-action panels), where the value is legible in both schemes. A number of legacy static foreground sites are not yet ported — tracked as a follow-up.
+> **Scheme-aware rule.** Use `useTheme().brandColors.primary` for any brand **foreground** so dark mode lifts to `#A78BFA`. The single discriminator: does white / `onPrimary` / auto-contrasted text (or a white icon) sit **on** the brand colour? If yes it's a **fill** — keep it static (filled buttons, badges, avatars, grade badges, swipe-action panels, selected chips, the amber `accent`), because the bright dark tints would break white-on-fill contrast. If no — icon/text/border/stroke/ripple/`tintColor`, low-alpha washes, and **text-free accent bars/fills** (tab underlines, slider fill+thumb, progress/percentile bars) — it's a foreground; read it from the theme. The legacy static foreground sites are now ported (issue #2583); the only intentional static foregrounds left are the root `ErrorBoundary` warning icon (renders outside `ThemeProvider`) and `PressableSurface`'s default Android ripple tint (core primitive, rarely-hit fallback).
+>
+> **Interactive accent.** `useTheme().systemColors.accent` is the scheme-aware foreground accent for links / active tab / "edit·copy·open" affordances — iOS `PlatformColor('link')`, Android/Material the brand violet (lifted to `#A78BFA` in dark). It replaces the static `iosSystemColors.systemBlue`, which now only backs the few white-text fills that used it.
 
 ### Neutrals
 
@@ -892,12 +894,12 @@ The Expo app (`packages/mobile/`) is a separate implementation from the web CSS 
 
 `packages/mobile/src/components/GlassSurface.tsx` is the single primitive for every translucent surface. It resolves the best material per device:
 
-| Condition                                   | Material                                              |
-| ------------------------------------------- | ----------------------------------------------------- |
-| iOS 26+ (Liquid Glass available)            | `expo-glass-effect` `GlassView`                       |
-| iOS < 26                                    | `@react-native-community/blur` `BlurView` (frosted)   |
-| Android                                     | Solid themed surface (`systemColors.secondaryBackground`) |
-| Reduce Transparency on (any platform)       | Solid themed surface                                  |
+| Condition                             | Material                                                  |
+| ------------------------------------- | --------------------------------------------------------- |
+| iOS 26+ (Liquid Glass available)      | `expo-glass-effect` `GlassView`                           |
+| iOS < 26                              | `@react-native-community/blur` `BlurView` (frosted)       |
+| Android                               | Solid themed surface (`systemColors.secondaryBackground`) |
+| Reduce Transparency on (any platform) | Solid themed surface                                      |
 
 Props: `glassEffectStyle` (`'regular'` for frosted chrome, `'clear'` for content-forward), `tintColor` (translucent hue composited onto the glass), `fallbackColor` (solid path).
 

--- a/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
+++ b/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
@@ -18,7 +18,7 @@ import { getBoardRenderData } from '../../../src/lib/board-details';
 import { hapticSuccess } from '../../../src/lib/haptics';
 import { track } from '../../../src/lib/analytics';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
-import { brandColors } from '../../../src/theme/colors';
+import { useTheme } from '../../../src/providers/theme-provider';
 import { spacing } from '../../../src/theme/tokens';
 
 type ClimbDetailParams = {
@@ -34,6 +34,7 @@ export default function ClimbDetail() {
   const params = useLocalSearchParams<ClimbDetailParams>();
   const { climbUuid, boardName, layoutId, sizeId, setIds, angle } = params;
   const { t } = useTranslation('climbs');
+  const { brandColors } = useTheme();
 
   const hasRequiredParams = boardName && layoutId && sizeId && setIds && angle;
 
@@ -178,7 +179,7 @@ export default function ClimbDetail() {
           {climb.userAscents != null && climb.userAscents > 0 && (
             <View style={styles.progressRow}>
               <Icon name="tick" size={16} color={brandColors.success} />
-              <Text variant="footnote" style={styles.progressText}>
+              <Text variant="footnote" style={[styles.progressText, { color: brandColors.success }]}>
                 {climb.userAttempts != null && climb.userAttempts > 0
                   ? t('mobile.detail.sentWithAttempts', {
                       count: climb.userAscents,
@@ -329,9 +330,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(107, 144, 128, 0.1)',
     borderRadius: 8,
   },
-  progressText: {
-    color: brandColors.success,
-  },
+  progressText: {},
   description: {
     marginTop: spacing[4],
     opacity: 0.8,

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -56,7 +56,6 @@ import { getFilterSummary } from '../../../src/lib/filter-summary';
 import { getActiveFilterTokens } from '../../../src/lib/filter-tokens';
 import { normalizeSearchName } from '../../../src/lib/search-name';
 import { track } from '../../../src/lib/analytics';
-import { brandColors } from '../../../src/theme/colors';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
 import { glassSize } from '../../../src/theme/layout';
@@ -104,7 +103,7 @@ function ClimbListInner() {
   const router = useRouter();
   const { t } = useTranslation('climbs');
   const { openClimbActions, openAddToPlaylist } = useDrawerHost();
-  const { systemColors, variant } = useTheme();
+  const { systemColors, variant, brandColors } = useTheme();
   const { addToQueue, state: queueState } = useQueue();
   const {
     filters,

--- a/packages/mobile/app/(tabs)/climbs/setters.tsx
+++ b/packages/mobile/app/(tabs)/climbs/setters.tsx
@@ -10,7 +10,6 @@ import { useTheme } from '../../../src/providers/theme-provider';
 import { useSetterStats } from '../../../src/lib/graphql/hooks';
 import { emitSetterSelection } from '../../../src/lib/filter-handoff';
 import { hapticSelection } from '../../../src/lib/haptics';
-import { brandColors } from '../../../src/theme/colors';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
 
@@ -30,7 +29,7 @@ export default function SettersPicker() {
   const router = useRouter();
   const navigation = useNavigation();
   const { t } = useTranslation('climbs');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
 
   const initialSelected = useMemo<string[]>(() => {
     if (!params.selected) return [];
@@ -110,7 +109,7 @@ export default function SettersPicker() {
         </Pressable>
       ),
     });
-  }, [navigation, done, cancel, t]);
+  }, [navigation, done, cancel, t, brandColors]);
 
   const toggle = useCallback((username: string) => {
     hapticSelection();
@@ -146,7 +145,7 @@ export default function SettersPicker() {
         </Pressable>
       );
     },
-    [selected, toggle, t],
+    [selected, toggle, t, brandColors],
   );
 
   return (

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -33,7 +33,6 @@ import { hapticSelection } from '../../../src/lib/haptics';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useToast } from '../../../src/providers/toast-provider';
 import { useTheme } from '../../../src/providers/theme-provider';
-import { brandColors } from '../../../src/theme/colors';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 
 type DetailParams = {
@@ -47,7 +46,7 @@ export default function PlaylistDetail() {
   const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
   const { showToast } = useToast();
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { updatePlaylist, deletePlaylist, pinPlaylist, unpinPlaylist, followPlaylist, unfollowPlaylist } =
     usePlaylistMutations();
 
@@ -322,6 +321,7 @@ export default function PlaylistDetail() {
       handleTogglePin,
       isOwner,
       systemColors,
+      brandColors,
       t,
     ],
   );

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -25,17 +25,18 @@ import {
 import { DiscoverTopChrome } from '../../../src/components/chrome';
 import { SMART_PLAYLISTS } from '../../../src/lib/smart-playlists';
 import { useAuth } from '../../../src/providers/auth-provider';
+import { useTheme } from '../../../src/providers/theme-provider';
 import { useToast } from '../../../src/providers/toast-provider';
 import { useAuthToken } from '../../../src/lib/graphql/use-auth-token';
 import { useProfile } from '../../../src/lib/graphql/hooks';
 import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
 import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
-import { brandColors } from '../../../src/theme/colors';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
 
 export default function DiscoverLibrary() {
   const { t } = useTranslation('playlists');
+  const { brandColors } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
   const insets = useSafeAreaInsets();
   const { isAuthenticated, isLoading: authLoading } = useAuth();

--- a/packages/mobile/app/(tabs)/profile/index.tsx
+++ b/packages/mobile/app/(tabs)/profile/index.tsx
@@ -12,7 +12,6 @@ import { ProgressTab } from '../../../src/components/you/ProgressTab';
 import { SessionsTab } from '../../../src/components/you/SessionsTab';
 import { LogbookTab } from '../../../src/components/you/LogbookTab';
 import { Icon } from '../../../src/components/Icon';
-import { brandColors } from '../../../src/theme/colors';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 
 type TabKey = 'progress' | 'sessions' | 'logbook';
@@ -20,7 +19,7 @@ type TabKey = 'progress' | 'sessions' | 'logbook';
 export default function YouScreen() {
   const navigation = useNavigation();
   const { t } = useTranslation('you');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
 
   const { data: profile } = useProfile();
   const userId = profile?.id;
@@ -87,7 +86,7 @@ export default function YouScreen() {
             )
           : undefined,
     });
-  }, [navigation, t, activeIndex, openFilters, youData.hasActiveFilters]);
+  }, [navigation, t, activeIndex, openFilters, youData.hasActiveFilters, brandColors]);
 
   return (
     <View style={[styles.container, { backgroundColor: systemColors.background }]}>

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -7,7 +7,6 @@ import { useTheme } from '../../../src/providers/theme-provider';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useProfile } from '../../../src/lib/graphql/hooks';
 import { spacing } from '../../../src/theme/tokens';
-import { brandColors } from '../../../src/theme/colors';
 import { DevMetadataPanel } from '../../../src/components/DevMetadataPanel';
 import { Icon } from '../../../src/components/Icon';
 import { Text } from '../../../src/components/Text';
@@ -19,7 +18,15 @@ import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { useGlassCapability } from '../../../src/hooks/use-glass-capability';
 
 export default function MoreScreen() {
-  const { systemColors, borderRadius, themeOverride, setThemeOverride, uiVariantPreference, setUiVariant } = useTheme();
+  const {
+    systemColors,
+    brandColors,
+    borderRadius,
+    themeOverride,
+    setThemeOverride,
+    uiVariantPreference,
+    setUiVariant,
+  } = useTheme();
   const { t } = useTranslation('common');
   const { t: tProfile } = useTranslation('profile');
   const { signOut } = useAuth();

--- a/packages/mobile/app/(tabs)/record/summary.tsx
+++ b/packages/mobile/app/(tabs)/record/summary.tsx
@@ -50,7 +50,7 @@ export default function SessionSummaryScreen() {
   const { sessionId } = useLocalSearchParams<{ sessionId: string }>();
   const { data: summary, isLoading } = useSessionSummary(sessionId ?? null);
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors: brand } = useTheme();
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { formatGrade } = useGradeFormat();
@@ -58,7 +58,7 @@ export default function SessionSummaryScreen() {
   if (isLoading || !summary) {
     return (
       <View style={styles.centered}>
-        <ActivityIndicator size="large" color={brandColors.primary} />
+        <ActivityIndicator size="large" color={brand.primary} />
       </View>
     );
   }

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -107,6 +107,9 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
   return (
     <View style={errorStyles.container}>
       <View style={errorStyles.iconContainer}>
+        {/* Static brand colour on purpose: this boundary can render outside the
+            ThemeProvider (the crash screen), where useTheme() would throw — so
+            it can't read the scheme-aware brand. */}
         <Icon name="warning" size={48} color={brandColors.warning} />
       </View>
       <Text variant="title2" style={errorStyles.title}>

--- a/packages/mobile/app/auth/callback.tsx
+++ b/packages/mobile/app/auth/callback.tsx
@@ -4,15 +4,16 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { exchangeTransferToken } from '../../src/lib/auth';
 import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { brandColors } from '../../src/theme/colors';
 import { track } from '../../src/lib/analytics';
 import { useAuth } from '../../src/providers/auth-provider';
+import { useTheme } from '../../src/providers/theme-provider';
 
 export default function AuthCallback() {
   const { transferToken } = useLocalSearchParams<{ transferToken: string }>();
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const { refreshAuthState } = useAuth();
+  const theme = useTheme();
   const exchangedRef = useRef(false);
 
   useEffect(() => {
@@ -47,7 +48,7 @@ export default function AuthCallback() {
   if (error) {
     return (
       <View style={styles.container}>
-        <Text style={styles.errorText}>Sign in failed: {error}</Text>
+        <Text style={[styles.errorText, { color: theme.brandColors.error }]}>Sign in failed: {error}</Text>
       </View>
     );
   }
@@ -63,5 +64,5 @@ export default function AuthCallback() {
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 20 },
   text: { marginTop: 16, fontSize: 16 },
-  errorText: { fontSize: 16, color: brandColors.error, textAlign: 'center' },
+  errorText: { fontSize: 16, textAlign: 'center' },
 });

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -150,7 +150,7 @@ export default function LoginScreen() {
         keyboardDismissMode="interactive"
       >
         <View style={styles.header}>
-          <Text style={styles.title}>Boardsesh</Text>
+          <Text style={[styles.title, { color: theme.brandColors.primary }]}>Boardsesh</Text>
           <Text style={styles.subtitle}>{t('nativeStart.tagline')}</Text>
         </View>
 
@@ -234,7 +234,7 @@ export default function LoginScreen() {
 const styles = StyleSheet.create({
   container: { flexGrow: 1, justifyContent: 'center', padding: 24 },
   header: { alignItems: 'center', marginBottom: 32 },
-  title: { fontSize: 34, fontWeight: '700', marginBottom: 8, color: brandColors.primary },
+  title: { fontSize: 34, fontWeight: '700', marginBottom: 8 },
   subtitle: { fontSize: 17, opacity: 0.7 },
   form: { gap: 12 },
   input: {

--- a/packages/mobile/app/boards/search.tsx
+++ b/packages/mobile/app/boards/search.tsx
@@ -17,7 +17,6 @@ import { BoardDetailSheet } from '../../src/components/board-discovery/BoardDeta
 import { userBoardToItem } from '../../src/components/board-discovery/board-items';
 import type { DiscoveryBoardItem } from '../../src/components/board-discovery/BoardDiscoveryCard';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
-import { brandColors } from '../../src/theme/colors';
 import { spacing, borderRadius } from '../../src/theme/tokens';
 
 // Lazy/guarded expo-maps load: it's a native module, so a JS-only OTA push to a
@@ -49,7 +48,7 @@ const MapView = isApple ? expoMaps?.AppleMaps.View : expoMaps?.GoogleMaps.View;
 type Camera = { latitude: number; longitude: number; zoom: number };
 
 export default function BoardSearchScreen() {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { returnTo } = useLocalSearchParams<{ returnTo?: string }>();
@@ -176,7 +175,7 @@ export default function BoardSearchScreen() {
             }
           : base;
       }),
-    [pinned, selectedUuid],
+    [pinned, selectedUuid, brandColors],
   );
 
   const searchField = (

--- a/packages/mobile/app/join/[sessionId].tsx
+++ b/packages/mobile/app/join/[sessionId].tsx
@@ -17,7 +17,6 @@ import { useToast } from '../../src/providers/toast-provider';
 import { useSessionPreview, useMyBoards, useCreateBoard } from '../../src/lib/graphql/hooks';
 import { resolveBoardForSession } from '../../src/lib/board-path-to-user-board';
 import { spacing, borderRadius } from '../../src/theme/tokens';
-import { brandColors } from '../../src/theme/colors';
 
 /** Human board label for the confirmation card, e.g. "Kilter · 40°". */
 function boardLabelFromPath(boardPath: string): string {
@@ -30,7 +29,7 @@ function boardLabelFromPath(boardPath: string): string {
 export default function JoinSessionScreen() {
   const { sessionId } = useLocalSearchParams<{ sessionId: string }>();
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { isAuthenticated } = useAuth();

--- a/packages/mobile/app/share-beta.tsx
+++ b/packages/mobile/app/share-beta.tsx
@@ -20,7 +20,6 @@ import { partitionAscentsForShare } from '../src/lib/match-ascents-to-caption';
 import { extractGraphqlMessage } from '../src/lib/graphql/extract-error-message';
 import { spacing, borderRadius } from '../src/theme/tokens';
 import { iosSystemColors } from '../src/theme/ios-colors';
-import { brandColors } from '../src/theme/colors';
 
 // Keep the ascents query from refiring on every keystroke; commit the search
 // term after a short pause.
@@ -36,7 +35,7 @@ const SEARCH_DEBOUNCE_MS = 300;
 export default function ShareBetaScreen() {
   const { link } = useLocalSearchParams<{ link: string }>();
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { isAuthenticated } = useAuth();

--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -9,7 +9,7 @@ import { Icon } from './Icon';
 import { Text } from './Text';
 import { useToast } from '../providers/toast-provider';
 import { usePlaylistsContext, type Playlist } from '../providers/playlists-provider';
-import { brandColors } from '../theme/colors';
+import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
 
@@ -29,6 +29,7 @@ function validHexColor(color: string | undefined): string | null {
 
 function AddToPlaylistSheet({ visible, climb, angle, onClose }: AddToPlaylistSheetProps) {
   const { t } = useTranslation('climbs');
+  const { brandColors, systemColors } = useTheme();
   const { showToast } = useToast();
   const { playlists, addToPlaylist, isLoading, isAuthenticated } = usePlaylistsContext();
   const sheetRef = useRef<BottomSheet>(null);
@@ -75,7 +76,7 @@ function AddToPlaylistSheet({ visible, climb, angle, onClose }: AddToPlaylistShe
   return (
     <Sheet ref={sheetRef} snapPoints={snapPoints} onClose={handleClose} enablePanDownToClose scrollable>
       <View style={styles.header}>
-        <Icon name="playlist" size={20} color={iosSystemColors.systemBlue} />
+        <Icon name="playlist" size={20} color={systemColors.accent} />
         <Text variant="headline" style={styles.headerTitle}>
           {t('actions.playlist.popover.title')}
         </Text>

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -13,7 +13,7 @@ import { Sheet } from './Sheet';
 import { ListRow } from './ListRow';
 import { Icon } from './Icon';
 import { useToast } from '../providers/toast-provider';
-import { brandColors } from '../theme/colors';
+import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
 import { WEB_BASE_URL } from '../lib/env';
@@ -59,6 +59,7 @@ function ClimbActionsSheet({
 }: ClimbActionsSheetProps) {
   const { t } = useTranslation('climbs');
   const { showToast } = useToast();
+  const theme = useTheme();
   const router = useRouter();
   const sheetRef = useRef<BottomSheet>(null);
 
@@ -182,7 +183,7 @@ function ClimbActionsSheet({
         {onAddToQueue && (
           <ListRow
             title={t('mobile.climbRow.addToQueue')}
-            leading={<Icon name="add" size={22} color={brandColors.success} />}
+            leading={<Icon name="add" size={22} color={theme.brandColors.success} />}
             onPress={handleAddToQueue}
             showSeparator
           />
@@ -198,7 +199,7 @@ function ClimbActionsSheet({
         {onTick && (
           <ListRow
             title={t('mobile.climbActions.tick')}
-            leading={<Icon name="tick" size={22} color={brandColors.success} />}
+            leading={<Icon name="tick" size={22} color={theme.brandColors.success} />}
             onPress={handleTick}
             showSeparator
           />
@@ -206,20 +207,20 @@ function ClimbActionsSheet({
         {canEdit && (
           <ListRow
             title={t('mobile.climbActions.edit')}
-            leading={<Icon name="edit" size={22} color={iosSystemColors.systemBlue} />}
+            leading={<Icon name="edit" size={22} color={theme.systemColors.accent} />}
             onPress={handleEdit}
             showSeparator
           />
         )}
         <ListRow
           title={t('mobile.climbActions.fork')}
-          leading={<Icon name="branch" size={22} color={iosSystemColors.systemBlue} />}
+          leading={<Icon name="branch" size={22} color={theme.systemColors.accent} />}
           onPress={handleFork}
           showSeparator
         />
         <ListRow
           title={t('mobile.climbActions.copyLink')}
-          leading={<Icon name="copy" size={22} color={iosSystemColors.systemBlue} />}
+          leading={<Icon name="copy" size={22} color={theme.systemColors.accent} />}
           onPress={handleCopyLink}
           showSeparator
         />
@@ -232,7 +233,7 @@ function ClimbActionsSheet({
         {auroraAppUrl && (
           <ListRow
             title={t('mobile.climbActions.openInApp')}
-            leading={<Icon name="open.external" size={22} color={iosSystemColors.systemBlue} />}
+            leading={<Icon name="open.external" size={22} color={theme.systemColors.accent} />}
             onPress={handleOpenInApp}
             showSeparator={false}
           />

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -49,7 +49,10 @@ import { useAuth } from '../providers/auth-provider';
 import { hapticSelection } from '../lib/haptics';
 import { subscribeToSetterSelection } from '../lib/filter-handoff';
 import { springs } from '../theme/animations';
-import { brandColors } from '../theme/colors';
+// Aliased: the active-filter label reads scheme-aware brand from `useTheme()`.
+// `staticBrandColors` is the static set, used only for the selected chip — a FILL
+// with white text that must stay legible in both schemes.
+import { brandColors as staticBrandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing, borderRadius } from '../theme/tokens';
 import { GradeRangeRail } from './grade';
@@ -104,7 +107,8 @@ function Chip({ label, selected, onPress }: { label: string; selected: boolean; 
     paddingHorizontal: spacing[3],
     paddingVertical: spacing[2],
     borderRadius: 20,
-    backgroundColor: selected ? brandColors.primary : systemColors.fill,
+    // Selected chip is a FILL with white text (see `chipText` below) → static brand.
+    backgroundColor: selected ? staticBrandColors.primary : systemColors.fill,
   };
   return (
     <AnimatedPressable

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -420,7 +420,7 @@ export function ClimbFilterSheet({
       <View style={styles.header}>
         <Text variant="title3">{t('mobile.filter.title')}</Text>
         <Pressable onPress={handleReset} hitSlop={8} accessibilityRole="button" disabled={!anyActive}>
-          <Text variant="subheadline" color={anyActive ? brandColors.primary : systemColors.secondaryLabel}>
+          <Text variant="subheadline" color={anyActive ? theme.brandColors.primary : systemColors.secondaryLabel}>
             {t('mobile.filter.reset')}
           </Text>
         </Pressable>
@@ -641,10 +641,7 @@ export function ClimbFilterSheet({
       </BottomSheetScrollView>
 
       <View
-        style={[
-          styles.footer,
-          { paddingBottom: insets.bottom + spacing[3], borderTopColor: systemColors.separator },
-        ]}
+        style={[styles.footer, { paddingBottom: insets.bottom + spacing[3], borderTopColor: systemColors.separator }]}
       >
         <Button title={applyLabel} onPress={handleApply} variant="filled" size="large" style={styles.applyButton} />
       </View>

--- a/packages/mobile/src/components/GlassIconButton.tsx
+++ b/packages/mobile/src/components/GlassIconButton.tsx
@@ -14,6 +14,7 @@ import { Icon } from './Icon';
 import { Text } from './Text';
 import { iconMap, type IconName } from './icon-map';
 import { useTheme } from '../providers/theme-provider';
+import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
 import { timing } from '../theme/animations';
 import { glassSize } from '../theme/layout';
@@ -145,7 +146,6 @@ function GlassIconButtonGlass({
   secondaryIconName,
   active = false,
 }: GlassIconButtonProps) {
-  const { brandColors } = useTheme();
   const reduceMotion = useReduceMotion();
   const showBadge = badgeCount != null && badgeCount > 0;
   const suppressPressRef = useRef(false);

--- a/packages/mobile/src/components/PressableSurface.tsx
+++ b/packages/mobile/src/components/PressableSurface.tsx
@@ -125,6 +125,10 @@ export function PressableSurface({
         onLongPress={onLongPress}
         onLayout={onLayout}
         disabled={disabled}
+        // Static brand tint by design: this is a core primitive and the default
+        // ripple is an Android-only, rarely-hit fallback (most callers pass an
+        // explicit rippleColor). Kept off the theme to avoid coupling every
+        // pressable to ThemeProvider for a colour the eye barely registers.
         android_ripple={androidRipple(rippleColor ?? brandColors.tint, rippleBorderless)}
         hitSlop={hitSlop}
         accessibilityRole={accessibilityRole}

--- a/packages/mobile/src/components/QueueAddedSnackbar.tsx
+++ b/packages/mobile/src/components/QueueAddedSnackbar.tsx
@@ -4,7 +4,6 @@ import Animated, { FadeInDown, FadeOutDown } from 'react-native-reanimated';
 import { Snackbar } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import { Text } from './Text';
-import { brandColors } from '../theme/colors';
 import { borderRadius, spacing, shadowColor } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 import { useBottomChromeMetrics } from '../hooks/use-bottom-chrome-metrics';
@@ -77,7 +76,7 @@ function QueueAddedSnackbarGlass({
   onOpen,
   duration = DEFAULT_DURATION,
 }: QueueAddedSnackbarProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { t } = useTranslation('session');
   const bottomChrome = useBottomChromeMetrics();
 

--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -14,7 +14,6 @@ import { Text } from './Text';
 import { Icon } from './Icon';
 import { ClimbListItemContent } from './ClimbListItemContent';
 import { THUMBNAIL_WIDTH } from './ClimbListThumbnail';
-import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
 import { springs } from '../theme/animations';
@@ -76,6 +75,7 @@ function PositionIndicator({
   isCurrentClimb: boolean;
   position: number;
 }) {
+  const { brandColors } = useTheme();
   if (isEditMode) {
     return (
       <Icon
@@ -114,7 +114,7 @@ export function QueueItemRow({
   queueIndex,
   isDraggable = false,
 }: QueueItemRowProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { t } = useTranslation('session');
   const translateX = useSharedValue(0);
   const rowOpacity = useSharedValue(1);
@@ -279,7 +279,7 @@ export function QueueItemRow({
       style={[
         styles.row,
         { backgroundColor: systemColors.secondaryBackground },
-        isCurrentClimb && !isHistoryItem && styles.currentClimbRow,
+        isCurrentClimb && !isHistoryItem && { backgroundColor: `${brandColors.primary}14` },
         isHistoryItem && styles.historyRow,
         rowAnimatedStyle,
       ]}
@@ -370,9 +370,6 @@ const styles = StyleSheet.create({
     columnGap: spacing[3],
     paddingVertical: spacing[2],
     paddingHorizontal: spacing[3],
-  },
-  currentClimbRow: {
-    backgroundColor: `${brandColors.primary}14`,
   },
   historyRow: {
     opacity: 0.5,

--- a/packages/mobile/src/components/RecentFilterPills.tsx
+++ b/packages/mobile/src/components/RecentFilterPills.tsx
@@ -7,11 +7,11 @@ import { Icon } from './Icon';
 import type { RecentFilter } from '../lib/recent-filter-store';
 import { getFilterKey } from '../lib/recent-filter-store';
 import type { ClimbFilters } from './ClimbFilterSheet';
-import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
 import { springs } from '../theme/animations';
 import { hapticSelection } from '../lib/haptics';
+import { useTheme } from '../providers/theme-provider';
 
 type RecentFilterPillsProps = {
   recentFilters: RecentFilter[];
@@ -32,6 +32,7 @@ function Pill({
   isActive: boolean;
   onApply: (filters: ClimbFilters, searchText: string) => void;
 }) {
+  const { brandColors } = useTheme();
   const scale = useSharedValue(1);
 
   const animatedStyle = useAnimatedStyle(() => ({
@@ -59,7 +60,13 @@ function Pill({
       accessibilityRole="button"
       accessibilityState={{ selected: isActive }}
       accessibilityLabel={filter.label}
-      style={[animatedStyle, styles.pill, isActive ? styles.pillActive : styles.pillInactive]}
+      style={[
+        animatedStyle,
+        styles.pill,
+        isActive
+          ? { borderColor: brandColors.primary, backgroundColor: `${brandColors.primary}14` }
+          : styles.pillInactive,
+      ]}
     >
       <Icon name="history" size={14} color={isActive ? brandColors.primary : iosSystemColors.systemGray} />
       <Text
@@ -82,6 +89,7 @@ export function RecentFilterPills({
   onClear,
 }: RecentFilterPillsProps) {
   const { t } = useTranslation('climbs');
+  const { brandColors } = useTheme();
   const currentKey = getFilterKey(currentFilters, currentSearchText);
 
   if (recentFilters.length === 0) return null;
@@ -146,10 +154,6 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
     borderRadius: 20,
     borderWidth: 1,
-  },
-  pillActive: {
-    borderColor: brandColors.primary,
-    backgroundColor: `${brandColors.primary}14`,
   },
   pillInactive: {
     borderColor: iosSystemColors.separator,

--- a/packages/mobile/src/components/Toast.tsx
+++ b/packages/mobile/src/components/Toast.tsx
@@ -7,7 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Text } from './Text';
 import { Icon } from './Icon';
 import type { IconName } from './icon-map';
-import { brandColors, blendOpaque, withAlpha } from '../theme/colors';
+import { blendOpaque, withAlpha } from '../theme/colors';
 import { borderRadius, spacing } from '../theme/tokens';
 import { TAB_BAR_HEIGHT, TOOLBAR_RESERVE } from '../theme/layout';
 import { isTabsRoute } from '../lib/route-segments';
@@ -27,12 +27,16 @@ type ToastProps = {
   onDismiss: (id: string) => void;
 };
 
-const VARIANT_CONFIG: Record<ToastVariant, { icon: IconName; color: string }> = {
-  success: { icon: 'success', color: brandColors.success },
-  error: { icon: 'error', color: brandColors.error },
-  info: { icon: 'info', color: brandColors.primary },
-  warning: { icon: 'warning', color: brandColors.warning },
-};
+// The icon glyph is static, but the colour must be scheme-aware: the `colorKey`
+// names a `brandColors` field resolved from `useTheme()` at render so dark mode
+// lifts to the brighter brand tones.
+const VARIANT_CONFIG: Record<ToastVariant, { icon: IconName; colorKey: 'success' | 'error' | 'primary' | 'warning' }> =
+  {
+    success: { icon: 'success', colorKey: 'success' },
+    error: { icon: 'error', colorKey: 'error' },
+    info: { icon: 'info', colorKey: 'primary' },
+    warning: { icon: 'warning', colorKey: 'warning' },
+  };
 
 /**
  * Toast routes to a Material 3 Paper Snackbar on the Material variant, and to the
@@ -63,9 +67,10 @@ function useToastBottomOffset() {
 }
 
 function ToastMaterial({ toast, onDismiss }: ToastProps) {
-  const { systemColors, colorScheme } = useTheme();
+  const { systemColors, colorScheme, brandColors } = useTheme();
   const bottomOffset = useToastBottomOffset();
   const config = VARIANT_CONFIG[toast.variant];
+  const variantColor = brandColors[config.colorKey];
 
   // Paper drives its own auto-dismiss timer off `duration` + `onDismiss`, so we
   // don't run a manual setTimeout on the Material path (it would double-fire).
@@ -84,7 +89,7 @@ function ToastMaterial({ toast, onDismiss }: ToastProps) {
   // opaque ref; blendOpaque also returns its background unchanged for non-hex
   // input, so the cast is safe.
   const backgroundColor = blendOpaque(
-    config.color,
+    variantColor,
     systemColors.secondaryBackground as string,
     colorScheme === 'dark' ? 0.24 : 0.15,
   );
@@ -102,8 +107,8 @@ function ToastMaterial({ toast, onDismiss }: ToastProps) {
           puts them on its container; here the content View is the equivalent
           announced node, so TalkBack reads the message assertively either way. */}
       <View style={styles.materialContent} accessibilityRole="alert" accessibilityLiveRegion="assertive">
-        <Icon name={config.icon} size={18} color={config.color} />
-        <Text variant="subheadline" color={config.color} style={styles.message} numberOfLines={2}>
+        <Icon name={config.icon} size={18} color={variantColor} />
+        <Text variant="subheadline" color={variantColor} style={styles.message} numberOfLines={2}>
           {toast.message}
         </Text>
       </View>
@@ -113,10 +118,11 @@ function ToastMaterial({ toast, onDismiss }: ToastProps) {
 
 // Liquid Glass / HIG toast — the original implementation, unchanged.
 function ToastGlass({ toast, onDismiss }: ToastProps) {
-  const { systemColors, colorScheme } = useTheme();
+  const { systemColors, colorScheme, brandColors } = useTheme();
   const bottomOffset = useToastBottomOffset();
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const config = VARIANT_CONFIG[toast.variant];
+  const variantColor = brandColors[config.colorKey];
 
   useEffect(() => {
     timerRef.current = setTimeout(() => onDismiss(toast.id), toast.duration);
@@ -128,7 +134,7 @@ function ToastGlass({ toast, onDismiss }: ToastProps) {
   // Opaque themed pill keeps the toast legible over any content; the brand-hued
   // wash on top carries the variant cue. Bump the wash alpha in dark mode where
   // a 15% tint barely registers.
-  const tintColor = withAlpha(config.color, colorScheme === 'dark' ? 0.24 : 0.15);
+  const tintColor = withAlpha(variantColor, colorScheme === 'dark' ? 0.24 : 0.15);
 
   return (
     <Animated.View
@@ -145,8 +151,8 @@ function ToastGlass({ toast, onDismiss }: ToastProps) {
       accessibilityLiveRegion="assertive"
     >
       <View pointerEvents="none" style={[StyleSheet.absoluteFill, { backgroundColor: tintColor }]} />
-      <Icon name={config.icon} size={18} color={config.color} />
-      <Text variant="subheadline" color={config.color} style={styles.message} numberOfLines={2}>
+      <Icon name={config.icon} size={18} color={variantColor} />
+      <Text variant="subheadline" color={variantColor} style={styles.message} numberOfLines={2}>
         {toast.message}
       </Text>
     </Animated.View>

--- a/packages/mobile/src/components/__tests__/glass-icon-button.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-icon-button.test.tsx
@@ -89,8 +89,11 @@ vi.mock('../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
 }));
 
+// GlassIconButton reads only `variant` from the theme; its count badge is a
+// white-text FILL drawn from the static `brandColors` import (mocked below), so
+// the theme mock deliberately omits brandColors rather than carry a dead field.
 vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({ variant: ctrl.variant, brandColors: { primary: '#6D28D9' } }),
+  useTheme: () => ({ variant: ctrl.variant }),
 }));
 
 // The material branch maps the semantic name to its MDI glyph via iconMap.
@@ -103,6 +106,7 @@ vi.mock('../icon-map', () => ({
   },
 }));
 
+// Live mock: the badge fill reads `brandColors.primary` from this static import.
 vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#6D28D9' } }));
 vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: { white: '#FFFFFF' } }));
 vi.mock('../../theme/animations', () => ({ timing: { fast: 150 } }));

--- a/packages/mobile/src/components/__tests__/glass-icon-button.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-icon-button.test.tsx
@@ -103,6 +103,7 @@ vi.mock('../icon-map', () => ({
   },
 }));
 
+vi.mock('../../theme/colors', () => ({ brandColors: { primary: '#6D28D9' } }));
 vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: { white: '#FFFFFF' } }));
 vi.mock('../../theme/animations', () => ({ timing: { fast: 150 } }));
 vi.mock('../../hooks/use-reduce-motion', () => ({ useReduceMotion: () => false }));

--- a/packages/mobile/src/components/__tests__/queue-added-snackbar.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-added-snackbar.test.tsx
@@ -76,7 +76,11 @@ vi.mock('../../theme/tokens', () => ({
   shadowColor: '#000',
 }));
 vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({ variant: ctrl.variant, systemColors: { secondaryBackground: '#EEE', label: '#000' } }),
+  useTheme: () => ({
+    variant: ctrl.variant,
+    brandColors: { primary: '#6D28D9' },
+    systemColors: { secondaryBackground: '#EEE', label: '#000' },
+  }),
 }));
 vi.mock('../../hooks/use-bottom-chrome-metrics', () => ({
   useBottomChromeMetrics: () => ({ floatingControlBottom: 100 }),

--- a/packages/mobile/src/components/__tests__/toast.test.tsx
+++ b/packages/mobile/src/components/__tests__/toast.test.tsx
@@ -69,6 +69,7 @@ vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({
     variant: ctrl.variant,
     colorScheme: 'light',
+    brandColors: { success: '#34C759', error: '#FF3B30', primary: '#6D28D9', warning: '#FF9500' },
     systemColors: { secondaryBackground: '#EEE', label: '#000' },
   }),
 }));

--- a/packages/mobile/src/components/__tests__/toast.test.tsx
+++ b/packages/mobile/src/components/__tests__/toast.test.tsx
@@ -56,7 +56,9 @@ vi.mock('../Text', () => ({
 }));
 vi.mock('../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }) }));
 vi.mock('../../theme/colors', () => ({
-  brandColors: { success: '#34C759', error: '#FF3B30', primary: '#6D28D9', warning: '#FF9500' },
+  // Real light-scheme brandColors values (the component reads these from useTheme;
+  // kept here in sync so the mock can't drift from the source palette).
+  brandColors: { success: '#047857', error: '#C81E1E', primary: '#6D28D9', warning: '#B45309' },
   withAlpha: (color: string) => color,
   // Encode both args so tests can assert the variant colour (foreground) and the
   // surface (background) both reach blendOpaque — i.e. the colour-selection logic.
@@ -69,7 +71,7 @@ vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({
     variant: ctrl.variant,
     colorScheme: 'light',
-    brandColors: { success: '#34C759', error: '#FF3B30', primary: '#6D28D9', warning: '#FF9500' },
+    brandColors: { success: '#047857', error: '#C81E1E', primary: '#6D28D9', warning: '#B45309' },
     systemColors: { secondaryBackground: '#EEE', label: '#000' },
   }),
 }));
@@ -90,7 +92,7 @@ describe('Toast', () => {
     // Variant cue carries through: leading icon, brand-tinted surface, alert role.
     expect(container.querySelector('[data-icon="success"]')).not.toBeNull();
     // blendOpaque(config.color, secondaryBackground): success → brand success hue.
-    expect(snackbar?.getAttribute('data-bg')).toBe('#34C759|#EEE');
+    expect(snackbar?.getAttribute('data-bg')).toBe('#047857|#EEE');
     expect(container.querySelector('[data-view][data-role="alert"]')).not.toBeNull();
     // The glass animated pill must not render on Material.
     expect(container.querySelector('[data-animated]')).toBeNull();
@@ -99,8 +101,8 @@ describe('Toast', () => {
   it('selects the matching icon + tint per variant on the Material variant', () => {
     ctrl.variant = 'material';
     const cases = [
-      { variant: 'error' as const, icon: 'error', color: '#FF3B30' },
-      { variant: 'warning' as const, icon: 'warning', color: '#FF9500' },
+      { variant: 'error' as const, icon: 'error', color: '#C81E1E' },
+      { variant: 'warning' as const, icon: 'warning', color: '#B45309' },
       { variant: 'info' as const, icon: 'info', color: '#6D28D9' },
     ];
     for (const { variant, icon, color } of cases) {

--- a/packages/mobile/src/components/ble/BleControlSheet.tsx
+++ b/packages/mobile/src/components/ble/BleControlSheet.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Sheet } from '../Sheet';
 import { ListRow } from '../ListRow';
 import { Icon } from '../Icon';
-import { brandColors } from '../../theme/colors';
+import { useTheme } from '../../providers/theme-provider';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
 
@@ -23,6 +23,7 @@ type BleControlSheetProps = {
 function BleControlSheet({ visible, onReassert, onDisconnect, onClose }: BleControlSheetProps) {
   const { t: tSettings } = useTranslation('settings');
   const { t: tCommon } = useTranslation('common');
+  const { brandColors } = useTheme();
   const sheetRef = useRef<BottomSheet>(null);
 
   useEffect(() => {

--- a/packages/mobile/src/components/ble/ConnectionBanner.tsx
+++ b/packages/mobile/src/components/ble/ConnectionBanner.tsx
@@ -14,7 +14,6 @@ import { useTheme } from '../../providers/theme-provider';
 import { hapticLight } from '../../lib/haptics';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { timing } from '../../theme/animations';
-import { brandColors } from '../../theme/colors';
 
 const AUTO_DISMISS_MS = 10_000;
 
@@ -50,7 +49,7 @@ function useSlideAnimation(
 
 export function ConnectionBanner({ visible, onReconnect, onDismiss }: ConnectionBannerProps) {
   const { t } = useTranslation('settings');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const autoDismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Keep the component mounted until the exit animation completes
@@ -102,7 +101,15 @@ export function ConnectionBanner({ visible, onReconnect, onDismiss }: Connection
 
   return (
     <Animated.View style={[styles.wrapper, animatedStyle]}>
-      <View style={styles.container}>
+      <View
+        style={[
+          styles.container,
+          {
+            backgroundColor: `${brandColors.warning}1F`,
+            borderColor: `${brandColors.warning}40`,
+          },
+        ]}
+      >
         <Icon name="bluetooth.off" size={18} color={brandColors.warning} />
 
         <Text variant="subheadline" color={systemColors.label} style={styles.messageText} numberOfLines={1}>
@@ -136,9 +143,7 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: `${brandColors.warning}1F`,
     borderWidth: 1,
-    borderColor: `${brandColors.warning}40`,
     borderRadius: borderRadius.lg,
     paddingHorizontal: spacing[3],
     paddingVertical: spacing[2],

--- a/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
@@ -6,7 +6,6 @@ import { getBoardRenderData } from '../../lib/board-details';
 import { hapticLight } from '../../lib/haptics';
 import { springs } from '../../theme/animations';
 import { spacing, borderRadius, overlays } from '../../theme/tokens';
-import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { useTheme } from '../../providers/theme-provider';
 import { Text } from '../Text';
@@ -47,7 +46,7 @@ type BoardDiscoveryCardProps = {
 };
 
 export function BoardDiscoveryCard({ item, onPress }: BoardDiscoveryCardProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const scale = useSharedValue(1);
 
   const animatedStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));

--- a/packages/mobile/src/components/board-discovery/BoardModeCard.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardModeCard.tsx
@@ -3,7 +3,6 @@ import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-na
 import { hapticLight } from '../../lib/haptics';
 import { springs } from '../../theme/animations';
 import { spacing, borderRadius } from '../../theme/tokens';
-import { brandColors } from '../../theme/colors';
 import { useTheme } from '../../providers/theme-provider';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
@@ -29,7 +28,7 @@ type BoardModeCardProps = {
  * idle is tappable, loading shows a spinner, denied/unavailable dim and disable.
  */
 export function BoardModeCard({ icon, label, sublabel, state = 'idle', onPress }: BoardModeCardProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const scale = useSharedValue(1);
   const animatedStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
 

--- a/packages/mobile/src/components/board-discovery/CustomBoardSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/CustomBoardSheet.tsx
@@ -55,7 +55,7 @@ export const CustomBoardSheet = forwardRef<BottomSheet, CustomBoardSheetProps>(f
   { seed, existingBoards, onCreated, onSelectExisting, onError },
   ref,
 ) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors: themeBrandColors } = useTheme();
   const { t } = useTranslation('boards');
   const createBoard = useCreateBoard();
 
@@ -174,7 +174,10 @@ export const CustomBoardSheet = forwardRef<BottomSheet, CustomBoardSheetProps>(f
             style={[
               styles.chip,
               {
-                borderColor: selected ? brandColors.primary : systemColors.separator,
+                // Border is a foreground accent → scheme-aware (lifts in dark).
+                borderColor: selected ? themeBrandColors.primary : systemColors.separator,
+                // Fill stays static: the selected chip's label turns white and
+                // must sit on the saturated brand fill at full contrast.
                 backgroundColor: selected ? brandColors.primary : 'transparent',
               },
             ]}

--- a/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
@@ -161,7 +161,11 @@ function SaveButton({ saveState, onSave }: { saveState: SaveButtonState; onSave:
       icon={view.icon ?? undefined}
       variant="filled"
       size="small"
-      tintColor={view.tint === 'success' ? brandColors.success : brandColors.primary}
+      // Success keeps the static green fill (white-legible in both schemes; the
+      // lifted dark success tint would fail white-on-fill). For the default tint
+      // we pass nothing so the filled Button uses its own scheme-aware
+      // `primaryFill` (lifts to #7C3AED in dark), matching every other CTA.
+      tintColor={view.tint === 'success' ? brandColors.success : undefined}
       disabled={view.disabled}
       onPress={onSave}
     />

--- a/packages/mobile/src/components/create-climb/DuplicateBanner.tsx
+++ b/packages/mobile/src/components/create-climb/DuplicateBanner.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { useTheme } from '../../providers/theme-provider';
-import { brandColors } from '../../theme/colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 
 type DuplicateBannerProps = {
@@ -19,7 +18,7 @@ type DuplicateBannerProps = {
  */
 export function DuplicateBanner({ name, onView, onDismiss }: DuplicateBannerProps) {
   const { t } = useTranslation('climbs');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   return (
     <View style={[styles.banner, { backgroundColor: systemColors.fill }]}>
       <View style={styles.bannerText}>

--- a/packages/mobile/src/components/grade/GradeChip.tsx
+++ b/packages/mobile/src/components/grade/GradeChip.tsx
@@ -10,7 +10,7 @@ import {
 import { Text } from '../Text';
 import { PressableSurface } from '../PressableSurface';
 import { useTheme } from '../../providers/theme-provider';
-import { brandColors, withAlpha } from '../../theme/colors';
+import { withAlpha } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { readableTextColor } from './grade-chip-colors';
 
@@ -39,7 +39,7 @@ export function GradeChip({
   onLayout,
   style,
 }: GradeChipProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const accentColor = gradeColor ?? brandColors.primary;
   const selected = tone === 'selected';
   const ranged = tone === 'range';

--- a/packages/mobile/src/components/grade/GradeRail.tsx
+++ b/packages/mobile/src/components/grade/GradeRail.tsx
@@ -23,7 +23,6 @@ import { useTheme } from '../../providers/theme-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { gradeRailCenter } from '../../lib/grade-seed';
 import { hapticSelection } from '../../lib/haptics';
-import { brandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { GradeChip } from './GradeChip';
 
@@ -83,7 +82,7 @@ export function GradeRangeRail({
   style,
 }: GradeRangeRailProps) {
   const { t } = useTranslation('climbs');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { formatGrade } = useGradeFormat();
   const scrollRef = useRef<ElementRef<typeof ScrollView>>(null);
   const chipLayoutsRef = useRef<Record<number, ChipLayout>>({});

--- a/packages/mobile/src/components/grade/__tests__/grade-range-rail.test.tsx
+++ b/packages/mobile/src/components/grade/__tests__/grade-range-rail.test.tsx
@@ -118,6 +118,7 @@ vi.mock('../../Icon', () => ({
 
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
+    brandColors: { primary: '#6D28D9' },
     systemColors: {
       fill: '#eee',
       secondaryBackground: '#fff',

--- a/packages/mobile/src/components/navigation/MaterialTabBar.tsx
+++ b/packages/mobile/src/components/navigation/MaterialTabBar.tsx
@@ -3,7 +3,7 @@ import type { BottomTabBarProps } from 'expo-router/tabs';
 import { Text } from '../Text';
 import { PressableSurface } from '../PressableSurface';
 import { useTheme } from '../../providers/theme-provider';
-import { withAlpha } from '../../theme/colors';
+import { brandColors as staticBrandColors, withAlpha } from '../../theme/colors';
 import { material } from '../../theme/tokens';
 import { TAB_BAR_HEIGHT } from '../../theme/layout';
 
@@ -73,7 +73,9 @@ export function MaterialTabBar({ state, descriptors, navigation, insets }: Botto
                   testID="badge"
                   style={[
                     styles.badge,
-                    { backgroundColor: brandColors.success, borderColor: systemColors.elevatedSurface },
+                    // Badge dot is a FILL (no text on it) → static light brand
+                    // success, not the scheme-lifted theme value.
+                    { backgroundColor: staticBrandColors.success, borderColor: systemColors.elevatedSurface },
                   ]}
                 />
               ) : null}

--- a/packages/mobile/src/components/play-drawer/BetaVideosSection.tsx
+++ b/packages/mobile/src/components/play-drawer/BetaVideosSection.tsx
@@ -7,8 +7,8 @@ import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { useBetaLinks } from '../../lib/graphql/hooks';
 import { useAuth } from '../../providers/auth-provider';
+import { useTheme } from '../../providers/theme-provider';
 import { iosSystemColors } from '../../theme/ios-colors';
-import { brandColors } from '../../theme/colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { BetaVideoCard, BETA_CARD_WIDTH, BETA_CARD_HEIGHT } from './BetaVideoCard';
 import { BetaVideoAddSheet, type BetaVideoAddSheetHandle } from './BetaVideoAddSheet';
@@ -29,6 +29,7 @@ export const BetaVideosSection = memo(function BetaVideosSection({
 }: BetaVideosSectionProps) {
   const { t } = useTranslation('session');
   const { isAuthenticated } = useAuth();
+  const { brandColors } = useTheme();
   const addSheetRef = useRef<BetaVideoAddSheetHandle>(null);
   const { data: links, isLoading, isError, refetch, isRefetching } = useBetaLinks(boardName, climbUuid);
 
@@ -58,7 +59,7 @@ export const BetaVideosSection = memo(function BetaVideosSection({
             onPress={handleOpenAddSheet}
             accessibilityRole="button"
             accessibilityLabel={t('mobile.betaVideos.addButton')}
-            style={({ pressed }) => [styles.addButton, pressed && styles.addButtonPressed]}
+            style={({ pressed }) => [styles.addButton, pressed && { backgroundColor: `${brandColors.primary}1A` }]}
             hitSlop={8}
           >
             <Icon name="add" size={22} color={brandColors.primary} />
@@ -90,8 +91,9 @@ export const BetaVideosSection = memo(function BetaVideosSection({
             accessibilityLabel={t('mobile.betaVideos.retry')}
             style={({ pressed }) => [
               styles.retryButton,
+              { borderColor: brandColors.primary },
               isRefetching && styles.retryButtonDisabled,
-              pressed && !isRefetching && styles.retryButtonPressed,
+              pressed && !isRefetching && { backgroundColor: `${brandColors.primary}1A` },
             ]}
           >
             <Text variant="footnote" color={brandColors.primary}>
@@ -145,9 +147,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     borderRadius: borderRadius.full,
   },
-  addButtonPressed: {
-    backgroundColor: `${brandColors.primary}1A`,
-  },
   scrollContent: {
     gap: CARD_GAP,
     paddingVertical: spacing[1],
@@ -178,12 +177,8 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[1],
     borderRadius: borderRadius.full,
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: brandColors.primary,
   },
   retryButtonDisabled: {
     opacity: 0.5,
-  },
-  retryButtonPressed: {
-    backgroundColor: `${brandColors.primary}1A`,
   },
 });

--- a/packages/mobile/src/components/play-drawer/InlineStarPicker.tsx
+++ b/packages/mobile/src/components/play-drawer/InlineStarPicker.tsx
@@ -2,10 +2,10 @@ import React, { useCallback } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../Icon';
-import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { hapticSelection } from '../../lib/haptics';
 import { spacing } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
 
 type InlineStarPickerProps = {
   quality: number | null;
@@ -14,6 +14,7 @@ type InlineStarPickerProps = {
 
 export const InlineStarPicker = React.memo(function InlineStarPicker({ quality, onSelect }: InlineStarPickerProps) {
   const { t } = useTranslation('session');
+  const { brandColors } = useTheme();
 
   const handlePress = useCallback(
     (value: number) => {

--- a/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
@@ -5,6 +5,7 @@ import { Icon } from '../Icon';
 import { Text } from '../Text';
 import { BleLightbulbButton } from '../ble/BleLightbulbButton';
 import { ActionButton, SIZES, type ButtonSize, drawerActionBarStyles } from '../drawer-action-bar/DrawerActionBar';
+import { useTheme } from '../../providers/theme-provider';
 import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { glassSize } from '../../theme/layout';
@@ -68,6 +69,7 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
   const { t } = useTranslation('session');
   const { t: tClimbs } = useTranslation('climbs');
   const { t: tSettings } = useTranslation('settings');
+  const theme = useTheme();
 
   const handlePrev = useCallback(() => {
     hapticMedium();
@@ -109,7 +111,7 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
               iconName="mirror"
               onPress={handleMirror}
               active={isMirrored}
-              activeColor={brandColors.primary}
+              activeColor={theme.brandColors.primary}
               accessibilityLabel={
                 isMirrored ? t('playView.actionBar.unmirrorAria') : t('playView.actionBar.mirrorAria')
               }
@@ -264,6 +266,7 @@ type TickButtonProps = {
 
 function TickButton({ size, ascentCount, onPress, onLongPress, accessibilityLabel }: TickButtonProps) {
   const { dim, icon } = SIZES[size];
+  const theme = useTheme();
   const handlePress = useCallback(() => {
     hapticMedium();
     onPress();
@@ -288,7 +291,7 @@ function TickButton({ size, ascentCount, onPress, onLongPress, accessibilityLabe
     >
       {/* The primary log action: a green glyph on the glass sheet (colour on the
           icon, not a fill) — its hue and the count badge mark it as the hero. */}
-      <Icon name="tick.outline" size={icon} color={brandColors.success} />
+      <Icon name="tick.outline" size={icon} color={theme.brandColors.success} />
       {ascentCount > 0 && (
         <View style={styles.countBadge}>
           <Text variant="caption2" color={iosSystemColors.white} style={styles.countText}>

--- a/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
@@ -6,7 +6,10 @@ import { Text } from '../Text';
 import { BleLightbulbButton } from '../ble/BleLightbulbButton';
 import { ActionButton, SIZES, type ButtonSize, drawerActionBarStyles } from '../drawer-action-bar/DrawerActionBar';
 import { useTheme } from '../../providers/theme-provider';
-import { brandColors } from '../../theme/colors';
+// Aliased: foregrounds in this file read scheme-aware brand from `useTheme()`.
+// `staticBrandColors` is the static set, used only for the count badge — a FILL
+// with white text that must stay legible in both schemes.
+import { brandColors as staticBrandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { glassSize } from '../../theme/layout';
 import { hapticMedium } from '../../lib/haptics';
@@ -325,7 +328,8 @@ const styles = StyleSheet.create({
     minWidth: 16,
     height: 16,
     borderRadius: 8,
-    backgroundColor: brandColors.primary,
+    // FILL with white count text → static brand (see import note).
+    backgroundColor: staticBrandColors.primary,
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 3,

--- a/packages/mobile/src/components/play-drawer/PlaybackControls.tsx
+++ b/packages/mobile/src/components/play-drawer/PlaybackControls.tsx
@@ -158,7 +158,8 @@ function SpeedSlider({
   onChange: (speed: number) => void;
   onLiveChange: (speed: number) => void;
 }) {
-  const { systemColors } = useTheme();
+  const theme = useTheme();
+  const { systemColors } = theme;
   const [trackWidth, setTrackWidth] = useState(0);
   const usable = Math.max(0, trackWidth - THUMB_SIZE);
   const position = useSharedValue(0);
@@ -261,7 +262,7 @@ function SpeedSlider({
     <GestureDetector gesture={composed}>
       <View style={styles.sliderTrackWrapper} onLayout={handleLayout}>
         <View style={[styles.sliderTrack, { backgroundColor: systemColors.fill }]} />
-        <Animated.View style={[styles.sliderFill, fillStyle]} />
+        <Animated.View style={[styles.sliderFill, { backgroundColor: theme.brandColors.primary }, fillStyle]} />
         <Animated.View style={[styles.sliderThumb, thumbStyle]} />
       </View>
     </GestureDetector>
@@ -288,7 +289,8 @@ export function PlaybackControls({
   onSeek,
   onSpeedChange,
 }: PlaybackControlsProps) {
-  const { systemColors } = useTheme();
+  const theme = useTheme();
+  const { systemColors } = theme;
   const { t } = useTranslation('session');
   const atFirstFrame = frameIndex <= 0;
   const atLastFrame = frameIndex >= frameCount - 1;
@@ -362,7 +364,10 @@ export function PlaybackControls({
 
   return (
     <View style={[styles.container, { backgroundColor: systemColors.tertiaryBackground }]}>
-      <Animated.View style={[styles.progressBar, progressStyle]} pointerEvents="none" />
+      <Animated.View
+        style={[styles.progressBar, { backgroundColor: theme.brandColors.primary }, progressStyle]}
+        pointerEvents="none"
+      />
 
       <View style={styles.transportRow}>
         <View style={styles.sideLeft}>
@@ -445,7 +450,6 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     height: 3,
-    backgroundColor: brandColors.primary,
   },
   transportRow: {
     flexDirection: 'row',
@@ -509,7 +513,6 @@ const styles = StyleSheet.create({
     left: 0,
     height: TRACK_HEIGHT,
     borderRadius: TRACK_HEIGHT / 2,
-    backgroundColor: brandColors.primary,
   },
   sliderThumb: {
     position: 'absolute',

--- a/packages/mobile/src/components/play-drawer/PlaybackControls.tsx
+++ b/packages/mobile/src/components/play-drawer/PlaybackControls.tsx
@@ -17,7 +17,11 @@ import { Icon } from '../Icon';
 import type { IconName } from '../icon-map';
 import { useTheme } from '../../providers/theme-provider';
 import { hapticLight, hapticSelection, hapticSuccess } from '../../lib/haptics';
-import { brandColors } from '../../theme/colors';
+// Aliased: this file reads scheme-aware brand from `useTheme()` for foregrounds
+// (slider/progress fills). `staticBrandColors` is intentionally the static set,
+// used only for the active speed pill — a FILL with white text that must stay
+// legible in both schemes (the lifted dark tint would fail white-on-fill).
+import { brandColors as staticBrandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { springs, timing } from '../../theme/animations';
@@ -132,7 +136,11 @@ function SpeedPill({
       accessibilityRole="button"
       accessibilityState={{ expanded: active }}
       accessibilityLabel={accessibilityLabel}
-      style={[styles.speedPill, { backgroundColor: active ? brandColors.primary : systemColors.fill }, animatedStyle]}
+      style={[
+        styles.speedPill,
+        { backgroundColor: active ? staticBrandColors.primary : systemColors.fill },
+        animatedStyle,
+      ]}
     >
       <Text variant="footnote" color={active ? iosSystemColors.white : systemColors.label} style={styles.speedPillText}>
         {label}

--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -11,7 +11,6 @@ import { Text } from '../Text';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
-import { brandColors } from '../../theme/colors';
 import { hapticSelection } from '../../lib/haptics';
 import { useSearchClimbs } from '../../lib/graphql/hooks';
 import { toClimbSearchInput, DEFAULT_CLIMB_FILTER_STATE } from '@boardsesh/climb-filters';
@@ -75,7 +74,7 @@ export function QueueList({
   onDraggingChange,
 }: QueueListProps) {
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const flatListRef = useRef<BottomSheetFlatListMethods | null>(null);
 
   const { flatRows, currentItemFlatIndex } = useMemo(
@@ -326,6 +325,7 @@ export function QueueList({
       handleSuggestionPress,
       systemColors.separator,
       systemColors.secondaryBackground,
+      brandColors.primary,
       t,
     ],
   );

--- a/packages/mobile/src/components/play-drawer/QueueSheetHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheetHeader.tsx
@@ -3,7 +3,7 @@ import { View, Pressable, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
-import { brandColors } from '../../theme/colors';
+import { useTheme } from '../../providers/theme-provider';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
 import { hapticSelection } from '../../lib/haptics';
@@ -32,6 +32,7 @@ export const QueueSheetHeader = memo(function QueueSheetHeader({
   onClearAll,
 }: QueueSheetHeaderProps) {
   const { t } = useTranslation('session');
+  const { brandColors } = useTheme();
 
   const handleToggleHistory = useCallback(() => {
     hapticSelection();
@@ -86,7 +87,11 @@ export const QueueSheetHeader = memo(function QueueSheetHeader({
           accessibilityRole="button"
           accessibilityLabel={t('mobile.queueSheet.toggleHistory')}
           hitSlop={8}
-          style={[styles.headerButton, showHistory && styles.headerButtonActive]}
+          style={[
+            styles.headerButton,
+            showHistory && styles.headerButtonActive,
+            showHistory && { borderColor: brandColors.primary, backgroundColor: `${brandColors.primary}14` },
+          ]}
         >
           <Icon name="history" size={22} color={showHistory ? brandColors.primary : iosSystemColors.systemGray} />
         </Pressable>
@@ -163,7 +168,5 @@ const styles = StyleSheet.create({
   },
   headerButtonActive: {
     borderWidth: 1,
-    borderColor: brandColors.primary,
-    backgroundColor: `${brandColors.primary}14`,
   },
 });

--- a/packages/mobile/src/components/play-drawer/SimilarClimbsSection.tsx
+++ b/packages/mobile/src/components/play-drawer/SimilarClimbsSection.tsx
@@ -10,8 +10,8 @@ import { ClimbListThumbnail } from '../ClimbListThumbnail';
 import { buildClimbStub, formatByline, rankBySizeCompatibility } from './similar-climbs-utils';
 import { useSimilarClimbs } from '../../lib/graphql/hooks';
 import { useGradeFormat } from '../../hooks/use-grade-format';
+import { useTheme } from '../../providers/theme-provider';
 import { iosSystemColors } from '../../theme/ios-colors';
-import { brandColors } from '../../theme/colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 
 type SimilarClimbsSectionProps = {
@@ -38,6 +38,7 @@ export const SimilarClimbsSection = memo(function SimilarClimbsSection({
 }: SimilarClimbsSectionProps) {
   const { t } = useTranslation('session');
   const { t: tClimbs } = useTranslation('climbs');
+  const { brandColors } = useTheme();
   const { formatGrade } = useGradeFormat();
   const { data: climbs, isLoading, isError, refetch } = useSimilarClimbs(boardName, climbUuid, layoutId, angle);
 

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-action-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-action-bar.test.tsx
@@ -65,6 +65,9 @@ vi.mock('../../drawer-action-bar/DrawerActionBar', () => ({
   },
 }));
 vi.mock('../../../theme/colors', () => ({ brandColors: { primary: '#6D28D9', success: '#047857' } }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ brandColors: { primary: '#6D28D9', success: '#047857' } }),
+}));
 vi.mock('../../../theme/ios-colors', () => ({
   iosSystemColors: { white: '#FFFFFF', systemGray: '#8E8E93', systemRed: '#FF3B30', separator: '#ccc' },
 }));

--- a/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { ModalSheet } from '../ModalSheet';
 import { ListRow } from '../ListRow';
 import { Icon } from '../Icon';
+import { useTheme } from '../../providers/theme-provider';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
 
@@ -21,6 +22,7 @@ type PlaylistActionsMenuProps = {
  */
 export function PlaylistActionsMenu({ visible, onEdit, onDelete, onClose }: PlaylistActionsMenuProps) {
   const { t } = useTranslation('playlists');
+  const { systemColors } = useTheme();
   const sheetRef = useRef<BottomSheetModal>(null);
   // Track presented state so we never call dismiss() on a not-presented modal
   // (which leaves gorhom in a state where the next present() is a no-op — the
@@ -49,7 +51,7 @@ export function PlaylistActionsMenu({ visible, onEdit, onDelete, onClose }: Play
       <View style={styles.content}>
         <ListRow
           title={t('detail.menu.edit')}
-          leading={<Icon name="edit" size={22} color={iosSystemColors.systemBlue} />}
+          leading={<Icon name="edit" size={22} color={systemColors.accent} />}
           onPress={onEdit}
           showSeparator
         />

--- a/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
@@ -11,7 +11,6 @@ import { SwitchRow } from '../SwitchRow';
 import { PlaylistPreviewSquare } from './PlaylistPreviewSquare';
 import { PLAYLIST_COLORS } from './playlist-colors';
 import { useTheme } from '../../providers/theme-provider';
-import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
 import { buildPlaylistFormValues, NAME_MAX, DESCRIPTION_MAX, type PlaylistFormValues } from './playlist-form-values';
@@ -42,7 +41,7 @@ type PlaylistFormSheetProps = {
  */
 export function PlaylistFormSheet({ mode, visible, submitting, playlist, onSubmit, onClose }: PlaylistFormSheetProps) {
   const { t } = useTranslation('playlists');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const sheetRef = useRef<BottomSheetModal>(null);
   const isEdit = mode === 'edit';
 
@@ -201,7 +200,9 @@ export function PlaylistFormSheet({ mode, visible, submitting, playlist, onSubmi
                 style={[
                   styles.emojiChip,
                   { backgroundColor: systemColors.fill },
-                  selected && styles.emojiChipSelected,
+                  // Selected border is a FOREGROUND → scheme-aware brand (the
+                  // StyleSheet can't read the theme, so the colour is inline).
+                  selected && [styles.emojiChipSelected, { borderColor: brandColors.primary }],
                 ]}
               >
                 <Text style={styles.emoji} allowFontScaling={false}>
@@ -303,7 +304,6 @@ const styles = StyleSheet.create({
   },
   emojiChipSelected: {
     borderWidth: 2,
-    borderColor: brandColors.primary,
   },
   emoji: {
     fontSize: 22,

--- a/packages/mobile/src/components/playlist/PlaylistPinButton.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistPinButton.tsx
@@ -2,7 +2,7 @@ import { Pressable, StyleSheet, type StyleProp, type ViewStyle } from 'react-nat
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../Icon';
 import { hapticSelection } from '../../lib/haptics';
-import { brandColors } from '../../theme/colors';
+import { useTheme } from '../../providers/theme-provider';
 import { iosSystemColors } from '../../theme/ios-colors';
 
 type PlaylistPinButtonProps = {
@@ -19,6 +19,7 @@ type PlaylistPinButtonProps = {
  */
 export function PlaylistPinButton({ isPinned, onToggle, size = 22, style }: PlaylistPinButtonProps) {
   const { t } = useTranslation('playlists');
+  const { brandColors } = useTheme();
   return (
     <Pressable
       onPress={() => {

--- a/packages/mobile/src/components/session-screen/SessionScreenHeader.tsx
+++ b/packages/mobile/src/components/session-screen/SessionScreenHeader.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { useTheme } from '../../providers/theme-provider';
-import { brandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 
 type SessionScreenHeaderProps = {
@@ -41,7 +40,7 @@ export function SessionScreenHeader({
   dragGesture,
 }: SessionScreenHeaderProps) {
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
 
   const title = sessionActive ? t('mobile.session.headerActive') : t('mobile.session.headerStart');
 

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -31,7 +31,7 @@ import { getBoardConfigForPlaylist } from '../../../lib/playlists/board-details-
 import { navigateToSessionClimb } from '../../../lib/session-tick-mapping';
 import { useGradeFormat } from '../../../hooks/use-grade-format';
 import { useBottomChromeMetrics } from '../../../hooks/use-bottom-chrome-metrics';
-import { brandColors, withAlpha } from '../../../theme/colors';
+import { withAlpha } from '../../../theme/colors';
 import { iosSystemColors } from '../../../theme/ios-colors';
 import { springs } from '../../../theme/animations';
 import { borderRadius, spacing } from '../../../theme/tokens';
@@ -61,14 +61,31 @@ function isSessionHistoryTick(tick: SessionDetailTick): tick is SessionDetailTic
   return isSessionHistoryStatus(tick.status);
 }
 
-function statusMeta(status: SessionHistoryStatus): { icon: IconName; tint: string } {
+// Icon name per status — colour-free so the map can stay at module scope. The
+// matching tint is resolved in render from the scheme-aware theme brand colours
+// (see `statusTint`), since `flash`/`send` are brand foregrounds that must lift
+// in dark mode.
+function statusIcon(status: SessionHistoryStatus): IconName {
   switch (status) {
     case 'flash':
-      return { icon: 'flash', tint: brandColors.warning };
+      return 'flash';
     case 'send':
-      return { icon: 'tick', tint: brandColors.success };
+      return 'tick';
     case 'attempt':
-      return { icon: 'circle', tint: iosSystemColors.systemGray };
+      return 'circle';
+  }
+}
+
+// Resolve the status tint from the current theme. `flash`/`send` are brand
+// foregrounds (lifted in dark); `attempt` stays the neutral system gray.
+function statusTint(status: SessionHistoryStatus, brand: { warning: string; success: string }): string {
+  switch (status) {
+    case 'flash':
+      return brand.warning;
+    case 'send':
+      return brand.success;
+    case 'attempt':
+      return iosSystemColors.systemGray;
   }
 }
 
@@ -108,9 +125,10 @@ type SessionHistoryRowProps = {
 
 function SessionHistoryRow({ tick, status, participant, onPress }: SessionHistoryRowProps) {
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { formatGrade, formatGradeByDifficultyId } = useGradeFormat();
-  const meta = statusMeta(status);
+  const statusIconName = statusIcon(status);
+  const statusColor = statusTint(status, brandColors);
   let statusLabel: string;
   switch (status) {
     case 'flash':
@@ -152,8 +170,8 @@ function SessionHistoryRow({ tick, status, participant, onPress }: SessionHistor
         style={[styles.historyRow, { backgroundColor: systemColors.secondaryBackground }]}
       >
         <View style={styles.historyStatusSlot}>
-          <View style={[styles.historyStatusIcon, { backgroundColor: withAlpha(meta.tint, 0.15) }]}>
-            <Icon name={meta.icon} size={14} color={meta.tint} />
+          <View style={[styles.historyStatusIcon, { backgroundColor: withAlpha(statusColor, 0.15) }]}>
+            <Icon name={statusIconName} size={14} color={statusColor} />
           </View>
         </View>
 
@@ -186,8 +204,8 @@ function SessionHistoryRow({ tick, status, participant, onPress }: SessionHistor
           </>
         )}
 
-        <View style={[styles.historyStatusPill, { backgroundColor: withAlpha(meta.tint, 0.15) }]}>
-          <Text variant="caption1" color={meta.tint} style={styles.historyStatusLabel}>
+        <View style={[styles.historyStatusPill, { backgroundColor: withAlpha(statusColor, 0.15) }]}>
+          <Text variant="caption1" color={statusColor} style={styles.historyStatusLabel}>
             {statusLabel}
           </Text>
         </View>

--- a/packages/mobile/src/components/session-screen/in-session/SessionAnalytics.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/SessionAnalytics.tsx
@@ -8,7 +8,6 @@ import { type IconName } from '../../icon-map';
 import { Avatar } from '../../Avatar';
 import { useTheme } from '../../../providers/theme-provider';
 import { gradeBadgeColor } from '../../you/profile-chart-colors';
-import { brandColors } from '../../../theme/colors';
 import { spacing, borderRadius } from '../../../theme/tokens';
 import { hapticSuccess } from '../../../lib/haptics';
 import { useGradeFormat } from '../../../hooks/use-grade-format';
@@ -43,7 +42,7 @@ export function SessionAnalytics({
   gradeDistribution,
 }: SessionAnalyticsProps) {
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { formatGrade, formatGradeByDifficultyId } = useGradeFormat();
 
   // Celebrate a fresh hardest grade once. Seeded with the initial grade so the

--- a/packages/mobile/src/components/session-screen/in-session/SessionLeaderboard.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/SessionLeaderboard.tsx
@@ -8,7 +8,7 @@ import { type IconName } from '../../icon-map';
 import { Avatar } from '../../Avatar';
 import { SectionHeader } from '../../SectionHeader';
 import { useTheme } from '../../../providers/theme-provider';
-import { brandColors, withAlpha } from '../../../theme/colors';
+import { withAlpha } from '../../../theme/colors';
 import { iosSystemColors } from '../../../theme/ios-colors';
 import { spacing, borderRadius } from '../../../theme/tokens';
 
@@ -26,7 +26,7 @@ type SessionLeaderboardProps = {
  */
 export function SessionLeaderboard({ participants, driverUserId, selfUserId }: SessionLeaderboardProps) {
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
 
   const ranked = useMemo(
     () => [...participants].sort((a, b) => b.sends - a.sends || b.flashes - a.flashes),

--- a/packages/mobile/src/components/session-screen/in-session/SessionPresenceRow.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/SessionPresenceRow.tsx
@@ -6,7 +6,6 @@ import { Text } from '../../Text';
 import { Icon } from '../../Icon';
 import { AvatarGroup } from '../../you/AvatarGroup';
 import { useTheme } from '../../../providers/theme-provider';
-import { brandColors } from '../../../theme/colors';
 import { spacing, opacity } from '../../../theme/tokens';
 
 type SessionPresenceRowProps = {
@@ -23,7 +22,7 @@ type SessionPresenceRowProps = {
  */
 export function SessionPresenceRow({ users, driverParticipantId, selfParticipantId }: SessionPresenceRowProps) {
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
 
   // Connected climbers first so the visible (non-overflow) avatars favour the
   // people actually present. The AvatarGroup participant shape carries no

--- a/packages/mobile/src/components/session-screen/in-session/SessionStatsHeader.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/SessionStatsHeader.tsx
@@ -4,7 +4,7 @@ import type { SessionSummary } from '@boardsesh/shared-schema';
 import { Text } from '../../Text';
 import { Icon } from '../../Icon';
 import { useTheme } from '../../../providers/theme-provider';
-import { brandColors } from '../../../theme/colors';
+import { brandColors as staticBrandColors } from '../../../theme/colors';
 import { spacing, borderRadius } from '../../../theme/tokens';
 import { useGradeFormat } from '../../../hooks/use-grade-format';
 import { SessionTimer } from './SessionTimer';
@@ -21,7 +21,7 @@ type SessionStatsHeaderProps = {
  */
 export function SessionStatsHeader({ summary }: SessionStatsHeaderProps) {
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { formatGrade } = useGradeFormat();
 
   const sends = summary?.totalSends ?? 0;
@@ -62,7 +62,7 @@ export function SessionStatsHeader({ summary }: SessionStatsHeaderProps) {
             {t('mobile.session.inStatsHardest')}
           </Text>
           <View style={styles.hardestRow}>
-            <View style={[styles.gradeBadge, { backgroundColor: brandColors.primary }]}>
+            <View style={[styles.gradeBadge, { backgroundColor: staticBrandColors.primary }]}>
               <Text variant="subheadline" color="#FFFFFF" style={styles.gradeBadgeText}>
                 {formatGrade(hardest.grade) ?? hardest.grade}
               </Text>
@@ -70,6 +70,8 @@ export function SessionStatsHeader({ summary }: SessionStatsHeaderProps) {
             <Text variant="body" numberOfLines={1} style={styles.hardestName}>
               {hardest.climbName}
             </Text>
+            {/* gradeBadge above keeps the static brand fill (white text on it);
+                this star glyph is a foreground → scheme-aware brand warning. */}
             <Icon name="star.fill" size={18} color={brandColors.warning} />
           </View>
         </View>

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/session-leaderboard.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/session-leaderboard.test.tsx
@@ -34,6 +34,11 @@ vi.mock('../../../SectionHeader', () => ({
 
 vi.mock('../../../../providers/theme-provider', () => ({
   useTheme: () => ({
+    brandColors: {
+      primary: '#007aff',
+      success: '#34c759',
+      warning: '#ff9500',
+    },
     systemColors: {
       secondaryBackground: '#f2f2f7',
       separator: '#c6c6c8',

--- a/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
@@ -14,7 +14,7 @@ import { Text } from '../../Text';
 import { useTheme } from '../../../providers/theme-provider';
 import { useGradeFormat } from '../../../hooks/use-grade-format';
 import { spacing, borderRadius } from '../../../theme/tokens';
-import { brandColors } from '../../../theme/colors';
+import { brandColors as staticBrandColors } from '../../../theme/colors';
 import { iosSystemColors } from '../../../theme/ios-colors';
 
 export type GeneratorSelection = { type: 'off' } | { type: 'on'; options: GeneratorOptions };
@@ -76,7 +76,7 @@ function getDefaultTargetGrade(boardName: BoardName | null): number {
  */
 export function GeneratorPickerCard({ boardName, selection, onChange }: GeneratorPickerCardProps) {
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { formatGrade } = useGradeFormat();
 
   const handleSelectType = (value: ChipValue) => {
@@ -114,8 +114,10 @@ export function GeneratorPickerCard({ boardName, selection, onChange }: Generato
               style={[
                 styles.chip,
                 {
+                  // Border is a FOREGROUND → scheme-aware brand; the active fill
+                  // (white text on it) stays the static light brand.
                   borderColor: isActive ? brandColors.primary : systemColors.separator,
-                  backgroundColor: isActive ? brandColors.primary : 'transparent',
+                  backgroundColor: isActive ? staticBrandColors.primary : 'transparent',
                 },
               ]}
               accessibilityRole="button"
@@ -145,8 +147,9 @@ export function GeneratorPickerCard({ boardName, selection, onChange }: Generato
                   style={[
                     styles.gradeChip,
                     {
+                      // Border is a FOREGROUND → scheme-aware; active fill stays static.
                       borderColor: isActive ? brandColors.primary : systemColors.separator,
-                      backgroundColor: isActive ? brandColors.primary : 'transparent',
+                      backgroundColor: isActive ? staticBrandColors.primary : 'transparent',
                     },
                   ]}
                   accessibilityRole="button"

--- a/packages/mobile/src/components/session/SessionParticipantBreakdown.tsx
+++ b/packages/mobile/src/components/session/SessionParticipantBreakdown.tsx
@@ -7,7 +7,7 @@ import { type IconName } from '../icon-map';
 import { Avatar } from '../Avatar';
 import { ListRow } from '../ListRow';
 import { SectionHeader } from '../SectionHeader';
-import { brandColors, withAlpha } from '../../theme/colors';
+import { withAlpha } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
@@ -16,6 +16,7 @@ import { useTheme } from '../../providers/theme-provider';
 export function SessionParticipantBreakdown({ participants }: { participants: SessionFeedParticipant[] }) {
   const { t } = useTranslation('session');
   const { t: tYou } = useTranslation('you');
+  const { brandColors } = useTheme();
 
   if (participants.length <= 1) return null;
 

--- a/packages/mobile/src/components/session/SessionStatTiles.tsx
+++ b/packages/mobile/src/components/session/SessionStatTiles.tsx
@@ -6,7 +6,6 @@ import { Icon } from '../Icon';
 import { type IconName } from '../icon-map';
 import { Card } from '../Card';
 import { gradeBadgeColor } from '../you/profile-chart-colors';
-import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
@@ -23,6 +22,7 @@ type SessionStatTilesProps = {
 export function SessionStatTiles({ sends, flashes, attempts, hardestGrade }: SessionStatTilesProps) {
   const { t } = useTranslation('you');
   const { t: tFeed } = useTranslation('feed');
+  const { brandColors } = useTheme();
 
   return (
     <Card style={styles.card}>

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -11,13 +11,15 @@ import { Avatar } from '../Avatar';
 import { FeedSocialRow } from '../you/FeedSocialRow';
 import { gradeBadgeColor } from '../you/profile-chart-colors';
 import { useGradeFormat } from '../../hooks/use-grade-format';
-import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
+import { useTheme, type Theme } from '../../providers/theme-provider';
 
 type TickStatusMeta = { icon: IconName; color: string };
 
-function statusMeta(status: string): TickStatusMeta {
+// Icon names are scheme-agnostic; the badge fill colour is resolved from the
+// theme (brand tones lift in dark) so this reads the per-scheme brand set.
+function statusMeta(status: string, brandColors: Theme['brandColors']): TickStatusMeta {
   if (status === 'flash') return { icon: 'flash', color: brandColors.warning };
   if (status === 'send') return { icon: 'tick', color: brandColors.success };
   return { icon: 'circle', color: iosSystemColors.systemGray };
@@ -74,9 +76,10 @@ export const SessionTickRow = memo(function SessionTickRow({
   onOpenComments,
 }: SessionTickRowProps) {
   const { t } = useTranslation('session');
+  const { brandColors } = useTheme();
   const { formatGrade, formatGradeByDifficultyId } = useGradeFormat();
 
-  const meta = statusMeta(tick.status);
+  const meta = statusMeta(tick.status, brandColors);
   const attemptText = formatAttemptText(tick, t);
   const subtitleParts = [attemptText, tick.comment ?? null].filter((part): part is string => !!part);
   const subtitle = subtitleParts.length > 0 ? subtitleParts.join(' · ') : undefined;

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -11,18 +11,23 @@ import { Avatar } from '../Avatar';
 import { FeedSocialRow } from '../you/FeedSocialRow';
 import { gradeBadgeColor } from '../you/profile-chart-colors';
 import { useGradeFormat } from '../../hooks/use-grade-format';
+import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
-import { useTheme, type Theme } from '../../providers/theme-provider';
 
 type TickStatusMeta = { icon: IconName; color: string };
 
-// Icon names are scheme-agnostic; the badge fill colour is resolved from the
-// theme (brand tones lift in dark) so this reads the per-scheme brand set.
-function statusMeta(status: string, brandColors: Theme['brandColors']): TickStatusMeta {
-  if (status === 'flash') return { icon: 'flash', color: brandColors.warning };
-  if (status === 'send') return { icon: 'tick', color: brandColors.success };
-  return { icon: 'circle', color: iosSystemColors.systemGray };
+// The status badge is a FILL with a white icon on top, so the brand tones stay
+// STATIC (the lifted dark tints would fail white-on-fill contrast). Module-level
+// constants → zero allocation per row in this virtualised list.
+const STATUS_META: Record<string, TickStatusMeta> = {
+  flash: { icon: 'flash', color: brandColors.warning },
+  send: { icon: 'tick', color: brandColors.success },
+};
+const ATTEMPT_META: TickStatusMeta = { icon: 'circle', color: iosSystemColors.systemGray };
+
+function statusMeta(status: string): TickStatusMeta {
+  return STATUS_META[status] ?? ATTEMPT_META;
 }
 
 type TFunc = (key: string, options?: Record<string, unknown>) => string;
@@ -76,10 +81,9 @@ export const SessionTickRow = memo(function SessionTickRow({
   onOpenComments,
 }: SessionTickRowProps) {
   const { t } = useTranslation('session');
-  const { brandColors } = useTheme();
   const { formatGrade, formatGradeByDifficultyId } = useGradeFormat();
 
-  const meta = statusMeta(tick.status, brandColors);
+  const meta = statusMeta(tick.status);
   const attemptText = formatAttemptText(tick, t);
   const subtitleParts = [attemptText, tick.comment ?? null].filter((part): part is string => !!part);
   const subtitle = subtitleParts.length > 0 ? subtitleParts.join(' · ') : undefined;

--- a/packages/mobile/src/components/you/CommentSheet.tsx
+++ b/packages/mobile/src/components/you/CommentSheet.tsx
@@ -11,7 +11,6 @@ import { ActivityIndicator } from '../ActivityIndicator';
 import { useComments, useAddComment } from '../../lib/graphql/hooks';
 import { formatTickRelativeTime } from '@boardsesh/profile-stats';
 import { hapticLight } from '../../lib/haptics';
-import { brandColors } from '../../theme/colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 
@@ -27,7 +26,7 @@ type CommentSheetProps = {
 /** Comment thread for a social entity (session or tick), with an inline composer. */
 export function CommentSheet({ sheetRef, entityId, entityType = 'session', onClose }: CommentSheetProps) {
   const { t } = useTranslation('you');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const [draft, setDraft] = useState('');
 
   const commentsQuery = useComments(entityType, entityId ?? undefined, !!entityId);

--- a/packages/mobile/src/components/you/FeedSocialRow.tsx
+++ b/packages/mobile/src/components/you/FeedSocialRow.tsx
@@ -4,7 +4,6 @@ import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { useOptimisticVote } from './use-optimistic-vote';
 import { hapticLight } from '../../lib/haptics';
-import { brandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 
@@ -33,7 +32,7 @@ export function FeedSocialRow({
   onOpenComments,
   compact = false,
 }: FeedSocialRowProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { voted, count, toggle, isPending } = useOptimisticVote(entityId, upvotes, userVote, entityType);
 
   const iconSize = compact ? 16 : 18;

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -14,7 +14,6 @@ import { SectionHeader } from '../SectionHeader';
 import { GradeSingleSelectRail } from '../grade';
 import { useGrades } from '../../lib/graphql/hooks';
 import { hapticSuccess, hapticError } from '../../lib/haptics';
-import { brandColors } from '../../theme/colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
@@ -30,7 +29,7 @@ type LogbookEditSheetProps = {
 /** Edit (status / grade / stars / tries / comment) or delete a logged ascent. */
 export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheetProps) {
   const { t } = useTranslation('you');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
   const updateTick = useUpdateTick();
   const deleteTick = useDeleteTick();

--- a/packages/mobile/src/components/you/LogbookRow.tsx
+++ b/packages/mobile/src/components/you/LogbookRow.tsx
@@ -9,7 +9,6 @@ import { Icon } from '../Icon';
 import { type IconName } from '../icon-map';
 import { ListRow } from '../ListRow';
 import { gradeBadgeColor } from './profile-chart-colors';
-import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
@@ -20,18 +19,25 @@ type LogbookRowProps = {
   onPress: (ascent: AscentFeedItem) => void;
 };
 
-const STATUS_META: Record<AscentFeedItem['status'], { icon: IconName; color: string }> = {
-  flash: { icon: 'flash', color: brandColors.warning },
-  send: { icon: 'tick', color: brandColors.success },
-  attempt: { icon: 'circle', color: iosSystemColors.systemGray },
+// Icon names are scheme-agnostic; the badge fill colour is resolved from the
+// theme in render (brand tones lift in dark) so the static map keeps icons only.
+const STATUS_ICON: Record<AscentFeedItem['status'], IconName> = {
+  flash: 'flash',
+  send: 'tick',
+  attempt: 'circle',
 };
 
 export const LogbookRow = memo(function LogbookRow({ ascent, onPress }: LogbookRowProps) {
   const { t } = useTranslation('you');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { formatGrade, formatGradeByDifficultyId } = useGradeFormat();
 
-  const meta = STATUS_META[ascent.status];
+  const statusColor: Record<AscentFeedItem['status'], string> = {
+    flash: brandColors.warning,
+    send: brandColors.success,
+    attempt: iosSystemColors.systemGray,
+  };
+  const meta = { icon: STATUS_ICON[ascent.status], color: statusColor[ascent.status] };
   const rawGradeLabel = ascent.difficultyName ?? ascent.consensusDifficultyName;
   const gradeLabel =
     formatGradeByDifficultyId(ascent.difficulty ?? ascent.consensusDifficulty) ??

--- a/packages/mobile/src/components/you/LogbookRow.tsx
+++ b/packages/mobile/src/components/you/LogbookRow.tsx
@@ -9,6 +9,7 @@ import { Icon } from '../Icon';
 import { type IconName } from '../icon-map';
 import { ListRow } from '../ListRow';
 import { gradeBadgeColor } from './profile-chart-colors';
+import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
@@ -19,25 +20,21 @@ type LogbookRowProps = {
   onPress: (ascent: AscentFeedItem) => void;
 };
 
-// Icon names are scheme-agnostic; the badge fill colour is resolved from the
-// theme in render (brand tones lift in dark) so the static map keeps icons only.
-const STATUS_ICON: Record<AscentFeedItem['status'], IconName> = {
-  flash: 'flash',
-  send: 'tick',
-  attempt: 'circle',
+// The status badge is a FILL with a white icon on top, so the brand tones stay
+// STATIC (the lifted dark tints would fail white-on-fill contrast). Module-level
+// = zero allocation per row in this virtualised list.
+const STATUS_META: Record<AscentFeedItem['status'], { icon: IconName; color: string }> = {
+  flash: { icon: 'flash', color: brandColors.warning },
+  send: { icon: 'tick', color: brandColors.success },
+  attempt: { icon: 'circle', color: iosSystemColors.systemGray },
 };
 
 export const LogbookRow = memo(function LogbookRow({ ascent, onPress }: LogbookRowProps) {
   const { t } = useTranslation('you');
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors } = useTheme();
   const { formatGrade, formatGradeByDifficultyId } = useGradeFormat();
 
-  const statusColor: Record<AscentFeedItem['status'], string> = {
-    flash: brandColors.warning,
-    send: brandColors.success,
-    attempt: iosSystemColors.systemGray,
-  };
-  const meta = { icon: STATUS_ICON[ascent.status], color: statusColor[ascent.status] };
+  const meta = STATUS_META[ascent.status];
   const rawGradeLabel = ascent.difficultyName ?? ascent.consensusDifficultyName;
   const gradeLabel =
     formatGradeByDifficultyId(ascent.difficulty ?? ascent.consensusDifficulty) ??

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -11,13 +11,12 @@ import { LogbookRow } from './LogbookRow';
 import { LogbookEditSheet } from './LogbookEditSheet';
 import { useUserAscentsFeed } from '../../lib/graphql/hooks';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
-import { brandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 
 export function LogbookTab({ userId }: { userId: string | undefined }) {
   const { t } = useTranslation('you');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[4];
 

--- a/packages/mobile/src/components/you/ProgressTab.tsx
+++ b/packages/mobile/src/components/you/ProgressTab.tsx
@@ -11,7 +11,6 @@ import { StatsSummaryCard } from './StatsSummaryCard';
 import { StackedBarChart, GroupedBarChart, TotalAreaChart, type ChartLegendItem } from './YouCharts';
 import { layoutChartColor, flashRedpointColor } from './profile-chart-colors';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
-import { brandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 
@@ -20,7 +19,7 @@ type YouData = ReturnType<typeof useYouProfileData>;
 export function ProgressTab({ data }: { data: YouData }) {
   const { t } = useTranslation('profile');
   const { t: tYou } = useTranslation('you');
-  const { systemColors, colorScheme } = useTheme();
+  const { systemColors, colorScheme, brandColors } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[6];
 

--- a/packages/mobile/src/components/you/SessionFeedCard.tsx
+++ b/packages/mobile/src/components/you/SessionFeedCard.tsx
@@ -12,7 +12,7 @@ import { AvatarGroup } from './AvatarGroup';
 import { FeedSocialRow } from './FeedSocialRow';
 import { StackedBarChart } from './YouCharts';
 import { gradeBadgeColor, buildSessionGradeBars } from './profile-chart-colors';
-import { brandColors, withAlpha } from '../../theme/colors';
+import { withAlpha } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
@@ -40,7 +40,7 @@ export const SessionFeedCard = memo(function SessionFeedCard({
   onPress,
 }: SessionFeedCardProps) {
   const { t } = useTranslation('feed');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { formatGrade } = useGradeFormat();
 
   const names = session.participants

--- a/packages/mobile/src/components/you/SessionsFeedHeader.tsx
+++ b/packages/mobile/src/components/you/SessionsFeedHeader.tsx
@@ -5,7 +5,6 @@ import type { SessionFeedItem } from '@boardsesh/shared-schema';
 import { parseTickTime } from '@boardsesh/profile-stats';
 import { Text } from '../Text';
 import { Card } from '../Card';
-import { brandColors } from '../../theme/colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 
@@ -52,7 +51,7 @@ function computeRollup(sessions: SessionFeedItem[], now: number): WeeklyRollup {
 
 export function SessionsFeedHeader({ sessions, now }: { sessions: SessionFeedItem[]; now: number }) {
   const { t } = useTranslation('you');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
 
   const rollup = useMemo(() => computeRollup(sessions, now), [sessions, now]);
 

--- a/packages/mobile/src/components/you/SessionsTab.tsx
+++ b/packages/mobile/src/components/you/SessionsTab.tsx
@@ -16,7 +16,6 @@ import { CommentSheet } from './CommentSheet';
 import { bucketSessionsByRecency, type FeedRecencyBucket } from '../../lib/feed-time-buckets';
 import { useSessionGroupedFeed, useBulkVoteSummaries } from '../../lib/graphql/hooks';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
-import { brandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 
@@ -33,7 +32,7 @@ function sectionLabel(bucket: FeedRecencyBucket, t: TFunc): string {
 
 export function SessionsTab({ userId }: { userId: string | undefined }) {
   const { t } = useTranslation('you');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const router = useRouter();
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[4];

--- a/packages/mobile/src/components/you/StatsSummaryCard.tsx
+++ b/packages/mobile/src/components/you/StatsSummaryCard.tsx
@@ -8,7 +8,6 @@ import { type IconName } from '../icon-map';
 import { Card } from '../Card';
 import { LayoutPercentageBar } from './LayoutPercentageBar';
 import { gradeBadgeColor } from './profile-chart-colors';
-import { brandColors } from '../../theme/colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 
@@ -23,7 +22,7 @@ type StatsSummaryCardProps = {
 
 export function StatsSummaryCard({ statisticsSummary, hardestSend, hardestFlash, percentile }: StatsSummaryCardProps) {
   const { t } = useTranslation('profile');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
 
   const showPercentile = percentile != null && percentile.percentile > 0;
   // "Top X%" — invert the percentile, clamped so a 100th-percentile climber
@@ -54,7 +53,12 @@ export function StatsSummaryCard({ statisticsSummary, hardestSend, hardestFlash,
             </Text>
           </View>
           <View style={[styles.percentileTrack, { backgroundColor: systemColors.fill }]}>
-            <View style={[styles.percentileFill, { width: `${percentile.percentile}%` }]} />
+            <View
+              style={[
+                styles.percentileFill,
+                { width: `${percentile.percentile}%`, backgroundColor: brandColors.primary },
+              ]}
+            />
           </View>
           <Text variant="caption2" color={systemColors.tertiaryLabel} style={styles.percentileCaption}>
             {t('stats.moreSentThan', { value: percentile.percentile.toFixed(0) })}
@@ -131,7 +135,6 @@ const styles = StyleSheet.create({
   percentileFill: {
     height: '100%',
     borderRadius: borderRadius.full,
-    backgroundColor: brandColors.primary,
   },
   percentileCaption: {
     marginTop: spacing[1],

--- a/packages/mobile/src/components/you/YouFilterSheet.tsx
+++ b/packages/mobile/src/components/you/YouFilterSheet.tsx
@@ -11,7 +11,6 @@ import { Sheet } from '../Sheet';
 import { Button } from '../Button';
 import { SegmentedControl } from '../SegmentedControl';
 import { SectionHeader } from '../SectionHeader';
-import { brandColors } from '../../theme/colors';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 
@@ -32,7 +31,7 @@ export function YouFilterSheet({
   onSelectTimeframe,
 }: YouFilterSheetProps) {
   const { t } = useTranslation('you');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
 
   const boardOptions = useMemo(() => ['all', ...BOARD_TYPES], []);
   const timeframeOptions = useMemo<{ key: UnifiedTimeframeType; label: string }[]>(

--- a/packages/mobile/src/components/you/YouTabBar.tsx
+++ b/packages/mobile/src/components/you/YouTabBar.tsx
@@ -3,7 +3,6 @@ import { View, Pressable, StyleSheet, type LayoutChangeEvent } from 'react-nativ
 import Animated, { useAnimatedStyle, useSharedValue, type SharedValue } from 'react-native-reanimated';
 import { Text } from '../Text';
 import { hapticSelection } from '../../lib/haptics';
-import { brandColors } from '../../theme/colors';
 import { useTheme } from '../../providers/theme-provider';
 
 export type YouTab<K extends string> = { key: K; label: string };
@@ -21,7 +20,7 @@ type YouTabBarProps<K extends string> = {
  * so it can glide between selected sections while labels update from state.
  */
 export function YouTabBar<K extends string>({ tabs, activeIndex, scrollPosition, onTabPress }: YouTabBarProps<K>) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   // Tab width lives on the UI thread so the indicator worklet always reads the
   // live value. A JS-thread useState captured in the worklet would go stale
   // after a resize / orientation change — the worklet wouldn't see the new width.
@@ -72,7 +71,7 @@ export function YouTabBar<K extends string>({ tabs, activeIndex, scrollPosition,
           </Pressable>
         );
       })}
-      <Animated.View style={[styles.indicator, indicatorStyle]} />
+      <Animated.View style={[styles.indicator, { backgroundColor: brandColors.primary }, indicatorStyle]} />
     </View>
   );
 }
@@ -99,6 +98,5 @@ const styles = StyleSheet.create({
     left: 0,
     height: 2.5,
     borderRadius: 2,
-    backgroundColor: brandColors.primary,
   },
 });

--- a/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
@@ -183,6 +183,32 @@ describe('ThemeProvider', () => {
     });
   });
 
+  describe('scheme-aware brand + accent colours (#2583)', () => {
+    it('light scheme exposes the base brand palette and the violet accent', async () => {
+      useColorSchemeMock.mockReturnValue('light');
+      const { result } = renderHook(() => useTheme(), { wrapper });
+      await waitFor(() => expect(getMock).toHaveBeenCalled());
+      expect(result.current.colorScheme).toBe('light');
+      expect(result.current.brandColors.primary).toBe('#6D28D9');
+      expect(result.current.brandColors.success).toBe('#047857');
+      // New scheme-aware interactive accent (replaces the static systemBlue).
+      expect(result.current.systemColors.accent).toBe('#6D28D9');
+    });
+
+    it('dark scheme lifts brand foregrounds + the accent so they clear AA on near-black', async () => {
+      useColorSchemeMock.mockReturnValue('dark');
+      const { result } = renderHook(() => useTheme(), { wrapper });
+      await waitFor(() => expect(getMock).toHaveBeenCalled());
+      expect(result.current.colorScheme).toBe('dark');
+      // The core #2583 fix: foreground brand + semantic tones lift in dark.
+      expect(result.current.brandColors.primary).toBe('#A78BFA');
+      expect(result.current.brandColors.success).toBe('#34D399');
+      expect(result.current.brandColors.warning).toBe('#FBBF24');
+      expect(result.current.brandColors.error).toBe('#F87171');
+      expect(result.current.systemColors.accent).toBe('#A78BFA');
+    });
+  });
+
   describe('hydration race guard', () => {
     it("does not stomp the user's choice if setThemeOverride lands before the SecureStore read resolves", async () => {
       // Hold the hydration read until we say go. Lets us set the override

--- a/packages/mobile/src/providers/__tests__/toast-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/toast-provider.test.tsx
@@ -40,7 +40,7 @@ vi.mock('../../lib/haptics', () => ({
 vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({
     colorScheme: 'light',
-    brandColors: { success: '#34C759', error: '#FF3B30', primary: '#6D28D9', warning: '#FF9500' },
+    brandColors: { success: '#047857', error: '#C81E1E', primary: '#6D28D9', warning: '#B45309' },
     systemColors: { secondaryBackground: '#fff' },
   }),
 }));

--- a/packages/mobile/src/providers/__tests__/toast-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/toast-provider.test.tsx
@@ -40,6 +40,7 @@ vi.mock('../../lib/haptics', () => ({
 vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({
     colorScheme: 'light',
+    brandColors: { success: '#34C759', error: '#FF3B30', primary: '#6D28D9', warning: '#FF9500' },
     systemColors: { secondaryBackground: '#fff' },
   }),
 }));

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -56,6 +56,13 @@ type ResolvedSystemColors = {
   tertiaryLabel: string | OpaqueColorValue;
   separator: string | OpaqueColorValue;
   fill: string | OpaqueColorValue;
+  /**
+   * Interactive-accent foreground (links, active tab, edit·copy·open). iOS uses
+   * Apple's link blue; Android/Material use the brand violet, lifted to #A78BFA
+   * in dark so it clears AA on near-black. Replaces the static
+   * `iosSystemColors.systemBlue` for foreground use.
+   */
+  accent: string | OpaqueColorValue;
 };
 
 type Theme = {
@@ -120,6 +127,7 @@ function resolveSystemColors(colorScheme: ColorScheme, variant: UiVariant): Reso
     tertiaryLabel: fallback.tertiaryLabel,
     separator: fallback.separator,
     fill: fallback.fill,
+    accent: fallback.accent,
   };
 }
 

--- a/packages/mobile/src/theme/colors.ts
+++ b/packages/mobile/src/theme/colors.ts
@@ -24,6 +24,9 @@ export const iosSystemColors: Record<string, OpaqueColorValue> | null =
         tertiaryLabel: PlatformColor('tertiaryLabel'),
         separator: PlatformColor('separator'),
         fill: PlatformColor('systemFill'),
+        // Interactive-accent (links, active tab, edit·copy·open affordances).
+        // PlatformColor('link') is Apple's link blue and adapts to dark natively.
+        accent: PlatformColor('link'),
       }
     : null;
 
@@ -92,6 +95,9 @@ export const androidFallbackColors = {
     tertiaryLabel: '#8E8898',
     separator: 'rgba(60, 55, 75, 0.18)',
     fill: 'rgba(109, 40, 217, 0.1)',
+    // Interactive-accent foreground (links, active tab, edit·copy·open). The
+    // brand violet, lifted to #A78BFA in dark so it clears AA on near-black.
+    accent: '#6D28D9',
   },
   dark: {
     background: '#0F0B16',
@@ -104,6 +110,7 @@ export const androidFallbackColors = {
     tertiaryLabel: '#6E687C',
     separator: 'rgba(180, 168, 205, 0.2)',
     fill: 'rgba(199, 184, 232, 0.12)',
+    accent: '#A78BFA',
   },
 } as const;
 
@@ -137,6 +144,8 @@ export const materialSurfaces = {
     // Faint violet track for segmented controls / fills (bumped to 0.14 so selected
     // pills read on white).
     fill: 'rgba(109, 40, 217, 0.14)',
+    // Interactive-accent foreground — brand violet, lifted in dark.
+    accent: '#6D28D9',
   },
   dark: {
     background: '#15101E',
@@ -149,6 +158,7 @@ export const materialSurfaces = {
     tertiaryLabel: '#6E687C',
     separator: 'rgba(180, 168, 205, 0.18)',
     fill: 'rgba(199, 184, 232, 0.14)',
+    accent: '#A78BFA',
   },
 } as const;
 

--- a/packages/mobile/src/theme/ios-colors.ts
+++ b/packages/mobile/src/theme/ios-colors.ts
@@ -4,12 +4,14 @@ import { brandColors } from './colors';
 /**
  * The interactive-accent blue. iOS keeps Apple's #007AFF; Android resolves it to
  * the brand tint so the active tab, links, and "edit / copy / open" affordances
- * read as Boardsesh violet rather than an out-of-place iOS blue. This is the one
- * value in `iosSystemColors` that genuinely leaks an iOS aesthetic onto Android
- * (it's used as a *tint*, not a fixed status colour); resolving it here fixes
- * every static (StyleSheet / default-prop) consumer at once without a wide
- * per-file refactor. Every other value below is intentionally identical across
- * platforms — iOS system reds/greens/grays read fine on Android too.
+ * read as Boardsesh violet rather than an out-of-place iOS blue.
+ *
+ * For FOREGROUND use prefer the scheme-aware `useTheme().systemColors.accent`
+ * (lifts to #A78BFA in Android dark so it clears AA on near-black). This static
+ * value stays as the FILL fallback for the few StyleSheet backgrounds that carry
+ * white text (e.g. the logbook angle chip), where lifting would break white-on-fill
+ * contrast. Every other value below is intentionally identical across platforms —
+ * iOS system reds/greens/grays read fine on Android too.
  */
 const ACCENT_TINT = Platform.OS === 'android' ? brandColors.tint : '#007AFF';
 


### PR DESCRIPTION
Fixes #2583.

## Problem
PR #2580 made `theme.brandColors` scheme-aware, but ~90 foreground call sites across `packages/mobile` still imported the **static** light-scheme `brandColors`. In dark mode those rendered the light violet `#6D28D9` on near-black (~2.5:1 — below WCAG AA). Parity with the old maroon, but the legibility bug we want gone.

## The rule
One discriminator: **does white / `onPrimary` / auto-contrasted text (or a white icon) sit *on* the brand colour?**
- **Yes → fill, stays static** (filled buttons, badges, avatars, grade badges, swipe panels, selected chips, the amber `accent`). The bright dark tints would *break* white-on-fill contrast (esp. `success`).
- **No → foreground, now scheme-aware** via `useTheme().brandColors` — icon/text/border/stroke/ripple/`tintColor` colours, low-alpha washes, and text-free accent bars/fills (You-tab underline, slider fill+thumb, progress/percentile bars). Dark lifts to `#A78BFA` (and brighter success/warning/error).

## Also
- New scheme-aware **`useTheme().systemColors.accent`** (iOS `PlatformColor('link')`; Android/Material brand violet, lifted in dark) replaces the static `iosSystemColors.systemBlue` for foreground icons (edit/copy/open/playlist). The one white-text fill that used `systemBlue` (logbook angle chip) stays static.
- `CreateDrawerActionBar` save button: stop overriding the filled Button's scheme-aware `primaryFill` for the default tint (it now lifts in dark like every other CTA); success keeps its static green fill.
- Intentional static foregrounds left, documented in code: the root `ErrorBoundary` warning icon (renders outside `ThemeProvider`) and `PressableSurface`'s default Android ripple tint (core primitive, rarely-hit fallback).
- Docs: updated the "Scheme-aware rule" in `docs/ai-design-guidelines.md` and documented `systemColors.accent`.

## Validation
- `vp run typecheck:mobile` ✓
- `vp test --project mobile` ✓ (143 files / 1116 tests; added theme-provider cases asserting the per-scheme lift of `brandColors` + `accent`)
- `vp run check:mobile-bundle` ✓
- **On-device dark-mode QA still required** — the change can't be visually verified on Linux/CI (per the issue). QA sweep written to `.boardsesh/qa-notes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)