### PR TITLE
fix(mobile): restore playlist actions in Material PlaylistDetailView header

### DIFF
--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -22,7 +22,9 @@ import {
   PlaylistActionsMenu,
   PlaylistFollowButton,
   PlaylistBackFab,
+  SKELETON_PLACEHOLDERS,
   type PlaylistFormValues,
+  type PlaylistMaterialActions,
 } from '../../../src/components/playlist';
 import { GlassIconButton } from '../../../src/components/GlassIconButton';
 import { getHttpClient } from '../../../src/lib/graphql/client';
@@ -42,6 +44,7 @@ type DetailParams = {
 export default function PlaylistDetail() {
   const { playlist_uuid: playlistUuid } = useLocalSearchParams<DetailParams>();
   const { t } = useTranslation('playlists');
+  const { t: tCommon } = useTranslation('common');
   const navigation = useNavigation();
   const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
@@ -326,6 +329,63 @@ export default function PlaylistDetail() {
     ],
   );
 
+  // Material-branch equivalent of `renderActions`: the same follow / pin / more
+  // capabilities, as structured descriptors the Paper header renders as
+  // `Appbar.Action`s + an overflow `Menu`. Owners keep edit/delete here too —
+  // the regression this fixes was Material owners losing those controls.
+  const materialActions = useMemo<PlaylistMaterialActions | undefined>(() => {
+    if (!playlist) return undefined;
+    const inline: NonNullable<PlaylistMaterialActions['inline']> = [];
+    if (isAuthenticated && isFollowable) {
+      inline.push({
+        key: 'follow',
+        icon: isFollowing ? 'check.small' : 'person.badge.plus',
+        accessibilityLabel: isFollowing ? tCommon('follow.following') : tCommon('follow.follow'),
+        onPress: handleToggleFollow,
+        disabled: followLoading,
+        tint: isFollowing ? brandColors.primary : undefined,
+      });
+    }
+    if (isAuthenticated) {
+      inline.push({
+        key: 'pin',
+        icon: isPinned ? 'pin.fill' : 'pin',
+        accessibilityLabel: isPinned ? t('library.pin.unpinAriaLabel') : t('library.pin.pinAriaLabel'),
+        onPress: () => {
+          hapticSelection();
+          handleTogglePin();
+        },
+        tint: isPinned ? brandColors.primary : undefined,
+      });
+    }
+    // Wire edit straight to the form sheet (not `openEdit`, which sequences the
+    // glass actions bottom sheet's dismiss → open handoff that Material doesn't
+    // use). The Paper `Menu` closes itself before invoking onPress, so there's no
+    // double-sheet animation to coordinate.
+    const menu: NonNullable<PlaylistMaterialActions['menu']> = isOwner
+      ? [
+          { key: 'edit', title: t('detail.menu.edit'), icon: 'edit', onPress: () => setEditVisible(true) },
+          { key: 'delete', title: t('detail.menu.delete'), icon: 'delete', onPress: handleDelete, destructive: true },
+        ]
+      : [];
+    if (inline.length === 0 && menu.length === 0) return undefined;
+    return { inline, menu };
+  }, [
+    playlist,
+    isAuthenticated,
+    isFollowable,
+    isFollowing,
+    handleToggleFollow,
+    followLoading,
+    isPinned,
+    handleTogglePin,
+    isOwner,
+    handleDelete,
+    brandColors,
+    t,
+    tCommon,
+  ]);
+
   const hero = useMemo(
     () => ({
       name: playlist?.name ?? t('metadata.detail.fallbackTitle'),
@@ -382,6 +442,7 @@ export default function PlaylistDetail() {
         onActivateClimb={activate}
         emptyMessage={t('detail.empty')}
         actions={renderActions}
+        materialActions={materialActions}
       />
 
       <PlaylistActionsMenu
@@ -402,9 +463,6 @@ export default function PlaylistDetail() {
     </>
   );
 }
-
-// Stable hoisted keys for the first-page skeleton rows.
-const SKELETON_PLACEHOLDERS = Array.from({ length: 8 }, (_, index) => `skeleton-${index}`);
 
 const styles = StyleSheet.create({
   stateContainer: {

--- a/packages/mobile/app/(tabs)/discover/smart/[type].tsx
+++ b/packages/mobile/app/(tabs)/discover/smart/[type].tsx
@@ -15,6 +15,7 @@ import { ClimbListRowSkeleton } from '../../../../src/components/ClimbListRowSke
 import {
   PlaylistDetailView,
   PlaylistBackFab,
+  SKELETON_PLACEHOLDERS,
   type PlaylistDetailEmptyState,
 } from '../../../../src/components/playlist';
 import { getHttpClient } from '../../../../src/lib/graphql/client';
@@ -142,9 +143,6 @@ export default function SmartPlaylistDetail() {
     />
   );
 }
-
-// Stable hoisted keys for the first-page skeleton rows.
-const SKELETON_PLACEHOLDERS = Array.from({ length: 8 }, (_, index) => `skeleton-${index}`);
 
 const styles = StyleSheet.create({
   stateContainer: {

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useCallback, useState } from 'react';
 import {
+  type ColorValue,
   type LayoutChangeEvent,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
@@ -18,13 +19,13 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FlashList } from '@shopify/flash-list';
-import { Appbar } from 'react-native-paper';
+import { Appbar, Menu } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import type { BoardName, Climb as SchemaClimb } from '@boardsesh/shared-schema';
 import type { Climb } from '@boardsesh/queue';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
-import { type IconName } from '../icon-map';
+import { type IconName, iconMap } from '../icon-map';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { ClimbListRow } from '../ClimbListRow';
 import { ClimbListRowSkeleton } from '../ClimbListRowSkeleton';
@@ -40,6 +41,7 @@ import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { glassSize } from '../../theme/layout';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
+import { SKELETON_PLACEHOLDERS } from './skeleton-placeholders';
 
 /** Bottom scrim that keeps white title/meta legible across the palette (amber
  *  and green included) without per-colour luminance branching. */
@@ -51,8 +53,6 @@ const GRADIENT_END = { x: 1, y: 1 } as const;
  *  enough to contain the floating FABs (which sit `spacing[1]` below the inset),
  *  so they're centered in the bar rather than poking out under it. */
 const NAV_BAR_HEIGHT = glassSize.standard + spacing[1] * 2;
-/** Rows of skeleton placeholder shown while the first page loads. */
-const SKELETON_ROW_COUNT = 8;
 
 /** Optional richer empty state (Material branch only). When omitted, the
  *  Material branch falls back to the same generic icon + `emptyMessage` the
@@ -64,6 +64,42 @@ export type PlaylistDetailEmptyState = {
   title: string;
   /** Supporting line under the headline (already translated). */
   supporting?: string;
+};
+
+/** A primary owner/viewer control rendered as a Paper `Appbar.Action` in the
+ *  Material header (e.g. follow, pin). Mirrors a glass action FAB. */
+export type PlaylistMaterialAction = {
+  /** Stable React key. */
+  key: string;
+  /** Semantic icon name, mapped to its MaterialCommunityIcons glyph for Paper. */
+  icon: IconName;
+  /** Already-translated accessibility label. */
+  accessibilityLabel: string;
+  onPress: () => void;
+  /** When set, tints the action (e.g. the brand colour for a pinned playlist). */
+  tint?: ColorValue;
+  /** Disables the action while a request is in flight (e.g. follow toggling). */
+  disabled?: boolean;
+};
+
+/** An item inside the Material header's overflow (`dots-vertical`) `Menu` — the
+ *  owner edit/delete controls the glass branch exposes via its more-FAB sheet. */
+export type PlaylistMaterialMenuItem = {
+  key: string;
+  /** Already-translated row label. */
+  title: string;
+  icon: IconName;
+  onPress: () => void;
+  /** Renders the row in the destructive (red) tone, e.g. Delete. */
+  destructive?: boolean;
+};
+
+/** Material-branch action set. `inline` actions become `Appbar.Action`s; `menu`
+ *  items (if any) hang off a trailing overflow `Menu`. The glass branch ignores
+ *  this and renders its `actions` render-prop FABs instead. */
+export type PlaylistMaterialActions = {
+  inline?: PlaylistMaterialAction[];
+  menu?: PlaylistMaterialMenuItem[];
 };
 
 export type PlaylistDetailHero = {
@@ -104,6 +140,11 @@ export type PlaylistDetailViewProps = {
    *  the colour header bar takes over. The back FAB on the left is always
    *  rendered; absent here = a back-only top bar. */
   actions?: (collapsed: boolean) => ReactNode;
+  /** Material-branch equivalent of `actions`. The glass branch can't share the
+   *  same nodes (its FABs are glass surfaces), so the Material header renders
+   *  these structured descriptors as Paper `Appbar.Action`s + an overflow
+   *  `Menu`. Absent here = a back-only Material header. */
+  materialActions?: PlaylistMaterialActions;
 };
 
 /**
@@ -128,6 +169,7 @@ export function PlaylistDetailView({
   emptyMessage,
   emptyState,
   actions,
+  materialActions,
 }: PlaylistDetailViewProps) {
   const { t } = useTranslation('playlists');
   const { t: tCommon } = useTranslation('common');
@@ -180,6 +222,12 @@ export function PlaylistDetailView({
     },
   );
   const actionNode = actions?.(collapsed);
+
+  // Material overflow `Menu` open state (owner edit/delete). Only used when the
+  // Material branch is active and `materialActions.menu` is non-empty.
+  const [menuVisible, setMenuVisible] = useState(false);
+  const openMenu = useCallback(() => setMenuVisible(true), []);
+  const closeMenu = useCallback(() => setMenuVisible(false), []);
 
   const handleEndReached = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) fetchNextPage();
@@ -337,6 +385,52 @@ export function PlaylistDetailView({
               onPress={handleActivateAll}
               accessibilityLabel={t('detail.activateAll')}
             />
+          ) : null}
+          {/* Owner/viewer controls (follow, pin) the glass branch floats over the
+              hero, surfaced here as Paper actions so Material owners keep them. */}
+          {materialActions?.inline?.map((action) => (
+            <Appbar.Action
+              key={action.key}
+              icon={iconMap[action.icon].android}
+              color={(action.tint ?? systemColors.label) as string}
+              rippleColor={withAlpha(accent, 0.16)}
+              onPress={action.onPress}
+              disabled={action.disabled}
+              accessibilityLabel={action.accessibilityLabel}
+            />
+          ))}
+          {/* Overflow menu for the owner edit/delete actions the glass branch
+              opens via its more-FAB bottom sheet. */}
+          {materialActions?.menu && materialActions.menu.length > 0 ? (
+            <Menu
+              visible={menuVisible}
+              onDismiss={closeMenu}
+              anchor={
+                <Appbar.Action
+                  icon="dots-vertical"
+                  color={systemColors.label as string}
+                  rippleColor={withAlpha(accent, 0.16)}
+                  onPress={openMenu}
+                  accessibilityLabel={t('detail.actions')}
+                />
+              }
+              contentStyle={{ backgroundColor: systemColors.elevatedSurface }}
+            >
+              {materialActions.menu.map((item) => (
+                <Menu.Item
+                  key={item.key}
+                  title={item.title}
+                  leadingIcon={iconMap[item.icon].android}
+                  titleStyle={{
+                    color: (item.destructive ? iosSystemColors.systemRed : systemColors.label) as string,
+                  }}
+                  onPress={() => {
+                    closeMenu();
+                    item.onPress();
+                  }}
+                />
+              ))}
+            </Menu>
           ) : null}
         </Appbar.Header>
       </View>
@@ -499,8 +593,8 @@ function MaterialEmptyState({
   icon: IconName;
   title: string;
   supporting?: string;
-  titleColor: string | import('react-native').OpaqueColorValue;
-  supportingColor: string | import('react-native').OpaqueColorValue;
+  titleColor: ColorValue;
+  supportingColor: ColorValue;
 }) {
   return (
     <View style={styles.stateContainer}>
@@ -522,10 +616,6 @@ function MaterialEmptyState({
 function keyExtractor(item: Climb) {
   return item.uuid;
 }
-
-// Hoisted stable keys for the first-page skeleton rows — never reorder, so index
-// keys are fine and avoid allocating an array on every render.
-const SKELETON_PLACEHOLDERS = Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => `skeleton-${index}`);
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -4,7 +4,9 @@ import { render, fireEvent } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/queue';
 
-const ctrl = vi.hoisted(() => ({ back: vi.fn(), variant: 'glass' as 'glass' | 'material' }));
+import type { UiVariant } from '../../../theme/resolve-ui-variant';
+
+const ctrl = vi.hoisted(() => ({ back: vi.fn(), variant: 'liquidGlass' as UiVariant }));
 
 // ── React Native ──────────────────────────────────────────────────────────────
 vi.mock('react-native', () => ({
@@ -99,6 +101,7 @@ vi.mock('../../../providers/theme-provider', () => ({
       background: '#ffffff',
       secondaryBackground: '#f2f2f2',
       tertiaryBackground: '#e5e5e5',
+      elevatedSurface: '#ffffff',
     },
     brandColors: { primary: '#6D28D9' },
   }),
@@ -121,7 +124,7 @@ vi.mock('../../../theme/colors', () => ({
   withAlpha: (color: string, alpha: number) => `${color}|${alpha}`,
 }));
 vi.mock('../../../theme/ios-colors', () => ({
-  iosSystemColors: { white: '#ffffff', systemGray4: '#aeaeb2' },
+  iosSystemColors: { white: '#ffffff', systemGray4: '#aeaeb2', systemRed: '#ff3b30' },
 }));
 
 // ── Leaf components ───────────────────────────────────────────────────────────
@@ -146,8 +149,18 @@ vi.mock('../../ClimbListRowSkeleton', () => ({
 }));
 
 // icon-map is pure data but pulls in expo-symbols types via Icon's import chain;
-// stub it so the component's `type IconName` import resolves without RN deps.
-vi.mock('../../icon-map', () => ({ iconMap: {} }));
+// stub the entries the Material header maps to MaterialCommunityIcons glyphs so
+// `iconMap[name].android` resolves without RN deps.
+vi.mock('../../icon-map', () => ({
+  iconMap: {
+    'person.badge.plus': { ios: 'person.badge.plus', android: 'account-plus-outline' },
+    'check.small': { ios: 'checkmark', android: 'check' },
+    pin: { ios: 'pin', android: 'pin-outline' },
+    'pin.fill': { ios: 'pin.fill', android: 'pin' },
+    edit: { ios: 'pencil', android: 'pencil-outline' },
+    delete: { ios: 'trash', android: 'delete-outline' },
+  },
+}));
 
 // react-native-paper drags in expo-modules-core at import time; stub the only
 // pieces the Material branch uses so the suite can load.
@@ -160,12 +173,34 @@ vi.mock('react-native-paper', () => {
     icon,
     onPress,
     accessibilityLabel,
+    disabled,
   }: {
     icon?: string;
     onPress?: () => void;
     accessibilityLabel?: string;
-  }) => createElement('button', { 'data-appbar-action': icon, onClick: onPress, 'aria-label': accessibilityLabel });
-  return { Appbar: { Header, BackAction, Content, Action } };
+    disabled?: boolean;
+  }) =>
+    createElement('button', {
+      'data-appbar-action': icon,
+      onClick: onPress,
+      'aria-label': accessibilityLabel,
+      disabled: disabled ?? false,
+    });
+  // Render the anchor (the dots-vertical action) always; render the children
+  // (menu items) only when `visible`, matching Paper's open/closed behaviour.
+  const MenuComponent = ({
+    visible,
+    anchor,
+    children,
+  }: {
+    visible?: boolean;
+    anchor?: ReactNode;
+    children?: ReactNode;
+  }) => createElement('div', { 'data-menu': 'true' }, anchor ?? null, visible ? children : null);
+  const MenuItem = ({ title, onPress }: { title?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { 'data-menu-item': 'true', onClick: onPress }, title);
+  const Menu = Object.assign(MenuComponent, { Item: MenuItem });
+  return { Appbar: { Header, BackAction, Content, Action }, Menu };
 });
 
 vi.mock('../../GlassIconButton', () => ({
@@ -225,7 +260,7 @@ function makeProps(overrides: Partial<PlaylistDetailViewProps> = {}): PlaylistDe
 describe('PlaylistDetailView', () => {
   beforeEach(() => {
     ctrl.back.mockClear();
-    ctrl.variant = 'glass';
+    ctrl.variant = 'liquidGlass';
   });
 
   // ── Navigation ──────────────────────────────────────────────────────────────
@@ -428,6 +463,89 @@ describe('PlaylistDetailView', () => {
     it('shows skeleton rows while loading', () => {
       const { container } = render(<PlaylistDetailView {...makeProps({ isLoading: true, climbs: [] })} />);
       expect(container.querySelectorAll('[data-skeleton-row]').length).toBeGreaterThan(0);
+    });
+
+    // ── Material actions (regression: owners lost follow/pin/edit/delete) ──────
+
+    it('renders inline materialActions as Appbar actions and wires onPress', () => {
+      const onFollow = vi.fn();
+      const onPin = vi.fn();
+      const materialActions = {
+        inline: [
+          { key: 'follow', icon: 'person.badge.plus' as const, accessibilityLabel: 'Follow', onPress: onFollow },
+          { key: 'pin', icon: 'pin' as const, accessibilityLabel: 'Pin playlist', onPress: onPin },
+        ],
+      };
+      const { container } = render(<PlaylistDetailView {...makeProps({ materialActions })} />);
+      const follow = container.querySelector('[data-appbar-action="account-plus-outline"]');
+      const pin = container.querySelector('[data-appbar-action="pin-outline"]');
+      expect(follow).not.toBeNull();
+      expect(pin).not.toBeNull();
+      fireEvent.click(follow as HTMLElement);
+      fireEvent.click(pin as HTMLElement);
+      expect(onFollow).toHaveBeenCalledTimes(1);
+      expect(onPin).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables an inline action when disabled is set', () => {
+      const materialActions = {
+        inline: [
+          {
+            key: 'follow',
+            icon: 'person.badge.plus' as const,
+            accessibilityLabel: 'Follow',
+            onPress: vi.fn(),
+            disabled: true,
+          },
+        ],
+      };
+      const { container } = render(<PlaylistDetailView {...makeProps({ materialActions })} />);
+      const follow = container.querySelector('[data-appbar-action="account-plus-outline"]') as HTMLButtonElement;
+      expect(follow.disabled).toBe(true);
+    });
+
+    it('renders an overflow menu anchor for owner edit/delete actions', () => {
+      const materialActions = {
+        menu: [
+          { key: 'edit', title: 'Edit', icon: 'edit' as const, onPress: vi.fn() },
+          { key: 'delete', title: 'Delete', icon: 'delete' as const, onPress: vi.fn(), destructive: true },
+        ],
+      };
+      const { container } = render(<PlaylistDetailView {...makeProps({ materialActions })} />);
+      // The dots-vertical anchor is present; menu items are hidden until opened.
+      expect(container.querySelector('[data-appbar-action="dots-vertical"]')).not.toBeNull();
+      expect(container.querySelectorAll('[data-menu-item]')).toHaveLength(0);
+    });
+
+    it('opens the overflow menu and fires the edit/delete handlers', () => {
+      const onEdit = vi.fn();
+      const onDelete = vi.fn();
+      const materialActions = {
+        menu: [
+          { key: 'edit', title: 'Edit', icon: 'edit' as const, onPress: onEdit },
+          { key: 'delete', title: 'Delete', icon: 'delete' as const, onPress: onDelete, destructive: true },
+        ],
+      };
+      const { container } = render(<PlaylistDetailView {...makeProps({ materialActions })} />);
+      const openOverflow = () =>
+        fireEvent.click(container.querySelector('[data-appbar-action="dots-vertical"]') as HTMLElement);
+      // Open the menu → both items render → tapping one closes the menu (so the
+      // next tap re-opens) and fires its handler.
+      openOverflow();
+      expect(container.querySelectorAll('[data-menu-item]')).toHaveLength(2);
+      fireEvent.click(container.querySelectorAll('[data-menu-item]')[0] as HTMLElement);
+      openOverflow();
+      fireEvent.click(container.querySelectorAll('[data-menu-item]')[1] as HTMLElement);
+      expect(onEdit).toHaveBeenCalledTimes(1);
+      expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders no overflow anchor when materialActions has no menu items', () => {
+      const materialActions = {
+        inline: [{ key: 'pin', icon: 'pin' as const, accessibilityLabel: 'Pin playlist', onPress: vi.fn() }],
+      };
+      const { container } = render(<PlaylistDetailView {...makeProps({ materialActions })} />);
+      expect(container.querySelector('[data-appbar-action="dots-vertical"]')).toBeNull();
     });
   });
 });

--- a/packages/mobile/src/components/playlist/index.ts
+++ b/packages/mobile/src/components/playlist/index.ts
@@ -14,3 +14,5 @@ export { PlaylistPinButton } from './PlaylistPinButton';
 export { PlaylistFollowButton } from './PlaylistFollowButton';
 export { PlaylistActionsMenu } from './PlaylistActionsMenu';
 export { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';
+export { SKELETON_PLACEHOLDERS, SKELETON_ROW_COUNT } from './skeleton-placeholders';
+export type { PlaylistMaterialAction, PlaylistMaterialMenuItem, PlaylistMaterialActions } from './PlaylistDetailView';

--- a/packages/mobile/src/components/playlist/skeleton-placeholders.ts
+++ b/packages/mobile/src/components/playlist/skeleton-placeholders.ts
@@ -1,0 +1,10 @@
+/** Number of skeleton rows shown while the first page of a playlist loads. */
+export const SKELETON_ROW_COUNT = 8;
+
+/**
+ * Stable hoisted keys for the first-page skeleton rows. Shared by the
+ * playlist-detail view and the two detail routes' early-return loading states so
+ * the row count never drifts between them. Never reordered, so index keys are
+ * fine and we avoid allocating an array on every render.
+ */
+export const SKELETON_PLACEHOLDERS = Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => `skeleton-${index}`);


### PR DESCRIPTION
## Why

Follow-up to the merged **#2620** (Material 3 `PlaylistDetailView`) review. The review flagged a real functional regression that is now live in `main`: the Material 3 branch of `PlaylistDetailView` `return`s before rendering the `actions` prop. On the `[playlist_uuid]` route, `renderActions` carries the **Follow**, **Pin**, and **More** (edit / delete) controls — so in **Material** mode a playlist **owner** sees **no edit / pin / follow controls** at all. The glass branch floats those as FABs over the hero; the Material branch silently dropped them.

## What changed

- **Restored the actions in the Material header.** The glass action FABs are glass surfaces and can't be dropped into a Paper `Appbar`, so the `[playlist_uuid]` route now passes a structured `materialActions` descriptor set alongside the existing glass `actions` render-prop. The Material branch renders:
  - **Follow** and **Pin** as Paper `Appbar.Action`s (pinned/following get the brand-colour tint; follow disables while toggling),
  - an **overflow `Menu`** (Paper `Menu` anchored on a `dots-vertical` `Appbar.Action`) carrying the owner **Edit** / **Delete** items (Delete in the destructive red).
  - Edit opens the existing form sheet directly; Delete reuses the existing confirm `Alert`. Glass branch is byte-for-byte unchanged.
- **Test type fix.** `playlist-detail-view.test.tsx` used `'glass' as 'glass' | 'material'`, but the real `UiVariant` is `'liquidGlass' | 'material'` — the cast hid the type error and the glass tests passed only by accident. The mock now uses the real `UiVariant` type with `'liquidGlass'` and no cast. Added Material-branch coverage for `materialActions` (inline follow/pin wiring, disabled state, overflow-menu open + edit/delete handlers, no anchor when there are no menu items).
- **Minor cleanups from the review.** `MaterialEmptyState` param colours now use the top-level `ColorValue` import instead of inline `import('react-native').OpaqueColorValue`. `SKELETON_PLACEHOLDERS` is extracted to one shared `skeleton-placeholders.ts` module and imported by the view and both detail routes (no more hardcoded `8` duplicated across files).

No new user-facing strings — all labels reuse existing keys (`common.follow.*`, `playlists.library.pin.*`, `playlists.detail.menu.*`, `playlists.detail.actions`).

## How to verify

1. Switch the app to the **Material** UI variant (Settings → appearance).
2. Open an **owned** playlist (Discover → a playlist you created).
3. The Material header now shows **Pin** and (for public non-owned playlists) **Follow** actions, plus a **dots-vertical** overflow menu with **Edit** / **Delete**. Tapping Edit opens the form sheet; Delete prompts the confirm dialog.
4. Switch back to **Liquid Glass**: the gradient hero, floating follow/pin/more FABs, and collapsed colour bar are unchanged.

## Validation

- `vp run typecheck:mobile` — pass
- `vp test --project mobile` (playlist-detail-view) — pass (32 tests across the 2 view test files; 6 new Material-action tests)
- `vp run check:mobile-bundle` — pass (Android bundle OK, 10.5 MB)
- Pre-existing unrelated flake: `use-playlist-activation.test.tsx` (`opens the play drawer without re-setting the current climb`) fails identically on clean `origin/main` — untouched here, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)