### PR TITLE
Tighten QueueItemRow memoization and drag-controls contract

### DIFF
--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -333,10 +333,7 @@ function QueueItemRowComponent({
   );
 
   return (
-    <Animated.View
-      style={[containerAnimatedStyle, dragAnimatedStyle]}
-      onLayout={handleRowLayout}
-    >
+    <Animated.View style={[containerAnimatedStyle, dragAnimatedStyle]} onLayout={handleRowLayout}>
       <View style={styles.swipeContainer}>
         {/* Delete action behind the row */}
         {swipeEnabled && (

--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useMemo, useCallback, useEffect } from 'react';
-import { Pressable, View, StyleSheet } from 'react-native';
+import { Pressable, View, StyleSheet, type LayoutChangeEvent } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming, runOnJS } from 'react-native-reanimated';
 import {
   Gesture,
@@ -227,7 +227,7 @@ function QueueItemRowComponent({
     overflow: 'hidden' as const,
   }));
 
-  const handlePress = () => {
+  const handlePress = useCallback(() => {
     if (isEditMode) {
       hapticSelection();
       onToggleSelect?.(item.uuid);
@@ -242,25 +242,28 @@ function QueueItemRowComponent({
     }
     hapticSelection();
     onPress(item);
-  };
+  }, [isEditMode, isOpen, onToggleSelect, onPress, item, translateX, isSwipeOpen]);
 
-  const handleDeletePress = () => {
+  const handleDeletePress = useCallback(() => {
     // Animate the row out
     translateX.value = withTiming(-400, { duration: 200 });
     rowOpacity.value = withTiming(0, { duration: 200 });
     rowHeight.value = withTiming(0, { duration: 200 }, () => {
       runOnJS(handleRemove)();
     });
-  };
+  }, [translateX, rowOpacity, rowHeight, handleRemove]);
 
   const handleTickPress = useCallback(() => {
     hapticSelection();
     onTickHistory?.(item);
   }, [onTickHistory, item]);
 
+  // Take the layout event directly so the same stable function can be passed to
+  // `onLayout` — an inline `(event) => ...` wrapper would be a fresh arrow each
+  // render, defeating the row's memoization on the wrapping `Animated.View`.
   const handleRowLayout = useCallback(
-    (height: number) => {
-      if (isDraggable) drag?.onRowHeight(height);
+    (event: LayoutChangeEvent) => {
+      if (isDraggable) drag?.onRowHeight(event.nativeEvent.layout.height);
     },
     [isDraggable, drag],
   );
@@ -332,7 +335,7 @@ function QueueItemRowComponent({
   return (
     <Animated.View
       style={[containerAnimatedStyle, dragAnimatedStyle]}
-      onLayout={(event) => handleRowLayout(event.nativeEvent.layout.height)}
+      onLayout={handleRowLayout}
     >
       <View style={styles.swipeContainer}>
         {/* Delete action behind the row */}

--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useMemo, useCallback, useEffect } from 'react';
+import { memo, useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { Pressable, View, StyleSheet, type LayoutChangeEvent } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming, runOnJS } from 'react-native-reanimated';
 import {
@@ -122,6 +122,14 @@ function QueueItemRowComponent({
   const isSwipeOpen = useSharedValue(false);
   const [isOpen, setIsOpen] = useState(false);
 
+  // The queue reducer rebuilds the array (and each item object) on every update,
+  // so `item` arrives with a fresh reference even when this row's data hasn't
+  // changed. Read the live item through a ref and key the press callbacks on the
+  // stable `item.uuid` — otherwise every queue update hands `AnimatedPressable` a
+  // new `onPress`/`onTickHistory` and forces a re-render despite the memo.
+  const itemRef = useRef(item);
+  itemRef.current = item;
+
   // Disable swipe-to-delete for edit mode and history items.
   const swipeEnabled = !isEditMode && !isHistoryItem;
 
@@ -132,7 +140,7 @@ function QueueItemRowComponent({
       isSwipeOpen.value = false;
       runOnJS(setIsOpen)(false);
     }
-  }, [swipeEnabled]);
+  }, [swipeEnabled, translateX, isSwipeOpen]);
 
   const handleRemove = useCallback(() => {
     hapticMedium();
@@ -230,7 +238,7 @@ function QueueItemRowComponent({
   const handlePress = useCallback(() => {
     if (isEditMode) {
       hapticSelection();
-      onToggleSelect?.(item.uuid);
+      onToggleSelect?.(itemRef.current.uuid);
       return;
     }
     if (isOpen) {
@@ -241,8 +249,8 @@ function QueueItemRowComponent({
       return;
     }
     hapticSelection();
-    onPress(item);
-  }, [isEditMode, isOpen, onToggleSelect, onPress, item, translateX, isSwipeOpen]);
+    onPress(itemRef.current);
+  }, [isEditMode, isOpen, onToggleSelect, onPress, translateX, isSwipeOpen]);
 
   const handleDeletePress = useCallback(() => {
     // Animate the row out
@@ -255,8 +263,8 @@ function QueueItemRowComponent({
 
   const handleTickPress = useCallback(() => {
     hapticSelection();
-    onTickHistory?.(item);
-  }, [onTickHistory, item]);
+    onTickHistory?.(itemRef.current);
+  }, [onTickHistory]);
 
   // Take the layout event directly so the same stable function can be passed to
   // `onLayout` — an inline `(event) => ...` wrapper would be a fresh arrow each

--- a/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
@@ -123,10 +123,6 @@ describe('QueueItemRow React.memo', () => {
     vi.clearAllMocks();
   });
 
-  it('is a memoized component', () => {
-    expect((QueueItemRow as unknown as { $$typeof: symbol }).$$typeof).toBe(Symbol.for('react.memo'));
-  });
-
   it('skips re-render when given referentially-equal props', () => {
     const item = makeItem('a', 'Crimp Master');
     const element = (

--- a/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
-import { createElement, type ReactNode } from 'react';
+import { createElement, useRef, type ReactNode } from 'react';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import type { QueueItemRowBoard } from '../QueueItemRow';
 
@@ -10,6 +10,13 @@ import type { QueueItemRowBoard } from '../QueueItemRow';
 // faithful proxy for "QueueItemRow's body ran". If React.memo is working, an
 // identical-props re-render must NOT bump this counter.
 const renderCounter = vi.hoisted(() => ({ count: 0 }));
+
+// Capture the latest `onPress` handed to the row's main pressable and trailing
+// tick button, so a test can assert they keep their identity across re-renders.
+const captured = vi.hoisted(() => ({
+  rowPress: null as null | (() => void),
+  tickPress: null as null | (() => void),
+}));
 
 vi.mock('react-native', () => {
   const passthrough =
@@ -20,7 +27,12 @@ vi.mock('react-native', () => {
     Platform: { OS: 'ios' },
     PlatformColor: (name: string) => name,
     View: passthrough('div'),
-    Pressable: passthrough('button'),
+    // History rows render exactly one Pressable (the tick button), so capturing
+    // its onPress here gives us `handleTickPress`.
+    Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) => {
+      if (onPress) captured.tickPress = onPress;
+      return createElement('button', null, children);
+    },
     StyleSheet: {
       create: (styles: Record<string, unknown>) => styles,
       hairlineWidth: 1,
@@ -30,11 +42,23 @@ vi.mock('react-native', () => {
 
 vi.mock('react-native-reanimated', () => {
   const passthrough = ({ children }: { children?: ReactNode }) => createElement('div', null, children);
+  // The row's `AnimatedPressable` is the only animated component, so capturing
+  // its onPress gives us `handlePress`.
+  const animatedPressable = ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) => {
+    if (onPress) captured.rowPress = onPress;
+    return createElement('div', null, children);
+  };
   return {
-    default: { View: passthrough, createAnimatedComponent: () => passthrough },
-    createAnimatedComponent: () => passthrough,
+    default: { View: passthrough, createAnimatedComponent: () => animatedPressable },
+    createAnimatedComponent: () => animatedPressable,
     useAnimatedStyle: (fn: () => unknown) => fn(),
-    useSharedValue: (initial: unknown) => ({ value: initial }),
+    // Real reanimated returns a stable ref across renders; mirror that so the
+    // callback-stability test reflects production behaviour (a fresh object each
+    // render would churn every callback that reads a shared value).
+    useSharedValue: (initial: unknown) => {
+      const ref = useRef({ value: initial });
+      return ref.current;
+    },
     withSpring: (value: unknown) => value,
     withTiming: (value: unknown) => value,
     runOnJS:
@@ -120,6 +144,8 @@ const onToggleSelect = vi.fn();
 describe('QueueItemRow React.memo', () => {
   beforeEach(() => {
     renderCounter.count = 0;
+    captured.rowPress = null;
+    captured.tickPress = null;
     vi.clearAllMocks();
   });
 
@@ -176,5 +202,38 @@ describe('QueueItemRow React.memo', () => {
       />,
     );
     expect(renderCounter.count).toBe(2);
+  });
+
+  it('keeps press callbacks stable when item identity changes but its data is equal', () => {
+    const onTickHistory = vi.fn();
+    const rowProps = {
+      position: 1,
+      board,
+      isCurrentClimb: false,
+      isHistoryItem: true,
+      onPress,
+      onRemove,
+      onToggleSelect,
+      onTickHistory,
+    };
+
+    const first = makeItem('a', 'Crimp Master');
+    const { rerender } = render(<QueueItemRow item={first} {...rowProps} />);
+
+    const rowPress = captured.rowPress;
+    const tickPress = captured.tickPress;
+    expect(rowPress).toBeTypeOf('function');
+    expect(tickPress).toBeTypeOf('function');
+
+    // A fresh item object with the same uuid + data — exactly what the queue
+    // reducer produces when it rebuilds the array on an unrelated update. The
+    // callbacks must keep their identity (they read the live item via a ref and
+    // dep only on `item.uuid`), or the row's pressables churn and defeat memo.
+    const second = makeItem('a', 'Crimp Master');
+    expect(second).not.toBe(first);
+    rerender(<QueueItemRow item={second} {...rowProps} />);
+
+    expect(captured.rowPress).toBe(rowPress);
+    expect(captured.tickPress).toBe(tickPress);
   });
 });

--- a/packages/mobile/src/components/play-drawer/use-queue-drag.ts
+++ b/packages/mobile/src/components/play-drawer/use-queue-drag.ts
@@ -22,7 +22,15 @@ export type QueueDragShared = {
 };
 
 type UseQueueDragOptions = {
-  /** Optimistically reorder + broadcast (queue-array indices). */
+  /**
+   * Optimistically reorder + broadcast (queue-array indices).
+   *
+   * MUST be referentially stable across the caller's renders (wrap in
+   * `useCallback`). `controls` is memoized below, but `commit` →
+   * `makeHandleGesture` → `controls` all depend on this identity, so a fresh
+   * `reorderQueue` each render silently churns `controls` and re-renders every
+   * memoized row — exactly the cost this hook exists to avoid.
+   */
   reorderQueue: (uuid: string, oldIndex: number, newIndex: number) => void;
   /** flatRows index of the first/last contiguous `future-item` row (-1 when none). */
   firstFutureRowIndex: number;


### PR DESCRIPTION
Follow-up review fixes on the queue-item memoization work.

## Changes

- **`handlePress` / `handleDeletePress` memoized** (`QueueItemRow.tsx`) — both were plain arrows recreated each render, unlike `handleTickPress`. Wrapped in `useCallback` so the handlers passed into the trailing/swipe `Pressable`s stay referentially stable.
- **`onLayout` no longer an inline arrow** — `handleRowLayout` now takes the `LayoutChangeEvent` directly so `onLayout={handleRowLayout}` passes a stable function instead of a fresh `(event) => ...` wrapper each render, which was defeating the row memo on the wrapping `Animated.View`.
- **Documented the `reorderQueue` stability contract** (`use-queue-drag.ts`) — `controls` is `useMemo`'d, but its identity flows from `reorderQueue` via `commit` → `makeHandleGesture`. A fresh `reorderQueue` each render silently churns `controls` and re-renders every memoized row. Added a warning on the option. The production caller (`queue-provider.tsx`) already wraps it in `useCallback`.
- **Dropped the `Symbol.for('react.memo')` `$$typeof` assertion** (`queue-item-row-memo.test.tsx`) — a React internal; the render-count tests already prove the memo skips equal-prop re-renders.

## Validation

Dependency install was still resolving in this environment when the changes landed; `vp run typecheck:mobile` / `vp test --project mobile` to be confirmed once deps are available. Changes are isolated memoization/comment/test edits with no behavioral change.

https://claude.ai/code/session_01F6nmr9GuHej1BQczAAaKht

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6nmr9GuHej1BQczAAaKht)_