### PR TITLE
Dock the Material queue bar against the measured tab-bar height (#2611)

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -26,6 +26,7 @@ import { QueueSnackbarProvider } from '../src/providers/queue-snackbar-provider'
 import { DrawerHostProvider } from '../src/providers/drawer-host-provider';
 import { DeepLinkProvider } from '../src/providers/deep-link-provider';
 import { ShareTargetProvider } from '../src/providers/share-target-provider';
+import { TabBarHeightProvider } from '../src/providers/tab-bar-height-provider';
 import { FeatureFlagsProvider } from '../src/providers/feature-flags-provider';
 import { PartyProfileProvider } from '../src/providers/party-profile-provider';
 import { ConnectionSettingsProvider } from '../src/providers/connection-settings-provider';
@@ -269,36 +270,38 @@ function RootLayout() {
                                           <DrawerHostProvider>
                                             <DeepLinkProvider>
                                               <ShareTargetProvider>
-                                                <ThemedNavigation>
-                                                  <Stack
-                                                    screenOptions={{ headerShown: false }}
-                                                    initialRouteName="index"
-                                                  >
-                                                    <Stack.Screen name="index" />
-                                                    <Stack.Screen name="(tabs)" />
-                                                    <Stack.Screen
-                                                      name="auth"
-                                                      options={{ headerShown: false, gestureEnabled: false }}
-                                                    />
-                                                    <Stack.Screen name="session/[sessionId]" />
-                                                    <Stack.Screen
-                                                      name="join/[sessionId]"
-                                                      options={{ presentation: 'modal', headerShown: false }}
-                                                    />
-                                                    <Stack.Screen
-                                                      name="share-beta"
-                                                      options={{ presentation: 'modal', headerShown: false }}
-                                                    />
-                                                    {/* Board selection is a modal off the Climbs capsule /
+                                                <TabBarHeightProvider>
+                                                  <ThemedNavigation>
+                                                    <Stack
+                                                      screenOptions={{ headerShown: false }}
+                                                      initialRouteName="index"
+                                                    >
+                                                      <Stack.Screen name="index" />
+                                                      <Stack.Screen name="(tabs)" />
+                                                      <Stack.Screen
+                                                        name="auth"
+                                                        options={{ headerShown: false, gestureEnabled: false }}
+                                                      />
+                                                      <Stack.Screen name="session/[sessionId]" />
+                                                      <Stack.Screen
+                                                        name="join/[sessionId]"
+                                                        options={{ presentation: 'modal', headerShown: false }}
+                                                      />
+                                                      <Stack.Screen
+                                                        name="share-beta"
+                                                        options={{ presentation: 'modal', headerShown: false }}
+                                                      />
+                                                      {/* Board selection is a modal off the Climbs capsule /
                                                       no-board CTA — board switching is rare, so it doesn't
                                                       earn a tab. Its own _layout owns the headers. */}
-                                                    <Stack.Screen
-                                                      name="boards"
-                                                      options={{ presentation: 'modal', headerShown: false }}
-                                                    />
-                                                  </Stack>
-                                                </ThemedNavigation>
-                                                <PersistentQueueBar />
+                                                      <Stack.Screen
+                                                        name="boards"
+                                                        options={{ presentation: 'modal', headerShown: false }}
+                                                      />
+                                                    </Stack>
+                                                  </ThemedNavigation>
+                                                  <PersistentQueueBar />
+                                                </TabBarHeightProvider>
                                                 <AnalyticsScreenTracker />
                                               </ShareTargetProvider>
                                             </DeepLinkProvider>

--- a/packages/mobile/src/components/navigation/MaterialTabBar.tsx
+++ b/packages/mobile/src/components/navigation/MaterialTabBar.tsx
@@ -1,8 +1,10 @@
-import { Platform, StyleSheet, View } from 'react-native';
+import { useCallback } from 'react';
+import { type LayoutChangeEvent, Platform, StyleSheet, View } from 'react-native';
 import type { BottomTabBarProps } from 'expo-router/tabs';
 import { Text } from '../Text';
 import { PressableSurface } from '../PressableSurface';
 import { useTheme } from '../../providers/theme-provider';
+import { useSetMeasuredTabBarHeight } from '../../providers/tab-bar-height-provider';
 import { brandColors as staticBrandColors, withAlpha } from '../../theme/colors';
 import { material } from '../../theme/tokens';
 import { TAB_BAR_HEIGHT } from '../../theme/layout';
@@ -25,8 +27,17 @@ export function MaterialTabBar({ state, descriptors, navigation, insets }: Botto
   const inactiveColor = systemColors.secondaryLabel;
   const indicatorColor = withAlpha(brandColors.primary, 0.1);
 
+  // Publish the real rendered height so the root-level queue bar docks flush against
+  // it (rather than re-deriving the tab-bar top from TAB_BAR_HEIGHT + inset). #2611.
+  const setMeasuredTabBarHeight = useSetMeasuredTabBarHeight();
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => setMeasuredTabBarHeight(event.nativeEvent.layout.height),
+    [setMeasuredTabBarHeight],
+  );
+
   return (
     <View
+      onLayout={handleLayout}
       style={[
         styles.bar,
         {

--- a/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
+++ b/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
@@ -21,10 +21,12 @@ import {
   TOOLBAR_GAP,
   TOOLBAR_FAB_SIZE,
   TOOLBAR_GAP_ABOVE_TABBAR,
+  TABBAR_SEAM_OVERLAP,
   glassSize,
 } from '../../theme/layout';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { useMeasuredTabBarHeight } from '../../providers/tab-bar-height-provider';
 
 type ActiveContextBarProps = {
   /** Optional leading widget; defaults to an empty gutter that balances the bar. */
@@ -38,8 +40,11 @@ type ActiveContextBarProps = {
   /** Render the primary edge-to-edge (no leading/trailing slots) — the Material
    *  full-width bar, where the trailing action lives inside the primary. */
   fillPrimary?: boolean;
-  /** Lift above the tab bar (defaults to TOOLBAR_GAP_ABOVE_TABBAR). */
+  /** Lift above the tab bar (defaults to TOOLBAR_GAP_ABOVE_TABBAR). Floating only. */
   gapAboveTabBar?: number;
+  /** Dock flush against the tab bar (Material) rather than floating above it. Positions
+   *  the bar's bottom on the tab bar's *measured* top, tucked under its hairline. */
+  dockToTabBar?: boolean;
   /** Horizontal inset from the screen edge; Material uses 0 for a docked bar. */
   horizontalInset?: number;
 };
@@ -51,10 +56,20 @@ export function ActiveContextBar({
   trailingWidth = glassSize.hero,
   fillPrimary = false,
   gapAboveTabBar = TOOLBAR_GAP_ABOVE_TABBAR,
+  dockToTabBar = false,
   horizontalInset = TOOLBAR_SIDE_MARGIN,
 }: ActiveContextBarProps) {
   const reduceMotion = useReduceMotion();
   const bottomChrome = useBottomChromeMetrics();
+  const measuredTabBarHeight = useMeasuredTabBarHeight();
+
+  // Docked (Material): sit on the tab bar's REAL measured top, tucked under its hairline
+  // by one px. Before the first measurement, fall back to the constant-estimated top
+  // (≤2px off for a single frame, then it snaps to the truth). Floating (glass) keeps
+  // its lift above the tab bar.
+  const bottom = dockToTabBar
+    ? (measuredTabBarHeight ?? bottomChrome.tabBarBottom) - TABBAR_SEAM_OVERLAP
+    : bottomChrome.tabBarBottom + gapAboveTabBar;
 
   return (
     <Animated.View
@@ -63,7 +78,7 @@ export function ActiveContextBar({
       style={[
         styles.toolbar,
         {
-          bottom: bottomChrome.tabBarBottom + gapAboveTabBar,
+          bottom,
           left: horizontalInset,
           right: horizontalInset,
         },

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -9,6 +9,7 @@ const cfg = vi.hoisted(() => ({
   onClimbsTab: true,
   currentClimbQueueItem: { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem | null,
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
+  measuredTabBarHeight: null as number | null,
 }));
 
 vi.mock('react-native', () => ({
@@ -48,7 +49,13 @@ vi.mock('../../../theme/layout', () => ({
   TOOLBAR_GAP: 8,
   TOOLBAR_FAB_SIZE: 56,
   TOOLBAR_GAP_ABOVE_TABBAR: 10,
+  TABBAR_SEAM_OVERLAP: 1,
   glassSize: { hero: 64, inline: 44 },
+}));
+// The docked Material bar reads the tab bar's measured height to position itself.
+vi.mock('../../../providers/tab-bar-height-provider', () => ({
+  useMeasuredTabBarHeight: () => cfg.measuredTabBarHeight,
+  useSetMeasuredTabBarHeight: () => vi.fn(),
 }));
 vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4 } }));
 // Default to the Liquid Glass layout (centered capsule + standalone hero tick).
@@ -96,6 +103,7 @@ describe('PersistentQueueBar', () => {
     cfg.onClimbsTab = true;
     cfg.currentClimbQueueItem = { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem;
     cfg.variant = 'liquidGlass';
+    cfg.measuredTabBarHeight = null;
   });
 
   it('renders nothing when no climb is current', () => {
@@ -131,5 +139,13 @@ describe('PersistentQueueBar', () => {
     expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"right":0');
     expect(container.querySelector('[data-tick-inline]')).not.toBeNull();
     expect(container.querySelector('[data-tick]')).toBeNull();
+  });
+
+  it('docks the Material bar on the measured tab-bar top, tucked under the hairline', () => {
+    // Measured tab bar = 80px tall → the docked bar sits at 80 - TABBAR_SEAM_OVERLAP(1).
+    cfg.variant = 'material';
+    cfg.measuredTabBarHeight = 80;
+    const { container } = render(<PersistentQueueBar />);
+    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"bottom":79');
   });
 });

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -25,12 +25,6 @@ import { ClimbCapsule } from './ClimbCapsule';
 import { LogAscentFab } from './LogAscentFab';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
 
-// The docked Material bar tucks a couple of px under the tab bar's top edge so the
-// elevated tab bar covers the seam — without this overlap a 1–2px gap shows through.
-// The -2 is reasoned, not yet measured on-device; hardware verification across
-// gesture vs 3-button nav and varying insets is tracked in #2611.
-const MATERIAL_TABBAR_OVERLAP = -2;
-
 // Re-export so layout consumers that already import toolbar metrics from this
 // module don't need to know which file owns them. Source of truth: theme/layout.
 export { TOOLBAR_RESERVE, TAB_BAR_HEIGHT };
@@ -49,7 +43,7 @@ export function PersistentQueueBar() {
     return (
       <ActiveContextBar
         fillPrimary
-        gapAboveTabBar={MATERIAL_TABBAR_OVERLAP}
+        dockToTabBar
         horizontalInset={0}
         primary={
           <ClimbCapsule

--- a/packages/mobile/src/providers/__tests__/tab-bar-height-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/tab-bar-height-provider.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import {
+  TabBarHeightProvider,
+  useMeasuredTabBarHeight,
+  useSetMeasuredTabBarHeight,
+} from '../tab-bar-height-provider';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(TabBarHeightProvider, null, children);
+}
+
+function useBoth() {
+  return { height: useMeasuredTabBarHeight(), setHeight: useSetMeasuredTabBarHeight() };
+}
+
+describe('TabBarHeightProvider', () => {
+  it('starts null and exposes the latest published height', () => {
+    const { result } = renderHook(useBoth, { wrapper });
+    expect(result.current.height).toBeNull();
+    act(() => result.current.setHeight(80));
+    expect(result.current.height).toBe(80);
+  });
+
+  it('ignores sub-0.5px churn but commits meaningful changes', () => {
+    const { result } = renderHook(useBoth, { wrapper });
+    act(() => result.current.setHeight(80));
+    expect(result.current.height).toBe(80);
+    act(() => result.current.setHeight(80.3)); // < 0.5px drift → ignored (no render loop)
+    expect(result.current.height).toBe(80);
+    act(() => result.current.setHeight(80.6)); // >= 0.5px → committed
+    expect(result.current.height).toBe(80.6);
+  });
+
+  it('degrades to null / no-op without a provider', () => {
+    const { result } = renderHook(useBoth);
+    expect(result.current.height).toBeNull();
+    expect(() => act(() => result.current.setHeight(50))).not.toThrow();
+    expect(result.current.height).toBeNull();
+  });
+});

--- a/packages/mobile/src/providers/tab-bar-height-provider.tsx
+++ b/packages/mobile/src/providers/tab-bar-height-provider.tsx
@@ -1,0 +1,39 @@
+// Publishes the Material bottom tab bar's *measured* height so the persistent queue
+// control bar — which mounts at the app root, outside the Tabs navigator — can dock
+// flush against the real rendered tab bar instead of re-deriving its top from a
+// hardcoded constant (which left a 1–2px seam patched by a hand-tuned offset; #2611).
+//
+// MaterialTabBar (deep inside the navigator) publishes via `useSetMeasuredTabBarHeight`;
+// ActiveContextBar (root overlay) consumes via `useMeasuredTabBarHeight`. Both hooks
+// degrade gracefully to null / no-op when no provider is mounted (e.g. unit tests, or
+// the Liquid Glass variant which uses native tabs and never measures).
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+
+type TabBarHeightContextValue = {
+  /** Measured tab-bar height incl. the safe-area inset, or null before the first layout. */
+  height: number | null;
+  /** Publish a freshly measured height; sub-0.5px churn is ignored to avoid render loops. */
+  setHeight: (measured: number) => void;
+};
+
+const TabBarHeightContext = createContext<TabBarHeightContextValue | null>(null);
+
+const noop = () => {};
+
+export function TabBarHeightProvider({ children }: { children: ReactNode }) {
+  const [height, setHeightState] = useState<number | null>(null);
+  const setHeight = useCallback((measured: number) => {
+    setHeightState((prev) => (prev == null || Math.abs(prev - measured) >= 0.5 ? measured : prev));
+  }, []);
+  const value = useMemo(() => ({ height, setHeight }), [height, setHeight]);
+  return <TabBarHeightContext.Provider value={value}>{children}</TabBarHeightContext.Provider>;
+}
+
+export function useMeasuredTabBarHeight(): number | null {
+  return useContext(TabBarHeightContext)?.height ?? null;
+}
+
+export function useSetMeasuredTabBarHeight(): (measured: number) => void {
+  return useContext(TabBarHeightContext)?.setHeight ?? noop;
+}

--- a/packages/mobile/src/theme/layout.ts
+++ b/packages/mobile/src/theme/layout.ts
@@ -69,3 +69,10 @@ export const TOOLBAR_RESERVE = glassSize.hero + TOOLBAR_GAP_ABOVE_TABBAR;
 
 /** Height of the Material active-context bar docked directly above the tab bar. */
 export const MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT = glassSize.standard;
+
+/** One logical px the docked Material bar tucks under the tab bar's top hairline.
+ *  Because the bar now docks against the tab bar's *measured* height (not the
+ *  `TAB_BAR_HEIGHT` constant), this only has to cover the hairline border / sub-pixel
+ *  rounding — not absorb a constant-vs-reality mismatch — so it stays a fixed hairline
+ *  instead of a hand-tuned per-device offset. */
+export const TABBAR_SEAM_OVERLAP = 1;


### PR DESCRIPTION
Closes #2611.

## Problem

The docked Material queue control bar positioned itself with `bottom = insets.bottom + TAB_BAR_HEIGHT(49) + MATERIAL_TABBAR_OVERLAP(-2)`. The `-2` was a hand-tuned fudge hiding a 1–2px seam against the bottom tab bar (the tab bar's hairline top border / elevation, plus the queue bar independently re-deriving the tab-bar top from the `49` constant rather than the real rendered height).

`PersistentQueueBar` mounts at the **app root** (`app/_layout.tsx`), a sibling of the `<Stack>` — *outside* the Tabs navigator — so React Navigation's `useBottomTabBarHeight()` isn't reachable, and the `-2` was an unverified per-device guess (#2611).

## Fix

Measure the Material tab bar's **actual rendered height** and dock the queue bar against it, instead of tuning a magic offset:

- **New `TabBarHeightProvider`** (`src/providers/tab-bar-height-provider.tsx`) — a small context mounted at root wrapping both the navigation tree and the queue bar. `setHeight` ignores sub-0.5px churn (reusing `CreateDrawer`'s `setHeightIfChanged` idea) to avoid render loops. Both hooks degrade to `null` / no-op without a provider.
- **`MaterialTabBar`** publishes its measured height via `onLayout`.
- **`ActiveContextBar`** gains an explicit `dockToTabBar` prop; when docking it positions `bottom = measuredTabBarHeight - TABBAR_SEAM_OVERLAP` (1px, to tuck under the tab bar's top hairline), falling back to the constant-estimated top for the single frame before measurement arrives.
- **`MATERIAL_TABBAR_OVERLAP` is removed**; the Material branch passes `dockToTabBar`.

The Liquid Glass float path (native tabs) is untouched. `computeBottomChromeMetrics` / `scrollBottomPadding` stay on the constant — that's a scroll reserve where a couple px of slack is intentional.

This makes the position self-correct across gesture vs 3-button nav, varying insets, and densities, so the seam no longer needs on-device pixel tuning — the #2611 hardware check becomes a confirmation rather than a tuning exercise.

## Validation
- `vp run typecheck:mobile` ✓
- `vp test --project mobile` — 1214 passed (added a provider test + a docking-math assertion to `persistent-queue-bar.test.tsx`) ✓
- `vp lint` on changed files — 0/0 ✓
- `vp run check:mobile-bundle` — Android bundle OK ✓

## Still worth an on-device glance
Confirm the bar butts flush against the tab bar with no seam on both gesture and 3-button nav across a couple of devices — but it should now be correct by construction rather than tuned.

https://claude.ai/code/session_014ssD3dvrJ8rR9Nan2SHPDv

---
_Generated by [Claude Code](https://claude.ai/code/session_014ssD3dvrJ8rR9Nan2SHPDv)_