### PR TITLE
Harden RN Swift test CI

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - 'mobile/**'
+      - 'packages/mobile/**'
       - '.github/workflows/ios-ci.yml'
   push:
     branches-ignore: [main]
     paths:
       - 'mobile/**'
+      - 'packages/mobile/**'
       - '.github/workflows/ios-ci.yml'
   workflow_dispatch:
 

--- a/.github/workflows/ios-rn-ci.yml
+++ b/.github/workflows/ios-rn-ci.yml
@@ -7,6 +7,10 @@ on:
       - 'packages/shared/**'
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
+      - 'package.json'
+      - 'bun.lock'
+      - 'patches/**'
+      - 'vite.config.ts'
       - 'scripts/prepare-rn-ios-tests.mjs'
       - '.github/workflows/ios-rn-ci.yml'
   push:
@@ -16,6 +20,10 @@ on:
       - 'packages/shared/**'
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
+      - 'package.json'
+      - 'bun.lock'
+      - 'patches/**'
+      - 'vite.config.ts'
       - 'scripts/prepare-rn-ios-tests.mjs'
       - '.github/workflows/ios-rn-ci.yml'
   workflow_dispatch:
@@ -29,6 +37,8 @@ permissions:
 
 jobs:
   build-and-test:
+    # macos-26 is GA on GitHub-hosted runners and matches the RN TestFlight
+    # workflow's Xcode line; the PR workflow has passed on this label.
     runs-on: macos-26
     timeout-minutes: 60
 
@@ -53,6 +63,9 @@ jobs:
 
       - name: Install Node.js dependencies
         run: bun install --frozen-lockfile
+
+      - name: Check widget Swift duplicate drift
+        run: vp test run packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts --reporter=agent
 
       - name: Write .env for Expo build-time inlining
         working-directory: packages/mobile

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -132,7 +132,6 @@ function findGroupKey(project, groupName) {
 function ensureGroup(project, groupName) {
   const existingGroupKey = findGroupKey(project, groupName);
   if (existingGroupKey) {
-    delete project.hash.project.objects.PBXGroup[existingGroupKey].path;
     return existingGroupKey;
   }
 
@@ -366,11 +365,21 @@ function updateScheme(testTargetUuid) {
             </BuildableReference>
          </TestableReference>
       </Testables>`;
+  const testablesPattern = /\n\s*<Testables\b[^>]*>[\s\S]*?\n\s*<\/Testables>/;
+  const testActionClosePattern = /(\s*)<\/TestAction>/;
 
-  if (scheme.includes('<Testables>')) {
-    scheme = scheme.replace(/      <Testables>[\s\S]*?      <\/Testables>/, testables);
+  if (testablesPattern.test(scheme)) {
+    scheme = scheme.replace(testablesPattern, `\n${testables}`);
   } else {
-    scheme = scheme.replace(/   <\/TestAction>/, `${testables}\n   </TestAction>`);
+    const testActionCloseMatch = scheme.match(testActionClosePattern);
+    if (!testActionCloseMatch) {
+      throw new Error(`Could not find TestAction close tag in ${schemePath}`);
+    }
+    scheme = scheme.replace(testActionClosePattern, `\n${testables}\n${testActionCloseMatch[1]}</TestAction>`);
+  }
+
+  if (!scheme.includes(`BlueprintIdentifier = "${testTargetUuid}"`)) {
+    throw new Error(`Could not attach ${TEST_TARGET_NAME} to ${schemePath}`);
   }
 
   writeFileSync(schemePath, scheme);


### PR DESCRIPTION
## Summary
- run the widget Swift duplicate drift test explicitly in the RN iOS workflow
- broaden RN iOS workflow triggers for root dependency/prebuild inputs
- include `packages/mobile/**` in the legacy iOS workflow path filters
- make the RN iOS test prep script preserve existing PBXGroup paths and fail closed when scheme testable injection cannot attach the target

## Validation
- `vp test run packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts packages/mobile/src/lib/live-activity/__tests__/widget-build-settings.test.ts packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx --reporter=agent`
- `node --check scripts/prepare-rn-ios-tests.mjs`
- `node scripts/prepare-rn-ios-tests.mjs`
- `vp fmt --check .github/workflows/ios-ci.yml .github/workflows/ios-rn-ci.yml scripts/prepare-rn-ios-tests.mjs`
- `vp check --no-fmt --no-error-on-unmatched-pattern scripts/prepare-rn-ios-tests.mjs`
- `git diff --check`
- `xcodebuild build-for-testing -quiet -workspace packages/mobile/ios/Boardsesh.xcworkspace -scheme Boardsesh -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -derivedDataPath /private/tmp/boardsesh-rn-swift-tests`
- `xcodebuild test-without-building -quiet -workspace packages/mobile/ios/Boardsesh.xcworkspace -scheme Boardsesh -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' -derivedDataPath /private/tmp/boardsesh-rn-swift-tests`

Subagent review and QA found no blocking issues in commit `49c36519f`.