### PR TITLE
fix(mobile): play-drawer board sometimes never renders until reopen

### DIFF
--- a/packages/mobile/src/components/play-drawer/DeferredBoard.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredBoard.tsx
@@ -1,8 +1,9 @@
-import { memo, useEffect, useState } from 'react';
-import { InteractionManager, View, StyleSheet } from 'react-native';
+import { memo } from 'react';
+import { View, StyleSheet } from 'react-native';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { SwipeBoardCarousel } from './SwipeBoardCarousel';
 import { iosSystemColors } from '../../theme/ios-colors';
+import { useDeferredAfterInteractions } from '../../hooks/use-deferred-after-interactions';
 
 type BoardRenderData = {
   boardWidth: number;
@@ -57,22 +58,12 @@ export const DeferredBoard = memo(function DeferredBoard({
   boardRenderData,
   ...carouselProps
 }: DeferredBoardProps) {
-  const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    if (!open) {
-      setReady(false);
-      return;
-    }
-
-    const handle = InteractionManager.runAfterInteractions(() => {
-      setReady(true);
-    });
-
-    return () => {
-      handle.cancel();
-    };
-  }, [open]);
+  // Gate on the open transition only (no resetKey) so the board stays mounted
+  // across in-drawer swipes once the drawer is open. The hook defers past the
+  // present animation in the common case but falls back to a bounded timeout, so
+  // a starved interaction queue can't leave the board permanently unmounted
+  // (the "blank board until you reopen" bug).
+  const ready = useDeferredAfterInteractions(open);
 
   if (!ready) {
     return (

--- a/packages/mobile/src/components/play-drawer/DeferredSections.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredSections.tsx
@@ -1,5 +1,5 @@
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
-import { InteractionManager, View, StyleSheet } from 'react-native';
+import { memo, useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { Climb } from '@boardsesh/shared-schema';
 import { CollapsibleSection } from '../CollapsibleSection';
@@ -8,6 +8,7 @@ import { SimilarClimbsSection } from './SimilarClimbsSection';
 import { CommunitySection } from './CommunitySection';
 import { BetaVideosSection } from './BetaVideosSection';
 import { spacing } from '../../theme/tokens';
+import { useDeferredAfterInteractions } from '../../hooks/use-deferred-after-interactions';
 
 type DeferredSectionsProps = {
   climb: Climb;
@@ -39,8 +40,11 @@ export const DeferredSections = memo(function DeferredSections({
   onBetaHeaderLayout,
 }: DeferredSectionsProps) {
   const { t } = useTranslation('session');
-  const [readyToRender, setReadyToRender] = useState(false);
-  const previousClimbUuid = useRef(climb.uuid);
+  // Defer the JS-heavy below-fold sections until just after the drawer's open
+  // animation. Re-defers per climb (resetKey = uuid) and — unlike a bare
+  // runAfterInteractions — falls back to a bounded timeout, so a starved
+  // interaction queue can't leave these sections blank until the drawer reopens.
+  const readyToRender = useDeferredAfterInteractions(enabled, climb.uuid);
 
   // Tally shown next to the collapsed Logbook header so the user sees their
   // history without expanding. Mirrors LogbookSection's summary fallback.
@@ -52,32 +56,6 @@ export const DeferredSections = memo(function DeferredSections({
     if (attempts > 0) return t('mobile.logbook.attemptsOnly', { attempts });
     return null;
   }, [climb.userAscents, climb.userAttempts, t]);
-
-  // Both effects key on climb.uuid. React runs effects in declaration order
-  // within the same commit, so the reset below always fires before the
-  // InteractionManager re-schedule — readyToRender goes false, then the
-  // deferred callback sets it back to true after animations settle.
-  useEffect(() => {
-    if (climb.uuid !== previousClimbUuid.current) {
-      previousClimbUuid.current = climb.uuid;
-      setReadyToRender(false);
-    }
-  }, [climb.uuid]);
-
-  useEffect(() => {
-    if (!enabled) {
-      setReadyToRender(false);
-      return;
-    }
-
-    const handle = InteractionManager.runAfterInteractions(() => {
-      setReadyToRender(true);
-    });
-
-    return () => {
-      handle.cancel();
-    };
-  }, [enabled, climb.uuid]);
 
   if (!enabled) {
     return null;

--- a/packages/mobile/src/hooks/__tests__/use-deferred-after-interactions.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-deferred-after-interactions.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Controllable InteractionManager: the test decides whether (and when) a
+// scheduled callback ever runs, so it can simulate a STARVED interaction queue
+// (the production stall this hook guards against).
+const { scheduled, runAfterInteractions } = vi.hoisted(() => {
+  const scheduled: Array<() => void> = [];
+  return {
+    scheduled,
+    runAfterInteractions: vi.fn((callback: () => void) => {
+      scheduled.push(callback);
+      return { cancel: vi.fn() };
+    }),
+  };
+});
+
+vi.mock('react-native', () => ({ InteractionManager: { runAfterInteractions } }));
+
+import { useDeferredAfterInteractions } from '../use-deferred-after-interactions';
+
+function flushInteractions() {
+  for (const callback of scheduled.splice(0)) callback();
+}
+
+describe('useDeferredAfterInteractions', () => {
+  beforeEach(() => {
+    scheduled.length = 0;
+    runAfterInteractions.mockClear();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns false until interactions settle, then true', () => {
+    const { result } = renderHook(() => useDeferredAfterInteractions(true));
+    expect(result.current).toBe(false);
+    act(() => flushInteractions());
+    expect(result.current).toBe(true);
+  });
+
+  it('falls back to true after the timeout if runAfterInteractions never fires (the stall bug)', () => {
+    const { result } = renderHook(() => useDeferredAfterInteractions(true, undefined, 350));
+    expect(result.current).toBe(false);
+    // Never flush the interaction queue — simulate a starved queue.
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('stays false while inactive', () => {
+    const { result } = renderHook(() => useDeferredAfterInteractions(false));
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('re-defers when resetKey changes', () => {
+    const { result, rerender } = renderHook(({ key }) => useDeferredAfterInteractions(true, key), {
+      initialProps: { key: 'a' },
+    });
+    act(() => flushInteractions());
+    expect(result.current).toBe(true);
+
+    rerender({ key: 'b' });
+    expect(result.current).toBe(false);
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('only applies once when both the interaction callback and the timeout fire', () => {
+    const { result } = renderHook(() => useDeferredAfterInteractions(true, undefined, 350));
+    act(() => {
+      flushInteractions();
+      vi.advanceTimersByTime(350);
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/packages/mobile/src/hooks/use-deferred-after-interactions.ts
+++ b/packages/mobile/src/hooks/use-deferred-after-interactions.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { InteractionManager } from 'react-native';
+
+/**
+ * Defer mounting heavy content until just after an open/transition animation,
+ * WITHOUT the risk that a starved interaction queue leaves it permanently
+ * unmounted.
+ *
+ * Returns `false` until the JS interaction queue settles after `active` becomes
+ * true (so the heavy content mounts AFTER the animation rather than blocking its
+ * first frame), then `true`. Crucially it ALSO flips `true` after `timeoutMs` as
+ * a safety net: `InteractionManager.runAfterInteractions` can be starved
+ * indefinitely if any interaction handle (e.g. a bottom-sheet present animation,
+ * or a leaked handle anywhere in the app) never clears — which would otherwise
+ * leave the deferred content blank until the surface is reopened. The timeout
+ * guarantees the content mounts within a bounded time regardless.
+ *
+ * Resets to `false` whenever `active` goes false or `resetKey` changes, so the
+ * next transition re-defers. Omit `resetKey` to stay ready across in-place
+ * content changes (e.g. the play-drawer board, which should render immediately
+ * when you swipe to the next climb once the drawer is already open).
+ */
+export function useDeferredAfterInteractions(active: boolean, resetKey?: string | number, timeoutMs = 350): boolean {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!active) {
+      setReady(false);
+      return;
+    }
+
+    // Re-defer from scratch on each (re)activation / resetKey change.
+    setReady(false);
+
+    let settled = false;
+    const markReady = () => {
+      if (settled) return;
+      settled = true;
+      setReady(true);
+    };
+
+    const handle = InteractionManager.runAfterInteractions(markReady);
+    const fallback = setTimeout(markReady, timeoutMs);
+
+    return () => {
+      handle.cancel();
+      clearTimeout(fallback);
+    };
+  }, [active, resetKey, timeoutMs]);
+
+  return ready;
+}


### PR DESCRIPTION
## The bug (TestFlight build 156)
Sometimes the board inside the play drawer doesn't render — it stays blank — and **closing the drawer and reopening it (e.g. via the accessory) makes it render**.

## Root cause — a regression from #2603
#2603 deferred the above-fold `SwipeBoardCarousel` mount until `InteractionManager.runAfterInteractions` fired, so the sheet could animate open before the heavy board rendered. But `runAfterInteractions` can be **starved indefinitely**: if any interaction handle never clears (the bottom-sheet present animation, an in-flight gesture, or a leaked handle anywhere in the app), its queued callbacks never run. When that happened, `DeferredBoard`'s `ready` flag stayed `false` → only the placeholder showed. Reopening scheduled a fresh callback, which is why the second open rendered.

`DeferredSections` (below-fold) shared the identical latent stall.

## The fix
Extract **`useDeferredAfterInteractions(active, resetKey?, timeoutMs = 350)`**:
- Still defers past the present animation via `runAfterInteractions` in the common case (no mid-animation jank).
- **Also** flips `ready` after a bounded timeout as a safety net, so a starved interaction queue can no longer leave the content permanently unmounted.
- The two fire-once paths are guarded so only the first applies.

Wired into both `DeferredBoard` (gated on the open transition — no `resetKey`, board stays mounted across in-drawer swipes) and `DeferredSections` (`resetKey = climb.uuid`, re-defers per climb — replaces its two effects + reset ref).

## Validation
- New hook test proves the board mounts via the **timeout fallback even when the interaction queue never settles** (the exact stall).
- Existing `deferred-board` behavior tests pass **unchanged** (placeholder→board, no swipe flash, reset on close, etc.).
- `vp run typecheck:mobile`, full mobile suite (1197 tests), play-drawer suite (85), `vp check`/lint clean, `vp run check:mobile-bundle` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)