### PR TITLE
Drive provider sign-out from the 401 interceptor on failed refresh (#2684)

### DIFF
--- a/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
@@ -232,6 +232,39 @@ describe('authenticatedFetch', () => {
     expect(onForcedSignOut).toHaveBeenCalledTimes(1);
   });
 
+  it('still runs the captured cleanup when the hook is cleared mid sign-out (provider unmount race)', async () => {
+    // signOut() awaits a network revoke. If AuthProvider unmounts during that
+    // window it nulls the hook — but the cleanup it registered must still fire,
+    // or the forced sign-out silently drops in exactly the case this guards.
+    mockIsTokenExpiringSoon.mockResolvedValue(false);
+    mockGetAuthToken.mockResolvedValue('old-jwt');
+    const onForcedSignOut = vi.fn();
+    setOnForcedSignOut(onForcedSignOut);
+
+    // Hold signOut open so we can clear the hook (simulating unmount) before it
+    // resolves and the callback is invoked.
+    let releaseSignOut!: () => void;
+    mockSignOut.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releaseSignOut = resolve;
+      }),
+    );
+
+    mockFetch
+      .mockResolvedValueOnce({ status: 401, ok: false }) // initial 401
+      .mockResolvedValueOnce({ ok: false, status: 403 }); // refresh fails
+
+    const fetchPromise = authenticatedFetch('https://api.example.com/data');
+    await vi.waitFor(() => expect(mockSignOut).toHaveBeenCalledTimes(1));
+
+    // Provider unmounts mid sign-out, then the revoke resolves.
+    setOnForcedSignOut(null);
+    releaseSignOut();
+    await fetchPromise;
+
+    expect(onForcedSignOut).toHaveBeenCalledTimes(1);
+  });
+
   it('handles a failed-refresh 401 without throwing when no forced-sign-out hook is registered', async () => {
     // The interceptor can fire before the provider mounts (or after it unmounts),
     // leaving onForcedSignOut null. The optional-chain call must be a no-op.

--- a/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
@@ -13,7 +13,6 @@ vi.mock('../auth-store', () => ({
   getAuthToken: vi.fn().mockResolvedValue('test-jwt'),
   getRefreshToken: vi.fn().mockResolvedValue('test-refresh-token'),
   storeTokens: vi.fn().mockResolvedValue(undefined),
-  clearTokens: vi.fn().mockResolvedValue(undefined),
   isTokenExpiringSoon: vi.fn().mockResolvedValue(false),
   getTokenExpiresAt: vi.fn().mockResolvedValue(null),
 }));
@@ -204,6 +203,33 @@ describe('authenticatedFetch', () => {
     // screens immediately, and only after the token revoke/clear.
     expect(onForcedSignOut).toHaveBeenCalledTimes(1);
     expect(mockSignOut.mock.invocationCallOrder[0]).toBeLessThan(onForcedSignOut.mock.invocationCallOrder[0]);
+  });
+
+  it('fires the forced-sign-out hook once when concurrent requests both 401 and refresh fails', async () => {
+    // deduplicatedRefresh collapses the refresh, but each waiting caller still
+    // sees refreshed=false. The forced sign-out must run once — not once per
+    // request — so PostHog gets a single `forced` Logout, not N duplicates.
+    mockIsTokenExpiringSoon.mockResolvedValue(false);
+    mockGetAuthToken.mockResolvedValue('old-jwt');
+    const onForcedSignOut = vi.fn();
+    setOnForcedSignOut(onForcedSignOut);
+
+    // Key on the URL rather than call order: any data request 401s, the refresh
+    // 403s — so the assertion can't hinge on how the two requests interleave.
+    mockFetch.mockImplementation((url: string) =>
+      Promise.resolve(url.includes('/auth/native/refresh') ? { ok: false, status: 403 } : { status: 401, ok: false }),
+    );
+
+    const [responseA, responseB] = await Promise.all([
+      authenticatedFetch('https://api.example.com/a'),
+      authenticatedFetch('https://api.example.com/b'),
+    ]);
+
+    expect(responseA.status).toBe(401);
+    expect(responseB.status).toBe(401);
+    // One refresh fetch (deduped), one revoke, one cleanup callback.
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    expect(onForcedSignOut).toHaveBeenCalledTimes(1);
   });
 
   it('handles a failed-refresh 401 without throwing when no forced-sign-out hook is registered', async () => {

--- a/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
@@ -25,13 +25,12 @@ vi.mock('../auth', () => ({
 }));
 
 import { ensureFreshToken, authenticatedFetch, setOnForcedSignOut } from '../auth-interceptor';
-import { getAuthToken, getRefreshToken, storeTokens, clearTokens, isTokenExpiringSoon } from '../auth-store';
+import { getAuthToken, getRefreshToken, storeTokens, isTokenExpiringSoon } from '../auth-store';
 
 const mockIsTokenExpiringSoon = isTokenExpiringSoon as Mock;
 const mockGetAuthToken = getAuthToken as Mock;
 const mockGetRefreshToken = getRefreshToken as Mock;
 const mockStoreTokens = storeTokens as Mock;
-const mockClearTokens = clearTokens as Mock;
 
 // ── Global fetch mock ────────────────────────────────────────────────────
 const mockFetch = vi.fn();
@@ -205,6 +204,22 @@ describe('authenticatedFetch', () => {
     // screens immediately, and only after the token revoke/clear.
     expect(onForcedSignOut).toHaveBeenCalledTimes(1);
     expect(mockSignOut.mock.invocationCallOrder[0]).toBeLessThan(onForcedSignOut.mock.invocationCallOrder[0]);
+  });
+
+  it('handles a failed-refresh 401 without throwing when no forced-sign-out hook is registered', async () => {
+    // The interceptor can fire before the provider mounts (or after it unmounts),
+    // leaving onForcedSignOut null. The optional-chain call must be a no-op.
+    mockIsTokenExpiringSoon.mockResolvedValue(false);
+    mockGetAuthToken.mockResolvedValue('old-jwt');
+    setOnForcedSignOut(null);
+
+    mockFetch.mockResolvedValueOnce({ status: 401, ok: false }); // initial 401
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 403 }); // refresh fails
+
+    const response = await authenticatedFetch('https://api.example.com/data');
+
+    expect(response.status).toBe(401);
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
   });
 
   it('does not fire the forced-sign-out hook when the 401 retry succeeds', async () => {

--- a/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
@@ -24,7 +24,7 @@ vi.mock('../auth', () => ({
   signOut: (...args: unknown[]) => mockSignOut(...args),
 }));
 
-import { ensureFreshToken, authenticatedFetch } from '../auth-interceptor';
+import { ensureFreshToken, authenticatedFetch, setOnForcedSignOut } from '../auth-interceptor';
 import { getAuthToken, getRefreshToken, storeTokens, clearTokens, isTokenExpiringSoon } from '../auth-store';
 
 const mockIsTokenExpiringSoon = isTokenExpiringSoon as Mock;
@@ -42,6 +42,9 @@ beforeEach(() => {
   mockGetAuthToken.mockResolvedValue('test-jwt');
   mockGetRefreshToken.mockResolvedValue('test-refresh-token');
   mockIsTokenExpiringSoon.mockResolvedValue(false);
+  // The forced-sign-out hook is module-level state — clear it so a callback
+  // registered by one test doesn't leak into the next.
+  setOnForcedSignOut(null);
 });
 
 // ── ensureFreshToken ─────────────────────────────────────────────────────
@@ -177,9 +180,11 @@ describe('authenticatedFetch', () => {
     expect(retryHeaders.get('Authorization')).toBe('Bearer new-jwt');
   });
 
-  it('clears tokens when 401 retry refresh fails', async () => {
+  it('clears tokens and fires the forced-sign-out hook when 401 retry refresh fails', async () => {
     mockIsTokenExpiringSoon.mockResolvedValue(false);
     mockGetAuthToken.mockResolvedValue('old-jwt');
+    const onForcedSignOut = vi.fn();
+    setOnForcedSignOut(onForcedSignOut);
 
     // Initial request returns 401
     mockFetch.mockResolvedValueOnce({
@@ -196,7 +201,33 @@ describe('authenticatedFetch', () => {
 
     expect(response.status).toBe(401);
     expect(mockSignOut).toHaveBeenCalledTimes(1);
-    // signOut called once in the 401 handler after refresh fails (revokes + clears tokens)
+    // The provider's cleanup hook fires so the UI leaves the authenticated
+    // screens immediately, and only after the token revoke/clear.
+    expect(onForcedSignOut).toHaveBeenCalledTimes(1);
+    expect(mockSignOut.mock.invocationCallOrder[0]).toBeLessThan(onForcedSignOut.mock.invocationCallOrder[0]);
+  });
+
+  it('does not fire the forced-sign-out hook when the 401 retry succeeds', async () => {
+    mockIsTokenExpiringSoon.mockResolvedValue(false);
+    mockGetAuthToken
+      .mockResolvedValueOnce('old-jwt') // initial request
+      .mockResolvedValueOnce('new-jwt') // retry after refresh
+      .mockResolvedValue('new-jwt');
+    const onForcedSignOut = vi.fn();
+    setOnForcedSignOut(onForcedSignOut);
+
+    mockFetch.mockResolvedValueOnce({ status: 401, ok: false }); // initial 401
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ jwt: 'new-jwt', refreshToken: 'new-refresh', expiresAt: '2099-01-01T00:00:00Z' }),
+    });
+    mockFetch.mockResolvedValueOnce({ status: 200, ok: true }); // retry succeeds
+
+    const response = await authenticatedFetch('https://api.example.com/data');
+
+    expect(response.status).toBe(200);
+    expect(mockSignOut).not.toHaveBeenCalled();
+    expect(onForcedSignOut).not.toHaveBeenCalled();
   });
 
   it('attaches Authorization header from stored token', async () => {
@@ -229,6 +260,8 @@ describe('authenticatedFetch', () => {
   it('returns 401 directly without refresh attempt when no token exists', async () => {
     mockIsTokenExpiringSoon.mockResolvedValue(false);
     mockGetAuthToken.mockResolvedValue(null);
+    const onForcedSignOut = vi.fn();
+    setOnForcedSignOut(onForcedSignOut);
     mockFetch.mockResolvedValueOnce({ status: 401, ok: false });
 
     const response = await authenticatedFetch('https://api.example.com/data');
@@ -236,6 +269,7 @@ describe('authenticatedFetch', () => {
     expect(response.status).toBe(401);
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockSignOut).not.toHaveBeenCalled();
+    expect(onForcedSignOut).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/lib/auth-interceptor.ts
+++ b/packages/mobile/src/lib/auth-interceptor.ts
@@ -4,6 +4,17 @@ import { BACKEND_URL } from './env';
 
 let refreshPromise: Promise<boolean> | null = null;
 
+// The interceptor lives in the lib layer and can't import the AuthProvider, but
+// a failed-refresh 401 means the session is dead and the provider must run its
+// full signed-out cleanup (flip isAuthenticated → redirect to login, dispose the
+// WS client, reset analytics, clear caches). The provider registers that cleanup
+// here in a useEffect; we invoke it from the 401 branch below.
+let onForcedSignOut: (() => void) | null = null;
+
+export function setOnForcedSignOut(callback: (() => void) | null): void {
+  onForcedSignOut = callback;
+}
+
 async function refreshTokens(): Promise<boolean> {
   const currentRefreshToken = await getRefreshToken();
   if (!currentRefreshToken) return false;
@@ -68,6 +79,10 @@ export async function authenticatedFetch(url: string | URL | Request, options: R
       }
     }
     await signOut();
+    // signOut() only revoked + cleared tokens. Tell the provider to run the rest
+    // of the cleanup so the UI leaves the authenticated screens immediately,
+    // instead of waiting for the next background→foreground checkAuth.
+    onForcedSignOut?.();
   }
 
   return response;

--- a/packages/mobile/src/lib/auth-interceptor.ts
+++ b/packages/mobile/src/lib/auth-interceptor.ts
@@ -56,6 +56,25 @@ export async function ensureFreshToken(): Promise<boolean> {
   return deduplicatedRefresh();
 }
 
+let forcedSignOutPromise: Promise<void> | null = null;
+
+// A burst of concurrent requests all 401 and all see deduplicatedRefresh() return
+// false, so without collapsing them each would revoke + fire onForcedSignOut —
+// duplicate `forced` Logout events and redundant provider cleanup. Run the sign-out
+// once; reset on settle so a genuinely new 401 (after a later sign-in) still signs
+// out. signOut() must complete (revoke + clearTokens) before onForcedSignOut runs.
+function forceSignOut(): Promise<void> {
+  if (!forcedSignOutPromise) {
+    forcedSignOutPromise = (async () => {
+      await signOut();
+      onForcedSignOut?.();
+    })().finally(() => {
+      forcedSignOutPromise = null;
+    });
+  }
+  return forcedSignOutPromise;
+}
+
 export async function authenticatedFetch(url: string | URL | Request, options: RequestInit = {}): Promise<Response> {
   await ensureFreshToken();
 
@@ -78,11 +97,10 @@ export async function authenticatedFetch(url: string | URL | Request, options: R
         return fetch(url, { ...options, headers });
       }
     }
-    await signOut();
-    // signOut() only revoked + cleared tokens. Tell the provider to run the rest
-    // of the cleanup so the UI leaves the authenticated screens immediately,
-    // instead of waiting for the next background→foreground checkAuth.
-    onForcedSignOut?.();
+    // signOut() only revokes + clears tokens. forceSignOut also tells the provider
+    // to run the rest of the cleanup so the UI leaves the authenticated screens
+    // immediately, instead of waiting for the next background→foreground checkAuth.
+    await forceSignOut();
   }
 
   return response;

--- a/packages/mobile/src/lib/auth-interceptor.ts
+++ b/packages/mobile/src/lib/auth-interceptor.ts
@@ -65,9 +65,15 @@ let forcedSignOutPromise: Promise<void> | null = null;
 // out. signOut() must complete (revoke + clearTokens) before onForcedSignOut runs.
 function forceSignOut(): Promise<void> {
   if (!forcedSignOutPromise) {
+    // Capture the hook now. signOut() awaits a network revoke; if the provider
+    // unmounts during that window its effect nulls the module ref, but the
+    // cleanup it registered must still run (dispose the WS, reset the http
+    // client, clear caches) or the forced sign-out silently drops — the exact
+    // failure this path exists to prevent.
+    const notifyProvider = onForcedSignOut;
     forcedSignOutPromise = (async () => {
       await signOut();
-      onForcedSignOut?.();
+      notifyProvider?.();
     })().finally(() => {
       forcedSignOutPromise = null;
     });

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -66,6 +66,16 @@ vi.mock('../../lib/graphql/use-active-board', () => ({
   ACTIVE_BOARD_QUERY_KEY: ['activeBoard'] as const,
 }));
 
+// The provider registers its forced-sign-out cleanup against this lib-layer hook
+// (and lazily imports ensureFreshToken in checkAuth). Record the register/clear
+// calls so the lifecycle test can assert the contract.
+const setOnForcedSignOutMock = vi.fn();
+const ensureFreshTokenMock = vi.fn().mockResolvedValue(true);
+vi.mock('../../lib/auth-interceptor', () => ({
+  setOnForcedSignOut: (callback: (() => void) | null) => setOnForcedSignOutMock(callback),
+  ensureFreshToken: () => ensureFreshTokenMock(),
+}));
+
 import { AuthProvider, useAuth } from '../auth-provider';
 
 describe('AuthProvider.signOut', () => {
@@ -145,6 +155,35 @@ describe('AuthProvider.signOut', () => {
     // Active board cache was wiped — both the targeted removeQueries and the
     // subsequent clear() do this; verifying the end state is enough.
     expect(queryClient.getQueryData(['activeBoard'])).toBeUndefined();
+  });
+});
+
+describe('AuthProvider forced sign-out registration', () => {
+  beforeEach(() => {
+    getAuthTokenMock.mockReset();
+    isTokenExpiringSoonMock.mockReset();
+    setOnForcedSignOutMock.mockReset();
+    getAuthTokenMock.mockResolvedValue('jwt-token');
+    isTokenExpiringSoonMock.mockResolvedValue(false);
+  });
+
+  // The interceptor's null-guard is the safety net, but the provider owns the
+  // contract: register a callable while mounted, clear it (null) on unmount so a
+  // 401 firing after teardown can't drive a dead provider.
+  it('registers the forced-sign-out hook on mount and clears it on unmount', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { unmount } = render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{null}</AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(setOnForcedSignOutMock).toHaveBeenCalled());
+    const registered = setOnForcedSignOutMock.mock.calls.at(-1)?.[0];
+    expect(typeof registered).toBe('function');
+
+    unmount();
+    expect(setOnForcedSignOutMock).toHaveBeenLastCalledWith(null);
   });
 });
 

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -14,6 +14,7 @@ import {
 } from '../lib/auth';
 import { reset as resetAnalytics, track } from '../lib/analytics';
 import { reportError } from '../lib/sentry';
+import { setOnForcedSignOut } from '../lib/auth-interceptor';
 import { resetHttpClient } from '../lib/graphql/client';
 import { disposeWsClient } from '../lib/graphql/ws-client';
 import { clearStoredSessionId } from '../lib/session-store';
@@ -119,9 +120,12 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     [checkAuth],
   );
 
-  const signOut = useCallback(async () => {
-    track(SHARED_EVENTS.Logout, { method: 'manual' });
-    await authSignOut();
+  // The shared signed-out cleanup, used by both the manual `signOut` below and
+  // the interceptor's forced sign-out (failed-refresh 401). It deliberately
+  // omits the two caller-specific steps: the manual `Logout` analytics event,
+  // and `authSignOut()` (the token revoke + clear) — the forced path's caller
+  // already revoked, so running it here would double-revoke.
+  const runSignedOutCleanup = useCallback(async () => {
     resetAnalytics();
     await Promise.all([clearStoredSessionId(), clearStoredActiveBoard()]);
     // Drop the in-memory active-board cache too. It's `staleTime: Infinity`, so
@@ -138,6 +142,24 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     queryClient.clear();
     setIsAuthenticated(false);
   }, [queryClient]);
+
+  const signOut = useCallback(async () => {
+    track(SHARED_EVENTS.Logout, { method: 'manual' });
+    await authSignOut();
+    await runSignedOutCleanup();
+  }, [runSignedOutCleanup]);
+
+  // Let the lib-layer 401 interceptor drive the same cleanup. On a failed-refresh
+  // 401 it has already revoked + cleared tokens; this flips the provider out of
+  // the authenticated UI right away instead of waiting for the next foreground
+  // checkAuth. `setOnForcedSignOut` is our own module setter (not React state),
+  // so the function value is stored verbatim.
+  useEffect(() => {
+    setOnForcedSignOut(() => {
+      void runSignedOutCleanup();
+    });
+    return () => setOnForcedSignOut(null);
+  }, [runSignedOutCleanup]);
 
   const onReadyRef = useRef(onReady);
   onReadyRef.current = onReady;

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -127,7 +127,11 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   // already revoked, so running it here would double-revoke.
   const runSignedOutCleanup = useCallback(async () => {
     resetAnalytics();
-    await Promise.all([clearStoredSessionId(), clearStoredActiveBoard()]);
+    // Best-effort store clears — clearStoredSessionId/clearStoredActiveBoard hit
+    // SecureStore/AsyncStorage and can reject. allSettled (not all) so a failed
+    // delete can't abort the rest of the teardown and leave the user stuck on the
+    // authenticated screens with the critical setIsAuthenticated(false) skipped.
+    await Promise.allSettled([clearStoredSessionId(), clearStoredActiveBoard()]);
     // Drop the in-memory active-board cache too. It's `staleTime: Infinity`, so
     // without this the next user to sign in on a shared device would inherit the
     // previous user's board until a manual switch.
@@ -153,10 +157,14 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   // 401 it has already revoked + cleared tokens; this flips the provider out of
   // the authenticated UI right away instead of waiting for the next foreground
   // checkAuth. `setOnForcedSignOut` is our own module setter (not React state),
-  // so the function value is stored verbatim.
+  // so the function value is stored verbatim. Each caller emits its own Logout
+  // event so manual vs. server-revoked sign-outs are distinguishable in PostHog.
   useEffect(() => {
     setOnForcedSignOut(() => {
-      void runSignedOutCleanup();
+      track(SHARED_EVENTS.Logout, { method: 'forced' });
+      // runSignedOutCleanup swallows store-clear failures internally; report any
+      // unexpected rejection rather than letting it become an unhandled one.
+      runSignedOutCleanup().catch(reportError);
     });
     return () => setOnForcedSignOut(null);
   }, [runSignedOutCleanup]);


### PR DESCRIPTION
## What

When the server revokes a mobile session (password change, admin revoke, refresh-token rotation failure), the app stayed on the authenticated screens with a dead token. `authenticatedFetch`'s 401 handler only called the **library** `signOut` (`auth.ts` — best-effort revoke + `clearTokens`), which never touches the `AuthProvider`. Result: `isAuthenticated` stayed `true`, every later request went out with no `Authorization` header and 401'd (empty lists, spinners, "something went wrong"), the WS stayed connected on the revoked token, and PostHog kept the old identity — until the next background→foreground `checkAuth` happened to notice the missing token and redirect to login.

The structural cause: the lib-layer interceptor can't import the provider.

## Fix

- **`auth-interceptor.ts`** — add a module-level `onForcedSignOut` hook + `setOnForcedSignOut(cb)` setter, invoked right after the existing `await signOut()` in the unrecoverable 401 branch. It only fires on the failed-refresh path (the recoverable retry `return`s first), so a successful refresh+retry never triggers it.
- **`auth-provider.tsx`** — factor the provider's signed-out cleanup into a shared `runSignedOutCleanup` helper (analytics reset, store clears, active-board cache drop, HTTP client reset, WS dispose, `queryClient.clear()`, `setIsAuthenticated(false)`). The manual `signOut` reuses it; a `useEffect` registers it against the interceptor hook. The helper deliberately omits the two caller-specific steps — the manual `Logout` analytics event, and `authSignOut()` (the token revoke the forced path's caller already ran) — so the forced path never double-revokes.

Net result on a revoked session: tokens cleared → provider cleanup runs → `setIsAuthenticated(false)` → immediate `<Redirect href="/auth/login">`, WS torn down, caches cleared. Same end state as a manual logout, minus the manual `Logout` event.

## Scope

Addresses **only** #2684. `runSignedOutCleanup` is the shared piece the sibling audit item is noted to reuse; no further audit work is included here.

## Tests

Extended `auth-interceptor.test.ts`:
- failed-refresh 401 fires the forced-sign-out hook exactly once, after the token revoke;
- successful 401→refresh→retry does **not** fire it;
- no-token 401 does **not** fire it.

## Validation

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` ✅ (1448 passed; auth-interceptor: 14 passed)
- `vp run check:mobile-bundle` ✅ (10.6 MB)
- `vp check` ✅ (changed files clean)

Fixes #2684

🤖 Generated with [Claude Code](https://claude.com/claude-code)