### PR TITLE
perf(mobile): make the play drawer open instantly (defer board mount)

### DIFF
--- a/packages/mobile/src/components/play-drawer/DeferredBoard.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredBoard.tsx
@@ -1,0 +1,100 @@
+import { memo, useEffect, useState } from 'react';
+import { InteractionManager, View, StyleSheet } from 'react-native';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { SwipeBoardCarousel } from './SwipeBoardCarousel';
+import { iosSystemColors } from '../../theme/ios-colors';
+
+type BoardRenderData = {
+  boardWidth: number;
+  boardHeight: number;
+};
+
+type DeferredBoardProps = {
+  /** Drives the InteractionManager gate. While the sheet is presenting this is
+   *  false and a sized placeholder stands in for the board; once the present
+   *  animation settles it flips true and the interactive carousel mounts. */
+  open: boolean;
+  boardName: BoardName;
+  boardRenderData: BoardRenderData;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  currentFrames: string;
+  currentFrameOverride?: string | null;
+  nextFrames: string | null;
+  prevFrames: string | null;
+  mirrored: boolean;
+  canSwipeNext: boolean;
+  canSwipePrevious: boolean;
+  onSwipeNext: () => void;
+  onSwipePrevious: () => void;
+  onResetZoomReady?: (resetZoom: () => void) => void;
+  enabled?: boolean;
+};
+
+/**
+ * Defers mounting the interactive {@link SwipeBoardCarousel} until after the
+ * play drawer's present animation settles. The carousel mounts 2×
+ * `BoardImageNative` plus a pinch/swipe/zoom gesture composition; rendering all
+ * of that synchronously the moment the sheet opens blocks the present animation
+ * for ~0.5–1s (the user-reported stall). Mirrors `DeferredSections`'
+ * `InteractionManager.runAfterInteractions` approach: the sheet animates open
+ * immediately over a board-sized placeholder, then the board mounts a frame
+ * later.
+ *
+ * The gate is keyed on the OPEN TRANSITION (`open`), not on the displayed
+ * climb's uuid, so once the drawer is open, swiping to next/prev climbs renders
+ * the board immediately with no placeholder flash — the carousel stays mounted
+ * across in-drawer swipes.
+ *
+ * The placeholder occupies the board's exact footprint (`width: '100%'` +
+ * `aspectRatio`, identical to `BoardImageNative`) so the above-fold measurement
+ * that derives the peek snap-point is the same whether or not the board has
+ * mounted yet — no full→peek jump.
+ */
+export const DeferredBoard = memo(function DeferredBoard({
+  open,
+  boardRenderData,
+  ...carouselProps
+}: DeferredBoardProps) {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setReady(false);
+      return;
+    }
+
+    const handle = InteractionManager.runAfterInteractions(() => {
+      setReady(true);
+    });
+
+    return () => {
+      handle.cancel();
+    };
+  }, [open]);
+
+  if (!ready) {
+    return (
+      <View
+        style={[styles.placeholder, { aspectRatio: boardRenderData.boardWidth / boardRenderData.boardHeight }]}
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+        testID="deferred-board-placeholder"
+      />
+    );
+  }
+
+  return <SwipeBoardCarousel boardRenderData={boardRenderData} {...carouselProps} />;
+});
+
+const styles = StyleSheet.create({
+  placeholder: {
+    width: '100%',
+    // Faint board-coloured fill so the present animation lands on a soft skeleton
+    // rather than a hard gap. No image decode, no gesture handlers — cheap to
+    // mount on the present frame. Matches the section skeleton tint used
+    // elsewhere in the play drawer.
+    backgroundColor: `${iosSystemColors.systemGray}14`,
+  },
+});

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -17,7 +17,7 @@ import { computeNavigationStateWithSuggestions, boardSupportsMirroring } from '@
 import { climbToQueueItem } from '../../lib/climb-to-queue-item';
 import type { ActiveSubDrawer } from '@boardsesh/play-view';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { SwipeBoardCarousel } from './SwipeBoardCarousel';
+import { DeferredBoard } from './DeferredBoard';
 import { PlaybackControls } from './PlaybackControls';
 import { useMobilePlayback } from './use-mobile-playback';
 import { PlayDrawerHeader } from './PlayDrawerHeader';
