### PR TITLE
[codex] fix ios ble reconnect availability guard

### DIFF
--- a/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -249,6 +249,8 @@ public class LiveActivityModule: Module {
     }
 
     private func handleBleReconnectFromWidget() {
+        guard #available(iOS 17.0, *) else { return }
+
         Task { @MainActor in
             _ = await LiveActivityBleBridge.reconnectForIntent()
         }


### PR DESCRIPTION
## What changed

- Added an iOS 17 availability guard before the Live Activity BLE reconnect fallback calls `LiveActivityBleBridge.reconnectForIntent()`.

## Why

`LiveActivityBleBridge` is marked `@available(iOS 17.0, *)`, but the Darwin notification fallback in `LiveActivityModule` called it from an unguarded method. Swift rejected the iOS build with `LiveActivityBleBridge is only available in iOS 17.0 or newer`.

## Validation

- `vp run mobile:ios -- --device 00008150-001A4C1101A1401C --port 8084` built successfully after the fix.
- Installed the resulting `Boardsesh.app` to `Marco's Iphone` using `xcrun devicectl device install app`.