### PR TITLE
Test play-drawer preview-only cleanup and clear stale pinned ref

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -47,6 +47,7 @@ import {
   resolvePlayDrawerWallControlQueueItem,
   shouldRestoreFailedTakeControlPreview,
 } from './lightbulb-control';
+import { usePreviewOnlyExitCleanup } from './use-preview-only-exit-cleanup';
 import { useWallConfirmFallback } from './use-wall-confirm-fallback';
 import { track } from '../../lib/analytics';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -243,15 +244,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   // mode or mounting never clears a fresh preview. Safe for the lightbulb flow:
   // handleLightbulb reads drawerPreviewSuggestionSource synchronously at press
   // time and hands it to takeControl before the driver flip lands here.
-  const wasPartyPreviewOnlyRef = useRef(isPartyPreviewOnly);
-  useEffect(() => {
-    const wasPreviewOnly = wasPartyPreviewOnlyRef.current;
-    wasPartyPreviewOnlyRef.current = isPartyPreviewOnly;
-    if (wasPreviewOnly && !isPartyPreviewOnly) {
-      setDrawerPreviewItem(null);
-      setDrawerPreviewSuggestionSource(null);
-    }
-  }, [isPartyPreviewOnly]);
+  usePreviewOnlyExitCleanup(isPartyPreviewOnly, () => {
+    setDrawerPreviewItem(null);
+    setDrawerPreviewSuggestionSource(null);
+  });
 
   const { showToast } = useToast();
 

