### PR TITLE
perf(mobile): hoist inline renderItem/onPress closures off memoized list rows

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/setters.tsx
+++ b/packages/mobile/app/(tabs)/climbs/setters.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, Pressable, StyleSheet, TextInput } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useLocalSearchParams, useRouter, useNavigation } from 'expo-router';
@@ -14,6 +14,46 @@ import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
 
 const SEARCH_DEBOUNCE_MS = 250;
+
+type SetterStat = { setterUsername: string; climbCount: number };
+
+/** Stable hairline separator — passed to FlashList by reference so it isn't a
+ *  fresh component type each render (which would remount every separator). The
+ *  separator colour is theme-static, so no per-render props are needed. */
+const SetterSeparator = memo(function SetterSeparator() {
+  return <View style={[styles.separator, { backgroundColor: iosSystemColors.separator }]} />;
+});
+
+type SetterRowProps = {
+  setter: SetterStat;
+  isSelected: boolean;
+  onToggle: (username: string) => void;
+};
+
+/** Memoized row so toggling one setter only re-renders that row, not the whole
+ *  windowed list. Pulls `t` / `brandColors` from hooks rather than props so the
+ *  parent's `renderItem` identity stays stable across selection changes. */
+const SetterRow = memo(function SetterRow({ setter, isSelected, onToggle }: SetterRowProps) {
+  const { t } = useTranslation('climbs');
+  const { brandColors } = useTheme();
+  return (
+    <Pressable
+      onPress={() => onToggle(setter.setterUsername)}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: isSelected }}
+      accessibilityLabel={setter.setterUsername}
+      style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+    >
+      <View style={styles.rowText}>
+        <Text variant="body">{setter.setterUsername}</Text>
+        <Text variant="footnote" style={styles.count}>
+          {t('mobile.search.climbsCount', { count: setter.climbCount })}
+        </Text>
+      </View>
+      {isSelected ? <Icon name="check.small" size={20} color={brandColors.primary} /> : null}
+    </Pressable>
+  );
+});
 
 type Params = {
   boardName?: string;
@@ -45,6 +85,12 @@ export default function SettersPicker() {
   }, [params.selected]);
 
   const [selected, setSelected] = useState<Set<string>>(() => new Set(initialSelected));
