### PR TITLE
fix(mobile): close four QueueItemRow/drag performance gaps

### DIFF
--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { memo, useMemo, useCallback, useEffect, useRef } from 'react';
 import { Pressable, View, StyleSheet, type LayoutChangeEvent } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming, runOnJS } from 'react-native-reanimated';
 import {
@@ -120,7 +120,6 @@ function QueueItemRowComponent({
   const rowOpacity = useSharedValue(1);
   const rowHeight = useSharedValue<number | undefined>(undefined);
   const isSwipeOpen = useSharedValue(false);
-  const [isOpen, setIsOpen] = useState(false);
 
   // The queue reducer rebuilds the array (and each item object) on every update,
   // so `item` arrives with a fresh reference even when this row's data hasn't
@@ -138,7 +137,6 @@ function QueueItemRowComponent({
     if (!swipeEnabled) {
       translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
       isSwipeOpen.value = false;
-      runOnJS(setIsOpen)(false);
     }
   }, [swipeEnabled, translateX, isSwipeOpen]);
 
@@ -163,18 +161,14 @@ function QueueItemRowComponent({
         })
         .onEnd(() => {
           if (translateX.value < SWIPE_DELETE_THRESHOLD) {
-            // Snap open to show delete button
             translateX.value = withSpring(-DELETE_BUTTON_WIDTH, {
               damping: 20,
               stiffness: 200,
             });
             isSwipeOpen.value = true;
-            runOnJS(setIsOpen)(true);
           } else {
-            // Snap back
             translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
             isSwipeOpen.value = false;
-            runOnJS(setIsOpen)(false);
           }
         }),
     [swipeEnabled, translateX, isSwipeOpen],
@@ -241,16 +235,16 @@ function QueueItemRowComponent({
       onToggleSelect?.(itemRef.current.uuid);
       return;
     }
-    if (isOpen) {
-      // Close the swipe first
+    if (isSwipeOpen.value) {
+      // Close the swipe first; read the shared value so this callback's
+      // identity doesn't churn on every swipe open/close.
       translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
       isSwipeOpen.value = false;
-      setIsOpen(false);
       return;
     }
     hapticSelection();
     onPress(itemRef.current);
-  }, [isEditMode, isOpen, onToggleSelect, onPress, translateX, isSwipeOpen]);
+  }, [isEditMode, onToggleSelect, onPress, translateX, isSwipeOpen]);
 
   const handleDeletePress = useCallback(() => {
     // Animate the row out
@@ -318,6 +312,7 @@ function QueueItemRowComponent({
       {/* Trailing action: tick (history) or drag handle (upcoming) */}
       {showTick ? (
         <Pressable
+          testID="tick-button"
           onPress={handleTickPress}
           hitSlop={8}
           accessibilityRole="button"
@@ -347,6 +342,7 @@ function QueueItemRowComponent({
         {swipeEnabled && (
           <Animated.View style={[styles.deleteAction, deleteButtonStyle]}>
             <Pressable
+              testID="delete-button"
               onPress={handleDeletePress}
               accessibilityRole="button"
               accessibilityLabel={t('mobile.queue.removeClimb')}

--- a/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
@@ -11,11 +11,12 @@ import type { QueueItemRowBoard } from '../QueueItemRow';
 // identical-props re-render must NOT bump this counter.
 const renderCounter = vi.hoisted(() => ({ count: 0 }));
 
-// Capture the latest `onPress` handed to the row's main pressable and trailing
-// tick button, so a test can assert they keep their identity across re-renders.
+// Capture the latest `onPress` handed to the row's main pressable, trailing
+// tick button, and delete button so a test can assert identity across re-renders.
 const captured = vi.hoisted(() => ({
   rowPress: null as null | (() => void),
   tickPress: null as null | (() => void),
+  deletePress: null as null | (() => void),
 }));
 
 vi.mock('react-native', () => {
@@ -27,10 +28,11 @@ vi.mock('react-native', () => {
     Platform: { OS: 'ios' },
     PlatformColor: (name: string) => name,
     View: passthrough('div'),
-    // History rows render exactly one Pressable (the tick button), so capturing
-    // its onPress here gives us `handleTickPress`.
-    Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) => {
-      if (onPress) captured.tickPress = onPress;
+    // Capture by testID so any future Pressable addition doesn't silently
+    // overwrite the wrong slot.
+    Pressable: ({ children, onPress, testID }: { children?: ReactNode; onPress?: () => void; testID?: string }) => {
+      if (testID === 'tick-button' && onPress) captured.tickPress = onPress;
+      if (testID === 'delete-button' && onPress) captured.deletePress = onPress;
       return createElement('button', null, children);
     },
     StyleSheet: {
@@ -146,6 +148,7 @@ describe('QueueItemRow React.memo', () => {
     renderCounter.count = 0;
     captured.rowPress = null;
     captured.tickPress = null;
+    captured.deletePress = null;
     vi.clearAllMocks();
   });
 
@@ -235,5 +238,29 @@ describe('QueueItemRow React.memo', () => {
 
     expect(captured.rowPress).toBe(rowPress);
     expect(captured.tickPress).toBe(tickPress);
+  });
+
+  it('keeps handleDeletePress stable when item identity changes but its data is equal', () => {
+    const rowProps = {
+      position: 1,
+      board,
+      isCurrentClimb: false,
+      onPress,
+      onRemove,
+      onToggleSelect,
+    };
+
+    const first = makeItem('a', 'Crimp Master');
+    const { rerender } = render(<QueueItemRow item={first} {...rowProps} />);
+
+    const deletePress = captured.deletePress;
+    expect(deletePress).toBeTypeOf('function');
+
+    // A fresh item object with the same uuid — same case as the tick-press test.
+    const second = makeItem('a', 'Crimp Master');
+    expect(second).not.toBe(first);
+    rerender(<QueueItemRow item={second} {...rowProps} />);
+
+    expect(captured.deletePress).toBe(deletePress);
   });
 });

--- a/packages/mobile/src/components/play-drawer/use-queue-drag.ts
+++ b/packages/mobile/src/components/play-drawer/use-queue-drag.ts
@@ -25,11 +25,8 @@ type UseQueueDragOptions = {
   /**
    * Optimistically reorder + broadcast (queue-array indices).
    *
-   * MUST be referentially stable across the caller's renders (wrap in
-   * `useCallback`). `controls` is memoized below, but `commit` →
-   * `makeHandleGesture` → `controls` all depend on this identity, so a fresh
-   * `reorderQueue` each render silently churns `controls` and re-renders every
-   * memoized row — exactly the cost this hook exists to avoid.
+   * The hook internalises a ref so an unstable (non-`useCallback`) function
+   * doesn't churn `controls` or re-render memoized rows.
    */
   reorderQueue: (uuid: string, oldIndex: number, newIndex: number) => void;
   /** flatRows index of the first/last contiguous `future-item` row (-1 when none). */
@@ -95,7 +92,10 @@ export function useQueueDrag({
     lastRowIndexSV.value = lastFutureRowIndex;
   }, [firstFutureRowIndex, lastFutureRowIndex, firstRowIndexSV, lastRowIndexSV]);
 
-  // Latest window mapping read on the JS thread when committing.
+  // Latest callbacks/mappings read on the JS thread when committing. Refs so
+  // commit stays stable regardless of whether the caller wraps in useCallback.
+  const reorderQueueRef = useRef(reorderQueue);
+  reorderQueueRef.current = reorderQueue;
   const windowRef = useRef({ firstRowIndex: firstFutureRowIndex, firstQueueIndex: firstFutureQueueIndex });
   windowRef.current = { firstRowIndex: firstFutureRowIndex, firstQueueIndex: firstFutureQueueIndex };
 
@@ -115,9 +115,9 @@ export function useQueueDrag({
   const commit = useCallback(
     (uuid: string, oldQueueIndex: number, toRowIndex: number) => {
       const move = resolveReorderCommit(uuid, oldQueueIndex, toRowIndex, windowRef.current);
-      if (move) reorderQueue(move.uuid, move.oldIndex, move.newIndex);
+      if (move) reorderQueueRef.current(move.uuid, move.oldIndex, move.newIndex);
     },
-    [reorderQueue],
+    [], // reads refs at call time — stable regardless of reorderQueue identity
   );
 
   const makeHandleGesture = useCallback(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`handlePress` no longer churns on swipe open/close** — dropped the `isOpen` `useState` entirely. `handlePress` now reads `isSwipeOpen.value` (the reanimated shared value that already tracks this) so its dep array loses `isOpen`. Every swipe open/close previously triggered a React re-render + new `onPress` on `AnimatedPressable`; now neither happens.
- **Test capture mechanism hardened** — tick and delete Pressables now carry `testID="tick-button"` / `testID="delete-button"`. The mock captures by testID rather than "last Pressable with an onPress", so any future UI addition can't silently capture the wrong callback and produce a false-green stability assertion.
- **`handleDeletePress` stability now tested** — adds a fourth assertion in the memo test suite mirroring the existing `handlePress`/`handleTickPress` tests.
- **`reorderQueue` stability contract enforced in `useQueueDrag`** — the hook now keeps a `reorderQueueRef` and uses it inside `commit` (empty deps). A caller that forgets `useCallback` no longer silently churns `commit` → `makeHandleGesture` → `controls` → every memoized row.

## Test plan

- [ ] All four `QueueItemRow React.memo` tests pass (`queue-item-row-memo.test.tsx`)
- [ ] `vp run typecheck:mobile` clean
- [ ] Swipe-to-delete gesture still works end-to-end (open row, tap row to close, tap delete button)
- [ ] Drag-to-reorder still commits correctly when caller does not wrap `reorderQueue` in `useCallback`

https://claude.ai/code/session_01Gg6SCaBpHy4hTeUqVx7via
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gg6SCaBpHy4hTeUqVx7via)_