--- a/packages/mobile/src/components/play-drawer/__tests__/use-preview-only-exit-cleanup.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-preview-only-exit-cleanup.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { usePreviewOnlyExitCleanup } from '../use-preview-only-exit-cleanup';
+
+describe('usePreviewOnlyExitCleanup', () => {
+  it('does not fire on mount when starting in preview-only', () => {
+    const onExit = vi.fn();
+    renderHook(({ isPreviewOnly }) => usePreviewOnlyExitCleanup(isPreviewOnly, onExit), {
+      initialProps: { isPreviewOnly: true },
+    });
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('does not fire on mount when starting outside preview-only', () => {
+    const onExit = vi.fn();
+    renderHook(({ isPreviewOnly }) => usePreviewOnlyExitCleanup(isPreviewOnly, onExit), {
+      initialProps: { isPreviewOnly: false },
+    });
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('fires once when preview-only flips true → false', () => {
+    const onExit = vi.fn();
+    const { rerender } = renderHook(({ isPreviewOnly }) => usePreviewOnlyExitCleanup(isPreviewOnly, onExit), {
+      initialProps: { isPreviewOnly: true },
+    });
+    rerender({ isPreviewOnly: false });
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when entering preview-only (false → true)', () => {
+    const onExit = vi.fn();
+    const { rerender } = renderHook(({ isPreviewOnly }) => usePreviewOnlyExitCleanup(isPreviewOnly, onExit), {
+      initialProps: { isPreviewOnly: false },
+    });
+    rerender({ isPreviewOnly: true });
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when preview-only stays unchanged', () => {
+    const onExit = vi.fn();
+    const { rerender } = renderHook(({ isPreviewOnly }) => usePreviewOnlyExitCleanup(isPreviewOnly, onExit), {
+      initialProps: { isPreviewOnly: true },
+    });
+    rerender({ isPreviewOnly: true });
+    rerender({ isPreviewOnly: false });
+    rerender({ isPreviewOnly: false });
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes the latest callback on the transition', () => {
+    const firstCallback = vi.fn();
+    const latestCallback = vi.fn();
+    const { rerender } = renderHook(({ isPreviewOnly, onExit }) => usePreviewOnlyExitCleanup(isPreviewOnly, onExit), {
+      initialProps: { isPreviewOnly: true, onExit: firstCallback },
+    });
+    rerender({ isPreviewOnly: false, onExit: latestCallback });
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(latestCallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/use-preview-only-exit-cleanup.ts
+++ b/packages/mobile/src/components/play-drawer/use-preview-only-exit-cleanup.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Runs `onExitPreviewOnly` exactly when party preview-only mode flips true→false.
+ * Transition-gated so mounting and entering preview-only never fire. The callback
+ * is read through a ref so callers may pass an inline closure without memoizing and
+ * the effect keeps a single [isPartyPreviewOnly] dependency (preserving the original
+ * inline-effect semantics).
+ */
+export function usePreviewOnlyExitCleanup(isPartyPreviewOnly: boolean, onExitPreviewOnly: () => void): void {
+  const onExitRef = useRef(onExitPreviewOnly);
+  onExitRef.current = onExitPreviewOnly;
+  const wasPartyPreviewOnlyRef = useRef(isPartyPreviewOnly);
+  useEffect(() => {
+    const wasPreviewOnly = wasPartyPreviewOnlyRef.current;
+    wasPartyPreviewOnlyRef.current = isPartyPreviewOnly;
+    if (wasPreviewOnly && !isPartyPreviewOnly) {
+      onExitRef.current();
+    }
+  }, [isPartyPreviewOnly]);
+}

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -169,6 +169,29 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     expect(item?.climb).toEqual(climbB);
   });
 
+  it('clears the pinned item when a preview-only tap intervenes', async () => {
+    const { result, rerender } = renderActivation();
+    const climb = makeClimb('a');
+
+    // Solo tap pins the ref. The mocked activation never reaches
+    // queueApi.setCurrentClimb, so the pinned item is left dangling.
+    await result.current(climb);
+    const soloPinnedItem = mocks.openPlayDrawer.mock.calls[0][1].previewQueueItem;
+
+    // A preview-only tap for the same uuid must drop the stale pin.
+    mocks.isPartyPreviewOnly = true;
+    rerender();
+    await result.current(climb);
+
+    // Back to solo: a later dispatch for the same uuid builds a fresh item
+    // rather than reusing the instance the first solo tap pinned.
+    mocks.isPartyPreviewOnly = false;
+    rerender();
+    const item = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
+    expect(item).not.toBe(soloPinnedItem);
+    expect(item?.uuid).not.toBe(soloPinnedItem.uuid);
+  });
+
   describe('party preview-only mode', () => {
     beforeEach(() => {
       mocks.isPartyPreviewOnly = true;

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -171,6 +171,10 @@ export function usePlaylistActivation({
           previewQueueItem: previewItem,
           previewPlaylistSuggestionSource: previewSource,
         });
+        // A preview-only tap never reaches setCurrentClimb, so drop any item a
+        // prior solo tap pinned — otherwise a later same-uuid solo activation
+        // reuses the stale instance instead of building a fresh one.
+        pendingQueueItemRef.current = null;
         return Promise.resolve();
       }
       const item = climbToQueueItem(toSchemaClimb(climb));


### PR DESCRIPTION
Follow-ups from a PR review of the play-drawer preview-source fixes.

## 1. Stale-closure concern in `handleLightbulb` rollback — no change needed
The review asked whether the rollback's functional updater captures a stale
`drawerPreviewSuggestionSource`. It does not: the `useCallback` deps array already
includes `drawerPreviewSuggestionSource`, so the callback is rebuilt each render with the
current value and the rollback reads the at-press value as intended. Verified, left as-is.

## 2. Cover the preview-only cleanup effect (was untested)
The `isPartyPreviewOnly` true→false transition that clears the drawer-local preview state
lived inline in `PlayDrawer.tsx` with no test coverage (the component has no test harness).
Extracted it into `usePreviewOnlyExitCleanup`, which keeps a single `[isPartyPreviewOnly]`
dependency by reading the callback through a ref — preserving the original semantics while
making the transition gating unit-testable. Added a test covering mount, both transition
directions, no-op same-value renders, and latest-callback invocation.

## 3. Clear `pendingQueueItemRef` in the preview-only activation path
`use-playlist-activation.ts`'s party preview-only branch returned early without clearing
`pendingQueueItemRef`. A preview-only tap never reaches `setCurrentClimb`, so a pinned item
from a prior solo tap could be reused on a later same-uuid solo activation (the uuid guard
only protects *different* climbs). Now cleared in that branch, with a regression test
covering the solo → preview → solo sequence.

## Validation
- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 1402 passed (includes the new tests)
- `vp check` on the changed files — lint + format clean
- `vp run check:mobile-bundle` — OK

https://claude.ai/code/session_01QCccnbyWGnrf5AMaKukVdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCccnbyWGnrf5AMaKukVdX)_