### PR TITLE
Verify session liveness before cold-start rejoin (#2683)

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -126,7 +126,12 @@ describe('QueueProvider clearSession notifyServer', () => {
     sessionStore.getStoredSessionId.mockResolvedValue('session-1');
     sessionStore.clearStoredSessionId.mockClear();
     http.request.mockReset();
-    http.request.mockResolvedValue({});
+    // Cold-start restore verifies session liveness via GET_SESSION (#2683); keep
+    // the stored session alive so these tests land in-session before clearSession.
+    http.request.mockImplementation(async (operation: unknown) => {
+      const operationText = typeof operation === 'string' ? operation : '';
+      return operationText.includes('GetSession') ? { session: { id: 'session-1', endedAt: null } } : {};
+    });
     graph.execute.mockReset();
     // joinSession resolves the active session; leaveSession resolves true.
     graph.execute.mockResolvedValue({

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -32,6 +32,12 @@ const http = vi.hoisted(() => ({
   request: vi.fn(),
 }));
 
+const sessionStore = vi.hoisted(() => ({
+  getStoredSessionId: vi.fn(async () => 'session-1' as string | null),
+  setStoredSessionId: vi.fn(async () => {}),
+  clearStoredSessionId: vi.fn(async () => {}),
+}));
+
 const activeBoard = vi.hoisted(() => ({
   stored: {
     uuid: 'board-1',
@@ -113,11 +119,7 @@ vi.mock('../../lib/graphql/ws-client', () => ({
   getWsClient: () => ws.client,
 }));
 
-vi.mock('../../lib/session-store', () => ({
-  getStoredSessionId: vi.fn(async () => 'session-1'),
-  setStoredSessionId: vi.fn(async () => {}),
-  clearStoredSessionId: vi.fn(async () => {}),
-}));
+vi.mock('../../lib/session-store', () => sessionStore);
 
 vi.mock('../../lib/active-board-store', () => ({
   getStoredActiveBoard: activeBoard.getStoredActiveBoard,
@@ -186,6 +188,20 @@ const user = (overrides: Partial<SessionUser> = {}): SessionUser => ({
   userId: 'db-user-1',
   connectionState: 'CONNECTED',
   ...overrides,
+});
+
+// Shape returned by the GET_SESSION liveness check during cold-start restore.
+// endedAt: null means the session is still live and should be rejoined.
+const aliveSession = (id: string, endedAt: string | null = null) => ({
+  id,
+  name: null,
+  boardPath: '/kilter/1/10/1,2/40/list',
+  color: null,
+  goal: null,
+  startedAt: '2026-01-01T00:00:00.000Z',
+  endedAt,
+  driverParticipantId: null,
+  users: [],
 });
 
 function makeQueueItem(uuid: string, climbUuid = uuid, options: { suggested?: boolean } = {}): ClimbQueueItem {
@@ -330,13 +346,22 @@ describe('QueueProvider session update subscription', () => {
       mutation.mockResolvedValue(undefined);
     }
     wallConfirm.emitWallConfirm.mockClear();
+    sessionStore.getStoredSessionId.mockReset();
+    sessionStore.getStoredSessionId.mockResolvedValue('session-1');
+    sessionStore.setStoredSessionId.mockClear();
+    sessionStore.clearStoredSessionId.mockClear();
     graph.execute.mockReset();
     http.request.mockReset();
-    http.request.mockResolvedValue({
-      endSession: {
-        sessionId: 'session-1',
-      },
-    });
+    // The restore effect verifies session liveness via GET_SESSION before
+    // rejoining (#2683). Default to an alive session so existing tests still
+    // auto-restore into session-1; END_SESSION keeps its endSession shape.
+    // GetSessionQueueState (resync) shares the GetSession prefix, so exclude it
+    // here — the resync tests route http.request themselves.
+    http.request.mockImplementation((query: string) =>
+      typeof query === 'string' && query.includes('GetSession') && !query.includes('GetSessionQueueState')
+        ? Promise.resolve({ session: aliveSession('session-1') })
+        : Promise.resolve({ endSession: { sessionId: 'session-1' } }),
+    );
     graph.execute.mockResolvedValue({
       joinSession: {
         participantId: 'participant-self',
@@ -814,6 +839,48 @@ describe('QueueProvider session update subscription', () => {
     });
   });
 
+  it('drops a server-ended stored session on cold start without rejoining (#2683)', async () => {
+    sessionStore.getStoredSessionId.mockResolvedValue('session-ended');
+    http.request.mockImplementation((query: string) =>
+      typeof query === 'string' && query.includes('GetSession')
+        ? Promise.resolve({ session: aliveSession('session-ended', '2026-06-10T12:00:00.000Z') })
+        : Promise.resolve({ endSession: { sessionId: 'session-ended' } }),
+    );
+
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(sessionStore.clearStoredSessionId).toHaveBeenCalled();
+    });
+
+    // The dead session is never restored: no sessionId, no join, no subscription.
+    expect(snapshots.at(-1)?.sessionId).toBeNull();
+    expect(graph.execute).not.toHaveBeenCalled();
+    expect(ws.getSessionUpdatesSink()).toBeNull();
+  });
+
+  it('restores optimistically when the liveness check fails (offline cold start)', async () => {
+    http.request.mockImplementation((query: string) =>
+      typeof query === 'string' && query.includes('GetSession')
+        ? Promise.reject(new Error('offline'))
+        : Promise.resolve({ endSession: { sessionId: 'session-1' } }),
+    );
+
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    // Can't verify liveness offline, so the stored id is still applied...
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+    // ...and the session is joined as before, without clearing the stored id.
+    await waitFor(() => {
+      expect(graph.execute).toHaveBeenCalled();
+    });
+    expect(sessionStore.clearStoredSessionId).not.toHaveBeenCalled();
+  });
+
   it('applies board serial and follows same-board angle changes', async () => {
     const snapshots: Snapshot[] = [];
     renderProvider((snapshot) => snapshots.push(snapshot));
@@ -1075,6 +1142,11 @@ describe('QueueProvider mutation-failure resync', () => {
         options.onQueueStateCall?.();
         return queueStateResponse;
       }
+      // Cold-start liveness check (#2683) — keep the session alive so restore
+      // lands in-session for these resync tests.
+      if (operationText.includes('GetSession')) {
+        return { session: aliveSession('session-1') };
+      }
       return { endSession: { sessionId: 'session-1' } };
     });
   }
@@ -1235,6 +1307,10 @@ describe('QueueProvider mutation-failure resync', () => {
       if (operationText.includes('GetSessionQueueState')) {
         queueStateCalls += 1;
         throw new Error('resync fetch failed');
+      }
+      // Cold-start liveness check (#2683) — alive so restore lands in-session.
+      if (operationText.includes('GetSession')) {
+        return { session: aliveSession('session-1') };
       }
       return { endSession: { sessionId: 'session-1' } };
     });

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -55,12 +55,14 @@ import {
   CREATE_SESSION,
   END_SESSION,
   GET_CLIMB,
+  GET_SESSION,
   GET_SESSION_QUEUE_STATE,
   type CreateSessionMutationResponse,
   type EndSessionMutationResponse,
   type SessionUpdateEvent,
   type SessionLiveStatsEvent,
   type GetClimbQueryResponse,
+  type GetSessionQueryResponse,
   type GetSessionQueueStateQueryResponse,
 } from '../lib/graphql/operations';
 import { getStoredActiveBoard } from '../lib/active-board-store';
@@ -517,12 +519,41 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   }, [sessionId]);
 
   useEffect(() => {
-    void getStoredSessionId().then((storedId) => {
+    let cancelled = false;
+    void getStoredSessionId().then(async (storedId) => {
       if (__DEV__) {
         console.info(`[session] restored from store: ${storedId ?? '(none)'}`);
       }
-      if (storedId) setSessionId(storedId);
+      if (!storedId) return;
+      try {
+        // Verify the stored session is still alive before rejoining. Without
+        // this, JOIN_SESSION recreates a server-ended room as an empty zombie
+        // and we land in InSessionView with no peers (#2683).
+        const { session } = await getHttpClient().request<GetSessionQueryResponse>(GET_SESSION, {
+          sessionId: storedId,
+        });
+        if (cancelled) return;
+        if (!session || session.endedAt != null) {
+          if (__DEV__) {
+            console.info(`[session] stored session ${storedId} ended/missing; clearing`);
+          }
+          await clearStoredSessionId();
+          return;
+        }
+        setSessionId(storedId);
+      } catch (err) {
+        // Offline cold start: can't verify liveness, so restore optimistically
+        // so the queue still comes back. A genuinely-dead session stays
+        // escapable via End Session.
+        if (__DEV__) {
+          console.warn('[session] liveness check failed; restoring optimistically', err);
+        }
+        if (!cancelled) setSessionId(storedId);
+      }
     });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // showToast and t aren't stable callbacks — capture via refs so the WS


### PR DESCRIPTION
Fixes #2683.

## Problem
On mobile cold start, the persisted party-session id was restored from SecureStore and rejoined **without any liveness check** (`queue-provider.tsx` restore effect → WS effect → `JOIN_SESSION`). If the session ended while the app was dead — the host tapped **End Session**, or the backend's 60-min inactivity sweep ended it (the `SessionEnded` broadcast is missed by a killed app) — `JOIN_SESSION` recreated the server-ended room as an empty zombie. The climber landed in `InSessionView` with no peers, broadcasting queue mutations into a dead room, with ticks stamped after the session's `endedAt`. The only escape was to manually tap **End Session**.

## Fix (mobile client only)
The restore effect now fires a `GET_SESSION` liveness check (HTTP, mirroring the existing join-confirmation preview in `use-session-detail.ts`) before setting session state:

- **ended (`endedAt != null`) or missing session** → clear the stored id, do not rejoin → Record tab shows `PreSessionView`.
- **live session** → restore as before (brief one-RTT `PreSessionView` flash is acceptable).
- **request failure (offline cold start)** → optimistic restore, so the queue still comes back offline.

`GET_SESSION` / `GetSessionQueryResponse` already existed in `operations.ts`; `getHttpClient` was already imported.

Backend hardening (rejecting joins to `status='ended'` sessions instead of recreating them) is a real but separate latent gap, intentionally **out of scope** here — the client check fully addresses the reported cold-start user impact.

## Tests
- New: **ended session is dropped on cold start** — asserts stored id cleared, `sessionId` stays null, no join, no subscription.
- New: **offline optimistic restore** — `GET_SESSION` rejects → `sessionId` still restored, join fires, stored id not cleared.
- Updated the suite's default `http.request` mock to return an alive `GET_SESSION` so existing auto-restore tests stay green; refactored the `session-store` mock to a hoisted handle.

## Validation
- `vp run typecheck:mobile` ✓
- `vp run test:mobile` — 1449 tests pass (incl. 2 new) ✓
- `vp run check:mobile-bundle` — OK ✓
- `vp check` — lint + format clean on changed files ✓

Behaviour is hard to exercise in CI (needs a real ended session + force-quit), so it's covered by unit tests; device-QA steps are in `.boardsesh/qa-notes.md` (ended-by-host, ended-by-sweep, live restore, solo implicit session, offline relaunch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)