### PR TITLE
Run RN Swift tests in CI

### DIFF
--- a/.github/workflows/ios-rn-ci.yml
+++ b/.github/workflows/ios-rn-ci.yml
@@ -1,29 +1,44 @@
-name: iOS CI
+name: iOS CI (React Native)
 
 on:
   pull_request:
     paths:
-      - 'mobile/**'
-      - '.github/workflows/ios-ci.yml'
+      - 'packages/mobile/**'
+      - 'packages/shared/**'
+      - 'packages/board-constants/**'
+      - 'packages/shared-schema/**'
+      - 'scripts/prepare-rn-ios-tests.mjs'
+      - '.github/workflows/ios-rn-ci.yml'
   push:
     branches-ignore: [main]
     paths:
-      - 'mobile/**'
-      - '.github/workflows/ios-ci.yml'
+      - 'packages/mobile/**'
+      - 'packages/shared/**'
+      - 'packages/board-constants/**'
+      - 'packages/shared-schema/**'
+      - 'scripts/prepare-rn-ios-tests.mjs'
+      - '.github/workflows/ios-rn-ci.yml'
   workflow_dispatch:
 
 concurrency:
-  group: ios-ci-${{ github.ref }}
+  group: ios-rn-ci-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build-and-test:
-    runs-on: macos-15
-    timeout-minutes: 30
+    runs-on: macos-26
+    timeout-minutes: 60
 
     env:
-      WORKSPACE_PATH: mobile/ios/App/App.xcworkspace
-      SCHEME: App
+      WORKSPACE_PATH: packages/mobile/ios/Boardsesh.xcworkspace
+      SCHEME: Boardsesh
+      EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
+      EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
+      EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
+      SENTRY_DISABLE_AUTO_UPLOAD: 'true'
 
     steps:
       - name: Checkout repository
@@ -36,30 +51,41 @@ jobs:
           node-version: 'lts'
           cache: true
 
+      - name: Install Node.js dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Write .env for Expo build-time inlining
+        working-directory: packages/mobile
+        run: |
+          cat > .env <<EOF
+          EXPO_PUBLIC_BACKEND_URL=$EXPO_PUBLIC_BACKEND_URL
+          EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
+          EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
+          EOF
+
+      - name: Expo prebuild (generate ios/)
+        working-directory: packages/mobile
+        run: bunx expo prebuild --platform ios --clean --no-install
+
       - name: Cache CocoaPods
         uses: actions/cache@v4
         with:
