### PR TITLE
feat(mobile): hold-type search filter (both UI variants)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -359,6 +359,7 @@
       "name": "@boardsesh/climb-filters",
       "version": "1.0.0",
       "dependencies": {
+        "@boardsesh/board-constants": "*",
         "@boardsesh/shared-schema": "*",
       },
       "devDependencies": {

--- a/packages/mobile/app/(tabs)/climbs/__tests__/holds.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/holds.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { HoldFilterType, HoldsFilter } from '@boardsesh/shared-schema';
+
+// Captured cleanup from the screen's useFocusEffect, so a test can simulate the
+// screen losing focus (Done / swipe-back) and assert the handoff fires.
+const focus = vi.hoisted(() => ({ cleanup: null as null | (() => void) }));
+
+// The active hold the picker is editing. The screen sets this via onHoldTap; the
+// stubbed InteractiveFilterBoard exposes a button that taps a fixed hold id so we
+// can open the picker and drive type toggles deterministically.
+const TAPPED_HOLD_ID = 42;
+
+const trackMock = vi.hoisted(() => vi.fn());
+const emitMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({
+    boardName: 'kilter',
+    layoutId: '1',
+    sizeId: '10',
+    setIds: '1,2',
+    holdsFilter: undefined,
+  }),
+  useRouter: () => ({ back: vi.fn() }),
+  // Run the effect immediately and stash its cleanup so the test can fire it.
+  useFocusEffect: (effect: () => void | (() => void)) => {
+    const cleanup = effect();
+    focus.cleanup = typeof cleanup === 'function' ? cleanup : null;
+  },
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+}));
+
+vi.mock('@boardsesh/analytics', () => ({
+  SHARED_EVENTS: {
+    SearchHoldFilterChanged: 'Search Hold Filter Changed',
+    SearchHoldFilterCleared: 'Search Hold Filter Cleared',
+  },
+}));
+
+vi.mock('@boardsesh/board-constants/product-sizes', () => ({
+  getLayout: () => ({ name: 'Kilter Board Original' }),
+}));
+
+// Pure filter helpers: keep the real toggle/parse behaviour but mock the module
+// so the test doesn't depend on the package resolving in the node env.
+vi.mock('@boardsesh/climb-filters', () => ({
+  parseHoldsFilter: (raw: string | undefined): HoldsFilter => (raw ? (JSON.parse(raw) as HoldsFilter) : {}),
+  countFilteredHolds: (filter: HoldsFilter) => Object.keys(filter).length,
+  toggleHoldFilterType: (entry: Record<string, string>, type: HoldFilterType, mode: string) => {
+    const next = { ...entry };
+    if (next[type]) delete next[type];
+    else next[type] = mode;
+    return next;
+  },
+}));
+
+vi.mock('../../../../src/lib/analytics', () => ({ track: trackMock }));
+vi.mock('../../../../src/lib/hold-filter-handoff', () => ({ emitHoldsFilterSelection: emitMock }));
+
+vi.mock('../../../../src/lib/create-board-holds', () => ({
+  getCreateBoardHolds: () => ({
+    holdTargets: [{ id: TAPPED_HOLD_ID, cx: 100, cy: 100, r: 10 }],
+    boardWidth: 1000,
+    boardHeight: 1000,
+  }),
+  parseSetIdsParam: (setIds: string) => setIds.split(',').map(Number),
+}));
+
+vi.mock('../../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { background: '#fff', secondaryLabel: '#666' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+
+vi.mock('../../../../src/theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityRole,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityRole?: string;
+  }) => createElement('button', { onClick: onPress, 'data-role': accessibilityRole }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1, absoluteFill: {} },
+  useWindowDimensions: () => ({ width: 390, height: 844 }),
+}));
+
+vi.mock('../../../../src/components/Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../../src/components/ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-spinner': 'true' }),
+}));
+
+// The board stub surfaces a single button that routes a fixed hold id to
+// onHoldTap, opening the picker for that hold.
+vi.mock('../../../../src/components/search/InteractiveFilterBoard', () => ({
+  InteractiveFilterBoard: ({ onHoldTap }: { onHoldTap: (id: number) => void }) =>
+    createElement('button', { 'data-board-tap': 'true', onClick: () => onHoldTap(TAPPED_HOLD_ID) }, 'board'),
+}));
+
+// The picker stub exposes a button per call that toggles a STARTING type filter,
+// so a test can drive the screen's handleToggleType without the real bottom sheet.
+vi.mock('../../../../src/components/search/HoldFilterPicker', () => ({
+  HoldFilterPicker: ({
+    holdId,
+    onToggleType,
+  }: {
+    holdId: number | null;
+    onToggleType: (type: HoldFilterType) => void;
+  }) =>
+    holdId != null
+      ? createElement(
+          'button',
+          { 'data-toggle-start': 'true', onClick: () => onToggleType('STARTING' as HoldFilterType) },
+          'toggle',
+        )
+      : null,
+}));
+
+import HoldFilterScreen from '../holds';
+
+beforeEach(() => {
+  trackMock.mockClear();
+  emitMock.mockClear();
+  focus.cleanup = null;
+});
+
+describe('HoldFilterScreen', () => {
+  it('emits a hold-filter-changed analytics event with the layout name when a type is toggled', () => {
+    const { getByText } = render(<HoldFilterScreen />);
+
+    // Tap a hold to open the picker, then toggle the STARTING filter on it.
+    fireEvent.click(getByText('board'));
+    fireEvent.click(getByText('toggle'));
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith('Search Hold Filter Changed', {
+      type: 'STARTING',
+      mode: 'include',
+      boardLayout: 'Kilter Board Original',
+    });
+  });
+
+  it('hands the current filter back when the screen loses focus', () => {
+    const { getByText } = render(<HoldFilterScreen />);
+
+    // Edit the filter so the handoff carries a non-empty value.
+    fireEvent.click(getByText('board'));
+    fireEvent.click(getByText('toggle'));
+
+    // Simulate the focus-effect cleanup (Done pops / swipe-back).
+    expect(focus.cleanup).toBeTypeOf('function');
+    focus.cleanup?.();
+
+    expect(emitMock).toHaveBeenCalledTimes(1);
+    expect(emitMock).toHaveBeenCalledWith({ [String(TAPPED_HOLD_ID)]: { STARTING: 'include' } });
+  });
+});

--- a/packages/mobile/app/(tabs)/climbs/_layout.tsx
+++ b/packages/mobile/app/(tabs)/climbs/_layout.tsx
@@ -51,6 +51,17 @@ export default function ClimbsLayout() {
           animation: 'fade',
         }}
       />
+      <Stack.Screen
+        name="holds"
+        options={{
+          // Full-screen interactive board for the hold-type filter. Owns its own
+          // header (Done / Clear all), and the board gestures need the full card,
+          // so the native header is hidden and it's a pushed route (not a modal,
+          // which would compete with the board's pan/pinch).
+          title: t('mobile.nav.holdFilter'),
+          headerShown: false,
+        }}
+      />
     </Stack>
   );
 }

--- a/packages/mobile/app/(tabs)/climbs/holds.tsx
+++ b/packages/mobile/app/(tabs)/climbs/holds.tsx
@@ -22,7 +22,6 @@ type Params = {
   sizeId?: string;
   setIds?: string;
   angle?: string;
-  layoutName?: string;
   holdsFilter?: string;
 };
 
@@ -62,7 +61,9 @@ export default function HoldFilterScreen() {
   const layoutId = Number(params.layoutId ?? 0);
   const sizeId = Number(params.sizeId ?? 0);
   const setIds = params.setIds ?? '';
-  const layoutName = params.layoutName ?? '';
+  // Matches the web `boardLayout` property: the layout identity, not the board
+  // name. Mobile carries the numeric layoutId at this call site (PR #2618).
+  const boardLayout = String(layoutId);
 
   const [holdsFilter, setHoldsFilter] = useState<HoldsFilter>(() => parseHoldsFilter(params.holdsFilter));
   // Mirror of the latest holdsFilter so the focus-effect cleanup hands back the
@@ -128,10 +129,10 @@ export default function HoldFilterScreen() {
       track(SHARED_EVENTS.SearchHoldFilterChanged, {
         type,
         mode: applyMode,
-        boardLayout: layoutName,
+        boardLayout,
       });
     },
-    [activeHoldId, applyMode, layoutName],
+    [activeHoldId, applyMode, boardLayout],
   );
 
   const handleClearHold = useCallback(() => {
@@ -143,13 +144,13 @@ export default function HoldFilterScreen() {
       delete next[holdKey];
       return next;
     });
-    track(SHARED_EVENTS.SearchHoldFilterCleared, { boardLayout: layoutName });
-  }, [activeHoldId, layoutName]);
+    track(SHARED_EVENTS.SearchHoldFilterCleared, { boardLayout });
+  }, [activeHoldId, boardLayout]);
 
   const handleClearAll = useCallback(() => {
     setHoldsFilter({});
-    track(SHARED_EVENTS.SearchHoldFilterCleared, { boardLayout: layoutName });
-  }, [layoutName]);
+    track(SHARED_EVENTS.SearchHoldFilterCleared, { boardLayout });
+  }, [boardLayout]);
 
   const closePicker = useCallback(() => setActiveHoldId(null), []);
 

--- a/packages/mobile/app/(tabs)/climbs/holds.tsx
+++ b/packages/mobile/app/(tabs)/climbs/holds.tsx
@@ -4,6 +4,7 @@ import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { getLayout } from '@boardsesh/board-constants/product-sizes';
 import { countFilteredHolds, toggleHoldFilterType } from '@boardsesh/climb-filters';
 import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType, HoldsFilter } from '@boardsesh/shared-schema';
 import { Text } from '../../../src/components/Text';
@@ -21,12 +22,15 @@ type Params = {
   layoutId?: string;
   sizeId?: string;
   setIds?: string;
-  angle?: string;
   holdsFilter?: string;
 };
 
