### PR TITLE
fix(mobile): pre-release bug audit — 37 fixes across queue/party, play drawer, BLE, search, discover, You page, auth and shell

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/__tests__/zone-screen.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/zone-screen.test.tsx
@@ -288,5 +288,20 @@ describe('ZoneFilterScreen', () => {
       const selection = emitZoneFilterSelection.mock.calls.at(-1)?.[0] as { holdsFilter?: HoldsFilter };
       expect(selection.holdsFilter).toEqual({});
     });
+
+    it('strips an invalid leaf mode from holdsFilter, matching the holds screen', () => {
+      // Hold 1 sits inside the default zone; carry a valid leaf plus a bogus one.
+      // anyHold keeps the filter (no prune), so the emitted value reflects parse.
+      routeParams.current = baseParams({
+        zoneBox: JSON.stringify({ edgeLeft: 20, edgeRight: 80, edgeBottom: 20, edgeTop: 80 }),
+        zoneMode: 'anyHold',
+        holdsFilter: JSON.stringify({ '1': { HAND: 'include', FINISH: 'bogus' } }),
+      });
+      const { unmount } = render(<ZoneFilterScreen />);
+      unmount();
+      const selection = emitZoneFilterSelection.mock.calls.at(-1)?.[0] as { holdsFilter?: HoldsFilter };
+      // The bogus FINISH leaf is dropped; the valid HAND leaf survives.
+      expect(selection.holdsFilter).toEqual({ '1': { HAND: 'include' } });
+    });
   });
 });

--- a/packages/mobile/app/(tabs)/climbs/create.tsx
+++ b/packages/mobile/app/(tabs)/climbs/create.tsx
@@ -5,6 +5,7 @@ import type { BoardName } from '@boardsesh/shared-schema';
 import { CreateClimbScreen } from '../../../src/components/create-climb/CreateClimbScreen';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
 import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
