### PR TITLE
fix: address PR review feedback on analytics instrumentation

### DIFF
--- a/packages/board-constants/src/__tests__/product-sizes.test.ts
+++ b/packages/board-constants/src/__tests__/product-sizes.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { isKilterHomewallTallSizeId, isKilterHomewallWideSizeId } from '../product-sizes';
+import { getLayoutName, isKilterHomewallTallSizeId, isKilterHomewallWideSizeId } from '../product-sizes';
+
+describe('getLayoutName', () => {
+  it('returns the human-readable name for a known board + layoutId', () => {
+    expect(getLayoutName('kilter', 1)).toBe('Kilter Board Original');
+  });
+
+  it("returns '' for an unknown layoutId", () => {
+    expect(getLayoutName('kilter', 99999)).toBe('');
+  });
+});
 
 describe('Kilter Homewall size filter capabilities', () => {
   it('marks 8x12 and 10x12 Homewall sizes as tall-capable', () => {

--- a/packages/mobile/app/join/[sessionId].tsx
+++ b/packages/mobile/app/join/[sessionId].tsx
@@ -75,11 +75,13 @@ export default function JoinSessionScreen() {
       // queue provider only emits Session Started/Ended, never Joined. Mirror
       // web's props (session_id, board_name, layout_id), derived from the path.
       const parsedBoard = parseBoardPath(session.boardPath);
-      track(SHARED_EVENTS.SessionJoined, {
-        session_id: session.id,
-        board_name: parsedBoard?.boardName ?? null,
-        layout_id: parsedBoard?.layoutId ?? null,
-      });
+      if (parsedBoard) {
+        track(SHARED_EVENTS.SessionJoined, {
+          session_id: session.id,
+          board_name: parsedBoard.boardName,
+          layout_id: parsedBoard.layoutId,
+        });
+      }
       // Land on the Record tab so the user drops straight into the joined session.
       router.replace('/(tabs)/record');
     } catch (error) {

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -379,7 +379,8 @@ export function useCreateClimbScreen({
     const frames = generateFramesString();
     // Encode the no-match marker into the description only at save time.
     const fullDescription = withNoMatch(description, noMatch);
-    // Mirror web's `holdCount` property (create-climb-form.tsx).
+    // The reducer removes OFF-state holds from the map, so key count equals
+    // web's `totalHolds` (non-OFF hold count, used in Climb Created events).
     const holdCount = Object.keys(litUpHoldsMap).length;
     // Web sends the human-readable layout name (`boardDetails.layout_name || ''`)
     // for `boardLayout`; mobile only carries the numeric layout id, so resolve it

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-analytics.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-analytics.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GeneratorSelection } from '../GeneratorPickerCard';
@@ -92,31 +92,33 @@ describe('PreSessionView analytics', () => {
         type: 'on',
         options: {
           type: 'volume',
+          warmUp: 'standard',
+          mainSetClimbs: 3,
+          mainSetVariability: 0,
           targetGrade: 10,
           minAscents: 0,
           minRating: 0,
           onlyTallClimbs: false,
-          climbBias: 'none',
-        } as never,
+          climbBias: 'any',
+        },
       });
     });
 
     await act(async () => {
       startButton.onPress?.();
-      // Let the async handleStart chain (startSession → select → track) settle.
-      await Promise.resolve();
-      await Promise.resolve();
     });
+    await waitFor(() =>
+      expect(analytics.track).toHaveBeenCalledWith('Session Queue Generated', {
+        workoutType: 'volume',
+        boardName: 'kilter',
+        angle: 40,
+        // 2 climbs queued out of a 3-slot plan → 1 short.
+        savedCount: 2,
+        failedCount: 1,
+      }),
+    );
 
     expect(queue.addToQueue).toHaveBeenCalledTimes(2);
-    expect(analytics.track).toHaveBeenCalledWith('Session Queue Generated', {
-      workoutType: 'volume',
-      boardName: 'kilter',
-      angle: 40,
-      // 2 climbs queued out of a 3-slot plan → 1 short.
-      savedCount: 2,
-      failedCount: 1,
-    });
   });
 
   it('does not fire when the generator is off', async () => {
@@ -124,9 +126,8 @@ describe('PreSessionView analytics', () => {
 
     await act(async () => {
       startButton.onPress?.();
-      await Promise.resolve();
-      await Promise.resolve();
     });
+    await waitFor(() => expect(queue.startSession).toHaveBeenCalled());
 
     expect(analytics.track).not.toHaveBeenCalledWith('Session Queue Generated', expect.anything());
   });


### PR DESCRIPTION
## Summary

- **Medium** — Guard `Session Joined` `track()` behind `if (parsedBoard)` so a malformed `boardPath` never sends null-property events to PostHog funnels
- **Medium** — Improve `holdCount` comment to explain the OFF-removal invariant (reducer deletes OFF entries from the map, so `Object.keys(litUpHoldsMap).length` is always equal to web's `totalHolds`)
- **Minor** — Replace fragile double `Promise.resolve()` flushes with `waitFor()` in `pre-session-view-analytics.test.tsx`, matching the refactored pattern in `join-session-analytics.test.tsx`
- **Minor** — Remove `as never` bypass; supply all required `VolumeOptions` fields with valid values (`warmUp`, `mainSetClimbs`, `mainSetVariability`, valid `climbBias: 'any'`) so TypeScript catches future type mismatches
- **Minor** — Add `getLayoutName` unit tests: known board+layoutId → expected name, unknown layoutId → `''`

Not addressed (low priority, pre-existing):
- Backend `getLayoutName` private duplicate in `user-data-export-format.ts` — intentional fallback difference (`String(layoutId)` vs `''`) for export context
- Web call sites using hardcoded strings instead of `SHARED_EVENTS` — string values already match; purely cosmetic

## Test plan

- [ ] `vp test run --project mobile` — pre-session analytics tests pass with `waitFor()` pattern
- [ ] `vp run test:web` — board-constants `getLayoutName` tests pass
- [ ] `vp run typecheck:mobile` — no type errors (removed `as never`, valid `VolumeOptions`)

https://claude.ai/code/session_01RMTUNZP2cqEkPLFeUceXuL

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMTUNZP2cqEkPLFeUceXuL)_