### PR TITLE
refactor(mobile): dedupe homewall layout id + tidy workout-preview state

### DIFF
--- a/packages/board-constants/src/__tests__/product-sizes.test.ts
+++ b/packages/board-constants/src/__tests__/product-sizes.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { getLayoutName, isKilterHomewallTallSizeId, isKilterHomewallWideSizeId } from '../product-sizes';
+import {
+  KILTER_HOMEWALL_LAYOUT_ID,
+  KILTER_HOMEWALL_PRODUCT_ID,
+  getLayoutName,
+  isKilterHomewallTallSizeId,
+  isKilterHomewallWideSizeId,
+} from '../product-sizes';
 
 describe('getLayoutName', () => {
   it('returns the human-readable name for a known board + layoutId', () => {
@@ -8,6 +14,13 @@ describe('getLayoutName', () => {
 
   it("returns '' for an unknown layoutId", () => {
     expect(getLayoutName('kilter', 99999)).toBe('');
+  });
+});
+
+describe('Kilter Homewall identifiers', () => {
+  it('pins the Aurora layout and product ids the filters key off', () => {
+    expect(KILTER_HOMEWALL_LAYOUT_ID).toBe(8);
+    expect(KILTER_HOMEWALL_PRODUCT_ID).toBe(7);
   });
 });
 

--- a/packages/board-constants/src/product-sizes.ts
+++ b/packages/board-constants/src/product-sizes.ts
@@ -24,6 +24,13 @@ export const PRODUCT_SIZES: Record<BoardName, Record<number, ProductSizeData>> =
 
 export { LAYOUTS, SETS, IMAGE_FILENAMES, HOLE_PLACEMENTS };
 
+// The Kilter Homewall is layout 8 / product 7 in Aurora's data. These gate the
+// tall/wide climb filters and the expansion-aware hold filtering, so web,
+// mobile, and the db query layer all read the same value from here rather than
+// each redefining the magic number.
+export const KILTER_HOMEWALL_LAYOUT_ID = 8;
+export const KILTER_HOMEWALL_PRODUCT_ID = 7;
+
 // 23/24 are 8x12 Full Ride/Mainline, 25/26 are 10x12 Full Ride/Mainline.
 const KILTER_HOMEWALL_TALL_SIZE_ID_SET: ReadonlySet<number> = new Set([23, 24, 25, 26]);
 

--- a/packages/db/src/queries/climbs/create-climb-filters.ts
+++ b/packages/db/src/queries/climbs/create-climb-filters.ts
@@ -1,5 +1,7 @@
 import { type SQL, eq, gt, gte, sql, like, notLike, inArray, isNull, or, and } from 'drizzle-orm';
 import {
+  KILTER_HOMEWALL_LAYOUT_ID,
+  KILTER_HOMEWALL_PRODUCT_ID,
   getHolePlacements,
   getProductSize,
   isKilterHomewallTallSizeId,
@@ -19,9 +21,8 @@ import {
 } from '../../schema/index';
 import type { BoardRouteParams, ClimbSearchParams } from './types';
 
-// Kilter Homewall constants for expansion-aware filtering
-const KILTER_HOMEWALL_LAYOUT_ID = 8;
-const KILTER_HOMEWALL_PRODUCT_ID = 7;
+// Kilter Homewall constants for expansion-aware filtering (layout/product ids
+// come from @boardsesh/board-constants; these sizes/sets are db-query-local).
 const KILTER_HOMEWALL_SMALL_SIZE_ID = 17;
 const KILTER_HOMEWALL_WIDE_REFERENCE_SIZE_ID = 21;
 const KILTER_HOMEWALL_WIDE_EXPANSION_SET_IDS = [26, 27, 28, 29] as const;

--- a/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
@@ -3,7 +3,11 @@ import { ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { getGradesForBoard } from '@boardsesh/board-config';
-import { isKilterHomewallTallSizeId, isKilterHomewallWideSizeId } from '@boardsesh/board-constants';
+import {
+  KILTER_HOMEWALL_LAYOUT_ID,
+  isKilterHomewallTallSizeId,
+  isKilterHomewallWideSizeId,
+} from '@boardsesh/board-constants';
 import {
   formatMinAscentsFilterCount,
   getMinAscentsFilterOptions,
@@ -53,8 +57,6 @@ type CommonGeneratorPatch = Partial<
     'warmUp' | 'targetGrade' | 'climbBias' | 'minAscents' | 'minRating' | 'onlyTallClimbs' | 'onlyWideClimbs'
   >
 >;
-
-const KILTER_HOMEWALL_LAYOUT_ID = 8;
 
 // Static value list — the labels are looked up via inline `t('mobile.session.preGenerator…')`
 // calls in `chipLabel()` so the i18n key analyser can see every key as a
@@ -231,7 +233,7 @@ export function GeneratorPickerCard({
   onChange,
 }: GeneratorPickerCardProps) {
   const { t } = useTranslation('session');
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors } = useTheme();
   const { formatGrade } = useGradeFormat();
 
   const isKilterHomewall = boardName === 'kilter' && layoutId === KILTER_HOMEWALL_LAYOUT_ID;

--- a/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useTranslation } from 'react-i18next';
@@ -52,6 +52,24 @@ export function PreSessionView() {
   const preview = useWorkoutPreview(selection, activeBoard ?? null, { isAuthenticated });
   const { items: previewItems, status, refreshingUuids, plannedCount, refreshSlot, toQueueItems } = preview;
 
+  // Refreshes run one at a time, so once any row is regenerating every row's
+  // refresh button is disabled (the rows dim it). Derived as a primitive so
+  // renderItem keeps a stable, length-free dep.
+  const isRefreshingAnyRow = refreshingUuids.size > 0;
+
+  // A rebuild (generator options changed) mints fresh queue-item uuids, so a
+  // previously highlighted preview row no longer exists. Drop the stale uuid so
+  // the highlight doesn't point at a row that's gone. (A single-row refresh
+  // keeps its uuid, so this leaves an active refresh's highlight intact.)
+  useEffect(() => {
+    if (
+      activePreviewUuid !== null &&
+      !previewItems.some((previewItem) => previewItem.item.uuid === activePreviewUuid)
+    ) {
+      setActivePreviewUuid(null);
+    }
+  }, [previewItems, activePreviewUuid]);
+
   // Board context for the preview rows (thumbnails + grade colours).
   const previewBoard = useMemo<QueueItemRowBoard | null>(() => {
     if (!activeBoard) return null;
@@ -77,18 +95,20 @@ export function PreSessionView() {
   const renderPreviewRow = useCallback(
     ({ item: previewItem }: { item: PreviewItem }) => {
       if (!previewBoard) return null;
+      const isRefreshing = refreshingUuids.has(previewItem.item.uuid);
       return (
         <WorkoutPreviewRow
           item={previewItem.item}
           board={previewBoard}
           isActive={previewItem.item.uuid === activePreviewUuid}
-          isRefreshing={refreshingUuids.has(previewItem.item.uuid)}
+          isRefreshing={isRefreshing}
+          refreshDisabled={isRefreshingAnyRow && !isRefreshing}
           onPress={handlePreviewPress}
           onRefresh={refreshSlot}
         />
       );
     },
-    [previewBoard, activePreviewUuid, refreshingUuids, handlePreviewPress, refreshSlot],
+    [previewBoard, activePreviewUuid, refreshingUuids, isRefreshingAnyRow, handlePreviewPress, refreshSlot],
   );
 
   const handleStart = useCallback(async () => {

--- a/packages/mobile/src/components/session-screen/pre-session/WorkoutPreviewRow.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/WorkoutPreviewRow.tsx
@@ -19,6 +19,13 @@ type WorkoutPreviewRowProps = {
   isActive: boolean;
   /** Show a spinner + disable the refresh button while this row regenerates. */
   isRefreshing: boolean;
+  /**
+   * Dim + disable this row's refresh button while a *different* row is
+   * regenerating. Refreshes run one at a time (the hook serializes them to avoid
+   * clobbering each other's state), so this makes that constraint visible
+   * instead of silently swallowing the tap.
+   */
+  refreshDisabled: boolean;
   onPress: (item: ClimbQueueItem) => void;
   onRefresh: (uuid: string) => void;
 };
@@ -34,11 +41,15 @@ function WorkoutPreviewRowComponent({
   board,
   isActive,
   isRefreshing,
+  refreshDisabled,
   onPress,
   onRefresh,
 }: WorkoutPreviewRowProps) {
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors, brandColors, opacity } = useTheme();
   const { t } = useTranslation('session');
+  // Blocked while this row spins, or while another row holds the single refresh
+  // slot. Only this row shows a spinner; the rest dim to read as "busy, wait".
+  const refreshBlocked = isRefreshing || refreshDisabled;
   const itemRef = useRef(item);
   itemRef.current = item;
 
@@ -83,13 +94,13 @@ function WorkoutPreviewRowComponent({
 
         <PressableSurface
           onPress={handleRefresh}
-          disabled={isRefreshing}
+          disabled={refreshBlocked}
           feedback="scale"
           hitSlop={2}
           accessibilityRole="button"
           accessibilityLabel={t('mobile.session.preRegenerateClimbForClimb', { name: climbName })}
-          accessibilityState={{ disabled: isRefreshing, busy: isRefreshing }}
-          style={styles.refreshButton}
+          accessibilityState={{ disabled: refreshBlocked, busy: isRefreshing }}
+          style={[styles.refreshButton, refreshDisabled && !isRefreshing ? { opacity: opacity.disabled } : null]}
         >
           {isRefreshing ? (
             <ActivityIndicator size="small" color={iosSystemColors.systemGray} />
@@ -114,6 +125,7 @@ export const WorkoutPreviewRow = memo(WorkoutPreviewRowComponent, (prev, next) =
     prev.item.climb.uuid === next.item.climb.uuid &&
     prev.isActive === next.isActive &&
     prev.isRefreshing === next.isRefreshing &&
+    prev.refreshDisabled === next.refreshDisabled &&
     prev.onPress === next.onPress &&
     prev.onRefresh === next.onRefresh &&
     prev.board.boardName === next.board.boardName &&

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/generator-picker-card-analytics.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/generator-picker-card-analytics.test.tsx
@@ -52,6 +52,7 @@ vi.mock('@boardsesh/board-config', () => ({
   ],
 }));
 vi.mock('@boardsesh/board-constants', () => ({
+  KILTER_HOMEWALL_LAYOUT_ID: 8,
   isKilterHomewallTallSizeId: () => false,
   isKilterHomewallWideSizeId: () => false,
 }));

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-preview.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-preview.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+
+// The preview hook is mocked; the test mutates `preview.result.items` /
+// `refreshingUuids` and rerenders to drive the view's row props.
+const preview = vi.hoisted(() => ({
+  result: {
+    items: [] as unknown[],
+    status: 'ready' as 'idle' | 'loading' | 'ready' | 'error',
+    refreshingUuids: new Set<string>(),
+    plannedCount: 0,
+    regenerate: vi.fn(),
+    refreshSlot: vi.fn(),
+    toQueueItems: () => [] as ClimbQueueItem[],
+  },
+}));
+
+// Captures every WorkoutPreviewRow render so the test can read isActive /
+// refreshDisabled per row, plus the latest onPress to simulate a tap.
+const rows = vi.hoisted(() => ({
+  rendered: [] as Array<{ uuid: string; isActive: boolean; isRefreshing: boolean; refreshDisabled: boolean }>,
+  onPress: null as ((item: ClimbQueueItem) => void) | null,
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('@shopify/flash-list', () => ({
+  // Render the header plus each data row through renderItem (the real FlashList's
+  // rows are what we assert on here).
+  FlashList: ({
+    ListHeaderComponent,
+    data,
+    renderItem,
+  }: {
+    ListHeaderComponent?: ReactNode;
+    data?: unknown[];
+    renderItem?: (info: { item: unknown }) => ReactNode;
+  }) =>
+    createElement(
+      'div',
+      null,
+      ListHeaderComponent,
+      ...(data ?? []).map((rowItem, index) => createElement('div', { key: index }, renderItem?.({ item: rowItem }))),
+    ),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@boardsesh/board-config', () => ({ toBoardName: (boardType: string) => boardType }));
+vi.mock('../../../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('../../../Button', () => ({ Button: () => createElement('button') }));
+vi.mock('../../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../../providers/theme-provider', () => ({ useTheme: () => ({ systemColors: {} }) }));
+vi.mock('../../../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: { boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 } }),
+}));
+vi.mock('../../../../providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock('../../../../providers/queue-provider', () => ({
+  useQueueActions: () => ({ startSession: vi.fn(), setQueue: vi.fn() }),
+}));
+vi.mock('../../../../providers/drawer-host-provider', () => ({ useDrawerHost: () => ({ openPlayDrawer: vi.fn() }) }));
+vi.mock('../../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+}));
+vi.mock('../../../../theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
+vi.mock('../BoardSummaryCard', () => ({ BoardSummaryCard: () => null }));
+vi.mock('../GeneratorPickerCard', () => ({ GeneratorPickerCard: () => null }));
+vi.mock('../use-workout-preview', () => ({ useWorkoutPreview: () => preview.result }));
+vi.mock('../WorkoutPreviewRow', () => ({
+  WorkoutPreviewRow: ({
+    item,
+    isActive,
+    isRefreshing,
+    refreshDisabled,
+    onPress,
+  }: {
+    item: ClimbQueueItem;
+    isActive: boolean;
+    isRefreshing: boolean;
+    refreshDisabled: boolean;
+    onPress: (item: ClimbQueueItem) => void;
+  }) => {
+    rows.rendered.push({ uuid: item.uuid, isActive, isRefreshing, refreshDisabled });
+    rows.onPress = onPress;
+    return null;
+  },
+}));
+
+import { PreSessionView } from '../PreSessionView';
+
+function makeRow(uuid: string) {
+  return {
+    item: { uuid, climb: { uuid: `${uuid}-climb`, name: uuid } },
+    slot: { grade: 10, section: 'main', index: 0 },
+  };
+}
+
+beforeEach(() => {
+  rows.rendered = [];
+  rows.onPress = null;
+  preview.result.items = [makeRow('a'), makeRow('b')] as unknown[];
+  preview.result.refreshingUuids = new Set<string>();
+});
+
+describe('PreSessionView preview rows', () => {
+  it('clears the active highlight once a regeneration replaces the rows', () => {
+    const view = render(createElement(PreSessionView));
+
+    // Tap row "a" → it becomes the highlighted preview row.
+    act(() => {
+      rows.onPress?.({ uuid: 'a' } as ClimbQueueItem);
+    });
+    expect(rows.rendered.some((row) => row.uuid === 'a' && row.isActive)).toBe(true);
+
+    // Regenerate: fresh uuids replace the old rows, so "a" no longer exists.
+    rows.rendered = [];
+    preview.result.items = [makeRow('c'), makeRow('d')] as unknown[];
+    act(() => {
+      view.rerender(createElement(PreSessionView));
+    });
+
+    // The effect dropped the stale uuid, so nothing is highlighted.
+    expect(rows.rendered.length).toBeGreaterThan(0);
+    expect(rows.rendered.every((row) => !row.isActive)).toBe(true);
+  });
+
+  it('blocks the other rows refresh button while one row regenerates', () => {
+    preview.result.refreshingUuids = new Set<string>(['a']);
+    render(createElement(PreSessionView));
+
+    const rowA = rows.rendered.find((row) => row.uuid === 'a');
+    const rowB = rows.rendered.find((row) => row.uuid === 'b');
+    // The regenerating row spins (isRefreshing) rather than going to the dimmed
+    // disabled state, so refreshDisabled stays false for it.
+    expect(rowA).toMatchObject({ isRefreshing: true, refreshDisabled: false });
+    // Every other row's refresh is disabled so the dropped tap is visible.
+    expect(rowB).toMatchObject({ isRefreshing: false, refreshDisabled: true });
+  });
+});

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-row.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-row.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { QueueItemRowBoard } from '../../../QueueItemRow';
+
+// Each PressableSurface render lands here so the test can read the refresh
+// button's disabled/accessibility state.
+const surfaces = vi.hoisted(() => ({
+  entries: [] as Array<{ label?: string; disabled?: boolean; accessibilityState?: Record<string, unknown> }>,
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ActivityIndicator: () => createElement('span', { 'data-testid': 'refresh-spinner' }),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('../../../PressableSurface', () => ({
+  PressableSurface: ({
+    accessibilityLabel,
+    disabled,
+    accessibilityState,
+    children,
+  }: {
+    accessibilityLabel?: string;
+    disabled?: boolean;
+    accessibilityState?: Record<string, unknown>;
+    children?: ReactNode;
+  }) => {
+    surfaces.entries.push({ label: accessibilityLabel, disabled, accessibilityState });
+    return createElement('button', null, children);
+  },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../../ClimbListItemContent', () => ({ ClimbListItemContent: () => null }));
+vi.mock('../../../ClimbListThumbnail', () => ({ THUMBNAIL_WIDTH: 64 }));
+vi.mock('../../../Icon', () => ({ Icon: () => createElement('span', { 'data-testid': 'refresh-icon' }) }));
+vi.mock('../../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {}, brandColors: { primary: '#000' }, opacity: { disabled: 0.5 } }),
+}));
+vi.mock('../../../../theme/ios-colors', () => ({ iosSystemColors: {} }));
+vi.mock('../../../../theme/tokens', () => ({ spacing: {} }));
+vi.mock('../../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+
+import { WorkoutPreviewRow } from '../WorkoutPreviewRow';
+
+const board = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 } as QueueItemRowBoard;
+const item = { uuid: 'qi-1', climb: { uuid: 'c1', name: 'Test Climb' } } as unknown as ClimbQueueItem;
+
+// The mocked `t` returns the key, so the refresh button surfaces under its key.
+const REFRESH_LABEL = 'mobile.session.preRegenerateClimbForClimb';
+const refreshButton = () => surfaces.entries.find((entry) => entry.label === REFRESH_LABEL);
+
+function renderRow(overrides: { isRefreshing: boolean; refreshDisabled: boolean }) {
+  return render(
+    createElement(WorkoutPreviewRow, {
+      item,
+      board,
+      isActive: false,
+      onPress: vi.fn(),
+      onRefresh: vi.fn(),
+      ...overrides,
+    }),
+  );
+}
+
+beforeEach(() => {
+  surfaces.entries = [];
+});
+
+describe('WorkoutPreviewRow refresh button', () => {
+  it('is tappable when no row is regenerating', () => {
+    renderRow({ isRefreshing: false, refreshDisabled: false });
+    expect(refreshButton()?.disabled).toBe(false);
+    expect(refreshButton()?.accessibilityState).toMatchObject({ disabled: false, busy: false });
+  });
+
+  it('is disabled (and busy=false) while a different row regenerates', () => {
+    const { getByTestId } = renderRow({ isRefreshing: false, refreshDisabled: true });
+    expect(refreshButton()?.disabled).toBe(true);
+    expect(refreshButton()?.accessibilityState).toMatchObject({ disabled: true, busy: false });
+    // The dimmed, non-spinning state — the climb's own refresh icon stays put.
+    expect(getByTestId('refresh-icon')).toBeTruthy();
+  });
+
+  it('shows a spinner and reports busy while this row regenerates', () => {
+    const { getByTestId } = renderRow({ isRefreshing: true, refreshDisabled: false });
+    expect(getByTestId('refresh-spinner')).toBeTruthy();
+    expect(refreshButton()?.disabled).toBe(true);
+    expect(refreshButton()?.accessibilityState).toMatchObject({ disabled: true, busy: true });
+  });
+});

--- a/packages/web/app/lib/board-constants.ts
+++ b/packages/web/app/lib/board-constants.ts
@@ -28,8 +28,8 @@ export const FALLBACK_BOARD_PREVIEW_CONFIGS: Record<string, { layout_id: number;
     grasshopper: { layout_id: 1, size_id: 4, set_ids: [1, 2] },
     soill: { layout_id: 1, size_id: 1, set_ids: [1] },
   };
-export const KILTER_HOMEWALL_LAYOUT_ID = 8;
-export const KILTER_HOMEWALL_PRODUCT_ID = 7;
+// KILTER_HOMEWALL_LAYOUT_ID / KILTER_HOMEWALL_PRODUCT_ID are re-exported above
+// via `export * from '@boardsesh/board-constants/product-sizes'`.
 export const BOARD_NAME_PREFIX_REGEX = new RegExp(`^(?:${SUPPORTED_BOARDS.join('|')})\\s*(?:board)?\\s*`, 'i');
 
 export function isAuroraBoardName(boardName: string): boardName is AuroraBoardName {


### PR DESCRIPTION
Three review cleanups on the pre-session workout-preview flow (`packages/mobile/src/components/session-screen/pre-session/`). No behaviour change beyond the two UX/state fixes below.

## 1. `KILTER_HOMEWALL_LAYOUT_ID` extracted to the shared package
The constant (and its sibling `KILTER_HOMEWALL_PRODUCT_ID`) was redefined in three places: `GeneratorPickerCard.tsx` (mobile), `app/lib/board-constants.ts` (web), and `create-climb-filters.ts` (db). Moved both into `@boardsesh/board-constants` (`product-sizes.ts`, next to the existing `isKilterHomewall*SizeId` helpers) and import from there everywhere.

- Web keeps exporting them through its existing `export * from '@boardsesh/board-constants/product-sizes'`, so the `@/app/lib/board-constants` call sites (`accordion-search-form`, `generator-options-form`) are unchanged.
- A small test pins the values (`8` / `7`).

## 2. Refresh serialization is now visible instead of silent
`use-workout-preview` serializes row refreshes one-at-a-time (to avoid concurrent refreshes clobbering each other's state), but the in-flight guard silently dropped taps on every *other* row. Now, while one row regenerates, the rest dim and disable their refresh button (with `accessibilityState.disabled`), so the constraint reads as "busy, wait" rather than an unresponsive button. The hook's guard stays as defense-in-depth.

## 3. Stale `activePreviewUuid` cleared on regeneration
Changing generator options rebuilds the preview with fresh queue-item uuids, so the highlighted row's uuid no longer existed. Added an effect that clears `activePreviewUuid` once it drops out of `previewItems`. A single-row refresh keeps its uuid (swaps `.climb` only), so an in-flight refresh's highlight is left intact.

## Tests / validation
- New: `workout-preview-row.test.tsx` (refresh button enabled / disabled-dimmed / spinning states) and `pre-session-view-preview.test.tsx` (highlight cleared on regeneration; other rows blocked during a refresh).
- `vp check` (lint + format), `vp run typecheck` (mobile/web/db/shared), `vp test` (mobile pre-session + board-constants = 37), the db `create-climb-filters` suite (40), and `vp run check:mobile-bundle` all pass.

https://claude.ai/code/session_019FpyE4jhndkwFKKVYE77nC

---
_Generated by [Claude Code](https://claude.ai/code/session_019FpyE4jhndkwFKKVYE77nC)_