### PR TITLE
perf(mobile): split QueueContext to cut in-session + queue-context re-renders

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -35,7 +35,7 @@ import { ClimbFilterFab } from '../../../src/components/search/ClimbFilterFab';
 import { ClimbTopChrome } from '../../../src/components/search/ClimbTopChrome';
 import { useDrawerHost } from '../../../src/providers/drawer-host-provider';
 import { useTheme } from '../../../src/providers/theme-provider';
-import { useQueue } from '../../../src/providers/queue-provider';
+import { useActiveClimbUuid, useQueueActions } from '../../../src/providers/queue-provider';
 import { ClimbSearchProvider, useClimbSearch, type GradeBound } from '../../../src/providers/climb-search-provider';
 import { useBoardProvider } from '@boardsesh/board-react';
 import { randomUUID } from 'expo-crypto';
@@ -118,7 +118,7 @@ function ClimbListInner() {
   const { t } = useTranslation('climbs');
   const { openClimbActions, openAddToPlaylist } = useDrawerHost();
   const { systemColors, variant, brandColors } = useTheme();
-  const { addToQueue, state: queueState } = useQueue();
+  const { addToQueue } = useQueueActions();
   const {
     filters,
     boardFilters,
@@ -132,8 +132,10 @@ function ClimbListInner() {
     patchBoardFilters,
   } = useClimbSearch();
   // The active climb (driving the board / persistent queue bar). We highlight
-  // its row so the search → tap → change-active loop is always visible.
-  const activeClimbUuid = queueState.currentClimbQueueItem?.climb?.uuid;
+  // its row so the search → tap → change-active loop is always visible. The
+  // selector changes identity only when the active uuid changes, so unrelated
+  // queue mutations / party pushes no longer re-render this screen.
+  const activeClimbUuid = useActiveClimbUuid();
   const { getLogbook } = useBoardProvider();
   const searchHeaderRef = useRef<SearchHeaderHandle>(null);
   const nativeSearchRef = useRef<NativeSearchBarRef>(null);

--- a/packages/mobile/src/components/session-screen/SessionScreen.tsx
+++ b/packages/mobile/src/components/session-screen/SessionScreen.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { PanGesture } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
-import { useQueue } from '../../providers/queue-provider';
+import { useQueue, useQueueLiveStats } from '../../providers/queue-provider';
 import { SessionScreenHeader } from './SessionScreenHeader';
 import { PreSessionView } from './pre-session/PreSessionView';
 import { InSessionView } from './in-session/InSessionView';
@@ -27,7 +27,8 @@ type SessionScreenProps = {
  * Record tab; the overlay-only props (drag/pull-to-dismiss) are omitted there.
  */
 export function SessionScreen({ onClose, headerGesture, translateY, screenHeight }: SessionScreenProps) {
-  const { sessionId, sessionUsers } = useQueue();
+  const { sessionId } = useQueue();
+  const { sessionUsers } = useQueueLiveStats();
   const insets = useSafeAreaInsets();
   const [showInvite, setShowInvite] = useState(false);
 

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -1,12 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { type NativeScrollEvent, type NativeSyntheticEvent, Pressable, StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, {
-  useAnimatedScrollHandler,
-  useSharedValue,
-  withSpring,
-  type SharedValue,
-} from 'react-native-reanimated';
+import { useSharedValue, withSpring, type SharedValue } from 'react-native-reanimated';
+import { FlashList } from '@shopify/flash-list';
 import { randomUUID } from 'expo-crypto';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -23,7 +19,7 @@ import { Icon } from '../../Icon';
 import { Text } from '../../Text';
 import { type IconName } from '../../icon-map';
 import { useTheme } from '../../../providers/theme-provider';
-import { useQueue } from '../../../providers/queue-provider';
+import { useQueue, useQueueLiveStats } from '../../../providers/queue-provider';
 import { useDrawerHost } from '../../../providers/drawer-host-provider';
 import { useSessionDetail, useSessionSummary } from '../../../lib/graphql/hooks';
 import { climbToQueueItem } from '../../../lib/climb-to-queue-item';
@@ -48,6 +44,10 @@ type InSessionViewProps = {
   /** Screen height for the dismiss-distance threshold. Absent in tab mode. */
   screenHeight?: number;
 };
+
+// Coalesce live-stats-triggered detail refetches: a burst of `SessionStatsUpdated`
+// pushes settles into one refetch of the (unbounded) tick list instead of N.
+const SESSION_DETAIL_REFETCH_DEBOUNCE_MS = 1500;
 
 type SessionHistoryStatus = 'attempt' | 'send' | 'flash';
 
@@ -116,6 +116,10 @@ function tickToQueueItem(tick: SessionDetailTick): ClimbQueueItem | null {
   return climbToQueueItem(climb, { uuid: randomUUID() });
 }
 
+function historyKeyExtractor(tick: SessionDetailTick): string {
+  return tick.uuid;
+}
+
 type SessionHistoryRowProps = {
   tick: SessionDetailTick;
   status: SessionHistoryStatus;
@@ -123,7 +127,12 @@ type SessionHistoryRowProps = {
   onPress: (tick: SessionDetailTick) => void;
 };
 
-function SessionHistoryRow({ tick, status, participant, onPress }: SessionHistoryRowProps) {
+const SessionHistoryRow = memo(function SessionHistoryRow({
+  tick,
+  status,
+  participant,
+  onPress,
+}: SessionHistoryRowProps) {
   const { t } = useTranslation('session');
   const { systemColors, brandColors } = useTheme();
   const { formatGrade, formatGradeByDifficultyId } = useGradeFormat();
@@ -213,7 +222,7 @@ function SessionHistoryRow({ tick, status, participant, onPress }: SessionHistor
       <View style={[styles.historySeparator, { backgroundColor: systemColors.separator }]} />
     </View>
   );
-}
+});
 
 export function InSessionView({ translateY, screenHeight }: InSessionViewProps) {
   const { t } = useTranslation('session');
@@ -222,8 +231,8 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
   const router = useRouter();
   const queryClient = useQueryClient();
   const { openPlayDrawer } = useDrawerHost();
-  const { sessionId, liveStats, sessionUsers, driverParticipantId, participantId, setCurrentClimb, endSession } =
-    useQueue();
+  const { sessionId, driverParticipantId, participantId, setCurrentClimb, endSession } = useQueue();
+  const { liveStats, sessionUsers } = useQueueLiveStats();
 
   // Seed the live view from the full session detail (rich grade split, flashes,
   // per-participant flashes, and the tick list used for hardest-send names and
@@ -244,13 +253,21 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
   const startedAt = summaryQuery.data?.startedAt ?? null;
 
   // Refresh detail whenever live tick aggregates move so the history list and
-  // hardest-send names catch the newly logged tick.
+  // hardest-send names catch the newly logged tick. The live push only carries
+  // aggregates (not the tick list), so a refetch is the only path by which a new
+  // tick reaches the history list — we can't drop it. But it pulls the full
+  // unbounded tick list, so we DEBOUNCE it: rapid pushes (the party stats stream
+  // is debounced server-side to ≤1/2s, and a busy party can still log several in
+  // a row) coalesce into a single refetch rather than one per push.
   const liveTickCount = live?.tickCount ?? null;
   const liveHardestGrade = live?.hardestGrade ?? null;
   useEffect(() => {
-    if (!sessionId) return;
-    if (liveTickCount == null && !liveHardestGrade) return;
-    void queryClient.invalidateQueries({ queryKey: ['sessionDetail', sessionId] });
+    if (!sessionId) return undefined;
+    if (liveTickCount == null && !liveHardestGrade) return undefined;
+    const handle = setTimeout(() => {
+      void queryClient.invalidateQueries({ queryKey: ['sessionDetail', sessionId] });
+    }, SESSION_DETAIL_REFETCH_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
   }, [sessionId, liveTickCount, liveHardestGrade, queryClient]);
 
   // Live push takes precedence over the seed for every aggregate.
@@ -385,9 +402,17 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
   const overlayMode = translateY !== undefined && screenHeight !== undefined;
   const scrollOffset = useSharedValue(0);
   const startedAtTop = useSharedValue(true);
-  const scrollHandler = useAnimatedScrollHandler((event) => {
-    scrollOffset.value = event.contentOffset.y;
-  });
+  // FlashList forwards a plain JS scroll event (it isn't a reanimated host
+  // component), so we mirror the offset into the shared value here — the same
+  // pattern the climbs list uses to drive its collapsing chrome. The dismiss
+  // gesture only reads `scrollOffset.value <= 0` on start, so JS-thread latency
+  // is immaterial.
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      scrollOffset.value = event.nativeEvent.contentOffset.y;
+    },
+    [scrollOffset],
+  );
   const dismissGesture = useMemo(() => {
     if (translateY === undefined || screenHeight === undefined) return null;
     return Gesture.Pan()
@@ -420,15 +445,35 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
     }
   }, [endSession, router]);
 
-  const scrollView = (
-    <Animated.ScrollView
-      style={styles.scroll}
-      contentContainerStyle={[styles.content, { paddingBottom: 100 + footerBottomPadding }]}
-      showsVerticalScrollIndicator={false}
-      onScroll={scrollHandler}
-      scrollEventThrottle={16}
-      bounces={false}
-    >
+  // The history tick list is unbounded (it grows with every logged ascent in a
+  // long party session), so it virtualizes through a FlashList instead of a
+  // `.map` inside a ScrollView. The presence row + analytics ride as the list
+  // header and the leaderboard as the footer, keeping the screen one scroll
+  // surface. The rounded "card" look around the rows is preserved by rounding
+  // the first/last row corners (they share the secondary-background fill).
+  const lastHistoryIndex = sessionHistoryTicks.length - 1;
+  const renderHistoryRow = useCallback(
+    ({ item: tick, index }: { item: SessionDetailTick & { status: SessionHistoryStatus }; index: number }) => (
+      <View
+        style={[
+          { backgroundColor: systemColors.secondaryBackground },
+          index === 0 ? styles.historyListFirst : null,
+          index === lastHistoryIndex ? styles.historyListLast : null,
+        ]}
+      >
+        <SessionHistoryRow
+          tick={tick}
+          status={tick.status}
+          participant={participantByUserId.get(tick.userId)}
+          onPress={handlePressHistoryTick}
+        />
+      </View>
+    ),
+    [systemColors.secondaryBackground, lastHistoryIndex, participantByUserId, handlePressHistoryTick],
+  );
+
+  const listHeader = (
+    <View style={styles.headerContent}>
       <SessionPresenceRow
         users={sessionUsers}
         driverParticipantId={driverParticipantId}
@@ -454,23 +499,35 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
               {t('mobile.session.inHistoryEmpty')}
             </Text>
           </View>
-        ) : (
-          <View style={[styles.historyList, { backgroundColor: systemColors.secondaryBackground }]}>
-            {sessionHistoryTicks.map((tick) => (
-              <SessionHistoryRow
-                key={tick.uuid}
-                tick={tick}
-                status={tick.status}
-                participant={participantByUserId.get(tick.userId)}
-                onPress={handlePressHistoryTick}
-              />
-            ))}
-          </View>
-        )}
+        ) : null}
       </View>
+    </View>
+  );
 
+  const listFooter = (
+    <View style={styles.footerContent}>
       <SessionLeaderboard participants={participants} driverUserId={driverUserId} selfUserId={selfUserId} />
-    </Animated.ScrollView>
+    </View>
+  );
+
+  const scrollView = (
+    <FlashList
+      style={styles.scroll}
+      data={sessionHistoryTicks}
+      renderItem={renderHistoryRow}
+      keyExtractor={historyKeyExtractor}
+      ListHeaderComponent={listHeader}
+      ListFooterComponent={listFooter}
+      contentContainerStyle={{
+        paddingHorizontal: spacing[4],
+        paddingTop: spacing[2],
+        paddingBottom: 100 + footerBottomPadding,
+      }}
+      showsVerticalScrollIndicator={false}
+      onScroll={handleScroll}
+      scrollEventThrottle={16}
+      bounces={false}
+    />
   );
 
   const body = (
@@ -512,10 +569,11 @@ const styles = StyleSheet.create({
   scroll: {
     flex: 1,
   },
-  content: {
-    paddingHorizontal: spacing[4],
-    paddingTop: spacing[2],
+  headerContent: {
     gap: spacing[5],
+  },
+  footerContent: {
+    marginTop: spacing[5],
   },
   historySection: {
     gap: spacing[2],
@@ -525,8 +583,19 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     letterSpacing: 0,
   },
-  historyList: {
-    borderRadius: borderRadius.lg,
+  // First/last history rows round the card's outer corners, reproducing the
+  // single rounded-card look the old `.map`-in-a-View had (it had
+  // overflow:hidden + borderRadius on the wrapping View). The first row also
+  // takes the spacing[2] label→card gap that lived inside `historySection`.
+  historyListFirst: {
+    marginTop: spacing[2],
+    borderTopLeftRadius: borderRadius.lg,
+    borderTopRightRadius: borderRadius.lg,
+    overflow: 'hidden',
+  },
+  historyListLast: {
+    borderBottomLeftRadius: borderRadius.lg,
+    borderBottomRightRadius: borderRadius.lg,
     overflow: 'hidden',
   },
   historyRow: {

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, render, waitFor } from '@testing-library/react';
-import { createElement, useEffect, type ReactNode } from 'react';
+import { createElement, useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import type { SessionUser, UserBoard } from '@boardsesh/shared-schema';
@@ -144,7 +144,7 @@ vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
 }));
 
-import { QueueProvider, useQueue } from '../queue-provider';
+import { QueueProvider, useQueue, useQueueLiveStats } from '../queue-provider';
 
 type Snapshot = {
   state: ReturnType<typeof useQueue>['state'];
@@ -207,11 +207,14 @@ function createDeferred<T>() {
 
 function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
   const queue = useQueue();
+  // sessionUsers moved out of useQueue() into its own live-stats context so the
+  // ≤1/2s party push no longer re-renders every queue consumer; read it here.
+  const { sessionUsers } = useQueueLiveStats();
   useEffect(() => {
     onSnapshot({
       state: queue.state,
       sessionId: queue.sessionId,
-      users: queue.sessionUsers,
+      users: sessionUsers,
       driverParticipantId: queue.driverParticipantId,
       lastConnectedBoardSerial: queue.lastConnectedBoardSerial,
       playlistSuggestionSource: queue.playlistSuggestionSource,
@@ -229,7 +232,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
   }, [
     queue.sessionId,
     queue.state,
-    queue.sessionUsers,
+    sessionUsers,
     queue.driverParticipantId,
     queue.lastConnectedBoardSerial,
     queue.playlistSuggestionSource,

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -84,17 +84,6 @@ type QueueContextValue = {
   dispatch: React.Dispatch<QueueAction>;
   sessionId: string | null;
   setSessionId: (id: string | null) => void;
-  /**
-   * Live aggregate stats for the active session, pushed over `sessionUpdates`
-   * (the `SessionStatsUpdated` event) as ticks are logged. Null until the first
-   * push arrives (or when there's no session).
-   */
-  liveStats: SessionLiveStatsEvent | null;
-  /**
-   * Connected participants in the active session. Seeded from the JOIN_SESSION
-   * response and kept current via UserJoined/UserLeft/UserPresenceChanged.
-   */
-  sessionUsers: SessionUser[];
   /** Participant id of the member currently driving the wall, if any. */
   driverParticipantId: string | null;
   /** Most recently published physical board serial for this session, if any. */
@@ -184,6 +173,59 @@ type QueueSessionControlContextValue = Pick<
 
 const QueueSessionControlContext = createContext<QueueSessionControlContextValue | null>(null);
 
+/**
+ * Live session analytics + presence, split out of the main QueueContext so the
+ * ≤1/2s `SessionStatsUpdated` party push (and roster deltas) re-renders only the
+ * session screen — not every `useQueue()` consumer (climb list, persistent bar,
+ * tab layout, board adapter, bluetooth provider, drawer host, live-activity
+ * bridge). Consumed solely by SessionScreen + InSessionView.
+ */
+type QueueLiveStatsContextValue = {
+  /**
+   * Live aggregate stats for the active session, pushed over `sessionUpdates`
+   * (the `SessionStatsUpdated` event) as ticks are logged. Null until the first
+   * push arrives (or when there's no session).
+   */
+  liveStats: SessionLiveStatsEvent | null;
+  /**
+   * Connected participants in the active session. Seeded from the JOIN_SESSION
+   * response and kept current via UserJoined/UserLeft/UserPresenceChanged.
+   */
+  sessionUsers: SessionUser[];
+};
+
+const QueueLiveStatsContext = createContext<QueueLiveStatsContextValue | null>(null);
+
+/**
+ * Active-climb selector context. Changes identity ONLY when the active climb's
+ * uuid changes, so the climb list (which highlights the active row) stops
+ * re-rendering on every unrelated queue mutation or party push.
+ */
+type QueueActiveClimbContextValue = {
+  activeClimbUuid: string | null;
+};
+
+const QueueActiveClimbContext = createContext<QueueActiveClimbContextValue | null>(null);
+
+/**
+ * Stable queue actions, split out so consumers that only dispatch actions (e.g.
+ * the climb list's add-to-queue) don't subscribe to the whole reducer `state`.
+ * Holds everything in QueueContextValue except `state`, `dispatch`, `sessionId`,
+ * `setSessionId`, and the live-stats fields (which live in their own contexts).
+ */
+type QueueActionsContextValue = Omit<
+  QueueContextValue,
+  | 'state'
+  | 'dispatch'
+  | 'sessionId'
+  | 'setSessionId'
+  | 'driverParticipantId'
+  | 'lastConnectedBoardSerial'
+  | 'participantId'
+>;
+
+const QueueActionsContext = createContext<QueueActionsContextValue | null>(null);
+
 export function useQueue(): QueueContextValue {
   const context = useContext(QueueContext);
   if (!context) throw new Error('useQueue must be used within QueueProvider');
@@ -193,6 +235,24 @@ export function useQueue(): QueueContextValue {
 export function useQueueSessionControls(): QueueSessionControlContextValue {
   const context = useContext(QueueSessionControlContext);
   if (!context) throw new Error('useQueueSessionControls must be used within QueueProvider');
+  return context;
+}
+
+export function useQueueLiveStats(): QueueLiveStatsContextValue {
+  const context = useContext(QueueLiveStatsContext);
+  if (!context) throw new Error('useQueueLiveStats must be used within QueueProvider');
+  return context;
+}
+
+export function useActiveClimbUuid(): string | null {
+  const context = useContext(QueueActiveClimbContext);
+  if (!context) throw new Error('useActiveClimbUuid must be used within QueueProvider');
+  return context.activeClimbUuid;
+}
+
+export function useQueueActions(): QueueActionsContextValue {
+  const context = useContext(QueueActionsContext);
+  if (!context) throw new Error('useQueueActions must be used within QueueProvider');
   return context;
 }
 
@@ -1179,17 +1239,13 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     [mutations],
   );
 
-  const contextValue = useMemo<QueueContextValue>(
+  // Stable action bundle. Split out of contextValue so consumers that only need
+  // to dispatch (the climb list's addToQueue) can subscribe via useQueueActions()
+  // without re-rendering on every reducer `state` change. Every member is an
+  // individually-stable useCallback, so this memo only ever recomputes if one of
+  // them genuinely changes identity (it shouldn't, in practice).
+  const actionsValue = useMemo<QueueActionsContextValue>(
     () => ({
-      state,
-      dispatch,
-      sessionId,
-      setSessionId,
-      liveStats,
-      sessionUsers,
-      driverParticipantId,
-      lastConnectedBoardSerial,
-      participantId,
       addToQueue,
       removeFromQueue,
       reorderQueue,
@@ -1213,13 +1269,6 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       publishPlaybackState,
     }),
     [
-      state,
-      sessionId,
-      liveStats,
-      sessionUsers,
-      driverParticipantId,
-      lastConnectedBoardSerial,
-      participantId,
       addToQueue,
       removeFromQueue,
       reorderQueue,
@@ -1242,6 +1291,33 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       subscribeToQueueEvents,
       publishPlaybackState,
     ],
+  );
+
+  const contextValue = useMemo<QueueContextValue>(
+    () => ({
+      state,
+      dispatch,
+      sessionId,
+      setSessionId,
+      driverParticipantId,
+      lastConnectedBoardSerial,
+      participantId,
+      ...actionsValue,
+    }),
+    [state, sessionId, driverParticipantId, lastConnectedBoardSerial, participantId, actionsValue],
+  );
+
+  // Active-climb selector: identity changes ONLY when the active climb uuid
+  // changes (memoized on the uuid string), so highlight-only consumers like the
+  // climb list don't re-render on unrelated queue mutations or party pushes.
+  const activeClimbUuid = state.currentClimbQueueItem?.climb?.uuid ?? null;
+  const activeClimbValue = useMemo<QueueActiveClimbContextValue>(() => ({ activeClimbUuid }), [activeClimbUuid]);
+
+  // Live analytics + presence: the ≤1/2s party push recreates only this small
+  // value, re-rendering only SessionScreen + InSessionView.
+  const liveStatsValue = useMemo<QueueLiveStatsContextValue>(
+    () => ({ liveStats, sessionUsers }),
+    [liveStats, sessionUsers],
   );
 
   const sessionControlValue = useMemo<QueueSessionControlContextValue>(
@@ -1269,7 +1345,13 @@ export function QueueProvider({ children }: { children: ReactNode }) {
 
   return (
     <QueueSessionControlContext.Provider value={sessionControlValue}>
-      <QueueContext.Provider value={contextValue}>{children}</QueueContext.Provider>
+      <QueueLiveStatsContext.Provider value={liveStatsValue}>
+        <QueueActionsContext.Provider value={actionsValue}>
+          <QueueActiveClimbContext.Provider value={activeClimbValue}>
+            <QueueContext.Provider value={contextValue}>{children}</QueueContext.Provider>
+          </QueueActiveClimbContext.Provider>
+        </QueueActionsContext.Provider>
+      </QueueLiveStatsContext.Provider>
     </QueueSessionControlContext.Provider>
   );
 }


### PR DESCRIPTION
## Why

The mobile `QueueProvider` exposed **one big** `QueueContext` bundling the reducer `state`, ~25 action callbacks, `liveStats`, and `sessionUsers`. Its `contextValue` memo depended on `state`, `liveStats`, **and** `sessionUsers`, so every queue mutation **and** every ≤1/2s `SessionStatsUpdated` party push recreated the value and re-rendered **every** `useQueue()` consumer app-wide (climbs list, persistent bar, tab layout, board adapter, bluetooth provider, drawer host, live-activity bridge). This is the #2540 cost.

Surgical, behavior-preserving context split following the existing `QueueSessionControlContext` pattern.

## Part A — live-stats context (the #2540 fix; contained, 2 consumers)

- New `QueueLiveStatsContext` + `useQueueLiveStats()` → `{ liveStats, sessionUsers }`, memoized on `[liveStats, sessionUsers]`.
- **Removed** `liveStats`/`sessionUsers` from `QueueContextValue`, the `contextValue` object, and its memo deps.
- Migrated **`SessionScreen.tsx`** and **`InSessionView.tsx`** (the only consumers) to read them from the new hook.
- Updated the session-updates test's `Probe` to read `sessionUsers` from `useQueueLiveStats()`.

Result: the 2s party push now recreates only the small live-stats value → only the session screen re-renders, not every queue consumer. The `SessionStatsUpdated` subscription still calls `setLiveStats`; presence deltas still feed `sessionUsers`.

## Part B — active-climb selector + actions context

- New `QueueActiveClimbContext` + `useActiveClimbUuid()` → `activeClimbUuid`, memoized on the uuid **string** so identity changes **only** when the active uuid changes (not on unrelated state changes).
- New `QueueActionsContext` + `useQueueActions()` exposing the stable action callbacks (everything in `QueueContextValue` except `state`, `dispatch`, `sessionId`, `setSessionId`, the driver/participant ids, and the now-removed live-stats). `contextValue` now spreads `actionsValue`, so **legacy `useQueue()` is unchanged** for every other consumer (still returns `state` + all actions + ids).
- Migrated **`climbs/index.tsx`** to `useActiveClimbUuid()` + `useQueueActions().addToQueue`, so the search screen no longer subscribes to the whole reducer `state`. `renderClimbItem` keeps `activeClimbUuid` in its deps, but the selector now guarantees the screen only re-renders when the uuid actually changes.

### Migrated vs. left on `useQueue()`

- **Migrated:** `climbs/index.tsx` (Part B), `SessionScreen.tsx` + `InSessionView.tsx` (Part A live-stats only — they still read `sessionId`/driver/participant/actions from `useQueue()`).
- **Left on `useQueue()`:** every other consumer (persistent bar, queue carousel, drawer host, play drawer, bluetooth/board adapters, live-activity bridge, tab layout, etc.). I checked **`persistent-queue-bar.tsx`** — it needs the full `state.currentClimbQueueItem?.climb` object and its `ClimbCapsule`/`useQueueCarousel` read swipe state, not just the uuid, so migrating it would be higher-risk and out of scope. Left as-is.

## Part C — InSessionView session history (the #2540 worst new cost)

- The full tick history rendered via `.map` inside an `Animated.ScrollView` (no virtualization). Replaced with a **`@shopify/flash-list` `FlashList`** (mirrors the post-session `session/[sessionId].tsx`). Presence + analytics ride as `ListHeaderComponent`, leaderboard as `ListFooterComponent`, so it stays one scroll surface. The rounded-card look is preserved by rounding the first/last rows (they share the secondary-background fill).
- Wrapped `SessionHistoryRow` in `React.memo`; its press handler is a stable `useCallback`.
- The scroll-offset shared value that drives pull-to-dismiss now updates via a **JS `onScroll`** callback (FlashList isn't a reanimated host component) — the same pattern the climbs list uses. The dismiss gesture only reads `scrollOffset.value <= 0` on start, so JS-thread latency is immaterial; collapsing/dismiss behavior is preserved.

### Invalidate decision

There was an effect calling `queryClient.invalidateQueries(['sessionDetail', sessionId])` on **every** `liveStats` change (≤2s), refetching the **unbounded** tick list each time. I **debounced** it (1.5s) rather than dropping it: the live push carries only **aggregates**, not the tick list, so a refetch is the **only** path by which a newly-logged tick reaches the history list — dropping it would stop new ticks from appearing. Debouncing coalesces a burst of pushes into a single refetch. New ticks still arrive (correctly), just at most once per 1.5s.

### Ticks query bound — skipped (follow-up)

`sessionDetail(sessionId: ID!)` has **no** `limit` arg, so bounding `GET_SESSION_DETAIL.ticks` would require a **schema + resolver change** — out of scope per the brief (don't touch the backend schema). Left as a follow-up. Note the same operation backs the post-session screen, which intentionally renders all ticks.

## Validation

- `vp run typecheck` (full) — pass
- `vp test run queue-provider session in-session InSessionView` — 625 pass
- `vp test run --project=mobile` — 154 files / 1185 tests pass
- `vp fmt --check` (changed files) — clean
- `vp lint` — no new findings in changed files (one pre-existing `no-floating-promises` in untouched `queue-provider` code, on `main` baseline; also removed a pre-existing unused `ReactNode` import in the test)
- `vp run check:mobile-bundle` — OK (Android bundle 10.4 MB)

## Risks for the reviewer

- **Party mode / sync:** the queue mutation + WS subscription paths are untouched; only the context **shape** changed. Worth a glance that `useQueueActions()` exposes every action the migrated `addToQueue` needs and that `QueueActionsContextValue` (an `Omit` of `QueueContextValue`) stays in lockstep with `actionsValue`.
- **Live-stats split:** confirm no consumer still reads `liveStats`/`sessionUsers` off `useQueue()` (grep is clean) and that SessionScreen/InSessionView still re-render on party pushes via the new hook.
- **InSessionView FlashList:** confirm no nested-VirtualizedList warning (FlashList is not inside a ScrollView), the rounded-card visuals match, and the pull-to-dismiss still works in overlay mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)