### PR TITLE
fix(mobile): queue sheet won't open — present() from visible-effect is a no-op

### DIFF
--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState, type ReactNode } from 'react';
 import { View, Pressable, Platform, StyleSheet } from 'react-native';
 import { BottomSheetModal, BottomSheetBackdrop, type BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
 import { FullWindowOverlay } from 'react-native-screens';
@@ -26,26 +26,35 @@ function ModalSheetContainer({ children }: { children?: ReactNode }) {
 const modalContainerComponent = Platform.OS === 'ios' ? ModalSheetContainer : undefined;
 
 type QueueSheetProps = {
-  visible: boolean;
   board: QueueItemRowBoard;
-  /** Request an animated close (header button) — host flips `visible` to false. */
+  /** Request an animated close (header button) — calls the imperative handle's
+   *  `dismiss()` on the host side. */
   onClose: () => void;
-  /** Fired AFTER the dismiss animation finishes so the host can unmount. */
-  onDismissed: () => void;
+  /** Optional: fired AFTER the dismiss animation finishes. The imperative model
+   *  no longer needs this to unmount, so callers may omit it. */
+  onDismissed?: () => void;
   onClimbPress: (item: ClimbQueueItem) => void;
   onSuggestionPress: (climb: Climb, source: PlaylistSuggestionSource) => void;
   onTickHistory: (item: ClimbQueueItem) => void;
 };
 
-export function QueueSheet({
-  visible,
-  board,
-  onClose,
-  onDismissed,
-  onClimbPress,
-  onSuggestionPress,
-  onTickHistory,
-}: QueueSheetProps) {
+/**
+ * Imperative handle exposed to DrawerHostProvider. gorhom `present()` driven
+ * from a `visible`-prop effect is a silent no-op in this app (RN 0.79 / Expo
+ * SDK 56 / @gorhom/bottom-sheet v5 / react-native-screens): the effect runs and
+ * `present()` is called, but gorhom never fires `onAnimate`/`onChange` and the
+ * sheet never appears. Calling `present()` synchronously from the tap handler —
+ * the same pattern PlayDrawer uses — fixes it.
+ */
+export type QueueSheetHandle = {
+  present: () => void;
+  dismiss: () => void;
+};
+
+export const QueueSheet = forwardRef<QueueSheetHandle, QueueSheetProps>(function QueueSheet(
+  { board, onClose, onDismissed, onClimbPress, onSuggestionPress, onTickHistory },
+  ref,
+) {
   const { t } = useTranslation('session');
   const insets = useSafeAreaInsets();
   const { systemColors, sheet } = useTheme();
@@ -60,18 +69,27 @@ export function QueueSheet({
   const [showFullHistory, setShowFullHistory] = useState(false);
   const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
   const [isDragging, setIsDragging] = useState(false);
+  // Tracks whether the sheet is currently presented so the list only
+  // auto-scrolls to the current item on a real open (not on background mounts).
+  const [isPresented, setIsPresented] = useState(false);
 
   const snapPoints = useMemo(() => ['70%', '95%'], []);
 
   const currentItemUuid = currentClimbQueueItem?.uuid ?? null;
 
-  useEffect(() => {
-    if (visible) {
-      sheetRef.current?.present();
-    } else {
-      sheetRef.current?.dismiss();
-    }
-  }, [visible]);
+  useImperativeHandle(
+    ref,
+    () => ({
+      present: () => {
+        setIsPresented(true);
+        sheetRef.current?.present();
+      },
+      dismiss: () => {
+        sheetRef.current?.dismiss();
+      },
+    }),
+    [],
+  );
 
   const resetState = useCallback(() => {
     setIsEditMode(false);
@@ -80,10 +98,12 @@ export function QueueSheet({
   }, []);
 
   // The modal's dismiss animation has finished (header request, backdrop, or
-  // pan-down). Reset local UI state and let the host unmount.
+  // pan-down). Reset local UI state; the sheet stays mounted (imperative model)
+  // and is re-presented on the next open.
   const handleDismissed = useCallback(() => {
+    setIsPresented(false);
     resetState();
-    onDismissed();
+    onDismissed?.();
   }, [resetState, onDismissed]);
 
   const handleToggleEditMode = useCallback(() => {
@@ -194,7 +214,7 @@ export function QueueSheet({
         showFullHistory={showFullHistory}
         selectedItems={selectedItems}
         playlistSuggestionSource={playlistSuggestionSource}
-        autoScrollOnMount={visible}
+        autoScrollOnMount={isPresented}
         onToggleSelect={handleToggleSelect}
         onClimbPress={onClimbPress}
         onRemove={handleRemove}
@@ -230,7 +250,7 @@ export function QueueSheet({
       )}
     </BottomSheetModal>
   );
-}
+});
 
 const styles = StyleSheet.create({
   sheet: {

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -21,12 +21,12 @@ const playDrawer = vi.hoisted(() => ({
 
 const queueSheet = vi.hoisted(() => ({
   props: null as null | {
-    visible: boolean;
     onClose: () => void;
-    onDismissed: () => void;
     onClimbPress: (item: ClimbQueueItem) => void;
     onSuggestionPress: (climb: ClimbQueueItem['climb'], source: PlaylistSuggestionSource) => void;
   },
+  present: vi.fn(),
+  dismiss: vi.fn(),
 }));
 
 const climbActions = vi.hoisted(() => ({
@@ -88,18 +88,28 @@ vi.mock('../../components/play-drawer', async () => {
   };
 });
 
-vi.mock('../../components/play-drawer/QueueSheet', () => ({
-  QueueSheet: (props: {
-    visible: boolean;
-    onClose: () => void;
-    onDismissed: () => void;
-    onClimbPress: (item: ClimbQueueItem) => void;
-    onSuggestionPress: (climb: ClimbQueueItem['climb'], source: PlaylistSuggestionSource) => void;
-  }) => {
-    queueSheet.props = props;
-    return createElement('div', { 'data-queue-sheet': 'true' });
-  },
-}));
+vi.mock('../../components/play-drawer/QueueSheet', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  return {
+    QueueSheet: React.forwardRef(
+      (
+        props: {
+          onClose: () => void;
+          onClimbPress: (item: ClimbQueueItem) => void;
+          onSuggestionPress: (climb: ClimbQueueItem['climb'], source: PlaylistSuggestionSource) => void;
+        },
+        ref,
+      ) => {
+        queueSheet.props = props;
+        React.useImperativeHandle(ref, () => ({
+          present: queueSheet.present,
+          dismiss: queueSheet.dismiss,
+        }));
+        return React.createElement('div', { 'data-queue-sheet': 'true' });
+      },
+    ),
+  };
+});
 
 vi.mock('../../components/LogAscentSheet', () => ({
   LogAscentSheet: () => createElement('div', { 'data-log-ascent': 'true' }),
@@ -205,6 +215,8 @@ describe('DrawerHostProvider queue sheet wall-control gating', () => {
     playDrawer.open.mockClear();
     playDrawer.close.mockClear();
     queueSheet.props = null;
+    queueSheet.present.mockClear();
+    queueSheet.dismiss.mockClear();
     climbActions.props = null;
   });
 
@@ -329,69 +341,54 @@ describe('DrawerHostProvider queue sheet open / re-open', () => {
     queue.driverParticipantId = 'participant-other';
     queue.participantId = 'participant-self';
     queueSheet.props = null;
+    queueSheet.present.mockClear();
+    queueSheet.dismiss.mockClear();
     climbActions.props = null;
   });
 
-  it('presents the queue sheet on open (mount first, then visible on the next commit)', async () => {
-    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
-    renderHost((host) => hosts.push(host));
-    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
-
-    act(() => {
-      hosts.at(-1)?.openQueueSheet();
-    });
-
-    await waitFor(() => expect(queueSheet.props?.visible).toBe(true));
-  });
-
-  it('re-presents the queue sheet when re-opened mid dismiss-animation, before it unmounts', async () => {
-    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
-    renderHost((host) => hosts.push(host));
-    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
-
-    act(() => {
-      hosts.at(-1)?.openQueueSheet();
-    });
-    await waitFor(() => expect(queueSheet.props?.visible).toBe(true));
-
-    // Animated close request: visible flips false but the sheet stays mounted
-    // until its dismiss animation reports back via onDismissed (not fired here).
-    act(() => {
-      queueSheet.props?.onClose();
-    });
-    await waitFor(() => expect(queueSheet.props?.visible).toBe(false));
-
-    // Re-open while still mounted. The fresh-mount path alone (set mounted only)
-    // would no-op here — mounted is already true — and the mount effect would
-    // never re-fire, leaving the sheet hidden. This guards the direct re-present.
-    act(() => {
-      hosts.at(-1)?.openQueueSheet();
-    });
-    await waitFor(() => expect(queueSheet.props?.visible).toBe(true));
-  });
-
-  it('unmounts after the dismiss animation completes, then re-opens cleanly', async () => {
+  it('stays mounted and presents via the imperative handle on open', async () => {
     const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
     const { container } = renderHost((host) => hosts.push(host));
     await waitFor(() => expect(hosts.at(-1)).toBeDefined());
 
-    act(() => {
-      hosts.at(-1)?.openQueueSheet();
-    });
-    await waitFor(() => expect(queueSheet.props?.visible).toBe(true));
-
-    act(() => {
-      queueSheet.props?.onClose(); // request animated close
-    });
-    act(() => {
-      queueSheet.props?.onDismissed(); // animation finished → host unmounts the sheet
-    });
-    await waitFor(() => expect(container.querySelector('[data-queue-sheet]')).toBeNull());
+    // The sheet is always mounted (gorhom present() from a visible-prop effect
+    // was a confirmed no-op), so it's in the tree before any open.
+    expect(container.querySelector('[data-queue-sheet]')).not.toBeNull();
+    expect(queueSheet.present).not.toHaveBeenCalled();
 
     act(() => {
       hosts.at(-1)?.openQueueSheet();
     });
-    await waitFor(() => expect(queueSheet.props?.visible).toBe(true));
+
+    await waitFor(() => expect(queueSheet.present).toHaveBeenCalledTimes(1));
+  });
+
+  it('dismisses via the imperative handle on close, then re-presents on re-open without remounting', async () => {
+    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
+    const { container } = renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const sheetNode = container.querySelector('[data-queue-sheet]');
+    expect(sheetNode).not.toBeNull();
+
+    act(() => {
+      hosts.at(-1)?.openQueueSheet();
+    });
+    await waitFor(() => expect(queueSheet.present).toHaveBeenCalledTimes(1));
+
+    // Animated close request goes through the handle's dismiss().
+    act(() => {
+      queueSheet.props?.onClose();
+    });
+    await waitFor(() => expect(queueSheet.dismiss).toHaveBeenCalledTimes(1));
+
+    // Re-open: the always-mounted sheet is presented again (no remount, so the
+    // same DOM node persists).
+    act(() => {
+      hosts.at(-1)?.openQueueSheet();
+    });
+    await waitFor(() => expect(queueSheet.present).toHaveBeenCalledTimes(2));
+    expect(container.querySelector('[data-queue-sheet]')).toBe(sheetNode);
   });
 });
 

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -20,7 +20,7 @@ import { deriveIsDriver } from '@boardsesh/queue-runtime';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { PlayDrawer, type PlayDrawerHandle, type PlayDrawerOpenOptions } from '../components/play-drawer';
 import { LogAscentSheet } from '../components/LogAscentSheet';
-import { QueueSheet } from '../components/play-drawer/QueueSheet';
+import { QueueSheet, type QueueSheetHandle } from '../components/play-drawer/QueueSheet';
 import { QueueAddedSnackbar } from '../components/QueueAddedSnackbar';
 import type { QueueItemRowBoard } from '../components/QueueItemRow';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
@@ -94,17 +94,16 @@ export function useDrawerHost(): DrawerHostValue {
 
 export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const playDrawerRef = useRef<PlayDrawerHandle>(null);
+  // QueueSheet stays mounted (whenever a board is resolved) and is opened via its
+  // imperative handle. gorhom `present()` driven from a `visible`-prop effect is
+  // a silent no-op in this app, so we present/dismiss synchronously from the
+  // handler — the same pattern PlayDrawer uses.
+  const queueSheetRef = useRef<QueueSheetHandle>(null);
   const { data: activeBoard } = useActiveBoard();
   const [boardConfigOverride, setBoardConfigOverride] = useState<BoardConfig | null>(null);
   const [logAscentInput, setLogAscentInput] = useState<LogAscentInput | null>(null);
   const [climbActions, setClimbActions] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const [playlistClimb, setPlaylistClimb] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
-  // `mounted` controls whether QueueSheet is in the tree (so its suggestion
-  // query only runs while open); `visible` drives the present/dismiss animation.
-  // Splitting them lets a programmatic close play the dismiss animation before
-  // unmounting instead of vanishing instantly.
-  const [queueSheetMounted, setQueueSheetMounted] = useState(false);
-  const [queueSheetVisible, setQueueSheetVisible] = useState(false);
   const { addToQueue, setSessionBoardPath, setCurrentClimb } = useQueueActions();
   const { sessionId, driverParticipantId, participantId } = useQueueSessionControls();
   const setActiveBoard = useSetActiveBoard();
@@ -280,33 +279,17 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     });
   }, [climbActions]);
 
+  // Present the always-mounted queue sheet imperatively. Calling `present()`
+  // synchronously from the handler (rather than from a `visible`-prop effect)
+  // is what actually shows the sheet — see QueueSheetHandle for the gorhom
+  // no-op this avoids.
   const openQueueSheet = useCallback(() => {
-    // Already mounted (e.g. re-opening mid dismiss-animation, before
-    // handleQueueSheetDismissed has unmounted it): re-present directly.
-    // `setQueueSheetMounted(true)` would be a no-op and the mount effect below
-    // would never re-fire, leaving the sheet hidden.
-    if (queueSheetMounted) {
-      setQueueSheetVisible(true);
-    } else {
-      setQueueSheetMounted(true);
-    }
-  }, [queueSheetMounted]);
-  // Fresh mount: present only AFTER the sheet has mounted (and registered with
-  // the modal provider). Flipping `mounted` and `visible` in one commit drops
-  // the `present()` when another modal — the Play Drawer — is already open:
-  // that's the bug where the play drawer's queue button did nothing while the
-  // snackbar's Open (fired with no modal open) worked. The two-commit path
-  // mirrors the always-mounted angle selector — present fires on a real
-  // `visible` transition over the already-stable Play Drawer.
-  useEffect(() => {
-    if (queueSheetMounted) setQueueSheetVisible(true);
-  }, [queueSheetMounted]);
-  // Request an animated close (flip `visible`; the sheet's dismiss animation then
-  // fires onDismissed → unmount).
-  const requestCloseQueueSheet = useCallback(() => setQueueSheetVisible(false), []);
-  const handleQueueSheetDismissed = useCallback(() => {
-    setQueueSheetVisible(false);
-    setQueueSheetMounted(false);
+    queueSheetRef.current?.present();
+  }, []);
+  // Request an animated close. The sheet's dismiss animation plays and it stays
+  // mounted, ready to be re-presented on the next open.
+  const requestCloseQueueSheet = useCallback(() => {
+    queueSheetRef.current?.dismiss();
   }, []);
   // Snackbar "Open": dismiss the snackbar, then open the queue sheet.
   const handleSnackbarOpen = useCallback(() => {
@@ -479,12 +462,11 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           onClose={closeAddToPlaylist}
         />
       ) : null}
-      {queueSheetMounted && queueBoard ? (
+      {queueBoard ? (
         <QueueSheet
-          visible={queueSheetVisible}
+          ref={queueSheetRef}
           board={queueBoard}
           onClose={requestCloseQueueSheet}
-          onDismissed={handleQueueSheetDismissed}
           onClimbPress={handleQueueClimbPress}
           onSuggestionPress={handleQueueSuggestionPress}
           onTickHistory={handleQueueTickHistory}

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -43,7 +43,6 @@
     "ordinalSecond": "{{n}}nd",
     "ordinalThird": "{{n}}rd",
     "ordinalDefault": "{{n}}th",
-    "sessionNotesPlaceholder": "Session notes or goal...",
     "noClimbsYet": "No climbs yet",
     "logSomeClimbs": "Log some climbs to see your grade breakdown",
     "climbsLogged_one": "{{count}} climb logged",
@@ -72,11 +71,6 @@
     "notFound": {
       "title": "Session Not Found",
       "subtitle": "This session could not be found. It may have been removed."
-    },
-    "userSearch": {
-      "title": "Add Climber",
-      "placeholder": "Search by name...",
-      "noUsersFound": "No users found"
     }
   },
   "join": {
@@ -475,13 +469,7 @@
   },
   "mobileDetail": {
     "notFound": "Session not found",
-    "editTitle": "Edit session",
-    "nameLabel": "Name",
-    "goalLabel": "Goal",
-    "save": "Save",
     "participants": "Climbers",
-    "updated": "Session updated",
-    "updateError": "Couldn't update session",
     "title": "Session"
   },
   "mobileJoin": {

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -43,7 +43,6 @@
     "ordinalSecond": "{{n}}º",
     "ordinalThird": "{{n}}º",
     "ordinalDefault": "{{n}}º",
-    "sessionNotesPlaceholder": "Notas de la sesión u objetivo...",
     "noClimbsYet": "Sin bloques todavía",
     "logSomeClimbs": "Registra algunos bloques para ver el desglose por grados",
     "climbsLogged_one": "{{count}} bloque registrado",
@@ -72,11 +71,6 @@
     "notFound": {
       "title": "Sesión no encontrada",
       "subtitle": "No se pudo encontrar esta sesión. Puede que haya sido eliminada."
-    },
-    "userSearch": {
-      "title": "Añadir escalador",
-      "placeholder": "Buscar por nombre...",
-      "noUsersFound": "No se encontraron usuarios"
     }
   },
   "join": {
@@ -475,13 +469,7 @@
   },
   "mobileDetail": {
     "notFound": "Sesión no encontrada",
-    "editTitle": "Editar sesión",
-    "nameLabel": "Nombre",
-    "goalLabel": "Objetivo",
-    "save": "Guardar",
     "participants": "Escaladores",
-    "updated": "Sesión actualizada",
-    "updateError": "No se pudo actualizar la sesión",
     "title": "Sesión"
   },
   "mobileJoin": {

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -43,7 +43,6 @@
     "ordinalSecond": "{{n}}e",
     "ordinalThird": "{{n}}e",
     "ordinalDefault": "{{n}}e",
-    "sessionNotesPlaceholder": "Notes ou objectif de session…",
     "noClimbsYet": "Aucun bloc pour l'instant",
     "logSomeClimbs": "Enregistre quelques blocs pour voir la répartition par cotation",
     "climbsLogged_one": "{{count}} bloc enregistré",
@@ -72,11 +71,6 @@
     "notFound": {
       "title": "Session introuvable",
       "subtitle": "Cette session est introuvable. Elle a peut-être été supprimée."
-    },
-    "userSearch": {
-      "title": "Ajouter un grimpeur",
-      "placeholder": "Rechercher par nom…",
-      "noUsersFound": "Aucun utilisateur trouvé"
     }
   },
   "join": {
@@ -475,13 +469,7 @@
   },
   "mobileDetail": {
     "notFound": "Session introuvable",
-    "editTitle": "Modifier la session",
-    "nameLabel": "Nom",
-    "goalLabel": "Objectif",
-    "save": "Enregistrer",
     "participants": "Grimpeurs",
-    "updated": "Session mise à jour",
-    "updateError": "Impossible de mettre à jour la session",
     "title": "Session"
   },
   "mobileJoin": {


### PR DESCRIPTION
## The bug

The mobile **Queue sheet never opened**. Tapping the play-drawer queue button (or the "Climb added to queue" snackbar's **Open**) called the open handler, but the gorhom `BottomSheetModal` stayed hidden.

## Root cause (confirmed on a physical device)

gorhom `BottomSheetModal.present()`, when driven from a **`visible`-prop `useEffect`**, is a **silent no-op** in this build (RN 0.79 / Expo SDK 56 / @gorhom/bottom-sheet v5 / react-native-screens). On-device logging proved the effect ran, `visible` was true, the modal ref was non-null, and `present()` was called — yet gorhom **never fired `onAnimate`/`onChange`**, so the sheet never animated in. The host's two-commit mount→visible dance (added to work around an earlier variant of this) never actually presented over the already-open Play Drawer.

The proven working pattern in this same app is **`PlayDrawer`**: an imperative `useImperativeHandle` exposing `open()` that calls `sheetRef.current?.present()` **synchronously from the event handler**, not from an effect.

## The fix

Drive the queue sheet imperatively, matching `PlayDrawer`:

- **`QueueSheet`** is now a `forwardRef` exposing `QueueSheetHandle` (`{ present, dismiss }`) via `useImperativeHandle`. `present()` is called synchronously from the tap handler instead of from a `visible`-prop effect. Removed the `visible` prop and its effect; `onDismissed` is now optional; `autoScrollOnMount` is gated on a local `isPresented` flag so the list only auto-scrolls on a real open.
- **`DrawerHostProvider`** keeps the sheet mounted whenever a board is resolved and opens/closes it through `queueSheetRef` (`openQueueSheet` → `present()`, `requestCloseQueueSheet` → `dismiss()`). Dropped the now-dead `queueSheetMounted` / `queueSheetVisible` state, the mount effect, and `handleQueueSheetDismissed`.
- Tests updated to the imperative model (mock `QueueSheet` as a `forwardRef`; assert the handle's `present`/`dismiss` are wired and the sheet stays mounted across open/close/re-open).

## Validation

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 1381 tests pass
- `vp run check:mobile-bundle` — Android bundle OK (10.6 MB)
- `vp check` / `vp staged` (pre-commit) — pass (no `--no-verify`)

## Note

Also removes 10 **pre-existing** orphaned `session` i18n keys (`detail.sessionNotesPlaceholder`, `detail.userSearch.*`, `mobileDetail` edit keys) left behind by the merged "remove-inferred-sessions" change. They had zero source references and were already failing `check:i18n:orphans`, which the pre-commit hook runs for any mobile-touching commit. No queue logic depends on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)