### PR TITLE
feat(mobile): board switcher in the Material 3 climbs header

### DIFF
--- a/packages/mobile/src/components/chrome/BoardSwitcherButton.tsx
+++ b/packages/mobile/src/components/chrome/BoardSwitcherButton.tsx
@@ -1,0 +1,75 @@
+import { useCallback, useMemo } from 'react';
+import { StyleSheet } from 'react-native';
+import { useTheme } from '../../providers/theme-provider';
+import { useActiveBoard } from '../../lib/graphql/use-active-board';
+import { formatActiveBoardLabel } from '../../lib/boards/active-board-label';
+import { hapticLight } from '../../lib/haptics';
+import { spacing } from '../../theme/tokens';
+import { PressableSurface } from '../PressableSurface';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+
+type BoardSwitcherButtonProps = {
+  /** What a tap does — open the board switcher (the `/boards` modal). */
+  onPress: () => void;
+  /** VoiceOver / TalkBack hint, e.g. "Opens the board switcher". */
+  accessibilityHint?: string;
+};
+
+/**
+ * The Material variant's board switcher: the active board label ("Kilter • M •
+ * 45°", or "Garage Wall • 40°" for a named board) shown as the app-bar title
+ * with a trailing down-caret affordance, so it reads as a tappable context
+ * switcher rather than the static subtitle it replaces. It is the flat M3
+ * counterpart of the liquid-glass `BoardPill` — reads the active board itself,
+ * renders nothing when none is set, and fires the haptic here while the caller
+ * injects what a tap does. Lives where `Appbar.Content` did, taking `flex: 1`.
+ */
+export function BoardSwitcherButton({ onPress, accessibilityHint }: BoardSwitcherButtonProps) {
+  const { systemColors } = useTheme();
+  const { data: activeBoard } = useActiveBoard();
+
+  const boardLabel = useMemo(() => formatActiveBoardLabel(activeBoard), [activeBoard]);
+
+  const handlePress = useCallback(() => {
+    hapticLight();
+    onPress();
+  }, [onPress]);
+
+  if (!boardLabel) return null;
+
+  return (
+    <PressableSurface
+      onPress={handlePress}
+      feedback="none"
+      rippleColor={systemColors.fill as string}
+      accessibilityRole="button"
+      accessibilityLabel={boardLabel}
+      accessibilityHint={accessibilityHint}
+      style={styles.press}
+    >
+      <Text variant="title3" numberOfLines={1} ellipsizeMode="tail" color={systemColors.label} style={styles.label}>
+        {boardLabel}
+      </Text>
+      <Icon name="chevron.down" size={18} color={systemColors.secondaryLabel as string} />
+    </PressableSurface>
+  );
+}
+
+const styles = StyleSheet.create({
+  // Fills the row left of the trailing actions (where Appbar.Content sat); the
+  // label flex-shrinks and truncates so the caret stays visible and the actions
+  // are never pushed off-screen. paddingLeft lands the title near the M3 16dp
+  // margin (the Appbar adds its own ~4dp), aligning it with the search row below.
+  press: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+    paddingLeft: spacing[3],
+    paddingRight: spacing[1],
+  },
+  label: {
+    flexShrink: 1,
+  },
+});

