### PR TITLE
perf(mobile): memoize QueueItemRow + stabilize useQueueDrag controls

### DIFF
--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from 'react';
+import { memo, useState, useMemo, useCallback, useEffect } from 'react';
 import { Pressable, View, StyleSheet } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming, runOnJS } from 'react-native-reanimated';
 import {
@@ -97,7 +97,7 @@ function PositionIndicator({
   );
 }
 
-export function QueueItemRow({
+function QueueItemRowComponent({
   item,
   position,
   board,
@@ -357,6 +357,14 @@ export function QueueItemRow({
     </Animated.View>
   );
 }
+
+// Memoized: the queue list re-renders on every drag start/end, every selection
+// toggle, and unrelated parent updates. Every prop is referentially stable —
+// `board`, the `on*` callbacks, and `drag` (the stable row-facing controls from
+// `useQueueDrag`) — so a shallow compare lets each row skip re-rendering unless
+// its own data changes. The actively-dragged row still reacts via the drag
+// shared values on the UI thread, which sit outside React's render cycle.
+export const QueueItemRow = memo(QueueItemRowComponent);
 
 const styles = StyleSheet.create({
   swipeContainer: {

--- a/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { QueueItemRowBoard } from '../QueueItemRow';
+
+// Count how many times the inner component body actually renders. The body
+// renders `ClimbListItemContent` once per render, so a render counter there is a
+// faithful proxy for "QueueItemRow's body ran". If React.memo is working, an
+// identical-props re-render must NOT bump this counter.
+const renderCounter = vi.hoisted(() => ({ count: 0 }));
+
+vi.mock('react-native', () => {
+  const passthrough =
+    (tag: string) =>
+    ({ children }: { children?: ReactNode }) =>
+      createElement(tag, null, children);
+  return {
+    Platform: { OS: 'ios' },
+    PlatformColor: (name: string) => name,
+    View: passthrough('div'),
+    Pressable: passthrough('button'),
+    StyleSheet: {
+      create: (styles: Record<string, unknown>) => styles,
+      hairlineWidth: 1,
+    },
+  };
+});
+
+vi.mock('react-native-reanimated', () => {
+  const passthrough = ({ children }: { children?: ReactNode }) => createElement('div', null, children);
+  return {
+    default: { View: passthrough, createAnimatedComponent: () => passthrough },
+    createAnimatedComponent: () => passthrough,
+    useAnimatedStyle: (fn: () => unknown) => fn(),
+    useSharedValue: (initial: unknown) => ({ value: initial }),
+    withSpring: (value: unknown) => value,
+    withTiming: (value: unknown) => value,
+    runOnJS:
+      (fn: (...args: unknown[]) => unknown) =>
+      (...args: unknown[]) =>
+        fn(...args),
+  };
+});
+
+vi.mock('react-native-gesture-handler', () => {
+  const makeBuilder = () => {
+    const builder: Record<string, (...args: unknown[]) => unknown> = {};
+    const proxy: typeof builder = new Proxy(builder, { get: () => () => proxy });
+    return proxy;
+  };
+  return {
+    GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+    Gesture: { Pan: () => makeBuilder() },
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { secondaryBackground: '#fff', separator: '#ccc' },
+    brandColors: { primary: '#6D28D9', success: '#0a0', error: '#a00' },
+  }),
+}));
+
+vi.mock('../../lib/haptics', () => ({ hapticSelection: vi.fn(), hapticMedium: vi.fn() }));
+
+vi.mock('../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../Icon', () => ({
+  Icon: () => createElement('span', { 'data-icon': 'true' }),
+}));
+
+vi.mock('../ClimbListItemContent', () => ({
+  ClimbListItemContent: ({ climb }: { climb?: { name?: string } }) => {
+    renderCounter.count += 1;
+    return createElement('span', { 'data-climb-name': climb?.name ?? '' });
+  },
+}));
+
+vi.mock('../ClimbListThumbnail', () => ({ THUMBNAIL_WIDTH: 96 }));
+
+vi.mock('../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12 } }));
+
+vi.mock('../../theme/animations', () => ({ springs: { interactive: {} } }));
+
+vi.mock('../play-drawer/queue-drag-math', () => ({ rowReorderShift: () => 0 }));
+
+import { QueueItemRow } from '../QueueItemRow';
+
+const board: QueueItemRowBoard = {
+  boardName: 'kilter',
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,2',
+  angle: 40,
+};
+
+function makeItem(uuid: string, name: string): ClimbQueueItem {
+  return {
+    uuid,
+    climb: { uuid: `climb-${uuid}`, name } as ClimbQueueItem['climb'],
+    addedBy: null,
+    source: null,
+  } as ClimbQueueItem;
+}
+
+// Stable callbacks — the production callers (QueueSheet / drawer-host) pass
+// useCallback/useMemo-stable handlers, so the memo compare sees equal props.
+const onPress = vi.fn();
+const onRemove = vi.fn();
+const onToggleSelect = vi.fn();
+
+describe('QueueItemRow React.memo', () => {
+  beforeEach(() => {
+    renderCounter.count = 0;
+    vi.clearAllMocks();
+  });
+
+  it('is a memoized component', () => {
+    expect((QueueItemRow as unknown as { $$typeof: symbol }).$$typeof).toBe(Symbol.for('react.memo'));
+  });
+
+  it('skips re-render when given referentially-equal props', () => {
+    const item = makeItem('a', 'Crimp Master');
+    const element = (
+      <QueueItemRow
+        item={item}
+        position={1}
+        board={board}
+        isCurrentClimb={false}
+        onPress={onPress}
+        onRemove={onRemove}
+        onToggleSelect={onToggleSelect}
+      />
+    );
+
+    const { rerender } = render(element);
+    expect(renderCounter.count).toBe(1);
+
+    // Re-render the SAME element (identical props). A working memo skips the body.
+    rerender(element);
+    expect(renderCounter.count).toBe(1);
+  });
+
+  it('re-renders when a prop actually changes (selection toggles)', () => {
+    const item = makeItem('a', 'Crimp Master');
+    const { rerender } = render(
+      <QueueItemRow
+        item={item}
+        position={1}
+        board={board}
+        isCurrentClimb={false}
+        isEditMode
+        isSelected={false}
+        onPress={onPress}
+        onRemove={onRemove}
+        onToggleSelect={onToggleSelect}
+      />,
+    );
+    expect(renderCounter.count).toBe(1);
+
+    rerender(
+      <QueueItemRow
+        item={item}
+        position={1}
+        board={board}
+        isCurrentClimb={false}
+        isEditMode
+        isSelected
+        onPress={onPress}
+        onRemove={onRemove}
+        onToggleSelect={onToggleSelect}
+      />,
+    );
+    expect(renderCounter.count).toBe(2);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -147,7 +147,7 @@ export function QueueList({
     return { firstFutureRowIndex: first, lastFutureRowIndex: last, firstFutureQueueIndex: firstQueue };
   }, [rows]);
 
-  const drag = useQueueDrag({
+  const { isDragging, controls: dragControls } = useQueueDrag({
     reorderQueue,
     firstFutureRowIndex,
     lastFutureRowIndex,
@@ -155,8 +155,8 @@ export function QueueList({
   });
 
   useEffect(() => {
-    onDraggingChange?.(drag.isDragging);
-  }, [drag.isDragging, onDraggingChange]);
+    onDraggingChange?.(isDragging);
+  }, [isDragging, onDraggingChange]);
 
   useEffect(() => {
     if (autoScrollOnMount && currentItemFlatIndex >= 0 && rows.length > 0) {
@@ -278,7 +278,7 @@ export function QueueList({
               onPress={onClimbPress}
               onRemove={onRemove}
               onToggleSelect={onToggleSelect}
-              drag={drag}
+              drag={dragControls}
               rowIndex={index}
               queueIndex={row.queueIndex}
               isDraggable={!isEditMode}
@@ -314,7 +314,7 @@ export function QueueList({
     },
     [
       board,
-      drag,
+      dragControls,
       isEditMode,
       selectedItems,
       onClimbPress,
@@ -348,7 +348,7 @@ export function QueueList({
       renderItem={renderRow}
       contentContainerStyle={styles.listContent}
       showsVerticalScrollIndicator={false}
-      scrollEnabled={!drag.isDragging}
+      scrollEnabled={!isDragging}
       onScrollToIndexFailed={() => {
         // Silently handle if scroll target isn't rendered yet
       }}

--- a/packages/mobile/src/components/play-drawer/__tests__/use-queue-drag.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-queue-drag.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// `useQueueDrag` reaches for reanimated shared values, gesture-handler gestures,
+// and haptics — all UI-thread / native concerns. Stub them so the hook runs in
+// node and we can assert what this perf fix is really about: the returned
+// controls keep a stable identity across re-renders, and `isDragging` is the
+// only thing that flips when a drag starts/ends.
+
+// Mirror reanimated's real contract: useSharedValue returns the SAME mutable
+// ref across re-renders (backed by useRef here). That stable identity is exactly
+// what lets the memoized `shared` bag and `controls` keep a stable identity —
+// the behaviour this perf fix relies on.
+vi.mock('react-native-reanimated', async () => {
+  const { useRef } = await import('react');
+  return {
+    useSharedValue: (initial: unknown) => {
+      const ref = useRef<{ value: unknown } | null>(null);
+      if (ref.current === null) ref.current = { value: initial };
+      return ref.current;
+    },
+    runOnJS:
+      (fn: (...args: unknown[]) => unknown) =>
+      (...args: unknown[]) =>
+        fn(...args),
+  };
+});
+
+// A chainable Gesture.Pan() builder: every method returns the same builder so
+// `.activateAfterLongPress(...).onStart(...).onUpdate(...)` resolves.
+vi.mock('react-native-gesture-handler', () => {
+  const makeBuilder = () => {
+    const builder: Record<string, (...args: unknown[]) => unknown> = {};
+    const proxy: typeof builder = new Proxy(builder, { get: () => () => proxy });
+    return proxy;
+  };
+  return {
+    Gesture: { Pan: () => makeBuilder() },
+  };
+});
+
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+
+import { useQueueDrag } from '../use-queue-drag';
+
+type Options = Parameters<typeof useQueueDrag>[0];
+
+// A single stable reorderQueue ref across re-renders — mirrors the real
+// QueueContext callback, which is referentially stable. (A fresh function each
+// render would churn the internal `commit`/`makeHandleGesture` callbacks, which
+// is a test artifact, not a regression in the hook.)
+const reorderQueue = vi.fn();
+
+function makeOptions(overrides: Partial<Options> = {}): Options {
+  return {
+    reorderQueue,
+    firstFutureRowIndex: 3,
+    lastFutureRowIndex: 6,
+    firstFutureQueueIndex: 3,
+    ...overrides,
+  };
+}
+
+describe('useQueueDrag identity stability', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the result and controls identity stable across unrelated re-renders', () => {
+    const { result, rerender } = renderHook((props: Options) => useQueueDrag(props), {
+      initialProps: makeOptions(),
+    });
+
+    const firstResult = result.current;
+    const firstControls = result.current.controls;
+    const firstShared = result.current.controls.shared;
+    const firstMakeHandle = result.current.controls.makeHandleGesture;
+    const firstOnRowHeight = result.current.controls.onRowHeight;
+
+    // Re-render with identical options (an unrelated parent update).
+    rerender(makeOptions());
+
+    expect(result.current).toBe(firstResult);
+    expect(result.current.controls).toBe(firstControls);
+    expect(result.current.controls.shared).toBe(firstShared);
+    expect(result.current.controls.makeHandleGesture).toBe(firstMakeHandle);
+    expect(result.current.controls.onRowHeight).toBe(firstOnRowHeight);
+  });
+
+  it('keeps the row-facing controls stable when the future window shifts', () => {
+    const { result, rerender } = renderHook((props: Options) => useQueueDrag(props), {
+      initialProps: makeOptions({ firstFutureRowIndex: 3, lastFutureRowIndex: 6, firstFutureQueueIndex: 3 }),
+    });
+
+    const firstControls = result.current.controls;
+
+    // A queue change that moves the future window must not churn the controls
+    // identity (rows would needlessly re-render otherwise).
+    rerender(makeOptions({ firstFutureRowIndex: 4, lastFutureRowIndex: 8, firstFutureQueueIndex: 4 }));
+
+    expect(result.current.controls).toBe(firstControls);
+  });
+
+  it('starts not-dragging and builds a handle gesture without flipping isDragging', () => {
+    const { result } = renderHook((props: Options) => useQueueDrag(props), { initialProps: makeOptions() });
+
+    expect(result.current.isDragging).toBe(false);
+    const controlsBeforeDrag = result.current.controls;
+
+    // Building the gesture for a row must not start a drag or change the
+    // controls identity (the rows hold this object).
+    const gesture = result.current.controls.makeHandleGesture(3, 'climb-a', 3);
+    expect(gesture).toBeDefined();
+    expect(result.current.isDragging).toBe(false);
+    expect(result.current.controls).toBe(controlsBeforeDrag);
+  });
+
+  it('exposes a shared bag with the five drag coordinate values', () => {
+    const { result } = renderHook((props: Options) => useQueueDrag(props), { initialProps: makeOptions() });
+    const { shared } = result.current.controls;
+
+    expect(shared.activeUuid.value).toBeNull();
+    expect(shared.dragTranslateY.value).toBe(0);
+    expect(shared.activeRowIndex.value).toBe(-1);
+    expect(shared.targetRowIndex.value).toBe(-1);
+    expect(typeof shared.rowHeight.value).toBe('number');
+  });
+});

--- a/packages/mobile/src/components/play-drawer/use-queue-drag.ts
+++ b/packages/mobile/src/components/play-drawer/use-queue-drag.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import { useSharedValue, runOnJS, type SharedValue } from 'react-native-reanimated';
 import { hapticSelection } from '../../lib/haptics';
@@ -31,15 +31,27 @@ type UseQueueDragOptions = {
   firstFutureQueueIndex: number;
 };
 
+/**
+ * Row-facing drag controls. Passed down to every future `QueueItemRow`, so its
+ * identity must stay stable across renders — it deliberately excludes the
+ * `isDragging` flag (which flips on drag start/end). Each member is memoized in
+ * `useQueueDrag`, so a memoized row only re-renders when its own props change,
+ * never on drag start/end.
+ */
 export type QueueDragControls = {
-  /** True while a row is lifted — drives the FlatList scroll + sheet-pan lock. */
-  isDragging: boolean;
   /** Shared values read by each row's animated style (lift + sibling shift). */
   shared: QueueDragShared;
   /** Report a future row's measured height (call once from onLayout). */
   onRowHeight: (height: number) => void;
   /** Build the long-press drag Pan for a future row's handle. */
   makeHandleGesture: (rowIndex: number, uuid: string, queueIndex: number) => GestureType;
+};
+
+export type UseQueueDragResult = {
+  /** True while a row is lifted — drives the FlatList scroll + sheet-pan lock. */
+  isDragging: boolean;
+  /** Stable row-facing controls (no `isDragging`); safe to pass into memoized rows. */
+  controls: QueueDragControls;
 };
 
 /**
@@ -58,7 +70,7 @@ export function useQueueDrag({
   firstFutureRowIndex,
   lastFutureRowIndex,
   firstFutureQueueIndex,
-}: UseQueueDragOptions): QueueDragControls {
+}: UseQueueDragOptions): UseQueueDragResult {
   const activeUuid = useSharedValue<string | null>(null);
   const dragTranslateY = useSharedValue(0);
   const activeRowIndex = useSharedValue(-1);
@@ -138,10 +150,27 @@ export function useQueueDrag({
     [activeUuid, activeRowIndex, targetRowIndex, dragTranslateY, rowHeight, firstRowIndexSV, lastRowIndexSV, commit],
   );
 
-  return {
-    isDragging,
-    shared: { activeUuid, dragTranslateY, activeRowIndex, targetRowIndex, rowHeight },
-    onRowHeight,
-    makeHandleGesture,
-  };
+  // The shared-values bag holds stable `SharedValue` refs (reanimated never
+  // swaps them), so memoize it once. A fresh wrapper each render would give
+  // every row a new `drag.shared`, churning `renderRow`'s deps and re-rendering
+  // the whole list on unrelated parent updates.
+  const shared = useMemo<QueueDragShared>(
+    () => ({ activeUuid, dragTranslateY, activeRowIndex, targetRowIndex, rowHeight }),
+    [activeUuid, dragTranslateY, activeRowIndex, targetRowIndex, rowHeight],
+  );
+
+  // Row-facing controls: a permanently stable object (its three members are all
+  // memoized above and never change identity). Passing this — rather than an
+  // object that also carries `isDragging` — into memoized rows means a drag
+  // start/end never re-renders the rows; only the dragged row reacts, via the
+  // shared values on the UI thread.
+  const controls = useMemo<QueueDragControls>(
+    () => ({ shared, onRowHeight, makeHandleGesture }),
+    [shared, onRowHeight, makeHandleGesture],
+  );
+
+  // Keep the result identity stable across unrelated renders; it changes only
+  // when `isDragging` flips, which the host (QueueList) needs for scroll/sheet
+  // locking — but that flip never reaches the rows (they read `controls`).
+  return useMemo<UseQueueDragResult>(() => ({ isDragging, controls }), [isDragging, controls]);
 }


### PR DESCRIPTION
## Problem

The mobile queue sheet re-rendered **every** `QueueItemRow` on unrelated parent updates and on every reorder-drag start/end. Two compounding causes:

1. **`useQueueDrag` returned a fresh object literal each render** — `{ isDragging, shared: {...}, onRowHeight, makeHandleGesture }` — with a fresh `shared` bag too. `isDragging` flips on drag start/end, which re-renders `QueueList`, produces a new `drag` object, and since `drag` is in `renderRow`'s `useCallback` deps, `renderRow` is recreated and **all** rows re-render.
2. **`QueueItemRow` was a plain function component** (no `React.memo`), so it re-rendered whenever `renderRow` churned.

## Fix

- **`useQueueDrag`** now `useMemo`s the inner `shared` bag (keyed on reanimated's stable shared-value refs) and a row-facing `controls` object, and splits the changing `isDragging` flag *out* of `controls`. The hook now returns `{ isDragging, controls }`. `controls` has a permanently stable identity, so passing it into rows never re-renders them on drag start/end.
- **`QueueList`** destructures `{ isDragging, controls }`, passes the stable `controls` as each row's `drag` prop, and depends on `controls` (not the changing result) in `renderRow`. `isDragging` still drives `scrollEnabled` and the `onDraggingChange` effect.
- **`QueueItemRow`** is wrapped in `React.memo`. All its props from `QueueSheet` / `drawer-host-provider` are referentially stable (`useCallback` / `useMemo`), so the default shallow compare lets each row skip re-render unless its own data changes.

The actively-dragged row still reacts via the drag **shared values on the UI thread** (outside React's render cycle), so the lift/scale/sibling-shift animations and haptics are byte-for-byte unchanged. Drag/reorder behaviour is identical.

## Tests

- `use-queue-drag.test.tsx` — asserts the returned result + `controls` + `shared` keep a stable identity across unrelated re-renders and when the future window shifts.
- `queue-item-row-memo.test.tsx` — asserts `QueueItemRow` is a memo and skips re-render on referentially-equal props, but re-renders when a prop (selection) actually changes.

## Validation

- `vp run typecheck:mobile` — pass
- `vp test run --project mobile` — 157 files / 1199 tests pass
- `vp fmt --check` on changed files — clean
- `vp lint` — no findings against changed files
- `vp run check:mobile-bundle` — OK (10.4 MB)

## Risk

Low. No behaviour change to drag/reorder, swipe-to-delete, or animations; the change is identity-stability of objects the rows consume. The one API change is `useQueueDrag`'s return shape (`{ isDragging, controls }` instead of a flat object); its only caller, `QueueList`, is updated in the same PR, and `QueueItemRow`'s `drag` prop now receives the row-facing `controls` (which never carried `isDragging`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)