### PR TITLE
ci: disable e2e tests workflow automatic triggers

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,21 +1,7 @@
 name: E2E Tests
 
 on:
-  push:
-    branches: [main, develop]
-    paths:
-      - 'packages/**'
-      - 'bun.lock'
-      - 'package.json'
-      - 'vite.config.ts'
-      - '.github/workflows/e2e-tests.yml'
-  pull_request:
-    paths:
-      - 'packages/**'
-      - 'bun.lock'
-      - 'package.json'
-      - 'vite.config.ts'
-      - '.github/workflows/e2e-tests.yml'
+  workflow_dispatch:
 
 concurrency:
   group: e2e-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Replaces `push` and `pull_request` triggers in `e2e-tests.yml` with `workflow_dispatch` only
- The workflow will no longer run automatically on push or PR — it can still be triggered manually from the Actions tab

## Test plan

- [ ] Confirm no E2E workflow run is triggered on next PR push
- [ ] Confirm the workflow can still be run manually via Actions → E2E Tests → Run workflow

https://claude.ai/code/session_01EvTLCdsGSnWn5XUmu4q3q6

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvTLCdsGSnWn5XUmu4q3q6)_