### PR TITLE
fix(mobile): stop queue bar peeks overlapping the current climb on Android

### DIFF
--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -88,6 +88,7 @@ export function ClimbCapsule({
     currentItem,
     previousItem,
     nextItem,
+    canPeek,
     handleNext,
     handlePrevious,
     swipeAccessibilityActions,
@@ -161,7 +162,7 @@ export function ClimbCapsule({
               boardConfig={boardConfig}
             />
           </Animated.View>
-          {nextClimb ? (
+          {nextClimb && canPeek ? (
             <Animated.View style={[styles.peekSlot, { right: labelRight }, nextPeekStyle]} pointerEvents="none">
               <ClimbLabel
                 climb={nextClimb}
@@ -173,7 +174,7 @@ export function ClimbCapsule({
               />
             </Animated.View>
           ) : null}
-          {previousClimb ? (
+          {previousClimb && canPeek ? (
             <Animated.View style={[styles.peekSlot, { right: labelRight }, prevPeekStyle]} pointerEvents="none">
               <ClimbLabel
                 climb={previousClimb}

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -84,6 +84,7 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
     currentItem,
     previousItem,
     nextItem,
+    canPeek,
     handleNext,
     handlePrevious,
     swipeAccessibilityActions,
@@ -124,7 +125,7 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
               boardConfig={boardConfig}
             />
           </Animated.View>
-          {nextQueueClimb ? (
+          {nextQueueClimb && canPeek ? (
             <Animated.View style={[styles.peekSlot, nextPeekStyle]} pointerEvents="none">
               <ClimbLabel
                 climb={nextQueueClimb}
@@ -135,7 +136,7 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
               />
             </Animated.View>
           ) : null}
-          {previousClimb ? (
+          {previousClimb && canPeek ? (
             <Animated.View style={[styles.peekSlot, prevPeekStyle]} pointerEvents="none">
               <ClimbLabel
                 climb={previousClimb}

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
-import { createElement, type ReactNode, type CSSProperties } from 'react';
+import { createElement, useEffect, type ReactNode, type CSSProperties } from 'react';
 import type { ClimbQueueItem, Climb } from '@boardsesh/queue';
 
 // --- hoisted spies so individual tests can reconfigure provider state ---------
@@ -38,9 +38,26 @@ function backgroundOf(style: unknown): string {
   }
   return '';
 }
+type LayoutHandler = (event: { nativeEvent: { layout: { width: number; height: number } } }) => void;
 vi.mock('react-native', () => ({
-  View: ({ children, testID, style }: { children?: ReactNode; testID?: string; style?: unknown }) =>
-    createElement('div', { 'data-testid': testID, 'data-bg': backgroundOf(style) }, children),
+  View: ({
+    children,
+    testID,
+    style,
+    onLayout,
+  }: {
+    children?: ReactNode;
+    testID?: string;
+    style?: unknown;
+    onLayout?: LayoutHandler;
+  }) => {
+    // jsdom never lays out, so simulate the swipe viewport being measured —
+    // otherwise width stays 0, canPeek is false, and the peek slots never render.
+    useEffect(() => {
+      onLayout?.({ nativeEvent: { layout: { width: 400, height: 48 } } });
+    }, [onLayout]);
+    return createElement('div', { 'data-testid': testID, 'data-bg': backgroundOf(style) }, children);
+  },
   StyleSheet: {
     create: (styles: Record<string, unknown>) => styles,
     absoluteFill: {},
@@ -54,6 +71,7 @@ vi.mock('react-native-reanimated', () => ({
   runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
   useAnimatedStyle: () => ({}),
   useDerivedValue: () => ({ value: 0 }),
+  useSharedValue: (initial: number) => ({ value: initial }),
 }));
 
 // GestureDetector just renders its child; Gesture is a fluent no-op builder so

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
-import { createElement, type ReactNode, type CSSProperties } from 'react';
+import { createElement, useEffect, type ReactNode, type CSSProperties } from 'react';
 import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
 import type { BoardConfig } from '../../../providers/drawer-host-provider';
 
@@ -45,13 +45,20 @@ vi.mock('react-native', () => ({
     accessibilityRole,
     accessibilityLabel,
     accessibilityActions,
+    onLayout,
   }: {
     children?: ReactNode;
     style?: unknown;
     accessibilityRole?: string;
     accessibilityLabel?: string;
     accessibilityActions?: ReadonlyArray<{ name: string; label?: string }>;
+    onLayout?: (event: { nativeEvent: { layout: { width: number; height: number } } }) => void;
   }) => {
+    // jsdom never lays out, so simulate the swipe viewport being measured —
+    // otherwise width stays 0, canPeek is false, and the peek slots never render.
+    useEffect(() => {
+      onLayout?.({ nativeEvent: { layout: { width: 400, height: 48 } } });
+    }, [onLayout]);
     const readStyleValue = (styleKey: string): unknown => {
       const styles = Array.isArray(style) ? style : [style];
       for (const styleEntry of styles) {
@@ -103,6 +110,7 @@ vi.mock('react-native-reanimated', () => ({
   runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
   useAnimatedStyle: () => ({}),
   useDerivedValue: () => ({ value: 0 }),
+  useSharedValue: (initial: number) => ({ value: initial }),
 }));
 
 vi.mock('react-native-gesture-handler', () => {

--- a/packages/mobile/src/components/queue-control/use-queue-carousel.ts
+++ b/packages/mobile/src/components/queue-control/use-queue-carousel.ts
@@ -1,7 +1,13 @@
 import { useCallback, useMemo, useState } from 'react';
 import { type LayoutChangeEvent } from 'react-native';
 import { Gesture, type ComposedGesture } from 'react-native-gesture-handler';
-import { runOnJS, useAnimatedStyle, useDerivedValue, type AnimatedStyle } from 'react-native-reanimated';
+import {
+  runOnJS,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  type AnimatedStyle,
+} from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import { computePeekOffset, computeNavigationStateWithSuggestions } from '@boardsesh/play-view';
 import type { ClimbQueueItem } from '@boardsesh/queue';
@@ -33,6 +39,9 @@ export type QueueCarousel = {
   currentItem: ClimbQueueItem | null | undefined;
   previousItem: ClimbQueueItem | null | undefined;
   nextItem: ClimbQueueItem | null | undefined;
+  /** Peek slots may render: the viewport has been measured (width > 0). Until
+   *  then the peeks would resolve to translateX 0 and stack on the current label. */
+  canPeek: boolean;
   canPrevious: boolean;
   canNext: boolean;
   handleNext: () => void;
@@ -48,6 +57,13 @@ export function useQueueCarousel(): QueueCarousel {
   const reduceMotion = useReduceMotion();
 
   const [width, setWidth] = useState(0);
+  // Mirror the measured viewport width into a shared value so the peek-offset
+  // worklets read it on the UI thread instead of capturing the React-state
+  // primitive. On Android's new architecture the derived-value worklet does not
+  // reliably rebuild when `width` updates from its initial 0, which left the
+  // peeks stuck at translateX 0 (stacked on the current label). Same pattern as
+  // `boardWidthSV` in use-carousel-gesture.ts.
+  const widthSV = useSharedValue(0);
   const { currentClimbQueueItem, queue } = state;
 
   // Suggestion-aware so the capsule carousel matches the play drawer: at the
@@ -121,16 +137,21 @@ export function useQueueCarousel(): QueueCarousel {
     [panGesture, swipeUpGesture, tapGesture],
   );
 
-  const onLayout = useCallback((event: LayoutChangeEvent) => {
-    setWidth(event.nativeEvent.layout.width);
-  }, []);
+  const onLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const measured = event.nativeEvent.layout.width;
+      setWidth(measured);
+      widthSV.value = measured;
+    },
+    [widthSV],
+  );
 
   const currentLabelStyle = useAnimatedStyle(() => ({ transform: [{ translateX: translateX.value }] }));
   const nextPeekX = useDerivedValue(() =>
-    computePeekOffset({ direction: 'next', swipeOffset: translateX.value, viewportWidth: width }),
+    computePeekOffset({ direction: 'next', swipeOffset: translateX.value, viewportWidth: widthSV.value }),
   );
   const prevPeekX = useDerivedValue(() =>
-    computePeekOffset({ direction: 'prev', swipeOffset: translateX.value, viewportWidth: width }),
+    computePeekOffset({ direction: 'prev', swipeOffset: translateX.value, viewportWidth: widthSV.value }),
   );
   const nextPeekStyle = useAnimatedStyle(() => ({ transform: [{ translateX: nextPeekX.value }] }));
   const prevPeekStyle = useAnimatedStyle(() => ({ transform: [{ translateX: prevPeekX.value }] }));
@@ -149,6 +170,7 @@ export function useQueueCarousel(): QueueCarousel {
     currentItem: currentClimbQueueItem,
     previousItem: prevItem,
     nextItem,
+    canPeek: width > 0,
     canPrevious,
     canNext,
     handleNext,

--- a/packages/shared/play-view/src/__tests__/swipe-carousel.test.ts
+++ b/packages/shared/play-view/src/__tests__/swipe-carousel.test.ts
@@ -29,6 +29,15 @@ describe('computePeekOffset', () => {
   it('never lets the prev-peek overshoot past the viewport edge', () => {
     expect(computePeekOffset({ direction: 'prev', swipeOffset: 800, viewportWidth: 400 })).toBe(0);
   });
+
+  // Regression: before the viewport is measured (width 0) both peeks resolve to
+  // translateX 0 — i.e. stacked directly on the current label. Consumers must not
+  // render the peek slots until width > 0 (the `canPeek` guard in useQueueCarousel),
+  // or the queue bar shows several climbs' text overlapping. See ClimbCapsule.
+  it('collapses both peeks onto the current label when the viewport is unmeasured', () => {
+    expect(computePeekOffset({ direction: 'next', swipeOffset: 0, viewportWidth: 0 })).toBe(0);
+    expect(computePeekOffset({ direction: 'prev', swipeOffset: 0, viewportWidth: 0 })).toBe(0);
+  });
 });
 
 describe('decideSwipeDirection', () => {


### PR DESCRIPTION
## What

On Android the docked queue bar renders several climbs' worth of text — thumbnail + name + grade — stacked on top of each other after switching climbs. This fixes that.

## Root cause

The bar's content (`ClimbCapsule`, and the iOS twin `NativeAccessoryClimbRow`) stacks three absolutely-positioned, fully-overlapping label slots — current climb, next-peek, prev-peek — and separates them **only** by a `translateX` of `±viewportWidth` (`computePeekOffset`):

```ts
// at rest (swipeOffset === 0):
next → Math.max(0,  viewportWidth) =  viewportWidth   // offscreen right
prev → Math.min(0, -viewportWidth) = -viewportWidth   // offscreen left
```

When `viewportWidth` is `0`, **both peeks collapse to `translateX: 0`** and render directly on top of the current label at center.

The peek-offset worklets in `useQueueCarousel` read `width` as a **captured React-state primitive**. On Android's new architecture (Reanimated 4) the `useDerivedValue` worklet does not reliably rebuild when `onLayout` updates `width` from its initial `0`, so the offset stays stuck at `0` — a *persistent* overlap that only shows once the queue has neighbours (i.e. after switching climbs). iOS rebuilds the worklet, so it was Android-only.

The sibling gesture hook (`use-carousel-gesture.ts`) already dodges this exact trap by mirroring width into a `SharedValue` (`boardWidthSV`); the carousel hook never applied that to its peek offsets.

## Fix

- **`use-queue-carousel.ts`** — mirror `width` into `widthSV = useSharedValue(0)` (set in `onLayout` alongside `setWidth`) and read `widthSV.value` in the `nextPeekX` / `prevPeekX` worklets, so the offset recomputes on the UI thread the moment the viewport is measured. **Load-bearing change.** Also expose `canPeek: width > 0`.
- **`ClimbCapsule.tsx` / `NativeAccessoryClimbRow.tsx`** — gate the peek `Animated.View`s on `canPeek` so they never mount before measurement (defense-in-depth; also covers the alternate "onLayout never fires" failure mode).

No behaviour change once the bar is laid out — peeks only matter mid-swipe, which can't happen before layout.

## Tests

- New `computePeekOffset` regression case: `viewportWidth: 0` collapses both directions to `0`.
- `climb-capsule` / `native-accessory-climb-row` jsdom mocks now fire `onLayout` so the peek-render assertions reflect a measured bar, and mock `useSharedValue`.

## Validation

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` ✅ 1247/1247
- `vp run check:mobile-bundle` (Android) ✅
- lint ✅ 0 errors

## Verify on device

With ≥2 climbs queued, tap several different climbs in the Climbs list — the docked bar should show exactly one climb's thumbnail + name + grade each time, no overlap. Then swipe the bar left/right to confirm the prev/next climb still slides in cleanly from the correct side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
