### PR TITLE
fix(mobile): gate queue sheet suggestion feed on sheet being open

### DIFF
--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -43,6 +43,11 @@ type QueueListProps = {
   showFullHistory: boolean;
   selectedItems: Set<string>;
   playlistSuggestionSource: PlaylistSuggestionSource | null;
+  /** True while the queue sheet is presented. Gates the suggestion feed query
+   *  so it only runs while the sheet is open — the sheet stays mounted (for the
+   *  imperative present()), so without this the feed would fetch continuously
+   *  for the whole session. */
+  active: boolean;
   autoScrollOnMount?: boolean;
   onToggleSelect: (uuid: string) => void;
   onClimbPress: (item: ClimbQueueItem) => void;
@@ -63,6 +68,7 @@ export function QueueList({
   showFullHistory,
   selectedItems,
   playlistSuggestionSource,
+  active,
   autoScrollOnMount,
   onToggleSelect,
   onClimbPress,
@@ -90,11 +96,12 @@ export function QueueList({
   // Suggested climbs flow directly after the queue rows — NO header, NO divider
   // (the intentional divergence from web). Playlist suggestions (when a playlist
   // is active) come first, then a popular (by-ascents) feed for the board tops
-  // the list up. The feed query is enabled unconditionally (not gated on the
-  // playlist source) — but this list only mounts while the queue sheet is open,
-  // so it only runs then. Fetching regardless of the source means suggestions
-  // never vanish when the source flips or its climbs go empty; they fall back to
-  // the feed. Everything already in the queue is excluded.
+  // the list up. The feed query is gated on `active` (sheet presented), not on
+  // the playlist source: the sheet stays mounted for the imperative present(),
+  // so without this gate the feed would fetch for the whole session. Fetching
+  // regardless of the source means suggestions never vanish when the source
+  // flips or its climbs go empty; they fall back to the feed. Everything already
+  // in the queue is excluded.
   const playlistSuggestions = useMemo(
     () => getPlaylistSuggestedClimbs(playlistSuggestionSource, queue),
     [playlistSuggestionSource, queue],
@@ -104,7 +111,7 @@ export function QueueList({
     () => toClimbSearchInput(DEFAULT_CLIMB_FILTER_STATE, board, { page: 0, pageSize: SUGGESTION_PAGE_SIZE }),
     [board],
   );
-  const { data: searchResult } = useSearchClimbs(searchInput, true, {
+  const { data: searchResult } = useSearchClimbs(searchInput, active, {
     staleTime: SUGGESTION_STALE_MS,
     gcTime: SUGGESTION_GC_MS,
   });

--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -214,6 +214,7 @@ export const QueueSheet = forwardRef<QueueSheetHandle, QueueSheetProps>(function
         showFullHistory={showFullHistory}
         selectedItems={selectedItems}
         playlistSuggestionSource={playlistSuggestionSource}
+        active={isPresented}
         autoScrollOnMount={isPresented}
         onToggleSelect={handleToggleSelect}
         onClimbPress={onClimbPress}


### PR DESCRIPTION
## What

The mobile queue sheet became always-mounted when it switched to the imperative `present()`/`dismiss()` model in #2667 (the `visible`-prop effect was a silent gorhom no-op). That switch dropped the old `queueSheetMounted` guard, whose documented job was to keep the suggestion feed query out of the tree until the sheet actually opened.

With the guard gone, `QueueList` ran `useSearchClimbs(searchInput, true, …)` for the entire session whenever a board was active — `queueBoard` is truthy the whole time (`drawer-host-provider.tsx:301`), not just while the sheet is open. The comment at `QueueList.tsx` still claimed "this list only mounts while the queue sheet is open, so it only runs then," which was no longer true.

## Fix

Thread the `isPresented` flag the sheet already tracks (`QueueSheet.tsx`) into `QueueList` as a new `active` prop, and use it as the query's `enabled` flag. The feed now fetches only while the sheet is presented. The sheet stays mounted so the imperative `present()` keeps working, and `gcTime` (10 min) keeps suggestions warm across close/re-open so re-opening shows results instantly.

- `QueueList.tsx`: new required `active: boolean` prop → `useSearchClimbs(searchInput, active, …)`; comment updated to describe the gate.
- `QueueSheet.tsx`: pass `active={isPresented}` (alongside the existing `autoScrollOnMount={isPresented}`).

No change in `drawer-host-provider.tsx` — the sheet stays always-mounted; only the inner query is gated.

## Behavior

- Board active, sheet closed → `useSearchClimbs` disabled, no `searchClimbs` request fires.
- Open sheet → `active` flips true, feed runs, suggestions appear under the queue rows.
- Close sheet → query disabled again; re-open within `gcTime` shows cached suggestions immediately.

## Validation

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 1381 passed
- `vp run check:mobile-bundle` — OK (10.6 MB)
- `vp check` on the two changed files — clean (lint + format)

https://claude.ai/code/session_01SnyeTHrG5WhdjzDxcuVzav

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnyeTHrG5WhdjzDxcuVzav)_