### PR TITLE
fix(mobile): stop fetching board art over HTTP on climbs screen

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -3,7 +3,6 @@ import {
   View,
   StyleSheet,
   RefreshControl,
-  Image,
   Keyboard,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
@@ -52,7 +51,7 @@ import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-a
 import { toQueueClimb, toQueueClimbs } from '../../../src/lib/climb-types';
 import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
 import { useAuth } from '../../../src/providers/auth-provider';
-import { getBoardRenderData } from '../../../src/lib/board-details';
+import { ensureBackgroundsCached } from '../../../src/lib/background-image-cache';
 import {
   getRecentFilters,
   addRecentFilter,
@@ -378,21 +377,18 @@ function ClimbListInner() {
     return () => clearTimeout(handle);
   }, [filters, name, boardFilters, boardConfig, boardKey]);
 
-  // Pre-warm board images so they're cached before the user taps into a climb.
+  // Pre-warm bundled board backgrounds so the first tap into a climb paints
+  // instantly. Backgrounds are bundled file:// assets — never fetch board art
+  // over HTTP (the production CDN/WAF 403s the app's request).
   useEffect(() => {
     if (!activeBoard) return;
     const parsedSetIds = activeBoard.setIds.split(',').map(Number);
-    const renderData = getBoardRenderData({
+    void ensureBackgroundsCached({
       boardName: activeBoard.boardType as BoardName,
       layoutId: activeBoard.layoutId,
       sizeId: activeBoard.sizeId,
       setIds: parsedSetIds,
     });
-    if (renderData?.imageUrls) {
-      for (const url of renderData.imageUrls) {
-        void Image.prefetch(url);
-      }
-    }
   }, [activeBoard]);
 
   const searchInput = useMemo(


### PR DESCRIPTION
## Problem

Production Sentry error (Android, `com.boardsesh.app@2.0.0`):

```
java.io.IOException: Unexpected HTTP code Response{protocol=h2, code=403, ...
url=https://www.boardsesh.com/images/kilter/product_sizes_layouts_sets/original-16x12-bolt-ons-v2.png}
mechanism: onunhandledrejection
```

## Root cause

The climbs list screen pre-warmed board art with React Native's `Image.prefetch` against absolute `https://www.boardsesh.com/images/.../*.png` URLs:

```ts
if (renderData?.imageUrls) {
  for (const url of renderData.imageUrls) {
    void Image.prefetch(url); // react-native Image → okhttp on Android
  }
}
```

On Android, okhttp rejects the response with `java.io.IOException` when the request 403s. The `void` swallowed the return value but **not** the rejection, so it surfaced as an unhandled promise rejection that Sentry reports.

Two things were wrong:

1. **The mobile app must never fetch board art over HTTP.** It ships every board background as a bundled `.webp` asset and renders from `file://` paths (the documented no-network rule). The list thumbnails, play view, accessory bar, and playlist backdrop all already use bundled assets. This `Image.prefetch` loop was the only live network board-image fetch left — and the `.png` it pulled was never even displayed.
2. **The 403 is infrastructure-level** (Vercel/CDN/WAF rejecting the okhttp `User-Agent` / empty `Referer`), not Next.js app code. The images exist under `packages/web/public/images/...` and serve fine to browsers. Not fixable in-repo, and the app shouldn't make the request at all.

## Fix

Warm the **bundled** assets via the existing `ensureBackgroundsCached` helper (already used by `PlaylistBoardBackdrop`) instead of fetching over the network. This preserves the pre-warm intent (no-op in production where assets are already on disk; materializes from Metro in dev) and removes the unhandled rejection.

Single file: `packages/mobile/app/(tabs)/climbs/index.tsx` — swap the prefetch loop, drop the now-unused `Image` and `getBoardRenderData` imports.

## Verification

- `vp run typecheck:mobile` — passes
- `vp test --project mobile` — passes (1 unrelated pre-existing failure in `use-playlist-activation.test.tsx`, confirmed failing on the clean tree before this change)
- `vp run check:mobile-bundle` — OK (10.5 MB)
- `vp fmt --check` on the changed file — clean
- Grep confirms no live `Image.prefetch` / `boardsesh.com/images` network fetch remains in the rendered tree

## Follow-up (not in this PR)

`ClimbThumbnail` + `BoardRenderer` render board art via a remote `<SvgImage href>` and appear unused outside tests/exports — a latent second source of the same network fetch. Worth removing as dead-code cleanup, but kept out of scope here to keep the blast radius small.

https://claude.ai/code/session_01YCV2UAV7Mw2UQgh3ZYMUra

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCV2UAV7Mw2UQgh3ZYMUra)_