### PR TITLE
[codex] Fix mobile session setup scrolling

### DIFF
--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -127,7 +127,15 @@ describe('TabLayout', () => {
     expect(container.querySelector('[data-tabs="true"]')?.getAttribute('data-minimize-behavior')).toBe('onScrollDown');
   });
 
-  it('only mounts the native bottom accessory when that path is active', () => {
+  it('mounts the native bottom accessory when that path is active', () => {
+    const { container } = render(<TabLayout />);
+
+    const accessorySlot = container.querySelector('[data-bottom-accessory="true"]');
+    expect(accessorySlot).not.toBeNull();
+    expect(accessorySlot?.querySelector('[data-accessory="true"]')).not.toBeNull();
+  });
+
+  it('skips the native bottom accessory when that path is inactive', () => {
     cfg.nativeAccessoryActive = false;
 
     const { container } = render(<TabLayout />);

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -6,6 +6,18 @@ import { createElement, type ReactNode } from 'react';
 const cfg = vi.hoisted(() => ({
   bluetoothConnected: false,
   sessionId: null as string | null,
+  nativeAccessoryActive: true,
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
+  platformOS: 'ios' as 'ios' | 'android',
+  materialScreens: [] as Array<{ name: string; options?: { lazy?: boolean } }>,
+}));
+
+vi.mock('react-native', () => ({
+  Platform: {
+    get OS() {
+      return cfg.platformOS;
+    },
+  },
 }));
 
 vi.mock('react-i18next', () => ({
@@ -29,13 +41,30 @@ vi.mock('../../../src/theme/colors', () => ({
 }));
 
 vi.mock('../../../src/providers/theme-provider', () => ({
-  useTheme: () => ({ variant: 'liquidGlass' }),
+  useTheme: () => ({ variant: cfg.variant }),
+}));
+
+vi.mock('../../../src/hooks/use-bottom-accessory', () => ({
+  useNativeAccessoryActive: () => cfg.nativeAccessoryActive,
 }));
 
 // Stub the Material-variant path so it doesn't pull in native modules.
-vi.mock('expo-router', () => ({
-  Tabs: ({ children }: { children?: ReactNode }) => createElement('nav', { 'data-tabs-material': 'true' }, children),
-}));
+vi.mock('expo-router', () => {
+  const Tabs = Object.assign(
+    ({ children }: { children?: ReactNode }) => createElement('nav', { 'data-tabs-material': 'true' }, children),
+    {
+      Screen: ({ name, options }: { name: string; options?: { lazy?: boolean } }) => {
+        const screen = { name, options };
+        const existingIndex = cfg.materialScreens.findIndex((entry) => entry.name === name);
+        if (existingIndex === -1) cfg.materialScreens.push(screen);
+        else cfg.materialScreens[existingIndex] = screen;
+        return null;
+      },
+    },
+  );
+
+  return { Tabs };
+});
 
 vi.mock('../../../src/components/navigation/MaterialTabBar', () => ({
   MaterialTabBar: () => createElement('nav', { 'data-material-tab-bar': 'true' }),
@@ -75,6 +104,10 @@ describe('TabLayout', () => {
   beforeEach(() => {
     cfg.bluetoothConnected = false;
     cfg.sessionId = null;
+    cfg.nativeAccessoryActive = true;
+    cfg.variant = 'liquidGlass';
+    cfg.platformOS = 'ios';
+    cfg.materialScreens = [];
   });
 
   it('lands on the climbs tab by default', () => {
@@ -92,6 +125,31 @@ describe('TabLayout', () => {
     const { container } = render(<TabLayout />);
 
     expect(container.querySelector('[data-tabs="true"]')?.getAttribute('data-minimize-behavior')).toBe('onScrollDown');
+  });
+
+  it('only mounts the native bottom accessory when that path is active', () => {
+    cfg.nativeAccessoryActive = false;
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-bottom-accessory="true"]')).toBeNull();
+  });
+
+  it('keeps the Record tab lazy outside Android dev builds', () => {
+    cfg.variant = 'material';
+
+    render(<TabLayout />);
+
+    expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options?.lazy).not.toBe(false);
+  });
+
+  it('eager-mounts the Record tab on Android dev builds', () => {
+    cfg.variant = 'material';
+    cfg.platformOS = 'android';
+
+    render(<TabLayout />);
+
+    expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options).toMatchObject({ lazy: false });
   });
 
   it('renders the Record badge when a session is active', () => {

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from 'react';
-import type { ColorValue } from 'react-native';
+import { Platform, type ColorValue } from 'react-native';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import { Tabs } from 'expo-router';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
@@ -10,6 +10,7 @@ import { QueueBottomAccessory } from '../../src/components/queue-control/QueueBo
 import { MaterialTabBar } from '../../src/components/navigation/MaterialTabBar';
 import { useTheme } from '../../src/providers/theme-provider';
 import { brandColors } from '../../src/theme/colors';
+import { useNativeAccessoryActive } from '../../src/hooks/use-bottom-accessory';
 
 // Cold-start on the climbs list (our search surface), not the boards tab — board
 // switching is rare, so the filtered climb list is the home base. Drives the
@@ -40,6 +41,7 @@ export default function TabLayout() {
   const { t: tPlaylists } = useTranslation('playlists');
   const { t: tSession } = useTranslation('session');
   const { variant } = useTheme();
+  const nativeAccessoryActive = useNativeAccessoryActive();
 
   // Record-tab status cue: a badge when a board is connected over Bluetooth or a
   // session is live.
@@ -49,6 +51,7 @@ export default function TabLayout() {
   // on every queue mutation. useQueueSessionId only changes on session start/end.
   const { sessionId } = useQueueSessionId();
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
+  const eagerMountRecord = __DEV__ && Platform.OS === 'android';
 
   if (variant === 'material') {
     return (
@@ -63,6 +66,9 @@ export default function TabLayout() {
             title: tSession('mobile.session.recordTab'),
             tabBarIcon: materialTabIcon('record-circle', 'record-circle-outline'),
             tabBarBadge: showRecordBadge ? '' : undefined,
+            // Android Fast Refresh can stall the first lazy mount of this nested
+            // stack in Metro. Keep production cold start lazy.
+            lazy: eagerMountRecord ? false : undefined,
           }}
         />
         <Tabs.Screen
@@ -89,9 +95,11 @@ export default function TabLayout() {
     // lives in patches/react-native-screens@4.25.2.patch. `vp run check:mobile-patches`
     // (CI) fails the build if that patch ever stops applying after a dep bump.
     <NativeTabs minimizeBehavior="onScrollDown">
-      <NativeTabs.BottomAccessory>
-        <QueueBottomAccessory />
-      </NativeTabs.BottomAccessory>
+      {nativeAccessoryActive ? (
+        <NativeTabs.BottomAccessory>
+          <QueueBottomAccessory />
+        </NativeTabs.BottomAccessory>
+      ) : null}
 
       <NativeTabs.Trigger name="climbs" role="search">
         <NativeTabs.Trigger.Icon sf="magnifyingglass" md="search" />

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -7,12 +7,15 @@ import type { ClimbQueueItem } from '@boardsesh/queue';
 // Hoisted, per-test-configurable view of the global state the bar reads.
 const cfg = vi.hoisted(() => ({
   onClimbsTab: true,
+  insideTabs: true,
   currentClimbQueueItem: { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem | null,
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
   measuredTabBarHeight: null as number | null,
+  nativeAccessoryActive: false,
 }));
 
 vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
 }));
@@ -34,7 +37,7 @@ vi.mock('react-native-safe-area-context', () => ({
 vi.mock('expo-router', () => ({ useSegments: () => [] }));
 vi.mock('../../../lib/route-segments', () => ({
   isClimbsTabRoute: () => cfg.onClimbsTab,
-  isTabsRoute: () => false,
+  isTabsRoute: () => cfg.insideTabs,
 }));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: { currentClimbQueueItem: cfg.currentClimbQueueItem } }),
@@ -67,7 +70,7 @@ vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ variant
 // reads now (variant-aware); the capability function stays for other callers.
 vi.mock('../../../hooks/use-bottom-accessory', () => ({
   isBottomAccessoryAvailable: () => false,
-  useNativeAccessoryActive: () => false,
+  useNativeAccessoryActive: () => cfg.nativeAccessoryActive,
 }));
 vi.mock('../ClimbCapsule', () => ({
   ClimbCapsule: ({
@@ -102,9 +105,11 @@ import { PersistentQueueBar } from '../persistent-queue-bar';
 describe('PersistentQueueBar', () => {
   beforeEach(() => {
     cfg.onClimbsTab = true;
+    cfg.insideTabs = true;
     cfg.currentClimbQueueItem = { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem;
     cfg.variant = 'liquidGlass';
     cfg.measuredTabBarHeight = null;
+    cfg.nativeAccessoryActive = false;
   });
 
   it('renders nothing when no climb is current', () => {
@@ -115,6 +120,26 @@ describe('PersistentQueueBar', () => {
 
   it('shows the capsule and standalone tick when a climb is current', () => {
     const { container } = render(<PersistentQueueBar />);
+    expect(container.querySelector('[data-capsule]')).not.toBeNull();
+    expect(container.querySelector('[data-tick]')).not.toBeNull();
+  });
+
+  it('does not render the JS toolbar when the native bottom accessory is active', () => {
+    cfg.nativeAccessoryActive = true;
+    cfg.insideTabs = true;
+
+    const { container } = render(<PersistentQueueBar />);
+
+    expect(container.querySelector('[data-capsule]')).toBeNull();
+    expect(container.querySelector('[data-tick]')).toBeNull();
+  });
+
+  it('keeps the JS toolbar fallback outside tabs when the native accessory path is active', () => {
+    cfg.nativeAccessoryActive = true;
+    cfg.insideTabs = false;
+
+    const { container } = render(<PersistentQueueBar />);
+
     expect(container.querySelector('[data-capsule]')).not.toBeNull();
     expect(container.querySelector('[data-tick]')).not.toBeNull();
   });

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -429,7 +429,7 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
 
   const [showEndSession, setShowEndSession] = useState(false);
   const [isEnding, setIsEnding] = useState(false);
-  const footerBottomPadding = bottomChrome.scrollBottomPadding + spacing[3];
+  const footerBottomPadding = bottomChrome.fixedFooterBottom + spacing[3];
 
   const handleConfirmEnd = useCallback(async () => {
     setIsEnding(true);
@@ -530,7 +530,10 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
     <View style={styles.container}>
       {scrollView}
 
-      <View style={[styles.footer, { backgroundColor: systemColors.background, paddingBottom: footerBottomPadding }]}>
+      <View
+        testID="in-session-footer"
+        style={[styles.footer, { backgroundColor: systemColors.background, paddingBottom: footerBottomPadding }]}
+      >
         <Button
           title={t('mobile.session.inEndSession')}
           onPress={() => setShowEndSession(true)}

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -33,6 +33,7 @@ import { springs } from '../../../theme/animations';
 import { borderRadius, spacing } from '../../../theme/tokens';
 import { gradeBadgeColor } from '../../you/profile-chart-colors';
 import { hapticSelection } from '../../../lib/haptics';
+import { SESSION_FOOTER_CLEARANCE } from '../session-footer-clearance';
 import { SessionAnalytics } from './SessionAnalytics';
 import { SessionLeaderboard } from './SessionLeaderboard';
 import { SessionPresenceRow } from './SessionPresenceRow';
@@ -517,7 +518,7 @@ export function InSessionView({ translateY, screenHeight }: InSessionViewProps) 
       contentContainerStyle={{
         paddingHorizontal: spacing[4],
         paddingTop: spacing[2],
-        paddingBottom: 100 + footerBottomPadding,
+        paddingBottom: SESSION_FOOTER_CLEARANCE + footerBottomPadding,
       }}
       showsVerticalScrollIndicator={false}
       onScroll={handleScroll}

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const footer = vi.hoisted(() => ({
+  styles: [] as unknown[],
+}));
+
+const bottomChrome = vi.hoisted(() => ({
+  metrics: {
+    fixedFooterBottom: 88,
+  },
+}));
+
+vi.mock('react-native', () => ({
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  View: ({ children, testID, style }: { children?: ReactNode; testID?: string; style?: unknown }) => {
+    if (testID === 'in-session-footer') {
+      footer.styles = Array.isArray(style) ? style : [style];
+    }
+    return createElement('div', testID ? { 'data-testid': testID } : null, children);
+  },
+}));
+
+vi.mock('react-native-gesture-handler', () => ({
+  Gesture: {
+    Pan: () => ({
+      activeOffsetY: () => ({
+        onStart: () => ({
+          onUpdate: () => ({
+            onEnd: () => ({}),
+          }),
+        }),
+      }),
+    }),
+  },
+  GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  useSharedValue: (value: number) => ({ value }),
+  withSpring: (value: number) => value,
+}));
+
+vi.mock('@shopify/flash-list', () => ({
+  FlashList: ({
+    ListHeaderComponent,
+    ListFooterComponent,
+  }: {
+    ListHeaderComponent?: ReactNode;
+    ListFooterComponent?: ReactNode;
+  }) => createElement('div', null, ListHeaderComponent, ListFooterComponent),
+}));
+
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-uuid' }));
+vi.mock('expo-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ invalidateQueries: vi.fn() }) }));
+vi.mock('@boardsesh/queue-runtime', () => ({ deriveIsDriver: () => true }));
+vi.mock('@boardsesh/play-view', () => ({ formatGrade: (grade: string) => grade, getGradeTextColor: () => '#fff' }));
+vi.mock('../../../Button', () => ({ Button: () => createElement('button') }));
+vi.mock('../../../ClimbListItemContent', () => ({ ClimbListItemContent: () => null }));
+vi.mock('../../../EndSessionSheet', () => ({ EndSessionSheet: () => null }));
+vi.mock('../../../Icon', () => ({ Icon: () => null }));
+vi.mock('../../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      background: '#000',
+      secondaryBackground: '#111',
+      secondaryLabel: '#999',
+      separator: '#222',
+    },
+    brandColors: { success: '#0f0', warning: '#ff0' },
+  }),
+}));
+vi.mock('../../../../providers/queue-provider', () => ({
+  useQueueActions: () => ({ endSession: vi.fn(async () => null), setCurrentClimb: vi.fn() }),
+  useQueueLiveStats: () => ({ liveStats: null, sessionUsers: [] }),
+  useQueueSessionControls: () => ({
+    driverParticipantId: null,
+    participantId: 'participant-1',
+    sessionId: 'session-1',
+  }),
+}));
+vi.mock('../../../../providers/drawer-host-provider', () => ({ useDrawerHost: () => ({ openPlayDrawer: vi.fn() }) }));
+vi.mock('../../../../lib/graphql/hooks', () => ({
+  useSessionDetail: () => ({
+    data: { totalSends: 0, totalFlashes: 0, gradeDistribution: [], participants: [], hardestGrade: null, ticks: [] },
+  }),
+  useSessionSummary: () => ({ data: { startedAt: '2026-01-01T00:00:00.000Z' } }),
+}));
+vi.mock('../../../../lib/climb-to-queue-item', () => ({ climbToQueueItem: vi.fn() }));
+vi.mock('../../../../lib/playlists/board-details-for-playlist', () => ({ getBoardConfigForPlaylist: () => null }));
+vi.mock('../../../../lib/session-tick-mapping', () => ({ navigateToSessionClimb: vi.fn() }));
+vi.mock('../../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (grade: string | null) => grade, formatGradeByDifficultyId: () => null }),
+}));
+vi.mock('../../../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => bottomChrome.metrics,
+}));
+vi.mock('../../../../theme/colors', () => ({ withAlpha: (color: string) => color }));
+vi.mock('../../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#999' } }));
+vi.mock('../../../../theme/animations', () => ({ springs: { gentle: {} } }));
+vi.mock('../../../../theme/tokens', () => ({ borderRadius: { lg: 16 }, spacing: { 2: 8, 3: 12, 4: 16 } }));
+vi.mock('../../../you/profile-chart-colors', () => ({ gradeBadgeColor: () => '#fff' }));
+vi.mock('../../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+vi.mock('../SessionAnalytics', () => ({ SessionAnalytics: () => null }));
+vi.mock('../SessionLeaderboard', () => ({ SessionLeaderboard: () => null }));
+vi.mock('../SessionPresenceRow', () => ({ SessionPresenceRow: () => null }));
+
+import { InSessionView } from '../InSessionView';
+
+function getPaddingBottom(styles: unknown[]): number | null {
+  for (const style of styles) {
+    if (style == null || typeof style !== 'object' || Array.isArray(style)) continue;
+    const paddingBottom = (style as { paddingBottom?: unknown }).paddingBottom;
+    if (typeof paddingBottom === 'number') return paddingBottom;
+  }
+  return null;
+}
+
+describe('InSessionView footer', () => {
+  beforeEach(() => {
+    footer.styles = [];
+    bottomChrome.metrics = { fixedFooterBottom: 88 };
+  });
+
+  it('uses the fixed footer bottom metric for footer padding', () => {
+    render(createElement(InSessionView));
+
+    expect(getPaddingBottom(footer.styles)).toBe(100);
+  });
+});

--- a/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { useEffect, useMemo, type ReactNode } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { getGradesForBoard } from '@boardsesh/board-config';
@@ -218,6 +219,20 @@ function OptionChip({ label, active, onPress, accessibilityLabel }: OptionChipPr
   );
 }
 
+function ChipRail({ children }: { children: ReactNode }) {
+  return (
+    <ScrollView
+      horizontal
+      nestedScrollEnabled
+      showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+      contentContainerStyle={styles.chipRow}
+    >
+      {children}
+    </ScrollView>
+  );
+}
+
 /**
  * Workout-type selector. Off keeps the queue empty (user fills it manually);
  * any other choice pre-populates the queue from the shared `@boardsesh/playlist-generator`
@@ -386,7 +401,7 @@ export function GeneratorPickerCard({
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.settingLabel}>
             {warmUpGroupLabel}
           </Text>
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipRow}>
+          <ChipRail>
             {WARM_UP_OPTIONS.map((warmUp) => (
               <OptionChip
                 key={warmUp}
@@ -399,7 +414,7 @@ export function GeneratorPickerCard({
                 })}
               />
             ))}
-          </ScrollView>
+          </ChipRail>
         </View>
 
         {boardName != null ? (
@@ -407,7 +422,7 @@ export function GeneratorPickerCard({
             <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.settingLabel}>
               {targetGradeLabel}
             </Text>
-            <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipRow}>
+            <ChipRail>
               {gradeChoices.map((grade) => {
                 const isActive = grade.difficulty_id === options.targetGrade;
                 const gradeLabel = formatGrade(grade.difficulty_name) ?? grade.difficulty_name;
@@ -424,7 +439,7 @@ export function GeneratorPickerCard({
                   />
                 );
               })}
-            </ScrollView>
+            </ChipRail>
           </View>
         ) : null}
 
@@ -434,7 +449,7 @@ export function GeneratorPickerCard({
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.settingLabel}>
             {minAscentsGroupLabel}
           </Text>
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipRow}>
+          <ChipRail>
             {minAscentsOptions.map((minAscents) => {
               const label = t('mobile.session.preGeneratorMinAscentsOption', {
                 value: formatMinAscentsFilterCount(minAscents),
@@ -452,7 +467,7 @@ export function GeneratorPickerCard({
                 />
               );
             })}
-          </ScrollView>
+          </ChipRail>
         </View>
 
         <View style={styles.settingBlock}>
@@ -489,7 +504,7 @@ export function GeneratorPickerCard({
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.settingLabel}>
             {climbBiasGroupLabel}
           </Text>
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipRow}>
+          <ChipRail>
             {CLIMB_BIAS_OPTIONS.map((climbBias) => (
               <OptionChip
                 key={climbBias}
@@ -502,7 +517,7 @@ export function GeneratorPickerCard({
                 })}
               />
             ))}
-          </ScrollView>
+          </ChipRail>
         </View>
 
         {showTallClimbsFilter || showWideClimbsFilter ? (
@@ -537,7 +552,7 @@ export function GeneratorPickerCard({
         {t('mobile.session.preGeneratorLabel')}
       </Text>
 
-      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipRow}>
+      <ChipRail>
         {CHIP_VALUES.map((value) => {
           const isActive = value === activeType;
           const label = chipLabel(value, t);
@@ -554,7 +569,7 @@ export function GeneratorPickerCard({
             />
           );
         })}
-      </ScrollView>
+      </ChipRail>
 
       {renderGeneratorOptions()}
     </View>

--- a/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
@@ -20,6 +20,7 @@ import { useToast } from '../../../providers/toast-provider';
 import { useDrawerHost } from '../../../providers/drawer-host-provider';
 import { useBottomChromeMetrics } from '../../../hooks/use-bottom-chrome-metrics';
 import { reportError } from '../../../lib/sentry';
+import { SESSION_FOOTER_CLEARANCE } from '../session-footer-clearance';
 import { BoardSummaryCard } from './BoardSummaryCard';
 import { GeneratorPickerCard, type GeneratorSelection } from './GeneratorPickerCard';
 import { WorkoutPreviewRow } from './WorkoutPreviewRow';
@@ -234,11 +235,12 @@ export function PreSessionView() {
         renderItem={renderPreviewRow}
         keyExtractor={previewKeyExtractor}
         ListHeaderComponent={listHeader}
-        // FlashList exposes this prop in its public TS surface. Use a
+        // Supported in FlashList 2.3.1: typed in FlashListProps and consumed at
+        // runtime (useSecondaryProps wraps it via createAnimatedComponent). Use a
         // gesture-handler scroll host so Android nested chip rails keep their
         // horizontal gestures while the preview rows stay virtualized.
         renderScrollComponent={GestureScrollView}
-        contentContainerStyle={{ paddingBottom: 100 + footerBottomPadding }}
+        contentContainerStyle={{ paddingBottom: SESSION_FOOTER_CLEARANCE + footerBottomPadding }}
         showsVerticalScrollIndicator={false}
         nestedScrollEnabled
         keyboardShouldPersistTaps="handled"

--- a/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
+import { ScrollView as GestureScrollView } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
 import { toBoardName } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -162,7 +163,7 @@ export function PreSessionView() {
   const generatorPreviewReady =
     selection.type !== 'on' || (status === 'ready' && previewItems.length > 0 && refreshingUuids.size === 0);
   const canStart = activeBoard != null && !isStarting && generatorPreviewReady;
-  const footerBottomPadding = bottomChrome.scrollBottomPadding + spacing[3];
+  const footerBottomPadding = spacing[3] + bottomChrome.fixedFooterBottom;
 
   // Inline status copy shown above an empty preview (loading / no results /
   // error). When rows are already present a rebuild keeps them mounted, so these
@@ -179,53 +180,74 @@ export function PreSessionView() {
             ? t('mobile.session.preWorkoutPreviewEmpty')
             : null;
 
-  const listHeader = (
-    <View style={styles.header}>
-      <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.eyebrow}>
-        {t('mobile.session.headerStart')}
-      </Text>
+  const listHeader = useMemo(
+    () => (
+      <View style={styles.header}>
+        <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.eyebrow}>
+          {t('mobile.session.headerStart')}
+        </Text>
 
-      <BoardSummaryCard board={activeBoard ?? null} />
+        <BoardSummaryCard board={activeBoard ?? null} />
 
-      <GeneratorPickerCard
-        boardName={activeBoard ? toBoardName(activeBoard.boardType) : null}
-        layoutId={activeBoard?.layoutId ?? null}
-        sizeId={activeBoard?.sizeId ?? null}
-        angle={activeBoard?.angle ?? null}
-        selection={selection}
-        onChange={setSelection}
-      />
+        <GeneratorPickerCard
+          boardName={activeBoard ? toBoardName(activeBoard.boardType) : null}
+          layoutId={activeBoard?.layoutId ?? null}
+          sizeId={activeBoard?.sizeId ?? null}
+          angle={activeBoard?.angle ?? null}
+          selection={selection}
+          onChange={setSelection}
+        />
 
-      {showPreviewSection ? (
-        <View style={styles.previewSection}>
-          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
-            {t('mobile.session.preWorkoutPreviewTitle')}
-          </Text>
-          {previewStateMessage ? (
-            <View style={[styles.stateCard, { backgroundColor: systemColors.secondaryBackground }]}>
-              <Text variant="body" color={systemColors.secondaryLabel}>
-                {previewStateMessage}
-              </Text>
-            </View>
-          ) : null}
-        </View>
-      ) : null}
-    </View>
+        {showPreviewSection ? (
+          <View style={styles.previewSection}>
+            <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
+              {t('mobile.session.preWorkoutPreviewTitle')}
+            </Text>
+            {previewStateMessage ? (
+              <View style={[styles.stateCard, { backgroundColor: systemColors.secondaryBackground }]}>
+                <Text variant="body" color={systemColors.secondaryLabel}>
+                  {previewStateMessage}
+                </Text>
+              </View>
+            ) : null}
+          </View>
+        ) : null}
+      </View>
+    ),
+    [
+      activeBoard,
+      previewStateMessage,
+      selection,
+      setSelection,
+      showPreviewSection,
+      systemColors.secondaryBackground,
+      systemColors.secondaryLabel,
+      t,
+    ],
   );
 
   return (
     <View style={styles.container}>
       <FlashList
-        style={styles.list}
+        style={styles.scroll}
         data={previewItems}
         renderItem={renderPreviewRow}
         keyExtractor={previewKeyExtractor}
         ListHeaderComponent={listHeader}
+        // FlashList exposes this prop in its public TS surface. Use a
+        // gesture-handler scroll host so Android nested chip rails keep their
+        // horizontal gestures while the preview rows stay virtualized.
+        renderScrollComponent={GestureScrollView}
         contentContainerStyle={{ paddingBottom: 100 + footerBottomPadding }}
         showsVerticalScrollIndicator={false}
+        nestedScrollEnabled
+        keyboardShouldPersistTaps="handled"
       />
 
-      <View style={[styles.footer, { backgroundColor: systemColors.background, paddingBottom: footerBottomPadding }]}>
+      <View
+        testID="pre-session-footer"
+        style={[styles.footer, { backgroundColor: systemColors.background, paddingBottom: footerBottomPadding }]}
+      >
         <Button
           title={isStarting ? t('mobile.session.preStarting') : t('mobile.session.preStart')}
           onPress={() => void handleStart()}
@@ -243,7 +265,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  list: {
+  scroll: {
     flex: 1,
   },
   header: {

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/generator-picker-card-analytics.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/generator-picker-card-analytics.test.tsx
@@ -11,12 +11,32 @@ const analytics = vi.hoisted(() => ({ track: vi.fn() }));
 // test can tap a specific chip.
 const chips = vi.hoisted(() => ({ entries: [] as Array<{ label?: string; onPress: () => void }> }));
 
+const scrollViews = vi.hoisted(() => ({
+  props: [] as Array<{ horizontal?: boolean; nestedScrollEnabled?: boolean; keyboardShouldPersistTaps?: unknown }>,
+}));
+
 vi.mock('../../../../lib/analytics', () => ({ track: analytics.track }));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('react-native-gesture-handler', () => ({
+  ScrollView: ({
+    children,
+    horizontal,
+    nestedScrollEnabled,
+    keyboardShouldPersistTaps,
+  }: {
+    children?: ReactNode;
+    horizontal?: boolean;
+    nestedScrollEnabled?: boolean;
+    keyboardShouldPersistTaps?: unknown;
+  }) => {
+    scrollViews.props.push({ horizontal, nestedScrollEnabled, keyboardShouldPersistTaps });
+    return createElement('div', null, children);
+  },
 }));
 
 vi.mock('../../../PressableSurface', () => ({
@@ -129,9 +149,45 @@ import { GeneratorPickerCard } from '../GeneratorPickerCard';
 beforeEach(() => {
   analytics.track.mockClear();
   chips.entries = [];
+  scrollViews.props = [];
 });
 
 describe('GeneratorPickerCard analytics', () => {
+  it('renders chip rails as nested horizontal gesture scroll views', () => {
+    render(
+      createElement(GeneratorPickerCard, {
+        boardName: 'kilter',
+        layoutId: 8,
+        sizeId: 21,
+        angle: 40,
+        selection: {
+          type: 'on',
+          options: {
+            type: 'volume',
+            warmUp: 'standard',
+            targetGrade: 20,
+            mainSetClimbs: 20,
+            mainSetVariability: 0,
+            climbBias: 'unfamiliar',
+            minAscents: 5,
+            minRating: 2,
+            onlyTallClimbs: false,
+            onlyWideClimbs: false,
+          },
+        } satisfies GeneratorSelection,
+        onChange: vi.fn(),
+      }),
+    );
+
+    expect(scrollViews.props.length).toBeGreaterThanOrEqual(5);
+    expect(
+      scrollViews.props.every(
+        ({ horizontal, nestedScrollEnabled, keyboardShouldPersistTaps }) =>
+          horizontal === true && nestedScrollEnabled === true && keyboardShouldPersistTaps === 'handled',
+      ),
+    ).toBe(true);
+  });
+
   it('fires "Workout Generator Opened" with web-aligned targetType + angle when switching off → a workout type', () => {
     render(
       createElement(GeneratorPickerCard, {

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-analytics.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-analytics.test.tsx
@@ -63,11 +63,28 @@ vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
 }));
 
+vi.mock('react-native-gesture-handler', () => ({
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
 vi.mock('@shopify/flash-list', () => ({
-  // Render just the header (which holds the generator picker); the rows are
-  // irrelevant to the analytics flow and WorkoutPreviewRow is mocked to null.
-  FlashList: ({ ListHeaderComponent }: { ListHeaderComponent?: ReactNode }) =>
-    createElement('div', null, ListHeaderComponent),
+  FlashList: ({
+    data,
+    renderItem,
+    ListHeaderComponent,
+  }: {
+    data?: unknown[];
+    renderItem?: (info: { item: unknown; index: number }) => ReactNode;
+    ListHeaderComponent?: ReactNode;
+  }) =>
+    createElement(
+      'div',
+      null,
+      ListHeaderComponent,
+      ...(data ?? []).map((rowItem, index) =>
+        createElement('div', { key: index }, renderItem?.({ item: rowItem, index })),
+      ),
+    ),
 }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
@@ -92,9 +109,15 @@ vi.mock('../../../../providers/drawer-host-provider', () => ({
 }));
 vi.mock('../../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../../../../hooks/use-bottom-chrome-metrics', () => ({
-  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+  useBottomChromeMetrics: () => ({
+    insideTabs: true,
+    scrollBottomPadding: 0,
+    tabBarBottom: 0,
+    tabBarHeight: 0,
+    fixedFooterBottom: 0,
+  }),
 }));
-vi.mock('../../../../theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
+vi.mock('../../../../theme/tokens', () => ({ spacing: { 2: 8, 3: 12, 4: 16 }, borderRadius: { lg: 16 } }));
 vi.mock('../BoardSummaryCard', () => ({ BoardSummaryCard: () => null }));
 vi.mock('../WorkoutPreviewRow', () => ({ WorkoutPreviewRow: () => null }));
 vi.mock('../use-workout-preview', () => ({ useWorkoutPreview: () => preview.result }));

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-preview.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-preview.test.tsx
@@ -25,29 +25,76 @@ const rows = vi.hoisted(() => ({
   onPress: null as ((item: ClimbQueueItem) => void) | null,
 }));
 
+const footer = vi.hoisted(() => ({
+  styles: [] as unknown[],
+}));
+
+const list = vi.hoisted(() => ({
+  props: [] as Array<{
+    nestedScrollEnabled?: boolean;
+    keyboardShouldPersistTaps?: unknown;
+    dataLength: number;
+    hasGestureScrollComponent: boolean;
+    hasHeaderComponent: boolean;
+  }>,
+}));
+
+const bottomChrome = vi.hoisted(() => ({
+  metrics: {
+    insideTabs: true,
+    scrollBottomPadding: 200,
+    tabBarBottom: 120,
+    tabBarHeight: 49,
+    fixedFooterBottom: 120,
+  },
+}));
+
 vi.mock('react-native', () => ({
-  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  View: ({ children, testID, style }: { children?: ReactNode; testID?: string; style?: unknown }) => {
+    if (testID === 'pre-session-footer') {
+      footer.styles = Array.isArray(style) ? style : [style];
+    }
+    return createElement('div', testID ? { 'data-testid': testID } : null, children);
+  },
   StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
 }));
 
+vi.mock('react-native-gesture-handler', () => ({
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
 vi.mock('@shopify/flash-list', () => ({
-  // Render the header plus each data row through renderItem (the real FlashList's
-  // rows are what we assert on here).
   FlashList: ({
-    ListHeaderComponent,
     data,
     renderItem,
+    renderScrollComponent,
+    ListHeaderComponent,
+    nestedScrollEnabled,
+    keyboardShouldPersistTaps,
   }: {
-    ListHeaderComponent?: ReactNode;
     data?: unknown[];
-    renderItem?: (info: { item: unknown }) => ReactNode;
-  }) =>
-    createElement(
+    renderItem?: (info: { item: unknown; index: number }) => ReactNode;
+    renderScrollComponent?: unknown;
+    ListHeaderComponent?: ReactNode;
+    nestedScrollEnabled?: boolean;
+    keyboardShouldPersistTaps?: unknown;
+  }) => {
+    list.props.push({
+      nestedScrollEnabled,
+      keyboardShouldPersistTaps,
+      dataLength: data?.length ?? 0,
+      hasGestureScrollComponent: renderScrollComponent != null,
+      hasHeaderComponent: ListHeaderComponent != null,
+    });
+    return createElement(
       'div',
       null,
       ListHeaderComponent,
-      ...(data ?? []).map((rowItem, index) => createElement('div', { key: index }, renderItem?.({ item: rowItem }))),
-    ),
+      ...(data ?? []).map((rowItem, index) =>
+        createElement('div', { key: index }, renderItem?.({ item: rowItem, index })),
+      ),
+    );
+  },
 }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
@@ -68,9 +115,9 @@ vi.mock('../../../../providers/queue-provider', () => ({
 vi.mock('../../../../providers/drawer-host-provider', () => ({ useDrawerHost: () => ({ openPlayDrawer: vi.fn() }) }));
 vi.mock('../../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../../../../hooks/use-bottom-chrome-metrics', () => ({
-  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+  useBottomChromeMetrics: () => bottomChrome.metrics,
 }));
-vi.mock('../../../../theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
+vi.mock('../../../../theme/tokens', () => ({ spacing: { 2: 8, 3: 12, 4: 16 }, borderRadius: { lg: 16 } }));
 vi.mock('../BoardSummaryCard', () => ({ BoardSummaryCard: () => null }));
 vi.mock('../GeneratorPickerCard', () => ({ GeneratorPickerCard: () => null }));
 vi.mock('../use-workout-preview', () => ({ useWorkoutPreview: () => preview.result }));
@@ -103,9 +150,27 @@ function makeRow(uuid: string) {
   };
 }
 
+function getPaddingBottom(styles: unknown[]): number | null {
+  for (const style of styles) {
+    if (style == null || typeof style !== 'object' || Array.isArray(style)) continue;
+    const paddingBottom = (style as { paddingBottom?: unknown }).paddingBottom;
+    if (typeof paddingBottom === 'number') return paddingBottom;
+  }
+  return null;
+}
+
 beforeEach(() => {
   rows.rendered = [];
   rows.onPress = null;
+  footer.styles = [];
+  list.props = [];
+  bottomChrome.metrics = {
+    insideTabs: true,
+    scrollBottomPadding: 200,
+    tabBarBottom: 120,
+    tabBarHeight: 49,
+    fixedFooterBottom: 120,
+  };
   preview.result.items = [makeRow('a'), makeRow('b')] as unknown[];
   preview.result.refreshingUuids = new Set<string>();
 });
@@ -143,5 +208,49 @@ describe('PreSessionView preview rows', () => {
     expect(rowA).toMatchObject({ isRefreshing: true, refreshDisabled: false });
     // Every other row's refresh is disabled so the dropped tap is visible.
     expect(rowB).toMatchObject({ isRefreshing: false, refreshDisabled: true });
+  });
+
+  it('keeps the preview rows virtualized in a nested FlashList', () => {
+    render(createElement(PreSessionView));
+
+    expect(list.props.at(-1)).toMatchObject({
+      nestedScrollEnabled: true,
+      keyboardShouldPersistTaps: 'handled',
+      dataLength: 2,
+      hasGestureScrollComponent: true,
+      hasHeaderComponent: true,
+    });
+    expect(rows.rendered.map((row) => row.uuid)).toEqual(['a', 'b']);
+  });
+
+  it('keeps the generator controls in the list header when the preview is empty', () => {
+    preview.result.items = [];
+
+    render(createElement(PreSessionView));
+
+    expect(list.props.at(-1)).toMatchObject({ dataLength: 0, hasHeaderComponent: true });
+    expect(rows.rendered).toEqual([]);
+  });
+
+  it('uses the fixed footer bottom metric for footer padding', () => {
+    render(createElement(PreSessionView));
+
+    expect(getPaddingBottom(footer.styles)).toBe(132);
+  });
+
+  it('uses only local spacing when the fixed footer metric has no chrome reserve', () => {
+    bottomChrome.metrics = { ...bottomChrome.metrics, fixedFooterBottom: 0 };
+
+    render(createElement(PreSessionView));
+
+    expect(getPaddingBottom(footer.styles)).toBe(12);
+  });
+
+  it('uses safe-area footer padding outside the tabs group', () => {
+    bottomChrome.metrics = { ...bottomChrome.metrics, insideTabs: false, fixedFooterBottom: 34 };
+
+    render(createElement(PreSessionView));
+
+    expect(getPaddingBottom(footer.styles)).toBe(46);
   });
 });

--- a/packages/mobile/src/components/session-screen/session-footer-clearance.ts
+++ b/packages/mobile/src/components/session-screen/session-footer-clearance.ts
@@ -1,0 +1,7 @@
+/**
+ * Approximate rendered height of the fixed Start/End-session footer (large
+ * button + the footer's own vertical padding). Pre/in-session scroll content
+ * reserves this on top of `fixedFooterBottom` so the last rows clear the
+ * footer overlaying the bottom of the screen.
+ */
+export const SESSION_FOOTER_CLEARANCE = 100;

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -25,6 +25,7 @@ describe('computeBottomChromeMetrics', () => {
     expect(metrics.tabBarBottom).toBe(34);
     expect(metrics.scrollBottomPadding).toBe(34);
     expect(metrics.floatingControlBottom).toBe(34);
+    expect(metrics.fixedFooterBottom).toBe(34);
     expect(metrics.jsQueueToolbarVisible).toBe(false);
     expect(metrics.nativeAccessoryVisible).toBe(false);
   });
@@ -41,6 +42,7 @@ describe('computeBottomChromeMetrics', () => {
     expect(metrics.jsQueueReserve).toBe(TOOLBAR_RESERVE);
     expect(metrics.scrollBottomPadding).toBe(TAB_BAR_HEIGHT + TOOLBAR_RESERVE);
     expect(metrics.floatingControlBottom).toBe(TAB_BAR_HEIGHT + TOOLBAR_RESERVE);
+    expect(metrics.fixedFooterBottom).toBe(TAB_BAR_HEIGHT + TOOLBAR_RESERVE);
   });
 
   it('reserves the docked Material bar when the JS toolbar is visible', () => {
@@ -55,6 +57,7 @@ describe('computeBottomChromeMetrics', () => {
     expect(metrics.jsQueueReserve).toBe(MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
     expect(metrics.scrollBottomPadding).toBe(TAB_BAR_HEIGHT + MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
     expect(metrics.floatingControlBottom).toBe(TAB_BAR_HEIGHT + MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
+    expect(metrics.fixedFooterBottom).toBe(MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
   });
 
   it('does not pad scroll content for the UIKit-owned native accessory', () => {
@@ -73,6 +76,21 @@ describe('computeBottomChromeMetrics', () => {
     // But floating controls must still clear the accessory.
     expect(metrics.nativeAccessoryReserve).toBe(NATIVE_ACCESSORY_RESERVE);
     expect(metrics.floatingControlBottom).toBe(TAB_BAR_HEIGHT + NATIVE_ACCESSORY_RESERVE);
+    expect(metrics.fixedFooterBottom).toBe(TAB_BAR_HEIGHT + NATIVE_ACCESSORY_RESERVE);
+  });
+
+  it('reserves queue chrome for fixed footers outside the tabs group', () => {
+    const metrics = computeBottomChromeMetrics({
+      uiVariant: 'liquidGlass',
+      insetsBottom: 34,
+      insideTabs: false,
+      hasCurrentClimb: true,
+      nativeAccessoryMounted: false,
+    });
+
+    expect(metrics.tabBarHeight).toBe(0);
+    expect(metrics.scrollBottomPadding).toBe(34 + TOOLBAR_RESERVE);
+    expect(metrics.fixedFooterBottom).toBe(34 + TOOLBAR_RESERVE);
   });
 
   it('keeps the tab bar but no toolbar reserve when no climb is set, even if the accessory is mounted', () => {
@@ -87,6 +105,21 @@ describe('computeBottomChromeMetrics', () => {
     expect(metrics.nativeAccessoryVisible).toBe(false); // mounted, but no climb to show
     expect(metrics.scrollBottomPadding).toBe(34 + TAB_BAR_HEIGHT);
     expect(metrics.floatingControlBottom).toBe(34 + TAB_BAR_HEIGHT);
+    expect(metrics.fixedFooterBottom).toBe(34 + TAB_BAR_HEIGHT);
+  });
+
+  it('keeps scroll tab clearance but not fixed-footer tab clearance inside Material tabs', () => {
+    const metrics = computeBottomChromeMetrics({
+      uiVariant: 'material',
+      insetsBottom: 24,
+      insideTabs: true,
+      hasCurrentClimb: false,
+      nativeAccessoryMounted: false,
+    });
+
+    expect(metrics.tabBarBottom).toBe(24 + TAB_BAR_HEIGHT);
+    expect(metrics.scrollBottomPadding).toBe(24 + TAB_BAR_HEIGHT);
+    expect(metrics.fixedFooterBottom).toBe(0);
   });
 
   it('never reports both the JS toolbar and the native accessory as visible at once', () => {

--- a/packages/mobile/src/hooks/bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/bottom-chrome-metrics.ts
@@ -44,6 +44,12 @@ export type BottomChromeMetrics = {
   scrollBottomPadding: number;
   /** Bottom offset for floating controls (FABs, snackbar) so they clear all chrome. */
   floatingControlBottom: number;
+  /**
+   * Bottom padding for fixed footers. NativeTabs overlays content, so fixed
+   * footers clear the tab bar there. Material JS tabs are in flow, so fixed
+   * footers clear only active queue/accessory chrome.
+   */
+  fixedFooterBottom: number;
 };
 
 /**
@@ -51,10 +57,12 @@ export type BottomChromeMetrics = {
  * `jsQueueToolbarVisible` are mutually exclusive (the JS toolbar only mounts
  * when the native accessory does not). The native accessory is UIKit-owned and
  * adds its own content inset, so `scrollBottomPadding` reserves only for the JS
- * toolbar. Liquid Glass/fallback reserves the taller floating island stack;
- * Material reserves the docked active-context bar height. `floatingControlBottom`
- * takes the max of the JS/native reserves so floating controls clear whichever
- * chrome is present.
+ * toolbar. Liquid Glass reserves the taller floating island stack; Material
+ * reserves the docked active-context bar height. `scrollBottomPadding` remains
+ * conservative for list/scroll consumers and keeps tab-bar clearance on both
+ * tab implementations; fixed footers use `fixedFooterBottom` because they need
+ * the in-flow-vs-overlay tab-bar distinction. `floatingControlBottom` clears
+ * the physical tab bar because those controls are absolute overlays.
  */
 export function computeBottomChromeMetrics({
   uiVariant,
@@ -66,6 +74,7 @@ export function computeBottomChromeMetrics({
   const nativeAccessoryVisible = nativeAccessoryMounted && hasCurrentClimb;
   const jsQueueToolbarVisible = hasCurrentClimb && !nativeAccessoryMounted;
   const tabBarHeight = insideTabs ? TAB_BAR_HEIGHT : 0;
+  const tabBarOverlaysContent = insideTabs && uiVariant !== 'material';
   // The Material bar reserves its full height even though it's tucked ~2px into the
   // tab bar (MATERIAL_TABBAR_OVERLAP in persistent-queue-bar), so its visible height
   // above the tab bar is ~2px less. The resulting 2px of extra scroll padding is
@@ -74,6 +83,10 @@ export function computeBottomChromeMetrics({
   const jsQueueToolbarReserve = uiVariant === 'material' ? MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT : TOOLBAR_RESERVE;
   const jsQueueReserve = jsQueueToolbarVisible ? jsQueueToolbarReserve : 0;
   const nativeAccessoryReserve = nativeAccessoryVisible ? glassSize.standard + TOOLBAR_GAP_ABOVE_TABBAR : 0;
+  const tabBarBottom = insetsBottom + tabBarHeight;
+  const activeQueueChromeReserve = Math.max(jsQueueReserve, nativeAccessoryReserve);
+  const contentInsetBottom = tabBarOverlaysContent || !insideTabs ? tabBarBottom : 0;
+  const fixedFooterBottom = contentInsetBottom + activeQueueChromeReserve;
 
   return {
     hasCurrentClimb,
@@ -82,10 +95,11 @@ export function computeBottomChromeMetrics({
     nativeAccessoryVisible,
     jsQueueToolbarVisible,
     tabBarHeight,
-    tabBarBottom: insetsBottom + tabBarHeight,
+    tabBarBottom,
     jsQueueReserve,
     nativeAccessoryReserve,
     scrollBottomPadding: insetsBottom + tabBarHeight + jsQueueReserve,
     floatingControlBottom: insetsBottom + tabBarHeight + Math.max(jsQueueReserve, nativeAccessoryReserve),
+    fixedFooterBottom,
   };
 }

--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -121,12 +121,24 @@ function leaveSessionCalls() {
   });
 }
 
+function operationText(operation: unknown): string {
+  if (typeof operation === 'string') return operation;
+  if (operation == null || typeof operation !== 'object') return '';
+  const operationRecord = operation as Record<string, unknown>;
+  if (typeof operationRecord.query === 'string') return operationRecord.query;
+  const loc = operationRecord.loc;
+  if (loc == null || typeof loc !== 'object') return '';
+  const source = (loc as Record<string, unknown>).source;
+  if (source == null || typeof source !== 'object') return '';
+  const body = (source as Record<string, unknown>).body;
+  return typeof body === 'string' ? body : '';
+}
+
 // resyncQueueFromServer is the only thing that fires GET_SESSION_QUEUE_STATE, so
 // counting these calls tracks how many mutation-failure resyncs actually ran.
 function queueStateCalls() {
   return http.request.mock.calls.filter((call) => {
-    const operation = call[0];
-    return typeof operation === 'string' && operation.includes('GetSessionQueueState');
+    return operationText(call[0]).includes('GetSessionQueueState');
   });
 }
 
@@ -146,8 +158,8 @@ describe('QueueProvider clearSession notifyServer', () => {
     // Cold-start restore verifies the session via SESSION_STATUS (#2683);
     // keep the stored session active so these tests land in-session before
     // clearSession.
-    http.request.mockImplementation(async (operation: string) =>
-      operation.includes('SessionStatus') ? { sessionStatus: 'active' } : {},
+    http.request.mockImplementation(async (operation: unknown) =>
+      operationText(operation).includes('SessionStatus') ? { sessionStatus: 'active' } : {},
     );
     graph.execute.mockReset();
     // joinSession resolves the active session; leaveSession resolves true.
@@ -216,10 +228,10 @@ describe('QueueProvider clearSession notifyServer', () => {
     // session switch on a still-mounted provider, blocks every future resync.
     let hangNextQueueState = false;
     http.request.mockImplementation((operation: unknown) => {
-      const operationText = typeof operation === 'string' ? operation : '';
+      const queryText = operationText(operation);
       // Match GetSessionQueueState before the generic GetSession branch — its name
       // contains 'GetSession' too.
-      if (operationText.includes('GetSessionQueueState')) {
+      if (queryText.includes('GetSessionQueueState')) {
         // The first resync hangs (pins the guard true); later resyncs resolve.
         if (hangNextQueueState) return new Promise<never>(() => {});
         return Promise.resolve({ session: { queueState: { queue: [], currentClimbQueueItem: null } } });
@@ -228,10 +240,10 @@ describe('QueueProvider clearSession notifyServer', () => {
       // replaces the beforeEach mock wholesale, so it must answer SessionStatus
       // itself — otherwise the restore guard sees no status and clears the
       // stored session before the test gets in-session.
-      if (operationText.includes('SessionStatus')) {
+      if (queryText.includes('SessionStatus')) {
         return Promise.resolve({ sessionStatus: 'active' });
       }
-      if (operationText.includes('GetSession')) {
+      if (queryText.includes('GetSession')) {
         return Promise.resolve({ session: { id: 'session-1', endedAt: null } });
       }
       return Promise.resolve({});

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -154,6 +154,7 @@ import {
   useQueueLiveStats,
   useQueueSessionId,
 } from '../queue-provider';
+import { clearStoredSessionId } from '../../lib/session-store';
 
 type Snapshot = {
   state: ReturnType<typeof useQueue>['state'];
@@ -343,6 +344,7 @@ describe('QueueProvider session update subscription', () => {
     sessionStore.setStoredSessionId.mockClear();
     sessionStore.clearStoredSessionId.mockClear();
     graph.execute.mockReset();
+    vi.mocked(clearStoredSessionId).mockClear();
     http.request.mockReset();
     // The restore effect verifies the session via SESSION_STATUS before
     // rejoining (#2683). Default to an active session so existing tests still
@@ -1128,6 +1130,54 @@ describe('QueueProvider session update subscription', () => {
     expect(toast.showToast).toHaveBeenCalledWith('mobile.toast.sessionEnded', 'success');
     expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
   });
+
+  it('clears local persisted session state when an explicit end-session request fails', async () => {
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const currentItem = makeQueueItem('queue-current', 'climb-current');
+    const suggestedItem = makeQueueItem('queue-suggested', 'climb-suggested', { suggested: true });
+    const playlistSuggestionSource: PlaylistSuggestionSource = {
+      playlistUuid: 'playlist-1',
+      activatedClimbUuid: currentItem.climb.uuid,
+      boardKey: 'kilter:1:10:1,2',
+      climbs: [currentItem.climb, suggestedItem.climb],
+    };
+    const preparedSnapshot = snapshots.at(-1);
+    if (!preparedSnapshot) throw new Error('queue snapshot was not captured');
+
+    act(() => {
+      preparedSnapshot.addToQueue(currentItem);
+      preparedSnapshot.setPlaylistSuggestionSource(playlistSuggestionSource);
+    });
+
+    await waitFor(() => {
+      const latestSnapshot = snapshots.at(-1);
+      expect(latestSnapshot?.state.queue.map((item) => item.uuid)).toEqual(['queue-current']);
+      expect(latestSnapshot?.playlistSuggestionSource).toEqual(playlistSuggestionSource);
+    });
+
+    http.request.mockRejectedValueOnce(new Error('stale session'));
+
+    await act(async () => {
+      await snapshots.at(-1)?.endSession();
+    });
+
+    await waitFor(() => {
+      const latestSnapshot = snapshots.at(-1);
+      expect(latestSnapshot?.sessionId).toBeNull();
+      expect(latestSnapshot?.state.queue).toEqual([]);
+      expect(latestSnapshot?.state.currentClimbQueueItem).toBeNull();
+      expect(latestSnapshot?.playlistSuggestionSource).toBeNull();
+    });
+    expect(clearStoredSessionId).toHaveBeenCalledTimes(1);
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.toast.sessionEnded', 'success');
+  });
 });
 
 // ── SEED-1: queue mutations resync on failure (GH #2419) ─────────────────────
@@ -1141,6 +1191,10 @@ describe('QueueProvider session update subscription', () => {
 // an INITIAL_QUEUE_DATA dispatch, then toasts. A rejection with no session must
 // NOT resync or toast.
 describe('QueueProvider mutation-failure resync', () => {
+  beforeEach(() => {
+    toast.showToast.mockClear();
+  });
+
   // The harness routes both endSession and the queueState query through
   // http.request. Branch on the operation text so the resync query returns the
   // authoritative snapshot while everything else keeps the default endSession

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -1512,15 +1512,15 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       showToast(t('mobile.toast.sessionEnded'), 'success');
       return response.endSession;
     } catch {
-      if (suppressedRemoteEndSessionIdRef.current === currentSessionId) {
-        locallyEndingSessionIdRef.current = null;
-        suppressedRemoteEndSessionIdRef.current = null;
-        await clearSession();
-        showToast(t('mobile.toast.sessionEnded'), 'success');
-        return null;
-      }
+      const remoteEndAlreadyApplied = suppressedRemoteEndSessionIdRef.current === currentSessionId;
       locallyEndingSessionIdRef.current = null;
-      showToast(t('mobile.queue.actionFailed'), 'error');
+      suppressedRemoteEndSessionIdRef.current = null;
+      await clearSession();
+      if (remoteEndAlreadyApplied) {
+        showToast(t('mobile.toast.sessionEnded'), 'success');
+      } else {
+        showToast(t('mobile.queue.actionFailed'), 'error');
+      }
       return null;
     }
   }, [clearSession, showToast, t]);


### PR DESCRIPTION
Fixes the Record pre-session mobile layout issues: Android chip rails now use gesture-handler nested horizontal ScrollViews, the pre-session content uses a gesture-handler vertical ScrollView, and the Start session footer no longer uses the oversized scroll reserve. The footer now keeps Android's corrected spacing while adding iOS tab-bar-height clearance so it does not sit under the native tab bar. Validated with: vp test run --project mobile -- packages/mobile/src/components/session-screen/pre-session; vp run typecheck:mobile; git diff --check. Note: vp check still reports unrelated pre-existing formatting issues outside this change.