### PR TITLE
Fix climb list and play drawer interaction bugs

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -667,6 +667,43 @@ function ClimbListInner() {
     return { label: t('mobile.filter.gradeRange'), active: false };
   }, [gradeFilterToken, t]);
 
+  // Memoized so FlashList doesn't re-measure/re-render the header on every
+  // ClimbListInner render — only when the title, pills, or filters change.
+  const listHeader = useMemo(
+    () => (
+      <>
+        {/* Glass variant: the screen's identity in-body under the floating
+            chrome — the active filter ("V4–V6 · Quality") or "All climbs" —
+            collapsing into the centered header capsule as it scrolls up. The
+            Material variant shows the title in its Appbar instead. */}
+        {variant === 'material' ? null : (
+          <Text variant="largeTitle" numberOfLines={2} ellipsizeMode="tail" style={styles.screenTitle}>
+            {searchTitle}
+          </Text>
+        )}
+        {showRecentPills ? (
+          <RecentFilterPills
+            recentFilters={recentFilters}
+            currentFilters={filters}
+            currentSearchText={name}
+            onApply={handleApplyRecentFilter}
+            onClear={handleClearRecentFilters}
+          />
+        ) : null}
+      </>
+    ),
+    [
+      variant,
+      searchTitle,
+      showRecentPills,
+      recentFilters,
+      filters,
+      name,
+      handleApplyRecentFilter,
+      handleClearRecentFilters,
+    ],
+  );
+
   const stackOptions = useMemo(
     () =>
       useNativeSearch
@@ -791,28 +828,7 @@ function ClimbListInner() {
         refreshControl={
           <RefreshControl refreshing={isRefetching} onRefresh={handleRefresh} tintColor={brandColors.primary} />
         }
-        ListHeaderComponent={
-          <>
-            {/* Glass variant: the screen's identity in-body under the floating
-                chrome — the active filter ("V4–V6 · Quality") or "All climbs" —
-                collapsing into the centered header capsule as it scrolls up. The
-                Material variant shows the title in its Appbar instead. */}
-            {variant === 'material' ? null : (
-              <Text variant="largeTitle" numberOfLines={2} ellipsizeMode="tail" style={styles.screenTitle}>
-                {searchTitle}
-              </Text>
-            )}
-            {showRecentPills ? (
-              <RecentFilterPills
-                recentFilters={recentFilters}
-                currentFilters={filters}
-                currentSearchText={name}
-                onApply={handleApplyRecentFilter}
-                onClear={handleClearRecentFilters}
-              />
-            ) : null}
-          </>
-        }
+        ListHeaderComponent={listHeader}
         ListFooterComponent={isFetchingNextPage ? <ClimbListSkeletonRows count={FOOTER_SKELETON_ROW_COUNT} /> : null}
         ListEmptyComponent={
           showInitialSkeletons ? (

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -227,10 +227,31 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   // When the board angle changes, drop the locally-pinned climb so the drawer
   // re-derives the displayed climb from currentClimbQueueItem — which the queue
   // re-grade effect patches with the new angle's grade. Without this, the header
-  // would keep showing the stale grade baked into the locally-held climb.
+  // would keep showing the stale grade baked into the locally-held climb. The
+  // preview suggestion source anchors peeks on that pinned climb, so it must
+  // drop with it — kept alone it would aim next-peeks at the wrong climb.
   useEffect(() => {
     setDrawerPreviewItem(null);
+    setDrawerPreviewSuggestionSource(null);
   }, [angle]);
+
+  // When this client stops being preview-only (took control, or the session
+  // ended), drop the drawer-local preview state: commits now go through the
+  // provider, and a lingering drawerPreviewSuggestionSource would keep shadowing
+  // the provider's source for displayed peeks while nextClimb() commits against
+  // the provider source. Transition-gated (true→false only) so entering preview
+  // mode or mounting never clears a fresh preview. Safe for the lightbulb flow:
+  // handleLightbulb reads drawerPreviewSuggestionSource synchronously at press
+  // time and hands it to takeControl before the driver flip lands here.
+  const wasPartyPreviewOnlyRef = useRef(isPartyPreviewOnly);
+  useEffect(() => {
+    const wasPreviewOnly = wasPartyPreviewOnlyRef.current;
+    wasPartyPreviewOnlyRef.current = isPartyPreviewOnly;
+    if (wasPreviewOnly && !isPartyPreviewOnly) {
+      setDrawerPreviewItem(null);
+      setDrawerPreviewSuggestionSource(null);
+    }
+  }, [isPartyPreviewOnly]);
 
   const { showToast } = useToast();
 
@@ -490,6 +511,13 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
           })
         ) {
           setDrawerPreviewItem((currentItem) => currentItem ?? queueItem);
+          // The optimistic driver flip cleared the drawer-local suggestion
+          // source (preview-only → driver transition effect above); the
+          // rollback restores preview-only, so restore the at-press source
+          // alongside the preview item to keep playlist peeks working.
+          if (drawerPreviewSuggestionSource) {
+            setDrawerPreviewSuggestionSource((currentSource) => currentSource ?? drawerPreviewSuggestionSource);
+          }
         }
       });
     armWallConfirmWatcher({

--- a/packages/mobile/src/components/play-drawer/__tests__/use-carousel-gesture.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-carousel-gesture.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { SWIPE_THRESHOLD } from '@boardsesh/play-view';
+
+// The hook composes a reanimated worklet gesture — stub the native layers so it
+// runs in node. What these tests are really about: the Pan gesture composes
+// ONCE per mount (recomposing mid-session left RNGH stuck on iOS), with
+// canSwipeNext/canSwipePrevious read through shared values so boundary flips
+// don't rebuild it but still gate the worklet handlers.
+
+// Mirror reanimated's contract: useSharedValue returns the SAME mutable ref
+// across re-renders; animations resolve to their target value synchronously.
+vi.mock('react-native-reanimated', async () => {
+  const { useRef } = await import('react');
+  return {
+    useSharedValue: (initial: unknown) => {
+      const ref = useRef<{ value: unknown } | null>(null);
+      if (ref.current === null) ref.current = { value: initial };
+      return ref.current;
+    },
+    withTiming: (toValue: unknown) => toValue,
+    withSpring: (toValue: unknown) => toValue,
+    runOnJS:
+      (fn: (...args: unknown[]) => unknown) =>
+      (...args: unknown[]) =>
+        fn(...args),
+  };
+});
+
+// Chainable Gesture.Pan() builder that is FRESH per call (so gesture identity
+// assertions are meaningful) and records the worklet handlers for driving.
+type RecordedHandlers = Record<string, (...args: unknown[]) => unknown>;
+const recordedBuilders: { handlers: RecordedHandlers }[] = [];
+vi.mock('react-native-gesture-handler', () => {
+  const makeBuilder = () => {
+    const handlers: RecordedHandlers = {};
+    recordedBuilders.push({ handlers });
+    const builder: Record<string, (...args: unknown[]) => unknown> = {};
+    const proxy: typeof builder = new Proxy(builder, {
+      get: (_target, prop: string) => {
+        return (maybeHandler: unknown) => {
+          if (typeof maybeHandler === 'function' && prop.startsWith('on')) {
+            handlers[prop] = maybeHandler as RecordedHandlers[string];
+          }
+          return proxy;
+        };
+      },
+    });
+    return proxy;
+  };
+  return {
+    Gesture: { Pan: () => makeBuilder() },
+  };
+});
+
+vi.mock('../../../lib/haptics', () => ({ hapticMedium: vi.fn() }));
+
+import { useCarouselGesture } from '../use-carousel-gesture';
+
+type Options = Parameters<typeof useCarouselGesture>[0];
+
+const onSwipeNext = vi.fn();
+const onSwipePrevious = vi.fn();
+
+function makeOptions(overrides: Partial<Options> = {}): Options {
+  return {
+    onSwipeNext,
+    onSwipePrevious,
+    canSwipeNext: true,
+    canSwipePrevious: true,
+    boardWidth: 320,
+    ...overrides,
+  };
+}
+
+function latestHandlers(): RecordedHandlers {
+  const latest = recordedBuilders[recordedBuilders.length - 1];
+  if (!latest) throw new Error('no Gesture.Pan() composed');
+  return latest.handlers;
+}
+
+describe('useCarouselGesture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recordedBuilders.length = 0;
+  });
+
+  it('keeps the gesture identity stable across swipe-availability, enabled, and board-width changes', () => {
+    const { result, rerender } = renderHook((props: Options) => useCarouselGesture(props), {
+      initialProps: makeOptions(),
+    });
+
+    const firstGesture = result.current.gesture;
+
+    rerender(makeOptions({ canSwipeNext: false, canSwipePrevious: false, enabled: false, boardWidth: 280 }));
+    rerender(makeOptions({ canSwipeNext: true, canSwipePrevious: false, reduceMotion: true }));
+
+    expect(result.current.gesture).toBe(firstGesture);
+    // One composition total — recomposing mid-session is the iOS RNGH wedge.
+    expect(recordedBuilders).toHaveLength(1);
+  });
+
+  it('onEnd commits per the LATEST canSwipeNext, not the value captured at composition', () => {
+    const { result, rerender } = renderHook((props: Options) => useCarouselGesture(props), {
+      // reduceMotion keeps the commit synchronous (no slide-off timer).
+      initialProps: makeOptions({ reduceMotion: true }),
+    });
+    const handlers = latestHandlers();
+
+    result.current.translateX.value = -(SWIPE_THRESHOLD + 1);
+    handlers.onEnd();
+    expect(onSwipeNext).toHaveBeenCalledTimes(1);
+
+    rerender(makeOptions({ reduceMotion: true, canSwipeNext: false }));
+    result.current.translateX.value = -(SWIPE_THRESHOLD + 1);
+    handlers.onEnd();
+    expect(onSwipeNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('onUpdate clamps the drag once canSwipeNext flips false', () => {
+    const { result, rerender } = renderHook((props: Options) => useCarouselGesture(props), {
+      initialProps: makeOptions(),
+    });
+    const handlers = latestHandlers();
+
+    handlers.onUpdate({ translationX: -50 });
+    expect(result.current.translateX.value).toBe(-50);
+
+    rerender(makeOptions({ canSwipeNext: false }));
+    handlers.onUpdate({ translationX: -50 });
+    expect(result.current.translateX.value).toBe(0);
+  });
+
+  it('onEnd springs back without committing below the threshold', () => {
+    const { result } = renderHook((props: Options) => useCarouselGesture(props), {
+      initialProps: makeOptions({ reduceMotion: true }),
+    });
+    const handlers = latestHandlers();
+
+    result.current.translateX.value = -(SWIPE_THRESHOLD - 1);
+    handlers.onEnd();
+
+    expect(onSwipeNext).not.toHaveBeenCalled();
+    expect(onSwipePrevious).not.toHaveBeenCalled();
+    expect(result.current.translateX.value).toBe(0);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/use-carousel-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-carousel-gesture.ts
@@ -63,6 +63,18 @@ export function useCarouselGesture({
     boardWidthSV.value = boardWidth;
   }, [boardWidth, boardWidthSV]);
 
+  // Mirror swipe availability into shared values for the same reason — these
+  // flip at queue boundaries (and on queue mutations during the commit window),
+  // and recomposing the gesture then would hit the same iOS RNGH wedge.
+  const canSwipeNextSV = useSharedValue(canSwipeNext);
+  useEffect(() => {
+    canSwipeNextSV.value = canSwipeNext;
+  }, [canSwipeNext, canSwipeNextSV]);
+  const canSwipePreviousSV = useSharedValue(canSwipePrevious);
+  useEffect(() => {
+    canSwipePreviousSV.value = canSwipePrevious;
+  }, [canSwipePrevious, canSwipePreviousSV]);
+
   const callbacksRef = useRef({ onSwipeNext, onSwipePrevious });
   callbacksRef.current = { onSwipeNext, onSwipePrevious };
 
@@ -73,6 +85,9 @@ export function useCarouselGesture({
     [],
   );
 
+  // The three JS callbacks below are captured ONCE by the gesture memo (it
+  // composes a single time per mount) — they must only close over refs and
+  // shared values. Route any new render-scoped value through callbacksRef.
   const triggerHaptic = () => {
     hapticMedium();
   };
@@ -168,8 +183,8 @@ export function useCarouselGesture({
 
           let offset = event.translationX;
 
-          if (offset < 0 && !canSwipeNext) offset = 0;
-          if (offset > 0 && !canSwipePrevious) offset = 0;
+          if (offset < 0 && !canSwipeNextSV.value) offset = 0;
+          if (offset > 0 && !canSwipePreviousSV.value) offset = 0;
 
           translateX.value = offset;
 
@@ -185,7 +200,7 @@ export function useCarouselGesture({
           const offset = translateX.value;
           const skipAnimation = reduceMotionSV.value;
 
-          if (offset < -SWIPE_THRESHOLD && canSwipeNext) {
+          if (offset < -SWIPE_THRESHOLD && canSwipeNextSV.value) {
             if (skipAnimation) {
               translateX.value = 0;
               runOnJS(commitImmediate)('next');
@@ -194,7 +209,7 @@ export function useCarouselGesture({
               translateX.value = withTiming(-boardWidthSV.value, { duration: EXIT_DURATION });
               runOnJS(scheduleCommit)('next');
             }
-          } else if (offset > SWIPE_THRESHOLD && canSwipePrevious) {
+          } else if (offset > SWIPE_THRESHOLD && canSwipePreviousSV.value) {
             if (skipAnimation) {
               translateX.value = 0;
               runOnJS(commitImmediate)('previous');
@@ -208,8 +223,8 @@ export function useCarouselGesture({
           }
         }),
     [
-      canSwipeNext,
-      canSwipePrevious,
+      canSwipeNextSV,
+      canSwipePreviousSV,
       boardWidthSV,
       translateX,
       isAnimating,

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -17,9 +17,11 @@ const mocks = vi.hoisted(() => ({
   refreshPlaylistSuggestionSource: vi.fn(),
   openPlayDrawer: vi.fn(),
   activeBoard: { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 } as ActiveBoard,
+  isPartyPreviewOnly: false,
   activate: vi.fn<(climb: Climb) => Promise<void>>(),
   fetchSuggestion: vi.fn(),
   captured: undefined as UsePlaylistClimbActivationOptions | undefined,
+  queueItemCounter: 0,
 }));
 
 vi.mock('@boardsesh/playlists-react', () => ({
@@ -34,6 +36,7 @@ vi.mock('../../../providers/queue-provider', () => ({
     setCurrentClimb: mocks.setCurrentClimb,
     refreshPlaylistSuggestionSource: mocks.refreshPlaylistSuggestionSource,
   }),
+  useIsPartyPreviewOnly: () => mocks.isPartyPreviewOnly,
 }));
 vi.mock('../../../providers/drawer-host-provider', () => ({
   useDrawerHost: () => ({ openPlayDrawer: mocks.openPlayDrawer }),
@@ -41,8 +44,14 @@ vi.mock('../../../providers/drawer-host-provider', () => ({
 vi.mock('../../graphql/use-active-board', () => ({
   useActiveBoard: () => ({ data: mocks.activeBoard }),
 }));
+// Unique uuid per call (mirrors the real randomUUID wrapper) — the "same item"
+// assertions below would be vacuous if every call minted the same uuid.
 vi.mock('../../climb-to-queue-item', () => ({
-  climbToQueueItem: (climb: { uuid: string }) => ({ uuid: `qi-${climb.uuid}`, climb }),
+  climbToQueueItem: (climb: { uuid: string }, options?: { suggested?: boolean }) => ({
+    uuid: `qi-${climb.uuid}-${++mocks.queueItemCounter}`,
+    suggested: options?.suggested,
+    climb,
+  }),
 }));
 
 function makeClimb(uuid: string): Climb {
@@ -75,8 +84,10 @@ function captured(): UsePlaylistClimbActivationOptions {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.activeBoard = { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 };
+  mocks.isPartyPreviewOnly = false;
   mocks.captured = undefined;
   mocks.activate.mockResolvedValue(undefined);
+  mocks.queueItemCounter = 0;
 });
 
 describe('usePlaylistActivation (mobile wrapper)', () => {
@@ -84,10 +95,12 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     renderActivation();
     const climb = makeClimb('a');
     const item = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
-    expect(mocks.setCurrentClimb).toHaveBeenCalledWith({ uuid: 'qi-a', climb }, { playlistSuggestionSource: null });
+    expect(mocks.setCurrentClimb).toHaveBeenCalledWith(expect.objectContaining({ climb }), {
+      playlistSuggestionSource: null,
+    });
     // Returning the item (non-null) tells the shared hook the synchronous
     // activation phase succeeded.
-    expect(item).toEqual({ uuid: 'qi-a', climb });
+    expect(item).toEqual(mocks.setCurrentClimb.mock.calls[0][0]);
   });
 
   it('resolves the active board into a board target, or null when no board', () => {
@@ -108,11 +121,92 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     // The drawer opens FIRST — before the shared activation's setCurrentClimb +
     // suggestion-source work — so BottomSheetModal.present() fires on the same
     // frame as the tap. setAsCurrent:false stops the drawer re-dispatching and
-    // wiping the suggestion source the activation builds.
-    expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { setAsCurrent: false });
+    // wiping the suggestion source the activation builds. previewQueueItem is
+    // the navigation anchor the queue dispatch will reuse.
+    expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, {
+      setAsCurrent: false,
+      previewQueueItem: expect.objectContaining({ climb }),
+    });
     // The shared activation still runs (suggestion source + the queue dispatch,
     // which is wrapped in startTransition).
     expect(mocks.activate).toHaveBeenCalledWith(climb);
+  });
+
+  it('dispatches the exact previewQueueItem instance the drawer pinned', async () => {
+    const { result } = renderActivation();
+    const climb = makeClimb('a');
+    await result.current(climb);
+    const previewItem = mocks.openPlayDrawer.mock.calls[0][1].previewQueueItem;
+
+    const item = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
+    // Same instance, not a second item with a fresh uuid — otherwise the drawer
+    // anchors prev/remaining-count on an orphan uuid that is never in the queue.
+    expect(mocks.setCurrentClimb.mock.calls[0][0]).toBe(previewItem);
+    expect(item).toBe(previewItem);
+  });
+
+  it('reuses the pinned item once — a second dispatch builds a fresh item', async () => {
+    const { result } = renderActivation();
+    const climb = makeClimb('a');
+    await result.current(climb);
+    const previewItem = mocks.openPlayDrawer.mock.calls[0][1].previewQueueItem;
+
+    const first = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
+    const second = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
+    expect(first).toBe(previewItem);
+    expect(second).not.toBe(previewItem);
+    expect(second?.uuid).not.toBe(previewItem.uuid);
+  });
+
+  it('ignores the pinned item when the dispatched climb differs', async () => {
+    const { result } = renderActivation();
+    await result.current(makeClimb('a'));
+    const previewItem = mocks.openPlayDrawer.mock.calls[0][1].previewQueueItem;
+
+    const climbB = makeClimb('b');
+    const item = await captured().queueApi!.setCurrentClimb(climbB, { playlistSuggestionSource: null });
+    expect(item).not.toBe(previewItem);
+    expect(item?.climb).toEqual(climbB);
+  });
+
+  describe('party preview-only mode', () => {
+    beforeEach(() => {
+      mocks.isPartyPreviewOnly = true;
+    });
+
+    it('never dispatches to the shared queue — opens a local preview instead', async () => {
+      const { result } = renderActivation();
+      const climb = makeClimb('a');
+      await result.current(climb);
+
+      // A non-driver tap must not change the session's current climb for peers.
+      expect(mocks.activate).not.toHaveBeenCalled();
+      expect(mocks.setCurrentClimb).not.toHaveBeenCalled();
+      expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, {
+        setAsCurrent: false,
+        previewQueueItem: expect.objectContaining({ climb, suggested: true }),
+        previewPlaylistSuggestionSource: expect.objectContaining({
+          playlistUuid: 'pl-1',
+          activatedClimbUuid: 'a',
+          boardKey: expect.stringContaining('kilter'),
+          climbs: expect.arrayContaining([expect.objectContaining({ uuid: 'a' })]),
+        }),
+      });
+    });
+
+    it('opens with a null preview source when no board resolves', async () => {
+      mocks.activeBoard = null;
+      const { result } = renderActivation();
+      const climb = makeClimb('a');
+      await result.current(climb);
+
+      expect(mocks.setCurrentClimb).not.toHaveBeenCalled();
+      expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, {
+        setAsCurrent: false,
+        previewQueueItem: expect.objectContaining({ climb }),
+        previewPlaylistSuggestionSource: null,
+      });
+    });
   });
 
   it('fetchClimbsForBoard pages the playlist via the injected fetchPage', async () => {

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -10,10 +10,10 @@
 // swaps in a richer suggestion source so swiping through the play drawer walks
 // the whole playlist.
 
-import { useCallback, useMemo, startTransition } from 'react';
+import { useCallback, useMemo, useRef, startTransition } from 'react';
 import { usePlaylistClimbActivation, fetchPlaylistSuggestionClimbs } from '@boardsesh/playlists-react';
-import { getQueueBoardKey, type Climb } from '@boardsesh/queue';
-import { useQueueActions } from '../../providers/queue-provider';
+import { createPlaylistSuggestionSource, getQueueBoardKey, type Climb, type ClimbQueueItem } from '@boardsesh/queue';
+import { useIsPartyPreviewOnly, useQueueActions } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { useActiveBoard } from '../graphql/use-active-board';
 import { climbToQueueItem } from '../climb-to-queue-item';
@@ -55,15 +55,27 @@ export function usePlaylistActivation({
   const { setCurrentClimb, refreshPlaylistSuggestionSource } = useQueueActions();
   const { openPlayDrawer } = useDrawerHost();
   const activeBoard = useActiveBoard().data ?? null;
+  const isPartyPreviewOnly = useIsPartyPreviewOnly();
+
+  // The queue item the returned callback already pinned in the drawer as
+  // previewQueueItem. queueApi.setCurrentClimb dispatches that exact item so
+  // the drawer's navigation anchor and the queue entry share one uuid —
+  // otherwise prev/remaining-count anchor on an orphan uuid that's never in
+  // the queue. Single-use; the climb-uuid match guards against a stale ref
+  // from an earlier tap whose activation never reached setCurrentClimb.
+  const pendingQueueItemRef = useRef<ClimbQueueItem | null>(null);
 
   // The shared hook expects setCurrentClimb to return the activated item (so it
   // knows activation succeeded and can fire onActivated). Mobile's provider
-  // method returns void, so wrap it: build the queue item, dispatch, and return
-  // the item.
+  // method returns void, so wrap it: reuse the pinned queue item (or build one
+  // for paths that bypassed the drawer pin), dispatch, and return the item.
   const queueApi = useMemo(
     () => ({
       setCurrentClimb: async (climb: Climb, options: Parameters<typeof setCurrentClimb>[1]) => {
-        const item = climbToQueueItem(toSchemaClimb(climb));
+        const pendingItem = pendingQueueItemRef.current;
+        pendingQueueItemRef.current = null;
+        const item =
+          pendingItem && pendingItem.climb.uuid === climb.uuid ? pendingItem : climbToQueueItem(toSchemaClimb(climb));
         // Mark as a non-urgent transition so React can flush the drawer's
         // opening animation frame before processing the queue re-renders.
         startTransition(() => {
@@ -136,11 +148,38 @@ export function usePlaylistActivation({
   // the animation frame runs.
   return useCallback(
     (climb: Climb) => {
-      openPlayDrawer(toSchemaClimb(climb), { setAsCurrent: false });
+      if (isPartyPreviewOnly) {
+        // Non-driver in a party session: never touch the shared queue (same
+        // gating as the queue sheet's tap paths). Open a local preview with a
+        // drawer-local suggestion source so next-swipes walk the playlist
+        // locally; the lightbulb promotes it via takeControl(queueItem,
+        // { playlistSuggestionSource }). Preview mode uses the loaded climbs
+        // only — no async full-list refresh, matching the queue-sheet preview.
+        const previewItem = climbToQueueItem(toSchemaClimb(climb), { suggested: true });
+        const target = resolveTarget(climb);
+        const previewSource = target
+          ? createPlaylistSuggestionSource({
+              playlistUuid: sourceId,
+              activatedClimb: climb,
+              climbs: allClimbs,
+              boardKey: target.boardKey,
+              isClimbable: target.isClimbable,
+            })
+          : null;
+        openPlayDrawer(toSchemaClimb(climb), {
+          setAsCurrent: false,
+          previewQueueItem: previewItem,
+          previewPlaylistSuggestionSource: previewSource,
+        });
+        return Promise.resolve();
+      }
+      const item = climbToQueueItem(toSchemaClimb(climb));
+      pendingQueueItemRef.current = item;
+      openPlayDrawer(toSchemaClimb(climb), { setAsCurrent: false, previewQueueItem: item });
       return activate(climb).catch((error: unknown) => {
         console.error('Playlist climb activation failed:', error);
       });
     },
-    [activate, openPlayDrawer],
+    [activate, openPlayDrawer, isPartyPreviewOnly, resolveTarget, sourceId, allClimbs],
   );
 }

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -127,18 +127,32 @@ vi.mock('../../components/QueueAddedSnackbar', () => ({
   QueueAddedSnackbar: () => createElement('div', { 'data-queue-snackbar': 'true' }),
 }));
 
-vi.mock('../queue-provider', () => ({
-  useQueueActions: () => ({
-    addToQueue: queue.addToQueue,
-    setSessionBoardPath: queue.setSessionBoardPath,
-    setCurrentClimb: queue.setCurrentClimb,
-  }),
-  useQueueSessionControls: () => ({
-    sessionId: queue.sessionId,
-    driverParticipantId: queue.driverParticipantId,
-    participantId: queue.participantId,
-  }),
-}));
+vi.mock('../queue-provider', async () => {
+  const { deriveIsDriver } =
+    await vi.importActual<typeof import('@boardsesh/queue-runtime')>('@boardsesh/queue-runtime');
+  return {
+    useQueueActions: () => ({
+      addToQueue: queue.addToQueue,
+      setSessionBoardPath: queue.setSessionBoardPath,
+      setCurrentClimb: queue.setCurrentClimb,
+    }),
+    useQueueSessionControls: () => ({
+      sessionId: queue.sessionId,
+      driverParticipantId: queue.driverParticipantId,
+      participantId: queue.participantId,
+    }),
+    // Mirror the provider's real selector so the existing driver/participant
+    // fixtures keep driving the preview-only branch after the handlers moved
+    // to the useIsPartyPreviewOnly hook.
+    useIsPartyPreviewOnly: () =>
+      queue.sessionId !== null &&
+      !deriveIsDriver({
+        isPersistentSessionActive: true,
+        participantId: queue.participantId,
+        driverParticipantId: queue.driverParticipantId,
+      }),
+  };
+});
 
 vi.mock('../queue-snackbar-provider', () => ({
   useQueueSnackbar: () => ({

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -16,7 +16,6 @@ import { randomUUID } from 'expo-crypto';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { buildBoardPath } from '@boardsesh/board-config';
 import type { Climb as QueueClimb, ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
-import { deriveIsDriver } from '@boardsesh/queue-runtime';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { PlayDrawer, type PlayDrawerHandle, type PlayDrawerOpenOptions } from '../components/play-drawer';
 import { LogAscentSheet } from '../components/LogAscentSheet';
@@ -30,7 +29,7 @@ import { AddToPlaylistSheet } from '../components/AddToPlaylistSheet';
 import { useToggleFavorite, useProfile } from '../lib/graphql/hooks';
 import { favoritesStore } from '@boardsesh/climb-actions';
 import { climbToQueueItem } from '../lib/climb-to-queue-item';
-import { useQueueActions, useQueueSessionControls } from './queue-provider';
+import { useIsPartyPreviewOnly, useQueueActions, useQueueSessionControls } from './queue-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
 
 export type BoardConfig = {
@@ -105,7 +104,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const [climbActions, setClimbActions] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const [playlistClimb, setPlaylistClimb] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const { addToQueue, setSessionBoardPath, setCurrentClimb } = useQueueActions();
-  const { sessionId, driverParticipantId, participantId } = useQueueSessionControls();
+  const { sessionId } = useQueueSessionControls();
+  const isPartyPreviewOnly = useIsPartyPreviewOnly();
   const setActiveBoard = useSetActiveBoard();
   const { visible: snackbarVisible, nonce: snackbarNonce, dismissSnackbar } = useQueueSnackbar();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
@@ -312,13 +312,6 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // Tap a queue item → make it current and show it in the play drawer.
   const handleQueueClimbPress = useCallback(
     (item: ClimbQueueItem) => {
-      const isPartyPreviewOnly =
-        sessionId !== null &&
-        !deriveIsDriver({
-          isPersistentSessionActive: true,
-          participantId,
-          driverParticipantId,
-        });
       if (isPartyPreviewOnly) {
         openPlayDrawer(item.climb, { setAsCurrent: false, previewQueueItem: item });
         requestCloseQueueSheet();
@@ -328,7 +321,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       openPlayDrawer(item.climb, { setAsCurrent: false, previewQueueItem: item });
       requestCloseQueueSheet();
     },
-    [driverParticipantId, participantId, sessionId, setCurrentClimb, openPlayDrawer, requestCloseQueueSheet],
+    [isPartyPreviewOnly, setCurrentClimb, openPlayDrawer, requestCloseQueueSheet],
   );
 
   // Tap a suggestion → activate it with a suggestion source built from the
@@ -338,13 +331,6 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     (climb: QueueClimb, source: PlaylistSuggestionSource) => {
       const item = climbToQueueItem(climb, { suggested: true });
       const schemaClimb = item.climb as Climb;
-      const isPartyPreviewOnly =
-        sessionId !== null &&
-        !deriveIsDriver({
-          isPersistentSessionActive: true,
-          participantId,
-          driverParticipantId,
-        });
       if (isPartyPreviewOnly) {
         openPlayDrawer(schemaClimb, {
           setAsCurrent: false,
@@ -358,7 +344,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       openPlayDrawer(schemaClimb, { setAsCurrent: false, previewQueueItem: item });
       requestCloseQueueSheet();
     },
-    [driverParticipantId, participantId, sessionId, setCurrentClimb, openPlayDrawer, requestCloseQueueSheet],
+    [isPartyPreviewOnly, setCurrentClimb, openPlayDrawer, requestCloseQueueSheet],
   );
 
   // Tick a history climb → open the log-ascent sheet (stacks above the queue

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -32,6 +32,7 @@ import {
   createJoinSessionTracker,
   createReleaseControlOptimisticPlan,
   createTakeControlOptimisticPlan,
+  deriveIsDriver,
   mapSubscriptionEnvelopeToAction,
   shouldRollbackReleaseControlDriver,
   shouldRollbackTakeControlDriver,
@@ -169,6 +170,7 @@ const QueueContext = createContext<QueueContextValue | null>(null);
  * - useActiveClimbUuid(): row-level active-climb highlighting.
  * - useHasActiveClimb(): presence-only bottom chrome metrics.
  * - usePlaylistSuggestionSource(): playlist peek/suggestion navigation.
+ * - useIsPartyPreviewOnly(): party non-driver gating for activation taps.
  */
 type TakeControlOptions = {
   playlistSuggestionSource?: PlaylistSuggestionSource | null;
@@ -274,6 +276,19 @@ type QueuePlaylistSuggestionContextValue = {
 
 const QueuePlaylistSuggestionContext = createContext<QueuePlaylistSuggestionContextValue | null>(null);
 
+/**
+ * Boolean "this client may only preview, not mutate the shared queue" selector
+ * (party session active and someone else — or nobody — is driving). Identity
+ * flips ONLY on session start/end or driver gain/loss, never on queue mutations,
+ * serial changes, or party stat pushes. Consumed by the playlist-activation hook
+ * on the climbs/playlist screens, which must not subscribe to broader contexts.
+ */
+type QueuePartyPreviewOnlyContextValue = {
+  isPartyPreviewOnly: boolean;
+};
+
+const QueuePartyPreviewOnlyContext = createContext<QueuePartyPreviewOnlyContextValue | null>(null);
+
 export function useQueue(): QueueContextValue {
   const context = useContext(QueueContext);
   if (!context) throw new Error('useQueue must be used within QueueProvider');
@@ -325,6 +340,12 @@ export function usePlaylistSuggestionSource(): PlaylistSuggestionSource | null {
   const context = useContext(QueuePlaylistSuggestionContext);
   if (!context) throw new Error('usePlaylistSuggestionSource must be used within QueueProvider');
   return context.playlistSuggestionSource;
+}
+
+export function useIsPartyPreviewOnly(): boolean {
+  const context = useContext(QueuePartyPreviewOnlyContext);
+  if (!context) throw new Error('useIsPartyPreviewOnly must be used within QueueProvider');
+  return context.isPartyPreviewOnly;
 }
 
 const defaultSearchParams: QueueSearchParams = {};
@@ -1445,6 +1466,16 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     [playlistSuggestionSource],
   );
 
+  // Preview-only selector: same derivation as the play drawer's
+  // isPlayDrawerPreviewOnly and the queue sheet's inline deriveIsDriver checks
+  // (a released driver — driverParticipantId null — leaves everyone preview-only).
+  const isPartyPreviewOnly =
+    sessionId !== null && !deriveIsDriver({ isPersistentSessionActive: true, participantId, driverParticipantId });
+  const partyPreviewOnlyValue = useMemo<QueuePartyPreviewOnlyContextValue>(
+    () => ({ isPartyPreviewOnly }),
+    [isPartyPreviewOnly],
+  );
+
   const sessionControlValue = useMemo<QueueSessionControlContextValue>(
     () => ({
       sessionId,
@@ -1476,7 +1507,9 @@ export function QueueProvider({ children }: { children: ReactNode }) {
             <QueuePlaylistSuggestionContext.Provider value={playlistSuggestionValue}>
               <QueueActiveClimbContext.Provider value={activeClimbValue}>
                 <QueueHasActiveClimbContext.Provider value={hasActiveClimbValue}>
-                  <QueueContext.Provider value={contextValue}>{children}</QueueContext.Provider>
+                  <QueuePartyPreviewOnlyContext.Provider value={partyPreviewOnlyValue}>
+                    <QueueContext.Provider value={contextValue}>{children}</QueueContext.Provider>
+                  </QueuePartyPreviewOnlyContext.Provider>
                 </QueueHasActiveClimbContext.Provider>
               </QueueActiveClimbContext.Provider>
             </QueuePlaylistSuggestionContext.Provider>


### PR DESCRIPTION
# Climb list / play drawer bug fixes (mobile GA)

Review of the climb list, its play drawer, and their interactions ahead of GA. The list itself (search, filters, pagination, pull-to-refresh, dedup) checked out — backend paging is 0-indexed end to end and the row memoization follows the repo perf rules. Five real bugs found and fixed:

## 1. Orphan preview item breaks prev-navigation and the queue badge (solo)

Tapping a climb in the list opens the drawer via `usePlaylistActivation` with `setAsCurrent: false` and no `previewQueueItem`, so `PlayDrawer.open()` built queue item #1 (fresh uuid) and pinned it, while the activation flow dispatched a *different* item #2 to the queue. The pinned anchor's uuid was never in the queue, so `findPreviousQueueItem` returned null (prev button + back-swipe disabled despite queue history) and the action bar's remaining count showed `queue.length` instead of 0 — until the user navigated, changed angle, or closed the drawer.

**Fix:** the activation hook builds the queue item once, pins it as `previewQueueItem` (the option the queue-sheet path already uses), and `queueApi.setCurrentClimb` dispatches that exact item (climb-uuid match guards stale refs).

## 2. Party non-driver tap mutated the shared session

The activation hook always dispatched `setCurrentClimb` (optimistic dispatch + WS mutation), changing the session's current climb for everyone — while `PlayDrawer.open()` and both queue-sheet tap paths explicitly gate on preview-only.

**Fix:** new narrow `useIsPartyPreviewOnly()` selector in the queue provider (flips only on session start/end or driver gain/loss — the climbs tab must not subscribe to broader contexts). When preview-only, the activation hook skips dispatching entirely and opens a local preview with a drawer-local suggestion source built from the loaded climbs, mirroring the queue-sheet suggestion path. The lightbulb still promotes the preview via `takeControl(queueItem, { playlistSuggestionSource })`. Covers the climbs list, playlist detail, and smart playlist screens (all use this hook).

## 3. Swipe carousel gesture recomposed mid-session

`canSwipeNext`/`canSwipePrevious` were raw deps of the `Gesture.Pan()` `useMemo`, so the gesture recomposed whenever they flipped (queue boundaries, queue mutations during the 350ms commit window) — the file's own comments document that recomposing mid-session left RNGH stuck on iOS, which is why `enabled`/`reduceMotion`/`boardWidth` were already mirrored into shared values.

**Fix:** mirror both booleans into shared values too; the gesture now composes once per mount. New hook test asserts gesture identity stability plus that the SV-gated clamp/commit still track the latest values.

## 4. Stale `drawerPreviewSuggestionSource` (minor)

The angle-change effect cleared the pinned preview item but not its suggestion source; and when preview-only ended while the drawer was open (took control / session ended), the stale drawer-local source kept shadowing the provider source for displayed peeks while `nextClimb()` committed against the provider source.

**Fix:** angle changes clear both; a transition-gated effect (preview-only true→false) drops drawer-local preview state. A failed `takeControl` (optimistic driver flip + rollback) restores the at-press source together with the restored preview item.

## 5. Unmemoized `ListHeaderComponent` (minor perf)

The climb list header was inline JSX recreated on every screen render, churning FlashList's header. Now memoized.

## Ruled out during review

- Pagination off-by-one: backend `searchClimbs` is 0-indexed (`offset(page * pageSize)`), matching `getNextPageParam`.
- "Index drift" on queue mutations: navigation recomputes indices by uuid at call time against `stateRef.current`.
- Known/tracked, untouched: the drawer heart always starts unfavorited (favorites store gap, #2449).

## Validation

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` ✅ — 190 files, 1395 tests (includes new `use-carousel-gesture.test.ts` and 6 new activation-hook cases)
- `vp run check:mobile-bundle` ✅ — Android Metro bundle OK (10.6 MB)
- `vp check` ✅ on touched files (remaining repo formatting drift is pre-existing on `main` in files this PR doesn't touch)

## Manual QA (needs a device/simulator — this env is Linux)

- Solo: tap a climb from the list with items already queued → prev arrow enabled, remaining-count badge 0, back-swipe returns to the prior climb.
- Party as non-driver: tap a climb in the list → drawer opens as preview, peers' current climb does NOT change; lightbulb take-control promotes the previewed climb + playlist source.
- Drawer: swipe rapidly to the queue tail and back; gesture must not wedge.
- Change angle while previewing from a playlist → peeks stop following the old playlist source.

https://claude.ai/code/session_01MciHx4SJ7vxnAwQigh5Qem

---
_Generated by [Claude Code](https://claude.ai/code/session_01MciHx4SJ7vxnAwQigh5Qem)_