+import { createClimbScreenKey } from '../../../src/lib/create-climb-screen-key';
 
 type CreateClimbParams = {
   boardName?: string;
@@ -48,11 +49,13 @@ export default function CreateClimbRoute() {
   }
 
   return (
-    // Key by the edited climb so switching drafts (router.replace with a new
-    // editClimbUuid) remounts the editor — a clean re-seed and a fresh undo
-    // history per editing session.
+    // Key by the edited climb AND the board's hold-identity tuple so switching
+    // drafts OR boards (e.g. a bare-open screen while the active board changes)
+    // remounts the editor — a clean re-seed, fresh undo history, and dropped
+    // holds that don't exist on the new layout/size. Angle is excluded so a
+    // session-sync angle change doesn't wipe an in-progress paint.
     <CreateClimbScreen
-      key={params.editClimbUuid ?? 'new'}
+      key={createClimbScreenKey(params.editClimbUuid, board)}
       board={board}
       forkFrames={params.forkFrames}
       forkName={params.forkName}

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -61,7 +61,7 @@ import {
 import { getLastSearch, saveLastSearch, boardConfigKey } from '../../../src/lib/last-search-store';
 import { getFilterSummary, buildClimbFilterSummary } from '../../../src/lib/filter-summary';
 import { getActiveFilterTokens } from '../../../src/lib/filter-tokens';
-import { normalizeSearchName } from '../../../src/lib/search-name';
+import { normalizeSearchName, visibleSearchTextNeedsSync } from '../../../src/lib/search-name';
 import { track } from '../../../src/lib/analytics';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
@@ -353,12 +353,16 @@ function ClimbListInner() {
   const searchReady = hasBoardConfig && restoredKey === boardKey;
 
   useEffect(() => {
-    if (!searchReady || visibleSearchTextRef.current === name) return;
+    // Compare NORMALIZED so an in-progress trim-only difference (e.g. the user
+    // typed "crimp " before the next word) isn't treated as a desync and the
+    // field's trailing/leading whitespace isn't yanked out mid-typing. Genuine
+    // external changes (board restore, recent pill, cancel) still sync.
+    if (!searchReady || !visibleSearchTextNeedsSync(visibleSearchTextRef.current, name)) return;
     let cancelled = false;
     let syncAttempts = 0;
 
     const syncVisibleSearchText = () => {
-      if (cancelled || visibleSearchTextRef.current === name) return;
+      if (cancelled || !visibleSearchTextNeedsSync(visibleSearchTextRef.current, name)) return;
       const applied = applyVisibleSearchText(name);
       if (applied) {
         visibleSearchTextRef.current = name;

--- a/packages/mobile/app/(tabs)/climbs/zone.tsx
+++ b/packages/mobile/app/(tabs)/climbs/zone.tsx
@@ -6,6 +6,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import {
   buildDefaultZone,
+  parseHoldsFilter,
   pruneHoldsToZone,
   type BoardDimensions,
   type HoldPositionLookup,
@@ -73,19 +74,6 @@ function parseZoneBox(raw: string | undefined): ZoneBoxInput | null {
     // Malformed param → start with no zone rather than crash.
   }
   return null;
-}
-
-function parseHoldsFilter(raw: string | undefined): HoldsFilter {
-  if (!raw) return {};
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as HoldsFilter;
-    }
-  } catch {
-    // Malformed param → start empty.
-  }
-  return {};
 }
 
 function parseZoneMode(raw: string | undefined): ZoneMatchMode {

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { View, StyleSheet, Alert } from 'react-native';
+import { View, StyleSheet, Alert, Pressable } from 'react-native';
 import { useLocalSearchParams, useNavigation } from 'expo-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -53,7 +53,12 @@ export default function PlaylistDetail() {
 
   // Playlist metadata for the hero (name, climb count, colour, icon, ownership,
   // pin/follow state).
-  const { data: playlist, isLoading: metaLoading } = useQuery({
+  const {
+    data: playlist,
+    isLoading: metaLoading,
+    isError: metaError,
+    refetch: refetchMeta,
+  } = useQuery({
     queryKey: ['playlist', playlistUuid],
     queryFn: async () => {
       const response = await getHttpClient().request<GetPlaylistQueryResponse, GetPlaylistQueryVariables>(
@@ -342,6 +347,39 @@ export default function PlaylistDetail() {
     [playlist, allClimbs.length, followerCount, t],
   );
 
+  // Metadata fetch threw (network/server error): react-query leaves `playlist`
+  // undefined (never null), so the not-found guard below would be skipped and
+  // a blank fallback-titled hero would render as if it were a real empty
+  // playlist. Surface an explicit error + retry instead. Distinct from the
+  // resolved-null not-found case.
+  if (metaError && !playlist) {
+    return (
+      <View style={styles.stateContainer}>
+        <PlaylistBackFab />
+        <Icon name="error" size={48} color={iosSystemColors.systemGray4} />
+        <Text variant="headline" style={styles.stateTitle}>
+          {t('detail.errors.loadTitle')}
+        </Text>
+        <Text variant="subheadline" style={styles.stateSubtitle}>
+          {t('detail.errors.loadDescription')}
+        </Text>
+        <Pressable
+          onPress={() => {
+            void refetchMeta();
+            void query.refetch();
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={t('detail.errors.tryAgain')}
+          hitSlop={8}
+        >
+          <Text variant="subheadline" color={brandColors.primary} style={styles.stateRetry}>
+            {t('detail.errors.tryAgain')}
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
+
   // Playlist not found (resolved, null) — distinct from still-loading.
   if (!metaLoading && playlist === null) {
     return (
@@ -425,5 +463,9 @@ const styles = StyleSheet.create({
   stateSubtitle: {
     opacity: 0.4,
     textAlign: 'center',
+  },
+  stateRetry: {
+    marginTop: 12,
+    fontWeight: '600',
   },
 });

--- a/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 type PlaylistItem = { uuid: string; name: string; climbCount: number; creatorId?: string };
 
@@ -33,6 +34,10 @@ vi.mock('@boardsesh/playlists-react', () => ({
   useSmartPlaylistCounts: () => ({ data: [], isLoading: false }),
   usePlaylistMutations: () => ({ createPlaylist, pinPlaylist: vi.fn(), unpinPlaylist: vi.fn() }),
 }));
+
+// @tanstack/react-query is NOT mocked — the create flow writes to the real
+// ['userPlaylists'] cache, which the Add-to-Playlist picker reads, so the test
+// asserts against the live cache. Renders are wrapped in a QueryClientProvider.
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('expo-router', () => ({ router: { push: vi.fn() }, useFocusEffect: () => undefined }));
@@ -101,17 +106,35 @@ vi.mock('../../../../src/components/ActivityIndicator', () => ({
 vi.mock('../../../../src/components/SectionHeader', () => ({
   SectionHeader: ({ title }: { title: string }) => createElement('div', { 'data-section': title }),
 }));
+// The form sheet exposes a submit button driving onSubmit with fixed form
+// values, so the test can trigger the create flow without the real sheet UI.
+const FORM_VALUES = { name: 'Crimps', description: '', color: undefined, icon: undefined, isPublic: false };
 vi.mock('../../../../src/components/playlist', () => ({
   PlaylistCard: ({ name }: { name: string }) => createElement('div', { 'data-card': name }),
   PlaylistScrollSection: ({ children, title }: { children?: ReactNode; title: string }) =>
     createElement('div', { 'data-scroll-section': title }, children),
-  PlaylistFormSheet: () => createElement('div', { 'data-form-sheet': 'true' }),
+  PlaylistFormSheet: ({ onSubmit }: { onSubmit: (values: typeof FORM_VALUES) => void }) =>
+    createElement('button', { 'aria-label': 'submit-create', onClick: () => onSubmit(FORM_VALUES) }, 'submit'),
 }));
+// The chrome exposes the create button so the test can open + submit the flow.
 vi.mock('../../../../src/components/chrome', () => ({
-  DiscoverTopChrome: () => createElement('div', { 'data-chrome': 'true' }),
+  DiscoverTopChrome: ({ onCreate }: { onCreate: () => void }) =>
+    createElement('button', { 'aria-label': 'open-create', onClick: onCreate }, 'create'),
 }));
 
 import DiscoverLibrary from '../index';
+
+// The hub calls useQueryClient(); give it a real client so cache writes/reads
+// behave. Surface the client so the create test can read ['userPlaylists'].
+function renderHub() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <DiscoverLibrary />
+    </QueryClientProvider>,
+  );
+  return { ...utils, queryClient };
+}
 
 beforeEach(() => {
   userHook.playlists = [];
@@ -123,12 +146,13 @@ beforeEach(() => {
   discoverHook.isLoading = false;
   discoverHook.hasError = false;
   discoverHook.refetch.mockClear();
+  createPlaylist.mockReset();
 });
 
 describe('DiscoverLibrary error handling', () => {
   it('shows a load-error state with a retry (not the empty state) when a section fails and the hub is empty', () => {
     userHook.hasError = true;
-    const { getByText, queryByText, getByLabelText } = render(<DiscoverLibrary />);
+    const { getByText, queryByText, getByLabelText } = renderHub();
 
     expect(getByText('library.errors.loadTitle')).toBeTruthy();
     // Must not fall through to the misleading "no playlists yet" empty copy.
@@ -140,7 +164,7 @@ describe('DiscoverLibrary error handling', () => {
 
   it('retries only the discover stream when only it failed', () => {
     discoverHook.hasError = true;
-    const { getByLabelText } = render(<DiscoverLibrary />);
+    const { getByLabelText } = renderHub();
 
     fireEvent.click(getByLabelText('library.errors.tryAgain'));
     expect(discoverHook.refetch).toHaveBeenCalledTimes(1);
@@ -150,15 +174,47 @@ describe('DiscoverLibrary error handling', () => {
   it('keeps showing content (no error block) when a section errored but data is present', () => {
     userHook.hasError = true;
     userHook.playlists = [{ uuid: 'a', name: 'Alpha', climbCount: 1 }];
-    const { queryByText } = render(<DiscoverLibrary />);
+    const { queryByText } = renderHub();
 
     expect(queryByText('library.errors.loadTitle')).toBeNull();
   });
 
   it('still shows the empty state (not an error) when both sections succeed with no playlists', () => {
-    const { getByText, queryByText } = render(<DiscoverLibrary />);
+    const { getByText, queryByText } = renderHub();
 
     expect(getByText('library.empty.title')).toBeTruthy();
     expect(queryByText('library.errors.loadTitle')).toBeNull();
+  });
+});
+
+describe('DiscoverLibrary create flow', () => {
+  it('prepends a created playlist to the ["userPlaylists"] cache the picker reads', async () => {
+    const created = {
+      id: '99',
+      uuid: 'p-new',
+      name: 'Crimps',
+      climbCount: 0,
+      boardType: 'kilter',
+      layoutId: 1,
+      isPublic: false,
+      followerCount: 0,
+      isFollowedByMe: false,
+      isPinnedByMe: false,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+    createPlaylist.mockResolvedValue(created);
+
+    const { getByLabelText, queryClient } = renderHub();
+    // Seed the picker's cache so the prepend is observable against existing data.
+    queryClient.setQueryData(['userPlaylists'], [{ ...created, uuid: 'p-old', name: 'Slopers' }]);
+
+    fireEvent.click(getByLabelText('open-create'));
+    await act(async () => {
+      fireEvent.click(getByLabelText('submit-create'));
+    });
+
+    const cached = queryClient.getQueryData<Array<{ uuid: string }>>(['userPlaylists']);
+    expect(cached?.map((playlist) => playlist.uuid)).toEqual(['p-new', 'p-old']);
   });
 });

--- a/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type PlaylistItem = { uuid: string; name: string; climbCount: number; creatorId?: string };
+
+// Mutable hook return values — each test sets the slice it needs. The two
+// section hooks both expose `hasError`; the hub must read them.
+const userHook = vi.hoisted(() => ({
+  playlists: [] as PlaylistItem[],
+  isLoading: false,
+  isLoadingMore: false,
+  hasError: false,
+  loadMore: vi.fn(),
+  refetch: vi.fn(),
+}));
+const discoverHook = vi.hoisted(() => ({
+  popular: [] as PlaylistItem[],
+  recent: [] as PlaylistItem[],
+  isLoading: false,
+  isLoadingMore: false,
+  hasError: false,
+  loadMore: vi.fn(),
+  refetch: vi.fn(),
+}));
+const createPlaylist = vi.hoisted(() => vi.fn());
+
+vi.mock('@boardsesh/playlists-react', () => ({
+  useUserPlaylists: () => userHook,
+  useDiscoverPlaylists: () => discoverHook,
+  usePinnedPlaylists: () => ({ pinned: [], refetch: vi.fn() }),
+  useSmartPlaylistCounts: () => ({ data: [], isLoading: false }),
+  usePlaylistMutations: () => ({ createPlaylist, pinPlaylist: vi.fn(), unpinPlaylist: vi.fn() }),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('expo-router', () => ({ router: { push: vi.fn() }, useFocusEffect: () => undefined }));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
+
+// Reanimated primitives the hub touches → inert stubs. Animated.ScrollView just
+// renders its children so the in-body sections (and our error block) are in DOM.
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  },
+  useAnimatedRef: () => ({ current: null }),
+  useAnimatedScrollHandler: () => vi.fn(),
+  useSharedValue: (initial: unknown) => ({ value: initial }),
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1, absoluteFill: {} },
+  Platform: { OS: 'ios' },
+}));
+
+vi.mock('../../../../src/theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24, 8: 32, 10: 40, 16: 64 },
+}));
+vi.mock('../../../../src/theme/ios-colors', () => ({
+  iosSystemColors: { systemGray: '#8E8E93', systemGray4: '#C7C7CC', separator: '#ddd' },
+}));
+vi.mock('../../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({ brandColors: { primary: '#6D28D9' } }),
+}));
+vi.mock('../../../../src/providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+vi.mock('../../../../src/providers/toast-provider', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+vi.mock('../../../../src/lib/graphql/use-auth-token', () => ({ useAuthToken: () => ({ data: 'token' }) }));
+vi.mock('../../../../src/lib/graphql/hooks', () => ({ useProfile: () => ({ data: { id: 'me' } }) }));
+vi.mock('../../../../src/lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: { boardType: 'kilter', layoutId: 1 } }),
+}));
+vi.mock('../../../../src/hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+}));
+vi.mock('../../../../src/lib/smart-playlists', () => ({ SMART_PLAYLISTS: [] }));
+
+vi.mock('../../../../src/components/Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../../src/components/Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+vi.mock('../../../../src/components/ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-spinner': 'true' }),
+}));
+vi.mock('../../../../src/components/SectionHeader', () => ({
+  SectionHeader: ({ title }: { title: string }) => createElement('div', { 'data-section': title }),
+}));
+vi.mock('../../../../src/components/playlist', () => ({
+  PlaylistCard: ({ name }: { name: string }) => createElement('div', { 'data-card': name }),
+  PlaylistScrollSection: ({ children, title }: { children?: ReactNode; title: string }) =>
+    createElement('div', { 'data-scroll-section': title }, children),
+  PlaylistFormSheet: () => createElement('div', { 'data-form-sheet': 'true' }),
+}));
+vi.mock('../../../../src/components/chrome', () => ({
+  DiscoverTopChrome: () => createElement('div', { 'data-chrome': 'true' }),
+}));
+
+import DiscoverLibrary from '../index';
+
+beforeEach(() => {
+  userHook.playlists = [];
+  userHook.isLoading = false;
+  userHook.hasError = false;
+  userHook.refetch.mockClear();
+  discoverHook.popular = [];
+  discoverHook.recent = [];
+  discoverHook.isLoading = false;
+  discoverHook.hasError = false;
+  discoverHook.refetch.mockClear();
+});
+
+describe('DiscoverLibrary error handling', () => {
+  it('shows a load-error state with a retry (not the empty state) when a section fails and the hub is empty', () => {
+    userHook.hasError = true;
+    const { getByText, queryByText, getByLabelText } = render(<DiscoverLibrary />);
+
+    expect(getByText('library.errors.loadTitle')).toBeTruthy();
+    // Must not fall through to the misleading "no playlists yet" empty copy.
+    expect(queryByText('library.empty.title')).toBeNull();
+
+    fireEvent.click(getByLabelText('library.errors.tryAgain'));
+    expect(userHook.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries only the discover stream when only it failed', () => {
+    discoverHook.hasError = true;
+    const { getByLabelText } = render(<DiscoverLibrary />);
+
+    fireEvent.click(getByLabelText('library.errors.tryAgain'));
+    expect(discoverHook.refetch).toHaveBeenCalledTimes(1);
+    expect(userHook.refetch).not.toHaveBeenCalled();
+  });
+
+  it('keeps showing content (no error block) when a section errored but data is present', () => {
+    userHook.hasError = true;
+    userHook.playlists = [{ uuid: 'a', name: 'Alpha', climbCount: 1 }];
+    const { queryByText } = render(<DiscoverLibrary />);
+
+    expect(queryByText('library.errors.loadTitle')).toBeNull();
+  });
+
+  it('still shows the empty state (not an error) when both sections succeed with no playlists', () => {
+    const { getByText, queryByText } = render(<DiscoverLibrary />);
+
+    expect(getByText('library.empty.title')).toBeTruthy();
+    expect(queryByText('library.errors.loadTitle')).toBeNull();
+  });
+});

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// The metadata query goes through getHttpClient().request — mock it so we can
+// make GET_PLAYLIST reject (the error path) or resolve (the not-found path).
+const requestMock = vi.hoisted(() => vi.fn());
+vi.mock('../../../../src/lib/graphql/client', () => ({
+  getHttpClient: () => ({ request: requestMock }),
+}));
+
+// usePlaylistClimbs: the climbs infinite query. The detail screen only reads
+// query.refetch (for the retry) and allClimbs here.
+const climbsRefetch = vi.hoisted(() => vi.fn());
+vi.mock('@boardsesh/playlists-react', () => ({
+  usePlaylistClimbs: () => ({
+    query: {
+      isLoading: false,
+      isFetchingNextPage: false,
+      hasNextPage: false,
+      fetchNextPage: vi.fn(),
+      refetch: climbsRefetch,
+    },
+    allClimbs: [],
+  }),
+  usePlaylistMutations: () => ({
+    updatePlaylist: vi.fn(),
+    deletePlaylist: vi.fn(),
+    pinPlaylist: vi.fn(),
+    unpinPlaylist: vi.fn(),
+    followPlaylist: vi.fn(),
+    unfollowPlaylist: vi.fn(),
+  }),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ playlist_uuid: 'p-1' }),
+  useNavigation: () => ({ goBack: vi.fn() }),
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1, absoluteFill: {} },
+  Alert: { alert: vi.fn() },
+  Platform: { OS: 'ios' },
+}));
+
+vi.mock('../../../../src/theme/ios-colors', () => ({
+  iosSystemColors: { systemGray4: '#C7C7CC' },
+}));
+vi.mock('../../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { label: '#000', fill: '#eee' }, brandColors: { primary: '#6D28D9' } }),
+}));
+vi.mock('../../../../src/providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock('../../../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../../src/lib/playlists/use-playlist-activation', () => ({ usePlaylistActivation: () => vi.fn() }));
+vi.mock('../../../../src/lib/playlists/recents-store', () => ({ recordPlaylistOpen: vi.fn() }));
+vi.mock('../../../../src/lib/climb-types', () => ({ toQueueClimbs: (climbs: unknown) => climbs }));
+vi.mock('../../../../src/lib/haptics', () => ({ hapticSelection: vi.fn() }));
+
+vi.mock('../../../../src/components/Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../../src/components/Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+vi.mock('../../../../src/components/ClimbListRowSkeleton', () => ({
+  ClimbListRowSkeleton: () => createElement('div', { 'data-skeleton': 'true' }),
+}));
+vi.mock('../../../../src/components/GlassIconButton', () => ({
+  GlassIconButton: () => createElement('div', { 'data-glass-button': 'true' }),
+}));
+// PlaylistDetailView surfaces the hero title so we can prove the error branch
+// renders *instead of* a fallback-titled hero.
+vi.mock('../../../../src/components/playlist', () => ({
+  PlaylistDetailView: ({ hero }: { hero: { name: string } }) =>
+    createElement('div', { 'data-detail-view': 'true', 'data-hero-name': hero.name }),
+  SKELETON_PLACEHOLDERS: ['a', 'b'],
+  PlaylistFormSheet: () => null,
+  PlaylistActionsMenu: () => null,
+  PlaylistFollowButton: () => null,
+  PlaylistBackFab: () => createElement('div', { 'data-back-fab': 'true' }),
+}));
+
+import PlaylistDetail from '../[playlist_uuid]';
+
+function renderDetail() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PlaylistDetail />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  requestMock.mockReset();
+  climbsRefetch.mockClear();
+});
+
+describe('PlaylistDetail metadata error handling', () => {
+  it('renders an error + retry state (not a fallback-titled hero) when GET_PLAYLIST rejects', async () => {
+    // react-query leaves data undefined (never null) on a thrown error.
+    requestMock.mockRejectedValue(new Error('network down'));
+
+    const { findByText, queryByText, container } = renderDetail();
+
+    expect(await findByText('detail.errors.loadTitle')).toBeTruthy();
+    // The PlaylistDetailView (and its fallback-titled hero) must NOT render in
+    // its place.
+    expect(container.querySelector('[data-detail-view="true"]')).toBeNull();
+    expect(queryByText('metadata.detail.fallbackTitle')).toBeNull();
+  });
+
+  it('retries both the metadata and climbs queries from the error state', async () => {
+    requestMock.mockRejectedValue(new Error('network down'));
+
+    const { findByLabelText } = renderDetail();
+    const retry = await findByLabelText('detail.errors.tryAgain');
+
+    requestMock.mockResolvedValue({ playlist: null });
+    fireEvent.click(retry);
+
+    // The metadata query refetches (request fires again) and the climbs query
+    // is told to refetch too.
+    await waitFor(() => expect(requestMock).toHaveBeenCalledTimes(2));
+    expect(climbsRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the not-found state (not the load-error state) when GET_PLAYLIST resolves null', async () => {
+    requestMock.mockResolvedValue({ playlist: null });
+
+    const { findByText, queryByText } = renderDetail();
+
+    expect(await findByText('detail.errors.notFoundTitle')).toBeTruthy();
+    expect(queryByText('detail.errors.loadTitle')).toBeNull();
+  });
+});

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
 import Animated, { useAnimatedRef, useAnimatedScrollHandler, useSharedValue } from 'react-native-reanimated';
+import { useQueryClient } from '@tanstack/react-query';
 import { router, useFocusEffect } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
@@ -43,6 +44,7 @@ export default function DiscoverLibrary() {
   const { data: token = null, isLoading: tokenLoading } = useAuthToken();
   const { data: profile } = useProfile();
   const { data: activeBoard } = useActiveBoard();
+  const queryClient = useQueryClient();
 
   const userId = profile?.id ?? null;
   const effectiveToken = isAuthenticated ? token : null;
@@ -187,6 +189,13 @@ export default function DiscoverLibrary() {
         });
         setCreateVisible(false);
         showToast(t('bottomTabBar.createdPlaylistToast', { name: created.name }), 'success');
+        // refetchUser() only refreshes useUserPlaylists' own useState store
+        // (the Discover/all shelves). The Add-to-Playlist picker reads the
+        // react-query ['userPlaylists'] cache instead, which that refetch never
+        // touches — and the mobile QueryProvider wires no focus/online refetch,
+        // so the new playlist would stay missing from the picker for the rest
+        // of the session. Prepend it directly so it shows up immediately.
+        queryClient.setQueryData<Playlist[]>(['userPlaylists'], (prev) => (prev ? [created, ...prev] : [created]));
         refetchUser();
         router.push(`/(tabs)/discover/${created.uuid}`);
       } catch (err) {
@@ -196,7 +205,7 @@ export default function DiscoverLibrary() {
         setCreating(false);
       }
     },
-    [createBoard, createPlaylist, showToast, t, refetchUser],
+    [createBoard, createPlaylist, queryClient, showToast, t, refetchUser],
   );
 
   // Pin / unpin straight from a "Jump Back In" card. The shared-hook arrays

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -81,6 +81,7 @@ export default function DiscoverLibrary() {
     playlists: userPlaylists,
     isLoading: userLoading,
     isLoadingMore: userLoadingMore,
+    hasError: userError,
     loadMore: loadMoreUser,
     refetch: refetchUser,
   } = useUserPlaylists({
@@ -103,7 +104,9 @@ export default function DiscoverLibrary() {
     recent,
     isLoading: discoverLoading,
     isLoadingMore: discoverLoadingMore,
+    hasError: discoverError,
     loadMore: loadMoreDiscover,
+    refetch: refetchDiscover,
   } = useDiscoverPlaylists({
     boardType: filterBoardType,
     layoutId: filterLayoutId,
@@ -234,6 +237,17 @@ export default function DiscoverLibrary() {
 
   const showSignInPrompt = !isAuthenticated && !authLoading;
 
+  // The first-page fetch of one (or both) sections failed and the hub is empty
+  // — show a retry rather than the "no playlists yet" empty state, which would
+  // mislead a user who actually has playlists into thinking they have none.
+  const showLoadError =
+    (userError || discoverError) && jumpBackIn.length === 0 && discoverItems.length === 0 && !smartCountsLoading;
+
+  const handleRetryLoad = useCallback(() => {
+    if (userError) refetchUser();
+    if (discoverError) refetchDiscover();
+  }, [userError, discoverError, refetchUser, refetchDiscover]);
+
   return (
     <View style={styles.flex}>
       <Animated.ScrollView
@@ -345,11 +359,36 @@ export default function DiscoverLibrary() {
           </PlaylistScrollSection>
         ) : null}
 
-        {/* Empty state: signed in, nothing anywhere, nothing loading. */}
+        {/* Load error: a section's first page failed and the hub is empty.
+            Offer a retry instead of falsely claiming the library is empty. */}
+        {showLoadError ? (
+          <View style={styles.emptyContainer}>
+            <Icon name="error" size={48} color={iosSystemColors.systemGray4} />
+            <Text variant="headline" style={styles.emptyTitle}>
+              {t('library.errors.loadTitle')}
+            </Text>
+            <Text variant="subheadline" style={styles.emptySubtitle}>
+              {t('library.errors.loadDescription')}
+            </Text>
+            <Pressable
+              onPress={handleRetryLoad}
+              accessibilityRole="button"
+              accessibilityLabel={t('library.errors.tryAgain')}
+              hitSlop={8}
+            >
+              <Text variant="subheadline" color={brandColors.primary} style={styles.retryCta}>
+                {t('library.errors.tryAgain')}
+              </Text>
+            </Pressable>
+          </View>
+        ) : null}
+
+        {/* Empty state: signed in, nothing anywhere, nothing loading, no error. */}
         {isAuthenticated &&
         !userLoading &&
         !discoverLoading &&
         !smartCountsLoading &&
+        !showLoadError &&
         jumpBackIn.length === 0 &&
         discoverItems.length === 0 &&
         smartCardsToShow.length === 0 ? (
@@ -455,6 +494,10 @@ const styles = StyleSheet.create({
   emptySubtitle: {
     opacity: 0.4,
     textAlign: 'center',
+  },
+  retryCta: {
+    marginTop: spacing[3],
+    fontWeight: '600',
   },
   loadingContainer: {
     paddingTop: spacing[10] * 3,

--- a/packages/mobile/app/(tabs)/record/__tests__/summary-error-state.test.tsx
+++ b/packages/mobile/app/(tabs)/record/__tests__/summary-error-state.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type SummaryResult = {
+  data: unknown;
+  isPending: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  refetch: () => void;
+};
+
+const hook = vi.hoisted(() => ({
+  result: {
+    data: undefined as unknown,
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    refetch: vi.fn(),
+  } as SummaryResult,
+}));
+
+const router = vi.hoisted(() => ({ back: vi.fn() }));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ sessionId: 'session-1' }),
+  useRouter: () => router,
+}));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ bottom: 0 }) }));
+vi.mock('../../../../src/lib/graphql/hooks', () => ({ useSessionSummary: () => hook.result }));
+vi.mock('../../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {}, brandColors: { primary: '#6D28D9' } }),
+}));
+vi.mock('../../../../src/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (grade: string) => grade }),
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ActivityIndicator: () => createElement('div', { 'data-testid': 'spinner' }),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+// The screen pulls brandColors from the theme module, which evaluates
+// PlatformColor at import time; stub it so the node test env stays happy.
+vi.mock('../../../../src/theme/colors', () => ({ brandColors: { primary: '#6D28D9' } }));
+vi.mock('../../../../src/theme/tokens', () => ({
+  spacing: new Proxy({}, { get: () => 8 }),
+  borderRadius: new Proxy({}, { get: () => 8 }),
+}));
+
+// Lightweight component stubs — Button renders its title as a clickable button.
+vi.mock('../../../../src/components/Button', () => ({
+  Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
+    createElement('button', { onClick: onPress }, title),
+}));
+vi.mock('../../../../src/components/Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../../src/components/Icon', () => ({ Icon: () => createElement('i', null) }));
+vi.mock('../../../../src/components/Avatar', () => ({ Avatar: () => createElement('div', null) }));
+vi.mock('../../../../src/components/SectionHeader', () => ({ SectionHeader: () => createElement('div', null) }));
+vi.mock('../../../../src/components/Separator', () => ({ Separator: () => createElement('div', null) }));
+
+// Imported after mocks so it binds to the stubbed dependencies.
+const { default: SessionSummaryScreen } = await import('../summary');
+
+function setSummary(partial: Partial<SummaryResult>) {
+  hook.result = {
+    data: undefined,
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    refetch: hook.result.refetch,
+    ...partial,
+  };
+}
+
+describe('SessionSummaryScreen settled error/empty state', () => {
+  beforeEach(() => {
+    router.back.mockClear();
+    hook.result.refetch = vi.fn();
+  });
+
+  it('shows a spinner while the summary is still loading', () => {
+    setSummary({ isPending: true, isFetching: true });
+    const { queryByText, getByTestId } = render(<SessionSummaryScreen />);
+    expect(getByTestId('spinner')).toBeTruthy();
+    expect(queryByText('summary.done')).toBeNull();
+  });
+
+  it('shows a Done button (not an endless spinner) when the query errors', () => {
+    setSummary({ isError: true });
+    const { queryByTestId, getByText } = render(<SessionSummaryScreen />);
+    expect(queryByTestId('spinner')).toBeNull();
+    expect(getByText('summary.done')).toBeTruthy();
+    expect(getByText('summary.retry')).toBeTruthy();
+    fireEvent.click(getByText('summary.done'));
+    expect(router.back).toHaveBeenCalledOnce();
+  });
+
+  it('shows the error state (not a spinner) when the query settles with no summary', () => {
+    setSummary({ data: undefined, isPending: false, isFetching: false });
+    const { queryByTestId, getByText } = render(<SessionSummaryScreen />);
+    expect(queryByTestId('spinner')).toBeNull();
+    expect(getByText('summary.loadErrorTitle')).toBeTruthy();
+    expect(getByText('summary.done')).toBeTruthy();
+  });
+
+  it('retry triggers refetch', () => {
+    const refetch = vi.fn();
+    setSummary({ isError: true });
+    hook.result.refetch = refetch;
+    const { getByText } = render(<SessionSummaryScreen />);
+    fireEvent.click(getByText('summary.retry'));
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mobile/app/(tabs)/record/summary.tsx
+++ b/packages/mobile/app/(tabs)/record/summary.tsx
@@ -48,17 +48,40 @@ function getGradeColor(index: number): string {
 
 export default function SessionSummaryScreen() {
   const { sessionId } = useLocalSearchParams<{ sessionId: string }>();
-  const { data: summary, isLoading } = useSessionSummary(sessionId ?? null);
+  const { data: summary, isPending, isFetching, isError, refetch } = useSessionSummary(sessionId ?? null);
   const { t } = useTranslation('session');
   const { systemColors, brandColors: brand } = useTheme();
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { formatGrade } = useGradeFormat();
 
-  if (isLoading || !summary) {
+  // Still loading: query hasn't settled yet (first fetch in flight or refetching
+  // after a retry). isPending covers the disabled (no sessionId) case too.
+  if ((isPending || isFetching) && !summary) {
     return (
       <View style={styles.centered}>
         <ActivityIndicator size="large" color={brand.primary} />
+      </View>
+    );
+  }
+
+  // Settled but unusable: the query errored or resolved to no summary. Without
+  // this branch the screen would spin forever with no way out but the back
+  // gesture, right at the post-session payoff moment.
+  if (isError || !summary) {
+    return (
+      <View style={[styles.centered, styles.errorContent]}>
+        <Icon name="warning" size={40} color={systemColors.secondaryLabel} />
+        <Text variant="title3" style={styles.errorTitle}>
+          {t('summary.loadErrorTitle')}
+        </Text>
+        <Text variant="body" color={systemColors.secondaryLabel} style={styles.errorMessage}>
+          {t('summary.loadErrorMessage')}
+        </Text>
+        <View style={styles.errorActions}>
+          <Button title={t('summary.retry')} variant="text" onPress={() => void refetch()} />
+          <Button title={t('summary.done')} variant="filled" onPress={() => router.back()} />
+        </View>
       </View>
     );
   }
@@ -200,6 +223,22 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  errorContent: {
+    paddingHorizontal: spacing[6],
+    gap: spacing[3],
+  },
+  errorTitle: {
+    textAlign: 'center',
+  },
+  errorMessage: {
+    textAlign: 'center',
+  },
+  errorActions: {
+    marginTop: spacing[2],
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
   },
   durationRow: {
     flexDirection: 'row',

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -19,7 +19,7 @@ import { ThemeProvider, useTheme } from '../src/providers/theme-provider';
 import { MaterialThemeProvider } from '../src/providers/material-theme-provider';
 import { AuthProvider } from '../src/providers/auth-provider';
 import { I18nProvider } from '../src/providers/i18n-provider';
-import { BluetoothProvider } from '../src/providers/bluetooth-provider';
+import { BluetoothProviderWrapper } from '../src/providers/bluetooth-provider-wrapper';
 import { ToastProvider } from '../src/providers/toast-provider';
 import { QueueProvider } from '../src/providers/queue-provider';
 import { QueueSnackbarProvider } from '../src/providers/queue-snackbar-provider';
@@ -39,7 +39,6 @@ import { toBoardName } from '@boardsesh/board-config';
 import { PersistentQueueBar } from '../src/components/queue-control/persistent-queue-bar';
 import { useMobileClimbActionsData } from '../src/lib/graphql/hooks';
 import { useActiveBoard } from '../src/lib/graphql/use-active-board';
-import { LiveActivityBridge } from '../src/lib/live-activity/live-activity-bridge';
 import { Text } from '../src/components/Text';
 import { Button } from '../src/components/Button';
 import { Icon } from '../src/components/Icon';
@@ -138,32 +137,6 @@ function ClimbActionsDataWrapper({ children }: { children: ReactNode }) {
     <FavoritesProvider {...favoritesProviderProps}>
       <PlaylistsProvider {...playlistsProviderProps}>{children}</PlaylistsProvider>
     </FavoritesProvider>
-  );
-}
-
-function BluetoothProviderWrapper({ children }: { children: ReactNode }) {
-  const { data: activeBoard } = useActiveBoard();
-
-  if (!activeBoard) {
-    return <>{children}</>;
-  }
-
-  return (
-    <BluetoothProvider
-      boardName={activeBoard.boardType}
-      layoutId={activeBoard.layoutId}
-      sizeId={activeBoard.sizeId}
-      setIds={activeBoard.setIds}
-      boardUuid={activeBoard.uuid}
-    >
-      <LiveActivityBridge
-        boardName={activeBoard.boardType}
-        layoutId={activeBoard.layoutId}
-        sizeId={activeBoard.sizeId}
-        setIds={activeBoard.setIds}
-      />
-      {children}
-    </BluetoothProvider>
   );
 }
 

--- a/packages/mobile/app/auth/__tests__/callback-i18n.test.tsx
+++ b/packages/mobile/app/auth/__tests__/callback-i18n.test.tsx
@@ -31,9 +31,10 @@ vi.mock('expo-router', () => ({
 // up verbatim and fail the assertions below.
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
-vi.mock('../../../src/lib/auth', () => ({
+const auth = vi.hoisted(() => ({
   exchangeTransferToken: vi.fn(async () => ({ success: false, error: 'Invalid or expired transfer token' })),
 }));
+vi.mock('../../../src/lib/auth', () => ({ exchangeTransferToken: auth.exchangeTransferToken }));
 vi.mock('../../../src/lib/native-auth-analytics', () => ({ classifyNativeAuthFailureReason: () => 'invalid_token' }));
 vi.mock('../../../src/providers/auth-provider', () => ({
   useAuth: () => ({ refreshAuthState: vi.fn(async () => {}) }),
@@ -45,6 +46,7 @@ import AuthCallback from '../callback';
 beforeEach(() => {
   analytics.track.mockClear();
   router.replace.mockClear();
+  auth.exchangeTransferToken.mockClear();
   params.transferToken = undefined;
 });
 
@@ -72,5 +74,20 @@ describe('AuthCallback localization', () => {
     await waitFor(() => expect(container.textContent).toContain('callback.failed'));
     // The raw English/server string must never reach the user.
     expect(container.textContent).not.toContain('Invalid or expired transfer token');
+  });
+
+  // Android mounts this screen twice for one login: expo-router routes the
+  // deep link AND login.tsx routes here with openAuthSessionAsync's URL. The
+  // module-level exchangedTokens set must keep the duplicate mount from
+  // replaying the one-time token — the duplicate shows the spinner, never a
+  // "token already used" failure.
+  it('exchanges a token only once across a double mount', async () => {
+    params.transferToken = 'tok-double-mount';
+    const firstMount = render(createElement(AuthCallback));
+    const secondMount = render(createElement(AuthCallback));
+    await waitFor(() => expect(firstMount.container.textContent).toContain('callback.failed'));
+    expect(auth.exchangeTransferToken).toHaveBeenCalledTimes(1);
+    expect(secondMount.container.textContent).toContain('nativeStart.signingIn');
+    expect(secondMount.container.textContent).not.toContain('callback.failed');
   });
 });

--- a/packages/mobile/app/auth/__tests__/callback-i18n.test.tsx
+++ b/packages/mobile/app/auth/__tests__/callback-i18n.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { render, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Repro for A11-auth-onboarding-004: the OAuth callback screen rendered
+// hardcoded English ('Signing in...', 'Sign in failed: ...', 'No transfer
+// token received'). With `t` returning the key, a localized render must show
+// the catalog key rather than any English literal — so an es/fr user never
+// sees raw English at the most failure-prone step of the OAuth round-trip.
+
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+const router = vi.hoisted(() => ({ replace: vi.fn() }));
+const params = vi.hoisted(() => ({ transferToken: undefined as string | undefined }));
+
+vi.mock('../../../src/lib/analytics', () => ({ track: analytics.track }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+  ActivityIndicator: () => null,
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+vi.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ transferToken: params.transferToken }),
+  useRouter: () => router,
+}));
+
+// `t` echoes the key, so any English literal left in the component would show
+// up verbatim and fail the assertions below.
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../../../src/lib/auth', () => ({
+  exchangeTransferToken: vi.fn(async () => ({ success: false, error: 'Invalid or expired transfer token' })),
+}));
+vi.mock('../../../src/lib/native-auth-analytics', () => ({ classifyNativeAuthFailureReason: () => 'invalid_token' }));
+vi.mock('../../../src/providers/auth-provider', () => ({
+  useAuth: () => ({ refreshAuthState: vi.fn(async () => {}) }),
+}));
+vi.mock('../../../src/providers/theme-provider', () => ({ useTheme: () => ({ brandColors: { error: '#FF3B30' } }) }));
+
+import AuthCallback from '../callback';
+
+beforeEach(() => {
+  analytics.track.mockClear();
+  router.replace.mockClear();
+  params.transferToken = undefined;
+});
+
+describe('AuthCallback localization', () => {
+  it('renders the translated spinner label while exchanging the token', () => {
+    params.transferToken = 'tok-123';
+    const { container } = render(createElement(AuthCallback));
+    // Translated key, not the old hardcoded 'Signing in...'.
+    expect(container.textContent).toContain('nativeStart.signingIn');
+    expect(container.textContent).not.toContain('Signing in');
+  });
+
+  it('renders a translated failure message when no transfer token arrives', async () => {
+    params.transferToken = undefined;
+    const { container } = render(createElement(AuthCallback));
+    await waitFor(() => expect(container.textContent).toContain('callback.noTransferToken'));
+    // The old screen prefixed every error with hardcoded 'Sign in failed:'.
+    expect(container.textContent).not.toContain('Sign in failed');
+    expect(container.textContent).not.toContain('No transfer token received');
+  });
+
+  it('renders a translated generic message instead of raw server error text', async () => {
+    params.transferToken = 'tok-expired';
+    const { container } = render(createElement(AuthCallback));
+    await waitFor(() => expect(container.textContent).toContain('callback.failed'));
+    // The raw English/server string must never reach the user.
+    expect(container.textContent).not.toContain('Invalid or expired transfer token');
+  });
+});

--- a/packages/mobile/app/auth/callback.tsx
+++ b/packages/mobile/app/auth/callback.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
 import { exchangeTransferToken } from '../../src/lib/auth';
 import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -10,6 +11,9 @@ import { useTheme } from '../../src/providers/theme-provider';
 
 export default function AuthCallback() {
   const { transferToken } = useLocalSearchParams<{ transferToken: string }>();
+  const { t } = useTranslation('auth');
+  // Each entry holds a translated, user-facing failure message — never raw
+  // server text, which the backend returns in English only.
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const { refreshAuthState } = useAuth();
@@ -21,7 +25,7 @@ export default function AuthCallback() {
       // auth_method is unknown here — the OAuth provider isn't echoed back on the
       // transfer-token exchange (same reason Login Succeeded omits it).
       track(SHARED_EVENTS.LoginFailed, { flow: 'native', failure_reason: 'no_transfer_token' });
-      setError('No transfer token received');
+      setError(t('callback.noTransferToken'));
       return;
     }
 
@@ -36,19 +40,21 @@ export default function AuthCallback() {
           router.replace('/(tabs)/climbs');
         } else {
           track(SHARED_EVENTS.LoginFailed, { flow: 'native', failure_reason: classifyNativeAuthFailureReason(result) });
-          setError(result.error);
+          // result.error is a raw English/server string; show a translated
+          // generic message instead (mirrors login.tsx's networkError pattern).
+          setError(t('callback.failed'));
         }
       })
-      .catch((exchangeError: unknown) => {
+      .catch(() => {
         track(SHARED_EVENTS.LoginFailed, { flow: 'native', failure_reason: 'exception' });
-        setError(exchangeError instanceof Error ? exchangeError.message : 'Unexpected error');
+        setError(t('callback.unexpectedError'));
       });
-  }, [transferToken, router, refreshAuthState]);
+  }, [transferToken, router, refreshAuthState, t]);
 
   if (error) {
     return (
       <View style={styles.container}>
-        <Text style={[styles.errorText, { color: theme.brandColors.error }]}>Sign in failed: {error}</Text>
+        <Text style={[styles.errorText, { color: theme.brandColors.error }]}>{error}</Text>
       </View>
     );
   }
@@ -56,7 +62,7 @@ export default function AuthCallback() {
   return (
     <View style={styles.container}>
       <ActivityIndicator size="large" />
-      <Text style={styles.text}>Signing in...</Text>
+      <Text style={styles.text}>{t('nativeStart.signingIn')}</Text>
     </View>
   );
 }

--- a/packages/mobile/app/auth/callback.tsx
+++ b/packages/mobile/app/auth/callback.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -9,16 +9,24 @@ import { track } from '../../src/lib/analytics';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useTheme } from '../../src/providers/theme-provider';
 
+// Transfer tokens are one-time use, and this screen can mount twice for the
+// same token: on Android the callback deep link is routed by expo-router AND
+// the login screen routes here explicitly with the URL openAuthSessionAsync
+// returned. Module-level so a remount can't replay (and fail) the exchange —
+// the duplicate mount just shows the spinner until AuthProvider redirects.
+// Never cleared: one short string per login attempt for the process lifetime
+// is negligible, and clearing would reopen the replay window.
+const exchangedTokens = new Set<string>();
+
 export default function AuthCallback() {
   const { transferToken } = useLocalSearchParams<{ transferToken: string }>();
   const { t } = useTranslation('auth');
-  // Each entry holds a translated, user-facing failure message — never raw
-  // server text, which the backend returns in English only.
+  // Holds a translated, user-facing failure message — never raw server text,
+  // which the backend returns in English only.
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const { refreshAuthState } = useAuth();
   const theme = useTheme();
-  const exchangedRef = useRef(false);
 
   useEffect(() => {
     if (!transferToken) {
@@ -29,8 +37,8 @@ export default function AuthCallback() {
       return;
     }
 
-    if (exchangedRef.current) return;
-    exchangedRef.current = true;
+    if (exchangedTokens.has(transferToken)) return;
+    exchangedTokens.add(transferToken);
 
     exchangeTransferToken(transferToken)
       .then(async (result) => {

--- a/packages/mobile/app/join/[sessionId].tsx
+++ b/packages/mobile/app/join/[sessionId].tsx
@@ -103,7 +103,9 @@ export default function JoinSessionScreen() {
           style: 'destructive',
           onPress: () => {
             void (async () => {
-              await clearSession();
+              // notifyServer: leave session A on the backend before joining B so
+              // peers see the departure now, not after the 60s disconnect grace.
+              await clearSession({ notifyServer: true });
               await performJoin();
             })();
           },

--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -65,14 +65,19 @@ function AddToPlaylistSheet({
     async (playlist: Playlist) => {
       if (!climb) return;
       try {
-        await addToPlaylist(playlist.id, climb.uuid, angle);
+        // The backend addClimbToPlaylist resolver matches playlists.uuid, so
+        // the playlist *uuid* (not the bigserial id) must go on the wire — the
+        // id round-trips a "Playlist not found" error. It also keys the
+        // post-add cache invalidation onto the detail screen's ['playlist', uuid]
+        // / ['playlistClimbs', uuid] entries.
+        await addToPlaylist(playlist.uuid, climb.uuid, angle);
         showToast(t('actions.playlist.toast.added'), 'success');
       } catch (error) {
         // The toast is intentionally generic, but a swallowed error makes
         // "failed to add" impossible to diagnose. Log the real reason in dev.
         if (__DEV__) {
           console.warn('[playlist] add to playlist failed', {
-            playlistId: playlist.id,
+            playlistUuid: playlist.uuid,
             climbUuid: climb.uuid,
             angle,
             error,

--- a/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
@@ -89,6 +89,13 @@ export function BoardDiscoveryCard({ item, onPress }: BoardDiscoveryCardProps) {
             setIds={item.setIds}
             boardWidth={render.boardWidth}
             boardHeight={render.boardHeight}
+            // Resolve the thumb-sized (416px) background + a 400px overlay
+            // instead of the full-res native webp (up to ~1461px). A 168px cell
+            // doesn't need the native source, and decoding it on the main thread
+            // for every card in three stacked carousels stutters / hangs the
+            // picker. Matches ClimbListThumbnail's renderWidth so the thumb
+            // background and overlay cache entries are shared across surfaces.
+            renderWidth={400}
             style={styles.boardImage}
           />
         ) : (

--- a/packages/mobile/src/components/board-discovery/CustomBoardSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/CustomBoardSheet.tsx
@@ -3,7 +3,7 @@ import { View, ScrollView, Pressable, StyleSheet } from 'react-native';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { BoardName, UserBoard } from '@boardsesh/shared-schema';
-import { SUPPORTED_BOARDS, ANGLES } from '@boardsesh/board-config';
+import { SUPPORTED_BOARDS, ANGLES, normaliseSetIds } from '@boardsesh/board-config';
 import { useCreateBoard } from '../../lib/graphql/hooks';
 import {
   getBoardLayouts,
@@ -125,7 +125,10 @@ export const CustomBoardSheet = forwardRef<BottomSheet, CustomBoardSheetProps>(f
 
   const handleCreate = async () => {
     if (layoutId == null || sizeId == null || setIds.length === 0) return;
-    const wireSetIds = setIds.join(',');
+    // Store sets in canonical (deduped, numerically sorted) order so a board
+    // built by re-ticking sets (which re-appends at the end) matches an existing
+    // owned board instead of inserting a near-duplicate.
+    const wireSetIds = normaliseSetIds(setIds.join(','));
 
     // If the user already owns this exact config, the server would reject the
     // create as a duplicate — activate the existing board instead of erroring.

--- a/packages/mobile/src/components/board-discovery/__tests__/board-discovery-card.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-discovery-card.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { DiscoveryBoardItem } from '../BoardDiscoveryCard';
+
+// Capture the props the card hands to BoardImageNative. The regression is that
+// the discovery card omitted renderWidth, so the native renderer resolved the
+// full-res board background (~1080-1461px) into a 168px cell on the main thread.
+const boardImageProps = vi.hoisted(() => ({ last: null as Record<string, unknown> | null }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Platform: { select: (spec: Record<string, unknown>) => spec.ios },
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+// Reanimated host components: passthrough + no-op hooks so the card renders in
+// jsdom without the native runtime.
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    createAnimatedComponent:
+      () =>
+      ({ children }: { children?: ReactNode }) =>
+        createElement('div', null, children),
+  },
+  useAnimatedStyle: (factory: () => unknown) => factory(),
+  useSharedValue: (initial: unknown) => ({ value: initial }),
+  withSpring: (toValue: unknown) => toValue,
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn() }));
+vi.mock('../../../theme/animations', () => ({ springs: { snappy: {} } }));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: new Proxy({}, { get: () => 4 }),
+  borderRadius: { lg: 12, md: 8, full: 999 },
+  overlays: { scrim: '#0008', onScrim: '#fff' },
+}));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { white: '#fff' } }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { tertiaryBackground: '#eee', separator: '#ccc', tertiaryLabel: '#999', secondaryLabel: '#888' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('span', { 'data-icon': 'true' }) }));
+
+// A non-null render keeps the card on the BoardImageNative branch.
+vi.mock('../../../lib/board-details', () => ({
+  getBoardRenderData: () => ({ boardWidth: 1461, boardHeight: 1144 }),
+}));
+
+vi.mock('../../BoardImageNative', () => ({
+  BoardImageNative: (props: Record<string, unknown>) => {
+    boardImageProps.last = props;
+    return createElement('div', { 'data-testid': 'board-image' });
+  },
+}));
+
+import { BoardDiscoveryCard } from '../BoardDiscoveryCard';
+
+const item: DiscoveryBoardItem = {
+  key: 'popular:tension:9:8:1-2',
+  boardName: 'tension',
+  layoutId: 9,
+  sizeId: 8,
+  setIds: '1,2',
+  title: 'Tension 8x10',
+};
+
+describe('BoardDiscoveryCard', () => {
+  afterEach(() => {
+    cleanup();
+    boardImageProps.last = null;
+  });
+
+  it('renders the thumbnail at a small renderWidth, not the full-res board source', () => {
+    render(createElement(BoardDiscoveryCard, { item, onPress: vi.fn() }));
+
+    expect(boardImageProps.last).not.toBeNull();
+    // The discovery card cell is 168px; requesting renderWidth forces the
+    // thumb-variant background + small overlay instead of a full-res decode.
+    expect(boardImageProps.last?.renderWidth).toBe(400);
+  });
+});

--- a/packages/mobile/src/components/board-discovery/__tests__/board-items.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-items.test.ts
@@ -87,11 +87,32 @@ describe('findOwnedBoardForConfig', () => {
     expect(match?.uuid).toBe('b');
   });
 
+  it('matches an owned board whose set ids are in a different order', () => {
+    // Re-ticking a set in the builder re-appends it at the end, so the wire
+    // order can diverge from the stored order for the same physical board.
+    const match = findOwnedBoardForConfig(owned, { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '4,3' });
+    expect(match?.uuid).toBe('a');
+  });
+
+  it('matches regardless of whitespace or duplicate set ids', () => {
+    const match = findOwnedBoardForConfig(owned, {
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 2,
+      setIds: ' 3 , 4 , 4 ',
+    });
+    expect(match?.uuid).toBe('a');
+  });
+
   it('returns undefined when any field differs', () => {
     // same board/layout/size but different sets
-    expect(findOwnedBoardForConfig(owned, { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3' })).toBeUndefined();
+    expect(
+      findOwnedBoardForConfig(owned, { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3' }),
+    ).toBeUndefined();
     // different board type
-    expect(findOwnedBoardForConfig(owned, { boardType: 'decoy', layoutId: 1, sizeId: 2, setIds: '3,4' })).toBeUndefined();
+    expect(
+      findOwnedBoardForConfig(owned, { boardType: 'decoy', layoutId: 1, sizeId: 2, setIds: '3,4' }),
+    ).toBeUndefined();
   });
 
   it('returns undefined for an empty list', () => {

--- a/packages/mobile/src/components/board-discovery/board-items.ts
+++ b/packages/mobile/src/components/board-discovery/board-items.ts
@@ -3,7 +3,7 @@
 // per-shape branching.
 
 import type { BoardName, UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
-import { toBoardName } from '@boardsesh/board-config';
+import { toBoardName, normaliseSetIds } from '@boardsesh/board-config';
 import type { DiscoveryBoardItem } from './BoardDiscoveryCard';
 
 export function userBoardToItem(board: UserBoard, activeUuid?: string | null): DiscoveryBoardItem | null {
@@ -52,11 +52,17 @@ export type BoardConfigKey = {
  * guard when a popular/custom config the user already has is selected.
  */
 export function findOwnedBoardForConfig(boards: UserBoard[], config: BoardConfigKey): UserBoard | undefined {
+  // Compare set ids order/format-insensitively: '24,25,26,27' and '25,26,27,24'
+  // are the same physical board. Re-ticking a set in the builder re-appends it
+  // at the end of the array, so the wire order can diverge from the stored
+  // order even for the user's own board. Without normalising, the match misses,
+  // CREATE_BOARD fires, and the server inserts a near-duplicate UserBoard.
+  const configSetIds = normaliseSetIds(config.setIds);
   return boards.find(
     (b) =>
       b.boardType === config.boardType &&
       b.layoutId === config.layoutId &&
       b.sizeId === config.sizeId &&
-      b.setIds === config.setIds,
+      normaliseSetIds(b.setIds) === configSetIds,
   );
 }

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
@@ -40,6 +40,11 @@ const createClimb = vi.hoisted(() => ({
 }));
 
 // --- Module mocks. ---------------------------------------------------------
+// The controller only touches `AppState` from react-native (to flush autosave
+// on background); stub it so the test transformer doesn't load the real RN.
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: () => ({ remove: () => {} }) },
+}));
 vi.mock('../../../lib/analytics', () => ({ track: analytics.track }));
 
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Exercises the local-autosave effect's persistence guarantees:
+//  1. Flush-on-unmount: a pending debounced edit must be written immediately
+//     when the screen unmounts (drawer close / navigation), instead of being
+//     dropped by the cleanup's clearTimeout.
+//  2. Fork isolation: opening a fork must never overwrite the shared per-board
+//     new-climb autosave slot.
+
+const draftStore = vi.hoisted(() => ({
+  loadDraft: vi.fn(async () => null),
+  saveDraft: vi.fn(async (_key: string, _draft: { name: string }) => {}),
+  clearDraft: vi.fn(async () => {}),
+  createClimbDraftKey: vi.fn(() => 'draft-key'),
+}));
+
+const appState = vi.hoisted(() => ({
+  listeners: [] as Array<(state: string) => void>,
+  addEventListener: vi.fn((_event: string, handler: (state: string) => void) => {
+    appState.listeners.push(handler);
+    return { remove: vi.fn() };
+  }),
+  emit(state: string) {
+    appState.listeners.forEach((handler) => handler(state));
+  },
+}));
+
+const createClimb = vi.hoisted(() => ({
+  litUpHoldsMap: {} as Record<number, { state: string }>,
+  setHoldState: vi.fn(),
+  generateFramesString: vi.fn(() => ''),
+  startingCount: 0,
+  finishCount: 0,
+  isValid: false,
+  resetHolds: vi.fn(),
+  loadHolds: vi.fn(),
+  undo: vi.fn(),
+  redo: vi.fn(),
+  canUndo: false,
+  canRedo: false,
+}));
+
+vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
+vi.mock('expo-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: appState.addEventListener },
+}));
+vi.mock('@boardsesh/shared-schema', () => ({
+  isNoMatchClimb: () => false,
+  withNoMatch: (description: string) => description,
+}));
+vi.mock('@boardsesh/create-climb-react', () => ({
+  useCreateClimb: () => createClimb,
+  computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
+  computeEditLocked: () => false,
+  buildInitialHoldsMap: () => ({}),
+}));
+vi.mock('@boardsesh/board-react', () => ({
+  useBoardProvider: () => ({
+    isAuthenticated: true,
+    saveClimb: vi.fn(),
+    updateClimb: vi.fn(),
+  }),
+  isDuplicateClimbError: () => false,
+}));
+vi.mock('@boardsesh/graphql-client', () => ({
+  GraphQLOperationError: class GraphQLOperationError extends Error {},
+}));
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ refreshAuthState: vi.fn() }),
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: { displayName: 'Tester' } }),
+  useClimb: () => ({ data: undefined }),
+}));
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueueActions: () => ({ setCurrentClimb: vi.fn() }),
+}));
+vi.mock('../../../providers/bluetooth-provider', () => ({
+  useOptionalBluetoothContext: () => null,
+}));
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+vi.mock('../../../lib/climb-to-queue-item', () => ({ climbToQueueItem: () => ({}) }));
+vi.mock('../../../lib/create-climb-draft-store', () => ({
+  loadDraft: draftStore.loadDraft,
+  saveDraft: draftStore.saveDraft,
+  clearDraft: draftStore.clearDraft,
+  createClimbDraftKey: draftStore.createClimbDraftKey,
+}));
+vi.mock('../brush-roles', () => ({
+  getPaintRoles: () => ['HAND', 'STARTING', 'FINISH'],
+}));
+
+import { useCreateClimbScreen } from '../use-create-climb-screen';
+
+const BOARD = {
+  boardName: 'kilter' as const,
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,2',
+  angle: 40,
+};
+
+beforeEach(() => {
+  draftStore.saveDraft.mockClear();
+  draftStore.clearDraft.mockClear();
+  draftStore.loadDraft.mockClear();
+  draftStore.createClimbDraftKey.mockReturnValue('draft-key');
+  appState.listeners = [];
+  appState.addEventListener.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useCreateClimbScreen autosave flush', () => {
+  it('flushes the pending draft on unmount instead of dropping the edit', async () => {
+    vi.useFakeTimers();
+    const { result, unmount } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    // Let the mount restore resolve so restoredRef is set.
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    // Edit the name; do NOT advance past the 500ms debounce.
+    act(() => result.current.setName('WIP name'));
+    draftStore.saveDraft.mockClear();
+
+    // Close the drawer (unmount) within the debounce window.
+    unmount();
+
+    // The pending edit must have been persisted synchronously on unmount.
+    expect(draftStore.saveDraft).toHaveBeenCalledTimes(1);
+    expect(draftStore.saveDraft.mock.calls[0]?.[1]?.name).toBe('WIP name');
+  });
+
+  it('flushes the pending draft when the app is backgrounded', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    act(() => result.current.setName('Background WIP'));
+    draftStore.saveDraft.mockClear();
+
+    act(() => appState.emit('background'));
+
+    expect(draftStore.saveDraft).toHaveBeenCalledTimes(1);
+    expect(draftStore.saveDraft.mock.calls[0]?.[1]?.name).toBe('Background WIP');
+  });
+
+  it('does not write the shared new-climb slot when forking (debounced or flush)', async () => {
+    const { result, unmount } = renderHook(() =>
+      useCreateClimbScreen({ board: BOARD, forkFrames: 'p1r12', forkName: 'Original' }),
+    );
+    // A fork seeds its own holds/name; let any restore settle.
+    await waitFor(() => expect(result.current.name).toBe('Original fork'));
+
+    vi.useFakeTimers();
+    act(() => result.current.setDescription('forked beta'));
+    // Run past the debounce window — a non-fork WIP would persist here.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    // And exercise the unmount-flush path too.
+    unmount();
+
+    // Forks seed from their source and skip restore, so they must never persist
+    // into the per-board new-climb autosave key (it would clobber a real WIP).
+    expect(draftStore.saveDraft).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Drives the create-climb controller through Clear, then a fresh Save, asserting
+// the leftover "No match" toggle does not leak into the next brand-new climb.
+// Uses a real-ish `withNoMatch` (prefixes when enabled) so the description sent
+// to `saveClimb` reflects whether `noMatch` was reset.
+
+const board = vi.hoisted(() => ({
+  isAuthenticated: true,
+  saveClimb: vi.fn(),
+  updateClimb: vi.fn(),
+}));
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+const queue = vi.hoisted(() => ({ setCurrentClimb: vi.fn() }));
+const router = vi.hoisted(() => ({ push: vi.fn() }));
+
+const createClimb = vi.hoisted(() => ({
+  litUpHoldsMap: { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } },
+  setHoldState: vi.fn(),
+  generateFramesString: vi.fn(() => 'p1r12p2r13p3r14'),
+  startingCount: 1,
+  finishCount: 1,
+  isValid: true,
+  resetHolds: vi.fn(),
+  loadHolds: vi.fn(),
+  undo: vi.fn(),
+  redo: vi.fn(),
+  canUndo: false,
+  canRedo: false,
+}));
+
+vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
+vi.mock('expo-router', () => ({ useRouter: () => router }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+// Real-ish no-match encoding: enabling prepends the canonical marker so the
+// leaked-toggle bug is observable in the description sent to saveClimb.
+const NO_MATCH_PREFIX = 'No match\n';
+vi.mock('@boardsesh/shared-schema', () => ({
+  isNoMatchClimb: (description: string | null | undefined) => /^no match/i.test(description ?? ''),
+  withNoMatch: (description: string | null | undefined, enabled: boolean) => {
+    const current = description ?? '';
+    if (enabled) return /^no match/i.test(current) ? current : `${NO_MATCH_PREFIX}${current}`;
+    return current.replace(/^no match(?:\r?\n|$)/i, '');
+  },
+}));
+
+vi.mock('@boardsesh/create-climb-react', () => ({
+  useCreateClimb: () => createClimb,
+  computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
+  computeEditLocked: () => false,
+  buildInitialHoldsMap: () => ({}),
+}));
+
+vi.mock('@boardsesh/board-react', () => ({
+  useBoardProvider: () => ({
+    isAuthenticated: board.isAuthenticated,
+    saveClimb: board.saveClimb,
+    updateClimb: board.updateClimb,
+  }),
+  isDuplicateClimbError: () => false,
+}));
+
+vi.mock('@boardsesh/graphql-client', () => ({
+  GraphQLOperationError: class GraphQLOperationError extends Error {},
+}));
+
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ refreshAuthState: vi.fn() }),
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: { displayName: 'Tester' } }),
+  useClimb: () => ({ data: undefined }),
+}));
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueueActions: () => ({ setCurrentClimb: queue.setCurrentClimb }),
+}));
+vi.mock('../../../providers/bluetooth-provider', () => ({
+  useOptionalBluetoothContext: () => null,
+}));
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: toast.showToast }),
+}));
+vi.mock('../../../lib/climb-to-queue-item', () => ({ climbToQueueItem: () => ({}) }));
+vi.mock('../../../lib/create-climb-draft-store', () => ({
+  loadDraft: vi.fn(async () => null),
+  saveDraft: vi.fn(async () => {}),
+  clearDraft: vi.fn(async () => {}),
+  createClimbDraftKey: () => 'draft-key',
+}));
+vi.mock('../brush-roles', () => ({
+  getPaintRoles: () => ['HAND', 'STARTING', 'FINISH'],
+}));
+
+import { useCreateClimbScreen } from '../use-create-climb-screen';
+
+const BOARD = {
+  boardName: 'kilter' as const,
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,2',
+  angle: 40,
+};
+
+beforeEach(() => {
+  board.saveClimb.mockReset();
+  board.updateClimb.mockReset();
+  toast.showToast.mockClear();
+  queue.setCurrentClimb.mockClear();
+});
+
+describe('useCreateClimbScreen handleClear', () => {
+  it('resets the No-match toggle so a brand-new climb is not silently tagged no-match', async () => {
+    board.saveClimb.mockResolvedValue({ uuid: 'fresh', createdAt: null, publishedAt: null, isDraft: true });
+
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    // The previous climb used the No-match rule.
+    act(() => result.current.setNoMatch(true));
+    await waitFor(() => expect(result.current.noMatch).toBe(true));
+
+    // Start fresh.
+    act(() => result.current.handleClear());
+
+    // A brand-new climb must start without any rule markers.
+    expect(result.current.noMatch).toBe(false);
+
+    // And a Save immediately after Clear must not encode "No match\n".
+    act(() => result.current.setName('Fresh Problem'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(board.saveClimb).toHaveBeenCalledTimes(1);
+    const savedDescription = board.saveClimb.mock.calls[0]?.[0]?.description ?? '';
+    expect(savedDescription.startsWith('No match')).toBe(false);
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
@@ -31,6 +31,11 @@ const createClimb = vi.hoisted(() => ({
   canRedo: false,
 }));
 
+// The controller only touches `AppState` from react-native (autosave flush);
+// stub it so the test transformer doesn't load the real RN.
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: () => ({ remove: () => {} }) },
+}));
 vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
 vi.mock('expo-router', () => ({ useRouter: () => router }));

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -287,6 +287,7 @@ export function useCreateClimbScreen({
     // a Save straight after Clear reuses the old name and skips the name prompt.
     setName('');
     setDescription('');
+    setNoMatch(false);
     setIsDraft(true);
     setSavedClimb(null);
     setPublishDuplicateError(null);

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
 import { randomUUID } from 'expo-crypto';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -23,7 +24,13 @@ import { useQueueActions } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useToast } from '../../providers/toast-provider';
 import { climbToQueueItem } from '../../lib/climb-to-queue-item';
-import { loadDraft, saveDraft, clearDraft, createClimbDraftKey } from '../../lib/create-climb-draft-store';
+import {
+  loadDraft,
+  saveDraft,
+  clearDraft,
+  createClimbDraftKey,
+  type CreateClimbDraft,
+} from '../../lib/create-climb-draft-store';
 import { getPaintRoles, type BrushRole } from './brush-roles';
 
 // The save button's visual state, derived from auth + the saved-climb snapshot +
@@ -234,25 +241,66 @@ export function useCreateClimbScreen({
 
   // ---- Local autosave (debounced). ----
   const holdsJson = useMemo(() => JSON.stringify(litUpHoldsMap), [litUpHoldsMap]);
+  // The most recent autosave payload, kept current by the debounced effect so a
+  // flush-on-unmount / background can persist it synchronously without waiting
+  // for the (suspended-when-backgrounded) debounce timer. `dirty` gates whether
+  // there is anything worth flushing for the current per-board new-draft slot.
+  const pendingDraftRef = useRef<{ key: string; draft: CreateClimbDraft; dirty: boolean }>({
+    key: draftKey,
+    draft: { holdsJson, name, description, isDraft },
+    dirty: false,
+  });
+  // Forks seed from another climb's frames and skip restore, so — like edit
+  // mode — they must never write the shared per-board new-draft autosave slot,
+  // or merely opening a fork would clobber a real new-climb WIP under the same
+  // (board-config-only) key and resurface as a phantom on the next "new climb".
+  const autosaveDisabled = isEditing || isForking || !!savedClimb;
   useEffect(() => {
     if (!restoredRef.current) return;
-    // Edit mode operates on an existing climb — never persist it into the
-    // per-board new-draft autosave slot, or it resurfaces as a phantom draft.
-    if (isEditing) return;
-    // Once the WIP has been saved, stop autosaving. `handleSave` clears the
-    // draft and sets `savedClimb`; without this guard the debounced timer would
-    // re-write the just-cleared draft and resurface it as a phantom on reopen.
-    if (savedClimb) return;
+    // Edit mode / forks operate on a seeded climb, and a just-saved WIP is owned
+    // by the server row — none of them belong in the new-draft autosave slot.
+    if (autosaveDisabled) {
+      pendingDraftRef.current.dirty = false;
+      return;
+    }
     const hasContent = holdsJson !== '{}' || name.trim() !== '' || description.trim() !== '';
+    const draft: CreateClimbDraft = { holdsJson, name, description: withNoMatch(description, noMatch), isDraft };
+    // Mirror the latest payload so a flush (unmount/background) can persist the
+    // pending edit even before the debounce fires.
+    pendingDraftRef.current = { key: draftKey, draft, dirty: hasContent };
     const handle = setTimeout(() => {
       if (!hasContent) {
         void clearDraft(draftKey);
+        pendingDraftRef.current.dirty = false;
         return;
       }
-      void saveDraft(draftKey, { holdsJson, name, description: withNoMatch(description, noMatch), isDraft });
+      void saveDraft(draftKey, draft);
+      pendingDraftRef.current.dirty = false;
     }, AUTOSAVE_DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [holdsJson, name, description, noMatch, isDraft, draftKey, savedClimb]);
+  }, [holdsJson, name, description, noMatch, isDraft, draftKey, autosaveDisabled]);
+
+  // ---- Flush the pending draft on unmount / background. ----
+  // JS timers are suspended when the app is backgrounded and the cleanup's
+  // clearTimeout drops the pending edit when the drawer closes within the
+  // debounce window, so persist the latest payload immediately on both
+  // transitions. Keeps the draft-store's "a backgrounded app doesn't lose
+  // work-in-progress" promise.
+  const flushPendingDraft = useCallback(() => {
+    const pending = pendingDraftRef.current;
+    if (!restoredRef.current || !pending.dirty) return;
+    pending.dirty = false;
+    void saveDraft(pending.key, pending.draft);
+  }, []);
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state: AppStateStatus) => {
+      if (state === 'background' || state === 'inactive') flushPendingDraft();
+    });
+    return () => {
+      subscription.remove();
+      flushPendingDraft();
+    };
+  }, [flushPendingDraft]);
 
   // ---- BLE preview (debounced) while connected. ----
   const sendFramesRef = useRef(bluetooth?.sendFramesToBoard);

--- a/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
@@ -70,7 +70,13 @@ export const AngleSelectorSheet = memo(function AngleSelectorSheet({
   // diagram, grade, stars and sends all reflect this as the user slides.
   const [selectedAngle, setSelectedAngle] = useState(currentAngle);
 
-  const { data: statsHistory } = useClimbStatsHistory(boardName, climbUuid ?? null);
+  // The sheet stays mounted as a PlayDrawer sibling (stackBehavior=push needs an
+  // always-mounted modal), so gate the stats-history fetch on the sheet actually
+  // being presented — otherwise CLIMB_STATS_HISTORY would fire for every climb the
+  // user swipes through in the drawer, even when they never open the angle selector
+  // (mirrors the QueueList active-gate). React Query's 5-min staleTime keeps stats
+  // warm across re-opens and still dedupes with CommunitySection's below-fold query.
+  const { data: statsHistory } = useClimbStatsHistory(boardName, visible ? (climbUuid ?? null) : null);
   const statsByAngle = useMemo(() => buildAngleStatsMap(statsHistory, gradeFormat), [statsHistory, gradeFormat]);
   const stats: AngleStats | undefined = statsByAngle.get(selectedAngle);
   const quality = stats?.quality ?? 0;

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -32,7 +32,7 @@ import { Icon } from '../Icon';
 import { usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useToast } from '../../providers/toast-provider';
-import { useToggleFavorite } from '../../lib/graphql/hooks';
+import { useToggleFavorite, useFavoriteStatus } from '../../lib/graphql/hooks';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useShareClimb } from '../../hooks/use-share-climb';
 import { getBoardRenderData } from '../../lib/board-details';
@@ -121,7 +121,11 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     null,
   );
   const [isMirrored, setIsMirrored] = useState(false);
-  const [isFavorited, setIsFavorited] = useState(false);
+  // Local optimistic override for the heart. `null` means "no local change —
+  // show the server's favorite status". A tap sets it optimistically, the
+  // mutation's returned `favorited` confirms it, and a failure rolls it back.
+  // Cleared on every climb change so the next climb shows its real status.
+  const [favoriteOverride, setFavoriteOverride] = useState<boolean | null>(null);
   const [isTickBarActive, setIsTickBarActive] = useState(false);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [activeSubDrawer, setActiveSubDrawer] = useState<ActiveSubDrawer>('none');
@@ -182,6 +186,17 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const displayedClimb = displayedQueueItem?.climb;
   const displayedClimbUuidRef = useRef<string | null>(null);
   displayedClimbUuidRef.current = displayedClimb?.uuid ?? null;
+
+  // Real favorite status for the heart, keyed on (boardName, climbUuid, angle).
+  // Gated on the sheet being open so it doesn't fetch while the drawer is closed.
+  // The displayed state is the local optimistic override when set, otherwise the
+  // server's truth — so the heart reflects whether the climb is already a favorite
+  // on open, and a single tap can't invert reality (the previous always-false
+  // local state silently un-favorited already-favorited climbs).
+  const { data: serverFavorited } = useFavoriteStatus(boardName, displayedClimb?.uuid ?? null, angle, {
+    enabled: isSheetOpen,
+  });
+  const isFavorited = favoriteOverride ?? serverFavorited ?? false;
   const lightbulbState = useMemo(
     () =>
       derivePlayDrawerLightbulbState({
@@ -211,10 +226,13 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     isOpen: isSheetOpen,
   });
 
-  // Auto-close tick bar when climb changes
+  // Auto-close tick bar and drop the favorite override when climb changes, so the
+  // new climb's heart shows its real (server) status rather than the previous
+  // climb's optimistic value.
   const displayedClimbUuid = displayedClimb?.uuid;
   useEffect(() => {
     setIsTickBarActive(false);
+    setFavoriteOverride(null);
   }, [displayedClimbUuid]);
 
   // Once the user has requested below-fold content in an open sheet, keep it
@@ -328,7 +346,9 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       setDrawerPreviewSuggestionSource(previewPlaylistSuggestionSource);
       setDrawerPreviewItem(selectedItem);
       setIsMirrored(false);
-      setIsFavorited(false);
+      // Drop any stale optimistic heart so the opened climb shows its real
+      // (server) favorite status rather than a leftover from the last climb.
+      setFavoriteOverride(null);
       setIsTickBarActive(false);
       setIsSheetOpen(true);
       setActiveSubDrawer('none');
@@ -365,7 +385,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       previousClimb();
     }
     setIsMirrored(false);
-    setIsFavorited(false);
+    // The favorite override is cleared by the climb-change effect.
   }, [cancelPendingWallControlAttempt, isPartyPreviewOnly, navigationState.prevItem, previousClimb]);
 
   const handleNext = useCallback(() => {
@@ -379,7 +399,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       nextClimb();
     }
     setIsMirrored(false);
-    setIsFavorited(false);
+    // The favorite override is cleared by the climb-change effect.
   }, [cancelPendingWallControlAttempt, isPartyPreviewOnly, navigationState.nextItem, nextClimb]);
 
   const handleMirror = useCallback(() => {
@@ -390,7 +410,8 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     if (!displayedClimb) return;
     hapticSuccess();
     const nextIsFavorited = !isFavorited;
-    setIsFavorited(nextIsFavorited);
+    const previousOverride = favoriteOverride;
+    setFavoriteOverride(nextIsFavorited);
     track(SHARED_EVENTS.FavoriteToggle, {
       action: nextIsFavorited ? 'added' : 'removed',
       climbUuid: displayedClimb.uuid,
@@ -398,14 +419,30 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       layoutId,
       source: 'mobile_play_drawer',
     });
-    toggleFavoriteMutate({
-      input: {
-        boardName,
-        climbUuid: displayedClimb.uuid,
-        angle,
+    toggleFavoriteMutate(
+      {
+        input: {
+          boardName,
+          climbUuid: displayedClimb.uuid,
+          angle,
+        },
       },
-    });
-  }, [displayedClimb, isFavorited, boardName, layoutId, angle, toggleFavoriteMutate]);
+      {
+        // Reconcile to the server's authoritative result — the backend toggles
+        // off the real DB state, so this is the truth even if our optimistic
+        // guess was wrong.
+        onSuccess: (response) => {
+          setFavoriteOverride(response.toggleFavorite.favorited);
+        },
+        // Roll back the optimistic flip and tell the user it didn't stick, rather
+        // than leaving the heart diverged from the server.
+        onError: () => {
+          setFavoriteOverride(previousOverride);
+          showToast(t('playView.favoriteError'), 'error');
+        },
+      },
+    );
+  }, [displayedClimb, isFavorited, favoriteOverride, boardName, layoutId, angle, toggleFavoriteMutate, showToast, t]);
 
   const handleLightbulb = useCallback(() => {
     const pressAction = derivePlayDrawerLightbulbPressAction({
@@ -598,7 +635,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       setDrawerPreviewItem(queueItem);
       setDrawerPreviewSuggestionSource(null);
       setIsMirrored(false);
-      setIsFavorited(false);
+      // The favorite override is cleared by the climb-change effect.
       setIsTickBarActive(false);
       if (isPartyPreviewOnly) return;
       addToQueue(queueItem);

--- a/packages/mobile/src/components/play-drawer/PlaybackControls.tsx
+++ b/packages/mobile/src/components/play-drawer/PlaybackControls.tsx
@@ -25,6 +25,7 @@ import { brandColors as staticBrandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { springs, timing } from '../../theme/animations';
+import { roundedReportSpeed, shouldReportSpeed } from './playback-speed-report';
 
 // Continuous range; mirrors web's effective span. 1× is the natural default and
 // gets a gentle release-magnet (see commit()).
@@ -175,6 +176,10 @@ function SpeedSlider({
   const dragging = useSharedValue(false);
   const thumbScale = useSharedValue(1);
   const lastNotch = useSharedValue(-1);
+  // The last 0.1×-rounded speed pushed via `reportLive`, so the per-frame
+  // worklet skips the cross-thread `runOnJS` hop (and the PlaybackControls
+  // re-render it triggers) when the displayed value hasn't actually changed.
+  const lastReported = useSharedValue(-1);
 
   const ratioToSpeed = useCallback(
     (ratio: number) => Math.round((MIN_SPEED + clamp01(ratio) * (MAX_SPEED - MIN_SPEED)) * 10) / 10,
@@ -218,6 +223,7 @@ function SpeedSlider({
           thumbScale.value = withSpring(1.25, springs.snappy);
           lastNotch.value =
             Math.round((MIN_SPEED + (usable > 0 ? position.value / usable : 0) * (MAX_SPEED - MIN_SPEED)) * 2) / 2;
+          lastReported.value = roundedReportSpeed(position.value, usable);
           runOnJS(hapticSelection)();
         })
         .onUpdate((event) => {
@@ -230,7 +236,14 @@ function SpeedSlider({
             lastNotch.value = notch;
             runOnJS(hapticSelection)();
           }
-          runOnJS(reportLive)(next);
+          // Gate the cross-thread report on the 0.1×-rounded display value
+          // changing — without this it fires a runOnJS hop + a React setState
+          // (and a PlaybackControls re-render) on every drag frame.
+          const report = shouldReportSpeed(next, usable, lastReported.value);
+          if (report.changed) {
+            lastReported.value = report.rounded;
+            runOnJS(reportLive)(next);
+          }
         })
         .onEnd(() => {
           runOnJS(commit)(position.value);
@@ -239,7 +252,7 @@ function SpeedSlider({
           dragging.value = false;
           thumbScale.value = withSpring(1, springs.snappy);
         }),
-    [usable, position, startPosition, dragging, thumbScale, lastNotch, reportLive, commit],
+    [usable, position, startPosition, dragging, thumbScale, lastNotch, lastReported, reportLive, commit],
   );
 
   // Tap-to-seek on the track.

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -21,7 +21,7 @@ import { InlineTriesPicker } from './InlineTriesPicker';
 import { GradeSingleSelectRail } from '../grade';
 import { useTheme } from '../../providers/theme-provider';
 import { useGrades } from '../../lib/graphql/hooks';
-import { useOptionalBoardProvider, useSaveTick } from '@boardsesh/board-react';
+import { useOptionalBoardProvider, useSaveTick, logbookClimbAngleKey } from '@boardsesh/board-react';
 import { toBoardName } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { useToast } from '../../providers/toast-provider';
@@ -78,13 +78,19 @@ export const QuickTickBar = React.memo(function QuickTickBar({
   // Two failure modes the save-button label must guard against:
   // 1. `BoardProvider` not mounted → no logbook context at all → `Send`.
   // 2. Provider is mounted but this climb's ticks haven't been fetched
-  //    yet → `board.logbook.some(...)` returns false. We trigger
-  //    `getLogbook` on mount (idempotent thanks to useLogbook's fetched-
-  //    uuid dedupe) so the answer becomes authoritative on the next
-  //    render after the fetch resolves. In the brief window before then
-  //    the label may still read `Flash` for a climb that actually has
-  //    history — bounded to flows that bypass the climbs-index
-  //    pre-fetch (e.g. deep link to /climbs/[uuid]).
+  //    yet → the lookup returns nothing. We trigger `getLogbook` on mount
+  //    (idempotent thanks to useLogbook's fetched-uuid dedupe) so the
+  //    answer becomes authoritative on the next render after the fetch
+  //    resolves. In the brief window before then the label may still read
+  //    `Flash` for a climb that actually has history — bounded to flows
+  //    that bypass the climbs-index pre-fetch (e.g. deep link to
+  //    /climbs/[uuid]).
+  //
+  // Read the prebuilt `logbookByClimbAngle` index (an O(1) Map lookup the
+  // BoardProvider rebuilds once per logbook change) rather than scanning
+  // the raw `logbook` array — otherwise every logbook merge while this
+  // sheet is open (own tick saves, list paging, peer ticks in a session)
+  // re-runs an O(logbook) scan. Same index `useAscentStatus` reads.
   const board = useOptionalBoardProvider();
   useEffect(() => {
     if (!board) return;
@@ -92,7 +98,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
   }, [board, climbUuid]);
   const hasPriorHistory = useMemo(() => {
     if (!board) return true;
-    return board.logbook.some((entry) => entry.climb_uuid === climbUuid && entry.angle === angle);
+    return (board.logbookByClimbAngle.get(logbookClimbAngleKey(climbUuid, angle))?.length ?? 0) > 0;
   }, [board, climbUuid, angle]);
 
   const [tickState, setTickState] = useState(createInitialTickState);

--- a/packages/mobile/src/components/play-drawer/__tests__/angle-selector-sheet-stats-gate.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/angle-selector-sheet-stats-gate.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AngleSelectorSheet is always mounted as a PlayDrawer sibling (the stackBehavior=
+// push pattern needs an always-mounted modal) and toggled purely by its `visible`
+// prop. Its body — including useClimbStatsHistory — runs regardless of whether the
+// modal is actually presented. This test pins the regression: the stats-history
+// query must stay disabled (uuid passed as null) while the sheet is closed, so it
+// doesn't fire CLIMB_STATS_HISTORY for every climb the user swipes through in the
+// drawer, and only fetches the real uuid once the sheet is visible.
+
+const stats = vi.hoisted(() => ({
+  calls: [] as Array<{ boardName: string; climbUuid: string | null }>,
+}));
+
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useClimbStatsHistory: (boardName: string, climbUuid: string | null) => {
+    stats.calls.push({ boardName, climbUuid });
+    return { data: undefined };
+  },
+}));
+
+// Heavy UI / native deps stubbed so the component renders under jsdom. We only
+// care that the hook is called with the right uuid for the given `visible` state.
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android' },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+  StyleSheet: { create: (styleSheet: unknown) => styleSheet },
+}));
+
+vi.mock('@gorhom/bottom-sheet', () => ({
+  BottomSheetModal: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  BottomSheetBackdrop: () => null,
+  BottomSheetView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('react-native-screens', () => ({
+  FullWindowOverlay: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../../GlassSheetBackground', () => ({ GlassSheetBackground: () => null }));
+
+vi.mock('@boardsesh/board-config', () => ({ ANGLES: { kilter: [20, 25, 30, 40] } }));
+
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ gradeFormat: 'v_grade' }),
+}));
+
+vi.mock('../community-utils', () => ({ buildAngleStatsMap: () => new Map() }));
+
+vi.mock('../AngleBoardDiagram', () => ({ AngleBoardDiagram: () => null }));
+
+vi.mock('../AngleSlider', () => ({ AngleSlider: () => null }));
+
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: {} }));
+
+vi.mock('../../../theme/colors', () => ({ brandColors: { primary: '#000' } }));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: [0, 4, 8, 12, 16, 20],
+  sheetStyles: { indicator: {} },
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {} }),
+}));
+
+import { AngleSelectorSheet } from '../AngleSelectorSheet';
+
+const noop = () => {};
+
+beforeEach(() => {
+  stats.calls = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AngleSelectorSheet — stats-history fetch gating', () => {
+  it('does not fetch climb stats while the sheet is closed', () => {
+    render(
+      createElement(AngleSelectorSheet, {
+        visible: false,
+        onClose: noop,
+        boardName: 'kilter',
+        layoutId: 1,
+        climbUuid: 'climb-1',
+        currentAngle: 40,
+        onAngleChange: noop,
+      }),
+    );
+
+    expect(stats.calls.length).toBeGreaterThan(0);
+    // Every call while closed must pass null so the query stays disabled.
+    for (const call of stats.calls) {
+      expect(call.climbUuid).toBeNull();
+    }
+  });
+
+  it('fetches the climb stats once the sheet is presented', () => {
+    render(
+      createElement(AngleSelectorSheet, {
+        visible: true,
+        onClose: noop,
+        boardName: 'kilter',
+        layoutId: 1,
+        climbUuid: 'climb-1',
+        currentAngle: 40,
+        onAngleChange: noop,
+      }),
+    );
+
+    expect(stats.calls.some((call) => call.climbUuid === 'climb-1')).toBe(true);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/playback-speed-report.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/playback-speed-report.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { roundedReportSpeed, shouldReportSpeed } from '../playback-speed-report';
+
+// The pan `onUpdate` worklet runs ~60 frames/s. `shouldReportSpeed` is the gate
+// that keeps `runOnJS(reportLive)` (→ setLiveSpeed React state) from firing on
+// every frame: it reports only when the 0.1×-rounded display speed changes.
+
+const USABLE = 300; // 320px track - 20px thumb, the real geometry.
+
+/** Replay a drag (a px sequence) through the gate, threading lastReported the
+ *  way the worklet threads its shared value, and collect the reported speeds. */
+function reportsForDrag(pixels: number[]): number[] {
+  // Seed to a value the first frame can't equal so the first real frame reports.
+  let lastReported = -1;
+  const reported: number[] = [];
+  for (const px of pixels) {
+    const { rounded, changed } = shouldReportSpeed(px, USABLE, lastReported);
+    if (changed) {
+      lastReported = rounded;
+      reported.push(rounded);
+    }
+  }
+  return reported;
+}
+
+describe('shouldReportSpeed gate', () => {
+  it('matches the displayed 0.1x-rounded speed', () => {
+    // 0.5x..10x over 300px ≈ 0.0317x/px. Endpoints are exact.
+    expect(roundedReportSpeed(0, USABLE)).toBe(0.5);
+    expect(roundedReportSpeed(USABLE, USABLE)).toBe(10);
+    // Mid-track lands at (0.5 + 0.5 * 9.5) = 5.25; Math.round(52.5) = 53 → 5.3.
+    expect(roundedReportSpeed(USABLE / 2, USABLE)).toBe(5.3);
+  });
+
+  it('reports far fewer times than the frame count over a sub-pixel-per-frame drag', () => {
+    // 60 frames of 1px each = 60px of travel ≈ 1.9x. One report per 0.1x step,
+    // so ~19 reports vs 60 frames — never one per frame.
+    const pixels = Array.from({ length: 60 }, (_, index) => index + 1);
+    const reported = reportsForDrag(pixels);
+
+    expect(reported.length).toBeGreaterThan(0);
+    expect(reported.length).toBeLessThan(pixels.length);
+    // The gate's contract: no two consecutive reports carry the same value.
+    for (let index = 1; index < reported.length; index += 1) {
+      expect(reported[index]).not.toBe(reported[index - 1]);
+    }
+  });
+
+  it('does not report when several frames stay within the same 0.1x bucket', () => {
+    // ~0.0317x/px, so a 1px nudge near the same spot can stay in one bucket.
+    // Frames at the same px never re-report; the first reports, the rest skip.
+    let lastReported = roundedReportSpeed(100, USABLE);
+    const decisions = [101, 100, 100, 101].map((px) => {
+      const result = shouldReportSpeed(px, USABLE, lastReported);
+      if (result.changed) lastReported = result.rounded;
+      return result.changed;
+    });
+    // The repeated 100/101 frames that resolve to the same bucket must not all
+    // report; at most the boundary crossings do.
+    expect(decisions.filter(Boolean).length).toBeLessThan(decisions.length);
+  });
+
+  it('still reports every distinct 0.1x step (no coarsening of the live label)', () => {
+    // Walk px positions chosen to land on distinct 0.1 buckets and assert each
+    // produces a fresh report — the gate must not skip real value changes.
+    const distinctPixels = [0, 20, 40, 60, 80]; // ~0.5, 1.1, 1.8, 2.4, 3.0 → all distinct
+    const reported = reportsForDrag(distinctPixels);
+    expect(new Set(reported).size).toBe(reported.length);
+    expect(reported.length).toBe(distinctPixels.length);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { logbookClimbAngleKey, type LogbookEntry } from '@boardsesh/board-react';
+
+// QuickTickBar's `hasPriorHistory` decides flash vs send (deriveAscentType).
+// It must read the prebuilt O(1) `logbookByClimbAngle` Map, NOT scan the raw
+// `logbook` array. We prove this with a board whose `logbook` array is EMPTY
+// (an array scan returns false → "flash") while the Map HAS an entry for this
+// climb+angle (→ "send"). The save-button label is the observable.
+
+const CLIMB_UUID = 'climb-1';
+const ANGLE = 40;
+
+const boardState = vi.hoisted(() => ({
+  current: null as unknown,
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children, accessibilityLabel }: { children?: ReactNode; accessibilityLabel?: string }) =>
+    createElement('button', { 'data-label': accessibilityLabel }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+vi.mock('@gorhom/bottom-sheet', () => ({ BottomSheetTextInput: () => null }));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ bottom: 0 }) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('span') }));
+vi.mock('../InlineStarPicker', () => ({ InlineStarPicker: () => null }));
+vi.mock('../InlineTriesPicker', () => ({ InlineTriesPicker: () => null }));
+vi.mock('../../grade', () => ({ GradeSingleSelectRail: () => null }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {}, brandColors: { primary: '#6D28D9' } }),
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({ useGrades: () => ({ data: [] }) }));
+vi.mock('@boardsesh/board-config', () => ({ toBoardName: (name: string) => name }));
+vi.mock('@boardsesh/analytics', () => ({ SHARED_EVENTS: {} }));
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('../../../lib/haptics', () => ({ hapticSuccess: vi.fn(), hapticError: vi.fn() }));
+vi.mock('../../../theme/colors', () => ({ brandColors: { success: '#047857' } }));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: {} }));
+vi.mock('../../../theme/tokens', () => ({ spacing: new Proxy({}, { get: () => 0 }) }));
+
+// The board provider: an EMPTY logbook array (so an array scan finds nothing)
+// plus a populated `logbookByClimbAngle` Map (the correct O(1) index).
+vi.mock('@boardsesh/board-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@boardsesh/board-react')>();
+  return {
+    ...actual,
+    useOptionalBoardProvider: () => boardState.current,
+    useSaveTick: () => ({ mutate: vi.fn(), isPending: false }),
+  };
+});
+
+import { QuickTickBar } from '../QuickTickBar';
+
+function renderBar() {
+  return render(
+    createElement(QuickTickBar, {
+      climbUuid: CLIMB_UUID,
+      boardName: 'kilter',
+      angle: ANGLE,
+      isMirror: false,
+      isBenchmark: false,
+      onDismiss: vi.fn(),
+    }),
+  );
+}
+
+describe('QuickTickBar hasPriorHistory', () => {
+  it('reads the logbookByClimbAngle index, not the raw logbook array', () => {
+    const tick = { climb_uuid: CLIMB_UUID, angle: ANGLE } as unknown as LogbookEntry;
+    boardState.current = {
+      // Empty array: a `.some()` scan would return false → "flash".
+      logbook: [],
+      // Map index HAS history at this climb+angle → should resolve to "send".
+      logbookByClimbAngle: new Map<string, LogbookEntry[]>([[logbookClimbAngleKey(CLIMB_UUID, ANGLE), [tick]]]),
+      getLogbook: vi.fn(),
+    };
+
+    const { container } = renderBar();
+    const labels = Array.from(container.querySelectorAll('[data-label]')).map((node) =>
+      node.getAttribute('data-label'),
+    );
+    // deriveAscentType(true, 1) === 'send', so the log-ascent button is labelled
+    // for a send, not a flash. The array scan would have produced 'flash'.
+    expect(labels).toContain('playView.tickBar.logAscentAria');
+    const sendButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.sendSaveLabel',
+    );
+    const flashButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.flashSaveLabel',
+    );
+    expect(sendButton).toBeTruthy();
+    expect(flashButton).toBeUndefined();
+  });
+
+  it('falls back to "send" (history assumed) when there is no board provider', () => {
+    boardState.current = null;
+    const { container } = renderBar();
+    const flashButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.flashSaveLabel',
+    );
+    expect(flashButton).toBeUndefined();
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
@@ -128,19 +128,23 @@ beforeEach(() => {
 
 function renderPlayback(climb: Climb | null) {
   return renderHook(
-    (props: { climb: Climb | null }) =>
+    (props: { climb: Climb | null; mirrored?: boolean }) =>
       useMobilePlayback({
         climb: props.climb,
         boardName: KILTER,
-        mirrored: false,
+        mirrored: props.mirrored ?? false,
         isOpen: true,
       }),
-    { initialProps: { climb } },
+    { initialProps: { climb } as { climb: Climb | null; mirrored?: boolean } },
   );
 }
 
 /** Push a new current frame and rerender so the BLE effect re-evaluates. */
-async function setFrame(rerender: (props: { climb: Climb | null }) => void, climb: Climb | null, frame: string) {
+async function setFrame(
+  rerender: (props: { climb: Climb | null; mirrored?: boolean }) => void,
+  climb: Climb | null,
+  frame: string,
+) {
   await act(async () => {
     mocks.playback.currentFrameString = frame;
     rerender({ climb });
@@ -229,6 +233,50 @@ describe('useMobilePlayback — BLE drain', () => {
 
     await setFrame(rerender, climb, 'F0');
     expect(mocks.bluetooth.sendFramesToBoard).not.toHaveBeenCalled();
+  });
+
+  it('re-sends the current frame with the new orientation when mirror toggles on a stable frame', async () => {
+    const climb = climbWith('c1');
+    const { rerender } = renderPlayback(climb);
+
+    // Settle on a frame (e.g. paused / last frame): write it and resolve.
+    await setFrame(rerender, climb, 'F0');
+    await act(async () => {
+      mocks.sendCalls[0].resolve(true);
+    });
+    expect(mocks.bluetooth.sendFramesToBoard).toHaveBeenCalledTimes(1);
+    expect(mocks.sendCalls[0].mirrored).toBe(false);
+
+    // Toggle mirror with the SAME current frame string (no frame tick). The wall
+    // must re-flush the current frame with the flipped orientation rather than
+    // sitting on the old one until a frame change.
+    await act(async () => {
+      rerender({ climb, mirrored: true });
+    });
+    expect(mocks.bluetooth.sendFramesToBoard).toHaveBeenCalledTimes(2);
+    expect(mocks.sendCalls[1].frame).toBe('F0');
+    expect(mocks.sendCalls[1].mirrored).toBe(true);
+
+    await act(async () => {
+      mocks.sendCalls[1].resolve(true);
+    });
+  });
+
+  it('does not re-send when the mirror flag is unchanged across a rerender', async () => {
+    const climb = climbWith('c1');
+    const { rerender } = renderPlayback(climb);
+
+    await setFrame(rerender, climb, 'F0');
+    await act(async () => {
+      mocks.sendCalls[0].resolve(true);
+    });
+    expect(mocks.bluetooth.sendFramesToBoard).toHaveBeenCalledTimes(1);
+
+    // A rerender with the same (false) mirror flag and same frame must not write.
+    await act(async () => {
+      rerender({ climb, mirrored: false });
+    });
+    expect(mocks.bluetooth.sendFramesToBoard).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/mobile/src/components/play-drawer/playback-speed-report.ts
+++ b/packages/mobile/src/components/play-drawer/playback-speed-report.ts
@@ -1,0 +1,42 @@
+// Pure gating logic for the speed-slider's live-value reporting. Extracted so
+// the per-frame `runOnJS(reportLive)` decision (which otherwise lives only
+// inside a reanimated worklet) is unit-testable, and so the gate and the
+// reported value can never drift apart.
+//
+// The slider's `onUpdate` worklet runs ~60×/s during a drag. Reporting the live
+// value up to React (`onLiveChange` → `setLiveSpeed`) on every frame floods the
+// JS thread with a cross-thread hop + a PlaybackControls re-render per frame —
+// the rule-5 anti-pattern. The displayed label only shows 0.1× precision, so we
+// gate the hop on the 0.1-rounded speed actually changing, not on the raw frame.
+
+const MIN_SPEED = 0.5;
+const MAX_SPEED = 10;
+
+/**
+ * The displayed (0.1×-rounded) speed for a thumb position, matching the value
+ * `reportLive` forwards via `onLiveChange`. `usable` is the draggable track span
+ * in px (`trackWidth - THUMB_SIZE`); `px` is the clamped thumb offset.
+ */
+export function roundedReportSpeed(px: number, usable: number): number {
+  'worklet';
+  const ratio = usable > 0 ? px / usable : 0;
+  const clamped = ratio < 0 ? 0 : ratio > 1 ? 1 : ratio;
+  return Math.round((MIN_SPEED + clamped * (MAX_SPEED - MIN_SPEED)) * 10) / 10;
+}
+
+/**
+ * Decide whether this drag frame should push a new live value. Returns the
+ * 0.1-rounded speed for the position and whether it differs from the last one
+ * reported (`lastReported`, threaded by the caller through a shared value, seeded
+ * to a value the first real frame can't equal). When `changed` is false the
+ * caller skips the `runOnJS(reportLive)` hop entirely.
+ */
+export function shouldReportSpeed(
+  px: number,
+  usable: number,
+  lastReported: number,
+): { rounded: number; changed: boolean } {
+  'worklet';
+  const rounded = roundedReportSpeed(px, usable);
+  return { rounded, changed: rounded !== lastReported };
+}

--- a/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
+++ b/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
@@ -118,6 +118,7 @@ export function useMobilePlayback({
   const isWritingFrameRef = useRef(false);
   const pendingFrameRef = useRef<string | null>(null);
   const lastSentFrameRef = useRef<string | null>(null);
+  const lastSentMirroredRef = useRef(mirrored);
   const mirroredRef = useRef(mirrored);
   mirroredRef.current = mirrored;
 
@@ -127,6 +128,18 @@ export function useMobilePlayback({
     lastSentFrameRef.current = null;
     pendingFrameRef.current = null;
   }, [climbUuid]);
+
+  // A mirror toggle changes no frame string, so the writer effect's
+  // `currentFrameString === lastSentFrameRef.current` guard would skip the write
+  // and the wall would keep the old orientation while the on-screen board flips
+  // — visible whenever playback is paused (or sitting on a stable frame). Invalidate
+  // the last-sent frame so the current frame re-flushes with the new orientation.
+  // (During active playback this self-heals as frames tick; this covers the paused
+  // case web's bluetooth-context auto-sender covers there but mobile's does not.)
+  if (mirrored !== lastSentMirroredRef.current) {
+    lastSentMirroredRef.current = mirrored;
+    lastSentFrameRef.current = null;
+  }
 
   const { currentFrameString, isAnimatable } = playback;
   const bluetoothConnected = bluetooth?.isConnected ?? false;
@@ -168,7 +181,10 @@ export function useMobilePlayback({
       }
     };
     void drain();
-  }, [isOpen, isAnimatable, bluetoothConnected, bluetooth, currentFrameString]);
+    // `mirrored` is a dep so a mirror-only toggle (which leaves currentFrameString
+    // unchanged) re-runs this effect; the invalidation above clears the last-sent
+    // frame so the current frame re-flushes with the new orientation.
+  }, [isOpen, isAnimatable, bluetoothConnected, bluetooth, currentFrameString, mirrored]);
 
   const play = useCallback(() => {
     // Fire the analytics seam only on a deliberate user play of a route — peer

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -138,6 +138,9 @@ vi.mock('../../../providers/theme-provider', () => ({
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: queue.state, nextClimb: queue.nextClimb, previousClimb: queue.previousClimb }),
   usePlaylistSuggestionSource: () => null,
+  // Default to driver (not preview-only); these tests encode the bar's wiring,
+  // not party gating — that is covered in use-queue-carousel.test.tsx.
+  useIsPartyPreviewOnly: () => false,
 }));
 
 vi.mock('../../../providers/drawer-host-provider', () => ({

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -187,6 +187,9 @@ vi.mock('../../../providers/queue-provider', () => ({
     previousClimb: queue.previousClimb,
   }),
   usePlaylistSuggestionSource: () => null,
+  // Default to driver (not preview-only); these tests encode the bar's wiring,
+  // not party gating — that is covered in use-queue-carousel.test.tsx.
+  useIsPartyPreviewOnly: () => false,
 }));
 
 vi.mock('../../../providers/drawer-host-provider', () => ({

--- a/packages/mobile/src/components/queue-control/__tests__/use-queue-carousel.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-queue-carousel.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+
+// Hoisted provider/nav spies so each test drives party-preview gating + the
+// suggestion-aware navigation result the carousel reads.
+const queue = vi.hoisted(() => ({
+  state: {
+    currentClimbQueueItem: null as ClimbQueueItem | null,
+    queue: [] as ClimbQueueItem[],
+  },
+  nextClimb: vi.fn(),
+  previousClimb: vi.fn(),
+  isPartyPreviewOnly: false,
+}));
+
+const nav = vi.hoisted(() => ({
+  result: {
+    canNext: false,
+    canPrevious: false,
+    nextItem: null as ClimbQueueItem | null,
+    prevItem: null as ClimbQueueItem | null,
+    remainingCount: 0,
+  },
+}));
+
+// Capture the options useCarouselGesture is called with so we can assert the
+// gated canSwipeNext/canSwipePrevious flags fed into the pan gesture.
+const gestureCalls = vi.hoisted(() => ({ last: null as Record<string, unknown> | null }));
+
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueue: () => ({ state: queue.state, nextClimb: queue.nextClimb, previousClimb: queue.previousClimb }),
+  usePlaylistSuggestionSource: () => null,
+  useIsPartyPreviewOnly: () => queue.isPartyPreviewOnly,
+}));
+
+vi.mock('../../../providers/drawer-host-provider', () => ({
+  useDrawerHost: () => ({ openPlayDrawer: vi.fn() }),
+}));
+
+vi.mock('@boardsesh/play-view', () => ({
+  computePeekOffset: () => 0,
+  computeNavigationStateWithSuggestions: () => nav.result,
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('react-native', () => ({}));
+
+vi.mock('react-native-gesture-handler', () => {
+  const chainable: Record<string, () => unknown> = {};
+  const builder = new Proxy(chainable, { get: () => () => builder });
+  return { Gesture: { Tap: () => builder, Pan: () => builder, Race: () => builder } };
+});
+
+vi.mock('react-native-reanimated', () => ({
+  runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+  useAnimatedStyle: () => ({}),
+  useDerivedValue: () => ({ value: 0 }),
+  useSharedValue: (initial: number) => ({ value: initial }),
+}));
+
+vi.mock('../../play-drawer/use-carousel-gesture', () => ({
+  useCarouselGesture: (options: Record<string, unknown>) => {
+    gestureCalls.last = options;
+    return { gesture: {}, translateX: { value: 0 } };
+  },
+}));
+
+vi.mock('../../../hooks/use-reduce-motion', () => ({ useReduceMotion: () => false }));
+vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn(), hapticSelection: vi.fn() }));
+
+import { useQueueCarousel } from '../use-queue-carousel';
+
+function makeItem(uuid: string): ClimbQueueItem {
+  return {
+    uuid,
+    climb: {
+      uuid: `climb-${uuid}`,
+      name: `Climb ${uuid}`,
+      frames: '',
+      setter_username: 'setter',
+      angle: 40,
+      ascensionist_count: 5,
+      difficulty: 'V4',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0.5',
+      benchmark_difficulty: null,
+    },
+  };
+}
+
+describe('useQueueCarousel party-preview gating', () => {
+  beforeEach(() => {
+    queue.nextClimb.mockClear();
+    queue.previousClimb.mockClear();
+    queue.isPartyPreviewOnly = false;
+    gestureCalls.last = null;
+    const current = makeItem('current');
+    const next = makeItem('next');
+    queue.state.currentClimbQueueItem = current;
+    queue.state.queue = [current, next];
+    nav.result = { canNext: true, canPrevious: true, nextItem: next, prevItem: current, remainingCount: 1 };
+  });
+
+  it('drives the shared current climb when the user IS the driver (not preview-only)', () => {
+    const { result } = renderHook(() => useQueueCarousel());
+
+    result.current.handleNext();
+    result.current.handlePrevious();
+
+    // Driver: both stepping callbacks mutate the shared session.
+    expect(queue.nextClimb).toHaveBeenCalledTimes(1);
+    expect(queue.previousClimb).toHaveBeenCalledTimes(1);
+    expect(result.current.canNext).toBe(true);
+    expect(result.current.canPrevious).toBe(true);
+    expect(result.current.swipeAccessibilityActions.map((action) => action.name)).toEqual(['previous', 'next']);
+  });
+
+  it('does NOT mutate the shared current climb when party preview-only (gesture path)', () => {
+    queue.isPartyPreviewOnly = true;
+    const { result } = renderHook(() => useQueueCarousel());
+
+    result.current.handleNext();
+    result.current.handlePrevious();
+
+    // Non-driver: the bar swipe must not call into the session mutation path.
+    expect(queue.nextClimb).not.toHaveBeenCalled();
+    expect(queue.previousClimb).not.toHaveBeenCalled();
+  });
+
+  it('disables swipe + a11y prev/next for a preview-only member', () => {
+    queue.isPartyPreviewOnly = true;
+    const { result } = renderHook(() => useQueueCarousel());
+
+    // The exported flags that gate the swipe and the VoiceOver actions are off,
+    // even though the underlying navigation reports next/previous are available.
+    expect(result.current.canNext).toBe(false);
+    expect(result.current.canPrevious).toBe(false);
+    expect(result.current.swipeAccessibilityActions).toEqual([]);
+  });
+
+  it('passes the gated swipe flags into the pan gesture (RNGH cannot commit a step)', () => {
+    queue.isPartyPreviewOnly = true;
+    renderHook(() => useQueueCarousel());
+
+    expect(gestureCalls.last?.canSwipeNext).toBe(false);
+    expect(gestureCalls.last?.canSwipePrevious).toBe(false);
+  });
+
+  it('still surfaces the peek labels so a non-driver can SEE the next climb', () => {
+    queue.isPartyPreviewOnly = true;
+    const { result } = renderHook(() => useQueueCarousel());
+
+    // Preview, not blackout: the next/previous peek items still render.
+    expect(result.current.nextItem?.uuid).toBe('next');
+    expect(result.current.previousItem?.uuid).toBe('current');
+  });
+});

--- a/packages/mobile/src/components/queue-control/use-queue-carousel.ts
+++ b/packages/mobile/src/components/queue-control/use-queue-carousel.ts
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { computePeekOffset, computeNavigationStateWithSuggestions } from '@boardsesh/play-view';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
-import { usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
+import { useIsPartyPreviewOnly, usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { hapticLight, hapticSelection } from '../../lib/haptics';
 import { useCarouselGesture } from '../play-drawer/use-carousel-gesture';
@@ -53,6 +53,13 @@ export type QueueCarousel = {
 export function useQueueCarousel(): QueueCarousel {
   const { state, nextClimb, previousClimb } = useQueue();
   const playlistSuggestionSource = usePlaylistSuggestionSource();
+  // Party non-drivers may only preview — stepping the current climb is a
+  // shared-session mutation reserved for the driver. Mirrors PlayDrawer's
+  // prev/next gating and the climb-list activation guard (784f2a823): the
+  // always-visible bar is the one remaining ungated stepper, so a non-driver
+  // swipe (or VoiceOver next/previous action) must NOT call nextClimb/
+  // previousClimb and overwrite the driver's wall climb for everyone.
+  const isPartyPreviewOnly = useIsPartyPreviewOnly();
   const { openPlayDrawer } = useDrawerHost();
   const { t } = useTranslation('session');
   const reduceMotion = useReduceMotion();
@@ -71,20 +78,29 @@ export function useQueueCarousel(): QueueCarousel {
   // queue tail of an active playlist, `nextItem` falls through to the next
   // playlist climb (a transient "peek") instead of stopping. canPrevious/prevItem
   // stay queue-only — there is no backward suggestion fall-through.
-  const { canPrevious, canNext, nextItem, prevItem } = useMemo(
+  const nav = useMemo(
     () => computeNavigationStateWithSuggestions(queue, currentClimbQueueItem, playlistSuggestionSource),
     [queue, currentClimbQueueItem, playlistSuggestionSource],
   );
+  const { nextItem, prevItem } = nav;
+  // Preview-only members can't step the shared current climb, so the swipe and
+  // a11y prev/next actions are disabled for them (matching the queue sheet's
+  // precedent). The peek labels still render — non-drivers may *see* what's
+  // next, they just can't commit it.
+  const canPrevious = nav.canPrevious && !isPartyPreviewOnly;
+  const canNext = nav.canNext && !isPartyPreviewOnly;
 
   const handleNext = useCallback(() => {
+    if (isPartyPreviewOnly) return;
     hapticSelection();
     nextClimb();
-  }, [nextClimb]);
+  }, [isPartyPreviewOnly, nextClimb]);
 
   const handlePrevious = useCallback(() => {
+    if (isPartyPreviewOnly) return;
     hapticSelection();
     previousClimb();
-  }, [previousClimb]);
+  }, [isPartyPreviewOnly, previousClimb]);
 
   const handleOpenPlay = useCallback(() => {
     if (!currentClimbQueueItem?.climb) return;

--- a/packages/mobile/src/components/you/CommentSheet.tsx
+++ b/packages/mobile/src/components/you/CommentSheet.tsx
@@ -13,6 +13,7 @@ import { formatTickRelativeTime } from '@boardsesh/profile-stats';
 import { hapticLight } from '../../lib/haptics';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
+import { useToast } from '../../providers/toast-provider';
 
 type CommentSheetProps = {
   sheetRef: RefObject<BottomSheet | null>;
@@ -27,6 +28,7 @@ type CommentSheetProps = {
 export function CommentSheet({ sheetRef, entityId, entityType = 'session', onClose }: CommentSheetProps) {
   const { t } = useTranslation('you');
   const { systemColors, brandColors } = useTheme();
+  const { showToast } = useToast();
   const [draft, setDraft] = useState('');
 
   const commentsQuery = useComments(entityType, entityId ?? undefined, !!entityId);
@@ -37,8 +39,16 @@ export function CommentSheet({ sheetRef, entityId, entityType = 'session', onClo
     const body = draft.trim();
     if (!body || !entityId) return;
     hapticLight();
-    addComment.mutate({ entityType, entityId, body });
-    setDraft('');
+    // Clear the draft only once the comment lands. On failure keep the text in
+    // the composer and surface a toast so it isn't silently lost. The send
+    // button is disabled while the mutation is pending, so no double-send.
+    addComment.mutate(
+      { entityType, entityId, body },
+      {
+        onSuccess: () => setDraft(''),
+        onError: () => showToast(t('mobile.comments.sendError'), 'error'),
+      },
+    );
   };
 
   return (

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
-import { View, RefreshControl, StyleSheet } from 'react-native';
+import { View, RefreshControl, Pressable, StyleSheet } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useTranslation } from 'react-i18next';
 import type BottomSheet from '@gorhom/bottom-sheet';
@@ -13,7 +13,7 @@ import { LogbookRow } from './LogbookRow';
 import { LogbookEditSheet } from './LogbookEditSheet';
 import { useUserAscentsFeed } from '../../lib/graphql/hooks';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
-import { spacing } from '../../theme/tokens';
+import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 
 export function LogbookTab({ userId }: { userId: string | undefined }) {
@@ -38,6 +38,10 @@ export function LogbookTab({ userId }: { userId: string | undefined }) {
     if (feed.hasNextPage && !feed.isFetchingNextPage) void feed.fetchNextPage();
   }, [feed]);
 
+  const handleRetry = useCallback(() => {
+    void feed.refetch();
+  }, [feed]);
+
   const renderItem = useCallback(
     ({ item }: { item: AscentFeedItem }) => <LogbookRow ascent={item} onPress={handlePress} />,
     [handlePress],
@@ -47,6 +51,36 @@ export function LogbookTab({ userId }: { userId: string | undefined }) {
     return (
       <View style={styles.centered}>
         <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (feed.isError) {
+    return (
+      <View style={styles.errorContainer}>
+        <Icon name="error" size={48} color={systemColors.tertiaryLabel} />
+        <Text variant="headline" style={styles.errorTitle}>
+          {t('mobile.logbook.errorTitle')}
+        </Text>
+        <Text variant="subheadline" style={styles.errorBody}>
+          {t('mobile.logbook.errorBody')}
+        </Text>
+        <Pressable
+          onPress={handleRetry}
+          disabled={feed.isRefetching}
+          accessibilityRole="button"
+          accessibilityLabel={t('mobile.logbook.retry')}
+          style={({ pressed }) => [
+            styles.retryButton,
+            { borderColor: brandColors.primary },
+            feed.isRefetching && styles.retryButtonDisabled,
+            pressed && !feed.isRefetching && { backgroundColor: `${brandColors.primary}1A` },
+          ]}
+        >
+          <Text variant="footnote" color={brandColors.primary}>
+            {t('mobile.logbook.retry')}
+          </Text>
+        </Pressable>
       </View>
     );
   }
@@ -101,4 +135,21 @@ const styles = StyleSheet.create({
     gap: spacing[2],
   },
   emptyTitle: { opacity: 0.6, marginTop: spacing[3], textAlign: 'center' },
+  errorContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing[8],
+    gap: spacing[2],
+  },
+  errorTitle: { marginTop: spacing[3], textAlign: 'center' },
+  errorBody: { opacity: 0.6, textAlign: 'center' },
+  retryButton: {
+    marginTop: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+    borderRadius: borderRadius.full,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  retryButtonDisabled: { opacity: 0.5 },
 });

--- a/packages/mobile/src/components/you/SessionsTab.tsx
+++ b/packages/mobile/src/components/you/SessionsTab.tsx
@@ -13,7 +13,7 @@ import { SessionFeedCard } from './SessionFeedCard';
 import { SessionsFeedHeader } from './SessionsFeedHeader';
 import { FeedSectionLabel } from './FeedSectionLabel';
 import { CommentSheet } from './CommentSheet';
-import { bucketSessionsByRecency, type FeedRecencyBucket } from '../../lib/feed-time-buckets';
+import { bucketSessionsByRecency, dedupeSessionsById, type FeedRecencyBucket } from '../../lib/feed-time-buckets';
 import { useSessionGroupedFeed, useBulkVoteSummaries } from '../../lib/graphql/hooks';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { spacing } from '../../theme/tokens';
@@ -41,8 +41,11 @@ export function SessionsTab({ userId }: { userId: string | undefined }) {
   const [commentSessionId, setCommentSessionId] = useState<string | null>(null);
 
   const feed = useSessionGroupedFeed({ userId }, !!userId);
+  // De-dupe across pages: the OFFSET-paginated feed can return the same session
+  // on two adjacent pages when its rank shifts mid-refetch, which would
+  // otherwise produce duplicate FlashList keys (keyExtractor returns sessionId).
   const sessions = useMemo(
-    () => feed.data?.pages.flatMap((page) => page.sessionGroupedFeed.sessions) ?? [],
+    () => dedupeSessionsById(feed.data?.pages.flatMap((page) => page.sessionGroupedFeed.sessions) ?? []),
     [feed.data],
   );
 

--- a/packages/mobile/src/components/you/SessionsTab.tsx
+++ b/packages/mobile/src/components/you/SessionsTab.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { View, RefreshControl, StyleSheet } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
-import { useRouter } from 'expo-router';
+import { useRouter, useFocusEffect } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import type { SessionFeedItem } from '@boardsesh/shared-schema';
@@ -49,9 +49,16 @@ export function SessionsTab({ userId }: { userId: string | undefined }) {
     [feed.data],
   );
 
-  // One clock captured per mount (stable across renders) so the rollup header
-  // and the section bucketing agree and neither rebuckets on every render.
-  const [now] = useState(() => Date.now());
+  // A single `now` shared by the rollup header and the section bucketing so the
+  // two agree and neither rebuckets on every render. It re-evaluates on focus
+  // and on pull-to-refresh (not per frame), so a screen left mounted across
+  // midnight stops mislabelling yesterday's session as "Today".
+  const [now, setNow] = useState(() => Date.now());
+  useFocusEffect(
+    useCallback(() => {
+      setNow(Date.now());
+    }, []),
+  );
 
   // Flatten the recency groups into header + session rows for a single
   // virtualized list (FlashList has no built-in section support).
@@ -134,7 +141,10 @@ export function SessionsTab({ userId }: { userId: string | undefined }) {
         refreshControl={
           <RefreshControl
             refreshing={feed.isRefetching}
-            onRefresh={() => void feed.refetch()}
+            onRefresh={() => {
+              setNow(Date.now());
+              void feed.refetch();
+            }}
             tintColor={brandColors.primary}
           />
         }

--- a/packages/mobile/src/components/you/__tests__/comment-sheet-error.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/comment-sheet-error.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type MutateOptions = {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+const addComment = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  isPending: false,
+}));
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useComments: () => ({ data: { comments: [] }, isPending: false }),
+  useAddComment: () => addComment,
+}));
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => toast }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { fill: '#eee', label: '#000', tertiaryLabel: '#999' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn() }));
+vi.mock('@boardsesh/profile-stats', () => ({ formatTickRelativeTime: () => 'now' }));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children, onPress, disabled }: { children?: ReactNode; onPress?: () => void; disabled?: boolean }) =>
+    createElement('button', { onClick: onPress, disabled, 'data-testid': 'send' }, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+// Sheet renders its children + footer so the composer is interactable.
+vi.mock('../../Sheet', () => ({
+  Sheet: ({ children, footer }: { children?: ReactNode; footer?: ReactNode }) =>
+    createElement('div', null, children, footer),
+}));
+vi.mock('@gorhom/bottom-sheet', () => ({
+  __esModule: true,
+  default: () => null,
+  BottomSheetTextInput: ({
+    value,
+    onChangeText,
+    placeholder,
+  }: {
+    value?: string;
+    onChangeText?: (text: string) => void;
+    placeholder?: string;
+  }) =>
+    createElement('input', {
+      'data-testid': 'comment-input',
+      value: value ?? '',
+      placeholder,
+      onChange: (event: { target: { value: string } }) => onChangeText?.(event.target.value),
+    }),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Avatar', () => ({ Avatar: () => createElement('div', null) }));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('i', null) }));
+vi.mock('../../ActivityIndicator', () => ({ ActivityIndicator: () => createElement('div', null) }));
+
+const { CommentSheet } = await import('../CommentSheet');
+
+function renderSheet() {
+  const sheetRef = { current: null };
+  return render(<CommentSheet sheetRef={sheetRef} entityId="entity-1" entityType="session" onClose={() => {}} />);
+}
+
+describe('CommentSheet submit error handling', () => {
+  beforeEach(() => {
+    addComment.mutate.mockReset();
+    addComment.isPending = false;
+    toast.showToast.mockReset();
+  });
+
+  it('clears the draft only after the comment posts successfully', () => {
+    addComment.mutate.mockImplementation((_input: unknown, options: MutateOptions) => {
+      options.onSuccess?.();
+    });
+
+    const { getByTestId } = renderSheet();
+    const input = getByTestId('comment-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'nice send' } });
+    fireEvent.click(getByTestId('send'));
+
+    expect(addComment.mutate).toHaveBeenCalledOnce();
+    expect(input.value).toBe('');
+    expect(toast.showToast).not.toHaveBeenCalled();
+  });
+
+  it('keeps the draft and shows an error toast when posting fails', () => {
+    addComment.mutate.mockImplementation((_input: unknown, options: MutateOptions) => {
+      options.onError?.(new Error('network down'));
+    });
+
+    const { getByTestId } = renderSheet();
+    const input = getByTestId('comment-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'nice send' } });
+    fireEvent.click(getByTestId('send'));
+
+    expect(addComment.mutate).toHaveBeenCalledOnce();
+    // Draft must survive so the user's text isn't silently lost.
+    expect(input.value).toBe('nice send');
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.comments.sendError', 'error');
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-analytics.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-analytics.test.tsx
@@ -32,7 +32,8 @@ vi.mock('../../../lib/analytics', () => ({ track: analytics.track }));
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   RefreshControl: () => null,
-  StyleSheet: { create: (styles: unknown) => styles },
+  Pressable: () => null,
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
 }));
 
 // Render every data row through renderItem so the mocked LogbookRow mounts and
@@ -68,7 +69,7 @@ vi.mock('../../../lib/graphql/hooks', () => ({ useUserAscentsFeed: () => feed })
 vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({
   useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
 }));
-vi.mock('../../../theme/tokens', () => ({ spacing: {} }));
+vi.mock('../../../theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({ systemColors: {}, brandColors: {} }),
 }));

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-error.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-error.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mutable feed mock so each test can set the hook's return shape.
+const feed = vi.hoisted(() => ({
+  current: {
+    data: undefined as unknown,
+    isPending: false,
+    isError: false,
+    isRefetching: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    refetch: vi.fn(),
+    fetchNextPage: vi.fn(),
+  },
+}));
+
+vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  RefreshControl: () => null,
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Pressable: ({ children, onPress, disabled }: { children?: ReactNode; onPress?: () => void; disabled?: boolean }) =>
+    createElement('button', { onClick: disabled ? undefined : onPress, disabled }, children),
+}));
+
+vi.mock('@shopify/flash-list', () => ({
+  FlashList: ({
+    data,
+    renderItem,
+    ListEmptyComponent,
+  }: {
+    data: Array<{ uuid: string }>;
+    renderItem: (info: { item: { uuid: string } }) => ReactNode;
+    ListEmptyComponent?: ReactNode;
+  }) =>
+    createElement(
+      'div',
+      { 'data-testid': 'flash-list' },
+      data.length > 0 ? data.map((item) => renderItem({ item })) : ListEmptyComponent,
+    ),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../LogbookRow', () => ({ LogbookRow: () => createElement('div') }));
+vi.mock('../LogbookEditSheet', () => ({ LogbookEditSheet: () => null }));
+vi.mock('../../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
+vi.mock('../../Icon', () => ({ Icon: () => null }));
+vi.mock('../../ActivityIndicator', () => ({ ActivityIndicator: () => null }));
+vi.mock('../../../lib/graphql/hooks', () => ({ useUserAscentsFeed: () => feed.current }));
+vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {}, brandColors: {} }),
+}));
+
+import { LogbookTab } from '../LogbookTab';
+
+beforeEach(() => {
+  feed.current.refetch = vi.fn();
+  feed.current.data = undefined;
+  feed.current.isPending = false;
+  feed.current.isError = false;
+  feed.current.isRefetching = false;
+});
+
+describe('LogbookTab error state', () => {
+  it('renders the error view with a retry control when the feed errors', () => {
+    feed.current.isError = true;
+
+    render(createElement(LogbookTab, { userId: 'user-1' }));
+
+    // The error title must render, not the empty-state copy.
+    expect(screen.getByText('mobile.logbook.errorTitle')).toBeTruthy();
+    expect(screen.queryByText('mobile.logbook.empty')).toBeNull();
+    expect(screen.getByText('mobile.logbook.retry')).toBeTruthy();
+  });
+
+  it('calls refetch when the retry control is pressed', () => {
+    feed.current.isError = true;
+
+    render(createElement(LogbookTab, { userId: 'user-1' }));
+
+    fireEvent.click(screen.getByText('mobile.logbook.retry'));
+
+    expect(feed.current.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('still shows the empty state on a successful feed with zero items', () => {
+    feed.current.isError = false;
+    feed.current.data = { pages: [{ userAscentsFeed: { items: [] } }] };
+
+    render(createElement(LogbookTab, { userId: 'user-1' }));
+
+    expect(screen.getByText('mobile.logbook.empty')).toBeTruthy();
+    expect(screen.queryByText('mobile.logbook.errorTitle')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-error.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-error.test.tsx
@@ -47,7 +47,9 @@ vi.mock('@shopify/flash-list', () => ({
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('../LogbookRow', () => ({ LogbookRow: () => createElement('div') }));
 vi.mock('../LogbookEditSheet', () => ({ LogbookEditSheet: () => null }));
-vi.mock('../../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
 vi.mock('../../Icon', () => ({ Icon: () => null }));
 vi.mock('../../ActivityIndicator', () => ({ ActivityIndicator: () => null }));
 vi.mock('../../../lib/graphql/hooks', () => ({ useUserAscentsFeed: () => feed.current }));

--- a/packages/mobile/src/components/you/__tests__/sessions-tab-clock.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/sessions-tab-clock.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { render, act } from '@testing-library/react';
+import { createElement, useEffect, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Captures every `now` value SessionsTab feeds into the recency bucketing, plus
+// the RefreshControl onRefresh handler the test fires. Regression guard for
+// A5-you-profile-005: the Sessions clock must re-evaluate on pull-to-refresh
+// (and on focus) instead of staying frozen at mount.
+const captured = vi.hoisted(() => ({
+  bucketNows: [] as number[],
+  onRefresh: null as (() => void) | null,
+}));
+
+const feed = vi.hoisted(() => ({
+  data: {
+    pages: [{ sessionGroupedFeed: { sessions: [{ sessionId: 's1', lastTickAt: '2026-06-04T09:00:00.000Z' }] } }],
+  },
+  isPending: false,
+  isRefetching: false,
+  isFetchingNextPage: false,
+  hasNextPage: false,
+  refetch: vi.fn(),
+  fetchNextPage: vi.fn(),
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  // Expose onRefresh so the test can fire a pull-to-refresh without a real list.
+  RefreshControl: ({ onRefresh }: { onRefresh?: () => void }) => {
+    captured.onRefresh = onRefresh ?? null;
+    return null;
+  },
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('@shopify/flash-list', () => ({
+  FlashList: ({ refreshControl }: { refreshControl?: ReactNode }) => createElement('div', null, refreshControl),
+}));
+
+// Capture the injected clock; return a single section so a header renders.
+vi.mock('../../../lib/feed-time-buckets', () => ({
+  bucketSessionsByRecency: (sessions: Array<{ sessionId: string }>, now: number) => {
+    captured.bucketNows.push(now);
+    return sessions.length > 0 ? [{ bucket: 'today', sessions }] : [];
+  },
+  dedupeSessionsById: (sessions: unknown[]) => sessions,
+}));
+
+// Run the focus effect once on mount (mirrors first focus, runs after render —
+// not during it — so a setNow inside the effect can't loop). The test asserts
+// on the refresh-driven change.
+vi.mock('expo-router', () => ({
+  useRouter: () => ({ push: vi.fn(), navigate: vi.fn() }),
+  useFocusEffect: (effect: () => void | (() => void)) => {
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => effect(), []);
+  },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../SessionFeedCard', () => ({ SessionFeedCard: () => null }));
+vi.mock('../SessionsFeedHeader', () => ({ SessionsFeedHeader: () => null }));
+vi.mock('../FeedSectionLabel', () => ({ FeedSectionLabel: () => null }));
+vi.mock('../CommentSheet', () => ({ CommentSheet: () => null }));
+vi.mock('../../Text', () => ({ Text: () => null }));
+vi.mock('../../Icon', () => ({ Icon: () => null }));
+vi.mock('../../Button', () => ({ Button: () => null }));
+vi.mock('../../ActivityIndicator', () => ({ ActivityIndicator: () => null }));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useSessionGroupedFeed: () => feed,
+  useBulkVoteSummaries: () => ({ data: [] }),
+}));
+vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {}, brandColors: {} }),
+}));
+
+import { SessionsTab } from '../SessionsTab';
+
+beforeEach(() => {
+  captured.bucketNows = [];
+  captured.onRefresh = null;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('SessionsTab clock (A5-you-profile-005)', () => {
+  it('re-evaluates `now` on pull-to-refresh so buckets track the wall clock', () => {
+    vi.setSystemTime(new Date('2026-06-04T23:50:00.000Z'));
+    render(createElement(SessionsTab, { userId: 'user-1' }));
+
+    const mountNow = captured.bucketNows.at(-1);
+    expect(mountNow).toBe(Date.parse('2026-06-04T23:50:00.000Z'));
+    expect(captured.onRefresh).not.toBeNull();
+
+    // Advance the wall clock past midnight, then pull to refresh.
+    vi.setSystemTime(new Date('2026-06-05T00:10:00.000Z'));
+    act(() => {
+      captured.onRefresh?.();
+    });
+
+    // With the fix, refreshing updates `now`; without it `now` stays frozen at
+    // mount and this stays equal to mountNow.
+    const refreshedNow = captured.bucketNows.at(-1);
+    expect(refreshedNow).toBe(Date.parse('2026-06-05T00:10:00.000Z'));
+    expect(refreshedNow).not.toBe(mountNow);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/climb-to-queue-item.test.ts
+++ b/packages/mobile/src/lib/__tests__/climb-to-queue-item.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Climb } from '@boardsesh/shared-schema';
+
+vi.mock('expo-crypto', () => ({
+  randomUUID: () => 'generated-uuid',
+}));
+
+import { climbToQueueItem } from '../climb-to-queue-item';
+
+// A climb queued from search / detail must keep its multi-frame playback
+// metadata so playback uses the setter's pace rather than DEFAULT_PACE_MS.
+// climbToQueueItem hand-picks the climb fields (a whole-response copy would
+// fail server validation), so dropping framesCount/framesPace silently regresses
+// pacing. This round-trip pins them.
+
+function makeClimb(overrides: Partial<Climb> = {}): Climb {
+  return {
+    uuid: 'climb-1',
+    setter_username: 'setter',
+    name: 'Variable Speed Circuit',
+    frames: 'p1r12p2r13',
+    angle: 40,
+    ascensionist_count: 5,
+    difficulty: '21',
+    quality_average: '3.0',
+    stars: 3,
+    difficulty_error: '0.5',
+    benchmark_difficulty: null,
+    is_no_match: false,
+    userAscents: null,
+    userAttempts: null,
+    framesCount: 4,
+    framesPace: 1200,
+    ...overrides,
+  };
+}
+
+describe('climbToQueueItem (SEED-2 frame metadata)', () => {
+  it('carries framesCount and framesPace from the source climb', () => {
+    const result = climbToQueueItem(makeClimb());
+
+    expect(result.climb.framesCount).toBe(4);
+    expect(result.climb.framesPace).toBe(1200);
+  });
+
+  it('passes null frame metadata through unchanged (static climb)', () => {
+    const result = climbToQueueItem(makeClimb({ framesCount: null, framesPace: null }));
+
+    expect(result.climb.framesCount).toBeNull();
+    expect(result.climb.framesPace).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/create-climb-screen-key.test.ts
+++ b/packages/mobile/src/lib/__tests__/create-climb-screen-key.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { createClimbScreenKey } from '../create-climb-screen-key';
+
+const kilter = {
+  boardName: 'kilter' as BoardName,
+  layoutId: 1,
+  sizeId: 2,
+  setIds: '1,2',
+};
+
+describe('createClimbScreenKey', () => {
+  it('remounts when the board layout/size/setIds change (drops stale holds)', () => {
+    const base = createClimbScreenKey('new', kilter);
+    expect(createClimbScreenKey('new', { ...kilter, layoutId: 9 })).not.toBe(base);
+    expect(createClimbScreenKey('new', { ...kilter, sizeId: 9 })).not.toBe(base);
+    expect(createClimbScreenKey('new', { ...kilter, setIds: '3,4' })).not.toBe(base);
+    expect(createClimbScreenKey('new', { ...kilter, boardName: 'tension' as BoardName })).not.toBe(base);
+  });
+
+  it('does NOT remount on an angle-only change so an in-progress paint survives', () => {
+    // create.tsx never feeds angle into the key, so two boards differing only by
+    // angle must produce the same key. This guards against WS session-sync
+    // angle updates wiping a paint.
+    expect(createClimbScreenKey('new', kilter)).toBe(createClimbScreenKey('new', kilter));
+    // The key string itself must not contain the angle value.
+    expect(createClimbScreenKey('new', kilter)).not.toContain('40');
+  });
+
+  it('remounts when switching the edited climb (fresh undo history per draft)', () => {
+    expect(createClimbScreenKey('uuid-a', kilter)).not.toBe(createClimbScreenKey('uuid-b', kilter));
+    expect(createClimbScreenKey(undefined, kilter)).toBe(createClimbScreenKey('new', kilter));
+  });
+});

--- a/packages/mobile/src/lib/__tests__/feed-time-buckets.test.ts
+++ b/packages/mobile/src/lib/__tests__/feed-time-buckets.test.ts
@@ -60,6 +60,23 @@ describe('bucketSessionsByRecency', () => {
   it('returns an empty array for no sessions', () => {
     expect(bucketSessionsByRecency([], NOW)).toEqual([]);
   });
+
+  // The A5-you-profile-005 fix relies on the bucketing being driven entirely by
+  // the injected `now`: SessionsTab keeps `now` in state and re-evaluates it on
+  // focus / pull-to-refresh so a session labelled "Today" before midnight gets
+  // re-bucketed as the clock advances past the day boundary. This pins that
+  // property — a stale `now` keeps "Today"; a fresh `now` corrects it.
+  it('re-buckets a session from Today to Earlier when `now` advances past the day boundary', () => {
+    const sessionAt = '2026-06-04T23:30:00.000Z';
+    const beforeMidnight = Date.parse('2026-06-04T23:45:00.000Z');
+    const afterTwoDays = Date.parse('2026-06-06T12:00:00.000Z');
+
+    const staleClock = bucketSessionsByRecency([session('late', sessionAt)], beforeMidnight);
+    expect(staleClock[0].bucket).toBe('today');
+
+    const freshClock = bucketSessionsByRecency([session('late', sessionAt)], afterTwoDays);
+    expect(freshClock[0].bucket).not.toBe('today');
+  });
 });
 
 describe('dedupeSessionsById', () => {

--- a/packages/mobile/src/lib/__tests__/feed-time-buckets.test.ts
+++ b/packages/mobile/src/lib/__tests__/feed-time-buckets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { bucketSessionsByRecency } from '../feed-time-buckets';
+import { bucketSessionsByRecency, dedupeSessionsById } from '../feed-time-buckets';
 
 // Fixed clock: 2026-06-04T12:00:00Z. The helper buckets off the local calendar
 // day, but these timestamps are spaced far enough apart that they land in the
@@ -59,5 +59,27 @@ describe('bucketSessionsByRecency', () => {
 
   it('returns an empty array for no sessions', () => {
     expect(bucketSessionsByRecency([], NOW)).toEqual([]);
+  });
+});
+
+describe('dedupeSessionsById', () => {
+  it('drops a session repeated across page boundaries, keeping the first occurrence', () => {
+    // Page 0 then page 1 of an OFFSET-paginated feed: 's2' straddles the
+    // boundary and is returned in both pages after a concurrent reorder.
+    const page0 = [session('s1', '2026-06-04T10:00:00.000Z'), session('s2', '2026-06-04T09:00:00.000Z')];
+    const page1 = [session('s2', '2026-06-04T09:00:00.000Z'), session('s3', '2026-06-03T09:00:00.000Z')];
+
+    const deduped = dedupeSessionsById([...page0, ...page1]);
+
+    expect(deduped.map((s) => s.sessionId)).toEqual(['s1', 's2', 's3']);
+  });
+
+  it('preserves order and is a no-op when every sessionId is unique', () => {
+    const unique = [
+      session('a', '2026-06-04T10:00:00.000Z'),
+      session('b', '2026-06-03T10:00:00.000Z'),
+      session('c', '2026-06-02T10:00:00.000Z'),
+    ];
+    expect(dedupeSessionsById(unique)).toEqual(unique);
   });
 });

--- a/packages/mobile/src/lib/__tests__/filter-tokens.test.ts
+++ b/packages/mobile/src/lib/__tests__/filter-tokens.test.ts
@@ -27,6 +27,8 @@ const mockT = ((key: string, options?: Record<string, unknown>) => {
   if (key === 'mobile.filter.benchmark') return 'Benchmarks only';
   if (key === 'mobile.filter.status.drafts') return 'Drafts';
   if (key === 'mobile.filter.tallClimbs') return 'Tall climbs';
+  if (key === 'mobile.holdFilter.summaryCount') return `${options?.count} holds`;
+  if (key === 'mobile.zoneFilter.title') return 'Board region';
   return key;
 }) as unknown as Parameters<typeof getActiveFilterTokens>[0]['t'];
 
@@ -112,6 +114,31 @@ describe('getActiveFilterTokens', () => {
     expect(benchmark?.label).toBe('Benchmarks only');
     benchmark?.clear();
     expect(patchBoardFilters).toHaveBeenCalledWith({ onlyBenchmarks: false });
+  });
+
+  it('builds a holds token labelled by hold count and clears the holds filter', () => {
+    const { tokens, patchBoardFilters } = build(DEFAULT_FILTERS, {
+      holdsFilter: { '5': { HAND: 'include' }, '6': { FINISH: 'exclude' } },
+    });
+    const holds = tokens.find((token) => token.key === 'holds');
+    expect(holds?.label).toBe('2 holds');
+    holds?.clear();
+    expect(patchBoardFilters).toHaveBeenCalledWith({ holdsFilter: undefined });
+  });
+
+  it('omits the holds token when the holds filter has no entries', () => {
+    expect(keys(build(DEFAULT_FILTERS, { holdsFilter: {} }).tokens)).not.toContain('holds');
+  });
+
+  it('builds a zone token and clears the zone box and mode', () => {
+    const { tokens, patchBoardFilters } = build(DEFAULT_FILTERS, {
+      zoneBox: { edgeLeft: 0, edgeRight: 10, edgeBottom: 0, edgeTop: 10 },
+      zoneMode: 'allHolds',
+    });
+    const zone = tokens.find((token) => token.key === 'zone');
+    expect(zone?.label).toBe('Board region');
+    zone?.clear();
+    expect(patchBoardFilters).toHaveBeenCalledWith({ zoneBox: null, zoneMode: undefined });
   });
 
   it('orders grade first, then refinements in summary order', () => {

--- a/packages/mobile/src/lib/__tests__/queue-conversion.test.ts
+++ b/packages/mobile/src/lib/__tests__/queue-conversion.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { toClimbQueueItem, type SubscriptionQueueItem } from '../queue-conversion';
+
+// A reconnect FullSync wholesale-replaces the queue (and currentClimbQueueItem)
+// from the subscription payload. If toClimbQueueItem drops a field the
+// subscription now selects, the field is lost on every server-driven update:
+// a peer-set `mirrored` flag (read by the Bluetooth auto-sender) gets cleared
+// and multi-frame playback falls back to DEFAULT_PACE_MS instead of the
+// setter's framesPace. These round-trips pin the four SEED-2 fields.
+
+function makeSubscriptionItem(overrides: Partial<SubscriptionQueueItem['climb']> = {}): SubscriptionQueueItem {
+  return {
+    uuid: 'qi-1',
+    climb: {
+      uuid: 'climb-1',
+      name: 'Variable Speed Circuit',
+      frames: 'p1r12p2r13',
+      setter_username: 'setter',
+      angle: 40,
+      ascensionist_count: 5,
+      difficulty: '21',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0.5',
+      benchmark_difficulty: null,
+      mirrored: true,
+      is_no_match: true,
+      framesCount: 4,
+      framesPace: 1200,
+      ...overrides,
+    },
+  };
+}
+
+describe('toClimbQueueItem (SEED-2 fields)', () => {
+  it('carries mirrored, is_no_match, framesCount and framesPace through the conversion', () => {
+    const result = toClimbQueueItem(makeSubscriptionItem());
+
+    expect(result.climb.mirrored).toBe(true);
+    expect(result.climb.is_no_match).toBe(true);
+    expect(result.climb.framesCount).toBe(4);
+    expect(result.climb.framesPace).toBe(1200);
+  });
+
+  it('preserves a peer-set mirror flag of false (not just truthy)', () => {
+    const result = toClimbQueueItem(makeSubscriptionItem({ mirrored: false }));
+
+    expect(result.climb.mirrored).toBe(false);
+  });
+
+  it('passes null/undefined frame metadata through unchanged', () => {
+    const result = toClimbQueueItem(
+      makeSubscriptionItem({ mirrored: null, is_no_match: null, framesCount: null, framesPace: null }),
+    );
+
+    expect(result.climb.mirrored).toBeNull();
+    expect(result.climb.is_no_match).toBeNull();
+    expect(result.climb.framesCount).toBeNull();
+    expect(result.climb.framesPace).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/search-name.test.ts
+++ b/packages/mobile/src/lib/__tests__/search-name.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeSearchName } from '../search-name';
+import { normalizeSearchName, visibleSearchTextNeedsSync } from '../search-name';
 
 describe('normalizeSearchName', () => {
   it('trims leading and trailing whitespace', () => {
@@ -8,5 +8,23 @@ describe('normalizeSearchName', () => {
 
   it('normalizes whitespace-only searches to empty', () => {
     expect(normalizeSearchName('   ')).toBe('');
+  });
+});
+
+describe('visibleSearchTextNeedsSync', () => {
+  it('treats an in-progress trailing space as in sync (no re-seed)', () => {
+    // The user typed "crimp " (raw) and the debounce committed "crimp" (trimmed).
+    // The trailing space must NOT be yanked back out of the field.
+    expect(visibleSearchTextNeedsSync('crimp ', 'crimp')).toBe(false);
+  });
+
+  it('treats a leading space the same way', () => {
+    expect(visibleSearchTextNeedsSync(' crimp', 'crimp')).toBe(false);
+  });
+
+  it('reports a real external change as needing sync', () => {
+    // Board restore / recent pill / cancel committed a different name.
+    expect(visibleSearchTextNeedsSync('crimp', 'jugs')).toBe(true);
+    expect(visibleSearchTextNeedsSync('crimp ', '')).toBe(true);
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -296,7 +296,12 @@ describe('dispatchMoonboardPacket', () => {
 
   it('calls write() with the packet bytes, not the full packet object', async () => {
     const fakePacket = new Uint8Array([0x01, 0x02, 0x03]);
-    mockGetMoonboardBluetoothPacket.mockReturnValue({ packet: fakePacket });
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: fakePacket,
+      totalPlacements: 2,
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+    });
     const write = vi.fn().mockResolvedValue(undefined);
 
     await dispatchMoonboardPacket('p1r12p2r14', write);
@@ -308,7 +313,12 @@ describe('dispatchMoonboardPacket', () => {
   });
 
   it('returns true on success', async () => {
-    mockGetMoonboardBluetoothPacket.mockReturnValue({ packet: new Uint8Array([0x00]) });
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([0x00]),
+      totalPlacements: 1,
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+    });
     const write = vi.fn().mockResolvedValue(undefined);
 
     const result = await dispatchMoonboardPacket('p1r12', write);
@@ -327,12 +337,51 @@ describe('dispatchMoonboardPacket', () => {
 
   it('forwards the AbortSignal to write()', async () => {
     const fakePacket = new Uint8Array([0xaa]);
-    mockGetMoonboardBluetoothPacket.mockReturnValue({ packet: fakePacket });
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: fakePacket,
+      totalPlacements: 1,
+      skippedRoleCount: 0,
+      skippedPositionCount: 0,
+    });
     const write = vi.fn().mockResolvedValue(undefined);
     const controller = new AbortController();
 
     await dispatchMoonboardPacket('p5r3', write, controller.signal);
 
     expect(write).toHaveBeenCalledWith(fakePacket, controller.signal);
+  });
+
+  it('returns false and never writes when every placement is skipped (board would go dark)', async () => {
+    // getMoonboardBluetoothPacket emits the "clear all" packet `l##` with
+    // skippedRoleCount === totalPlacements when no hold maps to a known role.
+    // Writing that would silently dark the board while reporting success.
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: new TextEncoder().encode('l##'),
+      totalPlacements: 2,
+      skippedRoleCount: 2,
+      skippedPositionCount: 0,
+    });
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    const result = await dispatchMoonboardPacket('p1r99p2r98', write);
+
+    expect(result).toBe(false);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('writes and returns true when only some placements are skipped', async () => {
+    const fakePacket = new TextEncoder().encode('l#S0#');
+    mockGetMoonboardBluetoothPacket.mockReturnValue({
+      packet: fakePacket,
+      totalPlacements: 2,
+      skippedRoleCount: 1,
+      skippedPositionCount: 0,
+    });
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    const result = await dispatchMoonboardPacket('p1r42p2r99', write);
+
+    expect(result).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -94,7 +94,12 @@ vi.mock('../adapter-factory', () => ({
 }));
 
 import { createBluetoothAdapter } from '../adapter-factory';
-import { convertToMirroredFramesString, dispatchMoonboardPacket, useBoardBluetooth } from '../use-board-bluetooth';
+import {
+  convertToMirroredFramesString,
+  dispatchMoonboardPacket,
+  mergeAbortSignals,
+  useBoardBluetooth,
+} from '../use-board-bluetooth';
 
 // ── Factory helper ─────────────────────────────────────────────────────────
 
@@ -383,5 +388,54 @@ describe('dispatchMoonboardPacket', () => {
 
     expect(result).toBe(true);
     expect(write).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── mergeAbortSignals ───────────────────────────────────────────────────────
+
+describe('mergeAbortSignals', () => {
+  it('removes the abort listener from the long-lived signal once disposed (no leak per write)', () => {
+    // The AutoSender passes one lifetime-scoped signal to every send. Each send
+    // creates a fresh per-write controller and merges. Without dispose, every
+    // successful (non-aborted) write parked a permanent listener on the
+    // lifetime signal, leaking the per-write controller for the connection.
+    const lifetime = new AbortController();
+    const addSpy = vi.spyOn(lifetime.signal, 'addEventListener');
+    const removeSpy = vi.spyOn(lifetime.signal, 'removeEventListener');
+
+    // Simulate N consecutive successful sends: merge, then dispose without aborting.
+    for (let send = 0; send < 5; send++) {
+      const perWrite = new AbortController();
+      const { dispose } = mergeAbortSignals(lifetime.signal, perWrite.signal);
+      dispose();
+    }
+
+    // Every listener added to the lifetime signal must have been removed again.
+    const abortListenersAdded = addSpy.mock.calls.filter(([eventName]) => eventName === 'abort').length;
+    const abortListenersRemoved = removeSpy.mock.calls.filter(([eventName]) => eventName === 'abort').length;
+    expect(abortListenersAdded).toBe(5);
+    expect(abortListenersRemoved).toBe(5);
+  });
+
+  it('still aborts the merged signal when an input signal aborts', () => {
+    const lifetime = new AbortController();
+    const perWrite = new AbortController();
+    const { signal } = mergeAbortSignals(lifetime.signal, perWrite.signal);
+
+    expect(signal.aborted).toBe(false);
+    perWrite.abort();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('returns an already-aborted signal when an input is already aborted', () => {
+    const lifetime = new AbortController();
+    lifetime.abort();
+    const perWrite = new AbortController();
+
+    const { signal, dispose } = mergeAbortSignals(lifetime.signal, perWrite.signal);
+
+    expect(signal.aborted).toBe(true);
+    // dispose must be safe to call even on the early-aborted path.
+    expect(() => dispose()).not.toThrow();
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -41,10 +41,17 @@ vi.mock('expo-keep-awake', () => ({
   deactivateKeepAwake: vi.fn().mockResolvedValue(undefined),
 }));
 
+const mockParseApiLevel = vi.hoisted(() => vi.fn());
+const mockParseSerialNumber = vi.hoisted(() => vi.fn());
 vi.mock('@boardsesh/ble-protocol/aurora', () => ({
   getAuroraBluetoothPacket: vi.fn(),
-  parseApiLevel: vi.fn(),
-  parseSerialNumber: vi.fn(),
+  parseApiLevel: mockParseApiLevel,
+  parseSerialNumber: mockParseSerialNumber,
+}));
+
+const mockTrack = vi.hoisted(() => vi.fn());
+vi.mock('../../analytics', () => ({
+  track: mockTrack,
 }));
 
 const mockGetMoonboardBluetoothPacket = vi.hoisted(() => vi.fn());
@@ -125,6 +132,75 @@ describe('useBoardBluetooth', () => {
     expect(connected).toBe(false);
     expect(Alert.alert).toHaveBeenCalledWith('ble.permissionRequired', 'ble.errorPermissionDenied');
     expect(createBluetoothAdapter).not.toHaveBeenCalled();
+  });
+
+  it('emits apiLevel and deviceNamePresent on the connection-success event', async () => {
+    reactNativePermissionHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+      BLUETOOTH_SCAN: 'granted',
+      BLUETOOTH_CONNECT: 'granted',
+    });
+    const fakeAdapter = {
+      isAvailable: vi.fn().mockResolvedValue(true),
+      requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'dev-1', deviceName: 'Kilter A1#0042@3' }),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      write: vi.fn().mockResolvedValue(undefined),
+      onDisconnect: vi.fn().mockReturnValue(() => {}),
+    };
+    vi.mocked(createBluetoothAdapter).mockReturnValue(fakeAdapter);
+    mockParseApiLevel.mockReturnValue(3);
+    mockParseSerialNumber.mockReturnValue('0042');
+
+    const { result } = renderHook(() =>
+      useBoardBluetooth({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '1',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    const successCall = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success');
+    expect(successCall).toBeDefined();
+    expect(successCall?.[1]).toMatchObject({ apiLevel: 3, deviceNamePresent: true });
+  });
+
+  it('reports deviceNamePresent=false and the v2 fallback level when no name is advertised', async () => {
+    reactNativePermissionHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+      BLUETOOTH_SCAN: 'granted',
+      BLUETOOTH_CONNECT: 'granted',
+    });
+    const fakeAdapter = {
+      isAvailable: vi.fn().mockResolvedValue(true),
+      requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'dev-2', deviceName: undefined }),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      write: vi.fn().mockResolvedValue(undefined),
+      onDisconnect: vi.fn().mockReturnValue(() => {}),
+    };
+    vi.mocked(createBluetoothAdapter).mockReturnValue(fakeAdapter);
+    // Mirrors parseApiLevel's real default for a missing/unparseable name.
+    mockParseApiLevel.mockReturnValue(2);
+    mockParseSerialNumber.mockReturnValue(undefined);
+
+    const { result } = renderHook(() =>
+      useBoardBluetooth({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '1',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    const successCall = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success');
+    expect(successCall).toBeDefined();
+    expect(successCall?.[1]).toMatchObject({ apiLevel: 2, deviceNamePresent: false });
   });
 });
 

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -207,6 +207,55 @@ describe('useBoardBluetooth', () => {
     expect(successCall).toBeDefined();
     expect(successCall?.[1]).toMatchObject({ apiLevel: 2, deviceNamePresent: false });
   });
+
+  it('ignores a second connect() while the first is still in flight (no concurrent scan)', async () => {
+    reactNativePermissionHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+      BLUETOOTH_SCAN: 'granted',
+      BLUETOOTH_CONNECT: 'granted',
+    });
+
+    // The in-flight latch is set synchronously at the top of connect() before
+    // any await, so firing two connects back-to-back (a lightbulb double-tap)
+    // must let only the first proceed. Without the latch, both run to
+    // completion and each creates an adapter + starts a scan on the shared
+    // BleManager singleton, with each flow's stopDeviceScan killing the other.
+    const requestAndConnect = vi.fn().mockResolvedValue({ deviceId: 'dev-1', deviceName: 'Kilter A1#0042@3' });
+    const fakeAdapter = {
+      isAvailable: vi.fn().mockResolvedValue(true),
+      requestAndConnect,
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      write: vi.fn().mockResolvedValue(undefined),
+      onDisconnect: vi.fn().mockReturnValue(() => {}),
+    };
+    vi.mocked(createBluetoothAdapter).mockReturnValue(fakeAdapter);
+    mockParseApiLevel.mockReturnValue(3);
+    mockParseSerialNumber.mockReturnValue('0042');
+
+    const { result } = renderHook(() =>
+      useBoardBluetooth({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '1',
+      }),
+    );
+
+    let firstConnectResult: boolean | undefined;
+    let secondConnectResult: boolean | undefined;
+    await act(async () => {
+      // Fire both back-to-back; the second must early-return false because the
+      // first already holds the in-flight latch.
+      const first = result.current.connect();
+      const second = result.current.connect();
+      [firstConnectResult, secondConnectResult] = await Promise.all([first, second]);
+    });
+
+    expect(firstConnectResult).toBe(true);
+    expect(secondConnectResult).toBe(false);
+    // Exactly one adapter + one scan despite the double-tap.
+    expect(createBluetoothAdapter).toHaveBeenCalledTimes(1);
+    expect(requestAndConnect).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('convertToMirroredFramesString', () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -59,6 +59,14 @@ vi.mock('@boardsesh/ble-protocol/moonboard', () => ({
   getMoonboardBluetoothPacket: mockGetMoonboardBluetoothPacket,
 }));
 
+// The Aurora send path lazily imports the LED placement map. Provide a
+// non-empty map so a happy-path mirrored write reaches getAuroraBluetoothPacket
+// instead of bailing on the empty-placement guard.
+const mockGetLedPlacements = vi.hoisted(() => vi.fn(() => ({ 1: 0, 99: 1 })));
+vi.mock('@boardsesh/board-constants/led-placements', () => ({
+  getLedPlacements: mockGetLedPlacements,
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -93,6 +101,7 @@ vi.mock('../adapter-factory', () => ({
   isNativeIosBleAdapter: vi.fn().mockReturnValue(false),
 }));
 
+import { getAuroraBluetoothPacket } from '@boardsesh/ble-protocol/aurora';
 import { createBluetoothAdapter } from '../adapter-factory';
 import {
   convertToMirroredFramesString,
@@ -255,6 +264,102 @@ describe('useBoardBluetooth', () => {
     // Exactly one adapter + one scan despite the double-tap.
     expect(createBluetoothAdapter).toHaveBeenCalledTimes(1);
     expect(requestAndConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a mirrored send on a mirroring board when holdsData is missing (never sends un-mirrored frames)', async () => {
+    reactNativePermissionHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+      BLUETOOTH_SCAN: 'granted',
+      BLUETOOTH_CONNECT: 'granted',
+    });
+    const write = vi.fn().mockResolvedValue(undefined);
+    const fakeAdapter = {
+      isAvailable: vi.fn().mockResolvedValue(true),
+      requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'dev-1', deviceName: 'Tension A1#0042@3' }),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      write,
+      onDisconnect: vi.fn().mockReturnValue(() => {}),
+    };
+    vi.mocked(createBluetoothAdapter).mockReturnValue(fakeAdapter);
+    mockParseApiLevel.mockReturnValue(3);
+    mockParseSerialNumber.mockReturnValue('0042');
+
+    // Tension layout 1 supports mirroring. holdsData is intentionally omitted —
+    // the provider must thread it in; without it we must NOT silently send the
+    // un-mirrored frames (which would light the wrong holds on the wall).
+    const { result } = renderHook(() =>
+      useBoardBluetooth({
+        boardName: 'tension',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '1',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    let sendResult: boolean | undefined;
+    await act(async () => {
+      sendResult = await result.current.sendFramesToBoard('p1r12', true);
+    });
+
+    expect(sendResult).toBe(false);
+    expect(Alert.alert).toHaveBeenCalledWith('ble.notAvailable', 'ble.errorIncompatible');
+    // The board must never receive the original (un-mirrored) frames.
+    expect(write).not.toHaveBeenCalled();
+    const failureCall = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Failure');
+    expect(failureCall?.[1]).toMatchObject({ failureReason: 'missing_mirror_data', mirrored: true });
+  });
+
+  it('mirrors and sends when holdsData is present on a mirroring board', async () => {
+    reactNativePermissionHarness.permissionsAndroid.requestMultiple.mockResolvedValue({
+      BLUETOOTH_SCAN: 'granted',
+      BLUETOOTH_CONNECT: 'granted',
+    });
+    const write = vi.fn().mockResolvedValue(undefined);
+    const fakeAdapter = {
+      isAvailable: vi.fn().mockResolvedValue(true),
+      requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'dev-1', deviceName: 'Tension A1#0042@3' }),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      write,
+      onDisconnect: vi.fn().mockReturnValue(() => {}),
+    };
+    vi.mocked(createBluetoothAdapter).mockReturnValue(fakeAdapter);
+    mockParseApiLevel.mockReturnValue(3);
+    mockParseSerialNumber.mockReturnValue('0042');
+    // getAuroraBluetoothPacket is mocked at the module level (returns a stub
+    // packet) so a non-empty placement map lets the write proceed.
+    vi.mocked(getAuroraBluetoothPacket).mockReturnValue({
+      packet: new Uint8Array([0x01]),
+      skippedPositionCount: 0,
+      skippedRoleCount: 0,
+      totalPlacements: 1,
+    });
+
+    const { result } = renderHook(() =>
+      useBoardBluetooth({
+        boardName: 'tension',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '1',
+        holdsData: [makePlacement(1, 99)],
+      }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    let sendResult: boolean | undefined;
+    await act(async () => {
+      sendResult = await result.current.sendFramesToBoard('p1r12', true);
+    });
+
+    expect(sendResult).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+    // The mirrored frame (hold 1 -> 99) must have been fed to the packet builder.
+    expect(getAuroraBluetoothPacket).toHaveBeenCalledWith('p99r12', expect.anything(), 'tension', 3, undefined);
   });
 });
 

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -461,7 +461,19 @@ export function useBoardBluetooth({
         setIsConnected(true);
         onConnectionChange?.(true);
         onConnectSuccess?.(parsedSerial);
-        track(SHARED_EVENTS.BluetoothConnectionSuccess, { boardName, layoutId, sizeId });
+        // apiLevel is the level parseApiLevel actually picked; deviceNamePresent
+        // records whether an advertised name was even available. parseApiLevel
+        // silently defaults to v2 when the name is missing/unparseable, and v2
+        // encoding drops LED positions > 1023 — so a v3 board connecting with no
+        // advertised name would light only part of the wall. These two props let
+        // us see in PostHog whether that fallback ever fires in the wild.
+        track(SHARED_EVENTS.BluetoothConnectionSuccess, {
+          boardName,
+          layoutId,
+          sizeId,
+          apiLevel: apiLevelRef.current,
+          deviceNamePresent: !!connection.deviceName,
+        });
         return true;
       } catch (error) {
         console.error('Error connecting to Bluetooth:', error);

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -22,13 +22,25 @@ import type { HoldPlacement } from '../../components/board-renderer/types';
 import { track } from '../analytics';
 
 // Exported for testing — isolates the .packet extraction so regressions are caught.
+//
+// Returns:
+//  - undefined when there are no frames (nothing to send)
+//  - false when every placement was skipped (the packet builder still emits the
+//    "clear all" packet `l##`, so writing it would silently dark the board while
+//    the caller reported success). The caller surfaces the incompatible-climb
+//    error instead of writing — web parity (use-board-bluetooth.ts:348-363).
+//  - true after a successful write.
 export async function dispatchMoonboardPacket(
   frames: string,
   write: BluetoothAdapter['write'],
   signal?: AbortSignal,
-): Promise<true | undefined> {
+): Promise<boolean | undefined> {
   if (!frames) return undefined;
-  const { packet } = getMoonboardBluetoothPacket(frames);
+  const { packet, skippedRoleCount, skippedPositionCount, totalPlacements } = getMoonboardBluetoothPacket(frames);
+  const skippedCount = skippedRoleCount + skippedPositionCount;
+  if (totalPlacements > 0 && skippedCount === totalPlacements) {
+    return false;
+  }
   await write(packet, signal);
   return true;
 }
@@ -255,6 +267,20 @@ export function useBoardBluetooth({
             adapterRef.current.write.bind(adapterRef.current),
             combinedSignal,
           );
+          // false = every placement was skipped (unrecognised/corrupt hold
+          // data). The packet builder would emit a "clear all" packet, darking
+          // the board, so dispatchMoonboardPacket refuses to write. Surface the
+          // same incompatible-climb error the Aurora branch uses instead of
+          // letting the AutoSender buzz success on a dark board.
+          if (sent === false) {
+            console.warn('[BLE] All MoonBoard placements skipped — climb has unrecognised hold data');
+            Alert.alert(t('ble.notAvailable'), t('ble.errorIncompatible'));
+            track(SHARED_EVENTS.ClimbSentToBoardFailure, {
+              ...boardAnalyticsProperties,
+              failureReason: 'incompatible_climb',
+            });
+            return false;
+          }
           if (sent) track(SHARED_EVENTS.ClimbSentToBoardSuccess, boardAnalyticsProperties);
           return sent;
         }

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -209,6 +209,12 @@ export function useBoardBluetooth({
   const apiLevelRef = useRef<number>(3);
   const unsubDisconnectRef = useRef<(() => void) | null>(null);
   const writeAbortRef = useRef<AbortController | null>(null);
+  // Synchronous in-flight latch for connect(). The lightbulb button isn't
+  // disabled while a connect is pending (isScanning only drives a pulse), so a
+  // double-tap can re-enter connect(); without this, the second attempt creates
+  // a second adapter and starts a second scan on the shared BleManager
+  // singleton, and each flow's stopDeviceScan kills the other's scan.
+  const isConnectingRef = useRef(false);
 
   const [pickerState, setPickerState] = useState<PickerState | null>(null);
   const pickerRejectRef = useRef<((error: Error) => void) | null>(null);
@@ -412,6 +418,14 @@ export function useBoardBluetooth({
         return false;
       }
 
+      // Drop a re-entrant connect (lightbulb double-tap) — the first attempt
+      // owns the shared BleManager scan for its lifetime. Set synchronously
+      // before any await so two back-to-back calls can't both pass.
+      if (isConnectingRef.current) {
+        return false;
+      }
+      isConnectingRef.current = true;
+
       setLoading(true);
 
       try {
@@ -564,6 +578,7 @@ export function useBoardBluetooth({
         });
       } finally {
         setLoading(false);
+        isConnectingRef.current = false;
       }
 
       return false;

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -10,6 +10,7 @@ import {
 } from '@boardsesh/ble-protocol/aurora';
 import { getMoonboardBluetoothPacket } from '@boardsesh/ble-protocol/moonboard';
 import { isDisconnectionError } from '@boardsesh/ble-protocol/connection-error';
+import { boardSupportsMirroring } from '@boardsesh/play-view';
 import type { AuroraBoardName } from '@boardsesh/shared-schema';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { RECORD_BOARD_SERIAL } from '@boardsesh/graphql/operations';
@@ -326,7 +327,23 @@ export function useBoardBluetooth({
 
         let framesToSend = frames;
 
-        if (mirrored && holdsData && holdsData.length > 0) {
+        if (mirrored && boardSupportsMirroring(boardName, layoutId)) {
+          // On a board that supports mirroring, a mirrored send REQUIRES the
+          // hold map to produce mirrored frames. If it's missing/empty we must
+          // refuse rather than send the original (un-mirrored) frames — that
+          // would light the wrong holds on the wall while the AutoSender buzzed
+          // success. Web parity (use-board-bluetooth.ts:397-403).
+          if (!holdsData || holdsData.length === 0) {
+            console.error(
+              `[BLE] Cannot mirror frames: holdsData is missing or empty for ${boardName} layout=${layoutId}`,
+            );
+            Alert.alert(t('ble.notAvailable'), t('ble.errorIncompatible'));
+            track(SHARED_EVENTS.ClimbSentToBoardFailure, {
+              ...boardAnalyticsProperties,
+              failureReason: 'missing_mirror_data',
+            });
+            return false;
+          }
           framesToSend = convertToMirroredFramesString(frames, holdsData);
         }
 

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -138,25 +138,42 @@ const KEEP_AWAKE_TAG = 'boardsesh-ble';
  * Create a single AbortSignal that fires when either of the two input signals
  * is aborted. This lets us combine a caller-supplied signal with an internal
  * one without losing either.
+ *
+ * Returns the merged `signal` plus a `dispose()` that detaches the abort
+ * listeners from both inputs. The caller MUST call `dispose()` once the write
+ * settles (success or failure), via a `finally`. Without it, a write that never
+ * aborts (the common case) would leave the `onAbort` listener permanently
+ * parked on the caller's long-lived signal — the AutoSender hands its single
+ * lifetime signal to every send, so the listeners (and the per-write
+ * controllers they retain) accumulate for the life of the connection.
+ *
+ * Exported for testing the listener lifecycle.
  */
-function mergeAbortSignals(signalA: AbortSignal, signalB: AbortSignal): AbortSignal {
+export function mergeAbortSignals(
+  signalA: AbortSignal,
+  signalB: AbortSignal,
+): { signal: AbortSignal; dispose: () => void } {
   const controller = new AbortController();
+
+  if (signalA.aborted || signalB.aborted) {
+    controller.abort();
+    // Nothing was attached; dispose is a safe no-op on the early-aborted path.
+    return { signal: controller.signal, dispose: () => {} };
+  }
 
   const onAbort = () => {
     controller.abort();
+  };
+
+  const dispose = () => {
     signalA.removeEventListener('abort', onAbort);
     signalB.removeEventListener('abort', onAbort);
   };
 
-  if (signalA.aborted || signalB.aborted) {
-    controller.abort();
-    return controller.signal;
-  }
-
   signalA.addEventListener('abort', onAbort);
   signalB.addEventListener('abort', onAbort);
 
-  return controller.signal;
+  return { signal: controller.signal, dispose };
 }
 
 function classifyBleFailureReason(error: unknown): string {
@@ -257,8 +274,17 @@ export function useBoardBluetooth({
       const writeAbort = new AbortController();
       writeAbortRef.current = writeAbort;
 
-      // Combine caller-provided signal with the internal abort controller
-      const combinedSignal = signal ? mergeAbortSignals(signal, writeAbort.signal) : writeAbort.signal;
+      // Combine caller-provided signal with the internal abort controller. The
+      // merge attaches abort listeners to both inputs; `disposeMergedSignal`
+      // detaches them once the write settles so a non-aborting write doesn't
+      // leak a listener on the AutoSender's long-lived signal.
+      let combinedSignal = writeAbort.signal;
+      let disposeMergedSignal: (() => void) | undefined;
+      if (signal) {
+        const merged = mergeAbortSignals(signal, writeAbort.signal);
+        combinedSignal = merged.signal;
+        disposeMergedSignal = merged.dispose;
+      }
 
       try {
         if (boardName === 'moonboard') {
@@ -368,6 +394,12 @@ export function useBoardBluetooth({
           handleDisconnection();
         }
         return false;
+      } finally {
+        // Detach the merged-signal listeners now the write has settled. Without
+        // this, a non-aborting write leaves a listener parked on the caller's
+        // long-lived signal (the AutoSender's lifetime signal), retaining the
+        // per-write AbortController for the connection.
+        disposeMergedSignal?.();
       }
     },
     [boardName, layoutId, sizeId, holdsData, ledColorOverrides, handleDisconnection],

--- a/packages/mobile/src/lib/climb-to-queue-item.ts
+++ b/packages/mobile/src/lib/climb-to-queue-item.ts
@@ -66,6 +66,10 @@ export function climbToQueueItem(climb: Climb, options?: { suggested?: boolean; 
       is_no_match: climb.is_no_match,
       userAscents: climb.userAscents,
       userAttempts: climb.userAttempts,
+      // Carry multi-frame playback metadata so a climb queued from search /
+      // detail plays back at the setter's pace instead of DEFAULT_PACE_MS.
+      framesCount: climb.framesCount,
+      framesPace: climb.framesPace,
     },
   };
 }

--- a/packages/mobile/src/lib/create-climb-screen-key.ts
+++ b/packages/mobile/src/lib/create-climb-screen-key.ts
@@ -1,0 +1,26 @@
+import type { BoardName } from '@boardsesh/shared-schema';
+
+type CreateClimbKeyBoard = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+};
+
+/**
+ * React `key` for the mounted CreateClimbScreen.
+ *
+ * Keyed on the edited climb (so switching drafts remounts with a fresh undo
+ * history) AND on the board's hold-identity tuple (boardName/layoutId/sizeId/
+ * setIds). The hook seeds its holds reducer once at mount and never re-sanitizes
+ * the painted holds when the board changes, so a board switch under a bare-open
+ * create screen (active-board fallback) must remount to drop holds that don't
+ * exist on the new layout/size and to re-run the per-board draft restore.
+ *
+ * `angle` is deliberately EXCLUDED: WebSocket session sync updates the active
+ * board's angle, and an angle-only remount would wipe an in-progress paint.
+ * Angle does not affect which holds are valid.
+ */
+export function createClimbScreenKey(editClimbUuid: string | undefined, board: CreateClimbKeyBoard): string {
+  return `${editClimbUuid ?? 'new'}:${board.boardName}:${board.layoutId}:${board.sizeId}:${board.setIds}`;
+}

--- a/packages/mobile/src/lib/feed-time-buckets.ts
+++ b/packages/mobile/src/lib/feed-time-buckets.ts
@@ -13,6 +13,26 @@ export type FeedSessionGroup<TSession extends RecencySession> = {
 // Bucket order is fixed (most recent first); empty buckets are dropped.
 const BUCKET_ORDER: FeedRecencyBucket[] = ['today', 'thisWeek', 'earlier'];
 
+/** Minimal shape needed to de-duplicate a session by its id. */
+type IdentifiableSession = { sessionId: string };
+
+/**
+ * De-duplicate a flattened, multi-page session feed by `sessionId`, keeping the
+ * first occurrence (i.e. the earlier page wins). The backend feed uses OFFSET
+ * pagination over an `ORDER BY session_last_tick DESC` that mutates whenever a
+ * tick lands, so a session straddling a page boundary during a refetch can be
+ * returned in two adjacent pages. Without this guard the duplicate `sessionId`
+ * becomes a duplicate FlashList key (React duplicate-key warning + a doubled or
+ * dropped row). Pure and order-preserving.
+ */
+export function dedupeSessionsById<TSession extends IdentifiableSession>(sessions: TSession[]): TSession[] {
+  const byId = new Map<string, TSession>();
+  for (const session of sessions) {
+    if (!byId.has(session.sessionId)) byId.set(session.sessionId, session);
+  }
+  return [...byId.values()];
+}
+
 /**
  * Group sessions into Today / This week / Earlier buckets by their `lastTickAt`,
  * sorted most-recent-first within each bucket and across buckets. Pure: `now` is

--- a/packages/mobile/src/lib/filter-tokens.ts
+++ b/packages/mobile/src/lib/filter-tokens.ts
@@ -15,6 +15,7 @@ import type { Grade } from '@boardsesh/shared-schema';
 import {
   getGradeName,
   applyStatusChange,
+  countFilteredHolds,
   DEFAULT_CLIMB_FILTER_STATE,
   type ClimbFilterState,
   type ClimbBoardFilterState,
@@ -197,12 +198,31 @@ export function getActiveFilterTokens({
     tokens.push({ key: 'climbType', label, clear: () => patchFilters({ boulders: true, routes: false }) });
   }
 
-  // Board-renderer filters: only `onlyBenchmarks` is user-settable today.
+  // Board-renderer filters: benchmark, hold types, and board region are all
+  // user-settable from the filter sheet, so each gets a removable token. Their
+  // labels reuse the same keys the sheet's refine summary uses.
   if (boardFilters.onlyBenchmarks) {
     tokens.push({
       key: 'benchmark',
       label: t('mobile.filter.benchmark'),
       clear: () => patchBoardFilters({ onlyBenchmarks: false }),
+    });
+  }
+
+  const holdCount = countFilteredHolds(boardFilters.holdsFilter);
+  if (holdCount > 0) {
+    tokens.push({
+      key: 'holds',
+      label: t('mobile.holdFilter.summaryCount', { count: holdCount }),
+      clear: () => patchBoardFilters({ holdsFilter: undefined }),
+    });
+  }
+
+  if (boardFilters.zoneBox != null) {
+    tokens.push({
+      key: 'zone',
+      label: t('mobile.zoneFilter.title'),
+      clear: () => patchBoardFilters({ zoneBox: null, zoneMode: undefined }),
     });
   }
 

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-favorite-status.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-favorite-status.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GET_FAVORITES } from '@boardsesh/graphql/operations/favorites';
+
+// The play drawer's heart was a local boolean hard-reset to false on every open,
+// so it never reflected real favorite status and a single tap on an already-
+// favorited climb silently un-favorited it. useFavoriteStatus is the server-truth
+// seam the drawer now reads. These tests pin: it reports the real favorite state
+// keyed on (boardName, climbUuid, angle), stays disabled while the sheet is closed
+// or before a climb is selected, and a toggle busts its cache.
+
+const requestMock = vi.fn();
+vi.mock('../../client', () => ({
+  getHttpClient: () => ({ request: requestMock }),
+}));
+
+// The hooks barrel re-exports sibling hooks that transitively pull in
+// react-native / expo-router (auth provider, you-data, social, session-detail).
+// useFavoriteStatus + useToggleFavorite are pure React Query and touch none of
+// them, so stub the heavy re-exports so the barrel parses under the node SSR
+// transform.
+vi.mock('react-native', () => ({}));
+vi.mock('../use-infinite-search-climbs', () => ({ useInfiniteSearchClimbs: vi.fn() }));
+vi.mock('../use-beta-link-preview', () => ({ useBetaLinkPreview: vi.fn() }));
+vi.mock('../use-mobile-climb-actions-data', () => ({ useMobileClimbActionsData: vi.fn() }));
+vi.mock('../use-you-data', () => ({
+  useAllBoardsTicks: vi.fn(),
+  useUserProfileStats: vi.fn(),
+  useUserClimbPercentile: vi.fn(),
+  useUserAscentsFeed: vi.fn(),
+  useSessionGroupedFeed: vi.fn(),
+}));
+vi.mock('../use-you-profile-data', () => ({ useYouProfileData: vi.fn() }));
+vi.mock('../use-social', () => ({
+  useVote: vi.fn(),
+  useBulkVoteSummaries: vi.fn(),
+  useComments: vi.fn(),
+  useAddComment: vi.fn(),
+}));
+vi.mock('../use-session-detail', () => ({ useSessionDetail: vi.fn(), useSessionPreview: vi.fn() }));
+
+import { useFavoriteStatus, useToggleFavorite } from '../index';
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, Wrapper };
+}
+
+beforeEach(() => {
+  requestMock.mockReset();
+});
+
+describe('useFavoriteStatus', () => {
+  it('reports a climb as favorited when the server returns its uuid', async () => {
+    requestMock.mockResolvedValue({ favorites: ['climb-1'] });
+    const { Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useFavoriteStatus('kilter', 'climb-1', 40, { enabled: true }), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(true);
+    // The query keys the favorite on the supplied angle (favorites are per-angle
+    // on the backend).
+    expect(requestMock).toHaveBeenCalledWith(GET_FAVORITES, {
+      boardName: 'kilter',
+      climbUuids: ['climb-1'],
+      angle: 40,
+    });
+  });
+
+  it('reports a climb as not favorited when the server omits it', async () => {
+    requestMock.mockResolvedValue({ favorites: [] });
+    const { Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useFavoriteStatus('kilter', 'climb-1', 40, { enabled: true }), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(false);
+  });
+
+  it('does not fetch while disabled (sheet closed)', async () => {
+    requestMock.mockResolvedValue({ favorites: ['climb-1'] });
+    const { Wrapper } = makeWrapper();
+
+    renderHook(() => useFavoriteStatus('kilter', 'climb-1', 40, { enabled: false }), { wrapper: Wrapper });
+
+    // Give React Query a tick; nothing should fire while disabled.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch before a climb is selected (null uuid)', async () => {
+    requestMock.mockResolvedValue({ favorites: [] });
+    const { Wrapper } = makeWrapper();
+
+    renderHook(() => useFavoriteStatus('kilter', null, 40, { enabled: true }), { wrapper: Wrapper });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('useToggleFavorite', () => {
+  it('returns the server-authoritative favorited value so callers can reconcile', async () => {
+    requestMock.mockResolvedValue({ toggleFavorite: { favorited: false } });
+    const { Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useToggleFavorite(), { wrapper: Wrapper });
+
+    const response = await result.current.mutateAsync({
+      input: { boardName: 'kilter', climbUuid: 'climb-1', angle: 40 },
+    });
+
+    // A toggle on an already-favorited climb returns favorited:false — the heart
+    // must follow this, not the always-added optimistic guess.
+    expect(response.toggleFavorite.favorited).toBe(false);
+  });
+
+  it('busts the per-climb favorite-status cache on success', async () => {
+    requestMock.mockResolvedValueOnce({ favorites: ['climb-1'] });
+    const { queryClient, Wrapper } = makeWrapper();
+
+    // Seed a favorite-status query so we can observe its invalidation.
+    const statusHook = renderHook(() => useFavoriteStatus('kilter', 'climb-1', 40, { enabled: true }), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(statusHook.result.current.isSuccess).toBe(true));
+
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    requestMock.mockResolvedValueOnce({ toggleFavorite: { favorited: false } });
+    const toggleHook = renderHook(() => useToggleFavorite(), { wrapper: Wrapper });
+    await toggleHook.result.current.mutateAsync({
+      input: { boardName: 'kilter', climbUuid: 'climb-1', angle: 40 },
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['favoriteStatus', 'kilter', 'climb-1', 40],
+    });
+  });
+});

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
@@ -218,6 +218,67 @@ describe('useMobileClimbActionsData', () => {
         input: { playlistId: 'p-1', climbUuid: 'climb-x' },
       });
     });
+
+    it('invalidates the playlist detail caches and bumps climbCount after addToPlaylist resolves', async () => {
+      // Seed the picker cache so the optimistic climbCount bump is observable.
+      requestMock.mockResolvedValueOnce({
+        allUserPlaylists: { playlists: [mkPlaylist('p-1', 'Hard sends')] },
+      });
+      requestMock.mockResolvedValueOnce({ addClimbToPlaylist: {} });
+
+      const { queryClient, Wrapper } = makeWrapper();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.playlistsProviderProps.playlists.length).toBe(1));
+
+      await act(async () => {
+        await result.current.playlistsProviderProps.addToPlaylist('p-1', 'climb-x', 50);
+      });
+
+      // The detail screen keys its climb list + metadata by playlist uuid; a
+      // prefix invalidation refreshes them after the add lands.
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['playlistClimbs', 'p-1'] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['playlist', 'p-1'] });
+      // The picker's count subtitle reflects the add immediately.
+      expect(queryClient.getQueryData<Playlist[]>(['userPlaylists'])?.[0].climbCount).toBe(1);
+    });
+
+    it('invalidates the playlist detail caches and decrements climbCount after removeFromPlaylist resolves', async () => {
+      requestMock.mockResolvedValueOnce({
+        allUserPlaylists: { playlists: [{ ...mkPlaylist('p-1', 'Hard sends'), climbCount: 3 }] },
+      });
+      requestMock.mockResolvedValueOnce({ removeClimbFromPlaylist: true });
+
+      const { queryClient, Wrapper } = makeWrapper();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.playlistsProviderProps.playlists.length).toBe(1));
+
+      await act(async () => {
+        await result.current.playlistsProviderProps.removeFromPlaylist('p-1', 'climb-x');
+      });
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['playlistClimbs', 'p-1'] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['playlist', 'p-1'] });
+      expect(queryClient.getQueryData<Playlist[]>(['userPlaylists'])?.[0].climbCount).toBe(2);
+    });
+
+    it('does not drop climbCount below zero on removeFromPlaylist', async () => {
+      requestMock.mockResolvedValueOnce({
+        allUserPlaylists: { playlists: [{ ...mkPlaylist('p-1', 'Empty'), climbCount: 0 }] },
+      });
+      requestMock.mockResolvedValueOnce({ removeClimbFromPlaylist: true });
+
+      const { queryClient, Wrapper } = makeWrapper();
+      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.playlistsProviderProps.playlists.length).toBe(1));
+
+      await act(async () => {
+        await result.current.playlistsProviderProps.removeFromPlaylist('p-1', 'climb-x');
+      });
+
+      expect(queryClient.getQueryData<Playlist[]>(['userPlaylists'])?.[0].climbCount).toBe(0);
+    });
   });
 
   describe('createPlaylist', () => {

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -22,6 +22,11 @@ import {
   type ClimbStatsHistoryResponse,
 } from '@boardsesh/graphql/operations';
 import {
+  GET_FAVORITES,
+  type FavoritesQueryVariables,
+  type FavoritesQueryResponse,
+} from '@boardsesh/graphql/operations/favorites';
+import {
   DELETE_DRAFT_CLIMB_MUTATION,
   type DeleteDraftClimbMutationVariables,
   type DeleteDraftClimbMutationResponse,
@@ -295,9 +300,41 @@ export function useToggleFavorite() {
   return useMutation({
     mutationFn: (variables: ToggleFavoriteMutationVariables) =>
       getHttpClient().request<ToggleFavoriteMutationResponse>(TOGGLE_FAVORITE, variables),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
+      // Bust the per-climb favorite-status cache so a re-open reflects the new
+      // state from the server, not a stale 5-min-cached value.
+      void queryClient.invalidateQueries({
+        queryKey: ['favoriteStatus', variables.input.boardName, variables.input.climbUuid, variables.input.angle],
+      });
     },
+  });
+}
+
+/**
+ * Server-side favorite status for a single climb at the given angle. The
+ * favorite key is (userId, boardName, climbUuid, angle) on the backend, so the
+ * angle matters — favoriting at 40° is distinct from 25°. Disabled until a
+ * `climbUuid` is supplied (and via `enabled`, so callers can gate it on a sheet
+ * being open). Returns `true` when the climb is favorited at this angle.
+ */
+export function useFavoriteStatus(
+  boardName: string,
+  climbUuid: string | null,
+  angle: number,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    queryKey: ['favoriteStatus', boardName, climbUuid, angle],
+    queryFn: () =>
+      getHttpClient().request<FavoritesQueryResponse, FavoritesQueryVariables>(GET_FAVORITES, {
+        boardName,
+        climbUuids: [climbUuid!],
+        angle,
+      }),
+    select: (data) => data.favorites.includes(climbUuid!),
+    enabled: (options?.enabled ?? true) && !!climbUuid,
+    staleTime: 5 * 60 * 1000,
   });
 }
 

--- a/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
@@ -21,7 +21,7 @@
 // re-render — the toggle path here doesn't touch that store.
 
 import { useCallback, useRef } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { TOGGLE_FAVORITE, type ToggleFavoriteMutationResponse } from '@boardsesh/graphql/operations/favorites';
 import {
   GET_ALL_USER_PLAYLISTS,
@@ -38,6 +38,32 @@ import { useAuth } from '../../../providers/auth-provider';
 import { useActiveBoard } from '../use-active-board';
 
 const PLAYLISTS_QUERY_KEY = ['userPlaylists'] as const;
+
+// The play-drawer's Add-to-Playlist sheet adds/removes by playlist uuid (the
+// backend resolvers match playlists.uuid), so `playlistId` here is the uuid the
+// detail screen keys its caches by: the climb list lives under
+// ['playlistClimbs', uuid, ...] (use-playlist-climbs.ts) and the metadata/hero
+// count under ['playlist', uuid] ([playlist_uuid].tsx). Invalidating those
+// prefixes refreshes an open detail screen after a membership change.
+function invalidatePlaylistDetail(queryClient: QueryClient, playlistUuid: string): void {
+  void queryClient.invalidateQueries({ queryKey: ['playlistClimbs', playlistUuid] });
+  void queryClient.invalidateQueries({ queryKey: ['playlist', playlistUuid] });
+}
+
+// Optimistically nudge the picker's count subtitle (sourced from the cached
+// ['userPlaylists'] list) so it reflects the add/remove immediately rather than
+// waiting out the 5-minute staleTime. Mirrors web's optimistic +1/-1. Match on
+// uuid OR id so the bump lands regardless of which identifier the call site
+// passed.
+function bumpPlaylistClimbCount(queryClient: QueryClient, playlistUuid: string, delta: number): void {
+  queryClient.setQueryData<Playlist[]>(PLAYLISTS_QUERY_KEY, (prev) =>
+    prev?.map((playlist) =>
+      playlist.uuid === playlistUuid || playlist.id === playlistUuid
+        ? { ...playlist, climbCount: Math.max(0, playlist.climbCount + delta) }
+        : playlist,
+    ),
+  );
+}
 
 type MobileClimbActionsData = {
   favoritesProviderProps: {
@@ -112,6 +138,10 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
         input: { playlistId: vars.playlistId, climbUuid: vars.climbUuid, angle: vars.angle },
       });
     },
+    onSuccess: (_response, vars) => {
+      invalidatePlaylistDetail(mutationDepsRef.current.queryClient, vars.playlistId);
+      bumpPlaylistClimbCount(mutationDepsRef.current.queryClient, vars.playlistId, 1);
+    },
   });
 
   const removePlaylistMutation = useMutation({
@@ -119,6 +149,10 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
       return getHttpClient().request(REMOVE_CLIMB_FROM_PLAYLIST, {
         input: { playlistId: vars.playlistId, climbUuid: vars.climbUuid },
       });
+    },
+    onSuccess: (_response, vars) => {
+      invalidatePlaylistDetail(mutationDepsRef.current.queryClient, vars.playlistId);
+      bumpPlaylistClimbCount(mutationDepsRef.current.queryClient, vars.playlistId, -1);
     },
   });
 

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -22,6 +22,7 @@ import type {
   SessionFeedParticipant,
   SessionGradeDistributionItem,
 } from '@boardsesh/shared-schema';
+import type { SubscriptionQueueItem } from '../queue-conversion';
 
 // ============================================
 // Field Fragments (string interpolation, not GQL fragments)
@@ -590,6 +591,25 @@ export type GetSessionQueryResponse = {
   session: SessionPreview | null;
 };
 
+// Authoritative queue snapshot for the active session, fetched after a queue
+// mutation fails so the local optimistic delta can't silently diverge from
+// peers until the next reconnect FullSync. The shape mirrors the FullSync
+// `state.queue` / `state.currentClimbQueueItem` selection — items map through
+// `toClimbQueueItem` and feed an INITIAL_QUEUE_DATA dispatch. Declared after
+// SUBSCRIPTION_CLIMB_FIELDS is interpolated below.
+export type GetSessionQueueStateQueryVariables = {
+  sessionId: string;
+};
+
+export type GetSessionQueueStateQueryResponse = {
+  session: {
+    queueState: {
+      queue: SubscriptionQueueItem[];
+      currentClimbQueueItem: SubscriptionQueueItem | null;
+    };
+  } | null;
+};
+
 // ============================================
 // Tick Queries & Mutations
 // ============================================
@@ -1045,6 +1065,22 @@ export const QUEUE_UPDATES_SUBSCRIPTION = `
         stateHash
         mirroredUuid: uuid
         mirrored
+      }
+    }
+  }
+`;
+
+// Authoritative queue snapshot for the active session. Fetched over the HTTP
+// transport (it's a query, not a subscription) after a queue mutation fails, so
+// the local optimistic delta is reconciled against the server immediately
+// instead of waiting for the next reconnect FullSync. Selects the same climb
+// fields as the FullSync state so items map cleanly through toClimbQueueItem.
+export const GET_SESSION_QUEUE_STATE = gql`
+  query GetSessionQueueState($sessionId: ID!) {
+    session(sessionId: $sessionId) {
+      queueState {
+        queue { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
+        currentClimbQueueItem { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
       }
     }
   }

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -85,6 +85,8 @@ const CLIMB_SEARCH_FIELDS = `
   created_at
   userAscents
   userAttempts
+  framesCount
+  framesPace
 `;
 
 const CLIMB_DETAIL_FIELDS = `
@@ -107,6 +109,8 @@ const CLIMB_DETAIL_FIELDS = `
   is_draft
   created_at
   published_at
+  framesCount
+  framesPace
 `;
 
 // ============================================
@@ -1013,6 +1017,10 @@ const SUBSCRIPTION_CLIMB_FIELDS = `
   stars
   difficulty_error
   benchmark_difficulty
+  mirrored
+  is_no_match
+  framesCount
+  framesPace
 `;
 
 // QueueItemAdded.item is ClimbQueueItem! and CurrentClimbChanged.item is

--- a/packages/mobile/src/lib/live-activity/__tests__/use-live-activity-start-failure.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/use-live-activity-start-failure.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+
+// Force the session-presence branch (iOS) so the start effect actually runs.
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+}));
+
+vi.mock('../../auth-store', () => ({
+  getAuthToken: vi.fn().mockResolvedValue('token-abc'),
+}));
+
+const plugin = vi.hoisted(() => ({
+  startLiveActivitySession: vi.fn(),
+  endLiveActivitySession: vi.fn().mockResolvedValue(undefined),
+  updateLiveActivity: vi.fn().mockResolvedValue(undefined),
+  updateLiveActivityClimb: vi.fn().mockResolvedValue(undefined),
+  isLiveActivityAvailable: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../live-activity-plugin', () => ({
+  startLiveActivitySession: plugin.startLiveActivitySession,
+  endLiveActivitySession: plugin.endLiveActivitySession,
+  updateLiveActivity: plugin.updateLiveActivity,
+  updateLiveActivityClimb: plugin.updateLiveActivityClimb,
+  isLiveActivityAvailable: plugin.isLiveActivityAvailable,
+}));
+
+// Imported AFTER the mocks so the hook binds to the mocked plugin surface.
+const { useLiveActivity } = await import('../use-live-activity');
+
+function makeQueueItem(uuid: string): ClimbQueueItem {
+  return {
+    uuid,
+    climb: {
+      uuid: `climb-${uuid}`,
+      name: `Climb ${uuid}`,
+      difficulty: '7a',
+      angle: 40,
+      frames: 'p1r1',
+    },
+  } as unknown as ClimbQueueItem;
+}
+
+function Harness() {
+  useLiveActivity({
+    queue: [makeQueueItem('q1')],
+    currentClimbQueueItem: makeQueueItem('q1'),
+    board: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' },
+    sessionId: 'session-1',
+    isSessionActive: true,
+    widgetNavigationAllowed: true,
+    isPartySession: false,
+  });
+  return null;
+}
+
+// Flush the availability + auth-token promises and the resulting effects.
+async function flushStart() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('useLiveActivity start-failure cleanup', () => {
+  beforeEach(() => {
+    plugin.startLiveActivitySession.mockReset();
+    plugin.endLiveActivitySession.mockClear();
+    plugin.endLiveActivitySession.mockResolvedValue(undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('tears down the native session when the Live Activity start rejects', async () => {
+    plugin.startLiveActivitySession.mockRejectedValue(new Error('LA_START_FAILED'));
+
+    render(<Harness />);
+    await flushStart();
+
+    expect(plugin.startLiveActivitySession).toHaveBeenCalledTimes(1);
+    // The native start populated the WS connection + keychain/App-Group state
+    // before throwing, so the JS catch must call end to clean it up.
+    expect(plugin.endLiveActivitySession).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call end when the start succeeds', async () => {
+    plugin.startLiveActivitySession.mockResolvedValue(undefined);
+
+    render(<Harness />);
+    await flushStart();
+
+    expect(plugin.startLiveActivitySession).toHaveBeenCalledTimes(1);
+    expect(plugin.endLiveActivitySession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -197,6 +197,11 @@ export function useLiveActivity({
         .catch((error) => {
           console.warn('[LiveActivity] startSession failed:', error);
           isActiveRef.current = false;
+          // Native startSession connects the WebSocket and writes the shared
+          // keychain/App-Group state BEFORE the Activity.request that threw, so
+          // tear those down here — JS otherwise believes nothing is active and
+          // never reaches the teardown paths. endSession is idempotent.
+          void endLiveActivitySession();
         });
     } else if (!shouldBeActive && isActiveRef.current) {
       void endLiveActivitySession();

--- a/packages/mobile/src/lib/queue-conversion.ts
+++ b/packages/mobile/src/lib/queue-conversion.ts
@@ -24,6 +24,13 @@ export type SubscriptionClimb = {
   stars: number;
   difficulty_error: string;
   benchmark_difficulty: string | null;
+  // mirrored survives a reconnect FullSync so a peer-set mirror flag isn't
+  // dropped (the Bluetooth auto-sender repaints unmirrored otherwise).
+  // framesCount/framesPace drive multi-frame playback at the setter's pace.
+  mirrored?: boolean | null;
+  is_no_match?: boolean | null;
+  framesCount?: number | null;
+  framesPace?: number | null;
 };
 
 export type SubscriptionQueueItem = {
@@ -52,6 +59,10 @@ export function toClimbQueueItem(subscriptionItem: SubscriptionQueueItem): Climb
       stars: subscriptionItem.climb.stars,
       difficulty_error: subscriptionItem.climb.difficulty_error,
       benchmark_difficulty: subscriptionItem.climb.benchmark_difficulty,
+      mirrored: subscriptionItem.climb.mirrored,
+      is_no_match: subscriptionItem.climb.is_no_match,
+      framesCount: subscriptionItem.climb.framesCount,
+      framesPace: subscriptionItem.climb.framesPace,
     },
   };
 }

--- a/packages/mobile/src/lib/search-name.ts
+++ b/packages/mobile/src/lib/search-name.ts
@@ -1,3 +1,18 @@
 export function normalizeSearchName(text: string): string {
   return text.trim();
 }
+
+/**
+ * Whether the displayed search field text is genuinely out of sync with the
+ * committed `name` and so needs re-seeding into the field.
+ *
+ * The field stores the RAW text the user typed (with any leading/trailing
+ * whitespace), while `name` is committed normalized (trimmed). A trim-only
+ * difference — e.g. the user is mid-typing "crimp " before the next word — is
+ * NOT a desync and must not trigger a re-seed, which would yank the in-progress
+ * whitespace out from under the cursor. Compare normalized values so only a
+ * real external change (board restore, recent pill, cancel) re-seeds the field.
+ */
+export function visibleSearchTextNeedsSync(visibleText: string, name: string): boolean {
+  return normalizeSearchName(visibleText) !== name;
+}

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor, act } from '@testing-library/react';
+import { renderHook, render, waitFor, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -26,6 +26,13 @@ const isTokenExpiringSoonMock = vi.fn();
 vi.mock('../../lib/auth-store', () => ({
   getAuthToken: () => getAuthTokenMock(),
   isTokenExpiringSoon: () => isTokenExpiringSoonMock(),
+}));
+
+// checkAuth reports keychain read failures to Sentry; record the calls so the
+// rejection test can assert the failure was surfaced (and is a no-op otherwise).
+const reportErrorMock = vi.fn();
+vi.mock('../../lib/sentry', () => ({
+  reportError: (...args: unknown[]) => reportErrorMock(...args),
 }));
 
 const authSignOutMock = vi.fn();
@@ -70,6 +77,7 @@ describe('AuthProvider.signOut', () => {
     clearStoredActiveBoardMock.mockReset();
     resetHttpClientMock.mockReset();
     disposeWsClientMock.mockReset();
+    reportErrorMock.mockReset();
     // Default: a signed-in session whose token is fresh, so checkAuth flips
     // isAuthenticated to true without taking the refresh branch.
     getAuthTokenMock.mockResolvedValue('jwt-token');
@@ -137,5 +145,38 @@ describe('AuthProvider.signOut', () => {
     // Active board cache was wiped — both the targeted removeQueries and the
     // subsequent clear() do this; verifying the end state is enough.
     expect(queryClient.getQueryData(['activeBoard'])).toBeUndefined();
+  });
+});
+
+describe('AuthProvider.checkAuth keychain read failure', () => {
+  beforeEach(() => {
+    getAuthTokenMock.mockReset();
+    isTokenExpiringSoonMock.mockReset();
+    reportErrorMock.mockReset();
+    isTokenExpiringSoonMock.mockResolvedValue(false);
+  });
+
+  // Repro for A11-auth-onboarding-001: a locked-keychain launch makes
+  // SecureStore.getItemAsync REJECT (not return null). Without a try/catch in
+  // checkAuth the rejection escapes, isLoading never flips to false, onReady
+  // never fires, and the splash screen hangs forever. The fix treats a read
+  // failure as logged-out so the loading gate always resolves.
+  it('still resolves the loading gate (onReady fires) when the token read rejects', async () => {
+    getAuthTokenMock.mockRejectedValue(new Error('keychain locked'));
+    const onReady = vi.fn();
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider onReady={onReady}>{children}</AuthProvider>
+      </QueryClientProvider>
+    );
+
+    render(wrapper({ children: null }));
+
+    // The whole point: the splash gate must release even though the read threw.
+    await waitFor(() => expect(onReady).toHaveBeenCalled());
+    // The failure is surfaced to Sentry rather than swallowed silently.
+    expect(reportErrorMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -4,7 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createElement, type ReactNode } from 'react';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 
+type HoldPlacementStub = { id: number; mirroredHoldId: number | null; cx: number; cy: number; r: number };
+
 type BluetoothHookOptions = {
+  holdsData?: HoldPlacementStub[];
   onConnectSuccess?: (serial: string | null) => void;
 };
 
@@ -50,6 +53,17 @@ vi.mock('@boardsesh/play-view', () => ({
 
 vi.mock('../../lib/ble/use-board-bluetooth', () => ({
   useBoardBluetooth: bluetooth.useBoardBluetooth,
+}));
+
+// getBoardRenderData is the source the provider must thread `holdsData` from.
+// Stub it so the provider's holdsData wiring is observable without loading the
+// real board-placement tables in jsdom.
+const boardDetails = vi.hoisted(() => ({
+  holdsData: [{ id: 1, mirroredHoldId: 99, cx: 0, cy: 0, r: 10 }] as HoldPlacementStub[],
+  getBoardRenderData: vi.fn(),
+}));
+vi.mock('../../lib/board-details', () => ({
+  getBoardRenderData: boardDetails.getBoardRenderData,
 }));
 
 vi.mock('../../lib/ble/bluetooth-status-store', () => ({
@@ -131,6 +145,8 @@ describe('BluetoothProvider wall-confirm integration', () => {
     bluetooth.state.sendFramesToBoard.mockReset();
     bluetooth.state.sendFramesToBoard.mockResolvedValue(true);
     bluetooth.useBoardBluetooth.mockClear();
+    boardDetails.getBoardRenderData.mockReset();
+    boardDetails.getBoardRenderData.mockReturnValue({ holdsData: boardDetails.holdsData });
   });
 
   afterEach(() => {
@@ -211,6 +227,26 @@ describe('BluetoothProvider wall-confirm integration', () => {
       previousSerialKnown: false,
       boardLayout: 'kilter',
     });
+  });
+
+  it('threads the active board holdsData into useBoardBluetooth (so mirrored sends can be mirrored)', () => {
+    render(
+      createElement(BluetoothProvider, {
+        boardName: 'tension',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+        children: createElement('div', null),
+      }),
+    );
+
+    expect(boardDetails.getBoardRenderData).toHaveBeenCalledWith({
+      boardName: 'tension',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: [1, 2],
+    });
+    expect(bluetooth.options?.holdsData).toBe(boardDetails.holdsData);
   });
 
   it('suppresses board serial writes outside sessions or when the serial is unchanged', () => {

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wrapper.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wrapper.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { createElement, useEffect, type ReactNode } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+// Controllable active-board read. The whole point of the regression is the
+// async undefined -> board transition, so the test drives it explicitly.
+const activeBoard = vi.hoisted(() => ({ data: undefined as UserBoard | undefined }));
+vi.mock('../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: activeBoard.data }),
+}));
+
+// BluetoothProvider is stubbed to a passthrough so the test exercises only the
+// wrapper's element-stability decision, not the real BLE provider's internals.
+vi.mock('../bluetooth-provider', () => ({
+  BluetoothProvider: ({ children }: { children: ReactNode }) =>
+    createElement('div', { 'data-testid': 'bluetooth-provider' }, children),
+}));
+
+vi.mock('../../lib/live-activity/live-activity-bridge', () => ({
+  LiveActivityBridge: () => createElement('div', { 'data-testid': 'live-activity-bridge' }),
+}));
+
+import { BluetoothProviderWrapper } from '../bluetooth-provider-wrapper';
+
+const mountCounter = vi.fn();
+
+// A child that records each mount. If the wrapper swaps the element at its
+// position when the board resolves, React unmounts and remounts this subtree,
+// so the mount count climbs past 1.
+function MountProbe() {
+  useEffect(() => {
+    mountCounter();
+  }, []);
+  return createElement('div', { 'data-testid': 'mount-probe' });
+}
+
+const board = {
+  uuid: 'board-1',
+  boardType: 'kilter',
+  layoutId: 1,
+  sizeId: 2,
+  setIds: '3,4',
+} as unknown as UserBoard;
+
+describe('BluetoothProviderWrapper', () => {
+  beforeEach(() => {
+    activeBoard.data = undefined;
+    mountCounter.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('keeps the child subtree mounted across the undefined -> board transition', () => {
+    const { rerender } = render(createElement(BluetoothProviderWrapper, null, createElement(MountProbe)));
+
+    // First commit: no stored board yet (async AsyncStorage read pending).
+    expect(mountCounter).toHaveBeenCalledTimes(1);
+
+    // The stored board resolves a tick later.
+    activeBoard.data = board;
+    rerender(createElement(BluetoothProviderWrapper, null, createElement(MountProbe)));
+
+    // The child must NOT remount: BluetoothProvider stays at the same tree
+    // position, so the navigation subtree below it is untouched.
+    expect(mountCounter).toHaveBeenCalledTimes(1);
+  });
+
+  it('only mounts the LiveActivityBridge once a board is present', () => {
+    const { queryByTestId, rerender } = render(
+      createElement(BluetoothProviderWrapper, null, createElement(MountProbe)),
+    );
+    expect(queryByTestId('live-activity-bridge')).toBeNull();
+
+    activeBoard.data = board;
+    rerender(createElement(BluetoothProviderWrapper, null, createElement(MountProbe)));
+    expect(queryByTestId('live-activity-bridge')).not.toBeNull();
+  });
+});

--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+import { act, render, waitFor } from '@testing-library/react';
+import { createElement, useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+// Self-contained QueueProvider harness scoped to clearSession's notifyServer
+// option: an intentional session switch must emit LEAVE_SESSION so peers see
+// the departure immediately (web parity with sendLeaveOnCleanup).
+
+const ws = vi.hoisted(() => ({
+  client: {
+    on: vi.fn(() => vi.fn()),
+    subscribe: vi.fn(() => vi.fn()),
+  },
+}));
+
+const graph = vi.hoisted(() => ({ execute: vi.fn() }));
+const http = vi.hoisted(() => ({ request: vi.fn() }));
+
+const activeBoard = vi.hoisted(() => ({
+  stored: {
+    uuid: 'board-1',
+    slug: 'board-1',
+    ownerId: 'owner-1',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 10,
+    setIds: '1,2',
+    name: 'Test board',
+    isPublic: true,
+    isUnlisted: false,
+    hideLocation: false,
+    isOwned: true,
+    angle: 40,
+    isAngleAdjustable: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    totalAscents: 0,
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+  } satisfies UserBoard,
+  getStoredActiveBoard: vi.fn(),
+}));
+
+const queueMutations = vi.hoisted(() => ({
+  addQueueItem: vi.fn(async () => {}),
+  removeQueueItem: vi.fn(async () => {}),
+  reorderQueueItem: vi.fn(async () => {}),
+  setCurrentClimb: vi.fn(async () => {}),
+  mirrorCurrentClimb: vi.fn(async () => {}),
+  publishPlaybackState: vi.fn(async () => {}),
+  setQueue: vi.fn(async () => {}),
+  replaceQueueItem: vi.fn(async () => {}),
+  takeControl: vi.fn(async () => {}),
+  releaseControl: vi.fn(async () => {}),
+  confirmClimbOnWall: vi.fn(async () => {}),
+  setSessionBoardSerial: vi.fn(async () => {}),
+  setSessionBoardPath: vi.fn(async () => {}),
+}));
+
+const sessionStore = vi.hoisted(() => ({
+  getStoredSessionId: vi.fn(async () => 'session-1'),
+  setStoredSessionId: vi.fn(async () => {}),
+  clearStoredSessionId: vi.fn(async () => {}),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
+  AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
+}));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-correlation-id' }));
+vi.mock('@boardsesh/graphql-client', () => ({ execute: graph.execute }));
+vi.mock('@boardsesh/queue-react', () => ({ useQueueMutations: () => queueMutations }));
+vi.mock('@boardsesh/play-view', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/play-view')>()),
+  emitWallConfirm: vi.fn(),
+}));
+vi.mock('../../lib/graphql/ws-client', () => ({ getWsClient: () => ws.client }));
+vi.mock('../../lib/session-store', () => sessionStore);
+vi.mock('../../lib/active-board-store', () => ({ getStoredActiveBoard: activeBoard.getStoredActiveBoard }));
+vi.mock('../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: activeBoard.stored }),
+  useSetActiveBoard: () => vi.fn(async () => {}),
+}));
+vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: http.request }) }));
+vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+
+import { QueueProvider, useQueue, useQueueSessionId } from '../queue-provider';
+
+type Snapshot = {
+  sessionId: string | null;
+  clearSession: ReturnType<typeof useQueue>['clearSession'];
+};
+
+function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
+  const queue = useQueue();
+  const { sessionId } = useQueueSessionId();
+  useEffect(() => {
+    onSnapshot({ sessionId, clearSession: queue.clearSession });
+  }, [sessionId, queue.clearSession, onSnapshot]);
+  return null;
+}
+
+function leaveSessionCalls() {
+  return graph.execute.mock.calls.filter((call) => {
+    const operation = call[1] as { query?: string } | undefined;
+    return typeof operation?.query === 'string' && operation.query.includes('leaveSession');
+  });
+}
+
+describe('QueueProvider clearSession notifyServer', () => {
+  beforeEach(() => {
+    ws.client.on.mockClear();
+    ws.client.subscribe.mockClear();
+    activeBoard.getStoredActiveBoard.mockReset();
+    activeBoard.getStoredActiveBoard.mockResolvedValue(activeBoard.stored);
+    for (const mutation of Object.values(queueMutations) as Array<ReturnType<typeof vi.fn>>) {
+      mutation.mockReset();
+      mutation.mockResolvedValue(undefined);
+    }
+    sessionStore.getStoredSessionId.mockResolvedValue('session-1');
+    sessionStore.clearStoredSessionId.mockClear();
+    http.request.mockReset();
+    http.request.mockResolvedValue({});
+    graph.execute.mockReset();
+    // joinSession resolves the active session; leaveSession resolves true.
+    graph.execute.mockResolvedValue({
+      joinSession: {
+        participantId: 'participant-self',
+        clientId: 'client-self',
+        isLeader: false,
+        driverParticipantId: null,
+        lastConnectedBoardSerial: null,
+        boardPath: '/kilter/1/10/1,2/40/list',
+        users: [],
+      },
+      leaveSession: true,
+    });
+  });
+
+  it('emits LEAVE_SESSION when clearSession is called with notifyServer:true (session switch)', async () => {
+    const snapshots: Snapshot[] = [];
+    render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot: (snap) => snapshots.push(snap) })));
+
+    // Wait for the stored session to load + JOIN_SESSION to resolve.
+    await waitFor(() => expect(snapshots.at(-1)?.sessionId).toBe('session-1'));
+
+    await act(async () => {
+      await snapshots.at(-1)?.clearSession({ notifyServer: true });
+    });
+
+    // The backend was told we left, BEFORE local state reset cleared the id.
+    expect(leaveSessionCalls()).toHaveLength(1);
+    await waitFor(() => expect(snapshots.at(-1)?.sessionId).toBeNull());
+  });
+
+  it('does NOT emit LEAVE_SESSION for a plain clearSession (remote end / endSession callers)', async () => {
+    const snapshots: Snapshot[] = [];
+    render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot: (snap) => snapshots.push(snap) })));
+
+    await waitFor(() => expect(snapshots.at(-1)?.sessionId).toBe('session-1'));
+
+    await act(async () => {
+      await snapshots.at(-1)?.clearSession();
+    });
+
+    expect(leaveSessionCalls()).toHaveLength(0);
+    await waitFor(() => expect(snapshots.at(-1)?.sessionId).toBeNull());
+  });
+
+  it('still clears local state when the leave mutation rejects (degrades to disconnect grace)', async () => {
+    const snapshots: Snapshot[] = [];
+    render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot: (snap) => snapshots.push(snap) })));
+
+    await waitFor(() => expect(snapshots.at(-1)?.sessionId).toBe('session-1'));
+
+    graph.execute.mockRejectedValueOnce(new Error('ws wedged'));
+    await act(async () => {
+      await snapshots.at(-1)?.clearSession({ notifyServer: true });
+    });
+
+    // A failed leave must not block the local reset — the switch still proceeds.
+    await waitFor(() => expect(snapshots.at(-1)?.sessionId).toBeNull());
+  });
+});

--- a/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { act, render, waitFor } from '@testing-library/react';
+import { createElement, useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Climb, ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+// Self-contained QueueProvider harness (mirrors queue-provider-session-updates.test.tsx)
+// scoped to the angle-change re-grade of the displayed playlist suggestion peek.
+
+const ws = vi.hoisted(() => ({
+  client: {
+    on: vi.fn(() => vi.fn()),
+    subscribe: vi.fn(() => vi.fn()),
+  },
+}));
+
+const graph = vi.hoisted(() => ({ execute: vi.fn() }));
+const http = vi.hoisted(() => ({ request: vi.fn() }));
+
+const activeBoard = vi.hoisted(() => ({
+  stored: {
+    uuid: 'board-1',
+    slug: 'board-1',
+    ownerId: 'owner-1',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 10,
+    setIds: '1,2',
+    name: 'Test board',
+    isPublic: true,
+    isUnlisted: false,
+    hideLocation: false,
+    isOwned: true,
+    angle: 25,
+    isAngleAdjustable: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    totalAscents: 0,
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+  } satisfies UserBoard,
+  getStoredActiveBoard: vi.fn(),
+}));
+
+const queueMutations = vi.hoisted(() => ({
+  addQueueItem: vi.fn(async () => {}),
+  removeQueueItem: vi.fn(async () => {}),
+  reorderQueueItem: vi.fn(async () => {}),
+  setCurrentClimb: vi.fn(async () => {}),
+  mirrorCurrentClimb: vi.fn(async () => {}),
+  publishPlaybackState: vi.fn(async () => {}),
+  setQueue: vi.fn(async () => {}),
+  replaceQueueItem: vi.fn(async () => {}),
+  takeControl: vi.fn(async () => {}),
+  releaseControl: vi.fn(async () => {}),
+  confirmClimbOnWall: vi.fn(async () => {}),
+  setSessionBoardSerial: vi.fn(async () => {}),
+  setSessionBoardPath: vi.fn(async () => {}),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
+  AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
+}));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-correlation-id' }));
+vi.mock('@boardsesh/graphql-client', () => ({ execute: graph.execute }));
+vi.mock('@boardsesh/queue-react', () => ({ useQueueMutations: () => queueMutations }));
+vi.mock('@boardsesh/play-view', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/play-view')>()),
+  emitWallConfirm: vi.fn(),
+}));
+vi.mock('../../lib/graphql/ws-client', () => ({ getWsClient: () => ws.client }));
+// Solo (no session) keeps the regrade path isolated from join/subscription noise.
+vi.mock('../../lib/session-store', () => ({
+  getStoredSessionId: vi.fn(async () => null),
+  setStoredSessionId: vi.fn(async () => {}),
+  clearStoredSessionId: vi.fn(async () => {}),
+}));
+vi.mock('../../lib/active-board-store', () => ({ getStoredActiveBoard: activeBoard.getStoredActiveBoard }));
+vi.mock('../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: activeBoard.stored }),
+  useSetActiveBoard: () => vi.fn(async () => {}),
+}));
+vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: http.request }) }));
+vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
+
+import { QueueProvider, usePlaylistSuggestionSource, useQueue } from '../queue-provider';
+
+type Snapshot = {
+  state: ReturnType<typeof useQueue>['state'];
+  playlistSuggestionSource: PlaylistSuggestionSource | null;
+  setCurrentClimb: ReturnType<typeof useQueue>['setCurrentClimb'];
+};
+
+function makeClimb(uuid: string, angle: number, difficulty: string): Climb {
+  return {
+    uuid,
+    name: `Climb ${uuid}`,
+    frames: 'p1r12',
+    setter_username: 'setter',
+    angle,
+    ascensionist_count: 0,
+    difficulty,
+    quality_average: '3.0',
+    stars: 3,
+    difficulty_error: '0.3',
+    benchmark_difficulty: null,
+  };
+}
+
+function makeItem(climb: Climb): ClimbQueueItem {
+  return { uuid: climb.uuid, climb, suggested: false };
+}
+
+function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
+  const queue = useQueue();
+  const playlistSuggestionSource = usePlaylistSuggestionSource();
+  useEffect(() => {
+    onSnapshot({ state: queue.state, playlistSuggestionSource, setCurrentClimb: queue.setCurrentClimb });
+  }, [queue.state, playlistSuggestionSource, queue.setCurrentClimb, onSnapshot]);
+  return null;
+}
+
+describe('QueueProvider angle-change re-grade of the playlist suggestion peek', () => {
+  beforeEach(() => {
+    ws.client.on.mockClear();
+    ws.client.subscribe.mockClear();
+    activeBoard.getStoredActiveBoard.mockReset();
+    activeBoard.getStoredActiveBoard.mockResolvedValue(activeBoard.stored);
+    for (const mutation of Object.values(queueMutations) as Array<ReturnType<typeof vi.fn>>) {
+      mutation.mockReset();
+      mutation.mockResolvedValue(undefined);
+    }
+    graph.execute.mockReset();
+    http.request.mockReset();
+  });
+
+  it('re-grades the next-up source climb to the live board angle and patches the source', async () => {
+    // Current climb is already at the live angle (25); the next playlist climb
+    // carries a stale grade baked at 40, so it must be re-graded to 25.
+    const currentClimb = makeClimb('climb-current', 25, 'V3');
+    const nextClimb = makeClimb('climb-next', 40, 'V7');
+    const source: PlaylistSuggestionSource = {
+      playlistUuid: 'playlist-1',
+      activatedClimbUuid: 'climb-current',
+      boardKey: 'kilter:1:10:1,2',
+      climbs: [currentClimb, nextClimb],
+    };
+
+    // GET_CLIMB for the next climb at angle 25 returns the angle-25 grade.
+    http.request.mockImplementation(async (_query: string, variables: { climbUuid: string; angle: number }) => {
+      if (variables.climbUuid === 'climb-next' && variables.angle === 25) {
+        return { climb: makeClimb('climb-next', 25, 'V5') };
+      }
+      return { climb: null };
+    });
+
+    const snapshots: Snapshot[] = [];
+    render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot: (snap) => snapshots.push(snap) })));
+
+    await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+    // Activate the playlist: current climb + suggestion source. The peek resolves
+    // to the next source climb (baked at 40).
+    await act(async () => {
+      snapshots.at(-1)?.setCurrentClimb(makeItem(currentClimb), { playlistSuggestionSource: source });
+    });
+
+    // The self-healing re-grade effect re-fetches the peek climb at the live angle
+    // and patches it back into the suggestion source.
+    await waitFor(() => {
+      const patched = snapshots.at(-1)?.playlistSuggestionSource?.climbs.find((climb) => climb.uuid === 'climb-next');
+      expect(patched?.angle).toBe(25);
+      expect(patched?.difficulty).toBe('V5');
+    });
+
+    // It fetched ONLY the displayed next-up climb, never the whole playlist.
+    const fetchedUuids = http.request.mock.calls.map((call) => (call[1] as { climbUuid: string }).climbUuid);
+    expect(fetchedUuids).toContain('climb-next');
+    expect(fetchedUuids).not.toContain('climb-current');
+  });
+});

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -161,6 +161,7 @@ type Snapshot = {
   lastConnectedBoardSerial: string | null;
   playlistSuggestionSource: PlaylistSuggestionSource | null;
   addToQueue: ReturnType<typeof useQueue>['addToQueue'];
+  removeFromQueue: ReturnType<typeof useQueue>['removeFromQueue'];
   setCurrentClimb: ReturnType<typeof useQueue>['setCurrentClimb'];
   nextClimb: ReturnType<typeof useQueue>['nextClimb'];
   setPlaylistSuggestionSource: ReturnType<typeof useQueue>['setPlaylistSuggestionSource'];
@@ -232,6 +233,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
       lastConnectedBoardSerial: queue.lastConnectedBoardSerial,
       playlistSuggestionSource,
       addToQueue: queue.addToQueue,
+      removeFromQueue: queue.removeFromQueue,
       setCurrentClimb: queue.setCurrentClimb,
       nextClimb: queue.nextClimb,
       setPlaylistSuggestionSource: queue.setPlaylistSuggestionSource,
@@ -250,6 +252,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
     queue.lastConnectedBoardSerial,
     playlistSuggestionSource,
     queue.addToQueue,
+    queue.removeFromQueue,
     queue.setCurrentClimb,
     queue.nextClimb,
     queue.setPlaylistSuggestionSource,
@@ -1047,5 +1050,219 @@ describe('QueueProvider session update subscription', () => {
     });
     expect(toast.showToast).toHaveBeenCalledWith('mobile.toast.sessionEnded', 'success');
     expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+  });
+});
+
+// ── SEED-1: queue mutations resync on failure (GH #2419) ─────────────────────
+//
+// addToQueue / removeFromQueue / clearQueue / dispatchSetCurrent apply an
+// optimistic reducer delta then fire the server mutation. When that mutation
+// rejects in a party session the local queue silently diverges from peers until
+// the next reconnect FullSync. These tests pin the recovery: a rejection with an
+// active session refetches the authoritative queueState (GET_SESSION_QUEUE_STATE
+// over the HTTP client → the mocked http.request) and replaces local state with
+// an INITIAL_QUEUE_DATA dispatch, then toasts. A rejection with no session must
+// NOT resync or toast.
+describe('QueueProvider mutation-failure resync', () => {
+  // The harness routes both endSession and the queueState query through
+  // http.request. Branch on the operation text so the resync query returns the
+  // authoritative snapshot while everything else keeps the default endSession
+  // response.
+  function routeHttpRequest(queueStateResponse: unknown, options: { onQueueStateCall?: () => void } = {}) {
+    http.request.mockImplementation(async (operation: unknown) => {
+      const operationText = typeof operation === 'string' ? operation : '';
+      if (operationText.includes('GetSessionQueueState')) {
+        options.onQueueStateCall?.();
+        return queueStateResponse;
+      }
+      return { endSession: { sessionId: 'session-1' } };
+    });
+  }
+
+  function queueStateResponse(items: ClimbQueueItem[], current: ClimbQueueItem | null = null) {
+    return {
+      session: {
+        queueState: {
+          queue: items.map((item) => ({ uuid: item.uuid, climb: item.climb })),
+          currentClimbQueueItem: current ? { uuid: current.uuid, climb: current.climb } : null,
+        },
+      },
+    };
+  }
+
+  it('resyncs once from the server and replaces state when an add fails in a session', async () => {
+    const snapshots: Snapshot[] = [];
+    // Server is authoritative: it holds a single climb the failed local add
+    // never reached, so a resync must overwrite the optimistic local queue.
+    const serverItem = makeQueueItem('server-item', 'climb-server');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([serverItem]), { onQueueStateCall: () => (queueStateCalls += 1) });
+    queueMutations.addQueueItem.mockRejectedValueOnce(new Error('add failed'));
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+
+    act(() => {
+      snapshot.addToQueue(makeQueueItem('local-add', 'climb-local'));
+    });
+
+    await waitFor(() => {
+      // The reducer's INITIAL_QUEUE_DATA from the resync replaced the optimistic
+      // local item with the server's authoritative queue.
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-item']);
+    });
+    expect(queueStateCalls).toBe(1);
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
+  });
+
+  it('resyncs and replaces state when a remove fails in a session', async () => {
+    const snapshots: Snapshot[] = [];
+    const serverItem = makeQueueItem('server-kept', 'climb-kept');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([serverItem]), { onQueueStateCall: () => (queueStateCalls += 1) });
+    queueMutations.removeQueueItem.mockRejectedValueOnce(new Error('remove failed'));
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const prepared = snapshots.at(-1);
+    if (!prepared) throw new Error('queue snapshot was not captured');
+    act(() => {
+      prepared.addToQueue(makeQueueItem('to-remove', 'climb-remove'));
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toContain('to-remove');
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.removeFromQueue('to-remove');
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-kept']);
+    });
+    expect(queueStateCalls).toBe(1);
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
+  });
+
+  it('resyncs and replaces current climb when setCurrentClimb fails in a session', async () => {
+    const snapshots: Snapshot[] = [];
+    const serverCurrent = makeQueueItem('server-current', 'climb-server-current');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([serverCurrent], serverCurrent), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+    queueMutations.setCurrentClimb.mockRejectedValueOnce(new Error('set current failed'));
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.setCurrentClimb(makeQueueItem('local-current', 'climb-local-current'));
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('server-current');
+    });
+    expect(queueStateCalls).toBe(1);
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
+    // Solo's "Action failed" toast must NOT fire in a party session.
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+  });
+
+  it('does not resync or toast when a mutation fails with no active session', async () => {
+    const snapshots: Snapshot[] = [];
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([]), { onQueueStateCall: () => (queueStateCalls += 1) });
+    queueMutations.addQueueItem.mockRejectedValueOnce(new Error('add failed'));
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    // End the session so the next add runs with no active session.
+    await act(async () => {
+      await snapshots.at(-1)?.endSession();
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBeNull();
+    });
+    toast.showToast.mockClear();
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.addToQueue(makeQueueItem('solo-add', 'climb-solo'));
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toContain('solo-add');
+    });
+    // Let any (incorrectly scheduled) async resync settle before asserting.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(queueStateCalls).toBe(0);
+    expect(toast.showToast).not.toHaveBeenCalled();
+    // The optimistic local add stays — no server overwrite in solo.
+    expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['solo-add']);
+  });
+
+  it('does not retry-loop when the resync fetch itself fails', async () => {
+    const snapshots: Snapshot[] = [];
+    let queueStateCalls = 0;
+    http.request.mockImplementation(async (operation: unknown) => {
+      const operationText = typeof operation === 'string' ? operation : '';
+      if (operationText.includes('GetSessionQueueState')) {
+        queueStateCalls += 1;
+        throw new Error('resync fetch failed');
+      }
+      return { endSession: { sessionId: 'session-1' } };
+    });
+    queueMutations.addQueueItem.mockRejectedValueOnce(new Error('add failed'));
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.addToQueue(makeQueueItem('local-add', 'climb-local'));
+    });
+
+    await waitFor(() => {
+      // Optimistic add stays; the failed resync swallowed its error.
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toContain('local-add');
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Exactly one attempt — the single-flight guard released cleanly and no
+    // retry loop fired. No "refreshed" toast since nothing was applied.
+    expect(queueStateCalls).toBe(1);
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
   });
 });

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -13,6 +13,7 @@ import {
   type CredentialsSignInResult,
 } from '../lib/auth';
 import { reset as resetAnalytics, track } from '../lib/analytics';
+import { reportError } from '../lib/sentry';
 import { resetHttpClient } from '../lib/graphql/client';
 import { disposeWsClient } from '../lib/graphql/ws-client';
 import { clearStoredSessionId } from '../lib/session-store';
@@ -57,33 +58,47 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   }, []);
 
   const checkAuth = useCallback(async () => {
-    const token = await getAuthToken();
-    if (!token) {
-      resetAnalyticsForSignedOutTransition();
+    try {
+      const token = await getAuthToken();
+      if (!token) {
+        resetAnalyticsForSignedOutTransition();
+        setIsAuthenticated(false);
+        return;
+      }
+      const expiring = await isTokenExpiringSoon();
+      if (expiring) {
+        const { ensureFreshToken } = await import('../lib/auth-interceptor');
+        const refreshed = await ensureFreshToken();
+        if (!refreshed) resetAnalyticsForSignedOutTransition();
+        setIsAuthenticated(refreshed);
+      } else {
+        setIsAuthenticated(true);
+      }
+    } catch (authCheckError) {
+      // SecureStore.getItemAsync REJECTS (not returns null) when the keychain
+      // is inaccessible — a background launch before first unlock, or an
+      // undecryptable entry after an Android backup restore. Without this catch
+      // the rejection escapes, isLoading never clears, onReady never fires, and
+      // the splash screen hangs forever. Treat a read failure as logged-out so
+      // the loading gate always releases. Do NOT clear tokens: a later
+      // successful read (the AppState 'active' re-check below) restores auth.
+      reportError(authCheckError);
       setIsAuthenticated(false);
+    } finally {
       setIsLoading(false);
-      return;
     }
-    const expiring = await isTokenExpiringSoon();
-    if (expiring) {
-      const { ensureFreshToken } = await import('../lib/auth-interceptor');
-      const refreshed = await ensureFreshToken();
-      if (!refreshed) resetAnalyticsForSignedOutTransition();
-      setIsAuthenticated(refreshed);
-    } else {
-      setIsAuthenticated(true);
-    }
-    setIsLoading(false);
   }, [resetAnalyticsForSignedOutTransition]);
 
   useEffect(() => {
-    checkAuth();
+    // Belt-and-braces: checkAuth already resolves its own rejections, but keep
+    // the invocation from producing an unhandled rejection if that ever changes.
+    void checkAuth();
   }, [checkAuth]);
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextAppState) => {
       if (nextAppState === 'active') {
-        checkAuth();
+        void checkAuth();
       }
     });
     return () => subscription.remove();

--- a/packages/mobile/src/providers/bluetooth-provider-wrapper.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider-wrapper.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react';
+import { BluetoothProvider } from './bluetooth-provider';
+import { useActiveBoard } from '../lib/graphql/use-active-board';
+import { LiveActivityBridge } from '../lib/live-activity/live-activity-bridge';
+
+/**
+ * Supplies the active board to BluetoothProvider for the whole navigation
+ * subtree.
+ *
+ * `useActiveBoard` reads the stored board from AsyncStorage asynchronously, so
+ * on every cold start `activeBoard` is `undefined` for the first commit and then
+ * resolves one tick later. BluetoothProvider is therefore mounted
+ * **unconditionally** — all its props are optional and a board connection is
+ * user-initiated, so the provider is inert without a board. Swapping the element
+ * at this position from a Fragment (no board) to BluetoothProvider (board
+ * resolved) would change the element type at a fixed tree position, forcing
+ * React to unmount and remount everything below it (the navigation Stack,
+ * DeepLinkProvider, ShareTargetProvider, OnboardingGate, the analytics screen
+ * tracker, …) once per launch for any returning user. Keeping the provider
+ * stable across the `undefined → board` transition avoids that remount storm.
+ *
+ * The LiveActivityBridge is the only child that genuinely needs a board (it
+ * would otherwise trigger Live Activity authorization prompts for a guest), so
+ * it alone is gated on `activeBoard`.
+ */
+export function BluetoothProviderWrapper({ children }: { children: ReactNode }) {
+  const { data: activeBoard } = useActiveBoard();
+
+  return (
+    <BluetoothProvider
+      boardName={activeBoard?.boardType}
+      layoutId={activeBoard?.layoutId}
+      sizeId={activeBoard?.sizeId}
+      setIds={activeBoard?.setIds}
+      boardUuid={activeBoard?.uuid}
+    >
+      {activeBoard ? (
+        <LiveActivityBridge
+          boardName={activeBoard.boardType}
+          layoutId={activeBoard.layoutId}
+          sizeId={activeBoard.sizeId}
+          setIds={activeBoard.setIds}
+        />
+      ) : null}
+      {children}
+    </BluetoothProvider>
+  );
+}

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -1,8 +1,10 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { BoardName } from '@boardsesh/shared-schema';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { emitWallConfirm } from '@boardsesh/play-view';
 import { useBoardBluetooth } from '../lib/ble/use-board-bluetooth';
+import { getBoardRenderData } from '../lib/board-details';
 import { registerBluetoothConnection } from '../lib/ble/bluetooth-status-store';
 import { useQueue, useQueueSessionControls } from './queue-provider';
 import { hapticSuccess } from '../lib/haptics';
@@ -229,6 +231,27 @@ export function BluetoothProvider({
     [boardName, setSessionBoardSerial],
   );
 
+  // Hold map for the active board, needed to convert frames to their mirrored
+  // layout before a BLE write on mirroring boards (Tension/Decoy). Without it,
+  // useBoardBluetooth would refuse a mirrored send rather than light the wrong
+  // holds. getBoardRenderData is pure and memoized by board-config key, so this
+  // is effectively a cache lookup.
+  const holdsData = useMemo(() => {
+    if (!boardName || layoutId === undefined || sizeId === undefined || !setIds) return undefined;
+    const parsedSetIds = setIds
+      .split(',')
+      .map((token) => Number(token))
+      .filter((setId) => Number.isFinite(setId));
+    return (
+      getBoardRenderData({
+        boardName: boardName as BoardName,
+        layoutId,
+        sizeId,
+        setIds: parsedSetIds,
+      })?.holdsData ?? undefined
+    );
+  }, [boardName, layoutId, sizeId, setIds]);
+
   const { isConnected, loading, connect, disconnect, sendFramesToBoard, pickerState, reconnectSerialForCurrentBoard } =
     useBoardBluetooth({
       boardName,
@@ -236,6 +259,7 @@ export function BluetoothProvider({
       sizeId,
       setIds,
       boardUuid,
+      holdsData,
       onConnectSuccess: handleConnectSuccess,
     });
 

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -269,6 +269,12 @@ export function BluetoothProvider({
     track(SHARED_EVENTS.BluetoothDisconnected, { boardName, reason: 'user', inSession: sessionIdRef.current != null });
     try {
       await disconnect();
+    } catch {
+      // The native iOS adapter's disconnect() can reject (e.g. peripheral
+      // already torn down). Callers `void` this promise, so an unhandled
+      // rejection would surface as Sentry noise. Connection state is cleared
+      // before the await, so the disconnect is effectively done either way —
+      // safe to swallow, matching the keep-awake `.catch(() => {})` pattern.
     } finally {
       isUserDisconnectRef.current = false;
     }

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -46,7 +46,7 @@ import type { SessionSummary, SubscriptionQueueEvent, SessionUser, UserBoard } f
 import { execute } from '@boardsesh/graphql-client';
 import { buildBoardPath, parseBoardPath } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { JOIN_SESSION } from '@boardsesh/graphql/operations/queue-session';
+import { JOIN_SESSION, LEAVE_SESSION } from '@boardsesh/graphql/operations/queue-session';
 import { getWsClient } from '../lib/graphql/ws-client';
 import { getHttpClient } from '../lib/graphql/client';
 import {
@@ -108,7 +108,12 @@ type QueueContextValue = {
   setPlaylistSuggestionSource: (source: PlaylistSuggestionSource | null) => void;
   /** Refresh the suggestion source in place (no-op unless it matches the active one). */
   refreshPlaylistSuggestionSource: (source: PlaylistSuggestionSource) => void;
-  clearSession: () => Promise<void>;
+  /**
+   * Reset the active session locally. Pass `{ notifyServer: true }` on an
+   * intentional leave (e.g. switching sessions) to emit LEAVE_SESSION so peers
+   * see the departure immediately instead of after the disconnect grace timer.
+   */
+  clearSession: (options?: { notifyServer?: boolean }) => Promise<void>;
   endSession: () => Promise<SessionSummary | null>;
   /**
    * Explicitly create a session with optional config (name, goal, etc.).
@@ -529,7 +534,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   showToastRef.current = showToast;
   const tRef = useRef(t);
   tRef.current = t;
-  const clearSessionRef = useRef<() => Promise<void>>(async () => {});
+  const clearSessionRef = useRef<(options?: { notifyServer?: boolean }) => Promise<void>>(async () => {});
   const locallyEndingSessionIdRef = useRef<string | null>(null);
   const suppressedRemoteEndSessionIdRef = useRef<string | null>(null);
 
@@ -1423,7 +1428,22 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     );
   }, []);
 
-  const clearSession = useCallback(async () => {
+  const clearSession = useCallback(async (options?: { notifyServer?: boolean }) => {
+    // When the user intentionally leaves a session (switching into another via
+    // the join-confirm dialog), tell the backend so peers see them leave NOW —
+    // the driver/presence release shouldn't wait on the 60s disconnect grace
+    // timer. Best-effort and BEFORE we reset local state, so the WS registration
+    // for the old session is still alive: a failed/timed-out leave degrades to
+    // the prior disconnect-grace behavior. Default false keeps every other
+    // caller (remote SessionEnded, endSession) unchanged. Mirrors web's
+    // sendLeaveOnCleanup in use-session-lifecycle.ts.
+    if (options?.notifyServer && sessionIdRef.current) {
+      try {
+        await execute(getWsClient(), { query: LEAVE_SESSION }, 5000);
+      } catch (error) {
+        if (__DEV__) console.warn('[queue] leaveSession on switch failed', error);
+      }
+    }
     sessionIdRef.current = null;
     setSessionId(null);
     dispatch({

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -55,11 +55,13 @@ import {
   CREATE_SESSION,
   END_SESSION,
   GET_CLIMB,
+  GET_SESSION_QUEUE_STATE,
   type CreateSessionMutationResponse,
   type EndSessionMutationResponse,
   type SessionUpdateEvent,
   type SessionLiveStatsEvent,
   type GetClimbQueryResponse,
+  type GetSessionQueueStateQueryResponse,
 } from '../lib/graphql/operations';
 import { getStoredActiveBoard } from '../lib/active-board-store';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
@@ -389,6 +391,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const participantIdRef = useRef<string | null>(null);
   const unsubscribeRef = useRef<(() => void) | null>(null);
   const wallControlOperationRef = useRef(0);
+  // Single-flight guard for resyncQueueFromServer: a failed mutation in a party
+  // session refetches the authoritative queue, but several deltas can fail in a
+  // burst (e.g. clearQueue removes N items, the WS is down). Coalesce them into
+  // one in-flight fetch so we don't hammer the server or thrash the reducer.
+  const resyncInFlightRef = useRef(false);
 
   // The active board is the angle source of truth. Read it here so the
   // self-healing re-grade effect can compare each queued climb's display angle
@@ -899,6 +906,60 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     [],
   );
 
+  // Reconcile the local queue against the server's authoritative snapshot after
+  // a party-session mutation fails. The optimistic reducer delta already applied
+  // locally, so on failure (a 4xx, a dropped WS frame) this client's queue would
+  // silently diverge from peers until the next reconnect FullSync. Refetch the
+  // session's queueState over HTTP and replace state with INITIAL_QUEUE_DATA.
+  // Single-flight (a burst of failed deltas coalesces into one fetch) and a true
+  // no-op in solo (no session → nothing authoritative to reconcile against, the
+  // local queue IS the source of truth). The fetch itself failing is swallowed:
+  // we tried, the reducer keeps the optimistic state, and the next successful
+  // mutation or reconnect FullSync reconciles. Returns whether a refresh ran.
+  const resyncQueueFromServer = useCallback(async (): Promise<boolean> => {
+    const activeSessionId = sessionIdRef.current;
+    if (!activeSessionId) return false;
+    if (resyncInFlightRef.current) return false;
+    resyncInFlightRef.current = true;
+    try {
+      const response = await getHttpClient().request<GetSessionQueueStateQueryResponse>(GET_SESSION_QUEUE_STATE, {
+        sessionId: activeSessionId,
+      });
+      // The session may have ended (or we switched sessions) while the fetch was
+      // in flight — only apply when it's still the active one.
+      if (sessionIdRef.current !== activeSessionId) return false;
+      const queueState = response.session?.queueState;
+      if (!queueState) return false;
+      dispatch({
+        type: 'INITIAL_QUEUE_DATA',
+        payload: {
+          queue: queueState.queue.map(toClimbQueueItem),
+          currentClimbQueueItem: queueState.currentClimbQueueItem
+            ? toClimbQueueItem(queueState.currentClimbQueueItem)
+            : null,
+        },
+      });
+      return true;
+    } catch (error) {
+      if (__DEV__) console.warn('[queue] resyncQueueFromServer failed', error);
+      return false;
+    } finally {
+      resyncInFlightRef.current = false;
+    }
+  }, []);
+  const resyncQueueFromServerRef = useRef(resyncQueueFromServer);
+  resyncQueueFromServerRef.current = resyncQueueFromServer;
+
+  // After a queue mutation fails in a party session, reconcile against the
+  // server and tell the user their queue was refreshed. In solo (no session)
+  // the local queue is authoritative, so keep the existing best-effort
+  // behaviour: dev-log only, no resync, no toast.
+  const resyncQueueAfterMutationFailure = useCallback(async () => {
+    if (!sessionIdRef.current) return;
+    const refreshed = await resyncQueueFromServerRef.current();
+    if (refreshed) showToast(t('mobile.queue.outOfSyncRefreshed'), 'error');
+  }, [showToast, t]);
+
   const takeControl = useCallback(
     async (item?: ClimbQueueItem | null, options?: TakeControlOptions) => {
       if (!sessionIdRef.current) {
@@ -1115,6 +1176,17 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     };
   }, [state.queue, state.currentClimbQueueItem, activeBoard]);
 
+  // The reducer raises `needsResync` when it filters corrupted (null) items out
+  // of a server FullSync/UPDATE_QUEUE — the local queue is now known-stale.
+  // Mirror web (use-queue-event-subscription): in a party session, clear the
+  // flag and refetch the authoritative snapshot. No toast — this is silent
+  // corruption recovery, not a user-action failure.
+  useEffect(() => {
+    if (!state.needsResync || !sessionIdRef.current) return;
+    dispatch({ type: 'CLEAR_RESYNC_FLAG' });
+    void resyncQueueFromServerRef.current();
+  }, [state.needsResync]);
+
   const addToQueue = useCallback(
     (item: ClimbQueueItem) => {
       // Optimistic local dispatch is the source of truth for the user's queue.
@@ -1134,11 +1206,14 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       });
       mutations.addQueueItem(item).catch((error) => {
         if (__DEV__) console.warn('[queue] addQueueItem sync failed', error);
+        // In a party session the add never reached peers — reconcile against the
+        // server so this client doesn't silently diverge. Solo is a true no-op.
+        void resyncQueueAfterMutationFailure();
       });
       // Surface the "Climb added to queue · Open" snackbar for every add path.
       showQueueAddedSnackbar();
     },
-    [mutations, showQueueAddedSnackbar],
+    [mutations, resyncQueueAfterMutationFailure, showQueueAddedSnackbar],
   );
 
   const removeFromQueue = useCallback(
@@ -1157,9 +1232,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       });
       mutations.removeQueueItem(uuid).catch((error) => {
         if (__DEV__) console.warn('[queue] removeQueueItem sync failed', error);
+        // The remove never reached peers in a party session — reconcile so the
+        // dropped item doesn't linger on peers (or come back here). Solo no-ops.
+        void resyncQueueAfterMutationFailure();
       });
     },
-    [mutations],
+    [mutations, resyncQueueAfterMutationFailure],
   );
 
   const reorderQueue = useCallback(
@@ -1195,14 +1273,16 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     dispatch({ type: 'CLEAR_QUEUE' });
     track(SHARED_EVENTS.QueueCleared, { layoutId: activeBoardRef.current?.layoutId, totalCount: itemsToRemove.length });
     setPlaylistSuggestionSourceState(null);
-    // Surface at most one toast if any removal fails — a persistent join
-    // failure would otherwise toast once per queued item.
+    // If any per-item remove fails in a party session, the cleared items may
+    // still live on peers — reconcile once against the server (single-flight
+    // coalesces the burst) and tell the user we refreshed. Solo: the local
+    // clear is authoritative, so resync no-ops and no toast fires.
     void Promise.allSettled(itemsToRemove.map((item) => mutations.removeQueueItem(item.uuid))).then((results) => {
       if (results.some((result) => result.status === 'rejected')) {
-        showToast(t('mobile.queue.actionFailed'), 'error');
+        void resyncQueueAfterMutationFailure();
       }
     });
-  }, [mutations, showToast, t]);
+  }, [mutations, resyncQueueAfterMutationFailure]);
 
   // Replace the whole queue in one shot: optimistic local UPDATE_QUEUE (the
   // source of truth for the user's queue) + a best-effort SET_QUEUE sync that
@@ -1235,10 +1315,18 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       });
       coordinator.trackPendingMutation(correlationId);
       mutations.setCurrentClimb(item, shouldAddToQueue, correlationId).catch(() => {
-        showToast(t('mobile.queue.actionFailed'), 'error');
+        // In a party session the current-climb change never reached peers —
+        // reconcile against the server (and toast that we refreshed) so this
+        // client's current climb can't silently diverge. Solo keeps the prior
+        // best-effort "Action failed" toast (there's no server to reconcile).
+        if (sessionIdRef.current) {
+          void resyncQueueAfterMutationFailure();
+        } else {
+          showToast(t('mobile.queue.actionFailed'), 'error');
+        }
       });
     },
-    [coordinator, mutations, showToast, t],
+    [coordinator, mutations, resyncQueueAfterMutationFailure, showToast, t],
   );
 
   const setCurrentClimb = useCallback(

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -1120,6 +1120,18 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     };
     state.queue.forEach(consider);
     consider(state.currentClimbQueueItem);
+    // Also re-grade the single displayed playlist peek (the next-up suggestion
+    // shown at the queue tail). It lives in playlistSuggestionSource.climbs —
+    // NOT in state.queue — so the queue-only pass above never touches it, and
+    // the bar/drawer would keep showing the activation-angle grade until the
+    // peek is committed. Only the next-up climb is ever displayed, so re-grade
+    // that one alone; re-grading the whole source could be hundreds of climbs.
+    const peekItem = findNextQueueItemWithSuggestions(
+      state.queue,
+      state.currentClimbQueueItem,
+      playlistSuggestionSourceRef.current,
+    );
+    if (peekItem && isPlaylistPeekQueueItemUuid(peekItem.uuid)) consider(peekItem);
     if (uuids.size === 0) return undefined;
 
     const targetUuids = [...uuids];
@@ -1168,13 +1180,30 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       }
       if (Object.keys(grades).length > 0) {
         dispatch({ type: 'REGRADE_CLIMBS', payload: { grades } });
+        // REGRADE_CLIMBS only patches the reducer's queue + current item. The
+        // displayed peek lives in the provider-state suggestion source, so patch
+        // its climbs here too (same patch map) — otherwise the next-up grade pill
+        // keeps the old angle until the peek is committed. Idempotent: skips
+        // climbs already at the live angle, and preserves the prev reference when
+        // nothing changes so this never churns the source state.
+        setPlaylistSuggestionSourceState((prev) => {
+          if (!prev) return prev;
+          let changed = false;
+          const climbs = prev.climbs.map((climb) => {
+            const patch = grades[climb.uuid];
+            if (!patch || climb.angle === patch.angle) return climb;
+            changed = true;
+            return { ...climb, ...patch };
+          });
+          return changed ? { ...prev, climbs } : prev;
+        });
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [state.queue, state.currentClimbQueueItem, activeBoard]);
+  }, [state.queue, state.currentClimbQueueItem, activeBoard, playlistSuggestionSource]);
 
   // The reducer raises `needsResync` when it filters corrupted (null) items out
   // of a server FullSync/UPDATE_QUEUE — the local queue is now known-stale.

--- a/packages/shared/board-react/src/__tests__/use-mutate-tick.test.tsx
+++ b/packages/shared/board-react/src/__tests__/use-mutate-tick.test.tsx
@@ -13,6 +13,10 @@ const TICK_DEPENDENT_KEYS = [
   'logbook',
   'climb',
   'searchClimbs',
+  // The Sessions feed and session-detail cards aggregate from these caches and
+  // must refresh when a tick they contain is edited or deleted.
+  'sessionGroupedFeed',
+  'sessionDetail',
 ];
 
 const updateVars = {

--- a/packages/shared/board-react/src/__tests__/use-save-tick.test.tsx
+++ b/packages/shared/board-react/src/__tests__/use-save-tick.test.tsx
@@ -111,6 +111,29 @@ describe('useSaveTick (shared)', () => {
     expect(cache?.[0].uuid).toBe('real-77');
   });
 
+  it('invalidates the You-page feeds on success so a new tick appears in Logbook and Sessions', async () => {
+    const executeHttp = vi.fn().mockResolvedValue({ saveTick: savedTick({ uuid: 'real-feed' }) });
+    const { wrapper, queryClient } = createWrapper({ executeHttp: executeHttp as unknown as ExecuteHttp });
+    queryClient.setQueryData(accumulatedLogbookQueryKey('kilter'), []);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useSaveTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(tickOptions());
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const roots = invalidateSpy.mock.calls.map(
+      (call) => (call[0] as { queryKey?: unknown[] } | undefined)?.queryKey?.[0],
+    );
+    // Matches the edit/delete path: a freshly logged tick must refresh the
+    // Logbook tab feed and the Sessions feed/detail, not just the stats charts.
+    expect(roots).toContain('userAscentsFeed');
+    expect(roots).toContain('sessionGroupedFeed');
+    expect(roots).toContain('sessionDetail');
+  });
+
   it('rolls back the optimistic entry on error', async () => {
     const executeHttp = vi.fn().mockRejectedValue(new Error('Server exploded'));
     const { wrapper, queryClient } = createWrapper({ executeHttp: executeHttp as unknown as ExecuteHttp });

--- a/packages/shared/board-react/src/use-mutate-tick.ts
+++ b/packages/shared/board-react/src/use-mutate-tick.ts
@@ -21,6 +21,12 @@ function invalidateTickDependents(queryClient: QueryClient) {
   void queryClient.invalidateQueries({ queryKey: ['logbook'] });
   void queryClient.invalidateQueries({ queryKey: ['climb'] });
   void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
+  // The Sessions feed and session-detail screens aggregate sends/flashes/grade
+  // pyramids straight from these caches; without busting them, editing or
+  // deleting a tick leaves those cards showing stale totals until an unrelated
+  // refetch (pull-to-refresh, remount past staleTime, or a comment add).
+  void queryClient.invalidateQueries({ queryKey: ['sessionGroupedFeed'] });
+  void queryClient.invalidateQueries({ queryKey: ['sessionDetail'] });
 }
 
 /** Edit an existing tick (status / grade / quality / attempts / comment). */

--- a/packages/shared/board-react/src/use-save-tick.ts
+++ b/packages/shared/board-react/src/use-save-tick.ts
@@ -117,6 +117,14 @@ export function useSaveTick(boardName: BoardName | null) {
       void queryClient.invalidateQueries({ queryKey: ['climb'] });
       void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
 
+      // The You-page Logbook tab feed and the Sessions feed/detail are separate
+      // cache families from the optimistically-updated accumulated logbook, so
+      // a new tick won't appear there without busting them. Matches the
+      // edit/delete path (use-mutate-tick) — the create path was missing these.
+      void queryClient.invalidateQueries({ queryKey: ['userAscentsFeed'] });
+      void queryClient.invalidateQueries({ queryKey: ['sessionGroupedFeed'] });
+      void queryClient.invalidateQueries({ queryKey: ['sessionDetail'] });
+
       if (options.videoUrl) {
         void queryClient.invalidateQueries({
           queryKey: ['betaLinks', boardName, options.climbUuid],

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -101,6 +101,11 @@
     "orContinueWith": "or continue with",
     "networkError": "Could not reach Boardsesh. Check your connection and try again."
   },
+  "callback": {
+    "noTransferToken": "We didn't get a sign-in token. Head back and try again.",
+    "failed": "Sign in didn't go through. Head back and try again.",
+    "unexpectedError": "Something went wrong signing you in. Head back and try again."
+  },
   "metadata": {
     "login": {
       "title": "Login",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -150,6 +150,9 @@
     "savingToAppleHealth": "Saving to Apple Health…",
     "savedToAppleHealth": "Saved to Apple Health",
     "saveToAppleHealthRetry": "Save to Apple Health (retry)",
+    "loadErrorTitle": "Couldn't load your session",
+    "loadErrorMessage": "Your climbs are saved — the recap just didn't load. Try again or head back.",
+    "retry": "Try again",
     "minutes": "{{count}}min",
     "hours": "{{count}}h",
     "hoursAndMinutes": "{{hours}}h {{mins}}min"

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -422,6 +422,7 @@
     "triesCount_other": "{{count}} tries",
     "tickError": "Couldn't save your tick — it's saved as a draft",
     "shareError": "Couldn't share — try again",
+    "favoriteError": "Couldn't update your favorites — try again",
     "closeAria": "Close",
     "actionBar": {
       "previousAria": "Previous climb",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -292,6 +292,7 @@
       "removeClimb": "Remove climb",
       "positionLabel": "position {{position}}",
       "syncError": "Queue sync error",
+      "outOfSyncRefreshed": "Queue was out of sync. Refreshed from your crew.",
       "sessionCreateError": "Couldn't create session",
       "noBoardSelected": "Pick a board first",
       "actionFailed": "Action failed. Try again.",

--- a/packages/shared/i18n/locales/en-US/you.json
+++ b/packages/shared/i18n/locales/en-US/you.json
@@ -62,6 +62,9 @@
     },
     "logbook": {
       "empty": "Your logbook's empty — log your first send.",
+      "errorTitle": "Couldn't load your logbook",
+      "errorBody": "Check your connection and try again.",
+      "retry": "Try again",
       "editTitle": "Edit ascent",
       "statusLabel": "Status",
       "gradeLabel": "Grade",

--- a/packages/shared/i18n/locales/en-US/you.json
+++ b/packages/shared/i18n/locales/en-US/you.json
@@ -47,7 +47,8 @@
     "comments": {
       "title": "Comments",
       "empty": "No comments yet — start the conversation",
-      "placeholder": "Add a comment…"
+      "placeholder": "Add a comment…",
+      "sendError": "Couldn't post your comment. Give it another go."
     },
     "filter": {
       "title": "Filters",

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -101,6 +101,11 @@
     "orContinueWith": "o continúa con",
     "networkError": "No se pudo conectar con Boardsesh. Comprueba tu conexión e inténtalo de nuevo."
   },
+  "callback": {
+    "noTransferToken": "No recibimos un token de inicio de sesión. Vuelve e inténtalo otra vez.",
+    "failed": "El inicio de sesión no se completó. Vuelve e inténtalo otra vez.",
+    "unexpectedError": "Algo salió mal al iniciar tu sesión. Vuelve e inténtalo otra vez."
+  },
   "metadata": {
     "login": {
       "title": "Iniciar sesión",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -422,6 +422,7 @@
     "triesCount_other": "{{count}} intentos",
     "tickError": "No se pudo guardar tu marca — guardada como borrador",
     "shareError": "No se pudo compartir — inténtalo otra vez",
+    "favoriteError": "No se pudieron actualizar tus favoritos — inténtalo otra vez",
     "closeAria": "Cerrar",
     "actionBar": {
       "previousAria": "Bloque anterior",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -150,6 +150,9 @@
     "savingToAppleHealth": "Guardando en Apple Health…",
     "savedToAppleHealth": "Guardado en Apple Health",
     "saveToAppleHealthRetry": "Guardar en Apple Health (reintentar)",
+    "loadErrorTitle": "No se pudo cargar tu sesión",
+    "loadErrorMessage": "Tus vías están guardadas, solo falló el resumen. Inténtalo de nuevo o vuelve atrás.",
+    "retry": "Reintentar",
     "minutes": "{{count}}min",
     "hours": "{{count}}h",
     "hoursAndMinutes": "{{hours}}h {{mins}}min"

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -292,6 +292,7 @@
       "removeClimb": "Eliminar bloque",
       "positionLabel": "posición {{position}}",
       "syncError": "Error de sincronización de cola",
+      "outOfSyncRefreshed": "La cola estaba desincronizada. Se actualizó con tu grupo.",
       "sessionCreateError": "No se pudo crear la sesión",
       "noBoardSelected": "Selecciona un board primero",
       "actionFailed": "Acción fallida. Inténtalo de nuevo.",

--- a/packages/shared/i18n/locales/es/you.json
+++ b/packages/shared/i18n/locales/es/you.json
@@ -47,7 +47,8 @@
     "comments": {
       "title": "Comentarios",
       "empty": "Aún no hay comentarios — abre la conversación",
-      "placeholder": "Añade un comentario…"
+      "placeholder": "Añade un comentario…",
+      "sendError": "No se pudo publicar tu comentario. Inténtalo de nuevo."
     },
     "filter": {
       "title": "Filtros",

--- a/packages/shared/i18n/locales/es/you.json
+++ b/packages/shared/i18n/locales/es/you.json
@@ -62,6 +62,9 @@
     },
     "logbook": {
       "empty": "Tu historial está vacío — registra tu primer encadene.",
+      "errorTitle": "No se pudo cargar tu historial",
+      "errorBody": "Comprueba tu conexión e inténtalo de nuevo.",
+      "retry": "Inténtalo de nuevo",
       "editTitle": "Editar ascenso",
       "statusLabel": "Estado",
       "gradeLabel": "Grado",

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -101,6 +101,11 @@
     "orContinueWith": "ou continuez avec",
     "networkError": "Impossible de joindre Boardsesh. Vérifiez votre connexion et réessayez."
   },
+  "callback": {
+    "noTransferToken": "Nous n'avons pas reçu de jeton de connexion. Revenez en arrière et réessayez.",
+    "failed": "La connexion n'a pas abouti. Revenez en arrière et réessayez.",
+    "unexpectedError": "Un problème est survenu lors de votre connexion. Revenez en arrière et réessayez."
+  },
   "metadata": {
     "login": {
       "title": "Connexion",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -422,6 +422,7 @@
     "triesCount_other": "{{count}} essais",
     "tickError": "Impossible d'enregistrer ton tick. Sauvegardé en brouillon.",
     "shareError": "Impossible de partager — réessaie",
+    "favoriteError": "Impossible de mettre à jour tes favoris — réessaie",
     "closeAria": "Fermer",
     "actionBar": {
       "previousAria": "Bloc précédent",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -150,6 +150,9 @@
     "savingToAppleHealth": "Enregistrement dans Apple Santé…",
     "savedToAppleHealth": "Enregistré dans Apple Santé",
     "saveToAppleHealthRetry": "Enregistrer dans Apple Santé (réessayer)",
+    "loadErrorTitle": "Impossible de charger ta session",
+    "loadErrorMessage": "Tes voies sont enregistrées, seul le récap n'a pas chargé. Réessaie ou reviens en arrière.",
+    "retry": "Réessayer",
     "minutes": "{{count}} min",
     "hours": "{{count}} h",
     "hoursAndMinutes": "{{hours}} h {{mins}} min"

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -292,6 +292,7 @@
       "removeClimb": "Supprimer le bloc",
       "positionLabel": "position {{position}}",
       "syncError": "Erreur de synchronisation de la file",
+      "outOfSyncRefreshed": "La file était désynchronisée. Actualisée depuis ton groupe.",
       "sessionCreateError": "Impossible de créer la session",
       "noBoardSelected": "Choisissez d'abord un board",
       "actionFailed": "Action échouée. Réessayez.",

--- a/packages/shared/i18n/locales/fr/you.json
+++ b/packages/shared/i18n/locales/fr/you.json
@@ -47,7 +47,8 @@
     "comments": {
       "title": "Commentaires",
       "empty": "Aucun commentaire — lancez la discussion",
-      "placeholder": "Ajouter un commentaire…"
+      "placeholder": "Ajouter un commentaire…",
+      "sendError": "Impossible de publier ton commentaire. Réessaie."
     },
     "filter": {
       "title": "Filtres",

--- a/packages/shared/i18n/locales/fr/you.json
+++ b/packages/shared/i18n/locales/fr/you.json
@@ -62,6 +62,9 @@
     },
     "logbook": {
       "empty": "Ton carnet est vide — enregistre ta première croix.",
+      "errorTitle": "Impossible de charger ton carnet",
+      "errorBody": "Vérifie ta connexion et réessaie.",
+      "retry": "Réessaie",
       "editTitle": "Modifier la croix",
       "statusLabel": "Statut",
       "gradeLabel": "Cotation",

--- a/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
+++ b/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
@@ -196,6 +196,43 @@ describe('buildWeeklyBars', () => {
     expect(keys).toContain('2025-W1');
     expect(result.find((b) => b.key === '2024-W52')!.label).toContain("'24");
   });
+
+  // Regression: derive-view-model concatenates per-board tick arrays in
+  // BOARD_TYPES order (Object.values(...).flat()), each newest-first, so the
+  // combined array is NOT globally sorted. An early board (Kilter, 2024) whose
+  // oldest tick is newer than a later board's newest is impossible, but the
+  // reverse — an early board entirely older than a later board — makes
+  // entries[0] (treated as newest) older than entries[last] (treated as
+  // oldest), so first > last, the week loop never runs, and the whole chart
+  // disappears.
+  it('spans the full range for unsorted multi-board input (regression A5-you-profile-001)', () => {
+    // Kilter ticks from early 2024 (newest-first), then Tension ticks from
+    // late 2024 (newest-first) — concatenated, NOT globally sorted, and within
+    // the 52-week cap. Before the fix, entries[0] (treated as global-newest)
+    // was the Kilter March tick while entries[last] (treated as global-oldest)
+    // was the Tension October tick, so first > last and the loop produced no
+    // weeks → the whole chart returned null.
+    const kilterEarly2024 = [
+      makeEntry({ climbed_at: '2024-03-15T12:00:00Z', difficulty: 22 }),
+      makeEntry({ climbed_at: '2024-03-01T12:00:00Z', difficulty: 22 }),
+    ];
+    const tensionLate2024 = [
+      makeEntry({ climbed_at: '2024-10-15T12:00:00Z', difficulty: 16 }),
+      makeEntry({ climbed_at: '2024-10-01T12:00:00Z', difficulty: 16 }),
+    ];
+    const unsorted = [...kilterEarly2024, ...tensionLate2024];
+
+    const result = buildWeeklyBars(unsorted);
+    expect(result).not.toBeNull();
+    const keys = result!.map((b) => b.key);
+    // Range must cover both the March and October weeks, not collapse to empty.
+    expect(keys).toContain(
+      `${dayjs('2024-03-01T12:00:00Z').isoWeekYear()}-W${dayjs('2024-03-01T12:00:00Z').isoWeek()}`,
+    );
+    expect(keys).toContain(
+      `${dayjs('2024-10-15T12:00:00Z').isoWeekYear()}-W${dayjs('2024-10-15T12:00:00Z').isoWeek()}`,
+    );
+  });
 });
 
 describe('buildFlashRedpointBars', () => {

--- a/packages/shared/profile-stats/src/chart-builders.ts
+++ b/packages/shared/profile-stats/src/chart-builders.ts
@@ -150,9 +150,23 @@ export function buildWeeklyBars(
 
   const DEFAULT_MAX_WEEKS = 52;
   const allWeekKeys: string[] = [];
-  // Safe to drop the optional chain: `entries.length === 0` is handled above.
-  const first = parseTickTime(entries[entries.length - 1].climbed_at).startOf('isoWeek');
-  const last = parseTickTime(entries[0].climbed_at).endOf('isoWeek');
+  // `entries` is per-board tick arrays concatenated in BOARD_TYPES order
+  // (derive-view-model `Object.values(...).flat()`), each newest-first, so the
+  // combined array is NOT globally sorted. Derive the range from the true
+  // min/max timestamps rather than the array endpoints — otherwise multi-board
+  // logbooks can yield first > last (empty week loop → null chart). A single
+  // reduce pass avoids spread limits on huge logbooks.
+  let oldestMs = tickTimeMs(entries[0].climbed_at);
+  let newestMs = oldestMs;
+  for (const entry of entries) {
+    const ms = tickTimeMs(entry.climbed_at);
+    if (ms < oldestMs) oldestMs = ms;
+    if (ms > newestMs) newestMs = ms;
+  }
+  // `dayjs(ms)` is in local time (matching `parseTickTime`), so the isoWeek
+  // bounds line up with the per-entry week keys computed below.
+  const first = dayjs(oldestMs).startOf('isoWeek');
+  const last = dayjs(newestMs).endOf('isoWeek');
   let current = first;
   while (current.isBefore(last) || current.isSame(last)) {
     allWeekKeys.push(`${current.isoWeekYear()}-W${current.isoWeek()}`);

--- a/packages/shared/queue/src/types.ts
+++ b/packages/shared/queue/src/types.ts
@@ -41,6 +41,11 @@ export type Climb = {
   userAttempts?: number | null;
   created_at?: string | null;
   published_at?: string | null;
+  // Multi-frame playback metadata: how many snapshots the climb has and the
+  // setter-chosen per-frame pace (ms). Carried through queue conversion so
+  // multi-frame playback uses the setter's pace instead of DEFAULT_PACE_MS.
+  framesCount?: number | null;
+  framesPace?: number | null;
 };
 
 export type ClimbQueueItem = {


### PR DESCRIPTION
Pre-release bug audit of `packages/mobile`: a multi-agent sweep over every app surface plus the shared packages mobile consumes. 68 raw findings were triaged to 65 after dedup; **40 confirmed real** by adversarial verification, 22 rejected as false positives, 3 sent to product decisions. This PR lands **37 fixes**; 3 more confirmed findings were independently fixed upstream while the audit ran (#2674/#2675) and were dropped here after merging latest main. Every fix has a repro test that failed pre-fix (or documented manual QA where vitest can't reach), and every fixer was paired with a QA reviewer.

Fixes #2419.

## Highlights (P1s)

- **Party non-drivers could hijack the session from the bottom queue bar.** The always-visible bar's swipe + VoiceOver actions called `nextClimb()/previousClimb()` ungated, overwriting the driver's climb for everyone and re-lighting the wall. Now gated on `useIsPartyPreviewOnly` (handler, gesture shared-value, and a11y layers) — the one stepper 784f2a823 missed.
- **Failed queue mutations silently diverged from the party.** add/remove/clear/set-current now resync from `session.queueState` + toast on failure in a session (solo stays best-effort), plus web-parity `needsResync` handling.
- **Mirrored climbs could light the original holds.** With #2675's `holdsData` threading, this adds the web-parity refuse guard (alert + failure track instead of silently sending un-mirrored frames) — plus mirrored/frames fields carried through subscription payloads so reconnects stop dropping a peer's mirror flag.
- **Playlist adds failed server-side every time** (`id` passed where the backend matches `uuid`) and never invalidated playlist caches.
- **A SecureStore read rejection hung the splash forever**; checkAuth now releases as logged-out without wiping tokens.

## Everything else, by area

- **Queue/party**: angle-change regrade now patches the playlist peek; switching sessions tells the backend you left the old one (`LEAVE_SESSION`).
- **Play drawer**: favorite heart seeded from real server status with rollback on error (it used to open empty and could silently un-favorite); stats-history query gated on the angle sheet being open; QuickTickBar reads the prebuilt logbook index; speed scrubber stops firing `runOnJS` per frame.
- **BLE**: MoonBoard full-skip no longer clears the wall and reports success; disconnect rejections caught; `apiLevel`/`deviceNamePresent` added to connect analytics to size the v2-fallback risk.
- **Search/filters**: holds + zone filters now visible/clearable in the summary; zone screen uses the shared sanitizing parser; whitespace no longer yanked from the search field mid-typing.
- **Create-climb**: board switch remounts the editor (angle changes don't wipe paint); Clear resets the hidden No-match toggle; debounced autosave flushes on background/close.
- **Discover/playlists**: fetch errors no longer masquerade as "no playlists yet" (hub + detail get retry states); playlists created from Discover appear in the picker immediately.
- **You page**: weekly chart no longer vanishes for multi-board users; logging/editing ticks refreshes the feeds; sessions feed deduped across pages; recency buckets re-evaluate on focus; failed comments keep the draft + toast instead of eating it.
- **Sessions**: summary screen gets a settled error state; rejected Live Activity starts tear down the native socket.
- **Auth/shell**: OAuth callback fully localized with raw server text dropped (supersedes the partial #2673 version; its dead keys removed); `BluetoothProvider` no longer remounts the whole tree when the active board hydrates.
- **Images**: discovery cards render the 416px thumb variant instead of decoding full-res board art into 168px cells (the production App-Hang class).

## Validation

- `vp run typecheck:mobile` / `:shared` / `:backend` — clean
- `vp run test:mobile` (217 files / 1534 tests), `--project web`, `--project backend` — green
- `vp check` — only the 16 pre-existing formatting failures already on main (zero overlap with this diff)
- `vp run check:mobile-bundle` — green
- macOS-only simulator/screenshot checks not run (Linux host); all changes are JS-only, so EAS OTA preview covers device QA
- Recommended device QA: two-phone party (non-driver bar swipe must not change the shared climb; mirror toggle on a Tension wall must light mirrored holds); cold start with keychain locked; add-to-playlist round trip

## Not in this PR

- Deferred (medium-risk or needs decisions), filed as issues: #2683 (cold-start session resurrect), #2684/#2685 (auth cleanup paths), #2686 (dead BLE code), #2687 (can't paint holds while zoomed — verified real, needs gesture-design call), #2688 (Mini MoonBoard 2020 wrong dims), #2689 (playlist detail board context), #2690 (backend `framesCount`/`framesPace` columns).
- GH #2646 and #2649 turned out to be web-side bugs, not mobile (the #2646 web fix is a one-line `!success` check in `light-control-drawer.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
