### PR TITLE
perf(mobile): memoize My Playlists rows, stop renderItem churn on page drain

### DIFF
--- a/packages/mobile/app/(tabs)/discover/__tests__/all.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/all.test.tsx
@@ -109,6 +109,7 @@ vi.mock('../../../../src/components/ActivityIndicator', () => ({
 }));
 vi.mock('../../../../src/components/playlist', () => ({
   PlaylistListRow: ({ name }: { name: string }) => createElement('div', { 'data-playlist-row': name }),
+  PlaylistListRowSeparator: () => createElement('div', { 'data-playlist-separator': 'true' }),
 }));
 
 import AllPlaylistsScreen from '../all';

--- a/packages/mobile/app/(tabs)/discover/all.tsx
+++ b/packages/mobile/app/(tabs)/discover/all.tsx
@@ -7,7 +7,7 @@ import type { Playlist } from '@boardsesh/graphql/operations/playlists';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
-import { PlaylistListRow } from '../../../src/components/playlist';
+import { PlaylistListRow, PlaylistListRowSeparator } from '../../../src/components/playlist';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useTheme } from '../../../src/providers/theme-provider';
 import { useAuthToken } from '../../../src/lib/graphql/use-auth-token';
@@ -58,19 +58,23 @@ export default function AllPlaylistsScreen() {
     router.push(`/(tabs)/discover/${uuid}`);
   }, []);
 
+  // No `filtered.length` dependency: the row reports its own uuid to a single
+  // stable handler, and the hairline lives in `ItemSeparatorComponent`. So
+  // `renderItem` stays referentially stable across page appends and the memoised
+  // rows don't re-render while the library drains.
   const renderItem = useCallback(
     ({ item, index }: { item: Playlist; index: number }) => (
       <PlaylistListRow
+        uuid={item.uuid}
         name={item.name}
         climbCount={item.climbCount}
         color={item.color}
         icon={item.icon}
         index={index}
-        onPress={() => goToPlaylist(item.uuid)}
-        showSeparator={index < filtered.length - 1}
+        onPressUuid={goToPlaylist}
       />
     ),
-    [filtered.length, goToPlaylist],
+    [goToPlaylist],
   );
 
   // Signed-out (reachable only via deep link — the entry points are gated on auth).
