### PR TITLE
feat(mobile): board-region (zone) search filter on the interactive board

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/__tests__/zone-screen.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/zone-screen.test.tsx
@@ -222,4 +222,71 @@ describe('ZoneFilterScreen', () => {
     fireEvent.click(doneButton);
     expect(routerBack).toHaveBeenCalledTimes(1);
   });
+
+  // Route params arrive as strings from the navigator and can be malformed
+  // (manual deep link, stale handoff, the "null" string the sheet sends for an
+  // empty zone). The parse helpers must fall back to safe defaults, never crash.
+  describe('malformed route params', () => {
+    it('treats the literal "null" zoneBox string as no zone', () => {
+      routeParams.current = baseParams({ zoneBox: 'null' });
+      const { container } = render(<ZoneFilterScreen />);
+      // No zone → the add-a-region affordance, no mode island.
+      expect(container.querySelector('[data-button="mobile.zoneFilter.enable"]')).not.toBeNull();
+      expect(container.querySelector('[data-segment="allHolds"]')).toBeNull();
+    });
+
+    it('treats garbage JSON in zoneBox as no zone instead of crashing', () => {
+      routeParams.current = baseParams({ zoneBox: '{not valid json' });
+      const { container } = render(<ZoneFilterScreen />);
+      expect(container.querySelector('[data-button="mobile.zoneFilter.enable"]')).not.toBeNull();
+      expect(container.querySelector('[data-segment="allHolds"]')).toBeNull();
+    });
+
+    it('treats a zoneBox with non-numeric edges as no zone', () => {
+      routeParams.current = baseParams({
+        zoneBox: JSON.stringify({ edgeLeft: 'x', edgeRight: 80, edgeBottom: 20, edgeTop: 80 }),
+      });
+      const { container } = render(<ZoneFilterScreen />);
+      expect(container.querySelector('[data-button="mobile.zoneFilter.enable"]')).not.toBeNull();
+    });
+
+    it('falls back to allHolds for an unrecognised zoneMode value', () => {
+      routeParams.current = baseParams({
+        zoneBox: JSON.stringify({ edgeLeft: 20, edgeRight: 80, edgeBottom: 20, edgeTop: 80 }),
+        zoneMode: 'bananas',
+      });
+      const { container } = render(<ZoneFilterScreen />);
+      // The mode island renders with the safe-default mode selected.
+      const island = container.querySelector('[data-selected-key]');
+      expect(island?.getAttribute('data-selected-key')).toBe('allHolds');
+    });
+
+    it('treats garbage JSON in holdsFilter as an empty filter', () => {
+      routeParams.current = baseParams({
+        zoneBox: JSON.stringify({ edgeLeft: 20, edgeRight: 80, edgeBottom: 20, edgeTop: 80 }),
+        // Start in anyHold so flipping to allHolds runs the prune over the
+        // (defaulted-empty) holds filter and hands an empty object back.
+        zoneMode: 'anyHold',
+        holdsFilter: 'not-json',
+      });
+      const { container, unmount } = render(<ZoneFilterScreen />);
+      fireEvent.click(container.querySelector('[data-segment="allHolds"]') as HTMLButtonElement);
+      unmount();
+      const selection = emitZoneFilterSelection.mock.calls.at(-1)?.[0] as { holdsFilter?: HoldsFilter };
+      expect(selection.holdsFilter).toEqual({});
+    });
+
+    it('treats a JSON-array holdsFilter as an empty filter', () => {
+      routeParams.current = baseParams({
+        zoneBox: JSON.stringify({ edgeLeft: 20, edgeRight: 80, edgeBottom: 20, edgeTop: 80 }),
+        zoneMode: 'anyHold',
+        holdsFilter: JSON.stringify([1, 2, 3]),
+      });
+      const { container, unmount } = render(<ZoneFilterScreen />);
+      fireEvent.click(container.querySelector('[data-segment="allHolds"]') as HTMLButtonElement);
+      unmount();
+      const selection = emitZoneFilterSelection.mock.calls.at(-1)?.[0] as { holdsFilter?: HoldsFilter };
+      expect(selection.holdsFilter).toEqual({});
+    });
+  });
 });

