### PR TITLE
feat(mobile): first-run onboarding walkthrough (variant-aware)

### DIFF
--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -16,6 +16,7 @@ import { SegmentedControl } from '../../../src/components/SegmentedControl';
 import { isPreviewBuild } from '../../../src/lib/eas-api';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { useGlassCapability } from '../../../src/hooks/use-glass-capability';
+import { clearOnboardingSeen } from '../../../src/lib/onboarding/onboarding-storage';
 
 export default function MoreScreen() {
   const {
@@ -55,6 +56,13 @@ export default function MoreScreen() {
     { key: 'font', label: t('mobile.more.gradeFormat.font') },
     { key: 'both', label: t('mobile.more.gradeFormat.both') },
   ];
+
+  const handleReplayWalkthrough = () => {
+    // Clear the "seen" flag (best effort) then re-open the tour immediately —
+    // the push doesn't wait on the write, so the walkthrough opens instantly.
+    void clearOnboardingSeen();
+    router.push('/onboarding');
+  };
 
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.container}>
@@ -157,6 +165,28 @@ export default function MoreScreen() {
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.settingHint}>
             {t('mobile.more.gradeFormat.description')}
           </Text>
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: systemColors.secondaryBackground,
+              borderRadius: borderRadius.lg,
+              marginHorizontal: spacing[4],
+            },
+          ]}
+        >
+          <ListRow
+            title={t('mobile.onboarding.replayTitle')}
+            subtitle={t('mobile.onboarding.replaySubtitle')}
+            leading={<Icon name="play.circle" size={22} color={systemColors.secondaryLabel} />}
+            showChevron
+            showSeparator={false}
+            onPress={handleReplayWalkthrough}
+          />
         </View>
       </View>
 

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -19,7 +19,9 @@ import { SegmentedControl } from '../../../src/components/SegmentedControl';
 import { isPreviewBuild } from '../../../src/lib/eas-api';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { useGlassCapability } from '../../../src/hooks/use-glass-capability';
+import { useToast } from '../../../src/providers/toast-provider';
 import { replayOnboarding } from '../../../src/lib/onboarding/onboarding-storage';
