### PR TITLE
Add mobile "My Playlists" alphabetical list view

### DIFF
--- a/packages/mobile/app/(tabs)/discover/_layout.tsx
+++ b/packages/mobile/app/(tabs)/discover/_layout.tsx
@@ -26,6 +26,17 @@ export default function DiscoverLayout() {
         }}
       />
       <Stack.Screen
+        name="all"
+        options={{
+          // "My Playlists" — a plain vertical list. A solid native header gives it
+          // a title + automatic back button and avoids the transparent-blur top
+          // inset the index screen manages with its floating chrome.
+          headerShown: true,
+          headerTransparent: false,
+          title: t('library.allPlaylists.title'),
+        }}
+      />
+      <Stack.Screen
         name="[playlist_uuid]"
         options={{
           // The detail view owns its full-bleed gradient hero with a floating

--- a/packages/mobile/app/(tabs)/discover/all.tsx
+++ b/packages/mobile/app/(tabs)/discover/all.tsx
@@ -1,0 +1,214 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { FlatList, Pressable, StyleSheet, TextInput, View } from 'react-native';
+import { router } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useUserPlaylists } from '@boardsesh/playlists-react';
+import type { Playlist } from '@boardsesh/graphql/operations/playlists';
+import { Text } from '../../../src/components/Text';
+import { Icon } from '../../../src/components/Icon';
+import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
+import { PlaylistListRow } from '../../../src/components/playlist';
+import { useAuth } from '../../../src/providers/auth-provider';
+import { useTheme } from '../../../src/providers/theme-provider';
+import { useAuthToken } from '../../../src/lib/graphql/use-auth-token';
+import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
+import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
+import { sortAndFilterPlaylists } from '../../../src/lib/sort-filter-playlists';
+import { iosSystemColors } from '../../../src/theme/ios-colors';
+import { spacing } from '../../../src/theme/tokens';
+
+/**
+ * "My Playlists" — the full, vertical, alphabetical list of the signed-in user's
+ * own playlists with a title filter. The horizontal "Jump Back In" shelf on
+ * Discover surfaces a few by recency; this expands it so a categorized library
+ * (move type, projects at an angle) is easy to scan and search. Auto-generated /
+ * smart playlists never appear here — they come from separate queries, so
+ * `useUserPlaylists` already returns owned playlists only.
+ */
+export default function AllPlaylistsScreen() {
+  const { t } = useTranslation('playlists');
+  const { systemColors, brandColors } = useTheme();
+  const bottomChrome = useBottomChromeMetrics();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { data: token = null } = useAuthToken();
+  const { data: activeBoard } = useActiveBoard();
+
+  const effectiveToken = isAuthenticated ? token : null;
+
+  // Scope to the active board (matching the Discover hub's board filter), so this
+  // screen is the full version of the "Jump Back In" shelf it expands.
+  const { playlists, isLoading, isLoadingMore, hasMore, loadMore } = useUserPlaylists({
+    token: effectiveToken,
+    boardType: activeBoard?.boardType,
+    layoutId: activeBoard?.layoutId,
+    pageSize: 50,
+  });
+
+  // Drain every page so the alphabetical sort + title filter see the whole
+  // library, not just the first page.
+  useEffect(() => {
+    if (hasMore && !isLoadingMore && !isLoading) loadMore();
+  }, [hasMore, isLoadingMore, isLoading, loadMore]);
+
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => sortAndFilterPlaylists(playlists, query), [playlists, query]);
+
+  const goToPlaylist = useCallback((uuid: string) => {
+    router.push(`/(tabs)/discover/${uuid}`);
+  }, []);
+
+  const renderItem = useCallback(
+    ({ item, index }: { item: Playlist; index: number }) => (
+      <PlaylistListRow
+        name={item.name}
+        climbCount={item.climbCount}
+        color={item.color}
+        icon={item.icon}
+        index={index}
+        onPress={() => goToPlaylist(item.uuid)}
+        showSeparator={index < filtered.length - 1}
+      />
+    ),
+    [filtered.length, goToPlaylist],
+  );
+
+  // Signed-out (reachable only via deep link — the entry points are gated on auth).
+  if (!isAuthenticated && !authLoading) {
+    return (
+      <View style={[styles.flex, styles.centered, { backgroundColor: systemColors.background }]}>
+        <Icon name="person" size={48} color={iosSystemColors.systemGray4} />
+        <Text variant="headline" style={styles.stateTitle}>
+          {t('library.signInBanner.title')}
+        </Text>
+        <Pressable onPress={() => router.push('/auth/login')} accessibilityRole="button" hitSlop={8}>
+          <Text variant="subheadline" color={brandColors.primary} style={styles.stateCta}>
+            {t('library.signInBanner.cta')}
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const showInitialSpinner = isLoading && playlists.length === 0;
+  const showDrainingFooter = !showInitialSpinner && (isLoadingMore || hasMore);
+
+  return (
+    <View style={[styles.flex, { backgroundColor: systemColors.background }]}>
+      <View style={styles.searchWrap}>
+        <View style={[styles.searchField, { backgroundColor: systemColors.fill }]}>
+          <Icon name="search" size={18} color={systemColors.secondaryLabel} />
+          <TextInput
+            value={query}
+            onChangeText={setQuery}
+            placeholder={t('library.allPlaylists.searchPlaceholder')}
+            placeholderTextColor={iosSystemColors.systemGray}
+            style={[styles.searchInput, { color: systemColors.label }]}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="search"
+            clearButtonMode="while-editing"
+            accessibilityLabel={t('library.allPlaylists.searchPlaceholder')}
+          />
+          {query.length > 0 ? (
+            <Pressable
+              onPress={() => setQuery('')}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel={t('library.allPlaylists.searchPlaceholder')}
+            >
+              <Icon name="close" size={16} color={systemColors.secondaryLabel} />
+            </Pressable>
+          ) : null}
+        </View>
+      </View>
+
+      {showInitialSpinner ? (
+        <View style={[styles.flex, styles.centered]}>
+          <ActivityIndicator size="large" />
+        </View>
+      ) : (
+        <FlatList
+          data={filtered}
+          keyExtractor={(item) => item.uuid}
+          renderItem={renderItem}
+          contentContainerStyle={{ paddingBottom: bottomChrome.scrollBottomPadding + spacing[6] }}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
+          ListEmptyComponent={
+            <View style={[styles.centered, styles.emptyBlock]}>
+              <Icon name="playlist" size={48} color={iosSystemColors.systemGray4} />
+              <Text variant="headline" style={styles.stateTitle}>
+                {playlists.length === 0
+                  ? t('library.empty.title')
+                  : t('library.allPlaylists.noResults', { query: query.trim() })}
+              </Text>
+              {playlists.length === 0 ? (
+                <Text variant="subheadline" style={styles.stateSubtitle}>
+                  {t('library.empty.description')}
+                </Text>
+              ) : null}
+            </View>
+          }
+          ListFooterComponent={
+            showDrainingFooter ? (
+              <View style={styles.footer}>
+                <ActivityIndicator size="small" />
+              </View>
+            ) : null
+          }
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  centered: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  searchWrap: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+    paddingBottom: spacing[2],
+  },
+  searchField: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    height: 40,
+    borderRadius: 10,
+    paddingHorizontal: spacing[3],
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 17,
+    paddingVertical: 0,
+  },
+  emptyBlock: {
+    paddingTop: spacing[10] * 2,
+    paddingHorizontal: 32,
+    gap: 8,
+  },
+  stateTitle: {
+    marginTop: 12,
+    opacity: 0.6,
+    textAlign: 'center',
+  },
+  stateSubtitle: {
+    opacity: 0.4,
+    textAlign: 'center',
+  },
+  stateCta: {
+    marginTop: 12,
+    fontWeight: '600',
+  },
+  footer: {
+    paddingVertical: spacing[4],
+    alignItems: 'center',
+  },
+});

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -302,6 +302,8 @@ export default function DiscoverLibrary() {
             loading={userLoading && jumpBackIn.length === 0}
             isLoadingMore={userLoadingMore}
             onEndReached={loadMoreUser}
+            actionLabel={jumpBackIn.length > 0 ? t('library.allPlaylists.seeAll') : undefined}
+            onActionPress={jumpBackIn.length > 0 ? () => router.push('/(tabs)/discover/all') : undefined}
           >
             {jumpBackIn.map((playlist, index) => (
               <PlaylistCard

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -29,6 +29,7 @@ export default function MoreScreen() {
   } = useTheme();
   const { t } = useTranslation('common');
   const { t: tProfile } = useTranslation('profile');
+  const { t: tPlaylists } = useTranslation('playlists');
   const { signOut } = useAuth();
   const { data: profile } = useProfile();
   const { gradeFormat, setGradeFormat } = useGradeFormat();
@@ -58,6 +59,29 @@ export default function MoreScreen() {
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.container}>
       <DevMetadataPanel />
+
+      {profile?.id ? (
+        <View style={styles.section}>
+          <View
+            style={[
+              styles.card,
+              {
+                backgroundColor: systemColors.secondaryBackground,
+                borderRadius: borderRadius.lg,
+                marginHorizontal: spacing[4],
+              },
+            ]}
+          >
+            <ListRow
+              title={tPlaylists('library.allPlaylists.title')}
+              leading={<Icon name="playlist" size={22} color={systemColors.secondaryLabel} />}
+              showChevron
+              showSeparator={false}
+              onPress={() => router.push('/(tabs)/discover/all')}
+            />
+          </View>
+        </View>
+      ) : null}
 
       <View style={styles.section}>
         <SectionHeader title={t('mobile.more.appearance.title')} />

--- a/packages/mobile/src/components/SectionHeader.tsx
+++ b/packages/mobile/src/components/SectionHeader.tsx
@@ -1,18 +1,42 @@
 import { View, Platform, StyleSheet } from 'react-native';
 import { Text } from './Text';
+import { Icon } from './Icon';
+import { PressableSurface } from './PressableSurface';
+import { useTheme } from '../providers/theme-provider';
 
 type SectionHeaderProps = {
   title: string;
+  /** Trailing affordance label (e.g. "See all"). Renders a tappable action on
+   *  the right of the header when paired with `onActionPress`. */
+  actionLabel?: string;
+  onActionPress?: () => void;
 };
 
-export function SectionHeader({ title }: SectionHeaderProps) {
+export function SectionHeader({ title, actionLabel, onActionPress }: SectionHeaderProps) {
+  const { brandColors } = useTheme();
   const displayTitle = Platform.OS === 'ios' ? title.toUpperCase() : title;
+  const showAction = !!actionLabel && !!onActionPress;
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, showAction && styles.containerWithAction]}>
       <Text variant="footnote" style={styles.text}>
         {displayTitle}
       </Text>
+      {showAction ? (
+        <PressableSurface
+          onPress={onActionPress}
+          feedback="opacity"
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={actionLabel}
+          style={styles.action}
+        >
+          <Text variant="footnote" color={brandColors.primary} style={styles.actionText}>
+            {actionLabel}
+          </Text>
+          <Icon name="chevron.right" size={12} color={brandColors.primary} />
+        </PressableSurface>
+      ) : null}
     </View>
   );
 }
@@ -23,8 +47,21 @@ const styles = StyleSheet.create({
     paddingTop: 24,
     paddingBottom: 8,
   },
+  containerWithAction: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
   text: {
     opacity: 0.6,
     letterSpacing: 0.5,
+  },
+  action: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 2,
+  },
+  actionText: {
+    fontWeight: '600',
   },
 });

--- a/packages/mobile/src/components/playlist/PlaylistListRow.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistListRow.tsx
@@ -1,0 +1,101 @@
+import { useCallback } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { PressableSurface } from '../PressableSurface';
+import { useTheme } from '../../providers/theme-provider';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing } from '../../theme/tokens';
+import { hapticLight } from '../../lib/haptics';
+import { PlaylistPreviewSquare } from './PlaylistPreviewSquare';
+
+const THUMB_SIZE = 44;
+
+export type PlaylistListRowProps = {
+  name: string;
+  climbCount: number;
+  color?: string;
+  icon?: string;
+  /** Index into the preview's fallback colour palette. */
+  index?: number;
+  onPress: () => void;
+  /** Hide the bottom hairline on the last row. */
+  showSeparator?: boolean;
+};
+
+/**
+ * A scannable vertical playlist row for the "My Playlists" list: a small
+ * preview thumbnail, the name, its climb count, and a disclosure chevron. Unlike
+ * the generic `ListRow` (32px leading), this sizes the thumbnail to read clearly
+ * in a dense alphabetical list.
+ */
+export function PlaylistListRow({
+  name,
+  climbCount,
+  color,
+  icon,
+  index = 0,
+  onPress,
+  showSeparator = true,
+}: PlaylistListRowProps) {
+  const { t } = useTranslation('playlists');
+  const { systemColors } = useTheme();
+
+  const countLabel = t('detail.climbCount', { count: climbCount });
+
+  const handlePress = useCallback(() => {
+    hapticLight();
+    onPress();
+  }, [onPress]);
+
+  return (
+    <PressableSurface
+      onPress={handlePress}
+      feedback="opacity"
+      opacityTo={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={`${name}, ${countLabel}`}
+    >
+      <View style={styles.row}>
+        <PlaylistPreviewSquare color={color} icon={icon} index={index} size={THUMB_SIZE} />
+        <View style={styles.info}>
+          <Text variant="body" numberOfLines={1} style={styles.name}>
+            {name}
+          </Text>
+          <Text variant="subheadline" numberOfLines={1} style={styles.meta}>
+            {countLabel}
+          </Text>
+        </View>
+        <Icon name="chevron.right" size={14} color={iosSystemColors.systemGray4} />
+      </View>
+      {showSeparator ? <View style={[styles.separator, { backgroundColor: systemColors.separator }]} /> : null}
+    </PressableSurface>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+    minHeight: 60,
+  },
+  info: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2,
+  },
+  name: {
+    fontWeight: '600',
+  },
+  meta: {
+    opacity: 0.6,
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    marginLeft: spacing[4] + THUMB_SIZE + spacing[3],
+  },
+});