--- a/packages/mobile/app/(tabs)/climbs/__tests__/zone-screen.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/zone-screen.test.tsx
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, useEffect, type ReactNode } from 'react';
+import type { HoldsFilter, ZoneBoxInput } from '@boardsesh/shared-schema';
+
+const track = vi.hoisted(() => vi.fn());
+const haptics = vi.hoisted(() => ({ selection: vi.fn() }));
+const emitZoneFilterSelection = vi.hoisted(() => vi.fn());
+const routerBack = vi.hoisted(() => vi.fn());
+// Mutable across tests so each can seed its own route params.
+const routeParams = vi.hoisted(() => ({ current: {} as Record<string, string> }));
+
+// A 1000x1000 board over a 100x100 grid (spacing 10). buildDefaultZone → inner
+// 60% = {20,80,20,80}. Hold 1 sits at grid (50,50) → inside; hold 2 at (5,5) →
+// outside, so the allHolds prune must drop it.
+const BOARD_HOLDS = vi.hoisted(() => ({
+  holdTargets: [
+    { id: 1, cx: 500, cy: 500, r: 10 },
+    { id: 2, cx: 50, cy: 950, r: 10 },
+  ],
+  boardWidth: 1000,
+  boardHeight: 1000,
+  edgeLeft: 0,
+  edgeRight: 100,
+  edgeBottom: 0,
+  edgeTop: 100,
+  family: 'aurora' as const,
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { onClick: onPress }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
+  useWindowDimensions: () => ({ width: 400, height: 800 }),
+}));
+
+vi.mock('expo-router', () => ({
+  useLocalSearchParams: () => routeParams.current,
+  useRouter: () => ({ back: routerBack }),
+  // Route the focus effect through a real useEffect so its cleanup (the handoff
+  // emit) fires on unmount — matching useFocusEffect's blur/unmount behaviour.
+  useFocusEffect: (effect: () => void | (() => void)) => {
+    useEffect(() => effect(), [effect]);
+  },
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 47, bottom: 0, left: 0, right: 0 }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// Heavy native children → inert stand-ins; we drive the screen via the mode
+// control + buttons, not the actual board.
+vi.mock('../../../../src/components/Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../../src/components/ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-spinner': 'true' }),
+}));
+vi.mock('../../../../src/components/Button', () => ({
+  Button: ({ title, onPress }: { title?: string; onPress?: () => void }) =>
+    createElement('button', { onClick: onPress, 'data-button': title ?? '' }, title),
+}));
+vi.mock('../../../../src/components/GlassSurface', () => ({
+  GlassSurface: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('../../../../src/components/search/InteractiveFilterBoard', () => ({
+  InteractiveFilterBoard: () => createElement('div', { 'data-board': 'true' }),
+}));
+vi.mock('../../../../src/components/search/ZoneOverlay', () => ({
+  ZoneOverlay: () => createElement('div', { 'data-overlay': 'true' }),
+}));
+
+type SegmentMockProps = {
+  options: ReadonlyArray<{ key: string; label: string }>;
+  selectedKey: string;
+  onSelect: (key: string) => void;
+};
+vi.mock('../../../../src/components/SegmentedControl', () => ({
+  SegmentedControl: ({ options, selectedKey, onSelect }: SegmentMockProps) =>
+    createElement(
+      'div',
+      { 'data-selected-key': selectedKey },
+      options.map((option) =>
+        createElement(
+          'button',
+          { key: option.key, 'data-segment': option.key, onClick: () => onSelect(option.key) },
+          option.label,
+        ),
+      ),
+    ),
+}));
+
+vi.mock('../../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { background: '#000', elevatedSurface: '#111', fill: '#222', secondaryLabel: '#999' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+
+vi.mock('../../../../src/lib/create-board-holds', () => ({
+  getCreateBoardHolds: () => BOARD_HOLDS,
+}));
+vi.mock('../../../../src/lib/zone-filter-handoff', () => ({
+  emitZoneFilterSelection: (selection: unknown) => emitZoneFilterSelection(selection),
+}));
+vi.mock('../../../../src/lib/analytics', () => ({
+  track: (name: string, props?: Record<string, unknown>) => track(name, props),
+}));
+vi.mock('../../../../src/lib/haptics', () => ({ hapticSelection: () => haptics.selection() }));
+vi.mock('../../../../src/theme/tokens', () => ({
+  spacing: { 2: 8, 3: 12, 4: 16 },
+  overlays: { scrim: 'rgba(0,0,0,0.4)' },
+}));
+
+import ZoneFilterScreen from '../zone';
+
+// Kilter layout 1 resolves to "Kilter Board Original" via getLayout — the fix
+// under test replaces the wrong family-name (`kilter`) boardLayout value.
+const KILTER_ORIGINAL_LAYOUT_NAME = 'Kilter Board Original';
+
+function baseParams(overrides: Record<string, string> = {}): Record<string, string> {
+  return {
+    boardName: 'kilter',
+    layoutId: '1',
+    sizeId: '10',
+    setIds: '1',
+    angle: '40',
+    ...overrides,
+  };
+}
+
+describe('ZoneFilterScreen', () => {
+  beforeEach(() => {
+    track.mockClear();
+    haptics.selection.mockClear();
+    emitZoneFilterSelection.mockClear();
+    routerBack.mockClear();
+    routeParams.current = baseParams();
+  });
+
+  it('shows the Add-a-region affordance when no zone is set yet', () => {
+    const { container } = render(<ZoneFilterScreen />);
+    expect(container.querySelector('[data-button="mobile.zoneFilter.enable"]')).not.toBeNull();
+    // No mode island until a zone exists.
+    expect(container.querySelector('[data-segment="allHolds"]')).toBeNull();
+  });
+
+  it('enabling a zone logs the resolved layout NAME as boardLayout (not the family)', () => {
+    const { container } = render(<ZoneFilterScreen />);
+    fireEvent.click(container.querySelector('[data-button="mobile.zoneFilter.enable"]') as HTMLButtonElement);
+    expect(track).toHaveBeenCalledWith('Search Zone Enabled', {
+      boardLayout: KILTER_ORIGINAL_LAYOUT_NAME,
+      zoneMode: 'allHolds',
+    });
+    // Regression guard: it must NOT be the board family name.
+    expect(track).not.toHaveBeenCalledWith('Search Zone Enabled', expect.objectContaining({ boardLayout: 'kilter' }));
+  });
+
+  it('clearing a zone logs Search Zone Cleared with the layout name', () => {
+    routeParams.current = baseParams({
+      zoneBox: JSON.stringify({ edgeLeft: 20, edgeRight: 80, edgeBottom: 20, edgeTop: 80 }),
+      zoneMode: 'allHolds',
+    });
+    const { container } = render(<ZoneFilterScreen />);
+    fireEvent.click(container.querySelector('[data-button="mobile.zoneFilter.clearZone"]') as HTMLButtonElement);
+    expect(track).toHaveBeenCalledWith('Search Zone Cleared', { boardLayout: KILTER_ORIGINAL_LAYOUT_NAME });
+  });
+
+  it('switching to allHolds prunes out-of-zone hold filters before handing them back', () => {
+    const startZone: ZoneBoxInput = { edgeLeft: 20, edgeRight: 80, edgeBottom: 20, edgeTop: 80 };
+    // Hold 1 sits inside the zone, hold 2 outside — only hold 1 survives the prune.
+    const startHolds: HoldsFilter = { 1: { HAND: 'include' }, 2: { FOOT: 'include' } };
+    routeParams.current = baseParams({
+      zoneBox: JSON.stringify(startZone),
+      // Start in anyHold so flipping to allHolds is what triggers the prune.
+      zoneMode: 'anyHold',
+      holdsFilter: JSON.stringify(startHolds),
+    });
+    const { container, unmount } = render(<ZoneFilterScreen />);
+
+    fireEvent.click(container.querySelector('[data-segment="allHolds"]') as HTMLButtonElement);
+
+    expect(track).toHaveBeenCalledWith('Search Zone Mode Changed', {
+      boardLayout: KILTER_ORIGINAL_LAYOUT_NAME,
+      zoneMode: 'allHolds',
+    });
+
+    // The focus-effect cleanup hands the current (pruned) selection back. The
+    // out-of-zone hold 2 must be gone; hold 1 stays.
+    unmount();
+    const selection = emitZoneFilterSelection.mock.calls.at(-1)?.[0] as {
+      zoneMode: string;
+      holdsFilter?: HoldsFilter;
+    };
+    expect(selection.zoneMode).toBe('allHolds');
+    expect(selection.holdsFilter).toEqual({ 1: { HAND: 'include' } });
+  });
+
+  it('hands the current selection back to the sheet when the screen loses focus', () => {
+    routeParams.current = baseParams({
+      zoneBox: JSON.stringify({ edgeLeft: 20, edgeRight: 80, edgeBottom: 20, edgeTop: 80 }),
+      zoneMode: 'allHolds',
+    });
+    const { unmount } = render(<ZoneFilterScreen />);
+    unmount();
+    expect(emitZoneFilterSelection).toHaveBeenCalled();
+    const selection = emitZoneFilterSelection.mock.calls.at(-1)?.[0] as { zoneBox: ZoneBoxInput | null };
+    expect(selection.zoneBox).toEqual({ edgeLeft: 20, edgeRight: 80, edgeBottom: 20, edgeTop: 80 });
+  });
+
+  it('Done pops the screen', () => {
+    const { container } = render(<ZoneFilterScreen />);
+    const doneButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'mobile.filter.done',
+    ) as HTMLButtonElement;
+    fireEvent.click(doneButton);
+    expect(routerBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/app/(tabs)/climbs/_layout.tsx
+++ b/packages/mobile/app/(tabs)/climbs/_layout.tsx
@@ -62,6 +62,16 @@ export default function ClimbsLayout() {
           headerShown: false,
         }}
       />
+      <Stack.Screen
+        name="zone"
+        options={{
+          // Full-screen interactive board for the board-region (zone) filter.
+          // Like the hold filter: owns its own header and a pushed route so the
+          // board's drag/pinch never competes with a modal sheet's pan.
+          title: t('mobile.nav.zoneFilter'),
+          headerShown: false,
+        }}
+      />
     </Stack>
   );
 }

--- a/packages/mobile/app/(tabs)/climbs/zone.tsx
+++ b/packages/mobile/app/(tabs)/climbs/zone.tsx
@@ -10,6 +10,7 @@ import {
   type BoardDimensions,
   type HoldPositionLookup,
 } from '@boardsesh/climb-filters';
+import { getLayout } from '@boardsesh/board-constants';
 import type { BoardName, HoldsFilter, ZoneBoxInput, ZoneMatchMode } from '@boardsesh/shared-schema';
 import { Text } from '../../../src/components/Text';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
@@ -34,7 +35,6 @@ type Params = {
   sizeId?: string;
   setIds?: string;
   angle?: string;
-  layoutName?: string;
   zoneBox?: string;
   zoneMode?: string;
   holdsFilter?: string;
@@ -100,7 +100,11 @@ export default function ZoneFilterScreen() {
   const layoutId = Number(params.layoutId ?? 0);
   const sizeId = Number(params.sizeId ?? 0);
   const setIds = params.setIds ?? '';
-  const layoutName = params.layoutName ?? '';
+  // The `boardLayout` analytics property is the layout NAME (e.g. "Original"),
+  // matching web's `boardDetails.layout_name`. The route's `layoutName` param
+  // carried the board family (e.g. "kilter"), so resolve the real name from the
+  // board config instead of trusting the param.
+  const layoutName = getLayout(boardName, layoutId)?.name ?? '';
 
   const [zoneBox, setZoneBox] = useState<ZoneBoxInput | null>(() => parseZoneBox(params.zoneBox));
   const [zoneMode, setZoneMode] = useState<ZoneMatchMode>(() => parseZoneMode(params.zoneMode));
@@ -252,6 +256,7 @@ export default function ZoneFilterScreen() {
           bodyLabel={t('mobile.zoneFilter.regionLabel')}
           bodyHint={t('mobile.zoneFilter.regionHint')}
           cornerLabels={cornerLabels}
+          cornerHint={t('mobile.zoneFilter.corner.hint')}
         />
       );
     },

--- a/packages/mobile/app/(tabs)/climbs/zone.tsx
+++ b/packages/mobile/app/(tabs)/climbs/zone.tsx
@@ -1,0 +1,392 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { View, Pressable, StyleSheet, useWindowDimensions } from 'react-native';
+import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import {
+  buildDefaultZone,
+  pruneHoldsToZone,
+  type BoardDimensions,
+  type HoldPositionLookup,
+} from '@boardsesh/climb-filters';
+import type { BoardName, HoldsFilter, ZoneBoxInput, ZoneMatchMode } from '@boardsesh/shared-schema';
+import { Text } from '../../../src/components/Text';
+import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
+import { Button } from '../../../src/components/Button';
+import { SegmentedControl } from '../../../src/components/SegmentedControl';
+import { GlassSurface } from '../../../src/components/GlassSurface';
+import {
+  InteractiveFilterBoard,
+  type FilterBoardTransformContext,
+} from '../../../src/components/search/InteractiveFilterBoard';
+import { ZoneOverlay, type ZoneCornerLabels } from '../../../src/components/search/ZoneOverlay';
+import { useTheme } from '../../../src/providers/theme-provider';
+import { getCreateBoardHolds } from '../../../src/lib/create-board-holds';
+import { emitZoneFilterSelection } from '../../../src/lib/zone-filter-handoff';
+import { track } from '../../../src/lib/analytics';
+import { hapticSelection } from '../../../src/lib/haptics';
+import { overlays, spacing } from '../../../src/theme/tokens';
+
+type Params = {
+  boardName?: string;
+  layoutId?: string;
+  sizeId?: string;
+  setIds?: string;
+  angle?: string;
+  layoutName?: string;
+  zoneBox?: string;
+  zoneMode?: string;
+  holdsFilter?: string;
+};
+
+// Chrome above the board (header + mode island + footer) the board height budget
+// must leave room for, so the full board fits without scroll.
+const CHROME_BUDGET = 220;
+
+function parseZoneBox(raw: string | undefined): ZoneBoxInput | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'edgeLeft' in parsed &&
+      'edgeRight' in parsed &&
+      'edgeBottom' in parsed &&
+      'edgeTop' in parsed
+    ) {
+      return parsed as ZoneBoxInput;
+    }
+  } catch {
+    // Malformed param → start with no zone rather than crash.
+  }
+  return null;
+}
+
+function parseHoldsFilter(raw: string | undefined): HoldsFilter {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as HoldsFilter;
+    }
+  } catch {
+    // Malformed param → start empty.
+  }
+  return {};
+}
+
+function parseZoneMode(raw: string | undefined): ZoneMatchMode {
+  return raw === 'anyHold' ? 'anyHold' : 'allHolds';
+}
+
+/**
+ * Full-screen board sub-screen for the board-region (zone) search filter.
+ * Mirrors the hold filter handoff: the ClimbFilterSheet pushes here with the
+ * current zone serialized, the user drags a rectangle over the board to restrict
+ * results, and the edited zone (plus a possibly-pruned hold filter) is handed
+ * back via `emitZoneFilterSelection` when the screen pops (Done or swipe-back).
+ */
+export default function ZoneFilterScreen() {
+  const params = useLocalSearchParams<Params>();
+  const router = useRouter();
+  const { t } = useTranslation('climbs');
+  const { systemColors, brandColors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
+
+  const boardName = (params.boardName ?? '') as BoardName;
+  const layoutId = Number(params.layoutId ?? 0);
+  const sizeId = Number(params.sizeId ?? 0);
+  const setIds = params.setIds ?? '';
+  const layoutName = params.layoutName ?? '';
+
+  const [zoneBox, setZoneBox] = useState<ZoneBoxInput | null>(() => parseZoneBox(params.zoneBox));
+  const [zoneMode, setZoneMode] = useState<ZoneMatchMode>(() => parseZoneMode(params.zoneMode));
+  const [holdsFilter, setHoldsFilter] = useState<HoldsFilter>(() => parseHoldsFilter(params.holdsFilter));
+
+  // Mirror the latest selection so the focus-effect cleanup hands back the
+  // current value without re-subscribing on every edit.
+  const selectionRef = useRef({ zoneBox, zoneMode, holdsFilter });
+  selectionRef.current = { zoneBox, zoneMode, holdsFilter };
+
+  const boardHolds = useMemo(() => {
+    if (!boardName) return null;
+    return getCreateBoardHolds({
+      boardName,
+      layoutId,
+      sizeId,
+      setIds: setIds.split(',').map(Number).filter(Number.isFinite),
+    });
+  }, [boardName, layoutId, sizeId, setIds]);
+
+  const dims = useMemo<BoardDimensions | null>(() => {
+    if (!boardHolds) return null;
+    return {
+      boardWidth: boardHolds.boardWidth,
+      boardHeight: boardHolds.boardHeight,
+      edgeLeft: boardHolds.edgeLeft,
+      edgeRight: boardHolds.edgeRight,
+      edgeBottom: boardHolds.edgeBottom,
+      edgeTop: boardHolds.edgeTop,
+    };
+  }, [boardHolds]);
+
+  // Hold-position lookup so switching to allHolds can prune out-of-zone holds.
+  const holdsById = useMemo<HoldPositionLookup>(() => {
+    const map = new Map<number, { cx: number; cy: number }>();
+    if (boardHolds) {
+      for (const hold of boardHolds.holdTargets) map.set(hold.id, { cx: hold.cx, cy: hold.cy });
+    }
+    return map;
+  }, [boardHolds]);
+
+  const boardRender = useMemo(() => {
+    if (!boardHolds) return { width: 0, height: 0 };
+    const boardAspect = boardHolds.boardWidth / boardHolds.boardHeight;
+    const availWidth = windowWidth - spacing[4] * 2;
+    const availHeight = Math.max(200, windowHeight - insets.top - insets.bottom - CHROME_BUDGET);
+    if (availWidth / availHeight > boardAspect) {
+      return { width: availHeight * boardAspect, height: availHeight };
+    }
+    return { width: availWidth, height: availWidth / boardAspect };
+  }, [boardHolds, windowWidth, windowHeight, insets.top, insets.bottom]);
+
+  // Hand the current selection back to the sheet whenever this screen loses
+  // focus (Done button pops, or swipe-back). Matches the hold filter handoff.
+  useFocusEffect(
+    useCallback(() => {
+      return () =>
+        emitZoneFilterSelection({
+          zoneBox: selectionRef.current.zoneBox,
+          zoneMode: selectionRef.current.zoneMode,
+          holdsFilter: selectionRef.current.holdsFilter,
+        });
+    }, []),
+  );
+
+  const done = useCallback(() => {
+    router.back();
+  }, [router]);
+
+  const handleEnable = useCallback(() => {
+    if (!dims) return;
+    const next = buildDefaultZone(dims);
+    setZoneBox(next);
+    setZoneMode('allHolds');
+    setHoldsFilter((previous) => pruneHoldsToZone(previous, next, holdsById, dims));
+    hapticSelection();
+    track(SHARED_EVENTS.SearchZoneEnabled, { boardLayout: layoutName, zoneMode: 'allHolds' });
+  }, [dims, holdsById, layoutName]);
+
+  const handleClear = useCallback(() => {
+    setZoneBox(null);
+    hapticSelection();
+    track(SHARED_EVENTS.SearchZoneCleared, { boardLayout: layoutName });
+  }, [layoutName]);
+
+  // Commit a dragged box. In allHolds mode out-of-zone hold filters can't match,
+  // so prune them; anyHold keeps them (only one climb hold must intersect).
+  const handleCommitZone = useCallback(
+    (next: ZoneBoxInput) => {
+      if (!dims) return;
+      setZoneBox(next);
+      if (zoneMode === 'allHolds') {
+        setHoldsFilter((previous) => pruneHoldsToZone(previous, next, holdsById, dims));
+      }
+      track(SHARED_EVENTS.SearchZoneUpdated, {
+        boardLayout: layoutName,
+        zoneMode,
+        width: next.edgeRight - next.edgeLeft,
+        height: next.edgeTop - next.edgeBottom,
+      });
+    },
+    [dims, holdsById, layoutName, zoneMode],
+  );
+
+  const handleModeChange = useCallback(
+    (nextMode: ZoneMatchMode) => {
+      if (!dims || !zoneBox) return;
+      setZoneMode(nextMode);
+      if (nextMode === 'allHolds') {
+        setHoldsFilter((previous) => pruneHoldsToZone(previous, zoneBox, holdsById, dims));
+      }
+      track(SHARED_EVENTS.SearchZoneModeChanged, { boardLayout: layoutName, zoneMode: nextMode });
+    },
+    [dims, holdsById, layoutName, zoneBox],
+  );
+
+  const modeOptions = useMemo(
+    () => [
+      { key: 'allHolds' as const, label: t('mobile.zoneFilter.allHolds') },
+      { key: 'anyHold' as const, label: t('mobile.zoneFilter.anyHold') },
+    ],
+    [t],
+  );
+
+  const cornerLabels = useMemo<ZoneCornerLabels>(
+    () => ({
+      nw: t('mobile.zoneFilter.corner.topLeft'),
+      ne: t('mobile.zoneFilter.corner.topRight'),
+      sw: t('mobile.zoneFilter.corner.bottomLeft'),
+      se: t('mobile.zoneFilter.corner.bottomRight'),
+    }),
+    [t],
+  );
+
+  const renderZoneOverlay = useCallback(
+    ({ pinchGesture, scaleSV, renderWidth, renderHeight }: FilterBoardTransformContext) => {
+      if (!zoneBox || !dims) return null;
+      return (
+        <ZoneOverlay
+          zoneBox={zoneBox}
+          dims={dims}
+          renderWidth={renderWidth}
+          renderHeight={renderHeight}
+          zoomScale={scaleSV}
+          onCommit={handleCommitZone}
+          boardPinch={pinchGesture}
+          brandColor={brandColors.primary}
+          scrimColor={overlays.scrim}
+          bodyLabel={t('mobile.zoneFilter.regionLabel')}
+          bodyHint={t('mobile.zoneFilter.regionHint')}
+          cornerLabels={cornerLabels}
+        />
+      );
+    },
+    [zoneBox, dims, handleCommitZone, brandColors.primary, t, cornerLabels],
+  );
+
+  if (!boardHolds || !boardName || !dims) {
+    return (
+      <View style={[styles.loading, { backgroundColor: systemColors.background }]}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  const zoneEnabled = zoneBox != null;
+
+  return (
+    <View style={[styles.container, { backgroundColor: systemColors.background }]}>
+      <View style={[styles.header, { paddingTop: insets.top + spacing[2] }]}>
+        <Text variant="title3">{t('mobile.zoneFilter.title')}</Text>
+        <View style={styles.headerActions}>
+          {zoneEnabled ? (
+            <Pressable onPress={handleClear} hitSlop={8} accessibilityRole="button">
+              <Text variant="subheadline" color={brandColors.primary}>
+                {t('mobile.filter.clearAll')}
+              </Text>
+            </Pressable>
+          ) : null}
+          <Pressable onPress={done} hitSlop={8} accessibilityRole="button">
+            <Text variant="subheadline" color={brandColors.primary} style={styles.doneLabel}>
+              {t('mobile.filter.done')}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+
+      <View style={styles.boardSection}>
+        <InteractiveFilterBoard
+          boardName={boardName}
+          layoutId={layoutId}
+          sizeId={sizeId}
+          setIds={setIds}
+          boardWidth={boardHolds.boardWidth}
+          boardHeight={boardHolds.boardHeight}
+          holdTargets={boardHolds.holdTargets}
+          renderWidth={boardRender.width}
+          renderHeight={boardRender.height}
+          renderInTransform={renderZoneOverlay}
+        />
+      </View>
+
+      {zoneEnabled ? (
+        <GlassSurface
+          glassEffectStyle="regular"
+          fallbackColor={systemColors.elevatedSurface}
+          borderRadius={16}
+          style={styles.modeIsland}
+        >
+          <SegmentedControl
+            options={modeOptions}
+            selectedKey={zoneMode}
+            onSelect={handleModeChange}
+            trackColor={systemColors.fill}
+            accessibilityLabel={t('mobile.zoneFilter.modeLabel')}
+          />
+          <Button
+            title={t('mobile.zoneFilter.clearZone')}
+            onPress={handleClear}
+            variant="outlined"
+            size="small"
+            style={styles.clearButton}
+          />
+        </GlassSurface>
+      ) : (
+        <View style={styles.enableRow}>
+          <Button title={t('mobile.zoneFilter.enable')} onPress={handleEnable} variant="filled" size="medium" />
+        </View>
+      )}
+
+      <View style={[styles.footer, { paddingBottom: insets.bottom + spacing[3] }]}>
+        <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.footerText}>
+          {zoneEnabled ? t('mobile.zoneFilter.activeHint') : t('mobile.zoneFilter.hint')}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  loading: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[2],
+  },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[4],
+  },
+  doneLabel: {
+    fontWeight: '600',
+  },
+  boardSection: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  modeIsland: {
+    marginHorizontal: spacing[4],
+    padding: spacing[3],
+    gap: spacing[2],
+  },
+  clearButton: {
+    alignSelf: 'center',
+  },
+  enableRow: {
+    paddingHorizontal: spacing[4],
+    alignItems: 'center',
+  },
+  footer: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+    alignItems: 'center',
+  },
+  footerText: {
+    textAlign: 'center',
+  },
+});