-// Chrome above the board (header + footer summary) the board height budget must
-// leave room for, so the full board fits without scroll.
+// Vertical space (px) reserved for the on-screen chrome around the board so the
+// full board fits without scroll: the header row (~44) plus its top padding
+// (spacing[2]), and the footer summary (~44) plus its top padding — roughly 132
+// at the current type scale. A rough constant is fine: the board still fits as
+// long as the budget is in the right ballpark, and `availHeight` is clamped
+// below.
 const CHROME_BUDGET = 132;
 
 function parseHoldsFilter(raw: string | undefined): HoldsFilter {
@@ -61,9 +65,10 @@ export default function HoldFilterScreen() {
   const layoutId = Number(params.layoutId ?? 0);
   const sizeId = Number(params.sizeId ?? 0);
   const setIds = params.setIds ?? '';
-  // Matches the web `boardLayout` property: the layout identity, not the board
-  // name. Mobile carries the numeric layoutId at this call site (PR #2618).
-  const boardLayout = String(layoutId);
+  // Matches the web `boardLayout` property: the layout NAME (web sends
+  // `boardDetails.layout_name`), not the numeric id, so the hold-filter events
+  // join cleanly with web across platforms. Falls back to '' for unknown ids.
+  const boardLayout = getLayout(boardName, layoutId)?.name ?? '';
 
   const [holdsFilter, setHoldsFilter] = useState<HoldsFilter>(() => parseHoldsFilter(params.holdsFilter));
   // Mirror of the latest holdsFilter so the focus-effect cleanup hands back the
@@ -88,6 +93,8 @@ export default function HoldFilterScreen() {
     if (!boardHolds) return { width: 0, height: 0 };
     const boardAspect = boardHolds.boardWidth / boardHolds.boardHeight;
     const availWidth = windowWidth - spacing[4] * 2;
+    // Clamp to a 200px floor so a short window (small device in landscape, or an
+    // over-large CHROME_BUDGET estimate) never collapses the board to nothing.
     const availHeight = Math.max(200, windowHeight - insets.top - insets.bottom - CHROME_BUDGET);
     if (availWidth / availHeight > boardAspect) {
       return { width: availHeight * boardAspect, height: availHeight };
@@ -186,6 +193,8 @@ export default function HoldFilterScreen() {
       </View>
 
       <View style={styles.boardSection}>
+        {/* TODO: pass `mirrored` once BoardSearchConfig carries it — the board
+            renders un-mirrored here regardless of the search's mirror state. */}
         <InteractiveFilterBoard
           boardName={boardName}
           layoutId={layoutId}

--- a/packages/mobile/app/(tabs)/climbs/holds.tsx
+++ b/packages/mobile/app/(tabs)/climbs/holds.tsx
@@ -180,8 +180,10 @@ export default function HoldFilterScreen() {
       </View>
 
       <View style={styles.boardSection}>
-        {/* TODO: pass `mirrored` once BoardSearchConfig carries it — the board
-            renders un-mirrored here regardless of the search's mirror state. */}
+        {/* Known follow-up (not in this PR): `BoardSearchConfig` doesn't carry a
+            `mirrored` flag today, so the board always renders un-mirrored here
+            and a mirrored search shows its hold rings on the opposite side. Wire
+            `mirrored` through `BoardSearchConfig` to fix it. */}
         <InteractiveFilterBoard
           boardName={boardName}
           layoutId={layoutId}

--- a/packages/mobile/app/(tabs)/climbs/holds.tsx
+++ b/packages/mobile/app/(tabs)/climbs/holds.tsx
@@ -5,14 +5,14 @@ import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { getLayout } from '@boardsesh/board-constants/product-sizes';
-import { countFilteredHolds, toggleHoldFilterType } from '@boardsesh/climb-filters';
+import { countFilteredHolds, parseHoldsFilter, toggleHoldFilterType } from '@boardsesh/climb-filters';
 import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType, HoldsFilter } from '@boardsesh/shared-schema';
 import { Text } from '../../../src/components/Text';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
 import { InteractiveFilterBoard } from '../../../src/components/search/InteractiveFilterBoard';
 import { HoldFilterPicker } from '../../../src/components/search/HoldFilterPicker';
 import { useTheme } from '../../../src/providers/theme-provider';
-import { getCreateBoardHolds } from '../../../src/lib/create-board-holds';
+import { getCreateBoardHolds, parseSetIdsParam } from '../../../src/lib/create-board-holds';
 import { emitHoldsFilterSelection } from '../../../src/lib/hold-filter-handoff';
 import { track } from '../../../src/lib/analytics';
 import { spacing } from '../../../src/theme/tokens';
@@ -32,19 +32,6 @@ type Params = {
 // long as the budget is in the right ballpark, and `availHeight` is clamped
 // below.
 const CHROME_BUDGET = 132;
-
-function parseHoldsFilter(raw: string | undefined): HoldsFilter {
-  if (!raw) return {};
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as HoldsFilter;
-    }
-  } catch {
-    // Malformed param → start empty rather than crash.
-  }
-  return {};
-}
 
 /**
  * Full-screen board sub-screen for the hold-type search filter. Mirrors the
@@ -85,7 +72,7 @@ export default function HoldFilterScreen() {
       boardName,
       layoutId,
       sizeId,
-      setIds: setIds.split(',').map(Number).filter(Number.isFinite),
+      setIds: parseSetIdsParam(setIds),
     });
   }, [boardName, layoutId, sizeId, setIds]);
 

--- a/packages/mobile/app/(tabs)/climbs/holds.tsx
+++ b/packages/mobile/app/(tabs)/climbs/holds.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { View, Pressable, StyleSheet, useWindowDimensions } from 'react-native';
+import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { countFilteredHolds, toggleHoldFilterType } from '@boardsesh/climb-filters';
+import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType, HoldsFilter } from '@boardsesh/shared-schema';
+import { Text } from '../../../src/components/Text';
+import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
+import { InteractiveFilterBoard } from '../../../src/components/search/InteractiveFilterBoard';
+import { HoldFilterPicker } from '../../../src/components/search/HoldFilterPicker';
+import { useTheme } from '../../../src/providers/theme-provider';
+import { getCreateBoardHolds } from '../../../src/lib/create-board-holds';
+import { emitHoldsFilterSelection } from '../../../src/lib/hold-filter-handoff';
+import { track } from '../../../src/lib/analytics';
+import { spacing } from '../../../src/theme/tokens';
+
+type Params = {
+  boardName?: string;
+  layoutId?: string;
+  sizeId?: string;
+  setIds?: string;
+  angle?: string;
+  layoutName?: string;
+  holdsFilter?: string;
+};
+
+// Chrome above the board (header + footer summary) the board height budget must
+// leave room for, so the full board fits without scroll.
+const CHROME_BUDGET = 132;
+
+function parseHoldsFilter(raw: string | undefined): HoldsFilter {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as HoldsFilter;
+    }
+  } catch {
+    // Malformed param → start empty rather than crash.
+  }
+  return {};
+}
+
+/**
+ * Full-screen board sub-screen for the hold-type search filter. Mirrors the
+ * setters handoff: the ClimbFilterSheet pushes here with the current
+ * `holdsFilter` serialized, the user taps holds to include/exclude hold types,
+ * and the edited filter is handed back via `emitHoldsFilterSelection` when the
+ * screen pops (Done or swipe-back).
+ */
+export default function HoldFilterScreen() {
+  const params = useLocalSearchParams<Params>();
+  const router = useRouter();
+  const { t } = useTranslation('climbs');
+  const { systemColors, brandColors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
+
+  const boardName = (params.boardName ?? '') as BoardName;
+  const layoutId = Number(params.layoutId ?? 0);
+  const sizeId = Number(params.sizeId ?? 0);
+  const setIds = params.setIds ?? '';
+  const layoutName = params.layoutName ?? '';
+
+  const [holdsFilter, setHoldsFilter] = useState<HoldsFilter>(() => parseHoldsFilter(params.holdsFilter));
+  // Mirror of the latest holdsFilter so the focus-effect cleanup hands back the
+  // current value without re-subscribing on every edit.
+  const holdsFilterRef = useRef(holdsFilter);
+  holdsFilterRef.current = holdsFilter;
+
+  const [activeHoldId, setActiveHoldId] = useState<number | null>(null);
+  const [applyMode, setApplyMode] = useState<HoldFilterMode>('include');
+
+  const boardHolds = useMemo(() => {
+    if (!boardName) return null;
+    return getCreateBoardHolds({
+      boardName,
+      layoutId,
+      sizeId,
+      setIds: setIds.split(',').map(Number).filter(Number.isFinite),
+    });
+  }, [boardName, layoutId, sizeId, setIds]);
+
+  const boardRender = useMemo(() => {
+    if (!boardHolds) return { width: 0, height: 0 };
+    const boardAspect = boardHolds.boardWidth / boardHolds.boardHeight;
+    const availWidth = windowWidth - spacing[4] * 2;
+    const availHeight = Math.max(200, windowHeight - insets.top - insets.bottom - CHROME_BUDGET);
+    if (availWidth / availHeight > boardAspect) {
+      return { width: availHeight * boardAspect, height: availHeight };
+    }
+    return { width: availWidth, height: availWidth / boardAspect };
+  }, [boardHolds, windowWidth, windowHeight, insets.top, insets.bottom]);
+
+  // Hand the current filter back to the sheet whenever this screen loses focus
+  // (Done button pops, or swipe-back). Matches the setters handoff timing.
+  useFocusEffect(
+    useCallback(() => {
+      return () => emitHoldsFilterSelection(holdsFilterRef.current);
+    }, []),
+  );
+
+  const done = useCallback(() => {
+    router.back();
+  }, [router]);
+
+  const handleHoldTap = useCallback((holdId: number) => {
+    setActiveHoldId(holdId);
+  }, []);
+
+  const handleToggleType = useCallback(
+    (type: HoldFilterType) => {
+      if (activeHoldId == null) return;
+      const holdKey = String(activeHoldId);
+      setHoldsFilter((previous) => {
+        const existing: HoldFilterEntry = previous[holdKey] ?? {};
+        const nextEntry = toggleHoldFilterType(existing, type, applyMode);
+        const next: HoldsFilter = { ...previous };
+        if (Object.keys(nextEntry).length === 0) {
+          delete next[holdKey];
+        } else {
+          next[holdKey] = nextEntry;
+        }
+        return next;
+      });
+      track(SHARED_EVENTS.SearchHoldFilterChanged, {
+        type,
+        mode: applyMode,
+        boardLayout: layoutName,
+      });
+    },
+    [activeHoldId, applyMode, layoutName],
+  );
+
+  const handleClearHold = useCallback(() => {
+    if (activeHoldId == null) return;
+    const holdKey = String(activeHoldId);
+    setHoldsFilter((previous) => {
+      if (!(holdKey in previous)) return previous;
+      const next: HoldsFilter = { ...previous };
+      delete next[holdKey];
+      return next;
+    });
+    track(SHARED_EVENTS.SearchHoldFilterCleared, { boardLayout: layoutName });
+  }, [activeHoldId, layoutName]);
+
+  const handleClearAll = useCallback(() => {
+    setHoldsFilter({});
+    track(SHARED_EVENTS.SearchHoldFilterCleared, { boardLayout: layoutName });
+  }, [layoutName]);
+
+  const closePicker = useCallback(() => setActiveHoldId(null), []);
+
+  const activeEntry: HoldFilterEntry = activeHoldId != null ? (holdsFilter[String(activeHoldId)] ?? {}) : {};
+  const filteredCount = countFilteredHolds(holdsFilter);
+
+  if (!boardHolds || !boardName) {
+    return (
+      <View style={[styles.loading, { backgroundColor: systemColors.background }]}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: systemColors.background }]}>
+      <View style={[styles.header, { paddingTop: insets.top + spacing[2] }]}>
+        <Text variant="title3">{t('mobile.holdFilter.title')}</Text>
+        <View style={styles.headerActions}>
+          {filteredCount > 0 ? (
+            <Pressable onPress={handleClearAll} hitSlop={8} accessibilityRole="button">
+              <Text variant="subheadline" color={brandColors.primary}>
+                {t('mobile.filter.clearAll')}
+              </Text>
+            </Pressable>
+          ) : null}
+          <Pressable onPress={done} hitSlop={8} accessibilityRole="button">
+            <Text variant="subheadline" color={brandColors.primary} style={styles.doneLabel}>
+              {t('mobile.filter.done')}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+
+      <View style={styles.boardSection}>
+        <InteractiveFilterBoard
+          boardName={boardName}
+          layoutId={layoutId}
+          sizeId={sizeId}
+          setIds={setIds}
+          boardWidth={boardHolds.boardWidth}
+          boardHeight={boardHolds.boardHeight}
+          holdTargets={boardHolds.holdTargets}
+          holdsFilter={holdsFilter}
+          activeHoldId={activeHoldId}
+          onHoldTap={handleHoldTap}
+          renderWidth={boardRender.width}
+          renderHeight={boardRender.height}
+        />
+      </View>
+
+      <View style={[styles.footer, { paddingBottom: insets.bottom + spacing[3] }]}>
+        <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.footerText}>
+          {filteredCount > 0
+            ? t('mobile.holdFilter.summaryCount', { count: filteredCount })
+            : t('mobile.holdFilter.hint')}
+        </Text>
+      </View>
+
+      <HoldFilterPicker
+        holdId={activeHoldId}
+        boardName={boardName}
+        entry={activeEntry}
+        applyMode={applyMode}
+        onApplyModeChange={setApplyMode}
+        onToggleType={handleToggleType}
+        onClear={handleClearHold}
+        onClose={closePicker}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  loading: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[2],
+  },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[4],
+  },
+  doneLabel: {
+    fontWeight: '600',
+  },
+  boardSection: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  footer: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+    alignItems: 'center',
+  },
+  footerText: {
+    textAlign: 'center',
+  },
+});

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -27,6 +27,7 @@ import {
   mergeBoardFilters,
   formatMinAscentsFilterCount,
   DEFAULT_CLIMB_BOARD_FILTER_STATE,
+  countFilteredHolds,
   type SortOption,
   type SortOrder,
   type StatusFilter,
@@ -49,6 +50,7 @@ import { useGrades, useSearchClimbsCount } from '../lib/graphql/hooks';
 import { useAuth } from '../providers/auth-provider';
 import { hapticSelection } from '../lib/haptics';
 import { subscribeToSetterSelection } from '../lib/filter-handoff';
+import { subscribeToHoldsFilterSelection } from '../lib/hold-filter-handoff';
 import { springs } from '../theme/animations';
 // Aliased: the active-filter label reads scheme-aware brand from `useTheme()`.
 // `staticBrandColors` is the static set, used only for the selected chip — a FILL
@@ -170,6 +172,15 @@ export function ClimbFilterSheet({
   useEffect(() => {
     return subscribeToSetterSelection((setters) => {
       setLocalFilters((previous) => ({ ...previous, setter: setters.length > 0 ? setters : undefined }));
+    });
+  }, []);
+
+  useEffect(() => {
+    return subscribeToHoldsFilterSelection((holdsFilter) => {
+      setLocalBoardFilters((previous) => ({
+        ...previous,
+        holdsFilter: Object.keys(holdsFilter).length > 0 ? holdsFilter : undefined,
+      }));
     });
   }, []);
 
@@ -354,6 +365,24 @@ export function ClimbFilterSheet({
     });
   }, [router, boardConfig, localFilters.setter]);
 
+  const openHoldFilter = useCallback(() => {
+    if (!boardConfig) return;
+    router.push({
+      pathname: '/(tabs)/climbs/holds',
+      params: {
+        boardName: boardConfig.boardName,
+        layoutId: String(boardConfig.layoutId),
+        sizeId: String(boardConfig.sizeId),
+        setIds: boardConfig.setIds,
+        angle: String(boardConfig.angle),
+        layoutName: boardConfig.boardName,
+        holdsFilter: JSON.stringify(localBoardFilters.holdsFilter ?? {}),
+      },
+    });
+  }, [router, boardConfig, localBoardFilters.holdsFilter]);
+
+  const holdFilterCount = countFilteredHolds(localBoardFilters.holdsFilter);
+
   const refineSummary = useMemo(() => {
     const parts: string[] = [];
     // Boulders-only is the default, so only surface a chip when it differs.
@@ -365,10 +394,11 @@ export function ClimbFilterSheet({
     if (localFilters.setter && localFilters.setter.length > 0) {
       parts.push(t('mobile.search.settersCount', { count: localFilters.setter.length }));
     }
+    if (holdFilterCount > 0) parts.push(t('mobile.holdFilter.summaryCount', { count: holdFilterCount }));
     if (localFilters.onlyTallClimbs) parts.push(t('mobile.filter.tallClimbs'));
     if (localFilters.onlyWideClimbs) parts.push(t('mobile.filter.wideClimbs'));
     return parts.join(' · ') || null;
-  }, [localFilters, accuracyLabels, t]);
+  }, [localFilters, accuracyLabels, holdFilterCount, t]);
 
   const advancedSummary = useMemo(() => {
     const parts: string[] = [];
@@ -536,6 +566,30 @@ export function ClimbFilterSheet({
                 <Text variant="footnote" style={styles.tappableRowValue}>
                   {localFilters.setter && localFilters.setter.length > 0
                     ? t('mobile.search.settersCount', { count: localFilters.setter.length })
+                    : t('mobile.filter.none')}
+                </Text>
+                <Icon name="chevron.right" size={14} color={iosSystemColors.systemGray4} />
+              </View>
+            </Pressable>
+
+            <View style={styles.subsectionGap} />
+            <Pressable
+              onPress={openHoldFilter}
+              disabled={!boardConfig}
+              accessibilityRole="button"
+              accessibilityLabel={t('mobile.holdFilter.title')}
+              style={({ pressed }) => [
+                styles.tappableRow,
+                { backgroundColor: systemColors.tertiaryBackground },
+                pressed && styles.tappableRowPressed,
+                !boardConfig && styles.tappableRowDisabled,
+              ]}
+            >
+              <Text variant="body">{t('mobile.holdFilter.title')}</Text>
+              <View style={styles.tappableRowTrailing}>
+                <Text variant="footnote" style={styles.tappableRowValue}>
+                  {holdFilterCount > 0
+                    ? t('mobile.holdFilter.summaryCount', { count: holdFilterCount })
                     : t('mobile.filter.none')}
                 </Text>
                 <Icon name="chevron.right" size={14} color={iosSystemColors.systemGray4} />
@@ -724,6 +778,9 @@ const styles = StyleSheet.create({
   },
   tappableRowPressed: {
     opacity: 0.6,
+  },
+  tappableRowDisabled: {
+    opacity: 0.4,
   },
   tappableRowTrailing: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -375,7 +375,6 @@ export function ClimbFilterSheet({
         sizeId: String(boardConfig.sizeId),
         setIds: boardConfig.setIds,
         angle: String(boardConfig.angle),
-        layoutName: boardConfig.boardName,
         holdsFilter: JSON.stringify(localBoardFilters.holdsFilter ?? {}),
       },
     });

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -374,7 +374,6 @@ export function ClimbFilterSheet({
         layoutId: String(boardConfig.layoutId),
         sizeId: String(boardConfig.sizeId),
         setIds: boardConfig.setIds,
-        angle: String(boardConfig.angle),
         holdsFilter: JSON.stringify(localBoardFilters.holdsFilter ?? {}),
       },
     });

--- a/packages/mobile/src/components/search/HoldFilterPicker.tsx
+++ b/packages/mobile/src/components/search/HoldFilterPicker.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
 import BottomSheet from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType } from '@boardsesh/shared-schema';
-import { ANY_HOLD_COLOR, buildHoldFilterOptions } from '@boardsesh/climb-filters';
+import { buildHoldFilterOptions } from '@boardsesh/climb-filters';
 import { Sheet } from '../Sheet';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
@@ -79,10 +79,13 @@ export function HoldFilterPicker({
 
   const isEmpty = Object.keys(entry).length === 0;
 
-  const handleSwatch = (type: HoldFilterType) => {
-    hapticSelection();
-    onToggleType(type);
-  };
+  const handleSwatch = useCallback(
+    (type: HoldFilterType) => {
+      hapticSelection();
+      onToggleType(type);
+    },
+    [onToggleType],
+  );
 
   return (
     <Sheet ref={sheetRef} snapPoints={snapPoints} onClose={onClose} enablePanDownToClose fullWindowOverlay>
@@ -110,7 +113,7 @@ export function HoldFilterPicker({
               : isActive
                 ? t('mobile.holdFilter.includedSuffix')
                 : '';
-            const swatchColor = option.color === ANY_HOLD_COLOR ? '#FFFFFF' : option.color;
+            const swatchColor = option.color;
             return (
               <Pressable
                 key={option.type}

--- a/packages/mobile/src/components/search/HoldFilterPicker.tsx
+++ b/packages/mobile/src/components/search/HoldFilterPicker.tsx
@@ -189,7 +189,11 @@ const styles = StyleSheet.create({
     gap: spacing[2],
   },
   cell: {
-    width: '31%',
+    // Grow to share the row evenly; the minWidth keeps ~3 per row while letting
+    // a short final row (or a board with fewer swatches) stretch to fill.
+    flexGrow: 1,
+    flexBasis: '28%',
+    minWidth: 96,
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[2],

--- a/packages/mobile/src/components/search/HoldFilterPicker.tsx
+++ b/packages/mobile/src/components/search/HoldFilterPicker.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { View, Pressable, StyleSheet } from 'react-native';
+import BottomSheet from '@gorhom/bottom-sheet';
+import { useTranslation } from 'react-i18next';
+import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType } from '@boardsesh/shared-schema';
+import { ANY_HOLD_COLOR, buildHoldFilterOptions } from '@boardsesh/climb-filters';
+import { Sheet } from '../Sheet';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { SegmentedControl } from '../SegmentedControl';
+import { useTheme } from '../../providers/theme-provider';
+import { hapticSelection } from '../../lib/haptics';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+type HoldFilterPickerProps = {
+  /** The hold being edited, or null when the picker is closed. */
+  holdId: number | null;
+  boardName: BoardName;
+  /** Current filter entry for the active hold. */
+  entry: HoldFilterEntry;
+  applyMode: HoldFilterMode;
+  onApplyModeChange: (mode: HoldFilterMode) => void;
+  /** Toggle one type's filter on the active hold (the picker owns the cycle). */
+  onToggleType: (type: HoldFilterType) => void;
+  onClear: () => void;
+  onClose: () => void;
+};
+
+/**
+ * Per-hold hold-type picker. Opened by tapping a hold on the interactive board.
+ * Hosts an Include / Exclude apply-mode toggle plus one swatch per hold type
+ * (board-filtered) and a Clear button — the native port of the web
+ * `HoldTypePicker` search toolbar. Works in both UI variants: the chrome comes
+ * from `Sheet` (glass / Material via theme) and `SegmentedControl`.
+ */
+export function HoldFilterPicker({
+  holdId,
+  boardName,
+  entry,
+  applyMode,
+  onApplyModeChange,
+  onToggleType,
+  onClear,
+  onClose,
+}: HoldFilterPickerProps) {
+  const { t } = useTranslation('climbs');
+  const { systemColors } = useTheme();
+  const sheetRef = useRef<BottomSheet>(null);
+
+  useEffect(() => {
+    if (holdId != null) {
+      sheetRef.current?.snapToIndex(0);
+    } else {
+      sheetRef.current?.close();
+    }
+  }, [holdId]);
+
+  const options = useMemo(() => buildHoldFilterOptions(boardName), [boardName]);
+  const snapPoints = useMemo(() => ['42%'], []);
+
+  const typeLabels = useMemo<Record<HoldFilterType, string>>(
+    () => ({
+      STARTING: t('mobile.holdFilter.type.starting'),
+      HAND: t('mobile.holdFilter.type.hand'),
+      FINISH: t('mobile.holdFilter.type.finish'),
+      FOOT: t('mobile.holdFilter.type.foot'),
+      ANY: t('mobile.holdFilter.type.any'),
+    }),
+    [t],
+  );
+
+  const applyModeOptions = useMemo(
+    () => [
+      { key: 'include' as const, label: t('mobile.holdFilter.include') },
+      { key: 'exclude' as const, label: t('mobile.holdFilter.exclude') },
+    ],
+    [t],
+  );
+
+  const isEmpty = Object.keys(entry).length === 0;
+
+  const handleSwatch = (type: HoldFilterType) => {
+    hapticSelection();
+    onToggleType(type);
+  };
+
+  return (
+    <Sheet ref={sheetRef} snapPoints={snapPoints} onClose={onClose} enablePanDownToClose fullWindowOverlay>
+      <View style={styles.content}>
+        <Text variant="headline" style={styles.title}>
+          {t('mobile.holdFilter.pickerTitle')}
+        </Text>
+
+        <SegmentedControl
+          options={applyModeOptions}
+          selectedKey={applyMode}
+          onSelect={onApplyModeChange}
+          trackColor={systemColors.fill}
+          accessibilityLabel={t('mobile.holdFilter.applyModeLabel')}
+        />
+
+        <View style={styles.grid}>
+          {options.map((option) => {
+            const mode = entry[option.type];
+            const isActive = mode !== undefined;
+            const excluded = mode === 'exclude';
+            const accessibilityState = { selected: isActive };
+            const stateSuffix = excluded
+              ? t('mobile.holdFilter.excludedSuffix')
+              : isActive
+                ? t('mobile.holdFilter.includedSuffix')
+                : '';
+            const swatchColor = option.color === ANY_HOLD_COLOR ? '#FFFFFF' : option.color;
+            return (
+              <Pressable
+                key={option.type}
+                onPress={() => handleSwatch(option.type)}
+                accessibilityRole="button"
+                accessibilityState={accessibilityState}
+                accessibilityLabel={
+                  stateSuffix ? `${typeLabels[option.type]}, ${stateSuffix}` : typeLabels[option.type]
+                }
+                style={[
+                  styles.cell,
+                  { backgroundColor: systemColors.fill },
+                  isActive && { borderColor: swatchColor, borderWidth: 2 },
+                ]}
+              >
+                <View
+                  style={[
+                    styles.swatch,
+                    {
+                      borderColor: swatchColor,
+                      backgroundColor: excluded ? 'rgba(0,0,0,0.55)' : isActive ? swatchColor : 'transparent',
+                    },
+                  ]}
+                >
+                  {excluded ? <Icon name="close" size={12} color="#FFFFFF" /> : null}
+                </View>
+                <Text variant="subheadline" style={styles.cellLabel}>
+                  {typeLabels[option.type]}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <Pressable
+          onPress={() => {
+            if (isEmpty) return;
+            hapticSelection();
+            onClear();
+          }}
+          disabled={isEmpty}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: isEmpty }}
+          accessibilityLabel={t('mobile.holdFilter.clearHold')}
+          style={[styles.clearRow, isEmpty && styles.clearDisabled]}
+        >
+          <Icon name="ascent.attempt" size={16} color={systemColors.secondaryLabel} />
+          <Text variant="subheadline" color={systemColors.secondaryLabel}>
+            {t('mobile.holdFilter.clearHold')}
+          </Text>
+        </Pressable>
+
+        <Text variant="footnote" style={[styles.help, { color: systemColors.secondaryLabel }]}>
+          {t('mobile.holdFilter.pickerHelp')}
+        </Text>
+      </View>
+    </Sheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+    gap: spacing[3],
+  },
+  title: {
+    textAlign: 'center',
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+  },
+  cell: {
+    width: '31%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[2],
+    borderRadius: borderRadius.md,
+    borderColor: 'transparent',
+    borderWidth: 2,
+    minHeight: 48,
+  },
+  swatch: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cellLabel: {
+    fontWeight: '600',
+    flexShrink: 1,
+  },
+  clearRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[2],
+    paddingVertical: spacing[2],
+    minHeight: 44,
+  },
+  clearDisabled: {
+    opacity: 0.4,
+  },
+  help: {
+    textAlign: 'center',
+    paddingHorizontal: spacing[4],
+  },
+});

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -1,0 +1,186 @@
+import React, { useMemo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { View, StyleSheet, Pressable } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { GestureDetector } from 'react-native-gesture-handler';
+import type { BoardName, HoldsFilter } from '@boardsesh/shared-schema';
+import { BoardImageNative } from '../BoardImageNative';
+import { Text } from '../Text';
+import { useZoomPanGesture } from '../play-drawer/use-zoom-pan-gesture';
+import { HoldTargetLayer } from '../create-climb/HoldTargetLayer';
+import { holdGeometry } from '../create-climb/holdLayout';
+import { overlays } from '../../theme/tokens';
+import type { BoardHoldTarget } from '../../lib/create-board-holds';
+import { SearchHoldFilterRings } from './SearchHoldFilterRings';
+
+type InteractiveFilterBoardProps = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  boardWidth: number;
+  boardHeight: number;
+  holdTargets: BoardHoldTarget[];
+  holdsFilter: HoldsFilter;
+  /** The hold the picker is currently editing — drawn with a bright ring. */
+  activeHoldId: number | null;
+  onHoldTap: (holdId: number) => void;
+  mirrored?: boolean;
+  renderWidth: number;
+  renderHeight: number;
+  /** Optional chrome (e.g. a floating toolbar) rendered over the board canvas. */
+  children?: ReactNode;
+};
+
+/**
+ * Full-bleed interactive board for the search hold filter, built on the same
+ * no-SVG gesture model as `InteractiveCreateBoard`: the board PNG plus plain RN
+ * tap targets and filter rings INSIDE the zoom-transformed view, so taps and
+ * rings track holds at any zoom with no manual coordinate math. Pinch is always
+ * live; the 1-finger pan only mounts while zoomed.
+ *
+ * Unlike the create board this lives on a full-screen route (not a bottom
+ * sheet), so the pan overlay can stay simpler — there's no parent scroll to
+ * yield idle drags to.
+ */
+export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard({
+  boardName,
+  layoutId,
+  sizeId,
+  setIds,
+  boardWidth,
+  boardHeight,
+  holdTargets,
+  holdsFilter,
+  activeHoldId,
+  onHoldTap,
+  mirrored = false,
+  renderWidth,
+  renderHeight,
+  children,
+}: InteractiveFilterBoardProps) {
+  const { t } = useTranslation('common');
+  const { pinchGesture, zoomPanGesture, isZoomed, resetZoom, animatedZoomStyle } = useZoomPanGesture({
+    enabled: true,
+    containerWidth: renderWidth,
+    containerHeight: renderHeight,
+  });
+
+  // The picker uses a long-press-style commit, but holds here only need a single
+  // tap to open the picker, so we route both tap and "long press" to the same
+  // handler (HoldTargetLayer requires both).
+  const handleHoldTap = onHoldTap;
+
+  const activeHighlight = useMemo(() => {
+    if (activeHoldId == null || renderWidth <= 0) return null;
+    const hold = holdTargets.find((target) => target.id === activeHoldId);
+    if (!hold) return null;
+    const geometry = holdGeometry(hold, boardWidth, boardHeight, renderWidth, mirrored);
+    const diameter = geometry.ringDiameter * 1.5;
+    const radius = diameter / 2;
+    return (
+      <View
+        pointerEvents="none"
+        style={[
+          styles.activeRing,
+          {
+            left: `${geometry.leftPct}%`,
+            top: `${geometry.topPct}%`,
+            width: diameter,
+            height: diameter,
+            marginLeft: -radius,
+            marginTop: -radius,
+            borderRadius: radius,
+            borderWidth: Math.max(2.5, geometry.ringDiameter * 0.18),
+          },
+        ]}
+      />
+    );
+  }, [activeHoldId, holdTargets, boardWidth, boardHeight, renderWidth, mirrored]);
+
+  return (
+    <View style={styles.root}>
+      <GestureDetector gesture={pinchGesture}>
+        <View style={[styles.clip, { width: renderWidth, height: renderHeight }]}>
+          <Animated.View style={[styles.board, animatedZoomStyle]}>
+            <BoardImageNative
+              frames=""
+              boardName={boardName}
+              layoutId={layoutId}
+              sizeId={sizeId}
+              setIds={setIds}
+              boardWidth={boardWidth}
+              boardHeight={boardHeight}
+              mirrored={mirrored}
+            />
+            <SearchHoldFilterRings
+              boardName={boardName}
+              holdsFilter={holdsFilter}
+              holdTargets={holdTargets}
+              boardWidth={boardWidth}
+              boardHeight={boardHeight}
+              measuredWidth={renderWidth}
+              mirrored={mirrored}
+            />
+            {activeHighlight}
+            <HoldTargetLayer
+              holdTargets={holdTargets}
+              boardWidth={boardWidth}
+              boardHeight={boardHeight}
+              measuredWidth={renderWidth}
+              mirrored={mirrored}
+              showAllHolds
+              onPaint={handleHoldTap}
+              onLongPress={handleHoldTap}
+            />
+          </Animated.View>
+
+          {isZoomed ? (
+            <GestureDetector gesture={zoomPanGesture}>
+              <View style={StyleSheet.absoluteFill} />
+            </GestureDetector>
+          ) : null}
+
+          {isZoomed ? (
+            <Pressable style={styles.resetButton} onPress={resetZoom} hitSlop={8} accessibilityRole="button">
+              <Text variant="footnote" style={styles.resetLabel}>
+                {t('board.resetZoom')}
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </GestureDetector>
+      {children}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  root: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  clip: {
+    overflow: 'hidden',
+  },
+  board: {
+    width: '100%',
+    height: '100%',
+  },
+  activeRing: {
+    position: 'absolute',
+    borderColor: '#FFFFFF',
+  },
+  resetButton: {
+    position: 'absolute',
+    top: 12,
+    right: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    backgroundColor: overlays.scrim,
+  },
+  resetLabel: {
+    color: overlays.onScrim,
+  },
+});

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -69,7 +69,6 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   // The picker uses a long-press-style commit, but holds here only need a single
   // tap to open the picker, so we route both tap and "long press" to the same
   // handler (HoldTargetLayer requires both).
-  const handleHoldTap = onHoldTap;
 
   const activeHighlight = useMemo(() => {
     if (activeHoldId == null || renderWidth <= 0) return null;
@@ -130,8 +129,8 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
               measuredWidth={renderWidth}
               mirrored={mirrored}
               showAllHolds
-              onPaint={handleHoldTap}
-              onLongPress={handleHoldTap}
+              onPaint={onHoldTap}
+              onLongPress={onHoldTap}
             />
           </Animated.View>
 

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, type ReactNode } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View, StyleSheet, Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
@@ -28,8 +28,6 @@ type InteractiveFilterBoardProps = {
   mirrored?: boolean;
   renderWidth: number;
   renderHeight: number;
-  /** Optional chrome (e.g. a floating toolbar) rendered over the board canvas. */
-  children?: ReactNode;
 };
 
 /**
@@ -57,7 +55,6 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   mirrored = false,
   renderWidth,
   renderHeight,
-  children,
 }: InteractiveFilterBoardProps) {
   const { t } = useTranslation('common');
   const { pinchGesture, zoomPanGesture, isZoomed, resetZoom, animatedZoomStyle } = useZoomPanGesture({
@@ -70,9 +67,15 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   // tap to open the picker, so we route both tap and "long press" to the same
   // handler (HoldTargetLayer requires both).
 
+  const holdById = useMemo(() => {
+    const map = new Map<number, BoardHoldTarget>();
+    for (const hold of holdTargets) map.set(hold.id, hold);
+    return map;
+  }, [holdTargets]);
+
   const activeHighlight = useMemo(() => {
     if (activeHoldId == null || renderWidth <= 0) return null;
-    const hold = holdTargets.find((target) => target.id === activeHoldId);
+    const hold = holdById.get(activeHoldId);
     if (!hold) return null;
     const geometry = holdGeometry(hold, boardWidth, boardHeight, renderWidth, mirrored);
     const diameter = geometry.ringDiameter * 1.5;
@@ -95,7 +98,7 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
         ]}
       />
     );
-  }, [activeHoldId, holdTargets, boardWidth, boardHeight, renderWidth, mirrored]);
+  }, [activeHoldId, holdById, boardWidth, boardHeight, renderWidth, mirrored]);
 
   return (
     <View style={styles.root}>
@@ -149,7 +152,6 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
           ) : null}
         </View>
       </GestureDetector>
-      {children}
     </View>
   );
 });

--- a/packages/mobile/src/components/search/SearchHoldFilterRings.tsx
+++ b/packages/mobile/src/components/search/SearchHoldFilterRings.tsx
@@ -137,8 +137,11 @@ const HoldFilterMarker = React.memo(function HoldFilterMarker({
         const ringDiameter = ringRadius * 2;
         const color = colorByType.get(filter.type) ?? ANY_HOLD_COLOR;
         return (
+          // Key on type only: each type appears at most once per hold, so an
+          // include↔exclude flip reuses the same ring View instead of
+          // unmounting and recreating it.
           <View
-            key={`${filter.type}-${filter.mode}`}
+            key={filter.type}
             pointerEvents="none"
             style={[
               styles.absolute,

--- a/packages/mobile/src/components/search/SearchHoldFilterRings.tsx
+++ b/packages/mobile/src/components/search/SearchHoldFilterRings.tsx
@@ -1,0 +1,168 @@
+import React, { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType, HoldsFilter } from '@boardsesh/shared-schema';
+import { ANY_HOLD_COLOR, buildHoldFilterOptions } from '@boardsesh/climb-filters';
+import type { BoardHoldTarget } from '../../lib/create-board-holds';
+import { holdGeometry } from '../create-climb/holdLayout';
+
+type SearchHoldFilterRingsProps = {
+  boardName: BoardName;
+  holdsFilter: HoldsFilter;
+  holdTargets: BoardHoldTarget[];
+  boardWidth: number;
+  boardHeight: number;
+  measuredWidth: number;
+  mirrored: boolean;
+};
+
+// Outer rings first, so the most-typical roles draw outward and the ANY
+// wildcard nests inside — same draw order as the web overlay.
+const TYPE_DRAW_ORDER: readonly HoldFilterType[] = ['STARTING', 'HAND', 'FINISH', 'FOOT', 'ANY'];
+
+type ActiveFilter = { type: HoldFilterType; mode: HoldFilterMode };
+
+function collectActiveFilters(entry: HoldFilterEntry): ActiveFilter[] {
+  const out: ActiveFilter[] = [];
+  for (const type of TYPE_DRAW_ORDER) {
+    const mode = entry[type];
+    if (mode === 'include' || mode === 'exclude') out.push({ type, mode });
+  }
+  return out;
+}
+
+/**
+ * Renders concentric rings (one per active type filter) on each filtered hold,
+ * plus a dim scrim on holds with any "exclude" filter — the RN-View port of the
+ * web `SearchHoldFilterOverlay`. Lives INSIDE the zoom-transformed board view so
+ * the rings track the holds at any zoom level (percentage anchors), matching how
+ * the create-climb painted layer works. `pointerEvents="none"` so taps fall
+ * through to the hold targets underneath.
+ */
+export const SearchHoldFilterRings = React.memo(function SearchHoldFilterRings({
+  boardName,
+  holdsFilter,
+  holdTargets,
+  boardWidth,
+  boardHeight,
+  measuredWidth,
+  mirrored,
+}: SearchHoldFilterRingsProps) {
+  const colorByType = useMemo(() => {
+    const map = new Map<HoldFilterType, string>();
+    for (const option of buildHoldFilterOptions(boardName)) map.set(option.type, option.color);
+    return map;
+  }, [boardName]);
+
+  const holdById = useMemo(() => {
+    const map = new Map<number, BoardHoldTarget>();
+    for (const hold of holdTargets) map.set(hold.id, hold);
+    return map;
+  }, [holdTargets]);
+
+  const markers = useMemo(() => {
+    if (measuredWidth <= 0) return null;
+    const out: React.ReactNode[] = [];
+    for (const [holdIdRaw, entry] of Object.entries(holdsFilter)) {
+      if (!entry) continue;
+      const filters = collectActiveFilters(entry);
+      if (filters.length === 0) continue;
+      const hold = holdById.get(Number(holdIdRaw));
+      if (!hold) continue;
+      const geometry = holdGeometry(hold, boardWidth, boardHeight, measuredWidth, mirrored);
+      out.push(
+        <HoldFilterMarker
+          key={holdIdRaw}
+          leftPct={geometry.leftPct}
+          topPct={geometry.topPct}
+          baseDiameter={geometry.ringDiameter}
+          filters={filters}
+          colorByType={colorByType}
+        />,
+      );
+    }
+    return out;
+  }, [holdsFilter, holdById, boardWidth, boardHeight, measuredWidth, mirrored, colorByType]);
+
+  return (
+    <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+      {markers}
+    </View>
+  );
+});
+
+type HoldFilterMarkerProps = {
+  leftPct: number;
+  topPct: number;
+  baseDiameter: number;
+  filters: ActiveFilter[];
+  colorByType: Map<HoldFilterType, string>;
+};
+
+const HoldFilterMarker = React.memo(function HoldFilterMarker({
+  leftPct,
+  topPct,
+  baseDiameter,
+  filters,
+  colorByType,
+}: HoldFilterMarkerProps) {
+  const baseRadius = baseDiameter / 2;
+  const borderWidth = Math.min(3.5, Math.max(2, baseRadius * 0.32));
+  // Nest each subsequent ring inward by ~22% of the base radius, mirroring the
+  // web overlay so dense boards stay readable.
+  const ringStep = baseRadius * 0.22;
+  const hasExclude = filters.some((filter) => filter.mode === 'exclude');
+
+  return (
+    <>
+      {hasExclude ? (
+        <View
+          pointerEvents="none"
+          style={[
+            styles.absolute,
+            {
+              left: `${leftPct}%`,
+              top: `${topPct}%`,
+              width: baseDiameter,
+              height: baseDiameter,
+              marginLeft: -baseRadius,
+              marginTop: -baseRadius,
+              borderRadius: baseRadius,
+              backgroundColor: 'rgba(0,0,0,0.55)',
+            },
+          ]}
+        />
+      ) : null}
+      {filters.map((filter, index) => {
+        const ringRadius = Math.max(borderWidth, baseRadius - index * ringStep);
+        const ringDiameter = ringRadius * 2;
+        const color = colorByType.get(filter.type) ?? ANY_HOLD_COLOR;
+        return (
+          <View
+            key={`${filter.type}-${filter.mode}`}
+            pointerEvents="none"
+            style={[
+              styles.absolute,
+              {
+                left: `${leftPct}%`,
+                top: `${topPct}%`,
+                width: ringDiameter,
+                height: ringDiameter,
+                marginLeft: -ringRadius,
+                marginTop: -ringRadius,
+                borderRadius: ringRadius,
+                borderWidth,
+                borderColor: color,
+              },
+            ]}
+          />
+        );
+      })}
+    </>
+  );
+});
+
+const styles = StyleSheet.create({
+  absolute: {
+    position: 'absolute',
+  },
+});

--- a/packages/mobile/src/components/search/__tests__/hold-filter-picker.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/hold-filter-picker.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, forwardRef, type ReactNode } from 'react';
+import type { HoldFilterEntry, HoldFilterMode, HoldFilterType } from '@boardsesh/shared-schema';
+
+const haptics = vi.hoisted(() => ({ selection: vi.fn() }));
+
+type PressableMockProps = {
+  children?: ReactNode;
+  onPress?: () => void;
+  disabled?: boolean;
+  accessibilityLabel?: string;
+  accessibilityState?: { selected?: boolean; disabled?: boolean };
+};
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children, onPress, disabled, accessibilityLabel, accessibilityState }: PressableMockProps) =>
+    createElement(
+      'button',
+      {
+        onClick: onPress,
+        disabled: disabled ?? false,
+        'data-label': accessibilityLabel ?? '',
+        'data-selected': accessibilityState?.selected ? 'true' : 'false',
+      },
+      children,
+    ),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+// gorhom BottomSheet pulls in native modules; the picker only needs a ref with
+// imperative snap/close, neither of which affects the tap behaviour under test.
+vi.mock('@gorhom/bottom-sheet', () => ({ default: {} }));
+
+// Sheet wraps gorhom; render children inline so the swatches are queryable.
+vi.mock('../../Sheet', () => ({
+  Sheet: forwardRef<unknown, { children?: ReactNode }>(function SheetMock({ children }, _ref) {
+    return createElement('div', { 'data-sheet': 'true' }, children);
+  }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }),
+}));
+
+type SegmentMockProps = {
+  options: ReadonlyArray<{ key: string; label: string }>;
+  selectedKey: string;
+  onSelect: (key: string) => void;
+};
+vi.mock('../../SegmentedControl', () => ({
+  SegmentedControl: ({ options, selectedKey, onSelect }: SegmentMockProps) =>
+    createElement(
+      'div',
+      { 'data-segmented': 'true', 'data-selected-key': selectedKey },
+      options.map((option) =>
+        createElement(
+          'button',
+          { key: option.key, 'data-segment': option.key, onClick: () => onSelect(option.key) },
+          option.label,
+        ),
+      ),
+    ),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { fill: '#EEE', secondaryLabel: '#999' } }),
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: () => haptics.selection() }));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 2: 8, 3: 12, 4: 16 },
+  borderRadius: { md: 8 },
+}));
+
+vi.mock('react-i18next', () => ({
+  // The swatch a11y label is `${type label}, ${state suffix}`. Returning the key
+  // lets the test target a swatch by its stable label key.
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { HoldFilterPicker } from '../HoldFilterPicker';
+
+type PickerOverrides = {
+  entry?: HoldFilterEntry;
+  applyMode?: HoldFilterMode;
+  onToggleType?: (type: HoldFilterType) => void;
+  onApplyModeChange?: (mode: HoldFilterMode) => void;
+  onClear?: () => void;
+};
+
+function renderPicker(overrides: PickerOverrides = {}) {
+  const onToggleType = overrides.onToggleType ?? vi.fn();
+  const onApplyModeChange = overrides.onApplyModeChange ?? vi.fn();
+  const onClear = overrides.onClear ?? vi.fn();
+  const result = render(
+    <HoldFilterPicker
+      holdId={42}
+      boardName="kilter"
+      entry={overrides.entry ?? {}}
+      applyMode={overrides.applyMode ?? 'include'}
+      onApplyModeChange={onApplyModeChange}
+      onToggleType={onToggleType}
+      onClear={onClear}
+      onClose={vi.fn()}
+    />,
+  );
+  return { ...result, onToggleType, onApplyModeChange, onClear };
+}
+
+// Swatch buttons carry a `${typeLabel}` (or `${typeLabel}, ${suffix}`) a11y
+// label. With the i18n mock returning keys, an idle HAND swatch reads exactly
+// `mobile.holdFilter.type.hand`.
+function swatch(container: HTMLElement, typeKey: string): HTMLButtonElement | null {
+  const buttons = Array.from(container.querySelectorAll('button'));
+  return (buttons.find((button) => (button.getAttribute('data-label') ?? '').startsWith(typeKey)) ??
+    null) as HTMLButtonElement | null;
+}
+
+describe('HoldFilterPicker', () => {
+  beforeEach(() => {
+    haptics.selection.mockClear();
+  });
+
+  it('renders one swatch per board hold type plus ANY', () => {
+    const { container } = renderPicker();
+    // Kilter picker states + the trailing ANY swatch.
+    expect(swatch(container, 'mobile.holdFilter.type.hand')).not.toBeNull();
+    expect(swatch(container, 'mobile.holdFilter.type.starting')).not.toBeNull();
+    expect(swatch(container, 'mobile.holdFilter.type.finish')).not.toBeNull();
+    expect(swatch(container, 'mobile.holdFilter.type.foot')).not.toBeNull();
+    expect(swatch(container, 'mobile.holdFilter.type.any')).not.toBeNull();
+  });
+
+  it('tapping a swatch toggles that hold type (direction owned by apply mode)', () => {
+    const { container, onToggleType } = renderPicker({ applyMode: 'include' });
+    fireEvent.click(swatch(container, 'mobile.holdFilter.type.hand')!);
+    expect(onToggleType).toHaveBeenCalledTimes(1);
+    expect(onToggleType).toHaveBeenCalledWith('HAND');
+    expect(haptics.selection).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the exclude apply mode without changing the toggled type', () => {
+    // In exclude mode the same swatch tap still reports its type; the parent
+    // resolves include vs exclude from applyMode, so the picker only emits type.
+    const { container, onToggleType } = renderPicker({ applyMode: 'exclude' });
+    fireEvent.click(swatch(container, 'mobile.holdFilter.type.foot')!);
+    expect(onToggleType).toHaveBeenCalledWith('FOOT');
+  });
+
+  it('marks a swatch selected when its type is in the entry', () => {
+    const { container } = renderPicker({ entry: { HAND: 'include' } });
+    expect(swatch(container, 'mobile.holdFilter.type.hand')!.getAttribute('data-selected')).toBe('true');
+    expect(swatch(container, 'mobile.holdFilter.type.foot')!.getAttribute('data-selected')).toBe('false');
+  });
+
+  it('switches the apply mode via the segmented control', () => {
+    const { container, onApplyModeChange } = renderPicker({ applyMode: 'include' });
+    const excludeSegment = container.querySelector('[data-segment="exclude"]') as HTMLButtonElement;
+    fireEvent.click(excludeSegment);
+    expect(onApplyModeChange).toHaveBeenCalledWith('exclude');
+  });
+
+  it('clears the hold when the clear row is tapped and the entry is non-empty', () => {
+    const { container, onClear } = renderPicker({ entry: { HAND: 'include' } });
+    const clearButton = container.querySelector('[data-label="mobile.holdFilter.clearHold"]') as HTMLButtonElement;
+    fireEvent.click(clearButton);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables clear and does not fire onClear when the entry is empty', () => {
+    const { container, onClear } = renderPicker({ entry: {} });
+    const clearButton = container.querySelector('[data-label="mobile.holdFilter.clearHold"]') as HTMLButtonElement;
+    expect(clearButton.disabled).toBe(true);
+    fireEvent.click(clearButton);
+    expect(onClear).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { HoldsFilter } from '@boardsesh/shared-schema';
+import type { BoardHoldTarget } from '../../../lib/create-board-holds';
+
+// Controls the mocked zoom hook so each test can assert the zoomed-only chrome
+// (pan overlay + reset button) without driving real gestures.
+const zoomState = vi.hoisted(() => ({ isZoomed: false, resetZoom: vi.fn() }));
+
+type ChildrenProps = { children?: ReactNode };
+type StyleProps = ChildrenProps & { style?: unknown };
+
+vi.mock('react-native', () => ({
+  View: ({ children }: StyleProps) => createElement('div', null, children),
+  Pressable: ({ children, onPress }: StyleProps & { onPress?: () => void }) =>
+    createElement('button', { 'data-pressable': 'true', onClick: onPress }, children),
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    absoluteFill: { position: 'absolute' },
+  },
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  // Animated.View → plain div; the zoom style is irrelevant to behaviour here.
+  default: { View: ({ children }: StyleProps) => createElement('div', { 'data-animated': 'true' }, children) },
+}));
+
+vi.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: ChildrenProps) => createElement('div', { 'data-gesture': 'true' }, children),
+}));
+
+vi.mock('../../play-drawer/use-zoom-pan-gesture', () => ({
+  useZoomPanGesture: () => ({
+    pinchGesture: {},
+    zoomPanGesture: {},
+    isZoomed: zoomState.isZoomed,
+    resetZoom: zoomState.resetZoom,
+    animatedZoomStyle: {},
+  }),
+}));
+
+vi.mock('../../BoardImageNative', () => ({
+  BoardImageNative: () => createElement('div', { 'data-board-image': 'true' }),
+}));
+
+// SearchHoldFilterRings is covered by its own test; stub it so this test only
+// exercises the InteractiveFilterBoard composition + tap routing.
+vi.mock('../SearchHoldFilterRings', () => ({
+  SearchHoldFilterRings: () => createElement('div', { 'data-rings': 'true' }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: ChildrenProps) => createElement('span', null, children),
+}));
+
+// HoldTargetLayer renders a tap button per hold so the test can fire a tap and
+// assert it routes back through onHoldTap (wired to onPaint).
+type HoldTargetLayerMockProps = { holdTargets: BoardHoldTarget[]; onPaint: (id: number) => void };
+vi.mock('../../create-climb/HoldTargetLayer', () => ({
+  HoldTargetLayer: ({ holdTargets, onPaint }: HoldTargetLayerMockProps) =>
+    createElement(
+      'div',
+      { 'data-hold-layer': 'true' },
+      holdTargets.map((hold) =>
+        createElement('button', { key: hold.id, 'data-hold-id': hold.id, onClick: () => onPaint(hold.id) }),
+      ),
+    ),
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  overlays: { scrim: 'rgba(0,0,0,0.6)', onScrim: '#FFF' },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { InteractiveFilterBoard } from '../InteractiveFilterBoard';
+
+const holdTargets: BoardHoldTarget[] = [
+  { id: 10, cx: 100, cy: 100, r: 20 },
+  { id: 20, cx: 200, cy: 200, r: 20 },
+];
+
+type Overrides = {
+  holdsFilter?: HoldsFilter;
+  activeHoldId?: number | null;
+  onHoldTap?: (id: number) => void;
+};
+
+function renderBoard(overrides: Overrides = {}) {
+  const onHoldTap = overrides.onHoldTap ?? vi.fn();
+  const result = render(
+    <InteractiveFilterBoard
+      boardName="kilter"
+      layoutId={1}
+      sizeId={10}
+      setIds="1,2"
+      boardWidth={1000}
+      boardHeight={1000}
+      holdTargets={holdTargets}
+      holdsFilter={overrides.holdsFilter ?? {}}
+      activeHoldId={overrides.activeHoldId ?? null}
+      onHoldTap={onHoldTap}
+      renderWidth={400}
+      renderHeight={500}
+    />,
+  );
+  return { ...result, onHoldTap };
+}
+
+describe('InteractiveFilterBoard', () => {
+  beforeEach(() => {
+    zoomState.isZoomed = false;
+    zoomState.resetZoom.mockClear();
+  });
+
+  it('renders the board image, filter rings, and a tap target per hold', () => {
+    const { container } = renderBoard();
+    expect(container.querySelector('[data-board-image="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-rings="true"]')).not.toBeNull();
+    expect(container.querySelectorAll('[data-hold-id]').length).toBe(holdTargets.length);
+  });
+
+  it('routes a hold tap to onHoldTap with the hold id', () => {
+    const { container, onHoldTap } = renderBoard();
+    const tapTarget = container.querySelector('[data-hold-id="20"]') as HTMLButtonElement;
+    fireEvent.click(tapTarget);
+    expect(onHoldTap).toHaveBeenCalledTimes(1);
+    expect(onHoldTap).toHaveBeenCalledWith(20);
+  });
+
+  it('hides the pan overlay and reset button while not zoomed', () => {
+    const { container } = renderBoard();
+    // Only the active-hold chrome would add a Pressable; with no zoom and no
+    // active hold there is no reset button.
+    expect(container.querySelectorAll('[data-pressable="true"]').length).toBe(0);
+  });
+
+  it('shows a reset button that calls resetZoom while zoomed', () => {
+    zoomState.isZoomed = true;
+    const { container } = renderBoard();
+    const resetButton = container.querySelector('[data-pressable="true"]') as HTMLButtonElement;
+    expect(resetButton).not.toBeNull();
+    fireEvent.click(resetButton);
+    expect(zoomState.resetZoom).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an active highlight when a hold is active', () => {
+    // The highlight is built only when activeHoldId resolves to a known hold;
+    // an unknown id yields none. We assert the known-id path renders without
+    // throwing and the unknown-id path is a no-op.
+    const known = renderBoard({ activeHoldId: 10 });
+    expect(known.container.querySelector('[data-hold-layer="true"]')).not.toBeNull();
+    known.unmount();
+
+    const unknown = renderBoard({ activeHoldId: 999 });
+    expect(unknown.container.querySelector('[data-hold-layer="true"]')).not.toBeNull();
+  });
+});

--- a/packages/mobile/src/components/search/__tests__/search-hold-filter-rings.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/search-hold-filter-rings.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { HoldsFilter } from '@boardsesh/shared-schema';
+import type { BoardHoldTarget } from '../../../lib/create-board-holds';
+
+// Mock the RN host components down to plain DOM so the ring markers are
+// queryable. Each ring/scrim is a <View>, which we surface as a <div> tagging
+// its border colour + background so the test can count rings and detect the
+// exclude scrim. `holdGeometry` is a pure function and runs for real.
+type ViewMockProps = {
+  children?: ReactNode;
+  pointerEvents?: string;
+  style?: unknown;
+};
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return style.reduce<Record<string, unknown>>((acc, part) => ({ ...acc, ...flattenStyle(part) }), {});
+  }
+  if (style && typeof style === 'object') return style as Record<string, unknown>;
+  return {};
+}
+
+vi.mock('react-native', () => ({
+  View: ({ children, style }: ViewMockProps) => {
+    const flat = flattenStyle(style);
+    return createElement(
+      'div',
+      {
+        'data-view': 'true',
+        'data-border-color': flat.borderColor ?? '',
+        'data-bg': flat.backgroundColor ?? '',
+        'data-border-width': flat.borderWidth ?? '',
+      },
+      children,
+    );
+  },
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    absoluteFill: { position: 'absolute' },
+  },
+}));
+
+import { SearchHoldFilterRings } from '../SearchHoldFilterRings';
+
+const holdTargets: BoardHoldTarget[] = [
+  { id: 10, cx: 100, cy: 100, r: 20 },
+  { id: 20, cx: 200, cy: 200, r: 20 },
+  { id: 30, cx: 300, cy: 300, r: 20 },
+];
+
+function renderRings(holdsFilter: HoldsFilter, measuredWidth = 400) {
+  return render(
+    <SearchHoldFilterRings
+      boardName="kilter"
+      holdsFilter={holdsFilter}
+      holdTargets={holdTargets}
+      boardWidth={1000}
+      boardHeight={1000}
+      measuredWidth={measuredWidth}
+      mirrored={false}
+    />,
+  );
+}
+
+// A "ring" is a View carrying a non-empty borderColor; the wrapper + scrim have
+// no border colour, so this isolates the concentric type rings.
+function ringCount(container: HTMLElement): number {
+  return Array.from(container.querySelectorAll('[data-view="true"]')).filter(
+    (node) => (node.getAttribute('data-border-color') ?? '') !== '',
+  ).length;
+}
+
+function hasExcludeScrim(container: HTMLElement): boolean {
+  return Array.from(container.querySelectorAll('[data-view="true"]')).some((node) =>
+    (node.getAttribute('data-bg') ?? '').startsWith('rgba(0,0,0'),
+  );
+}
+
+describe('SearchHoldFilterRings', () => {
+  it('renders no rings when the filter is empty', () => {
+    const { container } = renderRings({});
+    expect(ringCount(container)).toBe(0);
+    expect(hasExcludeScrim(container)).toBe(false);
+  });
+
+  it('renders one ring per active type on a filtered hold', () => {
+    const { container } = renderRings({ '10': { STARTING: 'include', HAND: 'include' } });
+    expect(ringCount(container)).toBe(2);
+    expect(hasExcludeScrim(container)).toBe(false);
+  });
+
+  it('draws an exclude scrim on a hold with any exclude filter', () => {
+    const { container } = renderRings({ '20': { FOOT: 'exclude' } });
+    expect(ringCount(container)).toBe(1);
+    expect(hasExcludeScrim(container)).toBe(true);
+  });
+
+  it('skips holds whose id is not in the board targets', () => {
+    const { container } = renderRings({ '999': { HAND: 'include' } });
+    expect(ringCount(container)).toBe(0);
+  });
+
+  it('renders nothing until the board is measured (measuredWidth <= 0)', () => {
+    const { container } = renderRings({ '10': { HAND: 'include' } }, 0);
+    expect(ringCount(container)).toBe(0);
+  });
+
+  it('aggregates rings across multiple filtered holds', () => {
+    const { container } = renderRings({
+      '10': { STARTING: 'include' },
+      '20': { HAND: 'include', FINISH: 'include' },
+    });
+    expect(ringCount(container)).toBe(3);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/create-board-holds.test.ts
+++ b/packages/mobile/src/lib/__tests__/create-board-holds.test.ts
@@ -5,7 +5,7 @@ vi.mock('../board-details', () => ({
 }));
 
 import { getBoardRenderData } from '../board-details';
-import { getCreateBoardHolds } from '../create-board-holds';
+import { getCreateBoardHolds, parseSetIdsParam } from '../create-board-holds';
 
 const mockedGetBoardRenderData = vi.mocked(getBoardRenderData);
 
@@ -54,5 +54,19 @@ describe('getCreateBoardHolds', () => {
         setIds: [8],
       }),
     ).toBeNull();
+  });
+});
+
+describe('parseSetIdsParam', () => {
+  it('returns an empty array for an empty string (not [0])', () => {
+    expect(parseSetIdsParam('')).toEqual([]);
+  });
+
+  it('parses a comma-separated list of set ids', () => {
+    expect(parseSetIdsParam('24,25')).toEqual([24, 25]);
+  });
+
+  it('drops zero and blank tokens', () => {
+    expect(parseSetIdsParam('0,24,,25')).toEqual([24, 25]);
   });
 });

--- a/packages/mobile/src/lib/__tests__/hold-filter-handoff.test.ts
+++ b/packages/mobile/src/lib/__tests__/hold-filter-handoff.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { HoldsFilter } from '@boardsesh/shared-schema';
+import { emitHoldsFilterSelection, subscribeToHoldsFilterSelection } from '../hold-filter-handoff';
+
+describe('hold-filter-handoff', () => {
+  it('delivers the emitted holds filter to a subscriber', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToHoldsFilterSelection(listener);
+
+    const holdsFilter: HoldsFilter = { '12': { HAND: 'include' } };
+    emitHoldsFilterSelection(holdsFilter);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(holdsFilter);
+    unsubscribe();
+  });
+
+  it('stops delivering after the subscriber unsubscribes', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToHoldsFilterSelection(listener);
+    unsubscribe();
+
+    emitHoldsFilterSelection({ '3': { FOOT: 'exclude' } });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('fans out a single emit to every active subscriber', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const unsubFirst = subscribeToHoldsFilterSelection(first);
+    const unsubSecond = subscribeToHoldsFilterSelection(second);
+
+    const holdsFilter: HoldsFilter = { '7': { ANY: 'include' } };
+    emitHoldsFilterSelection(holdsFilter);
+
+    expect(first).toHaveBeenCalledWith(holdsFilter);
+    expect(second).toHaveBeenCalledWith(holdsFilter);
+    unsubFirst();
+    unsubSecond();
+  });
+
+  it('only one of two subscribers receives the emit after the other unsubscribes', () => {
+    const kept = vi.fn();
+    const dropped = vi.fn();
+    const unsubKept = subscribeToHoldsFilterSelection(kept);
+    const unsubDropped = subscribeToHoldsFilterSelection(dropped);
+    unsubDropped();
+
+    emitHoldsFilterSelection({ '9': { STARTING: 'include' } });
+
+    expect(kept).toHaveBeenCalledTimes(1);
+    expect(dropped).not.toHaveBeenCalled();
+    unsubKept();
+  });
+});

--- a/packages/mobile/src/lib/create-board-holds.ts
+++ b/packages/mobile/src/lib/create-board-holds.ts
@@ -17,6 +17,16 @@ export type CreateBoardHolds = {
 };
 
 /**
+ * Parse a comma-separated `setIds` route/param string into numeric set ids.
+ * Mirrors the `split(',').map(Number).filter(Boolean)` pattern the board render
+ * pipeline uses (see `use-native-climb-render.ts`): an empty string yields `[]`
+ * (not `[0]`), and any `0`/blank token is dropped — set ids are positive.
+ */
+export function parseSetIdsParam(setIds: string): number[] {
+  return setIds.split(',').map(Number).filter(Boolean);
+}
+
+/**
  * Resolve the full set of tappable holds for a board configuration, board-family
  * agnostic. Aurora boards come from the hole-placement pipeline; MoonBoard comes
  * from the grid-backed render data branch.

--- a/packages/mobile/src/lib/hold-filter-handoff.ts
+++ b/packages/mobile/src/lib/hold-filter-handoff.ts
@@ -1,0 +1,22 @@
+import type { HoldsFilter } from '@boardsesh/shared-schema';
+
+// Hands the edited hold filter back from the full-screen board sub-screen to the
+// ClimbFilterSheet, mirroring `filter-handoff` (setters). The sub-screen owns the
+// interactive board; the sheet stays mounted underneath and picks up the result
+// when the screen pops, so the user keeps editing the rest of the filters.
+type HoldsFilterListener = (holdsFilter: HoldsFilter) => void;
+
+const holdsFilterListeners = new Set<HoldsFilterListener>();
+
+export function emitHoldsFilterSelection(holdsFilter: HoldsFilter): void {
+  for (const listener of holdsFilterListeners) {
+    listener(holdsFilter);
+  }
+}
+
+export function subscribeToHoldsFilterSelection(listener: HoldsFilterListener): () => void {
+  holdsFilterListeners.add(listener);
+  return () => {
+    holdsFilterListeners.delete(listener);
+  };
+}

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -48,6 +48,8 @@ export const SHARED_EVENTS = {
   ClimbSentToBoardFailure: 'Climb Sent to Board Failure',
   // Search
   ClimbSearchPerformed: 'Climb Search Performed',
+  SearchHoldFilterChanged: 'Search Hold Filter Changed',
+  SearchHoldFilterCleared: 'Search Hold Filter Cleared',
   // Beta videos
   BetaVideoLinkClicked: 'Beta Video Link Clicked',
   BetaVideoClimbClicked: 'Beta Video Climb Clicked',

--- a/packages/shared/climb-filters/package.json
+++ b/packages/shared/climb-filters/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@boardsesh/board-constants": "*",
     "@boardsesh/shared-schema": "*"
   },
   "devDependencies": {

--- a/packages/shared/climb-filters/src/__tests__/hold-filter-options.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/hold-filter-options.test.ts
@@ -4,6 +4,8 @@ import {
   ANY_HOLD_COLOR,
   buildHoldFilterOptions,
   countFilteredHolds,
+  parseHoldsFilter,
+  sanitizeHoldsFilter,
   toggleHoldFilterType,
 } from '../hold-filter-options';
 
@@ -73,5 +75,55 @@ describe('countFilteredHolds', () => {
   it('returns 0 for an empty or undefined filter', () => {
     expect(countFilteredHolds({})).toBe(0);
     expect(countFilteredHolds(undefined)).toBe(0);
+  });
+});
+
+describe('parseHoldsFilter', () => {
+  it('returns an empty filter for missing or empty input', () => {
+    expect(parseHoldsFilter(undefined)).toEqual({});
+    expect(parseHoldsFilter(null)).toEqual({});
+    expect(parseHoldsFilter('')).toEqual({});
+  });
+
+  it('returns an empty filter for malformed JSON', () => {
+    expect(parseHoldsFilter('{not json')).toEqual({});
+  });
+
+  it('returns an empty filter for non-object JSON (array, number, string)', () => {
+    expect(parseHoldsFilter('[1,2,3]')).toEqual({});
+    expect(parseHoldsFilter('42')).toEqual({});
+    expect(parseHoldsFilter('"hand"')).toEqual({});
+  });
+
+  it('parses a valid serialized filter', () => {
+    const raw = JSON.stringify({ '12': { HAND: 'include', FOOT: 'exclude' } });
+    expect(parseHoldsFilter(raw)).toEqual({ '12': { HAND: 'include', FOOT: 'exclude' } });
+  });
+
+  it('rejects an invalid leaf mode value and drops the now-empty hold', () => {
+    // A crafted param sets a leaf to something outside include/exclude; it must
+    // not propagate to analytics or the GraphQL query.
+    const raw = JSON.stringify({ '12': { HAND: 'maybe' } });
+    expect(parseHoldsFilter(raw)).toEqual({});
+  });
+
+  it('keeps valid leaves while stripping invalid ones on the same hold', () => {
+    const raw = JSON.stringify({ '12': { HAND: 'include', FOOT: 'sometimes' } });
+    expect(parseHoldsFilter(raw)).toEqual({ '12': { HAND: 'include' } });
+  });
+
+  it('drops holds whose entry is not a plain object', () => {
+    const raw = JSON.stringify({ '12': 'include', '13': ['HAND'], '14': { ANY: 'exclude' } });
+    expect(parseHoldsFilter(raw)).toEqual({ '14': { ANY: 'exclude' } });
+  });
+});
+
+describe('sanitizeHoldsFilter', () => {
+  it('strips non-string and out-of-union leaf values', () => {
+    const raw: Record<string, unknown> = {
+      '1': { HAND: 'include', FOOT: 3, FINISH: 'nope' },
+      '2': { ANY: 'exclude' },
+    };
+    expect(sanitizeHoldsFilter(raw)).toEqual({ '1': { HAND: 'include' }, '2': { ANY: 'exclude' } });
   });
 });

--- a/packages/shared/climb-filters/src/__tests__/hold-filter-options.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/hold-filter-options.test.ts
@@ -26,6 +26,15 @@ describe('buildHoldFilterOptions', () => {
     expect(starting?.color).toMatch(/^#/);
     expect(starting?.color).not.toBe(ANY_HOLD_COLOR);
   });
+
+  it('never surfaces non-setter hold states (OFF / NOT / AUX) as options', () => {
+    // MoonBoard's HOLD_STATE_MAP carries an AUX live-preview role; the membership
+    // guard must keep it (and any OFF/NOT) out of the filter options.
+    const types = buildHoldFilterOptions('moonboard').map((option) => option.type);
+    expect(types).not.toContain('AUX');
+    expect(types).not.toContain('OFF');
+    expect(types).not.toContain('NOT');
+  });
 });
 
 describe('toggleHoldFilterType', () => {

--- a/packages/shared/climb-filters/src/__tests__/hold-filter-options.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/hold-filter-options.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import type { HoldFilterEntry, HoldsFilter } from '@boardsesh/shared-schema';
+import {
+  ANY_HOLD_COLOR,
+  buildHoldFilterOptions,
+  countFilteredHolds,
+  toggleHoldFilterType,
+} from '../hold-filter-options';
+
+describe('buildHoldFilterOptions', () => {
+  it('lists the named Kilter roles followed by the ANY wildcard', () => {
+    const options = buildHoldFilterOptions('kilter');
+    const types = options.map((option) => option.type);
+    expect(types).toEqual(['STARTING', 'HAND', 'FINISH', 'FOOT', 'ANY']);
+    // ANY has no LED colour, so it falls back to the plain-white swatch.
+    expect(options.at(-1)).toEqual({ type: 'ANY', color: ANY_HOLD_COLOR });
+  });
+
+  it('drops FOOT for MoonBoard but keeps ANY', () => {
+    const types = buildHoldFilterOptions('moonboard').map((option) => option.type);
+    expect(types).toEqual(['STARTING', 'HAND', 'FINISH', 'ANY']);
+  });
+
+  it('pulls swatch colours from the board hold-state map', () => {
+    const starting = buildHoldFilterOptions('kilter').find((option) => option.type === 'STARTING');
+    expect(starting?.color).toMatch(/^#/);
+    expect(starting?.color).not.toBe(ANY_HOLD_COLOR);
+  });
+});
+
+describe('toggleHoldFilterType', () => {
+  it('sets an unset type to the apply mode', () => {
+    expect(toggleHoldFilterType({}, 'STARTING', 'include')).toEqual({ STARTING: 'include' });
+    expect(toggleHoldFilterType({}, 'HAND', 'exclude')).toEqual({ HAND: 'exclude' });
+  });
+
+  it('unsets a type already at the apply mode', () => {
+    const entry: HoldFilterEntry = { FOOT: 'include' };
+    expect(toggleHoldFilterType(entry, 'FOOT', 'include')).toEqual({});
+  });
+
+  it('flips a type from the other mode to the apply mode', () => {
+    const entry: HoldFilterEntry = { FINISH: 'include' };
+    expect(toggleHoldFilterType(entry, 'FINISH', 'exclude')).toEqual({ FINISH: 'exclude' });
+  });
+
+  it('does not mutate the input entry', () => {
+    const entry: HoldFilterEntry = { ANY: 'include' };
+    toggleHoldFilterType(entry, 'STARTING', 'include');
+    expect(entry).toEqual({ ANY: 'include' });
+  });
+});
+
+describe('countFilteredHolds', () => {
+  it('counts only holds with at least one active type', () => {
+    const filter: HoldsFilter = {
+      '10': { STARTING: 'include' },
+      '20': { HAND: 'exclude', FOOT: 'include' },
+      '30': {},
+    };
+    expect(countFilteredHolds(filter)).toBe(2);
+  });
+
+  it('returns 0 for an empty or undefined filter', () => {
+    expect(countFilteredHolds({})).toBe(0);
+    expect(countFilteredHolds(undefined)).toBe(0);
+  });
+});

--- a/packages/shared/climb-filters/src/climb-zone-math.ts
+++ b/packages/shared/climb-filters/src/climb-zone-math.ts
@@ -1,0 +1,185 @@
+import type { ZoneBoxInput } from '@boardsesh/shared-schema';
+
+/**
+ * Platform-free geometry helpers for the board "zone" search filter — the
+ * draggable rectangle that restricts results to climbs whose holds fit inside
+ * it. Extracted from the web search drawer so web and mobile share one
+ * implementation (the web copy re-exports from here against its own `ZoneBox`
+ * alias, which is structurally identical to {@link ZoneBoxInput}).
+ *
+ * Coordinates: `ZoneBoxInput` edges are in placement-grid space (the same
+ * coordinate space as `board_holes.x/y` and the `edge_*` columns on board
+ * sizes). Hold positions (`cx`/`cy`) come from the renderer in SVG-pixel space,
+ * so {@link isHoldInsideZone} runs them back through {@link svgToGrid} first.
+ */
+
+/**
+ * Bounding edges of the board playing surface in placement-grid coordinates.
+ * Matches the `edge_*` fields on a board size / `BoardDetails`.
+ */
+export type BoardEdges = {
+  edgeLeft: number;
+  edgeRight: number;
+  edgeBottom: number;
+  edgeTop: number;
+};
+
+export type DragMode = 'move' | 'nw' | 'ne' | 'sw' | 'se';
+
+/**
+ * Default zone covers the inner 60% of the board so the user immediately
+ * sees a visible rectangle they can manipulate.
+ */
+export function buildDefaultZone(edges: BoardEdges): ZoneBoxInput {
+  const widthGrid = edges.edgeRight - edges.edgeLeft;
+  const heightGrid = edges.edgeTop - edges.edgeBottom;
+  const padX = Math.round(widthGrid * 0.2);
+  const padY = Math.round(heightGrid * 0.2);
+  return {
+    edgeLeft: edges.edgeLeft + padX,
+    edgeRight: edges.edgeRight - padX,
+    edgeBottom: edges.edgeBottom + padY,
+    edgeTop: edges.edgeTop - padY,
+  };
+}
+
+/**
+ * Constrain a (potentially mid-drag) box to fit inside the board edges
+ * and respect the 5%-of-board minimum size.
+ */
+export function clampZoneBox(box: ZoneBoxInput, edges: BoardEdges): ZoneBoxInput {
+  const minWidth = Math.max(1, Math.round((edges.edgeRight - edges.edgeLeft) * 0.05));
+  const minHeight = Math.max(1, Math.round((edges.edgeTop - edges.edgeBottom) * 0.05));
+  let { edgeLeft: left, edgeRight: right, edgeBottom: bottom, edgeTop: top } = box;
+  left = Math.max(edges.edgeLeft, Math.min(left, edges.edgeRight - minWidth));
+  right = Math.min(edges.edgeRight, Math.max(right, left + minWidth));
+  bottom = Math.max(edges.edgeBottom, Math.min(bottom, edges.edgeTop - minHeight));
+  top = Math.min(edges.edgeTop, Math.max(top, bottom + minHeight));
+  return {
+    edgeLeft: Math.round(left),
+    edgeRight: Math.round(right),
+    edgeBottom: Math.round(bottom),
+    edgeTop: Math.round(top),
+  };
+}
+
+/**
+ * Apply a drag delta (in grid coordinates) to a starting box, given the
+ * drag mode (which corner / move). Edge handles correspond to grid-axis
+ * pairs as follows: visually-upper-Y = larger `edgeTop`, visually-lower-Y =
+ * smaller `edgeBottom`.
+ */
+export function applyDrag(
+  startBox: ZoneBoxInput,
+  mode: DragMode,
+  dx: number,
+  dy: number,
+  edges: BoardEdges,
+): ZoneBoxInput {
+  if (mode === 'move') {
+    const widthGrid = startBox.edgeRight - startBox.edgeLeft;
+    const heightGrid = startBox.edgeTop - startBox.edgeBottom;
+    const next: ZoneBoxInput = {
+      edgeLeft: startBox.edgeLeft + dx,
+      edgeRight: startBox.edgeRight + dx,
+      edgeBottom: startBox.edgeBottom + dy,
+      edgeTop: startBox.edgeTop + dy,
+    };
+    if (next.edgeLeft < edges.edgeLeft) {
+      next.edgeLeft = edges.edgeLeft;
+      next.edgeRight = edges.edgeLeft + widthGrid;
+    }
+    if (next.edgeRight > edges.edgeRight) {
+      next.edgeRight = edges.edgeRight;
+      next.edgeLeft = edges.edgeRight - widthGrid;
+    }
+    if (next.edgeBottom < edges.edgeBottom) {
+      next.edgeBottom = edges.edgeBottom;
+      next.edgeTop = edges.edgeBottom + heightGrid;
+    }
+    if (next.edgeTop > edges.edgeTop) {
+      next.edgeTop = edges.edgeTop;
+      next.edgeBottom = edges.edgeTop - heightGrid;
+    }
+    return clampZoneBox(next, edges);
+  }
+  const next: ZoneBoxInput = { ...startBox };
+  if (mode === 'nw' || mode === 'sw') next.edgeLeft = startBox.edgeLeft + dx;
+  if (mode === 'ne' || mode === 'se') next.edgeRight = startBox.edgeRight + dx;
+  if (mode === 'nw' || mode === 'ne') next.edgeTop = startBox.edgeTop + dy;
+  if (mode === 'sw' || mode === 'se') next.edgeBottom = startBox.edgeBottom + dy;
+  return clampZoneBox(next, edges);
+}
+
+export type BoardDimensions = BoardEdges & {
+  boardWidth: number;
+  boardHeight: number;
+};
+
+/**
+ * Convert a grid-coordinate point to SVG-pixel coordinates. Mirrors the math
+ * the renderer uses so the rectangle lines up with the rendered hold positions.
+ */
+export function gridToSvg(x: number, y: number, dims: BoardDimensions): { x: number; y: number } {
+  const xSpacing = dims.boardWidth / (dims.edgeRight - dims.edgeLeft);
+  const ySpacing = dims.boardHeight / (dims.edgeTop - dims.edgeBottom);
+  return {
+    x: (x - dims.edgeLeft) * xSpacing,
+    y: dims.boardHeight - (y - dims.edgeBottom) * ySpacing,
+  };
+}
+
+/**
+ * Inverse of {@link gridToSvg} — translate a point in SVG coordinate space back
+ * to grid coordinates.
+ */
+export function svgToGrid(svgX: number, svgY: number, dims: BoardDimensions): { x: number; y: number } {
+  const xSpacing = dims.boardWidth / (dims.edgeRight - dims.edgeLeft);
+  const ySpacing = dims.boardHeight / (dims.edgeTop - dims.edgeBottom);
+  return {
+    x: svgX / xSpacing + dims.edgeLeft,
+    y: dims.edgeBottom + (dims.boardHeight - svgY) / ySpacing,
+  };
+}
+
+/**
+ * Pick a sensible handle radius in SVG units. Scales with board size but
+ * clamps against absolute lower/upper bounds so handles never overlap on
+ * tiny boards or balloon to cover half the rectangle on huge ones.
+ */
+export function computeHandleRadius(dims: BoardDimensions): number {
+  const HANDLE_FRACTION = 0.04;
+  const MIN_HANDLE = 8;
+  const MAX_HANDLE = 40;
+  const fromBoard = Math.max(dims.boardWidth, dims.boardHeight) * HANDLE_FRACTION;
+  return Math.max(MIN_HANDLE, Math.min(MAX_HANDLE, fromBoard));
+}
+
+/**
+ * Whether a hold sits inside (or on the edge of) a zone box. `cx`/`cy` come
+ * from the renderer in SVG-pixel space; the zone box is in grid coordinates, so
+ * we run the hold position through {@link svgToGrid} and compare against the box
+ * edges.
+ *
+ * Inclusive on all four sides — the backend zone filter keeps a climb if every
+ * hold fits inside the box, so a hold exactly on the edge still leaves the climb
+ * eligible.
+ *
+ * Returns `true` for a null/undefined zone — semantically "no zone constraint =
+ * every hold is unconstrained" — so callers that prune holds after a zone change
+ * can pass `null` without a separate guard.
+ */
+export function isHoldInsideZone(
+  hold: { cx: number; cy: number },
+  zone: ZoneBoxInput | null | undefined,
+  dims: BoardDimensions,
+): boolean {
+  if (!zone) return true;
+  const gridPoint = svgToGrid(hold.cx, hold.cy, dims);
+  return (
+    gridPoint.x >= zone.edgeLeft &&
+    gridPoint.x <= zone.edgeRight &&
+    gridPoint.y >= zone.edgeBottom &&
+    gridPoint.y <= zone.edgeTop
+  );
+}

--- a/packages/shared/climb-filters/src/hold-filter-options.ts
+++ b/packages/shared/climb-filters/src/hold-filter-options.ts
@@ -1,0 +1,98 @@
+import { HOLD_STATE_MAP, type HoldStateInfo } from '@boardsesh/board-constants/hold-states';
+import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType } from '@boardsesh/shared-schema';
+
+/**
+ * Hold-type swatch metadata for the search hold filter, shared by web (the
+ * MUI `HoldTypePicker`) and mobile (the native hold-filter sub-screen).
+ *
+ * The named setting roles (STARTING / HAND / FINISH / FOOT) come from each
+ * board's `HOLD_STATE_MAP` so the swatch colour matches the LED colour the
+ * board lights. `ANY` is a wildcard that matches a hold present in any state —
+ * it has no `HOLD_STATE_MAP` entry, so it renders as a plain white swatch
+ * (matching the on-board overlay, which uses `#FFFFFF` for `ANY`).
+ */
+
+// Display order of the named setting roles in the picker.
+const SETTER_STATE_ORDER: readonly HoldFilterType[] = ['STARTING', 'HAND', 'FINISH', 'FOOT'];
+
+// Per-board allowlist of selectable named states. MoonBoard climbs are
+// STARTING / HAND / FINISH only — its extra HOLD_STATE_MAP entries exist to
+// render live BLE preview frames, not to set climbs, so they're excluded here.
+const PICKER_STATES_BY_BOARD: Record<BoardName, readonly HoldFilterType[]> = {
+  kilter: SETTER_STATE_ORDER,
+  tension: SETTER_STATE_ORDER,
+  decoy: SETTER_STATE_ORDER,
+  touchstone: SETTER_STATE_ORDER,
+  grasshopper: SETTER_STATE_ORDER,
+  soill: SETTER_STATE_ORDER,
+  moonboard: ['STARTING', 'HAND', 'FINISH'],
+};
+
+/** Plain-white swatch colour for the `ANY` wildcard (no LED colour of its own). */
+export const ANY_HOLD_COLOR = '#FFFFFF';
+
+export type HoldFilterOption = {
+  type: HoldFilterType;
+  /** Swatch / ring colour. */
+  color: string;
+};
+
+/**
+ * Build the ordered list of hold-type filter options for a board: the named
+ * setting roles (board-filtered) followed by the `ANY` wildcard.
+ */
+export function buildHoldFilterOptions(boardName: BoardName): HoldFilterOption[] {
+  const boardMap = HOLD_STATE_MAP[boardName];
+  const colorByState = new Map<HoldFilterType, string>();
+  if (boardMap) {
+    for (const entry of Object.values(boardMap) as HoldStateInfo[]) {
+      const name = entry.name as HoldFilterType;
+      if (!colorByState.has(name)) colorByState.set(name, entry.displayColor ?? entry.color);
+    }
+  }
+
+  const options: HoldFilterOption[] = [];
+  for (const type of PICKER_STATES_BY_BOARD[boardName] ?? SETTER_STATE_ORDER) {
+    const color = colorByState.get(type);
+    if (!color) continue;
+    options.push({ type, color });
+  }
+  options.push({ type: 'ANY', color: ANY_HOLD_COLOR });
+  return options;
+}
+
+/**
+ * Apply a single swatch tap to a hold's filter entry, given a global
+ * include/exclude apply-mode. Returns the next entry (an empty object means the
+ * hold should be dropped from the filter).
+ *
+ *   - type unset           → set to apply-mode
+ *   - type already at mode  → unset
+ *   - type at the other mode → flip to apply-mode
+ *
+ * Mirrors the web `HoldTypePicker` tap semantics so both platforms behave the
+ * same.
+ */
+export function toggleHoldFilterType(
+  entry: HoldFilterEntry,
+  type: HoldFilterType,
+  applyMode: HoldFilterMode,
+): HoldFilterEntry {
+  const next: HoldFilterEntry = { ...entry };
+  if (next[type] === applyMode) {
+    delete next[type];
+  } else {
+    next[type] = applyMode;
+  }
+  return next;
+}
+
+/** Number of holds that carry at least one active type filter. */
+export function countFilteredHolds(holdsFilter: Record<string, HoldFilterEntry> | undefined): number {
+  if (!holdsFilter) return 0;
+  let count = 0;
+  for (const entry of Object.values(holdsFilter)) {
+    if (entry && Object.keys(entry).length > 0) count += 1;
+  }
+  return count;
+}

--- a/packages/shared/climb-filters/src/hold-filter-options.ts
+++ b/packages/shared/climb-filters/src/hold-filter-options.ts
@@ -1,5 +1,5 @@
 import { HOLD_STATE_MAP } from '@boardsesh/board-constants/hold-states';
-import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType } from '@boardsesh/shared-schema';
+import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType, HoldsFilter } from '@boardsesh/shared-schema';
 
 /**
  * Hold-type swatch metadata for the search hold filter, shared by web (the
@@ -102,4 +102,48 @@ export function countFilteredHolds(holdsFilter: Record<string, HoldFilterEntry> 
     if (entry && Object.keys(entry).length > 0) count += 1;
   }
   return count;
+}
+
+const HOLD_FILTER_MODES = new Set<string>(['include', 'exclude'] satisfies HoldFilterMode[]);
+
+/**
+ * Sanitise a raw `HoldsFilter`-shaped object into one whose leaf values are
+ * guaranteed to be a valid `HoldFilterMode`. Untrusted sources (a serialized
+ * URL/handoff param) can carry an arbitrary string in a leaf slot, which would
+ * otherwise propagate to analytics and the GraphQL search query. Each per-hold
+ * entry is rebuilt keeping only `include`/`exclude` leaves; holds left with no
+ * valid leaf are dropped.
+ */
+export function sanitizeHoldsFilter(raw: Record<string, unknown>): HoldsFilter {
+  const result: HoldsFilter = {};
+  for (const [holdKey, rawEntry] of Object.entries(raw)) {
+    if (!rawEntry || typeof rawEntry !== 'object' || Array.isArray(rawEntry)) continue;
+    const entry: HoldFilterEntry = {};
+    for (const [type, mode] of Object.entries(rawEntry as Record<string, unknown>)) {
+      if (typeof mode === 'string' && HOLD_FILTER_MODES.has(mode)) {
+        entry[type as HoldFilterType] = mode as HoldFilterMode;
+      }
+    }
+    if (Object.keys(entry).length > 0) result[holdKey] = entry;
+  }
+  return result;
+}
+
+/**
+ * Parse a serialized `HoldsFilter` JSON string (e.g. a navigation/handoff param)
+ * into a validated `HoldsFilter`. Returns `{}` for missing, malformed, or
+ * non-object input, and strips any leaf value that isn't a valid
+ * `HoldFilterMode` (see {@link sanitizeHoldsFilter}).
+ */
+export function parseHoldsFilter(raw: string | undefined | null): HoldsFilter {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return sanitizeHoldsFilter(parsed as Record<string, unknown>);
+    }
+  } catch {
+    // Malformed param → start empty rather than crash.
+  }
+  return {};
 }