@@ -682,7 +682,8 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
 
                 <View style={styles.boardSection}>
                   {boardRenderData && (
-                    <SwipeBoardCarousel
+                    <DeferredBoard
+                      open={isSheetOpen}
                       boardName={boardName as BoardName}
                       boardRenderData={boardRenderData}
                       layoutId={layoutId}

--- a/packages/mobile/src/components/play-drawer/__tests__/deferred-board.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/deferred-board.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Controllable InteractionManager: capture every scheduled callback + its
+// cancel so a test can decide whether the deferred work runs (open settles) or
+// is cancelled (sheet closed / unmounted before it fires). Hoisted so the
+// (top-of-file-hoisted) vi.mock factory below can close over it.
+const { scheduledTasks, runAfterInteractions } = vi.hoisted(() => {
+  const tasks: Array<{ run: () => void; cancel: ReturnType<typeof vi.fn> }> = [];
+  return {
+    scheduledTasks: tasks,
+    runAfterInteractions: vi.fn((callback: () => void) => {
+      const cancel = vi.fn();
+      tasks.push({ run: callback, cancel });
+      return { cancel };
+    }),
+  };
+});
+
+type ViewMockProps = { children?: ReactNode; testID?: string; style?: unknown };
+vi.mock('react-native', () => ({
+  View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  InteractionManager: { runAfterInteractions },
+}));
+
+// The carousel is the expensive thing we're deferring — stand it in with a
+// cheap marker that echoes the climb frames so we can assert which climb shows.
+vi.mock('../SwipeBoardCarousel', () => ({
+  SwipeBoardCarousel: ({ currentFrames }: { currentFrames: string }) =>
+    createElement('div', { 'data-testid': 'swipe-board', 'data-frames': currentFrames }),
+}));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#8E8E93' } }));
+
+import { DeferredBoard } from '../DeferredBoard';
+
+const baseProps = {
+  boardName: 'kilter' as const,
+  boardRenderData: { boardWidth: 1080, boardHeight: 1920 },
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,20',
+  currentFrames: 'p1145r15',
+  nextFrames: null,
+  prevFrames: null,
+  mirrored: false,
+  canSwipeNext: true,
+  canSwipePrevious: false,
+  onSwipeNext: vi.fn(),
+  onSwipePrevious: vi.fn(),
+};
+
+function settleAllInteractions() {
+  act(() => {
+    for (const task of scheduledTasks.splice(0)) {
+      task.run();
+    }
+  });
+}
+
+describe('DeferredBoard', () => {
+  beforeEach(() => {
+    scheduledTasks.length = 0;
+    runAfterInteractions.mockClear();
+  });
+
+  it('shows a board-sized placeholder before the present animation settles', () => {
+    const { container } = render(createElement(DeferredBoard, { ...baseProps, open: true }));
+
+    expect(container.querySelector('[data-testid="deferred-board-placeholder"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="swipe-board"]')).toBeNull();
+    expect(runAfterInteractions).toHaveBeenCalledTimes(1);
+  });
+
+  it('mounts the carousel after interactions settle', () => {
+    const { container } = render(createElement(DeferredBoard, { ...baseProps, open: true }));
+
+    settleAllInteractions();
+
+    expect(container.querySelector('[data-testid="deferred-board-placeholder"]')).toBeNull();
+    const board = container.querySelector('[data-testid="swipe-board"]');
+    expect(board?.getAttribute('data-frames')).toBe('p1145r15');
+  });
+
+  it('does NOT re-show the placeholder when the climb changes while open (no swipe flash)', () => {
+    const { container, rerender } = render(createElement(DeferredBoard, { ...baseProps, open: true }));
+    settleAllInteractions();
+    expect(container.querySelector('[data-testid="swipe-board"]')).toBeTruthy();
+
+    // Swipe to a different climb: same open transition, new frames. The gate is
+    // keyed on `open`, not on the climb, so the board stays mounted.
+    rerender(createElement(DeferredBoard, { ...baseProps, open: true, currentFrames: 'p9r12' }));
+
+    expect(container.querySelector('[data-testid="deferred-board-placeholder"]')).toBeNull();
+    expect(container.querySelector('[data-testid="swipe-board"]')?.getAttribute('data-frames')).toBe('p9r12');
+    // No second schedule — the open transition didn't recur.
+    expect(runAfterInteractions).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the scheduled mount and drops the board when the sheet closes before it fires', () => {
+    const { container, rerender } = render(createElement(DeferredBoard, { ...baseProps, open: true }));
+    const [scheduled] = scheduledTasks;
+
+    rerender(createElement(DeferredBoard, { ...baseProps, open: false }));
+
+    // The pending mount is cancelled (no setState-after-the-fact leaking a board).
+    expect(scheduled.cancel).toHaveBeenCalledTimes(1);
+    // Closed → reset to "not ready": the carousel is gone, only the cheap
+    // placeholder remains (the parent unmounts the whole block once it clears
+    // the displayed climb on dismiss).
+    expect(container.querySelector('[data-testid="swipe-board"]')).toBeNull();
+    expect(container.querySelector('[data-testid="deferred-board-placeholder"]')).toBeTruthy();
+  });
+
+  it('drops a mounted board back to the placeholder when the sheet closes (no stale board on reopen)', () => {
+    const { container, rerender } = render(createElement(DeferredBoard, { ...baseProps, open: true }));
+    settleAllInteractions();
+    expect(container.querySelector('[data-testid="swipe-board"]')).toBeTruthy();
+
+    rerender(createElement(DeferredBoard, { ...baseProps, open: false }));
+
+    expect(container.querySelector('[data-testid="swipe-board"]')).toBeNull();
+    expect(container.querySelector('[data-testid="deferred-board-placeholder"]')).toBeTruthy();
+  });
+
+  it('re-shows the placeholder on the next open and schedules a fresh mount', () => {
+    const { container, rerender } = render(createElement(DeferredBoard, { ...baseProps, open: true }));
+    settleAllInteractions();
+    rerender(createElement(DeferredBoard, { ...baseProps, open: false }));
+
+    // Re-open a different climb: placeholder again, then the new climb's board.
+    rerender(createElement(DeferredBoard, { ...baseProps, open: true, currentFrames: 'p77r15' }));
+    expect(container.querySelector('[data-testid="deferred-board-placeholder"]')).toBeTruthy();
+    expect(runAfterInteractions).toHaveBeenCalledTimes(2);
+
+    settleAllInteractions();
+    expect(container.querySelector('[data-testid="swipe-board"]')?.getAttribute('data-frames')).toBe('p77r15');
+  });
+
+  it('cancels the scheduled mount on unmount (no setState-after-unmount)', () => {
+    const { unmount } = render(createElement(DeferredBoard, { ...baseProps, open: true }));
+    const [scheduled] = scheduledTasks;
+
+    unmount();
+
+    expect(scheduled.cancel).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem (user-reported)

Tapping a climb on the climbs list — and pressing **Open** on the queue snackbar — took **~0.5–1s** for the play drawer to actually open.

Both paths call `useDrawerHost().openPlayDrawer` → `PlayDrawer`'s imperative `.open()`, which sets state (incl. `setIsSheetOpen(true)`) and presents the gorhom `BottomSheetModal`. The drawer's below-fold content is already deferred via `InteractionManager.runAfterInteractions` in `DeferredSections`. But the **above-fold board** — `<SwipeBoardCarousel>`, which mounts **2× `BoardImageNative`** plus a **pinch/swipe/zoom gesture composition** — rendered **synchronously** the moment `displayedClimb` + `boardRenderData` existed (i.e. on open). That synchronous render blocked the present animation → the visible stall.

## Fix

Defer the `SwipeBoardCarousel` mount until **after** the present animation settles, mirroring `DeferredSections`'s `InteractionManager.runAfterInteractions` approach. New `DeferredBoard` wrapper:

- While the sheet is presenting, renders a cheap board-sized placeholder (no image decode, no gesture handlers).
- Schedules `runAfterInteractions(() => setReady(true))`; once it fires, swaps in the interactive `SwipeBoardCarousel`.

The sheet now animates open immediately (header + board-sized placeholder), then the interactive board mounts a frame later.

## Snap-point / layout preservation

The peek snap-point is derived from the measured above-fold height (`handleAboveFoldLayout` on the `<View>` wrapping header + board + action bar → `aboveFoldHeight`). The placeholder uses `width: '100%'` + the board's **exact** `aspectRatio` (`boardWidth / boardHeight`), identical to how `BoardImageNative` derives its height. So the above-fold layout — and therefore the peek snap-point — measures the **same** whether or not the board has mounted yet. When the board mounts a frame later its height is identical, so the `setHeightIfChanged` guard (≤2px) no-ops and the per-climb corrective `snapToIndex(0)` still lands on the correct peek. **No full→peek jump.**

## Defer on the open transition, not per climb

The gate is keyed on `open` (`isSheetOpen`), **not** on `displayedClimb.uuid`. Once the drawer is open, swiping to next/prev climbs renders the board **immediately** with no placeholder flash — the carousel stays mounted across in-drawer swipes. On close, `open` goes false → reset to "not ready" and the scheduled `InteractionManager` handle is cancelled on cleanup (no `setState`-after-unmount, no stale board leaking on reopen). On the next open, the placeholder shows again and a fresh mount is scheduled.

## `setCurrentClimb` intentionally untouched

`.open()`'s `setCurrentClimb` (and the queue-dispatch re-render storm it triggers) is **left exactly as-is** — that's being addressed by a separate in-flight queue-context-split PR. This PR only defers the **mount** of `SwipeBoardCarousel`; `boardRenderData` stays a memo, and swipe/zoom/playback/party/BLE behaviour is unchanged once the board mounts. Party preview-only opens (`setAsCurrent === false`) are unaffected.

## Validation

- `vp run typecheck:mobile` — clean
- `vp test --project mobile` — 1192 tests pass (incl. new `deferred-board.test.tsx`: placeholder-before-settle, mount-after-settle, no-flash-on-swipe, cancel-on-close, re-show-on-reopen, cancel-on-unmount)
- `vp fmt --check` — clean on changed files
- `vp lint` — no findings in changed files
- `vp run check:mobile-bundle` — OK (10.4 MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)