--- a/packages/mobile/app/(tabs)/climbs/zone.tsx
+++ b/packages/mobile/app/(tabs)/climbs/zone.tsx
@@ -44,19 +44,30 @@ type Params = {
 // must leave room for, so the full board fits without scroll.
 const CHROME_BUDGET = 220;
 
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
 function parseZoneBox(raw: string | undefined): ZoneBoxInput | null {
-  if (!raw) return null;
+  // Absent or the literal "null" the sheet may have sent for "no zone".
+  if (!raw || raw === 'null') return null;
   try {
     const parsed: unknown = JSON.parse(raw);
     if (
       parsed &&
       typeof parsed === 'object' &&
-      'edgeLeft' in parsed &&
-      'edgeRight' in parsed &&
-      'edgeBottom' in parsed &&
-      'edgeTop' in parsed
+      isFiniteNumber((parsed as Record<string, unknown>).edgeLeft) &&
+      isFiniteNumber((parsed as Record<string, unknown>).edgeRight) &&
+      isFiniteNumber((parsed as Record<string, unknown>).edgeBottom) &&
+      isFiniteNumber((parsed as Record<string, unknown>).edgeTop)
     ) {
-      return parsed as ZoneBoxInput;
+      const box = parsed as Record<string, number>;
+      return {
+        edgeLeft: box.edgeLeft,
+        edgeRight: box.edgeRight,
+        edgeBottom: box.edgeBottom,
+        edgeTop: box.edgeTop,
+      };
     }
   } catch {
     // Malformed param → start with no zone rather than crash.

--- a/packages/mobile/app/(tabs)/climbs/zone.tsx
+++ b/packages/mobile/app/(tabs)/climbs/zone.tsx
@@ -250,12 +250,20 @@ export default function ZoneFilterScreen() {
     [t],
   );
 
+  // Whether a zone exists at all — the only `zoneBox` change that must rebuild
+  // this callback (so the overlay mounts/unmounts). The box's *value* updates
+  // every drag commit, but ZoneOverlay re-seeds its shared values from the
+  // `zoneBox` prop in a useEffect, so feeding the live value through the stable
+  // `selectionRef` (instead of the dep array) keeps `renderZoneOverlay` — and
+  // thus InteractiveFilterBoard's memo — stable across drags.
+  const zoneActive = zoneBox != null;
   const renderZoneOverlay = useCallback(
     ({ pinchGesture, scaleSV, renderWidth, renderHeight }: FilterBoardTransformContext) => {
-      if (!zoneBox || !dims) return null;
+      const currentZoneBox = selectionRef.current.zoneBox;
+      if (!currentZoneBox || !dims) return null;
       return (
         <ZoneOverlay
-          zoneBox={zoneBox}
+          zoneBox={currentZoneBox}
           dims={dims}
           renderWidth={renderWidth}
           renderHeight={renderHeight}
@@ -271,7 +279,9 @@ export default function ZoneFilterScreen() {
         />
       );
     },
-    [zoneBox, dims, handleCommitZone, brandColors.primary, t, cornerLabels],
+    // `zoneActive` (not `zoneBox`) so the overlay mounts/unmounts but the
+    // callback stays stable while a zone is being dragged.
+    [zoneActive, dims, handleCommitZone, brandColors.primary, t, cornerLabels],
   );
 
   if (!boardHolds || !boardName || !dims) {

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -406,7 +406,10 @@ export function ClimbFilterSheet({
         sizeId: String(boardConfig.sizeId),
         setIds: boardConfig.setIds,
         angle: String(boardConfig.angle),
-        zoneBox: JSON.stringify(localBoardFilters.zoneBox ?? null),
+        // Omit zoneBox entirely when no zone is set — passing
+        // `JSON.stringify(null)` would send the literal string "null", which the
+        // parse side then has to special-case. Absent param → no zone.
+        ...(localBoardFilters.zoneBox ? { zoneBox: JSON.stringify(localBoardFilters.zoneBox) } : {}),
         zoneMode: localBoardFilters.zoneMode ?? 'allHolds',
         holdsFilter: JSON.stringify(localBoardFilters.holdsFilter ?? {}),
       },

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -406,7 +406,6 @@ export function ClimbFilterSheet({
         sizeId: String(boardConfig.sizeId),
         setIds: boardConfig.setIds,
         angle: String(boardConfig.angle),
-        layoutName: boardConfig.boardName,
         zoneBox: JSON.stringify(localBoardFilters.zoneBox ?? null),
         zoneMode: localBoardFilters.zoneMode ?? 'allHolds',
         holdsFilter: JSON.stringify(localBoardFilters.holdsFilter ?? {}),

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -51,6 +51,7 @@ import { useAuth } from '../providers/auth-provider';
 import { hapticSelection } from '../lib/haptics';
 import { subscribeToSetterSelection } from '../lib/filter-handoff';
 import { subscribeToHoldsFilterSelection } from '../lib/hold-filter-handoff';
+import { subscribeToZoneFilterSelection } from '../lib/zone-filter-handoff';
 import { springs } from '../theme/animations';
 // Aliased: the active-filter label reads scheme-aware brand from `useTheme()`.
 // `staticBrandColors` is the static set, used only for the selected chip — a FILL
@@ -180,6 +181,21 @@ export function ClimbFilterSheet({
       setLocalBoardFilters((previous) => ({
         ...previous,
         holdsFilter: Object.keys(holdsFilter).length > 0 ? holdsFilter : undefined,
+      }));
+    });
+  }, []);
+
+  useEffect(() => {
+    return subscribeToZoneFilterSelection(({ zoneBox, zoneMode, holdsFilter }) => {
+      setLocalBoardFilters((previous) => ({
+        ...previous,
+        zoneBox,
+        zoneMode: zoneBox ? zoneMode : undefined,
+        // The zone editor may have pruned out-of-zone hold filters; fold the
+        // possibly-edited holds filter back in when it handed one over.
+        ...(holdsFilter !== undefined
+          ? { holdsFilter: Object.keys(holdsFilter).length > 0 ? holdsFilter : undefined }
+          : {}),
       }));
     });
   }, []);
@@ -381,7 +397,26 @@ export function ClimbFilterSheet({
     });
   }, [router, boardConfig, localBoardFilters.holdsFilter]);
 
+  const openZoneFilter = useCallback(() => {
+    if (!boardConfig) return;
+    router.push({
+      pathname: '/(tabs)/climbs/zone',
+      params: {
+        boardName: boardConfig.boardName,
+        layoutId: String(boardConfig.layoutId),
+        sizeId: String(boardConfig.sizeId),
+        setIds: boardConfig.setIds,
+        angle: String(boardConfig.angle),
+        layoutName: boardConfig.boardName,
+        zoneBox: JSON.stringify(localBoardFilters.zoneBox ?? null),
+        zoneMode: localBoardFilters.zoneMode ?? 'allHolds',
+        holdsFilter: JSON.stringify(localBoardFilters.holdsFilter ?? {}),
+      },
+    });
+  }, [router, boardConfig, localBoardFilters.zoneBox, localBoardFilters.zoneMode, localBoardFilters.holdsFilter]);
+
   const holdFilterCount = countFilteredHolds(localBoardFilters.holdsFilter);
+  const zoneActive = localBoardFilters.zoneBox != null;
 
   const refineSummary = useMemo(() => {
     const parts: string[] = [];
@@ -395,10 +430,11 @@ export function ClimbFilterSheet({
       parts.push(t('mobile.search.settersCount', { count: localFilters.setter.length }));
     }
     if (holdFilterCount > 0) parts.push(t('mobile.holdFilter.summaryCount', { count: holdFilterCount }));
+    if (zoneActive) parts.push(t('mobile.zoneFilter.title'));
     if (localFilters.onlyTallClimbs) parts.push(t('mobile.filter.tallClimbs'));
     if (localFilters.onlyWideClimbs) parts.push(t('mobile.filter.wideClimbs'));
     return parts.join(' · ') || null;
-  }, [localFilters, accuracyLabels, holdFilterCount, t]);
+  }, [localFilters, accuracyLabels, holdFilterCount, zoneActive, t]);
 
   const advancedSummary = useMemo(() => {
     const parts: string[] = [];
@@ -591,6 +627,28 @@ export function ClimbFilterSheet({
                   {holdFilterCount > 0
                     ? t('mobile.holdFilter.summaryCount', { count: holdFilterCount })
                     : t('mobile.filter.none')}
+                </Text>
+                <Icon name="chevron.right" size={14} color={iosSystemColors.systemGray4} />
+              </View>
+            </Pressable>
+
+            <View style={styles.subsectionGap} />
+            <Pressable
+              onPress={openZoneFilter}
+              disabled={!boardConfig}
+              accessibilityRole="button"
+              accessibilityLabel={t('mobile.zoneFilter.title')}
+              style={({ pressed }) => [
+                styles.tappableRow,
+                { backgroundColor: systemColors.tertiaryBackground },
+                pressed && styles.tappableRowPressed,
+                !boardConfig && styles.tappableRowDisabled,
+              ]}
+            >
+              <Text variant="body">{t('mobile.zoneFilter.title')}</Text>
+              <View style={styles.tappableRowTrailing}>
+                <Text variant="footnote" style={styles.tappableRowValue}>
+                  {zoneActive ? t('mobile.zoneFilter.summaryActive') : t('mobile.filter.none')}
                 </Text>
                 <Icon name="chevron.right" size={14} color={iosSystemColors.systemGray4} />
               </View>

--- a/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
@@ -23,6 +23,9 @@ type UseZoomPanGestureReturn = {
   zoomPanGesture: GestureType;
   isZoomed: boolean;
   isZoomedSV: SharedValue<boolean>;
+  /** Live zoom scale on the UI thread, so an overlay inside the transform can
+   * convert screen-pixel drag deltas into unscaled board-pixel deltas. */
+  scaleSV: SharedValue<number>;
   resetZoom: () => void;
   animatedZoomStyle: AnimatedStyle;
 };
@@ -233,6 +236,7 @@ export function useZoomPanGesture({
     zoomPanGesture,
     isZoomed,
     isZoomedSV,
+    scaleSV: scale,
     resetZoom,
     animatedZoomStyle,
   };

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -160,13 +160,26 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
                 onLongPress={onHoldTap}
               />
             ) : null}
-            {renderInTransform ? renderInTransform(transformContext) : null}
           </Animated.View>
 
+          {/* 1-finger pan-to-reposition the zoomed board. Sits ABOVE the board
+              layer (so a drag over the bare board pans it) but BELOW the
+              `renderInTransform` overlay layer (so the zone rectangle + corner
+              handles still win their touches while zoomed). */}
           {isZoomed ? (
             <GestureDetector gesture={zoomPanGesture}>
               <View style={StyleSheet.absoluteFill} />
             </GestureDetector>
+          ) : null}
+
+          {/* Overlay rendered INSIDE the same zoom transform but ABOVE the
+              pan-reset layer, so its gestures (e.g. the zone rectangle) receive
+              touches even when zoomed. Its root is `pointerEvents="box-none"`,
+              so taps on empty space fall through to the pan-reset layer below. */}
+          {renderInTransform ? (
+            <Animated.View pointerEvents="box-none" style={[StyleSheet.absoluteFill, animatedZoomStyle]}>
+              {renderInTransform(transformContext)}
+            </Animated.View>
           ) : null}
 
           {isZoomed ? (

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View, StyleSheet, Pressable } from 'react-native';
-import Animated from 'react-native-reanimated';
-import { GestureDetector } from 'react-native-gesture-handler';
+import Animated, { type SharedValue } from 'react-native-reanimated';
+import { GestureDetector, type GestureType } from 'react-native-gesture-handler';
 import type { BoardName, HoldsFilter } from '@boardsesh/shared-schema';
 import { BoardImageNative } from '../BoardImageNative';
 import { Text } from '../Text';
@@ -13,6 +13,16 @@ import { overlays } from '../../theme/tokens';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
 import { SearchHoldFilterRings } from './SearchHoldFilterRings';
 
+/** Context handed to an overlay rendered inside the board's zoom transform. */
+export type FilterBoardTransformContext = {
+  /** The board's pinch gesture, to compose overlay pans Simultaneous with it. */
+  pinchGesture: GestureType;
+  /** Live zoom scale, so an overlay can convert screen-pixel deltas to board px. */
+  scaleSV: SharedValue<number>;
+  renderWidth: number;
+  renderHeight: number;
+};
+
 type InteractiveFilterBoardProps = {
   boardName: BoardName;
   layoutId: number;
@@ -21,15 +31,23 @@ type InteractiveFilterBoardProps = {
   boardWidth: number;
   boardHeight: number;
   holdTargets: BoardHoldTarget[];
-  holdsFilter: HoldsFilter;
+  /** Hold-type filter rings, when this board edits hold types. Omit for zone mode. */
+  holdsFilter?: HoldsFilter;
   /** The hold the picker is currently editing — drawn with a bright ring. */
-  activeHoldId: number | null;
-  onHoldTap: (holdId: number) => void;
+  activeHoldId?: number | null;
+  /** Tap handler that opens the hold picker. Omit to disable hold taps (zone mode). */
+  onHoldTap?: (holdId: number) => void;
   mirrored?: boolean;
   renderWidth: number;
   renderHeight: number;
   /** Optional chrome (e.g. a floating toolbar) rendered over the board canvas. */
   children?: ReactNode;
+  /**
+   * Overlay rendered INSIDE the zoom transform (like the hold filter rings) so it
+   * tracks the board at any zoom — used by the zone editor for the draggable
+   * rectangle. Receives the board pinch + live scale so its pans compose cleanly.
+   */
+  renderInTransform?: (context: FilterBoardTransformContext) => ReactNode;
 };
 
 /**
@@ -52,15 +70,16 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   boardHeight,
   holdTargets,
   holdsFilter,
-  activeHoldId,
+  activeHoldId = null,
   onHoldTap,
   mirrored = false,
   renderWidth,
   renderHeight,
   children,
+  renderInTransform,
 }: InteractiveFilterBoardProps) {
   const { t } = useTranslation('common');
-  const { pinchGesture, zoomPanGesture, isZoomed, resetZoom, animatedZoomStyle } = useZoomPanGesture({
+  const { pinchGesture, zoomPanGesture, isZoomed, scaleSV, resetZoom, animatedZoomStyle } = useZoomPanGesture({
     enabled: true,
     containerWidth: renderWidth,
     containerHeight: renderHeight,
@@ -70,6 +89,11 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   // tap to open the picker, so we route both tap and "long press" to the same
   // handler (HoldTargetLayer requires both).
   const handleHoldTap = onHoldTap;
+
+  const transformContext = useMemo<FilterBoardTransformContext>(
+    () => ({ pinchGesture, scaleSV, renderWidth, renderHeight }),
+    [pinchGesture, scaleSV, renderWidth, renderHeight],
+  );
 
   const activeHighlight = useMemo(() => {
     if (activeHoldId == null || renderWidth <= 0) return null;
@@ -113,26 +137,31 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
               boardHeight={boardHeight}
               mirrored={mirrored}
             />
-            <SearchHoldFilterRings
-              boardName={boardName}
-              holdsFilter={holdsFilter}
-              holdTargets={holdTargets}
-              boardWidth={boardWidth}
-              boardHeight={boardHeight}
-              measuredWidth={renderWidth}
-              mirrored={mirrored}
-            />
+            {holdsFilter ? (
+              <SearchHoldFilterRings
+                boardName={boardName}
+                holdsFilter={holdsFilter}
+                holdTargets={holdTargets}
+                boardWidth={boardWidth}
+                boardHeight={boardHeight}
+                measuredWidth={renderWidth}
+                mirrored={mirrored}
+              />
+            ) : null}
             {activeHighlight}
-            <HoldTargetLayer
-              holdTargets={holdTargets}
-              boardWidth={boardWidth}
-              boardHeight={boardHeight}
-              measuredWidth={renderWidth}
-              mirrored={mirrored}
-              showAllHolds
-              onPaint={handleHoldTap}
-              onLongPress={handleHoldTap}
-            />
+            {handleHoldTap ? (
+              <HoldTargetLayer
+                holdTargets={holdTargets}
+                boardWidth={boardWidth}
+                boardHeight={boardHeight}
+                measuredWidth={renderWidth}
+                mirrored={mirrored}
+                showAllHolds
+                onPaint={handleHoldTap}
+                onLongPress={handleHoldTap}
+              />
+            ) : null}
+            {renderInTransform ? renderInTransform(transformContext) : null}
           </Animated.View>
 
           {isZoomed ? (

--- a/packages/mobile/src/components/search/ZoneOverlay.tsx
+++ b/packages/mobile/src/components/search/ZoneOverlay.tsx
@@ -298,10 +298,14 @@ export const ZoneOverlay = React.memo(function ZoneOverlay({
 
   // Four scrim panels (top / bottom / left / right of the box) dim the board
   // outside the rectangle, tracking the live box.
+  // Read the mirrored render bounds (not the JS props) so a mid-session layout
+  // change (e.g. orientation flip) recomputes scrim coverage against the fresh
+  // size, matching clampRectWorklet — otherwise the bottom/right scrim panels
+  // keep the pre-rotation extent and leave the board partially undimmed.
   const scrimTopStyle = useAnimatedStyle(() => ({ height: Math.max(0, top.value) }));
   const scrimBottomStyle = useAnimatedStyle(() => ({
     top: top.value + height.value,
-    height: Math.max(0, renderHeight - (top.value + height.value)),
+    height: Math.max(0, renderHeightSV.value - (top.value + height.value)),
   }));
   const scrimLeftStyle = useAnimatedStyle(() => ({
     top: top.value,
@@ -311,7 +315,7 @@ export const ZoneOverlay = React.memo(function ZoneOverlay({
   const scrimRightStyle = useAnimatedStyle(() => ({
     left: left.value + width.value,
     top: top.value,
-    width: Math.max(0, renderWidth - (left.value + width.value)),
+    width: Math.max(0, renderWidthSV.value - (left.value + width.value)),
     height: height.value,
   }));
 

--- a/packages/mobile/src/components/search/ZoneOverlay.tsx
+++ b/packages/mobile/src/components/search/ZoneOverlay.tsx
@@ -44,6 +44,8 @@ type ZoneOverlayProps = {
   bodyLabel: string;
   bodyHint: string;
   cornerLabels: ZoneCornerLabels;
+  /** Shared resize hint announced on every corner handle (VoiceOver). */
+  cornerHint: string;
 };
 
 // A grid-space zone box → a render-pixel rectangle. gridToSvg already inverts Y
@@ -116,6 +118,7 @@ export const ZoneOverlay = React.memo(function ZoneOverlay({
   bodyLabel,
   bodyHint,
   cornerLabels,
+  cornerHint,
 }: ZoneOverlayProps) {
   const { systemColors } = useTheme();
 
@@ -133,6 +136,11 @@ export const ZoneOverlay = React.memo(function ZoneOverlay({
 
   // Board-min-size clamp bound in render pixels, mirrored onto the UI thread.
   const minRenderSize = useSharedValue(0);
+  // Board render bounds mirrored onto the UI thread too, so a mid-gesture layout
+  // change (e.g. orientation flip) clamps against the fresh size instead of the
+  // stale JS-captured numbers.
+  const renderWidthSV = useSharedValue(renderWidth);
+  const renderHeightSV = useSharedValue(renderHeight);
 
   // Sync the shared rect whenever the committed grid box (or layout) changes.
   // After a commit the prop updates and we re-seed, so drag handoff is seamless.
@@ -143,11 +151,25 @@ export const ZoneOverlay = React.memo(function ZoneOverlay({
     top.value = rect.top;
     width.value = rect.width;
     height.value = rect.height;
+    renderWidthSV.value = renderWidth;
+    renderHeightSV.value = renderHeight;
     const renderScale = renderWidth / dims.boardWidth;
     const minGrid = Math.max(1, Math.round((dims.edgeRight - dims.edgeLeft) * 0.05));
     const gridToRenderPx = (dims.boardWidth / (dims.edgeRight - dims.edgeLeft)) * renderScale;
     minRenderSize.value = minGrid * gridToRenderPx;
-  }, [zoneBox, dims, renderWidth, renderHeight, left, top, width, height, minRenderSize]);
+  }, [
+    zoneBox,
+    dims,
+    renderWidth,
+    renderHeight,
+    left,
+    top,
+    width,
+    height,
+    minRenderSize,
+    renderWidthSV,
+    renderHeightSV,
+  ]);
 
   const commit = useCallback(
     (rect: RenderRect) => {
@@ -163,21 +185,23 @@ export const ZoneOverlay = React.memo(function ZoneOverlay({
     (rect: RenderRect): RenderRect => {
       'worklet';
       const minSize = minRenderSize.value;
+      const boundWidth = renderWidthSV.value;
+      const boundHeight = renderHeightSV.value;
       let rectLeft = rect.left;
       let rectTop = rect.top;
       let rectWidth = rect.width;
       let rectHeight = rect.height;
       if (rectWidth < minSize) rectWidth = minSize;
       if (rectHeight < minSize) rectHeight = minSize;
-      if (rectWidth > renderWidth) rectWidth = renderWidth;
-      if (rectHeight > renderHeight) rectHeight = renderHeight;
+      if (rectWidth > boundWidth) rectWidth = boundWidth;
+      if (rectHeight > boundHeight) rectHeight = boundHeight;
       if (rectLeft < 0) rectLeft = 0;
       if (rectTop < 0) rectTop = 0;
-      if (rectLeft + rectWidth > renderWidth) rectLeft = renderWidth - rectWidth;
-      if (rectTop + rectHeight > renderHeight) rectTop = renderHeight - rectHeight;
+      if (rectLeft + rectWidth > boundWidth) rectLeft = boundWidth - rectWidth;
+      if (rectTop + rectHeight > boundHeight) rectTop = boundHeight - rectHeight;
       return { left: rectLeft, top: rectTop, width: rectWidth, height: rectHeight };
     },
-    [minRenderSize, renderWidth, renderHeight],
+    [minRenderSize, renderWidthSV, renderHeightSV],
   );
 
   const handleRadius = useMemo(() => {
@@ -338,6 +362,7 @@ export const ZoneOverlay = React.memo(function ZoneOverlay({
           zoneBox={zoneBox}
           onCommit={onCommit}
           label={cornerLabels[corner.mode]}
+          hint={cornerHint}
         />
       ))}
     </View>
@@ -365,6 +390,7 @@ type CornerHandleProps = {
   zoneBox: ZoneBoxInput;
   onCommit: (box: ZoneBoxInput) => void;
   label: string;
+  hint: string;
 };
 
 const CornerHandle = React.memo(function CornerHandle({
@@ -388,6 +414,7 @@ const CornerHandle = React.memo(function CornerHandle({
   zoneBox,
   onCommit,
   label,
+  hint,
 }: CornerHandleProps) {
   const { mode, anchorX, anchorY } = corner;
 
@@ -500,6 +527,7 @@ const CornerHandle = React.memo(function CornerHandle({
         accessibilityRole="adjustable"
         accessible
         accessibilityLabel={label}
+        accessibilityHint={hint}
         accessibilityActions={ACCESSIBILITY_ACTIONS}
         onAccessibilityAction={onAccessibilityAction}
         style={[styles.handleHit, handleStyle]}

--- a/packages/mobile/src/components/search/ZoneOverlay.tsx
+++ b/packages/mobile/src/components/search/ZoneOverlay.tsx
@@ -1,0 +1,539 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { StyleSheet, View, type ColorValue, type ViewStyle } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, runOnJS, type SharedValue } from 'react-native-reanimated';
+import { Gesture, GestureDetector, type GestureType } from 'react-native-gesture-handler';
+import type { ZoneBoxInput } from '@boardsesh/shared-schema';
+import {
+  clampZoneBox,
+  computeHandleRadius,
+  gridToSvg,
+  svgToGrid,
+  type BoardDimensions,
+  type DragMode,
+} from '@boardsesh/climb-filters';
+import { useTheme } from '../../providers/theme-provider';
+import { hapticSelection } from '../../lib/haptics';
+
+// Apple HIG / Material minimum touch target. Glass uses 44, Material 48; we take
+// the larger so the transparent hit area satisfies both variants.
+const MIN_HIT = 48;
+// Step (in grid units) a single VoiceOver increment/decrement resizes a corner —
+// keeps the adjustable action usable without a precise drag.
+const A11Y_STEP = 2;
+
+const ACCESSIBILITY_ACTIONS = [{ name: 'increment' as const }, { name: 'decrement' as const }];
+
+type RenderRect = { left: number; top: number; width: number; height: number };
+
+/** Per-corner a11y label (e.g. "Top-left corner"); the body uses `bodyLabel`. */
+export type ZoneCornerLabels = Record<Exclude<DragMode, 'move'>, string>;
+
+type ZoneOverlayProps = {
+  zoneBox: ZoneBoxInput;
+  dims: BoardDimensions;
+  renderWidth: number;
+  renderHeight: number;
+  /** Live zoom scale, so screen-pixel drags convert to unscaled board pixels. */
+  zoomScale: SharedValue<number>;
+  /** Commit the clamped grid box to JS state — fired once per gesture end. */
+  onCommit: (box: ZoneBoxInput) => void;
+  /** Compose each handle/body pan with the board's pinch so 2-finger still wins. */
+  boardPinch: GestureType;
+  brandColor: ColorValue;
+  scrimColor: ColorValue;
+  bodyLabel: string;
+  bodyHint: string;
+  cornerLabels: ZoneCornerLabels;
+};
+
+// A grid-space zone box → a render-pixel rectangle. gridToSvg already inverts Y
+// (grid origin bottom-left, render origin top-left), so edgeTop is the small
+// render-y and edgeBottom the large one.
+function gridBoxToRenderRect(box: ZoneBoxInput, dims: BoardDimensions, renderWidth: number): RenderRect {
+  const renderScale = renderWidth / dims.boardWidth;
+  const topLeft = gridToSvg(box.edgeLeft, box.edgeTop, dims);
+  const bottomRight = gridToSvg(box.edgeRight, box.edgeBottom, dims);
+  return {
+    left: topLeft.x * renderScale,
+    top: topLeft.y * renderScale,
+    width: (bottomRight.x - topLeft.x) * renderScale,
+    height: (bottomRight.y - topLeft.y) * renderScale,
+  };
+}
+
+// Inverse of gridBoxToRenderRect — a render-pixel rect back to a grid box, then
+// clamped (board edges + 5% min size) so what we commit always round-trips.
+function renderRectToGridBox(rect: RenderRect, dims: BoardDimensions, renderWidth: number): ZoneBoxInput {
+  const renderScale = renderWidth / dims.boardWidth;
+  const topLeftGrid = svgToGrid(rect.left / renderScale, rect.top / renderScale, dims);
+  const bottomRightGrid = svgToGrid(
+    (rect.left + rect.width) / renderScale,
+    (rect.top + rect.height) / renderScale,
+    dims,
+  );
+  return clampZoneBox(
+    {
+      edgeLeft: topLeftGrid.x,
+      edgeRight: bottomRightGrid.x,
+      // grid Y is inverted vs render Y: the rect's top edge is the larger grid Y.
+      edgeBottom: bottomRightGrid.y,
+      edgeTop: topLeftGrid.y,
+    },
+    dims,
+  );
+}
+
+type Corner = { mode: Exclude<DragMode, 'move'>; anchorX: 'left' | 'right'; anchorY: 'top' | 'bottom' };
+
+const CORNERS: ReadonlyArray<Corner> = [
+  { mode: 'nw', anchorX: 'left', anchorY: 'top' },
+  { mode: 'ne', anchorX: 'right', anchorY: 'top' },
+  { mode: 'sw', anchorX: 'left', anchorY: 'bottom' },
+  { mode: 'se', anchorX: 'right', anchorY: 'bottom' },
+];
+
+/**
+ * The draggable rectangle + 4 corner handles for the board-region search
+ * filter, rendered INSIDE `InteractiveFilterBoard`'s zoom transform (as its
+ * `children`) so it tracks the board at any zoom. The rectangle's edges live on
+ * the UI thread as shared values (in render-pixel space); pans mutate them per
+ * frame with zero React renders and commit the clamped grid box to JS only on
+ * gesture end. A scrim dims the board outside the box.
+ *
+ * Works in both UI variants: chrome is plain RN Views tinted from `useTheme()`
+ * (brand stroke, scrim), so no variant branch is needed here.
+ */
+export const ZoneOverlay = React.memo(function ZoneOverlay({
+  zoneBox,
+  dims,
+  renderWidth,
+  renderHeight,
+  zoomScale,
+  onCommit,
+  boardPinch,
+  brandColor,
+  scrimColor,
+  bodyLabel,
+  bodyHint,
+  cornerLabels,
+}: ZoneOverlayProps) {
+  const { systemColors } = useTheme();
+
+  // Live render-pixel rect, the single source of truth the gestures mutate.
+  const left = useSharedValue(0);
+  const top = useSharedValue(0);
+  const width = useSharedValue(0);
+  const height = useSharedValue(0);
+
+  // Snapshot at gesture start so per-frame updates apply against a fixed base.
+  const startLeft = useSharedValue(0);
+  const startTop = useSharedValue(0);
+  const startWidth = useSharedValue(0);
+  const startHeight = useSharedValue(0);
+
+  // Board-min-size clamp bound in render pixels, mirrored onto the UI thread.
+  const minRenderSize = useSharedValue(0);
+
+  // Sync the shared rect whenever the committed grid box (or layout) changes.
+  // After a commit the prop updates and we re-seed, so drag handoff is seamless.
+  useEffect(() => {
+    if (renderWidth <= 0 || renderHeight <= 0) return;
+    const rect = gridBoxToRenderRect(zoneBox, dims, renderWidth);
+    left.value = rect.left;
+    top.value = rect.top;
+    width.value = rect.width;
+    height.value = rect.height;
+    const renderScale = renderWidth / dims.boardWidth;
+    const minGrid = Math.max(1, Math.round((dims.edgeRight - dims.edgeLeft) * 0.05));
+    const gridToRenderPx = (dims.boardWidth / (dims.edgeRight - dims.edgeLeft)) * renderScale;
+    minRenderSize.value = minGrid * gridToRenderPx;
+  }, [zoneBox, dims, renderWidth, renderHeight, left, top, width, height, minRenderSize]);
+
+  const commit = useCallback(
+    (rect: RenderRect) => {
+      hapticSelection();
+      onCommit(renderRectToGridBox(rect, dims, renderWidth));
+    },
+    [dims, renderWidth, onCommit],
+  );
+
+  // Clamp a render-pixel rect to the board surface + minimum size on the UI
+  // thread. Mirrors clampZoneBox semantics in render-pixel space.
+  const clampRectWorklet = useCallback(
+    (rect: RenderRect): RenderRect => {
+      'worklet';
+      const minSize = minRenderSize.value;
+      let rectLeft = rect.left;
+      let rectTop = rect.top;
+      let rectWidth = rect.width;
+      let rectHeight = rect.height;
+      if (rectWidth < minSize) rectWidth = minSize;
+      if (rectHeight < minSize) rectHeight = minSize;
+      if (rectWidth > renderWidth) rectWidth = renderWidth;
+      if (rectHeight > renderHeight) rectHeight = renderHeight;
+      if (rectLeft < 0) rectLeft = 0;
+      if (rectTop < 0) rectTop = 0;
+      if (rectLeft + rectWidth > renderWidth) rectLeft = renderWidth - rectWidth;
+      if (rectTop + rectHeight > renderHeight) rectTop = renderHeight - rectHeight;
+      return { left: rectLeft, top: rectTop, width: rectWidth, height: rectHeight };
+    },
+    [minRenderSize, renderWidth, renderHeight],
+  );
+
+  const handleRadius = useMemo(() => {
+    const renderScale = renderWidth > 0 ? renderWidth / dims.boardWidth : 1;
+    return computeHandleRadius(dims) * renderScale;
+  }, [dims, renderWidth]);
+
+  // Body pan (move). maxPointers(1) so a 2-finger pinch never starts a drag;
+  // Simultaneous-composed with the board pinch so pinch-to-zoom still wins while
+  // a finger is over the overlay.
+  const bodyGesture = useMemo(
+    () =>
+      Gesture.Simultaneous(
+        Gesture.Pan()
+          .maxPointers(1)
+          .onStart(() => {
+            'worklet';
+            startLeft.value = left.value;
+            startTop.value = top.value;
+            startWidth.value = width.value;
+            startHeight.value = height.value;
+          })
+          .onUpdate((event) => {
+            'worklet';
+            const dx = event.translationX / zoomScale.value;
+            const dy = event.translationY / zoomScale.value;
+            const next = clampRectWorklet({
+              left: startLeft.value + dx,
+              top: startTop.value + dy,
+              width: startWidth.value,
+              height: startHeight.value,
+            });
+            left.value = next.left;
+            top.value = next.top;
+            width.value = next.width;
+            height.value = next.height;
+          })
+          .onEnd(() => {
+            'worklet';
+            runOnJS(commit)({ left: left.value, top: top.value, width: width.value, height: height.value });
+          }),
+        boardPinch,
+      ),
+    [
+      boardPinch,
+      clampRectWorklet,
+      commit,
+      height,
+      left,
+      startHeight,
+      startLeft,
+      startTop,
+      startWidth,
+      top,
+      width,
+      zoomScale,
+    ],
+  );
+
+  // VoiceOver move: nudge the whole box without a drag, so it's usable without
+  // the gesture. Clamp keeps it on the board.
+  const moveByGrid = useCallback(
+    (direction: 1 | -1) => {
+      const delta = direction * A11Y_STEP;
+      onCommit(
+        clampZoneBox(
+          {
+            edgeLeft: zoneBox.edgeLeft + delta,
+            edgeRight: zoneBox.edgeRight + delta,
+            edgeBottom: zoneBox.edgeBottom + delta,
+            edgeTop: zoneBox.edgeTop + delta,
+          },
+          dims,
+        ),
+      );
+    },
+    [dims, onCommit, zoneBox],
+  );
+
+  const onBodyAccessibilityAction = useCallback(
+    (event: { nativeEvent: { actionName: string } }) => {
+      if (event.nativeEvent.actionName === 'increment') moveByGrid(1);
+      else if (event.nativeEvent.actionName === 'decrement') moveByGrid(-1);
+    },
+    [moveByGrid],
+  );
+
+  const bodyStyle = useAnimatedStyle(() => ({
+    left: left.value,
+    top: top.value,
+    width: width.value,
+    height: height.value,
+  }));
+
+  // Four scrim panels (top / bottom / left / right of the box) dim the board
+  // outside the rectangle, tracking the live box.
+  const scrimTopStyle = useAnimatedStyle(() => ({ height: Math.max(0, top.value) }));
+  const scrimBottomStyle = useAnimatedStyle(() => ({
+    top: top.value + height.value,
+    height: Math.max(0, renderHeight - (top.value + height.value)),
+  }));
+  const scrimLeftStyle = useAnimatedStyle(() => ({
+    top: top.value,
+    width: Math.max(0, left.value),
+    height: height.value,
+  }));
+  const scrimRightStyle = useAnimatedStyle(() => ({
+    left: left.value + width.value,
+    top: top.value,
+    width: Math.max(0, renderWidth - (left.value + width.value)),
+    height: height.value,
+  }));
+
+  if (renderWidth <= 0 || renderHeight <= 0) return null;
+
+  const scrimColumn: ViewStyle = { position: 'absolute', left: 0, right: 0, backgroundColor: scrimColor };
+  const scrimSide: ViewStyle = { position: 'absolute', left: 0, backgroundColor: scrimColor };
+
+  return (
+    <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+      <Animated.View pointerEvents="none" style={[scrimColumn, styles.scrimTop, scrimTopStyle]} />
+      <Animated.View pointerEvents="none" style={[scrimColumn, scrimBottomStyle]} />
+      <Animated.View pointerEvents="none" style={[scrimSide, scrimLeftStyle]} />
+      <Animated.View pointerEvents="none" style={[scrimSide, scrimRightStyle]} />
+
+      <GestureDetector gesture={bodyGesture}>
+        <Animated.View
+          accessibilityRole="adjustable"
+          accessible
+          accessibilityLabel={bodyLabel}
+          accessibilityHint={bodyHint}
+          accessibilityActions={ACCESSIBILITY_ACTIONS}
+          onAccessibilityAction={onBodyAccessibilityAction}
+          style={[styles.rect, { borderColor: brandColor }, bodyStyle]}
+        />
+      </GestureDetector>
+
+      {CORNERS.map((corner) => (
+        <CornerHandle
+          key={corner.mode}
+          corner={corner}
+          left={left}
+          top={top}
+          width={width}
+          height={height}
+          startLeft={startLeft}
+          startTop={startTop}
+          startWidth={startWidth}
+          startHeight={startHeight}
+          handleRadius={handleRadius}
+          zoomScale={zoomScale}
+          clampRectWorklet={clampRectWorklet}
+          commit={commit}
+          boardPinch={boardPinch}
+          brandColor={brandColor}
+          surfaceColor={systemColors.elevatedSurface}
+          dims={dims}
+          zoneBox={zoneBox}
+          onCommit={onCommit}
+          label={cornerLabels[corner.mode]}
+        />
+      ))}
+    </View>
+  );
+});
+
+type CornerHandleProps = {
+  corner: Corner;
+  left: SharedValue<number>;
+  top: SharedValue<number>;
+  width: SharedValue<number>;
+  height: SharedValue<number>;
+  startLeft: SharedValue<number>;
+  startTop: SharedValue<number>;
+  startWidth: SharedValue<number>;
+  startHeight: SharedValue<number>;
+  handleRadius: number;
+  zoomScale: SharedValue<number>;
+  clampRectWorklet: (rect: RenderRect) => RenderRect;
+  commit: (rect: RenderRect) => void;
+  boardPinch: GestureType;
+  brandColor: ColorValue;
+  surfaceColor: ColorValue;
+  dims: BoardDimensions;
+  zoneBox: ZoneBoxInput;
+  onCommit: (box: ZoneBoxInput) => void;
+  label: string;
+};
+
+const CornerHandle = React.memo(function CornerHandle({
+  corner,
+  left,
+  top,
+  width,
+  height,
+  startLeft,
+  startTop,
+  startWidth,
+  startHeight,
+  handleRadius,
+  zoomScale,
+  clampRectWorklet,
+  commit,
+  boardPinch,
+  brandColor,
+  surfaceColor,
+  dims,
+  zoneBox,
+  onCommit,
+  label,
+}: CornerHandleProps) {
+  const { mode, anchorX, anchorY } = corner;
+
+  const gesture = useMemo(
+    () =>
+      Gesture.Simultaneous(
+        Gesture.Pan()
+          .maxPointers(1)
+          .onStart(() => {
+            'worklet';
+            startLeft.value = left.value;
+            startTop.value = top.value;
+            startWidth.value = width.value;
+            startHeight.value = height.value;
+          })
+          .onUpdate((event) => {
+            'worklet';
+            const dx = event.translationX / zoomScale.value;
+            const dy = event.translationY / zoomScale.value;
+            let nextLeft = startLeft.value;
+            let nextTop = startTop.value;
+            let nextWidth = startWidth.value;
+            let nextHeight = startHeight.value;
+            if (anchorX === 'left') {
+              nextLeft = startLeft.value + dx;
+              nextWidth = startWidth.value - dx;
+            } else {
+              nextWidth = startWidth.value + dx;
+            }
+            if (anchorY === 'top') {
+              nextTop = startTop.value + dy;
+              nextHeight = startHeight.value - dy;
+            } else {
+              nextHeight = startHeight.value + dy;
+            }
+            // A resize that would invert the box: pin the moving edge to the
+            // opposite one before clamp re-expands to the minimum size.
+            if (nextWidth < 0) {
+              nextLeft = anchorX === 'left' ? startLeft.value + startWidth.value : startLeft.value;
+              nextWidth = 0;
+            }
+            if (nextHeight < 0) {
+              nextTop = anchorY === 'top' ? startTop.value + startHeight.value : startTop.value;
+              nextHeight = 0;
+            }
+            const next = clampRectWorklet({ left: nextLeft, top: nextTop, width: nextWidth, height: nextHeight });
+            left.value = next.left;
+            top.value = next.top;
+            width.value = next.width;
+            height.value = next.height;
+          })
+          .onEnd(() => {
+            'worklet';
+            runOnJS(commit)({ left: left.value, top: top.value, width: width.value, height: height.value });
+          }),
+        boardPinch,
+      ),
+    [
+      anchorX,
+      anchorY,
+      boardPinch,
+      clampRectWorklet,
+      commit,
+      height,
+      left,
+      startHeight,
+      startLeft,
+      startTop,
+      startWidth,
+      top,
+      width,
+      zoomScale,
+    ],
+  );
+
+  // Anchor the hit area centred on its corner of the live rect.
+  const handleStyle = useAnimatedStyle(() => {
+    const x = anchorX === 'left' ? left.value : left.value + width.value;
+    const y = anchorY === 'top' ? top.value : top.value + height.value;
+    return { left: x - MIN_HIT / 2, top: y - MIN_HIT / 2 };
+  });
+
+  // VoiceOver resize: grow/shrink the box from this corner without a drag.
+  const adjust = useCallback(
+    (direction: 1 | -1) => {
+      const next: ZoneBoxInput = { ...zoneBox };
+      const delta = direction * A11Y_STEP;
+      if (mode === 'nw' || mode === 'sw') next.edgeLeft = zoneBox.edgeLeft - delta;
+      if (mode === 'ne' || mode === 'se') next.edgeRight = zoneBox.edgeRight + delta;
+      if (mode === 'nw' || mode === 'ne') next.edgeTop = zoneBox.edgeTop + delta;
+      if (mode === 'sw' || mode === 'se') next.edgeBottom = zoneBox.edgeBottom - delta;
+      onCommit(clampZoneBox(next, dims));
+    },
+    [dims, mode, onCommit, zoneBox],
+  );
+
+  const onAccessibilityAction = useCallback(
+    (event: { nativeEvent: { actionName: string } }) => {
+      if (event.nativeEvent.actionName === 'increment') adjust(1);
+      else if (event.nativeEvent.actionName === 'decrement') adjust(-1);
+    },
+    [adjust],
+  );
+
+  const dotSize = handleRadius * 1.5;
+
+  return (
+    <GestureDetector gesture={gesture}>
+      <Animated.View
+        accessibilityRole="adjustable"
+        accessible
+        accessibilityLabel={label}
+        accessibilityActions={ACCESSIBILITY_ACTIONS}
+        onAccessibilityAction={onAccessibilityAction}
+        style={[styles.handleHit, handleStyle]}
+      >
+        <View
+          pointerEvents="none"
+          style={{
+            width: dotSize,
+            height: dotSize,
+            borderRadius: dotSize / 2,
+            backgroundColor: brandColor,
+            borderWidth: 2,
+            borderColor: surfaceColor,
+          }}
+        />
+      </Animated.View>
+    </GestureDetector>
+  );
+});
+
+const styles = StyleSheet.create({
+  rect: {
+    position: 'absolute',
+    borderWidth: 2.5,
+    borderRadius: 2,
+  },
+  scrimTop: {
+    top: 0,
+  },
+  handleHit: {
+    position: 'absolute',
+    width: MIN_HIT,
+    height: MIN_HIT,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/packages/mobile/src/components/search/ZoneOverlay.tsx
+++ b/packages/mobile/src/components/search/ZoneOverlay.tsx
@@ -85,6 +85,28 @@ function renderRectToGridBox(rect: RenderRect, dims: BoardDimensions, renderWidt
   );
 }
 
+// Clamp a render-pixel rect to the board surface + minimum size on the UI
+// thread. Mirrors clampZoneBox semantics in render-pixel space. Module-level
+// (params instead of closed-over shared values) to match the codebase worklet
+// pattern (see play-drawer/use-zoom-pan-gesture.ts) — keeps it stable and
+// callable from any gesture without a per-render closure.
+function clampRectWorklet(rect: RenderRect, minSize: number, boundWidth: number, boundHeight: number): RenderRect {
+  'worklet';
+  let rectLeft = rect.left;
+  let rectTop = rect.top;
+  let rectWidth = rect.width;
+  let rectHeight = rect.height;
+  if (rectWidth < minSize) rectWidth = minSize;
+  if (rectHeight < minSize) rectHeight = minSize;
+  if (rectWidth > boundWidth) rectWidth = boundWidth;
+  if (rectHeight > boundHeight) rectHeight = boundHeight;
+  if (rectLeft < 0) rectLeft = 0;
+  if (rectTop < 0) rectTop = 0;
+  if (rectLeft + rectWidth > boundWidth) rectLeft = boundWidth - rectWidth;
+  if (rectTop + rectHeight > boundHeight) rectTop = boundHeight - rectHeight;
+  return { left: rectLeft, top: rectTop, width: rectWidth, height: rectHeight };
+}
+
 type Corner = { mode: Exclude<DragMode, 'move'>; anchorX: 'left' | 'right'; anchorY: 'top' | 'bottom' };
 
 const CORNERS: ReadonlyArray<Corner> = [
@@ -179,31 +201,6 @@ export const ZoneOverlay = React.memo(function ZoneOverlay({
     [dims, renderWidth, onCommit],
   );
 
-  // Clamp a render-pixel rect to the board surface + minimum size on the UI
-  // thread. Mirrors clampZoneBox semantics in render-pixel space.
-  const clampRectWorklet = useCallback(
-    (rect: RenderRect): RenderRect => {
-      'worklet';
-      const minSize = minRenderSize.value;
-      const boundWidth = renderWidthSV.value;
-      const boundHeight = renderHeightSV.value;
-      let rectLeft = rect.left;
-      let rectTop = rect.top;
-      let rectWidth = rect.width;
-      let rectHeight = rect.height;
-      if (rectWidth < minSize) rectWidth = minSize;
-      if (rectHeight < minSize) rectHeight = minSize;
-      if (rectWidth > boundWidth) rectWidth = boundWidth;
-      if (rectHeight > boundHeight) rectHeight = boundHeight;
-      if (rectLeft < 0) rectLeft = 0;
-      if (rectTop < 0) rectTop = 0;
-      if (rectLeft + rectWidth > boundWidth) rectLeft = boundWidth - rectWidth;
-      if (rectTop + rectHeight > boundHeight) rectTop = boundHeight - rectHeight;
-      return { left: rectLeft, top: rectTop, width: rectWidth, height: rectHeight };
-    },
-    [minRenderSize, renderWidthSV, renderHeightSV],
-  );
-
   const handleRadius = useMemo(() => {
     const renderScale = renderWidth > 0 ? renderWidth / dims.boardWidth : 1;
     return computeHandleRadius(dims) * renderScale;
@@ -228,12 +225,17 @@ export const ZoneOverlay = React.memo(function ZoneOverlay({
             'worklet';
             const dx = event.translationX / zoomScale.value;
             const dy = event.translationY / zoomScale.value;
-            const next = clampRectWorklet({
-              left: startLeft.value + dx,
-              top: startTop.value + dy,
-              width: startWidth.value,
-              height: startHeight.value,
-            });
+            const next = clampRectWorklet(
+              {
+                left: startLeft.value + dx,
+                top: startTop.value + dy,
+                width: startWidth.value,
+                height: startHeight.value,
+              },
+              minRenderSize.value,
+              renderWidthSV.value,
+              renderHeightSV.value,
+            );
             left.value = next.left;
             top.value = next.top;
             width.value = next.width;
@@ -247,10 +249,12 @@ export const ZoneOverlay = React.memo(function ZoneOverlay({
       ),
     [
       boardPinch,
-      clampRectWorklet,
       commit,
       height,
       left,
+      minRenderSize,
+      renderHeightSV,
+      renderWidthSV,
       startHeight,
       startLeft,
       startTop,
@@ -262,23 +266,33 @@ export const ZoneOverlay = React.memo(function ZoneOverlay({
   );
 
   // VoiceOver move: nudge the whole box without a drag, so it's usable without
-  // the gesture. Clamp keeps it on the board.
+  // the gesture. Clamp keeps it on the board. We also seed the live shared rect
+  // locally (in addition to committing up): the parent intentionally keeps
+  // `renderInTransform` stable across box-value changes (so InteractiveFilterBoard
+  // doesn't re-render the board on every drag commit), which means this overlay
+  // is not re-rendered on a11y nudges — so the visual rect would otherwise lag.
   const moveByGrid = useCallback(
     (direction: 1 | -1) => {
       const delta = direction * A11Y_STEP;
-      onCommit(
-        clampZoneBox(
-          {
-            edgeLeft: zoneBox.edgeLeft + delta,
-            edgeRight: zoneBox.edgeRight + delta,
-            edgeBottom: zoneBox.edgeBottom + delta,
-            edgeTop: zoneBox.edgeTop + delta,
-          },
-          dims,
-        ),
+      const nextBox = clampZoneBox(
+        {
+          edgeLeft: zoneBox.edgeLeft + delta,
+          edgeRight: zoneBox.edgeRight + delta,
+          edgeBottom: zoneBox.edgeBottom + delta,
+          edgeTop: zoneBox.edgeTop + delta,
+        },
+        dims,
       );
+      if (renderWidth > 0) {
+        const rect = gridBoxToRenderRect(nextBox, dims, renderWidth);
+        left.value = rect.left;
+        top.value = rect.top;
+        width.value = rect.width;
+        height.value = rect.height;
+      }
+      onCommit(nextBox);
     },
-    [dims, onCommit, zoneBox],
+    [dims, onCommit, zoneBox, renderWidth, left, top, width, height],
   );
 
   const onBodyAccessibilityAction = useCallback(
@@ -357,7 +371,9 @@ export const ZoneOverlay = React.memo(function ZoneOverlay({
           startHeight={startHeight}
           handleRadius={handleRadius}
           zoomScale={zoomScale}
-          clampRectWorklet={clampRectWorklet}
+          minRenderSize={minRenderSize}
+          renderWidthSV={renderWidthSV}
+          renderHeightSV={renderHeightSV}
           commit={commit}
           boardPinch={boardPinch}
           brandColor={brandColor}
@@ -385,7 +401,9 @@ type CornerHandleProps = {
   startHeight: SharedValue<number>;
   handleRadius: number;
   zoomScale: SharedValue<number>;
-  clampRectWorklet: (rect: RenderRect) => RenderRect;
+  minRenderSize: SharedValue<number>;
+  renderWidthSV: SharedValue<number>;
+  renderHeightSV: SharedValue<number>;
   commit: (rect: RenderRect) => void;
   boardPinch: GestureType;
   brandColor: ColorValue;
@@ -409,7 +427,9 @@ const CornerHandle = React.memo(function CornerHandle({
   startHeight,
   handleRadius,
   zoomScale,
-  clampRectWorklet,
+  minRenderSize,
+  renderWidthSV,
+  renderHeightSV,
   commit,
   boardPinch,
   brandColor,
@@ -464,7 +484,12 @@ const CornerHandle = React.memo(function CornerHandle({
               nextTop = anchorY === 'top' ? startTop.value + startHeight.value : startTop.value;
               nextHeight = 0;
             }
-            const next = clampRectWorklet({ left: nextLeft, top: nextTop, width: nextWidth, height: nextHeight });
+            const next = clampRectWorklet(
+              { left: nextLeft, top: nextTop, width: nextWidth, height: nextHeight },
+              minRenderSize.value,
+              renderWidthSV.value,
+              renderHeightSV.value,
+            );
             left.value = next.left;
             top.value = next.top;
             width.value = next.width;
@@ -480,10 +505,12 @@ const CornerHandle = React.memo(function CornerHandle({
       anchorX,
       anchorY,
       boardPinch,
-      clampRectWorklet,
       commit,
       height,
       left,
+      minRenderSize,
+      renderHeightSV,
+      renderWidthSV,
       startHeight,
       startLeft,
       startTop,
@@ -501,7 +528,10 @@ const CornerHandle = React.memo(function CornerHandle({
     return { left: x - MIN_HIT / 2, top: y - MIN_HIT / 2 };
   });
 
-  // VoiceOver resize: grow/shrink the box from this corner without a drag.
+  // VoiceOver resize: grow/shrink the box from this corner without a drag. Also
+  // seeds the live shared rect locally — same reason as the body's moveByGrid:
+  // the overlay isn't re-rendered on a11y commits, so the visual rect would lag
+  // without a direct UI-thread update.
   const adjust = useCallback(
     (direction: 1 | -1) => {
       const next: ZoneBoxInput = { ...zoneBox };
@@ -510,9 +540,18 @@ const CornerHandle = React.memo(function CornerHandle({
       if (mode === 'ne' || mode === 'se') next.edgeRight = zoneBox.edgeRight + delta;
       if (mode === 'nw' || mode === 'ne') next.edgeTop = zoneBox.edgeTop + delta;
       if (mode === 'sw' || mode === 'se') next.edgeBottom = zoneBox.edgeBottom - delta;
-      onCommit(clampZoneBox(next, dims));
+      const clamped = clampZoneBox(next, dims);
+      const renderWidth = renderWidthSV.value;
+      if (renderWidth > 0) {
+        const rect = gridBoxToRenderRect(clamped, dims, renderWidth);
+        left.value = rect.left;
+        top.value = rect.top;
+        width.value = rect.width;
+        height.value = rect.height;
+      }
+      onCommit(clamped);
     },
-    [dims, mode, onCommit, zoneBox],
+    [dims, mode, onCommit, zoneBox, renderWidthSV, left, top, width, height],
   );
 
   const onAccessibilityAction = useCallback(

--- a/packages/mobile/src/components/search/__tests__/zone-overlay.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/zone-overlay.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { ZoneBoxInput } from '@boardsesh/shared-schema';
+import type { BoardDimensions } from '@boardsesh/climb-filters';
+
+const haptics = vi.hoisted(() => ({ selection: vi.fn() }));
+
+// The overlay's correctness under test is its a11y wiring + commit math, not the
+// reanimated host views. Render Animated.View as a div that forwards the a11y
+// props + action handler so increment/decrement can be triggered.
+type AnimatedViewProps = {
+  children?: ReactNode;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+  accessibilityRole?: string;
+  onAccessibilityAction?: (event: { nativeEvent: { actionName: string } }) => void;
+};
+function AnimatedViewMock({
+  children,
+  accessibilityLabel,
+  accessibilityHint,
+  accessibilityRole,
+  onAccessibilityAction,
+}: AnimatedViewProps) {
+  return createElement(
+    'div',
+    {
+      'data-role': accessibilityRole ?? '',
+      'data-label': accessibilityLabel ?? '',
+      'data-hint': accessibilityHint ?? '',
+      'data-has-action': onAccessibilityAction ? 'true' : 'false',
+      onClick: (event: { detail?: number }) => {
+        // detail 1 → increment, detail -1 → decrement (encoded by the test).
+        onAccessibilityAction?.({
+          nativeEvent: { actionName: event.detail === 2 ? 'decrement' : 'increment' },
+        });
+      },
+    },
+    children,
+  );
+}
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: { View: AnimatedViewMock },
+  useAnimatedStyle: () => ({}),
+  useSharedValue: (initial: number) => ({ value: initial }),
+  runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+vi.mock('react-native-gesture-handler', () => {
+  const chainable: Record<string, () => unknown> = {};
+  const builder = new Proxy(chainable, { get: () => () => builder });
+  return {
+    GestureDetector: ({ children }: { children?: ReactNode }) =>
+      createElement('div', { 'data-gesture': 'true' }, children),
+    Gesture: { Pan: () => builder, Simultaneous: () => builder },
+  };
+});
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { elevatedSurface: '#FFF' } }),
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: () => haptics.selection() }));
+
+import { ZoneOverlay, type ZoneCornerLabels } from '../ZoneOverlay';
+
+const DIMS: BoardDimensions = {
+  boardWidth: 1000,
+  boardHeight: 1000,
+  edgeLeft: 0,
+  edgeRight: 100,
+  edgeBottom: 0,
+  edgeTop: 100,
+};
+
+const ZONE: ZoneBoxInput = { edgeLeft: 20, edgeRight: 80, edgeBottom: 20, edgeTop: 80 };
+
+const CORNER_LABELS: ZoneCornerLabels = {
+  nw: 'Top-left corner',
+  ne: 'Top-right corner',
+  sw: 'Bottom-left corner',
+  se: 'Bottom-right corner',
+};
+
+function renderOverlay() {
+  const onCommit = vi.fn<(box: ZoneBoxInput) => void>();
+  const pinch = {} as never;
+  const result = render(
+    <ZoneOverlay
+      zoneBox={ZONE}
+      dims={DIMS}
+      renderWidth={500}
+      renderHeight={500}
+      zoomScale={{ value: 1 } as never}
+      onCommit={onCommit}
+      boardPinch={pinch}
+      brandColor="#6D28D9"
+      scrimColor="rgba(0,0,0,0.4)"
+      bodyLabel="Board region"
+      bodyHint="Swipe up or down to move the region across the board."
+      cornerLabels={CORNER_LABELS}
+      cornerHint="Swipe up or down to grow or shrink the region from this corner."
+    />,
+  );
+  return { ...result, onCommit };
+}
+
+function adjustables(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll('[data-role="adjustable"]')) as HTMLElement[];
+}
+
+function byLabel(container: HTMLElement, label: string): HTMLElement {
+  const match = adjustables(container).find((node) => node.getAttribute('data-label') === label);
+  if (!match) throw new Error(`no adjustable with label "${label}"`);
+  return match;
+}
+
+describe('ZoneOverlay', () => {
+  beforeEach(() => {
+    haptics.selection.mockClear();
+  });
+
+  it('renders the body plus four corner handles as adjustable a11y elements', () => {
+    const { container } = renderOverlay();
+    const nodes = adjustables(container);
+    // 1 body + 4 corners.
+    expect(nodes).toHaveLength(5);
+    expect(byLabel(container, 'Board region')).toBeTruthy();
+    expect(byLabel(container, 'Top-left corner')).toBeTruthy();
+    expect(byLabel(container, 'Bottom-right corner')).toBeTruthy();
+  });
+
+  it('gives every corner handle a resize accessibility hint (not just the body)', () => {
+    const { container } = renderOverlay();
+    const cornerHint = 'Swipe up or down to grow or shrink the region from this corner.';
+    for (const label of Object.values(CORNER_LABELS)) {
+      expect(byLabel(container, label).getAttribute('data-hint')).toBe(cornerHint);
+    }
+    // The body keeps its own (move) hint.
+    expect(byLabel(container, 'Board region').getAttribute('data-hint')).toBe(
+      'Swipe up or down to move the region across the board.',
+    );
+  });
+
+  it('returns null when the board has not been measured yet', () => {
+    const { container } = render(
+      <ZoneOverlay
+        zoneBox={ZONE}
+        dims={DIMS}
+        renderWidth={0}
+        renderHeight={0}
+        zoomScale={{ value: 1 } as never}
+        onCommit={vi.fn()}
+        boardPinch={{} as never}
+        brandColor="#6D28D9"
+        scrimColor="rgba(0,0,0,0.4)"
+        bodyLabel="Board region"
+        bodyHint="move"
+        cornerLabels={CORNER_LABELS}
+        cornerHint="resize"
+      />,
+    );
+    expect(adjustables(container)).toHaveLength(0);
+  });
+
+  it('VoiceOver increment on the NE corner grows the box outward (right + top)', () => {
+    const { container, onCommit } = renderOverlay();
+    fireEvent.click(byLabel(container, 'Top-right corner'), { detail: 1 });
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    const next = onCommit.mock.calls[0][0];
+    // A11Y_STEP = 2: NE grows edgeRight and edgeTop, leaves left/bottom alone.
+    expect(next.edgeRight).toBe(82);
+    expect(next.edgeTop).toBe(82);
+    expect(next.edgeLeft).toBe(20);
+    expect(next.edgeBottom).toBe(20);
+  });
+
+  it('VoiceOver decrement on the SW corner shrinks the box inward (left + bottom)', () => {
+    const { container, onCommit } = renderOverlay();
+    fireEvent.click(byLabel(container, 'Bottom-left corner'), { detail: 2 });
+    const next = onCommit.mock.calls[0][0];
+    // SW decrement: edgeLeft += step, edgeBottom += step (box shrinks).
+    expect(next.edgeLeft).toBe(22);
+    expect(next.edgeBottom).toBe(22);
+    expect(next.edgeRight).toBe(80);
+    expect(next.edgeTop).toBe(80);
+  });
+
+  it('VoiceOver increment on the body moves the whole box without resizing it', () => {
+    const { container, onCommit } = renderOverlay();
+    fireEvent.click(byLabel(container, 'Board region'), { detail: 1 });
+    const next = onCommit.mock.calls[0][0];
+    // All four edges shift by +A11Y_STEP; width/height unchanged.
+    expect(next.edgeLeft).toBe(22);
+    expect(next.edgeRight).toBe(82);
+    expect(next.edgeBottom).toBe(22);
+    expect(next.edgeTop).toBe(82);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/background-image-cache.test.ts
+++ b/packages/mobile/src/lib/__tests__/background-image-cache.test.ts
@@ -69,6 +69,10 @@ describe('ensureBackgroundsCached', () => {
     vi.mocked(getBoardRenderData).mockReturnValue({
       boardWidth: 100,
       boardHeight: 100,
+      edgeLeft: 0,
+      edgeRight: 11,
+      edgeBottom: 0,
+      edgeTop: 18,
       holdsData: [],
       imageUrls: ['https://www.boardsesh.com/images/kilter/product_sizes_layouts_sets/36-1.png'],
     } as ReturnType<typeof getBoardRenderData>);
@@ -91,6 +95,10 @@ describe('ensureBackgroundsCached', () => {
     vi.mocked(getBoardRenderData).mockReturnValue({
       boardWidth: 100,
       boardHeight: 100,
+      edgeLeft: 0,
+      edgeRight: 11,
+      edgeBottom: 0,
+      edgeTop: 18,
       holdsData: [],
       // Server URLs always come back with .png; manifest only has .webp.
       imageUrls: ['https://www.boardsesh.com/images/tension/product_sizes_layouts_sets/12.png'],
@@ -110,6 +118,10 @@ describe('ensureBackgroundsCached', () => {
     vi.mocked(getBoardRenderData).mockReturnValue({
       boardWidth: 100,
       boardHeight: 100,
+      edgeLeft: 0,
+      edgeRight: 11,
+      edgeBottom: 0,
+      edgeTop: 18,
       holdsData: [],
       imageUrls: ['https://www.boardsesh.com/images/newboard/bg.png'],
     } as ReturnType<typeof getBoardRenderData>);
@@ -132,6 +144,10 @@ describe('ensureBackgroundsCached', () => {
     vi.mocked(getBoardRenderData).mockReturnValue({
       boardWidth: 100,
       boardHeight: 100,
+      edgeLeft: 0,
+      edgeRight: 11,
+      edgeBottom: 0,
+      edgeTop: 18,
       holdsData: [],
       // First URL resolves via the manifest; second is a Tension layer
       // we never bundled (the bug this fix targets).
@@ -164,6 +180,10 @@ describe('tryGetBackgroundPathsSync', () => {
     vi.mocked(getBoardRenderData).mockReturnValue({
       boardWidth: 100,
       boardHeight: 100,
+      edgeLeft: 0,
+      edgeRight: 11,
+      edgeBottom: 0,
+      edgeTop: 18,
       holdsData: [],
       imageUrls: ['https://www.boardsesh.com/images/kilter/product_sizes_layouts_sets/36-1.png'],
     } as ReturnType<typeof getBoardRenderData>);
@@ -182,6 +202,10 @@ describe('tryGetBackgroundPathsSync', () => {
     vi.mocked(getBoardRenderData).mockReturnValue({
       boardWidth: 100,
       boardHeight: 100,
+      edgeLeft: 0,
+      edgeRight: 11,
+      edgeBottom: 0,
+      edgeTop: 18,
       holdsData: [],
       imageUrls: [
         'https://www.boardsesh.com/images/kilter/product_sizes_layouts_sets/36-1.png',

--- a/packages/mobile/src/lib/__tests__/create-board-holds.test.ts
+++ b/packages/mobile/src/lib/__tests__/create-board-holds.test.ts
@@ -18,6 +18,10 @@ describe('getCreateBoardHolds', () => {
     mockedGetBoardRenderData.mockReturnValue({
       boardWidth: 650,
       boardHeight: 1000,
+      edgeLeft: 0,
+      edgeRight: 11,
+      edgeBottom: 0,
+      edgeTop: 18,
       imageUrls: ['https://example.com/images/moonboard/moonboard-bg.png'],
       holdsData: [
         { id: 1, mirroredHoldId: null, cx: 68, cy: 950, r: 12 },
@@ -39,6 +43,10 @@ describe('getCreateBoardHolds', () => {
       ],
       boardWidth: 650,
       boardHeight: 1000,
+      edgeLeft: 0,
+      edgeRight: 11,
+      edgeBottom: 0,
+      edgeTop: 18,
       family: 'moonboard',
     });
   });

--- a/packages/mobile/src/lib/__tests__/zone-filter-handoff.test.tsx
+++ b/packages/mobile/src/lib/__tests__/zone-filter-handoff.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { useEffect } from 'react';
+import { renderHook } from '@testing-library/react';
+import type { ZoneBoxInput, ZoneMatchMode, HoldsFilter } from '@boardsesh/shared-schema';
+import {
+  emitZoneFilterSelection,
+  subscribeToZoneFilterSelection,
+  type ZoneFilterSelection,
+} from '../zone-filter-handoff';
+
+const ZONE_BOX: ZoneBoxInput = { edgeLeft: 20, edgeRight: 80, edgeBottom: 20, edgeTop: 80 };
+const ALL_HOLDS: ZoneMatchMode = 'allHolds';
+
+describe('zone-filter-handoff', () => {
+  it('delivers the emitted zone selection to a subscriber', () => {
+    const listener = vi.fn<(selection: ZoneFilterSelection) => void>();
+    const unsubscribe = subscribeToZoneFilterSelection(listener);
+
+    const holdsFilter: HoldsFilter = { '12': { HAND: 'include' } };
+    emitZoneFilterSelection({ zoneBox: ZONE_BOX, zoneMode: ALL_HOLDS, holdsFilter });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ zoneBox: ZONE_BOX, zoneMode: ALL_HOLDS, holdsFilter });
+    unsubscribe();
+  });
+
+  it('stops delivering after the subscriber unsubscribes', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToZoneFilterSelection(listener);
+    unsubscribe();
+
+    emitZoneFilterSelection({ zoneBox: null, zoneMode: ALL_HOLDS });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  // The ClimbFilterSheet subscribes in a useEffect whose cleanup returns the
+  // unsubscribe (ClimbFilterSheet.tsx ~line 188). This reproduces that exact
+  // wiring and asserts the subscription is torn down on unmount — so a sheet
+  // that opens and closes repeatedly doesn't leak a growing listener set that
+  // would re-apply a stale handoff to an unmounted sheet.
+  it('cleans up the subscription when the subscribing component unmounts', () => {
+    const onSelection = vi.fn<(selection: ZoneFilterSelection) => void>();
+
+    function useZoneFilterSubscription() {
+      useEffect(() => subscribeToZoneFilterSelection(onSelection), []);
+    }
+
+    const { unmount } = renderHook(() => useZoneFilterSubscription());
+
+    // While mounted, an emit reaches the subscriber.
+    emitZoneFilterSelection({ zoneBox: ZONE_BOX, zoneMode: ALL_HOLDS });
+    expect(onSelection).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    // After unmount, the effect cleanup must have removed the listener.
+    emitZoneFilterSelection({ zoneBox: null, zoneMode: ALL_HOLDS });
+    expect(onSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leave a dangling listener after repeated mount/unmount cycles', () => {
+    const onSelection = vi.fn();
+
+    function useZoneFilterSubscription() {
+      useEffect(() => subscribeToZoneFilterSelection(onSelection), []);
+    }
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      const { unmount } = renderHook(() => useZoneFilterSubscription());
+      unmount();
+    }
+
+    // Every cycle's listener was the same fn; if any unmount failed to clean up,
+    // this emit would still call it. None remain, so the fn is never invoked.
+    emitZoneFilterSelection({ zoneBox: ZONE_BOX, zoneMode: ALL_HOLDS });
+    expect(onSelection).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/board-details.ts
+++ b/packages/mobile/src/lib/board-details.ts
@@ -7,6 +7,13 @@ import { WEB_BASE_URL } from './env';
 type BoardRenderData = {
   boardWidth: number;
   boardHeight: number;
+  // Board playing-surface edges in placement-grid coordinates (the `edge_*`
+  // columns / BoardDetails). The zone search filter maps its grid-space box to
+  // SVG pixels through these.
+  edgeLeft: number;
+  edgeRight: number;
+  edgeBottom: number;
+  edgeTop: number;
   imageUrls: string[];
   holdsData: HoldPlacement[];
 };
@@ -66,7 +73,7 @@ export function getBoardRenderData(params: {
 
   const imageUrls = imageFilenames.map((filename) => `${WEB_BASE_URL}/images/${boardName}/${filename}`);
 
-  return { boardWidth, boardHeight, imageUrls, holdsData };
+  return { boardWidth, boardHeight, edgeLeft, edgeRight, edgeBottom, edgeTop, imageUrls, holdsData };
 }
 
 function getMoonBoardRenderData(params: {
@@ -93,6 +100,10 @@ function getMoonBoardRenderData(params: {
     return {
       boardWidth: details.boardWidth,
       boardHeight: details.boardHeight,
+      edgeLeft: details.edge_left,
+      edgeRight: details.edge_right,
+      edgeBottom: details.edge_bottom,
+      edgeTop: details.edge_top,
       imageUrls,
       holdsData,
     };

--- a/packages/mobile/src/lib/create-board-holds.ts
+++ b/packages/mobile/src/lib/create-board-holds.ts
@@ -1,4 +1,5 @@
 import type { BoardName } from '@boardsesh/shared-schema';
+import type { BoardEdges } from '@boardsesh/climb-filters';
 import { getBoardRenderData } from './board-details';
 
 /**
@@ -9,7 +10,7 @@ import { getBoardRenderData } from './board-details';
  */
 export type BoardHoldTarget = { id: number; cx: number; cy: number; r: number };
 
-export type CreateBoardHolds = {
+export type CreateBoardHolds = BoardEdges & {
   holdTargets: BoardHoldTarget[];
   boardWidth: number;
   boardHeight: number;
@@ -33,6 +34,10 @@ export function getCreateBoardHolds(cfg: {
     holdTargets: data.holdsData.map((hold) => ({ id: hold.id, cx: hold.cx, cy: hold.cy, r: hold.r })),
     boardWidth: data.boardWidth,
     boardHeight: data.boardHeight,
+    edgeLeft: data.edgeLeft,
+    edgeRight: data.edgeRight,
+    edgeBottom: data.edgeBottom,
+    edgeTop: data.edgeTop,
     family: cfg.boardName === 'moonboard' ? 'moonboard' : 'aurora',
   };
 }

--- a/packages/mobile/src/lib/zone-filter-handoff.ts
+++ b/packages/mobile/src/lib/zone-filter-handoff.ts
@@ -1,5 +1,4 @@
-import type { ZoneBoxInput, ZoneMatchMode } from '@boardsesh/shared-schema';
-import type { HoldsFilter } from '@boardsesh/shared-schema';
+import type { HoldsFilter, ZoneBoxInput, ZoneMatchMode } from '@boardsesh/shared-schema';
 
 /**
  * Hands the edited board-region (zone) filter back from the full-screen board

--- a/packages/mobile/src/lib/zone-filter-handoff.ts
+++ b/packages/mobile/src/lib/zone-filter-handoff.ts
@@ -1,0 +1,37 @@
+import type { ZoneBoxInput, ZoneMatchMode } from '@boardsesh/shared-schema';
+import type { HoldsFilter } from '@boardsesh/shared-schema';
+
+/**
+ * Hands the edited board-region (zone) filter back from the full-screen board
+ * sub-screen to the ClimbFilterSheet, mirroring `hold-filter-handoff`. The
+ * sub-screen owns the interactive board + draggable rectangle; the sheet stays
+ * mounted underneath and picks up the result when the screen pops, so the user
+ * keeps editing the rest of the filters.
+ *
+ * The zone screen can also prune out-of-zone hold filters (the `allHolds`
+ * backend filter discards a climb if any hold is outside the box), so it hands
+ * the possibly-pruned `holdsFilter` back alongside the zone — `undefined` means
+ * "leave the sheet's holds filter untouched".
+ */
+export type ZoneFilterSelection = {
+  zoneBox: ZoneBoxInput | null;
+  zoneMode: ZoneMatchMode;
+  holdsFilter?: HoldsFilter;
+};
+
+type ZoneFilterListener = (selection: ZoneFilterSelection) => void;
+
+const zoneFilterListeners = new Set<ZoneFilterListener>();
+
+export function emitZoneFilterSelection(selection: ZoneFilterSelection): void {
+  for (const listener of zoneFilterListeners) {
+    listener(selection);
+  }
+}
+
+export function subscribeToZoneFilterSelection(listener: ZoneFilterListener): () => void {
+  zoneFilterListeners.add(listener);
+  return () => {
+    zoneFilterListeners.delete(listener);
+  };
+}

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -50,6 +50,10 @@ export const SHARED_EVENTS = {
   ClimbSearchPerformed: 'Climb Search Performed',
   SearchHoldFilterChanged: 'Search Hold Filter Changed',
   SearchHoldFilterCleared: 'Search Hold Filter Cleared',
+  SearchZoneEnabled: 'Search Zone Enabled',
+  SearchZoneUpdated: 'Search Zone Updated',
+  SearchZoneCleared: 'Search Zone Cleared',
+  SearchZoneModeChanged: 'Search Zone Mode Changed',
   // Beta videos
   BetaVideoLinkClicked: 'Beta Video Link Clicked',
   BetaVideoClimbClicked: 'Beta Video Climb Clicked',

--- a/packages/shared/climb-filters/src/__tests__/climb-zone-math.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/climb-zone-math.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import type { HoldsFilter } from '@boardsesh/shared-schema';
+import {
+  gridToSvg,
+  pruneHoldsToZone,
+  type BoardDimensions,
+  type BoardEdges,
+  type HoldPositionLookup,
+} from '../climb-zone-math';
+
+const EDGES: BoardEdges = {
+  edgeLeft: 0,
+  edgeRight: 144,
+  edgeBottom: 0,
+  edgeTop: 156,
+};
+
+const DIMS: BoardDimensions = {
+  ...EDGES,
+  boardWidth: 1080,
+  boardHeight: 1170,
+};
+
+// Holds are stored in SVG-pixel space, so build the lookup from grid coords
+// through gridToSvg — the same adaptation the geometry tests use.
+function holdAtGrid(gridX: number, gridY: number): { cx: number; cy: number } {
+  const svgPoint = gridToSvg(gridX, gridY, DIMS);
+  return { cx: svgPoint.x, cy: svgPoint.y };
+}
+
+// Hold 1 inside, hold 2 outside (left of), hold 3 outside (below).
+const HOLDS_BY_ID: HoldPositionLookup = new Map([
+  [1, holdAtGrid(60, 80)],
+  [2, holdAtGrid(10, 80)],
+  [3, holdAtGrid(60, 20)],
+]);
+
+const ZONE = { edgeLeft: 30, edgeRight: 100, edgeBottom: 40, edgeTop: 120 };
+
+describe('pruneHoldsToZone', () => {
+  it('keeps only filters whose hold sits inside the zone', () => {
+    const holdsFilter: HoldsFilter = {
+      1: { HAND: 'include' },
+      2: { FOOT: 'include' },
+      3: { STARTING: 'exclude' },
+    };
+    expect(pruneHoldsToZone(holdsFilter, ZONE, HOLDS_BY_ID, DIMS)).toEqual({
+      1: { HAND: 'include' },
+    });
+  });
+
+  it('returns the original filter unchanged when the zone is null', () => {
+    const holdsFilter: HoldsFilter = { 2: { FOOT: 'include' }, 3: { STARTING: 'exclude' } };
+    expect(pruneHoldsToZone(holdsFilter, null, HOLDS_BY_ID, DIMS)).toBe(holdsFilter);
+  });
+
+  it('returns the original filter unchanged when the zone is undefined', () => {
+    const holdsFilter: HoldsFilter = { 2: { FOOT: 'include' } };
+    expect(pruneHoldsToZone(holdsFilter, undefined, HOLDS_BY_ID, DIMS)).toBe(holdsFilter);
+  });
+
+  it('drops filters whose hold id is missing from the lookup', () => {
+    const holdsFilter: HoldsFilter = { 1: { HAND: 'include' }, 999: { FOOT: 'include' } };
+    expect(pruneHoldsToZone(holdsFilter, ZONE, HOLDS_BY_ID, DIMS)).toEqual({ 1: { HAND: 'include' } });
+  });
+
+  it('returns an empty object when every hold is outside the zone', () => {
+    const holdsFilter: HoldsFilter = { 2: { FOOT: 'include' }, 3: { STARTING: 'exclude' } };
+    expect(pruneHoldsToZone(holdsFilter, ZONE, HOLDS_BY_ID, DIMS)).toEqual({});
+  });
+});

--- a/packages/shared/climb-filters/src/climb-zone-math.ts
+++ b/packages/shared/climb-filters/src/climb-zone-math.ts
@@ -1,4 +1,4 @@
-import type { ZoneBoxInput } from '@boardsesh/shared-schema';
+import type { HoldsFilter, ZoneBoxInput } from '@boardsesh/shared-schema';
 
 /**
  * Platform-free geometry helpers for the board "zone" search filter — the
@@ -182,4 +182,35 @@ export function isHoldInsideZone(
     gridPoint.y >= zone.edgeBottom &&
     gridPoint.y <= zone.edgeTop
   );
+}
+
+/** Hold-position lookup keyed by hold id (`board_holes`/SVG-pixel `cx`/`cy`). */
+export type HoldPositionLookup = ReadonlyMap<number, { cx: number; cy: number }>;
+
+/**
+ * Drop every hold filter whose hold sits outside the zone box. The backend
+ * `allHolds` zone filter keeps a climb only when every one of its holds fits
+ * inside the box, so a filter hold sitting outside the zone guarantees zero
+ * matches — pruning it stops the user staring at empty results.
+ *
+ * Holds the lookup doesn't know are dropped too: under an active zone a tap on a
+ * fabricated/stale id can't be the user's intent. A `null` zone means "no zone
+ * constraint", so every filter survives. Shared so web and mobile prune
+ * identically (extracted from the web search drawer's local `pruneHoldsToZone`).
+ */
+export function pruneHoldsToZone(
+  holdsFilter: HoldsFilter,
+  zone: ZoneBoxInput | null | undefined,
+  holdsById: HoldPositionLookup,
+  dims: BoardDimensions,
+): HoldsFilter {
+  if (!zone) return holdsFilter;
+  const pruned: HoldsFilter = {};
+  for (const [holdIdRaw, entry] of Object.entries(holdsFilter)) {
+    const hold = holdsById.get(Number(holdIdRaw));
+    if (hold && entry && isHoldInsideZone(hold, zone, dims)) {
+      pruned[Number(holdIdRaw)] = entry;
+    }
+  }
+  return pruned;
 }

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -792,7 +792,8 @@
         "topLeft": "Top-left corner",
         "topRight": "Top-right corner",
         "bottomLeft": "Bottom-left corner",
-        "bottomRight": "Bottom-right corner"
+        "bottomRight": "Bottom-right corner",
+        "hint": "Swipe up or down to grow or shrink the region from this corner."
       }
     }
   }

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -775,6 +775,25 @@
         "foot": "Foot",
         "any": "Any"
       }
+    },
+    "zoneFilter": {
+      "title": "Board region",
+      "summaryActive": "On",
+      "enable": "Add a region",
+      "clearZone": "Clear region",
+      "allHolds": "All holds",
+      "anyHold": "Any hold",
+      "modeLabel": "Which holds must fit the region",
+      "hint": "Add a region to find climbs that stay inside one part of the board.",
+      "activeHint": "Drag the box and its corners to set the region. All holds must fit inside; switch to Any hold to keep climbs that reach into it.",
+      "regionLabel": "Board region",
+      "regionHint": "Swipe up or down to move the region across the board.",
+      "corner": {
+        "topLeft": "Top-left corner",
+        "topRight": "Top-right corner",
+        "bottomLeft": "Bottom-left corner",
+        "bottomRight": "Bottom-right corner"
+      }
     }
   }
 }

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -40,7 +40,8 @@
       "climb": "Climb",
       "profile": "Profile",
       "setters": "Setters",
-      "holdFilter": "Hold types"
+      "holdFilter": "Hold types",
+      "zoneFilter": "Board region"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -792,7 +792,8 @@
         "topLeft": "Esquina superior izquierda",
         "topRight": "Esquina superior derecha",
         "bottomLeft": "Esquina inferior izquierda",
-        "bottomRight": "Esquina inferior derecha"
+        "bottomRight": "Esquina inferior derecha",
+        "hint": "Desliza hacia arriba o abajo para agrandar o reducir la zona desde esta esquina."
       }
     }
   }

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -775,6 +775,25 @@
         "foot": "Pie",
         "any": "Cualquiera"
       }
+    },
+    "zoneFilter": {
+      "title": "Zona del muro",
+      "summaryActive": "Activada",
+      "enable": "Añadir una zona",
+      "clearZone": "Borrar zona",
+      "allHolds": "Todas las presas",
+      "anyHold": "Alguna presa",
+      "modeLabel": "Qué presas deben caber en la zona",
+      "hint": "Añade una zona para encontrar bloques que se queden en una parte del muro.",
+      "activeHint": "Arrastra la caja y sus esquinas para fijar la zona. Todas las presas deben caber dentro; cambia a Alguna presa para conservar los bloques que la alcancen.",
+      "regionLabel": "Zona del muro",
+      "regionHint": "Desliza hacia arriba o abajo para mover la zona por el muro.",
+      "corner": {
+        "topLeft": "Esquina superior izquierda",
+        "topRight": "Esquina superior derecha",
+        "bottomLeft": "Esquina inferior izquierda",
+        "bottomRight": "Esquina inferior derecha"
+      }
     }
   }
 }

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -238,7 +238,8 @@
       "climb": "Bloque",
       "profile": "Perfil",
       "setters": "Equipadores",
-      "holdFilter": "Tipos de presa"
+      "holdFilter": "Tipos de presa",
+      "zoneFilter": "Zona del muro"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -775,6 +775,25 @@
         "foot": "Pied",
         "any": "Toute"
       }
+    },
+    "zoneFilter": {
+      "title": "Zone du mur",
+      "summaryActive": "Activée",
+      "enable": "Ajouter une zone",
+      "clearZone": "Effacer la zone",
+      "allHolds": "Toutes les prises",
+      "anyHold": "Une prise",
+      "modeLabel": "Quelles prises doivent tenir dans la zone",
+      "hint": "Ajoutez une zone pour trouver des blocs qui restent dans une partie du mur.",
+      "activeHint": "Faites glisser la boîte et ses coins pour régler la zone. Toutes les prises doivent tenir dedans ; passez à Une prise pour garder les blocs qui l'atteignent.",
+      "regionLabel": "Zone du mur",
+      "regionHint": "Balayez vers le haut ou le bas pour déplacer la zone sur le mur.",
+      "corner": {
+        "topLeft": "Coin supérieur gauche",
+        "topRight": "Coin supérieur droit",
+        "bottomLeft": "Coin inférieur gauche",
+        "bottomRight": "Coin inférieur droit"
+      }
     }
   }
 }

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -792,7 +792,8 @@
         "topLeft": "Coin supérieur gauche",
         "topRight": "Coin supérieur droit",
         "bottomLeft": "Coin inférieur gauche",
-        "bottomRight": "Coin inférieur droit"
+        "bottomRight": "Coin inférieur droit",
+        "hint": "Balayez vers le haut ou le bas pour agrandir ou réduire la zone depuis ce coin."
       }
     }
   }

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -40,7 +40,8 @@
       "climb": "Bloc",
       "profile": "Profil",
       "setters": "Ouvreurs",
-      "holdFilter": "Types de prise"
+      "holdFilter": "Types de prise",
+      "zoneFilter": "Zone du mur"
     }
   },
   "lightControl": {

--- a/packages/web/app/components/search-drawer/climb-search-form.tsx
+++ b/packages/web/app/components/search-drawer/climb-search-form.tsx
@@ -36,6 +36,7 @@ import {
   computeHandleRadius,
   gridToSvg,
   isHoldInsideZone,
+  pruneHoldsToZone as pruneHoldsToZoneShared,
   svgToGrid,
   type BoardDimensions,
   type DragMode,
@@ -263,17 +264,10 @@ const ClimbSearchForm: React.FC<ClimbSearchFormProps> = ({ boardDetails }) => {
   // The backend zone filter requires every hold of a climb to fit inside
   // the box. So a filter-hold sitting outside the zone guarantees zero
   // matches — drop it instead of leaving the user staring at empty results.
+  // Shared with mobile (`@boardsesh/climb-filters`); prunes against the latest
+  // ref snapshot so a hold tapped immediately before a corner grab still counts.
   const pruneHoldsToZone = useCallback(
-    (zone: ZoneBox): HoldsFilter => {
-      const prunedHoldsFilter: HoldsFilter = {};
-      for (const [holdIdRaw, entry] of Object.entries(holdsFilterRef.current)) {
-        const hold = holdsById.get(Number(holdIdRaw));
-        if (hold && entry && isHoldInsideZone(hold, zone, dims)) {
-          prunedHoldsFilter[Number(holdIdRaw)] = entry;
-        }
-      }
-      return prunedHoldsFilter;
-    },
+    (zone: ZoneBox): HoldsFilter => pruneHoldsToZoneShared(holdsFilterRef.current, zone, holdsById, dims),
     [dims, holdsById],
   );
 

--- a/packages/web/app/components/search-drawer/climb-zone-math.ts
+++ b/packages/web/app/components/search-drawer/climb-zone-math.ts
@@ -15,7 +15,9 @@ export {
   svgToGrid,
   computeHandleRadius,
   isHoldInsideZone,
+  pruneHoldsToZone,
   type BoardEdges,
   type DragMode,
   type BoardDimensions,
+  type HoldPositionLookup,
 } from '@boardsesh/climb-filters';


### PR DESCRIPTION
## Why

Completes the search-filters gap on mobile. The zone/region filter — a draggable rectangle over the board that restricts results to climbs whose holds fit inside it — was the last filter the old mobile app had that the new one didn't (~19 mobile users used it). It was deferred from the hold-type filter PR (#2622); this stacks the zone editor on top.

## What

- **New `climbs/zone` route** — full-screen interactive board sub-screen mirroring `climbs/holds`: header with Clear/Done, centered board, footer hint, and a mode-control island above the footer. Hands the edited zone (and any pruned hold filter) back to the `ClimbFilterSheet` via a new `zone-filter-handoff` on focus loss/Done.
- **`ZoneOverlay`** — a percentage/render-pixel-anchored rectangle + 4 corner handles, rendered inside `InteractiveFilterBoard`'s zoom transform (new `renderInTransform` slot) so it tracks the board at any zoom. A scrim dims the board outside the box.
- **Both UI variants from one screen** — chrome reuses the variant-aware `SegmentedControl` (Paper `SegmentedButtons` on Material), `Button` (`variant="outlined"` clear), and `GlassSurface` (glass island on iOS-26, M3 tonal surface on Material). No per-variant branch needed.
- **`ClimbFilterSheet`** — a "Board region" tappable row directly under "Hold types" (trailing On/None + chevron, disabled when no board config), an `openZoneFilter` push, a `subscribeToZoneFilterSelection` effect, and `zoneBox != null` folded into the refine summary.
- **`pruneHoldsToZone` extracted to `@boardsesh/climb-filters`** (built on `isHoldInsideZone`) and the web `climb-search-form` now imports it instead of its local `useCallback` — extract-don't-duplicate, same as #2622 did for the rest of the zone math. Switching to All-holds drops out-of-zone hold filters identically on both platforms.
- **Analytics** — `Search Zone Enabled / Updated / Cleared / Mode Changed` added to `SHARED_EVENTS`, matching the web event props.
- Mobile `board-details` / `create-board-holds` now surface board edges (Aurora via `getProductSize`, MoonBoard via `getMoonBoardDetails`) so the grid↔SVG zone mapping works for both families. `mergeBoardFilters` / `hasActiveBoardFilters` / `active-filter-count` already fold `zoneBox`/`zoneMode` in — no shared-state changes needed.

### Performance (per `docs/react-native-performance.md`)
The rectangle's edges live on the UI thread as shared values (render-pixel space). One pan per corner + one body move, each `maxPointers(1)` and `Gesture.Simultaneous`-composed with the board pinch so 2-finger zoom still wins. Pans mutate the shared values per frame with zero React renders; the clamped grid box commits to JS only on gesture `onEnd` (a single gated `runOnJS`). The live zoom scale is mirrored into a shared value (newly exposed from `use-zoom-pan-gesture`) so screen-pixel deltas convert to board pixels without a volatile box in the gesture `useMemo` deps. `hapticSelection` fires on commit + mode/clear taps.

### Accessibility
Each corner handle and the body get `accessibilityRole="adjustable"` with labels/hint and an `onAccessibilityAction` (increment/decrement) so VoiceOver resizes/moves the region without the gesture. Hit areas are ≥48dp transparent targets. Reduce Transparency is handled automatically by `GlassSurface`.

## How to verify
Filter sheet → **Board region** → **Add a region** → drag the rectangle and corners on the board → results filter. Toggle **All holds / Any hold**, **Clear region**. Confirm `Search Zone Enabled/Updated/Cleared/Mode Changed` fire (props match web). Works in both the iOS-26 glass and Material 3 variants.

## Validation
- `vp run typecheck` (full — web touched by the `pruneHoldsToZone` extraction): pass
- `vp test --project mobile`: 1207 pass
- `vp test --project climb-filters` (holds `climb-zone-math`, incl. new `pruneHoldsToZone` test): 161 pass
- `vp run check:mobile-bundle`: OK (Android bundle 10.6 MB)

## Stacking
Stacked on #2622 (`feat/rn-hold-zone-filters`); should merge after it, or be retargeted to `main` once #2622 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)