### PR TITLE
Mobile performance playbook + review checklist + context-value lint rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,6 +7,7 @@
   },
   "rules": {
     "no-unused-vars": "error",
+    "react/no-array-index-key": "warn",
     "import/no-cycle": "error",
     "prefer-const": "error",
     "no-template-curly-in-string": "error",
@@ -90,6 +91,14 @@
     "import/no-named-as-default-member": "error",
     "import/no-self-import": "error"
   },
+  "overrides": [
+    {
+      "files": ["packages/mobile/**/*.{ts,tsx}", "packages/shared/**/*.{ts,tsx}"],
+      "rules": {
+        "react/jsx-no-constructed-context-values": "error"
+      }
+    }
+  ],
   "ignorePatterns": [
     "dist/**",
     "node_modules/**",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,19 @@ After mobile changes:
 4. `vp run check:mobile-simulator` — macOS only; skips on Linux.
 5. `vp run mobile:screenshot` — macOS only.
 
+### Mobile performance checklist (PR review)
+
+For any list, provider, gesture, or board-art change, confirm:
+
+- **List virtualized?** `FlashList` / `BottomSheetFlatList`, never `.map()` in a `ScrollView`. Any `loadMore` is one page per end-reach, not a drain-until-`hasMore`.
+- **Row memoized & `renderItem` deps clean?** Row is `React.memo`'d; `renderItem` is a `useCallback` whose deps have **no array `.length`** and **no inline closures**; `keyExtractor` hoisted.
+- **Provider value memoized & state/actions split?** Context `value` is `useMemo`'d; a volatile array (logbook, reducer state, roster) is not bundled with the stable callbacks consumers depend on. Enforced for `packages/mobile/**` + `packages/shared/**` by `react/jsx-no-constructed-context-values` (error).
+- **Per-row hook O(1)?** Reads a pre-built index (`Map`), never `array.filter`/scan per row.
+- **Worklet `runOnJS` gated?** No `runOnJS(setState)` per frame — gate on a value change; mirror read JS values into shared values instead of listing them in the gesture `useMemo` deps.
+- **New effect bounded?** No unbounded `loadMore` loops or per-frame state churn.
+
+Full rationale + repo examples: `docs/react-native-performance.md`.
+
 ### Local iOS builds
 
 Use `vp run mobile:ios` for local `packages/mobile` iOS builds instead of raw `expo run:ios`. The wrapper points generated `packages/mobile/ios/build` at a shared cache under `~/Library/Caches/boardsesh/xcode/packages-mobile-ios/build`, so separate git worktrees reuse the same Xcode build products. Override with `BOARDSESH_IOS_BUILD_CACHE_DIR=/path/to/cache` only when deliberately isolating a cache. Do not pass `--no-build-cache`; it clears iOS derived data and defeats the shared-cache workflow.

--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -1,0 +1,246 @@
+# React Native Performance Playbook: Mobile App
+
+Best practices and enforcement for `packages/mobile`. This is the mobile counterpart to
+`docs/react-performance-audit.md` (web). The web audit catalogues _specific fixes_; this doc
+states the _rules_ — each with the rule, why it matters on a phone, and a real example already
+living in this codebase to copy from.
+
+The expensive surfaces on mobile are the same three as web — the climb list, the play-view
+drawer, and the queue — but the cost model is different. There is no browser to skip paints for
+us: every unnecessary re-render runs on the JS thread, competes with gesture/animation worklets on
+the UI thread, and shows up as dropped frames on a mid-range Android device, not as a profiler
+squiggle. The bar is "60fps while scrolling the climbs list and swiping the play drawer on a
+large-logbook account," and the evidence for clearing it is a before/after recording.
+
+---
+
+## 1. Provider context values: memoize, and split state from actions
+
+**Rule:** Any context that many screens subscribe to must provide a `useMemo`'d value object.
+When the provider holds both frequently-replaced state (a logbook array, reducer state, a roster)
+**and** the stable callbacks consumers depend on, split them into separate contexts so a callback-only
+consumer never re-renders when the data churns.
+
+**Why:** An inline `value={{ ... }}` allocates a new object every render, so every `useContext`
+consumer re-renders every time the provider does — regardless of `React.memo`. On mobile that
+cascade lands on the JS thread mid-scroll. Bundling a volatile array with the callbacks is the
+same trap one level up: a logbook merge while the user scrolls re-renders every component that only
+wanted `saveTick`.
+
+**Lint config:** `react/jsx-no-constructed-context-values` is configured as `error` for
+`packages/mobile/**` and `packages/shared/**` (in both `.oxlintrc.json` and the `vite.config.ts`
+`lint` block), with a repo-wide `warn`. It flags the inline `<Ctx.Provider value={{ ... }}>`
+anti-pattern. Caveat: vite-plus's bundled linter does not currently _execute_ this off-by-default
+`react/*` rule — it shows in `vp lint --rules` but never fires — so today the rule enforces at
+editor / raw-oxlint time and as a forward-looking guard, not in `vp lint` / CI. Until vite-plus
+runs it, this one is a **review-checklist item** (see CLAUDE.md → Mobile performance checklist), not
+an automated gate.
+
+**Examples in this repo:**
+
+- `packages/shared/board-react/src/board-provider.tsx` — the `value` is `useMemo`'d over
+  `[boardName, isAuthenticated, …, logbook, logbookByClimbAngle, getLogbook, saveTick, …]`. The
+  mutation callbacks (`saveTick`/`saveClimb`/`updateClimb`) are kept stable via the
+  ref-updated-in-`useEffect` + empty-dep-`useCallback` pattern (lines 90–116), so a React Query
+  `mutateAsync` reference change does not churn the context.
+- `packages/mobile/src/providers/queue-provider.tsx` — splits into **two** contexts:
+  `QueueContext` (full state + actions) and `QueueSessionControlContext` (just the wall-control
+  state + callbacks). A component that only drives take/release control subscribes to the smaller
+  context and skips the per-queue-update re-render. Both values are `useMemo`'d with explicit deps.
+- `packages/mobile/src/providers/toast-provider.tsx` / `auth-provider.tsx` — the value is a
+  `useMemo` over the single stable `showToast` / the auth callbacks. (Both previously used an inline
+  `value={{ … }}`; this is exactly what the lint rule now blocks.)
+
+**Anti-pattern:**
+
+```tsx
+// BAD: new object every render → every useToast() consumer re-renders.
+<ToastContext.Provider value={{ showToast }}>
+
+// GOOD: stable reference; only changes when showToast does (it never does).
+const value = useMemo<ToastContextValue>(() => ({ showToast }), [showToast]);
+<ToastContext.Provider value={value}>
+```
+
+---
+
+## 2. Virtualize anything user-growable; cap any `loadMore` drain
+
+**Rule:** A list backed by data the user can grow (search results, the logbook, a playlist) must be
+virtualized — `FlashList` for full screens, `BottomSheetFlatList` inside a Gorhom sheet. Never
+`.map()` a growable array inside a `ScrollView`. Any "fetch the next page until `hasMore` is false"
+loop must be capped or have a written justification.
+
+**Why:** `.map()` in a `ScrollView` mounts every row up front. The climbs search pages 30 at a time
+with infinite scroll, so the list grows unbounded; mounting 200+ `ClimbListRow`s (each with its own
+swipe gesture + thumbnail render) blows the frame budget on mount and holds the memory the whole
+session. Virtualization keeps the mounted set to the viewport plus an overscan window. An
+unbounded drain-until-`hasMore` loop quietly fetches and mounts the entire catalog.
+
+**Examples in this repo:**
+
+- `packages/mobile/app/(tabs)/climbs/index.tsx` — `FlashList` with `onEndReached` +
+  `onEndReachedThreshold={0.5}`. Crucially, `handleEndReached` (lines 488–495) is gated on
+  `hasNextPage && !isClimbsLoading && !isFetchingNextPage && !isRefetching && !isLoadingMoreRef.current`
+  — it fetches exactly one page per end-reached and the `isLoadingMoreRef` latch prevents a
+  re-entrant drain. There is no "loop until hasMore" anywhere.
+- `packages/mobile/src/components/play-drawer/BetaVideosSection.tsx` and queue lists use the Gorhom
+  `BottomSheetFlatList` so the virtualization cooperates with the sheet's scroll gesture.
+
+**Anti-pattern:** `{items.map((item) => <Row key={item.id} item={item} />)}` inside a
+`<ScrollView>` for anything that isn't a fixed, small, known-length list. A fixed footer of 6
+skeleton rows is fine; a search result set is not.
+
+---
+
+## 3. `React.memo` rows; `renderItem` deps with no `.length`, no inline closures
+
+**Rule:** The row component a list renders is wrapped in `React.memo`. The `renderItem` passed to
+the list is a `useCallback` whose dependency array contains **no array `.length`** and **no inline
+closures created in render**. Hoist `keyExtractor` to module scope.
+
+**Why:** FlashList recycles row instances; an unmemoized row re-renders on every recycle even when
+its climb is unchanged. A `renderItem` that depends on `climbs.length` (or any value that changes
+every page) gets a new identity every fetch, which defeats FlashList's recycling and re-renders the
+whole visible window. Inline closures (`onPress={() => …}`) passed to a memoized row break its
+`React.memo` by handing it a fresh prop each render.
+
+**Good template — `packages/mobile/app/(tabs)/climbs/index.tsx`:**
+
+- `keyExtractor` is a module-scope function (line 893), not an inline `(item) => item.uuid`.
+- `renderClimbItem` is a `useCallback` (lines 699–727) whose deps are the board identity tuple plus
+  the **stable** `handleClimbPress` / `openClimbActions` / `handleAddToQueue` callbacks and the
+  scalar `activeClimbUuid`. No `visibleClimbs.length`, no inline arrows.
+- The handlers it closes over (`handleClimbPress`, `handleAddToQueue`) are themselves `useCallback`s.
+- `ClimbListRow` (`packages/mobile/src/components/ClimbListRow.tsx`) is `React.memo`'d and keeps its
+  own gesture callbacks stable by reading the latest props through refs
+  (`onPressRef.current = onPress`), so a parent re-render never recomposes its RNGH gestures.
+
+**Anti-pattern:**
+
+```tsx
+// BAD: deps include .length → new renderItem every page → recycling defeated.
+const renderItem = useCallback(({ item }) => <Row item={item} onTap={() => open(item)} />, [climbs.length]);
+```
+
+---
+
+## 4. Per-row hooks do O(1) lookups, never O(N) scans
+
+**Rule:** A hook called once per visible row must not scan an accumulating array. Read from a
+pre-built index (a `Map`) keyed by the row's identity.
+
+**Why:** A per-row `logbook.filter(...)` turns the climbs list into O(rows × logbook): every time a
+scrolled page merges fresh ticks into a new `logbook` array, every visible row re-scans the whole
+logbook. On a large-logbook account that is the single biggest scroll stall, and it gets worse as
+the user logs more climbs — exactly the users we least want to punish.
+
+**Example in this repo:**
+
+- `packages/shared/board-react/src/board-provider.tsx` builds `logbookByClimbAngle` — a
+  `Map<\`${climb_uuid}:${angle}\`, LogbookEntry[]>` — once per logbook change (lines 71–83).
+- `packages/mobile/src/hooks/use-ascent-status.ts` reads it: `board.logbookByClimbAngle.get(key)`
+  is one map lookup over that row's handful of ticks, then a `useMemo` over `[entries, isMirror]`.
+  The whole climbs list dropped from O(rows × logbook) to O(rows) per merge.
+
+**Anti-pattern:** `const ticks = logbook.filter((e) => e.climb_uuid === climbUuid && e.angle === angle)`
+inside a hook that every row calls.
+
+---
+
+## 5. Worklet gestures: gate `runOnJS(setState)`, mirror read JS values into shared values
+
+**Rule:** A gesture worklet must not `runOnJS(setState)` on every frame — gate the cross-thread hop
+on a value _change_ (a boolean edge, a threshold crossing). JS values the worklet reads (flags like
+`enabled`, `reduceMotion`) must be **mirrored into shared values** via a `useEffect`, not listed in
+the gesture `useMemo`'s dependency array.
+
+**Why:** `onUpdate`/`onTouchesMove` fire ~60×/sec on the UI thread. A `runOnJS` per frame floods
+the JS thread with hops and serializes a UI-thread gesture behind JS-thread work — the exact stutter
+virtualization is meant to avoid. And rebuilding the gesture (`Gesture.Pan()`) mid-interaction
+because a dep flipped leaves React Native Gesture Handler stuck on iOS — the swipe just dies. The
+fix is to keep the gesture object referentially stable and feed it live values through shared values
+it can read on the UI thread.
+
+**Example in this repo — `packages/mobile/src/components/play-drawer/use-carousel-gesture.ts`:**
+
+- `enabled` and `reduceMotion` are mirrored into `enabledSV` / `reduceMotionSV` shared values via
+  `useEffect` (lines 44–56). The gesture `useMemo` reads `enabledSV.value` / `reduceMotionSV.value`
+  inside the worklet and does **not** list `enabled`/`reduceMotion` in its deps, so flipping either
+  flag never recomposes the gesture.
+- The haptic `runOnJS(triggerHaptic)()` (line 170) fires once per drag — gated behind
+  `!hasTriggeredHaptic.value`, a shared-value latch flipped on the threshold crossing — not on every
+  `onUpdate` frame.
+- `packages/mobile/src/components/ClimbListRow.tsx` follows the same pattern: the swipe-commit
+  haptic is gated by `useAnimatedReaction` on the `>= COMMIT_THRESHOLD` boolean edge (lines 39–43),
+  so `runOnJS(hapticLight)` fires once per arm, not per frame.
+
+**Anti-pattern:**
+
+```ts
+// BAD: a JS hop every frame, and `enabled` in deps rebuilds the gesture mid-swipe.
+const gesture = useMemo(
+  () =>
+    Gesture.Pan().onUpdate((e) => {
+      'worklet';
+      runOnJS(setOffset)(e.translationX); // floods JS thread
+    }),
+  [enabled],
+); // rebuild mid-gesture → RNGH stuck on iOS
+```
+
+---
+
+## 6. Warm board-art surfaces use the rasterized native-PNG path, not remote SVG
+
+**Rule:** Any board-art surface that appears repeatedly while scrolling or swiping (the list
+thumbnail, the play-drawer board) renders through the native-PNG path —
+`useNativeClimbRender` + `LayeredClimbImage` with `cachePolicy="memory-disk"` on bundled assets.
+Do **not** use the `react-native-svg` `BoardRenderer` with a remote `<SvgImage href={remoteUrl}>`
+on these surfaces.
+
+**Why:** `BoardRenderer` parses the frames string, builds an SVG hold overlay, and paints N
+`<Circle>`s in `react-native-svg` on every render, on top of an `<SvgImage>` that fetches the board
+photo over the network. That is fine for a one-off static diagram, but on a recycling list it
+re-parses and re-paints per row and re-fetches art that should be on disk. The native path renders
+the holds once into a cached PNG (deduped by cache key, warmed from disk on launch — see the
+`renderedOverlays` map and `warmupRenderedOverlaysOnce` in `use-native-climb-render.ts`) and stacks
+it over bundled background images via `expo-image` with `cachePolicy="memory-disk"`, so a scrolled-
+past climb is an instant cache hit with zero network and zero per-row SVG work. It also satisfies
+the no-network offline rule — missing layers render as visible gray blocks rather than silently
+fetching.
+
+**Examples in this repo:**
+
+- Warm path (use this): `packages/mobile/src/hooks/use-native-climb-render.ts` +
+  `packages/mobile/src/components/LayeredClimbImage.tsx` (`cachePolicy="memory-disk"`), wired up in
+  `packages/mobile/src/components/ClimbListThumbnail.tsx` and `BoardImageNative.tsx`.
+- Cold/static path (don't use on lists): `packages/mobile/src/components/board-renderer/BoardRenderer.tsx`
+  (`react-native-svg`, `<SvgImage href>`). Reserve it for genuinely static, non-recycled diagrams
+  like `AngleBoardDiagram.tsx`.
+
+---
+
+## Profiling workflow
+
+Required evidence for any list / provider / theme PR: a **before/after recording on the climbs list
+and the play drawer**, captured on a large-logbook account. A claim of "this is faster" without a
+recording does not clear review.
+
+1. **React DevTools Profiler — "Highlight updates when components render."** Turn it on, then scroll
+   the climbs list and navigate the queue / play drawer. Every row that flashes on an unrelated
+   state change is a missing `React.memo`, an unstable `renderItem` dep, or an unmemoized context
+   value. The goal: scrolling highlights only newly-mounted rows; toggling the active climb
+   highlights only the previously- and newly-selected rows, not the whole list; opening a toast
+   highlights nothing in the list.
+2. **Hermes sampling profiler with a large-logbook account.** Sign in as a user with a deep logbook
+   (the O(N)-scan bugs are invisible on a fresh account). Record a profile while scrolling and while
+   swiping the play-drawer carousel. Look for per-row `logbook.filter`, per-frame `runOnJS` hops, and
+   repeated `BoardRenderer`/SVG work — these dominate the flame graph exactly on the accounts we care
+   about.
+3. **Frame timing.** Watch the perf monitor (JS + UI FPS) on a mid-range device, not just the
+   simulator. UI-thread drops point at gesture/worklet issues (rule 5); JS-thread drops point at
+   re-render cascades (rules 1, 3, 4) or per-row work (rule 4, 6).
+
+When in doubt, copy the structure of `app/(tabs)/climbs/index.tsx` — it is the worked example for
+rules 2, 3, and 4, and the surface every list/provider PR is measured against.

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState, useCallback, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useMemo, useRef, useState, useCallback, type ReactNode } from 'react';
 import { AppState } from 'react-native';
 import type { WebBrowserAuthSessionResult } from 'expo-web-browser';
 import { useSegments, Redirect } from 'expo-router';
@@ -133,6 +133,22 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     }
   }, [isLoading]);
 
