### PR TITLE
Fix prod deploy: ship bun patch files in generated Docker contexts

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -15,6 +15,9 @@ RUN apk add --no-cache bash curl unzip && \
 # workspace manifests for the Bun install layer and only backend source after it.
 COPY manifests/package.json manifests/bun.lock ./
 COPY manifests/packages ./packages
+# Patch files referenced by package.json's patchedDependencies must be present
+# before install, or `bun install --frozen-lockfile` can't find them.
+COPY manifests/patches ./patches
 
 # Install dependencies (--production is incompatible with --frozen-lockfile in Bun)
 RUN bun install --frozen-lockfile

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -15,6 +15,9 @@ RUN apk add --no-cache bash curl unzip && \
 # workspace manifests for the Bun install layer and only web build source after it.
 COPY manifests/package.json manifests/bun.lock ./
 COPY manifests/packages ./packages
+# Patch files referenced by package.json's patchedDependencies must be present
+# before install, or `bun install --frozen-lockfile` can't find them.
+COPY manifests/patches ./patches
 
 # Install all dependencies (need devDependencies for the build)
 RUN bun install --frozen-lockfile
@@ -33,6 +36,7 @@ COPY --from=deps /app/node_modules ./node_modules
 
 # Source-only edits land after install, so they do not invalidate the dependency layer.
 COPY source/package.json source/bun.lock ./
+COPY source/patches ./patches
 COPY source/packages ./packages
 
 # Accept build arguments for environment variables baked into the Next.js build

