### PR TITLE
feat(mobile): grid/list view toggle on the climbs list

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -25,6 +25,7 @@ import {
   type ClimbBoardFilterState,
 } from '@boardsesh/climb-filters';
 import { ClimbListRow } from '../../../src/components/ClimbListRow';
+import { ClimbGridCard } from '../../../src/components/ClimbGridCard';
 import { ClimbListRowSkeleton } from '../../../src/components/ClimbListRowSkeleton';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
 import { Text } from '../../../src/components/Text';
@@ -60,12 +61,18 @@ import {
   type RecentFilter,
 } from '../../../src/lib/recent-filter-store';
 import { getLastSearch, saveLastSearch, boardConfigKey } from '../../../src/lib/last-search-store';
+import {
+  getViewMode,
+  saveViewMode,
+  DEFAULT_CLIMB_VIEW_MODE,
+  type ClimbViewMode,
+} from '../../../src/lib/view-mode-store';
 import { getFilterSummary, buildClimbFilterSummary } from '../../../src/lib/filter-summary';
 import { getActiveFilterTokens } from '../../../src/lib/filter-tokens';
 import { normalizeSearchName } from '../../../src/lib/search-name';
 import { track } from '../../../src/lib/analytics';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
-import { spacing } from '../../../src/theme/tokens';
+import { spacing, borderRadius } from '../../../src/theme/tokens';
 import { glassSize } from '../../../src/theme/layout';
 
 const PAGE_SIZE = 30;