+  // Stable context value: every callback below is a stable useCallback, so the
+  // value reference only changes when isAuthenticated / isLoading actually flip
+  // — not on each AuthProvider render. Declared before the early returns so the
+  // hook order stays unconditional.
+  const value = useMemo<AuthState>(
+    () => ({
+      isAuthenticated,
+      isLoading,
+      signIn,
+      signInWithCredentials,
+      signOut,
+      refreshAuthState: checkAuth,
+    }),
+    [isAuthenticated, isLoading, signIn, signInWithCredentials, signOut, checkAuth],
+  );
+
   if (isLoading) {
     return null;
   }
@@ -146,18 +162,5 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     return <Redirect href="/(tabs)/climbs" />;
   }
 
-  return (
-    <AuthContext.Provider
-      value={{
-        isAuthenticated,
-        isLoading,
-        signIn,
-        signInWithCredentials,
-        signOut,
-        refreshAuthState: checkAuth,
-      }}
-    >
-      {children}
-    </AuthContext.Provider>
-  );
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/packages/mobile/src/providers/toast-provider.tsx
+++ b/packages/mobile/src/providers/toast-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useRef, useState, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Toast, type ToastVariant, type ToastData } from '../components/Toast';
 import { hapticSuccess, hapticError } from '../lib/haptics';
