### PR TITLE
[codex] materialize climbs search header

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -360,7 +360,7 @@ function ClimbListInner() {
     });
     if (renderData?.imageUrls) {
       for (const url of renderData.imageUrls) {
-        Image.prefetch(url);
+        void Image.prefetch(url);
       }
     }
   }, [activeBoard]);
@@ -550,6 +550,17 @@ function ClimbListInner() {
   const handleClearAllFilters = useCallback(() => {
     replaceSearch(DEFAULT_CLIMB_FILTER_STATE, name, DEFAULT_CLIMB_BOARD_FILTER_STATE);
   }, [replaceSearch, name]);
+  const handleClearNonGradeFilters = useCallback(() => {
+    replaceSearch(
+      {
+        ...DEFAULT_CLIMB_FILTER_STATE,
+        minGrade: filters.minGrade,
+        maxGrade: filters.maxGrade,
+      },
+      name,
+      DEFAULT_CLIMB_BOARD_FILTER_STATE,
+    );
+  }, [replaceSearch, name, filters.minGrade, filters.maxGrade]);
 
   const handleGradeChange = useCallback(
     (next: GradeBound) => {
@@ -595,16 +606,21 @@ function ClimbListInner() {
       }),
     [filters, boardFilters, grades, t, formatGradeByDifficultyId, patchFilters, patchBoardFilters, setGrade],
   );
+  const nonGradeFilterTokens = useMemo(
+    () => filterTokens.filter((filterToken) => filterToken.key !== 'grade'),
+    [filterTokens],
+  );
+  const summaryFilterTokens = variant === 'material' ? nonGradeFilterTokens : filterTokens;
   // Condensed one-line summary of the active filters for the capsule below the
   // board name (2 parts max, then "+N more"). Tapping the capsule clears them.
   const filterSummary = useMemo(() => {
-    if (filterTokens.length === 0) return null;
+    if (summaryFilterTokens.length === 0) return null;
     return formatFilterSummary(
-      filterTokens.map((token) => token.label),
+      summaryFilterTokens.map((token) => token.label),
       { more: (count) => t('mobile.search.more', { count }) },
       2,
     );
-  }, [filterTokens, t]);
+  }, [summaryFilterTokens, t]);
   const gradeFilterToken = useMemo(
     () => filterTokens.find((filterToken) => filterToken.key === 'grade'),
     [filterTokens],
@@ -718,6 +734,7 @@ function ClimbListInner() {
   }
 
   const isEmpty = visibleClimbs.length === 0 && !isClimbsLoading;
+  const filterSummaryClear = variant === 'material' ? handleClearNonGradeFilters : handleClearAllFilters;
 
   return (
     <View style={[styles.container, { backgroundColor: systemColors.background }]}>
@@ -785,7 +802,7 @@ function ClimbListInner() {
         onCloseGrade={handleDismissGrade}
         activeFilterCount={activeFilterCount}
         onOpenFilters={handleOpenFilters}
-        filterSummary={filterSummary ? { text: filterSummary, onClear: handleClearAllFilters } : undefined}
+        filterSummary={filterSummary ? { text: filterSummary, onClear: filterSummaryClear } : undefined}
         gradeBound={gradeBound}
         grades={grades}
         gradeRailVisible={showGrade}

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -605,6 +605,16 @@ function ClimbListInner() {
       2,
     );
   }, [filterTokens, t]);
+  const gradeFilterToken = useMemo(
+    () => filterTokens.find((filterToken) => filterToken.key === 'grade'),
+    [filterTokens],
+  );
+  const gradeChip = useMemo(() => {
+    if (gradeFilterToken) {
+      return { label: gradeFilterToken.label, active: true, onClear: gradeFilterToken.clear };
+    }
+    return { label: t('mobile.filter.gradeRange'), active: false };
+  }, [gradeFilterToken, t]);
 
   const stackOptions = useMemo(
     () =>
@@ -776,6 +786,12 @@ function ClimbListInner() {
         activeFilterCount={activeFilterCount}
         onOpenFilters={handleOpenFilters}
         filterSummary={filterSummary ? { text: filterSummary, onClear: handleClearAllFilters } : undefined}
+        gradeBound={gradeBound}
+        grades={grades}
+        gradeRailVisible={showGrade}
+        gradeChip={gradeChip}
+        onOpenGrade={handleOpenGrade}
+        onGradeChange={handleGradeChange}
       />
 
       {filterInTopChrome ? null : (

--- a/packages/mobile/src/components/SearchHeader.tsx
+++ b/packages/mobile/src/components/SearchHeader.tsx
@@ -89,6 +89,7 @@ export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(fu
           value={text}
           onChangeText={handleChange}
           onClearIconPress={handleClear}
+          mode="bar"
           placeholder={placeholder}
           onFocus={onFocus}
           onBlur={onBlur}
@@ -98,12 +99,17 @@ export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(fu
           autoCorrect={false}
           accessibilityLabel={placeholder}
           elevation={0}
+          iconColor={systemColors.secondaryLabel as string}
+          rippleColor={systemColors.fill}
           inputStyle={styles.materialInput}
           // Pin the full footprint on first mount. Paper's Searchbar contains a
           // Surface + TextInput stack; on Android it can draw only the tonal
           // surface for one frame if its parent hands it an unconstrained flex
           // slot. The wrapper owns the slot, and the Searchbar fills it.
-          style={[styles.materialSearchbar, { height, borderRadius: radius }]}
+          style={[
+            styles.materialSearchbar,
+            { height, borderRadius: radius, backgroundColor: systemColors.tertiaryBackground as string },
+          ]}
         />
       </View>
     );
@@ -166,6 +172,7 @@ const styles = StyleSheet.create({
     minHeight: 0,
     paddingVertical: 0,
     textAlignVertical: 'center',
+    fontSize: 16,
   },
   capsule: {
     flex: 1,

--- a/packages/mobile/src/components/chrome/BoardPill.tsx
+++ b/packages/mobile/src/components/chrome/BoardPill.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { formatBoardDisplayName } from '@boardsesh/board-config';
 import { useTheme } from '../../providers/theme-provider';
 import { useActiveBoard } from '../../lib/graphql/use-active-board';
+import { formatActiveBoardLabel } from '../../lib/boards/active-board-label';
 import { useNativeGlass } from '../../hooks/use-native-glass';
 import { hapticLight } from '../../lib/haptics';
 import { shadows } from '../../theme/tokens';
@@ -33,13 +33,7 @@ export function BoardPill({ onPress, accessibilityHint }: BoardPillProps) {
   const { data: activeBoard } = useActiveBoard();
 
   const boardLabel = useMemo(() => {
-    if (!activeBoard) return null;
-    const angle = activeBoard.angle != null ? `${activeBoard.angle}°` : null;
-    const isNamed = activeBoard.name != null && activeBoard.name.trim().length > 0;
-    const parts = isNamed
-      ? [activeBoard.name, angle]
-      : [formatBoardDisplayName(activeBoard.boardType), activeBoard.sizeName ?? activeBoard.layoutName ?? null, angle];
-    return parts.filter(Boolean).join(' • ');
+    return formatActiveBoardLabel(activeBoard);
   }, [activeBoard]);
 
   const handlePress = useCallback(() => {

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -8,33 +8,41 @@
 // one system. This file keeps the climbs-only pieces: the search row, the
 // Material filter button, and the active-filter summary capsule.
 
-import { type RefObject, useCallback } from 'react';
+import { type RefObject, useCallback, useState } from 'react';
 import { Keyboard, type LayoutChangeEvent, StyleSheet, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useFocusEffect } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
+import { Appbar, Chip } from 'react-native-paper';
+import type { Grade } from '@boardsesh/shared-schema';
+import type { GradeBound } from '@boardsesh/climb-filters';
 import { useTheme } from '../../providers/theme-provider';
-import { useActiveBoard } from '../../lib/graphql/use-active-board';
+import { useActiveBoard, useSetActiveBoard } from '../../lib/graphql/use-active-board';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { spacing, shadows } from '../../theme/tokens';
 import { glassSize } from '../../theme/layout';
 import { hapticLight } from '../../lib/haptics';
+import { formatActiveBoardLabel } from '../../lib/boards/active-board-label';
 import { useNativeGlass } from '../../hooks/use-native-glass';
 import { GlassSurface } from '../GlassSurface';
 import { PressableSurface } from '../PressableSurface';
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
+import { iconMap } from '../icon-map';
 import { BoardPill } from '../chrome/BoardPill';
 import { GlassActionToolbar, GlassToolbarAction, TOP_ACTION_SIZE } from '../chrome/GlassActionToolbar';
 import { AngleToolbarAction } from '../chrome/AngleToolbarAction';
 import { LightbulbToolbarAction } from '../chrome/LightbulbToolbarAction';
+import { GradeRangeRail } from '../grade';
+import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
 import { FilterButton } from './FilterButton';
 
 const TOP_TOOLBAR_WIDTH = TOP_ACTION_SIZE * 2;
 const SUMMARY_CAPSULE_HEIGHT = glassSize.mini;
 const SUMMARY_CAPSULE_RADIUS = SUMMARY_CAPSULE_HEIGHT / 2;
+const MATERIAL_SEARCH_HEIGHT = 56;
 
 type ClimbTopChromeProps = {
   searchMode?: 'custom' | 'native';
@@ -57,6 +65,12 @@ type ClimbTopChromeProps = {
   /** Active-filter summary shown as a single capsule below the board name.
    *  Tapping it clears all filters (no per-chip remove). Absent = no filters. */
   filterSummary?: { text: string; onClear: () => void };
+  gradeBound?: GradeBound;
+  grades?: readonly Grade[];
+  gradeRailVisible?: boolean;
+  gradeChip?: { label: string; active: boolean; onClear?: () => void };
+  onOpenGrade?: () => void;
+  onGradeChange?: (grade: GradeBound) => void;
 };
 
 export function ClimbTopChrome({
@@ -75,8 +89,15 @@ export function ClimbTopChrome({
   activeFilterCount = 0,
   onOpenFilters,
   filterSummary,
+  gradeBound,
+  grades = [],
+  gradeRailVisible = false,
+  gradeChip,
+  onOpenGrade,
+  onGradeChange,
 }: ClimbTopChromeProps) {
   const { t } = useTranslation('climbs');
+  const { t: tCommon } = useTranslation('common');
   const { systemColors, variant } = useTheme();
   const nativeGlass = useNativeGlass();
   const insets = useSafeAreaInsets();
@@ -108,6 +129,132 @@ export function ClimbTopChrome({
 
   const canOpenAngleSelector = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
   const leftActionCount = (canCreate ? 1 : 0) + (canOpenAngleSelector ? 1 : 0);
+
+  if (variant === 'material') {
+    const boardLabel = formatActiveBoardLabel(activeBoard);
+    const hasGradeFilter = gradeChip?.active === true;
+    const hasNonGradeFilters = activeFilterCount > (hasGradeFilter ? 1 : 0);
+    const shouldShowFilterSummary = filterSummary != null && hasNonGradeFilters;
+    const visibleFilterSummary = shouldShowFilterSummary ? filterSummary : null;
+    const visibleGradeLabel = gradeChip?.label ?? t('mobile.filter.gradeRange');
+
+    return (
+      <View
+        pointerEvents="box-none"
+        style={[
+          styles.materialContainer,
+          {
+            paddingTop: insets.top,
+            backgroundColor: systemColors.secondaryBackground,
+            borderBottomColor: systemColors.separator,
+          },
+        ]}
+        onLayout={handleLayout}
+      >
+        <Appbar.Header
+          statusBarHeight={0}
+          mode="small"
+          elevated
+          style={[styles.materialAppbar, { backgroundColor: systemColors.secondaryBackground }]}
+        >
+          <Appbar.Content
+            title={tCommon('mobile.nav.climbs')}
+            subtitle={boardLabel ?? undefined}
+            onPress={
+              boardLabel
+                ? () => {
+                    hapticLight();
+                    onOpenBoardDetail();
+                  }
+                : undefined
+            }
+            titleStyle={styles.materialTitle}
+            subtitleStyle={styles.materialSubtitle}
+          />
+          {canCreate ? (
+            <Appbar.Action
+              icon={iconMap.plus.android}
+              color={systemColors.label as string}
+              onPress={onCreate}
+              accessibilityLabel={t('mobile.create.fab.ariaLabel')}
+            />
+          ) : null}
+          <MaterialAngleAction />
+          <MaterialLightbulbAction />
+        </Appbar.Header>
+
+        {usesCustomSearch ? (
+          <View pointerEvents="box-none" style={styles.materialSearchStack}>
+            <View pointerEvents="box-none" style={styles.materialSearchRow}>
+              <View pointerEvents="box-none" style={styles.materialSearchSlot}>
+                <SearchHeader
+                  ref={searchFieldRef}
+                  initialValue={searchInitialValue}
+                  placeholder={searchPlaceholder}
+                  onChangeText={onSearchChange}
+                  onFocus={handleFocus}
+                  onBlur={handleBlur}
+                  height={MATERIAL_SEARCH_HEIGHT}
+                />
+              </View>
+              {onOpenFilters ? <FilterButton activeFilterCount={activeFilterCount} onPress={onOpenFilters} /> : null}
+            </View>
+
+            <View pointerEvents="box-none" style={styles.materialQuickRow}>
+              <Chip
+                compact
+                mode={hasGradeFilter ? 'flat' : 'outlined'}
+                selected={hasGradeFilter}
+                showSelectedCheck={false}
+                selectedColor={systemColors.label as string}
+                icon={iconMap.angle.android}
+                onPress={() => {
+                  if (gradeRailVisible) {
+                    onCloseGrade();
+                    return;
+                  }
+                  onOpenGrade?.();
+                }}
+                onClose={hasGradeFilter ? gradeChip?.onClear : undefined}
+                closeIcon={iconMap.close.android}
+                accessibilityLabel={t('mobile.search.gradeAction')}
+                style={[styles.materialChip, hasGradeFilter ? { backgroundColor: systemColors.fill } : undefined]}
+                textStyle={styles.materialChipText}
+              >
+                {visibleGradeLabel}
+              </Chip>
+              {visibleFilterSummary ? (
+                <Chip
+                  compact
+                  mode="flat"
+                  icon={iconMap.filter.android}
+                  onPress={visibleFilterSummary.onClear}
+                  onClose={visibleFilterSummary.onClear}
+                  closeIcon={iconMap.close.android}
+                  accessibilityLabel={visibleFilterSummary.text}
+                  style={styles.materialChip}
+                  textStyle={styles.materialChipText}
+                >
+                  {visibleFilterSummary.text}
+                </Chip>
+              ) : null}
+            </View>
+
+            {gradeRailVisible && gradeBound && onGradeChange ? (
+              <GradeRangeRail
+                grades={grades}
+                bound={gradeBound}
+                onChange={onGradeChange}
+                onRequestClose={onCloseGrade}
+                dismissible={false}
+                style={styles.materialGradeRail}
+              />
+            ) : null}
+          </View>
+        ) : null}
+      </View>
+    );
+  }
 
   return (
     <View pointerEvents="box-none" style={[styles.container, { paddingTop: insets.top }]} onLayout={handleLayout}>
@@ -194,9 +341,6 @@ export function ClimbTopChrome({
       {usesCustomSearch ? (
         <View pointerEvents="box-none" style={styles.searchStack}>
           <View pointerEvents="box-none" style={styles.searchRow}>
-            {variant === 'material' && onOpenFilters ? (
-              <FilterButton activeFilterCount={activeFilterCount} onPress={onOpenFilters} />
-            ) : null}
             <View pointerEvents="box-none" style={styles.searchSlot}>
               <SearchHeader
                 ref={searchFieldRef}
@@ -212,6 +356,82 @@ export function ClimbTopChrome({
         </View>
       ) : null}
     </View>
+  );
+}
+
+function MaterialAngleAction() {
+  const { systemColors } = useTheme();
+  const { t: tSession } = useTranslation('session');
+  const { data: activeBoard } = useActiveBoard();
+  const setActiveBoard = useSetActiveBoard();
+  const [visible, setVisible] = useState(false);
+
+  const canAdjust = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
+  const handleOpen = useCallback(() => {
+    if (!activeBoard || activeBoard.isAngleAdjustable === false || activeBoard.angle == null) return;
+    hapticLight();
+    setVisible(true);
+  }, [activeBoard]);
+  const handleClose = useCallback(() => setVisible(false), []);
+  const handleAngleChange = useCallback(
+    (newAngle: number) => {
+      if (!activeBoard || activeBoard.isAngleAdjustable === false || newAngle === activeBoard.angle) return;
+      void setActiveBoard({ ...activeBoard, angle: newAngle });
+    },
+    [activeBoard, setActiveBoard],
+  );
+
+  if (!activeBoard || !canAdjust) return null;
+
+  return (
+    <>
+      <Appbar.Action
+        icon={() => (
+          <Text variant="caption1" style={[styles.materialAngleText, { color: systemColors.label }]}>
+            {activeBoard.angle}°
+          </Text>
+        )}
+        onPress={handleOpen}
+        accessibilityLabel={tSession('mobile.angleSelector.title')}
+      />
+      <AngleSelectorSheet
+        visible={visible}
+        onClose={handleClose}
+        boardName={activeBoard.boardType}
+        layoutId={activeBoard.layoutId}
+        currentAngle={activeBoard.angle}
+        onAngleChange={handleAngleChange}
+      />
+    </>
+  );
+}
+
+function MaterialLightbulbAction() {
+  const { systemColors, brandColors } = useTheme();
+  const { t: tCommon } = useTranslation('common');
+  const { t: tSettings } = useTranslation('settings');
+  const bluetooth = useOptionalBluetoothContext();
+  const connected = bluetooth?.isConnected ?? false;
+
+  const handlePress = useCallback(() => {
+    if (!bluetooth) return;
+    hapticLight();
+    if (bluetooth.isConnected) void bluetooth.disconnect();
+    else void bluetooth.connect();
+  }, [bluetooth]);
+
+  if (!bluetooth) return null;
+
+  const iconName = connected ? iconMap['lightbulb.fill'].android : iconMap.lightbulb.android;
+  const iconColor = connected ? brandColors.warning : systemColors.label;
+
+  return (
+    <Appbar.Action
+      icon={iconName}
+      color={iconColor as string}
+      onPress={handlePress}
+      accessibilityLabel={connected ? tCommon('lightControl.disconnect') : tSettings('ble.connectBoard')}
+    />
   );
 }
 
@@ -287,5 +507,57 @@ const styles = StyleSheet.create({
   summaryText: {
     fontWeight: '600',
     flexShrink: 1,
+  },
+  materialContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 20,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  materialAppbar: {
+    elevation: 0,
+    shadowOpacity: 0,
+  },
+  materialTitle: {
+    fontWeight: '700',
+  },
+  materialSubtitle: {
+    fontWeight: '500',
+  },
+  materialSearchStack: {
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[3],
+    gap: spacing[2],
+  },
+  materialSearchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  materialSearchSlot: {
+    flex: 1,
+    minWidth: 0,
+  },
+  materialQuickRow: {
+    minHeight: 36,
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+  },
+  materialChip: {
+    minHeight: 32,
+  },
+  materialChipText: {
+    fontWeight: '600',
+  },
+  materialGradeRail: {
+    marginTop: spacing[1],
+  },
+  materialAngleText: {
+    fontWeight: '700',
+    textAlign: 'center',
   },
 });

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -133,7 +133,8 @@ export function ClimbTopChrome({
   if (variant === 'material') {
     const boardLabel = formatActiveBoardLabel(activeBoard);
     const hasGradeFilter = gradeChip?.active === true;
-    const hasNonGradeFilters = activeFilterCount > (hasGradeFilter ? 1 : 0);
+    const nonGradeFilterCount = Math.max(0, activeFilterCount - (hasGradeFilter ? 1 : 0));
+    const hasNonGradeFilters = nonGradeFilterCount > 0;
     const shouldShowFilterSummary = filterSummary != null && hasNonGradeFilters;
     const visibleFilterSummary = shouldShowFilterSummary ? filterSummary : null;
     const visibleGradeLabel = gradeChip?.label ?? t('mobile.filter.gradeRange');
@@ -197,7 +198,7 @@ export function ClimbTopChrome({
                   height={MATERIAL_SEARCH_HEIGHT}
                 />
               </View>
-              {onOpenFilters ? <FilterButton activeFilterCount={activeFilterCount} onPress={onOpenFilters} /> : null}
+              {onOpenFilters ? <FilterButton activeFilterCount={nonGradeFilterCount} onPress={onOpenFilters} /> : null}
             </View>
 
             <View pointerEvents="box-none" style={styles.materialQuickRow}>
@@ -367,6 +368,14 @@ function MaterialAngleAction() {
   const [visible, setVisible] = useState(false);
 
   const canAdjust = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
+  const angleIcon = useCallback(
+    () => (
+      <Text variant="caption1" style={[styles.materialAngleText, { color: systemColors.label }]}>
+        {activeBoard?.angle}°
+      </Text>
+    ),
+    [activeBoard?.angle, systemColors.label],
+  );
   const handleOpen = useCallback(() => {
     if (!activeBoard || activeBoard.isAngleAdjustable === false || activeBoard.angle == null) return;
     hapticLight();
@@ -386,11 +395,7 @@ function MaterialAngleAction() {
   return (
     <>
       <Appbar.Action
-        icon={() => (
-          <Text variant="caption1" style={[styles.materialAngleText, { color: systemColors.label }]}>
-            {activeBoard.angle}°
-          </Text>
-        )}
+        icon={angleIcon}
         onPress={handleOpen}
         accessibilityLabel={tSession('mobile.angleSelector.title')}
       />

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -549,15 +549,99 @@ describe('ClimbTopChrome', () => {
     expect(haptics.light).toHaveBeenCalledTimes(1);
   });
 
+  it('excludes the dedicated grade chip from the Material filter badge count', () => {
+    ctrl.variant = 'material';
+    ctrl.board = typedBoard;
+    const { container, rerender } = render(
+      <ClimbTopChrome
+        {...makeProps({
+          onOpenFilters: vi.fn(),
+          activeFilterCount: 2,
+          gradeChip: { label: 'V6+', active: true, onClear: vi.fn() },
+          gradeBound: { minGradeId: 20, maxGradeId: undefined },
+          onOpenGrade: vi.fn(),
+          onGradeChange: vi.fn(),
+        })}
+      />,
+    );
+
+    expect(container.querySelector('[data-glass-icon="filter"]')?.getAttribute('data-badge')).toBe('1');
+
+    rerender(
+      <ClimbTopChrome
+        {...makeProps({
+          onOpenFilters: vi.fn(),
+          activeFilterCount: 1,
+          gradeChip: { label: 'V6+', active: true, onClear: vi.fn() },
+          gradeBound: { minGradeId: 20, maxGradeId: undefined },
+          onOpenGrade: vi.fn(),
+          onGradeChange: vi.fn(),
+        })}
+      />,
+    );
+    expect(container.querySelector('[data-glass-icon="filter"]')?.getAttribute('data-badge')).toBe('0');
+  });
+
+  it('omits the Material summary chip when only grade is active', () => {
+    ctrl.variant = 'material';
+    ctrl.board = typedBoard;
+    const onClearSummary = vi.fn();
+    const { container } = render(
+      <ClimbTopChrome
+        {...makeProps({
+          onOpenFilters: vi.fn(),
+          activeFilterCount: 1,
+          filterSummary: { text: 'V6+', onClear: onClearSummary },
+          gradeChip: { label: 'V6+', active: true, onClear: vi.fn() },
+          gradeBound: { minGradeId: 20, maxGradeId: undefined },
+          onOpenGrade: vi.fn(),
+          onGradeChange: vi.fn(),
+        })}
+      />,
+    );
+
+    expect(container.querySelector('[data-chip="V6+"]')).toBeNull();
+  });
+
+  it('clears only the Material summary chip callback for non-grade filters', () => {
+    ctrl.variant = 'material';
+    ctrl.board = typedBoard;
+    const onClearGrade = vi.fn();
+    const onClearSummary = vi.fn();
+    const { container } = render(
+      <ClimbTopChrome
+        {...makeProps({
+          onOpenFilters: vi.fn(),
+          activeFilterCount: 2,
+          filterSummary: { text: 'Benchmarks', onClear: onClearSummary },
+          gradeChip: { label: 'V6+', active: true, onClear: onClearGrade },
+          gradeBound: { minGradeId: 20, maxGradeId: undefined },
+          onOpenGrade: vi.fn(),
+          onGradeChange: vi.fn(),
+        })}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('[data-chip="Benchmarks"]') as HTMLButtonElement);
+    expect(onClearSummary).toHaveBeenCalledTimes(1);
+    expect(onClearGrade).not.toHaveBeenCalled();
+
+    fireEvent.click(container.querySelector('[data-chip-close="Benchmarks"]') as HTMLSpanElement);
+    expect(onClearSummary).toHaveBeenCalledTimes(2);
+    expect(onClearGrade).not.toHaveBeenCalled();
+  });
+
   it('opens the inline grade rail from the Material grade chip and clears the active grade', () => {
     ctrl.variant = 'material';
     ctrl.board = typedBoard;
     const onOpenGrade = vi.fn();
+    const onCloseGrade = vi.fn();
     const onClearGrade = vi.fn();
     const { container, rerender } = render(
       <ClimbTopChrome
         {...makeProps({
           onOpenGrade,
+          onCloseGrade,
           onOpenFilters: vi.fn(),
           activeFilterCount: 1,
           gradeChip: { label: 'V6+', active: true, onClear: onClearGrade },
@@ -576,6 +660,7 @@ describe('ClimbTopChrome', () => {
       <ClimbTopChrome
         {...makeProps({
           onOpenGrade,
+          onCloseGrade,
           onOpenFilters: vi.fn(),
           activeFilterCount: 1,
           gradeRailVisible: true,
@@ -586,5 +671,8 @@ describe('ClimbTopChrome', () => {
       />,
     );
     expect(container.querySelector('[data-grade-rail="true"]')).not.toBeNull();
+    fireEvent.click(container.querySelector('[data-chip="mobile.search.gradeAction"]') as HTMLButtonElement);
+    expect(onCloseGrade).toHaveBeenCalledTimes(1);
+    expect(onOpenGrade).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
-import { createElement, forwardRef, useImperativeHandle, type ReactNode, type RefObject } from 'react';
+import { createElement, forwardRef, useImperativeHandle, type MouseEvent, type ReactNode, type RefObject } from 'react';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import type { SearchHeaderHandle } from '../../SearchHeader';
 
@@ -63,6 +63,66 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
+vi.mock('react-native-paper', () => ({
+  Appbar: {
+    Header: ({ children }: { children?: ReactNode }) =>
+      createElement('div', { 'data-appbar-header': 'true' }, children),
+    Content: ({ title, subtitle, onPress }: { title?: ReactNode; subtitle?: ReactNode; onPress?: () => void }) =>
+      createElement(
+        'button',
+        { onClick: onPress, 'data-appbar-content': 'true' },
+        createElement('span', { 'data-appbar-title': 'true' }, title),
+        subtitle ? createElement('span', { 'data-appbar-subtitle': 'true' }, subtitle) : null,
+      ),
+    Action: ({
+      icon,
+      onPress,
+      accessibilityLabel,
+    }: {
+      icon?: ReactNode | ((props: { color: string; size: number }) => ReactNode);
+      onPress?: () => void;
+      accessibilityLabel?: string;
+    }) =>
+      createElement(
+        'button',
+        { onClick: onPress, 'data-appbar-action': accessibilityLabel ?? '' },
+        typeof icon === 'function' ? icon({ color: '#000', size: 24 }) : icon,
+      ),
+  },
+  Chip: ({
+    children,
+    onPress,
+    onClose,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    onClose?: () => void;
+    accessibilityLabel?: string;
+  }) =>
+    createElement(
+      'button',
+      { onClick: onPress, 'data-chip': accessibilityLabel ?? '' },
+      children,
+      onClose
+        ? createElement(
+            'span',
+            {
+              'data-chip-close': accessibilityLabel ?? '',
+              onClick: (event: MouseEvent<HTMLSpanElement>) => {
+                event.stopPropagation();
+                onClose();
+              },
+            },
+            'close',
+          )
+        : null,
+    ),
+  IconButton: ({ onPress, accessibilityLabel }: { onPress?: () => void; accessibilityLabel?: string }) =>
+    createElement('button', { onClick: onPress, 'data-paper-icon-button': accessibilityLabel ?? '' }),
+  Badge: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-paper-badge': 'true' }, children),
+}));
+
 vi.mock('@boardsesh/board-config', () => ({
   formatBoardDisplayName: (boardType: string) => `Display:${boardType}`,
 }));
@@ -73,15 +133,17 @@ vi.mock('@boardsesh/board-constants/grade-colors', () => ({
 
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
+    variant: ctrl.variant,
     systemColors: {
       label: '#000',
       fill: '#eee',
       secondaryLabel: '#888',
       separator: '#ccc',
       elevatedSurface: '#fff',
+      secondaryBackground: '#fff',
+      tertiaryBackground: '#f5f5f5',
     },
     brandColors: { primary: '#6D28D9', warning: '#FF9500' },
-    variant: ctrl.variant,
   }),
 }));
 
@@ -122,6 +184,35 @@ type PressMockProps = {
   accessibilityLabel?: string;
   accessibilityHint?: string;
 };
+
+type GlassIconButtonMockProps = {
+  iconName?: string;
+  onPress?: () => void;
+  onLongPress?: () => void;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  badgeCount?: number;
+};
+
+vi.mock('../../GlassIconButton', () => ({
+  GlassIconButton: ({
+    iconName,
+    onPress,
+    onLongPress,
+    accessibilityLabel,
+    accessibilityHint,
+    badgeCount,
+  }: GlassIconButtonMockProps) =>
+    createElement('button', {
+      onClick: onPress,
+      onDoubleClick: onLongPress,
+      'data-glass-icon': iconName ?? '',
+      'data-label': accessibilityLabel ?? '',
+      'data-hint': accessibilityHint ?? '',
+      'data-badge': badgeCount == null ? '' : String(badgeCount),
+    }),
+}));
+
 vi.mock('../../PressableSurface', () => ({
   PressableSurface: ({ children, onPress, onLongPress, accessibilityLabel, accessibilityHint }: PressMockProps) =>
     createElement(
@@ -353,7 +444,7 @@ describe('ClimbTopChrome', () => {
     ctrl.variant = 'material';
     const { container } = render(<ClimbTopChrome {...makeProps({ onOpenFilters: vi.fn() })} />);
     expect(container.querySelector('[data-search-field]')).not.toBeNull();
-    expect(container.querySelector('[data-paper="icon-button"]')).not.toBeNull();
+    expect(container.querySelector('[data-glass-icon="filter"][data-label="mobile.search.filters"]')).not.toBeNull();
   });
 
   it('native search mode leaves text search in the stack header and does not render filter chrome', () => {
@@ -427,5 +518,73 @@ describe('ClimbTopChrome', () => {
     const { container } = render(<ClimbTopChrome {...makeProps({ filterSummary: { text: 'V6 +1 more', onClear } })} />);
     fireEvent.click(summaryClear(container)!);
     expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the Material branch as an opaque app bar with search and grade controls', () => {
+    ctrl.variant = 'material';
+    ctrl.board = typedBoard;
+    const onOpenBoardDetail = vi.fn();
+    const { container } = render(
+      <ClimbTopChrome
+        {...makeProps({
+          onOpenBoardDetail,
+          onOpenFilters: vi.fn(),
+          activeFilterCount: 0,
+          gradeChip: { label: 'Grade range', active: false },
+          gradeBound: { minGradeId: undefined, maxGradeId: undefined },
+          onOpenGrade: vi.fn(),
+          onGradeChange: vi.fn(),
+        })}
+      />,
+    );
+
+    expect(container.querySelector('[data-gradient]')).toBeNull();
+    expect(container.querySelector('[data-appbar-title="true"]')?.textContent).toBe('mobile.nav.climbs');
+    expect(container.querySelector('[data-appbar-subtitle="true"]')?.textContent).toBe('Display:kilter • 12x12 • 40°');
+    expect(container.querySelector('[data-search-field]')).not.toBeNull();
+    expect(container.querySelector('[data-chip="mobile.search.gradeAction"]')?.textContent).toContain('Grade range');
+
+    fireEvent.click(container.querySelector('[data-appbar-content="true"]') as HTMLButtonElement);
+    expect(onOpenBoardDetail).toHaveBeenCalledTimes(1);
+    expect(haptics.light).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the inline grade rail from the Material grade chip and clears the active grade', () => {
+    ctrl.variant = 'material';
+    ctrl.board = typedBoard;
+    const onOpenGrade = vi.fn();
+    const onClearGrade = vi.fn();
+    const { container, rerender } = render(
+      <ClimbTopChrome
+        {...makeProps({
+          onOpenGrade,
+          onOpenFilters: vi.fn(),
+          activeFilterCount: 1,
+          gradeChip: { label: 'V6+', active: true, onClear: onClearGrade },
+          gradeBound: { minGradeId: 20, maxGradeId: undefined },
+          onGradeChange: vi.fn(),
+        })}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('[data-chip="mobile.search.gradeAction"]') as HTMLButtonElement);
+    expect(onOpenGrade).toHaveBeenCalledTimes(1);
+    fireEvent.click(container.querySelector('[data-chip-close="mobile.search.gradeAction"]') as HTMLSpanElement);
+    expect(onClearGrade).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ClimbTopChrome
+        {...makeProps({
+          onOpenGrade,
+          onOpenFilters: vi.fn(),
+          activeFilterCount: 1,
+          gradeRailVisible: true,
+          gradeChip: { label: 'V6+', active: true, onClear: onClearGrade },
+          gradeBound: { minGradeId: 20, maxGradeId: undefined },
+          onGradeChange: vi.fn(),
+        })}
+      />,
+    );
+    expect(container.querySelector('[data-grade-rail="true"]')).not.toBeNull();
   });
 });

--- a/packages/mobile/src/lib/boards/__tests__/active-board-label.test.ts
+++ b/packages/mobile/src/lib/boards/__tests__/active-board-label.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { formatActiveBoardLabel } from '../active-board-label';
+
+vi.mock('@boardsesh/board-config', () => ({
+  formatBoardDisplayName: (boardType: string) => `Display:${boardType}`,
+}));
+
+describe('formatActiveBoardLabel', () => {
+  it('returns null when there is no active board', () => {
+    expect(formatActiveBoardLabel(null)).toBeNull();
+    expect(formatActiveBoardLabel(undefined)).toBeNull();
+  });
+
+  it('uses a trimmed custom board name with the angle when present', () => {
+    expect(
+      formatActiveBoardLabel({
+        name: '  Garage Wall  ',
+        angle: 40,
+        boardType: 'kilter',
+        sizeName: '12x12',
+        layoutName: 'Homewall',
+      }),
+    ).toBe('Garage Wall • 40°');
+  });
+
+  it('falls back to display board name, size, and angle for unnamed boards', () => {
+    expect(
+      formatActiveBoardLabel({
+        name: '   ',
+        angle: 45,
+        boardType: 'tension',
+        sizeName: '12x12',
+        layoutName: 'Spray',
+      }),
+    ).toBe('Display:tension • 12x12 • 45°');
+  });
+
+  it('uses the layout name when the size name is missing', () => {
+    expect(
+      formatActiveBoardLabel({
+        angle: 25,
+        boardType: 'moonboard',
+        sizeName: null,
+        layoutName: '2019',
+      }),
+    ).toBe('Display:moonboard • 2019 • 25°');
+  });
+
+  it('keeps zero degrees and omits missing optional labels', () => {
+    expect(
+      formatActiveBoardLabel({
+        angle: 0,
+        boardType: 'kilter',
+        sizeName: null,
+        layoutName: null,
+      }),
+    ).toBe('Display:kilter • 0°');
+  });
+});

--- a/packages/mobile/src/lib/boards/active-board-label.ts
+++ b/packages/mobile/src/lib/boards/active-board-label.ts
@@ -1,0 +1,26 @@
+import { formatBoardDisplayName } from '@boardsesh/board-config';
+
+type BoardLabelFields = {
+  name?: string | null;
+  angle?: number | null;
+  boardType: string;
+  sizeName?: string | null;
+  layoutName?: string | null;
+};
+
+export function formatActiveBoardLabel(activeBoard: BoardLabelFields | null | undefined): string | null {
+  if (!activeBoard) return null;
+
+  const angleLabel = activeBoard.angle != null ? `${activeBoard.angle}°` : null;
+  const customName = activeBoard.name?.trim();
+  const hasCustomName = customName != null && customName.length > 0;
+  const labelParts = hasCustomName
+    ? [customName, angleLabel]
+    : [
+        formatBoardDisplayName(activeBoard.boardType),
+        activeBoard.sizeName ?? activeBoard.layoutName ?? null,
+        angleLabel,
+      ];
+
+  return labelParts.filter(Boolean).join(' • ');
+}

--- a/packages/mobile/test/react-native-paper-stub.tsx
+++ b/packages/mobile/test/react-native-paper-stub.tsx
@@ -21,6 +21,12 @@ export const Switch = stub('switch');
 export const Badge = stub('badge');
 export const Snackbar = stub('snackbar');
 export const Searchbar = stub('searchbar');
+export const Chip = stub('chip');
+export const Appbar = {
+  Header: stub('appbar-header'),
+  Content: stub('appbar-content'),
+  Action: stub('appbar-action'),
+};
 export const SegmentedButtons = stub('segmented-buttons');
 export const ActivityIndicator = stub('activity-indicator');
 export const TouchableRipple = stub('touchable-ripple');


### PR DESCRIPTION
## Summary

- Reworks the mobile climbs Material top chrome into a Material app bar with a paper-backed search/filter row instead of floating translucent controls.
- Keeps existing search, filters, grade range, angle switching, board detail, create, and lightbulb actions available in the new chrome.
- Shares active board label formatting with `BoardPill` and expands mobile tests/stubs for the Material branch.

## Impact

The climbs list/search page should read as Material UI in the React Native app while retaining the existing functionality and liquid glass path for the alternate variant.

## Validation

- `vp test run packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx packages/mobile/src/components/__tests__/search-header.test.tsx`
- `vp run typecheck:mobile`
- `vp fmt` on the changed files
- `vp check` still reports pre-existing formatting issues in unrelated files outside this PR scope, so I left those files untouched.
- `vp run dev:mobile` started Metro at `http://vibetunnel-2.tailedd9d5.ts.net:8085`.