### PR TITLE
Fix playlist-detail Material actions drop and review nits

### DIFF
--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -18,6 +18,7 @@ import { Icon } from '../../../src/components/Icon';
 import { ClimbListRowSkeleton } from '../../../src/components/ClimbListRowSkeleton';
 import {
   PlaylistDetailView,
+  SKELETON_PLACEHOLDERS,
   PlaylistFormSheet,
   PlaylistActionsMenu,
   PlaylistFollowButton,
@@ -402,9 +403,6 @@ export default function PlaylistDetail() {
     </>
   );
 }
-
-// Stable hoisted keys for the first-page skeleton rows.
-const SKELETON_PLACEHOLDERS = Array.from({ length: 8 }, (_, index) => `skeleton-${index}`);
 
 const styles = StyleSheet.create({
   stateContainer: {

--- a/packages/mobile/app/(tabs)/discover/smart/[type].tsx
+++ b/packages/mobile/app/(tabs)/discover/smart/[type].tsx
@@ -14,6 +14,7 @@ import { Icon } from '../../../../src/components/Icon';
 import { ClimbListRowSkeleton } from '../../../../src/components/ClimbListRowSkeleton';
 import {
   PlaylistDetailView,
+  SKELETON_PLACEHOLDERS,
   PlaylistBackFab,
   type PlaylistDetailEmptyState,
 } from '../../../../src/components/playlist';
@@ -142,9 +143,6 @@ export default function SmartPlaylistDetail() {
     />
   );
 }
-
-// Stable hoisted keys for the first-page skeleton rows.
-const SKELETON_PLACEHOLDERS = Array.from({ length: 8 }, (_, index) => `skeleton-${index}`);
 
 const styles = StyleSheet.create({
   stateContainer: {

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useCallback, useState } from 'react';
 import {
+  type ColorValue,
   type LayoutChangeEvent,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
@@ -329,6 +330,10 @@ export function PlaylistDetailView({
           <Animated.View style={[styles.materialAppbarTitle, headerBarStyle]}>
             <Appbar.Content title={hero.name} titleStyle={styles.materialAppbarTitleText} />
           </Animated.View>
+          {/* Owner / follow / pin controls. The app bar is always present on Material,
+              so we ask for the compact icon form (`actions(true)`) — `GlassIconButton`
+              routes to a Paper `IconButton` here, fitting the bar. */}
+          {actions?.(true)}
           {climbs.length > 0 ? (
             <Appbar.Action
               icon="play"
@@ -499,8 +504,8 @@ function MaterialEmptyState({
   icon: IconName;
   title: string;
   supporting?: string;
-  titleColor: string | import('react-native').OpaqueColorValue;
-  supportingColor: string | import('react-native').OpaqueColorValue;
+  titleColor: ColorValue;
+  supportingColor: ColorValue;
 }) {
   return (
     <View style={styles.stateContainer}>
@@ -524,8 +529,9 @@ function keyExtractor(item: Climb) {
 }
 
 // Hoisted stable keys for the first-page skeleton rows — never reorder, so index
-// keys are fine and avoid allocating an array on every render.
-const SKELETON_PLACEHOLDERS = Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => `skeleton-${index}`);
+// keys are fine and avoid allocating an array on every render. Exported so the
+// route-level early-return skeletons share the same count (no drift from this view).
+export const SKELETON_PLACEHOLDERS = Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => `skeleton-${index}`);
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -4,7 +4,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/queue';
 
-const ctrl = vi.hoisted(() => ({ back: vi.fn(), variant: 'glass' as 'glass' | 'material' }));
+const ctrl = vi.hoisted(() => ({ back: vi.fn(), variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
 
 // ── React Native ──────────────────────────────────────────────────────────────
 vi.mock('react-native', () => ({
@@ -225,7 +225,7 @@ function makeProps(overrides: Partial<PlaylistDetailViewProps> = {}): PlaylistDe
 describe('PlaylistDetailView', () => {
   beforeEach(() => {
     ctrl.back.mockClear();
-    ctrl.variant = 'glass';
+    ctrl.variant = 'liquidGlass';
   });
 
   // ── Navigation ──────────────────────────────────────────────────────────────
@@ -428,6 +428,19 @@ describe('PlaylistDetailView', () => {
     it('shows skeleton rows while loading', () => {
       const { container } = render(<PlaylistDetailView {...makeProps({ isLoading: true, climbs: [] })} />);
       expect(container.querySelectorAll('[data-skeleton-row]').length).toBeGreaterThan(0);
+    });
+
+    it('surfaces the actions node in the app bar (compact form)', () => {
+      // The owner's Follow / Pin / More controls must reach the Material app bar —
+      // dropping them leaves a playlist owner with no edit/pin/delete on Material.
+      const actions = vi.fn((collapsed: boolean) =>
+        createElement('span', { 'data-action-collapsed': String(collapsed) }, 'action'),
+      );
+      const { container } = render(<PlaylistDetailView {...makeProps({ climbs: [CLIMB], actions })} />);
+      // App bar is always present on Material, so actions are asked for the compact
+      // (collapsed) icon form rather than the scroll-driven pill.
+      expect(actions).toHaveBeenCalledWith(true);
+      expect(container.querySelector('[data-action-collapsed="true"]')).not.toBeNull();
     });
   });
 });

--- a/packages/mobile/src/components/playlist/index.ts
+++ b/packages/mobile/src/components/playlist/index.ts
@@ -4,6 +4,7 @@ export { PlaylistScrollSection, type PlaylistScrollSectionProps } from './Playli
 export { PlaylistListRow, PlaylistListRowSeparator, type PlaylistListRowProps } from './PlaylistListRow';
 export {
   PlaylistDetailView,
+  SKELETON_PLACEHOLDERS,
   type PlaylistDetailViewProps,
   type PlaylistDetailHero,
   type PlaylistDetailEmptyState,


### PR DESCRIPTION
Addresses review feedback on the mobile playlist-detail surface.

## Functional fix
- **Material branch silently dropped `actions`.** `PlaylistDetailView` computed `actionNode` but only rendered it in the Liquid Glass branch, so on Material (the default off iOS 26 — Android and any non-glass device) a playlist owner saw **no Follow / Pin / More (edit/delete) controls**. The actions now render in the `Appbar.Header`, just before the play action. They're requested in the compact icon form (`actions(true)`) since the app bar is always present on Material — `GlassIconButton` already routes to a Paper `IconButton` there, so the icons fit the bar.

## Test correctness
- The test mock typed the variant as `'glass' | 'material'`, but the real `UiVariant` is `'liquidGlass' | 'material'`. The glass-branch tests only passed by accident (anything `!== 'material'` renders the glass path). Corrected the literal throughout so a future guard on the real type would be caught.
- Added a Material-branch test that passes `actions` and asserts the node reaches the app bar — locking in the fix above (previously the only way to notice the drop was to run the app).

## Code smells
- Replaced the inline `import('react-native').OpaqueColorValue` param types in `MaterialEmptyState` with the standard `ColorValue` union from the top-level `react-native` import.
- `SKELETON_PLACEHOLDERS` was redeclared in three files, with the two route files hardcoding `8` rather than deriving from the view. The view now exports the array (single source of `SKELETON_ROW_COUNT`); both route-level early-return skeletons import it, so they can't drift.

## Validation
- `vp test --project mobile` — 26 passed (incl. new Material-actions test)
- `vp run typecheck:mobile` — clean
- `vp lint` (changed files) — 0 errors
- `vp run check:mobile-bundle` — OK (10.5 MB)

https://claude.ai/code/session_01WhAjLNh9dbBjSQhV1UGc69

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhAjLNh9dbBjSQhV1UGc69)_