--- a/packages/shared/climb-filters/src/hold-filter-options.ts
+++ b/packages/shared/climb-filters/src/hold-filter-options.ts
@@ -1,4 +1,4 @@
-import { HOLD_STATE_MAP, type HoldStateInfo } from '@boardsesh/board-constants/hold-states';
+import { HOLD_STATE_MAP } from '@boardsesh/board-constants/hold-states';
 import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType } from '@boardsesh/shared-schema';
 
 /**
@@ -14,6 +14,10 @@ import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType } from 
 
 // Display order of the named setting roles in the picker.
 const SETTER_STATE_ORDER: readonly HoldFilterType[] = ['STARTING', 'HAND', 'FINISH', 'FOOT'];
+
+// Membership guard for narrowing `HOLD_STATE_MAP` entry names (a `HoldState`,
+// which also includes OFF/NOT/AUX/ANY) down to a selectable `HoldFilterType`.
+const SETTER_STATE_ORDER_SET = new Set<string>(SETTER_STATE_ORDER);
 
 // Per-board allowlist of selectable named states. MoonBoard climbs are
 // STARTING / HAND / FINISH only — its extra HOLD_STATE_MAP entries exist to
@@ -45,7 +49,10 @@ export function buildHoldFilterOptions(boardName: BoardName): HoldFilterOption[]
   const boardMap = HOLD_STATE_MAP[boardName];
   const colorByState = new Map<HoldFilterType, string>();
   if (boardMap) {
-    for (const entry of Object.values(boardMap) as HoldStateInfo[]) {
+    for (const entry of Object.values(boardMap)) {
+      // Skip non-selectable states (OFF / NOT / AUX / ANY) so the narrowing to
+      // HoldFilterType is sound — no unsafe cast.
+      if (!SETTER_STATE_ORDER_SET.has(entry.name)) continue;
       const name = entry.name as HoldFilterType;
       if (!colorByState.has(name)) colorByState.set(name, entry.displayColor ?? entry.color);
     }

--- a/packages/shared/climb-filters/src/index.ts
+++ b/packages/shared/climb-filters/src/index.ts
@@ -5,3 +5,5 @@ export * from './filter-summary';
 export * from './filter-state';
 export * from './board-filter-state';
 export * from './active-filter-count';
+export * from './climb-zone-math';
+export * from './hold-filter-options';

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -754,6 +754,27 @@
         "draftToast": "Draft saved",
         "publishedToast": "Climb published"
       }
+    },
+    "holdFilter": {
+      "title": "Hold types",
+      "pickerTitle": "Hold filter",
+      "include": "Include",
+      "exclude": "Exclude",
+      "applyModeLabel": "Include or exclude",
+      "includedSuffix": "included",
+      "excludedSuffix": "excluded",
+      "clearHold": "Clear hold",
+      "pickerHelp": "Tap a swatch to include or exclude that hold type. Switch the toggle to flip a hold to exclude.",
+      "hint": "Tap holds on the board to filter by which type they must be.",
+      "summaryCount_one": "{{count}} hold",
+      "summaryCount_other": "{{count}} holds",
+      "type": {
+        "starting": "Start",
+        "hand": "Hand",
+        "finish": "Finish",
+        "foot": "Foot",
+        "any": "Any"
+      }
     }
   }
 }

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -39,7 +39,8 @@
       "climbs": "Climbs",
       "climb": "Climb",
       "profile": "Profile",
-      "setters": "Setters"
+      "setters": "Setters",
+      "holdFilter": "Hold types"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -754,6 +754,27 @@
         "draftToast": "Borrador guardado",
         "publishedToast": "Vía publicada"
       }
+    },
+    "holdFilter": {
+      "title": "Tipos de presa",
+      "pickerTitle": "Filtro de presas",
+      "include": "Incluir",
+      "exclude": "Excluir",
+      "applyModeLabel": "Incluir o excluir",
+      "includedSuffix": "incluida",
+      "excludedSuffix": "excluida",
+      "clearHold": "Borrar presa",
+      "pickerHelp": "Toca un color para incluir o excluir ese tipo de presa. Cambia el interruptor para pasar una presa a excluir.",
+      "hint": "Toca las presas del muro para filtrar por el tipo que deben ser.",
+      "summaryCount_one": "{{count}} presa",
+      "summaryCount_other": "{{count}} presas",
+      "type": {
+        "starting": "Inicio",
+        "hand": "Mano",
+        "finish": "Final",
+        "foot": "Pie",
+        "any": "Cualquiera"
+      }
     }
   }
 }

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -237,7 +237,8 @@
       "climbs": "Bloques",
       "climb": "Bloque",
       "profile": "Perfil",
-      "setters": "Equipadores"
+      "setters": "Equipadores",
+      "holdFilter": "Tipos de presa"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -754,6 +754,27 @@
         "draftToast": "Brouillon enregistré",
         "publishedToast": "Voie publiée"
       }
+    },
+    "holdFilter": {
+      "title": "Types de prise",
+      "pickerTitle": "Filtre de prises",
+      "include": "Inclure",
+      "exclude": "Exclure",
+      "applyModeLabel": "Inclure ou exclure",
+      "includedSuffix": "incluse",
+      "excludedSuffix": "exclue",
+      "clearHold": "Effacer la prise",
+      "pickerHelp": "Touchez une pastille pour inclure ou exclure ce type de prise. Changez le sélecteur pour passer une prise en exclusion.",
+      "hint": "Touchez les prises du mur pour filtrer selon le type requis.",
+      "summaryCount_one": "{{count}} prise",
+      "summaryCount_other": "{{count}} prises",
+      "type": {
+        "starting": "Départ",
+        "hand": "Main",
+        "finish": "Arrivée",
+        "foot": "Pied",
+        "any": "Toute"
+      }
     }
   }
 }

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -39,7 +39,8 @@
       "climbs": "Blocs",
       "climb": "Bloc",
       "profile": "Profil",
-      "setters": "Ouvreurs"
+      "setters": "Ouvreurs",
+      "holdFilter": "Types de prise"
     }
   },
   "lightControl": {

--- a/packages/web/app/components/search-drawer/climb-zone-math.ts
+++ b/packages/web/app/components/search-drawer/climb-zone-math.ts
@@ -1,168 +1,21 @@
-import type { ZoneBox } from '@/app/lib/types';
-
 /**
- * Bounding edges of the board playing surface in placement-grid coordinates.
- * Matches the `edge_*` fields on `BoardDetails`.
- */
-export type BoardEdges = {
-  edgeLeft: number;
-  edgeRight: number;
-  edgeBottom: number;
-  edgeTop: number;
-};
-
-export type DragMode = 'move' | 'nw' | 'ne' | 'sw' | 'se';
-
-/**
- * Default zone covers the inner 60% of the board so the user immediately
- * sees a visible rectangle they can manipulate.
- */
-export function buildDefaultZone(edges: BoardEdges): ZoneBox {
-  const widthGrid = edges.edgeRight - edges.edgeLeft;
-  const heightGrid = edges.edgeTop - edges.edgeBottom;
-  const padX = Math.round(widthGrid * 0.2);
-  const padY = Math.round(heightGrid * 0.2);
-  return {
-    edgeLeft: edges.edgeLeft + padX,
-    edgeRight: edges.edgeRight - padX,
-    edgeBottom: edges.edgeBottom + padY,
-    edgeTop: edges.edgeTop - padY,
-  };
-}
-
-/**
- * Constrain a (potentially mid-drag) box to fit inside the board edges
- * and respect the 5%-of-board minimum size.
- */
-export function clampZoneBox(box: ZoneBox, edges: BoardEdges): ZoneBox {
-  const minWidth = Math.max(1, Math.round((edges.edgeRight - edges.edgeLeft) * 0.05));
-  const minHeight = Math.max(1, Math.round((edges.edgeTop - edges.edgeBottom) * 0.05));
-  let { edgeLeft: l, edgeRight: r, edgeBottom: b, edgeTop: t } = box;
-  l = Math.max(edges.edgeLeft, Math.min(l, edges.edgeRight - minWidth));
-  r = Math.min(edges.edgeRight, Math.max(r, l + minWidth));
-  b = Math.max(edges.edgeBottom, Math.min(b, edges.edgeTop - minHeight));
-  t = Math.min(edges.edgeTop, Math.max(t, b + minHeight));
-  return {
-    edgeLeft: Math.round(l),
-    edgeRight: Math.round(r),
-    edgeBottom: Math.round(b),
-    edgeTop: Math.round(t),
-  };
-}
-
-/**
- * Apply a drag delta (in grid coordinates) to a starting box, given the
- * drag mode (which corner / move). Edge handles in the SVG correspond to
- * grid-axis pairs as follows: visually-upper-Y = larger `edgeTop`,
- * visually-lower-Y = smaller `edgeBottom`.
- */
-export function applyDrag(startBox: ZoneBox, mode: DragMode, dx: number, dy: number, edges: BoardEdges): ZoneBox {
-  if (mode === 'move') {
-    const widthGrid = startBox.edgeRight - startBox.edgeLeft;
-    const heightGrid = startBox.edgeTop - startBox.edgeBottom;
-    const next: ZoneBox = {
-      edgeLeft: startBox.edgeLeft + dx,
-      edgeRight: startBox.edgeRight + dx,
-      edgeBottom: startBox.edgeBottom + dy,
-      edgeTop: startBox.edgeTop + dy,
-    };
-    if (next.edgeLeft < edges.edgeLeft) {
-      next.edgeLeft = edges.edgeLeft;
-      next.edgeRight = edges.edgeLeft + widthGrid;
-    }
-    if (next.edgeRight > edges.edgeRight) {
-      next.edgeRight = edges.edgeRight;
-      next.edgeLeft = edges.edgeRight - widthGrid;
-    }
-    if (next.edgeBottom < edges.edgeBottom) {
-      next.edgeBottom = edges.edgeBottom;
-      next.edgeTop = edges.edgeBottom + heightGrid;
-    }
-    if (next.edgeTop > edges.edgeTop) {
-      next.edgeTop = edges.edgeTop;
-      next.edgeBottom = edges.edgeTop - heightGrid;
-    }
-    return clampZoneBox(next, edges);
-  }
-  const next: ZoneBox = { ...startBox };
-  if (mode === 'nw' || mode === 'sw') next.edgeLeft = startBox.edgeLeft + dx;
-  if (mode === 'ne' || mode === 'se') next.edgeRight = startBox.edgeRight + dx;
-  if (mode === 'nw' || mode === 'ne') next.edgeTop = startBox.edgeTop + dy;
-  if (mode === 'sw' || mode === 'se') next.edgeBottom = startBox.edgeBottom + dy;
-  return clampZoneBox(next, edges);
-}
-
-export type BoardDimensions = BoardEdges & {
-  boardWidth: number;
-  boardHeight: number;
-};
-
-/**
- * Convert a grid-coordinate point to SVG-pixel coordinates.
- * Mirrors the math in `board-constants.ts` so the rectangle lines up with
- * the rendered hold positions.
- */
-export function gridToSvg(x: number, y: number, dims: BoardDimensions): { x: number; y: number } {
-  const xSpacing = dims.boardWidth / (dims.edgeRight - dims.edgeLeft);
-  const ySpacing = dims.boardHeight / (dims.edgeTop - dims.edgeBottom);
-  return {
-    x: (x - dims.edgeLeft) * xSpacing,
-    y: dims.boardHeight - (y - dims.edgeBottom) * ySpacing,
-  };
-}
-
-/**
- * Inverse of `gridToSvg` — translate a point in SVG coordinate space back
- * to grid coordinates. Used to convert a pointer event (after applying
- * the SVG's screen CTM) back to where the user is in board space.
- */
-export function svgToGrid(svgX: number, svgY: number, dims: BoardDimensions): { x: number; y: number } {
-  const xSpacing = dims.boardWidth / (dims.edgeRight - dims.edgeLeft);
-  const ySpacing = dims.boardHeight / (dims.edgeTop - dims.edgeBottom);
-  return {
-    x: svgX / xSpacing + dims.edgeLeft,
-    y: dims.edgeBottom + (dims.boardHeight - svgY) / ySpacing,
-  };
-}
-
-/**
- * Pick a sensible handle radius in SVG units. Scales with board size but
- * clamps against absolute lower/upper bounds so handles never overlap on
- * tiny boards or balloon to cover half the rectangle on huge ones.
- */
-export function computeHandleRadius(dims: BoardDimensions): number {
-  const HANDLE_FRACTION = 0.04;
-  const MIN_HANDLE = 8;
-  const MAX_HANDLE = 40;
-  const fromBoard = Math.max(dims.boardWidth, dims.boardHeight) * HANDLE_FRACTION;
-  return Math.max(MIN_HANDLE, Math.min(MAX_HANDLE, fromBoard));
-}
-
-/**
- * Whether a hold sits inside (or on the edge of) a zone box. `cx`/`cy` come
- * from `BoardDetails.holdsData` in SVG-pixel space (see board-constants.ts);
- * the zone box is in grid coordinates, so we run the hold position through
- * `svgToGrid` and compare against the box edges.
+ * The zone-rectangle geometry now lives in the shared `@boardsesh/climb-filters`
+ * package so web and mobile share one implementation. This module re-exports it
+ * so existing relative imports (`../climb-zone-math`) keep working.
  *
- * Inclusive on all four sides — the backend zone filter keeps a climb if
- * every hold fits inside the box, so a hold exactly on the edge still
- * leaves the climb eligible.
- *
- * Returns `true` for a null/undefined zone — semantically "no zone
- * constraint = every hold is unconstrained" — so callers that prune holds
- * after a zone change can pass `null` without a separate guard.
+ * The shared functions are typed against {@link import('@boardsesh/shared-schema').ZoneBoxInput},
+ * which is structurally identical to the web `ZoneBox` alias, so call sites that
+ * pass a `ZoneBox` continue to type-check.
  */