--- a/scripts/check-service-deploy-inputs.mjs
+++ b/scripts/check-service-deploy-inputs.mjs
@@ -80,7 +80,16 @@ function requireDockerContextFile(failures, repoRoot, dockerfilePath) {
   const manifestPackagesCopy = 'COPY manifests/packages ./packages';
   const sourcePackagesCopy = 'COPY source/packages ./packages';
 
-  for (const copyLine of [manifestRootCopy, manifestPackagesCopy]) {
+  const requiredPreInstallCopies = [manifestRootCopy, manifestPackagesCopy];
+
+  // patchedDependencies are resolved during install, so the patch files must be
+  // copied into the install layer or `bun install --frozen-lockfile` fails.
+  const rootPackageJson = JSON.parse(readRepoFile(repoRoot, 'package.json'));
+  if (Object.keys(rootPackageJson.patchedDependencies ?? {}).length > 0) {
+    requiredPreInstallCopies.push('COPY manifests/patches ./patches');
+  }
+
+  for (const copyLine of requiredPreInstallCopies) {
     const copyIndex = dockerfileContents.indexOf(copyLine);
     if (copyIndex === -1) {
       failures.push(`${dockerfilePath}: missing ${copyLine}`);
@@ -134,6 +143,13 @@ function verifyGeneratedContext(failures, repoRoot, serviceName, outputRoot) {
     existsSync(join(result.outputDir, 'source', packageDirectory, 'package.json')),
   );
   comparePathLists(failures, `${serviceName} Docker context source packages`, actualSourceDirs, expectedSourceDirs);
+
+  const rootPackageJson = JSON.parse(readRepoFile(repoRoot, 'package.json'));
+  for (const patchRelativePath of Object.values(rootPackageJson.patchedDependencies ?? {}).map(String)) {
+    if (!existsSync(join(result.outputDir, 'manifests', patchRelativePath))) {
+      failures.push(`${serviceName} Docker context: missing manifests/${patchRelativePath}`);
+    }
+  }
 
   if (!existsSync(join(result.outputDir, 'Dockerfile'))) {
     failures.push(`${serviceName} Docker context: missing Dockerfile`);

--- a/scripts/check-service-deploy-inputs.test.mjs
+++ b/scripts/check-service-deploy-inputs.test.mjs
@@ -125,6 +125,59 @@ void test('rejects hand-maintained workspace manifest COPY lines in Dockerfiles'
   });
 });
 
+void test('rejects patchedDependencies without a patches COPY in the install layer', () => {
+  withFixtureRepo((repoRoot) => {
+    writeFixtureFile(
+      repoRoot,
+      'package.json',
+      `${JSON.stringify(
+        {
+          workspaces: ['packages/*', 'packages/shared/*'],
+          patchedDependencies: { 'left-pad@1.0.0': 'patches/left-pad@1.0.0.patch' },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    writeFixtureFile(repoRoot, 'patches/left-pad@1.0.0.patch', 'diff\n');
+
+    const failures = createServiceDeployInputFailures({ repoRoot });
+    assert.match(failures.join('\n'), /missing COPY manifests\/patches \.\/patches/);
+  });
+});
+
+void test('passes when patchedDependencies are wired into the install layer', () => {
+  withFixtureRepo((repoRoot) => {
+    writeFixtureFile(
+      repoRoot,
+      'package.json',
+      `${JSON.stringify(
+        {
+          workspaces: ['packages/*', 'packages/shared/*'],
+          patchedDependencies: { 'left-pad@1.0.0': 'patches/left-pad@1.0.0.patch' },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    writeFixtureFile(repoRoot, 'patches/left-pad@1.0.0.patch', 'diff\n');
+
+    const dockerfile = [
+      'FROM node:22-alpine',
+      'COPY manifests/package.json manifests/bun.lock ./',
+      'COPY manifests/packages ./packages',
+      'COPY manifests/patches ./patches',
+      'RUN bun install --frozen-lockfile',
+      'COPY source/packages ./packages',
+      '',
+    ].join('\n');
+    writeFixtureFile(repoRoot, 'Dockerfile.backend', dockerfile);
+    writeFixtureFile(repoRoot, 'Dockerfile.web', dockerfile);
+
+    assert.deepEqual(createServiceDeployInputFailures({ repoRoot }), []);
+  });
+});
+
 void test('rejects source package COPY instructions before bun install', () => {
   withFixtureRepo((repoRoot) => {
     writeFixtureFile(

--- a/scripts/create-service-docker-context.mjs
+++ b/scripts/create-service-docker-context.mjs
@@ -202,6 +202,20 @@ function createServiceDockerContext({ serviceName, repoRoot = defaultRepoRoot, o
     copyFileCreatingParent(join(absoluteRepoRoot, rootFile), join(absoluteOutputDir, 'source', rootFile));
   }
 
+  // Bun resolves `patchedDependencies` paths relative to the package.json that
+  // declares them, so the install layer needs the patch files next to the copied
+  // root manifest. Without them `bun install --frozen-lockfile` aborts with
+  // "Couldn't find patch file" and the image build fails.
+  const rootPackageJson = readJson(join(absoluteRepoRoot, 'package.json'));
+  for (const patchRelativePath of Object.values(rootPackageJson.patchedDependencies ?? {}).map(String)) {
+    const absolutePatchPath = join(absoluteRepoRoot, patchRelativePath);
+    if (!existsSync(absolutePatchPath)) {
+      throw new Error(`package.json patchedDependencies references ${patchRelativePath}, but that file is missing`);
+    }
+    copyFileCreatingParent(absolutePatchPath, join(absoluteOutputDir, 'manifests', patchRelativePath));
+    copyFileCreatingParent(absolutePatchPath, join(absoluteOutputDir, 'source', patchRelativePath));
+  }
+
   for (const packageJsonPath of getWorkspacePackageJsonPaths(absoluteRepoRoot)) {
     copyFileCreatingParent(
       join(absoluteRepoRoot, packageJsonPath),


### PR DESCRIPTION
## Problem

Every **Production Deploy** on `main` has failed since the `react-native-screens` patch landed (commit `31734edf9`, "Add native tab accessory climb toolbar"). The `build-backend` job dies in the Docker build at:

```
error: Couldn't find patch file: 'patches/react-native-screens@4.25.2.patch'
process "/bin/sh -c bun install --frozen-lockfile" did not complete successfully: exit code: 1
```

That commit added `patchedDependencies` to the root `package.json`, but `scripts/create-service-docker-context.mjs` copied the root manifest into the generated context **without** the patch files it references. `bun install --frozen-lockfile` reads `patchedDependencies` and aborts before it can find them.

Production web deploys go through the Vercel CLI (full repo, patch present), so `build-web` kept passing — but the `Dockerfile.web` path used by branch/preview deploys had the same latent break.

> The latest run also showed a one-off `curl 504` while downloading bun from GitHub — transient, not the recurring cause.

## Fix

- **`create-service-docker-context.mjs`** copies every file referenced by `patchedDependencies` into both the `manifests/` and `source/` trees of the generated context, and throws if a referenced patch is missing.
- **`Dockerfile.backend` / `Dockerfile.web`** `COPY patches/` into the install layer before `bun install --frozen-lockfile`.
- **`check-service-deploy-inputs.mjs`** (the *Service Deployment Inputs* check) now requires the patches COPY whenever `patchedDependencies` is non-empty and asserts the generated context ships the patch files — so the next regression of this kind fails in the input check, not in a prod deploy.

## Verification

- Generated backend context now contains `manifests/patches/react-native-screens@4.25.2.patch`.
- `bun install --frozen-lockfile --dry-run` resolves cleanly against the generated layout (previously errored immediately on the missing patch).
- `node scripts/check-service-deploy-inputs.mjs` → passes.
- `node --test scripts/check-service-deploy-inputs.test.mjs` → 5/5 pass (2 new tests cover the patch wiring).
- `vp check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)