### PR TITLE
perf(mobile): rasterize the accessory-bar climb thumbnail

### DIFF
--- a/packages/mobile/src/components/queue-control/AccessoryClimbThumbnail.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryClimbThumbnail.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, type ViewStyle } from 'react-native';
 import type { BoardName } from '@boardsesh/shared-schema';
 import type { Climb } from '@boardsesh/queue';
 import { getBoardRenderData } from '../../lib/board-details';
 import { type BoardConfig } from '../../providers/drawer-host-provider';
-import { BoardRenderer } from '../board-renderer/BoardRenderer';
+import { BoardImageNative } from '../BoardImageNative';
 
 /** Square slot size for the accessory-bar board thumbnail. */
 export const ACCESSORY_THUMBNAIL_SLOT_SIZE = 40;
@@ -26,6 +26,15 @@ function getAccessoryThumbnailBoardSize(boardWidth: number, boardHeight: number)
  * The small board render shown beside the climb name in the accessory bar (the
  * floating capsule and the iOS 26 native accessory). Renders nothing if the
  * board config or render data isn't available.
+ *
+ * Uses the rasterized native-PNG path (BoardImageNative → useNativeClimbRender
+ * + LayeredClimbImage, `cachePolicy="memory-disk"` over bundled `file://`
+ * backgrounds) — the same warm path the list thumbnails use — rather than the
+ * react-native-svg BoardRenderer with a remote `<SvgImage href>`. The accessory
+ * bar is always mounted and re-renders on every queue swipe, so the cheap
+ * cached-PNG path matters here. Cache keys dedupe across surfaces, so a climb
+ * already seen in the list/play view is an instant cache hit. See
+ * docs/react-native-performance.md §6.
  */
 export function AccessoryClimbThumbnail({ climb, boardConfig }: { climb: Climb; boardConfig: BoardConfig | null }) {
   const boardRenderData = useMemo(() => {
@@ -43,25 +52,30 @@ export function AccessoryClimbThumbnail({ climb, boardConfig }: { climb: Climb; 
     });
   }, [boardConfig]);
 
-  if (!boardRenderData) return null;
+  if (!boardRenderData || !boardConfig) return null;
 
-  const thumbnailBoardStyle = {
-    ...getAccessoryThumbnailBoardSize(boardRenderData.boardWidth, boardRenderData.boardHeight),
+  // Fit the board art into the 40×40 slot at its native aspect ratio, then
+  // hand BoardImageNative an explicitly-sized, rounded, clipped box. (Its
+  // default `width: '100%'` would otherwise stretch the art across the slot.)
+  const fittedSize = getAccessoryThumbnailBoardSize(boardRenderData.boardWidth, boardRenderData.boardHeight);
+  const thumbnailBoardStyle: ViewStyle = {
+    width: fittedSize.width,
+    height: fittedSize.height,
     borderRadius: ACCESSORY_THUMBNAIL_ART_RADIUS,
-    overflow: 'hidden' as const,
+    overflow: 'hidden',
   };
 
   return (
     <View style={styles.thumbnailSlot}>
-      <BoardRenderer
+      <BoardImageNative
         frames={climb.frames}
-        boardName={boardConfig?.boardName as BoardName}
+        boardName={boardConfig.boardName as BoardName}
+        layoutId={boardConfig.layoutId}
+        sizeId={boardConfig.sizeId}
+        setIds={boardConfig.setIds}
         boardWidth={boardRenderData.boardWidth}
         boardHeight={boardRenderData.boardHeight}
-        imageUrls={boardRenderData.imageUrls}
-        holdsData={boardRenderData.holdsData}
         mirrored={climb.mirrored === true}
-        fillContainer
         style={thumbnailBoardStyle}
       />
     </View>

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -202,8 +202,13 @@ vi.mock('../../../lib/board-details', () => ({
   }),
 }));
 
-vi.mock('../../board-renderer/BoardRenderer', () => ({
-  BoardRenderer: ({ frames, fillContainer, style }: { frames: string; fillContainer?: boolean; style?: unknown }) => {
+// The accessory thumbnail renders through BoardImageNative (the rasterized
+// native-PNG path) rather than the SVG BoardRenderer. The mock surfaces the
+// fitted box dimensions (width/height from `style`), the rounding/clipping it
+// applies, and the mirror flag so the aspect-fit + mirroring assertions hold
+// without a native renderer.
+vi.mock('../../BoardImageNative', () => ({
+  BoardImageNative: ({ frames, mirrored, style }: { frames: string; mirrored?: boolean; style?: unknown }) => {
     const readStyleValue = (styleKey: string): unknown => {
       const styles = Array.isArray(style) ? style : [style];
       for (const styleEntry of styles) {
@@ -224,7 +229,7 @@ vi.mock('../../board-renderer/BoardRenderer', () => ({
 
     return createElement('div', {
       'data-thumbnail': frames,
-      'data-fill-container': fillContainer ? 'true' : 'false',
+      'data-mirrored': mirrored ? 'true' : 'false',
       'data-board-width': width == null ? '' : String(width),
       'data-board-height': height == null ? '' : String(height),
       'data-board-border-radius': borderRadius == null ? '' : String(borderRadius),
@@ -303,7 +308,7 @@ describe('NativeAccessoryClimbRow', () => {
     expect(container.textContent).toContain("Alvin's Nuts");
     expect(container.textContent).toContain('V6');
     expect(container.querySelector('[data-thumbnail="p1r12"]')).not.toBeNull();
-    expect(container.querySelector('[data-fill-container="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-thumbnail="p1r12"]')?.getAttribute('data-mirrored')).toBe('false');
     expect(container.querySelector('[data-tick-size="44"]')).not.toBeNull();
     expect(container.querySelector('[data-icon-size="24"]')).not.toBeNull();
     expect(container.querySelector('[data-height="48"]')).not.toBeNull();


### PR DESCRIPTION
## What

The always-mounted floating queue bar (`PersistentQueueBar` → `ClimbCapsule`) and the iOS 26 native accessory (`NativeAccessoryClimbRow`) render up to **3** board thumbnails (current + next-peek + prev-peek) through `AccessoryClimbThumbnail`. It was the one warm board-art surface still on the expensive `react-native-svg` path.

`AccessoryClimbThumbnail` previously used `BoardRenderer`, which:
- mounts an `<Svg>` tree (one `<SvgImage>` per board image + one SVG node per lit hold, ~10–30 per climb), and
- fetches the board background as a **remote** `<SvgImage href={WEB_BASE_URL/...}>` with **no cache policy**.

The accessory bar re-renders on every queue swipe, so each swipe re-parsed the frames string, re-painted the SVG hold overlay, and could re-fetch board art that should already be on disk.

## The change

Switch `AccessoryClimbThumbnail` to the **same rasterized native path the list thumbnails already use**: `BoardImageNative` → `useNativeClimbRender` + `LayeredClimbImage`, `cachePolicy="memory-disk"` over bundled `file://` backgrounds. The holds render once into a cached PNG (deduped by cache key across surfaces, warmed from disk on launch via `renderedOverlays` / `warmupRenderedOverlaysOnce`), so a climb already seen in the list or play view is an instant cache hit — zero network, zero per-render SVG work. This also matches the best-practice in `docs/react-native-performance.md` §6 ("warm board-art surfaces use the rasterized native-PNG path, not remote SVG").

**Peeks preserved.** All three thumbnails (current + next + prev) still render during swipe — the goal is to make each thumbnail cheap, not to drop the peeks.

**Visuals equivalent.** Size, aspect-fit into the 40×40 slot (`getAccessoryThumbnailBoardSize`), rounding/clipping (radius 10, `overflow: hidden`), and CSS mirroring (`climb.mirrored`) are all unchanged. A board thumbnail with lit holds, just from a cached PNG instead of an SVG tree + network fetch.

## Did `BoardImageNative` need changes?

**No.** It already merges the caller-provided `style` after its own `width: '100%'` / `aspectRatio` defaults, so passing an explicit numeric `width` + `height` overrides them (React Native ignores `aspectRatio` when both dimensions are set). The fitted box keeps the exact native aspect ratio the SVG path produced.

## Validation

- `vp run typecheck:mobile` — pass
- `vp test --project mobile` — 1184 tests pass (incl. updated `native-accessory-climb-row` + `climb-capsule`)
- `vp fmt --check` on changed files — clean
- `vp lint` — no new findings on changed files (project baseline unchanged)
- `vp run check:mobile-bundle` — iOS + Android OK

## Test changes

`native-accessory-climb-row.test.tsx` mocked `BoardRenderer` and asserted on the SVG path. Its thumbnail mock now targets `BoardImageNative` and asserts the same fitted box dimensions + rounding/clipping, plus the mirror flag. The `fillContainer` assertion (no longer a prop) is replaced with a `mirrored` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)