-export function isHoldInsideZone(
-  hold: { cx: number; cy: number },
-  zone: ZoneBox | null | undefined,
-  dims: BoardDimensions,
-): boolean {
-  if (!zone) return true;
-  const gridPoint = svgToGrid(hold.cx, hold.cy, dims);
-  return (
-    gridPoint.x >= zone.edgeLeft &&
-    gridPoint.x <= zone.edgeRight &&
-    gridPoint.y >= zone.edgeBottom &&
-    gridPoint.y <= zone.edgeTop
-  );
-}
+export {
+  buildDefaultZone,
+  clampZoneBox,
+  applyDrag,
+  gridToSvg,
+  svgToGrid,
+  computeHandleRadius,
+  isHoldInsideZone,
+  type BoardEdges,
+  type DragMode,
+  type BoardDimensions,
+} from '@boardsesh/climb-filters';


### PR DESCRIPTION
## Why

The web search drawer lets climbers filter by hold type — "must include a start hold here", "must not use this foot hold there". Mobile (the React Native app replacing the Capacitor app) was missing it. ~20 users reached for the hold filter on the old app, ~19 for the zone filter.

## What ships

A **Hold types** entry in the ClimbFilterSheet's Refine section (a `tappableRow` with a count/None trailing summary + chevron, also folded into the Refine active-filter summary). It opens a full-screen interactive board sub-screen (`app/(tabs)/climbs/holds.tsx`):

