### PR TITLE
fix(mobile): single ascent indicator + correct in-session grade order

### DIFF
--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -52,6 +52,12 @@ type ClimbListItemContentProps = {
   sizeId: number;
   setIds: string;
   angle: number;
+  /**
+   * Whether to render the trailing ascent-status glyph. Defaults to true. Set
+   * false where the host already shows the ascent status (e.g. the in-session
+   * history row's leading badge) so it isn't duplicated beside the grade.
+   */
+  showAscentStatus?: boolean;
 };
 
 /**
@@ -107,6 +113,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
   sizeId,
   setIds,
   angle,
+  showAscentStatus = true,
 }: ClimbListItemContentProps) {
   const { t } = useTranslation('climbs');
   const { formatGrade } = useGradeFormat();
@@ -162,7 +169,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
 
       {/* Right: ascent-status glyph + colorized grade — the two scan keys together */}
       <View style={styles.rightSection}>
-        <AscentStatusGlyph climbUuid={climb.uuid} angle={angle} />
+        {showAscentStatus ? <AscentStatusGlyph climbUuid={climb.uuid} angle={angle} /> : null}
         <Text variant="title3" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
           {formattedGrade ?? climb.difficulty}
         </Text>

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -192,6 +192,7 @@ const SessionHistoryRow = memo(function SessionHistoryRow({
             sizeId={boardConfig.sizeId}
             setIds={boardConfig.setIds.join(',')}
             angle={tick.angle}
+            showAscentStatus={false}
           />
         ) : (
           <>
@@ -212,12 +213,6 @@ const SessionHistoryRow = memo(function SessionHistoryRow({
             ) : null}
           </>
         )}
-
-        <View style={[styles.historyStatusPill, { backgroundColor: withAlpha(statusColor, 0.15) }]}>
-          <Text variant="caption1" color={statusColor} style={styles.historyStatusLabel}>
-            {statusLabel}
-          </Text>
-        </View>
       </Pressable>
       <View style={[styles.historySeparator, { backgroundColor: systemColors.separator }]} />
     </View>
@@ -635,16 +630,6 @@ const styles = StyleSheet.create({
   },
   historyGradeText: {
     fontWeight: '700',
-  },
-  historyStatusPill: {
-    flexShrink: 0,
-    paddingHorizontal: spacing[2],
-    paddingVertical: 3,
-    borderRadius: borderRadius.full,
-  },
-  historyStatusLabel: {
-    fontWeight: '700',
-    textTransform: 'capitalize',
   },
   historySeparator: {
     height: StyleSheet.hairlineWidth,

--- a/packages/mobile/src/components/you/__tests__/grade-sort-value.test.ts
+++ b/packages/mobile/src/components/you/__tests__/grade-sort-value.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { gradeSortValue } from '../grade-sort-value';
+
+describe('gradeSortValue', () => {
+  it('orders V-only labels numerically, not alphabetically', () => {
+    const sorted = ['V10', 'V2', 'V0'].sort((a, b) => gradeSortValue(a) - gradeSortValue(b));
+    expect(sorted).toEqual(['V0', 'V2', 'V10']);
+  });
+
+  it('breaks the V3 / V3+ tie via the font token on combined grades', () => {
+    // "6a/V3" and "6a+/V3" both carry "/V3"; only the font "+" distinguishes them.
+    const sorted = ['7a/V6', '6a+/V3', '6a/V3', '4a/V0'].sort((a, b) => gradeSortValue(a) - gradeSortValue(b));
+    expect(sorted).toEqual(['4a/V0', '6a/V3', '6a+/V3', '7a/V6']);
+  });
+
+  it('orders font-only labels easy to hard, case-insensitively', () => {
+    const sorted = ['7A', '6A+', '6A'].sort((a, b) => gradeSortValue(a) - gradeSortValue(b));
+    expect(sorted).toEqual(['6A', '6A+', '7A']);
+  });
+
+  it('sorts unknown labels last', () => {
+    expect(gradeSortValue('???')).toBe(Number.MAX_SAFE_INTEGER);
+    const sorted = ['???', '6a/V3'].sort((a, b) => gradeSortValue(a) - gradeSortValue(b));
+    expect(sorted).toEqual(['6a/V3', '???']);
+  });
+});

--- a/packages/mobile/src/components/you/grade-sort-value.ts
+++ b/packages/mobile/src/components/you/grade-sort-value.ts
@@ -1,15 +1,19 @@
 /**
- * Sortable rank for a grade label so chart X-axes read easy to hard. Extracts
- * the V-number when present, else maps a font grade; unknown labels sort last.
+ * Sortable rank for a grade label so chart X-axes read easy to hard. The font
+ * token drives ordering: it is the finest-grained, `+`-aware key and is always
+ * present in the backend's combined `"<font>/V<n>"` strings (e.g. "6a/V3",
+ * "6a+/V3"). Reading only the V-number tied "6a/V3" and "6a+/V3" (both → 3), so
+ * adjacent `+` grades landed in backend order. We now sort on the font token,
+ * fall back to the V-number for V-only labels, and sort unknown labels last.
  */
 export function gradeSortValue(gradeLabel: string): number {
-  const vMatch = gradeLabel.match(/V(\d+)/i);
-  if (vMatch) return Number(vMatch[1]);
   const fontMatch = gradeLabel.match(/(\d)([abc])(\+?)/i);
   if (fontMatch) {
     const number = Number(fontMatch[1]);
     const letter = fontMatch[2].toLowerCase().charCodeAt(0) - 96;
     return 100 + number * 10 + letter * 2 + (fontMatch[3] ? 1 : 0);
   }
+  const vMatch = gradeLabel.match(/V(\d+)/i);
+  if (vMatch) return Number(vMatch[1]);
   return Number.MAX_SAFE_INTEGER;
 }


### PR DESCRIPTION
## What

Two cleanups on the React Native **live in-session screen**.

### 1. One ascent-status indicator per history row

Each row in the in-session history list rendered the flash/send/attempt status **three times**:

- a far-left colored icon badge,
- a grey status glyph next to the grade (inside the shared `ClimbListItemContent`),
- a full-text pill ("Flash" / "Send" / "Attempt") on the far right.

Now only the far-left indicator remains:

- `ClimbListItemContent` gains an optional `showAscentStatus` prop (default `true`, so the search list and queue rows are unchanged). `InSessionView`'s history row passes `showAscentStatus={false}`.
- The full-text pill is removed. The status still feeds the row's `accessibilityLabel`, so screen readers continue to announce it.

### 2. Correct grade ordering in the in-session grade chart

`SessionGradeChart` sorted bars with `gradeSortValue`, which read only the `V<n>` integer from the backend grade strings (`"6a/V3"`, `"6a+/V3"`). Because it ignored the font `+`, `"6a/V3"` (V3) and `"6a+/V3"` (V3+) both returned `3` and tied, so adjacent `+` grades fell back to backend order.

`gradeSortValue` now sorts on the `+`-aware font token first (always present in the combined `"<font>/V<n>"` strings), falling back to the V-number for V-only labels, then "unknown sorts last". The You/Progress-tab chart already sorted by difficulty ID and is untouched.

## Tests

- New `grade-sort-value.test.ts`: V2 before V10, the `6a/V3` < `6a+/V3` < `7a/V6` tie-break, font-only ordering, and unknown-sorts-last.

## Validation

- `vp run test:mobile` — 1353 passed
- `vp run typecheck:mobile` — clean
- `vp run check:mobile-bundle` — OK (10.6 MB)
- `vp check` — no lint errors; the only formatting hits are pre-existing files this PR doesn't touch.

https://claude.ai/code/session_019roNTkB5UhFLynywJAXQm6

---
_Generated by [Claude Code](https://claude.ai/code/session_019roNTkB5UhFLynywJAXQm6)_