### PR TITLE
fix(mobile): play drawer intermittently blank when reopened on another climb

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -38,7 +38,7 @@ import { useShareClimb } from '../../hooks/use-share-climb';
 import { getBoardRenderData } from '../../lib/board-details';
 import { hapticSuccess } from '../../lib/haptics';
 import { usePlayDrawerWakeLock } from './use-play-drawer-wake-lock';
-import { createSheetOpenSerializer } from './sheet-open-serializer';
+import { useDeferredSheetOpen } from './use-deferred-sheet-open';
 import {
   buildPlayDrawerBoardLayout,
   derivePlayDrawerLightbulbPressAction,
@@ -108,11 +108,6 @@ const DEFAULT_BETA_HEADER_HEIGHT = 52;
 // rendered inside the content instead; swipe-to-close still works via
 // enablePanDownToClose + enableContentPanningGesture.
 const renderNoHandle = () => null;
-// Safety net for an open() deferred behind an in-flight dismiss animation: if
-// gorhom ever skips the onDismiss that normally flushes the stashed open, this
-// bounded timeout flushes it instead so a tap is never silently dropped. The
-// close animation runs ~250ms; 400ms comfortably outlasts it.
-const DEFERRED_OPEN_FALLBACK_MS = 400;
 
 export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function PlayDrawer(
   { boardConfig, onAngleChange, isAngleAdjustable = true, onOpenQueue },
@@ -136,12 +131,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const [belowFoldContentRequested, setBelowFoldContentRequested] = useState(false);
   const wallControlPressOperationRef = useRef(0);
   const resetZoomRef = useRef<(() => void) | null>(null);
-  // Serializes open() requests against the sheet's dismiss animation: calling
-  // present() mid-dismiss races gorhom's onDismiss, which then fires AFTER the
-  // re-present and wipes isSheetOpen — leaving the sheet visibly open with the
-  // board gated off forever (the intermittent blank-board-on-reopen bug).
-  const openSerializerRef = useRef(createSheetOpenSerializer<{ climb: Climb; options?: PlayDrawerOpenOptions }>());
-  const deferredOpenFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Beta Videos section-header height feeds the first-screen reserve so the
   // header teases at the bottom of the full-screen view (the cue that there's
@@ -333,50 +322,36 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     [cancelPendingWallControlAttempt, state.currentClimbQueueItem, isPartyPreviewOnly, setCurrentClimb],
   );
 
-  // Flush a stashed open once the in-flight dismissal has fully settled.
-  // Idempotent (takePendingOpen is one-shot), so whichever of onDismiss / the
-  // fallback timeout runs first wins and the other is a no-op.
-  const flushPendingOpen = useCallback(() => {
-    if (deferredOpenFallbackRef.current !== null) {
-      clearTimeout(deferredOpenFallbackRef.current);
-      deferredOpenFallbackRef.current = null;
-    }
-    const pendingOpen = openSerializerRef.current.takePendingOpen();
-    if (pendingOpen) openDrawer(pendingOpen.climb, pendingOpen.options);
-  }, [openDrawer]);
-
-  useEffect(
-    () => () => {
-      if (deferredOpenFallbackRef.current !== null) clearTimeout(deferredOpenFallbackRef.current);
-    },
-    [],
+  // Serialize open() against the sheet's dismiss animation: presenting
+  // mid-dismiss races gorhom's onDismiss, which then fires AFTER the re-present
+  // and wipes isSheetOpen — leaving the sheet visibly open with the board gated
+  // off forever (the intermittent blank-board-on-reopen bug). The hook stashes
+  // an open requested mid-dismiss and replays it once the dismissal settles.
+  const openDrawerArgs = useCallback(
+    (args: { climb: Climb; options?: PlayDrawerOpenOptions }) => openDrawer(args.climb, args.options),
+    [openDrawer],
   );
+  const { requestOpen, onAnimate: handleSheetAnimateIndex, flushOnDismiss } = useDeferredSheetOpen(openDrawerArgs);
 
   useImperativeHandle(
     ref,
     () => ({
       open: (selectedClimb: Climb, options?: PlayDrawerOpenOptions) => {
-        const decision = openSerializerRef.current.requestOpen({ climb: selectedClimb, options });
-        if (decision === 'deferred') {
-          // The sheet is animating closed; present() now would race onDismiss.
-          // The open replays from handleClose, or from this bounded fallback if
-          // gorhom ever skips the dismiss callback.
-          if (deferredOpenFallbackRef.current !== null) clearTimeout(deferredOpenFallbackRef.current);
-          deferredOpenFallbackRef.current = setTimeout(flushPendingOpen, DEFERRED_OPEN_FALLBACK_MS);
-          return;
-        }
-        openDrawer(selectedClimb, options);
+        requestOpen({ climb: selectedClimb, options });
       },
       close: () => {
         sheetRef.current?.dismiss();
       },
     }),
-    [openDrawer, flushPendingOpen],
+    [requestOpen],
   );
 
-  const handleSheetAnimate = useCallback((_fromIndex: number, toIndex: number) => {
-    openSerializerRef.current.handleAnimate(toIndex);
-  }, []);
+  const handleSheetAnimate = useCallback(
+    (_fromIndex: number, toIndex: number) => {
+      handleSheetAnimateIndex(toIndex);
+    },
+    [handleSheetAnimateIndex],
+  );
 
   const handleClose = useCallback(() => {
     cancelPendingWallControlAttempt();
@@ -388,8 +363,8 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     setActiveSubDrawer('none');
     // Replay an open() that arrived while this dismissal was animating — the
     // modal is now fully dismissed, so the re-present is clean.
-    flushPendingOpen();
-  }, [cancelPendingWallControlAttempt, flushPendingOpen]);
+    flushOnDismiss();
+  }, [cancelPendingWallControlAttempt, flushOnDismiss]);
 
   const handlePrev = useCallback(() => {
     cancelPendingWallControlAttempt();

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -38,6 +38,7 @@ import { useShareClimb } from '../../hooks/use-share-climb';
 import { getBoardRenderData } from '../../lib/board-details';
 import { hapticSuccess } from '../../lib/haptics';
 import { usePlayDrawerWakeLock } from './use-play-drawer-wake-lock';
+import { createSheetOpenSerializer } from './sheet-open-serializer';
 import {
   buildPlayDrawerBoardLayout,
   derivePlayDrawerLightbulbPressAction,
@@ -107,6 +108,11 @@ const DEFAULT_BETA_HEADER_HEIGHT = 52;
 // rendered inside the content instead; swipe-to-close still works via
 // enablePanDownToClose + enableContentPanningGesture.
 const renderNoHandle = () => null;
+// Safety net for an open() deferred behind an in-flight dismiss animation: if
+// gorhom ever skips the onDismiss that normally flushes the stashed open, this
+// bounded timeout flushes it instead so a tap is never silently dropped. The
+// close animation runs ~250ms; 400ms comfortably outlasts it.
+const DEFERRED_OPEN_FALLBACK_MS = 400;
 
 export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function PlayDrawer(
   { boardConfig, onAngleChange, isAngleAdjustable = true, onOpenQueue },
@@ -130,6 +136,12 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const [belowFoldContentRequested, setBelowFoldContentRequested] = useState(false);
   const wallControlPressOperationRef = useRef(0);
   const resetZoomRef = useRef<(() => void) | null>(null);
+  // Serializes open() requests against the sheet's dismiss animation: calling
+  // present() mid-dismiss races gorhom's onDismiss, which then fires AFTER the
+  // re-present and wipes isSheetOpen — leaving the sheet visibly open with the
+  // board gated off forever (the intermittent blank-board-on-reopen bug).
+  const openSerializerRef = useRef(createSheetOpenSerializer<{ climb: Climb; options?: PlayDrawerOpenOptions }>());
+  const deferredOpenFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Beta Videos section-header height feeds the first-screen reserve so the
   // header teases at the bottom of the full-screen view (the cue that there's
@@ -291,8 +303,8 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     }
   }, [cancelPendingWallControlAttempt, lightbulbState.isPersistentSessionActive, pendingClimbUuid, sessionId]);
 
-  useImperativeHandle(ref, () => ({
-    open: (selectedClimb: Climb, options?: PlayDrawerOpenOptions) => {
+  const openDrawer = useCallback(
+    (selectedClimb: Climb, options?: PlayDrawerOpenOptions) => {
       cancelPendingWallControlAttempt();
       const previewPlaylistSuggestionSource = options?.previewPlaylistSuggestionSource ?? null;
       const shouldShowCurrentQueueItem =
@@ -318,10 +330,53 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       }
       sheetRef.current?.present();
     },
-    close: () => {
-      sheetRef.current?.dismiss();
+    [cancelPendingWallControlAttempt, state.currentClimbQueueItem, isPartyPreviewOnly, setCurrentClimb],
+  );
+
+  // Flush a stashed open once the in-flight dismissal has fully settled.
+  // Idempotent (takePendingOpen is one-shot), so whichever of onDismiss / the
+  // fallback timeout runs first wins and the other is a no-op.
+  const flushPendingOpen = useCallback(() => {
+    if (deferredOpenFallbackRef.current !== null) {
+      clearTimeout(deferredOpenFallbackRef.current);
+      deferredOpenFallbackRef.current = null;
+    }
+    const pendingOpen = openSerializerRef.current.takePendingOpen();
+    if (pendingOpen) openDrawer(pendingOpen.climb, pendingOpen.options);
+  }, [openDrawer]);
+
+  useEffect(
+    () => () => {
+      if (deferredOpenFallbackRef.current !== null) clearTimeout(deferredOpenFallbackRef.current);
     },
-  }));
+    [],
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      open: (selectedClimb: Climb, options?: PlayDrawerOpenOptions) => {
+        const decision = openSerializerRef.current.requestOpen({ climb: selectedClimb, options });
+        if (decision === 'deferred') {
+          // The sheet is animating closed; present() now would race onDismiss.
+          // The open replays from handleClose, or from this bounded fallback if
+          // gorhom ever skips the dismiss callback.
+          if (deferredOpenFallbackRef.current !== null) clearTimeout(deferredOpenFallbackRef.current);
+          deferredOpenFallbackRef.current = setTimeout(flushPendingOpen, DEFERRED_OPEN_FALLBACK_MS);
+          return;
+        }
+        openDrawer(selectedClimb, options);
+      },
+      close: () => {
+        sheetRef.current?.dismiss();
+      },
+    }),
+    [openDrawer, flushPendingOpen],
+  );
+
+  const handleSheetAnimate = useCallback((_fromIndex: number, toIndex: number) => {
+    openSerializerRef.current.handleAnimate(toIndex);
+  }, []);
 
   const handleClose = useCallback(() => {
     cancelPendingWallControlAttempt();
@@ -331,7 +386,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     setIsTickBarActive(false);
     setIsSheetOpen(false);
     setActiveSubDrawer('none');
-  }, [cancelPendingWallControlAttempt]);
+    // Replay an open() that arrived while this dismissal was animating — the
+    // modal is now fully dismissed, so the re-present is clean.
+    flushPendingOpen();
+  }, [cancelPendingWallControlAttempt, flushPendingOpen]);
 
   const handlePrev = useCallback(() => {
     cancelPendingWallControlAttempt();
@@ -630,6 +688,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         backdropComponent={renderBackdrop}
         backgroundComponent={renderBackground}
         handleComponent={renderNoHandle}
+        onAnimate={handleSheetAnimate}
         onDismiss={handleClose}
       >
         <BottomSheetScrollView

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -327,11 +327,11 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   // and wipes isSheetOpen — leaving the sheet visibly open with the board gated
   // off forever (the intermittent blank-board-on-reopen bug). The hook stashes
   // an open requested mid-dismiss and replays it once the dismissal settles.
-  const openDrawerArgs = useCallback(
+  const openDrawerFromArgs = useCallback(
     (args: { climb: Climb; options?: PlayDrawerOpenOptions }) => openDrawer(args.climb, args.options),
     [openDrawer],
   );
-  const { requestOpen, onAnimate: handleSheetAnimateIndex, flushOnDismiss } = useDeferredSheetOpen(openDrawerArgs);
+  const { requestOpen, onAnimate: handleSheetAnimateIndex, flushOnDismiss } = useDeferredSheetOpen(openDrawerFromArgs);
 
   useImperativeHandle(
     ref,

--- a/packages/mobile/src/components/play-drawer/__tests__/sheet-open-serializer.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/sheet-open-serializer.test.ts
@@ -34,6 +34,15 @@ describe('createSheetOpenSerializer', () => {
     expect(serializer.requestOpen('climb-b')).toBe('open-now');
   });
 
+  it('drops a stashed open when the sheet settles back on screen (aborted close)', () => {
+    const serializer = createSheetOpenSerializer<string>();
+    serializer.handleAnimate(-1); // close starts
+    expect(serializer.requestOpen('climb-b')).toBe('deferred'); // stashed mid-close
+    serializer.handleAnimate(0); // close aborted — sheet springs back
+    // The stash must not survive to replay on the next, unrelated close.
+    expect(serializer.takePendingOpen()).toBeNull();
+  });
+
   it('clears the dismissing flag after a flush so the next open is immediate', () => {
     const serializer = createSheetOpenSerializer<string>();
     serializer.handleAnimate(-1);

--- a/packages/mobile/src/components/play-drawer/__tests__/sheet-open-serializer.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/sheet-open-serializer.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { createSheetOpenSerializer } from '../sheet-open-serializer';
+
+describe('createSheetOpenSerializer', () => {
+  it('opens immediately when no dismissal is in flight', () => {
+    const serializer = createSheetOpenSerializer<string>();
+    expect(serializer.requestOpen('climb-a')).toBe('open-now');
+    // Nothing was stashed by an immediate open.
+    expect(serializer.takePendingOpen()).toBeNull();
+  });
+
+  it('defers an open requested mid-dismiss and flushes it on dismiss', () => {
+    const serializer = createSheetOpenSerializer<string>();
+    serializer.handleAnimate(-1); // dismiss animation starts
+    expect(serializer.requestOpen('climb-b')).toBe('deferred');
+    expect(serializer.takePendingOpen()).toBe('climb-b');
+    // Flush is one-shot — a second flush (e.g. timeout fallback after
+    // onDismiss already ran) is a no-op.
+    expect(serializer.takePendingOpen()).toBeNull();
+  });
+
+  it('keeps only the latest request when several arrive while dismissing', () => {
+    const serializer = createSheetOpenSerializer<string>();
+    serializer.handleAnimate(-1);
+    expect(serializer.requestOpen('climb-b')).toBe('deferred');
+    expect(serializer.requestOpen('climb-c')).toBe('deferred');
+    expect(serializer.takePendingOpen()).toBe('climb-c');
+  });
+
+  it('clears the dismissing flag when the sheet settles back on screen', () => {
+    const serializer = createSheetOpenSerializer<string>();
+    serializer.handleAnimate(-1); // swipe-down starts closing…
+    serializer.handleAnimate(0); // …but springs back open
+    expect(serializer.requestOpen('climb-b')).toBe('open-now');
+  });
+
+  it('clears the dismissing flag after a flush so the next open is immediate', () => {
+    const serializer = createSheetOpenSerializer<string>();
+    serializer.handleAnimate(-1);
+    expect(serializer.takePendingOpen()).toBeNull(); // dismissed with nothing stashed
+    expect(serializer.requestOpen('climb-b')).toBe('open-now');
+  });
+
+  it('treats a present animation like any on-screen settle', () => {
+    const serializer = createSheetOpenSerializer<string>();
+    serializer.handleAnimate(-1);
+    serializer.handleAnimate(0); // re-present
+    serializer.handleAnimate(-1); // close again
+    expect(serializer.requestOpen('climb-d')).toBe('deferred');
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/use-deferred-sheet-open.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-deferred-sheet-open.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDeferredSheetOpen } from '../use-deferred-sheet-open';
+
+const FALLBACK_MS = 400;
+
+describe('useDeferredSheetOpen', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('opens immediately when no dismissal is in flight', () => {
+    const openNow = vi.fn();
+    const { result } = renderHook(() => useDeferredSheetOpen(openNow, FALLBACK_MS));
+    act(() => result.current.requestOpen('climb-a'));
+    expect(openNow).toHaveBeenCalledExactlyOnceWith('climb-a');
+  });
+
+  it('defers an open requested mid-dismiss and replays it from onDismiss', () => {
+    const openNow = vi.fn();
+    const { result } = renderHook(() => useDeferredSheetOpen(openNow, FALLBACK_MS));
+    act(() => result.current.onAnimate(-1)); // dismiss animation starts
+    act(() => result.current.requestOpen('climb-b'));
+    expect(openNow).not.toHaveBeenCalled();
+    act(() => result.current.flushOnDismiss());
+    expect(openNow).toHaveBeenCalledExactlyOnceWith('climb-b');
+    // The fallback timer must not fire a second open afterward.
+    act(() => vi.advanceTimersByTime(FALLBACK_MS));
+    expect(openNow).toHaveBeenCalledTimes(1);
+  });
+
+  it('replays the deferred open via the fallback timer when onDismiss never fires', () => {
+    const openNow = vi.fn();
+    const { result } = renderHook(() => useDeferredSheetOpen(openNow, FALLBACK_MS));
+    act(() => result.current.onAnimate(-1));
+    act(() => result.current.requestOpen('climb-b'));
+    expect(openNow).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(FALLBACK_MS)); // gorhom skipped onDismiss
+    expect(openNow).toHaveBeenCalledExactlyOnceWith('climb-b');
+  });
+
+  it('replays through the latest openNow, not the closure captured at schedule time', () => {
+    const firstOpenNow = vi.fn();
+    const secondOpenNow = vi.fn();
+    const { result, rerender } = renderHook(({ openNow }) => useDeferredSheetOpen(openNow, FALLBACK_MS), {
+      initialProps: { openNow: firstOpenNow },
+    });
+    act(() => result.current.onAnimate(-1));
+    act(() => result.current.requestOpen('climb-b'));
+    // State changed during the dismiss window → a fresh openNow identity.
+    rerender({ openNow: secondOpenNow });
+    act(() => vi.advanceTimersByTime(FALLBACK_MS));
+    expect(firstOpenNow).not.toHaveBeenCalled();
+    expect(secondOpenNow).toHaveBeenCalledExactlyOnceWith('climb-b');
+  });
+
+  it('drops a deferred open when the close is aborted (sheet springs back)', () => {
+    const openNow = vi.fn();
+    const { result } = renderHook(() => useDeferredSheetOpen(openNow, FALLBACK_MS));
+    act(() => result.current.onAnimate(-1)); // close starts
+    act(() => result.current.requestOpen('climb-b')); // stashed + fallback armed
+    act(() => result.current.onAnimate(0)); // close aborted — springs back
+    act(() => vi.advanceTimersByTime(FALLBACK_MS));
+    expect(openNow).not.toHaveBeenCalled();
+    // A later, unrelated close must not replay the dropped open either.
+    act(() => result.current.flushOnDismiss());
+    expect(openNow).not.toHaveBeenCalled();
+  });
+
+  it('clears the fallback timer on unmount', () => {
+    const openNow = vi.fn();
+    const { result, unmount } = renderHook(() => useDeferredSheetOpen(openNow, FALLBACK_MS));
+    act(() => result.current.onAnimate(-1));
+    act(() => result.current.requestOpen('climb-b'));
+    unmount();
+    act(() => vi.advanceTimersByTime(FALLBACK_MS));
+    expect(openNow).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/use-deferred-sheet-open.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-deferred-sheet-open.test.ts
@@ -71,6 +71,15 @@ describe('useDeferredSheetOpen', () => {
     expect(openNow).not.toHaveBeenCalled();
   });
 
+  it('replays a falsy stashed value (generic OpenArgs may be falsy)', () => {
+    const openNow = vi.fn();
+    const { result } = renderHook(() => useDeferredSheetOpen<number>(openNow, FALLBACK_MS));
+    act(() => result.current.onAnimate(-1));
+    act(() => result.current.requestOpen(0)); // 0 is a valid, falsy OpenArgs
+    act(() => result.current.flushOnDismiss());
+    expect(openNow).toHaveBeenCalledExactlyOnceWith(0);
+  });
+
   it('clears the fallback timer on unmount', () => {
     const openNow = vi.fn();
     const { result, unmount } = renderHook(() => useDeferredSheetOpen(openNow, FALLBACK_MS));

--- a/packages/mobile/src/components/play-drawer/sheet-open-serializer.ts
+++ b/packages/mobile/src/components/play-drawer/sheet-open-serializer.ts
@@ -1,0 +1,63 @@
+/**
+ * Serializes imperative open() requests against a gorhom BottomSheetModal's
+ * dismiss animation. Calling `present()` while the modal is still animating
+ * closed races its `onDismiss`: the stale dismissal callback fires AFTER the
+ * re-present and wipes the open state (`isSheetOpen` → false), leaving the
+ * sheet visibly presented but with its deferred content gated off forever —
+ * the intermittent "drawer opens but no board renders" bug.
+ *
+ * Instead of presenting mid-dismiss, callers ask the serializer first:
+ * `requestOpen` returns 'open-now' when no dismissal is in flight, or stashes
+ * the request (last one wins) and returns 'deferred'. The stash is flushed via
+ * `takePendingOpen()` from the modal's `onDismiss`, once the dismissal has
+ * fully completed and the state reset has run — so the re-present always
+ * targets a cleanly dismissed modal.
+ *
+ * Pure TS (no React, no timers) so the open/dismiss interleavings are unit
+ * testable; the consuming component owns the refs and any timeout fallback.
+ */
+
+export type SheetOpenSerializer<OpenArgs> = {
+  /**
+   * Ask to open the sheet. Returns 'open-now' when it's safe to present
+   * immediately; otherwise stashes `args` (replacing any earlier stash) and
+   * returns 'deferred' — the caller opens later via `takePendingOpen()`.
+   */
+  requestOpen: (args: OpenArgs) => 'open-now' | 'deferred';
+  /**
+   * Wire to the modal's `onAnimate(fromIndex, toIndex)` with `toIndex`. The
+   * sheet is dismissing exactly while it's settling toward index -1; settling
+   * to any on-screen index (present, or a spring-back from an aborted swipe)
+   * clears the flag.
+   */
+  handleAnimate: (toIndex: number) => void;
+  /**
+   * Take the stashed open request, if any, clearing it and the dismissing
+   * flag. Wire to the modal's `onDismiss` (after the close-state reset) and to
+   * any caller-side timeout fallback — idempotent, so whichever flush runs
+   * first wins and the other is a no-op.
+   */
+  takePendingOpen: () => OpenArgs | null;
+};
+
+export function createSheetOpenSerializer<OpenArgs>(): SheetOpenSerializer<OpenArgs> {
+  let isDismissing = false;
+  let pendingOpen: OpenArgs | null = null;
+
+  return {
+    requestOpen: (args) => {
+      if (!isDismissing) return 'open-now';
+      pendingOpen = args;
+      return 'deferred';
+    },
+    handleAnimate: (toIndex) => {
+      isDismissing = toIndex === -1;
+    },
+    takePendingOpen: () => {
+      isDismissing = false;
+      const taken = pendingOpen;
+      pendingOpen = null;
+      return taken;
+    },
+  };
+}

--- a/packages/mobile/src/components/play-drawer/sheet-open-serializer.ts
+++ b/packages/mobile/src/components/play-drawer/sheet-open-serializer.ts
@@ -28,7 +28,10 @@ export type SheetOpenSerializer<OpenArgs> = {
    * Wire to the modal's `onAnimate(fromIndex, toIndex)` with `toIndex`. The
    * sheet is dismissing exactly while it's settling toward index -1; settling
    * to any on-screen index (present, or a spring-back from an aborted swipe)
-   * clears the flag.
+   * clears the dismissing flag AND drops any stashed open — that stash's only
+   * legitimate consumer is the dismissal's `onDismiss`, which won't fire if the
+   * sheet is staying on screen, so leaving it would replay an old climb on the
+   * next real close.
    */
   handleAnimate: (toIndex: number) => void;
   /**
@@ -51,7 +54,16 @@ export function createSheetOpenSerializer<OpenArgs>(): SheetOpenSerializer<OpenA
       return 'deferred';
     },
     handleAnimate: (toIndex) => {
-      isDismissing = toIndex === -1;
+      if (toIndex === -1) {
+        isDismissing = true;
+        return;
+      }
+      // Settled back on screen (spring-back from an aborted close, or a
+      // present): the dismissal that stashed an open is no longer happening, so
+      // its `onDismiss` won't fire to consume the stash. Drop it now so it can't
+      // replay on the next, unrelated close.
+      isDismissing = false;
+      pendingOpen = null;
     },
     takePendingOpen: () => {
       isDismissing = false;

--- a/packages/mobile/src/components/play-drawer/use-deferred-sheet-open.ts
+++ b/packages/mobile/src/components/play-drawer/use-deferred-sheet-open.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { createSheetOpenSerializer } from './sheet-open-serializer';
+
+/**
+ * Bounded fallback for an open() deferred behind an in-flight dismiss
+ * animation. The close animation runs ~250ms and normally completes with an
+ * `onDismiss` that flushes the stash; 400ms comfortably outlasts that, so this
+ * only actually fires when `onDismiss` is genuinely starved (the stall the
+ * original deferral guards against). A tap is then still never dropped.
+ */
+const DEFAULT_FALLBACK_MS = 400;
+
+type DeferredSheetOpen<OpenArgs> = {
+  /**
+   * Request an open. Opens immediately when no dismissal is in flight;
+   * otherwise stashes the args (last wins) to replay once the dismissal
+   * settles — via `flushOnDismiss`, or the bounded fallback timer.
+   */
+  requestOpen: (args: OpenArgs) => void;
+  /** Wire to the modal's `onAnimate(fromIndex, toIndex)` with `toIndex`. */
+  onAnimate: (toIndex: number) => void;
+  /** Wire to the modal's `onDismiss`, after the close-state reset. */
+  flushOnDismiss: () => void;
+};
+
+/**
+ * Coordinates imperative sheet open() requests against a gorhom
+ * BottomSheetModal's dismiss animation, so a re-present never races the
+ * dismissal's `onDismiss` (the bug where the stale `onDismiss` wipes
+ * `isSheetOpen` after the re-present, leaving the sheet open but its deferred
+ * content gated off forever).
+ *
+ * Wraps the pure {@link createSheetOpenSerializer} with the React/timer
+ * concerns:
+ *   - the fallback timer always replays through the LATEST `openNow` (held in a
+ *     ref) so a closure captured at schedule time can't reopen with stale state
+ *     (e.g. a `currentClimbQueueItem` that changed during the dismiss window);
+ *   - a spring-back / abort (`onAnimate` to an on-screen index) drops the
+ *     pending timer alongside the serializer's stash, so nothing replays;
+ *   - the timer is cleared on unmount.
+ */
+export function useDeferredSheetOpen<OpenArgs>(
+  openNow: (args: OpenArgs) => void,
+  fallbackMs: number = DEFAULT_FALLBACK_MS,
+): DeferredSheetOpen<OpenArgs> {
+  const serializerRef = useRef(createSheetOpenSerializer<OpenArgs>());
+  const fallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Always replay through the current openNow, never the one captured when the
+  // timer was scheduled.
+  const openNowRef = useRef(openNow);
+  openNowRef.current = openNow;
+
+  const clearFallback = useCallback(() => {
+    if (fallbackTimerRef.current !== null) {
+      clearTimeout(fallbackTimerRef.current);
+      fallbackTimerRef.current = null;
+    }
+  }, []);
+
+  // Flush a stashed open once the dismissal has settled. One-shot via
+  // takePendingOpen, so whichever of onDismiss / the fallback timer runs first
+  // wins and the other is a no-op.
+  const flush = useCallback(() => {
+    clearFallback();
+    const pending = serializerRef.current.takePendingOpen();
+    if (pending) openNowRef.current(pending);
+  }, [clearFallback]);
+
+  const requestOpen = useCallback(
+    (args: OpenArgs) => {
+      if (serializerRef.current.requestOpen(args) === 'open-now') {
+        openNowRef.current(args);
+        return;
+      }
+      // Deferred behind an in-flight dismiss: present() now would race
+      // onDismiss. Replay from onDismiss, or from this bounded fallback if
+      // gorhom ever skips it.
+      clearFallback();
+      fallbackTimerRef.current = setTimeout(flush, fallbackMs);
+    },
+    [clearFallback, flush, fallbackMs],
+  );
+
+  const onAnimate = useCallback(
+    (toIndex: number) => {
+      serializerRef.current.handleAnimate(toIndex);
+      // Settled back on screen: the serializer dropped the stash, so the
+      // pending fallback can only no-op — drop it too.
+      if (toIndex !== -1) clearFallback();
+    },
+    [clearFallback],
+  );
+
+  useEffect(() => clearFallback, [clearFallback]);
+
+  return { requestOpen, onAnimate, flushOnDismiss: flush };
+}

--- a/packages/mobile/src/components/play-drawer/use-deferred-sheet-open.ts
+++ b/packages/mobile/src/components/play-drawer/use-deferred-sheet-open.ts
@@ -63,7 +63,9 @@ export function useDeferredSheetOpen<OpenArgs>(
   const flush = useCallback(() => {
     clearFallback();
     const pending = serializerRef.current.takePendingOpen();
-    if (pending) openNowRef.current(pending);
+    // Explicit null check: OpenArgs is generic and could itself be falsy, so a
+    // truthy test would wrongly skip a legitimately stashed value.
+    if (pending !== null) openNowRef.current(pending);
   }, [clearFallback]);
 
   const requestOpen = useCallback(


### PR DESCRIPTION
## Bug

Opening the play drawer usually renders the board + climb, but intermittently — specifically when closing the drawer and reopening it by pressing **another** climb — the board area renders nothing. Closing and reopening on the **same** climb always recovers.

## Root cause

`PlayDrawer` is a gorhom `BottomSheetModal` whose `onDismiss` only fires when the close animation **completes** (~250 ms after the close starts). The race:

1. User closes the drawer → dismiss animation starts.
2. Before that dismissal's `onDismiss` lands on the JS thread, the user taps a different climb. The imperative `open()` sets `drawerPreviewItem` to the new climb, `setIsSheetOpen(true)`, and calls `present()` — while the modal is still dismissing.
3. The stale dismissal's `onDismiss` then fires and `handleClose()` wipes the state `open()` just set: `drawerPreviewItem = null`, `isSheetOpen = false`.
4. The sheet ends up visually presented (the header falls back to `state.currentClimbQueueItem`), but `DeferredBoard open={isSheetOpen}` is now `false`, so `useDeferredAfterInteractions` keeps `ready = false` forever → the board section shows only the gray placeholder. #2645's (`ae81b43`) timeout safety net can't arm because the gate's `active` input itself is `false`.
5. Re-pressing any climb runs `open()` with no dismissal in flight → renders fine — which is why reopening the same climb always recovered.

## Fix

Never `present()` while a dismissal is in flight — serialize the reopen:

- **`sheet-open-serializer.ts`** (pure TS, unit-tested): tracks dismissal-in-flight via the modal's `onAnimate` (`toIndex === -1`), stashes an `open()` requested mid-dismiss (last one wins), and hands it back one-shot via `takePendingOpen()`.
- **`PlayDrawer.tsx`**: the imperative `open()` asks the serializer first; if deferred, the open replays from `onDismiss` after the close-state reset, so the re-present always targets a cleanly dismissed modal. A bounded 400 ms fallback flushes the stash if gorhom ever skips `onDismiss`, so a tap can never be silently dropped.

All drawer-open paths (climb list, queue sheet, session views, playlists, persistent queue bar) funnel through this one imperative handle, so every caller is covered.

## Validation

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` — 190 files / 1392 tests pass, including 6 new serializer tests ✅
- `vp run check` ✅ (only pre-existing formatter drift in unrelated files, left untouched)
- `vp run check:mobile-bundle` ✅ (Android bundle OK)

### Manual repro for device QA

Open a climb from the list → swipe the drawer down → immediately (during / right after the close animation) tap a **different** climb. Before this fix the board area intermittently stayed a blank gray placeholder; after, the drawer closes and reopens with the new climb's board rendered every time.

https://claude.ai/code/session_01KpD2Ww87a78vqa92pR78cG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpD2Ww87a78vqa92pR78cG)_