- Board = `BoardImageNative` + `useZoomPanGesture` with RN-View hold targets/rings **inside** the zoom transform (the create-board gesture model, not the SVG thumbnail renderer).
- Tapping a hold opens a picker sheet: an **Include / Exclude** apply-mode toggle + one swatch per hold type. Swatches are board-filtered (MoonBoard drops FOOT; every board gets the `ANY` wildcard) with colours from `HOLD_STATE_MAP`. Tap-cycle = set → apply-mode, re-tap → unset, other-mode → flip (matches the web `HoldTypePicker`).
- Active filters render as concentric rings + an exclude scrim on the board (`SearchHoldFilterRings`, the RN-View port of the web `SearchHoldFilterOverlay`).
- Edits hand back to the sheet via a `subscribeToHoldsFilterSelection` channel mirroring the existing setters handoff, so the rest of the in-progress filters keep their state.

**Both UI variants** are covered by reusing the variant-aware primitives (`Sheet`/`GlassSurface`, `SegmentedControl`, theme tokens) — one screen, glass/HIG and Material 3 chrome both render from the same code, gated only where the primitives already gate on `useTheme().variant`.

The filter **changes results, not just the UI**: board filters already flow through `mergeBoardFilters` into the `ClimbSearchInput` GraphQL query, and the backend already validates `holdsFilter`. The live "Show N" count already recomputes from `localBoardFilters`.

