### PR TITLE
[codex] test(mobile): cover queue selector stability

### DIFF
--- a/packages/mobile/src/lib/board-details.ts
+++ b/packages/mobile/src/lib/board-details.ts
@@ -22,7 +22,7 @@ type BoardRenderData = {
 // filter plus per-hold coordinate math) on the PlayDrawer-open critical path and
 // on every carousel swap. The underlying placement data is static, so memoize by
 // board-config key. A session only ever touches a handful of distinct boards;
-// the cap just bounds memory if a picker churns through many.
+// the FIFO eviction cap just bounds memory if a picker churns through many.
 const RENDER_DATA_CACHE_LIMIT = 16;
 const renderDataCache = new Map<string, BoardRenderData | null>();
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -144,7 +144,14 @@ vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
 }));
 
-import { QueueProvider, usePlaylistSuggestionSource, useQueue, useQueueLiveStats } from '../queue-provider';
+import {
+  QueueProvider,
+  useHasActiveClimb,
+  usePlaylistSuggestionSource,
+  useQueue,
+  useQueueLiveStats,
+  useQueueSessionId,
+} from '../queue-provider';
 
 type Snapshot = {
   state: ReturnType<typeof useQueue>['state'];
@@ -163,6 +170,11 @@ type Snapshot = {
   releaseControl: ReturnType<typeof useQueue>['releaseControl'];
   confirmClimbOnWall: ReturnType<typeof useQueue>['confirmClimbOnWall'];
   setSessionBoardSerial: ReturnType<typeof useQueue>['setSessionBoardSerial'];
+};
+
+type SelectorSnapshot = {
+  sessionIdValue: ReturnType<typeof useQueueSessionId>;
+  hasActiveClimb: boolean;
 };
 
 const user = (overrides: Partial<SessionUser> = {}): SessionUser => ({
@@ -252,8 +264,31 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
   return null;
 }
 
+function SelectorProbe({ onSnapshot }: { onSnapshot: (snapshot: SelectorSnapshot) => void }) {
+  const sessionIdValue = useQueueSessionId();
+  const hasActiveClimb = useHasActiveClimb();
+  useEffect(() => {
+    onSnapshot({ sessionIdValue, hasActiveClimb });
+  }, [hasActiveClimb, onSnapshot, sessionIdValue]);
+  return null;
+}
+
 function renderProvider(onSnapshot: (snapshot: Snapshot) => void) {
   return render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot })));
+}
+
+function renderProviderWithSelectors(
+  onSnapshot: (snapshot: Snapshot) => void,
+  onSelectorSnapshot: (snapshot: SelectorSnapshot) => void,
+) {
+  return render(
+    createElement(
+      QueueProvider,
+      null,
+      createElement(Probe, { onSnapshot }),
+      createElement(SelectorProbe, { onSnapshot: onSelectorSnapshot }),
+    ),
+  );
 }
 
 describe('QueueProvider session update subscription', () => {
@@ -310,6 +345,76 @@ describe('QueueProvider session update subscription', () => {
         users: [user({ id: 'participant-self', username: 'Self', userId: 'db-self' })],
       },
     });
+  });
+
+  it('keeps the session-id selector value stable across queue mutations', async () => {
+    const snapshots: Snapshot[] = [];
+    const selectorSnapshots: SelectorSnapshot[] = [];
+    renderProviderWithSelectors(
+      (snapshot) => snapshots.push(snapshot),
+      (snapshot) => selectorSnapshots.push(snapshot),
+    );
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+      expect(selectorSnapshots.at(-1)?.sessionIdValue.sessionId).toBe('session-1');
+    });
+
+    const selectorSnapshotCount = selectorSnapshots.length;
+    const sessionIdValue = selectorSnapshots.at(-1)?.sessionIdValue;
+    const snapshot = snapshots.at(-1);
+    if (!snapshot || !sessionIdValue) throw new Error('queue selector snapshot was not captured');
+
+    act(() => {
+      snapshot.addToQueue(makeQueueItem('queue-extra', 'climb-extra'));
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toContain('queue-extra');
+    });
+    expect(selectorSnapshots).toHaveLength(selectorSnapshotCount);
+    expect(selectorSnapshots.at(-1)?.sessionIdValue).toBe(sessionIdValue);
+  });
+
+  it('keeps the active-climb presence selector stable when switching between climbs', async () => {
+    const snapshots: Snapshot[] = [];
+    const selectorSnapshots: SelectorSnapshot[] = [];
+    renderProviderWithSelectors(
+      (snapshot) => snapshots.push(snapshot),
+      (snapshot) => selectorSnapshots.push(snapshot),
+    );
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const firstItem = makeQueueItem('queue-first', 'climb-first');
+    const initialSnapshot = snapshots.at(-1);
+    if (!initialSnapshot) throw new Error('queue snapshot was not captured');
+
+    act(() => {
+      initialSnapshot.setCurrentClimb(firstItem);
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('queue-first');
+      expect(selectorSnapshots.at(-1)?.hasActiveClimb).toBe(true);
+    });
+
+    const selectorSnapshotCount = selectorSnapshots.length;
+    const secondItem = makeQueueItem('queue-second', 'climb-second');
+    const activeSnapshot = snapshots.at(-1);
+    if (!activeSnapshot) throw new Error('active queue snapshot was not captured');
+
+    act(() => {
+      activeSnapshot.setCurrentClimb(secondItem);
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('queue-second');
+    });
+    expect(selectorSnapshots).toHaveLength(selectorSnapshotCount);
+    expect(selectorSnapshots.at(-1)?.hasActiveClimb).toBe(true);
   });
 
   it('applies roster and driver events to public context state', async () => {

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -314,6 +314,11 @@ export function useQueueActions(): QueueActionsContextValue {
   return context;
 }
 
+/**
+ * Returns the active playlist suggestion source, or null when no playlist
+ * continuation is active. A missing context still throws: in-tree "no source"
+ * is represented by `null`, while no provider means the hook was misused.
+ */
 export function usePlaylistSuggestionSource(): PlaylistSuggestionSource | null {
   const context = useContext(QueuePlaylistSuggestionContext);
   if (!context) throw new Error('usePlaylistSuggestionSource must be used within QueueProvider');


### PR DESCRIPTION
## What changed

- Clarified that the board render-data cache uses FIFO eviction.
- Documented the `usePlaylistSuggestionSource()` contract: in-tree no-source state is `null`, while a missing provider still throws as misuse.
- Added queue provider tests proving `useQueueSessionId()` and `useHasActiveClimb()` stay stable across queue/current-climb mutations that should not affect those selector values.

## Validation

- `vp check packages/mobile/src/lib/board-details.ts packages/mobile/src/providers/queue-provider.tsx packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx`
- `vp test --project mobile packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx`
- `vp run typecheck:mobile`
- `vp test --project mobile`