### PR TITLE
Fix Material current climb bar

### DIFF
--- a/docs/ui/01-navigation.md
+++ b/docs/ui/01-navigation.md
@@ -50,6 +50,7 @@ There are **5 tabs** (the web has a 6th "Create" tab but it is between Discover 
 The mobile tab bar has two distinct implementations chosen by the active UI variant (set in the More tab under "UI Style"):
 
 **Liquid Glass variant** (default on iOS 26+):
+
 - Uses `expo-router/unstable-native-tabs` `NativeTabs` — a native UIKit tab bar.
 - 5 tabs: Boards, Climbs, Record, Discover, Profile.
 - Tab icons: SF Symbols (`sf=`) on iOS, Material Design strings (`md=`) on Android.
@@ -58,16 +59,18 @@ The mobile tab bar has two distinct implementations chosen by the active UI vari
 - `minimizeBehavior="onScrollDown"` hides the bar while scrolling the climbs list (requires the `react-native-screens` patch at `patches/react-native-screens@4.25.2.patch`).
 
 **Material variant**:
+
 - Uses Expo Router `<Tabs>` with a custom JS tab bar (`MaterialTabBar`, `packages/mobile/src/components/navigation/MaterialTabBar.tsx`).
 - Same 5 tabs as the Liquid Glass variant.
 - Tab icons: `MaterialCommunityIcons` (active/inactive glyph pairs, e.g. `view-dashboard` / `view-dashboard-outline`).
 - Record tab shows a badge dot (`tabBarBadge`) styled with `brandColors.success` when the same conditions apply.
-- The climb/tick chrome uses `PersistentQueueBar` (a floating JS toolbar) instead of the native `BottomAccessory`.
+- The climb/tick chrome uses `PersistentQueueBar` as a docked opaque active-context bar above the tab bar instead of the native `BottomAccessory`.
 - Opaque elevated surface with an M3 tonal active-indicator pill behind the focused icon.
 
 `_layout.tsx` reads `variant` directly from `useTheme()` (the stored UI-variant preference) and renders the appropriate navigator. `useEffectiveSurfaceMode()` is a separate hook used by surface-rendering components such as `GlassSurface` to apply the a11y (`reduceTransparency`) overlay on top of the stored preference.
 
 **Mobile tab set differs from the web table above:** The 5 mobile tabs are Boards, Climbs, Record, Discover, Profile. Climbs is the default route (`unstable_settings.initialRouteName = 'climbs'`); there is no separate "Create" or "Feed" tab.
+
 - **Board selection is a full-screen modal** (`app/boards/`), not the web's `BoardSelectorDrawer`. The board pill in the Climbs / Discover top chrome opens it (`/boards`).
 - **No board context shows a CTA, not a selector.** On a cold start with no active board the Climbs list renders a "select a board" prompt rather than auto-opening a drawer; tapping it routes to the `/boards` modal.
 

--- a/packages/mobile/src/components/Toast.tsx
+++ b/packages/mobile/src/components/Toast.tsx
@@ -9,7 +9,8 @@ import { Icon } from './Icon';
 import type { IconName } from './icon-map';
 import { blendOpaque, withAlpha } from '../theme/colors';
 import { borderRadius, spacing } from '../theme/tokens';
-import { TAB_BAR_HEIGHT, TOOLBAR_RESERVE } from '../theme/layout';
+import { MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT, TAB_BAR_HEIGHT, TOOLBAR_RESERVE } from '../theme/layout';
+import type { UiVariant } from '../theme/resolve-ui-variant';
 import { isTabsRoute } from '../lib/route-segments';
 import { useTheme } from '../providers/theme-provider';
 
@@ -58,17 +59,18 @@ export function Toast({ toast, onDismiss }: ToastProps) {
  * area. Shared by both variants — ToastProvider sits above QueueProvider, so this
  * must stay independent from queue context.
  */
-function useToastBottomOffset() {
+function useToastBottomOffset(uiVariant: UiVariant) {
   const insets = useSafeAreaInsets();
   const segments = useSegments();
+  const toolbarReserve = uiVariant === 'material' ? MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT : TOOLBAR_RESERVE;
   return isTabsRoute(segments)
-    ? insets.bottom + TAB_BAR_HEIGHT + TOOLBAR_RESERVE + spacing[2]
+    ? insets.bottom + TAB_BAR_HEIGHT + toolbarReserve + spacing[2]
     : insets.bottom + spacing[3];
 }
 
 function ToastMaterial({ toast, onDismiss }: ToastProps) {
-  const { systemColors, colorScheme, brandColors } = useTheme();
-  const bottomOffset = useToastBottomOffset();
+  const { systemColors, colorScheme, brandColors, variant: uiVariant } = useTheme();
+  const bottomOffset = useToastBottomOffset(uiVariant);
   const config = VARIANT_CONFIG[toast.variant];
   const variantColor = brandColors[config.colorKey];
 
@@ -118,8 +120,8 @@ function ToastMaterial({ toast, onDismiss }: ToastProps) {
 
 // Liquid Glass / HIG toast — the original implementation, unchanged.
 function ToastGlass({ toast, onDismiss }: ToastProps) {
-  const { systemColors, colorScheme, brandColors } = useTheme();
-  const bottomOffset = useToastBottomOffset();
+  const { systemColors, colorScheme, brandColors, variant: uiVariant } = useTheme();
+  const bottomOffset = useToastBottomOffset(uiVariant);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const config = VARIANT_CONFIG[toast.variant];
   const variantColor = brandColors[config.colorKey];

--- a/packages/mobile/src/components/__tests__/queue-added-snackbar.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-added-snackbar.test.tsx
@@ -37,16 +37,18 @@ type SnackbarMockProps = {
   duration?: number;
   onDismiss?: () => void;
   action?: SnackbarAction;
+  wrapperStyle?: unknown;
   children?: ReactNode;
 };
 vi.mock('react-native-paper', () => ({
-  Snackbar: ({ visible, duration, onDismiss, action, children }: SnackbarMockProps) =>
+  Snackbar: ({ visible, duration, onDismiss, action, wrapperStyle, children }: SnackbarMockProps) =>
     createElement(
       'div',
       {
         'data-paper-snackbar': 'true',
         'data-visible': visible ? 'true' : 'false',
         'data-duration': String(duration ?? ''),
+        'data-wrapper-style': JSON.stringify(wrapperStyle),
         onClick: onDismiss,
       },
       children,
@@ -103,6 +105,14 @@ describe('QueueAddedSnackbar', () => {
     expect(action?.textContent).toBe('mobile.queueSnackbar.open');
     expect(action?.getAttribute('data-action-label')).toBe('mobile.queueSnackbar.openAria');
     expect(container.querySelector('[data-animated]')).toBeNull();
+  });
+
+  it('positions the Material snackbar above the shared floating-control offset', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<QueueAddedSnackbar {...base} />);
+    expect(container.querySelector('[data-paper-snackbar]')?.getAttribute('data-wrapper-style')).toContain(
+      '"bottom":108',
+    );
   });
 
   it('maps duration prop and routes the action to onOpen on Material', () => {

--- a/packages/mobile/src/components/__tests__/toast.test.tsx
+++ b/packages/mobile/src/components/__tests__/toast.test.tsx
@@ -16,8 +16,20 @@ vi.mock('react-native', () => ({
 // Reanimated Animated.View → div exposing accessibility props (glass path).
 vi.mock('react-native-reanimated', () => ({
   default: {
-    View: ({ children, accessibilityRole }: { children?: ReactNode; accessibilityRole?: string }) =>
-      createElement('div', { 'data-animated': 'true', 'data-role': accessibilityRole ?? '' }, children),
+    View: ({
+      children,
+      accessibilityRole,
+      style,
+    }: {
+      children?: ReactNode;
+      accessibilityRole?: string;
+      style?: unknown;
+    }) =>
+      createElement(
+        'div',
+        { 'data-animated': 'true', 'data-role': accessibilityRole ?? '', 'data-style': JSON.stringify(style) },
+        children,
+      ),
   },
   FadeIn: { duration: () => ({}) },
   FadeOut: { duration: () => ({}) },
@@ -29,16 +41,18 @@ type SnackbarMockProps = {
   duration?: number;
   onDismiss?: () => void;
   children?: ReactNode;
+  wrapperStyle?: unknown;
   style?: { backgroundColor?: string };
 };
 vi.mock('react-native-paper', () => ({
-  Snackbar: ({ visible, duration, onDismiss, children, style }: SnackbarMockProps) =>
+  Snackbar: ({ visible, duration, onDismiss, children, wrapperStyle, style }: SnackbarMockProps) =>
     createElement(
       'div',
       {
         'data-paper-snackbar': 'true',
         'data-visible': visible ? 'true' : 'false',
         'data-duration': String(duration ?? ''),
+        'data-wrapper-style': JSON.stringify(wrapperStyle),
         'data-bg': style?.backgroundColor ?? '',
         onClick: onDismiss,
       },
@@ -65,7 +79,11 @@ vi.mock('../../theme/colors', () => ({
   blendOpaque: (foreground: string, background: string) => `${foreground}|${background}`,
 }));
 vi.mock('../../theme/tokens', () => ({ borderRadius: { full: 999 }, spacing: { 2: 8, 3: 12, 4: 16 } }));
-vi.mock('../../theme/layout', () => ({ TAB_BAR_HEIGHT: 49, TOOLBAR_RESERVE: 56 }));
+vi.mock('../../theme/layout', () => ({
+  MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT: 48,
+  TAB_BAR_HEIGHT: 49,
+  TOOLBAR_RESERVE: 56,
+}));
 vi.mock('../../lib/route-segments', () => ({ isTabsRoute: () => true }));
 vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({
@@ -96,6 +114,14 @@ describe('Toast', () => {
     expect(container.querySelector('[data-view][data-role="alert"]')).not.toBeNull();
     // The glass animated pill must not render on Material.
     expect(container.querySelector('[data-animated]')).toBeNull();
+  });
+
+  it('positions Material toasts above the docked climb bar and tab bar', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
+    expect(container.querySelector('[data-paper-snackbar]')?.getAttribute('data-wrapper-style')).toContain(
+      '"bottom":139',
+    );
   });
 
   it('selects the matching icon + tint per variant on the Material variant', () => {
@@ -131,6 +157,12 @@ describe('Toast', () => {
     expect(container.querySelector('[data-icon="success"]')).not.toBeNull();
     expect(container.textContent).toContain('Saved tick');
     expect(container.querySelector('[data-paper-snackbar]')).toBeNull();
+  });
+
+  it('positions Liquid Glass toasts above the floating toolbar reserve', () => {
+    ctrl.variant = 'liquidGlass';
+    const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
+    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"bottom":147');
   });
 
   it('auto-dismisses via timer on the Liquid Glass variant', () => {

--- a/packages/mobile/src/components/queue-control/AccessoryBarSurface.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryBarSurface.tsx
@@ -5,10 +5,14 @@ import { useTheme } from '../../providers/theme-provider';
 import { useEffectiveSurfaceMode } from '../../hooks/use-effective-surface-mode';
 import { shadows } from '../../theme/tokens';
 
+export type AccessoryBarSurfaceTreatment = 'floating' | 'docked';
+
 type AccessoryBarSurfaceProps = {
   /** Surface height; the default radius is a full pill (`height / 2`). */
   height: number;
   borderRadius?: number;
+  /** Material can dock the surface to the tab bar instead of rendering a floating pill. */
+  treatment?: AccessoryBarSurfaceTreatment;
   style?: StyleProp<ViewStyle>;
   children: ReactNode;
 };
@@ -19,17 +23,23 @@ type AccessoryBarSurfaceProps = {
  * occupant content stays variant-agnostic:
  *
  *   glass    → Liquid Glass pill (native edge — no border/shadow)
- *   material → opaque M3 tonal pill + elevation (no border)
+ *   material → opaque M3 tonal surface (floating pill or docked bar)
  *   blur/solid → frosted/solid fill + hairline border + separation shadow
  *
  * Reduce Transparency is handled inside `GlassSurface`/`useEffectiveSurfaceMode`
  * (it resolves to the solid branch here), so a11y stays correct without this
  * component knowing about it.
  */
-export function AccessoryBarSurface({ height, borderRadius, style, children }: AccessoryBarSurfaceProps) {
+export function AccessoryBarSurface({
+  height,
+  borderRadius,
+  treatment = 'floating',
+  style,
+  children,
+}: AccessoryBarSurfaceProps) {
   const mode = useEffectiveSurfaceMode();
-  const { systemColors } = useTheme();
-  const radius = borderRadius ?? height / 2;
+  const { systemColors, variant } = useTheme();
+  const radius = treatment === 'docked' ? 0 : (borderRadius ?? height / 2);
   const shape: ViewStyle = { height, borderRadius: radius };
 
   // Native Liquid Glass draws its own refractive edge + lift.
@@ -47,11 +57,18 @@ export function AccessoryBarSurface({ height, borderRadius, style, children }: A
     );
   }
 
-  // Material: opaque M3 tonal surface + elevation; no border (elevation separates).
-  if (mode === 'material') {
-    return (
-      <View style={[shape, { backgroundColor: systemColors.elevatedSurface }, shadows.sm, style]}>{children}</View>
-    );
+  // Material is already opaque, so keep it on the Material surface path even
+  // when Reduce Transparency resolves translucent surfaces to solid.
+  if (mode === 'material' || variant === 'material') {
+    const materialSurfaceStyle: ViewStyle =
+      treatment === 'docked'
+        ? {
+            backgroundColor: systemColors.elevatedSurface,
+            borderTopWidth: StyleSheet.hairlineWidth,
+            borderTopColor: systemColors.separator,
+          }
+        : { backgroundColor: systemColors.elevatedSurface, ...shadows.sm };
+    return <View style={[shape, materialSurfaceStyle, style]}>{children}</View>;
   }
 
   // Blur / solid fallback: the surface has no intrinsic edge, so add the hairline

--- a/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
+++ b/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
@@ -1,6 +1,6 @@
 /**
- * ActiveContextBar — the content-agnostic floating bar that sits above the tab
- * bar. It owns ONLY the layout (absolute lift above the tab bar, the
+ * ActiveContextBar — the content-agnostic bar that sits above the tab
+ * bar. It owns ONLY the layout (absolute lift/docking above the tab bar, the
  * leading / primary / trailing slot rhythm, fade-in) — not what fills it. Today
  * the primary slot holds the climb capsule; a later workout rep-timer drops into
  * the same slot with no changes here.
@@ -40,6 +40,8 @@ type ActiveContextBarProps = {
   fillPrimary?: boolean;
   /** Lift above the tab bar (defaults to TOOLBAR_GAP_ABOVE_TABBAR). */
   gapAboveTabBar?: number;
+  /** Horizontal inset from the screen edge; Material uses 0 for a docked bar. */
+  horizontalInset?: number;
 };
 
 export function ActiveContextBar({
@@ -49,6 +51,7 @@ export function ActiveContextBar({
   trailingWidth = glassSize.hero,
   fillPrimary = false,
   gapAboveTabBar = TOOLBAR_GAP_ABOVE_TABBAR,
+  horizontalInset = TOOLBAR_SIDE_MARGIN,
 }: ActiveContextBarProps) {
   const reduceMotion = useReduceMotion();
   const bottomChrome = useBottomChromeMetrics();
@@ -57,7 +60,14 @@ export function ActiveContextBar({
     <Animated.View
       entering={reduceMotion ? undefined : FadeIn.duration(timing.normal)}
       pointerEvents="box-none"
-      style={[styles.toolbar, { bottom: bottomChrome.tabBarBottom + gapAboveTabBar }]}
+      style={[
+        styles.toolbar,
+        {
+          bottom: bottomChrome.tabBarBottom + gapAboveTabBar,
+          left: horizontalInset,
+          right: horizontalInset,
+        },
+      ]}
     >
       {fillPrimary ? (
         <View style={styles.fillRow} pointerEvents="box-none" importantForAccessibility="auto">
@@ -83,10 +93,8 @@ export function ActiveContextBar({
 const styles = StyleSheet.create({
   toolbar: {
     position: 'absolute',
-    left: TOOLBAR_SIDE_MARGIN,
-    right: TOOLBAR_SIDE_MARGIN,
     // `bottom` is set inline from the safe-area inset + tab-bar height so the
-    // islands float just above the tab bar.
+    // bar can either float above or dock to the tab bar.
   },
   row: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -17,7 +17,7 @@ import { useGradeFormat } from '../../hooks/use-grade-format';
 import { Text } from '../Text';
 import { useTheme } from '../../providers/theme-provider';
 import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
-import { AccessoryBarSurface } from './AccessoryBarSurface';
+import { AccessoryBarSurface, type AccessoryBarSurfaceTreatment } from './AccessoryBarSurface';
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useQueueCarousel } from './use-queue-carousel';
 
@@ -65,6 +65,8 @@ type ClimbCapsuleProps = {
   /** Action floated inside the capsule on the right, outside the swipe target (e.g. the tick). */
   endAction?: ReactNode;
   endActionSize?: number;
+  /** Surface silhouette; Material docks this row while other variants float it. */
+  surfaceTreatment?: AccessoryBarSurfaceTreatment;
 };
 
 export function ClimbCapsule({
@@ -72,6 +74,7 @@ export function ClimbCapsule({
   fillWidth = false,
   endAction,
   endActionSize = 0,
+  surfaceTreatment = 'floating',
 }: ClimbCapsuleProps) {
   const { systemColors } = useTheme();
   const { boardConfig } = useDrawerHost();
@@ -111,7 +114,7 @@ export function ClimbCapsule({
 
   if (!currentClimb) return null;
 
-  const capsuleRadius = height / 2;
+  const capsuleRadius = surfaceTreatment === 'docked' ? 0 : height / 2;
   // Reserve room on the right so the name/grade never slide under the inline tick.
   const endActionReservedWidth = endAction ? endActionSize + 8 : 0;
   const labelRight = 16 + endActionReservedWidth;
@@ -120,6 +123,7 @@ export function ClimbCapsule({
     <AccessoryBarSurface
       height={height}
       borderRadius={capsuleRadius}
+      treatment={surfaceTreatment}
       style={[styles.capsule, fillWidth ? null : styles.capsuleCap]}
     >
       <GestureDetector gesture={composedGesture}>

--- a/packages/mobile/src/components/queue-control/__tests__/accessory-bar-surface.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/accessory-bar-surface.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const ctrl = vi.hoisted(() => ({
+  mode: 'material' as 'glass' | 'blur' | 'material' | 'solid',
+  variant: 'material' as 'liquidGlass' | 'material',
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+    createElement('div', { 'data-view': 'true', 'data-style': JSON.stringify(style) }, children),
+  StyleSheet: { absoluteFill: {}, create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('../../GlassSurface', () => ({
+  GlassSurface: () => createElement('div', { 'data-glass': 'true' }),
+}));
+
+vi.mock('../../../hooks/use-effective-surface-mode', () => ({
+  useEffectiveSurfaceMode: () => ctrl.mode,
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: ctrl.variant,
+    systemColors: {
+      elevatedSurface: '#FFFFFF',
+      separator: '#CCCCCC',
+    },
+  }),
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  shadows: { sm: { elevation: 2 } },
+}));
+
+import { AccessoryBarSurface } from '../AccessoryBarSurface';
+
+describe('AccessoryBarSurface', () => {
+  beforeEach(() => {
+    ctrl.mode = 'material';
+    ctrl.variant = 'material';
+  });
+
+  it('renders the Material docked treatment as an opaque full-width bar surface', () => {
+    const { container } = render(
+      <AccessoryBarSurface height={48} treatment="docked">
+        child
+      </AccessoryBarSurface>,
+    );
+
+    const surface = container.querySelector('[data-view]');
+    const style = surface?.getAttribute('data-style') ?? '';
+    expect(style).toContain('"height":48');
+    expect(style).toContain('"borderRadius":0');
+    expect(style).toContain('"backgroundColor":"#FFFFFF"');
+    expect(style).toContain('"borderTopWidth":1');
+    expect(style).toContain('"borderTopColor":"#CCCCCC"');
+    expect(style).not.toContain('"elevation":2');
+    expect(container.querySelector('[data-glass]')).toBeNull();
+  });
+
+  it('keeps Material on the opaque surface path when reduce-transparency resolves mode to solid', () => {
+    ctrl.mode = 'solid';
+    ctrl.variant = 'material';
+    const { container } = render(
+      <AccessoryBarSurface height={48} treatment="docked">
+        child
+      </AccessoryBarSurface>,
+    );
+
+    expect(container.querySelector('[data-glass]')).toBeNull();
+    expect(container.querySelector('[data-view]')?.getAttribute('data-style')).toContain('"backgroundColor":"#FFFFFF"');
+  });
+});

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -8,6 +8,7 @@ import type { ClimbQueueItem } from '@boardsesh/queue';
 const cfg = vi.hoisted(() => ({
   onClimbsTab: true,
   currentClimbQueueItem: { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem | null,
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
 }));
 
 vi.mock('react-native', () => ({
@@ -16,7 +17,10 @@ vi.mock('react-native', () => ({
 }));
 
 vi.mock('react-native-reanimated', () => ({
-  default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
+  default: {
+    View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+      createElement('div', { 'data-animated': 'true', 'data-style': JSON.stringify(style) }, children),
+  },
   FadeIn: { duration: () => ({}) },
   useAnimatedStyle: () => ({}),
   useSharedValue: (value: number) => ({ value }),
@@ -37,6 +41,7 @@ vi.mock('../../../providers/queue-provider', () => ({
 vi.mock('../../../hooks/use-reduce-motion', () => ({ useReduceMotion: () => true }));
 vi.mock('../../../theme/animations', () => ({ timing: { fast: 150, normal: 250 } }));
 vi.mock('../../../theme/layout', () => ({
+  MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT: 48,
   TAB_BAR_HEIGHT: 49,
   TOOLBAR_RESERVE: 74,
   TOOLBAR_SIDE_MARGIN: 16,
@@ -47,7 +52,7 @@ vi.mock('../../../theme/layout', () => ({
 }));
 vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4 } }));
 // Default to the Liquid Glass layout (centered capsule + standalone hero tick).
-vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ variant: 'liquidGlass' }) }));
+vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ variant: cfg.variant }) }));
 // The floating bar renders only where the native bottom accessory doesn't
 // (Material variant / iOS < 26 / Android) — force that path so the capsule/tick
 // assertions hold. `useNativeAccessoryActive` is what use-bottom-chrome-metrics
@@ -56,7 +61,29 @@ vi.mock('../../../hooks/use-bottom-accessory', () => ({
   isBottomAccessoryAvailable: () => false,
   useNativeAccessoryActive: () => false,
 }));
-vi.mock('../ClimbCapsule', () => ({ ClimbCapsule: () => createElement('div', { 'data-capsule': 'true' }) }));
+vi.mock('../ClimbCapsule', () => ({
+  ClimbCapsule: ({
+    fillWidth,
+    height,
+    surfaceTreatment,
+    endAction,
+  }: {
+    fillWidth?: boolean;
+    height?: number;
+    surfaceTreatment?: string;
+    endAction?: ReactNode;
+  }) =>
+    createElement(
+      'div',
+      {
+        'data-capsule': 'true',
+        'data-fill-width': fillWidth ? 'true' : 'false',
+        'data-height': height == null ? '' : String(height),
+        'data-surface-treatment': surfaceTreatment ?? '',
+      },
+      endAction,
+    ),
+}));
 vi.mock('../LogAscentFab', () => ({ LogAscentFab: () => createElement('div', { 'data-tick': 'true' }) }));
 vi.mock('../LogAscentToolbarButton', () => ({
   LogAscentToolbarButton: () => createElement('div', { 'data-tick-inline': 'true' }),
@@ -68,6 +95,7 @@ describe('PersistentQueueBar', () => {
   beforeEach(() => {
     cfg.onClimbsTab = true;
     cfg.currentClimbQueueItem = { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem;
+    cfg.variant = 'liquidGlass';
   });
 
   it('renders nothing when no climb is current', () => {
@@ -89,5 +117,19 @@ describe('PersistentQueueBar', () => {
     const { container } = render(<PersistentQueueBar />);
     expect(container.querySelector('[data-capsule]')).not.toBeNull();
     expect(container.querySelector('[data-tick]')).not.toBeNull();
+  });
+
+  it('uses a docked full-width inline-action bar on Material', () => {
+    cfg.variant = 'material';
+    const { container } = render(<PersistentQueueBar />);
+    const capsule = container.querySelector('[data-capsule]');
+    expect(capsule).not.toBeNull();
+    expect(capsule?.getAttribute('data-fill-width')).toBe('true');
+    expect(capsule?.getAttribute('data-height')).toBe('48');
+    expect(capsule?.getAttribute('data-surface-treatment')).toBe('docked');
+    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"left":0');
+    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"right":0');
+    expect(container.querySelector('[data-tick-inline]')).not.toBeNull();
+    expect(container.querySelector('[data-tick]')).toBeNull();
   });
 });

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -1,5 +1,5 @@
 /**
- * PersistentQueueBar — the floating climb toolbar that mounts at the app root
+ * PersistentQueueBar — the persistent climb toolbar that mounts at the app root
  * and is visible on every screen while a current climb is set.
  *
  * It is a thin adapter: it decides *whether* the climb bar should show (a current
@@ -10,14 +10,13 @@
  *     centered capsule + standalone hero tick (tap = PlayDrawer, swipe = prev/next)
  *
  *   Material                  [ ▢ grade · name              ✓ ]
- *     one full-width capsule with the tick inside, sitting close to the tab bar
+ *     one full-width opaque active-context bar docked above the tab bar
  *
  * On the Liquid Glass variant on iOS 26 the native bottom accessory owns this
  * pair, so `jsQueueToolbarVisible` is false here and this returns null.
  */
 
-import { TOOLBAR_RESERVE, TAB_BAR_HEIGHT, glassSize } from '../../theme/layout';
-import { spacing } from '../../theme/tokens';
+import { MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT, TOOLBAR_RESERVE, TAB_BAR_HEIGHT, glassSize } from '../../theme/layout';
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
@@ -44,10 +43,13 @@ export function PersistentQueueBar() {
     return (
       <ActiveContextBar
         fillPrimary
-        gapAboveTabBar={spacing[1]}
+        gapAboveTabBar={0}
+        horizontalInset={0}
         primary={
           <ClimbCapsule
             fillWidth
+            height={MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT}
+            surfaceTreatment="docked"
             endAction={<LogAscentToolbarButton climb={currentClimb} size={glassSize.inline} />}
             endActionSize={glassSize.inline}
           />

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { computeBottomChromeMetrics } from '../bottom-chrome-metrics';
-import { TAB_BAR_HEIGHT, TOOLBAR_GAP_ABOVE_TABBAR, TOOLBAR_RESERVE, glassSize } from '../../theme/layout';
+import {
+  MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
+  TAB_BAR_HEIGHT,
+  TOOLBAR_GAP_ABOVE_TABBAR,
+  TOOLBAR_RESERVE,
+  glassSize,
+} from '../../theme/layout';
 
 // Assert the arbitration in terms of the layout constants (not magic numbers) so
 // this stays correct when the glass-size ladder is retuned.
@@ -9,6 +15,7 @@ const NATIVE_ACCESSORY_RESERVE = glassSize.standard + TOOLBAR_GAP_ABOVE_TABBAR;
 describe('computeBottomChromeMetrics', () => {
   it('reserves nothing extra outside the tabs group', () => {
     const metrics = computeBottomChromeMetrics({
+      uiVariant: 'liquidGlass',
       insetsBottom: 34,
       insideTabs: false,
       hasCurrentClimb: false,
@@ -24,6 +31,7 @@ describe('computeBottomChromeMetrics', () => {
 
   it('reserves the JS toolbar when a climb is set and the native accessory is unavailable', () => {
     const metrics = computeBottomChromeMetrics({
+      uiVariant: 'liquidGlass',
       insetsBottom: 0,
       insideTabs: true,
       hasCurrentClimb: true,
@@ -35,8 +43,23 @@ describe('computeBottomChromeMetrics', () => {
     expect(metrics.floatingControlBottom).toBe(TAB_BAR_HEIGHT + TOOLBAR_RESERVE);
   });
 
+  it('reserves the docked Material bar when the JS toolbar is visible', () => {
+    const metrics = computeBottomChromeMetrics({
+      uiVariant: 'material',
+      insetsBottom: 0,
+      insideTabs: true,
+      hasCurrentClimb: true,
+      nativeAccessoryMounted: false,
+    });
+    expect(metrics.jsQueueToolbarVisible).toBe(true);
+    expect(metrics.jsQueueReserve).toBe(MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
+    expect(metrics.scrollBottomPadding).toBe(TAB_BAR_HEIGHT + MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
+    expect(metrics.floatingControlBottom).toBe(TAB_BAR_HEIGHT + MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
+  });
+
   it('does not pad scroll content for the UIKit-owned native accessory', () => {
     const metrics = computeBottomChromeMetrics({
+      uiVariant: 'liquidGlass',
       insetsBottom: 0,
       insideTabs: true,
       hasCurrentClimb: true,
@@ -54,6 +77,7 @@ describe('computeBottomChromeMetrics', () => {
 
   it('keeps the tab bar but no toolbar reserve when no climb is set, even if the accessory is mounted', () => {
     const metrics = computeBottomChromeMetrics({
+      uiVariant: 'liquidGlass',
       insetsBottom: 34,
       insideTabs: true,
       hasCurrentClimb: false,
@@ -69,6 +93,7 @@ describe('computeBottomChromeMetrics', () => {
     for (const hasCurrentClimb of [true, false]) {
       for (const nativeAccessoryMounted of [true, false]) {
         const metrics = computeBottomChromeMetrics({
+          uiVariant: 'liquidGlass',
           insetsBottom: 0,
           insideTabs: true,
           hasCurrentClimb,

--- a/packages/mobile/src/hooks/bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/bottom-chrome-metrics.ts
@@ -1,4 +1,11 @@
-import { TAB_BAR_HEIGHT, TOOLBAR_GAP_ABOVE_TABBAR, TOOLBAR_RESERVE, glassSize } from '../theme/layout';
+import type { UiVariant } from '../theme/resolve-ui-variant';
+import {
+  MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
+  TAB_BAR_HEIGHT,
+  TOOLBAR_GAP_ABOVE_TABBAR,
+  TOOLBAR_RESERVE,
+  glassSize,
+} from '../theme/layout';
 
 /**
  * Inputs the React hook gathers (safe-area insets, route, queue, capability)
@@ -11,6 +18,8 @@ import { TAB_BAR_HEIGHT, TOOLBAR_GAP_ABOVE_TABBAR, TOOLBAR_RESERVE, glassSize } 
  * folded into the hook.)
  */
 export type BottomChromeInputs = {
+  /** Resolved UI variant; controls the JS toolbar shape/reserve. */
+  uiVariant: UiVariant;
   /** Bottom safe-area inset. */
   insetsBottom: number;
   /** Whether the current route is inside the (tabs) group (tab bar present). */
@@ -42,10 +51,13 @@ export type BottomChromeMetrics = {
  * `jsQueueToolbarVisible` are mutually exclusive (the JS toolbar only mounts
  * when the native accessory does not). The native accessory is UIKit-owned and
  * adds its own content inset, so `scrollBottomPadding` reserves only for the JS
- * toolbar; `floatingControlBottom` takes the max of the two reserves so floating
- * controls clear whichever chrome is present.
+ * toolbar. Liquid Glass/fallback reserves the taller floating island stack;
+ * Material reserves the docked active-context bar height. `floatingControlBottom`
+ * takes the max of the JS/native reserves so floating controls clear whichever
+ * chrome is present.
  */
 export function computeBottomChromeMetrics({
+  uiVariant,
   insetsBottom,
   insideTabs,
   hasCurrentClimb,
@@ -54,7 +66,8 @@ export function computeBottomChromeMetrics({
   const nativeAccessoryVisible = nativeAccessoryMounted && hasCurrentClimb;
   const jsQueueToolbarVisible = hasCurrentClimb && !nativeAccessoryMounted;
   const tabBarHeight = insideTabs ? TAB_BAR_HEIGHT : 0;
-  const jsQueueReserve = jsQueueToolbarVisible ? TOOLBAR_RESERVE : 0;
+  const jsQueueToolbarReserve = uiVariant === 'material' ? MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT : TOOLBAR_RESERVE;
+  const jsQueueReserve = jsQueueToolbarVisible ? jsQueueToolbarReserve : 0;
   const nativeAccessoryReserve = nativeAccessoryVisible ? glassSize.standard + TOOLBAR_GAP_ABOVE_TABBAR : 0;
 
   return {

--- a/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useSegments } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useQueue } from '../providers/queue-provider';
+import { useTheme } from '../providers/theme-provider';
 import { isTabsRoute } from '../lib/route-segments';
 import { useNativeAccessoryActive } from './use-bottom-accessory';
 import { computeBottomChromeMetrics } from './bottom-chrome-metrics';
@@ -15,6 +16,7 @@ export function useBottomChromeMetrics() {
   const insets = useSafeAreaInsets();
   const segments = useSegments();
   const { state } = useQueue();
+  const { variant } = useTheme();
 
   const hasCurrentClimb = state.currentClimbQueueItem?.climb != null;
   const insideTabs = isTabsRoute(segments);
@@ -24,11 +26,12 @@ export function useBottomChromeMetrics() {
   return useMemo(
     () =>
       computeBottomChromeMetrics({
+        uiVariant: variant,
         insetsBottom: insets.bottom,
         insideTabs,
         hasCurrentClimb,
         nativeAccessoryMounted,
       }),
-    [insets.bottom, insideTabs, hasCurrentClimb, nativeAccessoryMounted],
+    [variant, insets.bottom, insideTabs, hasCurrentClimb, nativeAccessoryMounted],
   );
 }

--- a/packages/mobile/src/theme/layout.ts
+++ b/packages/mobile/src/theme/layout.ts
@@ -1,13 +1,15 @@
 /**
  * Shared layout metrics for chrome that floats over scrollable content.
  *
- * The persistent climb toolbar — a glass capsule (current climb) joined by a
- * standalone log-ascent tick when the native bottom accessory is unavailable —
- * floats above the tab bar while a climb is active. Screens
- * reserve it via `useBottomChromeMetrics()` so native-accessory screens do not
- * keep padding for a JS toolbar that is not mounted. Owned here (rather than
- * inside queue-control) so any screen can pad correctly without importing those
- * components' internals.
+ * The persistent climb toolbar is rendered by variant:
+ *
+ *   Liquid Glass / fallback — floating glass capsule + standalone log tick
+ *   Material                — docked opaque active-context bar above the tab bar
+ *
+ * Screens reserve it via `useBottomChromeMetrics()` so native-accessory screens
+ * do not keep padding for a JS toolbar that is not mounted. Owned here (rather
+ * than inside queue-control) so any screen can pad correctly without importing
+ * those components' internals.
  */
 
 /** Bottom tab bar height (excludes the safe-area inset). */
@@ -64,3 +66,6 @@ export const TOOLBAR_GAP_ABOVE_TABBAR = 10;
  *  last scrollable row clears the floating toolbar. Keyed off the tallest island
  *  — the hero log-ascent tick (`glassSize.hero`) — so nothing hides under it. */
 export const TOOLBAR_RESERVE = glassSize.hero + TOOLBAR_GAP_ABOVE_TABBAR;
+
+/** Height of the Material active-context bar docked directly above the tab bar. */
+export const MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT = glassSize.standard;


### PR DESCRIPTION
## Summary
- Render the Material current-climb chrome as a full-width docked opaque active-context bar above the tab bar.
- Make bottom chrome metrics variant-aware so scroll padding and transient UI reserve the docked Material bar height.
- Keep Liquid Glass/fallback behavior on the existing floating capsule plus standalone tick path.

## Validation
- `vp test run --project mobile packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx packages/mobile/src/components/queue-control/__tests__/accessory-bar-surface.test.tsx packages/mobile/src/components/__tests__/toast.test.tsx packages/mobile/src/components/__tests__/queue-added-snackbar.test.tsx`
- `vp run typecheck:mobile`
- `vp check --fix <touched files>`

Closes #2589