### PR TITLE
Fix mobile Bluetooth reliability bugs found in BLE audit

### DIFF
--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -73,6 +73,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     private var discoveredPeripherals: [String: CBPeripheral] = [:]
     private var discoveredNames: [String: String] = [:]
+    // What was last emitted to JS for each device in the CURRENT scan
+    // (name + advertised UUIDs). With allow-duplicates on and (on newer JS)
+    // an unfiltered scan, didDiscover fires continuously for every nearby
+    // device; without this gate every repeat advertisement would cross the
+    // native→JS bridge. Cleared on every startScan so a fresh scan re-emits.
+    private var emittedScanResults: [String: String] = [:]
     private var connectedPeripheral: CBPeripheral?
     private var writeCharacteristic: CBCharacteristic?
     private var pendingConnectCompletion: ((Result<Void, Error>) -> Void)?
@@ -286,6 +292,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         let uuids = serviceUuids.compactMap { CBUUID(string: $0) }
         scanServices = uuids
         scanRequested = true
+        emittedScanResults = [:]
 
         guard centralManager.state == .poweredOn else {
             if isAvailableOnBleQueue {
@@ -624,9 +631,19 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         if let name {
             discoveredNames[deviceId] = name
         }
-        let advertisedServiceUuids = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID] ?? [])
+        // Overflow UUIDs cover peripherals whose advertisement is too full to
+        // carry the service list in the main packet.
+        let advertisedServiceUuids = ((advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID] ?? [])
+            + (advertisementData[CBAdvertisementDataOverflowServiceUUIDsKey] as? [CBUUID] ?? []))
             .map { $0.uuidString }
