### PR TITLE
fix(mobile): handle OAuth callback URL returned by openAuthSessionAsync

### DIFF
--- a/docs/mobile-auth-flow.md
+++ b/docs/mobile-auth-flow.md
@@ -6,12 +6,23 @@ The mobile auth flow lets React Native (Expo) clients authenticate with the Boar
 
 ## Token exchange flow
 
-1. The mobile app opens the OAuth provider (Google/Apple) in a system browser via `expo-auth-session`.
+1. The mobile app opens the OAuth provider (Google/Apple) in a system browser via `expo-web-browser`'s `openAuthSessionAsync(url, 'com.boardsesh.app://auth/callback')` (`packages/mobile/src/lib/auth.ts`).
 2. The OAuth callback on the Next.js web app creates a **transfer token** -- an HMAC-SHA256 signed payload containing the authenticated `userId`, `iat`, and `exp`. The token is valid for 120 seconds.
-3. The web app redirects back to the mobile app with the transfer token in the deep link URL.
+3. The web app redirects to `com.boardsesh.app://auth/callback?transferToken=...`. How that callback reaches the app differs by platform -- see [Callback delivery](#callback-delivery-ios-vs-android) below.
 4. The mobile app sends the transfer token to `POST /auth/native/exchange`.
 5. The backend verifies the HMAC signature and expiry, checks for replay, then issues a JWT + refresh token pair.
 6. The mobile app stores both tokens in `expo-secure-store` and uses the JWT for all authenticated requests.
+
+## Callback delivery (iOS vs Android)
+
+The redirect to the `com.boardsesh.app://auth/callback` scheme is **not** uniformly delivered as a deep link:
+
+- **iOS:** `openAuthSessionAsync` uses `ASWebAuthenticationSession`, which _consumes_ the redirect and returns it as the function's result: `{ type: 'success', url: 'com.boardsesh.app://auth/callback?transferToken=...' }`. The OS never delivers the URL to the app as a deep link, so expo-router never routes it. The login screen (`packages/mobile/app/auth/login.tsx`) must parse `result.url` (via `parseAuthCallbackParams` in `packages/mobile/src/lib/auth-callback-url.ts`) and route the token to the `/auth/callback` screen itself.
+- **Android:** `openAuthSessionAsync` is polyfilled with a Custom Tab plus a `Linking` URL listener. The redirect arrives as a real deep link, which expo-router _also_ routes -- so `/auth/callback` can mount twice for the same token: once from expo-router's own deep-link handling and once from the login screen's explicit navigation.
+
+Because transfer tokens are one-time use, `app/auth/callback.tsx` deduplicates the exchange with a module-level `Set` of already-exchanged tokens. The duplicate mount shows the spinner until `AuthProvider` redirects out of the auth group; without the dedup, the second exchange would hit the replay guard (`409`) and flash an error after a successful login. The set grows by one short string per login attempt for the process lifetime, which is negligible.
+
+A `?error=...` query param on the callback (e.g. `session_missing`, `token_issue_failed`) means the web side could not issue a token; the login screen surfaces it as a translated error.
 
 ## Token format
 

--- a/packages/mobile/app/auth/callback.tsx
+++ b/packages/mobile/app/auth/callback.tsx
@@ -13,6 +13,8 @@ import { useTheme } from '../../src/providers/theme-provider';
 // the login screen routes here explicitly with the URL openAuthSessionAsync
 // returned. Module-level so a remount can't replay (and fail) the exchange —
 // the duplicate mount just shows the spinner until AuthProvider redirects.
+// Never cleared: one short string per login attempt for the process lifetime
+// is negligible, and clearing would reopen the replay window.
 const exchangedTokens = new Set<string>();
 
 export default function AuthCallback() {

--- a/packages/mobile/app/auth/callback.tsx
+++ b/packages/mobile/app/auth/callback.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
 import { exchangeTransferToken } from '../../src/lib/auth';
 import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -22,6 +23,7 @@ export default function AuthCallback() {
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const { refreshAuthState } = useAuth();
+  const { t } = useTranslation('auth');
   const theme = useTheme();
 
   useEffect(() => {
@@ -29,7 +31,7 @@ export default function AuthCallback() {
       // auth_method is unknown here — the OAuth provider isn't echoed back on the
       // transfer-token exchange (same reason Login Succeeded omits it).
       track(SHARED_EVENTS.LoginFailed, { flow: 'native', failure_reason: 'no_transfer_token' });
-      setError('No transfer token received');
+      setError(t('nativeStart.noTransferToken'));
       return;
     }
 
@@ -49,14 +51,16 @@ export default function AuthCallback() {
       })
       .catch((exchangeError: unknown) => {
         track(SHARED_EVENTS.LoginFailed, { flow: 'native', failure_reason: 'exception' });
-        setError(exchangeError instanceof Error ? exchangeError.message : 'Unexpected error');
+        setError(exchangeError instanceof Error ? exchangeError.message : t('nativeStart.unexpectedError'));
       });
-  }, [transferToken, router, refreshAuthState]);
+  }, [transferToken, router, refreshAuthState, t]);
 
   if (error) {
     return (
       <View style={styles.container}>
-        <Text style={[styles.errorText, { color: theme.brandColors.error }]}>Sign in failed: {error}</Text>
+        <Text style={[styles.errorText, { color: theme.brandColors.error }]}>
+          {t('nativeStart.signInFailed', { reason: error })}
+        </Text>
       </View>
     );
   }
