### PR TITLE
fix(mobile): swallow keep-awake deactivate rejections

### DIFF
--- a/packages/mobile/src/components/play-drawer/use-play-drawer-wake-lock.ts
+++ b/packages/mobile/src/components/play-drawer/use-play-drawer-wake-lock.ts
@@ -8,10 +8,10 @@ export function usePlayDrawerWakeLock(isOpen: boolean): void {
     if (isOpen) {
       activateKeepAwakeAsync(WAKE_LOCK_TAG).catch(() => {});
     } else {
-      deactivateKeepAwake(WAKE_LOCK_TAG);
+      deactivateKeepAwake(WAKE_LOCK_TAG).catch(() => {});
     }
     return () => {
-      deactivateKeepAwake(WAKE_LOCK_TAG);
+      deactivateKeepAwake(WAKE_LOCK_TAG).catch(() => {});
     };
   }, [isOpen]);
 }

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -37,8 +37,8 @@ vi.mock('../ble-manager', () => ({
 }));
 
 vi.mock('expo-keep-awake', () => ({
-  activateKeepAwakeAsync: vi.fn(),
-  deactivateKeepAwake: vi.fn(),
+  activateKeepAwakeAsync: vi.fn().mockResolvedValue(undefined),
+  deactivateKeepAwake: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@boardsesh/ble-protocol/aurora', () => ({

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -141,10 +141,10 @@ export function useBoardBluetooth({
     if (isConnected) {
       activateKeepAwakeAsync(KEEP_AWAKE_TAG).catch(() => {});
     } else {
-      deactivateKeepAwake(KEEP_AWAKE_TAG);
+      deactivateKeepAwake(KEEP_AWAKE_TAG).catch(() => {});
     }
     return () => {
-      deactivateKeepAwake(KEEP_AWAKE_TAG);
+      deactivateKeepAwake(KEEP_AWAKE_TAG).catch(() => {});
     };
   }, [isConnected]);
 


### PR DESCRIPTION
## Problem

Sentry issue 7526010294 (production, Android 15, `com.boardsesh.app@2.0.0+2000075`):

```
Error: Call to function 'ExpoKeepAwake.deactivate' has been rejected.
→ Caused by: The current activity is no longer available
mechanism: onunhandledrejection
```

`expo-keep-awake`'s `deactivateKeepAwake(tag)` is `async` and returns a `Promise<void>`. On Android, when the host Activity has been torn down (app backgrounded/closed while a wake lock is active), the native `ExpoKeepAwake.deactivate(tag)` call rejects with "The current activity is no longer available".

In both wake-lock hooks the paired `activateKeepAwakeAsync(...)` calls already swallow errors with `.catch(() => {})`, but the `deactivateKeepAwake(...)` calls did not. Their rejected promise went unhandled and was reported to Sentry via `onunhandledrejection`. The rejection is benign — the screen-lock state no longer matters once the activity is gone.

## Change

Chain `.catch(() => {})` on every `deactivateKeepAwake(...)` call, matching the existing activate pattern.

- `packages/mobile/src/components/play-drawer/use-play-drawer-wake-lock.ts`
- `packages/mobile/src/lib/ble/use-board-bluetooth.ts`
- `packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts` — the `expo-keep-awake` mock now returns resolved promises so `.catch` is valid on the mocked calls.

## Validation

- `vp run typecheck:mobile` — pass
- `vp test run --project mobile` on `use-board-bluetooth.test.ts` — 13 passed
- `vp run check:mobile-bundle` — OK (10.5 MB Android bundle)

(One unrelated pre-existing mobile test failure in `use-playlist-activation.test.tsx` exists on `main` independent of this change.)

https://claude.ai/code/session_01NpNWcgDmoc28hXyBuCvUWD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpNWcgDmoc28hXyBuCvUWD)_