-        onScanResult?(BoardBleScanResult(deviceId: deviceId, name: name, rssi: RSSI.intValue, serviceUuids: advertisedServiceUuids))
+        // Only cross the bridge when something material changed for this
+        // device (first sighting, name arriving in a later scan response, or
+        // a different advertised UUID set).
+        let emissionKey = "\(name ?? "")|\(advertisedServiceUuids.joined(separator: ","))"
+        if emittedScanResults[deviceId] != emissionKey {
+            emittedScanResults[deviceId] = emissionKey
+            onScanResult?(BoardBleScanResult(deviceId: deviceId, name: name, rssi: RSSI.intValue, serviceUuids: advertisedServiceUuids))
+        }
 
         // Reconnect-by-last-known-board scan fallback: the stored board just
         // advertised — hand its completion to connectOnBleQueue (which stops the

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -6,6 +6,11 @@ struct BoardBleScanResult {
     let deviceId: String
     let name: String?
     let rssi: Int
+    /// Service UUIDs from the advertisement packet. The JS layer filters scan
+    /// results by these (plus name patterns) now that the scan itself runs
+    /// unfiltered — a native service-UUID filter would hide MoonBoard
+    /// controllers, which don't reliably advertise the UART service UUID.
+    let serviceUuids: [String]
 }
 
 enum BoardBleError: LocalizedError {
@@ -92,6 +97,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     private var onScanResult: ((BoardBleScanResult) -> Void)?
     private var onDisconnect: ((String) -> Void)?
+    /// Fired whenever a connection becomes fully usable (write characteristic
+    /// discovered) — JS-initiated connects, widget-intent reconnects and
+    /// CoreBluetooth state restoration alike. The JS layer uses it to adopt
+    /// natively-established connections so the in-app lightbulb matches the
+    /// wall. Payload: (deviceId, deviceName).
+    private var onConnected: ((String, String?) -> Void)?
 
     override private init() {
         super.init()
@@ -114,13 +125,27 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
     }
 
+    /// The currently-connected, write-ready board (id + best-known name), or
+    /// nil. Exposed to JS as `getConnectedDevice` so a foregrounding app can
+    /// adopt a connection established while it was backgrounded (widget
+    /// reconnect) even if the `connected` event was missed.
+    var connectedDeviceInfo: (deviceId: String, name: String?)? {
+        runOnBleQueueSync {
+            guard let peripheral = connectedPeripheral, writeCharacteristic != nil else { return nil }
+            let deviceId = peripheral.identifier.uuidString
+            return (deviceId, discoveredNames[deviceId] ?? peripheral.name)
+        }
+    }
+
     func setEventHandlers(
         onScanResult: ((BoardBleScanResult) -> Void)?,
-        onDisconnect: ((String) -> Void)?
+        onDisconnect: ((String) -> Void)?,
+        onConnected: ((String, String?) -> Void)? = nil
     ) {
         runOnBleQueue { [weak self] in
             self?.onScanResult = onScanResult
             self?.onDisconnect = onDisconnect
+            self?.onConnected = onConnected
         }
     }
 
@@ -163,14 +188,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// scan, works while backgrounded); falls back to a time-boxed scan that
     /// connects when the stored UUID advertises.
     ///
-    /// Known limitation: this reconnects the native layer only. The wall re-lights
-    /// (displaySharedCurrentItemOnBleQueue) and widget next/prev keep driving it,
-    /// but the JS `isConnected` is NOT updated — there's no native→JS "connected"
-    /// event yet — so after a background widget reconnect the in-app lightbulb
-    /// shows disconnected and in-app climb navigation won't push to the wall until
-    /// the user taps it once (which connects JS to the already-connected board, a
-    /// fast no-op on the native side). Follow-up: bridge a `connected` event +
-    /// adopt the connection in NativeIosBleAdapter on app foreground.
+    /// The JS layer hears about the reconnect through the bridged `connected`
+    /// event (fired from didDiscoverCharacteristicsFor) and adopts the
+    /// connection; if the event fired while JS was suspended, the foreground
+    /// `getConnectedDevice` check in useBoardBluetooth picks it up instead.
     func reconnectToLastKnownBoard(completion: @escaping (Result<Void, Error>) -> Void) {
         runOnBleQueue { [weak self] in
             self?.reconnectToLastKnownBoardOnBleQueue(completion: completion)
@@ -258,8 +279,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     private func startScanOnBleQueue(serviceUuids: [String], completion: @escaping (Result<Void, Error>) -> Void) {
+        // An empty list means "scan unfiltered" (withServices: nil): the JS
+        // layer filters results itself so MoonBoard controllers — which don't
+        // reliably advertise the UART service UUID — still surface. Older JS
+        // bundles always pass explicit UUIDs and keep the filtered behaviour.
         let uuids = serviceUuids.compactMap { CBUUID(string: $0) }
-        scanServices = uuids.isEmpty ? [auroraServiceUuid] : uuids
+        scanServices = uuids
         scanRequested = true
 
         guard centralManager.state == .poweredOn else {
@@ -271,7 +296,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
-        centralManager.scanForPeripherals(withServices: scanServices, options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
+        centralManager.scanForPeripherals(
+            withServices: scanServices.isEmpty ? nil : scanServices,
+            options: [CBCentralManagerScanOptionAllowDuplicatesKey: true]
+        )
         completion(.success(()))
     }
 
@@ -558,7 +586,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 readyWaiters.signalAll()
             }
             if scanRequested {
-                central.scanForPeripherals(withServices: scanServices.isEmpty ? [auroraServiceUuid] : scanServices, options: [
+                // Empty scanServices = unfiltered scan (see startScanOnBleQueue).
+                central.scanForPeripherals(withServices: scanServices.isEmpty ? nil : scanServices, options: [
                     CBCentralManagerScanOptionAllowDuplicatesKey: true,
                 ])
             }
@@ -595,7 +624,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         if let name {
             discoveredNames[deviceId] = name
         }
-        onScanResult?(BoardBleScanResult(deviceId: deviceId, name: name, rssi: RSSI.intValue))
+        let advertisedServiceUuids = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID] ?? [])
+            .map { $0.uuidString }
+        onScanResult?(BoardBleScanResult(deviceId: deviceId, name: name, rssi: RSSI.intValue, serviceUuids: advertisedServiceUuids))
 
         // Reconnect-by-last-known-board scan fallback: the stored board just
         // advertised — hand its completion to connectOnBleQueue (which stops the
@@ -698,6 +729,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         persistLastConnectedPeripheral(peripheral)
         completePendingConnect(.success(()))
         logger.info("Connected to board BLE peripheral \(peripheral.identifier.uuidString, privacy: .public)")
+        // Tell JS the link is usable. This is the single success point for
+        // every connect path (JS connect, widget reconnect, state
+        // restoration), so the JS layer can adopt connections it didn't
+        // initiate.
+        let connectedDeviceId = peripheral.identifier.uuidString
+        onConnected?(connectedDeviceId, discoveredNames[connectedDeviceId] ?? peripheral.name)
         let hadPendingReadyWaiters = readyWaiters.hasPendingWaiters
         readyWaiters.signalAll()
         // Skip the implicit shared-state write when an intent is waiting on

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -27,7 +27,7 @@ public class BoardBleModule: Module {
     public func definition() -> ModuleDefinition {
         Name("BoardBle")
 
-        Events("scanResult", "disconnected")
+        Events("scanResult", "disconnected", "connected")
 
         OnCreate {
             BoardBleManager.shared.setEventHandlers(
@@ -38,17 +38,24 @@ public class BoardBleModule: Module {
                             "name": result.name ?? ""
                         ],
                         "localName": result.name ?? "",
-                        "rssi": result.rssi
+                        "rssi": result.rssi,
+                        "serviceUuids": result.serviceUuids
                     ])
                 },
                 onDisconnect: { [weak self] deviceId in
                     self?.emitOrBuffer(name: "disconnected", body: ["deviceId": deviceId])
+                },
+                onConnected: { [weak self] deviceId, deviceName in
+                    self?.emitOrBuffer(name: "connected", body: [
+                        "deviceId": deviceId,
+                        "deviceName": deviceName ?? ""
+                    ])
                 }
             )
         }
 
         OnDestroy {
-            BoardBleManager.shared.setEventHandlers(onScanResult: nil, onDisconnect: nil)
+            BoardBleManager.shared.setEventHandlers(onScanResult: nil, onDisconnect: nil, onConnected: nil)
         }
 
         OnStartObserving {
@@ -128,6 +135,17 @@ public class BoardBleModule: Module {
 
         AsyncFunction("cancelWrites") { () -> Void in
             BoardBleManager.shared.cancelWrites()
+        }
+
+        // Presence of this function doubles as the JS feature gate for the
+        // newer native surface (unfiltered scanning, the `connected` event,
+        // connection adoption) — see BoardBleNativeModule in src/index.ts.
+        AsyncFunction("getConnectedDevice") { () -> [String: Any]? in
+            guard let device = BoardBleManager.shared.connectedDeviceInfo else { return nil }
+            return [
+                "deviceId": device.deviceId,
+                "name": device.name ?? ""
+            ]
         }
 
         AsyncFunction("configureBoard") { (options: ConfigureBoardOptions) -> Void in

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -6,10 +6,27 @@ export type NativeBleScanEvent = {
   device: { deviceId: string; name: string };
   localName: string;
   rssi: number;
+  /**
+   * Advertised service UUIDs from the advertisement packet. Only present on
+   * binaries new enough to scan unfiltered (the ones that also expose
+   * `getConnectedDevice`); older binaries scan with a native UUID filter and
+   * omit the field.
+   */
+  serviceUuids?: string[];
 };
 
 export type NativeBleDisconnectEvent = {
   deviceId: string;
+};
+
+export type NativeBleConnectedEvent = {
+  deviceId: string;
+  deviceName?: string;
+};
+
+export type NativeBleConnectedDevice = {
+  deviceId: string;
+  name?: string;
 };
 
 export type NativeBleConfigureBoardOptions = {
@@ -23,6 +40,7 @@ export type NativeBleConfigureBoardOptions = {
 
 type BoardBleNativeModule = {
   isAvailable(): Promise<{ available: boolean }>;
+  /** An empty `services` array means "scan unfiltered" on newer binaries. */
   startScan(services?: string[]): Promise<void>;
   stopScan(): Promise<void>;
   connect(deviceId: string): Promise<void>;
@@ -30,8 +48,17 @@ type BoardBleNativeModule = {
   write(value: string): Promise<void>;
   cancelWrites(): Promise<void>;
   configureBoard(options: NativeBleConfigureBoardOptions): Promise<void>;
+  /**
+   * Returns the natively-connected board, or null. Only present on newer
+   * binaries — its presence doubles as the feature gate for unfiltered
+   * scanning, the `connected` event and connection adoption, so always check
+   * `typeof getConnectedDevice === 'function'` before relying on any of them
+   * (an OTA JS update can run against an older binary).
+   */
+  getConnectedDevice?(): Promise<NativeBleConnectedDevice | null>;
   addListener(event: 'scanResult', listener: (payload: NativeBleScanEvent) => void): EventSubscription;
   addListener(event: 'disconnected', listener: (payload: NativeBleDisconnectEvent) => void): EventSubscription;
+  addListener(event: 'connected', listener: (payload: NativeBleConnectedEvent) => void): EventSubscription;
 };
 
 // requireOptionalNativeModule returns null in Expo Go or any binary without

--- a/packages/mobile/src/components/ble/use-lightbulb-toggle.ts
+++ b/packages/mobile/src/components/ble/use-lightbulb-toggle.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react';
+import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
+import { hapticLight } from '../../lib/haptics';
+
+/**
+ * Shared press behaviour for the toolbar lightbulbs (iOS glass toolbar and
+ * Android app bar): toggle the app-wide BLE connection, ignoring taps while a
+ * connect is in flight, and silently reconnecting to the remembered board for
+ * the current config instead of always opening the picker. `bluetooth` is null
+ * when no board is selected yet — callers render nothing in that case.
+ */
+export function useLightbulbToggle() {
+  const bluetooth = useOptionalBluetoothContext();
+  const connected = bluetooth?.isConnected ?? false;
+
+  const handlePress = useCallback(() => {
+    if (!bluetooth) return;
+    // The hook's own in-flight guard is what actually prevents a double
+    // connect; skipping here just avoids a misleading haptic on a dead tap.
+    if (bluetooth.loading) return;
+    hapticLight();
+    if (bluetooth.isConnected) {
+      void bluetooth.disconnect();
+    } else {
+      void bluetooth.connect(undefined, undefined, bluetooth.reconnectSerialForCurrentBoard ?? undefined);
+    }
+  }, [bluetooth]);
+
+  return { bluetooth, connected, handlePress };
+}

--- a/packages/mobile/src/components/chrome/LightbulbToolbarAction.tsx
+++ b/packages/mobile/src/components/chrome/LightbulbToolbarAction.tsx
@@ -1,8 +1,6 @@
-import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '../../providers/theme-provider';
-import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
-import { hapticLight } from '../../lib/haptics';
+import { useLightbulbToggle } from '../ble/use-lightbulb-toggle';
 import { Icon } from '../Icon';
 import { GlassToolbarAction } from './GlassActionToolbar';
 
@@ -17,24 +15,7 @@ export function LightbulbToolbarAction() {
   const { systemColors, brandColors } = useTheme();
   const { t: tCommon } = useTranslation('common');
   const { t: tSettings } = useTranslation('settings');
-  const bluetooth = useOptionalBluetoothContext();
-  const connected = bluetooth?.isConnected ?? false;
-
-  const handlePress = useCallback(() => {
-    if (!bluetooth) return;
-    // Ignore taps while a connect is already running — a second concurrent
-    // connect tears down the first attempt's scan and strands the picker.
-    if (bluetooth.loading) return;
-    hapticLight();
-    if (bluetooth.isConnected) {
-      void bluetooth.disconnect();
-    } else {
-      // Reconnect silently to the remembered board when there is one for the
-      // current config (same behaviour as the play-drawer lightbulb);
-      // otherwise fall through to the device picker.
-      void bluetooth.connect(undefined, undefined, bluetooth.reconnectSerialForCurrentBoard ?? undefined);
-    }
-  }, [bluetooth]);
+  const { bluetooth, connected, handlePress } = useLightbulbToggle();
 
   if (!bluetooth) return null;
 

--- a/packages/mobile/src/components/chrome/LightbulbToolbarAction.tsx
+++ b/packages/mobile/src/components/chrome/LightbulbToolbarAction.tsx
@@ -22,9 +22,18 @@ export function LightbulbToolbarAction() {
 
   const handlePress = useCallback(() => {
     if (!bluetooth) return;
+    // Ignore taps while a connect is already running — a second concurrent
+    // connect tears down the first attempt's scan and strands the picker.
+    if (bluetooth.loading) return;
     hapticLight();
-    if (bluetooth.isConnected) void bluetooth.disconnect();
-    else void bluetooth.connect();
+    if (bluetooth.isConnected) {
+      void bluetooth.disconnect();
+    } else {
+      // Reconnect silently to the remembered board when there is one for the
+      // current config (same behaviour as the play-drawer lightbulb);
+      // otherwise fall through to the device picker.
+      void bluetooth.connect(undefined, undefined, bluetooth.reconnectSerialForCurrentBoard ?? undefined);
+    }
   }, [bluetooth]);
 
   if (!bluetooth) return null;

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -341,6 +341,9 @@ export function useCreateClimbScreen({
   // the current holds; tapping again disconnects. ----
   const handleToggleBle = useCallback(() => {
     if (!bluetooth) return;
+    // Ignore taps while a connect is already running — a second concurrent
+    // connect tears down the first attempt's scan and strands the picker.
+    if (bluetooth.loading) return;
     if (bluetooth.isConnected) void bluetooth.disconnect();
     else void bluetooth.connect(generateFramesString());
   }, [bluetooth, generateFramesString]);

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -362,8 +362,17 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   }, [cancelPendingWallControlAttempt, isPartyPreviewOnly, navigationState.nextItem, nextClimb]);
 
   const handleMirror = useCallback(() => {
-    setIsMirrored((prev) => !prev);
-  }, []);
+    const nextMirrored = !isMirrored;
+    setIsMirrored(nextMirrored);
+    // The wall doesn't follow the toggle by itself: the AutoSender keys off
+    // the queue item's own `climb.mirrored`, not this drawer-local state, so
+    // without an explicit re-push the LEDs would keep showing the previous
+    // orientation. isConnected means this device holds the BLE link (and
+    // therefore drives the wall).
+    if (bluetooth?.isConnected && displayedClimb?.frames) {
+      void bluetooth.sendFramesToBoard(displayedClimb.frames, nextMirrored);
+    }
+  }, [isMirrored, bluetooth, displayedClimb]);
 
   const handleToggleFavorite = useCallback(() => {
     if (!displayedClimb) return;

--- a/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
+++ b/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
@@ -110,11 +110,12 @@ export function useMobilePlayback({
   });
 
   // --- Latest-wins BLE frame writer ---
-  // Mobile's sendFramesToBoard has NO internal write mutex (web's does), so this
-  // drain is the ONLY guard against overlapping GATT writes. A second write
-  // issued before the first resolves throws "GATT operation already in progress"
-  // on Android, so this stays a faithful port of web's use-drawer-playback drain:
-  // collapse bursts to the newest frame, never overlap a write.
+  // sendFramesToBoard serialises writes across all callers (its writeChainRef
+  // mutex, mirroring web's), so overlapping calls can no longer interleave at
+  // the GATT boundary. This drain still matters for a different reason: it
+  // collapses animation-frame bursts to the newest frame instead of queueing
+  // every intermediate frame behind the mutex, which would let the wall lag
+  // arbitrarily far behind the on-screen playback.
   const isWritingFrameRef = useRef(false);
   const pendingFrameRef = useRef<string | null>(null);
   const lastSentFrameRef = useRef<string | null>(null);

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -17,9 +17,9 @@ import type { Grade } from '@boardsesh/shared-schema';
 import type { GradeBound } from '@boardsesh/climb-filters';
 import { useTheme } from '../../providers/theme-provider';
 import { useActiveBoard, useSetActiveBoard } from '../../lib/graphql/use-active-board';
-import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { spacing } from '../../theme/tokens';
 import { hapticLight } from '../../lib/haptics';
+import { useLightbulbToggle } from '../ble/use-lightbulb-toggle';
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 import { Text } from '../Text';
 import { iconMap } from '../icon-map';
@@ -322,24 +322,7 @@ function MaterialLightbulbAction() {
   const { systemColors, brandColors } = useTheme();
   const { t: tCommon } = useTranslation('common');
   const { t: tSettings } = useTranslation('settings');
-  const bluetooth = useOptionalBluetoothContext();
-  const connected = bluetooth?.isConnected ?? false;
-
-  const handlePress = useCallback(() => {
-    if (!bluetooth) return;
-    // Ignore taps while a connect is already running — a second concurrent
-    // connect tears down the first attempt's scan and strands the picker.
-    if (bluetooth.loading) return;
-    hapticLight();
-    if (bluetooth.isConnected) {
-      void bluetooth.disconnect();
-    } else {
-      // Reconnect silently to the remembered board when there is one for the
-      // current config (same behaviour as the play-drawer lightbulb);
-      // otherwise fall through to the device picker.
-      void bluetooth.connect(undefined, undefined, bluetooth.reconnectSerialForCurrentBoard ?? undefined);
-    }
-  }, [bluetooth]);
+  const { bluetooth, connected, handlePress } = useLightbulbToggle();
 
   if (!bluetooth) return null;
 

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -327,9 +327,18 @@ function MaterialLightbulbAction() {
 
   const handlePress = useCallback(() => {
     if (!bluetooth) return;
+    // Ignore taps while a connect is already running — a second concurrent
+    // connect tears down the first attempt's scan and strands the picker.
+    if (bluetooth.loading) return;
     hapticLight();
-    if (bluetooth.isConnected) void bluetooth.disconnect();
-    else void bluetooth.connect();
+    if (bluetooth.isConnected) {
+      void bluetooth.disconnect();
+    } else {
+      // Reconnect silently to the remembered board when there is one for the
+      // current config (same behaviour as the play-drawer lightbulb);
+      // otherwise fall through to the device picker.
+      void bluetooth.connect(undefined, undefined, bluetooth.reconnectSerialForCurrentBoard ?? undefined);
+    }
   }, [bluetooth]);
 
   if (!bluetooth) return null;

--- a/packages/mobile/src/lib/ble/__tests__/adapter-factory.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter-factory.test.ts
@@ -23,7 +23,10 @@ vi.mock('react-native', () => ({
 }));
 
 vi.mock('../adapter', () => ({ RNBleAdapter: harness.RNBleAdapter }));
-vi.mock('../native-ios-adapter', () => ({ NativeIosBleAdapter: harness.NativeIosBleAdapter }));
+vi.mock('../native-ios-adapter', () => ({
+  NativeIosBleAdapter: harness.NativeIosBleAdapter,
+  nativeBleSupportsConnectionAdoption: vi.fn(() => false),
+}));
 vi.mock('../../../../modules/live-activity/src/index', () => ({
   get boardBleNative() {
     return harness.module.boardBleNative;

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -174,6 +174,7 @@ describe('RNBleAdapter', () => {
               localName: 'TestBoard',
               name: 'TestBoard',
               rssi: -50,
+              serviceUUIDs: ['uart-uuid'],
             });
           },
         );
@@ -232,7 +233,7 @@ describe('RNBleAdapter', () => {
 
       mockBleManager.startDeviceScan.mockImplementation(
         (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
-          callback(null, { id: 'device-1', localName: 'Board', name: 'Board', rssi: -40 });
+          callback(null, { id: 'device-1', localName: 'Board', name: 'Board', rssi: -40, serviceUUIDs: ['uart-uuid'] });
         },
       );
 
@@ -268,7 +269,13 @@ describe('RNBleAdapter', () => {
       mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
       mockBleManager.startDeviceScan.mockImplementation(
         (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
-          callback(null, { id: 'write-device', localName: 'Board', name: 'Board', rssi: -40 });
+          callback(null, {
+            id: 'write-device',
+            localName: 'Board',
+            name: 'Board',
+            rssi: -40,
+            serviceUUIDs: ['uart-uuid'],
+          });
         },
       );
 
@@ -311,7 +318,13 @@ describe('RNBleAdapter', () => {
       mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
       mockBleManager.startDeviceScan.mockImplementation(
         (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
-          callback(null, { id: 'chunk-device', localName: 'Board', name: 'Board', rssi: -40 });
+          callback(null, {
+            id: 'chunk-device',
+            localName: 'Board',
+            name: 'Board',
+            rssi: -40,
+            serviceUUIDs: ['uart-uuid'],
+          });
         },
       );
 
@@ -359,7 +372,13 @@ describe('RNBleAdapter', () => {
       mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
       mockBleManager.startDeviceScan.mockImplementation(
         (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
-          callback(null, { id: 'abort-device', localName: 'Board', name: 'Board', rssi: -40 });
+          callback(null, {
+            id: 'abort-device',
+            localName: 'Board',
+            name: 'Board',
+            rssi: -40,
+            serviceUUIDs: ['uart-uuid'],
+          });
         },
       );
 
@@ -410,7 +429,13 @@ describe('RNBleAdapter', () => {
       mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
       mockBleManager.startDeviceScan.mockImplementation(
         (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
-          callback(null, { id: 'drop-device', localName: 'Board', name: 'Board', rssi: -40 });
+          callback(null, {
+            id: 'drop-device',
+            localName: 'Board',
+            name: 'Board',
+            rssi: -40,
+            serviceUUIDs: ['uart-uuid'],
+          });
         },
       );
 
@@ -449,7 +474,13 @@ describe('RNBleAdapter', () => {
       mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
       mockBleManager.startDeviceScan.mockImplementation(
         (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
-          callback(null, { id: 'live-device', localName: 'Board', name: 'Board', rssi: -40 });
+          callback(null, {
+            id: 'live-device',
+            localName: 'Board',
+            name: 'Board',
+            rssi: -40,
+            serviceUUIDs: ['uart-uuid'],
+          });
         },
       );
 
@@ -464,6 +495,49 @@ describe('RNBleAdapter', () => {
     });
   });
 
+  describe('requestAndConnect — scan filtering', () => {
+    it('scans unfiltered and filters results in JS so MoonBoards surface', async () => {
+      mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
+      mockBleManager.startDeviceScan.mockImplementation(
+        (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
+          // A MoonBoard advertising no service UUIDs (the case a UUID-filtered
+          // scan would never see), plus an unrelated speaker that must not
+          // reach the picker.
+          callback(null, { id: 'moon-device', localName: 'MoonBoard A1', name: 'MoonBoard A1', rssi: -42 });
+          callback(null, { id: 'speaker', localName: 'JBL Flip 6', name: 'JBL Flip 6', rssi: -30 });
+        },
+      );
+
+      const seenDevices: Array<{ deviceId: string }> = [];
+      const devicePicker: DevicePickerFn = (subscribe) => {
+        subscribe((devices) => {
+          seenDevices.splice(0, seenDevices.length, ...devices);
+        });
+        return Promise.resolve('moon-device');
+      };
+
+      const mockCharacteristic = { uuid: 'uart-write-uuid', writeWithoutResponse: vi.fn() };
+      const mockDeviceWithServices = {
+        id: 'moon-device',
+        characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
+        requestMTU: vi.fn().mockResolvedValue(undefined),
+        discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
+      };
+      mockBleManager.connectToDevice.mockResolvedValue({
+        id: 'moon-device',
+        requestMTU: vi.fn().mockResolvedValue(undefined),
+        discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
+      });
+
+      const adapter = new RNBleAdapter(devicePicker);
+      await adapter.requestAndConnect();
+
+      // Unfiltered scan: UUID filter must be null (a service filter hides MoonBoards).
+      expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(null, null, expect.any(Function));
+      expect(seenDevices.map((device) => device.deviceId)).toEqual(['moon-device']);
+    });
+  });
+
   describe('requestAndConnect — failure modes', () => {
     it('times out and rejects if connectToDevice hangs past CONNECTION_TIMEOUT_MS', async () => {
       vi.useFakeTimers();
@@ -474,7 +548,13 @@ describe('RNBleAdapter', () => {
         mockBleManager.connectToDevice.mockImplementation(() => new Promise(() => {}));
         mockBleManager.startDeviceScan.mockImplementation(
           (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
-            callback(null, { id: 'hang-device', localName: 'Board', name: 'Board', rssi: -40 });
+            callback(null, {
+              id: 'hang-device',
+              localName: 'Board',
+              name: 'Board',
+              rssi: -40,
+              serviceUUIDs: ['uart-uuid'],
+            });
           },
         );
 
@@ -569,7 +649,13 @@ describe('RNBleAdapter', () => {
         // picked" branch rather than the empty-result reject.
         mockBleManager.startDeviceScan.mockImplementation(
           (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
-            callback(null, { id: 'seen-device', localName: 'Board', name: 'Board', rssi: -40 });
+            callback(null, {
+              id: 'seen-device',
+              localName: 'Board',
+              name: 'Board',
+              rssi: -40,
+              serviceUUIDs: ['uart-uuid'],
+            });
           },
         );
 

--- a/packages/mobile/src/lib/ble/__tests__/board-device-filter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/board-device-filter.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID } from '@boardsesh/ble-protocol';
+import { isLikelyBoardDevice } from '../board-device-filter';
+
+describe('isLikelyBoardDevice', () => {
+  it('accepts a device advertising the Aurora service UUID regardless of name', () => {
+    expect(isLikelyBoardDevice({ name: undefined, serviceUuids: [AURORA_ADVERTISED_SERVICE_UUID] })).toBe(true);
+  });
+
+  it('accepts a device advertising the UART service UUID, case-insensitively', () => {
+    expect(isLikelyBoardDevice({ name: 'whatever', serviceUuids: [UART_SERVICE_UUID.toUpperCase()] })).toBe(true);
+  });
+
+  it('accepts a MoonBoard by name even when no service UUIDs are advertised', () => {
+    // The whole reason the scan runs unfiltered: MoonBoard controllers don't
+    // reliably include the UART UUID in their advertisements.
+    expect(isLikelyBoardDevice({ name: 'MoonBoard A1B2', serviceUuids: [] })).toBe(true);
+    expect(isLikelyBoardDevice({ name: 'Moonboard Mini', serviceUuids: null })).toBe(true);
+  });
+
+  it('accepts Aurora boards by product name when the advertisement lacks UUIDs', () => {
+    expect(isLikelyBoardDevice({ name: 'Kilter Board#751737@3', serviceUuids: [] })).toBe(true);
+    expect(isLikelyBoardDevice({ name: 'Tension Board#42@2' })).toBe(true);
+  });
+
+  it('accepts a renamed Aurora board that keeps the #serial@api suffix', () => {
+    expect(isLikelyBoardDevice({ name: 'Garage Wall#900001@3', serviceUuids: [] })).toBe(true);
+  });
+
+  it('rejects unrelated devices', () => {
+    expect(isLikelyBoardDevice({ name: 'JBL Flip 6', serviceUuids: [] })).toBe(false);
+    expect(isLikelyBoardDevice({ name: undefined, serviceUuids: [] })).toBe(false);
+    expect(isLikelyBoardDevice({ name: 'Fitbit Charge', serviceUuids: ['0000180d-0000-1000-8000-00805f9b34fb'] })).toBe(
+      false,
+    );
+  });
+});

--- a/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
@@ -195,4 +195,109 @@ describe('NativeIosBleAdapter connect flow', () => {
     expect(nativeMock.connect).toHaveBeenCalledWith('dev-9');
     expect(nativeMock.startScan).toHaveBeenCalledWith(['AURORA-UUID', 'UART-UUID']);
   });
+
+  it('does not mask the original failure when stopScan rejects in the cleanup path', async () => {
+    nativeMock.stopScan.mockRejectedValueOnce(new Error('bluetooth turned off'));
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('Device selection cancelled')));
+
+    // Must surface the user-cancel, not the stopScan error — otherwise the
+    // hook misclassifies the cancel and pops a spurious failure alert.
+    await expect(adapter.requestAndConnect()).rejects.toThrow('Device selection cancelled');
+  });
+
+  it('flushes the native write queue when an in-flight write is aborted', async () => {
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+    const connectPromise = adapter.requestAndConnect('Kilter A1B2C3');
+    await Promise.resolve();
+    scanListeners[0]?.({
+      device: { deviceId: 'dev-9', name: 'Kilter A1B2C3' },
+      localName: 'Kilter A1B2C3',
+      rssi: -55,
+    });
+    await vi.runAllTimersAsync();
+    await connectPromise;
+
+    let rejectNativeWrite!: (error: Error) => void;
+    nativeMock.write.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectNativeWrite = reject;
+        }),
+    );
+    const abortController = new AbortController();
+    const writePromise = adapter.write(new Uint8Array([0x01]), abortController.signal);
+    await Promise.resolve();
+
+    abortController.abort();
+    expect(nativeMock.cancelWrites).toHaveBeenCalled();
+
+    // The native queue rejects the cancelled write with its own error; the
+    // adapter normalises it to AbortError so callers treat it as cancellation.
+    rejectNativeWrite(new Error('BLE write cancelled'));
+    await expect(writePromise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('adoptConnection wires writes and the disconnect callback without scanning', async () => {
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+
+    adapter.adoptConnection('adopted-dev');
+    await adapter.write(new Uint8Array([0x01, 0x02]));
+    expect(nativeMock.write).toHaveBeenCalled();
+    expect(nativeMock.startScan).not.toHaveBeenCalled();
+
+    const onDisconnect = vi.fn();
+    adapter.onDisconnect(onDisconnect);
+    disconnectListeners[0]?.({ deviceId: 'adopted-dev' });
+    expect(onDisconnect).toHaveBeenCalled();
+  });
+});
+
+describe('NativeIosBleAdapter on newer binaries (adoption surface present)', () => {
+  beforeEach(() => {
+    (nativeMock as Record<string, unknown>).getConnectedDevice = vi.fn().mockResolvedValue(null);
+  });
+  afterEach(() => {
+    delete (nativeMock as Record<string, unknown>).getConnectedDevice;
+  });
+
+  it('scans unfiltered and filters scan results in JS so MoonBoards surface', async () => {
+    let manualPick: (deviceId: string) => void = () => {};
+    const seenDeviceIds: string[] = [];
+    const adapter = new NativeIosBleAdapter(
+      (subscribe) =>
+        new Promise<string>((resolve) => {
+          manualPick = resolve;
+          subscribe((devices) => {
+            seenDeviceIds.splice(0, seenDeviceIds.length, ...devices.map((device) => device.deviceId));
+          });
+        }),
+    );
+    const connectPromise = adapter.requestAndConnect();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Unfiltered scan on the newer surface — a native UUID filter would hide
+    // MoonBoards, which don't reliably advertise the UART UUID.
+    expect(nativeMock.startScan).toHaveBeenCalledWith([]);
+
+    // A MoonBoard with no advertised UUIDs must surface; a nameless device
+    // advertising nothing board-like must not.
+    scanListeners[0]?.({
+      device: { deviceId: 'moon-1', name: 'MoonBoard A1' },
+      localName: 'MoonBoard A1',
+      rssi: -40,
+    });
+    scanListeners[0]?.({
+      device: { deviceId: 'mystery', name: '' },
+      localName: '',
+      rssi: -30,
+    });
+
+    expect(seenDeviceIds).toEqual(['moon-1']);
+
+    manualPick('moon-1');
+    await vi.runAllTimersAsync();
+    await connectPromise;
+    expect(nativeMock.connect).toHaveBeenCalledWith('moon-1');
+  });
 });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -19,6 +19,7 @@ vi.mock('react-native', async () => {
   const { reactNativePermissionHarness: harness } = await import('./react-native-permissions-test-harness');
   return {
     Alert: { alert: vi.fn() },
+    AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
     Platform: harness.platform,
     PermissionsAndroid: harness.permissionsAndroid,
   };
@@ -41,10 +42,17 @@ vi.mock('expo-keep-awake', () => ({
   deactivateKeepAwake: vi.fn().mockResolvedValue(undefined),
 }));
 
+const mockGetAuroraBluetoothPacket = vi.hoisted(() => vi.fn());
 vi.mock('@boardsesh/ble-protocol/aurora', () => ({
-  getAuroraBluetoothPacket: vi.fn(),
+  getAuroraBluetoothPacket: mockGetAuroraBluetoothPacket,
   parseApiLevel: vi.fn(),
+  parseBoardTypeFromDeviceName: vi.fn(),
   parseSerialNumber: vi.fn(),
+}));
+
+const mockGetLedPlacements = vi.hoisted(() => vi.fn());
+vi.mock('@boardsesh/board-constants/led-placements', () => ({
+  getLedPlacements: mockGetLedPlacements,
 }));
 
 const mockGetMoonboardBluetoothPacket = vi.hoisted(() => vi.fn());
@@ -84,15 +92,31 @@ vi.mock('../adapter', () => ({
 vi.mock('../adapter-factory', () => ({
   createBluetoothAdapter: vi.fn(),
   isNativeIosBleAdapter: vi.fn().mockReturnValue(false),
+  // Adoption seam: null/absent = platform without native connection adoption.
+  subscribeNativeBleConnected: vi.fn(() => null),
+  getNativeBleConnectedDevice: vi.fn(async () => null),
 }));
 
 import { createBluetoothAdapter } from '../adapter-factory';
 import { convertToMirroredFramesString, dispatchMoonboardPacket, useBoardBluetooth } from '../use-board-bluetooth';
 
-// ── Factory helper ─────────────────────────────────────────────────────────
+// ── Factory helpers ────────────────────────────────────────────────────────
 
 function makePlacement(id: number, mirroredHoldId: number | null): HoldPlacement {
   return { id, mirroredHoldId, cx: 0, cy: 0, r: 10 };
+}
+
+type FakeAdapterOverrides = Partial<Record<'isAvailable' | 'requestAndConnect' | 'disconnect' | 'write', unknown>>;
+
+function makeFakeAdapter(overrides: FakeAdapterOverrides = {}) {
+  return {
+    isAvailable: vi.fn().mockResolvedValue(true),
+    requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'device-1', deviceName: 'Kilter Board#123@3' }),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    write: vi.fn().mockResolvedValue(undefined),
+    onDisconnect: vi.fn(() => () => {}),
+    ...overrides,
+  };
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -125,6 +149,201 @@ describe('useBoardBluetooth', () => {
     expect(connected).toBe(false);
     expect(Alert.alert).toHaveBeenCalledWith('ble.permissionRequired', 'ble.errorPermissionDenied');
     expect(createBluetoothAdapter).not.toHaveBeenCalled();
+  });
+
+  it('ignores a second connect while one is already in flight', async () => {
+    let resolveRequest!: (connection: { deviceId: string; deviceName?: string }) => void;
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn(
+        () =>
+          new Promise<{ deviceId: string; deviceName?: string }>((resolve) => {
+            resolveRequest = resolve;
+          }),
+      ),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+
+    let firstConnect!: Promise<boolean>;
+    let secondConnectResult = true;
+    await act(async () => {
+      firstConnect = result.current.connect();
+      // Let the first attempt get past permissions and adapter creation.
+      await Promise.resolve();
+      secondConnectResult = await result.current.connect();
+    });
+
+    expect(secondConnectResult).toBe(false);
+    expect(createBluetoothAdapter).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveRequest({ deviceId: 'device-1', deviceName: 'MoonBoard' });
+      await firstConnect;
+    });
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  it('alerts on a "cancelled"-flavoured native failure instead of staying silent', async () => {
+    // CoreBluetooth/ble-plx reject with "Operation was cancelled" for real
+    // failures. The old bare /cancel/i regex treated this as a user cancel and
+    // showed nothing — the headline "tapped connect and nothing happened" bug.
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockRejectedValue(new Error('Operation was cancelled')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.unknownError');
+  });
+
+  it('stays silent when the user dismisses the device picker', async () => {
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockRejectedValue(new Error('Device selection cancelled')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(Alert.alert).not.toHaveBeenCalled();
+  });
+
+  it('maps a connect timeout to the connect-failed copy', async () => {
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockRejectedValue(new Error('Connection timed out — board may be powered off')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.connectFailed');
+  });
+
+  it('serialises overlapping sendFramesToBoard calls so chunks never interleave', async () => {
+    const writeEvents: string[] = [];
+    let releaseFirstWrite!: () => void;
+    const write = vi.fn((packet: Uint8Array) => {
+      const label = String(packet[0]);
+      writeEvents.push(`start-${label}`);
+      if (writeEvents.length === 1) {
+        return new Promise<void>((resolve) => {
+          releaseFirstWrite = () => {
+            writeEvents.push(`end-${label}`);
+            resolve();
+          };
+        });
+      }
+      writeEvents.push(`end-${label}`);
+      return Promise.resolve();
+    });
+    const fakeAdapter = makeFakeAdapter({ write });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetMoonboardBluetoothPacket
+      .mockReturnValueOnce({ packet: new Uint8Array([1]) })
+      .mockReturnValueOnce({ packet: new Uint8Array([2]) });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    let firstSend!: Promise<boolean | undefined>;
+    let secondSend!: Promise<boolean | undefined>;
+    await act(async () => {
+      firstSend = result.current.sendFramesToBoard('p1r12');
+      secondSend = result.current.sendFramesToBoard('p2r12');
+      // Give the second send every chance to start out of order.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(writeEvents).toEqual(['start-1']);
+      releaseFirstWrite();
+      await Promise.all([firstSend, secondSend]);
+    });
+
+    expect(writeEvents).toEqual(['start-1', 'end-1', 'start-2', 'end-2']);
+  });
+
+  it('converts frames through the mirror map when mirrored and holdsData are provided', async () => {
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetLedPlacements.mockReturnValue({ 200: 7 });
+    mockGetAuroraBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([9]),
+      skippedPositionCount: 0,
+      skippedRoleCount: 0,
+      totalPlacements: 1,
+    });
+
+    const holdsData = [makePlacement(100, 200)];
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1, holdsData }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    await act(async () => {
+      await result.current.sendFramesToBoard('p100r12', true);
+    });
+
+    expect(mockGetAuroraBluetoothPacket).toHaveBeenCalledWith('p200r12', { 200: 7 }, 'kilter', undefined, undefined);
+    expect(fakeAdapter.write).toHaveBeenCalledWith(new Uint8Array([9]), expect.anything());
+  });
+
+  it('aborts queued and in-flight writes on disconnect', async () => {
+    const write = vi.fn(
+      (_packet: Uint8Array, signal?: AbortSignal) =>
+        new Promise<void>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(new DOMException('Write aborted', 'AbortError')));
+        }),
+    );
+    const fakeAdapter = makeFakeAdapter({ write });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetMoonboardBluetoothPacket.mockReturnValue({ packet: new Uint8Array([1]) });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'moonboard', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    let pendingSend!: Promise<boolean | undefined>;
+    await act(async () => {
+      pendingSend = result.current.sendFramesToBoard('p1r12');
+      await Promise.resolve();
+      await result.current.disconnect();
+    });
+
+    // The aborted write resolves as a cancellation (undefined), not a failure.
+    await expect(pendingSend).resolves.toBeUndefined();
+    expect(fakeAdapter.disconnect).toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { Alert } from 'react-native';
 import type { HoldPlacement } from '../../../components/board-renderer/types';
@@ -58,6 +58,7 @@ vi.mock('@boardsesh/board-constants/led-placements', () => ({
 const mockGetMoonboardBluetoothPacket = vi.hoisted(() => vi.fn());
 vi.mock('@boardsesh/ble-protocol/moonboard', () => ({
   getMoonboardBluetoothPacket: mockGetMoonboardBluetoothPacket,
+  isMoonboardDeviceName: vi.fn((name?: string) => !!name && name.startsWith('MoonBoard')),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -97,7 +98,13 @@ vi.mock('../adapter-factory', () => ({
   getNativeBleConnectedDevice: vi.fn(async () => null),
 }));
 
-import { createBluetoothAdapter } from '../adapter-factory';
+import {
+  createBluetoothAdapter,
+  getNativeBleConnectedDevice,
+  isNativeIosBleAdapter,
+  subscribeNativeBleConnected,
+} from '../adapter-factory';
+import { parseBoardTypeFromDeviceName } from '@boardsesh/ble-protocol/aurora';
 import { convertToMirroredFramesString, dispatchMoonboardPacket, useBoardBluetooth } from '../use-board-bluetooth';
 
 // ── Factory helpers ────────────────────────────────────────────────────────
@@ -344,6 +351,101 @@ describe('useBoardBluetooth', () => {
     // The aborted write resolves as a cancellation (undefined), not a failure.
     await expect(pendingSend).resolves.toBeUndefined();
     expect(fakeAdapter.disconnect).toHaveBeenCalled();
+  });
+});
+
+// ── Native connection adoption (iOS) ───────────────────────────────────────
+
+describe('useBoardBluetooth native connection adoption', () => {
+  type ConnectedListener = (payload: { deviceId: string; deviceName?: string }) => void;
+  let connectedListener: ConnectedListener | null = null;
+
+  function makeAdoptableAdapter() {
+    return {
+      ...makeFakeAdapter(),
+      adoptConnection: vi.fn(),
+      configureBoard: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetReactNativePermissionHarness();
+    connectedListener = null;
+    vi.mocked(subscribeNativeBleConnected).mockImplementation((listener) => {
+      connectedListener = listener;
+      return { remove: vi.fn() };
+    });
+    vi.mocked(isNativeIosBleAdapter).mockReturnValue(true);
+    vi.mocked(parseBoardTypeFromDeviceName).mockImplementation((name?: string) =>
+      name?.toLowerCase().startsWith('kilter') ? 'kilter' : undefined,
+    );
+  });
+
+  afterEach(() => {
+    vi.mocked(subscribeNativeBleConnected).mockImplementation(() => null);
+    vi.mocked(getNativeBleConnectedDevice).mockImplementation(async () => null);
+    vi.mocked(isNativeIosBleAdapter).mockReturnValue(false);
+    vi.mocked(parseBoardTypeFromDeviceName).mockReset();
+  });
+
+  it('adopts a natively-connected board matching the active config', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    expect(adapter.adoptConnection).toHaveBeenCalledWith('native-dev');
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  it('refuses to adopt a device it cannot positively identify as the active board type', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      // Unnamed device ('' from the bridge) — could be anything, e.g. a
+      // MoonBoard that would receive Aurora-format packets.
+      connectedListener?.({ deviceId: 'mystery-dev', deviceName: '' });
+      // Recognisable, but the wrong family for the active config.
+      connectedListener?.({ deviceId: 'moon-dev', deviceName: 'MoonBoard A1' });
+    });
+
+    expect(adapter.adoptConnection).not.toHaveBeenCalled();
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it('does not re-adopt after an explicit disconnect until the next deliberate connect', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+    expect(result.current.isConnected).toBe(true);
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.isConnected).toBe(false);
+
+    // The native disconnect can still be in flight when the app foregrounds —
+    // a late connected event (or getConnectedDevice poll) must not resurrect
+    // the connection the user just closed.
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    expect(adapter.adoptConnection).toHaveBeenCalledTimes(1);
+    expect(result.current.isConnected).toBe(false);
   });
 });
 

--- a/packages/mobile/src/lib/ble/adapter-factory.ts
+++ b/packages/mobile/src/lib/ble/adapter-factory.ts
@@ -1,7 +1,11 @@
 import { Platform } from 'react-native';
-import { boardBleNative } from '../../../modules/live-activity/src/index';
+import {
+  boardBleNative,
+  type NativeBleConnectedDevice,
+  type NativeBleConnectedEvent,
+} from '../../../modules/live-activity/src/index';
 import { RNBleAdapter } from './adapter';
-import { NativeIosBleAdapter } from './native-ios-adapter';
+import { NativeIosBleAdapter, nativeBleSupportsConnectionAdoption } from './native-ios-adapter';
 import type { BluetoothAdapter, DevicePickerFn } from './types';
 
 // Returns the BluetoothAdapter implementation appropriate for the current
@@ -25,4 +29,36 @@ export function createBluetoothAdapter(devicePicker: DevicePickerFn): BluetoothA
 // state for the widget intent path.
 export function isNativeIosBleAdapter(adapter: BluetoothAdapter): adapter is NativeIosBleAdapter {
   return adapter instanceof NativeIosBleAdapter;
+}
+
+// ── Native connection adoption seam ────────────────────────────────────────
+// useBoardBluetooth accesses the native module exclusively through these
+// helpers (rather than importing modules/live-activity directly) so the hook
+// stays testable — expo-modules-core touches React Native globals at import
+// time, and tests mock this factory module wholesale.
+
+/**
+ * Subscribe to the native `connected` event (a connection became write-ready,
+ * whether JS initiated it or not). Returns null when the platform/binary
+ * doesn't support adoption — callers treat that as "feature absent".
+ */
+export function subscribeNativeBleConnected(
+  listener: (payload: NativeBleConnectedEvent) => void,
+): { remove: () => void } | null {
+  if (!boardBleNative || !nativeBleSupportsConnectionAdoption()) return null;
+  return boardBleNative.addListener('connected', listener);
+}
+
+/**
+ * The natively-connected, write-ready board, or null. Null on Android, on
+ * older iOS binaries, and on any native error.
+ */
+export async function getNativeBleConnectedDevice(): Promise<NativeBleConnectedDevice | null> {
+  const native = boardBleNative;
+  if (!native || typeof native.getConnectedDevice !== 'function') return null;
+  try {
+    return (await native.getConnectedDevice()) ?? null;
+  } catch {
+    return null;
+  }
 }

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -1,6 +1,5 @@
 import { type Device, type Characteristic } from 'react-native-ble-plx';
 import {
-  AURORA_ADVERTISED_SERVICE_UUID,
   UART_SERVICE_UUID,
   UART_WRITE_CHARACTERISTIC_UUID,
   splitMessages,
@@ -9,6 +8,7 @@ import {
 } from '@boardsesh/ble-protocol';
 import { bleManager } from './ble-manager';
 import { waitForBlePoweredOn } from './availability';
+import { isLikelyBoardDevice } from './board-device-filter';
 import type { BluetoothAdapter, BleConnection, DevicePickerFn, DiscoveredDevice } from './types';
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
 
@@ -73,41 +73,45 @@ export class RNBleAdapter implements BluetoothAdapter {
     let scanTimeoutId: ReturnType<typeof setTimeout> | undefined;
     let selectedDeviceId: string;
     try {
-      bleManager.startDeviceScan(
-        [AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID],
-        null,
-        (scanError, scannedDevice) => {
-          if (scanError) {
-            bleManager.stopDeviceScan();
-            // Surface the failure immediately so the user sees feedback instead
-            // of waiting out the 30s scan window (the picker, if open, closes too).
-            rejectSelection(new Error(`BLE scan failed: ${scanError.message}`));
-            return;
+      // Scan unfiltered and filter results in JS: a service-UUID filter would
+      // hide MoonBoard controllers, which don't reliably advertise the UART
+      // service UUID (see isLikelyBoardDevice).
+      bleManager.startDeviceScan(null, null, (scanError, scannedDevice) => {
+        if (scanError) {
+          bleManager.stopDeviceScan();
+          // Surface the failure immediately so the user sees feedback instead
+          // of waiting out the 30s scan window (the picker, if open, closes too).
+          rejectSelection(new Error(`BLE scan failed: ${scanError.message}`));
+          return;
+        }
+
+        if (!scannedDevice) return;
+
+        const deviceName = scannedDevice.localName ?? scannedDevice.name ?? undefined;
+        if (!isLikelyBoardDevice({ name: deviceName, serviceUuids: scannedDevice.serviceUUIDs })) {
+          return;
+        }
+
+        const device: DiscoveredDevice = {
+          deviceId: scannedDevice.id,
+          name: deviceName,
+          rssi: scannedDevice.rssi ?? -100,
+        };
+
+        // Deduplicate by deviceId — react-native-ble-plx uses stable
+        // peripheral UUIDs on iOS and device addresses on Android.
+        devices.set(device.deviceId, device);
+        pushDevices();
+
+        // Auto-select the stored board only until the picker takes over.
+        if (autoSelecting && targetSerial) {
+          const serial = parseSerialNumber(device.name);
+          if (serial === targetSerial) {
+            autoSelecting = false;
+            resolveSelection(device.deviceId);
           }
-
-          if (!scannedDevice) return;
-
-          const device: DiscoveredDevice = {
-            deviceId: scannedDevice.id,
-            name: scannedDevice.localName ?? scannedDevice.name ?? undefined,
-            rssi: scannedDevice.rssi ?? -100,
-          };
-
-          // Deduplicate by deviceId — react-native-ble-plx uses stable
-          // peripheral UUIDs on iOS and device addresses on Android.
-          devices.set(device.deviceId, device);
-          pushDevices();
-
-          // Auto-select the stored board only until the picker takes over.
-          if (autoSelecting && targetSerial) {
-            const serial = parseSerialNumber(device.name);
-            if (serial === targetSerial) {
-              autoSelecting = false;
-              resolveSelection(device.deviceId);
-            }
-          }
-        },
-      );
+        }
+      });
 
       // Grace window: if the stored serial hasn't matched shortly, open the
       // picker (scan keeps running so it live-updates) instead of waiting out

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -88,18 +88,30 @@ export class RNBleAdapter implements BluetoothAdapter {
         if (!scannedDevice) return;
 
         const deviceName = scannedDevice.localName ?? scannedDevice.name ?? undefined;
-        if (!isLikelyBoardDevice({ name: deviceName, serviceUuids: scannedDevice.serviceUUIDs })) {
+        // Overflow UUIDs cover iOS peripherals whose advertisement is too full
+        // to carry the service list in the main packet.
+        const advertisedServiceUuids = [
+          ...(scannedDevice.serviceUUIDs ?? []),
+          ...(scannedDevice.overflowServiceUUIDs ?? []),
+        ];
+        if (!isLikelyBoardDevice({ name: deviceName, serviceUuids: advertisedServiceUuids })) {
           return;
         }
+
+        // Deduplicate by deviceId — react-native-ble-plx uses stable
+        // peripheral UUIDs on iOS and device addresses on Android. An
+        // unfiltered scan re-fires this callback for every repeat
+        // advertisement, so only update state (and re-render the picker) when
+        // something material changed: a new device, or its name arriving in a
+        // later scan-response packet.
+        const alreadyListed = devices.get(scannedDevice.id);
+        if (alreadyListed && alreadyListed.name === deviceName) return;
 
         const device: DiscoveredDevice = {
           deviceId: scannedDevice.id,
           name: deviceName,
           rssi: scannedDevice.rssi ?? -100,
         };
-
-        // Deduplicate by deviceId — react-native-ble-plx uses stable
-        // peripheral UUIDs on iOS and device addresses on Android.
         devices.set(device.deviceId, device);
         pushDevices();
 

--- a/packages/mobile/src/lib/ble/board-device-filter.ts
+++ b/packages/mobile/src/lib/ble/board-device-filter.ts
@@ -1,0 +1,34 @@
+import { AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID, parseSerialNumber } from '@boardsesh/ble-protocol';
+import { parseBoardTypeFromDeviceName } from '@boardsesh/ble-protocol/aurora';
+import { isMoonboardDeviceName } from '@boardsesh/ble-protocol/moonboard';
+
+const BOARD_SERVICE_UUIDS = new Set([AURORA_ADVERTISED_SERVICE_UUID.toLowerCase(), UART_SERVICE_UUID.toLowerCase()]);
+
+/**
+ * Decides whether a scan result looks like a climbing board. The adapters scan
+ * unfiltered (where supported) because MoonBoard controllers don't reliably
+ * include the UART service UUID in their advertisements — a service-UUID scan
+ * filter never surfaces them (web works around the same problem with
+ * `namePrefix` filters in MOONBOARD_REQUEST_DEVICE_OPTIONS). So the filtering
+ * moves here: accept anything advertising a known board service, any
+ * MoonBoard-prefixed name, any Aurora product name, and any name carrying the
+ * Aurora `#serial@api` suffix (covers renamed Aurora boards). When a platform
+ * still scans with a native UUID filter (older iOS binaries), pass
+ * `serviceUuids: undefined` and a known-service name match is not required —
+ * the native filter already vouched for the device.
+ */
+export function isLikelyBoardDevice({
+  name,
+  serviceUuids,
+}: {
+  name?: string;
+  serviceUuids?: string[] | null;
+}): boolean {
+  if (serviceUuids?.some((serviceUuid) => BOARD_SERVICE_UUIDS.has(serviceUuid.toLowerCase()))) {
+    return true;
+  }
+  if (!name) return false;
+  if (isMoonboardDeviceName(name)) return true;
+  if (parseBoardTypeFromDeviceName(name) !== undefined) return true;
+  return parseSerialNumber(name) !== undefined;
+}

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -102,6 +102,12 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
       if (scanUnfiltered && !isLikelyBoardDevice({ name: deviceName, serviceUuids: payload.serviceUuids })) {
         return;
       }
+      // Repeat advertisements of an unchanged device don't need a state
+      // update (or a picker re-render) — only a new device or a late-arriving
+      // name does.
+      const alreadyListed = devices.get(payload.device.deviceId);
+      if (alreadyListed && alreadyListed.name === deviceName) return;
+
       const device: DiscoveredDevice = {
         deviceId: payload.device.deviceId,
         name: deviceName,

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -6,6 +6,17 @@ import {
 } from '../../../modules/live-activity/src/index';
 import type { BluetoothAdapter, BleConnection, DevicePickerFn, DiscoveredDevice } from './types';
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
+import { isLikelyBoardDevice } from './board-device-filter';
+
+/**
+ * True when the running binary ships the newer BoardBle native surface
+ * (`getConnectedDevice`, the `connected` event, unfiltered scanning). JS rides
+ * OTA updates onto older binaries, so every new native capability is gated on
+ * this check.
+ */
+export function nativeBleSupportsConnectionAdoption(): boolean {
+  return typeof boardBleNative?.getConnectedDevice === 'function';
+}
 
 function uint8ArrayToHex(bytes: Uint8Array): string {
   let hex = '';
@@ -79,10 +90,21 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
       openPicker();
     }
 
+    // Newer binaries scan unfiltered (a native service-UUID filter would hide
+    // MoonBoard controllers, which don't reliably advertise the UART UUID) and
+    // report advertised service UUIDs so JS can filter; older binaries keep
+    // the native UUID filter and the JS filter passes their results through
+    // (no serviceUuids field, and their names match the board patterns).
+    const scanUnfiltered = nativeBleSupportsConnectionAdoption();
+
     const scanSubscription = native.addListener('scanResult', (payload: NativeBleScanEvent) => {
+      const deviceName = payload.localName || payload.device.name || undefined;
+      if (scanUnfiltered && !isLikelyBoardDevice({ name: deviceName, serviceUuids: payload.serviceUuids })) {
+        return;
+      }
       const device: DiscoveredDevice = {
         deviceId: payload.device.deviceId,
-        name: payload.localName || payload.device.name || undefined,
+        name: deviceName,
         rssi: payload.rssi,
       };
       devices.set(device.deviceId, device);
@@ -106,7 +128,9 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
     let scanTimeoutId: ReturnType<typeof setTimeout> | undefined;
     let selectedDeviceId: string;
     try {
-      await native.startScan([AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID]);
+      // Empty list = unfiltered scan on newer binaries; older binaries get the
+      // explicit UUID filter they understand.
+      await native.startScan(scanUnfiltered ? [] : [AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID]);
 
       // Grace window: if the stored serial hasn't matched shortly, open the
       // picker (scan keeps running so it live-updates) instead of waiting out
@@ -139,7 +163,10 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
       if (pickerFallbackId) clearTimeout(pickerFallbackId);
       if (scanTimeoutId) clearTimeout(scanTimeoutId);
       scanSubscription.remove();
-      await native.stopScan();
+      // Swallow stopScan rejections: a throw here (e.g. Bluetooth toggled off
+      // mid-flow) would mask the original error — turning a user-cancel into a
+      // spurious failure alert, or hiding the real scan/connect error.
+      await native.stopScan().catch(() => {});
     }
 
     let selectedDeviceName: string | undefined;
@@ -152,19 +179,36 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
 
     await native.connect(selectedDeviceId);
 
-    this.connectedDeviceId = selectedDeviceId;
-    this.disconnectSubscription = native.addListener('disconnected', (payload) => {
-      if (payload.deviceId !== selectedDeviceId) return;
-      this.connectedDeviceId = null;
-      this.disconnectSubscription?.remove();
-      this.disconnectSubscription = null;
-      this.disconnectCallback?.();
-    });
+    this.trackConnectedDevice(selectedDeviceId);
 
     return {
       deviceId: selectedDeviceId,
       deviceName: selectedDeviceName,
     };
+  }
+
+  /**
+   * Adopt a connection the native BoardBleManager already holds (a widget
+   * intent reconnected in the background) without scanning or connecting:
+   * just start tracking the device so writes and the disconnect callback
+   * work. The caller is responsible for verifying the device actually is
+   * connected (via `getConnectedDevice`) and for hook-level state.
+   */
+  adoptConnection(deviceId: string): void {
+    this.trackConnectedDevice(deviceId);
+  }
+
+  private trackConnectedDevice(deviceId: string): void {
+    const native = this.requireNative();
+    this.disconnectSubscription?.remove();
+    this.connectedDeviceId = deviceId;
+    this.disconnectSubscription = native.addListener('disconnected', (payload) => {
+      if (payload.deviceId !== deviceId) return;
+      this.connectedDeviceId = null;
+      this.disconnectSubscription?.remove();
+      this.disconnectSubscription = null;
+      this.disconnectCallback?.();
+    });
   }
 
   async disconnect(): Promise<void> {
@@ -185,8 +229,29 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
     }
     // Native side handles chunking (20-byte UART chunks with 5ms inter-chunk
     // delay) inside BoardBleManager, so we pass the full payload as a single
-    // hex string.
-    await native.write(uint8ArrayToHex(data));
+    // hex string. An abort while the chunks are still draining natively flushes
+    // the native queue too — without cancelWrites the stale climb would keep
+    // streaming to the wall after the caller gave up on it.
+    if (!signal) {
+      await native.write(uint8ArrayToHex(data));
+      return;
+    }
+    const onAbort = () => {
+      void native.cancelWrites().catch(() => {});
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    try {
+      await native.write(uint8ArrayToHex(data));
+    } catch (error) {
+      // The native queue rejects cancelled writes with its own error shape;
+      // normalise to AbortError so callers classify it as a cancellation.
+      if (signal.aborted) {
+        throw new DOMException('Write aborted', 'AbortError');
+      }
+      throw error;
+    } finally {
+      signal.removeEventListener('abort', onAbort);
+    }
   }
 
   onDisconnect(callback: () => void): () => void {

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -1,21 +1,27 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Alert } from 'react-native';
+import { Alert, AppState } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import {
   getAuroraBluetoothPacket,
   parseApiLevel,
+  parseBoardTypeFromDeviceName,
   parseSerialNumber,
   type LedColorOverrides,
 } from '@boardsesh/ble-protocol/aurora';
 import { getMoonboardBluetoothPacket } from '@boardsesh/ble-protocol/moonboard';
-import { isDisconnectionError } from '@boardsesh/ble-protocol/connection-error';
+import { classifyBleFailure, isDisconnectionError } from '@boardsesh/ble-protocol/connection-error';
 import type { AuroraBoardName } from '@boardsesh/shared-schema';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { RECORD_BOARD_SERIAL } from '@boardsesh/graphql/operations';
 import { getHttpClient } from '../graphql/client';
 import { getAuthToken } from '../auth-store';
-import { createBluetoothAdapter, isNativeIosBleAdapter } from './adapter-factory';
+import {
+  createBluetoothAdapter,
+  getNativeBleConnectedDevice,
+  isNativeIosBleAdapter,
+  subscribeNativeBleConnected,
+} from './adapter-factory';
 import { requestBleRuntimePermissions } from './use-ble-permissions';
 import type { BluetoothAdapter, DevicePickerFn, DiscoveredDevice } from './types';
 import type { HoldPlacement } from '../../components/board-renderer/types';
@@ -125,26 +131,33 @@ const KEEP_AWAKE_TAG = 'boardsesh-ble';
 /**
  * Create a single AbortSignal that fires when either of the two input signals
  * is aborted. This lets us combine a caller-supplied signal with an internal
- * one without losing either.
+ * one without losing either. Callers must invoke `dispose` once the guarded
+ * work settles — the caller-supplied signal can be long-lived (the
+ * AutoSender's lifetime controller), and without the dispose every write
+ * would leave one more dangling 'abort' listener on it for the rest of the
+ * session.
  */
-function mergeAbortSignals(signalA: AbortSignal, signalB: AbortSignal): AbortSignal {
+function mergeAbortSignals(signalA: AbortSignal, signalB: AbortSignal): { signal: AbortSignal; dispose: () => void } {
   const controller = new AbortController();
 
-  const onAbort = () => {
-    controller.abort();
+  const detach = () => {
     signalA.removeEventListener('abort', onAbort);
     signalB.removeEventListener('abort', onAbort);
+  };
+  const onAbort = () => {
+    controller.abort();
+    detach();
   };
 
   if (signalA.aborted || signalB.aborted) {
     controller.abort();
-    return controller.signal;
+    return { signal: controller.signal, dispose: () => {} };
   }
 
   signalA.addEventListener('abort', onAbort);
   signalB.addEventListener('abort', onAbort);
 
-  return controller.signal;
+  return { signal: controller.signal, dispose: detach };
 }
 
 function classifyBleFailureReason(error: unknown): string {
@@ -166,6 +179,9 @@ export function useBoardBluetooth({
   onConnectSuccess,
 }: UseBoardBluetoothOptions) {
   const { t } = useTranslation('settings');
+  // Connect-failure copy lives in the shared `common.bluetooth.*` keys so web
+  // and mobile describe the same failure the same way.
+  const { t: tCommon } = useTranslation('common');
   const [loading, setLoading] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
 
@@ -179,7 +195,26 @@ export function useBoardBluetooth({
   const adapterRef = useRef<BluetoothAdapter | null>(null);
   const apiLevelRef = useRef<number>(3);
   const unsubDisconnectRef = useRef<(() => void) | null>(null);
+  // One AbortController per connection generation, shared by every write of
+  // that generation. connect()/disconnect() abort it so ALL in-flight and
+  // queued writes against the old adapter cancel — a per-write controller
+  // would only ever cover the most recent one.
   const writeAbortRef = useRef<AbortController | null>(null);
+  // Serialises every adapter.write across all callers of sendFramesToBoard.
+  // The AutoSender (first frame on climb change), the play-drawer playback
+  // drain (subsequent frames) and the create-climb preview each guard only
+  // their own writes, so without a shared mutex their independent latest-wins
+  // loops can overlap at the GATT boundary. RNBleAdapter splits a packet into
+  // 20-byte chunks written sequentially with inter-chunk delays — two
+  // overlapping writes interleave chunks of two different packets and corrupt
+  // both. Mirrors the web hook's writeChainRef; reset on connect/disconnect
+  // so a hung write can't wedge the next connection's sends.
+  const writeChainRef = useRef<Promise<void>>(Promise.resolve());
+  // True while a connect attempt is running. Guards against a second
+  // concurrent connect (double-tapped lightbulb): both attempts would share
+  // the singleton BLE manager, and the first attempt's scan teardown kills
+  // the second attempt's scan, stranding the picker.
+  const connectInFlightRef = useRef(false);
 
   const [pickerState, setPickerState] = useState<PickerState | null>(null);
   const pickerRejectRef = useRef<((error: Error) => void) | null>(null);
@@ -240,109 +275,134 @@ export function useBoardBluetooth({
       if (!adapterRef.current || !boardName || layoutId === undefined || sizeId === undefined) return;
       const boardAnalyticsProperties = { boardName, layoutId, sizeId, mirrored };
 
-      // Create an AbortController for this write so connect() can cancel
-      // an in-flight write when creating a new adapter.
-      const writeAbort = new AbortController();
-      writeAbortRef.current = writeAbort;
-
-      // Combine caller-provided signal with the internal abort controller
-      const combinedSignal = signal ? mergeAbortSignals(signal, writeAbort.signal) : writeAbort.signal;
-
-      try {
-        if (boardName === 'moonboard') {
-          const sent = await dispatchMoonboardPacket(
-            frames,
-            adapterRef.current.write.bind(adapterRef.current),
-            combinedSignal,
-          );
-          if (sent) track(SHARED_EVENTS.ClimbSentToBoardSuccess, boardAnalyticsProperties);
-          return sent;
-        }
-
-        // Empty frames = "clear all LEDs" for Aurora boards
-        if (frames === '') {
-          const clearResult = getAuroraBluetoothPacket('', {}, boardName as AuroraBoardName, apiLevelRef.current);
-          await adapterRef.current.write(clearResult.packet, combinedSignal);
-          return true;
-        }
-
-        let framesToSend = frames;
-
-        if (mirrored && holdsData && holdsData.length > 0) {
-          framesToSend = convertToMirroredFramesString(frames, holdsData);
-        }
-
-        if (!cachedGetLedPlacements) {
-          const mod = await import('@boardsesh/board-constants/led-placements');
-          cachedGetLedPlacements = mod.getLedPlacements as GetLedPlacementsFn;
-        }
-        const getLedPlacementsFn = cachedGetLedPlacements;
-        const placementPositions = getLedPlacementsFn(boardName, layoutId, sizeId);
-
-        if (Object.keys(placementPositions).length === 0) {
-          console.error(
-            `[BLE] LED placement map is empty for ${boardName} layout=${layoutId} size=${sizeId}. Board configuration may be incorrect or LED data may need regeneration.`,
-          );
-          Alert.alert(t('ble.notAvailable'), t('ble.errorLedMissing'));
-          track(SHARED_EVENTS.ClimbSentToBoardFailure, {
-            ...boardAnalyticsProperties,
-            failureReason: 'missing_led_placements',
-          });
-          return false;
-        }
-
-        const result = getAuroraBluetoothPacket(
-          framesToSend,
-          placementPositions,
-          boardName as AuroraBoardName,
-          apiLevelRef.current,
-          ledColorOverrides,
-        );
-
-        const skippedCount = result.skippedPositionCount + result.skippedRoleCount;
-
-        if (skippedCount > 0 && result.packet.length === 0) {
-          console.warn(`[BLE] All ${result.totalPlacements} placements skipped — climb incompatible with board`);
-          Alert.alert(t('ble.notAvailable'), t('ble.errorIncompatible'));
-          track(SHARED_EVENTS.ClimbSentToBoardFailure, {
-            ...boardAnalyticsProperties,
-            failureReason: 'incompatible_climb',
-          });
-          return false;
-        }
-
-        if (skippedCount > 0) {
-          console.warn(`[BLE] ${skippedCount} of ${result.totalPlacements} placements skipped`);
-        }
-
-        await adapterRef.current.write(result.packet, combinedSignal);
-        track(SHARED_EVENTS.ClimbSentToBoardSuccess, boardAnalyticsProperties);
-        return true;
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          return;
-        }
-        console.error('Error sending frames to board:', error);
-        track(SHARED_EVENTS.ClimbSentToBoardFailure, {
-          ...boardAnalyticsProperties,
-          failureReason: classifyBleFailureReason(error),
-        });
-        // A write that fails because the link is gone (the board dropped or
-        // another device grabbed it — these boards are last-connection-wins) is
-        // often the only signal we get: the adapter's disconnect event may never
-        // fire. Mark the connection lost so the lightbulb stops showing
-        // "connected" and a deliberate reconnect can run. The native adapters
-        // throw the plain-Error signatures the predicate matches ("Not
-        // connected", "Device disconnected during write").
-        if (isDisconnectionError(error)) {
-          // The tug-of-war signal: we believed we were connected but a write just
-          // failed on a dead link. On a shared board this is usually another
-          // device having grabbed it. Recorded so the two-climber case is visible.
-          track(SHARED_EVENTS.BluetoothConnectionStolen, { boardName, layoutId, sizeId });
-          handleDisconnection();
-        }
-        return false;
+      // Lazily create the per-connection-generation controller so connect()
+      // can cancel every write of the old generation at once.
+      if (!writeAbortRef.current) {
+        writeAbortRef.current = new AbortController();
       }
+      const generationSignal = writeAbortRef.current.signal;
+
+      // Combine caller-provided signal with the generation controller.
+      const merged = signal ? mergeAbortSignals(signal, generationSignal) : null;
+      const combinedSignal = merged ? merged.signal : generationSignal;
+
+      const performSend = async (): Promise<boolean | undefined> => {
+        try {
+          // The send may have queued behind another write; by the time it runs
+          // the connection generation may be gone (reconnect/disconnect) — bail
+          // before touching the (possibly new) adapter.
+          if (combinedSignal.aborted || !adapterRef.current) return;
+
+          if (boardName === 'moonboard') {
+            const sent = await dispatchMoonboardPacket(
+              frames,
+              adapterRef.current.write.bind(adapterRef.current),
+              combinedSignal,
+            );
+            if (sent) track(SHARED_EVENTS.ClimbSentToBoardSuccess, boardAnalyticsProperties);
+            return sent;
+          }
+
+          // Empty frames = "clear all LEDs" for Aurora boards
+          if (frames === '') {
+            const clearResult = getAuroraBluetoothPacket('', {}, boardName as AuroraBoardName, apiLevelRef.current);
+            await adapterRef.current.write(clearResult.packet, combinedSignal);
+            return true;
+          }
+
+          let framesToSend = frames;
+
+          if (mirrored && holdsData && holdsData.length > 0) {
+            framesToSend = convertToMirroredFramesString(frames, holdsData);
+          }
+
+          if (!cachedGetLedPlacements) {
+            const mod = await import('@boardsesh/board-constants/led-placements');
+            cachedGetLedPlacements = mod.getLedPlacements as GetLedPlacementsFn;
+          }
+          const getLedPlacementsFn = cachedGetLedPlacements;
+          const placementPositions = getLedPlacementsFn(boardName, layoutId, sizeId);
+
+          if (Object.keys(placementPositions).length === 0) {
+            console.error(
+              `[BLE] LED placement map is empty for ${boardName} layout=${layoutId} size=${sizeId}. Board configuration may be incorrect or LED data may need regeneration.`,
+            );
+            Alert.alert(t('ble.notAvailable'), t('ble.errorLedMissing'));
+            track(SHARED_EVENTS.ClimbSentToBoardFailure, {
+              ...boardAnalyticsProperties,
+              failureReason: 'missing_led_placements',
+            });
+            return false;
+          }
+
+          const result = getAuroraBluetoothPacket(
+            framesToSend,
+            placementPositions,
+            boardName as AuroraBoardName,
+            apiLevelRef.current,
+            ledColorOverrides,
+          );
+
+          const skippedCount = result.skippedPositionCount + result.skippedRoleCount;
+
+          if (skippedCount > 0 && result.packet.length === 0) {
+            console.warn(`[BLE] All ${result.totalPlacements} placements skipped — climb incompatible with board`);
+            Alert.alert(t('ble.notAvailable'), t('ble.errorIncompatible'));
+            track(SHARED_EVENTS.ClimbSentToBoardFailure, {
+              ...boardAnalyticsProperties,
+              failureReason: 'incompatible_climb',
+            });
+            return false;
+          }
+
+          if (skippedCount > 0) {
+            console.warn(`[BLE] ${skippedCount} of ${result.totalPlacements} placements skipped`);
+          }
+
+          await adapterRef.current.write(result.packet, combinedSignal);
+          track(SHARED_EVENTS.ClimbSentToBoardSuccess, boardAnalyticsProperties);
+          return true;
+        } catch (error) {
+          // An aborted write (unmount, or a reconnect cancelling the old
+          // generation) is not a failure — some adapters surface it as a
+          // DOMException, others reject with their own cancellation error after
+          // the signal fired, so check the signal too.
+          if (combinedSignal.aborted || (error instanceof DOMException && error.name === 'AbortError')) {
+            return;
+          }
+          console.error('Error sending frames to board:', error);
+          track(SHARED_EVENTS.ClimbSentToBoardFailure, {
+            ...boardAnalyticsProperties,
+            failureReason: classifyBleFailureReason(error),
+          });
+          // A write that fails because the link is gone (the board dropped or
+          // another device grabbed it — these boards are last-connection-wins) is
+          // often the only signal we get: the adapter's disconnect event may never
+          // fire. Mark the connection lost so the lightbulb stops showing
+          // "connected" and a deliberate reconnect can run. The native adapters
+          // throw the plain-Error signatures the predicate matches ("Not
+          // connected", "Device disconnected during write").
+          if (isDisconnectionError(error)) {
+            // The tug-of-war signal: we believed we were connected but a write just
+            // failed on a dead link. On a shared board this is usually another
+            // device having grabbed it. Recorded so the two-climber case is visible.
+            track(SHARED_EVENTS.BluetoothConnectionStolen, { boardName, layoutId, sizeId });
+            handleDisconnection();
+          }
+          return false;
+        } finally {
+          merged?.dispose();
+        }
+      };
+
+      // Queue behind whatever write is already running or pending. The chain
+      // link swallows the result so one failed write never poisons the chain.
+      const queuedSend = writeChainRef.current.then(performSend, performSend);
+      writeChainRef.current = queuedSend.then(
+        () => undefined,
+        () => undefined,
+      );
+      return queuedSend;
     },
     [boardName, layoutId, sizeId, holdsData, ledColorOverrides, handleDisconnection],
   );
@@ -353,6 +413,14 @@ export function useBoardBluetooth({
         console.error('Cannot connect to Bluetooth without board name');
         return false;
       }
+
+      // A connect is already running (double-tapped lightbulb, or a second
+      // surface racing the first). Both attempts would share the singleton BLE
+      // manager and tear down each other's scans, so ignore the second tap.
+      if (connectInFlightRef.current) {
+        return false;
+      }
+      connectInFlightRef.current = true;
 
       setLoading(true);
 
@@ -367,14 +435,16 @@ export function useBoardBluetooth({
 
         const available = await adapter.isAvailable();
         if (!available) {
-          Alert.alert(t('ble.notAvailable'), t('ble.notAvailable'));
+          Alert.alert(t('ble.connectionFailedTitle'), tCommon('bluetooth.unavailable'));
           return false;
         }
 
-        // Abort any in-flight write from the previous adapter so it
-        // doesn't keep writing on a potentially-disconnected device.
+        // Abort every in-flight or queued write from the previous connection
+        // generation so nothing keeps writing on a potentially-disconnected
+        // device, and unblock the write chain in case a write hung.
         writeAbortRef.current?.abort();
         writeAbortRef.current = null;
+        writeChainRef.current = Promise.resolve();
 
         // Clean up any existing adapter
         if (adapterRef.current) {
@@ -478,21 +548,41 @@ export function useBoardBluetooth({
         pickerRejectRef.current = null;
         setPickerState(null);
 
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        const isUserCancel =
-          /user cancelled|cancel/i.test(errorMessage) || /Device selection cancelled/i.test(errorMessage);
-
-        if (!isUserCancel) {
-          Alert.alert(t('ble.notAvailable'), t('ble.errorConnectionFailed'));
+        // Classify the failure into actionable user copy via the shared,
+        // deliberately-tight predicate. A previous bare `/cancel/i` regex here
+        // also matched CoreBluetooth's "operation cancelled" / ble-plx's
+        // "Operation was cancelled", so those real failures showed nothing —
+        // the connect just looked like a dead tap. Only an explicit
+        // user-cancel stays silent now. Literal-key switch (the i18n linter
+        // forbids `t(variable)`).
+        const failureCategory = classifyBleFailure(error);
+        switch (failureCategory) {
+          case 'user_cancelled':
+            break;
+          case 'unavailable':
+            Alert.alert(t('ble.connectionFailedTitle'), tCommon('bluetooth.unavailable'));
+            break;
+          case 'board_not_found':
+            Alert.alert(t('ble.connectionFailedTitle'), tCommon('bluetooth.boardNotFound'));
+            break;
+          case 'service_missing':
+            Alert.alert(t('ble.connectionFailedTitle'), tCommon('bluetooth.serviceMissing'));
+            break;
+          case 'connect_failed':
+            Alert.alert(t('ble.connectionFailedTitle'), tCommon('bluetooth.connectFailed'));
+            break;
+          default:
+            Alert.alert(t('ble.connectionFailedTitle'), tCommon('bluetooth.unknownError'));
         }
 
         track(SHARED_EVENTS.BluetoothConnectionFailed, {
           boardName,
           layoutId,
           sizeId,
-          failureReason: classifyBleFailureReason(error),
+          failureReason: failureCategory === 'unknown' ? classifyBleFailureReason(error) : failureCategory,
         });
       } finally {
+        connectInFlightRef.current = false;
         setLoading(false);
       }
 
@@ -517,6 +607,11 @@ export function useBoardBluetooth({
     unsubDisconnectRef.current = null;
     const adapter = adapterRef.current;
     adapterRef.current = null;
+    // Cancel every in-flight and queued write of this connection generation,
+    // and unblock the write chain for the next connect.
+    writeAbortRef.current?.abort();
+    writeAbortRef.current = null;
+    writeChainRef.current = Promise.resolve();
     setIsConnected(false);
     // A deliberate disconnect clears the remembered board — only an involuntary
     // drop should offer a silent same-board reconnect.
@@ -524,6 +619,68 @@ export function useBoardBluetooth({
     onConnectionChange?.(false);
     await adapter?.disconnect();
   }, [onConnectionChange]);
+
+  // iOS-only: adopt a connection the native BoardBleManager established
+  // outside JS — the Dynamic Island lightbulb's reconnect-by-last-known-board,
+  // or CoreBluetooth state restoration after a relaunch. Without this the wall
+  // re-lights (native drives it) but the in-app lightbulb stays dark and climb
+  // navigation stops pushing until the user taps it again. Listens for the
+  // bridged `connected` event and re-checks on foreground (events fired while
+  // JS was suspended are missed). No-op on Android and on binaries older than
+  // the `getConnectedDevice` surface.
+  useEffect(() => {
+    const adopt = (deviceId: string, deviceName?: string) => {
+      // JS already has (or is establishing) its own adapter — nothing to adopt.
+      if (adapterRef.current || connectInFlightRef.current) return;
+      if (!boardName || layoutId === undefined || sizeId === undefined) return;
+      // Never adopt a different board type than the active config: the LED
+      // placement map wouldn't match and every send would misfire.
+      const adoptedBoardType = parseBoardTypeFromDeviceName(deviceName);
+      if (adoptedBoardType && adoptedBoardType !== boardName) return;
+
+      const adapter = createBluetoothAdapter(devicePicker);
+      if (!isNativeIosBleAdapter(adapter)) return;
+      adapter.adoptConnection(deviceId);
+      apiLevelRef.current = parseApiLevel(deviceName);
+      unsubDisconnectRef.current = adapter.onDisconnect(handleDisconnection);
+      adapterRef.current = adapter;
+      void adapter
+        .configureBoard({ boardName, layoutId, sizeId, apiLevel: apiLevelRef.current, deviceName })
+        .catch(() => {});
+
+      const serial = deviceName ? (parseSerialNumber(deviceName) ?? null) : null;
+      if (serial) {
+        setLastConnectedBoard({ serial, configKey: `${boardName}::${layoutId}::${sizeId}` });
+      }
+      setIsConnected(true);
+      onConnectionChange?.(true);
+      onConnectSuccess?.(serial);
+    };
+
+    const connectedSubscription = subscribeNativeBleConnected((payload) => {
+      // The bridge sends '' for a missing name — normalise so name parsing
+      // (board type, serial, API level) sees undefined instead.
+      adopt(payload.deviceId, payload.deviceName || undefined);
+    });
+    // null = platform/binary without the adoption surface — nothing to do.
+    if (!connectedSubscription) return;
+
+    const checkNativeConnection = () => {
+      void getNativeBleConnectedDevice().then((device) => {
+        if (device) adopt(device.deviceId, device.name || undefined);
+      });
+    };
+
+    checkNativeConnection();
+    const appStateSubscription = AppState.addEventListener('change', (appState) => {
+      if (appState === 'active') checkNativeConnection();
+    });
+
+    return () => {
+      connectedSubscription.remove();
+      appStateSubscription.remove();
+    };
+  }, [boardName, layoutId, sizeId, devicePicker, handleDisconnection, onConnectionChange, onConnectSuccess]);
 
   // Serial to silently reconnect to for the board currently in view, or null
   // when nothing is remembered or the user switched boards (in which case the
@@ -545,9 +702,13 @@ export function useBoardBluetooth({
   // Clean up on unmount
   useEffect(() => {
     return () => {
-      pickerRejectRef.current?.(new Error('Component unmounted'));
+      // Reject with the explicit user-cancel signature so a connect that's
+      // still awaiting the picker classifies as `user_cancelled` (silent)
+      // rather than popping an alert over whatever screen comes next.
+      pickerRejectRef.current?.(new Error('Device selection cancelled'));
       pickerRejectRef.current = null;
       unsubDisconnectRef.current?.();
+      writeAbortRef.current?.abort();
       void adapterRef.current?.disconnect();
     };
   }, []);

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -9,7 +9,7 @@ import {
   parseSerialNumber,
   type LedColorOverrides,
 } from '@boardsesh/ble-protocol/aurora';
-import { getMoonboardBluetoothPacket } from '@boardsesh/ble-protocol/moonboard';
+import { getMoonboardBluetoothPacket, isMoonboardDeviceName } from '@boardsesh/ble-protocol/moonboard';
 import { classifyBleFailure, isDisconnectionError } from '@boardsesh/ble-protocol/connection-error';
 import type { AuroraBoardName } from '@boardsesh/shared-schema';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -45,6 +45,24 @@ export type PickerState = {
   handleSelect: (deviceId: string) => void;
   handleCancel: () => void;
 };
+
+// Identity of a board pairing: the silent-reconnect and adoption guards only
+// trust a remembered/native connection while the active config still matches.
+// Deliberately excludes set_ids — see the reconnectSerialForCurrentBoard note.
+function boardConfigKey(boardName: string, layoutId: number, sizeId: number): string {
+  return `${boardName}::${layoutId}::${sizeId}`;
+}
+
+/**
+ * Board type parsed from a BLE device name, covering both families: Aurora
+ * names via the product-name prefix, MoonBoard via its name prefixes. Returns
+ * undefined when the name identifies neither.
+ */
+function parseAnyBoardTypeFromDeviceName(deviceName?: string): string | undefined {
+  if (!deviceName) return undefined;
+  if (isMoonboardDeviceName(deviceName)) return 'moonboard';
+  return parseBoardTypeFromDeviceName(deviceName);
+}
 
 /**
  * Fire-and-forget GraphQL mutation recording the (serial, board config, API
@@ -395,9 +413,12 @@ export function useBoardBluetooth({
         }
       };
 
-      // Queue behind whatever write is already running or pending. The chain
-      // link swallows the result so one failed write never poisons the chain.
-      const queuedSend = writeChainRef.current.then(performSend, performSend);
+      // Queue behind whatever write is already running or pending.
+      // writeChainRef.current is never left rejected (the bookkeeping below
+      // coerces both outcomes), so a single fulfilled-arm .then suffices here;
+      // the rejected arm below is belt-and-suspenders so a future edit that
+      // lets performSend throw still can't wedge the chain.
+      const queuedSend = writeChainRef.current.then(performSend);
       writeChainRef.current = queuedSend.then(
         () => undefined,
         () => undefined,
@@ -518,9 +539,11 @@ export function useBoardBluetooth({
 
         // Remember the board (keyed to the config it was paired against) so an
         // involuntary drop can be recovered with a silent reconnect. Only Aurora
-        // boards expose a parseable serial; moonboard can't be reconnected by serial.
-        if (parsedSerial) {
-          setLastConnectedBoard({ serial: parsedSerial, configKey: `${boardName}::${layoutId}::${sizeId}` });
+        // boards expose a parseable serial; moonboard can't be reconnected by
+        // serial. Without a full config there is no usable key (and the
+        // reconnect comparison against currentConfigKey could never match).
+        if (parsedSerial && layoutId !== undefined && sizeId !== undefined) {
+          setLastConnectedBoard({ serial: parsedSerial, configKey: boardConfigKey(boardName, layoutId, sizeId) });
         }
 
         // Send initial frames if provided
@@ -629,13 +652,19 @@ export function useBoardBluetooth({
   // JS was suspended are missed). No-op on Android and on binaries older than
   // the `getConnectedDevice` surface.
   useEffect(() => {
-    const adopt = (deviceId: string, deviceName?: string) => {
+    const adopt = (deviceId: string, rawDeviceName?: string) => {
+      // The bridge sends '' for a missing name — normalise so name parsing
+      // (board type, serial, API level) sees undefined instead.
+      const deviceName = rawDeviceName || undefined;
       // JS already has (or is establishing) its own adapter — nothing to adopt.
       if (adapterRef.current || connectInFlightRef.current) return;
       if (!boardName || layoutId === undefined || sizeId === undefined) return;
       // Never adopt a different board type than the active config: the LED
-      // placement map wouldn't match and every send would misfire.
-      const adoptedBoardType = parseBoardTypeFromDeviceName(deviceName);
+      // placement map / packet format wouldn't match and every send would
+      // misfire. Must recognise MoonBoard names too — parseBoardTypeFromDeviceName
+      // alone only knows Aurora boards, so a natively-reconnected MoonBoard
+      // would slip past an Aurora-config check (and vice versa).
+      const adoptedBoardType = parseAnyBoardTypeFromDeviceName(deviceName);
       if (adoptedBoardType && adoptedBoardType !== boardName) return;
 
       const adapter = createBluetoothAdapter(devicePicker);
@@ -650,7 +679,7 @@ export function useBoardBluetooth({
 
       const serial = deviceName ? (parseSerialNumber(deviceName) ?? null) : null;
       if (serial) {
-        setLastConnectedBoard({ serial, configKey: `${boardName}::${layoutId}::${sizeId}` });
+        setLastConnectedBoard({ serial, configKey: boardConfigKey(boardName, layoutId, sizeId) });
       }
       setIsConnected(true);
       onConnectionChange?.(true);
@@ -658,16 +687,14 @@ export function useBoardBluetooth({
     };
 
     const connectedSubscription = subscribeNativeBleConnected((payload) => {
-      // The bridge sends '' for a missing name — normalise so name parsing
-      // (board type, serial, API level) sees undefined instead.
-      adopt(payload.deviceId, payload.deviceName || undefined);
+      adopt(payload.deviceId, payload.deviceName);
     });
     // null = platform/binary without the adoption surface — nothing to do.
     if (!connectedSubscription) return;
 
     const checkNativeConnection = () => {
       void getNativeBleConnectedDevice().then((device) => {
-        if (device) adopt(device.deviceId, device.name || undefined);
+        if (device) adopt(device.deviceId, device.name);
       });
     };
 
@@ -693,7 +720,7 @@ export function useBoardBluetooth({
   // of set_ids. Don't thread set_ids in here without also passing it to the
   // provider.
   const currentConfigKey =
-    boardName && layoutId !== undefined && sizeId !== undefined ? `${boardName}::${layoutId}::${sizeId}` : null;
+    boardName && layoutId !== undefined && sizeId !== undefined ? boardConfigKey(boardName, layoutId, sizeId) : null;
   const reconnectSerialForCurrentBoard =
     lastConnectedBoard && currentConfigKey && lastConnectedBoard.configKey === currentConfigKey
       ? lastConnectedBoard.serial

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -233,6 +233,11 @@ export function useBoardBluetooth({
   // the singleton BLE manager, and the first attempt's scan teardown kills
   // the second attempt's scan, stranding the picker.
   const connectInFlightRef = useRef(false);
+  // True after an explicit user disconnect, false again on the next deliberate
+  // connect. While set, the native-connection adoption path is ignored — it
+  // would otherwise race the in-flight native disconnect and re-establish the
+  // connection the user just closed.
+  const adoptionSuppressedRef = useRef(false);
 
   const [pickerState, setPickerState] = useState<PickerState | null>(null);
   const pickerRejectRef = useRef<((error: Error) => void) | null>(null);
@@ -425,7 +430,7 @@ export function useBoardBluetooth({
       );
       return queuedSend;
     },
-    [boardName, layoutId, sizeId, holdsData, ledColorOverrides, handleDisconnection],
+    [boardName, layoutId, sizeId, holdsData, ledColorOverrides, handleDisconnection, t],
   );
 
   const connect = useCallback(
@@ -442,6 +447,9 @@ export function useBoardBluetooth({
         return false;
       }
       connectInFlightRef.current = true;
+      // A deliberate connect re-arms native-connection adoption after an
+      // earlier explicit disconnect suppressed it.
+      adoptionSuppressedRef.current = false;
 
       setLoading(true);
 
@@ -622,10 +630,17 @@ export function useBoardBluetooth({
       onConnectSuccess,
       sendFramesToBoard,
       devicePicker,
+      t,
+      tCommon,
     ],
   );
 
   const disconnect = useCallback(async () => {
+    // Suppress native-connection adoption until the next deliberate connect:
+    // the native disconnect below is async, so a backgrounding/foregrounding
+    // app could otherwise see getConnectedDevice still report the device the
+    // user just closed and silently re-adopt it.
+    adoptionSuppressedRef.current = true;
     unsubDisconnectRef.current?.();
     unsubDisconnectRef.current = null;
     const adapter = adapterRef.current;
@@ -658,14 +673,19 @@ export function useBoardBluetooth({
       const deviceName = rawDeviceName || undefined;
       // JS already has (or is establishing) its own adapter — nothing to adopt.
       if (adapterRef.current || connectInFlightRef.current) return;
+      // The user explicitly disconnected; don't re-adopt the connection the
+      // (possibly still in-flight) native disconnect is tearing down.
+      if (adoptionSuppressedRef.current) return;
       if (!boardName || layoutId === undefined || sizeId === undefined) return;
-      // Never adopt a different board type than the active config: the LED
-      // placement map / packet format wouldn't match and every send would
-      // misfire. Must recognise MoonBoard names too — parseBoardTypeFromDeviceName
-      // alone only knows Aurora boards, so a natively-reconnected MoonBoard
-      // would slip past an Aurora-config check (and vice versa).
+      // Only adopt a device positively identified as the active config's board
+      // type: the LED placement map / packet format wouldn't match otherwise
+      // and every send would misfire. Must recognise MoonBoard names too —
+      // parseBoardTypeFromDeviceName alone only knows Aurora boards, so a
+      // natively-reconnected MoonBoard would slip past an Aurora-config check.
+      // An unrecognisable (or missing) name also bails: a dark lightbulb beats
+      // streaming wrong-format packets at an unknown device.
       const adoptedBoardType = parseAnyBoardTypeFromDeviceName(deviceName);
-      if (adoptedBoardType && adoptedBoardType !== boardName) return;
+      if (!adoptedBoardType || adoptedBoardType !== boardName) return;
 
       const adapter = createBluetoothAdapter(devicePicker);
       if (!isNativeIosBleAdapter(adapter)) return;

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -6,6 +6,7 @@ import type { ClimbQueueItem } from '@boardsesh/queue';
 
 type BluetoothHookOptions = {
   onConnectSuccess?: (serial: string | null) => void;
+  holdsData?: unknown;
 };
 
 const wallConfirm = vi.hoisted(() => ({
@@ -79,6 +80,16 @@ vi.mock('../queue-provider', () => ({
     confirmClimbOnWall: queue.confirmClimbOnWall,
     setSessionBoardSerial: queue.setSessionBoardSerial,
   }),
+}));
+
+const boardDetails = vi.hoisted(() => ({
+  getBoardRenderData: vi.fn(() => ({
+    holdsData: [{ id: 100, mirroredHoldId: 200, cx: 0, cy: 0, r: 1 }],
+  })),
+}));
+
+vi.mock('../../lib/board-details', () => ({
+  getBoardRenderData: boardDetails.getBoardRenderData,
 }));
 
 import { BluetoothProvider } from '../bluetooth-provider';
@@ -227,5 +238,27 @@ describe('BluetoothProvider wall-confirm integration', () => {
 
     bluetooth.options?.onConnectSuccess?.('SERIAL-1');
     expect(queue.setSessionBoardSerial).not.toHaveBeenCalled();
+  });
+
+  it('threads the active board holds into the hook so mirrored sends can convert', () => {
+    render(
+      createElement(BluetoothProvider, {
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '26, 27',
+        children: createElement('div', null),
+      }),
+    );
+
+    expect(boardDetails.getBoardRenderData).toHaveBeenCalledWith({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: [26, 27],
+    });
+    expect((bluetooth.options as { holdsData?: unknown } | undefined)?.holdsData).toEqual([
+      { id: 100, mirroredHoldId: 200, cx: 0, cy: 0, r: 1 },
+    ]);
   });
 });

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -1,8 +1,10 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { BoardName } from '@boardsesh/shared-schema';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { emitWallConfirm } from '@boardsesh/play-view';
 import { useBoardBluetooth } from '../lib/ble/use-board-bluetooth';
+import { getBoardRenderData } from '../lib/board-details';
 import { registerBluetoothConnection } from '../lib/ble/bluetooth-status-store';
 import { useQueue, useQueueSessionControls } from './queue-provider';
 import { hapticSuccess } from '../lib/haptics';
@@ -229,6 +231,24 @@ export function BluetoothProvider({
     [boardName, setSessionBoardSerial],
   );
 
+  // Hold placements for the active board, required by the hook's
+  // mirrored-frames conversion (hold id → mirroredHoldId). Without this every
+  // `mirrored: true` send silently wrote the unmirrored frames to the wall.
+  // getBoardRenderData is pure + memoised by board-config key, so this is a
+  // cache lookup on re-render.
+  const holdsData = useMemo(() => {
+    if (!boardName || layoutId === undefined || sizeId === undefined || !setIds) return undefined;
+    const parsedSetIds = setIds
+      .split(',')
+      .map((setId) => Number(setId.trim()))
+      .filter((setId) => Number.isInteger(setId));
+    if (parsedSetIds.length === 0) return undefined;
+    return (
+      getBoardRenderData({ boardName: boardName as BoardName, layoutId, sizeId, setIds: parsedSetIds })?.holdsData ??
+      undefined
+    );
+  }, [boardName, layoutId, sizeId, setIds]);
+
   const { isConnected, loading, connect, disconnect, sendFramesToBoard, pickerState, reconnectSerialForCurrentBoard } =
     useBoardBluetooth({
       boardName,
@@ -236,6 +256,7 @@ export function BluetoothProvider({
       sizeId,
       setIds,
       boardUuid,
+      holdsData,
       onConnectSuccess: handleConnectSuccess,
     });
 

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -372,10 +372,10 @@
     "relightBoard": "Re-light board",
     "holdForControls": "Hold for board controls",
     "notAvailable": "Bluetooth is not available",
+    "connectionFailedTitle": "Couldn't connect",
     "permissionRequired": "Bluetooth permission required",
     "errorPermissionDenied": "Allow Bluetooth permissions to connect a board.",
     "errorLedMissing": "Could not send to board — LED data missing for this board configuration.",
-    "errorIncompatible": "This climb is for a different board configuration.",
-    "errorConnectionFailed": "Could not connect to the board. Make sure it is powered on and nearby."
+    "errorIncompatible": "This climb is for a different board configuration."
   }
 }

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -372,10 +372,10 @@
     "relightBoard": "Reiluminar tablero",
     "holdForControls": "Mantén pulsado para los controles",
     "notAvailable": "Bluetooth no está disponible",
+    "connectionFailedTitle": "No se pudo conectar",
     "permissionRequired": "Permiso de Bluetooth necesario",
     "errorPermissionDenied": "Permite los permisos de Bluetooth para conectar un tablero.",
     "errorLedMissing": "No se pudo enviar al tablero — faltan datos LED para esta configuración.",
-    "errorIncompatible": "Este boulder es para una configuración de tablero diferente.",
-    "errorConnectionFailed": "No se pudo conectar al tablero. Asegúrate de que esté encendido y cerca."
+    "errorIncompatible": "Este boulder es para una configuración de tablero diferente."
   }
 }

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -372,10 +372,10 @@
     "relightBoard": "Rallumer le panneau",
     "holdForControls": "Maintenir pour les commandes",
     "notAvailable": "Le Bluetooth n'est pas disponible",
+    "connectionFailedTitle": "Connexion impossible",
     "permissionRequired": "Autorisation Bluetooth requise",
     "errorPermissionDenied": "Autorisez le Bluetooth pour connecter un panneau.",
     "errorLedMissing": "Impossible d'envoyer au panneau — données LED manquantes pour cette configuration.",
-    "errorIncompatible": "Ce bloc est pour une configuration de panneau différente.",
-    "errorConnectionFailed": "Impossible de se connecter au panneau. Vérifiez qu'il est allumé et à proximité."
+    "errorIncompatible": "Ce bloc est pour une configuration de panneau différente."
   }
 }


### PR DESCRIPTION
## Why

We keep getting occasional "Bluetooth doesn't work" reports that are too vague to act on. An audit of `packages/mobile`'s BLE code (against the web implementation, which shares the protocol layer) found several intermittent failure modes that all fail silently or look like a dead tap — exactly the kind of bug users can't describe.

## What was broken

1. **No write mutex (Android / `RNBleAdapter` path).** The AutoSender, the play-drawer playback drain and the create-climb preview each guarded only their own writes. Overlapping `sendFramesToBoard` calls interleaved the 20-byte GATT chunks of two packets, corrupting both — LEDs don't update or show garbage. Web has a `writeChainRef` mutex for exactly this; mobile didn't. (The iOS native write queue was already per-packet atomic.)
2. **Real connect failures were silent.** The catch used a bare `/cancel/i` regex, which also matched CoreBluetooth / ble-plx "operation was cancelled" errors — so those connects showed no alert at all. The shared `classifyBleFailure()` already documents this exact footgun.
3. **Mirrored climbs lit the wrong holds.** `BluetoothProvider` never passed `holdsData` into the hook, so the mirror conversion was dead code: every `mirrored: true` send silently wrote the unmirrored frames. The drawer mirror toggle also never re-pushed boulders to the wall at all.
4. **Double-tapping the lightbulb stranded the picker.** Two concurrent `connect()` calls share the singleton BLE manager; the first attempt's scan teardown killed the second attempt's scan.
5. **MoonBoards could be undiscoverable.** Both adapters scanned filtered to the Aurora/UART service UUIDs, but MoonBoard controllers don't reliably advertise the UART UUID (web works around this with `namePrefix` filters).
6. **iOS background reconnect left the app dark.** The widget could reconnect natively, but JS `isConnected` never updated — documented as a known limitation in `BoardBleManager.swift`.

## What changed

- `sendFramesToBoard` now serialises every write through a promise-chain mutex, with one `AbortController` per connection generation (a reconnect/disconnect cancels *all* queued writes, not just the newest). `mergeAbortSignals` no longer leaks a listener per write.
- Connect failures are classified via the shared `classifyBleFailure()`; only an explicit user-cancel stays silent. Copy reuses web's `common.bluetooth.*` keys; the orphaned `ble.errorConnectionFailed` key was removed.
- `holdsData` is threaded from the active board into the hook (via the cached `getBoardRenderData`); the mirror toggle re-pushes the displayed climb.
- `connect()` has a re-entrancy guard; the toolbar lightbulbs ignore taps while loading and now reuse `reconnectSerialForCurrentBoard` for silent same-board reconnects (matching the play drawer). The duplicated handler was extracted into `useLightbulbToggle`.
- Scans run unfiltered and filter in JS (`isLikelyBoardDevice`: known service UUIDs incl. overflow, MoonBoard name prefixes, Aurora names, `#serial@api` suffix). Repeat advertisements are deduped before any state update / bridge crossing so the unfiltered scan doesn't flood the picker or the RN bridge.
- **Swift (needs a native build, does not ride OTA):** `BoardBleManager` emits a `connected` event from its single connect-success point and exposes `getConnectedDevice`; JS adopts natively-established connections (event + foreground re-check), so a background widget reconnect now lights the in-app lightbulb. The presence of `getConnectedDevice` doubles as the feature gate, so the new JS is safe on older binaries.

## Known limitations / follow-ups

- **Mirror state is still drawer-local** — it doesn't flow through the queue item, so party peers don't see a mobile-initiated mirror and an AutoSender re-broadcast can re-push the unmirrored frames. Routing it through the shared `MIRROR_CLIMB` action (like web) is a follow-up.
- A mirrored send on a board with incomplete mirror data fails the whole climb (same behaviour as web).
- `isLikelyBoardDevice` could move into `@boardsesh/ble-protocol` so web's Capacitor adapter shares it.
- **Hardware verification needed** (no board available in this environment): MoonBoard appears in the mobile picker; mirrored climb lights the mirrored holds; rapid next/next while a route animates doesn't corrupt the wall; double-tap lightbulb doesn't wedge the picker; background widget reconnect lights the in-app lightbulb after foregrounding (new native build only).

## Validation

- `vp run typecheck:mobile` ✓
- `vp run test:mobile` — 190 files / 1405 tests ✓ (new coverage: write serialisation, cancel-classification alerts, mirror conversion with holdsData, connect re-entrancy, unfiltered-scan filtering on both adapters, native write-abort → `cancelWrites`, `adoptConnection`, stopScan error masking, provider holdsData threading)
- `vp run check:mobile-bundle` ✓
- `vp check` / i18n parity + orphan checks ✓ (lint warnings/errors identical to main's baseline)

https://claude.ai/code/session_01WapJNHWNGXgYHQv7mNmnLk

---
_Generated by [Claude Code](https://claude.ai/code/session_01WapJNHWNGXgYHQv7mNmnLk)_