### PR TITLE
Add board-aware Home tab to the mobile app

### DIFF
--- a/packages/backend/src/__tests__/recommended-playlists.test.ts
+++ b/packages/backend/src/__tests__/recommended-playlists.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { playlistQueries } from '../graphql/resolvers/playlists/queries';
+
+const { mockDb } = vi.hoisted(() => {
+  const mockDb = {
+    execute: vi.fn(),
+    select: vi.fn(),
+    insert: vi.fn(),
+    delete: vi.fn(),
+    update: vi.fn(),
+  };
+  return { mockDb };
+});
+
+vi.mock('../db/client', () => ({
+  db: mockDb,
+}));
+
+vi.mock('../events/index', () => ({
+  publishSocialEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../utils/rate-limiter', () => ({
+  checkRateLimit: vi.fn(),
+}));
+
+vi.mock('../utils/redis-rate-limiter', () => ({
+  checkRateLimitRedis: vi.fn(),
+}));
+
+vi.mock('../db/queries/util/table-select', () => ({
+  UNIFIED_TABLES: {
+    climbs: { uuid: 'uuid', layoutId: 'layoutId', boardType: 'boardType' },
+    climbStats: { climbUuid: 'climbUuid', boardType: 'boardType', angle: 'angle' },
+    difficultyGrades: { boardType: 'boardType', difficulty: 'difficulty' },
+  },
+  isValidBoardName: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../db/queries/util/hold-state', () => ({
+  convertLitUpHoldsStringToMap: vi.fn().mockReturnValue([{}]),
+}));
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: false,
+    userId: null,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+/** Thenable Drizzle chain whose terminal await resolves to `resolveValue`. */
+function createMockChain(resolveValue: unknown = []) {
+  const chain: Record<string, unknown> = {};
+  const methods = ['select', 'from', 'where', 'innerJoin', 'leftJoin', 'groupBy', 'orderBy', 'limit', 'offset'];
+  chain.then = (resolve: (value: unknown) => unknown) => Promise.resolve(resolveValue).then(resolve);
+  for (const method of methods) {
+    chain[method] = vi.fn(() => chain);
+  }
+  return chain;
+}
+
+const NOW = new Date('2026-06-08T12:00:00Z');
+
+function makeCohortRow(slug: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id: BigInt(1),
+    uuid: `pl-${slug}`,
+    boardType: 'kilter',
+    layoutId: 8,
+    name: `${slug} · Kilter Board Homewall 10x12 @ 40°`,
+    description: null,
+    color: '#d65a4f',
+    icon: 'LocalFireDepartmentOutlined',
+    createdAt: NOW,
+    updatedAt: NOW,
+    creatorId: 'system-recommendations',
+    creatorName: 'Boardsesh',
+    climbCount: 50,
+    generatedRecommendation: `kilter:8:25:40:${slug}`,
+    ...overrides,
+  };
+}
+
+const INPUT = { boardType: 'kilter', layoutId: 8, sizeId: 25, angle: 40 };
+
+describe('recommendedPlaylists resolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the cohort playlists ordered by variant (crowd-favorites → hidden-gems → fresh)', async () => {
+    // Seed deliberately out of order to prove the resolver sorts them.
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([
+        makeCohortRow('fresh', { id: BigInt(3) }),
+        makeCohortRow('crowd-favorites', { id: BigInt(1) }),
+        makeCohortRow('hidden-gems', { id: BigInt(2) }),
+      ]),
+    );
+
+    const result = (await playlistQueries.recommendedPlaylists(null, { input: INPUT }, makeCtx())) as Array<{
+      uuid: string;
+    }>;
+
+    expect(result.map((playlist) => playlist.uuid)).toEqual(['pl-crowd-favorites', 'pl-hidden-gems', 'pl-fresh']);
+    // The cohort key is an internal detail — not leaked on the GraphQL shape.
+    expect(result[0]).not.toHaveProperty('generatedRecommendation');
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns [] when the board config has no generated cohort', async () => {
+    mockDb.select.mockReturnValueOnce(createMockChain([]));
+
+    const result = await playlistQueries.recommendedPlaylists(
+      null,
+      { input: { boardType: 'kilter', layoutId: 8, sizeId: 25, angle: 30 } },
+      makeCtx(),
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('does not require authentication', async () => {
+    mockDb.select.mockReturnValueOnce(createMockChain([makeCohortRow('crowd-favorites')]));
+
+    const result = (await playlistQueries.recommendedPlaylists(
+      null,
+      { input: INPUT },
+      makeCtx({ isAuthenticated: false, userId: undefined }),
+    )) as unknown[];
+
+    expect(result).toHaveLength(1);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/playlists/queries/index.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/index.ts
@@ -2,6 +2,7 @@ import { userPlaylists, allUserPlaylists } from './user-playlists';
 import { playlist, playlistsForClimb, playlistsForClimbs } from './playlist-detail';
 import { playlistClimbs } from './playlist-climbs';
 import { discoverPlaylists, playlistCreators } from './discover';
+import { recommendedPlaylists } from './recommended';
 import { searchPlaylists } from './search';
 import { myPinnedPlaylists } from './pinned';
 import { smartPlaylist, mySmartPlaylistCounts } from './smart-playlists';
@@ -14,6 +15,7 @@ export const playlistQueries = {
   playlistsForClimbs,
   playlistClimbs,
   discoverPlaylists,
+  recommendedPlaylists,
   playlistCreators,
   searchPlaylists,
   myPinnedPlaylists,

--- a/packages/backend/src/graphql/resolvers/playlists/queries/recommended.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/recommended.ts
@@ -8,6 +8,8 @@ import { RecommendedPlaylistsInputSchema } from '../../../../validation/schemas'
 import { formatPublicPlaylist } from '../helpers/enrichment';
 import { PUBLIC_PLAYLIST_SELECT, PUBLIC_PLAYLIST_GROUP_BY } from './discover';
 
+type RecommendedPlaylist = ReturnType<typeof formatPublicPlaylist>;
+
 /** Display order of the cohort variants by slug (crowd-favorites → fresh). */
 const VARIANT_ORDER = new Map(PUBLIC_RECOMMENDATION_VARIANTS.map((variant, index) => [variant.slug, index]));
 
@@ -34,7 +36,7 @@ export const recommendedPlaylists = async (
     };
   },
   _ctx: ConnectionContext,
-): Promise<unknown[]> => {
+): Promise<RecommendedPlaylist[]> => {
   validateInput(RecommendedPlaylistsInputSchema, input, 'input');
 
   const keys = cohortKeysForBoard(input.boardType, input.layoutId, input.sizeId, input.angle);

--- a/packages/backend/src/graphql/resolvers/playlists/queries/recommended.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/recommended.ts
@@ -1,0 +1,66 @@
+import { eq, and, inArray } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { cohortKeysForBoard, variantSlugFromKey, PUBLIC_RECOMMENDATION_VARIANTS } from '@boardsesh/db/queries';
+import { db } from '../../../../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { validateInput } from '../../shared/helpers';
+import { RecommendedPlaylistsInputSchema } from '../../../../validation/schemas';
+import { formatPublicPlaylist } from '../helpers/enrichment';
+import { PUBLIC_PLAYLIST_SELECT, PUBLIC_PLAYLIST_GROUP_BY } from './discover';
+
+/** Display order of the cohort variants by slug (crowd-favorites → fresh). */
+const VARIANT_ORDER = new Map(PUBLIC_RECOMMENDATION_VARIANTS.map((variant, index) => [variant.slug, index]));
+
+/**
+ * Public per-board recommendation cohort playlists (Crowd Favorites / Hidden
+ * Gems / Fresh) for an exact board config. The cohort's size + angle live only
+ * inside the `generated_recommendation` key, so we reconstruct the three keys
+ * and look the playlists up by them. Returns `[]` when the config isn't a
+ * generated cohort — callers (Home) fall back to a popularity sort.
+ *
+ * No authentication required: cohort playlists are public, owned by the
+ * `system-recommendations` user.
+ */
+export const recommendedPlaylists = async (
+  _: unknown,
+  {
+    input,
+  }: {
+    input: {
+      boardType: string;
+      layoutId: number;
+      sizeId: number;
+      angle: number;
+    };
+  },
+  _ctx: ConnectionContext,
+): Promise<unknown[]> => {
+  validateInput(RecommendedPlaylistsInputSchema, input, 'input');
+
+  const keys = cohortKeysForBoard(input.boardType, input.layoutId, input.sizeId, input.angle);
+
+  // Select the public-playlist projection plus the cohort key so we can order
+  // the (≤3) rows by canonical variant order without a second round-trip.
+  const rows = await db
+    .select({ ...PUBLIC_PLAYLIST_SELECT, generatedRecommendation: dbSchema.playlists.generatedRecommendation })
+    .from(dbSchema.playlists)
+    .innerJoin(dbSchema.playlistOwnership, eq(dbSchema.playlistOwnership.playlistId, dbSchema.playlists.id))
+    .innerJoin(dbSchema.playlistClimbs, eq(dbSchema.playlistClimbs.playlistId, dbSchema.playlists.id))
+    .innerJoin(dbSchema.users, eq(dbSchema.users.id, dbSchema.playlistOwnership.userId))
+    .where(
+      and(
+        eq(dbSchema.playlists.isPublic, true),
+        eq(dbSchema.playlistOwnership.role, 'owner'),
+        inArray(dbSchema.playlists.generatedRecommendation, keys),
+      ),
+    )
+    .groupBy(...PUBLIC_PLAYLIST_GROUP_BY, dbSchema.playlists.generatedRecommendation);
+
+  rows.sort(
+    (a, b) =>
+      (VARIANT_ORDER.get(variantSlugFromKey(a.generatedRecommendation)) ?? Number.MAX_SAFE_INTEGER) -
+      (VARIANT_ORDER.get(variantSlugFromKey(b.generatedRecommendation)) ?? Number.MAX_SAFE_INTEGER),
+  );
+
+  return rows.map(formatPublicPlaylist);
+};

--- a/packages/backend/src/validation/schemas/playlists.ts
+++ b/packages/backend/src/validation/schemas/playlists.ts
@@ -107,6 +107,14 @@ export const GetPlaylistCreatorsInputSchema = z.object({
   searchQuery: z.string().max(100).optional(),
 });
 
+export const RecommendedPlaylistsInputSchema = z.object({
+  boardType: BoardNameSchema,
+  layoutId: z.number().int().positive(),
+  sizeId: z.number().int().positive(),
+  // Board angles run 0–70 across our boards (matches GetSmartPlaylistInput).
+  angle: z.number().int().min(0).max(70),
+});
+
 export const SearchPlaylistsInputSchema = z.object({
   query: z.string().min(1).max(200),
   boardType: BoardNameSchema.optional(),

--- a/packages/db/scripts/refresh-recommendations.ts
+++ b/packages/db/scripts/refresh-recommendations.ts
@@ -22,8 +22,10 @@ import { boardClimbSendStats } from '../src/schema/app/recommendation-stats.js';
 import {
   buildRecomputeSetterStatsSql,
   buildRecommendationRefsSql,
+  cohortKey,
+  PUBLIC_RECOMMENDATION_VARIANTS,
   type BoardTarget,
-  type RecommendationType,
+  type PublicRecommendationVariant,
 } from '../src/queries/recommendations/index.js';
 import { rowsOf } from '../src/queries/util/rows.js';
 import { getSizeFullnessTiers } from '@boardsesh/board-constants/size-comparison';
@@ -49,30 +51,6 @@ const COHORTS: Cohort[] = [
   { boardType: 'tension', layoutId: 9, sizeId: 1, angle: 40 }, // Original Full Wall
   { boardType: 'tension', layoutId: 10, sizeId: 6, angle: 40 }, // TB2 Mirror 12x12
   { boardType: 'tension', layoutId: 11, sizeId: 6, angle: 40 }, // TB2 Spray 12x12
-];
-
-const PUBLIC_VARIANTS: ReadonlyArray<{
-  type: RecommendationType;
-  slug: string;
-  label: string;
-  color: string;
-  icon: string;
-}> = [
-  {
-    type: 'RECOMMENDED_CROWD_FAVORITES',
-    slug: 'crowd-favorites',
-    label: 'Crowd Favorites',
-    color: '#d65a4f',
-    icon: 'LocalFireDepartmentOutlined',
-  },
-  {
-    type: 'RECOMMENDED_HIDDEN_GEMS',
-    slug: 'hidden-gems',
-    label: 'Hidden Gems',
-    color: '#9C27B0',
-    icon: 'DiamondOutlined',
-  },
-  { type: 'RECOMMENDED_FRESH', slug: 'fresh', label: 'Fresh', color: '#FBBF24', icon: 'EnergySavingsLeafOutlined' },
 ];
 
 const BOARD_LABEL: Record<string, string> = { kilter: 'Kilter', tension: 'Tension' };
@@ -222,7 +200,7 @@ function cohortPlaylistName(variantLabel: string, cohort: Cohort): string {
 async function upsertCohortPlaylist(
   db: Db,
   cohort: Cohort,
-  variant: (typeof PUBLIC_VARIANTS)[number],
+  variant: PublicRecommendationVariant,
 ): Promise<{ name: string; count: number; skipped: boolean }> {
   const target = cohortTarget(cohort);
   const tiers = getSizeFullnessTiers(cohort.boardType, cohort.sizeId);
@@ -253,7 +231,7 @@ async function upsertCohortPlaylist(
     return { name, count: 0, skipped: true };
   }
 
-  const key = `${cohort.boardType}:${cohort.layoutId}:${cohort.sizeId}:${cohort.angle}:${variant.slug}`;
+  const key = cohortKey(cohort.boardType, cohort.layoutId, cohort.sizeId, cohort.angle, variant.slug);
 
   // Upsert the playlist and atomically swap its climbs — a crash mid-swap must
   // never leave a published playlist empty.
@@ -301,7 +279,7 @@ async function upsertCohortPlaylist(
 async function generateCohortPlaylists(db: Db): Promise<void> {
   console.log('[recs] generating cohort playlists…');
   for (const cohort of COHORTS) {
-    for (const variant of PUBLIC_VARIANTS) {
+    for (const variant of PUBLIC_RECOMMENDATION_VARIANTS) {
       const { name, count, skipped } = await upsertCohortPlaylist(db, cohort, variant);
       console.log(`[recs]   ${name} → ${skipped ? 'SKIPPED (0 climbs, kept previous)' : `${count} climbs`}`);
     }

--- a/packages/db/src/queries/recommendations/__tests__/cohort-keys.test.ts
+++ b/packages/db/src/queries/recommendations/__tests__/cohort-keys.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { cohortKey, cohortKeysForBoard, variantSlugFromKey, PUBLIC_RECOMMENDATION_VARIANTS } from '../cohort-keys';
+
+void describe('cohort keys', () => {
+  void it('builds the deterministic generated_recommendation key', () => {
+    assert.equal(cohortKey('kilter', 8, 25, 40, 'crowd-favorites'), 'kilter:8:25:40:crowd-favorites');
+  });
+
+  void it('returns one key per public variant in display order', () => {
+    assert.deepEqual(cohortKeysForBoard('tension', 9, 1, 40), [
+      'tension:9:1:40:crowd-favorites',
+      'tension:9:1:40:hidden-gems',
+      'tension:9:1:40:fresh',
+    ]);
+  });
+
+  void it('extracts the trailing slug from a key', () => {
+    assert.equal(variantSlugFromKey('kilter:1:10:40:hidden-gems'), 'hidden-gems');
+    assert.equal(variantSlugFromKey(null), '');
+    assert.equal(variantSlugFromKey(undefined), '');
+  });
+
+  void it('round-trips every public variant slug through the key', () => {
+    for (const variant of PUBLIC_RECOMMENDATION_VARIANTS) {
+      assert.equal(variantSlugFromKey(cohortKey('kilter', 8, 25, 40, variant.slug)), variant.slug);
+    }
+  });
+
+  void it('exposes exactly the three public cohort variants', () => {
+    assert.deepEqual(
+      PUBLIC_RECOMMENDATION_VARIANTS.map((variant) => variant.slug),
+      ['crowd-favorites', 'hidden-gems', 'fresh'],
+    );
+  });
+});

--- a/packages/db/src/queries/recommendations/cohort-keys.ts
+++ b/packages/db/src/queries/recommendations/cohort-keys.ts
@@ -1,0 +1,71 @@
+/**
+ * Single source of truth for the public per-board recommendation cohorts.
+ *
+ * The nightly generator (`scripts/refresh-recommendations.ts`) writes one
+ * playlist per (cohort × variant) keyed by a deterministic
+ * `generated_recommendation` string, and the `recommendedPlaylists` resolver
+ * reconstructs those keys to look the playlists back up by exact board config.
+ * Both sides import the slugs and key format from here so they can't drift.
+ */
+import type { RecommendationType } from './types';
+
+/** A public recommendation cohort variant. `slug` is part of the persisted
+ *  `generated_recommendation` key; label/color/icon seed the public playlist. */
+export type PublicRecommendationVariant = {
+  type: RecommendationType;
+  slug: string;
+  label: string;
+  color: string;
+  icon: string;
+};
+
+/**
+ * The public per-board cohort variants, in display order. Crowd Favorites leads
+ * (the broadest), then Hidden Gems, then Fresh — the order Home renders the
+ * rows in.
+ */
+export const PUBLIC_RECOMMENDATION_VARIANTS: readonly PublicRecommendationVariant[] = [
+  {
+    type: 'RECOMMENDED_CROWD_FAVORITES',
+    slug: 'crowd-favorites',
+    label: 'Crowd Favorites',
+    color: '#d65a4f',
+    icon: 'LocalFireDepartmentOutlined',
+  },
+  {
+    type: 'RECOMMENDED_HIDDEN_GEMS',
+    slug: 'hidden-gems',
+    label: 'Hidden Gems',
+    color: '#9C27B0',
+    icon: 'DiamondOutlined',
+  },
+  {
+    type: 'RECOMMENDED_FRESH',
+    slug: 'fresh',
+    label: 'Fresh',
+    color: '#FBBF24',
+    icon: 'EnergySavingsLeafOutlined',
+  },
+];
+
+/** Deterministic `generated_recommendation` key for one cohort playlist. */
+export function cohortKey(
+  boardType: string,
+  layoutId: number,
+  sizeId: number,
+  angle: number,
+  variantSlug: string,
+): string {
+  return `${boardType}:${layoutId}:${sizeId}:${angle}:${variantSlug}`;
+}
+
+/** All cohort keys (one per public variant) for an exact board config. */
+export function cohortKeysForBoard(boardType: string, layoutId: number, sizeId: number, angle: number): string[] {
+  return PUBLIC_RECOMMENDATION_VARIANTS.map((variant) => cohortKey(boardType, layoutId, sizeId, angle, variant.slug));
+}
+
+/** Pull the variant slug back out of a `generated_recommendation` key. */
+export function variantSlugFromKey(key: string | null | undefined): string {
+  if (!key) return '';
+  return key.slice(key.lastIndexOf(':') + 1);
+}

--- a/packages/db/src/queries/recommendations/index.ts
+++ b/packages/db/src/queries/recommendations/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './recommendation-query';
 export * from './user-grade';
 export * from './setter-stats';
+export * from './cohort-keys';

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -81,6 +81,13 @@ describe('TabLayout', () => {
     expect(unstable_settings.initialRouteName).toBe('climbs');
   });
 
+  it('renders Home as the leading tab, search last', () => {
+    const { container } = render(<TabLayout />);
+    const order = Array.from(container.querySelectorAll('[data-trigger]')).map((el) => el.getAttribute('data-trigger'));
+
+    expect(order).toEqual(['home', 'discover', 'record', 'profile', 'climbs']);
+  });
+
   it('does not render the Record badge when no status is active', () => {
     const { container } = render(<TabLayout />);
     const recordTrigger = container.querySelector('[data-trigger="record"]') as HTMLElement;

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -51,8 +51,15 @@ export default function TabLayout() {
     return (
       <Tabs tabBar={(props) => <MaterialTabBar {...props} />} screenOptions={{ headerShown: false }}>
         <Tabs.Screen
-          name="climbs"
-          options={{ title: t('mobile.nav.climbs'), tabBarIcon: materialTabIcon('magnify', 'magnify') }}
+          name="home"
+          options={{ title: t('mobile.nav.home'), tabBarIcon: materialTabIcon('home', 'home-outline') }}
+        />
+        <Tabs.Screen
+          name="discover"
+          options={{
+            title: tPlaylists('bottomTabBar.discover'),
+            tabBarIcon: materialTabIcon('bookmark-multiple', 'bookmark-multiple-outline'),
+          }}
         />
         <Tabs.Screen
           name="record"
@@ -63,18 +70,15 @@ export default function TabLayout() {
           }}
         />
         <Tabs.Screen
-          name="discover"
-          options={{
-            title: tPlaylists('bottomTabBar.discover'),
-            tabBarIcon: materialTabIcon('bookmark-multiple', 'bookmark-multiple-outline'),
-          }}
-        />
-        <Tabs.Screen
           name="profile"
           options={{
             title: t('mobile.nav.profile'),
             tabBarIcon: materialTabIcon('account-circle', 'account-circle-outline'),
           }}
+        />
+        <Tabs.Screen
+          name="climbs"
+          options={{ title: t('mobile.nav.climbs'), tabBarIcon: materialTabIcon('magnify', 'magnify') }}
         />
       </Tabs>
     );
@@ -90,9 +94,14 @@ export default function TabLayout() {
         <QueueBottomAccessory />
       </NativeTabs.BottomAccessory>
 
-      <NativeTabs.Trigger name="climbs" role="search">
-        <NativeTabs.Trigger.Icon sf="magnifyingglass" md="search" />
-        <NativeTabs.Trigger.Label>{t('mobile.nav.climbs')}</NativeTabs.Trigger.Label>
+      <NativeTabs.Trigger name="home">
+        <NativeTabs.Trigger.Icon sf="house" md="home" />
+        <NativeTabs.Trigger.Label>{t('mobile.nav.home')}</NativeTabs.Trigger.Label>
+      </NativeTabs.Trigger>
+
+      <NativeTabs.Trigger name="discover">
+        <NativeTabs.Trigger.Icon sf="bookmark" md="bookmarks" />
+        <NativeTabs.Trigger.Label>{tPlaylists('bottomTabBar.discover')}</NativeTabs.Trigger.Label>
       </NativeTabs.Trigger>
 
       <NativeTabs.Trigger name="record">
@@ -103,14 +112,14 @@ export default function TabLayout() {
         ) : null}
       </NativeTabs.Trigger>
 
-      <NativeTabs.Trigger name="discover">
-        <NativeTabs.Trigger.Icon sf="bookmark" md="bookmarks" />
-        <NativeTabs.Trigger.Label>{tPlaylists('bottomTabBar.discover')}</NativeTabs.Trigger.Label>
-      </NativeTabs.Trigger>
-
       <NativeTabs.Trigger name="profile">
         <NativeTabs.Trigger.Icon sf="person.crop.circle" md="account_circle" />
         <NativeTabs.Trigger.Label>{t('mobile.nav.profile')}</NativeTabs.Trigger.Label>
+      </NativeTabs.Trigger>
+
+      <NativeTabs.Trigger name="climbs" role="search">
+        <NativeTabs.Trigger.Icon sf="magnifyingglass" md="search" />
+        <NativeTabs.Trigger.Label>{t('mobile.nav.climbs')}</NativeTabs.Trigger.Label>
       </NativeTabs.Trigger>
     </NativeTabs>
   );

--- a/packages/mobile/app/(tabs)/home/_layout.tsx
+++ b/packages/mobile/app/(tabs)/home/_layout.tsx
@@ -1,0 +1,24 @@
+import { Stack } from 'expo-router';
+import { Platform } from 'react-native';
+
+export default function HomeLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerLargeTitle: false,
+        // Solid header on Android; transparent blur is iOS-only (mirrors discover).
+        headerTransparent: Platform.OS === 'ios',
+        headerBlurEffect: 'systemMaterial',
+        contentStyle: { backgroundColor: 'transparent' },
+      }}
+    >
+      <Stack.Screen
+        name="index"
+        options={{
+          // Home owns its in-body large title, so the native header is hidden.
+          headerShown: false,
+        }}
+      />
+    </Stack>
+  );
+}

--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -2,10 +2,16 @@ import { View, ScrollView, Pressable, StyleSheet } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
-import type { BoardName } from '@boardsesh/shared-schema';
+import { isBoardName } from '@boardsesh/shared-schema';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
-import { HomeBoardHeader, HomeRecommendedRows, HomeJumpBackIn, HomeBetaRow } from '../../../src/components/home';
+import {
+  HomeBoardHeader,
+  HomeRecommendedRows,
+  HomeJumpBackIn,
+  HomeBetaRow,
+  type HomeRowBoard,
+} from '../../../src/components/home';
 import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
 import { useProfile } from '../../../src/lib/graphql/hooks';
 import { useAuth } from '../../../src/providers/auth-provider';
@@ -31,6 +37,19 @@ export default function HomeScreen() {
 
   const userId = isAuthenticated ? (profile?.id ?? null) : null;
 
+  // Narrow the stored board type to a known BoardName before handing it to the
+  // board-scoped rows (defensive — the picker only stores supported boards).
+  const homeBoard: HomeRowBoard | null =
+    activeBoard && isBoardName(activeBoard.boardType)
+      ? {
+          boardName: activeBoard.boardType,
+          layoutId: activeBoard.layoutId,
+          sizeId: activeBoard.sizeId,
+          setIds: activeBoard.setIds,
+          angle: activeBoard.angle,
+        }
+      : null;
+
   return (
     <ScrollView
       style={styles.flex}
@@ -44,23 +63,17 @@ export default function HomeScreen() {
         {t('mobile.nav.home')}
       </Text>
 
-      {activeBoard ? (
+      {activeBoard && homeBoard ? (
         <>
           <HomeBoardHeader board={activeBoard} />
           <HomeRecommendedRows
-            board={{
-              boardName: activeBoard.boardType as BoardName,
-              layoutId: activeBoard.layoutId,
-              sizeId: activeBoard.sizeId,
-              setIds: activeBoard.setIds,
-              angle: activeBoard.angle,
-            }}
+            board={homeBoard}
             boardUuid={activeBoard.uuid}
             isOwned={activeBoard.isOwned}
             userId={userId}
           />
-          <HomeJumpBackIn boardType={activeBoard.boardType} layoutId={activeBoard.layoutId} />
-          <HomeBetaRow boardType={activeBoard.boardType} layoutId={activeBoard.layoutId} />
+          <HomeJumpBackIn boardType={homeBoard.boardName} layoutId={homeBoard.layoutId} />
+          <HomeBetaRow boardType={homeBoard.boardName} layoutId={homeBoard.layoutId} />
         </>
       ) : (
         <View style={styles.emptyContainer}>
@@ -98,12 +111,12 @@ const styles = StyleSheet.create({
   emptyContainer: {
     alignItems: 'center',
     justifyContent: 'center',
-    paddingTop: spacing[10] * 2,
-    paddingHorizontal: 32,
+    paddingTop: spacing[16],
+    paddingHorizontal: spacing[8],
     gap: spacing[2],
   },
   emptyTitle: {
-    marginTop: 12,
+    marginTop: spacing[3],
     opacity: 0.7,
   },
   emptySubtitle: {

--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -1,0 +1,123 @@
+import { View, ScrollView, Pressable, StyleSheet } from 'react-native';
+import { router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { Text } from '../../../src/components/Text';
+import { Icon } from '../../../src/components/Icon';
+import { HomeBoardHeader, HomeRecommendedRows, HomeJumpBackIn, HomeBetaRow } from '../../../src/components/home';
+import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
+import { useProfile } from '../../../src/lib/graphql/hooks';
+import { useAuth } from '../../../src/providers/auth-provider';
+import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
+import { brandColors } from '../../../src/theme/colors';
+import { iosSystemColors } from '../../../src/theme/ios-colors';
+import { spacing, borderRadius } from '../../../src/theme/tokens';
+
+/**
+ * Home — the board-aware landing. The app cold-starts on the climbs search tab,
+ * so Home is an optional, occasional visit: a place to see what's worth climbing
+ * on your board (curated/fresh rows), fresh community beta, and a path back into
+ * your playlists. Scoped entirely to the active board.
+ */
+export default function HomeScreen() {
+  const { t } = useTranslation('common');
+  const { t: tPlaylists } = useTranslation('playlists');
+  const insets = useSafeAreaInsets();
+  const bottomChrome = useBottomChromeMetrics();
+  const { data: activeBoard } = useActiveBoard();
+  const { data: profile } = useProfile();
+  const { isAuthenticated } = useAuth();
+
+  const userId = isAuthenticated ? (profile?.id ?? null) : null;
+
+  return (
+    <ScrollView
+      style={styles.flex}
+      contentInsetAdjustmentBehavior="never"
+      contentContainerStyle={{
+        paddingTop: insets.top + spacing[2],
+        paddingBottom: bottomChrome.scrollBottomPadding + spacing[6],
+      }}
+    >
+      <Text variant="largeTitle" style={styles.screenTitle}>
+        {t('mobile.nav.home')}
+      </Text>
+
+      {activeBoard ? (
+        <>
+          <HomeBoardHeader board={activeBoard} />
+          <HomeRecommendedRows
+            board={{
+              boardName: activeBoard.boardType as BoardName,
+              layoutId: activeBoard.layoutId,
+              sizeId: activeBoard.sizeId,
+              setIds: activeBoard.setIds,
+              angle: activeBoard.angle,
+            }}
+            boardUuid={activeBoard.uuid}
+            isOwned={activeBoard.isOwned}
+            userId={userId}
+          />
+          <HomeJumpBackIn boardType={activeBoard.boardType} layoutId={activeBoard.layoutId} />
+          <HomeBetaRow boardType={activeBoard.boardType} layoutId={activeBoard.layoutId} />
+        </>
+      ) : (
+        <View style={styles.emptyContainer}>
+          <Icon name="boards" size={48} color={iosSystemColors.systemGray4} />
+          <Text variant="headline" style={styles.emptyTitle}>
+            {tPlaylists('home.pickBoard.title')}
+          </Text>
+          <Text variant="subheadline" style={styles.emptySubtitle}>
+            {tPlaylists('home.pickBoard.description')}
+          </Text>
+          <Pressable
+            onPress={() => router.push('/boards')}
+            accessibilityRole="button"
+            style={({ pressed }) => [styles.pickButton, pressed && styles.pressed]}
+          >
+            <Text variant="headline" color={iosSystemColors.white}>
+              {tPlaylists('home.pickBoard.cta')}
+            </Text>
+          </Pressable>
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  screenTitle: {
+    paddingHorizontal: spacing[4],
+    paddingTop: 0,
+    paddingBottom: spacing[2],
+  },
+  emptyContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: spacing[10] * 2,
+    paddingHorizontal: 32,
+    gap: spacing[2],
+  },
+  emptyTitle: {
+    marginTop: 12,
+    opacity: 0.7,
+  },
+  emptySubtitle: {
+    opacity: 0.5,
+    textAlign: 'center',
+  },
+  pickButton: {
+    marginTop: spacing[4],
+    paddingHorizontal: spacing[6],
+    paddingVertical: spacing[3],
+    borderRadius: borderRadius.full,
+    backgroundColor: brandColors.primary,
+  },
+  pressed: {
+    opacity: 0.85,
+  },
+});

--- a/packages/mobile/src/components/home/ClimbCoverCard.tsx
+++ b/packages/mobile/src/components/home/ClimbCoverCard.tsx
@@ -6,6 +6,7 @@ import { ClimbListThumbnail, THUMBNAIL_WIDTH } from '../ClimbListThumbnail';
 import { Text } from '../Text';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import type { ClimbListItemClimb } from '../ClimbListItemContent';
+import { spacing } from '../../theme/tokens';
 
 export type ClimbCoverCardProps = {
   climb: ClimbListItemClimb;
@@ -62,7 +63,7 @@ export const ClimbCoverCard = memo(function ClimbCoverCard({
 const styles = StyleSheet.create({
   card: {
     width: THUMBNAIL_WIDTH,
-    gap: 4,
+    gap: spacing[1],
   },
   pressed: {
     opacity: 0.85,

--- a/packages/mobile/src/components/home/ClimbCoverCard.tsx
+++ b/packages/mobile/src/components/home/ClimbCoverCard.tsx
@@ -1,0 +1,77 @@
+import { memo } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { ClimbListThumbnail, THUMBNAIL_WIDTH } from '../ClimbListThumbnail';
+import { Text } from '../Text';
+import { useGradeFormat } from '../../hooks/use-grade-format';
+import type { ClimbListItemClimb } from '../ClimbListItemContent';
+
+export type ClimbCoverCardProps = {
+  climb: ClimbListItemClimb;
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  onPress: () => void;
+};
+
+/**
+ * Compact climb card for Home's horizontal rows: the portrait board thumbnail
+ * (the cached native render — `ClimbListThumbnail`) over the climb name and a
+ * colorized grade. The vertical sibling of `ClimbListItemContent`'s row layout,
+ * sized to the thumbnail width so a row of these reads as an even strip.
+ */
+export const ClimbCoverCard = memo(function ClimbCoverCard({
+  climb,
+  boardName,
+  layoutId,
+  sizeId,
+  setIds,
+  onPress,
+}: ClimbCoverCardProps) {
+  const { formatGrade } = useGradeFormat();
+  const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
+  const formattedGrade = formatGrade(climb.difficulty) ?? climb.difficulty;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={climb.name}
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+    >
+      <ClimbListThumbnail
+        frames={climb.frames}
+        boardName={boardName}
+        layoutId={layoutId}
+        sizeId={sizeId}
+        setIds={setIds}
+        mirrored={climb.mirrored ?? false}
+      />
+      <Text variant="footnote" numberOfLines={1} style={styles.name}>
+        {climb.name}
+      </Text>
+      <Text variant="caption1" numberOfLines={1} style={[styles.grade, { color: gradeColor }]}>
+        {formattedGrade}
+      </Text>
+    </Pressable>
+  );
+});
+
+const styles = StyleSheet.create({
+  card: {
+    width: THUMBNAIL_WIDTH,
+    gap: 4,
+  },
+  pressed: {
+    opacity: 0.85,
+    transform: [{ scale: 0.97 }],
+  },
+  name: {
+    fontWeight: '600',
+  },
+  grade: {
+    fontWeight: '700',
+  },
+});

--- a/packages/mobile/src/components/home/HomeBetaRow.tsx
+++ b/packages/mobile/src/components/home/HomeBetaRow.tsx
@@ -1,0 +1,31 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PlaylistScrollSection } from '../playlist';
+import { BetaVideoCard } from '../play-drawer/BetaVideoCard';
+import { betaLinkIdentity } from '../../lib/beta-video-url';
+import { useHomeBetaLinks } from '../../lib/home/use-home-beta-links';
+
+export type HomeBetaRowProps = {
+  boardType: string;
+  layoutId: number;
+};
+
+/**
+ * Recent community beta videos for the active board's layout. Hidden entirely
+ * when the layout has no recent beta — board-filtered recency is thin, and beta
+ * as a discovery feed is low-signal, so it stays a quiet freshness row.
+ */
+export const HomeBetaRow = memo(function HomeBetaRow({ boardType, layoutId }: HomeBetaRowProps) {
+  const { t } = useTranslation('playlists');
+  const { data: betaLinks = [], isLoading } = useHomeBetaLinks(boardType, layoutId);
+
+  if (!isLoading && betaLinks.length === 0) return null;
+
+  return (
+    <PlaylistScrollSection title={t('home.beta')} loading={isLoading && betaLinks.length === 0}>
+      {betaLinks.map((link) => (
+        <BetaVideoCard key={betaLinkIdentity(link.link)} link={link} />
+      ))}
+    </PlaylistScrollSection>
+  );
+});

--- a/packages/mobile/src/components/home/HomeBoardHeader.tsx
+++ b/packages/mobile/src/components/home/HomeBoardHeader.tsx
@@ -1,0 +1,106 @@
+import { memo } from 'react';
+import { View, Pressable, StyleSheet } from 'react-native';
+import { router } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { Text } from '../Text';
+import { useQueue } from '../../providers/queue-provider';
+import { brandColors } from '../../theme/colors';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+export type HomeBoardHeaderProps = {
+  board: UserBoard;
+};
+
+/**
+ * Compact header scoping Home to the active board: name + layout/size/angle, a
+ * "Switch" affordance to the board picker, and — only when a session is live —
+ * a "Continue session" chip. Deliberately light: Home is an optional visit, so
+ * the curated rows below are the draw, not this header.
+ */
+export const HomeBoardHeader = memo(function HomeBoardHeader({ board }: HomeBoardHeaderProps) {
+  const { t } = useTranslation('playlists');
+  const { sessionId } = useQueue();
+
+  const subtitle = [board.layoutName ?? board.sizeName ?? null, `${board.angle}°`].filter(Boolean).join(' · ');
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <View style={styles.titleColumn}>
+          <Text variant="title2" numberOfLines={1} style={styles.boardName}>
+            {board.name}
+          </Text>
+          {subtitle ? (
+            <Text variant="footnote" numberOfLines={1} style={styles.subtitle}>
+              {subtitle}
+            </Text>
+          ) : null}
+        </View>
+        <Pressable
+          onPress={() => router.push({ pathname: '/boards', params: { returnTo: '/(tabs)/home' } })}
+          accessibilityRole="button"
+          hitSlop={8}
+          style={({ pressed }) => pressed && styles.pressed}
+        >
+          <Text variant="subheadline" color={brandColors.primary} style={styles.switchLabel}>
+            {t('home.switchBoard')}
+          </Text>
+        </Pressable>
+      </View>
+
+      {sessionId ? (
+        <Pressable
+          onPress={() => router.push('/(tabs)/record')}
+          accessibilityRole="button"
+          style={({ pressed }) => [styles.sessionChip, pressed && styles.pressed]}
+        >
+          <Text variant="subheadline" color={iosSystemColors.white} style={styles.sessionLabel}>
+            {t('home.continueSession')}
+          </Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[2],
+    gap: spacing[3],
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+  },
+  titleColumn: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2,
+  },
+  boardName: {
+    fontWeight: '700',
+  },
+  subtitle: {
+    opacity: 0.6,
+  },
+  switchLabel: {
+    fontWeight: '600',
+  },
+  sessionChip: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+    borderRadius: borderRadius.full,
+    backgroundColor: brandColors.primary,
+  },
+  sessionLabel: {
+    fontWeight: '600',
+  },
+  pressed: {
+    opacity: 0.6,
+  },
+});

--- a/packages/mobile/src/components/home/HomeBoardHeader.tsx
+++ b/packages/mobile/src/components/home/HomeBoardHeader.tsx
@@ -23,7 +23,9 @@ export const HomeBoardHeader = memo(function HomeBoardHeader({ board }: HomeBoar
   const { t } = useTranslation('playlists');
   const { sessionId } = useQueue();
 
-  const subtitle = [board.layoutName ?? board.sizeName ?? null, `${board.angle}°`].filter(Boolean).join(' · ');
+  // Layout · size · angle — each part dropped only when absent, so a board with
+  // both a layout and size name shows both (not one silently masking the other).
+  const subtitle = [board.layoutName, board.sizeName, `${board.angle}°`].filter(Boolean).join(' · ');
 
   return (
     <View style={styles.container}>

--- a/packages/mobile/src/components/home/HomeClimbRow.tsx
+++ b/packages/mobile/src/components/home/HomeClimbRow.tsx
@@ -1,0 +1,62 @@
+import { memo } from 'react';
+import type { BoardName } from '@boardsesh/shared-schema';
+import type { Climb } from '@boardsesh/queue';
+import { PlaylistScrollSection } from '../playlist';
+import { ClimbCoverCard } from './ClimbCoverCard';
+
+/** Board scoping passed to each cover card so its thumbnail renders correctly. */
+export type HomeRowBoard = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
+
+export type HomeClimbRowProps = {
+  title: string;
+  climbs: Climb[];
+  board: HomeRowBoard;
+  onPressClimb: (climb: Climb) => void;
+  loading?: boolean;
+  onEndReached?: () => void;
+  isLoadingMore?: boolean;
+};
+
+/**
+ * Presentational horizontal row of `ClimbCoverCard`s under a section title.
+ * Renders nothing once a row has resolved to zero climbs, so empty curated /
+ * recommendation rows disappear instead of leaving a bare header.
+ */
+export const HomeClimbRow = memo(function HomeClimbRow({
+  title,
+  climbs,
+  board,
+  onPressClimb,
+  loading,
+  onEndReached,
+  isLoadingMore,
+}: HomeClimbRowProps) {
+  if (!loading && climbs.length === 0) return null;
+
+  return (
+    <PlaylistScrollSection
+      title={title}
+      loading={loading && climbs.length === 0}
+      isLoadingMore={isLoadingMore}
+      onEndReached={onEndReached}
+    >
+      {climbs.map((climb) => (
+        <ClimbCoverCard
+          key={climb.uuid}
+          climb={climb}
+          boardName={board.boardName}
+          layoutId={board.layoutId}
+          sizeId={board.sizeId}
+          setIds={board.setIds}
+          onPress={() => onPressClimb(climb)}
+        />
+      ))}
+    </PlaylistScrollSection>
+  );
+});

--- a/packages/mobile/src/components/home/HomeJumpBackIn.tsx
+++ b/packages/mobile/src/components/home/HomeJumpBackIn.tsx
@@ -1,0 +1,69 @@
+import { memo, useMemo } from 'react';
+import { router } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useUserPlaylists, usePinnedPlaylists } from '@boardsesh/playlists-react';
+import { PlaylistCard, PlaylistScrollSection } from '../playlist';
+import { useAuth } from '../../providers/auth-provider';
+import { useAuthToken } from '../../lib/graphql/use-auth-token';
+
+export type HomeJumpBackInProps = {
+  boardType: string;
+  layoutId: number;
+};
+
+/**
+ * "Jump Back In" — the user's pinned + owned playlists for the active board, a
+ * quick path back into their own stuff. Mirrors the Discover tab's section;
+ * hidden when signed out or empty.
+ */
+export const HomeJumpBackIn = memo(function HomeJumpBackIn({ boardType, layoutId }: HomeJumpBackInProps) {
+  const { t } = useTranslation('playlists');
+  const { isAuthenticated } = useAuth();
+  const { data: token = null } = useAuthToken();
+  const effectiveToken = isAuthenticated ? token : null;
+
+  const {
+    playlists: userPlaylists,
+    isLoading,
+    isLoadingMore,
+    loadMore,
+  } = useUserPlaylists({ token: effectiveToken, boardType, layoutId, pageSize: 20 });
+
+  const { pinned } = usePinnedPlaylists({
+    token: effectiveToken,
+    boardType,
+    layoutId,
+    candidatePlaylists: userPlaylists,
+  });
+
+  // Pinned lead, then owned with pinned removed so none appear twice.
+  const jumpBackIn = useMemo(() => {
+    const pinnedUuids = new Set(pinned.map((playlist) => playlist.uuid));
+    return [...pinned, ...userPlaylists.filter((playlist) => !pinnedUuids.has(playlist.uuid))];
+  }, [pinned, userPlaylists]);
+
+  if (!isAuthenticated) return null;
+  if (!isLoading && jumpBackIn.length === 0) return null;
+
+  return (
+    <PlaylistScrollSection
+      title={t('library.sections.jumpBackIn')}
+      loading={isLoading && jumpBackIn.length === 0}
+      isLoadingMore={isLoadingMore}
+      onEndReached={loadMore}
+    >
+      {jumpBackIn.map((playlist, index) => (
+        <PlaylistCard
+          key={playlist.uuid}
+          name={playlist.name}
+          climbCount={playlist.climbCount}
+          color={playlist.color}
+          icon={playlist.icon}
+          variant="scroll"
+          index={index}
+          onPress={() => router.push(`/(tabs)/discover/${playlist.uuid}`)}
+        />
+      ))}
+    </PlaylistScrollSection>
+  );
+});

--- a/packages/mobile/src/components/home/HomeRecommendedRows.tsx
+++ b/packages/mobile/src/components/home/HomeRecommendedRows.tsx
@@ -1,0 +1,266 @@
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ClimbSearchInput } from '@boardsesh/shared-schema';
+import type { Climb } from '@boardsesh/queue';
+import {
+  usePlaylistClimbs,
+  useSmartPlaylist,
+  useRecommendedPlaylists,
+  type PlaylistClimbsBoardInput,
+} from '@boardsesh/playlists-react';
+import {
+  GET_PLAYLIST_CLIMBS,
+  GET_SMART_PLAYLIST,
+  type DiscoverablePlaylist,
+  type GetPlaylistClimbsInput,
+  type GetPlaylistClimbsQueryResponse,
+  type GetSmartPlaylistInput,
+  type GetSmartPlaylistQueryResponse,
+} from '@boardsesh/graphql/operations/playlists';
+import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../lib/graphql/operations';
+import { useInfiniteSearchClimbs } from '../../lib/graphql/hooks/use-infinite-search-climbs';
+import { usePlaylistActivation } from '../../lib/playlists/use-playlist-activation';
+import { toQueueClimbs } from '../../lib/climb-types';
+import { getHttpClient } from '../../lib/graphql/client';
+import { HomeClimbRow, type HomeRowBoard } from './HomeClimbRow';
+
+const REFRESH_ERROR = 'Failed to refresh recommended climbs:';
+const ROW_PAGE_SIZE = 12;
+const SEARCH_STALE_TIME = 5 * 60 * 1000;
+
+/** Per-page fetch args the activation hook passes to refresh the swipe list. */
+type RowFetchArgs = {
+  page: number;
+  pageSize: number;
+  board: { boardName: string; layoutId: number; sizeId: number; setIds: string; angle: number };
+  signal: AbortSignal;
+};
+
+export type HomeRecommendedRowsProps = {
+  board: HomeRowBoard;
+  /** Active board uuid — scopes query keys and the owned-board AT_LEVEL target. */
+  boardUuid: string;
+  /** Whether the user owns the active board (gates the personalized row). */
+  isOwned: boolean;
+  /** Authenticated user id, or null when signed out. */
+  userId: string | null;
+};
+
+/** Section title from a generated cohort name ("Crowd Favorites · …" → "Crowd Favorites"). */
+function cohortTitle(name: string): string {
+  const separator = name.indexOf(' · ');
+  return separator > 0 ? name.slice(0, separator) : name;
+}
+
+/**
+ * The curated/recommended climb rows for Home. Prefers the board's public
+ * recommendation cohorts (Crowd Favorites / Hidden Gems / Fresh); when the
+ * board config has no generated cohort, falls back to popularity/quality/recency
+ * sorts of the catalog. Adds a personalized "At your level" row for signed-in
+ * board owners.
+ */
+export function HomeRecommendedRows({ board, boardUuid, isOwned, userId }: HomeRecommendedRowsProps) {
+  const { t } = useTranslation('playlists');
+  const { playlists: cohorts, isLoading } = useRecommendedPlaylists({
+    boardType: board.boardName,
+    layoutId: board.layoutId,
+    sizeId: board.sizeId,
+    angle: board.angle,
+  });
+
+  return (
+    <>
+      {isLoading ? null : cohorts.length > 0 ? (
+        cohorts.map((playlist) => (
+          <HomeCohortRow key={playlist.uuid} playlist={playlist} board={board} boardUuid={boardUuid} />
+        ))
+      ) : (
+        <>
+          <HomeSearchRow board={board} sortBy="ascents" title={t('home.popular')} />
+          <HomeSearchRow board={board} sortBy="quality" title={t('home.topRated')} />
+          <HomeSearchRow board={board} sortBy="creation" title={t('home.fresh')} />
+        </>
+      )}
+      {isOwned && userId ? (
+        <HomeAtLevelRow board={board} boardUuid={boardUuid} userId={userId} title={t('home.atLevel')} />
+      ) : null}
+    </>
+  );
+}
+
+/** A cohort playlist rendered as a horizontal climb row. */
+function HomeCohortRow({
+  playlist,
+  board,
+  boardUuid,
+}: {
+  playlist: DiscoverablePlaylist;
+  board: HomeRowBoard;
+  boardUuid: string;
+}) {
+  const boardInput = useMemo<PlaylistClimbsBoardInput>(
+    () => ({
+      boardName: board.boardName,
+      layoutId: board.layoutId,
+      sizeId: board.sizeId,
+      setIds: board.setIds,
+      angle: board.angle,
+    }),
+    [board.boardName, board.layoutId, board.sizeId, board.setIds, board.angle],
+  );
+
+  const { allClimbs, query } = usePlaylistClimbs({
+    playlistUuid: playlist.uuid,
+    boardUuid,
+    boardInput,
+    pageSize: ROW_PAGE_SIZE,
+  });
+
+  const fetchPage = useCallback(
+    async ({ page, pageSize, board: target }: RowFetchArgs) => {
+      const input: GetPlaylistClimbsInput = {
+        playlistId: playlist.uuid,
+        page,
+        pageSize,
+        boardName: target.boardName,
+        layoutId: target.layoutId,
+        sizeId: target.sizeId,
+        setIds: target.setIds,
+        angle: target.angle,
+      };
+      const response = await getHttpClient().request<GetPlaylistClimbsQueryResponse>(GET_PLAYLIST_CLIMBS, { input });
+      return { climbs: toQueueClimbs(response.playlistClimbs.climbs), hasMore: response.playlistClimbs.hasMore };
+    },
+    [playlist.uuid],
+  );
+
+  const activate = usePlaylistActivation({
+    sourceId: `home:cohort:${playlist.uuid}`,
+    allClimbs,
+    fetchPage,
+    refreshErrorMessage: REFRESH_ERROR,
+  });
+
+  return (
+    <HomeClimbRow
+      title={cohortTitle(playlist.name)}
+      climbs={allClimbs}
+      board={board}
+      onPressClimb={(climb: Climb) => void activate(climb)}
+      loading={query.isLoading}
+    />
+  );
+}
+
+/** A catalog sort (popular / top-rated / fresh) rendered as a horizontal row. */
+function HomeSearchRow({ board, sortBy, title }: { board: HomeRowBoard; sortBy: string; title: string }) {
+  const baseInput = useMemo<ClimbSearchInput>(
+    () => ({
+      boardName: board.boardName,
+      layoutId: board.layoutId,
+      sizeId: board.sizeId,
+      setIds: board.setIds,
+      angle: board.angle,
+      sortBy,
+      sortOrder: 'desc',
+      pageSize: ROW_PAGE_SIZE,
+    }),
+    [board.boardName, board.layoutId, board.sizeId, board.setIds, board.angle, sortBy],
+  );
+
+  const query = useInfiniteSearchClimbs(baseInput, true, { staleTime: SEARCH_STALE_TIME });
+  const climbs = useMemo(() => toQueueClimbs(query.data?.pages.flatMap((page) => page.climbs) ?? []), [query.data]);
+
+  const fetchPage = useCallback(
+    async ({ page, pageSize, board: target }: RowFetchArgs) => {
+      const input: ClimbSearchInput = {
+        boardName: target.boardName,
+        layoutId: target.layoutId,
+        sizeId: target.sizeId,
+        setIds: target.setIds,
+        angle: target.angle,
+        sortBy,
+        sortOrder: 'desc',
+        page,
+        pageSize,
+      };
+      const response = await getHttpClient().request<SearchClimbsQueryResponse>(SEARCH_CLIMBS, { input });
+      return { climbs: toQueueClimbs(response.searchClimbs.climbs), hasMore: response.searchClimbs.hasMore };
+    },
+    [sortBy],
+  );
+
+  const activate = usePlaylistActivation({
+    sourceId: `home:search:${sortBy}:${board.boardName}:${board.layoutId}:${board.sizeId}:${board.angle}`,
+    allClimbs: climbs,
+    fetchPage,
+    refreshErrorMessage: REFRESH_ERROR,
+  });
+
+  return (
+    <HomeClimbRow
+      title={title}
+      climbs={climbs}
+      board={board}
+      onPressClimb={(climb: Climb) => void activate(climb)}
+      loading={query.isLoading}
+      onEndReached={() => {
+        if (query.hasNextPage && !query.isFetchingNextPage) void query.fetchNextPage();
+      }}
+      isLoadingMore={query.isFetchingNextPage}
+    />
+  );
+}
+
+/** Personalized "At your level" row — owner-private, board-targeted. */
+function HomeAtLevelRow({
+  board,
+  boardUuid,
+  userId,
+  title,
+}: {
+  board: HomeRowBoard;
+  boardUuid: string;
+  userId: string;
+  title: string;
+}) {
+  const { allClimbs, query } = useSmartPlaylist({
+    smartPlaylistType: 'RECOMMENDED_AT_LEVEL',
+    userId,
+    boardUuid,
+    pageSize: ROW_PAGE_SIZE,
+  });
+
+  const fetchPage = useCallback(
+    async ({ page, pageSize, board: target }: RowFetchArgs) => {
+      const input: GetSmartPlaylistInput = {
+        type: 'RECOMMENDED_AT_LEVEL',
+        userId,
+        boardUuid,
+        boardName: target.boardName,
+        page,
+        pageSize,
+      };
+      const response = await getHttpClient().request<GetSmartPlaylistQueryResponse>(GET_SMART_PLAYLIST, { input });
+      return { climbs: toQueueClimbs(response.smartPlaylist.climbs), hasMore: response.smartPlaylist.hasMore };
+    },
+    [userId, boardUuid],
+  );
+
+  const activate = usePlaylistActivation({
+    sourceId: `home:atlevel:${boardUuid}:${userId}`,
+    allClimbs,
+    fetchPage,
+    refreshErrorMessage: REFRESH_ERROR,
+  });
+
+  return (
+    <HomeClimbRow
+      title={title}
+      climbs={allClimbs}
+      board={board}
+      onPressClimb={(climb: Climb) => void activate(climb)}
+      loading={query.isLoading}
+    />
+  );
+}

--- a/packages/mobile/src/components/home/index.ts
+++ b/packages/mobile/src/components/home/index.ts
@@ -1,0 +1,17 @@
+export { ClimbCoverCard } from './ClimbCoverCard';
+export type { ClimbCoverCardProps } from './ClimbCoverCard';
+
+export { HomeClimbRow } from './HomeClimbRow';
+export type { HomeClimbRowProps, HomeRowBoard } from './HomeClimbRow';
+
+export { HomeBoardHeader } from './HomeBoardHeader';
+export type { HomeBoardHeaderProps } from './HomeBoardHeader';
+
+export { HomeRecommendedRows } from './HomeRecommendedRows';
+export type { HomeRecommendedRowsProps } from './HomeRecommendedRows';
+
+export { HomeJumpBackIn } from './HomeJumpBackIn';
+export type { HomeJumpBackInProps } from './HomeJumpBackIn';
+
+export { HomeBetaRow } from './HomeBetaRow';
+export type { HomeBetaRowProps } from './HomeBetaRow';

--- a/packages/mobile/src/lib/home/use-home-beta-links.ts
+++ b/packages/mobile/src/lib/home/use-home-beta-links.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import { GET_RECENT_BETA_LINKS } from '@boardsesh/graphql/operations/beta-links';
+import type { BetaLink, BetaLinksGqlRow } from '@boardsesh/shared-schema';
+import { getHttpClient } from '../graphql/client';
+import { mapBetaLinks, dedupeBetaLinks } from '../beta-video-url';
+
+/** A single `recentBetaLinks` row — the GQL `betaLink` field is the camelCase
+ *  `BetaLinksGqlRow` the shared mapper expects. */
+type RecentBetaLinkRow = {
+  climbName: string | null;
+  boardType: string;
+  layoutId: number | null;
+  betaLink: BetaLinksGqlRow;
+};
+
+type RecentBetaLinksResponse = { recentBetaLinks: RecentBetaLinkRow[] };
+
+const HOME_BETA_LIMIT = 20;
+
+/**
+ * Recent community beta videos for the active board, filtered to the active
+ * layout. Maps the GQL rows to the `BetaLink` shape `BetaVideoCard` renders and
+ * dedupes by link. Returns an empty array when the board has no recent beta —
+ * Home hides the row in that case.
+ */
+export function useHomeBetaLinks(boardType: string | undefined, layoutId: number | undefined) {
+  return useQuery<BetaLink[]>({
+    queryKey: ['homeBetaLinks', boardType, layoutId],
+    enabled: boardType !== undefined,
+    staleTime: 5 * 60 * 1000,
+    queryFn: async () => {
+      const response = await getHttpClient().request<RecentBetaLinksResponse>(GET_RECENT_BETA_LINKS, {
+        limit: HOME_BETA_LIMIT,
+        boardType,
+      });
+      const rows = response.recentBetaLinks ?? [];
+      const scoped = layoutId === undefined ? rows : rows.filter((row) => row.layoutId === layoutId);
+      return dedupeBetaLinks(mapBetaLinks(scoped.map((row) => row.betaLink)));
+    },
+  });
+}

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -1686,6 +1686,20 @@ type DiscoverPlaylistsResult {
 }
 
 """
+Input for board-config-scoped recommendation cohort playlists.
+"""
+input RecommendedPlaylistsInput {
+  "Board type"
+  boardType: String!
+  "Layout ID"
+  layoutId: Int!
+  "Board size ID"
+  sizeId: Int!
+  "Board angle in degrees"
+  angle: Int!
+}
+
+"""
 Input for searching playlists globally.
 """
 input SearchPlaylistsInput {
@@ -3756,6 +3770,13 @@ type Query {
   Discover public playlists with at least 1 climb.
   """
   discoverPlaylists(input: DiscoverPlaylistsInput!): DiscoverPlaylistsResult!
+
+  """
+  Public per-board recommendation cohort playlists (Crowd Favorites / Hidden
+  Gems / Fresh) for an exact board config. Returns [] when the config has no
+  generated cohort — callers fall back to a popularity sort.
+  """
+  recommendedPlaylists(input: RecommendedPlaylistsInput!): [DiscoverablePlaylist!]!
 
   """
   Search public playlists globally by name.

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -3183,6 +3183,12 @@ export type Query = {
    * thumbnails are already cached in our S3; no live IG/TikTok enrichment.
    */
   recentBetaLinks: Array<RecentBetaLink>;
+  /**
+   * Public per-board recommendation cohort playlists (Crowd Favorites / Hidden
+   * Gems / Fresh) for an exact board config. Returns [] when the config has no
+   * generated cohort — callers fall back to a popularity sort.
+   */
+  recommendedPlaylists: Array<DiscoverablePlaylist>;
   /** Search public boards. */
   searchBoards: UserBoardConnection;
   /**
@@ -3594,6 +3600,11 @@ export type QueryRecentBetaLinksArgs = {
 };
 
 /** Root query type for all read operations. */
+export type QueryRecommendedPlaylistsArgs = {
+  input: RecommendedPlaylistsInput;
+};
+
+/** Root query type for all read operations. */
 export type QuerySearchBoardsArgs = {
   input: SearchBoardsInput;
 };
@@ -3850,6 +3861,18 @@ export type RecentBetaLink = {
   boardType: Scalars['String']['output'];
   climbName?: Maybe<Scalars['String']['output']>;
   layoutId?: Maybe<Scalars['Int']['output']>;
+};
+
+/** Input for board-config-scoped recommendation cohort playlists. */
+export type RecommendedPlaylistsInput = {
+  /** Board angle in degrees */
+  angle: Scalars['Int']['input'];
+  /** Board type */
+  boardType: Scalars['String']['input'];
+  /** Layout ID */
+  layoutId: Scalars['Int']['input'];
+  /** Board size ID */
+  sizeId: Scalars['Int']['input'];
 };
 
 export type RegisterControllerInput = {
@@ -5505,6 +5528,7 @@ export type ResolversTypes = ResolversObject<{
   QueueReordered: ResolverTypeWrapper<QueueReordered>;
   QueueState: ResolverTypeWrapper<QueueState>;
   RecentBetaLink: ResolverTypeWrapper<RecentBetaLink>;
+  RecommendedPlaylistsInput: RecommendedPlaylistsInput;
   RegisterControllerInput: RegisterControllerInput;
   RemoveClimbFromPlaylistInput: RemoveClimbFromPlaylistInput;
   RemoveGymMemberInput: RemoveGymMemberInput;
@@ -5760,6 +5784,7 @@ export type ResolversParentTypes = ResolversObject<{
   QueueReordered: QueueReordered;
   QueueState: QueueState;
   RecentBetaLink: RecentBetaLink;
+  RecommendedPlaylistsInput: RecommendedPlaylistsInput;
   RegisterControllerInput: RegisterControllerInput;
   RemoveClimbFromPlaylistInput: RemoveClimbFromPlaylistInput;
   RemoveGymMemberInput: RemoveGymMemberInput;
@@ -7810,6 +7835,12 @@ export type QueryResolvers<
     ParentType,
     ContextType,
     RequireFields<QueryRecentBetaLinksArgs, 'limit'>
+  >;
+  recommendedPlaylists?: Resolver<
+    Array<ResolversTypes['DiscoverablePlaylist']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryRecommendedPlaylistsArgs, 'input'>
   >;
   searchBoards?: Resolver<
     ResolversTypes['UserBoardConnection'],

--- a/packages/shared-schema/src/schema/playlists.ts
+++ b/packages/shared-schema/src/schema/playlists.ts
@@ -328,6 +328,20 @@ export const playlistsTypeDefs = /* GraphQL */ `
   }
 
   """
+  Input for board-config-scoped recommendation cohort playlists.
+  """
+  input RecommendedPlaylistsInput {
+    "Board type"
+    boardType: String!
+    "Layout ID"
+    layoutId: Int!
+    "Board size ID"
+    sizeId: Int!
+    "Board angle in degrees"
+    angle: Int!
+  }
+
+  """
   Input for searching playlists globally.
   """
   input SearchPlaylistsInput {

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -239,6 +239,13 @@ export const queriesTypeDefs = /* GraphQL */ `
     discoverPlaylists(input: DiscoverPlaylistsInput!): DiscoverPlaylistsResult!
 
     """
+    Public per-board recommendation cohort playlists (Crowd Favorites / Hidden
+    Gems / Fresh) for an exact board config. Returns [] when the config has no
+    generated cohort — callers fall back to a popularity sort.
+    """
+    recommendedPlaylists(input: RecommendedPlaylistsInput!): [DiscoverablePlaylist!]!
+
+    """
     Search public playlists globally by name.
     """
     searchPlaylists(input: SearchPlaylistsInput!): SearchPlaylistsResult!

--- a/packages/shared-schema/src/types/board-config.ts
+++ b/packages/shared-schema/src/types/board-config.ts
@@ -16,6 +16,11 @@ export const SUPPORTED_BOARDS = [
 export type BoardName = (typeof SUPPORTED_BOARDS)[number];
 export type AuroraBoardName = (typeof AURORA_BOARDS)[number];
 
+/** Runtime guard narrowing an arbitrary string to a supported BoardName. */
+export function isBoardName(value: string): value is BoardName {
+  return (SUPPORTED_BOARDS as readonly string[]).includes(value);
+}
+
 export type Grade = {
   difficultyId: number;
   name: string;

--- a/packages/shared/graphql/src/generated/gql.ts
+++ b/packages/shared/graphql/src/generated/gql.ts
@@ -70,6 +70,7 @@ type Documents = {
   '\n  mutation RemoveClimbFromPlaylist($input: RemoveClimbFromPlaylistInput!) {\n    removeClimbFromPlaylist(input: $input)\n  }\n': typeof types.RemoveClimbFromPlaylistDocument;
   '\n  query GetPlaylistClimbs($input: GetPlaylistClimbsInput!) {\n    playlistClimbs(input: $input) {\n      climbs {\n        uuid\n        layoutId\n        boardType\n        setter_username\n        name\n        description\n        frames\n        angle\n        ascensionist_count\n        difficulty\n        quality_average\n        stars\n        difficulty_error\n        benchmark_difficulty\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.GetPlaylistClimbsDocument;
   '\n  query DiscoverPlaylists($input: DiscoverPlaylistsInput!) {\n    discoverPlaylists(input: $input) {\n      playlists {\n        id\n        uuid\n        boardType\n        layoutId\n        name\n        description\n        color\n        icon\n        createdAt\n        updatedAt\n        climbCount\n        creatorId\n        creatorName\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.DiscoverPlaylistsDocument;
+  '\n  query RecommendedPlaylists($input: RecommendedPlaylistsInput!) {\n    recommendedPlaylists(input: $input) {\n      id\n      uuid\n      boardType\n      layoutId\n      name\n      description\n      color\n      icon\n      createdAt\n      updatedAt\n      climbCount\n      creatorId\n      creatorName\n    }\n  }\n': typeof types.RecommendedPlaylistsDocument;
   '\n  query GetPlaylistCreators($input: GetPlaylistCreatorsInput!) {\n    playlistCreators(input: $input) {\n      userId\n      displayName\n      playlistCount\n    }\n  }\n': typeof types.GetPlaylistCreatorsDocument;
   '\n  mutation UpdatePlaylistLastAccessed($playlistId: ID!) {\n    updatePlaylistLastAccessed(playlistId: $playlistId)\n  }\n': typeof types.UpdatePlaylistLastAccessedDocument;
   '\n  query SearchPlaylists($input: SearchPlaylistsInput!) {\n    searchPlaylists(input: $input) {\n      playlists {\n        id\n        uuid\n        boardType\n        layoutId\n        name\n        description\n        color\n        icon\n        climbCount\n        creatorId\n        creatorName\n        createdAt\n        updatedAt\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.SearchPlaylistsDocument;
@@ -235,6 +236,8 @@ const documents: Documents = {
     types.GetPlaylistClimbsDocument,
   '\n  query DiscoverPlaylists($input: DiscoverPlaylistsInput!) {\n    discoverPlaylists(input: $input) {\n      playlists {\n        id\n        uuid\n        boardType\n        layoutId\n        name\n        description\n        color\n        icon\n        createdAt\n        updatedAt\n        climbCount\n        creatorId\n        creatorName\n      }\n      totalCount\n      hasMore\n    }\n  }\n':
     types.DiscoverPlaylistsDocument,
+  '\n  query RecommendedPlaylists($input: RecommendedPlaylistsInput!) {\n    recommendedPlaylists(input: $input) {\n      id\n      uuid\n      boardType\n      layoutId\n      name\n      description\n      color\n      icon\n      createdAt\n      updatedAt\n      climbCount\n      creatorId\n      creatorName\n    }\n  }\n':
+    types.RecommendedPlaylistsDocument,
   '\n  query GetPlaylistCreators($input: GetPlaylistCreatorsInput!) {\n    playlistCreators(input: $input) {\n      userId\n      displayName\n      playlistCount\n    }\n  }\n':
     types.GetPlaylistCreatorsDocument,
   '\n  mutation UpdatePlaylistLastAccessed($playlistId: ID!) {\n    updatePlaylistLastAccessed(playlistId: $playlistId)\n  }\n':
@@ -687,6 +690,12 @@ export function graphql(
 export function graphql(
   source: '\n  query DiscoverPlaylists($input: DiscoverPlaylistsInput!) {\n    discoverPlaylists(input: $input) {\n      playlists {\n        id\n        uuid\n        boardType\n        layoutId\n        name\n        description\n        color\n        icon\n        createdAt\n        updatedAt\n        climbCount\n        creatorId\n        creatorName\n      }\n      totalCount\n      hasMore\n    }\n  }\n',
 ): (typeof documents)['\n  query DiscoverPlaylists($input: DiscoverPlaylistsInput!) {\n    discoverPlaylists(input: $input) {\n      playlists {\n        id\n        uuid\n        boardType\n        layoutId\n        name\n        description\n        color\n        icon\n        createdAt\n        updatedAt\n        climbCount\n        creatorId\n        creatorName\n      }\n      totalCount\n      hasMore\n    }\n  }\n'];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query RecommendedPlaylists($input: RecommendedPlaylistsInput!) {\n    recommendedPlaylists(input: $input) {\n      id\n      uuid\n      boardType\n      layoutId\n      name\n      description\n      color\n      icon\n      createdAt\n      updatedAt\n      climbCount\n      creatorId\n      creatorName\n    }\n  }\n',
+): (typeof documents)['\n  query RecommendedPlaylists($input: RecommendedPlaylistsInput!) {\n    recommendedPlaylists(input: $input) {\n      id\n      uuid\n      boardType\n      layoutId\n      name\n      description\n      color\n      icon\n      createdAt\n      updatedAt\n      climbCount\n      creatorId\n      creatorName\n    }\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -3180,6 +3180,12 @@ export type Query = {
    * thumbnails are already cached in our S3; no live IG/TikTok enrichment.
    */
   recentBetaLinks: Array<RecentBetaLink>;
+  /**
+   * Public per-board recommendation cohort playlists (Crowd Favorites / Hidden
+   * Gems / Fresh) for an exact board config. Returns [] when the config has no
+   * generated cohort — callers fall back to a popularity sort.
+   */
+  recommendedPlaylists: Array<DiscoverablePlaylist>;
   /** Search public boards. */
   searchBoards: UserBoardConnection;
   /**
@@ -3591,6 +3597,11 @@ export type QueryRecentBetaLinksArgs = {
 };
 
 /** Root query type for all read operations. */
+export type QueryRecommendedPlaylistsArgs = {
+  input: RecommendedPlaylistsInput;
+};
+
+/** Root query type for all read operations. */
 export type QuerySearchBoardsArgs = {
   input: SearchBoardsInput;
 };
@@ -3847,6 +3858,18 @@ export type RecentBetaLink = {
   boardType: Scalars['String']['output'];
   climbName?: Maybe<Scalars['String']['output']>;
   layoutId?: Maybe<Scalars['Int']['output']>;
+};
+
+/** Input for board-config-scoped recommendation cohort playlists. */
+export type RecommendedPlaylistsInput = {
+  /** Board angle in degrees */
+  angle: Scalars['Int']['input'];
+  /** Board type */
+  boardType: Scalars['String']['input'];
+  /** Layout ID */
+  layoutId: Scalars['Int']['input'];
+  /** Board size ID */
+  sizeId: Scalars['Int']['input'];
 };
 
 export type RegisterControllerInput = {
@@ -6186,6 +6209,30 @@ export type DiscoverPlaylistsQuery = {
       creatorName: string;
     }>;
   };
+};
+
+export type RecommendedPlaylistsQueryVariables = Exact<{
+  input: RecommendedPlaylistsInput;
+}>;
+
+export type RecommendedPlaylistsQuery = {
+  __typename?: 'Query';
+  recommendedPlaylists: Array<{
+    __typename?: 'DiscoverablePlaylist';
+    id: string;
+    uuid: string;
+    boardType: string;
+    layoutId?: number | null;
+    name: string;
+    description?: string | null;
+    color?: string | null;
+    icon?: string | null;
+    createdAt: string;
+    updatedAt: string;
+    climbCount: number;
+    creatorId: string;
+    creatorName: string;
+  }>;
 };
 
 export type GetPlaylistCreatorsQueryVariables = Exact<{
@@ -10090,6 +10137,60 @@ export const DiscoverPlaylistsDocument = {
     },
   ],
 } as unknown as DocumentNode<DiscoverPlaylistsQuery, DiscoverPlaylistsQueryVariables>;
+export const RecommendedPlaylistsDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'RecommendedPlaylists' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'input' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'RecommendedPlaylistsInput' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'recommendedPlaylists' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'input' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'input' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'uuid' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'boardType' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'layoutId' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'description' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'color' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'icon' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'updatedAt' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'climbCount' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'creatorId' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'creatorName' } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<RecommendedPlaylistsQuery, RecommendedPlaylistsQueryVariables>;
 export const GetPlaylistCreatorsDocument = {
   kind: 'Document',
   definitions: [

--- a/packages/shared/graphql/src/operations/playlists.ts
+++ b/packages/shared/graphql/src/operations/playlists.ts
@@ -470,6 +470,23 @@ export type DiscoverPlaylistsQueryResponse = {
   discoverPlaylists: DiscoverPlaylistsResult;
 };
 
+// Board-config-scoped recommendation cohort playlists (Crowd Favorites / Hidden
+// Gems / Fresh). Returns the matching cohort DiscoverablePlaylists or [].
+export type RecommendedPlaylistsInput = {
+  boardType: string;
+  layoutId: number;
+  sizeId: number;
+  angle: number;
+};
+
+export type RecommendedPlaylistsQueryVariables = {
+  input: RecommendedPlaylistsInput;
+};
+
+export type RecommendedPlaylistsQueryResponse = {
+  recommendedPlaylists: DiscoverablePlaylist[];
+};
+
 export type GetPlaylistCreatorsInput = {
   boardType: string;
   layoutId: number;
@@ -505,6 +522,27 @@ export const DISCOVER_PLAYLISTS = gql`
       }
       totalCount
       hasMore
+    }
+  }
+`;
+
+// Public per-board recommendation cohort playlists (board-config-scoped).
+export const RECOMMENDED_PLAYLISTS = gql`
+  query RecommendedPlaylists($input: RecommendedPlaylistsInput!) {
+    recommendedPlaylists(input: $input) {
+      id
+      uuid
+      boardType
+      layoutId
+      name
+      description
+      color
+      icon
+      createdAt
+      updatedAt
+      climbCount
+      creatorId
+      creatorName
     }
   }
 `;

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -35,6 +35,7 @@
     },
     "nav": {
       "boards": "Boards",
+      "home": "Home",
       "climbs": "Climbs",
       "climb": "Climb",
       "profile": "Profile",

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -253,5 +253,19 @@
     "selectBoardForPlaylist": "Select a board before creating a playlist",
     "createdPlaylistToast": "Created playlist \"{{name}}\"",
     "createPlaylistFailed": "Failed to create playlist"
+  },
+  "home": {
+    "popular": "Popular on your board",
+    "topRated": "Top rated",
+    "fresh": "Recently set",
+    "atLevel": "At your level",
+    "beta": "Fresh beta",
+    "switchBoard": "Switch",
+    "continueSession": "Continue session",
+    "pickBoard": {
+      "title": "Pick a board to get started",
+      "description": "Choose your board to see climbs worth trying, fresh beta, and picks for your wall.",
+      "cta": "Pick a board"
+    }
   }
 }

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -233,6 +233,7 @@
     },
     "nav": {
       "boards": "Tablas",
+      "home": "Inicio",
       "climbs": "Bloques",
       "climb": "Bloque",
       "profile": "Perfil",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -253,5 +253,19 @@
     "selectBoardForPlaylist": "Selecciona una tabla de escalada antes de crear una playlist",
     "createdPlaylistToast": "Playlist «{{name}}» creada",
     "createPlaylistFailed": "No se pudo crear la playlist"
+  },
+  "home": {
+    "popular": "Populares en tu tabla",
+    "topRated": "Mejor valorados",
+    "fresh": "Recién creados",
+    "atLevel": "A tu nivel",
+    "beta": "Beta reciente",
+    "switchBoard": "Cambiar",
+    "continueSession": "Continuar sesión",
+    "pickBoard": {
+      "title": "Elige una tabla para empezar",
+      "description": "Elige tu tabla para ver bloques que merecen la pena, beta reciente y recomendaciones para tu muro.",
+      "cta": "Elegir tabla"
+    }
   }
 }

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -35,6 +35,7 @@
     },
     "nav": {
       "boards": "Boards",
+      "home": "Accueil",
       "climbs": "Blocs",
       "climb": "Bloc",
       "profile": "Profil",

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -253,5 +253,19 @@
     "selectBoardForPlaylist": "Choisissez un board avant de créer une playlist",
     "createdPlaylistToast": "Playlist « {{name}} » créée",
     "createPlaylistFailed": "Impossible de créer la playlist"
+  },
+  "home": {
+    "popular": "Populaires sur ton board",
+    "topRated": "Les mieux notés",
+    "fresh": "Récemment ouverts",
+    "atLevel": "À ton niveau",
+    "beta": "Beta récente",
+    "switchBoard": "Changer",
+    "continueSession": "Reprendre la session",
+    "pickBoard": {
+      "title": "Choisis un board pour commencer",
+      "description": "Choisis ton board pour voir des blocs à essayer, de la beta récente et des sélections pour ton mur.",
+      "cta": "Choisir un board"
+    }
   }
 }

--- a/packages/shared/playlists-react/src/index.ts
+++ b/packages/shared/playlists-react/src/index.ts
@@ -14,6 +14,9 @@ export type { RecentPlaylistEntry, RecentsStorageAdapter } from './recents-adapt
 export { useDiscoverPlaylists } from './use-discover-playlists';
 export type { UseDiscoverPlaylistsOptions, UseDiscoverPlaylistsResult } from './use-discover-playlists';
 
+export { useRecommendedPlaylists } from './use-recommended-playlists';
+export type { UseRecommendedPlaylistsOptions, UseRecommendedPlaylistsResult } from './use-recommended-playlists';
+
 export { useUserPlaylists } from './use-user-playlists';
 export type { UseUserPlaylistsOptions, UseUserPlaylistsResult } from './use-user-playlists';
 

--- a/packages/shared/playlists-react/src/use-recommended-playlists.ts
+++ b/packages/shared/playlists-react/src/use-recommended-playlists.ts
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  RECOMMENDED_PLAYLISTS,
+  type DiscoverablePlaylist,
+  type RecommendedPlaylistsInput,
+  type RecommendedPlaylistsQueryResponse,
+} from '@boardsesh/graphql/operations/playlists';
+import { usePlaylistsAdapter, type ExecutePlaylistsGraphQL } from './adapter';
+
+export type UseRecommendedPlaylistsOptions = {
+  /** Active board config. The hook only fetches once all four are defined. */
+  boardType?: string;
+  layoutId?: number;
+  sizeId?: number;
+  angle?: number;
+  /** Override the adapter's `executeGraphQL` (used in tests). */
+  executeGraphQL?: ExecutePlaylistsGraphQL;
+};
+
+export type UseRecommendedPlaylistsResult = {
+  /** The 0–3 cohort playlists (Crowd Favorites / Hidden Gems / Fresh) for the
+   *  board, in display order. Empty when the config isn't a generated cohort. */
+  playlists: DiscoverablePlaylist[];
+  isLoading: boolean;
+  hasError: boolean;
+  refetch: () => void;
+};
+
+/**
+ * Fetches the public per-board recommendation cohort playlists for an exact
+ * board config (boardType + layoutId + sizeId + angle). Returns [] when the
+ * config has no generated cohort, so Home can fall back to a popularity sort.
+ *
+ * A single, fixed-size request (no pagination): the resolver returns at most
+ * three rows. Changing any board field resets and refetches.
+ */
+export function useRecommendedPlaylists({
+  boardType,
+  layoutId,
+  sizeId,
+  angle,
+  executeGraphQL: executeGraphQLOverride,
+}: UseRecommendedPlaylistsOptions): UseRecommendedPlaylistsResult {
+  const adapter = usePlaylistsAdapter();
+  const executeGraphQL = executeGraphQLOverride ?? adapter.executeGraphQL;
+
+  const ready = boardType !== undefined && layoutId !== undefined && sizeId !== undefined && angle !== undefined;
+
+  const [playlists, setPlaylists] = useState<DiscoverablePlaylist[]>([]);
+  const [isLoading, setIsLoading] = useState(ready);
+  const [hasError, setHasError] = useState(false);
+
+  // Bumping this triggers a refetch without changing the board inputs.
+  const [reloadToken, setReloadToken] = useState(0);
+
+  // Guard against a stale in-flight response overwriting a newer board's data.
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    if (!ready) {
+      setPlaylists([]);
+      setIsLoading(false);
+      setHasError(false);
+      return;
+    }
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setIsLoading(true);
+    setHasError(false);
+
+    const input: RecommendedPlaylistsInput = { boardType, layoutId, sizeId, angle };
+    executeGraphQL<RecommendedPlaylistsQueryResponse, { input: RecommendedPlaylistsInput }>(RECOMMENDED_PLAYLISTS, {
+      input,
+    })
+      .then((response) => {
+        if (requestId !== requestIdRef.current) return;
+        setPlaylists(response.recommendedPlaylists ?? []);
+        setIsLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (requestId !== requestIdRef.current) return;
+        console.error('Failed to fetch recommended playlists:', err);
+        setPlaylists([]);
+        setHasError(true);
+        setIsLoading(false);
+      });
+  }, [ready, boardType, layoutId, sizeId, angle, executeGraphQL, reloadToken]);
+
+  return {
+    playlists,
+    isLoading,
+    hasError,
+    refetch: () => setReloadToken((token) => token + 1),
+  };
+}


### PR DESCRIPTION
## What

Adds a **Home** tab to the RN mobile app, now the leftmost tab: `Home · Discover · Record · Profile · [Climbs/search]`. Home anchors the left so Record is no longer stranded there, and search keeps floating right via `role="search"`.

The app cold-starts on the climbs search tab, so Home is framed as an **optional, occasional, board-scoped** destination — it leans into discovery + freshness rather than being a forced landing.

## Why this shape (grounded in prod data)

- Existing home-tab usage on web/Capacitor is mostly forced traffic (it's the index route + the Capacitor app's default open), so it doesn't validate pull — the RN home has to earn visits. The behavioral data was used to decide *what content resonates*, not whether a home tab "works."
- Dominant climber behavior (90d): browse climb list (873 persons) › search (666) › sessions (445 started) › beta *watching* (154). → curated/fresh climb rows are the headline; a light board header + resume are supporting chrome.
- Beta is popular to *watch* (154 persons) but dead as a *discovery feed* — tapping from a beta card to its climb was 3 persons / 90d. So the beta row is secondary and hides when empty.
- The merged recommendation engine is prod-ready: 27 public cohort playlists exist; `board_climb_stats` is fully populated. Only ~166 users own a registered board, so public cohorts + `searchClimbs` carry the majority and personalized recs are additive.

## Content (scoped to the active board)

- **Board header** — name + layout/angle, a board switcher, and a "Continue session" chip only when a session is live.
- **Curated climb rows** — public cohort playlists (Crowd Favorites / Hidden Gems / Fresh) via a new `recommendedPlaylists` query when the board config has a cohort; otherwise `searchClimbs` Popular / Top-rated / Recently-set (anonymous-friendly, no DB work). Plus a personalized **At your level** row for signed-in board owners.
- **Jump back in** — pinned/owned playlists.
- **Fresh beta** — recent community videos for the active layout; hidden when empty.

Tapping a climb opens the play drawer and the swipe walks that row's full list (the existing `usePlaylistActivation` pattern).

## Implementation (mostly reuse)

- **Backend:** one small public `recommendedPlaylists(boardType, layoutId, sizeId, angle)` query. Cohort size/angle live inside the `generated_recommendation` key, so it reconstructs the keys (new shared `cohort-keys` module — also consumed by the nightly `refresh-recommendations` generator, so the format can't drift) and looks the cohorts up by exact config; returns `[]` on a miss.
- **Shared:** `RECOMMENDED_PLAYLISTS` op + `useRecommendedPlaylists` hook. Everything else reuses existing `playlistClimbs` / `useSmartPlaylist` / `searchClimbs` hooks, `BetaVideoCard`, and `PlaylistScrollSection`.
- **Mobile:** new `home/` route + `ClimbCoverCard`, `HomeBoardHeader`, `HomeClimbRow`, `HomeRecommendedRows`, `HomeJumpBackIn`, `HomeBetaRow`, and `useHomeBetaLinks`.

## Validation

- typecheck: shared, backend, db, mobile, web — pass
- tests: mobile 1115/1115, backend resolver 3/3 (cohort sort + miss→[] + no-auth), db cohort-keys 5/5, i18n parity 28/28, new tab-order test
- `vp run check:mobile-bundle` — Metro bundle OK
- `vp check` — feature files clean

## Notes

- `board_climb_send_stats` is empty in prod, so the recommendation send-boost is a neutral no-op until the nightly `refresh-recommendations` job runs with a PostHog key. Cohorts still rank on ascents × quality × setter.
- Not yet seen rendered live (simulator/screenshot checks are macOS-only) — worth a quick `vp run dev:mobile` look, especially cohort rows on Kilter @40° vs the `searchClimbs` fallback on a non-40° angle.

## QA

- No active board → "Pick a board" prompt; other rows hidden; routes to the board picker.
- Kilter Original/Homewall @40°, signed out → cohort rows (Crowd Favorites / Hidden Gems / Fresh) populate.
- Non-40° angle or MoonBoard → `searchClimbs` Popular/Top-rated/Recently-set fallback fills rows.
- Signed-in board owner → jump-back + "At your level" rows appear.
- Live session → header shows a "Continue session" chip.
- Tap a curated climb → play drawer opens and swipes the full list.
- Beta row only appears when the active layout has recent beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)