### PR TITLE
fix(session): surface createSession failures and fix silent no-board start

### DIFF
--- a/packages/backend/src/__tests__/sentry-dedupe.test.ts
+++ b/packages/backend/src/__tests__/sentry-dedupe.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { GraphQLError } from 'graphql';
+import { markErrorReported, wasErrorReported } from '../utils/sentry-dedupe';
+
+describe('sentry-dedupe', () => {
+  it('reports false for an unmarked error', () => {
+    expect(wasErrorReported(new Error('boom'))).toBe(false);
+  });
+
+  it('reports true after marking', () => {
+    const err = new Error('boom');
+    markErrorReported(err);
+    expect(wasErrorReported(err)).toBe(true);
+  });
+
+  it('sees a mark on the wrapped originalError (how graphql-js surfaces resolver throws)', () => {
+    const original = new Error('boom');
+    markErrorReported(original);
+    const wrapped = new GraphQLError('masked', { originalError: original });
+    expect(wasErrorReported(wrapped)).toBe(true);
+  });
+
+  it('reports false for a wrapper whose originalError is unmarked', () => {
+    const wrapped = new GraphQLError('masked', { originalError: new Error('boom') });
+    expect(wasErrorReported(wrapped)).toBe(false);
+  });
+
+  it('tolerates non-object inputs', () => {
+    expect(wasErrorReported(undefined)).toBe(false);
+    expect(wasErrorReported('nope')).toBe(false);
+    expect(() => markErrorReported('nope')).not.toThrow();
+  });
+});

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import * as Sentry from '@sentry/node';
 import type { ConnectionContext, SessionEvent, ClimbQueueItem } from '@boardsesh/shared-schema';
 import { roomManager } from '../../../services/room-manager';
 import { pubsub } from '../../../pubsub/index';