@@ -184,6 +191,9 @@ function ClimbListInner() {
   const [showFilters, setShowFilters] = useState(false);
   const [showGrade, setShowGrade] = useState(false);
   const [recentFilters, setRecentFilters] = useState<RecentFilter[]>([]);
+  // Climbs-list layout (single-column list vs 2-up grid). Restored per board and
+  // defaulted to list. Held as state so the FlashList can re-key on a change.
+  const [viewMode, setViewMode] = useState<ClimbViewMode>(DEFAULT_CLIMB_VIEW_MODE);
   // Measured height of the floating glass chrome (incl. the top safe-area inset).
   // The list pads its top by this so the first row rests below the chrome and the
   // rest scroll under it.
@@ -346,6 +356,41 @@ function ClimbListInner() {
 
   // Search is "ready" once this board's restore has landed — gate queries on it.
   const searchReady = hasBoardConfig && restoredKey === boardKey;
+
+  // Restore this board's saved view mode on arrival; a board that never had a
+  // non-default mode chosen falls back to list. Keyed on the board only.
+  useEffect(() => {
+    if (!boardConfig) return;
+    let cancelled = false;
+    getViewMode(boardConfig)
+      .then((savedMode) => {
+        if (!cancelled) setViewMode(savedMode);
+      })
+      .catch(() => {
+        if (!cancelled) setViewMode(DEFAULT_CLIMB_VIEW_MODE);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // Re-run only when the board changes — boardConfig is memoised on board fields.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [boardKey]);
+
+  const handleToggleViewMode = useCallback(() => {
+    setViewMode((current) => {
+      const next: ClimbViewMode = current === 'grid' ? 'list' : 'grid';
+      if (boardConfig) void saveViewMode(boardConfig, next);
+      track(SHARED_EVENTS.ViewModeChanged, {
+        mode: next,
+        boardName,
+        layoutId,
+        sizeId,
+        setIds,
+        angle,
+      });
+      return next;
+    });
+  }, [boardConfig, boardName, layoutId, sizeId, setIds, angle]);
 
   useEffect(() => {
     if (!searchReady || visibleSearchTextRef.current === name) return;
@@ -728,6 +773,25 @@ function ClimbListInner() {
     ],
   );
 
+  const renderClimbGridItem = useCallback(
+    ({ item: climb }: { item: Climb }) => (
+      <View style={styles.gridCell}>
+        <ClimbGridCard
+          climb={climb}
+          boardName={boardName as BoardName}
+          layoutId={layoutId}
+          sizeId={sizeId}
+          setIds={setIds}
+          angle={angle}
+          onPress={handleClimbPress}
+          onOpenActions={openClimbActions}
+          selected={climb.uuid === activeClimbUuid}
+        />
+      </View>
+    ),
+    [boardName, layoutId, sizeId, setIds, angle, handleClimbPress, openClimbActions, activeClimbUuid],
+  );
+
   if (!hasBoardConfig && !isBoardLoading) {
     return (
       <>
@@ -768,13 +832,20 @@ function ClimbListInner() {
 
   const isEmpty = visibleClimbs.length === 0 && !isClimbsLoading;
 
+  const isGrid = viewMode === 'grid';
+
   return (
     <View style={[styles.container, { backgroundColor: systemColors.background }]}>
       <Stack.Screen options={stackOptions} />
       <FlashList
+        // Re-key on the layout so a mode flip remounts the list — an instant
+        // swap (FlashList recycles cells, so a live numColumns change without a
+        // remount would mis-size recycled rows mid-flip).
+        key={viewMode}
         ref={listRef}
         data={visibleClimbs}
-        renderItem={renderClimbItem}
+        renderItem={isGrid ? renderClimbGridItem : renderClimbItem}
+        numColumns={isGrid ? 2 : 1}
         keyExtractor={keyExtractor}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
@@ -784,7 +855,11 @@ function ClimbListInner() {
         // inset and the list pads manually by the measured chrome height. Leaving
         // this 'automatic' would double-inset under the (invisible) native header.
         contentInsetAdjustmentBehavior="never"
-        contentContainerStyle={{ paddingTop: searchBarHeight, paddingBottom: listPaddingBottom }}
+        contentContainerStyle={{
+          paddingTop: searchBarHeight,
+          paddingBottom: listPaddingBottom,
+          paddingHorizontal: isGrid ? spacing[3] : 0,
+        }}
         scrollIndicatorInsets={{ top: searchBarHeight }}
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="interactive"
@@ -813,10 +888,22 @@ function ClimbListInner() {
             ) : null}
           </>
         }
-        ListFooterComponent={isFetchingNextPage ? <ClimbListSkeletonRows count={FOOTER_SKELETON_ROW_COUNT} /> : null}
+        ListFooterComponent={
+          isFetchingNextPage ? (
+            isGrid ? (
+              <ClimbGridSkeletonRows count={FOOTER_SKELETON_ROW_COUNT} />
+            ) : (
+              <ClimbListSkeletonRows count={FOOTER_SKELETON_ROW_COUNT} />
+            )
+          ) : null
+        }
         ListEmptyComponent={
           showInitialSkeletons ? (
-            <ClimbListSkeletonRows count={INITIAL_SKELETON_ROW_COUNT} />
+            isGrid ? (
+              <ClimbGridSkeletonRows count={INITIAL_SKELETON_ROW_COUNT} />
+            ) : (
+              <ClimbListSkeletonRows count={INITIAL_SKELETON_ROW_COUNT} />
+            )
           ) : isEmpty ? (
             <View style={styles.emptyContainer}>
               <Icon name="search" size={48} color={iosSystemColors.systemGray4} />
@@ -862,6 +949,8 @@ function ClimbListInner() {
         gradeChip={gradeChip}
         onOpenGrade={handleOpenGrade}
         onGradeChange={handleGradeChange}
+        viewMode={viewMode}
+        onToggleViewMode={handleToggleViewMode}
       />
 
       {filterInTopChrome ? null : (
@@ -906,6 +995,28 @@ function ClimbListSkeletonRows({ count }: { count: number }) {
   );
 }
 
+// 2-up skeleton tiles for the grid layout. Reuses the list-row skeleton's fill
+// colour, sized to a portrait card so the loading state matches the grid card.
+function ClimbGridSkeletonRows({ count }: { count: number }) {
+  return (
+    <View style={styles.gridSkeletonGrid}>
+      {Array.from({ length: count }, (_item, index) => (
+        <GridSkeletonCell key={`climb-grid-skeleton-${index}`} />
+      ))}
+    </View>
+  );
+}
+
+function GridSkeletonCell() {
+  const { systemColors } = useTheme();
+  return (
+    <View style={styles.gridCell} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+      <View style={[styles.gridSkeletonThumbnail, { backgroundColor: systemColors.fill }]} />
+      <View style={[styles.gridSkeletonName, { backgroundColor: systemColors.fill }]} />
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -938,5 +1049,30 @@ const styles = StyleSheet.create({
   },
   emptyCta: {
     marginTop: spacing[4],
+  },
+  // One grid cell: half the row (numColumns=2) with a half-gutter on each side,
+  // so the inter-card gap is spacing[2] and the outer edges align with the
+  // contentContainer's spacing[3] horizontal padding. Vertical gap via bottom margin.
+  gridCell: {
+    flex: 1,
+    paddingHorizontal: spacing[1],
+    marginBottom: spacing[3],
+  },
+  gridSkeletonGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  gridSkeletonThumbnail: {
+    width: '100%',
+    aspectRatio: 3 / 4,
+    borderRadius: borderRadius.md,
+    opacity: 0.55,
+  },
+  gridSkeletonName: {
+    marginTop: spacing[2],
+    width: '70%',
+    height: 16,
+    borderRadius: borderRadius.full,
+    opacity: 0.45,
   },
 });

--- a/packages/mobile/src/components/ClimbGridCard.tsx
+++ b/packages/mobile/src/components/ClimbGridCard.tsx
@@ -1,0 +1,199 @@
+import React, { useCallback, useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Card as PaperCard } from 'react-native-paper';
+import type { Climb, BoardName } from '@boardsesh/shared-schema';
+import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { Text } from './Text';
+import { PressableSurface } from './PressableSurface';
+import { ClimbListThumbnail } from './ClimbListThumbnail';
+import { AscentStatusGlyph } from './ClimbListItemContent';
+import { selectedRowColors } from './climb-list-row-colors';
+import { useGradeFormat } from '../hooks/use-grade-format';
+import { useTheme } from '../providers/theme-provider';
+import { hapticSelection, hapticMedium } from '../lib/haptics';
+import { spacing, borderRadius } from '../theme/tokens';
+
+// Portrait board art reads best a touch taller than wide, matching the list
+// thumbnail's 76×96 (≈3:4). The card sizes the art by aspect ratio so it scales
+// to whatever column width FlashList hands the row.
+const THUMBNAIL_ASPECT_RATIO = 3 / 4;
+
+type ClimbGridCardProps = {
+  climb: Climb;
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+  onPress: (climb: Climb) => void;
+  onOpenActions?: (climb: Climb) => void;
+  selected?: boolean;
+};
+
+/**
+ * Two-up grid card for the climbs list — the alternate to {@link ClimbListRow}.
+ * Reuses ClimbListThumbnail (sized to the column via an aspect-ratio wrapper) and
+ * the same AscentStatusGlyph badge as the list row, so a tick write re-renders
+ * only the 16px glyph, not the card. Tapping activates the climb (same path as
+ * the list row's onPress); long-press opens the climb-actions sheet. Swipe
+ * actions are intentionally list-only — a 2-up grid has no room for them.
+ *
+ * Variant-aware: a Paper `Card` (mode="elevated") on the Material variant, a
+ * plain pressable surface on systemColors.background for Liquid Glass (cards stay
+ * flat; glass is reserved for the floating chrome).
+ */
+const ClimbGridCard = React.memo(function ClimbGridCard({
+  climb,
+  boardName,
+  layoutId,
+  sizeId,
+  setIds,
+  angle,
+  onPress,
+  onOpenActions,
+  selected,
+}: ClimbGridCardProps) {
+  const { systemColors, brandColors, variant } = useTheme();
+  const { formatGrade } = useGradeFormat();
+
+  const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
+  const formattedGrade = formatGrade(climb.difficulty) ?? climb.difficulty;
+
+  const highlight = useMemo(() => selectedRowColors(brandColors.primary), [brandColors.primary]);
+
+  const handlePress = useCallback(() => {
+    hapticSelection();
+    onPress(climb);
+  }, [onPress, climb]);
+
+  const handleLongPress = useCallback(() => {
+    if (!onOpenActions) return;
+    hapticMedium();
+    onOpenActions(climb);
+  }, [onOpenActions, climb]);
+
+  // Inner: thumbnail with the ascent badge overlaid top-right, then a footer with
+  // the name + colorized grade. Shared by both variants so the layout is identical.
+  const body = (
+    <>
+      <View style={styles.thumbnailWrapper}>
+        <ClimbListThumbnail
+          frames={climb.frames}
+          boardName={boardName}
+          layoutId={layoutId}
+          sizeId={sizeId}
+          setIds={setIds}
+          mirrored={climb.mirrored ?? false}
+          style={styles.thumbnail}
+        />
+        <View style={styles.statusBadge}>
+          <AscentStatusGlyph climbUuid={climb.uuid} angle={angle} />
+        </View>
+      </View>
+
+      <View style={styles.footer}>
+        <Text variant="subheadline" numberOfLines={1} style={styles.name}>
+          {climb.name}
+        </Text>
+        {/* Colorized grade — same getGradeColor mapping ClimbListItemContent uses
+            for the list row, so the two layouts share one visual grade language. */}
+        <Text variant="subheadline" numberOfLines={1} style={[styles.grade, { color: gradeColor }]}>
+          {formattedGrade}
+        </Text>
+      </View>
+    </>
+  );
+
+  const accessibilityLabel = `${climb.name}, ${formattedGrade}`;
+
+  if (variant === 'material') {
+    return (
+      <PaperCard
+        mode="elevated"
+        elevation={1}
+        onPress={handlePress}
+        onLongPress={onOpenActions ? handleLongPress : undefined}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityState={{ selected: !!selected }}
+        style={[
+          styles.materialCard,
+          selected
+            ? { borderWidth: 2, borderColor: brandColors.primary, backgroundColor: highlight.fill }
+            : { borderWidth: 0 },
+        ]}
+      >
+        {body}
+      </PaperCard>
+    );
+  }
+
+  return (
+    <PressableSurface
+      onPress={handlePress}
+      onLongPress={onOpenActions ? handleLongPress : undefined}
+      feedback="scale"
+      scaleTo={0.97}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityState={{ selected: !!selected }}
+      style={[
+        styles.glassCard,
+        { backgroundColor: systemColors.background },
+        selected ? { backgroundColor: highlight.fill, borderColor: highlight.accent } : null,
+      ]}
+    >
+      {body}
+    </PressableSurface>
+  );
+});
+
+export { ClimbGridCard };
+
+const styles = StyleSheet.create({
+  glassCard: {
+    flex: 1,
+    borderRadius: borderRadius.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'transparent',
+    overflow: 'hidden',
+  },
+  materialCard: {
+    flex: 1,
+    borderRadius: borderRadius.lg,
+    overflow: 'hidden',
+  },
+  thumbnailWrapper: {
+    width: '100%',
+    aspectRatio: THUMBNAIL_ASPECT_RATIO,
+    position: 'relative',
+  },
+  thumbnail: {
+    // Override the fixed 76×96 list cell: fill the column-width wrapper.
+    width: '100%',
+    height: '100%',
+    borderRadius: 0,
+  },
+  statusBadge: {
+    position: 'absolute',
+    top: spacing[2],
+    right: spacing[2],
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing[2],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+  },
+  name: {
+    flexShrink: 1,
+    fontWeight: '600',
+  },
+  grade: {
+    flexShrink: 0,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+});

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -171,7 +171,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
   );
 });
 
-export { ClimbListItemContent };
+export { ClimbListItemContent, AscentStatusGlyph };
 
 const styles = StyleSheet.create({
   thumbnailContainer: {

--- a/packages/mobile/src/components/ClimbListThumbnail.tsx
+++ b/packages/mobile/src/components/ClimbListThumbnail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { useNativeClimbRender } from '../hooks/use-native-climb-render';
 import { borderRadius } from '../theme/tokens';
@@ -21,6 +21,12 @@ type ClimbListThumbnailProps = {
   sizeId: number;
   setIds: string;
   mirrored?: boolean;
+  /**
+   * Overrides the fixed 76×96 list cell. The grid card passes a column-width
+   * wrapper (`aspectRatio` instead of a fixed height) so the same thumbnail
+   * scales up to a 2-up tile. List rows omit it and keep the portrait cell.
+   */
+  style?: StyleProp<ViewStyle>;
 };
 
 /**
@@ -41,6 +47,7 @@ const ClimbListThumbnail = React.memo(function ClimbListThumbnail({
   sizeId,
   setIds,
   mirrored,
+  style,
 }: ClimbListThumbnailProps) {
   const { overlayUri, backgroundPaths, missingBackgroundCount } = useNativeClimbRender({
     frames,
@@ -52,7 +59,7 @@ const ClimbListThumbnail = React.memo(function ClimbListThumbnail({
   });
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, style]}>
       <LayeredClimbImage
         overlayUri={overlayUri}
         backgroundPaths={backgroundPaths}

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -124,6 +124,11 @@ export const iconMap = {
   clock: { ios: 'clock', android: 'clock-outline' },
   filter: { ios: 'line.3.horizontal.decrease', android: 'filter-variant' },
   sort: { ios: 'arrow.up.arrow.down', android: 'sort-variant' },
+  // Climbs view-mode toggle: the icon shows the TARGET mode the tap switches to
+  // (single-button toggle), so 'view-grid' is shown while in list mode and
+  // 'view-list' while in grid mode.
+  'view-list': { ios: 'list.bullet', android: 'view-list' },
+  'view-grid': { ios: 'square.grid.2x2', android: 'view-grid' },
   refresh: { ios: 'arrow.clockwise', android: 'refresh' },
   'crop.free': { ios: 'viewfinder', android: 'crop-free' },
   photo: { ios: 'photo', android: 'image-outline' },

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -15,15 +15,18 @@ import { useTranslation } from 'react-i18next';
 import { Appbar, Chip } from 'react-native-paper';
 import type { Grade } from '@boardsesh/shared-schema';
 import type { GradeBound } from '@boardsesh/climb-filters';
+import type { ClimbViewMode } from '../../lib/view-mode-store';
 import { useTheme } from '../../providers/theme-provider';
 import { useActiveBoard, useSetActiveBoard } from '../../lib/graphql/use-active-board';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { spacing } from '../../theme/tokens';
-import { hapticLight } from '../../lib/haptics';
+import { glassSize } from '../../theme/layout';
+import { hapticLight, hapticSelection } from '../../lib/haptics';
 import { formatActiveBoardLabel } from '../../lib/boards/active-board-label';
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 import { Text } from '../Text';
-import { iconMap } from '../icon-map';
+import { GlassIconButton } from '../GlassIconButton';
+import { iconMap, type IconName } from '../icon-map';
 import { CollapsingTopChrome, TOP_ACTION_SIZE } from '../chrome';
 import { GradeRangeRail } from '../grade';
 import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
@@ -69,6 +72,10 @@ type ClimbTopChromeProps = {
   gradeChip?: { label: string; active: boolean; onClear?: () => void };
   onOpenGrade?: () => void;
   onGradeChange?: (grade: GradeBound) => void;
+  /** Current climbs-list layout. The toggle button shows the OTHER mode's icon. */
+  viewMode?: ClimbViewMode;
+  /** Flips the list between single-column (`list`) and 2-up (`grid`). */
+  onToggleViewMode?: () => void;
 };
 
 export function ClimbTopChrome({
@@ -96,6 +103,8 @@ export function ClimbTopChrome({
   gradeChip,
   onOpenGrade,
   onGradeChange,
+  viewMode = 'list',
+  onToggleViewMode,
 }: ClimbTopChromeProps) {
   const { t } = useTranslation('climbs');
   const { t: tCommon } = useTranslation('common');
@@ -103,6 +112,16 @@ export function ClimbTopChrome({
   const insets = useSafeAreaInsets();
   const { data: activeBoard } = useActiveBoard();
   const usesCustomSearch = searchMode === 'custom';
+
+  // Single-button toggle: the glyph is the TARGET mode the tap switches to
+  // (list shows the grid icon, grid shows the list icon), and the a11y label
+  // names that target. Matches the legacy app's grid/list toggle.
+  const viewModeIcon: IconName = viewMode === 'grid' ? 'view-list' : 'view-grid';
+  const viewModeLabel = viewMode === 'grid' ? t('mobile.viewMode.toViewList') : t('mobile.viewMode.toViewGrid');
+  const handleToggleViewMode = useCallback(() => {
+    hapticSelection();
+    onToggleViewMode?.();
+  }, [onToggleViewMode]);
 
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => onHeightChange(event.nativeEvent.layout.height),
@@ -168,6 +187,15 @@ export function ClimbTopChrome({
             titleStyle={styles.materialTitle}
             subtitleStyle={styles.materialSubtitle}
           />
+          {onToggleViewMode ? (
+            <Appbar.Action
+              icon={iconMap[viewModeIcon].android}
+              color={systemColors.label as string}
+              onPress={handleToggleViewMode}
+              accessibilityLabel={viewModeLabel}
+              accessibilityHint={t('mobile.viewMode.hint')}
+            />
+          ) : null}
           {canCreate ? (
             <Appbar.Action
               icon={iconMap.plus.android}
@@ -249,6 +277,24 @@ export function ClimbTopChrome({
     );
   }
 
+  // Liquid-glass view-mode toggle: a glass island that cross-fades SF Symbols
+  // (list.bullet ↔ square.grid.2x2) on the active mode, honouring Reduce Motion.
+  // Shown right of the search field; on iOS 26 native search (no in-chrome field)
+  // it floats right-aligned so the toggle is still reachable in the chrome.
+  const viewModeToggle = onToggleViewMode ? (
+    <GlassIconButton
+      iconName="view-grid"
+      secondaryIconName="view-list"
+      active={viewMode === 'grid'}
+      iconColor={systemColors.label}
+      fallbackColor={systemColors.fill}
+      size={glassSize.standard}
+      onPress={handleToggleViewMode}
+      accessibilityLabel={viewModeLabel}
+      accessibilityHint={t('mobile.viewMode.hint')}
+    />
+  ) : null;
+
   // Liquid-glass variant: the shared collapsing chrome (centred board pill that
   // collapses into the filter title, board glyph docking into the toolbar) with
   // the climbs-only search row as its below-row content.
@@ -277,7 +323,14 @@ export function ClimbTopChrome({
                 height={TOP_ACTION_SIZE}
               />
             </View>
+            {viewModeToggle}
           </View>
+        </View>
+      ) : viewModeToggle ? (
+        // Native search (iOS 26): the search field lives in the tab bar, so the
+        // toggle floats alone, right-aligned, in the chrome's below-islands row.
+        <View pointerEvents="box-none" style={[styles.searchStack, styles.viewModeOnlyRow]}>
+          {viewModeToggle}
         </View>
       ) : null}
     </CollapsingTopChrome>
@@ -380,6 +433,10 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     minWidth: 0,
+  },
+  viewModeOnlyRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
   },
   materialContainer: {
     position: 'absolute',

--- a/packages/mobile/src/lib/__tests__/view-mode-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/view-mode-store.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { BoardSearchConfig } from '@boardsesh/climb-filters';
+
+vi.mock('expo-secure-store', () => {
+  let storage: Record<string, string> = {};
+  return {
+    getItemAsync: vi.fn(async (key: string) => storage[key] ?? null),
+    setItemAsync: vi.fn(async (key: string, value: string) => {
+      storage[key] = value;
+    }),
+    deleteItemAsync: vi.fn(async (key: string) => {
+      delete storage[key];
+    }),
+    __reset: () => {
+      storage = {};
+    },
+    __raw: () => storage,
+  };
+});
+
+const STORE_KEY = 'boardsesh_climbs_view_mode_by_board';
+
+const kilterBoard: BoardSearchConfig = {
+  boardName: 'kilter',
+  layoutId: 1,
+  sizeId: 7,
+  setIds: '1,20',
+  angle: 40,
+};
+
+const tensionBoard: BoardSearchConfig = {
+  boardName: 'tension',
+  layoutId: 9,
+  sizeId: 3,
+  setIds: '5',
+  angle: 30,
+};
+
+async function resetStore() {
+  const store = await import('expo-secure-store');
+  (store as unknown as { __reset: () => void }).__reset();
+}
+
+async function rawStorage(): Promise<Record<string, string>> {
+  const store = await import('expo-secure-store');
+  return (store as unknown as { __raw: () => Record<string, string> }).__raw();
+}
+
+describe('view-mode-store', () => {
+  beforeEach(async () => {
+    await resetStore();
+  });
+
+  it('defaults to list for a board that was never set', async () => {
+    const { getViewMode, DEFAULT_CLIMB_VIEW_MODE } = await import('../view-mode-store');
+    expect(DEFAULT_CLIMB_VIEW_MODE).toBe('list');
+    expect(await getViewMode(kilterBoard)).toBe('list');
+  });
+
+  it('persists and restores grid per board', async () => {
+    const { saveViewMode, getViewMode } = await import('../view-mode-store');
+    await saveViewMode(kilterBoard, 'grid');
+    expect(await getViewMode(kilterBoard)).toBe('grid');
+    // A different board is unaffected and keeps the default.
+    expect(await getViewMode(tensionBoard)).toBe('list');
+  });
+
+  it('deletes the entry when saving the default list mode', async () => {
+    const { saveViewMode, getViewMode } = await import('../view-mode-store');
+    await saveViewMode(kilterBoard, 'grid');
+    await saveViewMode(kilterBoard, 'list');
+    expect(await getViewMode(kilterBoard)).toBe('list');
+    const stored = JSON.parse((await rawStorage())[STORE_KEY] ?? '{}');
+    expect(Object.keys(stored)).toHaveLength(0);
+  });
+
+  it('ignores malformed stored values and falls back to the default', async () => {
+    const store = await import('expo-secure-store');
+    await store.setItemAsync(STORE_KEY, JSON.stringify({ 'kilter|1|7|1,20|40': 'bogus' }));
+    const { getViewMode } = await import('../view-mode-store');
+    expect(await getViewMode(kilterBoard)).toBe('list');
+  });
+});

--- a/packages/mobile/src/lib/view-mode-store.ts
+++ b/packages/mobile/src/lib/view-mode-store.ts
@@ -1,0 +1,87 @@
+import * as SecureStore from 'expo-secure-store';
+import type { BoardSearchConfig } from '@boardsesh/climb-filters';
+import { boardConfigKey } from './last-search-store';
+
+/**
+ * Climbs-list view mode. `list` is the single-column FlashList (the default and
+ * the only layout the app shipped with); `grid` is the two-up card layout. Held
+ * per board config so a climber who prefers the grid on their home board keeps
+ * the single-column scan on a denser comp board, mirroring the per-board memory
+ * of {@link getLastSearch}.
+ */
+export type ClimbViewMode = 'list' | 'grid';
+
+export const DEFAULT_CLIMB_VIEW_MODE: ClimbViewMode = 'list';
+
+// One secure-store key holds a JSON map of boardConfigKey -> ClimbViewMode.
+// Capped to bound growth when a user hops across many board configs.
+const VIEW_MODE_KEY = 'boardsesh_climbs_view_mode_by_board';
+const MAX_BOARDS = 20;
+
+type ViewModeMap = Record<string, ClimbViewMode>;
+
+function isClimbViewMode(value: unknown): value is ClimbViewMode {
+  return value === 'list' || value === 'grid';
+}
+
+async function readMap(): Promise<ViewModeMap> {
+  try {
+    const value = await SecureStore.getItemAsync(VIEW_MODE_KEY);
+    if (!value) return {};
+    const parsed: unknown = JSON.parse(value);
+    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const result: ViewModeMap = {};
+    for (const [key, mode] of Object.entries(parsed)) {
+      if (isClimbViewMode(mode)) result[key] = mode;
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+// Bound the map: keep the most recently inserted boards. Insertion order is the
+// natural recency proxy here (we re-insert a board's key on every save), so we
+// keep the last MAX_BOARDS keys.
+function capMap(map: ViewModeMap): ViewModeMap {
+  const keys = Object.keys(map);
+  if (keys.length <= MAX_BOARDS) return map;
+  const keep = keys.slice(keys.length - MAX_BOARDS);
+  const capped: ViewModeMap = {};
+  for (const key of keep) {
+    capped[key] = map[key];
+  }
+  return capped;
+}
+
+/**
+ * The saved view mode for this board, or {@link DEFAULT_CLIMB_VIEW_MODE} when the
+ * board has never had a non-default mode chosen (defaults to list).
+ */
+export async function getViewMode(board: BoardSearchConfig): Promise<ClimbViewMode> {
+  const map = await readMap();
+  return map[boardConfigKey(board)] ?? DEFAULT_CLIMB_VIEW_MODE;
+}
+
+/**
+ * Persists the view mode for this board. Saving the default `list` *deletes* any
+ * stored entry so the map only carries boards the user explicitly put on grid.
+ */
+export async function saveViewMode(board: BoardSearchConfig, mode: ClimbViewMode): Promise<void> {
+  try {
+    const key = boardConfigKey(board);
+    const map = await readMap();
+    if (mode === DEFAULT_CLIMB_VIEW_MODE) {
+      if (!(key in map)) return;
+      delete map[key];
+      await SecureStore.setItemAsync(VIEW_MODE_KEY, JSON.stringify(map));
+      return;
+    }
+    // Re-insert so this board moves to the end (most-recent) for capMap.
+    delete map[key];
+    map[key] = mode;
+    await SecureStore.setItemAsync(VIEW_MODE_KEY, JSON.stringify(capMap(map)));
+  } catch {
+    // Storage failure is non-critical — the session keeps the in-memory choice.
+  }
+}

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -48,6 +48,7 @@ export const SHARED_EVENTS = {
   ClimbSentToBoardFailure: 'Climb Sent to Board Failure',
   // Search
   ClimbSearchPerformed: 'Climb Search Performed',
+  ViewModeChanged: 'View Mode Changed',
   // Beta videos
   BetaVideoLinkClicked: 'Beta Video Link Clicked',
   BetaVideoClimbClicked: 'Beta Video Climb Clicked',

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -667,6 +667,11 @@
       "gradeCloseHint": "Closes the grade picker",
       "allClimbs": "All climbs"
     },
+    "viewMode": {
+      "toViewGrid": "View as grid",
+      "toViewList": "View as list",
+      "hint": "Switches the climbs list between a single column and a two-up grid"
+    },
     "gradeRail": {
       "setFilterAria": "Set grade filter to {{grade}}",
       "selectedFilterAria": "{{grade}} grade filter selected",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -667,6 +667,11 @@
       "gradeCloseHint": "Cierra el selector de grado",
       "allClimbs": "Todas las vías"
     },
+    "viewMode": {
+      "toViewGrid": "Ver en cuadrícula",
+      "toViewList": "Ver en lista",
+      "hint": "Cambia la lista de vías entre una columna y una cuadrícula de dos"
+    },
     "gradeRail": {
       "setFilterAria": "Filtrar por grado {{grade}}",
       "selectedFilterAria": "Filtro de grado {{grade}} seleccionado",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -667,6 +667,11 @@
       "gradeCloseHint": "Ferme le sélecteur de cotation",
       "allClimbs": "Toutes les voies"
     },
+    "viewMode": {
+      "toViewGrid": "Voir en grille",
+      "toViewList": "Voir en liste",
+      "hint": "Bascule la liste des voies entre une colonne et une grille à deux"
+    },
     "gradeRail": {
       "setFilterAria": "Filtrer par cotation {{grade}}",
       "selectedFilterAria": "Filtre de cotation {{grade}} sélectionné",


### PR DESCRIPTION
## Why

PostHog shows **266 mobile users** used a grid/list view toggle on the legacy Capacitor app, but the React Native climbs list shipped with only a single-column FlashList. This adds the toggle back as the RN app gets ready to replace Capacitor.

## What

A single-icon view-mode toggle (one tap flips) plus a two-up climb grid card, implemented in **both** UI variants:

- **Liquid Glass / Apple HIG**: a `GlassIconButton` in the search row, right of the search field, that cross-fades the SF Symbols `list.bullet` ↔ `square.grid.2x2` on the active mode (honours Reduce Motion). On iOS 26 native search it floats right-aligned in the chrome.
- **Material 3**: an `Appbar.Action` among the existing header actions, using the MDI `view-list` / `view-grid` glyphs.

The toggle icon always shows the **target** mode (list shows the grid icon, grid shows the list icon), matching the legacy toggle.

`ClimbGridCard`:
- `React.memo`'d, variant-aware: a Paper `Card` (`mode="elevated"`, elevation level1, ripple) on Material, a flat pressable surface on `systemColors.background` for Liquid Glass (cards stay flat — glass is reserved for the floating chrome).
- Reuses `ClimbListThumbnail` (sized to the column via an aspect-ratio wrapper) and the **same** memoized `AscentStatusGlyph` as the list row, so a tick write re-renders only the 16px badge — not the card.
- Colorized grade via `getGradeColor`, matching the list row's grade language.
- Tap → activates the climb (same path as the list row); long-press → climb-actions sheet. Swipe actions stay list-only.
- Selected climb gets the violet wash / primary outline (`selectedRowColors`).

Plumbing:
- The **one** FlashList switches `numColumns` (1 ↔ 2) + `renderItem`, and **re-keys** on the mode flip so the swap is instant (FlashList recycles cells, so a live `numColumns` change without a remount would mis-size recycled rows).
- Loading: list skeleton rows for list mode, a 2-up skeleton for grid.
- Choice **persists per board config** via a new SecureStore-backed `view-mode-store` (mirrors `last-search-store`), defaulting to **list**. Restored on board change.
- Fires the shared `View Mode Changed` event (added to `SHARED_EVENTS`, matching the web event name) with `{ mode, boardName, layoutId, sizeId, setIds, angle }`.
- i18n keys (`mobile.viewMode.toViewGrid` / `toViewList` / `hint`) added to all three locales (en-US, es, fr).

## How to verify

1. On the Climbs tab, tap the view toggle (search row, glass; header, Material).
2. The list swaps to a 2-up grid of climb cards (thumbnail on top, name + colorized grade below, ascent badge top-right).
3. Tap a card → activates the climb; long-press → climb actions sheet.
4. Switch boards and back → the grid/list choice persists per board.
5. In dev, `[analytics] View Mode Changed { mode, ... }` logs on each toggle.

## Validation

- `vp run typecheck:mobile` — pass
- `vp test --project mobile` — 1211 pass (incl. 4 new view-mode-store tests)
- `vp run check:mobile-bundle` — OK (Android bundle exported, 10.5 MB)
- `vp run check:i18n:orphans` — OK (no orphaned keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)