@@ -64,7 +68,7 @@ export default function AuthCallback() {
   return (
     <View style={styles.container}>
       <ActivityIndicator size="large" />
-      <Text style={styles.text}>Signing in...</Text>
+      <Text style={styles.text}>{t('nativeStart.signingIn')}</Text>
     </View>
   );
 }

--- a/packages/mobile/app/auth/callback.tsx
+++ b/packages/mobile/app/auth/callback.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { exchangeTransferToken } from '../../src/lib/auth';
@@ -8,13 +8,19 @@ import { track } from '../../src/lib/analytics';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useTheme } from '../../src/providers/theme-provider';
 
+// Transfer tokens are one-time use, and this screen can mount twice for the
+// same token: on Android the callback deep link is routed by expo-router AND
+// the login screen routes here explicitly with the URL openAuthSessionAsync
+// returned. Module-level so a remount can't replay (and fail) the exchange —
+// the duplicate mount just shows the spinner until AuthProvider redirects.
+const exchangedTokens = new Set<string>();
+
 export default function AuthCallback() {
   const { transferToken } = useLocalSearchParams<{ transferToken: string }>();
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const { refreshAuthState } = useAuth();
   const theme = useTheme();
-  const exchangedRef = useRef(false);
 
   useEffect(() => {
     if (!transferToken) {
@@ -25,8 +31,8 @@ export default function AuthCallback() {
       return;
     }
 
-    if (exchangedRef.current) return;
-    exchangedRef.current = true;
+    if (exchangedTokens.has(transferToken)) return;
+    exchangedTokens.add(transferToken);
 
     exchangeTransferToken(transferToken)
       .then(async (result) => {

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -77,6 +77,7 @@ export default function LoginScreen() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [oauthInProgress, setOauthInProgress] = useState(false);
 
   const trimmedEmail = email.trim();
   const canSubmit = !submitting && trimmedEmail.length > 0 && password.length > 0;
@@ -122,33 +123,40 @@ export default function LoginScreen() {
   }
 
   async function handleOAuthSignIn(provider: 'apple' | 'google') {
+    // A rapid double-tap would open two concurrent auth sessions.
+    if (oauthInProgress) return;
+    setOauthInProgress(true);
     setError(null);
     track(SHARED_EVENTS.LoginAttempted, { auth_method: provider, flow: 'native' });
-    const result = await signIn(provider);
-    if (result.type === 'success') {
-      // On iOS the auth session consumes the callback redirect and returns it
-      // here instead of delivering a deep link, so we must route the transfer
-      // token to /auth/callback ourselves. On Android the deep link can also
-      // arrive via expo-router; the callback screen dedupes the exchange.
-      const { transferToken, error: callbackError } = parseAuthCallbackParams(result.url);
-      if (transferToken) {
-        router.replace({ pathname: '/auth/callback', params: { transferToken } });
-      } else {
-        // callbackError comes from our own server (session_missing /
-        // token_issue_failed), so it's safe as a low-cardinality reason.
-        track(SHARED_EVENTS.LoginFailed, {
-          auth_method: provider,
-          flow: 'native',
-          failure_reason: callbackError ?? 'no_transfer_token',
-        });
-        setError(t('nativeStart.oauthError'));
+    try {
+      const result = await signIn(provider);
+      if (result.type === 'success') {
+        // On iOS the auth session consumes the callback redirect and returns it
+        // here instead of delivering a deep link, so we must route the transfer
+        // token to /auth/callback ourselves. On Android the deep link can also
+        // arrive via expo-router; the callback screen dedupes the exchange.
+        const { transferToken, error: callbackError } = parseAuthCallbackParams(result.url);
+        if (transferToken) {
+          router.replace({ pathname: '/auth/callback', params: { transferToken } });
+        } else {
+          // callbackError comes from our own server (session_missing /
+          // token_issue_failed), so it's safe as a low-cardinality reason.
+          track(SHARED_EVENTS.LoginFailed, {
+            auth_method: provider,
+            flow: 'native',
+            failure_reason: callbackError ?? 'no_transfer_token',
+          });
+          setError(t('nativeStart.oauthError'));
+        }
+        return;
       }
-      return;
-    }
-    // The user dismissing the system sheet is only observable here — track it
-    // so the funnel sees the Attempted→Succeeded drop-off instead of a silent gap.
-    if (result.type === 'cancel' || result.type === 'dismiss') {
+      // Everything else never reaches /auth/callback, so it's only observable
+      // here. cancel/dismiss is the user closing the system sheet; track every
+      // non-success type so the funnel sees the Attempted→Succeeded drop-off
+      // instead of a silent gap.
       track(SHARED_EVENTS.LoginFailed, { auth_method: provider, flow: 'native', failure_reason: result.type });
+    } finally {
+      setOauthInProgress(false);
     }
   }
 
@@ -239,6 +247,7 @@ export default function LoginScreen() {
               onPress={() => {
                 void handleOAuthSignIn('apple');
               }}
+              disabled={oauthInProgress}
             />
           )}
           <SignInButton
@@ -246,6 +255,7 @@ export default function LoginScreen() {
             onPress={() => {
               void handleOAuthSignIn('google');
             }}
+            disabled={oauthInProgress}
           />
         </View>
       </ScrollView>

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -11,9 +11,11 @@ import {
   type TextInput as RNTextInput,
 } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
+import { parseAuthCallbackParams } from '../../src/lib/auth-callback-url';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useTheme } from '../../src/providers/theme-provider';
 import { track } from '../../src/lib/analytics';
@@ -66,6 +68,7 @@ function SignInButton({
 
 export default function LoginScreen() {
   const { signIn, signInWithCredentials } = useAuth();
+  const router = useRouter();
   const { t } = useTranslation('auth');
   const theme = useTheme();
   const passwordRef = useRef<RNTextInput>(null);
@@ -119,12 +122,31 @@ export default function LoginScreen() {
   }
 
   async function handleOAuthSignIn(provider: 'apple' | 'google') {
+    setError(null);
     track(SHARED_EVENTS.LoginAttempted, { auth_method: provider, flow: 'native' });
     const result = await signIn(provider);
-    // A successful redirect ('success') hands off to /auth/callback, which fires
-    // Login Succeeded/Failed. The user dismissing the system sheet is only
-    // observable here — track it so the funnel sees the Attempted→Succeeded
-    // drop-off instead of a silent gap.
+    if (result.type === 'success') {
+      // On iOS the auth session consumes the callback redirect and returns it
+      // here instead of delivering a deep link, so we must route the transfer
+      // token to /auth/callback ourselves. On Android the deep link can also
+      // arrive via expo-router; the callback screen dedupes the exchange.
+      const { transferToken, error: callbackError } = parseAuthCallbackParams(result.url);
+      if (transferToken) {
+        router.replace({ pathname: '/auth/callback', params: { transferToken } });
+      } else {
+        // callbackError comes from our own server (session_missing /
+        // token_issue_failed), so it's safe as a low-cardinality reason.
+        track(SHARED_EVENTS.LoginFailed, {
+          auth_method: provider,
+          flow: 'native',
+          failure_reason: callbackError ?? 'no_transfer_token',
+        });
+        setError(t('nativeStart.oauthError'));
+      }
+      return;
+    }
+    // The user dismissing the system sheet is only observable here — track it
+    // so the funnel sees the Attempted→Succeeded drop-off instead of a silent gap.
     if (result.type === 'cancel' || result.type === 'dismiss') {
       track(SHARED_EVENTS.LoginFailed, { auth_method: provider, flow: 'native', failure_reason: result.type });
     }

--- a/packages/mobile/src/lib/__tests__/auth-callback-url.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-callback-url.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { parseAuthCallbackParams } from '../auth-callback-url';
+
+describe('parseAuthCallbackParams', () => {
+  it('extracts the transfer token from a successful callback URL', () => {
+    expect(parseAuthCallbackParams('com.boardsesh.app://auth/callback?transferToken=abc123&next=%2F')).toEqual({
+      transferToken: 'abc123',
+      error: null,
+    });
+  });
+
+  it('decodes a percent-encoded transfer token', () => {
+    expect(
+      parseAuthCallbackParams('com.boardsesh.app://auth/callback?transferToken=a%2Bb%3D%3D&next=%2Fclimbs'),
+    ).toEqual({ transferToken: 'a+b==', error: null });
+  });
+
+  it('extracts the server error param when no token was issued', () => {
+    expect(parseAuthCallbackParams('com.boardsesh.app://auth/callback?error=session_missing')).toEqual({
+      transferToken: null,
+      error: 'session_missing',
+    });
+  });
+
+  it('returns nulls when the URL has no query string', () => {
+    expect(parseAuthCallbackParams('com.boardsesh.app://auth/callback')).toEqual({
+      transferToken: null,
+      error: null,
+    });
+  });
+
+  it('ignores a fragment after the query string', () => {
+    expect(parseAuthCallbackParams('com.boardsesh.app://auth/callback?transferToken=abc#frag')).toEqual({
+      transferToken: 'abc',
+      error: null,
+    });
+  });
+
+  it('skips malformed percent-encoded pairs instead of throwing', () => {
+    expect(parseAuthCallbackParams('com.boardsesh.app://auth/callback?error=%E0%A4%A&transferToken=ok')).toEqual({
+      transferToken: 'ok',
+      error: null,
+    });
+  });
+});

--- a/packages/mobile/src/lib/auth-callback-url.ts
+++ b/packages/mobile/src/lib/auth-callback-url.ts
@@ -1,0 +1,31 @@
+// Parses the OAuth callback deep link (com.boardsesh.app://auth/callback?...)
+// that openAuthSessionAsync hands back when the in-app browser redirects.
+// Deliberately avoids `new URL().searchParams` (incomplete under Hermes) and
+// expo-linking (native imports break node-env unit tests).
+export function parseAuthCallbackParams(url: string): { transferToken: string | null; error: string | null } {
+  const queryIndex = url.indexOf('?');
+  if (queryIndex === -1) {
+    return { transferToken: null, error: null };
+  }
+
+  const hashIndex = url.indexOf('#', queryIndex);
+  const queryString = url.slice(queryIndex + 1, hashIndex === -1 ? undefined : hashIndex);
+
+  const params = new Map<string, string>();
+  for (const pair of queryString.split('&')) {
+    if (!pair) continue;
+    const equalsIndex = pair.indexOf('=');
+    const rawKey = equalsIndex === -1 ? pair : pair.slice(0, equalsIndex);
+    const rawValue = equalsIndex === -1 ? '' : pair.slice(equalsIndex + 1);
+    try {
+      params.set(decodeURIComponent(rawKey), decodeURIComponent(rawValue.replace(/\+/g, ' ')));
+    } catch {
+      // Malformed percent-encoding — skip the pair rather than fail the login.
+    }
+  }
+
+  return {
+    transferToken: params.get('transferToken') ?? null,
+    error: params.get('error') ?? null,
+  };
+}

--- a/packages/mobile/src/lib/auth.ts
+++ b/packages/mobile/src/lib/auth.ts
@@ -5,9 +5,12 @@ import { BACKEND_URL, WEB_BASE_URL } from './env';
 
 export type AuthProvider = 'google' | 'apple';
 
-// Returns the WebBrowser result so the caller can distinguish a successful
-// redirect from a user-cancelled/dismissed OAuth sheet — the cancel path never
-// reaches the /auth/callback deep link, so it's only observable here.
+// Returns the WebBrowser result because it's the only reliable way to receive
+// the callback. On iOS the in-app auth session consumes the redirect to the
+// callback scheme and returns it as `{ type: 'success', url }` — the URL is
+// never delivered to the app as a deep link, so the caller must parse
+// `result.url` (see parseAuthCallbackParams) and route the transfer token to
+// /auth/callback itself. Cancel/dismiss is likewise only observable here.
 export async function startSignIn(provider: AuthProvider): Promise<WebBrowser.WebBrowserAuthSessionResult> {
   const callbackUrl = encodeURIComponent('/api/auth/native/callback?next=/');
   const url = `${WEB_BASE_URL}/auth/native-start?provider=${provider}&callbackUrl=${callbackUrl}`;

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -99,7 +99,8 @@
     "signInGoogle": "Sign in with Google",
     "signIn": "Sign in",
     "orContinueWith": "or continue with",
-    "networkError": "Could not reach Boardsesh. Check your connection and try again."
+    "networkError": "Could not reach Boardsesh. Check your connection and try again.",
+    "oauthError": "Sign in didn't complete. Give it another go."
   },
   "metadata": {
     "login": {

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -100,7 +100,10 @@
     "signIn": "Sign in",
     "orContinueWith": "or continue with",
     "networkError": "Could not reach Boardsesh. Check your connection and try again.",
-    "oauthError": "Sign in didn't complete. Give it another go."
+    "oauthError": "Sign in didn't complete. Give it another go.",
+    "signInFailed": "Sign in failed: {{reason}}",
+    "noTransferToken": "No transfer token received",
+    "unexpectedError": "Unexpected error"
   },
   "metadata": {
     "login": {

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -99,7 +99,8 @@
     "signInGoogle": "Iniciar sesión con Google",
     "signIn": "Iniciar sesión",
     "orContinueWith": "o continúa con",
-    "networkError": "No se pudo conectar con Boardsesh. Comprueba tu conexión e inténtalo de nuevo."
+    "networkError": "No se pudo conectar con Boardsesh. Comprueba tu conexión e inténtalo de nuevo.",
+    "oauthError": "No se pudo completar el inicio de sesión. Inténtalo de nuevo."
   },
   "metadata": {
     "login": {

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -100,7 +100,10 @@
     "signIn": "Iniciar sesión",
     "orContinueWith": "o continúa con",
     "networkError": "No se pudo conectar con Boardsesh. Comprueba tu conexión e inténtalo de nuevo.",
-    "oauthError": "No se pudo completar el inicio de sesión. Inténtalo de nuevo."
+    "oauthError": "No se pudo completar el inicio de sesión. Inténtalo de nuevo.",
+    "signInFailed": "Error al iniciar sesión: {{reason}}",
+    "noTransferToken": "No se recibió el token de transferencia",
+    "unexpectedError": "Error inesperado"
   },
   "metadata": {
     "login": {

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -99,7 +99,8 @@
     "signInGoogle": "Se connecter avec Google",
     "signIn": "Se connecter",
     "orContinueWith": "ou continuez avec",
-    "networkError": "Impossible de joindre Boardsesh. Vérifiez votre connexion et réessayez."
+    "networkError": "Impossible de joindre Boardsesh. Vérifiez votre connexion et réessayez.",
+    "oauthError": "La connexion n'a pas abouti. Réessayez."
   },
   "metadata": {
     "login": {

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -100,7 +100,10 @@
     "signIn": "Se connecter",
     "orContinueWith": "ou continuez avec",
     "networkError": "Impossible de joindre Boardsesh. Vérifiez votre connexion et réessayez.",
-    "oauthError": "La connexion n'a pas abouti. Réessayez."
+    "oauthError": "La connexion n'a pas abouti. Réessayez.",
+    "signInFailed": "Échec de la connexion : {{reason}}",
+    "noTransferToken": "Aucun jeton de transfert reçu",
+    "unexpectedError": "Erreur inattendue"
   },
   "metadata": {
     "login": {


### PR DESCRIPTION
## Problem

OAuth login (Apple/Google) in the mobile app opened the browser and completed sign-in, but the browser closed and the user stayed stuck on the login screen.

**Root cause:** on iOS, `WebBrowser.openAuthSessionAsync(url, 'com.boardsesh.app://auth/callback')` uses `ASWebAuthenticationSession`, which consumes the redirect to the callback scheme and hands it back as the function's return value (`{ type: 'success', url }`). The URL is never delivered to the app as a deep link, so expo-router never mounted `app/auth/callback.tsx` and the transfer token was silently dropped. `handleOAuthSignIn` in `login.tsx` only handled `cancel`/`dismiss` and ignored a `success` result entirely.

The web side (`/api/auth/native/callback`) already worked: it issues the transfer token and redirects to the callback scheme correctly.

## Fix

- **`src/lib/auth-callback-url.ts` (new):** dependency-free parser that extracts `transferToken` / `error` from the callback URL. Avoids `new URL().searchParams` (incomplete under Hermes) and expo-linking (native imports break node-env unit tests).
- **`app/auth/login.tsx`:** on a `success` result, parse `result.url` and `router.replace` the token into the existing `/auth/callback` exchange screen. Server-side callback errors (`session_missing` / `token_issue_failed`) now show a translated error and fire `Login Failed` analytics.
- **`app/auth/callback.tsx`:** dedupe the one-time token exchange with a module-level `Set` keyed by token — on Android the deep link can *also* arrive via expo-router, mounting the screen a second time, and a replayed exchange would fail and flash an error after a successful login.
- **i18n:** new `nativeStart.oauthError` key in `en-US`, `es`, `fr` auth catalogs.

## Validation

- `vp run typecheck:mobile` ✓
- `vp run test:mobile` ✓ (1392 tests, 190 files, incl. new `parseAuthCallbackParams` suite)
- `vp check` ✓ (changed files clean; 17 files flagged by the formatter are pre-existing drift on main, untouched here)
- `vp run check:mobile-bundle` ✓ (Android bundle 10.6 MB)

On-device verification still needed (no simulator in this environment): tap "Sign in with Apple" → complete in browser → app shows "Signing in..." → lands on the Climbs tab. JS-only change, so it rides OTA via `vp run mobile:publish`.

https://claude.ai/code/session_01F7WAbXxAf57osAroLTip8U

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7WAbXxAf57osAroLTip8U)_