### PR TITLE
build: footgun-proof scoped test aliases + fix test-invocation docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Common commands:
 
 - `vp check` — format + lint (canonical validation; pre-commit)
 - `vp test` / `vp test run --reporter=agent` — tests (always use `--reporter=agent` to save context)
-- `vp test --project web|backend|mobile` — scope tests
+- `vp test run --project web|backend|mobile` — scope tests. **`--project` MUST come after `run`.** `vp test --project mobile run` (flag before `run`) silently treats the name as a filename filter and runs ~1 file — a false green. Prefer the footgun-proof aliases `vp run test:mobile` / `vp run test:web`.
 - `vp run dev` — start DB + backend + web
 - `vp run dev:mobile` — start mobile dev server (Metro)
 - `vp run db:up` / `vp run db:migrate` / `vp run db:studio`
@@ -217,7 +217,7 @@ React Native + Expo SDK 53, React Native 0.79, Expo Router 5.
 After mobile changes:
 
 1. `vp run typecheck:mobile` — always.
-2. `vp test --project mobile` — always.
+2. `vp run test:mobile` (or `vp test run --project mobile`) — always. Do **not** use `vp test --project mobile run` — the flag-before-`run` order runs ~1 file (false green).
 3. `vp run check:mobile-bundle` — Metro bundle check (Linux-safe; highest-value).
 4. `vp run check:mobile-simulator` — macOS only; skips on Linux.
 5. `vp run mobile:screenshot` — macOS only.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -364,6 +364,19 @@ export default defineConfig({
           'typecheck:sync-runtime',
         ],
       },
+      // Footgun-proof scoped test runs. `vp test --project <name> run` (the
+      // `--project` flag BEFORE the `run` subcommand) silently treats the name
+      // as a filename filter and runs ~1 file — a false green. These aliases
+      // wrap the correct `vp test run --project <name>` form so the order can't
+      // be got wrong. cache:false so tests always re-run.
+      'test:mobile': {
+        command: 'vp test run --project mobile',
+        cache: false,
+      },
+      'test:web': {
+        command: 'vp test run --project web',
+        cache: false,
+      },
 
       // --- Mobile validation ---
       'check:mobile-native-deps': {


### PR DESCRIPTION
## The quirk
`vp test --project mobile run` (the `--project` flag **before** the `run` subcommand) silently treats the project name as a filename filter and runs **~1 file** — a false green. The correct form is `vp test run --project mobile` (project **after** `run`).

```
vp test --project mobile run   → Test Files  1 passed (1)        ← footgun
vp test run --project mobile   → Test Files  164 passed (164)    ← correct
```

CLAUDE.md documented the broken order, so local validation (and agents following the docs) under-ran the mobile suite. That's the class of gap that let a red test reach `main` recently: a source-only change whose related test wasn't picked up by the PR's `--changed` run, merged into an unprotected `main` (the post-merge full run went red but didn't block).

## Fix
- **Add `vp run test:mobile` / `vp run test:web`** task aliases that wrap the correct `vp test run --project <name>` form, so the argument order can't be got wrong.
- **Fix `CLAUDE.md`** (the Commands list + the mobile validation sequence) to the correct invocation, with an explicit warning about the flag-before-`run` footgun.

## Verification
- `vp test --project mobile run` → 1 file (reproduces the footgun)
- `vp run test:mobile` → **164 files / 1247 tests, green**
- `vp fmt --check` clean

## Out of scope (flagged, not fixed here)
The deeper reasons the red test actually merged are CI-side: the PR `--changed` run didn't pick up the source change's related test, and `main` isn't branch-protected so the red post-merge full run didn't revert. Worth a follow-up to (a) require CI green on `main`, and (b) consider running the fast unit projects (mobile) in full rather than `--changed` on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)