### PR TITLE
Use dedicated RN Swift test scheme

### DIFF
--- a/.github/workflows/ios-rn-ci.yml
+++ b/.github/workflows/ios-rn-ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     env:
       WORKSPACE_PATH: packages/mobile/ios/Boardsesh.xcworkspace
-      SCHEME: Boardsesh
+      SCHEME: BoardseshTests
       EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
       EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
       EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -346,40 +346,81 @@ function ensureTestTarget(project) {
   return targetUuid;
 }
 
-function updateScheme(testTargetUuid) {
-  const schemePath = join(projectDir, 'Boardsesh.xcodeproj/xcshareddata/xcschemes/Boardsesh.xcscheme');
-  if (!existsSync(schemePath)) {
-    throw new Error(`Missing Boardsesh scheme at ${schemePath}`);
-  }
+function testBuildableReference(testTargetUuid, indentation) {
+  return `${indentation}<BuildableReference
+${indentation}   BuildableIdentifier = "primary"
+${indentation}   BlueprintIdentifier = "${testTargetUuid}"
+${indentation}   BuildableName = "${TEST_TARGET_NAME}.xctest"
+${indentation}   BlueprintName = "${TEST_TARGET_NAME}"
+${indentation}   ReferencedContainer = "container:Boardsesh.xcodeproj">
+${indentation}</BuildableReference>`;
+}
 
-  let scheme = readFileSync(schemePath, 'utf8');
-  const testables = `      <Testables>
+function writeTestScheme(testTargetUuid) {
+  const schemeDirectory = join(projectDir, 'Boardsesh.xcodeproj/xcshareddata/xcschemes');
+  const schemePath = join(schemeDirectory, `${TEST_TARGET_NAME}.xcscheme`);
+  mkdirSync(schemeDirectory, { recursive: true });
+
+  const scheme = `<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+${testBuildableReference(testTargetUuid, '            ')}
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
          <TestableReference
             skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "${testTargetUuid}"
-               BuildableName = "${TEST_TARGET_NAME}.xctest"
-               BlueprintName = "${TEST_TARGET_NAME}"
-               ReferencedContainer = "container:Boardsesh.xcodeproj">
-            </BuildableReference>
+${testBuildableReference(testTargetUuid, '            ')}
          </TestableReference>
-      </Testables>`;
-  const testablesPattern = /\n\s*<Testables\b[^>]*>[\s\S]*?\n\s*<\/Testables>/;
-  const testActionClosePattern = /(\s*)<\/TestAction>/;
-
-  if (testablesPattern.test(scheme)) {
-    scheme = scheme.replace(testablesPattern, `\n${testables}`);
-  } else {
-    const testActionCloseMatch = scheme.match(testActionClosePattern);
-    if (!testActionCloseMatch) {
-      throw new Error(`Could not find TestAction close tag in ${schemePath}`);
-    }
-    scheme = scheme.replace(testActionClosePattern, `\n${testables}\n${testActionCloseMatch[1]}</TestAction>`);
-  }
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>
+`;
 
   if (!scheme.includes(`BlueprintIdentifier = "${testTargetUuid}"`)) {
-    throw new Error(`Could not attach ${TEST_TARGET_NAME} to ${schemePath}`);
+    throw new Error(`Could not write ${TEST_TARGET_NAME} scheme at ${schemePath}`);
   }
 
   writeFileSync(schemePath, scheme);
@@ -400,6 +441,6 @@ if (!findNativeTarget(project, APP_TARGET_NAME)) {
 const testTargetUuid = ensureTestTarget(project);
 removeStaleSdkFrameworkSearchPaths(project);
 writeFileSync(projectFilePath, project.writeSync());
-updateScheme(testTargetUuid);
+writeTestScheme(testTargetUuid);
 
 console.log(`Prepared ${TEST_TARGET_NAME} (${testTargetUuid}) for RN iOS Swift tests.`);


### PR DESCRIPTION
## Summary
- switch RN Swift CI to a generated `BoardseshTests` scheme instead of the full `Boardsesh` app scheme
- have `scripts/prepare-rn-ios-tests.mjs` write a deterministic shared `BoardseshTests.xcscheme`
- keep the RN Swift CI job focused on the unhosted Swift XCTest bundle, avoiding the full app linker path that failed on PR #2676's merge ref

## Context
PR #2676 merged the Swift CI hardening, but its RN iOS workflow failed in `xcodebuild build-for-testing` while linking the full `Boardsesh` app target on `macos-26` / Xcode 26.4.1. The new drift test and prep script steps passed before that failure. This follow-up points the workflow at the standalone Swift test bundle scheme so the job validates the Swift unit tests without depending on the full app debug link.

## Validation
- `vp test run packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts packages/mobile/src/lib/live-activity/__tests__/widget-build-settings.test.ts packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx --reporter=agent`
- `node --check scripts/prepare-rn-ios-tests.mjs`
- `node scripts/prepare-rn-ios-tests.mjs`
- `xcodebuild -list -workspace packages/mobile/ios/Boardsesh.xcworkspace`
- `xcodebuild build-for-testing -quiet -workspace packages/mobile/ios/Boardsesh.xcworkspace -scheme BoardseshTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -derivedDataPath /private/tmp/boardsesh-rn-swift-tests-scheme`
- `xcodebuild test-without-building -quiet -workspace packages/mobile/ios/Boardsesh.xcworkspace -scheme BoardseshTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' -derivedDataPath /private/tmp/boardsesh-rn-swift-tests-scheme`
- `vp fmt --check .github/workflows/ios-rn-ci.yml scripts/prepare-rn-ios-tests.mjs`
- `vp check --no-fmt --no-error-on-unmatched-pattern scripts/prepare-rn-ios-tests.mjs`
- `git diff --check`

Fresh code-review and QA subagents found no blocking issues in commit `ab3f0bff6`.