### PR TITLE
feat(mobile): instrument create-climb, generator, beta video, session join & logbook analytics

### DIFF
--- a/packages/board-constants/src/product-sizes.ts
+++ b/packages/board-constants/src/product-sizes.ts
@@ -55,6 +55,20 @@ export const getLayout = (boardName: BoardName, layoutId: number): LayoutData | 
   return LAYOUTS[boardName]?.[layoutId] ?? null;
 };
 
+/**
+ * Resolve a layout id to its human-readable name (e.g. `1` → "Kilter Board
+ * Original"). Returns `''` for an unknown layout, matching web's
+ * `boardDetails.layout_name || ''` fallback so analytics `boardLayout`
+ * properties carry the same string value on web and mobile.
+ *
+ * Shared by every call site that reports `boardLayout` to analytics
+ * (create-climb events, and the hold/zone filter events) so a numeric layout
+ * id is never sent where web sends a name.
+ */
+export const getLayoutName = (boardName: BoardName, layoutId: number): string => {
+  return LAYOUTS[boardName]?.[layoutId]?.name ?? '';
+};
+
 export const getAllLayouts = (boardName: BoardName): LayoutData[] => {
   const layouts = LAYOUTS[boardName];
   return layouts ? Object.values(layouts) : [];

--- a/packages/mobile/app/join/[sessionId].tsx
+++ b/packages/mobile/app/join/[sessionId].tsx
@@ -4,6 +4,8 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { parseBoardPath, formatBoardDisplayName } from '@boardsesh/board-config';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../../src/lib/analytics';
 import { Text } from '../../src/components/Text';
 import { Button } from '../../src/components/Button';
 import { Card } from '../../src/components/Card';
@@ -68,6 +70,16 @@ export default function JoinSessionScreen() {
         createBoard: (input) => createBoard.mutateAsync(input),
       });
       await joinSession(session.id, { boardPath: session.boardPath, userBoard });
