### PR TITLE
fix(mobile): stop swipe panel remounting on drag start

### DIFF
--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { View, StyleSheet } from 'react-native';
 import Animated, {
   useAnimatedStyle,
@@ -19,6 +19,7 @@ import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { brandColors } from '../theme/colors';
 import { selectedRowColors } from './climb-list-row-colors';
+import { useSwipeArm } from './use-swipe-arm';
 
 // Swipe tuning. Each side reveals a panel up to ACTION_REVEAL wide; dragging
 // past COMMIT_THRESHOLD and RELEASING commits the action (Spotify-style swipe-
@@ -186,8 +187,10 @@ const ClimbListRow = React.memo(function ClimbListRow({
   // Lazy swipe panels: the heavy animated action content (icon interpolation +
   // haptic-detent reaction) only mounts once a drag actually starts on THIS
   // row. While the row is just sitting in the list — the common case during a
-  // scroll — only the cheap panel shells mount.
-  const [dragArmed, setDragArmed] = useState(false);
+  // scroll — only the cheap panel shells mount. The hook resets the machine on
+  // recycle (climb.uuid) and exposes a ref so the render callbacks below can
+  // read the live value without taking it as a dep (see useSwipeArm for why).
+  const { armedRef: dragArmedRef, arm, disarm } = useSwipeArm(climb.uuid);
 
   // FlashList recycles rows (same instance, new climb). Snap any open swipe
   // shut so a recycled row never shows the previous climb's open panel.
@@ -195,11 +198,10 @@ const ClimbListRow = React.memo(function ClimbListRow({
   // recycle would read as a glitch. The reset lands on the next UI frame, so a
   // row recycled mid-swipe can flash its panel for ~1 frame; the opaque
   // contentRow background occludes the panel once translation returns to 0, so
-  // that background must stay opaque. Disarm the lazy panels too, so a recycled
-  // row returns to the cheap steady state until it's dragged again.
+  // that background must stay opaque. (useSwipeArm disarms the lazy panels on
+  // the same climb.uuid change.)
   useEffect(() => {
     swipeableRef.current?.reset();
-    setDragArmed(false);
   }, [climb.uuid]);
 
   // Stable refs so gesture/worklet callbacks never close over stale props.
@@ -252,14 +254,23 @@ const ClimbListRow = React.memo(function ClimbListRow({
     swipeableRef.current?.close();
   }, []);
 
+  // Once the row has fully settled shut again — whether after a committed swipe
+  // (handleSwipeableOpened → close()) or a sub-threshold swipe that springs back
+  // — drop the lazy panels back to the cheap shell. translation is 0 by now, so
+  // unmounting the heavy inner is invisible, and an idle row that's been swiped
+  // once no longer keeps the animated inner mounted for the rest of its life.
+  const handleSwipeableClosed = useCallback(() => {
+    disarm();
+  }, [disarm]);
+
   // Fired once when a horizontal drag begins (from a resting/closed row). This
   // is the trigger that mounts the heavy animated action panels — the direction
   // doesn't matter (we arm both sides; the non-dragged side stays occluded by
   // the opaque row), so the panel reveal is fully animated by the time any
   // meaningful translation is on screen.
   const handleSwipeStartDrag = useCallback(() => {
-    setDragArmed(true);
-  }, []);
+    arm();
+  }, [arm]);
 
   const handleSwipeWillOpen = useCallback(
     (direction: 'left' | 'right') => {
@@ -302,18 +313,23 @@ const ClimbListRow = React.memo(function ClimbListRow({
   );
 
   // Left actions (revealed by a left-to-right swipe) = Queue; right actions
-  // (right-to-left swipe) = Playlist.
+  // (right-to-left swipe) = Playlist. These read dragArmedRef.current rather
+  // than the armed state directly so they stay dep-free: a changed render-
+  // callback reference makes ReanimatedSwipeable re-create the action-panel
+  // subtree, which would remount the heavy inner the instant it appears. The
+  // armed state change re-renders the row (and so re-runs these callbacks),
+  // while the stable identity keeps the shell→inner swap in place.
   const renderLeftActions = useCallback(
     (_progress: SharedValue<number>, translation: SharedValue<number>) => (
-      <QueueSwipeAction translation={translation} active={dragArmed} />
+      <QueueSwipeAction translation={translation} active={dragArmedRef.current} />
     ),
-    [dragArmed],
+    [dragArmedRef],
   );
   const renderRightActions = useCallback(
     (_progress: SharedValue<number>, translation: SharedValue<number>) => (
-      <PlaylistSwipeAction translation={translation} active={dragArmed} />
+      <PlaylistSwipeAction translation={translation} active={dragArmedRef.current} />
     ),
-    [dragArmed],
+    [dragArmedRef],
   );
 
   return (
@@ -330,6 +346,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
         onSwipeableOpenStartDrag={handleSwipeStartDrag}
         onSwipeableWillOpen={handleSwipeWillOpen}
         onSwipeableOpen={handleSwipeableOpened}
+        onSwipeableClose={handleSwipeableClosed}
       >
         <GestureDetector gesture={tapGesture}>
           <View

--- a/packages/mobile/src/components/__tests__/use-swipe-arm.test.tsx
+++ b/packages/mobile/src/components/__tests__/use-swipe-arm.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useSwipeArm } from '../use-swipe-arm';
+
+describe('useSwipeArm', () => {
+  it('starts disarmed', () => {
+    const { result } = renderHook(() => useSwipeArm('climb-1'));
+
+    expect(result.current.armed).toBe(false);
+    expect(result.current.armedRef.current).toBe(false);
+  });
+
+  it('arms on the first drag and keeps the ref and state in sync', () => {
+    const { result } = renderHook(() => useSwipeArm('climb-1'));
+
+    act(() => result.current.arm());
+
+    expect(result.current.armed).toBe(true);
+    expect(result.current.armedRef.current).toBe(true);
+  });
+
+  it('disarms again once a swipe settles shut', () => {
+    const { result } = renderHook(() => useSwipeArm('climb-1'));
+
+    act(() => result.current.arm());
+    expect(result.current.armed).toBe(true);
+
+    act(() => result.current.disarm());
+
+    expect(result.current.armed).toBe(false);
+    expect(result.current.armedRef.current).toBe(false);
+  });
+
+  it('resets to disarmed when the row recycles onto a new climb', () => {
+    const { result, rerender } = renderHook(({ uuid }) => useSwipeArm(uuid), {
+      initialProps: { uuid: 'climb-1' },
+    });
+
+    act(() => result.current.arm());
+    expect(result.current.armed).toBe(true);
+
+    // FlashList reuses the row instance for a different climb.
+    rerender({ uuid: 'climb-2' });
+
+    expect(result.current.armed).toBe(false);
+    expect(result.current.armedRef.current).toBe(false);
+  });
+
+  it('keeps a stable arm/disarm identity across re-renders so render callbacks stay dep-free', () => {
+    const { result, rerender } = renderHook(({ uuid }) => useSwipeArm(uuid), {
+      initialProps: { uuid: 'climb-1' },
+    });
+
+    const firstArm = result.current.arm;
+    const firstDisarm = result.current.disarm;
+    const firstRef = result.current.armedRef;
+
+    act(() => result.current.arm());
+    rerender({ uuid: 'climb-1' });
+
+    expect(result.current.arm).toBe(firstArm);
+    expect(result.current.disarm).toBe(firstDisarm);
+    expect(result.current.armedRef).toBe(firstRef);
+  });
+});

--- a/packages/mobile/src/components/use-swipe-arm.ts
+++ b/packages/mobile/src/components/use-swipe-arm.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Lazy-mount state machine for a swipeable row's animated action panels.
+ *
+ * The heavy animated swipe inners (icon interpolation + haptic-detent reaction)
+ * only mount once a drag actually starts on the row: `arm()` flips the machine
+ * on at the first horizontal drag and gates the inner's mount. It resets when
+ * the row recycles onto a new climb (`resetKey` change) and when a swipe settles
+ * the row back shut (`disarm()`), so an idle row always sits in the cheap
+ * shell-only state — even after its first swipe.
+ *
+ * Two views of the same flag are returned on purpose:
+ *
+ * - `armed` (state) re-renders the row so the `renderLeftActions` /
+ *   `renderRightActions` callbacks run again and pick up the new value.
+ * - `armedRef` mirrors it so those callbacks can read the live value while
+ *   keeping a stable (dep-free) identity. A changed render-callback reference
+ *   makes ReanimatedSwipeable tear down and re-create the action-panel subtree,
+ *   which would unmount and re-mount the heavy inner on the very frame it first
+ *   becomes visible (restarting its animated values from zero). Reading the ref
+ *   keeps the callbacks dep-free while the `armed` state change drives the
+ *   re-render, so the shell→inner swap happens in place.
+ */
+export function useSwipeArm(resetKey: string) {
+  const [armed, setArmed] = useState(false);
+  const armedRef = useRef(false);
+
+  const arm = useCallback(() => {
+    if (armedRef.current) return;
+    armedRef.current = true;
+    setArmed(true);
+  }, []);
+
+  const disarm = useCallback(() => {
+    if (!armedRef.current) return;
+    armedRef.current = false;
+    setArmed(false);
+  }, []);
+
+  // Recycle: FlashList reuses the row instance for a new climb. Drop back to the
+  // cheap shell so the recycled row isn't carrying the previous climb's inner.
+  useEffect(() => {
+    disarm();
+  }, [resetKey, disarm]);
+
+  return { armed, armedRef, arm, disarm };
+}


### PR DESCRIPTION
## What

`ClimbListRow`'s swipe action panels split into a cheap always-mounted shell and a heavy animated inner (icon interpolation + haptic-detent reaction) that lazily mounts once a drag begins. This PR fixes three issues in that lazy-mount path.

### 1. Render callbacks remounted the panel on drag start

`renderLeftActions` / `renderRightActions` took `dragArmed` as a `useCallback` dep, so the first drag (the `dragArmed` false→true flip) produced new render-callback references. `ReanimatedSwipeable` re-creates the action-panel subtree when those render props change, so the heavy inner unmounted and re-mounted on the very frame it first became visible — restarting its animated values from zero (`useAnimatedReaction` firing with `wasArmed = null`) and snapping the icon interpolation instead of tracking the live translation. It also defeated the stated shell→inner seamless transition.

**Fix:** extract the lazy-mount flag into a new `useSwipeArm` hook that exposes the value as both:
- `armed` (state) — drives the row re-render so the callbacks re-run and pick up the new value;
- `armedRef` (ref) — read inside the now **dep-free** render callbacks (`[dragArmedRef]`), giving them a stable identity.

Because the callback identity no longer changes, `ReanimatedSwipeable` keeps the panel subtree mounted and the shell→inner swap happens in place. This is the same `*Ref` pattern already used in the file for `onPressRef`, `climbRef`, etc.

### 2. `dragArmed` never reset after a committed swipe

It was only reset on recycle (`climb.uuid` change), so after the first swipe the heavy inner stayed mounted for the rest of the row's life.

**Fix:** `useSwipeArm` exposes `disarm()`, wired to a new `onSwipeableClose` handler. The row drops back to the cheap shell once it settles fully shut — whether after a committed swipe or a sub-threshold spring-back. `translation` is 0 by then, so unmounting the inner is invisible.

### 3. No test coverage for the lazy-mount state machine

**Fix:** added `use-swipe-arm.test.tsx` covering: starts disarmed, arms on first drag (state + ref in sync), disarms on close, resets on `climb.uuid` change (recycle), and stable `arm`/`disarm`/`armedRef` identity across re-renders.

## Validation

- `vp run typecheck:mobile` — pass
- `vp test --project mobile` — 1204 pass (incl. 5 new `useSwipeArm` tests)
- `vp run check:mobile-bundle` — OK (10.5 MB)

On-device QA still recommended for the timing edge cases (fast-flick, recycle mid-swipe) that are invisible to a static review.

https://claude.ai/code/session_01444Rs5To9FajBdUhoFpVLv

---
_Generated by [Claude Code](https://claude.ai/code/session_01444Rs5To9FajBdUhoFpVLv)_