### PR TITLE
Fix My Playlists list-view follow-up review issues

### DIFF
--- a/packages/mobile/app/(tabs)/discover/__tests__/all.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/all.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type PlaylistItem = { uuid: string; name: string; climbCount: number; color?: string; icon?: string };
+
+// Mutable return value for useUserPlaylists — each test sets the slice it needs.
+const hook = vi.hoisted(() => ({
+  playlists: [] as PlaylistItem[],
+  isLoading: false,
+  isLoadingMore: false,
+  hasMore: false,
+  totalCount: 0,
+  hasError: false,
+  hasLoadMoreError: false,
+  loadMore: vi.fn(),
+  retryLoadMore: vi.fn(),
+  refetch: vi.fn(),
+}));
+
+vi.mock('@boardsesh/playlists-react', () => ({ useUserPlaylists: () => hook }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('expo-router', () => ({ router: { push: vi.fn() } }));
+
+// react-native primitives → DOM. FlatList renders its data (or the empty
+// component) plus the footer so the error/retry affordances are assertable.
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+  TextInput: ({
+    value,
+    onChangeText,
+    accessibilityLabel,
+    placeholder,
+  }: {
+    value?: string;
+    onChangeText?: (text: string) => void;
+    accessibilityLabel?: string;
+    placeholder?: string;
+  }) =>
+    createElement('input', {
+      value: value ?? '',
+      placeholder,
+      'aria-label': accessibilityLabel,
+      onChange: (event: { target: { value: string } }) => onChangeText?.(event.target.value),
+    }),
+  FlatList: ({
+    data,
+    renderItem,
+    ListEmptyComponent,
+    ListFooterComponent,
+  }: {
+    data?: PlaylistItem[];
+    renderItem: (info: { item: PlaylistItem; index: number }) => ReactNode;
+    ListEmptyComponent?: ReactNode;
+    ListFooterComponent?: ReactNode;
+  }) =>
+    createElement(
+      'div',
+      { 'data-list': 'true' },
+      data && data.length > 0
+        ? data.map((item, index) => createElement('div', { key: item.uuid }, renderItem({ item, index })))
+        : ListEmptyComponent,
+      ListFooterComponent,
+    ),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1, absoluteFill: {} },
+  Platform: { OS: 'ios' },
+}));
+
+vi.mock('../../../../src/theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24, 8: 32, 10: 40, 16: 64 },
+}));
+vi.mock('../../../../src/theme/ios-colors', () => ({
+  iosSystemColors: { systemGray: '#8E8E93', systemGray4: '#C7C7CC' },
+}));
+vi.mock('../../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { background: '#fff', fill: '#eee', label: '#000', secondaryLabel: '#666', separator: '#ddd' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+vi.mock('../../../../src/providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+vi.mock('../../../../src/lib/graphql/use-auth-token', () => ({ useAuthToken: () => ({ data: 'token' }) }));
+vi.mock('../../../../src/lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: { boardType: 'kilter', layoutId: 1 } }),
+}));
+vi.mock('../../../../src/hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+}));
+vi.mock('../../../../src/components/Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../../src/components/Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+vi.mock('../../../../src/components/ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-spinner': 'true' }),
+}));
+vi.mock('../../../../src/components/playlist', () => ({
+  PlaylistListRow: ({ name }: { name: string }) => createElement('div', { 'data-playlist-row': name }),
+}));
+
+import AllPlaylistsScreen from '../all';
+
+beforeEach(() => {
+  hook.playlists = [];
+  hook.isLoading = false;
+  hook.isLoadingMore = false;
+  hook.hasMore = false;
+  hook.hasError = false;
+  hook.hasLoadMoreError = false;
+  hook.loadMore.mockClear();
+  hook.retryLoadMore.mockClear();
+  hook.refetch.mockClear();
+});
+
+describe('AllPlaylistsScreen', () => {
+  it('shows an error state with a working retry when the initial load fails', () => {
+    hook.hasError = true;
+    const { getByText, getByLabelText } = render(<AllPlaylistsScreen />);
+
+    expect(getByText('library.errors.loadTitle')).toBeTruthy();
+    fireEvent.click(getByLabelText('library.errors.tryAgain'));
+    expect(hook.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the loading spinner (not the error state) while a retry is in flight', () => {
+    hook.hasError = true;
+    hook.isLoading = true;
+    const { queryByText, container } = render(<AllPlaylistsScreen />);
+
+    expect(queryByText('library.errors.loadTitle')).toBeNull();
+    expect(container.querySelector('[data-spinner="true"]')).not.toBeNull();
+  });
+
+  it('flags an incomplete list and retries background pagination from the footer', () => {
+    hook.playlists = [{ uuid: 'a', name: 'Alpha', climbCount: 1 }];
+    hook.hasLoadMoreError = true;
+    const { getByText, getByLabelText } = render(<AllPlaylistsScreen />);
+
+    expect(getByText('library.allPlaylists.loadMoreError')).toBeTruthy();
+    fireEvent.click(getByLabelText('library.errors.tryAgain'));
+    expect(hook.retryLoadMore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/app/(tabs)/discover/__tests__/all.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/all.test.tsx
@@ -150,7 +150,9 @@ describe('AllPlaylistsScreen', () => {
     const { getByText, getByLabelText } = render(<AllPlaylistsScreen />);
 
     expect(getByText('library.allPlaylists.loadMoreError')).toBeTruthy();
-    fireEvent.click(getByLabelText('library.errors.tryAgain'));
+    // The retry button's a11y label carries the error context, not just "Try Again".
+    const retryButton = getByLabelText('library.allPlaylists.loadMoreError library.errors.tryAgain');
+    fireEvent.click(retryButton);
     expect(hook.retryLoadMore).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/app/(tabs)/discover/all.tsx
+++ b/packages/mobile/app/(tabs)/discover/all.tsx
@@ -182,9 +182,9 @@ export default function AllPlaylistsScreen() {
                 style={styles.footer}
                 onPress={retryLoadMore}
                 accessibilityRole="button"
-                accessibilityLabel={t('library.errors.tryAgain')}
+                accessibilityLabel={`${t('library.allPlaylists.loadMoreError')} ${t('library.errors.tryAgain')}`}
               >
-                <Text variant="footnote" style={styles.stateSubtitle}>
+                <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.footerError}>
                   {t('library.allPlaylists.loadMoreError')}
                 </Text>
                 <Text variant="subheadline" color={brandColors.primary} style={styles.footerRetry}>
@@ -254,6 +254,9 @@ const styles = StyleSheet.create({
   footer: {
     paddingVertical: spacing[4],
     alignItems: 'center',
+  },
+  footerError: {
+    textAlign: 'center',
   },
   footerRetry: {
     marginTop: spacing[1],

--- a/packages/mobile/app/(tabs)/discover/all.tsx
+++ b/packages/mobile/app/(tabs)/discover/all.tsx
@@ -38,12 +38,13 @@ export default function AllPlaylistsScreen() {
 
   // Scope to the active board (matching the Discover hub's board filter), so this
   // screen is the full version of the "Jump Back In" shelf it expands.
-  const { playlists, isLoading, isLoadingMore, hasMore, hasError, loadMore, refetch } = useUserPlaylists({
-    token: effectiveToken,
-    boardType: activeBoard?.boardType,
-    layoutId: activeBoard?.layoutId,
-    pageSize: 50,
-  });
+  const { playlists, isLoading, isLoadingMore, hasMore, hasError, hasLoadMoreError, loadMore, retryLoadMore, refetch } =
+    useUserPlaylists({
+      token: effectiveToken,
+      boardType: activeBoard?.boardType,
+      layoutId: activeBoard?.layoutId,
+      pageSize: 50,
+    });
 
   // Drain every page so the alphabetical sort + title filter see the whole
   // library, not just the first page.
@@ -102,7 +103,12 @@ export default function AllPlaylistsScreen() {
         <Text variant="subheadline" style={styles.stateSubtitle}>
           {t('library.errors.loadDescription')}
         </Text>
-        <Pressable onPress={refetch} accessibilityRole="button" hitSlop={8}>
+        <Pressable
+          onPress={refetch}
+          accessibilityRole="button"
+          accessibilityLabel={t('library.errors.tryAgain')}
+          hitSlop={8}
+        >
           <Text variant="subheadline" color={brandColors.primary} style={styles.stateCta}>
             {t('library.errors.tryAgain')}
           </Text>
@@ -171,7 +177,21 @@ export default function AllPlaylistsScreen() {
             </View>
           }
           ListFooterComponent={
-            showDrainingFooter ? (
+            hasLoadMoreError ? (
+              <Pressable
+                style={styles.footer}
+                onPress={retryLoadMore}
+                accessibilityRole="button"
+                accessibilityLabel={t('library.errors.tryAgain')}
+              >
+                <Text variant="footnote" style={styles.stateSubtitle}>
+                  {t('library.allPlaylists.loadMoreError')}
+                </Text>
+                <Text variant="subheadline" color={brandColors.primary} style={styles.footerRetry}>
+                  {t('library.errors.tryAgain')}
+                </Text>
+              </Pressable>
+            ) : showDrainingFooter ? (
               <View style={styles.footer}>
                 <ActivityIndicator size="small" />
               </View>
@@ -182,6 +202,10 @@ export default function AllPlaylistsScreen() {
     </View>
   );
 }
+
+// Drops the empty / no-results block below the search bar toward the optical
+// centre (spacing[16] + spacing[4] = 80).
+const STATE_BLOCK_TOP_INSET = spacing[16] + spacing[4];
 
 const styles = StyleSheet.create({
   flex: {
@@ -210,7 +234,7 @@ const styles = StyleSheet.create({
     paddingVertical: 0,
   },
   emptyBlock: {
-    paddingTop: spacing[10] * 2,
+    paddingTop: STATE_BLOCK_TOP_INSET,
     paddingHorizontal: spacing[8],
     gap: spacing[2],
   },
@@ -230,5 +254,9 @@ const styles = StyleSheet.create({
   footer: {
     paddingVertical: spacing[4],
     alignItems: 'center',
+  },
+  footerRetry: {
+    marginTop: spacing[1],
+    fontWeight: '600',
   },
 });

--- a/packages/mobile/app/(tabs)/discover/all.tsx
+++ b/packages/mobile/app/(tabs)/discover/all.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { FlatList, Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +13,7 @@ import { useTheme } from '../../../src/providers/theme-provider';
 import { useAuthToken } from '../../../src/lib/graphql/use-auth-token';
 import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
 import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
+import { useDrainAllPages } from '../../../src/hooks/use-drain-all-pages';
 import { sortAndFilterPlaylists } from '../../../src/lib/sort-filter-playlists';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
@@ -37,7 +38,7 @@ export default function AllPlaylistsScreen() {
 
   // Scope to the active board (matching the Discover hub's board filter), so this
   // screen is the full version of the "Jump Back In" shelf it expands.
-  const { playlists, isLoading, isLoadingMore, hasMore, loadMore } = useUserPlaylists({
+  const { playlists, isLoading, isLoadingMore, hasMore, hasError, loadMore, refetch } = useUserPlaylists({
     token: effectiveToken,
     boardType: activeBoard?.boardType,
     layoutId: activeBoard?.layoutId,
@@ -46,9 +47,7 @@ export default function AllPlaylistsScreen() {
 
   // Drain every page so the alphabetical sort + title filter see the whole
   // library, not just the first page.
-  useEffect(() => {
-    if (hasMore && !isLoadingMore && !isLoading) loadMore();
-  }, [hasMore, isLoadingMore, isLoading, loadMore]);
+  useDrainAllPages({ hasMore, isLoading, isLoadingMore, loadMore });
 
   const [query, setQuery] = useState('');
 
@@ -90,8 +89,30 @@ export default function AllPlaylistsScreen() {
     );
   }
 
+  // The first page failed and nothing is on screen — offer a retry rather than
+  // falling through to the "no playlists yet" empty state. A retry flips
+  // isLoading back on, so the spinner branch below takes over while it's inflight.
+  if (hasError && !isLoading && playlists.length === 0) {
+    return (
+      <View style={[styles.flex, styles.centered, { backgroundColor: systemColors.background }]}>
+        <Icon name="error" size={48} color={iosSystemColors.systemGray4} />
+        <Text variant="headline" style={styles.stateTitle}>
+          {t('library.errors.loadTitle')}
+        </Text>
+        <Text variant="subheadline" style={styles.stateSubtitle}>
+          {t('library.errors.loadDescription')}
+        </Text>
+        <Pressable onPress={refetch} accessibilityRole="button" hitSlop={8}>
+          <Text variant="subheadline" color={brandColors.primary} style={styles.stateCta}>
+            {t('library.errors.tryAgain')}
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
+
   const showInitialSpinner = isLoading && playlists.length === 0;
-  const showDrainingFooter = !showInitialSpinner && (isLoadingMore || hasMore);
+  const showDrainingFooter = isLoadingMore;
 
   return (
     <View style={[styles.flex, { backgroundColor: systemColors.background }]}>
@@ -107,7 +128,6 @@ export default function AllPlaylistsScreen() {
             autoCapitalize="none"
             autoCorrect={false}
             returnKeyType="search"
-            clearButtonMode="while-editing"
             accessibilityLabel={t('library.allPlaylists.searchPlaceholder')}
           />
           {query.length > 0 ? (
@@ -115,7 +135,7 @@ export default function AllPlaylistsScreen() {
               onPress={() => setQuery('')}
               hitSlop={8}
               accessibilityRole="button"
-              accessibilityLabel={t('library.allPlaylists.searchPlaceholder')}
+              accessibilityLabel={t('library.allPlaylists.clearSearch')}
             >
               <Icon name="close" size={16} color={systemColors.secondaryLabel} />
             </Pressable>
@@ -191,11 +211,11 @@ const styles = StyleSheet.create({
   },
   emptyBlock: {
     paddingTop: spacing[10] * 2,
-    paddingHorizontal: 32,
-    gap: 8,
+    paddingHorizontal: spacing[8],
+    gap: spacing[2],
   },
   stateTitle: {
-    marginTop: 12,
+    marginTop: spacing[3],
     opacity: 0.6,
     textAlign: 'center',
   },
@@ -204,7 +224,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   stateCta: {
-    marginTop: 12,
+    marginTop: spacing[3],
     fontWeight: '600',
   },
   footer: {

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -62,6 +62,7 @@ export default function MoreScreen() {
 
       {profile?.id ? (
         <View style={styles.section}>
+          <SectionHeader title={t('mobile.more.library')} />
           <View
             style={[
               styles.card,

--- a/packages/mobile/src/components/playlist/PlaylistListRow.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistListRow.tsx
@@ -14,7 +14,8 @@ const THUMB_SIZE = 44;
 
 export type PlaylistListRowProps = {
   name: string;
-  climbCount: number;
+  /** Nullable on some board configs — coerced to 0 so the count never renders "NaN". */
+  climbCount?: number | null;
   color?: string;
   icon?: string;
   /** Index into the preview's fallback colour palette. */
@@ -42,7 +43,7 @@ export function PlaylistListRow({
   const { t } = useTranslation('playlists');
   const { systemColors } = useTheme();
 
-  const countLabel = t('detail.climbCount', { count: climbCount });
+  const countLabel = t('detail.climbCount', { count: climbCount ?? 0 });
 
   const handlePress = useCallback(() => {
     hapticLight();

--- a/packages/mobile/src/hooks/__tests__/use-drain-all-pages.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-drain-all-pages.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDrainAllPages, type UseDrainAllPagesOptions } from '../use-drain-all-pages';
+
+const baseProps = (overrides: Partial<UseDrainAllPagesOptions> = {}): UseDrainAllPagesOptions => ({
+  hasMore: false,
+  isLoading: false,
+  isLoadingMore: false,
+  loadMore: vi.fn(),
+  ...overrides,
+});
+
+describe('useDrainAllPages', () => {
+  it('fires loadMore on mount when a page is available and nothing is loading', () => {
+    const loadMore = vi.fn();
+    renderHook(() => useDrainAllPages(baseProps({ hasMore: true, loadMore })));
+    expect(loadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire while the initial page is still loading', () => {
+    const loadMore = vi.fn();
+    renderHook(() => useDrainAllPages(baseProps({ hasMore: true, isLoading: true, loadMore })));
+    expect(loadMore).not.toHaveBeenCalled();
+  });
+
+  it('does not fire while a subsequent page is in flight', () => {
+    const loadMore = vi.fn();
+    renderHook(() => useDrainAllPages(baseProps({ hasMore: true, isLoadingMore: true, loadMore })));
+    expect(loadMore).not.toHaveBeenCalled();
+  });
+
+  it('does not fire once the list is exhausted', () => {
+    const loadMore = vi.fn();
+    renderHook(() => useDrainAllPages(baseProps({ hasMore: false, loadMore })));
+    expect(loadMore).not.toHaveBeenCalled();
+  });
+
+  it('requests the next page after the previous one settles', () => {
+    const loadMore = vi.fn();
+    const { rerender } = renderHook((props: UseDrainAllPagesOptions) => useDrainAllPages(props), {
+      initialProps: baseProps({ hasMore: true, isLoadingMore: true, loadMore }),
+    });
+    expect(loadMore).not.toHaveBeenCalled();
+
+    // Page settled, more remain → drain fires for the next page.
+    rerender(baseProps({ hasMore: true, isLoadingMore: false, loadMore }));
+    expect(loadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes draining after a reset re-arms hasMore (e.g. board switch)', () => {
+    const loadMore = vi.fn();
+    const { rerender } = renderHook((props: UseDrainAllPagesOptions) => useDrainAllPages(props), {
+      initialProps: baseProps({ hasMore: false, loadMore }),
+    });
+    expect(loadMore).not.toHaveBeenCalled();
+
+    // A board switch re-fetches page 0; once it lands hasMore is true again.
+    rerender(baseProps({ hasMore: true, loadMore }));
+    expect(loadMore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/hooks/use-drain-all-pages.ts
+++ b/packages/mobile/src/hooks/use-drain-all-pages.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+export type UseDrainAllPagesOptions = {
+  /** Whether another page is available to load. */
+  hasMore: boolean;
+  /** True while the initial page is loading. */
+  isLoading: boolean;
+  /** True while a subsequent page is loading. */
+  isLoadingMore: boolean;
+  /** Loads the next page. */
+  loadMore: () => void;
+};
+
+/**
+ * Eagerly loads every remaining page of an offset-paginated list. Each completed
+ * page flips `isLoadingMore` back to false (and `hasMore` to false once the list
+ * is exhausted), which re-runs this effect to fetch the next page until there's
+ * nothing left.
+ *
+ * Gated on `isLoading` so it waits for the initial page, and on `isLoadingMore`
+ * so only one fetch is in flight at a time. When the underlying list resets (e.g.
+ * a board switch re-fetches page 0), `hasMore` flips back to true and draining
+ * resumes automatically.
+ *
+ * Use when a screen needs the full set up front — to sort or filter across every
+ * item rather than just the loaded prefix.
+ */
+export function useDrainAllPages({ hasMore, isLoading, isLoadingMore, loadMore }: UseDrainAllPagesOptions): void {
+  useEffect(() => {
+    if (hasMore && !isLoading && !isLoadingMore) loadMore();
+  }, [hasMore, isLoading, isLoadingMore, loadMore]);
+}

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -8,6 +8,7 @@
   "mobile": {
     "more": {
       "title": "More",
+      "library": "Library",
       "development": "Development",
       "metroServersTitle": "Metro servers",
       "metroServersSubtitle": "Switch between Tailnet bundlers",

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -27,6 +27,7 @@
       "seeAll": "See all",
       "searchPlaceholder": "Filter by title",
       "clearSearch": "Clear search",
+      "loadMoreError": "Couldn't load all your playlists.",
       "noResults": "No playlists match \"{{query}}\""
     },
     "pin": {

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -26,6 +26,7 @@
       "title": "My Playlists",
       "seeAll": "See all",
       "searchPlaceholder": "Filter by title",
+      "clearSearch": "Clear search",
       "noResults": "No playlists match \"{{query}}\""
     },
     "pin": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -206,6 +206,7 @@
   "mobile": {
     "more": {
       "title": "Más",
+      "library": "Biblioteca",
       "development": "Desarrollo",
       "metroServersTitle": "Servidores Metro",
       "metroServersSubtitle": "Cambia entre bundlers de Tailnet",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -26,6 +26,7 @@
       "title": "Mis listas",
       "seeAll": "Ver todas",
       "searchPlaceholder": "Filtrar por título",
+      "clearSearch": "Borrar búsqueda",
       "noResults": "Ninguna lista coincide con \"{{query}}\""
     },
     "pin": {

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -27,6 +27,7 @@
       "seeAll": "Ver todas",
       "searchPlaceholder": "Filtrar por título",
       "clearSearch": "Borrar búsqueda",
+      "loadMoreError": "No se pudieron cargar todas tus listas.",
       "noResults": "Ninguna lista coincide con \"{{query}}\""
     },
     "pin": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -8,6 +8,7 @@
   "mobile": {
     "more": {
       "title": "Plus",
+      "library": "Bibliothèque",
       "development": "Développement",
       "metroServersTitle": "Serveurs Metro",
       "metroServersSubtitle": "Basculer entre les bundlers Tailnet",

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -27,6 +27,7 @@
       "seeAll": "Tout voir",
       "searchPlaceholder": "Filtrer par titre",
       "clearSearch": "Effacer la recherche",
+      "loadMoreError": "Impossible de charger toutes vos listes.",
       "noResults": "Aucune liste ne correspond à « {{query}} »"
     },
     "pin": {

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -26,6 +26,7 @@
       "title": "Mes listes",
       "seeAll": "Tout voir",
       "searchPlaceholder": "Filtrer par titre",
+      "clearSearch": "Effacer la recherche",
       "noResults": "Aucune liste ne correspond à « {{query}} »"
     },
     "pin": {

--- a/packages/shared/playlists-react/src/__tests__/use-user-playlists.test.tsx
+++ b/packages/shared/playlists-react/src/__tests__/use-user-playlists.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { PlaylistsAdapterProvider, type ExecutePlaylistsGraphQL, type PlaylistsAdapter } from '../adapter';
+import { noopRecentsAdapter } from '../recents-adapter';
+import { useUserPlaylists } from '../use-user-playlists';
+import type { Playlist } from '@boardsesh/graphql/operations/playlists';
+
+function makePlaylist(uuid: string): Playlist {
+  return {
+    id: uuid,
+    uuid,
+    boardType: 'kilter',
+    layoutId: 1,
+    name: `Playlist ${uuid}`,
+    isPublic: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    climbCount: 1,
+    followerCount: 0,
+    isFollowedByMe: false,
+    isPinnedByMe: false,
+  };
+}
+
+type AllUserPlaylistsResponse = {
+  allUserPlaylists: { playlists: Playlist[]; totalCount: number; hasMore: boolean };
+};
+
+function buildWrapper(executeGraphQL: ExecutePlaylistsGraphQL) {
+  const adapter: PlaylistsAdapter = { executeGraphQL, recents: noopRecentsAdapter };
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <PlaylistsAdapterProvider value={adapter}>{children}</PlaylistsAdapterProvider>
+  );
+  return { wrapper };
+}
+
+// The hook deliberately console.errors on a page failure; keep the test output
+// clean while still exercising the failure path.
+let consoleError: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  consoleError.mockRestore();
+});
+
+describe('useUserPlaylists (shared) — background pagination failure', () => {
+  it('flags hasLoadMoreError after three failed pages, then retryLoadMore re-arms and clears it on success', async () => {
+    let call = 0;
+    const executeGraphQL = vi.fn(async (): Promise<AllUserPlaylistsResponse> => {
+      call += 1;
+      // Page 0 (mount): succeeds, more pages remain.
+      if (call === 1) return { allUserPlaylists: { playlists: [makePlaylist('p0')], totalCount: 100, hasMore: true } };
+      // Pages 2–4 (three loadMore attempts): fail.
+      if (call <= 4) throw new Error('boom');
+      // Retry: succeeds, list now exhausted.
+      return { allUserPlaylists: { playlists: [makePlaylist('p1')], totalCount: 100, hasMore: false } };
+    }) as unknown as ExecutePlaylistsGraphQL;
+
+    const { wrapper } = buildWrapper(executeGraphQL);
+    const { result } = renderHook(() => useUserPlaylists({ token: 'tok' }), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.playlists).toHaveLength(1);
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.hasLoadMoreError).toBe(false);
+
+    // Three consecutive failures freeze pagination and surface the error.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await act(async () => {
+        result.current.loadMore();
+      });
+      await waitFor(() => expect(result.current.isLoadingMore).toBe(false));
+    }
+    expect(result.current.hasLoadMoreError).toBe(true);
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.playlists).toHaveLength(1);
+
+    // Manual retry re-arms hasMore, re-fetches the failed page, and clears the error.
+    await act(async () => {
+      result.current.retryLoadMore();
+    });
+    await waitFor(() => expect(result.current.hasLoadMoreError).toBe(false));
+    expect(result.current.playlists).toHaveLength(2);
+    expect(result.current.hasMore).toBe(false);
+    expect(executeGraphQL).toHaveBeenCalledTimes(5);
+  });
+
+  it('retryLoadMore is a no-op while a fetch is already in flight', async () => {
+    let resolveInitial: (() => void) | undefined;
+    const executeGraphQL = vi.fn(
+      () =>
+        new Promise<AllUserPlaylistsResponse>((resolve) => {
+          resolveInitial = () => resolve({ allUserPlaylists: { playlists: [], totalCount: 0, hasMore: false } });
+        }),
+    ) as unknown as ExecutePlaylistsGraphQL;
+
+    const { wrapper } = buildWrapper(executeGraphQL);
+    const { result } = renderHook(() => useUserPlaylists({ token: 'tok' }), { wrapper });
+
+    // Initial page is in flight (isFetchingRef is set).
+    expect(result.current.isLoading).toBe(true);
+    expect(executeGraphQL).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.retryLoadMore();
+    });
+    // Guarded by isFetchingRef → no second request.
+    expect(executeGraphQL).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveInitial?.();
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+});

--- a/packages/shared/playlists-react/src/use-user-playlists.ts
+++ b/packages/shared/playlists-react/src/use-user-playlists.ts
@@ -40,7 +40,13 @@ export type UseUserPlaylistsResult = {
    *  translated error UI on top of this signal — the hook deliberately
    *  doesn't carry a translatable message. */
   hasError: boolean;
+  /** True when background pagination (pages 2+) gave up after three
+   *  consecutive failures. The loaded list is incomplete; surface this and
+   *  offer `retryLoadMore` rather than letting the rest go missing silently. */
+  hasLoadMoreError: boolean;
   loadMore: () => void;
+  /** Re-arm and retry background pagination after `hasLoadMoreError`. */
+  retryLoadMore: () => void;
   refetch: () => void;
 };
 
@@ -73,6 +79,7 @@ export function useUserPlaylists({
   const [hasMore, setHasMore] = useState(hasInitialData ? (initialHasMore ?? false) : false);
   const [totalCount, setTotalCount] = useState(hasInitialData ? (initialTotalCount ?? initialData.length) : 0);
   const [hasError, setHasError] = useState(false);
+  const [hasLoadMoreError, setHasLoadMoreError] = useState(false);
 
   const hasMoreRef = useRef(hasMore);
   // SSR delivers page 0; the next loadMore() must request page 1, not page 0
@@ -111,6 +118,7 @@ export function useUserPlaylists({
         pageRef.current = page + 1;
         loadMoreFailCountRef.current = 0;
         setHasError(false);
+        setHasLoadMoreError(false);
       } catch (err: unknown) {
         console.error('Failed to fetch user playlists:', err);
         if (isInitial) {
@@ -118,8 +126,11 @@ export function useUserPlaylists({
         } else {
           loadMoreFailCountRef.current += 1;
           if (loadMoreFailCountRef.current >= 3) {
+            // Stop the auto-retry loop, but flag the list as incomplete so the
+            // screen can show a "couldn't load the rest" affordance.
             setHasMore(false);
             hasMoreRef.current = false;
+            setHasLoadMoreError(true);
           }
         }
       } finally {
@@ -142,6 +153,8 @@ export function useUserPlaylists({
       skipFirstFetchRef.current = false;
       return;
     }
+    loadMoreFailCountRef.current = 0;
+    setHasLoadMoreError(false);
     if (!token) {
       setPlaylists([]);
       setIsLoading(false);
@@ -162,10 +175,33 @@ export function useUserPlaylists({
     }
   }, [fetchPage]);
 
+  // Manual retry after the auto-retry loop gave up: clear the failure count,
+  // re-arm pagination, and re-fetch the page that failed (pageRef wasn't
+  // advanced on failure). Draining then resumes on its own.
+  const retryLoadMore = useCallback(() => {
+    if (isFetchingRef.current) return;
+    loadMoreFailCountRef.current = 0;
+    setHasLoadMoreError(false);
+    setHasMore(true);
+    hasMoreRef.current = true;
+    void fetchPage(pageRef.current, false);
+  }, [fetchPage]);
+
   const refetch = useCallback(() => {
     pageRef.current = 0;
     void fetchPage(0, true);
   }, [fetchPage]);
 
-  return { playlists, isLoading, isLoadingMore, hasMore, totalCount, hasError, loadMore, refetch };
+  return {
+    playlists,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    totalCount,
+    hasError,
+    hasLoadMoreError,
+    loadMore,
+    retryLoadMore,
+    refetch,
+  };
 }


### PR DESCRIPTION
Follow-up to #2594, addressing review feedback on the mobile "My Playlists" list view.

## Bugs
1. **Error state ignored** — `useUserPlaylists`'s `hasError` is now destructured; on an initial-page failure the screen shows an error state with a **Try Again** retry instead of falling through to "no playlists yet".
2. **Duplicate clear button on iOS** — dropped `clearButtonMode="while-editing"` so the native × and the custom clear button no longer both render. The custom button stays (cross-platform, consistent).
3. **Wrong a11y label on clear button** — now uses a distinct `library.allPlaylists.clearSearch` ("Clear search") instead of reusing the input's placeholder label.
4. **Footer spinner flicker** — `showDrainingFooter` now keys on `isLoadingMore` only, so it no longer blips on between every page while the drain effect queues the next call.
5. **`climbCount` NaN** — `PlaylistListRow` coerces a null/undefined count to `0` (the field is nullable on some board configs), so it never renders "NaN climbs".

## Tests
6. **Drain loop untested** — extracted the auto-drain `useEffect` into a reusable `useDrainAllPages` hook and covered it: fires on mount when `hasMore`, gated while `isLoading`/`isLoadingMore`, no-op when exhausted, requests the next page after one settles, and re-arms after a reset (board switch).

## Minor
7. **Magic numbers** — empty/state-block paddings now use `spacing[N]` tokens.
8. **Missing section header** — the profile → More "My Playlists" card gets a `SectionHeader` (new `common` key `mobile.more.library` = "Library") to match every other section.

i18n keys added across en-US / es / fr.

## Validation
- `vp run typecheck:mobile` ✓
- `vp test --project mobile` — 1151 passed (incl. 6 new `useDrainAllPages` tests + i18n parity) ✓
- Format + lint clean on touched files ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)