### PR TITLE
perf(mobile): open play drawer before queue state updates on climb press

### DIFF
--- a/packages/mobile/src/components/GlassSheetBackground.tsx
+++ b/packages/mobile/src/components/GlassSheetBackground.tsx
@@ -15,13 +15,22 @@ import { sheetStyles } from '../theme/tokens';
  * from gorhom positions the fill; the sheet corner radii round the top and
  * `overflow: 'hidden'` clips the blur fallback to those corners.
  */
-export function GlassSheetBackground({ style, pointerEvents }: BottomSheetBackgroundProps) {
+type GlassSheetBackgroundProps = BottomSheetBackgroundProps & {
+  /**
+   * Square off the top corners for full-screen presentations (the play drawer
+   * now-playing takeover). Overrides both the iOS top radius and the Material
+   * 28dp corners so the sheet reads as a screen, not a panel.
+   */
+  flatTop?: boolean;
+};
+
+export function GlassSheetBackground({ style, pointerEvents, flatTop }: GlassSheetBackgroundProps) {
   const { systemColors, sheet } = useTheme();
   return (
     <GlassSurface
       glassEffectStyle="regular"
       fallbackColor={systemColors.secondaryBackground}
-      style={[style, sheetStyles.background, sheet.corners, styles.clip]}
+      style={[style, sheetStyles.background, sheet.corners, flatTop && styles.flatTop, styles.clip]}
       pointerEvents={pointerEvents}
     />
   );
@@ -30,5 +39,9 @@ export function GlassSheetBackground({ style, pointerEvents }: BottomSheetBackgr
 const styles = StyleSheet.create({
   clip: {
     overflow: 'hidden',
+  },
+  flatTop: {
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0,
   },
 });

--- a/packages/mobile/src/components/play-drawer/DeferredBoard.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredBoard.tsx
@@ -48,10 +48,9 @@ type DeferredBoardProps = {
  * the board immediately with no placeholder flash — the carousel stays mounted
  * across in-drawer swipes.
  *
- * The placeholder occupies the board's exact footprint (`width: '100%'` +
- * `aspectRatio`, identical to `BoardImageNative`) so the above-fold measurement
- * that derives the peek snap-point is the same whether or not the board has
- * mounted yet — no full→peek jump.
+ * The placeholder fills the board's flex box (`flex: 1`, the same box the
+ * contained carousel lays out into) so the first-screen layout is identical
+ * whether or not the interactive board has mounted yet — no jump on open.
  */
 export const DeferredBoard = memo(function DeferredBoard({
   open,
@@ -68,7 +67,7 @@ export const DeferredBoard = memo(function DeferredBoard({
   if (!ready) {
     return (
       <View
-        style={[styles.placeholder, { aspectRatio: boardRenderData.boardWidth / boardRenderData.boardHeight }]}
+        style={styles.placeholder}
         accessibilityElementsHidden
         importantForAccessibility="no-hide-descendants"
         testID="deferred-board-placeholder"
@@ -81,7 +80,7 @@ export const DeferredBoard = memo(function DeferredBoard({
 
 const styles = StyleSheet.create({
   placeholder: {
-    width: '100%',
+    flex: 1,
     // Faint board-coloured fill so the present animation lands on a soft skeleton
     // rather than a hard gap. No image decode, no gesture handlers — cheap to
     // mount on the present frame. Matches the section skeleton tint used

--- a/packages/mobile/src/components/play-drawer/DeferredSections.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredSections.tsx
@@ -19,7 +19,8 @@ type DeferredSectionsProps = {
   angle: number;
   enabled: boolean;
   onSimilarClimbPress: (climb: Climb) => void;
-  /** Reports the measured height of the Beta Videos section header (drives peek snap-point). */
+  /** Reports the measured height of the Beta Videos section header (drives the play
+   *  drawer's first-screen reserve so the header teases at the bottom of the fold). */
   onBetaHeaderLayout?: (height: number) => void;
 };
 
@@ -62,11 +63,11 @@ export const DeferredSections = memo(function DeferredSections({
   }
 
   // Beta Videos section renders eagerly so its header height is laid out
-  // immediately — this is what drives the play drawer's peek snap-point.
-  // Without eager render the snap-point would only become known after
-  // InteractionManager fires, causing the drawer to visibly jump from full
-  // to peek on first open. BetaVideosSection's data fetch is React Query and
-  // cheap to schedule; only the JS-heavy sub-sections wait below.
+  // immediately — this is what drives the play drawer's first-screen reserve
+  // (the header teases at the bottom of the fold). Without eager render the
+  // reserve would only settle after InteractionManager fires, causing the board
+  // to visibly resize on first open. BetaVideosSection's data fetch is React
+  // Query and cheap to schedule; only the JS-heavy sub-sections wait below.
   return (
     <View style={styles.container}>
       <CollapsibleSection title={t('mobile.betaVideos.title')} keepExpanded onHeaderLayout={onBetaHeaderLayout}>

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -23,6 +23,7 @@ import { PlayDrawerHeader } from './PlayDrawerHeader';
 import { PlayDrawerActionBar } from './PlayDrawerActionBar';
 import { LogAscentSheet } from '../LogAscentSheet';
 import { DeferredSections } from './DeferredSections';
+import { computeFirstScreenHeight } from './play-drawer-layout';
 import { AngleSelectorSheet } from './AngleSelectorSheet';
 import { ClimbActionsSheet } from '../ClimbActionsSheet';
 import { BleControlSheet } from '../ble/BleControlSheet';
@@ -583,11 +584,13 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   // The first screen is sized so the action bar stays visible and the Beta
   // Videos header teases at the bottom across board sizes — the carousel fits
   // the leftover space (SwipeBoardCarousel contains the board). Reserve the
-  // home-indicator inset, the DeferredSections top padding, the beta header,
-  // and a small margin so that header peeks just above the fold.
+  // DeferredSections top padding, the beta header, and a small margin so that
+  // header peeks just above the fold. The home-indicator inset belongs to the
+  // scroll view's paddingBottom only — counting it here too would shrink the
+  // board by that inset twice.
   const firstScreenReserve =
-    insets.bottom + spacing[3] + (betaHeaderHeight > 0 ? betaHeaderHeight : DEFAULT_BETA_HEADER_HEIGHT) + spacing[2];
-  const firstScreenHeight = Math.max(windowHeight - firstScreenReserve, windowHeight * 0.5);
+    spacing[3] + (betaHeaderHeight > 0 ? betaHeaderHeight : DEFAULT_BETA_HEADER_HEIGHT) + spacing[2];
+  const firstScreenHeight = computeFirstScreenHeight(windowHeight, firstScreenReserve);
 
   const ascentCount = displayedClimb?.userAscents ?? 0;
   const supportsMirroring = boardSupportsMirroring(boardName, layoutId);

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -1,14 +1,13 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
-import { View, Pressable, StyleSheet, type LayoutChangeEvent } from 'react-native';
+import { View, Pressable, StyleSheet, useWindowDimensions } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   BottomSheetModal,
   BottomSheetBackdrop,
-  BottomSheetHandle,
   BottomSheetScrollView,
   type BottomSheetBackdropProps,
-  type BottomSheetHandleProps,
+  type BottomSheetBackgroundProps,
 } from '@gorhom/bottom-sheet';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
@@ -97,12 +96,24 @@ type PlayDrawerProps = {
   onOpenQueue: () => void;
 };
 
+// Full-screen now-playing takeover: a single 100% snap, no peek detent. The
+// mini-player (PersistentQueueBar) is the collapsed state, like Spotify.
+const SNAP_POINTS = ['100%'];
+// Fallback used for the first-screen reserve before the Beta Videos header has
+// been measured, so the board fits without a visible jump on first open.
+const DEFAULT_BETA_HEADER_HEIGHT = 52;
+// No gorhom handle — at topInset 0 it would sit under the notch. A grabber is
+// rendered inside the content instead; swipe-to-close still works via
+// enablePanDownToClose + enableContentPanningGesture.
+const renderNoHandle = () => null;
+
 export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function PlayDrawer(
   { boardConfig, onAngleChange, isAngleAdjustable = true, onOpenQueue },
   ref,
 ) {
   const { t } = useTranslation('session');
   const insets = useSafeAreaInsets();
+  const { height: windowHeight } = useWindowDimensions();
   const sheetRef = useRef<BottomSheetModal>(null);
   const [drawerPreviewItem, setDrawerPreviewItem] = useState<ClimbQueueItem | null>(null);
   const [drawerPreviewSuggestionSource, setDrawerPreviewSuggestionSource] = useState<PlaylistSuggestionSource | null>(
@@ -118,32 +129,13 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const wallControlPressOperationRef = useRef(0);
   const resetZoomRef = useRef<(() => void) | null>(null);
 
-  // Measured heights driving the peek snap-point. The peek opens the drawer
-  // just far enough to reveal the Beta Videos section header. Because board
-  // carousel height varies by board/layout and the gorhom handle owns its own
-  // padding, every contributor is measured at runtime rather than hardcoded.
-  const [handleHeight, setHandleHeight] = useState(0);
-  const [aboveFoldHeight, setAboveFoldHeight] = useState(0);
+  // Beta Videos section-header height feeds the first-screen reserve so the
+  // header teases at the bottom of the full-screen view (the cue that there's
+  // more to scroll). Measured because it varies with locale / font scaling.
   const [betaHeaderHeight, setBetaHeaderHeight] = useState(0);
-
-  const setHeightIfChanged = (setter: (updater: (prev: number) => number) => void, measured: number) => {
-    setter((prev) => (Math.abs(prev - measured) > 2 ? Math.round(measured) : prev));
-  };
-  const handleHandleLayout = useCallback((event: LayoutChangeEvent) => {
-    setHeightIfChanged(setHandleHeight, event.nativeEvent.layout.height);
-  }, []);
-  const handleAboveFoldLayout = useCallback((event: LayoutChangeEvent) => {
-    setHeightIfChanged(setAboveFoldHeight, event.nativeEvent.layout.height);
-  }, []);
   const handleBetaHeaderLayout = useCallback((measured: number) => {
-    setHeightIfChanged(setBetaHeaderHeight, measured);
+    setBetaHeaderHeight((prev) => (Math.abs(prev - measured) > 2 ? Math.round(measured) : prev));
   }, []);
-
-  // Tracks the last climb the corrective snap fired for. Without this, every
-  // aboveFold re-measurement on climb-switch would yank a user-expanded sheet
-  // back to peek; gating on UUID means the snap fires exactly once per climb
-  // and leaves manual user expansion alone afterwards.
-  const lastSnappedClimbUuidRef = useRef<string | null>(null);
 
   const {
     state,
@@ -310,7 +302,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       setIsTickBarActive(false);
       setIsSheetOpen(true);
       setActiveSubDrawer('none');
-      lastSnappedClimbUuidRef.current = null;
       if (selectedItem && (options?.setAsCurrent ?? true) && !isPartyPreviewOnly) {
         // Fresh activation from the list/search clears any playlist suggestion
         // source (web passes the same null option on every non-playlist set).
@@ -331,7 +322,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     setIsTickBarActive(false);
     setIsSheetOpen(false);
     setActiveSubDrawer('none');
-    lastSnappedClimbUuidRef.current = null;
   }, [cancelPendingWallControlAttempt]);
 
   const handlePrev = useCallback(() => {
@@ -583,47 +573,21 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     [],
   );
 
-  // Custom handle component wraps gorhom's default in a View whose onLayout
-  // reports the actual handle height (depends on indicator style + paddings).
-  // Memoized so gorhom doesn't see a new component identity each render.
-  const HandleComponent = useMemo(
-    () => (props: BottomSheetHandleProps) => (
-      <View onLayout={handleHandleLayout}>
-        <BottomSheetHandle {...props} indicatorStyle={sheetStyles.indicator} />
-      </View>
-    ),
-    [handleHandleLayout],
+  // Glass background with squared-off top corners so the sheet reads as a
+  // full-screen takeover, not a rounded panel.
+  const renderBackground = useCallback(
+    (props: BottomSheetBackgroundProps) => <GlassSheetBackground {...props} flatTop />,
+    [],
   );
 
-  // Sum the contributors so the Beta Videos title is fully revealed at peek
-  // with a small reveal margin below (the cue that there's more to scroll).
-  //   handleHeight     — measured: gorhom sheet handle
-  //   contentPadTop    — BottomSheetScrollView contentContainerStyle paddingTop
-  //   aboveFoldHeight  — measured: drawer header + carousel + action bar
-  //   deferredPadTop   — DeferredSections container.paddingTop (sits above Beta section)
-  //   betaHeaderHeight — measured: Beta Videos CollapsibleSection header row
-  //   revealMargin     — breathing room below the title so it doesn't hug the edge
-  const peekHeight =
-    handleHeight > 0 && aboveFoldHeight > 0 && betaHeaderHeight > 0
-      ? handleHeight + spacing[2] + aboveFoldHeight + spacing[3] + betaHeaderHeight + spacing[3]
-      : 0;
-
-  const snapPoints = useMemo<(number | string)[]>(
-    () => (peekHeight > 0 ? [peekHeight, '100%'] : ['100%']),
-    [peekHeight],
-  );
-
-  // First-frame measurement may land after the sheet has already presented at
-  // 100% — this single corrective snap settles into peek without a perceptible
-  // full-screen flash on subsequent climb opens. Guarded by a per-climb ref so
-  // it fires exactly once per climb (won't yank a user who has manually pulled
-  // the sheet to 100% while reading; subsequent height re-measurements no-op).
-  useEffect(() => {
-    if (peekHeight === 0 || !isSheetOpen || !displayedClimbUuid) return;
-    if (lastSnappedClimbUuidRef.current === displayedClimbUuid) return;
-    lastSnappedClimbUuidRef.current = displayedClimbUuid;
-    sheetRef.current?.snapToIndex(0);
-  }, [peekHeight, isSheetOpen, displayedClimbUuid]);
+  // The first screen is sized so the action bar stays visible and the Beta
+  // Videos header teases at the bottom across board sizes — the carousel fits
+  // the leftover space (SwipeBoardCarousel contains the board). Reserve the
+  // home-indicator inset, the DeferredSections top padding, the beta header,
+  // and a small margin so that header peeks just above the fold.
+  const firstScreenReserve =
+    insets.bottom + spacing[3] + (betaHeaderHeight > 0 ? betaHeaderHeight : DEFAULT_BETA_HEADER_HEIGHT) + spacing[2];
+  const firstScreenHeight = Math.max(windowHeight - firstScreenReserve, windowHeight * 0.5);
 
   const ascentCount = displayedClimb?.userAscents ?? 0;
   const supportsMirroring = boardSupportsMirroring(boardName, layoutId);
@@ -642,33 +606,34 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     <>
       <BottomSheetModal
         ref={sheetRef}
-        snapPoints={snapPoints}
+        snapPoints={SNAP_POINTS}
         index={0}
-        topInset={insets.top}
+        topInset={0}
         enablePanDownToClose
         enableContentPanningGesture={!subDrawerOpen}
         enableHandlePanningGesture={!subDrawerOpen}
         backdropComponent={renderBackdrop}
-        backgroundComponent={GlassSheetBackground}
-        handleComponent={HandleComponent}
+        backgroundComponent={renderBackground}
+        handleComponent={renderNoHandle}
         onDismiss={handleClose}
       >
-        <BottomSheetScrollView
-          style={styles.content}
-          contentContainerStyle={{ paddingTop: spacing[2], paddingBottom: insets.bottom }}
-        >
-          <Pressable
-            onPress={() => sheetRef.current?.dismiss()}
-            accessibilityRole="button"
-            accessibilityLabel={t('playView.closeAria')}
-            style={styles.closeButton}
-          >
-            <Icon name="chevron.down" size={20} color={iosSystemColors.systemGray} />
-          </Pressable>
-
+        <BottomSheetScrollView style={styles.content} contentContainerStyle={{ paddingBottom: insets.bottom }}>
           {displayedClimb && (
             <>
-              <View onLayout={handleAboveFoldLayout}>
+              <View style={[styles.firstScreen, { height: firstScreenHeight, paddingTop: insets.top }]}>
+                <View style={styles.topRow}>
+                  <View style={sheetStyles.indicator} />
+                  <Pressable
+                    onPress={() => sheetRef.current?.dismiss()}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('playView.closeAria')}
+                    style={styles.closeButton}
+                    hitSlop={8}
+                  >
+                    <Icon name="chevron.down" size={20} color={iosSystemColors.systemGray} />
+                  </Pressable>
+                </View>
+
                 <PlayDrawerHeader
                   name={displayedClimb.name}
                   difficulty={formatGrade(displayedClimb.difficulty) ?? displayedClimb.difficulty}
@@ -842,10 +807,19 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
   },
+  firstScreen: {
+    width: '100%',
+  },
+  // Centers the grabber; the close button overlays the left edge.
+  topRow: {
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   closeButton: {
     position: 'absolute',
-    top: 8,
-    left: 8,
+    top: 0,
+    left: spacing[2],
     zIndex: 2,
     width: 44,
     height: 44,

--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -1,5 +1,13 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { View, Pressable, Text, StyleSheet, useWindowDimensions, type LayoutChangeEvent } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  View,
+  Pressable,
+  Text,
+  StyleSheet,
+  useWindowDimensions,
+  type LayoutChangeEvent,
+  type ViewStyle,
+} from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useDerivedValue,
@@ -72,15 +80,34 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
 }: SwipeBoardCarouselProps) {
   const { t } = useTranslation('session');
   const { width: screenWidth } = useWindowDimensions();
-  // Starts at 0; populated by onLayout. clampTranslation returns zero for the
-  // first frame before layout fires — fine since the user can't pinch in
-  // pre-layout. The pinch hook re-reads this value, no remount needed.
-  const [containerHeight, setContainerHeight] = useState(0);
+  // Measured box the board is laid out into. The board is sized to *fit* this
+  // box (contain) so the play drawer's full-screen first view can keep the
+  // action bar and a Beta-videos teaser on screen instead of the tall board
+  // pushing them below the fold. Starts at 0; populated by onLayout. The zoom
+  // hook mirrors these into shared values, so updating after first layout
+  // doesn't rebuild the gestures.
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
+
+  const { boardWidth, boardHeight } = boardRenderData;
+  const aspectRatio = boardWidth / boardHeight;
+  // Contain the board within the measured box, preserving aspect ratio and
+  // centering. Letterboxes (vertically on tall boards, horizontally on wide
+  // ones) so the whole climb stays visible while the box drives the height.
+  const boardBox = useMemo(() => {
+    const { width, height } = containerSize;
+    if (width <= 0 || height <= 0) return null;
+    const widthAtFullHeight = height * aspectRatio;
+    return widthAtFullHeight <= width ? { width: widthAtFullHeight, height } : { width, height: width / aspectRatio };
+  }, [containerSize, aspectRatio]);
+  const boardStyle = useMemo<ViewStyle | undefined>(
+    () => (boardBox ? { width: boardBox.width, height: boardBox.height } : undefined),
+    [boardBox],
+  );
 
   const { pinchGesture, zoomPanGesture, isZoomed, isZoomedSV, resetZoom, animatedZoomStyle } = useZoomPanGesture({
     enabled,
-    containerWidth: screenWidth,
-    containerHeight,
+    containerWidth: boardBox?.width ?? screenWidth,
+    containerHeight: boardBox?.height ?? containerSize.height,
   });
 
   const onResetZoomReadyRef = useRef(onResetZoomReady);
@@ -146,7 +173,6 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
     return { opacity: 1, transform: [{ translateX: offset }] };
   });
 
-  const { boardWidth, boardHeight } = boardRenderData;
   const peekFrames = jsDirection === 'next' ? nextFrames : prevFrames;
 
   // Outer composition: pinch + swipe always. zoomPan is rendered separately
@@ -159,7 +185,10 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   );
 
   const handleLayout = useCallback((event: LayoutChangeEvent) => {
-    setContainerHeight(event.nativeEvent.layout.height);
+    const { width, height } = event.nativeEvent.layout;
+    setContainerSize((prev) =>
+      Math.abs(prev.width - width) > 1 || Math.abs(prev.height - height) > 1 ? { width, height } : prev,
+    );
   }, []);
 
   return (
@@ -176,6 +205,7 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
               boardWidth={boardWidth}
               boardHeight={boardHeight}
               mirrored={mirrored}
+              style={boardStyle}
             />
           </Animated.View>
         </Animated.View>
@@ -191,6 +221,7 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
               boardWidth={boardWidth}
               boardHeight={boardHeight}
               mirrored={mirrored}
+              style={boardStyle}
             />
           )}
         </Animated.View>
@@ -227,9 +258,12 @@ const styles = StyleSheet.create({
     flex: 1,
     width: '100%',
     overflow: 'hidden',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   boardWrapper: {
     width: '100%',
+    alignItems: 'center',
   },
   peekWrapper: {
     position: 'absolute',
@@ -237,6 +271,8 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   zoomPanOverlay: {
     position: 'absolute',

--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -24,6 +24,7 @@ import { BoardImageNative } from '../BoardImageNative';
 import { Icon } from '../Icon';
 import { useCarouselGesture } from './use-carousel-gesture';
 import { useZoomPanGesture } from './use-zoom-pan-gesture';
+import { computeContainedBoardSize } from './play-drawer-layout';
 import { timing } from '../../theme/animations';
 import { overlays } from '../../theme/tokens';
 
@@ -91,18 +92,20 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   const { boardWidth, boardHeight } = boardRenderData;
   const aspectRatio = boardWidth / boardHeight;
   // Contain the board within the measured box, preserving aspect ratio and
-  // centering. Letterboxes (vertically on tall boards, horizontally on wide
+  // centering. Letterboxes (horizontally on tall boards, vertically on wide
   // ones) so the whole climb stays visible while the box drives the height.
-  const boardBox = useMemo(() => {
-    const { width, height } = containerSize;
-    if (width <= 0 || height <= 0) return null;
-    const widthAtFullHeight = height * aspectRatio;
-    return widthAtFullHeight <= width ? { width: widthAtFullHeight, height } : { width, height: width / aspectRatio };
-  }, [containerSize, aspectRatio]);
+  const boardBox = useMemo(
+    () => computeContainedBoardSize(containerSize.width, containerSize.height, aspectRatio),
+    [containerSize, aspectRatio],
+  );
   const boardStyle = useMemo<ViewStyle | undefined>(
     () => (boardBox ? { width: boardBox.width, height: boardBox.height } : undefined),
     [boardBox],
   );
+  // The carousel works in board-width units: a letterboxed (narrower) board
+  // must slide off by its own width and the peek board must enter edge-adjacent.
+  // Using screenWidth instead leaves a gap equal to the letterbox margins.
+  const boardWidthForSwipe = boardBox?.width ?? screenWidth;
 
   const { pinchGesture, zoomPanGesture, isZoomed, isZoomedSV, resetZoom, animatedZoomStyle } = useZoomPanGesture({
     enabled,
@@ -132,7 +135,7 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
     onSwipePrevious,
     canSwipeNext,
     canSwipePrevious,
-    boardWidth: screenWidth,
+    boardWidth: boardWidthForSwipe,
     enabled,
     isZoomedSV,
   });
@@ -163,12 +166,12 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
 
   const peekStyle = useAnimatedStyle(() => {
     if (translateX.value === 0) {
-      return { opacity: 0, transform: [{ translateX: screenWidth }] };
+      return { opacity: 0, transform: [{ translateX: boardWidthForSwipe }] };
     }
     const offset = computePeekOffset({
       direction: peekDirection.value,
       swipeOffset: translateX.value,
-      viewportWidth: screenWidth,
+      viewportWidth: boardWidthForSwipe,
     });
     return { opacity: 1, transform: [{ translateX: offset }] };
   });
@@ -194,7 +197,7 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   return (
     <GestureDetector gesture={composedGesture}>
       <View style={styles.container} onLayout={handleLayout}>
-        <Animated.View style={[styles.boardWrapper, currentStyle]}>
+        <Animated.View style={[styles.boardWrapper, boardBox ? { width: boardBox.width } : null, currentStyle]}>
           <Animated.View style={animatedZoomStyle}>
             <BoardImageNative
               frames={currentFrameOverride ?? currentFrames}

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-layout.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-layout.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { computeContainedBoardSize, computeFirstScreenHeight } from '../play-drawer-layout';
+
+describe('computeContainedBoardSize', () => {
+  it('height-bounds a tall board on a wide box (horizontal letterbox)', () => {
+    // box 400x800, board aspect 0.4 → full height, width 320 < 400.
+    expect(computeContainedBoardSize(400, 800, 0.4)).toEqual({ width: 320, height: 800 });
+  });
+
+  it('width-bounds a wide board (vertical letterbox)', () => {
+    // box 400x800, board aspect 2 → full width, height 200 < 800.
+    expect(computeContainedBoardSize(400, 800, 2)).toEqual({ width: 400, height: 200 });
+  });
+
+  it('width-bounds a square board in a tall box', () => {
+    expect(computeContainedBoardSize(400, 800, 1)).toEqual({ width: 400, height: 400 });
+  });
+
+  it('height-bounds a square board in a wide box', () => {
+    expect(computeContainedBoardSize(800, 400, 1)).toEqual({ width: 400, height: 400 });
+  });
+
+  it('treats an exact fit as height-bound (boundary)', () => {
+    // box 300x400, aspect 0.75 → widthAtFullHeight === boxWidth (300).
+    expect(computeContainedBoardSize(300, 400, 0.75)).toEqual({ width: 300, height: 400 });
+  });
+
+  it('never exceeds the box on either axis', () => {
+    const box = computeContainedBoardSize(360, 500, 0.73);
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeLessThanOrEqual(360);
+    expect(box!.height).toBeLessThanOrEqual(500);
+  });
+
+  it('returns null for a not-yet-measured or invalid box', () => {
+    expect(computeContainedBoardSize(0, 800, 0.7)).toBeNull();
+    expect(computeContainedBoardSize(400, 0, 0.7)).toBeNull();
+    expect(computeContainedBoardSize(400, 800, 0)).toBeNull();
+    expect(computeContainedBoardSize(-1, 800, 0.7)).toBeNull();
+  });
+});
+
+describe('computeFirstScreenHeight', () => {
+  it('subtracts the reserve from the window when above the floor', () => {
+    expect(computeFirstScreenHeight(800, 100)).toBe(700);
+  });
+
+  it('floors at half the window when the reserve is too large', () => {
+    expect(computeFirstScreenHeight(800, 500)).toBe(400);
+  });
+
+  it('honours a custom floor fraction', () => {
+    expect(computeFirstScreenHeight(1000, 900, 0.6)).toBe(600);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/play-drawer-layout.ts
+++ b/packages/mobile/src/components/play-drawer/play-drawer-layout.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure layout math for the full-screen play drawer. Kept out of the components
+ * so the contain-fit and first-screen sizing can be unit-tested across board
+ * aspect ratios and screen sizes (the board catalog has many variants).
+ */
+
+export type BoardBox = { width: number; height: number };
+
+/**
+ * Contain a board of the given aspect ratio within a box, preserving aspect
+ * ratio and centering. Letterboxes horizontally on tall (portrait) boards and
+ * vertically on wide ones. Returns null when the box or aspect ratio isn't
+ * measurable yet (pre-layout), so callers fall back to a full-bleed default.
+ *
+ * `aspectRatio` is width / height.
+ */
+export function computeContainedBoardSize(boxWidth: number, boxHeight: number, aspectRatio: number): BoardBox | null {
+  if (boxWidth <= 0 || boxHeight <= 0 || aspectRatio <= 0) return null;
+  const widthAtFullHeight = boxHeight * aspectRatio;
+  return widthAtFullHeight <= boxWidth
+    ? { width: widthAtFullHeight, height: boxHeight }
+    : { width: boxWidth, height: boxWidth / aspectRatio };
+}
+
+/**
+ * Height of the play drawer's first screen: the window minus the reserve that
+ * keeps the action bar visible and the Beta Videos header teasing at the fold.
+ * Floored at a fraction of the window so an over-large reserve (e.g. a wildly
+ * mismeasured header) can never collapse the board to nothing.
+ */
+export function computeFirstScreenHeight(windowHeight: number, reserve: number, minFraction = 0.5): number {
+  return Math.max(windowHeight - reserve, windowHeight * minFraction);
+}

--- a/packages/mobile/src/components/play-drawer/use-carousel-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-carousel-gesture.ts
@@ -55,6 +55,14 @@ export function useCarouselGesture({
     reduceMotionSV.value = reduceMotion;
   }, [reduceMotion, reduceMotionSV]);
 
+  // Mirror the slide-off distance (board width) into a shared value so the
+  // post-layout change from screenWidth to the contained board width doesn't
+  // rebuild the gesture mid-session.
+  const boardWidthSV = useSharedValue(boardWidth);
+  useEffect(() => {
+    boardWidthSV.value = boardWidth;
+  }, [boardWidth, boardWidthSV]);
+
   const callbacksRef = useRef({ onSwipeNext, onSwipePrevious });
   callbacksRef.current = { onSwipeNext, onSwipePrevious };
 
@@ -183,7 +191,7 @@ export function useCarouselGesture({
               runOnJS(commitImmediate)('next');
             } else {
               isAnimating.value = true;
-              translateX.value = withTiming(-boardWidth, { duration: EXIT_DURATION });
+              translateX.value = withTiming(-boardWidthSV.value, { duration: EXIT_DURATION });
               runOnJS(scheduleCommit)('next');
             }
           } else if (offset > SWIPE_THRESHOLD && canSwipePrevious) {
@@ -192,7 +200,7 @@ export function useCarouselGesture({
               runOnJS(commitImmediate)('previous');
             } else {
               isAnimating.value = true;
-              translateX.value = withTiming(boardWidth, { duration: EXIT_DURATION });
+              translateX.value = withTiming(boardWidthSV.value, { duration: EXIT_DURATION });
               runOnJS(scheduleCommit)('previous');
             }
           } else {
@@ -202,7 +210,7 @@ export function useCarouselGesture({
     [
       canSwipeNext,
       canSwipePrevious,
-      boardWidth,
+      boardWidthSV,
       translateX,
       isAnimating,
       hasTriggeredHaptic,

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -10,7 +10,7 @@
 // swaps in a richer suggestion source so swiping through the play drawer walks
 // the whole playlist.
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, startTransition } from 'react';
 import { usePlaylistClimbActivation, fetchPlaylistSuggestionClimbs } from '@boardsesh/playlists-react';
 import { getQueueBoardKey, type Climb } from '@boardsesh/queue';
 import { useQueue } from '../../providers/queue-provider';
@@ -64,7 +64,11 @@ export function usePlaylistActivation({
     () => ({
       setCurrentClimb: async (climb: Climb, options: Parameters<typeof setCurrentClimb>[1]) => {
         const item = climbToQueueItem(toSchemaClimb(climb));
-        setCurrentClimb(item, options);
+        // Mark as a non-urgent transition so React can flush the drawer's
+        // opening animation frame before processing the queue re-renders.
+        startTransition(() => {
+          setCurrentClimb(item, options);
+        });
         return item;
       },
       refreshPlaylistSuggestionSource,
@@ -111,37 +115,32 @@ export function usePlaylistActivation({
     [activeBoard, fetchPage],
   );
 
-  const onActivated = useCallback(
-    (climb: Climb) => {
-      // setAsCurrent:false — the activation already dispatched setCurrentClimb
-      // with the suggestion source; re-dispatching from the drawer would wipe
-      // that source (it has no suggestion-source argument).
-      openPlayDrawer(toSchemaClimb(climb), { setAsCurrent: false });
-    },
-    [openPlayDrawer],
-  );
-
   const activate = usePlaylistClimbActivation({
     queueApi,
     sourceId,
     allClimbs,
     resolveTarget,
     fetchClimbsForBoard,
-    onActivated,
+    // onActivated is intentionally omitted — the drawer is opened in the
+    // returned callback BEFORE activate() runs, so the BottomSheet animation
+    // starts on the same frame as the tap with no state-update work in between.
     refreshErrorMessage,
   });
 
-  // The synchronous activation phase shouldn't reject in practice (the queue
-  // dispatch is fire-and-forget), but call sites invoke this as
-  // `void activate(climb)`. Guard the floating promise so a future change can't
-  // surface an unhandled rejection; the async suggestion refresh keeps its own
-  // catch inside the shared hook (graceful degradation — the drawer is already
-  // open with the initial source built from the loaded climbs).
+  // Open the drawer immediately, then let the shared hook do its state work.
+  // The drawer receives the climb directly via open() and renders correctly
+  // before DELTA_UPDATE_CURRENT_CLIMB propagates (setAsCurrent:false prevents
+  // the drawer from re-dispatching and wiping the suggestion source).
+  // The queue dispatch inside queueApi.setCurrentClimb is wrapped in
+  // startTransition so React processes those re-renders at low priority after
+  // the animation frame runs.
   return useCallback(
-    (climb: Climb) =>
-      activate(climb).catch((error: unknown) => {
+    (climb: Climb) => {
+      openPlayDrawer(toSchemaClimb(climb), { setAsCurrent: false });
+      return activate(climb).catch((error: unknown) => {
         console.error('Playlist climb activation failed:', error);
-      }),
-    [activate],
+      });
+    },
+    [activate, openPlayDrawer],
   );
 }


### PR DESCRIPTION
## Problem

Tapping a climb in the search list has a noticeable delay before the play drawer starts animating. The drawer should feel instant.

## Root cause

Before this change, the synchronous press path was:

```
tap → createPlaylistSuggestionSource()   ← O(n) over all loaded climbs
    → setPlaylistSuggestionSourceState() ← React state update → re-renders
    → dispatch(DELTA_UPDATE_CURRENT_CLIMB) ← React state update → re-renders
    → BottomSheetModal.present()         ← animation starts HERE
```

Two React state updates (and the cascade re-renders across every `QueueContext` subscriber) happened before `present()` was ever called. The JS thread was busy rendering when it should have been starting the animation.

## Fix

Two changes in `packages/mobile/src/lib/playlists/use-playlist-activation.ts`:

1. **Open the drawer first** — `openPlayDrawer()` is called before `activate()`, so `BottomSheetModal.present()` fires on the same frame as the tap. The drawer receives the climb directly via `open(climb, …)` and renders correctly without waiting for queue state.

2. **`startTransition` around the queue dispatch** — marks `setCurrentClimb` (and the `DELTA_UPDATE_CURRENT_CLIMB` + suggestion-source state updates inside it) as non-urgent. React flushes the animation frame before processing those re-renders.

The shared hook (`use-playlist-climb-activation.ts`) is **untouched** — web behaviour is unchanged.

## Testing

- `vp run typecheck:mobile` ✅
- `vp test --project mobile` ✅
- Manual: tap a climb in the simulator — drawer snaps open with no perceptible lag