### PR TITLE
fix(mobile): render accessory thumbnail with filled hold style

### DIFF
--- a/packages/mobile/src/components/BoardImageNative.tsx
+++ b/packages/mobile/src/components/BoardImageNative.tsx
@@ -13,6 +13,15 @@ type BoardImageNativeProps = {
   boardWidth: number;
   boardHeight: number;
   mirrored?: boolean;
+  /**
+   * Render lit holds as filled dots (filled style) instead of the default
+   * stroke-only outlines. The full-size play view leaves this false — thin
+   * strokes stay legible when large — but small surfaces like the 40×40
+   * accessory thumbnail pass true so holds read as solid dots once scaled
+   * down. Threaded into the render cache key, so the two styles cache as
+   * separate PNGs (see useNativeClimbRender).
+   */
+  filledStyle?: boolean;
   style?: ViewStyle;
 };
 
@@ -36,6 +45,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
   boardWidth,
   boardHeight,
   mirrored,
+  filledStyle = false,
   style,
 }: BoardImageNativeProps) {
   const { overlayUri, backgroundPaths, missingBackgroundCount } = useNativeClimbRender({
@@ -44,6 +54,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
     layoutId,
     sizeId,
     setIds,
+    filledStyle,
   });
 
   const containerStyle: ViewStyle = {

--- a/packages/mobile/src/components/queue-control/AccessoryClimbThumbnail.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryClimbThumbnail.tsx
@@ -32,8 +32,13 @@ function getAccessoryThumbnailBoardSize(boardWidth: number, boardHeight: number)
  * backgrounds) — the same warm path the list thumbnails use — rather than the
  * react-native-svg BoardRenderer with a remote `<SvgImage href>`. The accessory
  * bar is always mounted and re-renders on every queue swipe, so the cheap
- * cached-PNG path matters here. Cache keys dedupe across surfaces, so a climb
- * already seen in the list/play view is an instant cache hit. See
+ * cached-PNG path matters here.
+ *
+ * Renders with `filledStyle` so lit holds read as solid dots at the 40×40 slot
+ * size, matching the list thumbnail. That also means the cache key matches the
+ * list view's (both use the filled `_f_` token), so a climb already seen in the
+ * list is an instant cache hit. The play-view full-size render uses the
+ * stroke-only style (`_s_` token) and caches as a separate PNG. See
  * docs/react-native-performance.md §6.
  */
 export function AccessoryClimbThumbnail({ climb, boardConfig }: { climb: Climb; boardConfig: BoardConfig | null }) {
@@ -76,6 +81,7 @@ export function AccessoryClimbThumbnail({ climb, boardConfig }: { climb: Climb; 
         boardWidth={boardRenderData.boardWidth}
         boardHeight={boardRenderData.boardHeight}
         mirrored={climb.mirrored === true}
+        filledStyle
         style={thumbnailBoardStyle}
       />
     </View>

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -208,7 +208,17 @@ vi.mock('../../../lib/board-details', () => ({
 // applies, and the mirror flag so the aspect-fit + mirroring assertions hold
 // without a native renderer.
 vi.mock('../../BoardImageNative', () => ({
-  BoardImageNative: ({ frames, mirrored, style }: { frames: string; mirrored?: boolean; style?: unknown }) => {
+  BoardImageNative: ({
+    frames,
+    mirrored,
+    filledStyle,
+    style,
+  }: {
+    frames: string;
+    mirrored?: boolean;
+    filledStyle?: boolean;
+    style?: unknown;
+  }) => {
     const readStyleValue = (styleKey: string): unknown => {
       const styles = Array.isArray(style) ? style : [style];
       for (const styleEntry of styles) {
@@ -230,6 +240,7 @@ vi.mock('../../BoardImageNative', () => ({
     return createElement('div', {
       'data-thumbnail': frames,
       'data-mirrored': mirrored ? 'true' : 'false',
+      'data-filled': filledStyle ? 'true' : 'false',
       'data-board-width': width == null ? '' : String(width),
       'data-board-height': height == null ? '' : String(height),
       'data-board-border-radius': borderRadius == null ? '' : String(borderRadius),
@@ -309,6 +320,9 @@ describe('NativeAccessoryClimbRow', () => {
     expect(container.textContent).toContain('V6');
     expect(container.querySelector('[data-thumbnail="p1r12"]')).not.toBeNull();
     expect(container.querySelector('[data-thumbnail="p1r12"]')?.getAttribute('data-mirrored')).toBe('false');
+    // Filled hold style so the lit holds read as solid dots at the 40×40 slot,
+    // matching the list thumbnail (and sharing its render cache key).
+    expect(container.querySelector('[data-thumbnail="p1r12"]')?.getAttribute('data-filled')).toBe('true');
     expect(container.querySelector('[data-tick-size="44"]')).not.toBeNull();
     expect(container.querySelector('[data-icon-size="24"]')).not.toBeNull();
     expect(container.querySelector('[data-height="48"]')).not.toBeNull();
@@ -339,6 +353,19 @@ describe('NativeAccessoryClimbRow', () => {
     expect(gradeText?.getAttribute('data-color')).toBe('#111111');
     expect(gradeText?.getAttribute('data-variant')).toBe('subheadline');
     expect(gradeText?.getAttribute('data-font-weight')).toBe('600');
+  });
+
+  it('flips the thumbnail for a mirrored climb', () => {
+    const mirroredItem = makeItem(makeClimb({ mirrored: true }));
+    queue.state.currentClimbQueueItem = mirroredItem;
+    queue.state.queue = [mirroredItem];
+
+    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+
+    const thumbnail = getCurrentThumbnail(container);
+    expect(thumbnail.getAttribute('data-mirrored')).toBe('true');
+    // The filled style is independent of mirroring — still on.
+    expect(thumbnail.getAttribute('data-filled')).toBe('true');
   });
 
   it('uses the full silhouette for very tall board thumbnails', () => {


### PR DESCRIPTION
## What

The accessory-bar climb thumbnail rendered through `BoardImageNative`, which always asked `useNativeClimbRender` for the stroke-only hold style (`filledStyle: false`). At its 40×40 slot the thin outlines are hard to read, whereas `ClimbListThumbnail` uses the filled style at its larger 76×96 size. The accessory thumbnail is smaller, so legibility matters more there.

This addresses three points raised in review:

1. **`filledStyle` not passed → stroke-only holds at 40×40.**
   Added a `filledStyle?: boolean` prop to `BoardImageNative` (default `false`, so the full-size play view / climb detail page keep stroke-only outlines, which stay legible when large) and threaded it into `useNativeClimbRender`. `AccessoryClimbThumbnail` now passes `filledStyle`, so its lit holds read as solid dots.

2. **Corrected the cache-hit claim in the JSDoc.**
   The old comment said a climb "already seen in the list/play view is an instant cache hit." That was wrong: the list thumbnail uses `filledStyle: true` (`_f_` cache token) and the accessory previously used `filledStyle: false` (`_s_`), so only the play-view cache was shared, not the list. Now the accessory renders with the filled style, so its cache key matches the **list** view's (`_f_`); the play view's stroke-only render (`_s_`) caches separately. The JSDoc now states this accurately.

3. **Added a `mirrored=true` test case.**
   `native-accessory-climb-row.test.tsx` previously only asserted `data-mirrored="false"`. Added a dedicated test for a mirrored climb (the behavioural flag that changed in this area), plus an assertion that the filled style is passed. The `BoardImageNative` test mock now surfaces `filledStyle` as a `data-filled` attribute.

## Validation

- `vp run typecheck:mobile` — passes.
- `vp check` on the three changed files — 0 errors (the 12 `no-base-to-string` warnings are pre-existing in the test mocks; none are introduced here); files are format-clean.

Note: `vp test --project mobile` for the React-rendering test could not be exercised in this web session because dependencies had to be installed with npm (bun's installer hangs on this container's kernel), and npm's hoisting produced a duplicate React (`packages/mobile/node_modules/react@19.2.3` vs root `react-dom@19.2.7`), which crashes every test in the file at the first `useState` — including untouched tests. That's an environment artifact, not a logic change; the test assertions are straightforward and CI (bun-based) will run them cleanly.

https://claude.ai/code/session_01JYSvDhVLjNMKDPjbWQxE53

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYSvDhVLjNMKDPjbWQxE53)_