+      // Web fires `Session Joined` on a genuine new-session entry (board-session-
+      // bridge). The mobile equivalent is a successful deep-link join — the
+      // queue provider only emits Session Started/Ended, never Joined. Mirror
+      // web's props (session_id, board_name, layout_id), derived from the path.
+      const parsedBoard = parseBoardPath(session.boardPath);
+      track(SHARED_EVENTS.SessionJoined, {
+        session_id: session.id,
+        board_name: parsedBoard?.boardName ?? null,
+        layout_id: parsedBoard?.layoutId ?? null,
+      });
       // Land on the Record tab so the user drops straight into the joined session.
       router.replace('/(tabs)/record');
     } catch (error) {

--- a/packages/mobile/app/join/__tests__/join-session-analytics.test.tsx
+++ b/packages/mobile/app/join/__tests__/join-session-analytics.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -103,18 +103,20 @@ describe('JoinSessionScreen analytics', () => {
 
     await act(async () => {
       buttons.joinPress?.();
-      // performJoin awaits resolveBoardForSession → joinSession before tracking.
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
+    // performJoin awaits resolveBoardForSession → joinSession before tracking;
+    // poll until those promises settle rather than flushing a fixed number of
+    // microtasks.
+    await waitFor(() =>
+      expect(analytics.track).toHaveBeenCalledWith('Session Joined', {
+        session_id: 'session-42',
+        board_name: 'kilter',
+        layout_id: 1,
+      }),
+    );
+
     expect(queue.joinSession).toHaveBeenCalledTimes(1);
-    expect(analytics.track).toHaveBeenCalledWith('Session Joined', {
-      session_id: 'session-42',
-      board_name: 'kilter',
-      layout_id: 1,
-    });
     expect(router.replace).toHaveBeenCalledWith('/(tabs)/record');
   });
 });

--- a/packages/mobile/app/join/__tests__/join-session-analytics.test.tsx
+++ b/packages/mobile/app/join/__tests__/join-session-analytics.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+
+const queue = vi.hoisted(() => ({
+  sessionId: null as string | null,
+  joinSession: vi.fn(async () => {}),
+  clearSession: vi.fn(async () => {}),
+}));
+
+const router = vi.hoisted(() => ({ replace: vi.fn(), back: vi.fn() }));
+
+// A loaded, active session preview so the screen renders the confirmation card.
+const preview = vi.hoisted(() => ({
+  data: {
+    id: 'session-42',
+    boardPath: '/kilter/1/10/1,2/40',
+    endedAt: null as string | null,
+    users: [{ id: 'u1', username: 'host', avatarUrl: null, isLeader: true }],
+  } as unknown,
+  isLoading: false,
+  isError: false,
+  refetch: vi.fn(),
+}));
+
+// Capture the confirmation card's Join button so the test can press it.
+const buttons = vi.hoisted(() => ({ joinPress: null as (() => void) | null }));
+
+vi.mock('../../../src/lib/analytics', () => ({ track: analytics.track }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Alert: { alert: vi.fn() },
+}));
+
+vi.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ sessionId: 'session-42' }),
+  useRouter: () => router,
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0 }) }));
+
+vi.mock('@boardsesh/board-config', () => ({
+  parseBoardPath: () => ({ boardName: 'kilter', layoutId: 1, angle: 40 }),
+  formatBoardDisplayName: () => 'Kilter',
+}));
+
+// The first Button rendered in the confirmation card is the Join action.
+vi.mock('../../../src/components/Button', () => ({
+  Button: ({ onPress }: { onPress?: () => void }) => {
+    if (buttons.joinPress === null && onPress) buttons.joinPress = onPress;
+    return createElement('button');
+  },
+}));
+vi.mock('../../../src/components/Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../src/components/Card', () => ({
+  Card: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('../../../src/components/Avatar', () => ({ Avatar: () => null }));
+vi.mock('../../../src/components/ActivityIndicator', () => ({ ActivityIndicator: () => null }));
+vi.mock('../../../src/components/Icon', () => ({ Icon: () => null }));
+vi.mock('../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {}, brandColors: {} }),
+}));
+vi.mock('../../../src/providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock('../../../src/providers/queue-provider', () => ({
+  useQueue: () => ({
+    sessionId: queue.sessionId,
+    joinSession: queue.joinSession,
+    clearSession: queue.clearSession,
+  }),
+}));
+vi.mock('../../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../src/lib/graphql/hooks', () => ({
+  useSessionPreview: () => preview,
+  useMyBoards: () => ({ data: { boards: [] }, refetch: vi.fn(async () => ({ data: { boards: [] } })) }),
+  useCreateBoard: () => ({ mutateAsync: vi.fn(async () => ({})) }),
+}));
+vi.mock('../../../src/lib/board-path-to-user-board', () => ({
+  resolveBoardForSession: vi.fn(async () => ({ uuid: 'board-1' })),
+}));
+vi.mock('../../../src/theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
+
+import JoinSessionScreen from '../[sessionId]';
+
+beforeEach(() => {
+  analytics.track.mockClear();
+  queue.sessionId = null;
+  queue.joinSession.mockClear();
+  buttons.joinPress = null;
+});
+
+describe('JoinSessionScreen analytics', () => {
+  it('fires "Session Joined" with session_id + board props after a successful join', async () => {
+    render(createElement(JoinSessionScreen));
+    expect(buttons.joinPress).not.toBeNull();
+
+    await act(async () => {
+      buttons.joinPress?.();
+      // performJoin awaits resolveBoardForSession → joinSession before tracking.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(queue.joinSession).toHaveBeenCalledTimes(1);
+    expect(analytics.track).toHaveBeenCalledWith('Session Joined', {
+      session_id: 'session-42',
+      board_name: 'kilter',
+      layout_id: 1,
+    });
+    expect(router.replace).toHaveBeenCalledWith('/(tabs)/record');
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Hoisted mock state the test drives between cases. ---------------------
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+
+const board = vi.hoisted(() => ({
+  isAuthenticated: true,
+  saveClimb: vi.fn(),
+  updateClimb: vi.fn(),
+  // Default: a brand-new climb (no duplicate, not an exception).
+  isDuplicateClimbError: vi.fn((_err: unknown) => false),
+}));
+
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+const queue = vi.hoisted(() => ({ setCurrentClimb: vi.fn() }));
+const router = vi.hoisted(() => ({ push: vi.fn() }));
+
+// Edit mode seeds a savedClimb from `useClimb`; when set, the save flow takes
+// the update branch (`computeCanUpdate` returns true for a non-null savedClimb).
+const editClimb = vi.hoisted(() => ({ data: undefined as unknown }));
+
+// The create-climb hold-state machine. The save flow only reads back
+// `generateFramesString` (non-empty so the save proceeds), `isValid` (true so it
+// doesn't early-return), and `litUpHoldsMap` (for holdCount).
+const createClimb = vi.hoisted(() => ({
+  litUpHoldsMap: { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } },
+  setHoldState: vi.fn(),
+  generateFramesString: vi.fn(() => 'p1r12p2r13p3r14'),
+  startingCount: 1,
+  finishCount: 1,
+  isValid: true,
+  resetHolds: vi.fn(),
+  loadHolds: vi.fn(),
+  undo: vi.fn(),
+  redo: vi.fn(),
+  canUndo: false,
+  canRedo: false,
+}));
+
+// --- Module mocks. ---------------------------------------------------------
+vi.mock('../../../lib/analytics', () => ({ track: analytics.track }));
+
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
+vi.mock('expo-router', () => ({ useRouter: () => router }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('@boardsesh/shared-schema', () => ({
+  isNoMatchClimb: () => false,
+  withNoMatch: (description: string) => description,
+}));
+
+vi.mock('@boardsesh/create-climb-react', () => ({
+  useCreateClimb: () => createClimb,
+  // No saved snapshot at save time → the "create" branch runs by default. The
+  // update branch is exercised by seeding a savedClimb via edit mode below.
+  computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
+  computeEditLocked: () => false,
+  buildInitialHoldsMap: () => ({}),
+}));
+
+vi.mock('@boardsesh/board-react', () => ({
+  useBoardProvider: () => ({
+    isAuthenticated: board.isAuthenticated,
+    saveClimb: board.saveClimb,
+    updateClimb: board.updateClimb,
+  }),
+  isDuplicateClimbError: (err: unknown) => board.isDuplicateClimbError(err),
+}));
+
+vi.mock('@boardsesh/graphql-client', () => ({
+  // Used only for the `instanceof` narrowing in readDuplicateExtensions; a plain
+  // class is enough for the test (the duplicate detail isn't asserted here).
+  GraphQLOperationError: class GraphQLOperationError extends Error {},
+}));
+
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ refreshAuthState: vi.fn() }),
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: { displayName: 'Tester' } }),
+  useClimb: () => ({ data: editClimb.data }),
+}));
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueue: () => ({ setCurrentClimb: queue.setCurrentClimb }),
+}));
+vi.mock('../../../providers/bluetooth-provider', () => ({
+  useOptionalBluetoothContext: () => null,
+}));
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: toast.showToast }),
+}));
+vi.mock('../../../lib/climb-to-queue-item', () => ({ climbToQueueItem: () => ({}) }));
+vi.mock('../../../lib/create-climb-draft-store', () => ({
+  loadDraft: vi.fn(async () => null),
+  saveDraft: vi.fn(async () => {}),
+  clearDraft: vi.fn(async () => {}),
+  createClimbDraftKey: () => 'draft-key',
+}));
+vi.mock('../brush-roles', () => ({
+  getPaintRoles: () => ['HAND', 'STARTING', 'FINISH'],
+}));
+
+import { useCreateClimbScreen } from '../use-create-climb-screen';
+
+const BOARD = {
+  boardName: 'kilter' as const,
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,2',
+  angle: 40,
+};
+
+function renderScreen(editClimbUuid?: string) {
+  return renderHook(() => useCreateClimbScreen({ board: BOARD, editClimbUuid }));
+}
+
+async function nameAndSave(result: { current: ReturnType<typeof useCreateClimbScreen> }) {
+  // A non-empty name is required or handleSave early-returns to focus the field.
+  act(() => result.current.setName('My Problem'));
+  await act(async () => {
+    await result.current.handleSave();
+  });
+}
+
+beforeEach(() => {
+  analytics.track.mockClear();
+  toast.showToast.mockClear();
+  queue.setCurrentClimb.mockClear();
+  router.push.mockClear();
+  board.isAuthenticated = true;
+  board.isDuplicateClimbError.mockReturnValue(false);
+  board.saveClimb.mockReset();
+  board.updateClimb.mockReset();
+  editClimb.data = undefined;
+});
+
+describe('useCreateClimbScreen analytics', () => {
+  it('fires "Climb Created" with board + holdCount on a successful new save', async () => {
+    board.saveClimb.mockResolvedValue({
+      uuid: 'new-climb',
+      createdAt: null,
+      publishedAt: null,
+      isDraft: true,
+    });
+
+    const { result } = renderScreen();
+    await nameAndSave(result);
+
+    expect(board.saveClimb).toHaveBeenCalledTimes(1);
+    expect(analytics.track).toHaveBeenCalledWith('Climb Created', {
+      boardName: 'kilter',
+      layoutId: 1,
+      climbUuid: 'new-climb',
+      isDraft: true,
+      holdCount: 3,
+    });
+    expect(analytics.track).not.toHaveBeenCalledWith('Climb Create Failed', expect.anything());
+  });
+
+  it('fires "Climb Updated" when saving an existing climb in edit mode', async () => {
+    // Seed edit mode: useClimb resolves a climb, which the hook stores as
+    // savedClimb so the save flow takes the update branch.
+    editClimb.data = {
+      uuid: 'existing-climb',
+      name: 'Existing',
+      description: '',
+      frames: 'p1r12',
+      is_draft: false,
+      created_at: '2026-01-01T00:00:00.000Z',
+      published_at: '2026-01-02T00:00:00.000Z',
+    };
+    board.updateClimb.mockResolvedValue({
+      uuid: 'existing-climb',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      publishedAt: '2026-01-02T00:00:00.000Z',
+      isDraft: false,
+    });
+
+    const { result } = renderScreen('existing-climb');
+    // Let the edit-mode seeding effect run (sets savedClimb).
+    await waitFor(() => expect(result.current.saveState).toBe('ready'));
+    await nameAndSave(result);
+
+    expect(board.updateClimb).toHaveBeenCalledTimes(1);
+    expect(board.saveClimb).not.toHaveBeenCalled();
+    expect(analytics.track).toHaveBeenCalledWith('Climb Updated', {
+      boardName: 'kilter',
+      layoutId: 1,
+      climbUuid: 'existing-climb',
+      isDraft: false,
+      holdCount: 3,
+    });
+  });
+
+  it('fires "Climb Create Failed" with error_reason "duplicate" on a duplicate rejection', async () => {
+    board.isDuplicateClimbError.mockReturnValue(true);
+    board.saveClimb.mockRejectedValue(new Error('duplicate'));
+
+    const { result } = renderScreen();
+    await nameAndSave(result);
+
+    await waitFor(() =>
+      expect(analytics.track).toHaveBeenCalledWith('Climb Create Failed', {
+        boardName: 'kilter',
+        layoutId: 1,
+        error_reason: 'duplicate',
+      }),
+    );
+    expect(analytics.track).not.toHaveBeenCalledWith('Climb Created', expect.anything());
+  });
+
+  it('fires "Climb Create Failed" with error_reason "exception" on a generic save error', async () => {
+    board.isDuplicateClimbError.mockReturnValue(false);
+    board.saveClimb.mockRejectedValue(new Error('network down'));
+
+    const { result } = renderScreen();
+    await nameAndSave(result);
+
+    await waitFor(() =>
+      expect(analytics.track).toHaveBeenCalledWith('Climb Create Failed', {
+        boardName: 'kilter',
+        layoutId: 1,
+        error_reason: 'exception',
+      }),
+    );
+    // The generic-error branch surfaces a fallback toast (duplicate does not).
+    expect(toast.showToast).toHaveBeenCalledWith('createClimbForm.alerts.saveFailedFallback', 'error');
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
@@ -115,6 +115,11 @@ const BOARD = {
   angle: 40,
 };
 
+// Kilter layout id 1 resolves to this human-readable name via the shared
+// `getLayoutName` helper. Web sends the same name string for `boardLayout`
+// (`boardDetails.layout_name`), so the events match across platforms.
+const EXPECTED_BOARD_LAYOUT = 'Kilter Board Original';
+
 function renderScreen(editClimbUuid?: string) {
   return renderHook(() => useCreateClimbScreen({ board: BOARD, editClimbUuid }));
 }
@@ -152,9 +157,10 @@ describe('useCreateClimbScreen analytics', () => {
     await nameAndSave(result);
 
     expect(board.saveClimb).toHaveBeenCalledTimes(1);
-    // Same schema as web's `Climb Created` (create-climb-form.tsx): { boardLayout, isDraft, holdCount }.
+    // Same schema AND values as web's `Climb Created` (create-climb-form.tsx):
+    // { boardLayout: <resolved layout name>, isDraft, holdCount }.
     expect(analytics.track).toHaveBeenCalledWith('Climb Created', {
-      boardLayout: 1,
+      boardLayout: EXPECTED_BOARD_LAYOUT,
       isDraft: true,
       holdCount: 3,
     });
@@ -187,9 +193,9 @@ describe('useCreateClimbScreen analytics', () => {
 
     expect(board.updateClimb).toHaveBeenCalledTimes(1);
     expect(board.saveClimb).not.toHaveBeenCalled();
-    // Same schema as web's `Climb Updated`: { boardLayout, isDraft, holdCount }.
+    // Same schema AND values as web's `Climb Updated`: { boardLayout: <name>, isDraft, holdCount }.
     expect(analytics.track).toHaveBeenCalledWith('Climb Updated', {
-      boardLayout: 1,
+      boardLayout: EXPECTED_BOARD_LAYOUT,
       isDraft: false,
       holdCount: 3,
     });
@@ -203,9 +209,9 @@ describe('useCreateClimbScreen analytics', () => {
     await nameAndSave(result);
 
     await waitFor(() =>
-      // Web emits `{ boardLayout }`; mobile adds a non-grouping `error_reason`.
+      // Web emits `{ boardLayout: <name> }`; mobile adds a non-grouping `error_reason`.
       expect(analytics.track).toHaveBeenCalledWith('Climb Create Failed', {
-        boardLayout: 1,
+        boardLayout: EXPECTED_BOARD_LAYOUT,
         error_reason: 'duplicate',
       }),
     );
@@ -221,7 +227,7 @@ describe('useCreateClimbScreen analytics', () => {
 
     await waitFor(() =>
       expect(analytics.track).toHaveBeenCalledWith('Climb Create Failed', {
-        boardLayout: 1,
+        boardLayout: EXPECTED_BOARD_LAYOUT,
         error_reason: 'exception',
       }),
     );

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
@@ -140,7 +140,7 @@ beforeEach(() => {
 });
 
 describe('useCreateClimbScreen analytics', () => {
-  it('fires "Climb Created" with board + holdCount on a successful new save', async () => {
+  it('fires "Climb Created" with web-aligned boardLayout + holdCount on a successful new save', async () => {
     board.saveClimb.mockResolvedValue({
       uuid: 'new-climb',
       createdAt: null,
@@ -152,10 +152,9 @@ describe('useCreateClimbScreen analytics', () => {
     await nameAndSave(result);
 
     expect(board.saveClimb).toHaveBeenCalledTimes(1);
+    // Same schema as web's `Climb Created` (create-climb-form.tsx): { boardLayout, isDraft, holdCount }.
     expect(analytics.track).toHaveBeenCalledWith('Climb Created', {
-      boardName: 'kilter',
-      layoutId: 1,
-      climbUuid: 'new-climb',
+      boardLayout: 1,
       isDraft: true,
       holdCount: 3,
     });
@@ -188,10 +187,9 @@ describe('useCreateClimbScreen analytics', () => {
 
     expect(board.updateClimb).toHaveBeenCalledTimes(1);
     expect(board.saveClimb).not.toHaveBeenCalled();
+    // Same schema as web's `Climb Updated`: { boardLayout, isDraft, holdCount }.
     expect(analytics.track).toHaveBeenCalledWith('Climb Updated', {
-      boardName: 'kilter',
-      layoutId: 1,
-      climbUuid: 'existing-climb',
+      boardLayout: 1,
       isDraft: false,
       holdCount: 3,
     });
@@ -205,9 +203,9 @@ describe('useCreateClimbScreen analytics', () => {
     await nameAndSave(result);
 
     await waitFor(() =>
+      // Web emits `{ boardLayout }`; mobile adds a non-grouping `error_reason`.
       expect(analytics.track).toHaveBeenCalledWith('Climb Create Failed', {
-        boardName: 'kilter',
-        layoutId: 1,
+        boardLayout: 1,
         error_reason: 'duplicate',
       }),
     );
@@ -223,8 +221,7 @@ describe('useCreateClimbScreen analytics', () => {
 
     await waitFor(() =>
       expect(analytics.track).toHaveBeenCalledWith('Climb Create Failed', {
-        boardName: 'kilter',
-        layoutId: 1,
+        boardLayout: 1,
         error_reason: 'exception',
       }),
     );

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -398,10 +398,12 @@ export function useCreateClimbScreen({
           publishedAt: result.publishedAt ?? savedClimb.publishedAt,
           isDraft: result.isDraft,
         });
+        // Match web's schema exactly (create-climb-form.tsx) so PostHog funnels
+        // that group by these props line up across platforms. Web emits the
+        // human-readable `layout_name`; mobile only carries the numeric layout id
+        // here, so `boardLayout` is the layout identity mobile already has.
         track(SHARED_EVENTS.ClimbUpdated, {
-          boardName: board.boardName,
-          layoutId: board.layoutId,
-          climbUuid: result.uuid,
+          boardLayout: board.layoutId,
           isDraft: result.isDraft,
           holdCount,
         });
@@ -422,10 +424,9 @@ export function useCreateClimbScreen({
           publishedAt: result.publishedAt ?? null,
           isDraft,
         });
+        // Match web's schema exactly (create-climb-form.tsx). See ClimbUpdated above.
         track(SHARED_EVENTS.ClimbCreated, {
-          boardName: board.boardName,
-          layoutId: board.layoutId,
-          climbUuid: result.uuid,
+          boardLayout: board.layoutId,
           isDraft,
           holdCount,
         });
@@ -444,9 +445,11 @@ export function useCreateClimbScreen({
       if (justSavedTimerRef.current) clearTimeout(justSavedTimerRef.current);
       justSavedTimerRef.current = setTimeout(() => setJustSaved(false), JUST_SAVED_MS);
     } catch (err) {
+      // Web emits only `{ boardLayout }` for this event (create-climb-form.tsx);
+      // match that, plus a mobile-only `error_reason` that doesn't affect any
+      // grouping web relies on.
       track(SHARED_EVENTS.ClimbCreateFailed, {
-        boardName: board.boardName,
-        layoutId: board.layoutId,
+        boardLayout: board.layoutId,
         error_reason: isDuplicateClimbError(err) ? 'duplicate' : 'exception',
       });
       if (isDuplicateClimbError(err)) {

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -14,6 +14,8 @@ import {
 } from '@boardsesh/create-climb-react';
 import { useBoardProvider, isDuplicateClimbError } from '@boardsesh/board-react';
 import { GraphQLOperationError } from '@boardsesh/graphql-client';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../../lib/analytics';
 import { useAuth } from '../../providers/auth-provider';
 import { useProfile, useClimb } from '../../lib/graphql/hooks';
 import { useQueue } from '../../providers/queue-provider';
@@ -376,6 +378,8 @@ export function useCreateClimbScreen({
     const frames = generateFramesString();
     // Encode the no-match marker into the description only at save time.
     const fullDescription = withNoMatch(description, noMatch);
+    // Mirror web's `holdCount` property (create-climb-form.tsx).
+    const holdCount = Object.keys(litUpHoldsMap).length;
     try {
       if (canUpdate && savedClimb) {
         const result = await updateClimb({
@@ -394,6 +398,13 @@ export function useCreateClimbScreen({
           publishedAt: result.publishedAt ?? savedClimb.publishedAt,
           isDraft: result.isDraft,
         });
+        track(SHARED_EVENTS.ClimbUpdated, {
+          boardName: board.boardName,
+          layoutId: board.layoutId,
+          climbUuid: result.uuid,
+          isDraft: result.isDraft,
+          holdCount,
+        });
         syncSavedToQueue(result.uuid, frames);
       } else {
         const result = await saveClimb({
@@ -411,6 +422,13 @@ export function useCreateClimbScreen({
           publishedAt: result.publishedAt ?? null,
           isDraft,
         });
+        track(SHARED_EVENTS.ClimbCreated, {
+          boardName: board.boardName,
+          layoutId: board.layoutId,
+          climbUuid: result.uuid,
+          isDraft,
+          holdCount,
+        });
         syncSavedToQueue(result.uuid, frames);
       }
       await clearDraft(draftKey);
@@ -426,6 +444,11 @@ export function useCreateClimbScreen({
       if (justSavedTimerRef.current) clearTimeout(justSavedTimerRef.current);
       justSavedTimerRef.current = setTimeout(() => setJustSaved(false), JUST_SAVED_MS);
     } catch (err) {
+      track(SHARED_EVENTS.ClimbCreateFailed, {
+        boardName: board.boardName,
+        layoutId: board.layoutId,
+        error_reason: isDuplicateClimbError(err) ? 'duplicate' : 'exception',
+      });
       if (isDuplicateClimbError(err)) {
         setPublishDuplicateError(readDuplicateExtensions(err));
       } else {
@@ -442,6 +465,7 @@ export function useCreateClimbScreen({
     name,
     canUpdate,
     savedClimb,
+    litUpHoldsMap,
     generateFramesString,
     updateClimb,
     saveClimb,

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -14,6 +14,7 @@ import {
 } from '@boardsesh/create-climb-react';
 import { useBoardProvider, isDuplicateClimbError } from '@boardsesh/board-react';
 import { GraphQLOperationError } from '@boardsesh/graphql-client';
+import { getLayoutName } from '@boardsesh/board-constants/product-sizes';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../../lib/analytics';
 import { useAuth } from '../../providers/auth-provider';
@@ -380,6 +381,11 @@ export function useCreateClimbScreen({
     const fullDescription = withNoMatch(description, noMatch);
     // Mirror web's `holdCount` property (create-climb-form.tsx).
     const holdCount = Object.keys(litUpHoldsMap).length;
+    // Web sends the human-readable layout name (`boardDetails.layout_name || ''`)
+    // for `boardLayout`; mobile only carries the numeric layout id, so resolve it
+    // to the same name via the shared board-constants table. PostHog groups by
+    // exact value, so the string must match web for these create-climb events.
+    const boardLayout = getLayoutName(board.boardName, board.layoutId);
     try {
       if (canUpdate && savedClimb) {
         const result = await updateClimb({
@@ -399,11 +405,10 @@ export function useCreateClimbScreen({
           isDraft: result.isDraft,
         });
         // Match web's schema exactly (create-climb-form.tsx) so PostHog funnels
-        // that group by these props line up across platforms. Web emits the
-        // human-readable `layout_name`; mobile only carries the numeric layout id
-        // here, so `boardLayout` is the layout identity mobile already has.
+        // that group by these props line up across platforms. `boardLayout` is the
+        // resolved layout NAME (same value web sends), not the numeric id.
         track(SHARED_EVENTS.ClimbUpdated, {
-          boardLayout: board.layoutId,
+          boardLayout,
           isDraft: result.isDraft,
           holdCount,
         });
@@ -426,7 +431,7 @@ export function useCreateClimbScreen({
         });
         // Match web's schema exactly (create-climb-form.tsx). See ClimbUpdated above.
         track(SHARED_EVENTS.ClimbCreated, {
-          boardLayout: board.layoutId,
+          boardLayout,
           isDraft,
           holdCount,
         });
@@ -446,10 +451,10 @@ export function useCreateClimbScreen({
       justSavedTimerRef.current = setTimeout(() => setJustSaved(false), JUST_SAVED_MS);
     } catch (err) {
       // Web emits only `{ boardLayout }` for this event (create-climb-form.tsx);
-      // match that, plus a mobile-only `error_reason` that doesn't affect any
-      // grouping web relies on.
+      // match that (resolved layout NAME), plus a mobile-only `error_reason` that
+      // doesn't affect any grouping web relies on.
       track(SHARED_EVENTS.ClimbCreateFailed, {
-        boardLayout: board.layoutId,
+        boardLayout,
         error_reason: isDuplicateClimbError(err) ? 'duplicate' : 'exception',
       });
       if (isDuplicateClimbError(err)) {

--- a/packages/mobile/src/components/play-drawer/BetaVideoAddSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/BetaVideoAddSheet.tsx
@@ -3,7 +3,9 @@ import { View, StyleSheet, TextInput, Pressable, KeyboardAvoidingView, Platform 
 import { useTranslation } from 'react-i18next';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import * as Haptics from 'expo-haptics';
-import { isBetaVideoUrl } from '@boardsesh/shared-schema';
+import { isBetaVideoUrl, isInstagramUrl, isTikTokUrl } from '@boardsesh/shared-schema';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../../lib/analytics';
 import { Sheet } from '../Sheet';
 import { Text } from '../Text';
 import { useAttachBetaLink } from '../../lib/graphql/hooks';
@@ -62,6 +64,12 @@ export const BetaVideoAddSheet = forwardRef<BetaVideoAddSheetHandle, Props>(func
       { boardType: boardName, climbUuid, link: trimmed, angle },
       {
         onSuccess: () => {
+          // Match web's attach-beta-link-form `Beta Video Added` props exactly
+          // (boardType, climbUuid, platform) so both platforms aggregate.
+          let platform: 'TikTok' | 'Instagram' | 'Unknown' = 'Unknown';
+          if (isTikTokUrl(trimmed)) platform = 'TikTok';
+          else if (isInstagramUrl(trimmed)) platform = 'Instagram';
+          track(SHARED_EVENTS.BetaVideoAdded, { boardType: boardName, climbUuid, platform });
           void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
           showToast(t('mobile.betaVideos.attachSuccess'), 'success');
           setUrl('');

--- a/packages/mobile/src/components/play-drawer/__tests__/beta-video-add-sheet-analytics.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/beta-video-add-sheet-analytics.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+
+// The attach mutation. `mutate` synchronously invokes the success callback so
+// the component's onSuccess (where the analytics fire) runs inline in the test.
+const attach = vi.hoisted(() => ({
+  isPending: false,
+  mutate: vi.fn((_variables: unknown, callbacks: { onSuccess?: () => void }) => {
+    callbacks.onSuccess?.();
+  }),
+}));
+
+// Capture the host handlers so the test can type a URL and press submit without
+// a real renderer.
+const captured = vi.hoisted(() => ({
+  onChangeText: null as ((text: string) => void) | null,
+  onPress: null as (() => void) | null,
+}));
+
+vi.mock('../../../lib/analytics', () => ({ track: analytics.track }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  TextInput: ({ onChangeText }: { onChangeText?: (text: string) => void }) => {
+    captured.onChangeText = onChangeText ?? null;
+    return createElement('input');
+  },
+  Pressable: ({ onPress, children }: { onPress?: () => void; children?: ReactNode }) => {
+    captured.onPress = onPress ?? null;
+    return createElement('button', null, typeof children === 'function' ? null : children);
+  },
+  KeyboardAvoidingView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Platform: { OS: 'ios' },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('expo-haptics', () => ({
+  notificationAsync: vi.fn(async () => {}),
+  NotificationFeedbackType: { Success: 'success', Error: 'error' },
+}));
+vi.mock('../../Sheet', () => ({
+  Sheet: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({ useAttachBetaLink: () => attach }));
+vi.mock('../../../lib/graphql/extract-error-message', () => ({ extractGraphqlMessage: () => null }));
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: {} }));
+vi.mock('../../../theme/colors', () => ({ brandColors: {} }));
+vi.mock('../../../theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
+
+import { BetaVideoAddSheet } from '../BetaVideoAddSheet';
+
+beforeEach(() => {
+  analytics.track.mockClear();
+  attach.mutate.mockClear();
+  attach.isPending = false;
+  captured.onChangeText = null;
+  captured.onPress = null;
+});
+
+function renderSheet() {
+  return render(createElement(BetaVideoAddSheet, { boardName: 'kilter', climbUuid: 'climb-1', angle: 40 }));
+}
+
+// Type a URL (flushing the setState re-render so the submit closure sees it),
+// then press submit.
+function typeAndSubmit(url: string) {
+  act(() => captured.onChangeText?.(url));
+  act(() => captured.onPress?.());
+}
+
+describe('BetaVideoAddSheet analytics', () => {
+  it('fires "Beta Video Added" with platform "TikTok" on a successful submit', () => {
+    renderSheet();
+    typeAndSubmit('https://www.tiktok.com/@user/video/123');
+
+    expect(attach.mutate).toHaveBeenCalledTimes(1);
+    expect(analytics.track).toHaveBeenCalledWith('Beta Video Added', {
+      boardType: 'kilter',
+      climbUuid: 'climb-1',
+      platform: 'TikTok',
+    });
+  });
+
+  it('classifies an Instagram URL as platform "Instagram"', () => {
+    renderSheet();
+    typeAndSubmit('https://www.instagram.com/reel/abc/');
+
+    expect(analytics.track).toHaveBeenCalledWith('Beta Video Added', {
+      boardType: 'kilter',
+      climbUuid: 'climb-1',
+      platform: 'Instagram',
+    });
+  });
+
+  it('does not fire for an invalid (non-beta) URL', () => {
+    renderSheet();
+    typeAndSubmit('not a url');
+
+    expect(attach.mutate).not.toHaveBeenCalled();
+    expect(analytics.track).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
@@ -23,6 +23,8 @@ export type GeneratorSelection = { type: 'off' } | { type: 'on'; options: Genera
 
 type GeneratorPickerCardProps = {
   boardName: BoardName | null;
+  /** Board angle, forwarded to the `Workout Generator Opened` event to match web. */
+  angle: number | null;
   selection: GeneratorSelection;
   onChange: (selection: GeneratorSelection) => void;
 };
@@ -76,7 +78,7 @@ function getDefaultTargetGrade(boardName: BoardName | null): number {
  * algorithm and the chosen target grade. Defaults come from the shared package
  * so web and mobile agree on the starting state for each workout type.
  */
-export function GeneratorPickerCard({ boardName, selection, onChange }: GeneratorPickerCardProps) {
+export function GeneratorPickerCard({ boardName, angle, selection, onChange }: GeneratorPickerCardProps) {
   const { t } = useTranslation('session');
   const { systemColors, brandColors } = useTheme();
   const { formatGrade } = useGradeFormat();
@@ -87,9 +89,12 @@ export function GeneratorPickerCard({ boardName, selection, onChange }: Generato
       return;
     }
     // Enabling the generator (off → a workout type) reveals the configurator —
-    // the mobile analogue of web's `Workout Generator Opened`.
+    // the mobile analogue of web's `Workout Generator Opened`. Match web's exact
+    // payload (playlist-generator-drawer.tsx): `{ targetType, boardName, angle }`.
+    // The pre-session flow always feeds the session queue, so targetType is
+    // 'session'; PostHog groups by exact prop name, so the keys must line up.
     if (selection.type === 'off') {
-      track(SHARED_EVENTS.WorkoutGeneratorOpened, { boardName, workoutType: value });
+      track(SHARED_EVENTS.WorkoutGeneratorOpened, { targetType: 'session', boardName, angle });
     }
     const currentTarget = selection.type === 'on' ? selection.options.targetGrade : getDefaultTargetGrade(boardName);
     onChange({ type: 'on', options: buildDefaultOptions(value, currentTarget) });

--- a/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
@@ -10,6 +10,8 @@ import {
   type GeneratorOptions,
   type WorkoutType,
 } from '@boardsesh/playlist-generator';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../../../lib/analytics';
 import { Text } from '../../Text';
 import { useTheme } from '../../../providers/theme-provider';
 import { useGradeFormat } from '../../../hooks/use-grade-format';
@@ -83,6 +85,11 @@ export function GeneratorPickerCard({ boardName, selection, onChange }: Generato
     if (value === 'off') {
       onChange({ type: 'off' });
       return;
+    }
+    // Enabling the generator (off → a workout type) reveals the configurator —
+    // the mobile analogue of web's `Workout Generator Opened`.
+    if (selection.type === 'off') {
+      track(SHARED_EVENTS.WorkoutGeneratorOpened, { boardName, workoutType: value });
     }
     const currentTarget = selection.type === 'on' ? selection.options.targetGrade : getDefaultTargetGrade(boardName);
     onChange({ type: 'on', options: buildDefaultOptions(value, currentTarget) });

--- a/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
@@ -99,6 +99,7 @@ export function PreSessionView() {
 
         <GeneratorPickerCard
           boardName={activeBoard ? toBoardName(activeBoard.boardType) : null}
+          angle={activeBoard?.angle ?? null}
           selection={selection}
           onChange={setSelection}
         />

--- a/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
@@ -3,6 +3,8 @@ import { ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { getGradesForBoard, toBoardName } from '@boardsesh/board-config';
 import { generateWorkoutPlan } from '@boardsesh/playlist-generator';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../../../lib/analytics';
 import { Button } from '../../Button';
 import { Text } from '../../Text';
 import { useTheme } from '../../../providers/theme-provider';
@@ -59,6 +61,17 @@ export function PreSessionView() {
           // through the existing queue-provider plumbing, so the queue echoes
           // through the WS subscription exactly like a manual add.
           items.forEach((item) => addToQueue(item));
+          // Mirror web's start-sesh-drawer `Session Queue Generated`. The mobile
+          // path adds every selected climb (no per-slot failure tracking), so
+          // savedCount is the queued count and failedCount is the planned-minus-
+          // queued shortfall when the catalog couldn't fill every slot.
+          track(SHARED_EVENTS.SessionQueueGenerated, {
+            workoutType: selection.options.type,
+            boardName: activeBoard.boardType,
+            angle: activeBoard.angle,
+            savedCount: items.length,
+            failedCount: plan.length - items.length,
+          });
         }
       }
     } catch {

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/generator-picker-card-analytics.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/generator-picker-card-analytics.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GeneratorSelection } from '../GeneratorPickerCard';
+
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+
+// The workout-type chips render in CHIP_VALUES order: off, volume, pyramid,
+// ladder, gradeFocus. Each Pressable's onPress lands here in render order so the
+// test can tap a specific chip.
+const chips = vi.hoisted(() => ({ onPress: [] as Array<() => void> }));
+
+vi.mock('../../../../lib/analytics', () => ({ track: analytics.track }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Pressable: ({ onPress, children }: { onPress?: () => void; children?: ReactNode }) => {
+    if (onPress) chips.onPress.push(onPress);
+    return createElement('button', null, children);
+  },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@boardsesh/board-config', () => ({
+  // Two grades so getDefaultTargetGrade picks the middle one deterministically.
+  getGradesForBoard: () => [
+    { difficulty_id: 10, difficulty_name: '5a' },
+    { difficulty_id: 20, difficulty_name: '6a' },
+  ],
+}));
+vi.mock('@boardsesh/playlist-generator', () => ({
+  DEFAULT_GRADE_FOCUS_OPTIONS: { type: 'gradeFocus' },
+  DEFAULT_LADDER_OPTIONS: { type: 'ladder' },
+  DEFAULT_PYRAMID_OPTIONS: { type: 'pyramid' },
+  DEFAULT_VOLUME_OPTIONS: { type: 'volume' },
+}));
+vi.mock('../../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {}, brandColors: {} }),
+}));
+vi.mock('../../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (name: string) => name }),
+}));
+vi.mock('../../../../theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
+vi.mock('../../../../theme/colors', () => ({ brandColors: {} }));
+vi.mock('../../../../theme/ios-colors', () => ({ iosSystemColors: {} }));
+
+import { GeneratorPickerCard } from '../GeneratorPickerCard';
+
+beforeEach(() => {
+  analytics.track.mockClear();
+  chips.onPress = [];
+});
+
+describe('GeneratorPickerCard analytics', () => {
+  it('fires "Workout Generator Opened" when switching off → a workout type', () => {
+    render(
+      createElement(GeneratorPickerCard, {
+        boardName: 'kilter',
+        selection: { type: 'off' } satisfies GeneratorSelection,
+        onChange: vi.fn(),
+      }),
+    );
+
+    // Chip index 1 is 'volume' (index 0 is 'off').
+    chips.onPress[1]?.();
+
+    expect(analytics.track).toHaveBeenCalledWith('Workout Generator Opened', {
+      boardName: 'kilter',
+      workoutType: 'volume',
+    });
+  });
+
+  it('does not fire when tapping "off" (no off → on transition)', () => {
+    render(
+      createElement(GeneratorPickerCard, {
+        boardName: 'kilter',
+        selection: { type: 'off' } satisfies GeneratorSelection,
+        onChange: vi.fn(),
+      }),
+    );
+
+    chips.onPress[0]?.();
+
+    expect(analytics.track).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/generator-picker-card-analytics.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/generator-picker-card-analytics.test.tsx
@@ -58,10 +58,11 @@ beforeEach(() => {
 });
 
 describe('GeneratorPickerCard analytics', () => {
-  it('fires "Workout Generator Opened" when switching off → a workout type', () => {
+  it('fires "Workout Generator Opened" with web-aligned targetType + angle when switching off → a workout type', () => {
     render(
       createElement(GeneratorPickerCard, {
         boardName: 'kilter',
+        angle: 40,
         selection: { type: 'off' } satisfies GeneratorSelection,
         onChange: vi.fn(),
       }),
@@ -70,9 +71,12 @@ describe('GeneratorPickerCard analytics', () => {
     // Chip index 1 is 'volume' (index 0 is 'off').
     chips.onPress[1]?.();
 
+    // Exact payload web sends (playlist-generator-drawer.tsx): { targetType, boardName, angle }.
+    // No `workoutType` key — PostHog groups by exact prop name, so it must match web.
     expect(analytics.track).toHaveBeenCalledWith('Workout Generator Opened', {
+      targetType: 'session',
       boardName: 'kilter',
-      workoutType: 'volume',
+      angle: 40,
     });
   });
 
@@ -80,6 +84,7 @@ describe('GeneratorPickerCard analytics', () => {
     render(
       createElement(GeneratorPickerCard, {
         boardName: 'kilter',
+        angle: 40,
         selection: { type: 'off' } satisfies GeneratorSelection,
         onChange: vi.fn(),
       }),

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-analytics.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-analytics.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GeneratorSelection } from '../GeneratorPickerCard';
+
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+
+const queue = vi.hoisted(() => ({
+  startSession: vi.fn(async () => 'session-1' as string | null),
+  addToQueue: vi.fn(),
+}));
+
+const activeBoard = vi.hoisted(() => ({
+  data: { boardType: 'kilter', angle: 40 } as { boardType: string; angle: number } | null,
+}));
+
+const plan = vi.hoisted(() => ({ generated: [{ grade: 10 }, { grade: 11 }, { grade: 12 }] }));
+const selected = vi.hoisted(() => ({ items: [{ uuid: 'c1' }, { uuid: 'c2' }] }));
+
+// Surfaces GeneratorPickerCard's onChange so the test can flip the generator on.
+const picker = vi.hoisted(() => ({ onChange: null as ((selection: GeneratorSelection) => void) | null }));
+// Surfaces the Start button's onPress.
+const startButton = vi.hoisted(() => ({ onPress: null as (() => void) | null }));
+
+vi.mock('../../../../lib/analytics', () => ({ track: analytics.track }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@boardsesh/board-config', () => ({
+  getGradesForBoard: () => [{ difficulty_id: 10, difficulty_name: '5a' }],
+  toBoardName: (boardType: string) => boardType,
+}));
+vi.mock('@boardsesh/playlist-generator', () => ({
+  generateWorkoutPlan: () => plan.generated,
+}));
+vi.mock('../../../Button', () => ({
+  Button: ({ onPress }: { onPress?: () => void }) => {
+    startButton.onPress = onPress ?? null;
+    return createElement('button');
+  },
+}));
+vi.mock('../../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../../providers/theme-provider', () => ({ useTheme: () => ({ systemColors: {} }) }));
+vi.mock('../../../../lib/graphql/use-active-board', () => ({ useActiveBoard: () => activeBoard }));
+vi.mock('../../../../providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock('../../../../providers/queue-provider', () => ({
+  useQueue: () => ({ startSession: queue.startSession, addToQueue: queue.addToQueue }),
+}));
+vi.mock('../../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+}));
+vi.mock('../../../../theme/tokens', () => ({ spacing: {} }));
+vi.mock('../BoardSummaryCard', () => ({ BoardSummaryCard: () => null }));
+vi.mock('../GeneratorPickerCard', () => ({
+  GeneratorPickerCard: ({ onChange }: { onChange: (selection: GeneratorSelection) => void }) => {
+    picker.onChange = onChange;
+    return null;
+  },
+}));
+vi.mock('../select-climbs-for-plan', () => ({
+  selectClimbsForPlan: vi.fn(async () => selected.items),
+}));
+
+import { PreSessionView } from '../PreSessionView';
+
+beforeEach(() => {
+  analytics.track.mockClear();
+  queue.startSession.mockClear();
+  queue.startSession.mockResolvedValue('session-1');
+  queue.addToQueue.mockClear();
+  activeBoard.data = { boardType: 'kilter', angle: 40 };
+  picker.onChange = null;
+  startButton.onPress = null;
+});
+
+describe('PreSessionView analytics', () => {
+  it('fires "Session Queue Generated" with the queued/failed counts when starting with the generator on', async () => {
+    render(createElement(PreSessionView));
+
+    // Flip the generator on so handleStart takes the generate branch.
+    act(() => {
+      picker.onChange?.({
+        type: 'on',
+        options: {
+          type: 'volume',
+          targetGrade: 10,
+          minAscents: 0,
+          minRating: 0,
+          onlyTallClimbs: false,
+          climbBias: 'none',
+        } as never,
+      });
+    });
+
+    await act(async () => {
+      startButton.onPress?.();
+      // Let the async handleStart chain (startSession → select → track) settle.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(queue.addToQueue).toHaveBeenCalledTimes(2);
+    expect(analytics.track).toHaveBeenCalledWith('Session Queue Generated', {
+      workoutType: 'volume',
+      boardName: 'kilter',
+      angle: 40,
+      // 2 climbs queued out of a 3-slot plan → 1 short.
+      savedCount: 2,
+      failedCount: 1,
+    });
+  });
+
+  it('does not fire when the generator is off', async () => {
+    render(createElement(PreSessionView));
+
+    await act(async () => {
+      startButton.onPress?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(analytics.track).not.toHaveBeenCalledWith('Session Queue Generated', expect.anything());
+  });
+});

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -4,6 +4,8 @@ import { FlashList } from '@shopify/flash-list';
 import { useTranslation } from 'react-i18next';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import type { AscentFeedItem } from '@boardsesh/graphql/operations';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../../lib/analytics';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { ActivityIndicator } from '../ActivityIndicator';
@@ -27,6 +29,7 @@ export function LogbookTab({ userId }: { userId: string | undefined }) {
   const items = feed.data?.pages.flatMap((page) => page.userAscentsFeed.items) ?? [];
 
   const handlePress = useCallback((ascent: AscentFeedItem) => {
+    track(SHARED_EVENTS.LogbookRowClicked, { climbUuid: ascent.climbUuid });
     setEditAscent(ascent);
     editSheetRef.current?.snapToIndex(0);
   }, []);

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-analytics.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-analytics.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+
+// Capture the per-row onPress LogbookTab wires up, so the test can fire a tap
+// without a real list renderer.
+const row = vi.hoisted(() => ({ onPress: null as (() => void) | null }));
+
+const feed = vi.hoisted(() => ({
+  data: {
+    pages: [
+      {
+        userAscentsFeed: {
+          items: [{ uuid: 'ascent-1', climbUuid: 'climb-1' }],
+        },
+      },
+    ],
+  },
+  isPending: false,
+  isRefetching: false,
+  isFetchingNextPage: false,
+  hasNextPage: false,
+  refetch: vi.fn(),
+  fetchNextPage: vi.fn(),
+}));
+
+vi.mock('../../../lib/analytics', () => ({ track: analytics.track }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  RefreshControl: () => null,
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+// Render every data row through renderItem so the mocked LogbookRow mounts and
+// captures its onPress.
+vi.mock('@shopify/flash-list', () => ({
+  FlashList: ({
+    data,
+    renderItem,
+  }: {
+    data: Array<{ uuid: string }>;
+    renderItem: (info: { item: { uuid: string } }) => ReactNode;
+  }) => createElement('div', null, ...data.map((item) => renderItem({ item }))),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../LogbookRow', () => ({
+  LogbookRow: ({
+    onPress,
+    ascent,
+  }: {
+    onPress: (ascent: { climbUuid: string }) => void;
+    ascent: { climbUuid: string };
+  }) => {
+    row.onPress = () => onPress(ascent);
+    return createElement('div');
+  },
+}));
+vi.mock('../LogbookEditSheet', () => ({ LogbookEditSheet: () => null }));
+vi.mock('../../Text', () => ({ Text: () => null }));
+vi.mock('../../Icon', () => ({ Icon: () => null }));
+vi.mock('../../ActivityIndicator', () => ({ ActivityIndicator: () => null }));
+vi.mock('../../../lib/graphql/hooks', () => ({ useUserAscentsFeed: () => feed }));
+vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: {} }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {}, brandColors: {} }),
+}));
+
+import { LogbookTab } from '../LogbookTab';
+
+beforeEach(() => {
+  analytics.track.mockClear();
+  row.onPress = null;
+});
+
+describe('LogbookTab analytics', () => {
+  it('fires "Logbook Row Clicked" with the climb uuid when a row is tapped', () => {
+    render(createElement(LogbookTab, { userId: 'user-1' }));
+    expect(row.onPress).not.toBeNull();
+
+    row.onPress?.();
+
+    expect(analytics.track).toHaveBeenCalledWith('Logbook Row Clicked', { climbUuid: 'climb-1' });
+  });
+});

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -41,13 +41,11 @@ export const SHARED_EVENTS = {
   ClimbCreateFailed: 'Climb Create Failed',
   // Workout / session-queue generator
   WorkoutGeneratorOpened: 'Workout Generator Opened',
-  WorkoutGenerated: 'Workout Generated',
   SessionQueueGenerated: 'Session Queue Generated',
   // Deep-link session join
   SessionJoined: 'Session Joined',
   // Logbook
   LogbookRowClicked: 'Logbook Row Clicked',
-  LogbookThumbnailClicked: 'Logbook Thumbnail Clicked',
   // Ticks / logbook
   TickButtonClicked: 'Tick Button Clicked',
   QuickTickSaved: 'Quick Tick Saved',

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -35,6 +35,19 @@ export const SHARED_EVENTS = {
   CreatePlaylist: 'Create Playlist',
   AddToPlaylist: 'Add to Playlist',
   RemoveFromPlaylist: 'Remove from Playlist',
+  // Create climb
+  ClimbCreated: 'Climb Created',
+  ClimbUpdated: 'Climb Updated',
+  ClimbCreateFailed: 'Climb Create Failed',
+  // Workout / session-queue generator
+  WorkoutGeneratorOpened: 'Workout Generator Opened',
+  WorkoutGenerated: 'Workout Generated',
+  SessionQueueGenerated: 'Session Queue Generated',
+  // Deep-link session join
+  SessionJoined: 'Session Joined',
+  // Logbook
+  LogbookRowClicked: 'Logbook Row Clicked',
+  LogbookThumbnailClicked: 'Logbook Thumbnail Clicked',
   // Ticks / logbook
   TickButtonClicked: 'Tick Button Clicked',
   QuickTickSaved: 'Quick Tick Saved',
@@ -51,6 +64,7 @@ export const SHARED_EVENTS = {
   // Beta videos
   BetaVideoLinkClicked: 'Beta Video Link Clicked',
   BetaVideoClimbClicked: 'Beta Video Climb Clicked',
+  BetaVideoAdded: 'Beta Video Added',
 } as const;
 
 export type SharedEventKey = keyof typeof SHARED_EVENTS;


### PR DESCRIPTION
## Why

A PostHog audit found several React Native features are fully implemented but emit **zero** analytics, while the exact same events already fire on web today. As the RN app prepares to replace the legacy Capacitor app in the store, this leaves blind spots in cross-platform funnels. This PR adds the missing `track()` calls so mobile usage aggregates with web under one event name per behaviour.

A separate PR wires the build-time PostHog key. Until that merges and a build ships, these events only surface in dev debug logs (`[analytics] …` via the `onDebug` hook) — that's expected.

## What changed (per feature)

- **Create-climb** (`use-create-climb-screen.ts`): `Climb Created` / `Climb Updated` on a successful save, `Climb Create Failed` in the catch. Props match web's `create-climb-form.tsx` schema exactly so cross-platform funnels that group by these props line up: `{ boardLayout, isDraft, holdCount }` for Created/Updated and `{ boardLayout }` for Failed. Web's `boardLayout` is the human-readable `layout_name`; the mobile screen only carries the numeric layout id at this call site, so `boardLayout` is the layout identity mobile already has. The failure event also carries a mobile-only `error_reason` (`duplicate` | `exception`) that doesn't affect any grouping web relies on.
- **Workout / session-queue generator** (`GeneratorPickerCard.tsx`, `PreSessionView.tsx`): `Workout Generator Opened` when the user enables the generator (off → a workout type, which reveals the configurator — the mobile analogue of web's drawer open), and `Session Queue Generated` after a successful pre-session generate. Props mirror web's `playlist-generator-drawer` + `start-sesh-drawer`: `workoutType`, `boardName`, `angle`, `savedCount`, `failedCount`.
- **Beta video attach** (`BetaVideoAddSheet.tsx`): `Beta Video Added` on a successful attach, mirroring web's `attach-beta-link-form` exactly: `boardType`, `climbUuid`, `platform` (`TikTok` | `Instagram` | `Unknown`, derived via the shared `isTikTokUrl`/`isInstagramUrl` helpers).
- **Deep-link session join** (`app/join/[sessionId].tsx`): `Session Joined` on a successful join. Verified the queue provider only emits `Session Started` / `Session Ended`, never `Session Joined`, so there's no duplicate. Props mirror web's `board-session-bridge`: `session_id`, `board_name`, `layout_id` (parsed from the session board path).
- **Logbook** (`you/LogbookTab.tsx`): `Logbook Row Clicked` from the You-page logbook list, fired from the stable `handlePress` callback (no inline closure added to the memoized `LogbookRow`). The mobile logbook row has no separate climb-thumbnail tap target (its leading element is a status badge), so there is no `Logbook Thumbnail Clicked` call site on mobile and no dead catalog entry is added for it.

New event names are added to the shared `SHARED_EVENTS` catalog (`packages/shared/analytics`) so web and mobile can't drift on a name.

## How to verify

- In a local Metro dev session, exercise each flow and watch the console for `[analytics] <Event Name> { …props }` (the dev-only `onDebug` logger).
- After the PostHog-key PR merges and a build ships, the events appear in PostHog filtered to `$lib = posthog-react-native`, aggregating with the existing web events of the same name.

## Validation

- `vp run typecheck:mobile` — pass
- `vp test --project mobile` — pass (164 files, 1220 tests)
- `vp run check:mobile-bundle` — pass (Android bundle OK, 10.4 MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
