### PR TITLE
[codex] Fix workout preview row layout

### DIFF
--- a/packages/mobile/src/components/session-screen/pre-session/WorkoutPreviewRow.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/WorkoutPreviewRow.tsx
@@ -6,6 +6,7 @@ import { ClimbListItemContent } from '../../ClimbListItemContent';
 import { THUMBNAIL_WIDTH } from '../../ClimbListThumbnail';
 import { Icon } from '../../Icon';
 import { PressableSurface } from '../../PressableSurface';
+import { Text } from '../../Text';
 import type { QueueItemRowBoard } from '../../QueueItemRow';
 import { useTheme } from '../../../providers/theme-provider';
 import { iosSystemColors } from '../../../theme/ios-colors';
@@ -67,18 +68,22 @@ function WorkoutPreviewRowComponent({
     onRefresh(item.uuid);
   }, [item.uuid, onRefresh]);
 
-  const climbName = item.climb?.name ?? sessionT('mobile.queue.unknownClimb');
-  const formattedGrade = formatGrade(item.climb.difficulty) ?? item.climb.difficulty;
-  const quality = Number(formatQuality(item.climb.quality_average));
-  const rowAccessibilityLabel = [
-    climbName,
-    formattedGrade,
-    item.climb.ascensionist_count > 0 ? formatSends(item.climb.ascensionist_count, climbsT) : null,
-    quality > 0 ? sessionT('playView.tickBar.starRating', { count: quality }) : null,
-    item.climb.setter_username,
-  ]
-    .filter(Boolean)
-    .join(', ');
+  const climb: ClimbQueueItem['climb'] | null | undefined = item.climb;
+  const climbName = climb?.name ?? sessionT('mobile.queue.unknownClimb');
+  const formattedGrade = climb ? (formatGrade(climb.difficulty) ?? climb.difficulty) : null;
+  const quality = climb ? Number(formatQuality(climb.quality_average)) : 0;
+  const qualityStarCount = Math.round(quality);
+  const rowAccessibilityLabel = climb
+    ? [
+        climbName,
+        formattedGrade,
+        climb.ascensionist_count > 0 ? formatSends(climb.ascensionist_count, climbsT) : null,
+        qualityStarCount > 0 ? sessionT('playView.tickBar.starRating', { count: qualityStarCount }) : null,
+        climb.setter_username,
+      ]
+        .filter(Boolean)
+        .join(', ')
+    : climbName;
 
   return (
     <View>
@@ -97,14 +102,20 @@ function WorkoutPreviewRowComponent({
           accessibilityState={{ selected: isActive }}
           style={styles.rowButton}
         >
-          <ClimbListItemContent
-            climb={item.climb}
-            boardName={board.boardName}
-            layoutId={board.layoutId}
-            sizeId={board.sizeId}
-            setIds={board.setIds}
-            angle={board.angle}
-          />
+          {climb ? (
+            <ClimbListItemContent
+              climb={climb}
+              boardName={board.boardName}
+              layoutId={board.layoutId}
+              sizeId={board.sizeId}
+              setIds={board.setIds}
+              angle={board.angle}
+            />
+          ) : (
+            <Text variant="body" color={systemColors.secondaryLabel} numberOfLines={1} style={styles.missingClimbText}>
+              {climbName}
+            </Text>
+          )}
         </PressableSurface>
 
         <PressableSurface
@@ -138,7 +149,7 @@ function WorkoutPreviewRowComponent({
 export const WorkoutPreviewRow = memo(WorkoutPreviewRowComponent, (prev, next) => {
   return (
     prev.item.uuid === next.item.uuid &&
-    prev.item.climb.uuid === next.item.climb.uuid &&
+    prev.item.climb?.uuid === next.item.climb?.uuid &&
     prev.isActive === next.isActive &&
     prev.isRefreshing === next.isRefreshing &&
     prev.refreshDisabled === next.refreshDisabled &&
@@ -165,6 +176,10 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
     paddingLeft: spacing[3],
     paddingRight: spacing[2],
+  },
+  missingClimbText: {
+    flex: 1,
+    fontWeight: '600',
   },
   refreshButton: {
     width: 44,

--- a/packages/mobile/src/components/session-screen/pre-session/WorkoutPreviewRow.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/WorkoutPreviewRow.tsx
@@ -11,6 +11,8 @@ import { useTheme } from '../../../providers/theme-provider';
 import { iosSystemColors } from '../../../theme/ios-colors';
 import { spacing } from '../../../theme/tokens';
 import { hapticSelection } from '../../../lib/haptics';
+import { formatQuality, formatSends } from '../../../lib/format-climb-stats';
+import { useGradeFormat } from '../../../hooks/use-grade-format';
 
 type WorkoutPreviewRowProps = {
   item: ClimbQueueItem;
@@ -46,7 +48,9 @@ function WorkoutPreviewRowComponent({
   onRefresh,
 }: WorkoutPreviewRowProps) {
   const { systemColors, brandColors, opacity } = useTheme();
-  const { t } = useTranslation('session');
+  const { t: sessionT } = useTranslation('session');
+  const { t: climbsT } = useTranslation('climbs');
+  const { formatGrade } = useGradeFormat();
   // Blocked while this row spins, or while another row holds the single refresh
   // slot. Only this row shows a spinner; the rest dim to read as "busy, wait".
   const refreshBlocked = isRefreshing || refreshDisabled;
@@ -63,7 +67,18 @@ function WorkoutPreviewRowComponent({
     onRefresh(item.uuid);
   }, [item.uuid, onRefresh]);
 
-  const climbName = item.climb?.name ?? t('mobile.queue.unknownClimb');
+  const climbName = item.climb?.name ?? sessionT('mobile.queue.unknownClimb');
+  const formattedGrade = formatGrade(item.climb.difficulty) ?? item.climb.difficulty;
+  const quality = Number(formatQuality(item.climb.quality_average));
+  const rowAccessibilityLabel = [
+    climbName,
+    formattedGrade,
+    item.climb.ascensionist_count > 0 ? formatSends(item.climb.ascensionist_count, climbsT) : null,
+    quality > 0 ? sessionT('playView.tickBar.starRating', { count: quality }) : null,
+    item.climb.setter_username,
+  ]
+    .filter(Boolean)
+    .join(', ');
 
   return (
     <View>
@@ -78,7 +93,7 @@ function WorkoutPreviewRowComponent({
           onPress={handlePress}
           feedback="opacity"
           accessibilityRole="button"
-          accessibilityLabel={climbName}
+          accessibilityLabel={rowAccessibilityLabel}
           accessibilityState={{ selected: isActive }}
           style={styles.rowButton}
         >
@@ -97,8 +112,9 @@ function WorkoutPreviewRowComponent({
           disabled={refreshBlocked}
           feedback="scale"
           hitSlop={2}
+          rippleBorderless
           accessibilityRole="button"
-          accessibilityLabel={t('mobile.session.preRegenerateClimbForClimb', { name: climbName })}
+          accessibilityLabel={sessionT('mobile.session.preRegenerateClimbForClimb', { name: climbName })}
           accessibilityState={{ disabled: refreshBlocked, busy: isRefreshing }}
           style={[styles.refreshButton, refreshDisabled && !isRefreshing ? { opacity: opacity.disabled } : null]}
         >
@@ -140,8 +156,6 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     alignItems: 'center',
-    columnGap: spacing[3],
-    paddingHorizontal: spacing[3],
   },
   rowButton: {
     flex: 1,
@@ -149,13 +163,17 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     columnGap: spacing[3],
     paddingVertical: spacing[2],
+    paddingLeft: spacing[3],
+    paddingRight: spacing[2],
   },
   refreshButton: {
     width: 44,
     height: 44,
     alignItems: 'center',
     justifyContent: 'center',
+    borderRadius: 22,
     flexShrink: 0,
+    marginRight: spacing[3],
   },
   separator: {
     height: StyleSheet.hairlineWidth,

--- a/packages/mobile/src/components/session-screen/pre-session/WorkoutPreviewRow.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/WorkoutPreviewRow.tsx
@@ -145,6 +145,9 @@ const styles = StyleSheet.create({
   },
   rowButton: {
     flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: spacing[3],
     paddingVertical: spacing[2],
   },
   refreshButton: {

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-row.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-row.test.tsx
@@ -12,6 +12,7 @@ const surfaces = vi.hoisted(() => ({
     label?: string;
     disabled?: boolean;
     accessibilityState?: Record<string, unknown>;
+    rippleBorderless?: boolean;
     style?: unknown;
   }>,
 }));
@@ -27,24 +28,35 @@ vi.mock('../../../PressableSurface', () => ({
     accessibilityLabel,
     disabled,
     accessibilityState,
+    rippleBorderless,
     style,
     children,
   }: {
     accessibilityLabel?: string;
     disabled?: boolean;
     accessibilityState?: Record<string, unknown>;
+    rippleBorderless?: boolean;
     style?: unknown;
     children?: ReactNode;
   }) => {
-    surfaces.entries.push({ label: accessibilityLabel, disabled, accessibilityState, style });
+    surfaces.entries.push({ label: accessibilityLabel, disabled, accessibilityState, rippleBorderless, style });
     return createElement('button', null, children);
   },
 }));
 
-vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number; formattedCount?: string }) => {
+      if (key === 'sends') return `${options?.formattedCount ?? options?.count} sends`;
+      if (key === 'playView.tickBar.starRating') return `${options?.count} stars`;
+      return key;
+    },
+  }),
+}));
 vi.mock('../../../ClimbListItemContent', () => ({ ClimbListItemContent: () => null }));
 vi.mock('../../../ClimbListThumbnail', () => ({ THUMBNAIL_WIDTH: 64 }));
 vi.mock('../../../Icon', () => ({ Icon: () => createElement('span', { 'data-testid': 'refresh-icon' }) }));
+vi.mock('../../../../hooks/use-grade-format', () => ({ useGradeFormat: () => ({ formatGrade: () => 'V4' }) }));
 vi.mock('../../../../providers/theme-provider', () => ({
   useTheme: () => ({ systemColors: {}, brandColors: { primary: '#000' }, opacity: { disabled: 0.5 } }),
 }));
@@ -55,12 +67,22 @@ vi.mock('../../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
 import { WorkoutPreviewRow } from '../WorkoutPreviewRow';
 
 const board = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 } as QueueItemRowBoard;
-const item = { uuid: 'qi-1', climb: { uuid: 'c1', name: 'Test Climb' } } as unknown as ClimbQueueItem;
+const item = {
+  uuid: 'qi-1',
+  climb: {
+    uuid: 'c1',
+    name: 'Test Climb',
+    difficulty: '12',
+    ascensionist_count: 12,
+    quality_average: '4.2',
+    setter_username: 'setter',
+  },
+} as unknown as ClimbQueueItem;
 
 // The mocked `t` returns the key, so the refresh button surfaces under its key.
 const REFRESH_LABEL = 'mobile.session.preRegenerateClimbForClimb';
 const refreshButton = () => surfaces.entries.find((entry) => entry.label === REFRESH_LABEL);
-const rowButton = () => surfaces.entries.find((entry) => entry.label === item.climb.name);
+const rowButton = () => surfaces.entries.find((entry) => entry.label?.startsWith(item.climb.name));
 
 function renderRow(overrides: { isRefreshing: boolean; refreshDisabled: boolean }) {
   return render(
@@ -85,10 +107,16 @@ describe('WorkoutPreviewRow refresh button', () => {
     expect(JSON.stringify(rowButton()?.style)).toContain('"flexDirection":"row"');
   });
 
+  it('announces the visible climb details on the row action', () => {
+    renderRow({ isRefreshing: false, refreshDisabled: false });
+    expect(rowButton()?.label).toBe('Test Climb, V4, 12 sends, 4.2 stars, setter');
+  });
+
   it('is tappable when no row is regenerating', () => {
     renderRow({ isRefreshing: false, refreshDisabled: false });
     expect(refreshButton()?.disabled).toBe(false);
     expect(refreshButton()?.accessibilityState).toMatchObject({ disabled: false, busy: false });
+    expect(refreshButton()?.rippleBorderless).toBe(true);
   });
 
   it('is disabled (and busy=false) while a different row regenerates', () => {

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-row.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-row.test.tsx
@@ -8,7 +8,12 @@ import type { QueueItemRowBoard } from '../../../QueueItemRow';
 // Each PressableSurface render lands here so the test can read the refresh
 // button's disabled/accessibility state.
 const surfaces = vi.hoisted(() => ({
-  entries: [] as Array<{ label?: string; disabled?: boolean; accessibilityState?: Record<string, unknown> }>,
+  entries: [] as Array<{
+    label?: string;
+    disabled?: boolean;
+    accessibilityState?: Record<string, unknown>;
+    style?: unknown;
+  }>,
 }));
 
 vi.mock('react-native', () => ({
@@ -22,14 +27,16 @@ vi.mock('../../../PressableSurface', () => ({
     accessibilityLabel,
     disabled,
     accessibilityState,
+    style,
     children,
   }: {
     accessibilityLabel?: string;
     disabled?: boolean;
     accessibilityState?: Record<string, unknown>;
+    style?: unknown;
     children?: ReactNode;
   }) => {
-    surfaces.entries.push({ label: accessibilityLabel, disabled, accessibilityState });
+    surfaces.entries.push({ label: accessibilityLabel, disabled, accessibilityState, style });
     return createElement('button', null, children);
   },
 }));
@@ -53,6 +60,7 @@ const item = { uuid: 'qi-1', climb: { uuid: 'c1', name: 'Test Climb' } } as unkn
 // The mocked `t` returns the key, so the refresh button surfaces under its key.
 const REFRESH_LABEL = 'mobile.session.preRegenerateClimbForClimb';
 const refreshButton = () => surfaces.entries.find((entry) => entry.label === REFRESH_LABEL);
+const rowButton = () => surfaces.entries.find((entry) => entry.label === item.climb.name);
 
 function renderRow(overrides: { isRefreshing: boolean; refreshDisabled: boolean }) {
   return render(
@@ -72,6 +80,11 @@ beforeEach(() => {
 });
 
 describe('WorkoutPreviewRow refresh button', () => {
+  it('lays out the climb content horizontally', () => {
+    renderRow({ isRefreshing: false, refreshDisabled: false });
+    expect(JSON.stringify(rowButton()?.style)).toContain('"flexDirection":"row"');
+  });
+
   it('is tappable when no row is regenerating', () => {
     renderRow({ isRefreshing: false, refreshDisabled: false });
     expect(refreshButton()?.disabled).toBe(false);

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-row.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-row.test.tsx
@@ -56,6 +56,9 @@ vi.mock('react-i18next', () => ({
 vi.mock('../../../ClimbListItemContent', () => ({ ClimbListItemContent: () => null }));
 vi.mock('../../../ClimbListThumbnail', () => ({ THUMBNAIL_WIDTH: 64 }));
 vi.mock('../../../Icon', () => ({ Icon: () => createElement('span', { 'data-testid': 'refresh-icon' }) }));
+vi.mock('../../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
 vi.mock('../../../../hooks/use-grade-format', () => ({ useGradeFormat: () => ({ formatGrade: () => 'V4' }) }));
 vi.mock('../../../../providers/theme-provider', () => ({
   useTheme: () => ({ systemColors: {}, brandColors: { primary: '#000' }, opacity: { disabled: 0.5 } }),
@@ -83,11 +86,18 @@ const item = {
 const REFRESH_LABEL = 'mobile.session.preRegenerateClimbForClimb';
 const refreshButton = () => surfaces.entries.find((entry) => entry.label === REFRESH_LABEL);
 const rowButton = () => surfaces.entries.find((entry) => entry.label?.startsWith(item.climb.name));
+const flattenStyle = (style: unknown): Record<string, unknown> => {
+  if (Array.isArray(style)) {
+    return Object.assign({}, ...style.map((entry) => flattenStyle(entry)));
+  }
+  if (style && typeof style === 'object') return style as Record<string, unknown>;
+  return {};
+};
 
-function renderRow(overrides: { isRefreshing: boolean; refreshDisabled: boolean }) {
+function renderRow(overrides: { isRefreshing: boolean; refreshDisabled: boolean; item?: ClimbQueueItem }) {
   return render(
     createElement(WorkoutPreviewRow, {
-      item,
+      item: overrides.item ?? item,
       board,
       isActive: false,
       onPress: vi.fn(),
@@ -104,12 +114,18 @@ beforeEach(() => {
 describe('WorkoutPreviewRow refresh button', () => {
   it('lays out the climb content horizontally', () => {
     renderRow({ isRefreshing: false, refreshDisabled: false });
-    expect(JSON.stringify(rowButton()?.style)).toContain('"flexDirection":"row"');
+    expect(flattenStyle(rowButton()?.style)).toMatchObject({ flexDirection: 'row', alignItems: 'center' });
   });
 
   it('announces the visible climb details on the row action', () => {
     renderRow({ isRefreshing: false, refreshDisabled: false });
-    expect(rowButton()?.label).toBe('Test Climb, V4, 12 sends, 4.2 stars, setter');
+    expect(rowButton()?.label).toBe('Test Climb, V4, 12 sends, 4 stars, setter');
+  });
+
+  it('falls back safely when the climb payload is missing', () => {
+    const missingClimbItem = { uuid: 'qi-missing' } as unknown as ClimbQueueItem;
+    renderRow({ item: missingClimbItem, isRefreshing: false, refreshDisabled: false });
+    expect(surfaces.entries[0]?.label).toBe('mobile.queue.unknownClimb');
   });
 
   it('is tappable when no row is regenerating', () => {

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -43,7 +43,6 @@
     "ordinalSecond": "{{n}}nd",
     "ordinalThird": "{{n}}rd",
     "ordinalDefault": "{{n}}th",
-    "sessionNotesPlaceholder": "Session notes or goal...",
     "noClimbsYet": "No climbs yet",
     "logSomeClimbs": "Log some climbs to see your grade breakdown",
     "climbsLogged_one": "{{count}} climb logged",
@@ -72,11 +71,6 @@
     "notFound": {
       "title": "Session Not Found",
       "subtitle": "This session could not be found. It may have been removed."
-    },
-    "userSearch": {
-      "title": "Add Climber",
-      "placeholder": "Search by name...",
-      "noUsersFound": "No users found"
     }
   },
   "join": {
@@ -475,13 +469,7 @@
   },
   "mobileDetail": {
     "notFound": "Session not found",
-    "editTitle": "Edit session",
-    "nameLabel": "Name",
-    "goalLabel": "Goal",
-    "save": "Save",
     "participants": "Climbers",
-    "updated": "Session updated",
-    "updateError": "Couldn't update session",
     "title": "Session"
   },
   "mobileJoin": {

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -43,7 +43,6 @@
     "ordinalSecond": "{{n}}º",
     "ordinalThird": "{{n}}º",
     "ordinalDefault": "{{n}}º",
-    "sessionNotesPlaceholder": "Notas de la sesión u objetivo...",
     "noClimbsYet": "Sin bloques todavía",
     "logSomeClimbs": "Registra algunos bloques para ver el desglose por grados",
     "climbsLogged_one": "{{count}} bloque registrado",
@@ -72,11 +71,6 @@
     "notFound": {
       "title": "Sesión no encontrada",
       "subtitle": "No se pudo encontrar esta sesión. Puede que haya sido eliminada."
-    },
-    "userSearch": {
-      "title": "Añadir escalador",
-      "placeholder": "Buscar por nombre...",
-      "noUsersFound": "No se encontraron usuarios"
     }
   },
   "join": {
@@ -475,13 +469,7 @@
   },
   "mobileDetail": {
     "notFound": "Sesión no encontrada",
-    "editTitle": "Editar sesión",
-    "nameLabel": "Nombre",
-    "goalLabel": "Objetivo",
-    "save": "Guardar",
     "participants": "Escaladores",
-    "updated": "Sesión actualizada",
-    "updateError": "No se pudo actualizar la sesión",
     "title": "Sesión"
   },
   "mobileJoin": {

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -43,7 +43,6 @@
     "ordinalSecond": "{{n}}e",
     "ordinalThird": "{{n}}e",
     "ordinalDefault": "{{n}}e",
-    "sessionNotesPlaceholder": "Notes ou objectif de session…",
     "noClimbsYet": "Aucun bloc pour l'instant",
     "logSomeClimbs": "Enregistre quelques blocs pour voir la répartition par cotation",
     "climbsLogged_one": "{{count}} bloc enregistré",
@@ -72,11 +71,6 @@
     "notFound": {
       "title": "Session introuvable",
       "subtitle": "Cette session est introuvable. Elle a peut-être été supprimée."
-    },
-    "userSearch": {
-      "title": "Ajouter un grimpeur",
-      "placeholder": "Rechercher par nom…",
-      "noUsersFound": "Aucun utilisateur trouvé"
     }
   },
   "join": {
@@ -475,13 +469,7 @@
   },
   "mobileDetail": {
     "notFound": "Session introuvable",
-    "editTitle": "Modifier la session",
-    "nameLabel": "Nom",
-    "goalLabel": "Objectif",
-    "save": "Enregistrer",
     "participants": "Grimpeurs",
-    "updated": "Session mise à jour",
-    "updateError": "Impossible de mettre à jour la session",
     "title": "Session"
   },
   "mobileJoin": {


### PR DESCRIPTION
## What changed

- Restores horizontal layout for workout preview rows by making the row pressable the flex row expected by `ClimbListItemContent`.
- Makes the main row pressable own the row padding/surface and uses a borderless ripple for the refresh icon action.
- Improves the row accessibility label so VoiceOver gets the visible climb details: name, grade, sends, rating, and setter.
- Hardens the row against missing climb payloads and rounds rating counts before passing them to i18n pluralization.
- Adds regression tests that catch the stacked preview-row layout, row label, missing-climb fallback, and refresh ripple behavior.
- Removes stale session-detail i18n keys that were already orphaned on `main` and blocked the staged hook.

## Why

The deployed preview rows were stacking thumbnail, text, and grade vertically inside the pressable, producing very tall rows with large empty space. `ClimbListItemContent` returns sibling blocks and expects its host to provide `flexDirection: 'row'`.

## Validation

- `vp test run packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-row.test.tsx packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-preview.test.tsx`
- `vp run typecheck:mobile`
- `vp run check:i18n:orphans`
- `vp staged`

Metro is running on port 8082; the JS-only fix was reloaded through Metro.