### PR TITLE
test(mobile): fix stale playlist-activation test left red by #2623

### DIFF
--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -85,8 +85,8 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     const climb = makeClimb('a');
     const item = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
     expect(mocks.setCurrentClimb).toHaveBeenCalledWith({ uuid: 'qi-a', climb }, { playlistSuggestionSource: null });
-    // Returning the item (non-null) is what tells the shared hook activation
-    // succeeded so it fires onActivated.
+    // Returning the item (non-null) tells the shared hook the synchronous
+    // activation phase succeeded.
     expect(item).toEqual({ uuid: 'qi-a', climb });
   });
 
@@ -101,11 +101,18 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     expect(captured().resolveTarget(makeClimb('a'))).toBeNull();
   });
 
-  it('onActivated opens the play drawer without re-setting the current climb', () => {
-    renderActivation();
+  it('opens the play drawer immediately on activate, before the queue state updates', async () => {
+    const { result } = renderActivation();
     const climb = makeClimb('a');
-    captured().onActivated?.(climb);
+    await result.current(climb);
+    // The drawer opens FIRST — before the shared activation's setCurrentClimb +
+    // suggestion-source work — so BottomSheetModal.present() fires on the same
+    // frame as the tap. setAsCurrent:false stops the drawer re-dispatching and
+    // wiping the suggestion source the activation builds.
     expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { setAsCurrent: false });
+    // The shared activation still runs (suggestion source + the queue dispatch,
+    // which is wrapped in startTransition).
+    expect(mocks.activate).toHaveBeenCalledWith(climb);
   });
 
   it('fetchClimbsForBoard pages the playlist via the injected fetchPage', async () => {


### PR DESCRIPTION
## Problem
`main` is currently **red**: `use-playlist-activation.test.tsx` → "onActivated opens the play drawer without re-setting the current climb" fails.

#2623 reworked `usePlaylistActivation` to open the drawer in the returned `activate` callback **before** `activate()` runs (and dropped the `onActivated` side-effect, wrapping the queue dispatch in `startTransition`). But a pre-existing test still asserted the old `onActivated` path — `captured().onActivated` is now `undefined`, so `captured().onActivated?.(climb)` no-ops and `openPlayDrawer` is never called.

## Fix
Drive the hook's **returned `activate` callback** and assert the new behaviour: the drawer opens first with `{ setAsCurrent: false }`, and the shared activation still runs.

## How it slipped through
The mobile CI test step under-matches the project's files (the `vp test --project mobile` glob resolves relative to repo root and runs ~1 file), so this test didn't run at #2623's merge. A full-root `vp test run` exercises it — that's how it surfaced. Worth tightening the mobile CI invocation as a follow-up.

## Validation
- `vp test run --project mobile` — **1241 passed / 163 files** (was 1 failing)
- `vp run typecheck:mobile`, lint + format clean, `vp run check:mobile-bundle` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)