--- a/packages/mobile/src/components/playlist/PlaylistScrollSection.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistScrollSection.tsx
@@ -14,6 +14,9 @@ export type PlaylistScrollSectionProps = {
   loading?: boolean;
   /** True while a subsequent page is loading (renders a trailing spinner). */
   isLoadingMore?: boolean;
+  /** Trailing header affordance (e.g. "See all") — expands the shelf to a full list. */
+  actionLabel?: string;
+  onActionPress?: () => void;
 };
 
 // Right-edge slop (px) at which onEndReached fires, so the next page starts
@@ -31,10 +34,12 @@ export function PlaylistScrollSection({
   onEndReached,
   loading,
   isLoadingMore,
+  actionLabel,
+  onActionPress,
 }: PlaylistScrollSectionProps) {
   return (
     <View style={styles.section}>
-      <SectionHeader title={title} />
+      <SectionHeader title={title} actionLabel={actionLabel} onActionPress={onActionPress} />
       {loading ? (
         <View style={styles.loadingRow}>
           <ActivityIndicator size="small" />

--- a/packages/mobile/src/components/playlist/index.ts
+++ b/packages/mobile/src/components/playlist/index.ts
@@ -1,6 +1,7 @@
 export { PlaylistPreviewSquare, type PlaylistPreviewSquareProps } from './PlaylistPreviewSquare';
 export { PlaylistCard, type PlaylistCardProps } from './PlaylistCard';
 export { PlaylistScrollSection, type PlaylistScrollSectionProps } from './PlaylistScrollSection';
+export { PlaylistListRow, type PlaylistListRowProps } from './PlaylistListRow';
 export { PlaylistDetailView, type PlaylistDetailViewProps, type PlaylistDetailHero } from './PlaylistDetailView';
 export { PlaylistBackFab } from './PlaylistBackFab';
 export { PlaylistFormSheet, type PlaylistFormValues } from './PlaylistFormSheet';

--- a/packages/mobile/src/lib/__tests__/sort-filter-playlists.test.ts
+++ b/packages/mobile/src/lib/__tests__/sort-filter-playlists.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import type { Playlist } from '@boardsesh/graphql/operations/playlists';
+import { sortAndFilterPlaylists } from '../sort-filter-playlists';
+
+// A minimal Playlist factory — the helper only reads `name`, so the rest is
+// padding to satisfy the type.
+function playlist(name: string): Playlist {
+  return {
+    id: name,
+    uuid: name,
+    boardType: 'kilter',
+    layoutId: 1,
+    name,
+    isPublic: false,
+    createdAt: '',
+    updatedAt: '',
+    climbCount: 0,
+    followerCount: 0,
+    isFollowedByMe: false,
+    isPinnedByMe: false,
+  } as Playlist;
+}
+
+const names = (playlists: Playlist[]) => playlists.map((entry) => entry.name);
+
+describe('sortAndFilterPlaylists', () => {
+  it('sorts alphabetically, case- and accent-insensitively', () => {
+    const input = [playlist('banana'), playlist('Apple'), playlist('Éclair'), playlist('cherry')];
+    expect(names(sortAndFilterPlaylists(input, ''))).toEqual(['Apple', 'banana', 'cherry', 'Éclair']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [playlist('b'), playlist('a')];
+    sortAndFilterPlaylists(input, '');
+    expect(names(input)).toEqual(['b', 'a']);
+  });
+
+  it('filters by case-insensitive substring of the name', () => {
+    const input = [playlist('Crimps @ 45'), playlist('Dynos'), playlist('Slab crimping')];
+    expect(names(sortAndFilterPlaylists(input, 'CRIMP'))).toEqual(['Crimps @ 45', 'Slab crimping']);
+  });
+
+  it('trims the query and returns everything when it is blank', () => {
+    const input = [playlist('b'), playlist('a')];
+    expect(names(sortAndFilterPlaylists(input, '   '))).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    const input = [playlist('Projects'), playlist('Warmups')];
+    expect(sortAndFilterPlaylists(input, 'zzz')).toEqual([]);
+  });
+});

--- a/packages/mobile/src/lib/sort-filter-playlists.ts
+++ b/packages/mobile/src/lib/sort-filter-playlists.ts
@@ -1,0 +1,14 @@
+import type { Playlist } from '@boardsesh/graphql/operations/playlists';
+
+/**
+ * Sort playlists alphabetically by name (case- and accent-insensitive), then
+ * keep only those whose name contains the (trimmed, case-insensitive) query.
+ * Pure so the "My Playlists" screen can test ordering + filtering without a
+ * render. Does not mutate the input.
+ */
+export function sortAndFilterPlaylists(playlists: Playlist[], query: string): Playlist[] {
+  const sorted = [...playlists].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+  const needle = query.trim().toLowerCase();
+  if (!needle) return sorted;
+  return sorted.filter((playlist) => playlist.name.toLowerCase().includes(needle));
+}

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -22,6 +22,12 @@
       "smart": "Your Picks",
       "discover": "Discover"
     },
+    "allPlaylists": {
+      "title": "My Playlists",
+      "seeAll": "See all",
+      "searchPlaceholder": "Filter by title",
+      "noResults": "No playlists match \"{{query}}\""
+    },
     "pin": {
       "pinAriaLabel": "Pin playlist",
       "unpinAriaLabel": "Unpin playlist",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -22,6 +22,12 @@
       "smart": "Tus selecciones",
       "discover": "Descubre"
     },
+    "allPlaylists": {
+      "title": "Mis listas",
+      "seeAll": "Ver todas",
+      "searchPlaceholder": "Filtrar por título",
+      "noResults": "Ninguna lista coincide con \"{{query}}\""
+    },
     "pin": {
       "pinAriaLabel": "Fijar playlist",
       "unpinAriaLabel": "Desfijar playlist",

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -22,6 +22,12 @@
       "smart": "Vos sélections",
       "discover": "Découvrir"
     },
+    "allPlaylists": {
+      "title": "Mes listes",
+      "seeAll": "Tout voir",
+      "searchPlaceholder": "Filtrer par titre",
+      "noResults": "Aucune liste ne correspond à « {{query}} »"
+    },
     "pin": {
       "pinAriaLabel": "Épingler la playlist",
       "unpinAriaLabel": "Désépingler la playlist",


### PR DESCRIPTION
## Why

Feedback from a user:

> Is there a good way to view all of my playlists? I'd like a vertical view of all of them alphabetically so it's easy to find the list I'm looking for (I categorize climbs with playlists based on move type or projects at a certain angle). The only page I've found so far is going to my profile and then selecting My Playlists, but that shows them horizontally and not in alphabetical order.

On mobile, playlists live on the **Discover tab** (the profile path is the web app). The user's own playlists render in a **horizontal** "Jump Back In" scroller ordered by recency — there's no way to scan them all vertically, alphabetically, or filter by title.

## What

A dedicated **"My Playlists"** screen: a vertical, A–Z, title-filterable list of the user's *own* playlists. Auto-generated/smart/recommended playlists are excluded — they come from separate queries, so `useUserPlaylists` already returns owned playlists only.

Two entry points (chosen via a design panel):
- **Primary:** a **"See all ›"** action on the "Jump Back In" section header (the iOS pattern for expanding a horizontal shelf into a full list).
- **Secondary:** a **"My Playlists"** row on **profile → More** (matches where the original feedback looked).

### Details
- `app/(tabs)/discover/all.tsx` — drains all pages, sorts A–Z, filters by title; loading / empty-library / no-match states. Scoped to the active board (so it's the full version of the Jump Back In shelf).
- `PlaylistListRow` — scannable row (44px thumbnail + name + count + chevron).
- `SectionHeader` / `PlaylistScrollSection` — optional trailing action, threaded through (existing callers unaffected).
- `sortAndFilterPlaylists` pure helper + unit tests.
- i18n keys added to en-US, es, fr.

No backend / schema / DB changes — filtering and sorting are client-side.

## Validation
- `vp run typecheck:mobile` ✓
- `vp test --project mobile` — 1145 passed (incl. 5 new) ✓
- `vp run check:mobile-bundle` — iOS + Android bundles OK ✓
- Format + lint clean on touched files ✓

Not run: macOS-only simulator/screenshot checks (Linux dev box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)