### PR TITLE
Run cross-user cleanup on expiry/relaunch logout (#2685)

### DIFF
--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -187,10 +187,98 @@ describe('AuthProvider forced sign-out registration', () => {
   });
 });
 
+describe('AuthProvider.checkAuth signed-out cleanup', () => {
+  beforeEach(() => {
+    getAuthTokenMock.mockReset();
+    isTokenExpiringSoonMock.mockReset();
+    authSignOutMock.mockReset();
+    clearStoredSessionIdMock.mockReset();
+    clearStoredActiveBoardMock.mockReset();
+    resetHttpClientMock.mockReset();
+    disposeWsClientMock.mockReset();
+    ensureFreshTokenMock.mockReset();
+    setOnForcedSignOutMock.mockReset();
+    reportErrorMock.mockReset();
+    // Default: a signed-in session with a fresh token so the first checkAuth
+    // authenticates without taking the refresh branch.
+    getAuthTokenMock.mockResolvedValue('jwt-token');
+    isTokenExpiringSoonMock.mockResolvedValue(false);
+    ensureFreshTokenMock.mockResolvedValue(true);
+    clearStoredSessionIdMock.mockResolvedValue(undefined);
+    clearStoredActiveBoardMock.mockResolvedValue(undefined);
+  });
+
+  // The #2685 bug: an expiry-triggered logout (token within the expiry window,
+  // proactive refresh fails in checkAuth — NOT a live 401, so the interceptor's
+  // forced-sign-out never fires) used to only flip isAuthenticated. It must now
+  // run the same cross-user cleanup signOut does, or the next user on a shared
+  // device inherits the previous user's cache/board/clients.
+  it('runs the full cross-user cleanup when a foreground refresh fails', async () => {
+    ensureFreshTokenMock.mockResolvedValue(false);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(['userPlaylists'], [{ id: 'p-1', name: "User A's playlist" }]);
+    queryClient.setQueryData(['activeBoard'], { uuid: 'b-a' });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    );
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    // First pass authenticates (token fresh); authStateRef then reads
+    // isAuthenticated: true, which gates the heavy cleanup on the next checkAuth.
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    // Now the token is within the expiry window and the refresh fails — driven
+    // via the exposed refreshAuthState (the same checkAuth AppState 'active' runs).
+    isTokenExpiringSoonMock.mockResolvedValue(true);
+    await act(async () => {
+      await result.current.refreshAuthState();
+    });
+
+    // Same cleanup as the explicit signOut tests, minus authSignOut() — the
+    // expiry path skips re-revoking an already-invalid token.
+    expect(authSignOutMock).not.toHaveBeenCalled();
+    expect(clearStoredSessionIdMock).toHaveBeenCalledTimes(1);
+    expect(clearStoredActiveBoardMock).toHaveBeenCalledTimes(1);
+    expect(resetHttpClientMock).toHaveBeenCalledTimes(1);
+    expect(disposeWsClientMock).toHaveBeenCalledTimes(1);
+    expect(queryClient.getQueryData(['userPlaylists'])).toBeUndefined();
+    expect(queryClient.getQueryData(['activeBoard'])).toBeUndefined();
+  });
+
+  // Relaunch guard: if the app is killed before the next user signs in, the
+  // React Query cache is empty but the persisted board/session id survive. A
+  // signed-out cold start must clear those so user B can't inherit user A's
+  // stored board. The heavy in-memory cleanup stays gated behind the
+  // authenticated transition (nothing to wipe on a cold start).
+  it('clears persisted board/session on a signed-out cold start (relaunch guard)', async () => {
+    getAuthTokenMock.mockResolvedValue(null);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    );
+    // Provider returns its <Redirect> branch (children never mount), so assert
+    // via the mocks rather than a hook snapshot.
+    render(wrapper({ children: null }));
+
+    await waitFor(() => expect(clearStoredActiveBoardMock).toHaveBeenCalledTimes(1));
+    expect(clearStoredSessionIdMock).toHaveBeenCalledTimes(1);
+    expect(resetHttpClientMock).not.toHaveBeenCalled();
+    expect(disposeWsClientMock).not.toHaveBeenCalled();
+  });
+});
+
 describe('AuthProvider.checkAuth keychain read failure', () => {
   beforeEach(() => {
     getAuthTokenMock.mockReset();
     isTokenExpiringSoonMock.mockReset();
+    clearStoredSessionIdMock.mockReset();
+    clearStoredActiveBoardMock.mockReset();
     reportErrorMock.mockReset();
     isTokenExpiringSoonMock.mockResolvedValue(false);
   });
@@ -217,5 +305,27 @@ describe('AuthProvider.checkAuth keychain read failure', () => {
     await waitFor(() => expect(onReady).toHaveBeenCalled());
     // The failure is surfaced to Sentry rather than swallowed silently.
     expect(reportErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  // The catch branch must stay cleanup-free: a keychain read failure is
+  // transient (auth is restored on the next AppState 'active' re-check), so
+  // wiping a still-valid user's persisted board/session here would be a
+  // regression. Only the genuine signed-out branches clear persisted stores.
+  it('does not clear persisted stores when the token read rejects', async () => {
+    getAuthTokenMock.mockRejectedValue(new Error('keychain locked'));
+    const onReady = vi.fn();
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider onReady={onReady}>{children}</AuthProvider>
+      </QueryClientProvider>
+    );
+
+    render(wrapper({ children: null }));
+
+    await waitFor(() => expect(onReady).toHaveBeenCalled());
+    expect(clearStoredActiveBoardMock).not.toHaveBeenCalled();
+    expect(clearStoredSessionIdMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -58,23 +58,74 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     }
   }, []);
 
+  // Persisted (SecureStore/AsyncStorage-backed) per-user state that outlives a
+  // relaunch. allSettled (not all) so one failing delete can't abort the rest.
+  // These are the only sign-out leftovers that can carry a previous user across
+  // a cold start on a shared device, so a signed-out checkAuth clears them even
+  // when there's no live in-session cache to wipe (see handleSignedOutTransition).
+  const clearPersistedUserStores = useCallback(
+    () => Promise.allSettled([clearStoredSessionId(), clearStoredActiveBoard()]),
+    [],
+  );
+
+  // The shared signed-out cleanup, used by the manual `signOut`, the
+  // interceptor's forced sign-out (failed-refresh 401), and checkAuth's
+  // proactive expiry path. It deliberately omits the two caller-specific steps:
+  // the manual `Logout` analytics event, and `authSignOut()` (the token revoke +
+  // clear) — the forced/expiry paths' token is already revoked, so running it
+  // here would double-revoke.
+  const runSignedOutCleanup = useCallback(async () => {
+    resetAnalytics();
+    await clearPersistedUserStores();
+    // Drop the in-memory active-board cache too. It's `staleTime: Infinity`, so
+    // without this the next user to sign in on a shared device would inherit the
+    // previous user's board until a manual switch.
+    queryClient.removeQueries({ queryKey: ACTIVE_BOARD_QUERY_KEY });
+    resetHttpClient();
+    disposeWsClient();
+    // Drop every cached query so the next signed-in user doesn't inherit the
+    // previous user's data. Query keys don't currently include a user/token
+    // dimension, and individual keys' staleTime (e.g. userPlaylists' 5 min)
+    // would otherwise paper over the cross-user leak. Doing this at the auth
+    // boundary keeps the rest of the hooks simple.
+    queryClient.clear();
+    setIsAuthenticated(false);
+  }, [clearPersistedUserStores, queryClient]);
+
+  // checkAuth lands here when a token read/refresh shows the session is gone. If
+  // we were authenticated this session, run the full cleanup (cache + clients are
+  // live). Otherwise — a logged-out cold start / relaunch — the cache is empty
+  // and the clients are null, so only the persisted stores can carry a prior
+  // user forward; clear those. Gating the heavy cleanup on the transition keeps a
+  // normal logged-out launch from churning an empty cache. Both branches flip
+  // isAuthenticated → false, so checkAuth doesn't repeat it.
+  const handleSignedOutTransition = useCallback(async () => {
+    if (authStateRef.current.isAuthenticated) {
+      await runSignedOutCleanup();
+    } else {
+      resetAnalyticsForSignedOutTransition();
+      await clearPersistedUserStores();
+      setIsAuthenticated(false);
+    }
+  }, [runSignedOutCleanup, clearPersistedUserStores, resetAnalyticsForSignedOutTransition]);
+
   const checkAuth = useCallback(async () => {
     try {
       const token = await getAuthToken();
       if (!token) {
-        resetAnalyticsForSignedOutTransition();
-        setIsAuthenticated(false);
+        await handleSignedOutTransition();
         return;
       }
       const expiring = await isTokenExpiringSoon();
       if (expiring) {
         const { ensureFreshToken } = await import('../lib/auth-interceptor');
         const refreshed = await ensureFreshToken();
-        if (!refreshed) resetAnalyticsForSignedOutTransition();
-        setIsAuthenticated(refreshed);
-      } else {
-        setIsAuthenticated(true);
+        if (!refreshed) {
+          await handleSignedOutTransition();
+          return;
+        }
       }
+      setIsAuthenticated(true);
     } catch (authCheckError) {
       // SecureStore.getItemAsync REJECTS (not returns null) when the keychain
       // is inaccessible — a background launch before first unlock, or an
@@ -88,7 +139,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     } finally {
       setIsLoading(false);
     }
-  }, [resetAnalyticsForSignedOutTransition]);
+  }, [handleSignedOutTransition]);
 
   useEffect(() => {
     // Belt-and-braces: checkAuth already resolves its own rejections, but keep
@@ -119,33 +170,6 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     },
     [checkAuth],
   );
-
-  // The shared signed-out cleanup, used by both the manual `signOut` below and
-  // the interceptor's forced sign-out (failed-refresh 401). It deliberately
-  // omits the two caller-specific steps: the manual `Logout` analytics event,
-  // and `authSignOut()` (the token revoke + clear) — the forced path's caller
-  // already revoked, so running it here would double-revoke.
-  const runSignedOutCleanup = useCallback(async () => {
-    resetAnalytics();
-    // Best-effort store clears — clearStoredSessionId/clearStoredActiveBoard hit
-    // SecureStore/AsyncStorage and can reject. allSettled (not all) so a failed
-    // delete can't abort the rest of the teardown and leave the user stuck on the
-    // authenticated screens with the critical setIsAuthenticated(false) skipped.
-    await Promise.allSettled([clearStoredSessionId(), clearStoredActiveBoard()]);
-    // Drop the in-memory active-board cache too. It's `staleTime: Infinity`, so
-    // without this the next user to sign in on a shared device would inherit the
-    // previous user's board until a manual switch.
-    queryClient.removeQueries({ queryKey: ACTIVE_BOARD_QUERY_KEY });
-    resetHttpClient();
-    disposeWsClient();
-    // Drop every cached query so the next signed-in user doesn't inherit the
-    // previous user's data. Query keys don't currently include a user/token
-    // dimension, and individual keys' staleTime (e.g. userPlaylists' 5 min)
-    // would otherwise paper over the cross-user leak. Doing this at the auth
-    // boundary keeps the rest of the hooks simple.
-    queryClient.clear();
-    setIsAuthenticated(false);
-  }, [queryClient]);
 
   const signOut = useCallback(async () => {
     track(SHARED_EVENTS.Logout, { method: 'manual' });


### PR DESCRIPTION
Fixes #2685. Rebased on `main` after #2684 (forced sign-out) landed — reconciled to build on that work rather than duplicate it.

## Problem

On a shared mobile device, an **expiry-triggered** logout (token within 24h of expiry, refresh revoked) leaks the previous user's data to the next user: `AuthProvider.checkAuth`'s signed-out branches only flipped `isAuthenticated`, skipping the cache/session/WS cleanup that explicit "Log out" runs. Because `QueryProvider` sits **above** `AuthProvider`, the `QueryClient` cache survives the redirect, and `useActiveBoard`'s `staleTime: Infinity` means the next sign-in inherits the previous user's **active board, playlists, beta links, and undisposed WS/HTTP clients**.

## Why #2684 doesn't already cover this

#2684 added `runSignedOutCleanup` + a `setOnForcedSignOut` interceptor hook, but `forceSignOut` only fires from `authenticatedFetch` on a **live 401**. The path here — `checkAuth` → `ensureFreshToken()` returns false on foreground/cold-start (a *proactive* refresh, not a request 401) — never triggers it. So `checkAuth`'s own signed-out branches were still leaky.

## Fix

Reuse #2684's `runSignedOutCleanup` (now sharing a small `clearPersistedUserStores` helper) and wire it into `checkAuth`'s genuine signed-out branches via `handleSignedOutTransition`:

- **Authenticated → unauthenticated** (in-session expiry foreground): full `runSignedOutCleanup` (analytics reset, persisted stores, `removeQueries(activeBoard)`, HTTP/WS disposal, `queryClient.clear()`).
- **Logged-out cold start / relaunch**: cache is already empty and clients are null, so only the AsyncStorage-backed board + session id can carry a prior user across a kill/relaunch — clear just those. (Closes the relaunch variant per the follow-up ask on the issue.)

Boundaries preserved:
- The keychain-read **catch branch stays cleanup-free** — that failure is transient (auth restores on the next foreground re-check), so it must not wipe a still-valid user's state.
- `authSignOut()` (server revocation) stays on the explicit-button path only — the expiry/forced paths' token is already invalid.
- `runSignedOutCleanup`'s contract (used by manual signOut + forced sign-out) is unchanged; it just also gets called from the proactive expiry path.

## Tests

`auth-provider.test.tsx` (reusing #2684's `ensureFreshTokenMock` / `setOnForcedSignOutMock`):
- Foreground expiry path runs the full cross-user cleanup and asserts `authSignOut` is **not** called.
- Relaunch cold-start guard clears persisted board/session and leaves the heavy in-memory cleanup off.
- Regression guard: a keychain read rejection never clears persisted stores.

## Validation

- `vp run test:mobile` — 1545 passed (7 in the touched file)
- `vp run typecheck:mobile` — pass
- `vp check` — touched files clean
- `vp run check:mobile-bundle` — OK

Device repro is macOS/simulator-only (timing + AppState driven); QA steps in `.boardsesh/qa-notes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)