--- a/packages/mobile/src/components/chrome/BoardSwitcherButton.tsx
+++ b/packages/mobile/src/components/chrome/BoardSwitcherButton.tsx
@@ -59,10 +59,13 @@ export function BoardSwitcherButton({ onPress, accessibilityHint }: BoardSwitche
 const styles = StyleSheet.create({
   // Fills the row left of the trailing actions (where Appbar.Content sat); the
   // label flex-shrinks and truncates so the caret stays visible and the actions
-  // are never pushed off-screen. paddingLeft lands the title near the M3 16dp
-  // margin (the Appbar adds its own ~4dp), aligning it with the search row below.
+  // are never pushed off-screen. alignSelf stretch overrides the Appbar's
+  // alignItems:'center' so the tap target spans the full app-bar height, not just
+  // the label line. paddingLeft lands the title near the M3 16dp margin (the
+  // Appbar adds its own ~4dp), aligning it with the search row below.
   press: {
     flex: 1,
+    alignSelf: 'stretch',
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[1],

--- a/packages/mobile/src/components/chrome/__tests__/board-switcher-button.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/board-switcher-button.test.tsx
@@ -41,7 +41,10 @@ vi.mock('../../PressableSurface', () => ({
       {
         onClick: onPress,
         'data-hint': accessibilityHint ?? '',
-        'data-label': accessibilityLabel?.includes('•') ? accessibilityLabel : '',
+        // Always pass the label through (don't gate on the "•" separator): a
+        // named board with no angle has no bullet, and gating would make the
+        // button() helper silently return null and false-pass.
+        'data-label': accessibilityLabel ?? '',
       },
       children,
     ),
@@ -63,6 +66,20 @@ const typedBoard: BoardLabelFields = {
   boardType: 'kilter',
   sizeName: 'M',
   layoutName: 'Kilter Layout',
+};
+const namedBoard: BoardLabelFields = {
+  name: 'Garage Wall',
+  angle: 25,
+  boardType: 'tension',
+  sizeName: '8x10',
+  layoutName: 'Tension Layout',
+};
+const namedBoardNoAngle: BoardLabelFields = {
+  name: 'Garage Wall',
+  angle: null as unknown as number,
+  boardType: 'tension',
+  sizeName: '8x10',
+  layoutName: 'Tension Layout',
 };
 
 describe('BoardSwitcherButton', () => {
@@ -86,6 +103,18 @@ describe('BoardSwitcherButton', () => {
     fireEvent.click(target!);
     expect(onPress).toHaveBeenCalledTimes(1);
     expect(haptics.light).toHaveBeenCalledTimes(1);
+  });
+
+  it('leads with the custom board name for a named board', () => {
+    ctrl.board = namedBoard;
+    const { container } = render(createElement(BoardSwitcherButton, { onPress: vi.fn() }));
+    expect(button(container)?.getAttribute('data-label')).toBe('Garage Wall • 25°');
+  });
+
+  it('renders a named board with no angle (label has no separator)', () => {
+    ctrl.board = namedBoardNoAngle;
+    const { container } = render(createElement(BoardSwitcherButton, { onPress: vi.fn() }));
+    expect(button(container)?.getAttribute('data-label')).toBe('Garage Wall');
   });
 
   it('forwards the accessibility hint', () => {

--- a/packages/mobile/src/components/chrome/__tests__/board-switcher-button.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/board-switcher-button.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+type BoardLabelFields = Pick<UserBoard, 'name' | 'angle' | 'boardType' | 'sizeName' | 'layoutName'>;
+
+const ctrl = vi.hoisted(() => ({ board: null as BoardLabelFields | null }));
+const haptics = vi.hoisted(() => ({ light: vi.fn() }));
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('@boardsesh/board-config', () => ({
+  formatBoardDisplayName: (boardType: string) => `Display:${boardType}`,
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { label: '#000', secondaryLabel: '#888', fill: '#eee' } }),
+}));
+
+vi.mock('../../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: ctrl.board }),
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticLight: haptics.light }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 3: 12 } }));
+
+type PressMockProps = {
+  children?: ReactNode;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+};
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({ children, onPress, accessibilityLabel, accessibilityHint }: PressMockProps) =>
+    createElement(
+      'button',
+      {
+        onClick: onPress,
+        'data-hint': accessibilityHint ?? '',
+        'data-label': accessibilityLabel?.includes('•') ? accessibilityLabel : '',
+      },
+      children,
+    ),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
+
+import { BoardSwitcherButton } from '../BoardSwitcherButton';
+
+const button = (root: HTMLElement) =>
+  root.querySelector('[data-label]:not([data-label=""])') as HTMLButtonElement | null;
+
+const typedBoard: BoardLabelFields = {
+  name: '',
+  angle: 40,
+  boardType: 'kilter',
+  sizeName: 'M',
+  layoutName: 'Kilter Layout',
+};
+
+describe('BoardSwitcherButton', () => {
+  beforeEach(() => {
+    ctrl.board = null;
+    haptics.light.mockClear();
+  });
+
+  it('renders nothing when there is no active board', () => {
+    const { container } = render(createElement(BoardSwitcherButton, { onPress: vi.fn() }));
+    expect(button(container)).toBeNull();
+  });
+
+  it('renders the board label with a caret and fires onPress with a haptic', () => {
+    ctrl.board = typedBoard;
+    const onPress = vi.fn();
+    const { container } = render(createElement(BoardSwitcherButton, { onPress }));
+    const target = button(container);
+    expect(target?.getAttribute('data-label')).toBe('Display:kilter • M • 40°');
+    expect(container.querySelector('[data-icon="chevron.down"]')).not.toBeNull();
+    fireEvent.click(target!);
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(haptics.light).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards the accessibility hint', () => {
+    ctrl.board = typedBoard;
+    const { container } = render(
+      createElement(BoardSwitcherButton, { onPress: vi.fn(), accessibilityHint: 'Opens the board switcher' }),
+    );
+    expect(button(container)?.getAttribute('data-hint')).toBe('Opens the board switcher');
+  });
+});

--- a/packages/mobile/src/components/chrome/index.ts
+++ b/packages/mobile/src/components/chrome/index.ts
@@ -1,4 +1,5 @@
 export { BoardPill } from './BoardPill';
+export { BoardSwitcherButton } from './BoardSwitcherButton';
 export { GlassActionToolbar, GlassToolbarAction, TOP_ACTION_SIZE } from './GlassActionToolbar';
 export { AngleToolbarAction } from './AngleToolbarAction';
 export { LightbulbToolbarAction } from './LightbulbToolbarAction';

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -20,11 +20,10 @@ import { useActiveBoard, useSetActiveBoard } from '../../lib/graphql/use-active-
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { spacing } from '../../theme/tokens';
 import { hapticLight } from '../../lib/haptics';
-import { formatActiveBoardLabel } from '../../lib/boards/active-board-label';
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 import { Text } from '../Text';
 import { iconMap } from '../icon-map';
-import { CollapsingTopChrome, TOP_ACTION_SIZE } from '../chrome';
+import { BoardSwitcherButton, CollapsingTopChrome, TOP_ACTION_SIZE } from '../chrome';
 import { GradeRangeRail } from '../grade';
 import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
 import { FilterButton } from './FilterButton';
@@ -98,10 +97,8 @@ export function ClimbTopChrome({
   onGradeChange,
 }: ClimbTopChromeProps) {
   const { t } = useTranslation('climbs');
-  const { t: tCommon } = useTranslation('common');
   const { systemColors, variant } = useTheme();
   const insets = useSafeAreaInsets();
-  const { data: activeBoard } = useActiveBoard();
   const usesCustomSearch = searchMode === 'custom';
 
   const handleLayout = useCallback(
@@ -127,7 +124,6 @@ export function ClimbTopChrome({
   }, [onSearchBlur]);
 
   if (variant === 'material') {
-    const boardLabel = formatActiveBoardLabel(activeBoard);
     const hasGradeFilter = gradeChip?.active === true;
     const nonGradeFilterCount = Math.max(0, activeFilterCount - (hasGradeFilter ? 1 : 0));
     const hasNonGradeFilters = nonGradeFilterCount > 0;
@@ -154,20 +150,7 @@ export function ClimbTopChrome({
           elevated
           style={[styles.materialAppbar, { backgroundColor: systemColors.secondaryBackground }]}
         >
-          <Appbar.Content
-            title={tCommon('mobile.nav.climbs')}
-            subtitle={boardLabel ?? undefined}
-            onPress={
-              boardLabel
-                ? () => {
-                    hapticLight();
-                    onOpenBoardDetail();
-                  }
-                : undefined
-            }
-            titleStyle={styles.materialTitle}
-            subtitleStyle={styles.materialSubtitle}
-          />
+          <BoardSwitcherButton onPress={onOpenBoardDetail} accessibilityHint={t('mobile.search.boardSwitcherHint')} />
           {canCreate ? (
             <Appbar.Action
               icon={iconMap.plus.android}
@@ -392,12 +375,6 @@ const styles = StyleSheet.create({
   materialAppbar: {
     elevation: 0,
     shadowOpacity: 0,
-  },
-  materialTitle: {
-    fontWeight: '700',
-  },
-  materialSubtitle: {
-    fontWeight: '500',
   },
   materialSearchStack: {
     paddingHorizontal: spacing[4],

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -530,8 +530,11 @@ describe('ClimbTopChrome', () => {
 
     expect(container.querySelector('[data-gradient]')).toBeNull();
     // The board switcher replaces the static Appbar.Content subtitle: the board
-    // label shows as the title with a down-caret affordance.
-    expect(capsule(container)?.getAttribute('data-capsule')).toBe('Display:kilter • 12x12 • 40°');
+    // label shows as the title with a down-caret affordance. Assert the hint too
+    // so this pins the BoardSwitcherButton specifically, not any [data-capsule].
+    const switcher = capsule(container);
+    expect(switcher?.getAttribute('data-capsule')).toBe('Display:kilter • 12x12 • 40°');
+    expect(switcher?.getAttribute('data-hint')).toBe('mobile.search.boardSwitcherHint');
     expect(container.querySelector('[data-icon="chevron.down"]')).not.toBeNull();
     expect(container.querySelector('[data-search-field]')).not.toBeNull();
     expect(container.querySelector('[data-pressable="mobile.search.gradeAction"]')?.textContent).toContain(

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -166,7 +166,7 @@ vi.mock('../../../providers/bluetooth-provider', () => ({
 }));
 
 vi.mock('../../../theme/tokens', () => ({
-  spacing: { 1: 4, 2: 8, 4: 16 },
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
   shadows: { sm: {} },
 }));
 
@@ -510,7 +510,7 @@ describe('ClimbTopChrome', () => {
     expect(onHeightChange).toHaveBeenCalledWith(88);
   });
 
-  it('renders the Material branch as an opaque app bar with search and grade controls', () => {
+  it('renders the Material branch with the board switcher, search, and grade controls', () => {
     ctrl.variant = 'material';
     ctrl.board = typedBoard;
     const onOpenBoardDetail = vi.fn();
@@ -529,12 +529,16 @@ describe('ClimbTopChrome', () => {
     );
 
     expect(container.querySelector('[data-gradient]')).toBeNull();
-    expect(container.querySelector('[data-appbar-title="true"]')?.textContent).toBe('mobile.nav.climbs');
-    expect(container.querySelector('[data-appbar-subtitle="true"]')?.textContent).toBe('Display:kilter • 12x12 • 40°');
+    // The board switcher replaces the static Appbar.Content subtitle: the board
+    // label shows as the title with a down-caret affordance.
+    expect(capsule(container)?.getAttribute('data-capsule')).toBe('Display:kilter • 12x12 • 40°');
+    expect(container.querySelector('[data-icon="chevron.down"]')).not.toBeNull();
     expect(container.querySelector('[data-search-field]')).not.toBeNull();
-    expect(container.querySelector('[data-pressable="mobile.search.gradeAction"]')?.textContent).toContain('Grade range');
+    expect(container.querySelector('[data-pressable="mobile.search.gradeAction"]')?.textContent).toContain(
+      'Grade range',
+    );
 
-    fireEvent.click(container.querySelector('[data-appbar-content="true"]') as HTMLButtonElement);
+    fireEvent.click(capsule(container)!);
     expect(onOpenBoardDetail).toHaveBeenCalledTimes(1);
     expect(haptics.light).toHaveBeenCalledTimes(1);
   });
@@ -643,7 +647,9 @@ describe('ClimbTopChrome', () => {
 
     fireEvent.click(container.querySelector('[data-pressable="mobile.search.gradeAction"]') as HTMLButtonElement);
     expect(onOpenGrade).toHaveBeenCalledTimes(1);
-    fireEvent.click(container.querySelector('[data-pressable="mobile.gradeRail.clearFilterAria"]') as HTMLButtonElement);
+    fireEvent.click(
+      container.querySelector('[data-pressable="mobile.gradeRail.clearFilterAria"]') as HTMLButtonElement,
+    );
     expect(onClearGrade).toHaveBeenCalledTimes(1);
 
     rerender(

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -665,6 +665,7 @@
       "gradeAction": "Set grade range",
       "gradeOpenHint": "Opens the grade picker",
       "gradeCloseHint": "Closes the grade picker",
+      "boardSwitcherHint": "Opens the board switcher",
       "allClimbs": "All climbs"
     },
     "gradeRail": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -665,6 +665,7 @@
       "gradeAction": "Ajustar el rango de grado",
       "gradeOpenHint": "Abre el selector de grado",
       "gradeCloseHint": "Cierra el selector de grado",
+      "boardSwitcherHint": "Abre el selector de tabla",
       "allClimbs": "Todas las vías"
     },
     "gradeRail": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -665,6 +665,7 @@
       "gradeAction": "Définir la plage de cotation",
       "gradeOpenHint": "Ouvre le sélecteur de cotation",
       "gradeCloseHint": "Ferme le sélecteur de cotation",
+      "boardSwitcherHint": "Ouvre le sélecteur de board",
       "allClimbs": "Toutes les voies"
     },
     "gradeRail": {


### PR DESCRIPTION
## What

Adds a discoverable board switcher to the **Material 3** variant of the Climbs tab header.

Before, the active board sat in the `Appbar.Content` *subtitle* — technically tappable (it opened the `/boards` modal) but with no visible affordance, so it read as static text and users didn't realize they could switch boards. Now the board name is the app-bar title with a trailing **down-caret (⌄)** affordance, and tapping opens the existing `/boards` modal.

The iOS liquid-glass variant is untouched (it keeps its auto-minimizing `BoardPill` capsule — the wrong pattern for M3).

```
┌────────────────────────────────────────────┐
│ Kilter · M · 45°  ⌄          ＋   45°   💡  │   ← Appbar.Header (small)
├────────────────────────────────────────────┤
│ 🔍 Search climbs     V4–V6 ⌄     ☰ filter  │   ← unchanged search row
└────────────────────────────────────────────┘
```

## Design rationale (M3)

The board is the screen's *page context* (switching it re-datasets the whole list), so it belongs in the **headline** with a caret affordance — not as a 4th trailing icon, and not as the iOS capsule. Board switching is rare in usage, so it stays subordinate to search/filter. "Climbs" is dropped from the title (the bottom tab already names the screen), maximizing room for long board labels. Tapping opens the full `/boards` modal rather than an inline `Menu`, because the board is a complex tuple (type · layout · size · set · angle) and `/boards` already handles discovery.

## Changes

- **New** `chrome/BoardSwitcherButton.tsx` — flat M3 counterpart of the liquid-glass `BoardPill`: reads the active board itself, shows label + `chevron-down`, fires `hapticLight()`, returns `null` when there's no board. Borderless (it's the title, not a filter pill); label `onSurface`, caret `onSurfaceVariant`, no brand tint.
- `chrome/index.ts` — barrel export.
- `search/ClimbTopChrome.tsx` — swapped `Appbar.Content` for `<BoardSwitcherButton>` (reuses the already-wired `onOpenBoardDetail`, so `climbs/index.tsx` is unchanged); removed the now-dead `boardLabel`, the `formatActiveBoardLabel`/`tCommon` imports, and the `materialTitle`/`materialSubtitle` styles.
- i18n: new `mobile.search.boardSwitcherHint` a11y hint in en-US/es/fr.
- Tests: new `board-switcher-button.test.tsx`; updated the Material case in `climb-top-chrome.test.tsx`.

## Validation

- `vp run typecheck:mobile` ✓
- `vp lint` (changed files) — 0 warnings, 0 errors ✓
- `vp check` — changed files clean ✓
- `vp run check:mobile-bundle` — OK (10.5 MB) ✓
- i18n catalog-completeness — 28 passing ✓
- `vp test --project mobile` — 1243/1244; the single failure (`use-playlist-activation`) is pre-existing on `main` and unrelated to this change.

Not run on Linux: `mobile:screenshot` / simulator (macOS-only) — worth a glance to confirm a long named-board label truncates cleanly against the three trailing actions (label is `numberOfLines={1}` + `flexShrink`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)