### PR TITLE
Add language selector to mobile settings

### DIFF
--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -3,7 +3,10 @@ import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { GradeDisplayFormat } from '@boardsesh/play-view';
 import type { ThemeOverride, UiVariantPreference } from '@boardsesh/key-value-storage';
+import { SUPPORTED_LOCALES, LOCALE_LABELS } from '@boardsesh/i18n';
 import { useTheme } from '../../../src/providers/theme-provider';
+import { useLocalePreference } from '../../../src/providers/i18n-provider';
+import type { LocaleOverride } from '../../../src/lib/i18n/locale-preference';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useProfile } from '../../../src/lib/graphql/hooks';
 import { spacing } from '../../../src/theme/tokens';
@@ -34,6 +37,15 @@ export default function MoreScreen() {
   const { data: profile } = useProfile();
   const { gradeFormat, setGradeFormat } = useGradeFormat();
   const glassCapable = useGlassCapability();
+  const { localePreference, setLocalePreference } = useLocalePreference();
+
+  // 'System' follows the device language; the rest are the supported locales,
+  // labelled in their own script (English / Español / Français) from
+  // LOCALE_LABELS — language names are intentionally not translated.
+  const languageOptions: { key: LocaleOverride; label: string }[] = [
+    { key: 'system', label: t('mobile.more.language.system') },
+    ...SUPPORTED_LOCALES.map((locale) => ({ key: locale, label: LOCALE_LABELS[locale] })),
+  ];
 
   const appearanceOptions: { key: ThemeOverride; label: string }[] = [
     { key: 'system', label: t('mobile.more.appearance.system') },
@@ -160,6 +172,37 @@ export default function MoreScreen() {
         </View>
       </View>
 
+      <View style={styles.section}>
+        <SectionHeader title={t('mobile.more.language.title')} />
+        <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: systemColors.secondaryBackground,
+              borderRadius: borderRadius.lg,
+              marginHorizontal: spacing[4],
+            },
+          ]}
+        >
+          {languageOptions.map((option, index) => (
+            <ListRow
+              key={option.key}
+              title={option.label}
+              trailing={
+                localePreference === option.key ? (
+                  <Icon name="check.small" size={20} color={systemColors.accent} />
+                ) : undefined
+              }
+              showSeparator={index < languageOptions.length - 1}
+              onPress={() => setLocalePreference(option.key)}
+            />
+          ))}
+        </View>
+        <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.languageHint}>
+          {t('mobile.more.language.description')}
+        </Text>
+      </View>
+
       {__DEV__ ? (
         <View style={styles.section}>
           <SectionHeader title={t('mobile.more.development')} />
@@ -238,6 +281,10 @@ const styles = StyleSheet.create({
   },
   settingHint: {
     marginTop: spacing[2],
+  },
+  languageHint: {
+    marginTop: spacing[2],
+    paddingHorizontal: spacing[4],
   },
   accountEmail: {
     paddingHorizontal: spacing[4],

--- a/packages/mobile/src/lib/i18n/__tests__/locale-preference.test.ts
+++ b/packages/mobile/src/lib/i18n/__tests__/locale-preference.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// detectDeviceLocale (reached via resolveLanguage and i18n init at import) reads
+// the device locales through expo-localization. Pin it to a French device so the
+// 'system' case has a deterministic, non-default result to assert against.
+vi.mock('expo-localization', () => ({
+  getLocales: () => [{ languageTag: 'fr-FR', languageCode: 'fr' }],
+}));
+
+// locale-preference pulls in the secure-store adapter transitively; stub the
+// native module so importing it doesn't touch a real keychain.
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn(async () => null),
+  setItemAsync: vi.fn(async () => undefined),
+  deleteItemAsync: vi.fn(async () => undefined),
+}));
+
+import { isLocaleOverride, resolveLanguage } from '../locale-preference';
+
+describe('isLocaleOverride', () => {
+  it('accepts "system" and every supported locale', () => {
+    expect(isLocaleOverride('system')).toBe(true);
+    expect(isLocaleOverride('en-US')).toBe(true);
+    expect(isLocaleOverride('es')).toBe(true);
+    expect(isLocaleOverride('fr')).toBe(true);
+  });
+
+  it('rejects unknown locales and non-string junk', () => {
+    expect(isLocaleOverride('de')).toBe(false);
+    expect(isLocaleOverride('')).toBe(false);
+    expect(isLocaleOverride(null)).toBe(false);
+    expect(isLocaleOverride(undefined)).toBe(false);
+    expect(isLocaleOverride(42)).toBe(false);
+  });
+});
+
+describe('resolveLanguage', () => {
+  it('resolves "system" to the detected device locale', () => {
+    expect(resolveLanguage('system')).toBe('fr');
+  });
+
+  it('passes an explicit locale through unchanged', () => {
+    expect(resolveLanguage('es')).toBe('es');
+    expect(resolveLanguage('en-US')).toBe('en-US');
+  });
+});

--- a/packages/mobile/src/lib/i18n/config.ts
+++ b/packages/mobile/src/lib/i18n/config.ts
@@ -108,8 +108,11 @@ const resources = {
 /**
  * Detect the best matching locale from the device settings.
  * Falls back to en-US if no supported locale matches.
+ *
+ * Exported so the locale-preference layer can resolve the `'system'` choice
+ * to a concrete language without duplicating the matching logic.
  */
-function detectDeviceLocale(): Locale {
+export function detectDeviceLocale(): Locale {
   const deviceLocales = getLocales();
 
   for (const deviceLocale of deviceLocales) {

--- a/packages/mobile/src/lib/i18n/locale-preference.ts
+++ b/packages/mobile/src/lib/i18n/locale-preference.ts
@@ -1,0 +1,41 @@
+// User's explicit language choice, layered on top of the device locale that
+// `detectDeviceLocale()` picks at launch. `'system'` (or absent) means follow
+// the device; a concrete locale forces that language. Persisted via SecureStore
+// so the pick survives a cold start — without it, the app re-detects from the
+// device every launch and any override is lost.
+//
+// Mobile-only on purpose: the web app carries locale in the URL prefix + a
+// cookie (a different shape), so this does NOT live in
+// `@boardsesh/key-value-storage`. The storage key uses only [\w.-] to satisfy
+// expo-secure-store's validator (`:` and other punctuation throw at the
+// platform boundary), matching THEME_OVERRIDE_KEY's constraint.
+
+import { SUPPORTED_LOCALES, type Locale } from '@boardsesh/i18n';
+import { secureStorePreferences } from '../preferences/secure-store-adapter';
+import { detectDeviceLocale } from './config';
+
+export const LOCALE_OVERRIDE_KEY = 'locale_override';
+
+export type LocaleOverride = 'system' | Locale;
+
+export function isLocaleOverride(value: unknown): value is LocaleOverride {
+  return value === 'system' || (typeof value === 'string' && (SUPPORTED_LOCALES as readonly string[]).includes(value));
+}
+
+/**
+ * Resolve an override to the concrete language i18next should run in.
+ * `'system'` follows the device; an explicit locale passes through.
+ */
+export function resolveLanguage(override: LocaleOverride): Locale {
+  return override === 'system' ? detectDeviceLocale() : override;
+}
+
+/** Read the persisted override, defaulting to `'system'` when absent/malformed. */
+export async function getStoredLocaleOverride(): Promise<LocaleOverride> {
+  const stored = await secureStorePreferences.get<LocaleOverride>(LOCALE_OVERRIDE_KEY);
+  return isLocaleOverride(stored) ? stored : 'system';
+}
+
+export async function setStoredLocaleOverride(override: LocaleOverride): Promise<void> {
+  await secureStorePreferences.set(LOCALE_OVERRIDE_KEY, override);
+}

--- a/packages/mobile/src/providers/i18n-provider.tsx
+++ b/packages/mobile/src/providers/i18n-provider.tsx
@@ -1,30 +1,91 @@
-import { type ReactNode, useState, useEffect } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '../lib/i18n/config';
+import {
+  getStoredLocaleOverride,
+  resolveLanguage,
+  setStoredLocaleOverride,
+  type LocaleOverride,
+} from '../lib/i18n/locale-preference';
+
+type LocalePreference = {
+  /** The user's raw stored choice, including `'system'`. Drives the settings UI. */
+  localePreference: LocaleOverride;
+  /** Persist a new choice and switch i18next to the resolved language. */
+  setLocalePreference: (next: LocaleOverride) => void;
+};
+
+const LocaleContext = createContext<LocalePreference | null>(null);
 
 type I18nProviderProps = {
   children: ReactNode;
 };
 
 export function I18nProvider({ children }: I18nProviderProps) {
-  const [isReady, setIsReady] = useState(i18n.isInitialized);
+  const [isReady, setIsReady] = useState(false);
+  const [localePreference, setLocalePreferenceState] = useState<LocaleOverride>('system');
 
+  // Hydrate the persisted override and apply it before the first paint. The
+  // splash screen still covers this read (it hides only once auth + fonts are
+  // ready in the root layout), so there's no flash of the device-default
+  // language when the user previously picked another. Device-language changes
+  // while the app is backgrounded are not re-detected mid-session — detection
+  // runs at launch, matching the pre-existing behaviour.
   useEffect(() => {
-    if (i18n.isInitialized) {
-      return;
+    let cancelled = false;
+    async function hydrate() {
+      const stored = await getStoredLocaleOverride();
+      if (cancelled) return;
+      setLocalePreferenceState(stored);
+      const language = resolveLanguage(stored);
+      if (language !== i18n.language) {
+        await i18n.changeLanguage(language);
+      }
     }
-
-    const handleInitialized = () => setIsReady(true);
-    i18n.on('initialized', handleInitialized);
-
+    hydrate()
+      .catch(() => {
+        // A SecureStore read failure (rare) leaves us on the device-detected
+        // default rather than crashing — the app stays usable, the override is
+        // lost for this session only.
+      })
+      .finally(() => {
+        if (!cancelled) setIsReady(true);
+      });
     return () => {
-      i18n.off('initialized', handleInitialized);
+      cancelled = true;
     };
   }, []);
+
+  const setLocalePreference = useCallback((next: LocaleOverride) => {
+    setLocalePreferenceState(next);
+    void i18n.changeLanguage(resolveLanguage(next));
+    void setStoredLocaleOverride(next).catch(() => {
+      // Keep the in-memory choice on a write failure so the session reflects
+      // the pick; reverting would visibly snap the selection back.
+    });
+  }, []);
+
+  const localeValue = useMemo<LocalePreference>(
+    () => ({ localePreference, setLocalePreference }),
+    [localePreference, setLocalePreference],
+  );
 
   if (!isReady) {
     return null;
   }
 
-  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+  return (
+    <I18nextProvider i18n={i18n}>
+      <LocaleContext value={localeValue}>{children}</LocaleContext>
+    </I18nextProvider>
+  );
+}
+
+/** Access the language override + setter. Must be called inside an I18nProvider. */
+export function useLocalePreference(): LocalePreference {
+  const value = useContext(LocaleContext);
+  if (value === null) {
+    throw new Error('useLocalePreference must be used within an I18nProvider');
+  }
+  return value;
 }

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -32,6 +32,11 @@
         "vGrade": "V grade",
         "font": "French",
         "both": "Both"
+      },
+      "language": {
+        "title": "Language",
+        "system": "System",
+        "description": "System follows your device language."
       }
     },
     "nav": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -230,6 +230,11 @@
         "vGrade": "Grado V",
         "font": "Francés",
         "both": "Ambos"
+      },
+      "language": {
+        "title": "Idioma",
+        "system": "Sistema",
+        "description": "Sistema usa el idioma de tu dispositivo."
       }
     },
     "nav": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -32,6 +32,11 @@
         "vGrade": "Cotation V",
         "font": "Français",
         "both": "Les deux"
+      },
+      "language": {
+        "title": "Langue",
+        "system": "Système",
+        "description": "Système suit la langue de votre appareil."
       }
     },
     "nav": {


### PR DESCRIPTION
## What

The mobile app already ships `en-US` / `es` / `fr` translations and auto-detects the device locale at launch, but there was no way for a user to override that choice and no persistence — detection re-ran from scratch every cold start. This exposes those translations: a **Language** section on the More page lets users pick their language, and the choice persists via SecureStore.

## Changes

- **Locale preference helper** (`packages/mobile/src/lib/i18n/locale-preference.ts`, new) — a `'system' | Locale` override persisted under `LOCALE_OVERRIDE_KEY`, mirroring the existing `key-value-storage/theme.ts` shape. `resolveLanguage()` follows the device for `'system'` and passes explicit picks through. Kept mobile-side because web carries locale in the URL prefix + cookie (a different shape).
- **`detectDeviceLocale` exported** from `config.ts` so the helper reuses the existing matching logic instead of duplicating it.
- **`I18nProvider`** now hydrates the stored override before first paint (behind the splash screen, so there's no flash of the device-default language) and exposes `useLocalePreference()` for the settings UI. Context value + setter are memoized per the mobile perf lint rules.
- **More page** renders an inline checklist (System + the supported locales, labelled in their own script — English / Español / Français — from `LOCALE_LABELS`, intentionally untranslated) with a checkmark on the active option.
- **i18n keys** added to `common.json` for `en-US`, `es`, `fr` under `mobile.more.language`.
- **Unit test** for `isLocaleOverride` / `resolveLanguage`.

Auto-detect stays the default through the **System** option, which follows the device language; explicit picks override and persist.

## Verification

- `vp run typecheck:mobile` — pass
- `vp test run --project mobile` — 156 files / 1196 tests pass (incl. the new unit test)
- i18n catalog-completeness parity test — pass
- `vp run check:mobile-bundle` — pass (iOS + Android)

Manual (simulator) not run here (macOS-only): open Profile → More → **Language**; tapping a language re-renders visible copy and moves the checkmark; **System** follows the device; force-quit + relaunch keeps an explicit pick.

https://claude.ai/code/session_01UEKrwfASboz1TFKYwoDi77

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEKrwfASboz1TFKYwoDi77)_