+import { reportError } from '../../../src/lib/sentry';
 
 export default function MoreScreen() {
   const { systemColors, brandColors, themeOverride, setThemeOverride, uiVariantPreference, setUiVariant } = useTheme();
@@ -31,6 +33,7 @@ export default function MoreScreen() {
   const { gradeFormat, setGradeFormat } = useGradeFormat();
   const glassCapable = useGlassCapability();
   const { localePreference, setLocalePreference } = useLocalePreference();
+  const { showToast } = useToast();
 
   // 'System' follows the device language; the rest are the supported locales,
   // labelled in their own script (English / Español / Français) from
@@ -67,7 +70,16 @@ export default function MoreScreen() {
     // finished/skipped before the clear settles, markOnboardingSeen() could land
     // first and a late clear would wipe the flag — leaving the tour "unseen" and
     // re-showing on the next cold start.
-    void replayOnboarding(() => router.push('/onboarding'));
+    //
+    // If the SecureStore clear rejects (keychain locked / unavailable),
+    // replayOnboarding never navigates, so surface an error toast instead of the
+    // row silently doing nothing. Log + report so we notice a recurring failure.
+    replayOnboarding(() => router.push('/onboarding')).catch((error: unknown) => {
+      // eslint-disable-next-line no-console
+      console.warn('[onboarding] Failed to replay walkthrough', error);
+      reportError(error);
+      showToast(t('mobile.onboarding.replayError'), 'error');
+    });
   };
 
   return (
@@ -158,6 +170,7 @@ export default function MoreScreen() {
       </View>
 
       <View style={styles.section}>
+        <SectionHeader title={t('mobile.onboarding.replaySection')} />
         <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
           <ListRow
             title={t('mobile.onboarding.replayTitle')}

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -9,7 +9,7 @@ import { useLocalePreference } from '../../../src/providers/i18n-provider';
 import type { LocaleOverride } from '../../../src/lib/i18n/locale-preference';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useProfile } from '../../../src/lib/graphql/hooks';
-import { spacing } from '../../../src/theme/tokens';
+import { borderRadius, spacing } from '../../../src/theme/tokens';
 import { DevMetadataPanel } from '../../../src/components/DevMetadataPanel';
 import { Icon } from '../../../src/components/Icon';
 import { Text } from '../../../src/components/Text';
@@ -19,18 +19,10 @@ import { SegmentedControl } from '../../../src/components/SegmentedControl';
 import { isPreviewBuild } from '../../../src/lib/eas-api';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { useGlassCapability } from '../../../src/hooks/use-glass-capability';
-import { clearOnboardingSeen } from '../../../src/lib/onboarding/onboarding-storage';
+import { replayOnboarding } from '../../../src/lib/onboarding/onboarding-storage';
 
 export default function MoreScreen() {
-  const {
-    systemColors,
-    brandColors,
-    borderRadius,
-    themeOverride,
-    setThemeOverride,
-    uiVariantPreference,
-    setUiVariant,
-  } = useTheme();
+  const { systemColors, brandColors, themeOverride, setThemeOverride, uiVariantPreference, setUiVariant } = useTheme();
   const { t } = useTranslation('common');
   const { t: tProfile } = useTranslation('profile');
   const { t: tPlaylists } = useTranslation('playlists');
@@ -70,10 +62,12 @@ export default function MoreScreen() {
   ];
 
   const handleReplayWalkthrough = () => {
-    // Clear the "seen" flag (best effort) then re-open the tour immediately —
-    // the push doesn't wait on the write, so the walkthrough opens instantly.
-    void clearOnboardingSeen();
-    router.push('/onboarding');
+    // Clear the "seen" flag BEFORE opening the tour (the await is inside
+    // replayOnboarding). Ordering matters: if the replayed tour is
+    // finished/skipped before the clear settles, markOnboardingSeen() could land
+    // first and a late clear would wipe the flag — leaving the tour "unseen" and
+    // re-showing on the next cold start.
+    void replayOnboarding(() => router.push('/onboarding'));
   };
 
   return (
@@ -83,16 +77,7 @@ export default function MoreScreen() {
       {profile?.id ? (
         <View style={styles.section}>
           <SectionHeader title={t('mobile.more.library')} />
-          <View
-            style={[
-              styles.card,
-              {
-                backgroundColor: systemColors.secondaryBackground,
-                borderRadius: borderRadius.lg,
-                marginHorizontal: spacing[4],
-              },
-            ]}
-          >
+          <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
             <ListRow
               title={tPlaylists('library.allPlaylists.title')}
               leading={<Icon name="playlist" size={22} color={systemColors.secondaryLabel} />}
@@ -106,17 +91,7 @@ export default function MoreScreen() {
 
       <View style={styles.section}>
         <SectionHeader title={t('mobile.more.appearance.title')} />
-        <View
-          style={[
-            styles.card,
-            {
-              backgroundColor: systemColors.secondaryBackground,
-              borderRadius: borderRadius.lg,
-              marginHorizontal: spacing[4],
-              padding: spacing[3],
-            },
-          ]}
-        >
+        <View style={[styles.card, styles.cardPadded, { backgroundColor: systemColors.secondaryBackground }]}>
           <SegmentedControl
             options={appearanceOptions}
             selectedKey={themeOverride}
@@ -129,17 +104,7 @@ export default function MoreScreen() {
 
       <View style={styles.section}>
         <SectionHeader title={t('mobile.more.uiStyle.title')} />
-        <View
-          style={[
-            styles.card,
-            {
-              backgroundColor: systemColors.secondaryBackground,
-              borderRadius: borderRadius.lg,
-              marginHorizontal: spacing[4],
-              padding: spacing[3],
-            },
-          ]}
-        >
+        <View style={[styles.card, styles.cardPadded, { backgroundColor: systemColors.secondaryBackground }]}>
           <SegmentedControl
             options={uiStyleOptions}
             selectedKey={uiVariantPreference}
@@ -156,17 +121,7 @@ export default function MoreScreen() {
 
       <View style={styles.section}>
         <SectionHeader title={t('mobile.more.gradeFormat.title')} />
-        <View
-          style={[
-            styles.card,
-            {
-              backgroundColor: systemColors.secondaryBackground,
-              borderRadius: borderRadius.lg,
-              marginHorizontal: spacing[4],
-              padding: spacing[3],
-            },
-          ]}
-        >
+        <View style={[styles.card, styles.cardPadded, { backgroundColor: systemColors.secondaryBackground }]}>
           <SegmentedControl
             options={gradeFormatOptions}
             selectedKey={gradeFormat}
@@ -182,16 +137,7 @@ export default function MoreScreen() {
 
       <View style={styles.section}>
         <SectionHeader title={t('mobile.more.language.title')} />
-        <View
-          style={[
-            styles.card,
-            {
-              backgroundColor: systemColors.secondaryBackground,
-              borderRadius: borderRadius.lg,
-              marginHorizontal: spacing[4],
-            },
-          ]}
-        >
+        <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
           {languageOptions.map((option, index) => (
             <ListRow
               key={option.key}
@@ -212,16 +158,7 @@ export default function MoreScreen() {
       </View>
 
       <View style={styles.section}>
-        <View
-          style={[
-            styles.card,
-            {
-              backgroundColor: systemColors.secondaryBackground,
-              borderRadius: borderRadius.lg,
-              marginHorizontal: spacing[4],
-            },
-          ]}
-        >
+        <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
           <ListRow
             title={t('mobile.onboarding.replayTitle')}
             subtitle={t('mobile.onboarding.replaySubtitle')}
@@ -236,16 +173,7 @@ export default function MoreScreen() {
       {__DEV__ ? (
         <View style={styles.section}>
           <SectionHeader title={t('mobile.more.development')} />
-          <View
-            style={[
-              styles.card,
-              {
-                backgroundColor: systemColors.secondaryBackground,
-                borderRadius: borderRadius.lg,
-                marginHorizontal: spacing[4],
-              },
-            ]}
-          >
+          <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
             <ListRow
               title={t('mobile.more.metroServersTitle')}
               subtitle={t('mobile.more.metroServersSubtitle')}
@@ -283,7 +211,7 @@ export default function MoreScreen() {
           </Text>
         ) : null}
         <Pressable
-          style={[styles.signOut, { borderColor: systemColors.separator, marginHorizontal: spacing[4] }]}
+          style={[styles.signOut, { borderColor: systemColors.separator }]}
           onPress={signOut}
           accessibilityRole="button"
         >
@@ -308,6 +236,11 @@ const styles = StyleSheet.create({
   },
   card: {
     overflow: 'hidden',
+    borderRadius: borderRadius.lg,
+    marginHorizontal: spacing[4],
+  },
+  cardPadded: {
+    padding: spacing[3],
   },
   settingHint: {
     marginTop: spacing[2],
@@ -323,6 +256,7 @@ const styles = StyleSheet.create({
   signOut: {
     alignItems: 'center',
     paddingVertical: spacing[3],
+    marginHorizontal: spacing[4],
     borderRadius: 12,
     borderWidth: StyleSheet.hairlineWidth,
   },

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -49,6 +49,7 @@ import { wrapWithSentry, reportError } from '../src/lib/sentry';
 import { loadRequiredFonts } from '../src/lib/required-fonts';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
+import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
 
 void SplashScreen.preventAutoHideAsync();
 
@@ -296,9 +297,23 @@ function RootLayout() {
                                                       name="boards"
                                                       options={{ presentation: 'modal', headerShown: false }}
                                                     />
+                                                    {/* First-run welcome walkthrough. Full-screen cover
+                                                      over the Climbs tab; gesture disabled so the user
+                                                      leaves only via Skip / finish / the final CTA, never
+                                                      an accidental swipe-dismiss. */}
+                                                    <Stack.Screen
+                                                      name="onboarding"
+                                                      options={{
+                                                        presentation: 'fullScreenModal',
+                                                        headerShown: false,
+                                                        gestureEnabled: false,
+                                                        animation: 'fade',
+                                                      }}
+                                                    />
                                                   </Stack>
                                                 </ThemedNavigation>
                                                 <PersistentQueueBar />
+                                                <OnboardingGate ready={authReady && fontsReady} />
                                                 <AnalyticsScreenTracker />
                                               </ShareTargetProvider>
                                             </DeepLinkProvider>

--- a/packages/mobile/app/onboarding.tsx
+++ b/packages/mobile/app/onboarding.tsx
@@ -1,0 +1,54 @@
+import { useCallback } from 'react';
+import { router } from 'expo-router';
+import { useTheme as usePaperTheme } from 'react-native-paper';
+import { OnboardingCarousel } from '../src/components/onboarding/OnboardingCarousel';
+import { useTheme } from '../src/providers/theme-provider';
+import { markOnboardingSeen } from '../src/lib/onboarding/onboarding-storage';
+
+/**
+ * First-run welcome walkthrough. Presented as a full-screen cover over the
+ * Climbs tab (see app/_layout.tsx) with the swipe-to-dismiss gesture disabled —
+ * the user leaves via Skip, finish, or the final CTA, never an accidental drag.
+ *
+ * The carousel itself is variant-agnostic; this route resolves the palette from
+ * the active UI variant (Liquid Glass / HIG vs Material 3) and injects it, so
+ * one component serves both skins. Both exits persist the "seen" flag so the
+ * tour shows exactly once; an interrupted tour (app killed mid-tour) reshows
+ * because the flag is only written here.
+ */
+export default function OnboardingScreen() {
+  const { variant, systemColors } = useTheme();
+  const paperTheme = usePaperTheme();
+
+  const isMaterial = variant === 'material';
+  // Material reads MD3 roles from the Paper theme; HIG / Liquid Glass reads the
+  // iOS-style system colours. Background stays opaque under the reading text in
+  // both (no glass behind the copy — only the floating footer is glass).
+  const accentColor = isMaterial ? paperTheme.colors.primary : (systemColors.accent as string);
+  const iconColor = isMaterial ? paperTheme.colors.primary : (systemColors.accent as string);
+  const inactiveDotColor = isMaterial ? paperTheme.colors.surfaceVariant : (systemColors.separator as string);
+  const bodyColor = isMaterial ? paperTheme.colors.onSurfaceVariant : (systemColors.secondaryLabel as string);
+  const backgroundColor = isMaterial ? paperTheme.colors.background : (systemColors.background as string);
+
+  const dismissToClimbs = useCallback(() => {
+    void markOnboardingSeen();
+    router.replace('/(tabs)/climbs');
+  }, []);
+
+  const goToBoards = useCallback(() => {
+    void markOnboardingSeen();
+    router.replace('/boards');
+  }, []);
+
+  return (
+    <OnboardingCarousel
+      accentColor={accentColor}
+      iconColor={iconColor}
+      inactiveDotColor={inactiveDotColor}
+      bodyColor={bodyColor}
+      backgroundColor={backgroundColor}
+      onDone={dismissToClimbs}
+      onFinish={goToBoards}
+    />
+  );
+}

--- a/packages/mobile/app/onboarding.tsx
+++ b/packages/mobile/app/onboarding.tsx
@@ -4,6 +4,7 @@ import { useTheme as usePaperTheme } from 'react-native-paper';
 import { OnboardingCarousel } from '../src/components/onboarding/OnboardingCarousel';
 import { useTheme } from '../src/providers/theme-provider';
 import { markOnboardingSeen } from '../src/lib/onboarding/onboarding-storage';
+import { reportError } from '../src/lib/sentry';
 
 /**
  * First-run welcome walkthrough. Presented as a full-screen cover over the
@@ -30,15 +31,27 @@ export default function OnboardingScreen() {
   const bodyColor = isMaterial ? paperTheme.colors.onSurfaceVariant : (systemColors.secondaryLabel as string);
   const backgroundColor = isMaterial ? paperTheme.colors.background : (systemColors.background as string);
 
-  const dismissToClimbs = useCallback(() => {
-    void markOnboardingSeen();
-    router.replace('/(tabs)/climbs');
+  // Persist the "seen" flag without blocking the exit. If the SecureStore write
+  // rejects (keychain locked / unavailable), navigation still happens — but we
+  // log + report it, because a silent failure would reshow the tour on every
+  // cold start. console.warn for dev visibility, reportError for production.
+  const persistSeen = useCallback(() => {
+    markOnboardingSeen().catch((error: unknown) => {
+      // eslint-disable-next-line no-console
+      console.warn('[onboarding] Failed to persist "seen" flag', error);
+      reportError(error);
+    });
   }, []);
 
+  const dismissToClimbs = useCallback(() => {
+    persistSeen();
+    router.replace('/(tabs)/climbs');
+  }, [persistSeen]);
+
   const goToBoards = useCallback(() => {
-    void markOnboardingSeen();
+    persistSeen();
     router.replace('/boards');
-  }, []);
+  }, [persistSeen]);
 
   return (
     <OnboardingCarousel

--- a/packages/mobile/src/components/onboarding/OnboardingCard.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingCard.tsx
@@ -1,0 +1,70 @@
+import { memo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { spacing } from '../../theme/tokens';
+import type { IconName } from '../icon-map';
+
+const ILLUSTRATION_SIZE = 96;
+
+type OnboardingCardProps = {
+  /** Glyph for this page (resolved from the card data by the carousel). */
+  icon: IconName;
+  /** Already-translated heading. Resolved at the call site with a static `t()`
+   * literal so the i18n orphan checker can see the keys (no `t(variable)`). */
+  title: string;
+  /** Already-translated body copy. */
+  body: string;
+  /** Page width — each card fills exactly one viewport so paging snaps cleanly. */
+  width: number;
+  /** Tint for the illustration glyph (variant accent: systemColors.accent / colors.primary). */
+  iconColor: string;
+  /** Body/subtext colour (secondary label / onSurfaceVariant). */
+  bodyColor: string;
+};
+
+/**
+ * One full-width welcome page: a tinted glyph above a large title and body. The
+ * whole card is one accessibility element so VoiceOver/TalkBack reads the
+ * heading and body together as the user pages across. Memoised so FlatList row
+ * recycling doesn't re-render unchanged pages.
+ */
+function OnboardingCardComponent({ icon, title, body, width, iconColor, bodyColor }: OnboardingCardProps) {
+  return (
+    <View style={[styles.page, { width }]} accessible accessibilityRole="text" accessibilityLabel={`${title}. ${body}`}>
+      <View style={styles.illustration} importantForAccessibility="no-hide-descendants">
+        <Icon name={icon} size={ILLUSTRATION_SIZE} color={iconColor} />
+      </View>
+      <Text variant="largeTitle" style={styles.title}>
+        {title}
+      </Text>
+      <Text variant="body" color={bodyColor} style={styles.body}>
+        {body}
+      </Text>
+    </View>
+  );
+}
+
+export const OnboardingCard = memo(OnboardingCardComponent);
+
+const styles = StyleSheet.create({
+  page: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing[8],
+  },
+  illustration: {
+    marginBottom: spacing[8],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    textAlign: 'center',
+    marginBottom: spacing[4],
+  },
+  body: {
+    textAlign: 'center',
+    maxWidth: 340,
+  },
+});

--- a/packages/mobile/src/components/onboarding/OnboardingCarousel.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingCarousel.tsx
@@ -1,0 +1,259 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  FlatList,
+  StyleSheet,
+  View,
+  type LayoutChangeEvent,
+  type ListRenderItemInfo,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Button } from '../Button';
+import { GlassSurface } from '../GlassSurface';
+import { OnboardingCard } from './OnboardingCard';
+import { OnboardingPageControl } from './OnboardingPageControl';
+import { ONBOARDING_CARDS, type OnboardingCard as OnboardingCardData } from '../../lib/onboarding/onboarding-cards';
+import { useOnboardingCopy } from '../../lib/onboarding/use-onboarding-copy';
+import {
+  trackStepAdvanced,
+  trackStepViewed,
+  trackTourCompleted,
+  trackTourSkipped,
+  trackTourStarted,
+} from '../../lib/onboarding/onboarding-analytics';
+import { hapticSelection } from '../../lib/haptics';
+import { useTheme } from '../../providers/theme-provider';
+import { useReduceMotion } from '../../hooks/use-reduce-motion';
+import { spacing } from '../../theme/tokens';
+
+type OnboardingCarouselProps = {
+  /** Active dot + final CTA accent (HIG: systemColors.accent; Material: colors.primary). */
+  accentColor: string;
+  /** Illustration glyph tint. */
+  iconColor: string;
+  /** Inactive dot colour. */
+  inactiveDotColor: string;
+  /** Body/subtext colour. */
+  bodyColor: string;
+  /** Opaque background under the reading text. */
+  backgroundColor: string;
+  /** Skip (all but last) or completing the tour — both dismiss to the Climbs tab. */
+  onDone: () => void;
+  /** Final CTA — go connect a board. */
+  onFinish: () => void;
+};
+
+const LAST_INDEX = ONBOARDING_CARDS.length - 1;
+
+const keyExtractor = (card: OnboardingCardData) => card.id;
+
+/**
+ * Variant-agnostic 4-card welcome carousel. The route injects the resolved
+ * colours and the two exits, so this component is identical for the HIG and
+ * Material skins — the route picks the palette from the active variant.
+ *
+ * Paging: a horizontal `pagingEnabled` FlatList (virtualized; no `.map()` in a
+ * ScrollView). Under Reduce Motion the list is locked (`scrollEnabled=false`)
+ * and the Next button cross-fades pages via `scrollToIndex({ animated: false })`
+ * instead of sliding.
+ */
+export function OnboardingCarousel({
+  accentColor,
+  iconColor,
+  inactiveDotColor,
+  bodyColor,
+  backgroundColor,
+  onDone,
+  onFinish,
+}: OnboardingCarouselProps) {
+  const { t } = useTranslation('common');
+  const copy = useOnboardingCopy();
+  const insets = useSafeAreaInsets();
+  const { variant } = useTheme();
+  const reduceMotion = useReduceMotion();
+  const listRef = useRef<FlatList<OnboardingCardData>>(null);
+
+  const [pageWidth, setPageWidth] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(0);
+  // Live mirror so the momentum-scroll handler can compare against the current
+  // page without re-binding on every index change.
+  const activeIndexRef = useRef(0);
+  activeIndexRef.current = activeIndex;
+  const startedAtRef = useRef<number>(Date.now());
+
+  // Tour Started + first Step Viewed fire once on mount.
+  useEffect(() => {
+    startedAtRef.current = Date.now();
+    trackTourStarted();
+    trackStepViewed(ONBOARDING_CARDS[0], 0);
+  }, []);
+
+  const goToIndex = useCallback((nextIndex: number, trigger: 'next' | 'swipe') => {
+    const fromIndex = activeIndexRef.current;
+    if (nextIndex === fromIndex || nextIndex < 0 || nextIndex > LAST_INDEX) return;
+    hapticSelection();
+    setActiveIndex(nextIndex);
+    trackStepAdvanced(ONBOARDING_CARDS[fromIndex], ONBOARDING_CARDS[nextIndex], trigger);
+    trackStepViewed(ONBOARDING_CARDS[nextIndex], nextIndex);
+  }, []);
+
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
+    setPageWidth(event.nativeEvent.layout.width);
+  }, []);
+
+  // Swipe: derive the settled page from the momentum-scroll offset and reconcile
+  // analytics + the page control. Only fires on the slide path (Reduce Motion
+  // locks scrolling, so the Next button drives transitions there).
+  const handleMomentumEnd = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (pageWidth <= 0) return;
+      const nextIndex = Math.round(event.nativeEvent.contentOffset.x / pageWidth);
+      goToIndex(nextIndex, 'swipe');
+    },
+    [pageWidth, goToIndex],
+  );
+
+  const handleNext = useCallback(() => {
+    const fromIndex = activeIndexRef.current;
+    if (fromIndex >= LAST_INDEX) {
+      const durationSeconds = Math.max(0, Math.round((Date.now() - startedAtRef.current) / 1000));
+      trackTourCompleted(durationSeconds);
+      hapticSelection();
+      onFinish();
+      return;
+    }
+    const nextIndex = fromIndex + 1;
+    // Reduce Motion: cross-fade (no animated slide). Otherwise slide.
+    listRef.current?.scrollToIndex({ index: nextIndex, animated: !reduceMotion });
+    goToIndex(nextIndex, 'next');
+  }, [reduceMotion, goToIndex, onFinish]);
+
+  const handleSkip = useCallback(() => {
+    const index = activeIndexRef.current;
+    trackTourSkipped(ONBOARDING_CARDS[index], index);
+    onDone();
+  }, [onDone]);
+
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<OnboardingCardData>) => (
+      <OnboardingCard
+        icon={item.icon}
+        title={copy[item.id].title}
+        body={copy[item.id].body}
+        width={pageWidth}
+        iconColor={iconColor}
+        bodyColor={bodyColor}
+      />
+    ),
+    [copy, pageWidth, iconColor, bodyColor],
+  );
+
+  // Stable per-page geometry so FlatList can scrollToIndex without measuring.
+  const getItemLayout = useCallback(
+    (_: ArrayLike<OnboardingCardData> | null | undefined, index: number) => ({
+      length: pageWidth,
+      offset: pageWidth * index,
+      index,
+    }),
+    [pageWidth],
+  );
+
+  const isLast = activeIndex === LAST_INDEX;
+  const footerPadding = useMemo(() => Math.max(insets.bottom, spacing[4]), [insets.bottom]);
+
+  return (
+    <View
+      style={[styles.root, { backgroundColor, paddingTop: insets.top }]}
+      onLayout={handleLayout}
+      accessibilityViewIsModal
+    >
+      {pageWidth > 0 ? (
+        <FlatList
+          ref={listRef}
+          data={ONBOARDING_CARDS}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          getItemLayout={getItemLayout}
+          horizontal
+          pagingEnabled
+          // Reduce Motion: lock the swipe so transitions only happen via the
+          // Next button's non-animated scrollToIndex (a cross-fade-style jump).
+          scrollEnabled={!reduceMotion}
+          showsHorizontalScrollIndicator={false}
+          onMomentumScrollEnd={handleMomentumEnd}
+          bounces={false}
+          style={styles.list}
+        />
+      ) : (
+        <View style={styles.list} />
+      )}
+
+      <View style={styles.pageControl}>
+        <OnboardingPageControl activeIndex={activeIndex} activeColor={accentColor} inactiveColor={inactiveDotColor} />
+      </View>
+
+      <GlassSurface
+        glassEffectStyle="regular"
+        // On the Material / Android / Reduce-Transparency paths GlassSurface
+        // renders an opaque tonal surface; on iOS 26 the floating footer sits on
+        // real Liquid Glass while the reading area above stays opaque.
+        style={[styles.footer, { paddingBottom: footerPadding }]}
+      >
+        <View style={styles.footerInner}>
+          <View style={styles.footerSlot}>
+            {isLast ? null : (
+              <Button
+                title={t('mobile.onboarding.skip')}
+                onPress={handleSkip}
+                variant="text"
+                size="large"
+                haptic={false}
+              />
+            )}
+          </View>
+          <View style={styles.footerSlot}>
+            <Button
+              title={isLast ? t('mobile.onboarding.getStarted') : t('mobile.onboarding.next')}
+              onPress={handleNext}
+              variant="filled"
+              size="large"
+              tintColor={variant === 'material' ? undefined : accentColor}
+              haptic={false}
+              style={styles.cta}
+            />
+          </View>
+        </View>
+      </GlassSurface>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  list: {
+    flex: 1,
+  },
+  pageControl: {
+    paddingVertical: spacing[4],
+  },
+  footer: {
+    paddingTop: spacing[3],
+    paddingHorizontal: spacing[5],
+  },
+  footerInner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing[3],
+  },
+  footerSlot: {
+    flex: 1,
+  },
+  cta: {
+    alignSelf: 'flex-end',
+  },
+});

--- a/packages/mobile/src/components/onboarding/OnboardingGate.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingGate.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { router, useSegments } from 'expo-router';
+import * as Linking from 'expo-linking';
 import { hasSeenOnboarding } from '../../lib/onboarding/onboarding-storage';
 
 type OnboardingGateProps = {
@@ -36,11 +37,28 @@ export function OnboardingGate({ ready }: OnboardingGateProps) {
 
     let cancelled = false;
     void (async () => {
-      // Don't interrupt a deep-link / auth / share landing.
+      // Don't interrupt a deep-link / auth / share landing on a non-tab group.
       if (topSegmentRef.current && DEEP_LINK_SEGMENTS.has(topSegmentRef.current)) return;
+
+      // A custom-scheme deep link that resolves INTO a tab (e.g.
+      // com.boardsesh.app://climbs/...) lands with segments[0] === '(tabs)', so
+      // the segment guard above doesn't catch it and onboarding would cover the
+      // intended destination. The cold-start launch URL is the reliable signal:
+      // if the app was opened by ANY deep link, the user has explicit intent —
+      // don't auto-present the tour over it. A plain launch returns null here,
+      // so normal first-run (show once) is untouched.
+      let initialUrl: string | null = null;
+      try {
+        initialUrl = await Linking.getInitialURL();
+      } catch {
+        initialUrl = null;
+      }
+      if (cancelled) return;
+      if (initialUrl) return;
+
       const seen = await hasSeenOnboarding();
       if (cancelled || seen) return;
-      // Re-check the route after the async read — a deep link may have arrived
+      // Re-check the route after the async reads — a deep link may have arrived
       // in the meantime — so we never cover an intentional destination.
       if (topSegmentRef.current && DEEP_LINK_SEGMENTS.has(topSegmentRef.current)) return;
       router.push('/onboarding');

--- a/packages/mobile/src/components/onboarding/OnboardingGate.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingGate.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { router, useSegments } from 'expo-router';
 import * as Linking from 'expo-linking';
 import { hasSeenOnboarding } from '../../lib/onboarding/onboarding-storage';
+import { useProfile } from '../../lib/graphql/hooks';
 
 type OnboardingGateProps = {
   /** True once auth + fonts are resolved and the splash has hidden. */
@@ -22,6 +23,10 @@ const DEEP_LINK_SEGMENTS = new Set(['join', 'share-beta', 'session', 'auth', 'on
  * nothing. Mounting it below AuthProvider means it only runs for an
  * authenticated session — an unauthenticated cold start is redirected to login
  * by the auth gate, and the walkthrough shows after they sign in.
+ *
+ * The decision is keyed on the signed-in profile id, not the app process: on a
+ * shared device a user can sign out and a different user sign in without a
+ * relaunch, and the new account gets its own first-run check.
  */
 export function OnboardingGate({ ready }: OnboardingGateProps) {
   const segments = useSegments();
@@ -30,6 +35,19 @@ export function OnboardingGate({ ready }: OnboardingGateProps) {
   const topSegmentRef = useRef<string | undefined>(segments[0]);
   topSegmentRef.current = segments[0];
   const decidedRef = useRef(false);
+
+  // The gate decides once per signed-in account, not once per app process. On a
+  // shared device a user can sign out and a DIFFERENT user can sign in without a
+  // relaunch; keying the decision on the profile id lets the new account get its
+  // own first-run check. `undefined` while the profile loads — we only reset the
+  // decision on a transition between two concrete ids.
+  const { data: profile } = useProfile();
+  const userId = profile?.id;
+  const decidedForUserRef = useRef<string | undefined>(userId);
+  if (userId !== undefined && userId !== decidedForUserRef.current) {
+    decidedForUserRef.current = userId;
+    decidedRef.current = false;
+  }
 
   useEffect(() => {
     if (!ready || decidedRef.current) return;
@@ -67,7 +85,9 @@ export function OnboardingGate({ ready }: OnboardingGateProps) {
     return () => {
       cancelled = true;
     };
-  }, [ready]);
+    // `userId` is here so the effect re-runs after a sign-out/sign-in resets
+    // `decidedRef` above — the new account gets its own first-run evaluation.
+  }, [ready, userId]);
 
   return null;
 }

--- a/packages/mobile/src/components/onboarding/OnboardingGate.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingGate.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+import { router, useSegments } from 'expo-router';
+import { hasSeenOnboarding } from '../../lib/onboarding/onboarding-storage';
+
+type OnboardingGateProps = {
+  /** True once auth + fonts are resolved and the splash has hidden. */
+  ready: boolean;
+};
+
+// Route groups the gate must NOT interrupt: a cold start that landed on a
+// join/share/session deep link, the auth flow, or the onboarding screen itself.
+// On those the user has explicit intent elsewhere; the walkthrough would steal
+// focus. The Climbs tab (the launcher's default landing) is the only surface we
+// push over.
+const DEEP_LINK_SEGMENTS = new Set(['join', 'share-beta', 'session', 'auth', 'onboarding', 'boards']);
+
+/**
+ * First-run gate. Once the app is ready (auth + fonts loaded, splash hidden) it
+ * reads the persisted "seen" flag; if the walkthrough is unseen and the user
+ * isn't mid deep-link / auth flow, it pushes the onboarding route once. Renders
+ * nothing. Mounting it below AuthProvider means it only runs for an
+ * authenticated session — an unauthenticated cold start is redirected to login
+ * by the auth gate, and the walkthrough shows after they sign in.
+ */
+export function OnboardingGate({ ready }: OnboardingGateProps) {
+  const segments = useSegments();
+  // Latest top-level segment for the async check, without re-running the effect
+  // on every navigation — the gate decides once per app launch.
+  const topSegmentRef = useRef<string | undefined>(segments[0]);
+  topSegmentRef.current = segments[0];
+  const decidedRef = useRef(false);
+
+  useEffect(() => {
+    if (!ready || decidedRef.current) return;
+    decidedRef.current = true;
+
+    let cancelled = false;
+    void (async () => {
+      // Don't interrupt a deep-link / auth / share landing.
+      if (topSegmentRef.current && DEEP_LINK_SEGMENTS.has(topSegmentRef.current)) return;
+      const seen = await hasSeenOnboarding();
+      if (cancelled || seen) return;
+      // Re-check the route after the async read — a deep link may have arrived
+      // in the meantime — so we never cover an intentional destination.
+      if (topSegmentRef.current && DEEP_LINK_SEGMENTS.has(topSegmentRef.current)) return;
+      router.push('/onboarding');
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [ready]);
+
+  return null;
+}

--- a/packages/mobile/src/components/onboarding/OnboardingPageControl.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingPageControl.tsx
@@ -1,0 +1,63 @@
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { ONBOARDING_TOTAL_STEPS } from '../../lib/onboarding/onboarding-cards';
+import { spacing } from '../../theme/tokens';
+
+type OnboardingPageControlProps = {
+  activeIndex: number;
+  /** Active dot colour (HIG: systemColors.accent; Material: colors.primary). */
+  activeColor: string;
+  /** Inactive dot colour (separator / surfaceVariant). */
+  inactiveColor: string;
+};
+
+const DOT_SIZE = 8;
+
+/**
+ * A row of dots, one per card, the active one tinted. Announces "Page N of 4"
+ * as a single a11y element so screen-reader users hear their position; the dots
+ * themselves are decorative.
+ */
+export function OnboardingPageControl({ activeIndex, activeColor, inactiveColor }: OnboardingPageControlProps) {
+  const { t } = useTranslation('common');
+  return (
+    <View
+      style={styles.row}
+      accessible
+      accessibilityRole="progressbar"
+      accessibilityLabel={t('mobile.onboarding.pageIndicator', {
+        current: activeIndex + 1,
+        total: ONBOARDING_TOTAL_STEPS,
+      })}
+    >
+      {Array.from({ length: ONBOARDING_TOTAL_STEPS }, (_, index) => (
+        <View
+          key={index}
+          importantForAccessibility="no"
+          style={[
+            styles.dot,
+            { backgroundColor: index === activeIndex ? activeColor : inactiveColor },
+            index === activeIndex ? styles.dotActive : null,
+          ]}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[2],
+  },
+  dot: {
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: DOT_SIZE / 2,
+  },
+  dotActive: {
+    width: DOT_SIZE * 2.5,
+  },
+});

--- a/packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx
@@ -5,10 +5,14 @@ import { render, waitFor } from '@testing-library/react';
 const pushMock = vi.hoisted(() => vi.fn());
 const segmentsCtrl = vi.hoisted(() => ({ segments: ['(tabs)', 'climbs'] as string[] }));
 const hasSeenMock = vi.hoisted(() => vi.fn());
+const getInitialURLMock = vi.hoisted(() => vi.fn());
 
 vi.mock('expo-router', () => ({
   router: { push: pushMock },
   useSegments: () => segmentsCtrl.segments,
+}));
+vi.mock('expo-linking', () => ({
+  getInitialURL: getInitialURLMock,
 }));
 vi.mock('../../../lib/onboarding/onboarding-storage', () => ({
   hasSeenOnboarding: hasSeenMock,
@@ -20,6 +24,9 @@ describe('OnboardingGate', () => {
   beforeEach(() => {
     pushMock.mockClear();
     hasSeenMock.mockReset();
+    getInitialURLMock.mockReset();
+    // Default: a plain launch (no cold-start deep link).
+    getInitialURLMock.mockResolvedValue(null);
     segmentsCtrl.segments = ['(tabs)', 'climbs'];
   });
 
@@ -61,5 +68,41 @@ describe('OnboardingGate', () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('does not cover a cold-start deep link that lands ON a tab', async () => {
+    // The custom-scheme link resolved into the Climbs tab, so the segment guard
+    // sees a normal '(tabs)' landing and wouldn't catch it — the launch URL is
+    // what tells us the user arrived via an intentional deep link.
+    hasSeenMock.mockResolvedValue(false);
+    segmentsCtrl.segments = ['(tabs)', 'climbs'];
+    getInitialURLMock.mockResolvedValue('com.boardsesh.app://climbs/kilter');
+    render(<OnboardingGate ready />);
+    await waitFor(() => expect(getInitialURLMock).toHaveBeenCalled());
+    await Promise.resolve();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('does not read the seen flag when launched via a deep link', async () => {
+    hasSeenMock.mockResolvedValue(false);
+    getInitialURLMock.mockResolvedValue('com.boardsesh.app://climbs/tension');
+    render(<OnboardingGate ready />);
+    await waitFor(() => expect(getInitialURLMock).toHaveBeenCalled());
+    await Promise.resolve();
+    expect(hasSeenMock).not.toHaveBeenCalled();
+  });
+
+  it('still shows once on a normal launch with no deep link', async () => {
+    hasSeenMock.mockResolvedValue(false);
+    getInitialURLMock.mockResolvedValue(null);
+    render(<OnboardingGate ready />);
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/onboarding'));
+  });
+
+  it('treats a launch-URL read error as a normal launch (shows the tour)', async () => {
+    hasSeenMock.mockResolvedValue(false);
+    getInitialURLMock.mockRejectedValue(new Error('linking unavailable'));
+    render(<OnboardingGate ready />);
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/onboarding'));
   });
 });

--- a/packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+const pushMock = vi.hoisted(() => vi.fn());
+const segmentsCtrl = vi.hoisted(() => ({ segments: ['(tabs)', 'climbs'] as string[] }));
+const hasSeenMock = vi.hoisted(() => vi.fn());
+
+vi.mock('expo-router', () => ({
+  router: { push: pushMock },
+  useSegments: () => segmentsCtrl.segments,
+}));
+vi.mock('../../../lib/onboarding/onboarding-storage', () => ({
+  hasSeenOnboarding: hasSeenMock,
+}));
+
+import { OnboardingGate } from '../OnboardingGate';
+
+describe('OnboardingGate', () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    hasSeenMock.mockReset();
+    segmentsCtrl.segments = ['(tabs)', 'climbs'];
+  });
+
+  it('does nothing until the app is ready', async () => {
+    hasSeenMock.mockResolvedValue(false);
+    render(<OnboardingGate ready={false} />);
+    await Promise.resolve();
+    expect(hasSeenMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('pushes the onboarding route on a fresh, ready, non-deep-link launch', async () => {
+    hasSeenMock.mockResolvedValue(false);
+    render(<OnboardingGate ready />);
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/onboarding'));
+  });
+
+  it('does not re-show the tour once it has been seen', async () => {
+    hasSeenMock.mockResolvedValue(true);
+    render(<OnboardingGate ready />);
+    await waitFor(() => expect(hasSeenMock).toHaveBeenCalled());
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('does not interrupt a join deep-link landing', async () => {
+    hasSeenMock.mockResolvedValue(false);
+    segmentsCtrl.segments = ['join', '[sessionId]'];
+    render(<OnboardingGate ready />);
+    await Promise.resolve();
+    await Promise.resolve();
+    // Short-circuits before reading the flag — the deep-link destination wins.
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('does not interrupt the auth flow', async () => {
+    hasSeenMock.mockResolvedValue(false);
+    segmentsCtrl.segments = ['auth', 'login'];
+    render(<OnboardingGate ready />);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx
@@ -6,6 +6,9 @@ const pushMock = vi.hoisted(() => vi.fn());
 const segmentsCtrl = vi.hoisted(() => ({ segments: ['(tabs)', 'climbs'] as string[] }));
 const hasSeenMock = vi.hoisted(() => vi.fn());
 const getInitialURLMock = vi.hoisted(() => vi.fn());
+// Controllable signed-in profile: the gate keys its first-run decision on the
+// profile id, so tests drive sign-out/sign-in by swapping this id.
+const profileCtrl = vi.hoisted(() => ({ id: undefined as string | undefined }));
 
 vi.mock('expo-router', () => ({
   router: { push: pushMock },
@@ -16,6 +19,9 @@ vi.mock('expo-linking', () => ({
 }));
 vi.mock('../../../lib/onboarding/onboarding-storage', () => ({
   hasSeenOnboarding: hasSeenMock,
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: profileCtrl.id ? { id: profileCtrl.id } : undefined }),
 }));
 
 import { OnboardingGate } from '../OnboardingGate';
@@ -28,6 +34,7 @@ describe('OnboardingGate', () => {
     // Default: a plain launch (no cold-start deep link).
     getInitialURLMock.mockResolvedValue(null);
     segmentsCtrl.segments = ['(tabs)', 'climbs'];
+    profileCtrl.id = undefined;
   });
 
   it('does nothing until the app is ready', async () => {
@@ -104,5 +111,34 @@ describe('OnboardingGate', () => {
     getInitialURLMock.mockRejectedValue(new Error('linking unavailable'));
     render(<OnboardingGate ready />);
     await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/onboarding'));
+  });
+
+  it('re-evaluates first-run when a different user signs in during the session', async () => {
+    // User A has already seen the tour — no push.
+    hasSeenMock.mockResolvedValue(true);
+    profileCtrl.id = 'user-a';
+    const { rerender } = render(<OnboardingGate ready />);
+    await waitFor(() => expect(hasSeenMock).toHaveBeenCalledTimes(1));
+    expect(pushMock).not.toHaveBeenCalled();
+
+    // User B signs in (different id) and hasn't seen it — the gate must
+    // re-check and push, rather than staying "decided" from user A.
+    hasSeenMock.mockResolvedValue(false);
+    profileCtrl.id = 'user-b';
+    rerender(<OnboardingGate ready />);
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/onboarding'));
+    expect(hasSeenMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-decide when the same user id stays stable across rerenders', async () => {
+    hasSeenMock.mockResolvedValue(true);
+    profileCtrl.id = 'user-a';
+    const { rerender } = render(<OnboardingGate ready />);
+    await waitFor(() => expect(hasSeenMock).toHaveBeenCalledTimes(1));
+    rerender(<OnboardingGate ready />);
+    await Promise.resolve();
+    // Same id → the gate stays decided; no extra flag read, no push.
+    expect(hasSeenMock).toHaveBeenCalledTimes(1);
+    expect(pushMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/lib/onboarding/__tests__/onboarding-analytics.test.ts
+++ b/packages/mobile/src/lib/onboarding/__tests__/onboarding-analytics.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const trackMock = vi.hoisted(() => vi.fn());
+vi.mock('../../analytics', () => ({ track: trackMock }));
+
+import {
+  trackStepAdvanced,
+  trackStepViewed,
+  trackTourCompleted,
+  trackTourSkipped,
+  trackTourStarted,
+} from '../onboarding-analytics';
+import { ONBOARDING_CARDS, ONBOARDING_TOTAL_STEPS } from '../onboarding-cards';
+
+describe('onboarding analytics', () => {
+  beforeEach(() => trackMock.mockClear());
+
+  // The event NAMES must match web's onboarding-tour-provider so both platforms
+  // share one PostHog funnel — assert the literal strings, not a re-export.
+  it('fires "Onboarding Tour Started" with the web property shape', () => {
+    trackTourStarted();
+    expect(trackMock).toHaveBeenCalledWith('Onboarding Tour Started', {
+      resumed: false,
+      restartedFrom: '',
+      source: 'mobile-first-run',
+    });
+  });
+
+  it('fires "Onboarding Tour Step Viewed" with stepId/stepIndex/totalSteps', () => {
+    trackStepViewed(ONBOARDING_CARDS[1], 1);
+    expect(trackMock).toHaveBeenCalledWith('Onboarding Tour Step Viewed', {
+      stepId: ONBOARDING_CARDS[1].id,
+      stepIndex: 1,
+      totalSteps: ONBOARDING_TOTAL_STEPS,
+    });
+  });
+
+  it('fires "Onboarding Tour Step Advanced" with fromStepId/toStepId/trigger', () => {
+    trackStepAdvanced(ONBOARDING_CARDS[0], ONBOARDING_CARDS[1], 'swipe');
+    expect(trackMock).toHaveBeenCalledWith('Onboarding Tour Step Advanced', {
+      fromStepId: ONBOARDING_CARDS[0].id,
+      toStepId: ONBOARDING_CARDS[1].id,
+      trigger: 'swipe',
+    });
+  });
+
+  it('fires "Onboarding Tour Completed" with durationSeconds', () => {
+    trackTourCompleted(42);
+    expect(trackMock).toHaveBeenCalledWith('Onboarding Tour Completed', { durationSeconds: 42 });
+  });
+
+  it('fires "Onboarding Tour Skipped" with atStepId/stepIndex', () => {
+    trackTourSkipped(ONBOARDING_CARDS[2], 2);
+    expect(trackMock).toHaveBeenCalledWith('Onboarding Tour Skipped', {
+      atStepId: ONBOARDING_CARDS[2].id,
+      stepIndex: 2,
+    });
+  });
+});

--- a/packages/mobile/src/lib/onboarding/__tests__/onboarding-cards.test.ts
+++ b/packages/mobile/src/lib/onboarding/__tests__/onboarding-cards.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { iconMap } from '../../../components/icon-map';
+import { ONBOARDING_CARDS, ONBOARDING_TOTAL_STEPS } from '../onboarding-cards';
+import commonEn from '@boardsesh/i18n/locales/en-US/common.json';
+
+function resolveKey(catalog: unknown, dottedKey: string): unknown {
+  return dottedKey.split('.').reduce<unknown>((node, segment) => {
+    if (node && typeof node === 'object') {
+      return (node as Record<string, unknown>)[segment];
+    }
+    return undefined;
+  }, catalog);
+}
+
+describe('ONBOARDING_CARDS', () => {
+  it('has exactly four cards (the welcome carousel scope)', () => {
+    expect(ONBOARDING_CARDS).toHaveLength(4);
+    expect(ONBOARDING_TOTAL_STEPS).toBe(4);
+  });
+
+  it('keeps the spec page order: welcome → connect → find → play', () => {
+    expect(ONBOARDING_CARDS.map((card) => card.id)).toEqual(['welcome', 'connect', 'find', 'play']);
+  });
+
+  it('has unique ids (stable analytics keys)', () => {
+    const ids = ONBOARDING_CARDS.map((card) => card.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('references real icon-map glyphs (no synthesized imagery)', () => {
+    for (const card of ONBOARDING_CARDS) {
+      expect(iconMap).toHaveProperty(card.icon);
+    }
+  });
+
+  it('has title + body copy for every card id in the en-US common catalog', () => {
+    for (const card of ONBOARDING_CARDS) {
+      expect(typeof resolveKey(commonEn, `mobile.onboarding.cards.${card.id}.title`)).toBe('string');
+      expect(typeof resolveKey(commonEn, `mobile.onboarding.cards.${card.id}.body`)).toBe('string');
+    }
+  });
+});

--- a/packages/mobile/src/lib/onboarding/__tests__/onboarding-storage.test.ts
+++ b/packages/mobile/src/lib/onboarding/__tests__/onboarding-storage.test.ts
@@ -44,6 +44,14 @@ describe('onboarding storage', () => {
     expect(setMock).toHaveBeenCalledWith(ONBOARDING_SEEN_KEY, true);
   });
 
+  it('propagates a write failure so callers can log/report it', async () => {
+    // The onboarding screen catches this rejection (console.warn + reportError)
+    // instead of silently swallowing it — a lost write reshows the tour on every
+    // cold start, so it must not fail quietly.
+    setMock.mockRejectedValue(new Error('keychain locked'));
+    await expect(markOnboardingSeen()).rejects.toThrow('keychain locked');
+  });
+
   it('clears the seen flag for replay', async () => {
     removeMock.mockResolvedValue(undefined);
     await clearOnboardingSeen();
@@ -68,6 +76,15 @@ describe('onboarding storage', () => {
       // The clear must settle first; otherwise a fast finish/skip could write the
       // flag and a late clear would wipe it, re-showing the tour on next launch.
       expect(order).toEqual(['clear', 'navigate']);
+    });
+
+    it('rejects (without navigating) when the clear fails, so the row can show an error', async () => {
+      removeMock.mockRejectedValue(new Error('keychain locked'));
+      const navigate = vi.fn();
+      await expect(replayOnboarding(navigate)).rejects.toThrow('keychain locked');
+      // Don't open a tour that the failed clear would re-show forever — the
+      // caller surfaces an error toast instead.
+      expect(navigate).not.toHaveBeenCalled();
     });
 
     it('does not navigate until the clear promise resolves', async () => {

--- a/packages/mobile/src/lib/onboarding/__tests__/onboarding-storage.test.ts
+++ b/packages/mobile/src/lib/onboarding/__tests__/onboarding-storage.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the secure-store adapter (the seam) rather than expo-secure-store.
+const getMock = vi.fn();
+const setMock = vi.fn();
+const removeMock = vi.fn();
+vi.mock('../../preferences/secure-store-adapter', () => ({
+  secureStorePreferences: {
+    get: (key: string) => getMock(key),
+    set: (key: string, value: unknown) => setMock(key, value),
+    remove: (key: string) => removeMock(key),
+  },
+}));
+
+import { ONBOARDING_SEEN_KEY } from '@boardsesh/key-value-storage';
+import { clearOnboardingSeen, hasSeenOnboarding, markOnboardingSeen } from '../onboarding-storage';
+
+describe('onboarding storage', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    setMock.mockReset();
+    removeMock.mockReset();
+  });
+
+  it('reports unseen on a fresh install (flag absent)', async () => {
+    getMock.mockResolvedValue(null);
+    await expect(hasSeenOnboarding()).resolves.toBe(false);
+    expect(getMock).toHaveBeenCalledWith(ONBOARDING_SEEN_KEY);
+  });
+
+  it('reports seen once the flag is true', async () => {
+    getMock.mockResolvedValue(true);
+    await expect(hasSeenOnboarding()).resolves.toBe(true);
+  });
+
+  it('treats a storage read error as unseen (show the tour rather than skip it)', async () => {
+    getMock.mockRejectedValue(new Error('keychain unavailable'));
+    await expect(hasSeenOnboarding()).resolves.toBe(false);
+  });
+
+  it('persists the seen flag as true', async () => {
+    setMock.mockResolvedValue(undefined);
+    await markOnboardingSeen();
+    expect(setMock).toHaveBeenCalledWith(ONBOARDING_SEEN_KEY, true);
+  });
+
+  it('clears the seen flag for replay', async () => {
+    removeMock.mockResolvedValue(undefined);
+    await clearOnboardingSeen();
+    expect(removeMock).toHaveBeenCalledWith(ONBOARDING_SEEN_KEY);
+  });
+});

--- a/packages/mobile/src/lib/onboarding/__tests__/onboarding-storage.test.ts
+++ b/packages/mobile/src/lib/onboarding/__tests__/onboarding-storage.test.ts
@@ -13,7 +13,7 @@ vi.mock('../../preferences/secure-store-adapter', () => ({
 }));
 
 import { ONBOARDING_SEEN_KEY } from '@boardsesh/key-value-storage';
-import { clearOnboardingSeen, hasSeenOnboarding, markOnboardingSeen } from '../onboarding-storage';
+import { clearOnboardingSeen, hasSeenOnboarding, markOnboardingSeen, replayOnboarding } from '../onboarding-storage';
 
 describe('onboarding storage', () => {
   beforeEach(() => {
@@ -48,5 +48,46 @@ describe('onboarding storage', () => {
     removeMock.mockResolvedValue(undefined);
     await clearOnboardingSeen();
     expect(removeMock).toHaveBeenCalledWith(ONBOARDING_SEEN_KEY);
+  });
+
+  describe('replayOnboarding', () => {
+    it('clears the seen flag BEFORE navigating (race-free)', async () => {
+      const order: string[] = [];
+      // remove resolves on the next microtask, after which navigate runs.
+      removeMock.mockImplementation(async () => {
+        order.push('clear');
+      });
+      const navigate = vi.fn(() => {
+        order.push('navigate');
+      });
+
+      await replayOnboarding(navigate);
+
+      expect(removeMock).toHaveBeenCalledWith(ONBOARDING_SEEN_KEY);
+      expect(navigate).toHaveBeenCalledTimes(1);
+      // The clear must settle first; otherwise a fast finish/skip could write the
+      // flag and a late clear would wipe it, re-showing the tour on next launch.
+      expect(order).toEqual(['clear', 'navigate']);
+    });
+
+    it('does not navigate until the clear promise resolves', async () => {
+      let resolveClear: () => void = () => {};
+      removeMock.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveClear = resolve;
+          }),
+      );
+      const navigate = vi.fn();
+
+      const pending = replayOnboarding(navigate);
+      // The clear is still in flight — navigation must NOT have happened yet.
+      await Promise.resolve();
+      expect(navigate).not.toHaveBeenCalled();
+
+      resolveClear();
+      await pending;
+      expect(navigate).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/mobile/src/lib/onboarding/__tests__/use-onboarding-copy.test.tsx
+++ b/packages/mobile/src/lib/onboarding/__tests__/use-onboarding-copy.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { ONBOARDING_CARDS } from '../onboarding-cards';
+
+// Controllable translator: each render reads the current `t` from this ref, so a
+// test can hold the identity stable (memo should reuse) or swap it (memo should
+// recompute), exercising the useMemo `[t]` dependency.
+const translatorRef = vi.hoisted(() => ({
+  t: ((key: string) => key) as (key: string) => string,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: translatorRef.t }),
+}));
+
+import { useOnboardingCopy } from '../use-onboarding-copy';
+
+describe('useOnboardingCopy', () => {
+  beforeEach(() => {
+    translatorRef.t = (key: string) => key;
+  });
+
+  it('resolves title + body for every card id', () => {
+    const { result } = renderHook(() => useOnboardingCopy());
+    for (const card of ONBOARDING_CARDS) {
+      expect(result.current[card.id]).toEqual({
+        title: `mobile.onboarding.cards.${card.id}.title`,
+        body: `mobile.onboarding.cards.${card.id}.body`,
+      });
+    }
+  });
+
+  it('uses static literal keys per card (orphan-checker contract)', () => {
+    const seen: string[] = [];
+    translatorRef.t = (key: string) => {
+      seen.push(key);
+      return key;
+    };
+    renderHook(() => useOnboardingCopy());
+    // Eight keys total: title + body for each of the four cards.
+    for (const card of ONBOARDING_CARDS) {
+      expect(seen).toContain(`mobile.onboarding.cards.${card.id}.title`);
+      expect(seen).toContain(`mobile.onboarding.cards.${card.id}.body`);
+    }
+    expect(seen).toHaveLength(ONBOARDING_CARDS.length * 2);
+  });
+
+  it('returns a stable map while the translator identity is unchanged (memoised)', () => {
+    const { result, rerender } = renderHook(() => useOnboardingCopy());
+    const first = result.current;
+    rerender();
+    // Same `t` reference across renders → useMemo([t]) must reuse the map.
+    expect(result.current).toBe(first);
+  });
+
+  it('recomputes when the translator identity changes (deps on [t])', () => {
+    const { result, rerender } = renderHook(() => useOnboardingCopy());
+    const first = result.current;
+    // Swap `t` (e.g. a language change) — the memo dep changes, so the map must
+    // be rebuilt rather than served stale.
+    translatorRef.t = (key: string) => key;
+    rerender();
+    expect(result.current).not.toBe(first);
+  });
+});

--- a/packages/mobile/src/lib/onboarding/__tests__/use-onboarding-copy.test.tsx
+++ b/packages/mobile/src/lib/onboarding/__tests__/use-onboarding-copy.test.tsx
@@ -57,8 +57,9 @@ describe('useOnboardingCopy', () => {
   it('recomputes when the translator identity changes (deps on [t])', () => {
     const { result, rerender } = renderHook(() => useOnboardingCopy());
     const first = result.current;
-    // Swap `t` (e.g. a language change) — the memo dep changes, so the map must
-    // be rebuilt rather than served stale.
+    // Swap the translator for a new function reference (a fresh `t` is how a
+    // real language switch surfaces to the hook). The memo dep changes, so the
+    // map must be rebuilt rather than served stale.
     translatorRef.t = (key: string) => key;
     rerender();
     expect(result.current).not.toBe(first);

--- a/packages/mobile/src/lib/onboarding/onboarding-analytics.ts
+++ b/packages/mobile/src/lib/onboarding/onboarding-analytics.ts
@@ -1,0 +1,46 @@
+// Thin wrappers around the shared onboarding-tour events so the carousel
+// component stays free of property-key bookkeeping. Property names mirror web's
+// onboarding-tour-provider exactly (stepId/stepIndex, fromStepId/toStepId/
+// trigger, durationSeconds, atStepId) so both platforms feed one PostHog funnel.
+
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { track } from '../analytics';
+import { ONBOARDING_TOTAL_STEPS, type OnboardingCard } from './onboarding-cards';
+
+export function trackTourStarted(): void {
+  // The mobile tour always starts fresh on a first run (no resume / restart
+  // semantics), and the only entry points are the first-run gate and the
+  // More-tab replay row. Keep the web property shape, filled for mobile.
+  track(SHARED_EVENTS.OnboardingTourStarted, {
+    resumed: false,
+    restartedFrom: '',
+    source: 'mobile-first-run',
+  });
+}
+
+export function trackStepViewed(card: OnboardingCard, stepIndex: number): void {
+  track(SHARED_EVENTS.OnboardingTourStepViewed, {
+    stepId: card.id,
+    stepIndex,
+    totalSteps: ONBOARDING_TOTAL_STEPS,
+  });
+}
+
+export function trackStepAdvanced(fromCard: OnboardingCard, toCard: OnboardingCard, trigger: 'next' | 'swipe'): void {
+  track(SHARED_EVENTS.OnboardingTourStepAdvanced, {
+    fromStepId: fromCard.id,
+    toStepId: toCard.id,
+    trigger,
+  });
+}
+
+export function trackTourCompleted(durationSeconds: number): void {
+  track(SHARED_EVENTS.OnboardingTourCompleted, { durationSeconds });
+}
+
+export function trackTourSkipped(card: OnboardingCard, stepIndex: number): void {
+  track(SHARED_EVENTS.OnboardingTourSkipped, {
+    atStepId: card.id,
+    stepIndex,
+  });
+}

--- a/packages/mobile/src/lib/onboarding/onboarding-cards.ts
+++ b/packages/mobile/src/lib/onboarding/onboarding-cards.ts
@@ -1,0 +1,28 @@
+import type { IconName } from '../../components/icon-map';
+
+/**
+ * The four first-run walkthrough cards. Order is the page order. `id` is a
+ * stable analytics key (mirrors web's tour step ids) and `icon` resolves to an
+ * SF Symbol on iOS / MDI glyph on Android via the shared icon-map (no
+ * synthesized imagery). Card COPY is resolved separately via `useOnboardingCopy`
+ * with static `t()` literals so the i18n orphan checker can see every key — the
+ * project lint hard-fails on `t(variable)`, so the keys can't live here as data.
+ *
+ * Pure data — kept out of the component so it can be unit-tested and so the
+ * carousel's `renderItem` stays a hoisted, dependency-free callback.
+ */
+export type OnboardingCardId = 'welcome' | 'connect' | 'find' | 'play';
+
+export type OnboardingCard = {
+  id: OnboardingCardId;
+  icon: IconName;
+};
+
+export const ONBOARDING_CARDS: readonly OnboardingCard[] = [
+  { id: 'welcome', icon: 'lightbulb.fill' },
+  { id: 'connect', icon: 'bluetooth' },
+  { id: 'find', icon: 'search' },
+  { id: 'play', icon: 'playlist' },
+] as const;
+
+export const ONBOARDING_TOTAL_STEPS = ONBOARDING_CARDS.length;

--- a/packages/mobile/src/lib/onboarding/onboarding-storage.ts
+++ b/packages/mobile/src/lib/onboarding/onboarding-storage.ts
@@ -1,0 +1,32 @@
+// First-run onboarding flag, persisted in SecureStore via the shared key-value
+// adapter (same backing store as the theme / UI-variant preferences). The flag
+// is a single boolean: present-and-true means the user has seen (finished or
+// skipped) the welcome walkthrough, so it never shows again. Absent means a
+// fresh install — show it once.
+
+import { ONBOARDING_SEEN_KEY } from '@boardsesh/key-value-storage';
+import { secureStorePreferences } from '../preferences/secure-store-adapter';
+
+/**
+ * Whether the user has already seen the first-run walkthrough. Returns `false`
+ * on a read error (SecureStore unavailable) so a brand-new user still gets the
+ * tour rather than being silently skipped past it.
+ */
+export async function hasSeenOnboarding(): Promise<boolean> {
+  try {
+    const seen = await secureStorePreferences.get<boolean>(ONBOARDING_SEEN_KEY);
+    return seen === true;
+  } catch {
+    return false;
+  }
+}
+
+/** Mark the walkthrough as seen. Called on finish or skip — never mid-tour. */
+export async function markOnboardingSeen(): Promise<void> {
+  await secureStorePreferences.set(ONBOARDING_SEEN_KEY, true);
+}
+
+/** Clear the flag so the walkthrough shows again. Backs the "Replay" row. */
+export async function clearOnboardingSeen(): Promise<void> {
+  await secureStorePreferences.remove(ONBOARDING_SEEN_KEY);
+}

--- a/packages/mobile/src/lib/onboarding/onboarding-storage.ts
+++ b/packages/mobile/src/lib/onboarding/onboarding-storage.ts
@@ -30,3 +30,16 @@ export async function markOnboardingSeen(): Promise<void> {
 export async function clearOnboardingSeen(): Promise<void> {
   await secureStorePreferences.remove(ONBOARDING_SEEN_KEY);
 }
+
+/**
+ * Replay the walkthrough from the "Replay" row: clear the seen flag, THEN
+ * navigate. The await is load-bearing — if navigation fired before the clear
+ * settled, a quickly finished/skipped replay could write `markOnboardingSeen`
+ * first and let a late clear wipe it, leaving the tour "unseen" and re-showing
+ * on the next cold start. `navigate` is injected so this stays unit-testable
+ * without Expo Router.
+ */
+export async function replayOnboarding(navigate: () => void): Promise<void> {
+  await clearOnboardingSeen();
+  navigate();
+}

--- a/packages/mobile/src/lib/onboarding/use-onboarding-copy.ts
+++ b/packages/mobile/src/lib/onboarding/use-onboarding-copy.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { OnboardingCardId } from './onboarding-cards';
+
+export type OnboardingCardCopy = { title: string; body: string };
+
+/**
+ * Resolves the four cards' translated copy keyed by card id. Every key is a
+ * STATIC `t()` literal — the project lint hard-fails on `t(variable)` and the
+ * i18n orphan checker only sees literal keys, so we can't fold these into the
+ * card data and resolve them dynamically. Memoised on the translator so the
+ * carousel's `renderItem` reads from a stable map.
+ */
+export function useOnboardingCopy(): Record<OnboardingCardId, OnboardingCardCopy> {
+  const { t } = useTranslation('common');
+  return useMemo(
+    () => ({
+      welcome: {
+        title: t('mobile.onboarding.cards.welcome.title'),
+        body: t('mobile.onboarding.cards.welcome.body'),
+      },
+      connect: {
+        title: t('mobile.onboarding.cards.connect.title'),
+        body: t('mobile.onboarding.cards.connect.body'),
+      },
+      find: {
+        title: t('mobile.onboarding.cards.find.title'),
+        body: t('mobile.onboarding.cards.find.body'),
+      },
+      play: {
+        title: t('mobile.onboarding.cards.play.title'),
+        body: t('mobile.onboarding.cards.play.body'),
+      },
+    }),
+    [t],
+  );
+}

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -51,6 +51,14 @@ export const SHARED_EVENTS = {
   // Beta videos
   BetaVideoLinkClicked: 'Beta Video Link Clicked',
   BetaVideoClimbClicked: 'Beta Video Climb Clicked',
+  // Onboarding tour (first-run walkthrough). Web fires the same names from its
+  // step-based guided tour; the mobile welcome carousel reuses them so both
+  // platforms land in one PostHog funnel.
+  OnboardingTourStarted: 'Onboarding Tour Started',
+  OnboardingTourStepViewed: 'Onboarding Tour Step Viewed',
+  OnboardingTourStepAdvanced: 'Onboarding Tour Step Advanced',
+  OnboardingTourCompleted: 'Onboarding Tour Completed',
+  OnboardingTourSkipped: 'Onboarding Tour Skipped',
 } as const;
 
 export type SharedEventKey = keyof typeof SHARED_EVENTS;

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -43,8 +43,10 @@
       "skip": "Skip",
       "next": "Next",
       "getStarted": "Connect a board",
+      "replaySection": "Walkthrough",
       "replayTitle": "Replay walkthrough",
       "replaySubtitle": "See the welcome tour again",
+      "replayError": "Couldn't reopen the walkthrough. Try again.",
       "pageIndicator": "Page {{current}} of {{total}}",
       "cards": {
         "welcome": {

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -34,6 +34,32 @@
         "both": "Both"
       }
     },
+    "onboarding": {
+      "skip": "Skip",
+      "next": "Next",
+      "getStarted": "Connect a board",
+      "replayTitle": "Replay walkthrough",
+      "replaySubtitle": "See the welcome tour again",
+      "pageIndicator": "Page {{current}} of {{total}}",
+      "cards": {
+        "welcome": {
+          "title": "Light up your home board",
+          "body": "Boardsesh drives your wall — search, queue, and play, all from your phone."
+        },
+        "connect": {
+          "title": "Pair over Bluetooth",
+          "body": "Connect your board once and the holds light up as you climb."
+        },
+        "find": {
+          "title": "Search by grade, send the wall",
+          "body": "Filter thousands of problems by grade, angle, and setter to find your next send."
+        },
+        "play": {
+          "title": "Tap a climb, light the holds",
+          "body": "Build a queue, hit play, and the wall shows you exactly where to grab."
+        }
+      }
+    },
     "nav": {
       "boards": "Boards",
       "climbs": "Climbs",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -232,6 +232,32 @@
         "both": "Ambos"
       }
     },
+    "onboarding": {
+      "skip": "Omitir",
+      "next": "Siguiente",
+      "getStarted": "Conecta una tabla",
+      "replayTitle": "Repetir el tutorial",
+      "replaySubtitle": "Vuelve a ver el recorrido de bienvenida",
+      "pageIndicator": "Página {{current}} de {{total}}",
+      "cards": {
+        "welcome": {
+          "title": "Ilumina tu tabla",
+          "body": "Boardsesh controla tu muro: busca, encola y juega, todo desde tu móvil."
+        },
+        "connect": {
+          "title": "Conecta por Bluetooth",
+          "body": "Conecta tu tabla una vez y las presas se iluminan mientras escalas."
+        },
+        "find": {
+          "title": "Busca por grado, encadena el muro",
+          "body": "Filtra miles de bloques por grado, ángulo y equipador para encontrar tu próximo encadene."
+        },
+        "play": {
+          "title": "Toca un bloque, ilumina las presas",
+          "body": "Crea una cola, dale a reproducir y el muro te muestra exactamente dónde agarrar."
+        }
+      }
+    },
     "nav": {
       "boards": "Tablas",
       "climbs": "Bloques",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -241,8 +241,10 @@
       "skip": "Omitir",
       "next": "Siguiente",
       "getStarted": "Conecta una tabla",
+      "replaySection": "Tutorial",
       "replayTitle": "Repetir el tutorial",
       "replaySubtitle": "Vuelve a ver el recorrido de bienvenida",
+      "replayError": "No se pudo abrir el tutorial. Inténtalo de nuevo.",
       "pageIndicator": "Página {{current}} de {{total}}",
       "cards": {
         "welcome": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -43,8 +43,10 @@
       "skip": "Passer",
       "next": "Suivant",
       "getStarted": "Connecter un board",
+      "replaySection": "Tutoriel",
       "replayTitle": "Revoir le tutoriel",
       "replaySubtitle": "Affiche à nouveau la visite de bienvenue",
+      "replayError": "Impossible de rouvrir le tutoriel. Réessaie.",
       "pageIndicator": "Page {{current}} sur {{total}}",
       "cards": {
         "welcome": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -34,6 +34,32 @@
         "both": "Les deux"
       }
     },
+    "onboarding": {
+      "skip": "Passer",
+      "next": "Suivant",
+      "getStarted": "Connecter un board",
+      "replayTitle": "Revoir le tutoriel",
+      "replaySubtitle": "Affiche à nouveau la visite de bienvenue",
+      "pageIndicator": "Page {{current}} sur {{total}}",
+      "cards": {
+        "welcome": {
+          "title": "Allume ton board",
+          "body": "Boardsesh pilote ton mur : recherche, file d'attente et lecture, le tout depuis ton téléphone."
+        },
+        "connect": {
+          "title": "Connecte-toi en Bluetooth",
+          "body": "Connecte ton board une fois et les prises s'allument pendant que tu grimpes."
+        },
+        "find": {
+          "title": "Cherche par cotation, enchaîne le mur",
+          "body": "Filtre des milliers de blocs par cotation, angle et ouvreur pour trouver ton prochain enchaînement."
+        },
+        "play": {
+          "title": "Touche un bloc, allume les prises",
+          "body": "Crée une file, lance la lecture et le mur te montre exactement où attraper."
+        }
+      }
+    },
     "nav": {
       "boards": "Boards",
       "climbs": "Blocs",

--- a/packages/shared/key-value-storage/src/index.ts
+++ b/packages/shared/key-value-storage/src/index.ts
@@ -9,3 +9,4 @@
 export type { KeyValueStorage } from './storage';
 export { THEME_OVERRIDE_KEY, isThemeOverride, type ThemeOverride } from './theme';
 export { UI_VARIANT_KEY, isUiVariantPreference, type UiVariantPreference } from './ui-variant';
+export { ONBOARDING_SEEN_KEY } from './onboarding';

--- a/packages/shared/key-value-storage/src/onboarding.ts
+++ b/packages/shared/key-value-storage/src/onboarding.ts
@@ -1,0 +1,10 @@
+// First-run onboarding flag: whether the user has seen the mobile welcome
+// walkthrough. Written only when the tour is finished or skipped (an interrupted
+// tour reshows on next launch). Lives here next to THEME_OVERRIDE_KEY /
+// UI_VARIANT_KEY so every user-scoped preference shares one home and a future
+// server-side sync can read/write the same slot.
+//
+// The key uses only [\w.-] so it satisfies expo-secure-store's validator
+// (anything with `:` or other punctuation throws at the platform boundary).
+
+export const ONBOARDING_SEEN_KEY = 'onboarding_seen';


### PR DESCRIPTION
## Why

The React Native app (replacing the legacy Capacitor app) has no first-run onboarding today — just a splash. 48 users started the web onboarding tour, and for a fresh app-store launch with brand-new users we want them to grasp the core loop before they hit a board-less Climbs tab.

## What

A short, skippable, **shown-once** welcome carousel covering the core loop: connect a board → search climbs → build a queue → play/light up the wall. Built **variant-aware** in both skins, gated on `useTheme().variant`:

- **iOS-26 liquid glass / HIG**: opaque `systemColors.background` under the reading text, `largeTitle`/`body` copy, a 4-dot page control (active = accent), and the floating footer on `GlassSurface glassEffectStyle="regular"`.
- **Material 3 (react-native-paper)**: `colors.background` surface, `headlineSmall`-scale title, MDI illustration tinted `colors.primary`, M3 dots (active `primary`, inactive `surfaceVariant`), Paper-ripple Skip/Next buttons via the existing wrapped `Button`.

Per the reconciliation note in the brief, this is the **4-card carousel only** for v1 — the optional Material coachmark is intentionally skipped (a brand-new install has no active board to anchor a spotlight to).

### Pieces
- `app/onboarding.tsx` — `fullScreenModal` route, `gestureEnabled: false`, picks the variant palette and injects it into one shared carousel.
- `OnboardingCarousel` — virtualized horizontal **paged FlatList** (memoized row, hoisted `keyExtractor`, `renderItem` deps clean of `.length`/inline closures, `getItemLayout`). Reduce Motion locks the swipe and cross-fades via Next instead of sliding. VoiceOver/TalkBack read each card heading+body; the page control announces "Page N of 4"; `accessibilityViewIsModal`; ≥44/48dp button targets.
- **First-run gate** (`OnboardingGate` in `_layout.tsx`) — after `SplashScreen.hideAsync()` and once auth+fonts are ready, reads a persisted flag and pushes `/onboarding` once, **skipping deep-link/join/auth/share landings**. The flag (`ONBOARDING_SEEN_KEY`, new in `@boardsesh/key-value-storage`, read/written via `secureStorePreferences`) is written **only on Skip/finish**, so an interrupted tour reshows.
- **"Replay walkthrough"** row on the More tab — clears the flag and re-pushes the route.
- **Analytics** — mobile `track()` + `SHARED_EVENTS` (added the five `Onboarding Tour *` names) with property keys matching web (`stepId`/`stepIndex`, `fromStepId`/`toStepId`/`trigger`, `durationSeconds`, `atStepId`) so both platforms feed one PostHog funnel.
- **i18n** — copy in the `common` namespace (`mobile.onboarding.*`) across en-US / es / fr (parity test passes). Card text resolves via static `t()` literals (lint hard-fails on `t(variable)`). Icons reuse existing `icon-map` glyphs — **no synthesized imagery**.

## How to verify

1. Fresh install (or clear the flag via the More-tab **Replay walkthrough** row): after splash, the walkthrough covers the Climbs tab once.
2. Skip on any card, or page to the last card and tap **Connect a board** (→ `/boards`); reopen the app — the tour does **not** show again. Quitting mid-tour (no Skip/finish) **does** reshow it.
3. **Replay walkthrough** on More re-opens it; finishing/skipping re-persists the flag.
4. In dev, `[analytics]` logs show `Onboarding Tour Started` / `Step Viewed` / `Step Advanced` / `Completed` / `Skipped` with the expected props as you page.
5. Toggle UI style (More → UI style) between Liquid Glass and Material — both render their native skin. Enable Reduce Motion → Next cross-fades instead of sliding.

## Validation
- `vp run typecheck:mobile` — pass
- `vp test --project mobile` — pass (incl. 4 new onboarding test files / 20 tests)
- `vp run check:mobile-bundle` — pass (Android bundle OK)

## Risks / follow-ups
- The gate mounts **below `AuthProvider`**, so it only fires for an authenticated session — an unauthenticated cold start is redirected to `/auth/login` by the existing auth gate and the walkthrough shows after sign-in. It short-circuits when the top route segment is `join` / `share-beta` / `session` / `auth` / `onboarding` / `boards`, and re-checks the segment after the async flag read, so a deep link arriving mid-read still wins. Worth a device pass on the cold-start-via-join-link path to confirm the join modal isn't covered.
- Persistence uses SecureStore (same store as theme/variant prefs); a SecureStore read failure is treated as "unseen" (show the tour) rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)