### Shared extraction (extract-don't-duplicate)

- `climb-zone-math` (`buildDefaultZone`, `applyDrag`, `clampZoneBox`, `gridToSvg`/`svgToGrid`, `computeHandleRadius`, `isHoldInsideZone`) moved from `packages/web` into `@boardsesh/climb-filters`; web now re-exports it (existing relative imports unchanged, 58 web zone-math/search-form tests still green).
- `hold-filter-options` (per-board swatch list + `toggleHoldFilterType` + `countFilteredHolds`) added to the shared package, used by mobile and ready for web to adopt.
- New `SHARED_EVENTS`: `Search Hold Filter Changed` / `Search Hold Filter Cleared`, matching the web names and props.

## Deferred (clearly scoped follow-up)

The **zone/region** filter (the draggable rectangle) is **not** in this PR. Its pure math is already extracted and shared here, so the follow-up is just the gesture-driven board UI (pan-driven rectangle + corner handles composed `Gesture.Exclusive` with the board pinch, an `allHolds`/`anyHold` toggle, and `pruneHoldsToZone` on mode/zone change). Splitting it keeps this PR small and green rather than landing a large gesture surface unvalidated. The branch name keeps `hold-zone` for the eventual second PR.

**Mirrored boards** also remain a known follow-up: `BoardSearchConfig` doesn't carry a `mirrored` flag today, so the hold-filter board always renders un-mirrored and a mirrored search shows its hold rings on the opposite side. Fixing it means wiring `mirrored` through `BoardSearchConfig` (see the TODO comment in `holds.tsx`); deliberately out of scope here.

## How to verify

1. Open the climb filter sheet → Refine → **Hold types**.
2. On the board, tap a hold → pick Include/Exclude + a swatch → rings appear; the count updates in the sheet row and the "Show N" preview.
3. Switch to MoonBoard → FOOT swatch is gone; ANY remains.
4. Apply → the climb list filters. PostHog fires `Search Hold Filter Changed` / `Cleared`.
5. Flip the app to the Material UI variant → same flow, Material chrome.

## Validation

- `vp run typecheck` (full — web touched): pass
- `vp test --project mobile`: 1234 pass (adds a `holds.tsx` screen test)
- `vp test --project climb-filters`: 165 pass
- `vp run check:mobile-bundle`: iOS + Android OK
- `vp check`: pass on changed files; web zone-math/search-form tests (58) pass

## Risks / notes

- `bun.lock` gains one edge (`@boardsesh/climb-filters` → `@boardsesh/board-constants`) for the shared swatch colours; portable, no new external dep.
- No native deps added — rides OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