@@ -158,6 +162,7 @@ export default function AllPlaylistsScreen() {
           data={filtered}
           keyExtractor={(item) => item.uuid}
           renderItem={renderItem}
+          ItemSeparatorComponent={PlaylistListRowSeparator}
           contentContainerStyle={{ paddingBottom: bottomChrome.scrollBottomPadding + spacing[6] }}
           keyboardShouldPersistTaps="handled"
           keyboardDismissMode="on-drag"

--- a/packages/mobile/src/components/playlist/PlaylistListRow.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistListRow.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { memo, useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
@@ -13,6 +13,8 @@ import { PlaylistPreviewSquare } from './PlaylistPreviewSquare';
 const THUMB_SIZE = 44;
 
 export type PlaylistListRowProps = {
+  /** Identifies the row to its parent so a single stable handler can serve every row. */
+  uuid: string;
   name: string;
   /** Nullable on some board configs — coerced to 0 so the count never renders "NaN". */
   climbCount?: number | null;
@@ -20,9 +22,12 @@ export type PlaylistListRowProps = {
   icon?: string;
   /** Index into the preview's fallback colour palette. */
   index?: number;
-  onPress: () => void;
-  /** Hide the bottom hairline on the last row. */
-  showSeparator?: boolean;
+  /**
+   * Called with this row's `uuid`. Passing the uuid back (rather than a
+   * per-row closure) lets the parent supply one stable callback for the whole
+   * list, so `React.memo` here actually prevents re-renders on page appends.
+   */
+  onPressUuid: (uuid: string) => void;
 };
 
 /**
@@ -30,25 +35,28 @@ export type PlaylistListRowProps = {
  * preview thumbnail, the name, its climb count, and a disclosure chevron. Unlike
  * the generic `ListRow` (32px leading), this sizes the thumbnail to read clearly
  * in a dense alphabetical list.
+ *
+ * Memoised so that draining the rest of the library (each page append grows the
+ * list) doesn't re-render every already-mounted row. The separator lives in the
+ * list's `ItemSeparatorComponent`, keeping every prop here primitive + stable.
  */
-export function PlaylistListRow({
+export const PlaylistListRow = memo(function PlaylistListRow({
+  uuid,
   name,
   climbCount,
   color,
   icon,
   index = 0,
-  onPress,
-  showSeparator = true,
+  onPressUuid,
 }: PlaylistListRowProps) {
   const { t } = useTranslation('playlists');
-  const { systemColors } = useTheme();
 
   const countLabel = t('detail.climbCount', { count: climbCount ?? 0 });
 
   const handlePress = useCallback(() => {
     hapticLight();
-    onPress();
-  }, [onPress]);
+    onPressUuid(uuid);
+  }, [onPressUuid, uuid]);
 
   return (
     <PressableSurface
@@ -70,10 +78,9 @@ export function PlaylistListRow({
         </View>
         <Icon name="chevron.right" size={14} color={iosSystemColors.systemGray4} />
       </View>
-      {showSeparator ? <View style={[styles.separator, { backgroundColor: systemColors.separator }]} /> : null}
     </PressableSurface>
   );
-}
+});
 
 const styles = StyleSheet.create({
   row: {
@@ -95,6 +102,19 @@ const styles = StyleSheet.create({
   meta: {
     opacity: 0.6,
   },
+});
+
+/**
+ * The hairline between rows. Lives here (next to the row that defines its inset)
+ * so `all.tsx` can pass it straight to the list's `ItemSeparatorComponent`,
+ * keeping the separator out of `renderItem` and its dependency list.
+ */
+export const PlaylistListRowSeparator = memo(function PlaylistListRowSeparator() {
+  const { systemColors } = useTheme();
+  return <View style={[separatorStyles.separator, { backgroundColor: systemColors.separator }]} />;
+});
+
+const separatorStyles = StyleSheet.create({
   separator: {
     height: StyleSheet.hairlineWidth,
     marginLeft: spacing[4] + THUMB_SIZE + spacing[3],

--- a/packages/mobile/src/components/playlist/index.ts
+++ b/packages/mobile/src/components/playlist/index.ts
@@ -1,7 +1,7 @@
 export { PlaylistPreviewSquare, type PlaylistPreviewSquareProps } from './PlaylistPreviewSquare';
 export { PlaylistCard, type PlaylistCardProps } from './PlaylistCard';
 export { PlaylistScrollSection, type PlaylistScrollSectionProps } from './PlaylistScrollSection';
-export { PlaylistListRow, type PlaylistListRowProps } from './PlaylistListRow';
+export { PlaylistListRow, PlaylistListRowSeparator, type PlaylistListRowProps } from './PlaylistListRow';
 export { PlaylistDetailView, type PlaylistDetailViewProps, type PlaylistDetailHero } from './PlaylistDetailView';
 export { PlaylistBackFab } from './PlaylistBackFab';
 export { PlaylistFormSheet, type PlaylistFormValues } from './PlaylistFormSheet';


### PR DESCRIPTION
## Why

The mobile **My Playlists** list (`discover/all`, shipped in #2594) eagerly drains every page up front so the alphabetical sort + title filter see the whole library, not just the first page. But each page append grew the list, and the rendering path re-rendered *every* mounted row on each appended page:

1. `PlaylistListRow` had no `React.memo`, so it re-rendered whenever `renderItem`'s identity changed.
2. `renderItem` was a `useCallback` whose deps included `filtered.length` (which grows on every page append) and it created a per-item inline `onPress={() => goToPlaylist(item.uuid)}` closure plus `showSeparator={index < filtered.length - 1}`. So `renderItem` churned its identity on every page, re-rendering all mounted rows.

With ~hundreds of playlists draining 50 at a time, that's O(pages × rows) wasted renders during the initial load.

## What changed

- **`PlaylistListRow`** is now wrapped in `React.memo`. All props are primitives.
- Replaced the per-row `onPress` closure + `showSeparator` with a single **`onPressUuid: (uuid) => void`** — the row reports its own `uuid` to one stable parent `useCallback`. `renderItem`'s deps drop to `[goToPlaylist]`; **`filtered.length` is gone**, so `renderItem` stays referentially stable across page appends and the memoised rows don't re-render while the library drains.
- Moved the row hairline into the FlatList's **`ItemSeparatorComponent`** via a new memoised module-level `PlaylistListRowSeparator`. This pulls the separator (and its `filtered.length`/`index` math) out of `renderItem` entirely. Visually identical: FlatList draws a separator between rows only — i.e. after every row except the last — which matches the old `index < filtered.length - 1` rule.
- **Eager page drain kept.** Removing it would break the client-side alphabetical sort + title filter (they need the whole library loaded). It's already documented inline and on the shared `useDrainAllPages` hook, so no behaviour change.

Visual output and accessibility (`accessibilityRole`/`accessibilityLabel` on the row) are unchanged.

## Validation (from the worktree root)

- `vp run typecheck:mobile` — pass
- `vp test run --reporter=agent playlist` — 275 pass; `discover` suite 66 pass (updated the `all.test.tsx` mock to export `PlaylistListRowSeparator`)
- `vp fmt --check` on changed files — clean
- `vp lint` — no findings in the changed files (pre-existing warnings/errors elsewhere are not from this PR)
- `vp run check:mobile-bundle` — bundle OK (10.4 MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)