+  // Mirror of `selected` so the stable `renderRow` can look up per-row selection
+  // without listing the whole Set as a dep (which would recreate `renderRow` —
+  // and thus re-render every windowed row — on each toggle). FlashList is told to
+  // re-render via `extraData={selected}` instead.
+  const selectedRef = useRef(selected);
+  selectedRef.current = selected;
   const [searchInput, setSearchInput] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -125,27 +171,10 @@ export default function SettersPicker() {
   }, []);
 
   const renderRow = useCallback(
-    ({ item }: { item: { setterUsername: string; climbCount: number } }) => {
-      const isSelected = selected.has(item.setterUsername);
-      return (
-        <Pressable
-          onPress={() => toggle(item.setterUsername)}
-          accessibilityRole="checkbox"
-          accessibilityState={{ checked: isSelected }}
-          accessibilityLabel={item.setterUsername}
-          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
-        >
-          <View style={styles.rowText}>
-            <Text variant="body">{item.setterUsername}</Text>
-            <Text variant="footnote" style={styles.count}>
-              {t('mobile.search.climbsCount', { count: item.climbCount })}
-            </Text>
-          </View>
-          {isSelected ? <Icon name="check.small" size={20} color={brandColors.primary} /> : null}
-        </Pressable>
-      );
-    },
-    [selected, toggle, t, brandColors],
+    ({ item }: { item: SetterStat }) => (
+      <SetterRow setter={item} isSelected={selectedRef.current.has(item.setterUsername)} onToggle={toggle} />
+    ),
+    [toggle],
   );
 
   return (
@@ -184,11 +213,10 @@ export default function SettersPicker() {
       ) : (
         <FlashList
           data={setters ?? []}
+          extraData={selected}
           keyExtractor={(item) => item.setterUsername}
           renderItem={renderRow}
-          ItemSeparatorComponent={() => (
-            <View style={[styles.separator, { backgroundColor: iosSystemColors.separator }]} />
-          )}
+          ItemSeparatorComponent={SetterSeparator}
           contentInsetAdjustmentBehavior="automatic"
           ListEmptyComponent={
             <View style={styles.empty}>

--- a/packages/mobile/app/session/[sessionId].tsx
+++ b/packages/mobile/app/session/[sessionId].tsx
@@ -67,6 +67,22 @@ export default function SessionDetailScreen() {
 
   const handleTickPress = useCallback((tick: SessionDetailTick) => navigateToSessionClimb(router, tick), [router]);
 
+  // Stable per-row factory so the memoized `SessionTickRow`s keep their identity
+  // across re-renders — a fresh inline arrow would force FlashList to re-evaluate
+  // every visible item each pass.
+  const renderItem = useCallback(
+    ({ item }: { item: SessionDetailTick }) => (
+      <SessionTickRow
+        tick={item}
+        isMultiUser={isMultiUser}
+        participant={participantById.get(item.userId)}
+        onPress={handleTickPress}
+        onOpenComments={handleOpenTickComments}
+      />
+    ),
+    [isMultiUser, participantById, handleTickPress, handleOpenTickComments],
+  );
+
   // Header: title + edit overflow for an owned inferred session.
   useEffect(() => {
     navigation.setOptions({
@@ -137,15 +153,7 @@ export default function SessionDetailScreen() {
     <View style={styles.flex}>
       <FlashList
         data={session.ticks}
-        renderItem={({ item }) => (
-          <SessionTickRow
-            tick={item}
-            isMultiUser={isMultiUser}
-            participant={participantById.get(item.userId)}
-            onPress={handleTickPress}
-            onOpenComments={handleOpenTickComments}
-          />
-        )}
+        renderItem={renderItem}
         keyExtractor={(tick) => tick.uuid}
         ListHeaderComponent={header}
         contentContainerStyle={{ paddingBottom }}

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -19,7 +19,7 @@ import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FlashList } from '@shopify/flash-list';
 import { useTranslation } from 'react-i18next';
-import type { BoardName } from '@boardsesh/shared-schema';
+import type { BoardName, Climb as SchemaClimb } from '@boardsesh/shared-schema';
 import type { Climb } from '@boardsesh/queue';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
@@ -156,6 +156,11 @@ export function PlaylistDetailView({
     if (hasNextPage && !isFetchingNextPage) fetchNextPage();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
+  // Stable per-row activate handler so the memoized `ClimbListRow`s aren't handed
+  // a fresh closure each render — every renderItem rebuild (e.g. when the sticky
+  // header `collapsed` flips during scroll) would otherwise re-render every row.
+  const handleActivate = useCallback((tapped: SchemaClimb) => onActivateClimb(toQueueClimb(tapped)), [onActivateClimb]);
+
   const renderItem = useCallback(
     ({ item }: { item: Climb }) => {
       if (!boardConfig) return null;
@@ -167,11 +172,11 @@ export function PlaylistDetailView({
           sizeId={boardConfig.sizeId}
           setIds={boardConfig.setIds}
           angle={boardConfig.angle}
-          onPress={(tapped) => onActivateClimb(toQueueClimb(tapped))}
+          onPress={handleActivate}
         />
       );
     },
-    [boardConfig, onActivateClimb],
+    [boardConfig, handleActivate],
   );
 
   const baseColor = hero.color && isValidHexColor(hero.color) ? hero.color : PLAYLIST_COLORS[0];


### PR DESCRIPTION
## What

Three React Native list surfaces were handing **fresh closures to memoized rows on every render**, defeating the row memoization and forcing FlashList to re-evaluate visible items on unrelated state changes. This hoists those closures to stable identities. No visual or behavioral change.

### 1. `PlaylistDetailView.tsx`
`renderItem` passed `onPress={(tapped) => onActivateClimb(toQueueClimb(tapped))}` — a fresh arrow per row per render. `ClimbListRow` is `React.memo`'d, so this defeated the memo: when the sticky-header `collapsed` flips during scroll (`useAnimatedReaction → setCollapsed`), FlashList re-ran `renderItem` with new closures and every visible row re-rendered. Now a stable `handleActivate = useCallback(...)` is passed instead.

### 2. `climbs/setters.tsx`
- `ItemSeparatorComponent={() => (...)}` was a new component type every render — FlashList unmounts/remounts all separators each render. Replaced with a module-level memoized `SetterSeparator` passed by reference.
- `renderRow`'s `useCallback` depended on the whole `selected` Set, so toggling any setter created a new `renderItem` identity and re-rendered the windowed list. Extracted a `React.memo`'d `SetterRow` that takes an `isSelected` boolean; `renderRow` now closes only over a stable `toggle` and reads per-row selection via a ref. Re-render is driven by `extraData={selected}`, matching the existing `SessionsTab` idiom (`extraData={summaryMap}` + memoized card reading from a map).

### 3. `session/[sessionId].tsx`
`renderItem` was an inline arrow recreated every render, building `SessionTickRow` with `participantById.get(...)` and inline handlers. `SessionTickRow` is memoized but the fresh `renderItem` identity forced FlashList to re-evaluate items each pass. Wrapped `renderItem` in `useCallback([isMultiUser, participantById, handleTickPress, handleOpenTickComments])`, matching the `LogbookTab`/`SessionsTab` pattern.

## Validation

- `vp run typecheck:mobile` — clean
- targeted tests (`playlist-detail-view setters session`) — 612 passed
- `vp fmt --check` on the three files — clean
- `vp lint` — no findings reference the changed files
- `vp run check:mobile-bundle` — OK (10.4 MB)

(The only failing tests in the full suite are pre-existing `|backend|` WebSocket-daemon integration tests — socket-closure infra flakiness, unrelated to these mobile UI changes.)

## Risk

Low. Identity-only refactor; behavior is identical. The one slightly non-obvious piece is the setters selection driven by `extraData` + a ref instead of a Set dep — but this mirrors the already-shipped `SessionsTab` pattern in the same codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)