### PR TITLE
[codex] perf(mobile): reduce queue render cascades

### DIFF
--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -17,7 +17,7 @@ vi.mock('../../../src/lib/ble/bluetooth-status-store', () => ({
 }));
 
 vi.mock('../../../src/providers/queue-provider', () => ({
-  useQueue: () => ({ sessionId: cfg.sessionId }),
+  useQueueSessionId: () => ({ sessionId: cfg.sessionId }),
 }));
 
 vi.mock('../../../src/components/queue-control/QueueBottomAccessory', () => ({

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -5,7 +5,7 @@ import { Tabs } from 'expo-router';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useTranslation } from 'react-i18next';
 import { useBluetoothConnectedStatus } from '../../src/lib/ble/bluetooth-status-store';
-import { useQueue } from '../../src/providers/queue-provider';
+import { useQueueSessionId } from '../../src/providers/queue-provider';
 import { QueueBottomAccessory } from '../../src/components/queue-control/QueueBottomAccessory';
 import { MaterialTabBar } from '../../src/components/navigation/MaterialTabBar';
 import { useTheme } from '../../src/providers/theme-provider';
@@ -44,7 +44,10 @@ export default function TabLayout() {
   // Record-tab status cue: a badge when a board is connected over Bluetooth or a
   // session is live.
   const isBluetoothConnected = useBluetoothConnectedStatus();
-  const { sessionId } = useQueue();
+  // sessionId-only subscription: the tab layout renders the whole NativeTabs
+  // tree inline, so reading the volatile useQueue() here re-rendered every tab
+  // on every queue mutation. useQueueSessionId only changes on session start/end.
+  const { sessionId } = useQueueSessionId();
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
 
   if (variant === 'material') {

--- a/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
+++ b/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
@@ -13,7 +13,7 @@ import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
 import { BoardImageNative } from '../../../src/components/BoardImageNative';
 import { LogAscentSheet } from '../../../src/components/LogAscentSheet';
 import { useClimb, useToggleFavorite } from '../../../src/lib/graphql/hooks';
-import { useQueue } from '../../../src/providers/queue-provider';
+import { useQueueSessionId, useQueueActions } from '../../../src/providers/queue-provider';
 import { getBoardRenderData } from '../../../src/lib/board-details';
 import { hapticSuccess } from '../../../src/lib/haptics';
 import { track } from '../../../src/lib/analytics';
@@ -52,7 +52,8 @@ export default function ClimbDetail() {
 
   const { data: climb, isLoading } = useClimb(climbVariables);
   const toggleFavorite = useToggleFavorite();
-  const { sessionId, addToQueue } = useQueue();
+  const { sessionId } = useQueueSessionId();
+  const { addToQueue } = useQueueActions();
   const { formatGrade } = useGradeFormat();
   const [showLogAscent, setShowLogAscent] = useState(false);
 

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { memo, useState, useCallback, useMemo, useRef, useEffect, type ComponentProps } from 'react';
 import {
   View,
   StyleSheet,
@@ -112,6 +112,17 @@ export default function ClimbList() {
   );
 }
 
+// Reads the active-climb selector itself, so navigating climbs re-renders only
+// these cheap row wrappers (and the two ClimbListRows whose `selected` flips) —
+// never ClimbListInner or the FlashList. ClimbListRow stays presentational (a
+// plain `selected` prop), so PlaylistDetailView's rows are unaffected.
+const ActiveAwareClimbListRow = memo(function ActiveAwareClimbListRow(
+  props: Omit<ComponentProps<typeof ClimbListRow>, 'selected'>,
+) {
+  const activeClimbUuid = useActiveClimbUuid();
+  return <ClimbListRow {...props} selected={props.climb.uuid === activeClimbUuid} />;
+});
+
 function ClimbListInner() {
   const router = useRouter();
   const { t } = useTranslation('climbs');
@@ -130,11 +141,6 @@ function ClimbListInner() {
     patchFilters,
     patchBoardFilters,
   } = useClimbSearch();
-  // The active climb (driving the board / persistent queue bar). We highlight
-  // its row so the search → tap → change-active loop is always visible. The
-  // selector changes identity only when the active uuid changes, so unrelated
-  // queue mutations / party pushes no longer re-render this screen.
-  const activeClimbUuid = useActiveClimbUuid();
   const { getLogbook } = useBoardProvider();
   const searchHeaderRef = useRef<SearchHeaderHandle>(null);
   const nativeSearchRef = useRef<NativeSearchBarRef>(null);
@@ -696,7 +702,7 @@ function ClimbListInner() {
 
   const renderClimbItem = useCallback(
     ({ item: climb }: { item: Climb }) => (
-      <ClimbListRow
+      <ActiveAwareClimbListRow
         climb={climb}
         boardName={boardName as BoardName}
         layoutId={layoutId}
@@ -707,7 +713,6 @@ function ClimbListInner() {
         onOpenActions={openClimbActions}
         onOpenPlaylist={openAddToPlaylist}
         onAddToQueue={handleAddToQueue}
-        selected={climb.uuid === activeClimbUuid}
       />
     ),
     [
@@ -720,7 +725,6 @@ function ClimbListInner() {
       openClimbActions,
       openAddToPlaylist,
       handleAddToQueue,
-      activeClimbUuid,
     ],
   );
 

--- a/packages/mobile/app/join/[sessionId].tsx
+++ b/packages/mobile/app/join/[sessionId].tsx
@@ -14,7 +14,7 @@ import { ActivityIndicator } from '../../src/components/ActivityIndicator';
 import { Icon } from '../../src/components/Icon';
 import { useTheme } from '../../src/providers/theme-provider';
 import { useAuth } from '../../src/providers/auth-provider';
-import { useQueue } from '../../src/providers/queue-provider';
+import { useQueueSessionId, useQueueActions } from '../../src/providers/queue-provider';
 import { useToast } from '../../src/providers/toast-provider';
 import { useSessionPreview, useMyBoards, useCreateBoard } from '../../src/lib/graphql/hooks';
 import { resolveBoardForSession } from '../../src/lib/board-path-to-user-board';
@@ -37,7 +37,8 @@ export default function JoinSessionScreen() {
   const { isAuthenticated } = useAuth();
   const { showToast } = useToast();
 
-  const { sessionId: activeSessionId, joinSession, clearSession } = useQueue();
+  const { sessionId: activeSessionId } = useQueueSessionId();
+  const { joinSession, clearSession } = useQueueActions();
 
   const preview = useSessionPreview(sessionId);
   const myBoards = useMyBoards(undefined, { enabled: isAuthenticated });

--- a/packages/mobile/app/join/__tests__/join-session-analytics.test.tsx
+++ b/packages/mobile/app/join/__tests__/join-session-analytics.test.tsx
@@ -70,8 +70,8 @@ vi.mock('../../../src/providers/theme-provider', () => ({
 }));
 vi.mock('../../../src/providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
 vi.mock('../../../src/providers/queue-provider', () => ({
-  useQueue: () => ({
-    sessionId: queue.sessionId,
+  useQueueSessionId: () => ({ sessionId: queue.sessionId }),
+  useQueueActions: () => ({
     joinSession: queue.joinSession,
     clearSession: queue.clearSession,
   }),

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
@@ -86,7 +86,7 @@ vi.mock('../../../lib/graphql/hooks', () => ({
   useClimb: () => ({ data: editClimb.data }),
 }));
 vi.mock('../../../providers/queue-provider', () => ({
-  useQueue: () => ({ setCurrentClimb: queue.setCurrentClimb }),
+  useQueueActions: () => ({ setCurrentClimb: queue.setCurrentClimb }),
 }));
 vi.mock('../../../providers/bluetooth-provider', () => ({
   useOptionalBluetoothContext: () => null,

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -19,7 +19,7 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../../lib/analytics';
 import { useAuth } from '../../providers/auth-provider';
 import { useProfile, useClimb } from '../../lib/graphql/hooks';
-import { useQueue } from '../../providers/queue-provider';
+import { useQueueActions } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useToast } from '../../providers/toast-provider';
 import { climbToQueueItem } from '../../lib/climb-to-queue-item';
@@ -91,7 +91,7 @@ export function useCreateClimbScreen({
   const { isAuthenticated, saveClimb, updateClimb } = useBoardProvider();
   const auth = useAuth();
   const { data: profile } = useProfile();
-  const { setCurrentClimb } = useQueue();
+  const { setCurrentClimb } = useQueueActions();
   const bluetooth = useOptionalBluetoothContext();
   const { showToast } = useToast();
   const queryClient = useQueryClient();
@@ -441,8 +441,8 @@ export function useCreateClimbScreen({
       await clearDraft(draftKey);
       // Refresh the inline Open Drafts table so the just-saved climb appears /
       // updates (delete already invalidates these keys; save must too).
-      queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
-      queryClient.invalidateQueries({ queryKey: ['searchClimbsCount'] });
+      void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
+      void queryClient.invalidateQueries({ queryKey: ['searchClimbsCount'] });
       setJustSaved(true);
       showToast(isDraft ? t('mobile.create.save.draftToast') : t('mobile.create.save.publishedToast'), 'success');
       // A publish is commit-and-done — dismiss the drawer so the toast shows

--- a/packages/mobile/src/components/play-drawer/DeferredSections.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredSections.tsx
@@ -18,6 +18,7 @@ type DeferredSectionsProps = {
   setIds: string;
   angle: number;
   enabled: boolean;
+  contentEnabled: boolean;
   onSimilarClimbPress: (climb: Climb) => void;
   /** Reports the measured height of the Beta Videos section header (drives the play
    *  drawer's first-screen reserve so the header teases at the bottom of the fold). */
@@ -37,15 +38,19 @@ export const DeferredSections = memo(function DeferredSections({
   setIds,
   angle,
   enabled,
+  contentEnabled,
   onSimilarClimbPress,
   onBetaHeaderLayout,
 }: DeferredSectionsProps) {
   const { t } = useTranslation('session');
   // Defer the JS-heavy below-fold sections until just after the drawer's open
-  // animation. Re-defers per climb (resetKey = uuid) and — unlike a bare
+  // animation and only after the user has started scrolling below the fold.
+  // Beta videos stay eager below because their header/body is the user's first
+  // scroll affordance once the drawer opens.
+  // Re-defers per climb (resetKey = uuid) and — unlike a bare
   // runAfterInteractions — falls back to a bounded timeout, so a starved
   // interaction queue can't leave these sections blank until the drawer reopens.
-  const readyToRender = useDeferredAfterInteractions(enabled, climb.uuid);
+  const readyToRender = useDeferredAfterInteractions(enabled && contentEnabled, climb.uuid);
 
   // Tally shown next to the collapsed Logbook header so the user sees their
   // history without expanding. Mirrors LogbookSection's summary fallback.
@@ -62,12 +67,9 @@ export const DeferredSections = memo(function DeferredSections({
     return null;
   }
 
-  // Beta Videos section renders eagerly so its header height is laid out
-  // immediately — this is what drives the play drawer's first-screen reserve
-  // (the header teases at the bottom of the fold). Without eager render the
-  // reserve would only settle after InteractionManager fires, causing the board
-  // to visibly resize on first open. BetaVideosSection's data fetch is React
-  // Query and cheap to schedule; only the JS-heavy sub-sections wait below.
+  // Keep Beta Videos eager so it can measure immediately and tease real content
+  // at the bottom of the first screen. The heavier Logbook/Community/Similar
+  // sections still wait for scroll + the interaction queue.
   return (
     <View style={styles.container}>
       <CollapsibleSection title={t('mobile.betaVideos.title')} keepExpanded onHeaderLayout={onBetaHeaderLayout}>

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -29,7 +29,7 @@ import { ClimbActionsSheet } from '../ClimbActionsSheet';
 import { BleControlSheet } from '../ble/BleControlSheet';
 import { GlassSheetBackground } from '../GlassSheetBackground';
 import { Icon } from '../Icon';
-import { useQueue } from '../../providers/queue-provider';
+import { usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useToast } from '../../providers/toast-provider';
 import { useToggleFavorite } from '../../lib/graphql/hooks';
@@ -127,6 +127,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const [activeSubDrawer, setActiveSubDrawer] = useState<ActiveSubDrawer>('none');
   const [bleControlOpen, setBleControlOpen] = useState(false);
   const [pendingClimbUuid, setPendingClimbUuid] = useState<string | null>(null);
+  const [belowFoldContentRequested, setBelowFoldContentRequested] = useState(false);
   const wallControlPressOperationRef = useRef(0);
   const resetZoomRef = useRef<(() => void) | null>(null);
 
@@ -143,7 +144,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     setCurrentClimb,
     nextClimb,
     previousClimb,
-    playlistSuggestionSource,
     sessionId,
     addToQueue,
     takeControl,
@@ -152,6 +152,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     participantId,
     lastConnectedBoardSerial,
   } = useQueue();
+  const playlistSuggestionSource = usePlaylistSuggestionSource();
   const bluetooth = useOptionalBluetoothContext();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
   const { formatGrade } = useGradeFormat();
@@ -215,6 +216,13 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   useEffect(() => {
     setIsTickBarActive(false);
   }, [displayedClimbUuid]);
+
+  // Once the user has requested below-fold content in an open sheet, keep it
+  // mounted across climb changes because the scroll view stays below the fold.
+  // Reset only after close so the next fresh open starts cheap again.
+  useEffect(() => {
+    if (!isSheetOpen) setBelowFoldContentRequested(false);
+  }, [isSheetOpen]);
 
   // When the board angle changes, drop the locally-pinned climb so the drawer
   // re-derives the displayed climb from currentClimbQueueItem — which the queue
@@ -523,6 +531,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     setActiveSubDrawer('actions');
   }, []);
 
+  const handleScrollTowardBelowFold = useCallback(() => {
+    setBelowFoldContentRequested(true);
+  }, []);
+
   const handleOpenAngleSelector = useCallback(() => {
     setActiveSubDrawer('angleSelector');
   }, []);
@@ -620,7 +632,11 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         handleComponent={renderNoHandle}
         onDismiss={handleClose}
       >
-        <BottomSheetScrollView style={styles.content} contentContainerStyle={{ paddingBottom: insets.bottom }}>
+        <BottomSheetScrollView
+          style={styles.content}
+          contentContainerStyle={{ paddingBottom: insets.bottom }}
+          onScrollBeginDrag={handleScrollTowardBelowFold}
+        >
           {displayedClimb && (
             <>
               <View style={[styles.firstScreen, { height: firstScreenHeight, paddingTop: insets.top }]}>
@@ -723,6 +739,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
                 setIds={setIds}
                 angle={angle}
                 enabled={isSheetOpen}
+                contentEnabled={belowFoldContentRequested}
                 onSimilarClimbPress={handleSimilarClimbPress}
                 onBetaHeaderLayout={handleBetaHeaderLayout}
               />

--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -10,7 +10,7 @@ import { QueueList } from './QueueList';
 import { GlassSheetBackground } from '../GlassSheetBackground';
 import { Text } from '../Text';
 import type { QueueItemRowBoard } from '../QueueItemRow';
-import { useQueue } from '../../providers/queue-provider';
+import { usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { hapticMedium, hapticWarning } from '../../lib/haptics';
 import { brandColors } from '../../theme/colors';
@@ -51,7 +51,8 @@ export function QueueSheet({
   const { systemColors, sheet } = useTheme();
   const sheetRef = useRef<BottomSheetModal>(null);
 
-  const { state, removeFromQueue, clearQueue, reorderQueue, playlistSuggestionSource } = useQueue();
+  const { state, removeFromQueue, clearQueue, reorderQueue } = useQueue();
+  const playlistSuggestionSource = usePlaylistSuggestionSource();
   const { queue, currentClimbQueueItem } = state;
 
   const [isEditMode, setIsEditMode] = useState(false);

--- a/packages/mobile/src/components/play-drawer/__tests__/deferred-sections.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/deferred-sections.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Climb } from '@boardsesh/shared-schema';
+
+const deferred = vi.hoisted(() => ({
+  ready: false,
+  calls: [] as Array<{ active: boolean; resetKey: string | number | undefined }>,
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../../../hooks/use-deferred-after-interactions', () => ({
+  useDeferredAfterInteractions: (active: boolean, resetKey?: string | number) => {
+    deferred.calls.push({ active, resetKey });
+    return deferred.ready;
+  },
+}));
+
+vi.mock('../../CollapsibleSection', () => ({
+  CollapsibleSection: ({
+    title,
+    children,
+    onHeaderLayout,
+  }: {
+    title: string;
+    children?: ReactNode;
+    onHeaderLayout?: (height: number) => void;
+  }) => {
+    onHeaderLayout?.(44);
+    return createElement('section', { 'data-title': title }, children);
+  },
+}));
+
+vi.mock('../BetaVideosSection', () => ({
+  BetaVideosSection: () => createElement('div', { 'data-testid': 'beta-videos' }),
+}));
+
+vi.mock('../LogbookSection', () => ({
+  LogbookSection: () => createElement('div', { 'data-testid': 'logbook' }),
+}));
+
+vi.mock('../CommunitySection', () => ({
+  CommunitySection: () => createElement('div', { 'data-testid': 'community' }),
+}));
+
+vi.mock('../SimilarClimbsSection', () => ({
+  SimilarClimbsSection: () => createElement('div', { 'data-testid': 'similar-climbs' }),
+}));
+
+import { DeferredSections } from '../DeferredSections';
+
+const climb = {
+  uuid: 'climb-1',
+  userAscents: 0,
+  userAttempts: 0,
+  quality_average: '3',
+  ascensionist_count: 0,
+} as Climb;
+
+function renderSections(options: { enabled?: boolean; contentEnabled?: boolean } = {}) {
+  return render(
+    <DeferredSections
+      climb={climb}
+      boardName="kilter"
+      layoutId={1}
+      sizeId={10}
+      setIds="1,2"
+      angle={40}
+      enabled={options.enabled ?? true}
+      contentEnabled={options.contentEnabled ?? false}
+      onSimilarClimbPress={vi.fn()}
+    />,
+  );
+}
+
+describe('DeferredSections', () => {
+  beforeEach(() => {
+    deferred.ready = false;
+    deferred.calls = [];
+  });
+
+  it('keeps Beta videos eager while heavier sections wait for scroll and interaction readiness', () => {
+    renderSections({ contentEnabled: false });
+
+    expect(screen.getByTestId('beta-videos')).not.toBeNull();
+    expect(screen.queryByTestId('logbook')).toBeNull();
+    expect(screen.queryByTestId('community')).toBeNull();
+    expect(screen.queryByTestId('similar-climbs')).toBeNull();
+    expect(deferred.calls.at(-1)).toEqual({ active: false, resetKey: 'climb-1' });
+  });
+
+  it('still waits for the interaction defer after the content is requested', () => {
+    renderSections({ contentEnabled: true });
+
+    expect(screen.getByTestId('beta-videos')).not.toBeNull();
+    expect(screen.queryByTestId('logbook')).toBeNull();
+    expect(deferred.calls.at(-1)).toEqual({ active: true, resetKey: 'climb-1' });
+  });
+
+  it('renders the heavier sections once both gates are open', () => {
+    deferred.ready = true;
+    renderSections({ contentEnabled: true });
+
+    expect(screen.getByTestId('beta-videos')).not.toBeNull();
+    expect(screen.getByTestId('logbook')).not.toBeNull();
+    expect(screen.getByTestId('community')).not.toBeNull();
+    expect(screen.getByTestId('similar-climbs')).not.toBeNull();
+  });
+
+  it('renders nothing while disabled', () => {
+    const { container } = renderSections({ enabled: false, contentEnabled: true });
+
+    expect(container.childElementCount).toBe(0);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
@@ -73,7 +73,7 @@ mocks.queueValue = {
 };
 
 vi.mock('../../../providers/queue-provider', () => ({
-  useQueue: () => mocks.queueValue,
+  useQueueActions: () => mocks.queueValue,
 }));
 
 vi.mock('../../../providers/bluetooth-provider', () => ({

--- a/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
+++ b/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { useClimbFrames, usePlaybackEngine, type ExternalPlaybackState } from '@boardsesh/playback-react';
-import { useQueue } from '../../providers/queue-provider';
+import { useQueueActions } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 
 type UseMobilePlaybackInput = {
@@ -52,7 +52,7 @@ export function useMobilePlayback({
   isOpen,
   onRoutePlayed,
 }: UseMobilePlaybackInput): UseMobilePlaybackOutput {
-  const { subscribeToQueueEvents, publishPlaybackState } = useQueue();
+  const { subscribeToQueueEvents, publishPlaybackState } = useQueueActions();
   const bluetooth = useOptionalBluetoothContext();
   // Stable per-hook id so the engine can suppress echoes of its own broadcasts.
   const playbackClientId = useId();

--- a/packages/mobile/src/components/playlist/PlaylistCard.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { memo, useCallback } from 'react';
 import { Pressable, View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
@@ -27,7 +27,7 @@ export type PlaylistCardProps = {
   onTogglePin?: () => void;
 };
 
-export function PlaylistCard({
+export const PlaylistCard = memo(function PlaylistCard({
   name,
   climbCount,
   color,
@@ -97,7 +97,7 @@ export function PlaylistCard({
       </View>
     </Pressable>
   );
-}
+});
 
 const styles = StyleSheet.create({
   gridCard: {

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -137,6 +137,7 @@ vi.mock('../../../providers/theme-provider', () => ({
 
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: queue.state, nextClimb: queue.nextClimb, previousClimb: queue.previousClimb }),
+  usePlaylistSuggestionSource: () => null,
 }));
 
 vi.mock('../../../providers/drawer-host-provider', () => ({

--- a/packages/mobile/src/components/queue-control/__tests__/log-ascent-fab.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/log-ascent-fab.test.tsx
@@ -67,7 +67,7 @@ vi.mock('../../../providers/theme-provider', () => ({
   }),
 }));
 
-vi.mock('../../../providers/queue-provider', () => ({ useQueue: () => ({ sessionId: queue.sessionId }) }));
+vi.mock('../../../providers/queue-provider', () => ({ useQueueSessionId: () => ({ sessionId: queue.sessionId }) }));
 
 vi.mock('../../../providers/drawer-host-provider', () => ({
   useDrawerHost: () => ({ openLogAscent: drawer.openLogAscent, boardConfig: drawer.boardConfig }),
@@ -141,7 +141,13 @@ describe('LogAscentFab', () => {
   });
 
   it('opens the log-ascent sheet with the expected payload when tapped', () => {
-    const climb = makeClimb({ uuid: 'climb-123', angle: 40, difficulty: 'V5', mirrored: true, benchmark_difficulty: 'V6' });
+    const climb = makeClimb({
+      uuid: 'climb-123',
+      angle: 40,
+      difficulty: 'V5',
+      mirrored: true,
+      benchmark_difficulty: 'V6',
+    });
     drawer.boardConfig = makeBoardConfig({ boardName: 'tension', layoutId: 8, sizeId: 17, setIds: '26,27' });
     queue.sessionId = 'sess-42';
 

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -36,6 +36,14 @@ const nav = vi.hoisted(() => ({
   },
 }));
 
+function styleDataValue(styleValue: unknown): string {
+  if (styleValue == null) return '';
+  if (typeof styleValue === 'string' || typeof styleValue === 'number' || typeof styleValue === 'boolean') {
+    return String(styleValue);
+  }
+  return JSON.stringify(styleValue);
+}
+
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
   PlatformColor: (name: string) => name,
@@ -83,14 +91,14 @@ vi.mock('react-native', () => ({
     return createElement(
       'div',
       {
-        'data-width': width == null ? '' : String(width),
-        'data-height': height == null ? '' : String(height),
-        'data-padding-right': paddingRight == null ? '' : String(paddingRight),
-        'data-background-color': backgroundColor == null ? '' : String(backgroundColor),
-        'data-border-width': borderWidth == null ? '' : String(borderWidth),
-        'data-border-color': borderColor == null ? '' : String(borderColor),
-        'data-border-radius': borderRadius == null ? '' : String(borderRadius),
-        'data-overflow': overflow == null ? '' : String(overflow),
+        'data-width': styleDataValue(width),
+        'data-height': styleDataValue(height),
+        'data-padding-right': styleDataValue(paddingRight),
+        'data-background-color': styleDataValue(backgroundColor),
+        'data-border-width': styleDataValue(borderWidth),
+        'data-border-color': styleDataValue(borderColor),
+        'data-border-radius': styleDataValue(borderRadius),
+        'data-overflow': styleDataValue(overflow),
         'data-role': accessibilityRole ?? '',
         'data-label': accessibilityLabel ?? '',
         'data-actions': Array.isArray(accessibilityActions)
@@ -178,6 +186,7 @@ vi.mock('../../../providers/queue-provider', () => ({
     nextClimb: queue.nextClimb,
     previousClimb: queue.previousClimb,
   }),
+  usePlaylistSuggestionSource: () => null,
 }));
 
 vi.mock('../../../providers/drawer-host-provider', () => ({
@@ -249,10 +258,10 @@ vi.mock('../../BoardImageNative', () => ({
       'data-thumbnail': frames,
       'data-mirrored': mirrored ? 'true' : 'false',
       'data-filled': filledStyle ? 'true' : 'false',
-      'data-board-width': width == null ? '' : String(width),
-      'data-board-height': height == null ? '' : String(height),
-      'data-board-border-radius': borderRadius == null ? '' : String(borderRadius),
-      'data-board-overflow': overflow == null ? '' : String(overflow),
+      'data-board-width': styleDataValue(width),
+      'data-board-height': styleDataValue(height),
+      'data-board-border-radius': styleDataValue(borderRadius),
+      'data-board-overflow': styleDataValue(overflow),
     });
   },
 }));

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -38,6 +38,7 @@ vi.mock('../../../lib/route-segments', () => ({
 }));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: { currentClimbQueueItem: cfg.currentClimbQueueItem } }),
+  useHasActiveClimb: () => cfg.currentClimbQueueItem?.climb != null,
 }));
 vi.mock('../../../hooks/use-reduce-motion', () => ({ useReduceMotion: () => true }));
 vi.mock('../../../theme/animations', () => ({ timing: { fast: 150, normal: 250 } }));

--- a/packages/mobile/src/components/queue-control/use-log-ascent-action.ts
+++ b/packages/mobile/src/components/queue-control/use-log-ascent-action.ts
@@ -4,7 +4,7 @@ import type { Climb } from '@boardsesh/queue';
 import { useOptionalBoardProvider } from '@boardsesh/board-react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '../../providers/theme-provider';
-import { useQueue } from '../../providers/queue-provider';
+import { useQueueSessionId } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { springs } from '../../theme/animations';
@@ -15,7 +15,7 @@ export function useLogAscentAction(climb: Climb) {
   const { t } = useTranslation('session');
   const { systemColors, brandColors } = useTheme();
   const { boardConfig, openLogAscent } = useDrawerHost();
-  const { sessionId } = useQueue();
+  const { sessionId } = useQueueSessionId();
   const board = useOptionalBoardProvider();
   const reduceMotion = useReduceMotion();
 

--- a/packages/mobile/src/components/queue-control/use-queue-carousel.ts
+++ b/packages/mobile/src/components/queue-control/use-queue-carousel.ts
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { computePeekOffset, computeNavigationStateWithSuggestions } from '@boardsesh/play-view';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
-import { useQueue } from '../../providers/queue-provider';
+import { usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { hapticLight, hapticSelection } from '../../lib/haptics';
 import { useCarouselGesture } from '../play-drawer/use-carousel-gesture';
@@ -51,7 +51,8 @@ export type QueueCarousel = {
 };
 
 export function useQueueCarousel(): QueueCarousel {
-  const { state, nextClimb, previousClimb, playlistSuggestionSource } = useQueue();
+  const { state, nextClimb, previousClimb } = useQueue();
+  const playlistSuggestionSource = usePlaylistSuggestionSource();
   const { openPlayDrawer } = useDrawerHost();
   const { t } = useTranslation('session');
   const reduceMotion = useReduceMotion();

--- a/packages/mobile/src/components/session-screen/SessionScreen.tsx
+++ b/packages/mobile/src/components/session-screen/SessionScreen.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { PanGesture } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
-import { useQueue, useQueueLiveStats } from '../../providers/queue-provider';
+import { useQueueSessionId, useQueueLiveStats } from '../../providers/queue-provider';
 import { SessionScreenHeader } from './SessionScreenHeader';
 import { PreSessionView } from './pre-session/PreSessionView';
 import { InSessionView } from './in-session/InSessionView';
@@ -27,7 +27,7 @@ type SessionScreenProps = {
  * Record tab; the overlay-only props (drag/pull-to-dismiss) are omitted there.
  */
 export function SessionScreen({ onClose, headerGesture, translateY, screenHeight }: SessionScreenProps) {
-  const { sessionId } = useQueue();
+  const { sessionId } = useQueueSessionId();
   const { sessionUsers } = useQueueLiveStats();
   const insets = useSafeAreaInsets();
   const [showInvite, setShowInvite] = useState(false);

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -19,7 +19,7 @@ import { Icon } from '../../Icon';
 import { Text } from '../../Text';
 import { type IconName } from '../../icon-map';
 import { useTheme } from '../../../providers/theme-provider';
-import { useQueue, useQueueLiveStats } from '../../../providers/queue-provider';
+import { useQueueSessionControls, useQueueActions, useQueueLiveStats } from '../../../providers/queue-provider';
 import { useDrawerHost } from '../../../providers/drawer-host-provider';
 import { useSessionDetail, useSessionSummary } from '../../../lib/graphql/hooks';
 import { climbToQueueItem } from '../../../lib/climb-to-queue-item';
@@ -231,7 +231,8 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
   const router = useRouter();
   const queryClient = useQueryClient();
   const { openPlayDrawer } = useDrawerHost();
-  const { sessionId, driverParticipantId, participantId, setCurrentClimb, endSession } = useQueue();
+  const { sessionId, driverParticipantId, participantId } = useQueueSessionControls();
+  const { setCurrentClimb, endSession } = useQueueActions();
   const { liveStats, sessionUsers } = useQueueLiveStats();
 
   // Seed the live view from the full session detail (rich grade split, flashes,

--- a/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
@@ -11,7 +11,7 @@ import { useTheme } from '../../../providers/theme-provider';
 import { spacing } from '../../../theme/tokens';
 import { useActiveBoard } from '../../../lib/graphql/use-active-board';
 import { useAuth } from '../../../providers/auth-provider';
-import { useQueue } from '../../../providers/queue-provider';
+import { useQueueActions } from '../../../providers/queue-provider';
 import { useToast } from '../../../providers/toast-provider';
 import { useBottomChromeMetrics } from '../../../hooks/use-bottom-chrome-metrics';
 import { BoardSummaryCard } from './BoardSummaryCard';
@@ -30,7 +30,7 @@ export function PreSessionView() {
   const bottomChrome = useBottomChromeMetrics();
   const { data: activeBoard } = useActiveBoard();
   const { isAuthenticated } = useAuth();
-  const { startSession, addToQueue } = useQueue();
+  const { startSession, addToQueue } = useQueueActions();
   const { showToast } = useToast();
 
   const [selection, setSelection] = useState<GeneratorSelection>({ type: 'off' });

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-analytics.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-analytics.test.tsx
@@ -52,7 +52,7 @@ vi.mock('../../../../providers/theme-provider', () => ({ useTheme: () => ({ syst
 vi.mock('../../../../lib/graphql/use-active-board', () => ({ useActiveBoard: () => activeBoard }));
 vi.mock('../../../../providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
 vi.mock('../../../../providers/queue-provider', () => ({
-  useQueue: () => ({ startSession: queue.startSession, addToQueue: queue.addToQueue }),
+  useQueueActions: () => ({ startSession: queue.startSession, addToQueue: queue.addToQueue }),
 }));
 vi.mock('../../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../../../../hooks/use-bottom-chrome-metrics', () => ({

--- a/packages/mobile/src/components/you/ProgressTab.tsx
+++ b/packages/mobile/src/components/you/ProgressTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { View, ScrollView, RefreshControl, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { useYouProfileData } from '../../lib/graphql/hooks';
@@ -16,7 +16,7 @@ import { useTheme } from '../../providers/theme-provider';
 
 type YouData = ReturnType<typeof useYouProfileData>;
 
-export function ProgressTab({ data }: { data: YouData }) {
+export const ProgressTab = memo(function ProgressTab({ data }: { data: YouData }) {
   const { t } = useTranslation('profile');
   const { t: tYou } = useTranslation('you');
   const { systemColors, colorScheme, brandColors } = useTheme();
@@ -121,7 +121,7 @@ export function ProgressTab({ data }: { data: YouData }) {
       )}
     </ScrollView>
   );
-}
+});
 
 const styles = StyleSheet.create({
   flex: { flex: 1 },

--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from 'react';
+import { memo, useMemo, useState, type ReactNode } from 'react';
 import { View, StyleSheet, type LayoutChangeEvent } from 'react-native';
 import { BarChart, LineChart } from 'react-native-gifted-charts';
 import type { RawGroupedBar, RawVPointsTimeline } from '@boardsesh/profile-stats';
@@ -103,7 +103,7 @@ type StackedBarsProps = {
 };
 
 /** Stacked bars (weekly activity, grade distribution). */
-export function StackedBarChart({
+export const StackedBarChart = memo(function StackedBarChart({
   bars,
   colorBy,
   height = 170,
@@ -112,7 +112,7 @@ export function StackedBarChart({
   legend,
   maxXLabels,
 }: StackedBarsProps) {
-  const { systemColors, colorScheme, variant } = useTheme();
+  const { colorScheme, variant } = useTheme();
   const isEmpty = !bars || bars.length === 0;
   // gifted-charts color props require plain strings (not PlatformColor). On the
   // Material variant resolveSystemColors pulls from materialSurfaces; on glass/
@@ -181,7 +181,7 @@ export function StackedBarChart({
       {legend && !isEmpty ? <Legend items={legend} /> : null}
     </View>
   );
-}
+});
 
 type GroupedBarsProps = {
   bars: RawGroupedBar[] | null;
@@ -196,8 +196,14 @@ type GroupedBarsProps = {
  * API, so we flatten to a single data array: two adjacent bars per grade with a
  * wider gap separating groups, and the grade label centered under each pair.
  */
-export function GroupedBarChart({ bars, height = 150, loading, emptyLabel, legend }: GroupedBarsProps) {
-  const { systemColors, colorScheme, variant } = useTheme();
+export const GroupedBarChart = memo(function GroupedBarChart({
+  bars,
+  height = 150,
+  loading,
+  emptyLabel,
+  legend,
+}: GroupedBarsProps) {
+  const { colorScheme, variant } = useTheme();
   const isEmpty = !bars || bars.length === 0;
   const chartColors = variant === 'material' ? materialSurfaces[colorScheme] : androidFallbackColors[colorScheme];
   const groupGap = 14;
@@ -245,7 +251,7 @@ export function GroupedBarChart({ bars, height = 150, loading, emptyLabel, legen
       {legend && !isEmpty ? <Legend items={legend} /> : null}
     </View>
   );
-}
+});
 
 type AreaProps = {
   timeline: RawVPointsTimeline | null;
@@ -261,8 +267,14 @@ type AreaProps = {
  * (gifted-charts' multi-area stacking is unreliable; the per-layout breakdown
  * is conveyed by the grade-distribution chart instead).
  */
-export function TotalAreaChart({ timeline, color, height = 170, loading, emptyLabel }: AreaProps) {
-  const { systemColors, colorScheme, variant } = useTheme();
+export const TotalAreaChart = memo(function TotalAreaChart({
+  timeline,
+  color,
+  height = 170,
+  loading,
+  emptyLabel,
+}: AreaProps) {
+  const { colorScheme, variant } = useTheme();
   const chartColors = variant === 'material' ? materialSurfaces[colorScheme] : androidFallbackColors[colorScheme];
   const isEmpty = !timeline || timeline.series.length === 0;
 
@@ -323,7 +335,7 @@ export function TotalAreaChart({ timeline, color, height = 170, loading, emptyLa
       }}
     </ChartFrame>
   );
-}
+});
 
 const styles = StyleSheet.create({
   frame: {

--- a/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useSegments } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useQueue } from '../providers/queue-provider';
+import { useHasActiveClimb } from '../providers/queue-provider';
 import { useTheme } from '../providers/theme-provider';
 import { isTabsRoute } from '../lib/route-segments';
 import { useNativeAccessoryActive } from './use-bottom-accessory';
@@ -15,10 +15,12 @@ import { computeBottomChromeMetrics } from './bottom-chrome-metrics';
 export function useBottomChromeMetrics() {
   const insets = useSafeAreaInsets();
   const segments = useSegments();
-  const { state } = useQueue();
+  // Only the *presence* of a current climb matters here — subscribe to the
+  // presence-only selector, which flips solely when a climb appears/disappears.
+  // This keeps bottom chrome from re-rendering on queue mutations OR on
+  // climb-to-climb navigation across every screen that floats it.
+  const hasCurrentClimb = useHasActiveClimb();
   const { variant } = useTheme();
-
-  const hasCurrentClimb = state.currentClimbQueueItem?.climb != null;
   const insideTabs = isTabsRoute(segments);
   const nativeAccessoryActive = useNativeAccessoryActive();
   const nativeAccessoryMounted = insideTabs && nativeAccessoryActive;

--- a/packages/mobile/src/lib/__tests__/board-details.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-details.test.ts
@@ -22,7 +22,7 @@ vi.mock('../env', () => ({
 
 import { getImageFilename } from '@boardsesh/board-constants/product-sizes';
 import { BOARD_IMAGE_DIMENSIONS, getMoonBoardDetails } from '@boardsesh/board-config';
-import { getBoardAspectRatio, getBoardRenderData } from '../board-details';
+import { clearBoardRenderDataCache, getBoardAspectRatio, getBoardRenderData } from '../board-details';
 
 const mockedGetImageFilename = vi.mocked(getImageFilename);
 const mockedGetMoonBoardDetails = vi.mocked(getMoonBoardDetails);
@@ -36,6 +36,7 @@ const baseParams = {
 describe('getBoardAspectRatio', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    clearBoardRenderDataCache();
     BOARD_IMAGE_DIMENSIONS.kilter = {};
   });
 
@@ -86,6 +87,7 @@ describe('getBoardAspectRatio', () => {
 describe('getBoardRenderData', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    clearBoardRenderDataCache();
   });
 
   it('builds MoonBoard render data from the shared MoonBoard config', () => {

--- a/packages/mobile/src/lib/board-details.ts
+++ b/packages/mobile/src/lib/board-details.ts
@@ -11,11 +11,50 @@ type BoardRenderData = {
   holdsData: HoldPlacement[];
 };
 
+// `getBoardRenderData` is pure but does O(n) work over ~1400 hold tuples (a
+// filter plus per-hold coordinate math) on the PlayDrawer-open critical path and
+// on every carousel swap. The underlying placement data is static, so memoize by
+// board-config key. A session only ever touches a handful of distinct boards;
+// the cap just bounds memory if a picker churns through many.
+const RENDER_DATA_CACHE_LIMIT = 16;
+const renderDataCache = new Map<string, BoardRenderData | null>();
+
 /**
  * Computes board rendering data (dimensions, image URLs, hold positions)
  * from board config parameters. Mirrors the web's `getBoardDetails()`.
+ * Cached by board config — the placement data behind it never changes.
  */
 export function getBoardRenderData(params: {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: number[];
+}): BoardRenderData | null {
+  const { boardName, layoutId, sizeId, setIds } = params;
+
+  const cacheKey = `${boardName}-${layoutId}-${sizeId}-${setIds.join(',')}`;
+  const cached = renderDataCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const result = computeBoardRenderData(params);
+  if (renderDataCache.size >= RENDER_DATA_CACHE_LIMIT) {
+    const oldestKey = renderDataCache.keys().next().value;
+    if (oldestKey !== undefined) renderDataCache.delete(oldestKey);
+  }
+  renderDataCache.set(cacheKey, result);
+  return result;
+}
+
+/**
+ * Clears the render-data memo. Production never needs this (the placement data
+ * behind a board key is static), but tests mock different board data under the
+ * same config key and must reset between cases.
+ */
+export function clearBoardRenderDataCache(): void {
+  renderDataCache.clear();
+}
+
+function computeBoardRenderData(params: {
   boardName: BoardName;
   layoutId: number;
   sizeId: number;

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -30,7 +30,7 @@ vi.mock('@boardsesh/playlists-react', () => ({
   fetchPlaylistSuggestionClimbs: (args: unknown) => mocks.fetchSuggestion(args),
 }));
 vi.mock('../../../providers/queue-provider', () => ({
-  useQueue: () => ({
+  useQueueActions: () => ({
     setCurrentClimb: mocks.setCurrentClimb,
     refreshPlaylistSuggestionSource: mocks.refreshPlaylistSuggestionSource,
   }),

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -13,7 +13,7 @@
 import { useCallback, useMemo, startTransition } from 'react';
 import { usePlaylistClimbActivation, fetchPlaylistSuggestionClimbs } from '@boardsesh/playlists-react';
 import { getQueueBoardKey, type Climb } from '@boardsesh/queue';
-import { useQueue } from '../../providers/queue-provider';
+import { useQueueActions } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { useActiveBoard } from '../graphql/use-active-board';
 import { climbToQueueItem } from '../climb-to-queue-item';
@@ -52,7 +52,7 @@ export function usePlaylistActivation({
   fetchPage,
   refreshErrorMessage,
 }: UsePlaylistActivationOptions): (climb: Climb) => Promise<void> {
-  const { setCurrentClimb, refreshPlaylistSuggestionSource } = useQueue();
+  const { setCurrentClimb, refreshPlaylistSuggestionSource } = useQueueActions();
   const { openPlayDrawer } = useDrawerHost();
   const activeBoard = useActiveBoard().data ?? null;
 

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -118,10 +118,12 @@ vi.mock('../../components/QueueAddedSnackbar', () => ({
 }));
 
 vi.mock('../queue-provider', () => ({
-  useQueue: () => ({
+  useQueueActions: () => ({
     addToQueue: queue.addToQueue,
     setSessionBoardPath: queue.setSessionBoardPath,
     setCurrentClimb: queue.setCurrentClimb,
+  }),
+  useQueueSessionControls: () => ({
     sessionId: queue.sessionId,
     driverParticipantId: queue.driverParticipantId,
     participantId: queue.participantId,

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -144,7 +144,7 @@ vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
 }));
 
-import { QueueProvider, useQueue, useQueueLiveStats } from '../queue-provider';
+import { QueueProvider, usePlaylistSuggestionSource, useQueue, useQueueLiveStats } from '../queue-provider';
 
 type Snapshot = {
   state: ReturnType<typeof useQueue>['state'];
@@ -207,6 +207,7 @@ function createDeferred<T>() {
 
 function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
   const queue = useQueue();
+  const playlistSuggestionSource = usePlaylistSuggestionSource();
   // sessionUsers moved out of useQueue() into its own live-stats context so the
   // ≤1/2s party push no longer re-renders every queue consumer; read it here.
   const { sessionUsers } = useQueueLiveStats();
@@ -217,7 +218,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
       users: sessionUsers,
       driverParticipantId: queue.driverParticipantId,
       lastConnectedBoardSerial: queue.lastConnectedBoardSerial,
-      playlistSuggestionSource: queue.playlistSuggestionSource,
+      playlistSuggestionSource,
       addToQueue: queue.addToQueue,
       setCurrentClimb: queue.setCurrentClimb,
       nextClimb: queue.nextClimb,
@@ -235,7 +236,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
     sessionUsers,
     queue.driverParticipantId,
     queue.lastConnectedBoardSerial,
-    queue.playlistSuggestionSource,
+    playlistSuggestionSource,
     queue.addToQueue,
     queue.setCurrentClimb,
     queue.nextClimb,

--- a/packages/mobile/src/providers/board-adapter.tsx
+++ b/packages/mobile/src/providers/board-adapter.tsx
@@ -8,14 +8,14 @@ import { useTranslation } from 'react-i18next';
 import { BoardAdapterProvider, type BoardAdapter } from '@boardsesh/board-react';
 import { execute } from '@boardsesh/graphql-client';
 import { useAuth } from './auth-provider';
-import { useQueue } from './queue-provider';
+import { useQueueSessionId } from './queue-provider';
 import { useToast } from './toast-provider';
 import { getHttpClient } from '../lib/graphql/client';
 import { getWsClient } from '../lib/graphql/ws-client';
 
 export function BoardAdapterWrapper({ children }: { children: ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth();
-  const { sessionId } = useQueue();
+  const { sessionId } = useQueueSessionId();
   const { showToast } = useToast();
   const { t } = useTranslation('climbs');
 

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -30,7 +30,7 @@ import { AddToPlaylistSheet } from '../components/AddToPlaylistSheet';
 import { useToggleFavorite, useProfile } from '../lib/graphql/hooks';
 import { favoritesStore } from '@boardsesh/climb-actions';
 import { climbToQueueItem } from '../lib/climb-to-queue-item';
-import { useQueue } from './queue-provider';
+import { useQueueActions, useQueueSessionControls } from './queue-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
 
 export type BoardConfig = {
@@ -105,8 +105,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // unmounting instead of vanishing instantly.
   const [queueSheetMounted, setQueueSheetMounted] = useState(false);
   const [queueSheetVisible, setQueueSheetVisible] = useState(false);
-  const { addToQueue, setSessionBoardPath, setCurrentClimb, sessionId, driverParticipantId, participantId } =
-    useQueue();
+  const { addToQueue, setSessionBoardPath, setCurrentClimb } = useQueueActions();
+  const { sessionId, driverParticipantId, participantId } = useQueueSessionControls();
   const setActiveBoard = useSetActiveBoard();
   const { visible: snackbarVisible, nonce: snackbarNonce, dismissSnackbar } = useQueueSnackbar();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -97,8 +97,6 @@ type QueueContextValue = {
   setCurrentClimb: (item: ClimbQueueItem, options?: SetCurrentClimbOptions) => void;
   nextClimb: () => void;
   previousClimb: () => void;
-  /** Active playlist suggestion source (client-only; survives server syncs). */
-  playlistSuggestionSource: PlaylistSuggestionSource | null;
   /** Replace the playlist suggestion source that drives swipe-through climbs. */
   setPlaylistSuggestionSource: (source: PlaylistSuggestionSource | null) => void;
   /** Refresh the suggestion source in place (no-op unless it matches the active one). */
@@ -156,6 +154,18 @@ type QueueContextValue = {
 
 const QueueContext = createContext<QueueContextValue | null>(null);
 
+/**
+ * QueueProvider intentionally exposes several narrow hooks. Pick the smallest
+ * subscription that matches the read:
+ * - useQueue(): legacy/full reducer state plus actions; use only when state shape is required.
+ * - useQueueActions(): stable command surface for enqueue/session/playback writes.
+ * - useQueueSessionId(): rare session-id changes for structural chrome.
+ * - useQueueSessionControls(): session id plus driver/serial controls for party surfaces.
+ * - useQueueLiveStats(): high-frequency live stats and roster updates.
+ * - useActiveClimbUuid(): row-level active-climb highlighting.
+ * - useHasActiveClimb(): presence-only bottom chrome metrics.
+ * - usePlaylistSuggestionSource(): playlist peek/suggestion navigation.
+ */
 type TakeControlOptions = {
   playlistSuggestionSource?: PlaylistSuggestionSource | null;
 };
@@ -172,6 +182,21 @@ type QueueSessionControlContextValue = Pick<
 >;
 
 const QueueSessionControlContext = createContext<QueueSessionControlContextValue | null>(null);
+
+/**
+ * SessionId-only selector context. Its identity changes ONLY when the active
+ * session id changes (session start / end / join — rare), never on queue
+ * mutations or the ≤1/2s party pushes. Consumed by high-fanout *structural*
+ * readers — the tab layout (which renders every tab inline), the board adapter,
+ * and the session screen — so a queue change can't cascade a re-render through
+ * the whole navigation tree. Narrower than QueueSessionControlContext, which
+ * also churns on driver / board-serial changes.
+ */
+type QueueSessionIdContextValue = {
+  sessionId: string | null;
+};
+
+const QueueSessionIdContext = createContext<QueueSessionIdContextValue | null>(null);
 
 /**
  * Live session analytics + presence, split out of the main QueueContext so the
@@ -208,10 +233,23 @@ type QueueActiveClimbContextValue = {
 const QueueActiveClimbContext = createContext<QueueActiveClimbContextValue | null>(null);
 
 /**
+ * Boolean "is any climb currently active" selector. Identity changes ONLY when a
+ * climb appears/disappears (none↔some) — NOT when navigating *between* climbs.
+ * Consumed by bottom-chrome metrics (climbs, discover, You screens) so navigating
+ * climbs in the play drawer no longer re-renders those whole tab screens.
+ */
+type QueueHasActiveClimbContextValue = {
+  hasActiveClimb: boolean;
+};
+
+const QueueHasActiveClimbContext = createContext<QueueHasActiveClimbContextValue | null>(null);
+
+/**
  * Stable queue actions, split out so consumers that only dispatch actions (e.g.
  * the climb list's add-to-queue) don't subscribe to the whole reducer `state`.
- * Holds everything in QueueContextValue except `state`, `dispatch`, `sessionId`,
- * `setSessionId`, and the live-stats fields (which live in their own contexts).
+ * Holds everything in QueueContextValue except volatile state and selector-only
+ * values. Playlist suggestion state lives in QueuePlaylistSuggestionContext so
+ * playlist activation does not wake every action-only consumer in the tab tree.
  */
 type QueueActionsContextValue = Omit<
   QueueContextValue,
@@ -226,6 +264,12 @@ type QueueActionsContextValue = Omit<
 
 const QueueActionsContext = createContext<QueueActionsContextValue | null>(null);
 
+type QueuePlaylistSuggestionContextValue = {
+  playlistSuggestionSource: PlaylistSuggestionSource | null;
+};
+
+const QueuePlaylistSuggestionContext = createContext<QueuePlaylistSuggestionContextValue | null>(null);
+
 export function useQueue(): QueueContextValue {
   const context = useContext(QueueContext);
   if (!context) throw new Error('useQueue must be used within QueueProvider');
@@ -235,6 +279,12 @@ export function useQueue(): QueueContextValue {
 export function useQueueSessionControls(): QueueSessionControlContextValue {
   const context = useContext(QueueSessionControlContext);
   if (!context) throw new Error('useQueueSessionControls must be used within QueueProvider');
+  return context;
+}
+
+export function useQueueSessionId(): QueueSessionIdContextValue {
+  const context = useContext(QueueSessionIdContext);
+  if (!context) throw new Error('useQueueSessionId must be used within QueueProvider');
   return context;
 }
 
@@ -250,10 +300,22 @@ export function useActiveClimbUuid(): string | null {
   return context.activeClimbUuid;
 }
 
+export function useHasActiveClimb(): boolean {
+  const context = useContext(QueueHasActiveClimbContext);
+  if (!context) throw new Error('useHasActiveClimb must be used within QueueProvider');
+  return context.hasActiveClimb;
+}
+
 export function useQueueActions(): QueueActionsContextValue {
   const context = useContext(QueueActionsContext);
   if (!context) throw new Error('useQueueActions must be used within QueueProvider');
   return context;
+}
+
+export function usePlaylistSuggestionSource(): PlaylistSuggestionSource | null {
+  const context = useContext(QueuePlaylistSuggestionContext);
+  if (!context) throw new Error('usePlaylistSuggestionSource must be used within QueueProvider');
+  return context.playlistSuggestionSource;
 }
 
 const defaultSearchParams: QueueSearchParams = {};
@@ -413,7 +475,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   }, [sessionId]);
 
   useEffect(() => {
-    getStoredSessionId().then((storedId) => {
+    void getStoredSessionId().then((storedId) => {
       if (__DEV__) {
         console.info(`[session] restored from store: ${storedId ?? '(none)'}`);
       }
@@ -1253,7 +1315,6 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       setCurrentClimb,
       nextClimb,
       previousClimb,
-      playlistSuggestionSource,
       setPlaylistSuggestionSource,
       refreshPlaylistSuggestionSource,
       clearSession,
@@ -1276,7 +1337,6 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       setCurrentClimb,
       nextClimb,
       previousClimb,
-      playlistSuggestionSource,
       setPlaylistSuggestionSource,
       refreshPlaylistSuggestionSource,
       clearSession,
@@ -1313,11 +1373,27 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const activeClimbUuid = state.currentClimbQueueItem?.climb?.uuid ?? null;
   const activeClimbValue = useMemo<QueueActiveClimbContextValue>(() => ({ activeClimbUuid }), [activeClimbUuid]);
 
+  // Presence-only selector: flips solely when a climb appears/disappears, so
+  // bottom-chrome consumers (whole tab screens) don't re-render on climb-to-climb
+  // navigation — only the climb-row highlight (useActiveClimbUuid) does.
+  const hasActiveClimb = activeClimbUuid != null;
+  const hasActiveClimbValue = useMemo<QueueHasActiveClimbContextValue>(() => ({ hasActiveClimb }), [hasActiveClimb]);
+
+  // SessionId-only selector: identity changes only when a session starts/ends,
+  // so structural readers (tab layout, board adapter, session screen) stop
+  // re-rendering the navigation tree on every queue mutation.
+  const sessionIdValue = useMemo<QueueSessionIdContextValue>(() => ({ sessionId }), [sessionId]);
+
   // Live analytics + presence: the ≤1/2s party push recreates only this small
   // value, re-rendering only SessionScreen + InSessionView.
   const liveStatsValue = useMemo<QueueLiveStatsContextValue>(
     () => ({ liveStats, sessionUsers }),
     [liveStats, sessionUsers],
+  );
+
+  const playlistSuggestionValue = useMemo<QueuePlaylistSuggestionContextValue>(
+    () => ({ playlistSuggestionSource }),
+    [playlistSuggestionSource],
   );
 
   const sessionControlValue = useMemo<QueueSessionControlContextValue>(
@@ -1345,13 +1421,19 @@ export function QueueProvider({ children }: { children: ReactNode }) {
 
   return (
     <QueueSessionControlContext.Provider value={sessionControlValue}>
-      <QueueLiveStatsContext.Provider value={liveStatsValue}>
-        <QueueActionsContext.Provider value={actionsValue}>
-          <QueueActiveClimbContext.Provider value={activeClimbValue}>
-            <QueueContext.Provider value={contextValue}>{children}</QueueContext.Provider>
-          </QueueActiveClimbContext.Provider>
-        </QueueActionsContext.Provider>
-      </QueueLiveStatsContext.Provider>
+      <QueueSessionIdContext.Provider value={sessionIdValue}>
+        <QueueLiveStatsContext.Provider value={liveStatsValue}>
+          <QueueActionsContext.Provider value={actionsValue}>
+            <QueuePlaylistSuggestionContext.Provider value={playlistSuggestionValue}>
+              <QueueActiveClimbContext.Provider value={activeClimbValue}>
+                <QueueHasActiveClimbContext.Provider value={hasActiveClimbValue}>
+                  <QueueContext.Provider value={contextValue}>{children}</QueueContext.Provider>
+                </QueueHasActiveClimbContext.Provider>
+              </QueueActiveClimbContext.Provider>
+            </QueuePlaylistSuggestionContext.Provider>
+          </QueueActionsContext.Provider>
+        </QueueLiveStatsContext.Provider>
+      </QueueSessionIdContext.Provider>
     </QueueSessionControlContext.Provider>
   );
 }


### PR DESCRIPTION
## What changed

- Split mobile queue context into narrower selector/action providers so high-fanout consumers do not subscribe to volatile queue state.
- Memoized expensive mobile row/chart/card surfaces and cached static board render data.
- Kept Beta videos eager as the below-fold scroll cue, while deferring heavier Logbook, Community, and Similar sections until scroll plus interaction readiness.

## Why

React DevTools profiles showed queue updates and below-fold drawer content causing broad render commits while swiping/opening climbs. The latest analyzed profile showed queue-wide cascades removed and the remaining below-fold work isolated behind explicit render gates.

## Validation

- `vp check <37 changed mobile files>`
- `vp test --project mobile`
- `vp run typecheck:mobile`
- `vp run check:mobile-native-deps`
- `vp run check:mobile-patches`
- `vp run check:mobile-bundle`
- `vp run check:mobile-simulator`
- `vp run mobile:screenshot`

Note: full-repo `vp check` still reports pre-existing formatting failures outside this PR plus local profiling artifacts; the changed mobile files check is clean.