-          path: mobile/ios/App/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('mobile/ios/App/Podfile.lock') }}
+          path: packages/mobile/ios/Pods
+          key: ${{ runner.os }}-pods-rn-ci-${{ hashFiles('packages/mobile/ios/Podfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-pods-
-
-      - name: Install Node.js dependencies
-        working-directory: mobile
-        run: bun install --frozen-lockfile
-
-      - name: Sync Capacitor iOS project
-        working-directory: mobile
-        run: bunx cap sync ios
+            ${{ runner.os }}-pods-rn-ci-
+            ${{ runner.os }}-pods-rn-
 
       - name: Install CocoaPods dependencies
-        working-directory: mobile/ios/App
+        working-directory: packages/mobile/ios
         run: pod install
+
+      - name: Add RN Swift test target
+        run: node scripts/prepare-rn-ios-tests.mjs
 
       - name: Resolve simulator destination
         id: simulator
         run: |
-          # Pick the first booted iPhone, or boot one from the latest available runtime
           DEVICE_NAME=$(xcrun simctl list devices available -j \
             | python3 -c "
           import json, sys
@@ -76,7 +102,7 @@ jobs:
           echo "device=$DEVICE_NAME" >> "$GITHUB_OUTPUT"
           echo "Using simulator: $DEVICE_NAME"
 
-      - name: Build for testing (compiler check)
+      - name: Build for testing
         run: |
           xcodebuild build-for-testing \
             -workspace "$WORKSPACE_PATH" \
@@ -87,7 +113,7 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
 
-      - name: Run unit tests
+      - name: Run Swift unit tests
         run: |
           xcodebuild test-without-building \
             -workspace "$WORKSPACE_PATH" \

--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -213,6 +213,18 @@ Source locations:
 - Widget extension target (Live Activity SwiftUI, AppIntents, WidgetNetworking, plus byte-identical copies of ClimbSessionAttributes / SharedConstants / SharedKeychain / Intent files): `packages/mobile/targets/BoardseshWidgets/` — managed by `@bacons/apple-targets`
 - Widget target build settings that @bacons/apple-targets does not expose directly, including `WIDGET_EXTENSION`: `packages/mobile/plugins/with-boardsesh-widget-build-settings.js`
 
+#### Swift unit tests and CI
+
+The RN app's `packages/mobile/ios/` directory is generated and gitignored, so tracked Swift
+unit tests live in `packages/mobile/ios-tests/`. The CI workflow runs Expo prebuild, then
+`scripts/prepare-rn-ios-tests.mjs` creates a generated `BoardseshTests` XCTest target and
+stages the Live Activity Swift sources into that target before invoking `xcodebuild`.
+
+Swift test coverage runs in two workflows:
+
+- `.github/workflows/ios-rn-ci.yml` builds and tests the React Native / Expo app and widget helpers.
+- `.github/workflows/ios-ci.yml` builds and tests the legacy Capacitor app Swift target.
+
 #### 1. Generate the native project
 
 ```bash

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+
+@available(iOS 17.0, *)
+final class LiveActivityWidgetTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "com.boardsesh.rn.live-activity-tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func makeQueueItem(
+        uuid: String = "queue-1",
+        climbUuid: String = "climb-1",
+        climbName: String = "Test Climb",
+        difficulty: String = "6c+/V5",
+        angle: Int = 40,
+        mirrored: Bool = false
+    ) -> SharedQueueItem {
+        SharedQueueItem(
+            uuid: uuid,
+            climbUuid: climbUuid,
+            climbName: climbName,
+            difficulty: difficulty,
+            angle: angle,
+            frames: "p1r12p2r13",
+            setterUsername: "tester",
+            mirrored: mirrored
+        )
+    }
+
+    func testLocalSessionAllowsNavigationWithoutServerAuthorization() {
+        defaults.set("local-activity-1", forKey: SharedConstants.sessionIdKey)
+
+        let wallControl = SharedWidgetWallControlState.load(from: defaults)
+
+        XCTAssertTrue(wallControl.navigationAllowed)
+        XCTAssertFalse(wallControl.requiresServerAuthorization)
+        XCTAssertEqual(SharedWidgetTakeControlRuntime.action(for: wallControl), .enableLocalNavigation)
+    }
+
+    func testLegacyPartySessionFailsClosedWhenDriverStateMissing() {
+        defaults.set("session-party-1", forKey: SharedConstants.sessionIdKey)
+
+        let wallControl = SharedWidgetWallControlState.load(from: defaults)
+
+        XCTAssertFalse(wallControl.navigationAllowed)
+        XCTAssertTrue(wallControl.requiresServerAuthorization)
+        XCTAssertEqual(SharedWidgetTakeControlRuntime.action(for: wallControl), .requestServerAuthorization)
+    }
+
+    func testPartyNonDriverRequiresServerTakeControl() {
+        SharedWidgetWallControlState.save(navigationAllowed: false, isPartySession: true, to: defaults)
+
+        let wallControl = SharedWidgetWallControlState.load(from: defaults)
+
+        XCTAssertFalse(wallControl.navigationAllowed)
+        XCTAssertTrue(wallControl.requiresServerAuthorization)
+        XCTAssertEqual(SharedWidgetTakeControlRuntime.action(for: wallControl), .requestServerAuthorization)
+    }
+
+    func testPartyDriverDoesNotRequestTakeControlAgain() {
+        SharedWidgetWallControlState.save(navigationAllowed: true, isPartySession: true, to: defaults)
+
+        let wallControl = SharedWidgetWallControlState.load(from: defaults)
+
+        XCTAssertTrue(wallControl.navigationAllowed)
+        XCTAssertTrue(wallControl.requiresServerAuthorization)
+        XCTAssertEqual(SharedWidgetTakeControlRuntime.action(for: wallControl), .alreadyAllowed)
+    }
+
+    func testMarkControlClaimedEnablesPartyNavigationButKeepsAuthorization() {
+        SharedWidgetWallControlState.save(navigationAllowed: false, isPartySession: true, to: defaults)
+
+        SharedWidgetTakeControlRuntime.markControlClaimed(isPartySession: true, to: defaults)
+        let wallControl = SharedWidgetWallControlState.load(from: defaults)
+
+        XCTAssertTrue(wallControl.navigationAllowed)
+        XCTAssertTrue(wallControl.requiresServerAuthorization)
+        XCTAssertEqual(SharedWidgetTakeControlRuntime.action(for: wallControl), .alreadyAllowed)
+    }
+
+    func testNavigationDirectionBounds() {
+        XCTAssertEqual(ClimbNavigationDirection.next.newIndex(from: 0, count: 2), 1)
+        XCTAssertNil(ClimbNavigationDirection.next.newIndex(from: 1, count: 2))
+        XCTAssertEqual(ClimbNavigationDirection.previous.newIndex(from: 1, count: 2), 0)
+        XCTAssertNil(ClimbNavigationDirection.previous.newIndex(from: 0, count: 2))
+        XCTAssertNil(ClimbNavigationDirection.previous.newIndex(from: 3, count: 2))
+    }
+
+    func testSharedQueueItemDecodesOldPayloadWithoutMirroredField() throws {
+        let json = """
+        {
+          "uuid": "queue-1",
+          "climbUuid": "climb-1",
+          "climbName": "Old Payload",
+          "difficulty": "V4",
+          "angle": 40,
+          "frames": "p1r12",
+          "setterUsername": "tester"
+        }
+        """
+
+        let item = try JSONDecoder().decode(SharedQueueItem.self, from: Data(json.utf8))
+
+        XCTAssertFalse(item.mirrored)
+    }
+
+    func testSharedQueueStateCurrentItemRequiresValidIndex() {
+        let items = [
+            makeQueueItem(uuid: "queue-1", climbUuid: "climb-1", climbName: "First"),
+            makeQueueItem(uuid: "queue-2", climbUuid: "climb-2", climbName: "Second")
+        ]
+        SharedQueueState.save(items: items, currentIndex: 1, to: defaults)
+
+        XCTAssertEqual(SharedQueueState.currentItem(from: defaults)?.climbName, "Second")
+
+        SharedQueueState.saveCurrentIndex(2, to: defaults)
+        XCTAssertNil(SharedQueueState.currentItem(from: defaults))
+
+        SharedQueueState.saveCurrentIndex(-1, to: defaults)
+        XCTAssertNil(SharedQueueState.currentItem(from: defaults))
+    }
+
+    func testBoardRenderUrlUsesSharedBoardContext() {
+        defaults.set("https://www.boardsesh.com", forKey: SharedConstants.serverUrlKey)
+        defaults.set("kilter", forKey: SharedConstants.boardNameKey)
+        defaults.set(1, forKey: SharedConstants.layoutIdKey)
+        defaults.set(12, forKey: SharedConstants.sizeIdKey)
+        defaults.set("10,12", forKey: SharedConstants.setIdsKey)
+
+        let url = SharedQueueState.boardRenderUrl(for: makeQueueItem(), from: defaults)
+
+        XCTAssertEqual(url?.scheme, "https")
+        XCTAssertEqual(url?.host, "www.boardsesh.com")
+        XCTAssertEqual(url?.path, "/api/internal/board-render")
+        XCTAssertTrue(url?.absoluteString.contains("board_name=kilter") ?? false)
+        XCTAssertTrue(url?.absoluteString.contains("frames=p1r12p2r13") ?? false)
+        XCTAssertTrue(url?.absoluteString.contains("thumbnail=1") ?? false)
+    }
+}

--- a/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -249,6 +249,8 @@ public class LiveActivityModule: Module {
     }
 
     private func handleBleReconnectFromWidget() {
+        guard #available(iOS 17.0, *) else { return }
+
         Task { @MainActor in
             _ = await LiveActivityBleBridge.reconnectForIntent()
         }

--- a/packages/mobile/modules/live-activity/ios/SharedConstants.swift
+++ b/packages/mobile/modules/live-activity/ios/SharedConstants.swift
@@ -219,6 +219,12 @@ struct SharedWidgetWallControl {
     let requiresServerAuthorization: Bool
 }
 
+enum SharedWidgetTakeControlAction: Equatable {
+    case enableLocalNavigation
+    case alreadyAllowed
+    case requestServerAuthorization
+}
+
 enum SharedWidgetWallControlState {
     static func save(navigationAllowed: Bool, isPartySession: Bool, to defaults: UserDefaults) {
         defaults.set(navigationAllowed, forKey: SharedConstants.widgetNavigationAllowedKey)
@@ -236,6 +242,26 @@ enum SharedWidgetWallControlState {
         return SharedWidgetWallControl(
             navigationAllowed: defaults.bool(forKey: SharedConstants.widgetNavigationAllowedKey),
             requiresServerAuthorization: true
+        )
+    }
+}
+
+enum SharedWidgetTakeControlRuntime {
+    static func action(for wallControl: SharedWidgetWallControl) -> SharedWidgetTakeControlAction {
+        if !wallControl.requiresServerAuthorization {
+            return .enableLocalNavigation
+        }
+        if wallControl.navigationAllowed {
+            return .alreadyAllowed
+        }
+        return .requestServerAuthorization
+    }
+
+    static func markControlClaimed(isPartySession: Bool, to defaults: UserDefaults) {
+        SharedWidgetWallControlState.save(
+            navigationAllowed: true,
+            isPartySession: isPartySession,
+            to: defaults
         )
     }
 }

--- a/packages/mobile/modules/live-activity/ios/TakeControlIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/TakeControlIntent.swift
@@ -13,15 +13,16 @@ struct TakeControlIntent: LiveActivityIntent {
         guard let defaults = SharedConstants.sharedDefaults else { return .result() }
 
         let wallControl = SharedWidgetWallControlState.load(from: defaults)
-        guard wallControl.requiresServerAuthorization else {
-            SharedWidgetWallControlState.save(navigationAllowed: true, isPartySession: false, to: defaults)
+        switch SharedWidgetTakeControlRuntime.action(for: wallControl) {
+        case .enableLocalNavigation:
+            SharedWidgetTakeControlRuntime.markControlClaimed(isPartySession: false, to: defaults)
             await refreshActivities()
             return .result()
-        }
-
-        guard !wallControl.navigationAllowed else {
+        case .alreadyAllowed:
             await refreshActivities()
             return .result()
+        case .requestServerAuthorization:
+            break
         }
 
         let result = await WidgetNetworking.sendTakeControl()
@@ -30,7 +31,7 @@ struct TakeControlIntent: LiveActivityIntent {
             return .result()
         }
 
-        SharedWidgetWallControlState.save(navigationAllowed: true, isPartySession: true, to: defaults)
+        SharedWidgetTakeControlRuntime.markControlClaimed(isPartySession: true, to: defaults)
         await refreshActivities()
         return .result()
     }

--- a/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
+++ b/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
@@ -219,6 +219,12 @@ struct SharedWidgetWallControl {
     let requiresServerAuthorization: Bool
 }
 
+enum SharedWidgetTakeControlAction: Equatable {
+    case enableLocalNavigation
+    case alreadyAllowed
+    case requestServerAuthorization
+}
+
 enum SharedWidgetWallControlState {
     static func save(navigationAllowed: Bool, isPartySession: Bool, to defaults: UserDefaults) {
         defaults.set(navigationAllowed, forKey: SharedConstants.widgetNavigationAllowedKey)
@@ -236,6 +242,26 @@ enum SharedWidgetWallControlState {
         return SharedWidgetWallControl(
             navigationAllowed: defaults.bool(forKey: SharedConstants.widgetNavigationAllowedKey),
             requiresServerAuthorization: true
+        )
+    }
+}
+
+enum SharedWidgetTakeControlRuntime {
+    static func action(for wallControl: SharedWidgetWallControl) -> SharedWidgetTakeControlAction {
+        if !wallControl.requiresServerAuthorization {
+            return .enableLocalNavigation
+        }
+        if wallControl.navigationAllowed {
+            return .alreadyAllowed
+        }
+        return .requestServerAuthorization
+    }
+
+    static func markControlClaimed(isPartySession: Bool, to defaults: UserDefaults) {
+        SharedWidgetWallControlState.save(
+            navigationAllowed: true,
+            isPartySession: isPartySession,
+            to: defaults
         )
     }
 }

--- a/packages/mobile/targets/BoardseshWidgets/TakeControlIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/TakeControlIntent.swift
@@ -13,15 +13,16 @@ struct TakeControlIntent: LiveActivityIntent {
         guard let defaults = SharedConstants.sharedDefaults else { return .result() }
 
         let wallControl = SharedWidgetWallControlState.load(from: defaults)
-        guard wallControl.requiresServerAuthorization else {
-            SharedWidgetWallControlState.save(navigationAllowed: true, isPartySession: false, to: defaults)
+        switch SharedWidgetTakeControlRuntime.action(for: wallControl) {
+        case .enableLocalNavigation:
+            SharedWidgetTakeControlRuntime.markControlClaimed(isPartySession: false, to: defaults)
             await refreshActivities()
             return .result()
-        }
-
-        guard !wallControl.navigationAllowed else {
+        case .alreadyAllowed:
             await refreshActivities()
             return .result()
+        case .requestServerAuthorization:
+            break
         }
 
         let result = await WidgetNetworking.sendTakeControl()
@@ -30,7 +31,7 @@ struct TakeControlIntent: LiveActivityIntent {
             return .result()
         }
 
-        SharedWidgetWallControlState.save(navigationAllowed: true, isPartySession: true, to: defaults)
+        SharedWidgetTakeControlRuntime.markControlClaimed(isPartySession: true, to: defaults)
         await refreshActivities()
         return .result()
     }

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -1,0 +1,396 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TEST_TARGET_NAME = 'BoardseshTests';
+const APP_TARGET_NAME = 'Boardsesh';
+const BUNDLE_IDENTIFIER = 'com.boardsesh.app.tests';
+const DEPLOYMENT_TARGET = '17.0';
+const SWIFT_FLAGS = '"$(inherited) -D WIDGET_EXTENSION"';
+
+const TEST_SOURCE_FILES = [
+  {
+    sourcePath: '../ios-tests/LiveActivityWidgetTests.swift',
+    projectPath: 'BoardseshTests/LiveActivityWidgetTests.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/ClimbSessionAttributes.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/ClimbSessionAttributes.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/SharedConstants.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/SharedConstants.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/SharedKeychain.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/SharedKeychain.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/WidgetNetworking.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/WidgetNetworking.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/ClimbNavigationIntent.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/ClimbNavigationIntent.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/NextClimbIntent.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/NextClimbIntent.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/PreviousClimbIntent.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/PreviousClimbIntent.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/TakeControlIntent.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/TakeControlIntent.swift',
+  },
+];
+
+const SYSTEM_FRAMEWORKS = [
+  'XCTest.framework',
+  'ActivityKit.framework',
+  'AppIntents.framework',
+  'Foundation.framework',
+  'Security.framework',
+];
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const projectFilePath = resolve(
+  process.argv[2] ?? join(repoRoot, 'packages/mobile/ios/Boardsesh.xcodeproj/project.pbxproj'),
+);
+const projectDir = dirname(dirname(projectFilePath));
+
+const require = createRequire(import.meta.url);
+
+function loadXcode() {
+  const candidates = [
+    'xcode',
+    join(repoRoot, 'node_modules/.bun/node_modules/xcode'),
+    join(repoRoot, 'packages/mobile/node_modules/.bun/node_modules/xcode'),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      return require(candidate);
+    } catch (error) {
+      if (error?.code !== 'MODULE_NOT_FOUND') {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error('Could not load the xcode package. Run `bun install --frozen-lockfile` before this script.');
+}
+
+function unquote(value) {
+  return typeof value === 'string' ? value.replace(/^"|"$/g, '') : value;
+}
+
+function normalizedBuildSetting(value) {
+  return String(value).replaceAll('\\', '').replaceAll('"', '');
+}
+
+function isCommentKey(key) {
+  return key.endsWith('_comment');
+}
+
+function findNativeTarget(project, targetName) {
+  const targets = project.pbxNativeTargetSection();
+  for (const [uuid, target] of Object.entries(targets)) {
+    if (isCommentKey(uuid)) continue;
+    if (unquote(target.name) === targetName || unquote(target.productName) === targetName) {
+      return { uuid, target };
+    }
+  }
+  return null;
+}
+
+function ensureBuildPhase(project, targetUuid, phaseType, comment) {
+  const target = project.pbxNativeTargetSection()[targetUuid];
+  const hasPhase = target.buildPhases.some((phase) => phase.comment === comment);
+  if (!hasPhase) {
+    project.addBuildPhase([], phaseType, comment, targetUuid);
+  }
+}
+
+function findGroupKey(project, groupName) {
+  const groups = project.hash.project.objects.PBXGroup;
+  for (const [uuid, group] of Object.entries(groups)) {
+    if (isCommentKey(uuid)) continue;
+    if (unquote(group.name) === groupName || unquote(group.path) === groupName) {
+      return uuid;
+    }
+  }
+  return null;
+}
+
+function ensureGroup(project, groupName) {
+  const existingGroupKey = findGroupKey(project, groupName);
+  if (existingGroupKey) {
+    delete project.hash.project.objects.PBXGroup[existingGroupKey].path;
+    return existingGroupKey;
+  }
+
+  const groupKey = project.pbxCreateGroup(groupName);
+  const projectRoot = project.getFirstProject().firstProject.mainGroup;
+  project.addToPbxGroup(groupKey, projectRoot);
+  return groupKey;
+}
+
+function hasSourceBuildFile(project, targetUuid, sourcePath) {
+  const phase = project.pbxSourcesBuildPhaseObj(targetUuid);
+  const fileReferenceSection = project.pbxFileReferenceSection();
+  const buildFileSection = project.pbxBuildFileSection();
+  const expectedBasename = sourcePath.split('/').at(-1);
+
+  return phase.files.some((entry) => {
+    const buildFile = buildFileSection[entry.value];
+    const fileReference = buildFile ? fileReferenceSection[buildFile.fileRef] : null;
+    return unquote(fileReference?.path) === sourcePath || entry.comment === `${expectedBasename} in Sources`;
+  });
+}
+
+function addSourceFile(project, targetUuid, groupKey, sourcePath) {
+  const absolutePath = resolve(projectDir, sourcePath);
+  if (!existsSync(absolutePath)) {
+    throw new Error(`Missing RN iOS test source: ${absolutePath}`);
+  }
+  if (!hasSourceBuildFile(project, targetUuid, sourcePath)) {
+    project.addSourceFile(sourcePath, { target: targetUuid }, groupKey);
+  }
+}
+
+function pruneUnexpectedSourceFiles(project, targetUuid) {
+  const allowedSourcePaths = new Set(TEST_SOURCE_FILES.map(({ projectPath }) => projectPath));
+  const phase = project.pbxSourcesBuildPhaseObj(targetUuid);
+  const fileReferenceSection = project.pbxFileReferenceSection();
+  const buildFileSection = project.pbxBuildFileSection();
+
+  phase.files = phase.files.filter((entry) => {
+    const buildFile = buildFileSection[entry.value];
+    const fileReference = buildFile ? fileReferenceSection[buildFile.fileRef] : null;
+    const sourcePath = unquote(fileReference?.path);
+    const keep = allowedSourcePaths.has(sourcePath);
+    if (!keep) {
+      delete buildFileSection[entry.value];
+      delete buildFileSection[`${entry.value}_comment`];
+    }
+    return keep;
+  });
+}
+
+function stageSourceFile(sourcePath, projectPath) {
+  const sourceAbsolutePath = resolve(projectDir, sourcePath);
+  const projectAbsolutePath = resolve(projectDir, projectPath);
+
+  if (!existsSync(sourceAbsolutePath)) {
+    throw new Error(`Missing tracked RN iOS test source: ${sourceAbsolutePath}`);
+  }
+
+  mkdirSync(dirname(projectAbsolutePath), { recursive: true });
+  const sourceContents = readFileSync(sourceAbsolutePath);
+  if (!existsSync(projectAbsolutePath) || !readFileSync(projectAbsolutePath).equals(sourceContents)) {
+    writeFileSync(projectAbsolutePath, sourceContents);
+  }
+}
+
+function findFrameworkReference(project, frameworkName) {
+  const sdkPath = `System/Library/Frameworks/${frameworkName}`;
+  const fileReferenceSection = project.pbxFileReferenceSection();
+  for (const [uuid, fileReference] of Object.entries(fileReferenceSection)) {
+    if (isCommentKey(uuid)) continue;
+    if (
+      unquote(fileReference.path) === frameworkName ||
+      unquote(fileReference.path) === sdkPath ||
+      unquote(fileReference.name) === frameworkName
+    ) {
+      return uuid;
+    }
+  }
+  return null;
+}
+
+function addFrameworkReference(project, frameworkName) {
+  const fileRef = project.generateUuid();
+  project.pbxFileReferenceSection()[fileRef] = {
+    isa: 'PBXFileReference',
+    fileEncoding: 4,
+    includeInIndex: 0,
+    lastKnownFileType: 'wrapper.framework',
+    name: frameworkName,
+    path: `System/Library/Frameworks/${frameworkName}`,
+    sourceTree: 'SDKROOT',
+  };
+  project.pbxFileReferenceSection()[`${fileRef}_comment`] = frameworkName;
+
+  const frameworksGroupKey = findGroupKey(project, 'Frameworks');
+  if (frameworksGroupKey) {
+    const frameworksGroup = project.hash.project.objects.PBXGroup[frameworksGroupKey];
+    const hasFrameworkChild = frameworksGroup.children?.some((child) => child.value === fileRef);
+    if (!hasFrameworkChild) {
+      frameworksGroup.children ??= [];
+      frameworksGroup.children.push({ value: fileRef, comment: frameworkName });
+    }
+  }
+
+  return fileRef;
+}
+
+function ensureFrameworkReference(project, frameworkName) {
+  const existingReference = findFrameworkReference(project, frameworkName);
+  const fileReference = existingReference ? project.pbxFileReferenceSection()[existingReference] : null;
+  if (existingReference && fileReference) {
+    fileReference.sourceTree = 'SDKROOT';
+    fileReference.path = `System/Library/Frameworks/${frameworkName}`;
+    return existingReference;
+  }
+
+  return addFrameworkReference(project, frameworkName);
+}
+
+function hasFrameworkBuildFile(project, targetUuid, frameworkName) {
+  const phase = project.pbxFrameworksBuildPhaseObj(targetUuid);
+  return phase.files.some((entry) => entry.comment === `${frameworkName} in Frameworks`);
+}
+
+function addFrameworkToTarget(project, targetUuid, frameworkName) {
+  const phase = project.pbxFrameworksBuildPhaseObj(targetUuid);
+  if (hasFrameworkBuildFile(project, targetUuid, frameworkName)) {
+    return;
+  }
+
+  const fileRef = ensureFrameworkReference(project, frameworkName);
+  const buildFileUuid = project.generateUuid();
+  project.pbxBuildFileSection()[buildFileUuid] = {
+    isa: 'PBXBuildFile',
+    fileRef,
+    fileRef_comment: frameworkName,
+  };
+  project.pbxBuildFileSection()[`${buildFileUuid}_comment`] = `${frameworkName} in Frameworks`;
+  phase.files.push({
+    value: buildFileUuid,
+    comment: `${frameworkName} in Frameworks`,
+  });
+}
+
+function setBuildSettings(project, targetUuid) {
+  const target = project.pbxNativeTargetSection()[targetUuid];
+  const configurationList = project.pbxXCConfigurationList()[target.buildConfigurationList];
+  const buildConfigurationSection = project.pbxXCBuildConfigurationSection();
+
+  for (const configuration of configurationList.buildConfigurations) {
+    const buildSettings = buildConfigurationSection[configuration.value].buildSettings;
+    delete buildSettings.INFOPLIST_FILE;
+
+    buildSettings.BUNDLE_LOADER = '""';
+    buildSettings.ENABLE_TESTABILITY = 'YES';
+    buildSettings.GENERATE_INFOPLIST_FILE = 'YES';
+    buildSettings.IPHONEOS_DEPLOYMENT_TARGET = DEPLOYMENT_TARGET;
+    buildSettings.LD_RUNPATH_SEARCH_PATHS = '"$(inherited) @executable_path/Frameworks @loader_path/Frameworks"';
+    buildSettings.MARKETING_VERSION = '1.0';
+    buildSettings.OTHER_SWIFT_FLAGS = SWIFT_FLAGS;
+    buildSettings.PRODUCT_BUNDLE_IDENTIFIER = BUNDLE_IDENTIFIER;
+    buildSettings.PRODUCT_NAME = '"$(TARGET_NAME)"';
+    buildSettings.SWIFT_VERSION = '5.0';
+    buildSettings.TEST_HOST = '""';
+  }
+}
+
+function removeStaleSdkFrameworkSearchPaths(project) {
+  const buildConfigurationSection = project.pbxXCBuildConfigurationSection();
+  for (const [uuid, buildConfiguration] of Object.entries(buildConfigurationSection)) {
+    if (isCommentKey(uuid)) continue;
+
+    const buildSettings = buildConfiguration.buildSettings;
+    const searchPaths = buildSettings?.FRAMEWORK_SEARCH_PATHS;
+    if (Array.isArray(searchPaths)) {
+      const filteredSearchPaths = searchPaths.filter(
+        (searchPath) => normalizedBuildSetting(searchPath) !== 'System/Library/Frameworks',
+      );
+      if (filteredSearchPaths.length === 0) {
+        delete buildSettings.FRAMEWORK_SEARCH_PATHS;
+      } else {
+        buildSettings.FRAMEWORK_SEARCH_PATHS = filteredSearchPaths;
+      }
+    } else if (searchPaths && normalizedBuildSetting(searchPaths) === 'System/Library/Frameworks') {
+      delete buildSettings.FRAMEWORK_SEARCH_PATHS;
+    }
+  }
+}
+
+function ensureTestTarget(project) {
+  const existingTarget = findNativeTarget(project, TEST_TARGET_NAME);
+  const targetUuid =
+    existingTarget?.uuid ??
+    project.addTarget(TEST_TARGET_NAME, 'unit_test_bundle', TEST_TARGET_NAME, BUNDLE_IDENTIFIER).uuid;
+
+  ensureBuildPhase(project, targetUuid, 'PBXSourcesBuildPhase', 'Sources');
+  ensureBuildPhase(project, targetUuid, 'PBXFrameworksBuildPhase', 'Frameworks');
+  ensureBuildPhase(project, targetUuid, 'PBXResourcesBuildPhase', 'Resources');
+
+  const groupKey = ensureGroup(project, TEST_TARGET_NAME);
+  pruneUnexpectedSourceFiles(project, targetUuid);
+  for (const { sourcePath, projectPath } of TEST_SOURCE_FILES) {
+    stageSourceFile(sourcePath, projectPath);
+    addSourceFile(project, targetUuid, groupKey, projectPath);
+  }
+  for (const frameworkName of SYSTEM_FRAMEWORKS) {
+    addFrameworkToTarget(project, targetUuid, frameworkName);
+  }
+
+  setBuildSettings(project, targetUuid);
+  return targetUuid;
+}
+
+function updateScheme(testTargetUuid) {
+  const schemePath = join(projectDir, 'Boardsesh.xcodeproj/xcshareddata/xcschemes/Boardsesh.xcscheme');
+  if (!existsSync(schemePath)) {
+    throw new Error(`Missing Boardsesh scheme at ${schemePath}`);
+  }
+
+  let scheme = readFileSync(schemePath, 'utf8');
+  const testables = `      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "${testTargetUuid}"
+               BuildableName = "${TEST_TARGET_NAME}.xctest"
+               BlueprintName = "${TEST_TARGET_NAME}"
+               ReferencedContainer = "container:Boardsesh.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>`;
+
+  if (scheme.includes('<Testables>')) {
+    scheme = scheme.replace(/      <Testables>[\s\S]*?      <\/Testables>/, testables);
+  } else {
+    scheme = scheme.replace(/   <\/TestAction>/, `${testables}\n   </TestAction>`);
+  }
+
+  writeFileSync(schemePath, scheme);
+}
+
+if (!existsSync(projectFilePath)) {
+  throw new Error(`Missing generated Xcode project: ${projectFilePath}`);
+}
+
+mkdirSync(projectDir, { recursive: true });
+
+const xcode = loadXcode();
+const project = xcode.project(projectFilePath).parseSync();
+if (!findNativeTarget(project, APP_TARGET_NAME)) {
+  throw new Error(`Could not find ${APP_TARGET_NAME} target in ${projectFilePath}`);
+}
+
+const testTargetUuid = ensureTestTarget(project);
+removeStaleSdkFrameworkSearchPaths(project);
+writeFileSync(projectFilePath, project.writeSync());
+updateScheme(testTargetUuid);
+
+console.log(`Prepared ${TEST_TARGET_NAME} (${testTargetUuid}) for RN iOS Swift tests.`);


### PR DESCRIPTION
## Summary
- add a React Native iOS CI workflow that prebuilds the generated Expo iOS project, attaches a generated `BoardseshTests` XCTest target, and runs Swift tests
- add tracked RN Live Activity/widget Swift unit tests for wall-control take-control decisions, queue decoding, navigation bounds, and render URL generation
- run the legacy Capacitor Swift workflow on PRs too, and document where Swift CI/test sources live
- guard the widget BLE reconnect path below iOS 17 so the RN native module still compiles at its 16.4 deployment target

## Validation
- `vp test run packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts packages/mobile/src/lib/live-activity/__tests__/widget-build-settings.test.ts --reporter=agent`
- `vp fmt --check .github/workflows/ios-ci.yml .github/workflows/ios-rn-ci.yml docs/live-activity-push-testing.md scripts/prepare-rn-ios-tests.mjs packages/mobile/ios-tests/LiveActivityWidgetTests.swift packages/mobile/modules/live-activity/ios/SharedConstants.swift packages/mobile/modules/live-activity/ios/TakeControlIntent.swift packages/mobile/modules/live-activity/ios/LiveActivityModule.swift packages/mobile/targets/BoardseshWidgets/SharedConstants.swift packages/mobile/targets/BoardseshWidgets/TakeControlIntent.swift`
- `node --check scripts/prepare-rn-ios-tests.mjs`
- byte-identical duplicate Swift check for `SharedConstants.swift` and `TakeControlIntent.swift`
- `git diff --check`
- `node scripts/prepare-rn-ios-tests.mjs`
- `xcodebuild build-for-testing -workspace packages/mobile/ios/Boardsesh.xcworkspace -scheme Boardsesh -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' -configuration Debug -derivedDataPath /private/tmp/boardsesh-rn-swift-tests CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test-without-building -workspace packages/mobile/ios/Boardsesh.xcworkspace -scheme Boardsesh -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' -derivedDataPath /private/tmp/boardsesh-rn-swift-tests`

## Notes
- Legacy `mobile/ios/App` `build-for-testing` passed locally after running the same dependency/sync setup as CI, but `test-without-building` hung before XCTest connected to the app-hosted runner under this local Xcode 26 simulator. The workflow still uses `macos-15`, matching the existing legacy CI target.