@@ -43,8 +43,13 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     setToasts((prev) => prev.filter((toastItem) => toastItem.id !== id));
   }, []);
 
+  // Stable context value: showToast is a stable useCallback, so memoising the
+  // wrapper object keeps every useToast() consumer from re-rendering on each
+  // ToastProvider render (toasts state churns as toasts appear/dismiss).
+  const value = useMemo<ToastContextValue>(() => ({ showToast }), [showToast]);
+
   return (
-    <ToastContext.Provider value={{ showToast }}>
+    <ToastContext.Provider value={value}>
       {children}
       <View style={styles.overlay} pointerEvents="none">
         {toasts.map((toast) => (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,28 @@ export default defineConfig({
       typeAware: true,
       typeCheck: true,
     },
+    rules: {
+      // Catch unmemoized React context values (the inline `value={{ ... }}`
+      // anti-pattern that re-renders every consumer). Warn repo-wide so the
+      // pre-existing web/test violations don't fail CI; promoted to `error` for
+      // the mobile + shared-react surfaces below. See docs/react-native-performance.md.
+      //
+      // NOTE: vite-plus's bundled linter (@oxlint/plugins) does not currently
+      // *execute* these two off-by-default `react/*` rules — they show in
+      // `vp lint --rules` but never fire — so this is editor/raw-oxlint
+      // enforcement + a forward-looking guard, not CI enforcement today. The
+      // two mobile providers were fixed by hand to satisfy it.
+      'react/jsx-no-constructed-context-values': 'warn',
+      // Index keys defeat list reconciliation when rows reorder. Low-noise warn.
+      'react/no-array-index-key': 'warn',
+    },
     overrides: [
+      {
+        files: ['packages/mobile/**/*.{ts,tsx}', 'packages/shared/**/*.{ts,tsx}'],
+        rules: {
+          'react/jsx-no-constructed-context-values': 'error',
+        },
+      },
       {
         files: ['packages/backend/src/**/*.ts'],
         rules: {


### PR DESCRIPTION
## What

One self-contained "performance best-practices + enforcement" change for the React Native app.

### (A) `docs/react-native-performance.md` (new)
Ports the web `docs/react-performance-audit.md` playbook to React Native, made concrete to this codebase. Six rules, each with the rule, the why (in mobile-thread terms — every wasted re-render runs on the JS thread and competes with UI-thread worklets), and a real repo file to copy from:

1. **Provider context values memoized & state/actions split** — `board-provider.tsx` (logbook index + ref-stable mutation callbacks), `queue-provider.tsx` (split `QueueContext` / `QueueSessionControlContext`).
2. **Virtualize growable lists; cap `loadMore`** — `climbs/index.tsx` `FlashList` with the gated, one-page-per-end-reach `handleEndReached` (no drain-until-`hasMore`).
3. **`React.memo` rows; `renderItem` deps clean (no `.length`, no inline closures); hoisted `keyExtractor`** — `climbs/index.tsx` + `ClimbListRow.tsx` as the worked template.
4. **Per-row hooks O(1)** — `useAscentStatus` reads `logbookByClimbAngle` (Map) instead of `logbook.filter`, turning the list from O(rows × logbook) to O(rows).
5. **Worklet gestures gate `runOnJS`, mirror read JS values into shared values** — `use-carousel-gesture.ts` (`enabledSV`/`reduceMotionSV`, threshold-gated haptic).
6. **Warm board art via native PNG, not remote SVG** — `useNativeClimbRender` + `LayeredClimbImage` (`cachePolicy="memory-disk"`) vs the `react-native-svg` `BoardRenderer` with remote `<SvgImage href>`.

Plus a required **profiling workflow**: React DevTools "Highlight updates while scrolling the list / navigating the queue" + Hermes sampling profiler on a large-logbook account, with a before/after recording on the climbs list + play drawer as required evidence for any list/provider/theme PR.

### (B) Mobile PR-review checklist in `CLAUDE.md`
Short checklist under Mobile Development: list virtualized? row `React.memo`'d & `renderItem` deps clean? provider value memoized & state/actions split? per-row hook O(1)? worklet `runOnJS` gated? new effect bounded? — linking the doc.

### (C) oxlint rule

Goal: catch the unmemoized inline-context-value anti-pattern (`value={{ showToast }}`).

**Investigation.** `react/jsx-no-constructed-context-values` is a valid oxlint 1.63 rule and fires correctly when run against the repo with the raw oxlint binary:
- **2 violations in `packages/mobile`** (`toast-provider.tsx`, `auth-provider.tsx`)
- 8 more in `packages/web` (mix of prod providers + test files) — out of scope.

**But:** this repo's `vp lint` runs through vite-plus's bundled `@oxlint/plugins`, which **does not execute** this rule (nor `react/no-array-index-key`). Both appear in `vp lint --rules` but never fire — verified by adding each rule and watching `vp lint`'s rule count stay at 110 and warning totals stay flat, while a control rule (`typescript/no-non-null-assertion`) correctly jumped the count to 111 and added 900 hits. So the rule cannot gate in CI today.

**Rule state chosen.** `react/jsx-no-constructed-context-values` → **`error` scoped to `packages/mobile/**` + `packages/shared/**`**, `warn` repo-wide (so the pre-existing web/test violations never fail CI), configured in both `.oxlintrc.json` and the `vite.config.ts` `lint` block. `react/no-array-index-key` → repo-wide **`warn`** (2 mobile / 13 repo-wide). Because `vp lint` doesn't run them, today they enforce at editor / raw-oxlint time and as a forward-looking guard; the **review checklist (B)** is the live gate.

**Fixes applied.** Both mobile violations fixed by hand: `toast-provider.tsx` and `auth-provider.tsx` now wrap their context value in `useMemo` (auth's `useMemo` declared before the early returns to keep hook order unconditional) instead of an inline `value={{ ... }}`.

**Follow-ups (not in this PR):** the 8 web `jsx-no-constructed-context-values` violations (`party-context.tsx`, `auth-modal-provider.tsx`, `snackbar-provider.tsx`, `ui-searchparams-provider.tsx`, + 4 test files) and the remaining `no-array-index-key` sites. And: revisit promoting these `react/*` rules to a CI gate once vite-plus's linter executes them.

## Validation
- `vp lint` — **green at baseline** (224 warnings / 3 pre-existing `embedded/**` errors, no increase; the `error`-level mobile rule has zero violations).
- `vp fmt --check` — clean on all changed files.
- `vp run typecheck:mobile` — passes.
- `vp run check:mobile-bundle` — OK (Android bundle).
- Mobile test suite — 1185/1185 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)