### PR TITLE
ci(mobile): inject EXPO_PUBLIC_POSTHOG_KEY so the RN app actually emits analytics

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -49,6 +49,12 @@ jobs:
       # on this var). Same DSN/project as web + backend; not secret — already
       # hardcoded in packages/web and packages/backend source.
       EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
+      # PostHog product analytics. Intentionally the SAME project token as web
+      # (vars.NEXT_PUBLIC_POSTHOG_KEY) so a signed-in user's web + mobile activity
+      # resolves to one person. EXPO_PUBLIC_* vars are inlined into the JS bundle at
+      # build time; without this, analytics.ts sees no key and isAnalyticsEnabled is
+      # false, so every track() silently no-ops (the app shipped zero events before).
+      EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
 
     steps:
       - name: Checkout repository
@@ -91,6 +97,7 @@ jobs:
           EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
           EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
           EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
+          EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
           EOF
 
       # @sentry/react-native's Gradle upload task currently calls an API that is

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -48,6 +48,12 @@ jobs:
       # on this var). Same DSN/project as web + backend; not secret — already
       # hardcoded in packages/web and packages/backend source.
       EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
+      # PostHog product analytics. Intentionally the SAME project token as web
+      # (vars.NEXT_PUBLIC_POSTHOG_KEY) so a signed-in user's web + mobile activity
+      # resolves to one person. EXPO_PUBLIC_* vars are inlined into the JS bundle at
+      # build time; without this, analytics.ts sees no key and isAnalyticsEnabled is
+      # false, so every track() silently no-ops (the app shipped zero events before).
+      EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
 
     steps:
       - name: Checkout repository
@@ -66,6 +72,7 @@ jobs:
           EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
           EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
           EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
+          EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
           EOF
 
       - name: Expo prebuild (generate ios/)

--- a/.github/workflows/mobile-eas-update.yml
+++ b/.github/workflows/mobile-eas-update.yml
@@ -38,6 +38,16 @@ jobs:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       INPUT_BRANCH: ${{ github.event.inputs.branch }}
       INPUT_PLATFORM: ${{ github.event.inputs.platform || 'all' }}
+      # Build-time env inlined into the OTA JS bundle, matching the native build
+      # workflows (ios-testflight-rn.yml / android-apk-rn.yml). Without these, an OTA
+      # update ships a bundle that re-resolves EXPO_PUBLIC_* to its in-code fallbacks
+      # (and undefined for keys that have none) — which is why preview channels never
+      # produced PostHog analytics or Sentry events.
+      EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
+      EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
+      EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
+      EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
+      EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
 
     steps:
       - name: Checkout repository
@@ -57,6 +67,17 @@ jobs:
             sanitized=$(printf '%s' "$GITHUB_REF_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g')
           fi
           echo "name=$sanitized" >> "$GITHUB_OUTPUT"
+
+      - name: Write .env for Expo build-time inlining
+        working-directory: packages/mobile
+        run: |
+          cat > .env <<EOF
+          EXPO_PUBLIC_BACKEND_URL=$EXPO_PUBLIC_BACKEND_URL
+          EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
+          EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
+          EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
+          EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
+          EOF
 
       - name: Publish EAS Update
         working-directory: packages/mobile


### PR DESCRIPTION
## Why

The React Native app has emitted **zero** PostHog events — ever — despite the key being "added" in code. Audit (PostHog project 412845, last 90d): no `posthog-react-native` events at all, while the Capacitor webview app (`$lib=js`, iOS+Android ≈ **91%** of all client users) keeps reporting.

Root cause: `EXPO_PUBLIC_POSTHOG_KEY` is **never injected at build time**. The native build workflows set `EXPO_PUBLIC_BACKEND_URL/WS_URL/WEB_URL/SENTRY_DSN` but not the PostHog key; `eas.json` has no `env`; the OTA workflow sets none of the `EXPO_PUBLIC_*` vars. So `process.env.EXPO_PUBLIC_POSTHOG_KEY` inlines as `undefined`, `isAnalyticsEnabled = !!apiKey && !__DEV__` is `false`, the client is `null`, and every `track()` no-ops. Same class of bug as the web Vercel blackout.

## What

- Inject `EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}` into the `env:` block **and** the `.env` heredoc of `ios-testflight-rn.yml` and `android-apk-rn.yml`.
- `mobile-eas-update.yml` (OTA previews) set **none** of the `EXPO_PUBLIC_*` build vars, so its bundles dropped Sentry + backend config to in-code fallbacks. Mirror the full native-build env block + add a `.env` write so preview channels carry the same config (and now emit analytics).

Reuses the existing `vars.NEXT_PUBLIC_POSTHOG_KEY` repo variable (already used by `production-deploy.yml`) — **no new secret/variable to configure**. It's intentionally the same project token as web so a signed-in user resolves to one person across platforms; mobile talks to PostHog cloud directly (host defaults to `us.i.posthog.com` in `analytics.ts`, no proxy), so only the key is needed.

## Verify

After the next TestFlight/preview build, open the app and query:
\`\`\`sql
SELECT event, count() FROM events
WHERE properties.$lib = 'posthog-react-native' AND timestamp > now() - INTERVAL 1 DAY
GROUP BY event
\`\`\`
Expect `$screen`, `Application opened`, and manual events (e.g. `Climb Added to Queue`) to appear. Post-fix, RN vs Capacitor usage splits cleanly by `$lib` (`posthog-react-native` vs `js`).

## Follow-up (not in this PR)
`vp run mobile:preview-build` uses EAS Build (cloud), which reads env from `eas.json` build profiles rather than these workflows. If that path is used for release artifacts, add the key as an EAS env var too. The GitHub Actions native builds (the actual store vehicle) are fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)