@@ -194,115 +195,143 @@ export const sessionMutations = {
    * Optionally creates a discoverable session with GPS coordinates
    */
   createSession: async (_: unknown, { input }: { input: CreateSessionInput }, ctx: ConnectionContext) => {
-    if (DEBUG) logger.info(`[createSession] START - connectionId: ${ctx.connectionId}, boardPath: ${input.boardPath}`);
-
-    await applyRateLimit(ctx, 5); // Limit session creation to prevent abuse
-
-    // Validate input
-    validateInput(CreateSessionInputSchema, input, 'createSession input');
-
-    // Generate a unique session ID
-    const sessionId = uuidv4();
-    if (DEBUG) logger.info(`[createSession] Generated sessionId: ${sessionId}`);
-
-    if (input.discoverable) {
-      // Discoverable sessions require authentication (they write to DB with userId)
-      requireAuthenticated(ctx);
-      // Use authenticated userId from context
-      const userId = ctx.userId || ctx.connectionId;
-      await roomManager.createDiscoverableSession(
-        sessionId,
-        input.boardPath,
-        userId,
-        input.latitude,
-        input.longitude,
-        input.name,
-        input.goal,
-        input.isPermanent,
-        input.color,
-      );
-
-      // If boardIds provided, create sessionBoards junction rows
-      if (input.boardIds && input.boardIds.length > 0) {
-        // Verify boards exist
-        const boards = await db
-          .select({ id: userBoards.id, gymId: userBoards.gymId })
-          .from(userBoards)
-          .where(inArray(userBoards.id, input.boardIds));
-
-        if (boards.length !== input.boardIds.length) {
-          throw new Error('One or more board IDs do not exist');
-        }
-
-        // Validate all boards share the same gym (multi-board requires same gym)
-        const gymIds = new Set(boards.map((b) => b.gymId).filter(Boolean));
-        if (gymIds.size > 1) {
-          throw new Error('All boards must belong to the same gym for multi-board sessions');
-        }
-
-        // Insert junction rows
-        await db.insert(sessionBoards).values(
-          input.boardIds.map((boardId) => ({
-            sessionId,
-            boardId,
-          })),
-        );
-      }
-    }
-
-    // For HTTP requests (stateless), skip joining the session in-memory.
-    // The creator will join via WebSocket when they navigate to the board page.
-    const isHttpRequest = ctx.transport === 'http';
-
-    if (!isHttpRequest) {
-      // WebSocket path: join the session as the creator.
-      // For non-discoverable sessions, this also creates the board_sessions row
-      // via ensureSessionRecordExists inside roomManager.joinSession.
-      const result = await roomManager.joinSession(
-        ctx.connectionId,
-        sessionId,
-        input.boardPath,
-        undefined, // username will be set later
-        undefined, // avatarUrl will be set later
-        undefined, // initialQueue
-        null, // initialCurrentClimb
-        input.discoverable ? undefined : input.name,
-      );
+    try {
       if (DEBUG)
-        logger.info(`[createSession] Joined session - clientId: ${result.clientId}, isLeader: ${result.isLeader}`);
+        logger.info(`[createSession] START - connectionId: ${ctx.connectionId}, boardPath: ${input.boardPath}`);
 
-      updateContext(ctx.connectionId, { sessionId, participantId: result.participantId });
+      await applyRateLimit(ctx, 5); // Limit session creation to prevent abuse
 
-      // Adopt recent solo ticks now that the session row exists in board_sessions
-      // (boardsesh_ticks.session_id is a FK to board_sessions.id)
-      if (ctx.isAuthenticated && ctx.userId) {
-        const boardTypeFromPath = extractBoardType(input.boardPath);
-        adoptRecentTicksForSession(ctx.userId, sessionId, boardTypeFromPath).catch((err) => {
-          logger.error(`[createSession] Failed to adopt recent ticks for session ${sessionId}:`, err);
-        });
+      // Validate input
+      validateInput(CreateSessionInputSchema, input, 'createSession input');
+
+      // Generate a unique session ID
+      const sessionId = uuidv4();
+      if (DEBUG) logger.info(`[createSession] Generated sessionId: ${sessionId}`);
+
+      if (input.discoverable) {
+        // Discoverable sessions require authentication (they write to DB with userId)
+        requireAuthenticated(ctx);
+        // Use authenticated userId from context
+        const userId = ctx.userId || ctx.connectionId;
+        await roomManager.createDiscoverableSession(
+          sessionId,
+          input.boardPath,
+          userId,
+          input.latitude,
+          input.longitude,
+          input.name,
+          input.goal,
+          input.isPermanent,
+          input.color,
+        );
+
+        // If boardIds provided, create sessionBoards junction rows
+        if (input.boardIds && input.boardIds.length > 0) {
+          // Verify boards exist
+          const boards = await db
+            .select({ id: userBoards.id, gymId: userBoards.gymId })
+            .from(userBoards)
+            .where(inArray(userBoards.id, input.boardIds));
+
+          if (boards.length !== input.boardIds.length) {
+            throw new Error('One or more board IDs do not exist');
+          }
+
+          // Validate all boards share the same gym (multi-board requires same gym)
+          const gymIds = new Set(boards.map((b) => b.gymId).filter(Boolean));
+          if (gymIds.size > 1) {
+            throw new Error('All boards must belong to the same gym for multi-board sessions');
+          }
+
+          // Insert junction rows
+          await db.insert(sessionBoards).values(
+            input.boardIds.map((boardId) => ({
+              sessionId,
+              boardId,
+            })),
+          );
+        }
       }
+
+      // For HTTP requests (stateless), skip joining the session in-memory.
+      // The creator will join via WebSocket when they navigate to the board page.
+      const isHttpRequest = ctx.transport === 'http';
+
+      if (!isHttpRequest) {
+        // WebSocket path: join the session as the creator.
+        // For non-discoverable sessions, this also creates the board_sessions row
+        // via ensureSessionRecordExists inside roomManager.joinSession.
+        const result = await roomManager.joinSession(
+          ctx.connectionId,
+          sessionId,
+          input.boardPath,
+          undefined, // username will be set later
+          undefined, // avatarUrl will be set later
+          undefined, // initialQueue
+          null, // initialCurrentClimb
+          input.discoverable ? undefined : input.name,
+        );
+        if (DEBUG)
+          logger.info(`[createSession] Joined session - clientId: ${result.clientId}, isLeader: ${result.isLeader}`);
+
+        updateContext(ctx.connectionId, { sessionId, participantId: result.participantId });
+
+        // Adopt recent solo ticks now that the session row exists in board_sessions
+        // (boardsesh_ticks.session_id is a FK to board_sessions.id)
+        if (ctx.isAuthenticated && ctx.userId) {
+          const boardTypeFromPath = extractBoardType(input.boardPath);
+          adoptRecentTicksForSession(ctx.userId, sessionId, boardTypeFromPath).catch((err) => {
+            logger.error(`[createSession] Failed to adopt recent ticks for session ${sessionId}:`, err);
+          });
+        }
+
+        return {
+          id: sessionId,
+          name: input.name || null,
+          boardPath: input.boardPath,
+          users: result.users,
+          queueState: {
+            sequence: result.sequence,
+            stateHash: result.stateHash,
+            queue: result.queue,
+            currentClimbQueueItem: result.currentClimbQueueItem,
+          },
+          isLeader: result.isLeader,
+          // Newly created sessions start with no driver — the creator must press
+          // the lightbulb to claim the wall. Null here lets the bar render the
+          // empty/outlined state in PR 2 onward.
+          driverParticipantId: null,
+          // No board has been paired yet; gets set the first time anyone in the
+          // session calls setSessionBoardSerial.
+          lastConnectedBoardSerial: null,
+          clientId: result.clientId,
+          participantId: result.participantId,
+          goal: input.goal || null,
+          isPublic: true,
+          startedAt: new Date().toISOString(),
+          endedAt: null,
+          isPermanent: input.isPermanent || false,
+          color: input.color || null,
+        };
+      }
+
+      // HTTP path: adoption is handled by joinSession when the client connects
+      // via WebSocket (avoids double invocation for HTTP + discoverable sessions).
+
+      // HTTP path: return session metadata only; client joins via WebSocket later
+      if (DEBUG) logger.info(`[createSession] HTTP request - returning session metadata without joining`);
 
       return {
         id: sessionId,
         name: input.name || null,
         boardPath: input.boardPath,
-        users: result.users,
-        queueState: {
-          sequence: result.sequence,
-          stateHash: result.stateHash,
-          queue: result.queue,
-          currentClimbQueueItem: result.currentClimbQueueItem,
-        },
-        isLeader: result.isLeader,
-        // Newly created sessions start with no driver — the creator must press
-        // the lightbulb to claim the wall. Null here lets the bar render the
-        // empty/outlined state in PR 2 onward.
+        users: [],
+        queueState: null,
+        isLeader: false,
         driverParticipantId: null,
-        // No board has been paired yet; gets set the first time anyone in the
-        // session calls setSessionBoardSerial.
         lastConnectedBoardSerial: null,
-        clientId: result.clientId,
-        participantId: result.participantId,
+        clientId: null,
+        participantId: ctx.participantId || ctx.connectionId || '',
         goal: input.goal || null,
         isPublic: true,
         startedAt: new Date().toISOString(),
@@ -310,32 +339,25 @@ export const sessionMutations = {
         isPermanent: input.isPermanent || false,
         color: input.color || null,
       };
+    } catch (err) {
+      // Production masks GraphQL errors to "Unexpected error" (yoga.ts), and the
+      // mobile client discards the rest — so capture the true cause here, before
+      // masking, with enough context to triage a failed Start session. Rethrow so
+      // client behaviour and the existing error pipeline are unchanged.
+      Sentry.captureException(err, {
+        tags: { source: 'createSession', transport: ctx.transport },
+        extra: {
+          boardPath: input.boardPath,
+          discoverable: input.discoverable,
+          isAuthenticated: ctx.isAuthenticated,
+          userId: ctx.userId,
+          hasName: !!input.name,
+          hasGoal: !!input.goal,
+          boardIdCount: input.boardIds?.length ?? 0,
+        },
+      });
+      throw err;
     }
-
-    // HTTP path: adoption is handled by joinSession when the client connects
-    // via WebSocket (avoids double invocation for HTTP + discoverable sessions).
-
-    // HTTP path: return session metadata only; client joins via WebSocket later
-    if (DEBUG) logger.info(`[createSession] HTTP request - returning session metadata without joining`);
-
-    return {
-      id: sessionId,
-      name: input.name || null,
-      boardPath: input.boardPath,
-      users: [],
-      queueState: null,
-      isLeader: false,
-      driverParticipantId: null,
-      lastConnectedBoardSerial: null,
-      clientId: null,
-      participantId: ctx.participantId || ctx.connectionId || '',
-      goal: input.goal || null,
-      isPublic: true,
-      startedAt: new Date().toISOString(),
-      endedAt: null,
-      isPermanent: input.isPermanent || false,
-      color: input.color || null,
-    };
   },
 
   /**

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -25,6 +25,7 @@ import {
   QueueArraySchema,
 } from '../../../validation/schemas';
 import { logger } from '../../../utils/logger';
+import { markErrorReported } from '../../../utils/sentry-dedupe';
 import type { CreateSessionInput } from '../shared/types';
 import { db } from '../../../db/client';
 import { esp32Controllers, userBoards } from '@boardsesh/db/schema/app';
@@ -340,10 +341,12 @@ export const sessionMutations = {
         color: input.color || null,
       };
     } catch (err) {
+      // Rate-limit hits are expected abuse-protection noise, not a session-start
+      // bug — let them flow through without a Sentry event.
+      if (err instanceof Error && err.message.startsWith('Rate limit exceeded')) throw err;
       // Production masks GraphQL errors to "Unexpected error" (yoga.ts), and the
       // mobile client discards the rest — so capture the true cause here, before
-      // masking, with enough context to triage a failed Start session. Rethrow so
-      // client behaviour and the existing error pipeline are unchanged.
+      // masking, with enough context to triage a failed Start session.
       Sentry.captureException(err, {
         tags: { source: 'createSession', transport: ctx.transport },
         extra: {
@@ -356,6 +359,10 @@ export const sessionMutations = {
           boardIdCount: input.boardIds?.length ?? 0,
         },
       });
+      // Mark so the generic Yoga error handler skips its own capture (this would
+      // otherwise be a second event). Rethrow so client behaviour and the rest of
+      // the error pipeline are unchanged.
+      markErrorReported(err);
       throw err;
     }
   },

--- a/packages/backend/src/graphql/yoga.ts
+++ b/packages/backend/src/graphql/yoga.ts
@@ -8,6 +8,7 @@ import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { maxDepthPlugin } from '@escape.tech/graphql-armor-max-depth';
 import { costLimitPlugin } from '@escape.tech/graphql-armor-cost-limit';
 import { logger } from '../utils/logger';
+import { wasErrorReported } from '../utils/sentry-dedupe';
 
 /**
  * Create and configure the GraphQL Yoga instance
@@ -87,6 +88,9 @@ export function createYogaInstance() {
         for (const arg of args) {
           if (!(arg instanceof Error)) continue;
           if (arg instanceof GraphQLError && !arg.originalError) continue;
+          // A resolver already reported this with finer-grained tags/context
+          // (e.g. createSession); don't emit a duplicate event.
+          if (wasErrorReported(arg)) continue;
           Sentry.captureException(arg, { tags: { source: 'graphql-yoga' } });
         }
       },

--- a/packages/backend/src/utils/sentry-dedupe.ts
+++ b/packages/backend/src/utils/sentry-dedupe.ts
@@ -1,0 +1,25 @@
+// Dedupe marker for errors a resolver-level catch has already reported to Sentry
+// with finer-grained tags/context. The generic graphql-yoga error handler
+// (yoga.ts) checks this before its own capture so a single failure produces a
+// single Sentry event.
+//
+// graphql-js wraps a thrown resolver error in a GraphQLError whose `originalError`
+// is the exact thrown error, so the resolver marks the original and the Yoga
+// handler sees the wrapper — `wasErrorReported` therefore checks both. A global
+// `Symbol.for` keeps the marker non-enumerable (it won't leak into logs or
+// serialization) and stable even if this module is evaluated more than once.
+
+const REPORTED = Symbol.for('boardsesh.sentryReported');
+
+export function markErrorReported(err: unknown): void {
+  if (err && typeof err === 'object') {
+    (err as Record<symbol, unknown>)[REPORTED] = true;
+  }
+}
+
+export function wasErrorReported(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  if ((err as Record<symbol, unknown>)[REPORTED]) return true;
+  const original = (err as { originalError?: unknown }).originalError;
+  return !!original && typeof original === 'object' && !!(original as Record<symbol, unknown>)[REPORTED];
+}

--- a/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
@@ -14,6 +14,7 @@ import { useAuth } from '../../../providers/auth-provider';
 import { useQueue } from '../../../providers/queue-provider';
 import { useToast } from '../../../providers/toast-provider';
 import { useBottomChromeMetrics } from '../../../hooks/use-bottom-chrome-metrics';
+import { reportError } from '../../../lib/sentry';
 import { BoardSummaryCard } from './BoardSummaryCard';
 import { GeneratorPickerCard, type GeneratorSelection } from './GeneratorPickerCard';
 import { selectClimbsForPlan } from './select-climbs-for-plan';
@@ -74,7 +75,8 @@ export function PreSessionView() {
           });
         }
       }
-    } catch {
+    } catch (error) {
+      reportError(error, { tags: { source: 'preSessionStart' } });
       showToast(t('mobile.session.preStartError'), 'error');
     } finally {
       setIsStarting(false);

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -23,11 +23,13 @@ if (isSentryEnabled) {
 }
 
 /**
- * Report an error to Sentry if it is active. No-op otherwise.
+ * Report an error to Sentry if it is active. No-op otherwise. The optional
+ * `context` (tags/extra/etc.) is forwarded to `captureException` so callers can
+ * attach triage data — e.g. boardPath and HTTP status on a failed session start.
  */
-export function reportError(error: unknown): void {
+export function reportError(error: unknown, context?: Parameters<typeof Sentry.captureException>[1]): void {
   if (!isSentryEnabled) return;
-  Sentry.captureException(error);
+  Sentry.captureException(error, context);
 }
 
 /**

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -68,6 +68,8 @@ import { toClimbQueueItem, type SubscriptionQueueItem } from '../lib/queue-conve
 import { toMobileSessionRuntimeEvent } from '../lib/session-runtime-event';
 import { climbToQueueItem, toClimbInput } from '../lib/climb-to-queue-item';
 import { track } from '../lib/analytics';
+import { reportError } from '../lib/sentry';
+import { extractGraphqlMessage } from '../lib/graphql/extract-error-message';
 import { useToast } from './toast-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
 
@@ -681,7 +683,13 @@ export function QueueProvider({ children }: { children: ReactNode }) {
 
       const createPromise = (async () => {
         const activeBoard = await getStoredActiveBoard();
-        if (!activeBoard) return null;
+        if (!activeBoard) {
+          // The Start button is gated on the React Query copy of the active board;
+          // if the stored board is somehow missing, fail loudly so the user knows
+          // to pick a board instead of tapping into a silent no-op.
+          showToast(t('mobile.queue.noBoardSelected'), 'error');
+          return null;
+        }
 
         const boardPath = buildBoardPath(
           activeBoard.boardType,
@@ -714,8 +722,25 @@ export function QueueProvider({ children }: { children: ReactNode }) {
           });
           await setStoredSessionId(newId);
           return newId;
-        } catch {
-          showToast(t('mobile.queue.sessionCreateError'), 'error');
+        } catch (error) {
+          // Production masks the GraphQL message to "Unexpected error", but the
+          // graphql-request ClientError still carries the HTTP status — so Sentry
+          // can distinguish network-down from a 4xx/5xx from a masked server
+          // throw. Capture it with boardPath context; the backend captures the
+          // unmasked cause for the same request (see createSession resolver).
+          const httpStatus =
+            error && typeof error === 'object' && 'response' in error
+              ? ((error as { response?: { status?: number } }).response?.status ?? null)
+              : null;
+          reportError(error, {
+            tags: { source: 'createSession' },
+            extra: { boardPath, httpStatus, discoverable: config?.discoverable ?? false },
+          });
+          // Against a local backend (dev) errors aren't masked, so surface the
+          // real server message to speed up diagnosis; shipped builds keep the
+          // friendly fallback.
+          const devMessage = __DEV__ ? extractGraphqlMessage(error) : null;
+          showToast(devMessage ?? t('mobile.queue.sessionCreateError'), 'error');
           return null;
         } finally {
           sessionCreationRef.current = null;

--- a/packages/mobile/test/sentry-react-native-stub.ts
+++ b/packages/mobile/test/sentry-react-native-stub.ts
@@ -1,0 +1,20 @@
+// Vitest stub for `@sentry/react-native`.
+//
+// The real package's entry pulls in React Native internals (react-native's
+// `Libraries/Promise.js`, which imports `promise/setimmediate/es6-extensions`
+// without a file extension) that fail to resolve under vitest's node ESM
+// environment, breaking every suite that transitively imports `src/lib/sentry`
+// (via the queue provider, the root layout, PreSessionView, etc.).
+//
+// Sentry is disabled in tests anyway — `isSentryEnabled` is false without a DSN
+// — so this lightweight stub just needs to satisfy the static imports.
+//
+// Wired via the `@sentry/react-native` alias in packages/mobile/vite.config.ts.
+
+export function init(): void {}
+
+export function captureException(): void {}
+
+export function wrap<T>(component: T): T {
+  return component;
+}

--- a/packages/mobile/test/sentry-react-native-stub.ts
+++ b/packages/mobile/test/sentry-react-native-stub.ts
@@ -15,6 +15,20 @@ export function init(): void {}
 
 export function captureException(): void {}
 
+export function captureMessage(): void {}
+
+export function addBreadcrumb(): void {}
+
+export function setUser(): void {}
+
+export function setContext(): void {}
+
+export function setTag(): void {}
+
+export function withScope(callback: (scope: unknown) => void): void {
+  callback({ setTag: () => {}, setContext: () => {}, setExtra: () => {} });
+}
+
 export function wrap<T>(component: T): T {
   return component;
 }

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -24,6 +24,12 @@ export default defineConfig({
       // so any suite can import a Paper-backed primitive; component tests that
       // assert Paper props register their own vi.mock which takes precedence.
       'react-native-paper': fileURLToPath(new URL('./test/react-native-paper-stub.tsx', import.meta.url)),
+      // @sentry/react-native's real entry pulls in react-native's Promise.js,
+      // which imports `promise/setimmediate/es6-extensions` (no extension) and
+      // fails to resolve under vitest's node ESM env — breaking every suite that
+      // transitively imports `src/lib/sentry`. Sentry is disabled in tests, so a
+      // lightweight stub satisfies the static imports.
+      '@sentry/react-native': fileURLToPath(new URL('./test/sentry-react-native-stub.ts', import.meta.url)),
     },
     // .tsx test files can opt into a jsdom environment per file via the
     // `// @vitest-environment jsdom` pragma — needed to render React

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -299,6 +299,7 @@
       "positionLabel": "position {{position}}",
       "syncError": "Queue sync error",
       "sessionCreateError": "Couldn't create session",
+      "noBoardSelected": "Pick a board first",
       "actionFailed": "Action failed. Try again.",
       "endSession": "End session",
       "endSessionConfirm": "Are you sure you want to end this session?",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -299,6 +299,7 @@
       "positionLabel": "posición {{position}}",
       "syncError": "Error de sincronización de cola",
       "sessionCreateError": "No se pudo crear la sesión",
+      "noBoardSelected": "Selecciona un board primero",
       "actionFailed": "Acción fallida. Inténtalo de nuevo.",
       "endSession": "Terminar sesión",
       "endSessionConfirm": "¿Estás seguro de que quieres terminar esta sesión?",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -299,6 +299,7 @@
       "positionLabel": "position {{position}}",
       "syncError": "Erreur de synchronisation de la file",
       "sessionCreateError": "Impossible de créer la session",
+      "noBoardSelected": "Choisissez d'abord un board",
       "actionFailed": "Action échouée. Réessayez.",
       "endSession": "Terminer la session",
       "endSessionConfirm": "Êtes-vous sûr de vouloir terminer cette session ?",


### PR DESCRIPTION
## Problem

In the RN app, tapping **Start session** fails with a generic "Couldn't start session" toast (reproduced on a TestFlight build), and the real cause is **invisible**:

- The backend runs Yoga with `maskedErrors` in production (`yoga.ts`), so any server-side failure reaches the client as a generic "Unexpected error."
- Both client `catch` blocks (`queue-provider.tsx`, `PreSessionView.tsx`) discarded the error with no logging or Sentry capture.
- Yoga's own Sentry hook skips client-input GraphQLErrors (validation / auth / rate-limit), so a whole class of `createSession` failures never reached Sentry either.

For a default (non-discoverable) session the backend doesn't even require auth, and web uses the same HTTP `/graphql` endpoint successfully — so this is mobile-specific or transient, not a missing backend.

## What this does

Makes the failure **diagnosable** (the actual root cause is unknown until we can see it) and fixes the one concrete silent-failure bug found along the way. It does **not** yet fix the underlying failure — that's the follow-up once the captured error names the cause.

- **Backend** (`sessions/mutations.ts`): wrap the `createSession` resolver in try/catch → `Sentry.captureException` with `boardPath` / `transport` / `isAuthenticated` / `userId` **before** masking, then rethrow (client behaviour unchanged). Backend Sentry is already initialized and enabled in prod (`instrument.ts`).
- **Mobile** (`queue-provider.tsx`): report the createSession error to Sentry with the graphql-request `ClientError` **HTTP status** + `boardPath` — so we can distinguish network-down from a 4xx/5xx from a masked server throw. Surface the real server message in dev (a local backend doesn't mask).
- **Mobile**: the missing-stored-board path now shows **"Pick a board first"** instead of a tap that silently does nothing.
- **i18n**: add `mobile.queue.noBoardSelected` to en-US / es / fr.
- **Test infra**: stub `@sentry/react-native` for vitest (the new import pulls in RN internals that break under vitest), matching the existing `posthog-react-native` stub.

## How to find the real cause (next step)

- Fastest: run the mobile app against a **local** backend (which doesn't mask), tap Start session, read the real message in the toast/console.
- Otherwise it lands in Sentry tagged `source: createSession` after the next TestFlight build.

## Validation

- ✅ `typecheck:backend`, `typecheck:mobile`, i18n catalog parity, mobile Metro bundle check
- ✅ mobile tests — only the pre-existing `use-playlist-activation` failure remains (verified identical on the clean branch base); the new stub fixes the suite the import had broken
- ✅ backend tests — the failures are all pre-existing flaky/unrelated suites (verified identical on clean base: WS `integration.test.ts` "socket hang up" + `user-data-export` / `feed-fanout` / `pageSize`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)