### PR TITLE
feat(mobile): Material 3 PlaylistDetailView (liked climbs + smart playlists)

### DIFF
--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -15,7 +15,7 @@ import {
 } from '@boardsesh/graphql/operations/playlists';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
-import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
+import { ClimbListRowSkeleton } from '../../../src/components/ClimbListRowSkeleton';
 import {
   PlaylistDetailView,
   PlaylistFormSheet,
@@ -359,9 +359,13 @@ export default function PlaylistDetail() {
 
   if (metaLoading && allClimbs.length === 0) {
     return (
-      <View style={styles.stateContainer}>
+      <View style={styles.skeletonContainer}>
         <PlaylistBackFab />
-        <ActivityIndicator size="large" />
+        <View style={styles.skeletonList}>
+          {SKELETON_PLACEHOLDERS.map((key) => (
+            <ClimbListRowSkeleton key={key} />
+          ))}
+        </View>
       </View>
     );
   }
@@ -399,6 +403,9 @@ export default function PlaylistDetail() {
   );
 }
 
+// Stable hoisted keys for the first-page skeleton rows.
+const SKELETON_PLACEHOLDERS = Array.from({ length: 8 }, (_, index) => `skeleton-${index}`);
+
 const styles = StyleSheet.create({
   stateContainer: {
     flex: 1,
@@ -406,6 +413,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingHorizontal: 32,
     gap: 8,
+  },
+  skeletonContainer: {
+    flex: 1,
+  },
+  skeletonList: {
+    paddingTop: 64,
   },
   stateTitle: {
     marginTop: 12,

--- a/packages/mobile/app/(tabs)/discover/smart/[type].tsx
+++ b/packages/mobile/app/(tabs)/discover/smart/[type].tsx
@@ -11,8 +11,12 @@ import {
 } from '@boardsesh/graphql/operations/playlists';
 import { Text } from '../../../../src/components/Text';
 import { Icon } from '../../../../src/components/Icon';
-import { ActivityIndicator } from '../../../../src/components/ActivityIndicator';
-import { PlaylistDetailView, PlaylistBackFab } from '../../../../src/components/playlist';
+import { ClimbListRowSkeleton } from '../../../../src/components/ClimbListRowSkeleton';
+import {
+  PlaylistDetailView,
+  PlaylistBackFab,
+  type PlaylistDetailEmptyState,
+} from '../../../../src/components/playlist';
 import { getHttpClient } from '../../../../src/lib/graphql/client';
 import { usePlaylistActivation } from '../../../../src/lib/playlists/use-playlist-activation';
 import { toQueueClimbs } from '../../../../src/lib/climb-types';
@@ -82,6 +86,20 @@ export default function SmartPlaylistDetail() {
     [preset, meta, allClimbs.length, t],
   );
 
+  // The liked-climbs surface gets a climber-voice empty state (heart prompt) on
+  // the Material branch; other smart playlists fall back to the generic message.
+  const emptyState = useMemo<PlaylistDetailEmptyState | undefined>(
+    () =>
+      preset?.type === 'LIKED_CLIMBS'
+        ? {
+            icon: 'favorite',
+            title: t('library.smart.likedClimbs.empty.title'),
+            supporting: t('library.smart.likedClimbs.empty.supporting'),
+          }
+        : undefined,
+    [preset, t],
+  );
+
   if (!preset && !query.isLoading) {
     return (
       <View style={styles.stateContainer}>
@@ -99,9 +117,13 @@ export default function SmartPlaylistDetail() {
 
   if (query.isLoading && allClimbs.length === 0) {
     return (
-      <View style={styles.stateContainer}>
+      <View style={styles.skeletonContainer}>
         <PlaylistBackFab />
-        <ActivityIndicator size="large" />
+        <View style={styles.skeletonList}>
+          {SKELETON_PLACEHOLDERS.map((key) => (
+            <ClimbListRowSkeleton key={key} />
+          ))}
+        </View>
       </View>
     );
   }
@@ -116,9 +138,13 @@ export default function SmartPlaylistDetail() {
       fetchNextPage={query.fetchNextPage}
       onActivateClimb={activate}
       emptyMessage={t('library.smart.empty')}
+      emptyState={emptyState}
     />
   );
 }
+
+// Stable hoisted keys for the first-page skeleton rows.
+const SKELETON_PLACEHOLDERS = Array.from({ length: 8 }, (_, index) => `skeleton-${index}`);
 
 const styles = StyleSheet.create({
   stateContainer: {
@@ -127,6 +153,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingHorizontal: 32,
     gap: 8,
+  },
+  skeletonContainer: {
+    flex: 1,
+  },
+  skeletonList: {
+    paddingTop: 64,
   },
   stateTitle: {
     marginTop: 12,

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -18,13 +18,16 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FlashList } from '@shopify/flash-list';
+import { Appbar } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import type { BoardName, Climb as SchemaClimb } from '@boardsesh/shared-schema';
 import type { Climb } from '@boardsesh/queue';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
+import { type IconName } from '../icon-map';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { ClimbListRow } from '../ClimbListRow';
+import { ClimbListRowSkeleton } from '../ClimbListRowSkeleton';
 import { GlassIconButton } from '../GlassIconButton';
 import { PlaylistBoardBackdrop } from './PlaylistBoardBackdrop';
 import { buildHeroGradient, shiftLightness } from './playlist-gradient';
@@ -48,6 +51,20 @@ const GRADIENT_END = { x: 1, y: 1 } as const;
  *  enough to contain the floating FABs (which sit `spacing[1]` below the inset),
  *  so they're centered in the bar rather than poking out under it. */
 const NAV_BAR_HEIGHT = glassSize.standard + spacing[1] * 2;
+/** Rows of skeleton placeholder shown while the first page loads. */
+const SKELETON_ROW_COUNT = 8;
+
+/** Optional richer empty state (Material branch only). When omitted, the
+ *  Material branch falls back to the same generic icon + `emptyMessage` the
+ *  glass branch uses, so non-liked playlists keep their existing copy. */
+export type PlaylistDetailEmptyState = {
+  /** Semantic icon name (e.g. `favorite` for the liked-climbs surface). */
+  icon: IconName;
+  /** Headline (already translated). */
+  title: string;
+  /** Supporting line under the headline (already translated). */
+  supporting?: string;
+};
 
 export type PlaylistDetailHero = {
   name: string;
@@ -79,6 +96,9 @@ export type PlaylistDetailViewProps = {
   onActivateClimb: (climb: Climb) => void;
   /** Already-resolved empty-list copy (callers translate with a static key). */
   emptyMessage: string;
+  /** Richer Material-branch empty state (e.g. the liked-climbs heart prompt).
+   *  Glass branch ignores this and keeps `emptyMessage`. */
+  emptyState?: PlaylistDetailEmptyState;
   /** Floating top-right controls (follow / pin / more) over the hero, given the
    *  current collapse state so a control can swap to its compact icon form once
    *  the colour header bar takes over. The back FAB on the left is always
@@ -91,6 +111,11 @@ export type PlaylistDetailViewProps = {
  * smart-playlist-detail screens. Renders the colour/emoji hero, then a FlashList
  * of `ClimbListRow`s bound to the user's active board, paginating via
  * `fetchNextPage` as the list nears its end.
+ *
+ * Two presentations: the Liquid Glass variant keeps the full-bleed gradient hero
+ * with white text and floating FABs; the Material 3 variant swaps in a Paper
+ * `Appbar.Header` over a tonal hero band. Both share the scroll math, FlashList,
+ * list state, and row rendering — only the hero chrome + state visuals branch.
  */
 export function PlaylistDetailView({
   hero,
@@ -101,20 +126,23 @@ export function PlaylistDetailView({
   fetchNextPage,
   onActivateClimb,
   emptyMessage,
+  emptyState,
   actions,
 }: PlaylistDetailViewProps) {
   const { t } = useTranslation('playlists');
   const { t: tCommon } = useTranslation('common');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors, variant } = useTheme();
   const { boardConfig } = useDrawerHost();
   const bottomChrome = useBottomChromeMetrics();
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const listPaddingBottom = bottomChrome.scrollBottomPadding;
+  const isMaterial = variant === 'material';
 
   // Scroll offset + measured hero-banner height drive the collapsed colour header
   // bar (the playlist colour + centered name) that fades in once the hero scrolls
-  // off the top — the Apple Music album-header idiom.
+  // off the top — the Apple Music album-header idiom. The Material branch reuses
+  // the same math to fade its app-bar title in as the hero band scrolls away.
   const scrollY = useSharedValue(0);
   const heroBannerHeight = useSharedValue(0);
   const headerBarHeight = insets.top + NAV_BAR_HEIGHT;
@@ -139,7 +167,8 @@ export function PlaylistDetailView({
   });
 
   // `collapsed` flips when the colour header bar takes over, so action FABs (e.g.
-  // follow) can swap to their compact icon form.
+  // follow) can swap to their compact icon form. On Material it drives the app-bar
+  // title fade-in.
   const [collapsed, setCollapsed] = useState(false);
   useAnimatedReaction(
     () => {
@@ -161,6 +190,14 @@ export function PlaylistDetailView({
   // header `collapsed` flips during scroll) would otherwise re-render every row.
   const handleActivate = useCallback((tapped: SchemaClimb) => onActivateClimb(toQueueClimb(tapped)), [onActivateClimb]);
 
+  // Activate-all: queue the playlist from the top. Reuses the same row-tap path
+  // (which seeds the suggestion source from the whole list), so swiping the play
+  // drawer walks the playlist. No-op on an empty list.
+  const handleActivateAll = useCallback(() => {
+    const first = climbs[0];
+    if (first) onActivateClimb(first);
+  }, [climbs, onActivateClimb]);
+
   const renderItem = useCallback(
     ({ item }: { item: Climb }) => {
       if (!boardConfig) return null;
@@ -180,6 +217,133 @@ export function PlaylistDetailView({
   );
 
   const baseColor = hero.color && isValidHexColor(hero.color) ? hero.color : PLAYLIST_COLORS[0];
+
+  // Shared list state visuals. The first-page load renders skeleton rows (a far
+  // better "shape of what's coming" cue than a bare spinner). Empty + footer are
+  // shared; the empty body is variant-aware below.
+  const listEmptyComponent = isLoading ? (
+    <View style={styles.skeletonList}>
+      {SKELETON_PLACEHOLDERS.map((key) => (
+        <ClimbListRowSkeleton key={key} />
+      ))}
+    </View>
+  ) : isMaterial ? (
+    <MaterialEmptyState
+      icon={emptyState?.icon ?? 'playlist'}
+      title={emptyState?.title ?? emptyMessage}
+      supporting={emptyState?.supporting}
+      titleColor={systemColors.label}
+      supportingColor={systemColors.secondaryLabel}
+    />
+  ) : (
+    <View style={styles.stateContainer}>
+      <Icon name="playlist" size={44} color={iosSystemColors.systemGray4} />
+      <Text variant="subheadline" style={styles.emptyText}>
+        {emptyMessage}
+      </Text>
+    </View>
+  );
+
+  const listFooterComponent = isFetchingNextPage ? (
+    <View style={styles.footer}>
+      <ActivityIndicator size="small" />
+    </View>
+  ) : null;
+
+  // ── Material 3 branch ───────────────────────────────────────────────────────
+  if (isMaterial) {
+    const accent = brandColors.primary;
+    return (
+      <View style={[styles.container, { backgroundColor: systemColors.background }]}>
+        <FlashList
+          data={climbs}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          onEndReached={handleEndReached}
+          onEndReachedThreshold={0.5}
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
+          contentContainerStyle={{ paddingBottom: listPaddingBottom }}
+          ListHeaderComponent={
+            <View onLayout={handleHeroLayout} style={styles.materialHero}>
+              <View
+                style={[
+                  styles.materialHeroBand,
+                  { paddingTop: headerBarHeight + spacing[4], backgroundColor: systemColors.secondaryBackground },
+                ]}
+              >
+                <View style={[styles.materialHeroEmojiCircle, { backgroundColor: systemColors.tertiaryBackground }]}>
+                  {hero.icon ? (
+                    <Text style={styles.materialHeroEmoji} allowFontScaling={false}>
+                      {hero.icon}
+                    </Text>
+                  ) : (
+                    <Icon name="tag" size={36} color={systemColors.secondaryLabel} />
+                  )}
+                </View>
+                <Text variant="title2" numberOfLines={2} color={systemColors.label} style={styles.materialHeroName}>
+                  {hero.name}
+                </Text>
+                <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.materialHeroMeta}>
+                  {t('detail.climbCount', { count: hero.climbCount })}
+                </Text>
+                {hero.followerLabel ? (
+                  <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.materialHeroMeta}>
+                    {hero.followerLabel}
+                  </Text>
+                ) : null}
+              </View>
+              {hero.description || hero.subtitle ? (
+                <View style={styles.heroBelow}>
+                  {hero.description ? (
+                    <Text variant="footnote" numberOfLines={3} color={systemColors.secondaryLabel}>
+                      {hero.description}
+                    </Text>
+                  ) : null}
+                  {hero.subtitle ? (
+                    <Text variant="footnote" numberOfLines={1} color={systemColors.tertiaryLabel}>
+                      {hero.subtitle}
+                    </Text>
+                  ) : null}
+                </View>
+              ) : null}
+            </View>
+          }
+          ListFooterComponent={listFooterComponent}
+          ListEmptyComponent={listEmptyComponent}
+        />
+
+        {/* Collapsing M3 top app bar — sits over the hero band; its title fades in
+            as the band scrolls under it, then the band's name is hidden behind. */}
+        <Appbar.Header
+          statusBarHeight={insets.top}
+          mode="small"
+          style={[styles.materialAppbar, { backgroundColor: systemColors.secondaryBackground }]}
+        >
+          <Appbar.BackAction
+            onPress={() => router.back()}
+            color={systemColors.label as string}
+            rippleColor={withAlpha(accent, 0.16)}
+            accessibilityLabel={tCommon('ariaLabels.back')}
+          />
+          <Animated.View style={[styles.materialAppbarTitle, headerBarStyle]}>
+            <Appbar.Content title={hero.name} titleStyle={styles.materialAppbarTitleText} />
+          </Animated.View>
+          {climbs.length > 0 ? (
+            <Appbar.Action
+              icon="play"
+              color={accent as string}
+              rippleColor={withAlpha(accent, 0.16)}
+              onPress={handleActivateAll}
+              accessibilityLabel={t('detail.activateAll')}
+            />
+          ) : null}
+        </Appbar.Header>
+      </View>
+    );
+  }
+
+  // ── Liquid Glass branch (unchanged) ─────────────────────────────────────────
   // The collapsed bar uses the gradient's deeper tone so white text stays legible.
   const headerColor = shiftLightness(baseColor, -20);
   const gradient = buildHeroGradient(hero.color);
@@ -283,27 +447,8 @@ export function PlaylistDetailView({
         automaticallyAdjustContentInsets={false}
         contentContainerStyle={{ paddingBottom: listPaddingBottom }}
         ListHeaderComponent={header}
-        ListFooterComponent={
-          isFetchingNextPage ? (
-            <View style={styles.footer}>
-              <ActivityIndicator size="small" />
-            </View>
-          ) : null
-        }
-        ListEmptyComponent={
-          isLoading ? (
-            <View style={styles.stateContainer}>
-              <ActivityIndicator size="large" />
-            </View>
-          ) : (
-            <View style={styles.stateContainer}>
-              <Icon name="playlist" size={44} color={iosSystemColors.systemGray4} />
-              <Text variant="subheadline" style={styles.emptyText}>
-                {emptyMessage}
-              </Text>
-            </View>
-          )
-        }
+        ListFooterComponent={listFooterComponent}
+        ListEmptyComponent={listEmptyComponent}
       />
 
       {/* Collapsed colour header bar — the playlist colour + centered name, fading
@@ -343,9 +488,44 @@ export function PlaylistDetailView({
   );
 }
 
+/** Centered Material empty state: tonal icon + headline + supporting copy. */
+function MaterialEmptyState({
+  icon,
+  title,
+  supporting,
+  titleColor,
+  supportingColor,
+}: {
+  icon: IconName;
+  title: string;
+  supporting?: string;
+  titleColor: string | import('react-native').OpaqueColorValue;
+  supportingColor: string | import('react-native').OpaqueColorValue;
+}) {
+  return (
+    <View style={styles.stateContainer}>
+      <View accessibilityRole="image" accessibilityLabel={title}>
+        <Icon name={icon} size={48} color={supportingColor} />
+      </View>
+      <Text variant="headline" color={titleColor} style={styles.materialEmptyTitle}>
+        {title}
+      </Text>
+      {supporting ? (
+        <Text variant="subheadline" color={supportingColor} style={styles.materialEmptySupporting}>
+          {supporting}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
 function keyExtractor(item: Climb) {
   return item.uuid;
 }
+
+// Hoisted stable keys for the first-page skeleton rows — never reorder, so index
+// keys are fine and avoid allocating an array on every render.
+const SKELETON_PLACEHOLDERS = Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => `skeleton-${index}`);
 
 const styles = StyleSheet.create({
   container: {
@@ -434,9 +614,65 @@ const styles = StyleSheet.create({
   heroDescription: {
     opacity: 0.7,
   },
+  // ── Material hero ──────────────────────────────────────────────────────────
+  materialAppbar: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 2,
+    elevation: 0,
+  },
+  // Wraps Appbar.Content so the title can fade in (opacity-animated) as the hero
+  // band scrolls under the bar, without animating the back / play actions.
+  materialAppbarTitle: {
+    flex: 1,
+  },
+  materialAppbarTitleText: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  materialHero: {
+    marginBottom: spacing[2],
+  },
+  materialHeroBand: {
+    alignItems: 'center',
+    paddingHorizontal: spacing[5],
+    paddingBottom: spacing[6],
+    borderBottomLeftRadius: borderRadius.xl,
+    borderBottomRightRadius: borderRadius.xl,
+  },
+  materialHeroEmojiCircle: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing[3],
+  },
+  materialHeroEmoji: {
+    fontSize: 36,
+    lineHeight: 44,
+  },
+  materialHeroName: {
+    textAlign: 'center',
+  },
+  materialHeroMeta: {
+    marginTop: 2,
+    textAlign: 'center',
+  },
+  materialEmptyTitle: {
+    textAlign: 'center',
+  },
+  materialEmptySupporting: {
+    textAlign: 'center',
+  },
   footer: {
     paddingVertical: 20,
     alignItems: 'center',
+  },
+  skeletonList: {
+    paddingTop: spacing[2],
   },
   stateContainer: {
     alignItems: 'center',

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -4,7 +4,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/queue';
 
-const ctrl = vi.hoisted(() => ({ back: vi.fn() }));
+const ctrl = vi.hoisted(() => ({ back: vi.fn(), variant: 'glass' as 'glass' | 'material' }));
 
 // ── React Native ──────────────────────────────────────────────────────────────
 vi.mock('react-native', () => ({
@@ -50,13 +50,8 @@ vi.mock('react-native-reanimated', () => ({
 
 // ── Expo / third-party ────────────────────────────────────────────────────────
 vi.mock('expo-linear-gradient', () => ({
-  LinearGradient: ({
-    colors,
-    children,
-  }: {
-    colors: string[];
-    children?: ReactNode;
-  }) => createElement('div', { 'data-gradient': JSON.stringify(colors) }, children ?? null),
+  LinearGradient: ({ colors, children }: { colors: string[]; children?: ReactNode }) =>
+    createElement('div', { 'data-gradient': JSON.stringify(colors) }, children ?? null),
 }));
 
 vi.mock('@shopify/flash-list', () => ({
@@ -77,7 +72,7 @@ vi.mock('@shopify/flash-list', () => ({
       'div',
       { 'data-list': 'true', onClick: onEndReached },
       ListHeaderComponent ?? null,
-      data?.length === 0 ? ListEmptyComponent ?? null : null,
+      data?.length === 0 ? (ListEmptyComponent ?? null) : null,
       ListFooterComponent ?? null,
     ),
 }));
@@ -94,7 +89,19 @@ vi.mock('react-i18next', () => ({
 
 // ── Theme / providers ─────────────────────────────────────────────────────────
 vi.mock('../../../providers/theme-provider', () => ({
-  useTheme: () => ({ systemColors: { label: '#000000', fill: '#eeeeee' } }),
+  useTheme: () => ({
+    variant: ctrl.variant,
+    systemColors: {
+      label: '#000000',
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#999999',
+      fill: '#eeeeee',
+      background: '#ffffff',
+      secondaryBackground: '#f2f2f2',
+      tertiaryBackground: '#e5e5e5',
+    },
+    brandColors: { primary: '#6D28D9' },
+  }),
 }));
 
 vi.mock('../../../providers/drawer-host-provider', () => ({
@@ -129,11 +136,37 @@ vi.mock('../../Icon', () => ({
 }));
 
 vi.mock('../../ActivityIndicator', () => ({
-  ActivityIndicator: ({ size }: { size?: string }) =>
-    createElement('div', { 'data-spinner': size ?? 'default' }),
+  ActivityIndicator: ({ size }: { size?: string }) => createElement('div', { 'data-spinner': size ?? 'default' }),
 }));
 
 vi.mock('../../ClimbListRow', () => ({ ClimbListRow: () => null }));
+
+vi.mock('../../ClimbListRowSkeleton', () => ({
+  ClimbListRowSkeleton: () => createElement('div', { 'data-skeleton-row': 'true' }),
+}));
+
+// icon-map is pure data but pulls in expo-symbols types via Icon's import chain;
+// stub it so the component's `type IconName` import resolves without RN deps.
+vi.mock('../../icon-map', () => ({ iconMap: {} }));
+
+// react-native-paper drags in expo-modules-core at import time; stub the only
+// pieces the Material branch uses so the suite can load.
+vi.mock('react-native-paper', () => {
+  const Header = ({ children }: { children?: ReactNode }) => createElement('div', { 'data-appbar': 'true' }, children);
+  const BackAction = ({ onPress, accessibilityLabel }: { onPress?: () => void; accessibilityLabel?: string }) =>
+    createElement('button', { 'data-icon': 'back', onClick: onPress, 'aria-label': accessibilityLabel });
+  const Content = ({ title }: { title?: ReactNode }) => createElement('span', { 'data-appbar-title': 'true' }, title);
+  const Action = ({
+    icon,
+    onPress,
+    accessibilityLabel,
+  }: {
+    icon?: string;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { 'data-appbar-action': icon, onClick: onPress, 'aria-label': accessibilityLabel });
+  return { Appbar: { Header, BackAction, Content, Action } };
+});
 
 vi.mock('../../GlassIconButton', () => ({
   GlassIconButton: ({
@@ -148,8 +181,7 @@ vi.mock('../../GlassIconButton', () => ({
 }));
 
 vi.mock('../PlaylistBoardBackdrop', () => ({
-  PlaylistBoardBackdrop: ({ boardType }: { boardType: string }) =>
-    createElement('div', { 'data-backdrop': boardType }),
+  PlaylistBoardBackdrop: ({ boardType }: { boardType: string }) => createElement('div', { 'data-backdrop': boardType }),
 }));
 
 // Use real playlist-gradient and playlist-colors (pure TS, no RN imports).
@@ -193,6 +225,7 @@ function makeProps(overrides: Partial<PlaylistDetailViewProps> = {}): PlaylistDe
 describe('PlaylistDetailView', () => {
   beforeEach(() => {
     ctrl.back.mockClear();
+    ctrl.variant = 'glass';
   });
 
   // ── Navigation ──────────────────────────────────────────────────────────────
@@ -237,7 +270,9 @@ describe('PlaylistDetailView', () => {
   });
 
   it('renders the emoji icon when hero.icon is set', () => {
-    const { getByText } = render(<PlaylistDetailView {...makeProps({ hero: { name: 'P', climbCount: 0, icon: '🏔️' } })} />);
+    const { getByText } = render(
+      <PlaylistDetailView {...makeProps({ hero: { name: 'P', climbCount: 0, icon: '🏔️' } })} />,
+    );
     expect(getByText('🏔️')).not.toBeNull();
   });
 
@@ -269,30 +304,24 @@ describe('PlaylistDetailView', () => {
 
   // ── Loading / empty states ──────────────────────────────────────────────────
 
-  it('shows large loading spinner when isLoading=true and climbs is empty', () => {
+  it('shows skeleton rows when isLoading=true and climbs is empty', () => {
     const { container } = render(<PlaylistDetailView {...makeProps({ isLoading: true, climbs: [] })} />);
-    expect(container.querySelector('[data-spinner="large"]')).not.toBeNull();
+    expect(container.querySelectorAll('[data-skeleton-row]').length).toBeGreaterThan(0);
   });
 
   it('shows empty message and playlist icon when not loading and climbs is empty', () => {
-    const { getByText, container } = render(
-      <PlaylistDetailView {...makeProps({ isLoading: false, climbs: [] })} />,
-    );
+    const { getByText, container } = render(<PlaylistDetailView {...makeProps({ isLoading: false, climbs: [] })} />);
     expect(getByText('No climbs yet')).not.toBeNull();
     expect(container.querySelector('[data-icon="playlist"]')).not.toBeNull();
   });
 
   it('shows a small footer spinner when isFetchingNextPage=true', () => {
-    const { container } = render(
-      <PlaylistDetailView {...makeProps({ isFetchingNextPage: true, climbs: [CLIMB] })} />,
-    );
+    const { container } = render(<PlaylistDetailView {...makeProps({ isFetchingNextPage: true, climbs: [CLIMB] })} />);
     expect(container.querySelector('[data-spinner="small"]')).not.toBeNull();
   });
 
   it('shows no footer spinner when isFetchingNextPage=false', () => {
-    const { container } = render(
-      <PlaylistDetailView {...makeProps({ isFetchingNextPage: false, climbs: [CLIMB] })} />,
-    );
+    const { container } = render(<PlaylistDetailView {...makeProps({ isFetchingNextPage: false, climbs: [CLIMB] })} />);
     expect(container.querySelector('[data-spinner="small"]')).toBeNull();
   });
 
@@ -319,7 +348,9 @@ describe('PlaylistDetailView', () => {
   it('uses translucent gradient colors when board backdrop is enabled', () => {
     const { container } = render(
       <PlaylistDetailView
-        {...makeProps({ hero: { name: 'P', climbCount: 0, showBoardBackdrop: true, boardType: 'kilter', color: '#8C4A52' } })}
+        {...makeProps({
+          hero: { name: 'P', climbCount: 0, showBoardBackdrop: true, boardType: 'kilter', color: '#8C4A52' },
+        })}
       />,
     );
     const gradients = container.querySelectorAll('[data-gradient]');
@@ -338,5 +369,65 @@ describe('PlaylistDetailView', () => {
     const firstGradientColors: string[] = JSON.parse(gradients[0]?.getAttribute('data-gradient') ?? '[]');
     // No alpha suffix means opaque colors from buildHeroGradient
     expect(firstGradientColors.every((c) => !c.includes('|0.82'))).toBe(true);
+  });
+
+  // ── Material 3 branch ─────────────────────────────────────────────────────────
+  describe('material variant', () => {
+    beforeEach(() => {
+      ctrl.variant = 'material';
+    });
+
+    it('renders the Paper app bar instead of the gradient hero', () => {
+      const { container } = render(<PlaylistDetailView {...makeProps({ climbs: [CLIMB] })} />);
+      expect(container.querySelector('[data-appbar]')).not.toBeNull();
+      // No gradient hero in the Material branch.
+      expect(container.querySelector('[data-gradient]')).toBeNull();
+    });
+
+    it('back action calls router.back', () => {
+      const { container } = render(<PlaylistDetailView {...makeProps()} />);
+      fireEvent.click(container.querySelector('[data-icon="back"]') as HTMLElement);
+      expect(ctrl.back).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the activate-all play action and wires it to the first climb', () => {
+      const onActivateClimb = vi.fn();
+      const { container } = render(<PlaylistDetailView {...makeProps({ climbs: [CLIMB], onActivateClimb })} />);
+      const playAction = container.querySelector('[data-appbar-action="play"]');
+      expect(playAction).not.toBeNull();
+      fireEvent.click(playAction as HTMLElement);
+      expect(onActivateClimb).toHaveBeenCalledWith(CLIMB);
+    });
+
+    it('omits the activate-all action when the list is empty', () => {
+      const { container } = render(<PlaylistDetailView {...makeProps({ climbs: [] })} />);
+      expect(container.querySelector('[data-appbar-action="play"]')).toBeNull();
+    });
+
+    it('renders the richer empty state when emptyState is provided', () => {
+      const { getByText } = render(
+        <PlaylistDetailView
+          {...makeProps({
+            climbs: [],
+            isLoading: false,
+            emptyState: { icon: 'favorite', title: 'No likes yet', supporting: 'Tap the heart' },
+          })}
+        />,
+      );
+      expect(getByText('No likes yet')).not.toBeNull();
+      expect(getByText('Tap the heart')).not.toBeNull();
+    });
+
+    it('falls back to emptyMessage when no emptyState is given', () => {
+      const { getByText } = render(
+        <PlaylistDetailView {...makeProps({ climbs: [], isLoading: false, emptyMessage: 'Nothing here' })} />,
+      );
+      expect(getByText('Nothing here')).not.toBeNull();
+    });
+
+    it('shows skeleton rows while loading', () => {
+      const { container } = render(<PlaylistDetailView {...makeProps({ isLoading: true, climbs: [] })} />);
+      expect(container.querySelectorAll('[data-skeleton-row]').length).toBeGreaterThan(0);
+    });
   });
 });

--- a/packages/mobile/src/components/playlist/index.ts
+++ b/packages/mobile/src/components/playlist/index.ts
@@ -2,7 +2,12 @@ export { PlaylistPreviewSquare, type PlaylistPreviewSquareProps } from './Playli
 export { PlaylistCard, type PlaylistCardProps } from './PlaylistCard';
 export { PlaylistScrollSection, type PlaylistScrollSectionProps } from './PlaylistScrollSection';
 export { PlaylistListRow, PlaylistListRowSeparator, type PlaylistListRowProps } from './PlaylistListRow';
-export { PlaylistDetailView, type PlaylistDetailViewProps, type PlaylistDetailHero } from './PlaylistDetailView';
+export {
+  PlaylistDetailView,
+  type PlaylistDetailViewProps,
+  type PlaylistDetailHero,
+  type PlaylistDetailEmptyState,
+} from './PlaylistDetailView';
 export { PlaylistBackFab } from './PlaylistBackFab';
 export { PlaylistFormSheet, type PlaylistFormValues } from './PlaylistFormSheet';
 export { PlaylistPinButton } from './PlaylistPinButton';

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -51,7 +51,11 @@
       },
       "likedClimbs": {
         "title": "Liked Climbs",
-        "description": "All climbs you've hearted."
+        "description": "All climbs you've hearted.",
+        "empty": {
+          "title": "No likes yet",
+          "supporting": "Tap the heart on a climb to stash it here."
+        }
       },
       "crowdFavorites": {
         "title": "Crowd Favorites",
@@ -93,6 +97,7 @@
   "detail": {
     "share": "Share playlist",
     "actions": "Playlist actions",
+    "activateAll": "Queue every climb",
     "menu": {
       "generate": "Generate",
       "edit": "Edit",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -51,7 +51,11 @@
       },
       "likedClimbs": {
         "title": "Bloques favoritos",
-        "description": "Todos los bloques que has marcado con corazón."
+        "description": "Todos los bloques que has marcado con corazón.",
+        "empty": {
+          "title": "Aún no hay favoritos",
+          "supporting": "Toca el corazón de un bloque para guardarlo aquí."
+        }
       },
       "crowdFavorites": {
         "title": "Favoritos de todos",
@@ -93,6 +97,7 @@
   "detail": {
     "share": "Compartir playlist",
     "actions": "Acciones de la playlist",
+    "activateAll": "Poner en cola todos los bloques",
     "menu": {
       "generate": "Generar",
       "edit": "Editar",

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -51,7 +51,11 @@
       },
       "likedClimbs": {
         "title": "Voies aimées",
-        "description": "Toutes les voies que vous avez aimées."
+        "description": "Toutes les voies que vous avez aimées.",
+        "empty": {
+          "title": "Aucune voie aimée",
+          "supporting": "Touchez le cœur d'une voie pour la garder ici."
+        }
       },
       "crowdFavorites": {
         "title": "Favoris de la communauté",
@@ -93,6 +97,7 @@
   "detail": {
     "share": "Partager la playlist",
     "actions": "Actions de la playlist",
+    "activateAll": "Mettre toutes les voies en file",
     "menu": {
       "generate": "Générer",
       "edit": "Modifier",


### PR DESCRIPTION
## Why

`PlaylistDetailView` was **glass-only**: a full-bleed `LinearGradient` hero with white text that ignored `useTheme().variant`. On the **Material 3** variant, every playlist + smart-playlist detail surface rendered that glass hero — wrong chrome for Material users.

This affects all of them, not just liked climbs. Note: **liked-climbs browsing already exists** — the `LIKED_CLIMBS` smart playlist renders a Discover **"Your Picks"** tile straight into this same view over the backend `userFavoriteClimbs` query. So this PR is variant-consistency polish, **not a new feature**.

## What changed

- **Material 3 branch** in `PlaylistDetailView.tsx`, gated on `variant === 'material'`. Replaces the gradient hero with a collapsing Paper `Appbar.Header` (`BackAction` + an activate-all `play` `Action`) over a **tonal hero band** (`secondaryBackground`/`tertiaryBackground`, which resolve to `materialSurfaces` on Material) carrying the playlist emoji, title, and climb count. Reuses the existing `heroBannerHeight` scroll math so the app-bar title fades in as the hero band scrolls away.
- **Glass branch left pixel-identical** — same gradient, scrim, floating FABs, collapsed colour bar.
- **Skeleton loading**: first-page load now renders `ClimbListRowSkeleton` rows (both detail routes' early-return state + the view's `ListEmptyComponent`) instead of a bare `ActivityIndicator`.
- **Material empty state**: centered tonal icon + headline + supporting copy. The liked-climbs surface gets a climber-voice heart prompt ("No likes yet" / "Tap the heart on a climb to stash it here"); other playlists keep the generic message. Variant-aware.
- The existing FlashList of `ClimbListRow` (memoized, virtualized, swipe-enabled) is **unchanged** — no row fork, no client sort, recency order stays server-side.
- New i18n keys (`library.smart.likedClimbs.empty.title/supporting`, `detail.activateAll`) added to **all three locales** (en-US, es, fr).

## How to verify

1. Switch the app to the **Material** UI variant (Settings → appearance).
2. Open **Discover → Your Picks → Liked Climbs** (or any playlist). You should see a Material `Appbar` + tonal hero band, skeleton rows while loading, and — with no likes — the heart empty state.
3. Switch back to the **Liquid Glass** variant: the gradient hero, floating FABs, and collapsed colour bar are unchanged.

## Validation

- `vp run typecheck:mobile` — pass
- `vp test --project mobile` — pass (1214 tests; added Material-branch coverage)
- `vp run check:mobile-bundle` — pass (Android bundle OK, 10.5 MB)
- i18n catalog completeness + orphan checks — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)