### PR TITLE
fix(mobile): render playlist climbs against the playlist's own board (#2689)

### DIFF
--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -28,6 +28,7 @@ import {
 import { GlassIconButton } from '../../../src/components/GlassIconButton';
 import { getHttpClient } from '../../../src/lib/graphql/client';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
+import { usePlaylistRenderBoard } from '../../../src/lib/playlists/use-playlist-render-board';
 import { recordPlaylistOpen } from '../../../src/lib/playlists/recents-store';
 import { toQueueClimbs } from '../../../src/lib/climb-types';
 import { hapticSelection } from '../../../src/lib/haptics';
@@ -114,6 +115,14 @@ export default function PlaylistDetail() {
     fetchPage,
     refreshErrorMessage: 'Failed to refresh playlist suggestions:',
   });
+
+  // Render the climbs against the playlist's own board. When it matches the
+  // active board this is the active board (tapping queues normally); when it
+  // differs (or there's no active board) rows render read-only against the
+  // playlist's board and `boardBanner` prompts a switch.
+  const { renderBoard, banner: boardBanner } = usePlaylistRenderBoard(
+    playlist ? { boardType: playlist.boardType, layoutId: playlist.layoutId } : null,
+  );
 
   const isOwner = playlist?.userRole === 'owner';
   const isFollowable = !!playlist?.isPublic && !isOwner;
@@ -414,6 +423,8 @@ export default function PlaylistDetail() {
       <PlaylistDetailView
         hero={hero}
         climbs={allClimbs}
+        renderBoard={renderBoard}
+        boardBanner={boardBanner}
         isLoading={query.isLoading}
         isFetchingNextPage={query.isFetchingNextPage}
         hasNextPage={query.hasNextPage ?? false}

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -66,6 +66,9 @@ vi.mock('../../../../src/providers/theme-provider', () => ({
 vi.mock('../../../../src/providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
 vi.mock('../../../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../../../../src/lib/playlists/use-playlist-activation', () => ({ usePlaylistActivation: () => vi.fn() }));
+vi.mock('../../../../src/lib/playlists/use-playlist-render-board', () => ({
+  usePlaylistRenderBoard: () => ({ renderBoard: null, banner: null }),
+}));
 vi.mock('../../../../src/lib/playlists/recents-store', () => ({ recordPlaylistOpen: vi.fn() }));
 vi.mock('../../../../src/lib/climb-types', () => ({ toQueueClimbs: (climbs: unknown) => climbs }));
 vi.mock('../../../../src/lib/haptics', () => ({ hapticSelection: vi.fn() }));

--- a/packages/mobile/app/(tabs)/discover/smart/[type].tsx
+++ b/packages/mobile/app/(tabs)/discover/smart/[type].tsx
@@ -20,6 +20,7 @@ import {
 } from '../../../../src/components/playlist';
 import { getHttpClient } from '../../../../src/lib/graphql/client';
 import { usePlaylistActivation } from '../../../../src/lib/playlists/use-playlist-activation';
+import { usePlaylistRenderBoard } from '../../../../src/lib/playlists/use-playlist-render-board';
 import { toQueueClimbs } from '../../../../src/lib/climb-types';
 import { smartPlaylistByType } from '../../../../src/lib/smart-playlists';
 import { useProfile } from '../../../../src/lib/graphql/hooks';
@@ -75,6 +76,10 @@ export default function SmartPlaylistDetail() {
     fetchPage,
     refreshErrorMessage: 'Failed to refresh smart playlist suggestions:',
   });
+
+  // Smart playlists are computed relative to the active board, so they always
+  // render against it (no mismatch banner).
+  const { renderBoard } = usePlaylistRenderBoard(null);
 
   const hero = useMemo(
     () => ({
@@ -133,6 +138,7 @@ export default function SmartPlaylistDetail() {
     <PlaylistDetailView
       hero={hero}
       climbs={allClimbs}
+      renderBoard={renderBoard}
       isLoading={query.isLoading}
       isFetchingNextPage={query.isFetchingNextPage}
       hasNextPage={query.hasNextPage ?? false}

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -30,12 +30,13 @@ import { ActivityIndicator } from '../ActivityIndicator';
 import { ClimbListRow } from '../ClimbListRow';
 import { ClimbListRowSkeleton } from '../ClimbListRowSkeleton';
 import { GlassIconButton } from '../GlassIconButton';
+import { Button } from '../Button';
 import { PlaylistBoardBackdrop } from './PlaylistBoardBackdrop';
 import { buildHeroGradient, shiftLightness } from './playlist-gradient';
 import { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';
 import { withAlpha } from '../../theme/colors';
 import { toQueueClimb, toSchemaClimb } from '../../lib/climb-types';
-import { useDrawerHost } from '../../providers/drawer-host-provider';
+import type { PlaylistRenderBoard, PlaylistBoardBanner } from '../../lib/playlists/use-playlist-render-board';
 import { useTheme } from '../../providers/theme-provider';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { glassSize } from '../../theme/layout';
@@ -87,6 +88,15 @@ export type PlaylistDetailHero = {
 export type PlaylistDetailViewProps = {
   hero: PlaylistDetailHero;
   climbs: Climb[];
+  /** Board the climb rows render against (resolved by `usePlaylistRenderBoard`).
+   *  Null while the active board is still loading, or when the playlist's board
+   *  can't be resolved — every row renders null in that case. */
+  renderBoard: PlaylistRenderBoard | null;
+  /** Set when the playlist belongs to a board other than the active one (or
+   *  there is no active board). Rows render read-only against the playlist's own
+   *  board, a switch-board banner shows above the list, and queueing (row tap +
+   *  activate-all) is disabled. */
+  boardBanner?: PlaylistBoardBanner | null;
   /** True while the first page loads (hero still renders; list shows a spinner). */
   isLoading: boolean;
   /** True while a subsequent page loads (trailing spinner). */
@@ -110,8 +120,14 @@ export type PlaylistDetailViewProps = {
 /**
  * Shared hero + paginated climb list for the playlist-detail and
  * smart-playlist-detail screens. Renders the colour/emoji hero, then a FlashList
- * of `ClimbListRow`s bound to the user's active board, paginating via
+ * of `ClimbListRow`s rendered against `renderBoard`, paginating via
  * `fetchNextPage` as the list nears its end.
+ *
+ * `renderBoard` is the user's active board for the common case. When a playlist
+ * belongs to a different board, the caller passes the playlist's own board plus
+ * a `boardBanner`: rows then render read-only against that board, a switch-board
+ * banner shows above the list, and queueing is disabled (the queue / play drawer
+ * / BLE LEDs follow the single active board).
  *
  * Two presentations: the Liquid Glass variant keeps the full-bleed gradient hero
  * with white text and floating FABs; the Material 3 variant swaps in a Paper
@@ -121,6 +137,8 @@ export type PlaylistDetailViewProps = {
 export function PlaylistDetailView({
   hero,
   climbs,
+  renderBoard,
+  boardBanner,
   isLoading,
   isFetchingNextPage,
   hasNextPage,
@@ -133,7 +151,6 @@ export function PlaylistDetailView({
   const { t } = useTranslation('playlists');
   const { t: tCommon } = useTranslation('common');
   const { systemColors, brandColors, variant } = useTheme();
-  const { boardConfig } = useDrawerHost();
   const bottomChrome = useBottomChromeMetrics();
   const insets = useSafeAreaInsets();
   const router = useRouter();
@@ -191,30 +208,39 @@ export function PlaylistDetailView({
   // header `collapsed` flips during scroll) would otherwise re-render every row.
   const handleActivate = useCallback((tapped: SchemaClimb) => onActivateClimb(toQueueClimb(tapped)), [onActivateClimb]);
 
+  // Read-only mode (board mismatch): tapping a climb routes to the board
+  // switcher — the one action that lets the user actually climb it. The hook
+  // memoizes `boardBanner`, so this stays stable and doesn't churn the rows.
+  const handleSwitchBoard = useCallback(() => boardBanner?.onPress(), [boardBanner]);
+
   // Activate-all: queue the playlist from the top. Reuses the same row-tap path
   // (which seeds the suggestion source from the whole list), so swiping the play
-  // drawer walks the playlist. No-op on an empty list.
+  // drawer walks the playlist. No-op on an empty list or in read-only mode.
   const handleActivateAll = useCallback(() => {
+    if (boardBanner) return;
     const first = climbs[0];
     if (first) onActivateClimb(first);
-  }, [climbs, onActivateClimb]);
+  }, [boardBanner, climbs, onActivateClimb]);
 
   const renderItem = useCallback(
     ({ item }: { item: Climb }) => {
-      if (!boardConfig) return null;
+      if (!renderBoard) return null;
+      const readOnly = !!boardBanner;
       return (
         <ClimbListRow
           climb={toSchemaClimb(item)}
-          boardName={boardConfig.boardName as BoardName}
-          layoutId={boardConfig.layoutId}
-          sizeId={boardConfig.sizeId}
-          setIds={boardConfig.setIds}
-          angle={boardConfig.angle}
-          onPress={handleActivate}
+          boardName={renderBoard.boardName as BoardName}
+          layoutId={renderBoard.layoutId}
+          sizeId={renderBoard.sizeId}
+          setIds={renderBoard.setIds}
+          // Read-only rows render at each climb's own angle (the angle its grade
+          // was baked at); the matching case uses the active board's angle.
+          angle={readOnly ? item.angle : renderBoard.angle}
+          onPress={readOnly ? handleSwitchBoard : handleActivate}
         />
       );
     },
-    [boardConfig, handleActivate],
+    [renderBoard, boardBanner, handleActivate, handleSwitchBoard],
   );
 
   const baseColor = hero.color && isValidHexColor(hero.color) ? hero.color : PLAYLIST_COLORS[0];
@@ -251,6 +277,11 @@ export function PlaylistDetailView({
     </View>
   ) : null;
 
+  // Switch-board banner shown above the read-only list when the playlist's board
+  // differs from the active one. Sits inside the list header so it scrolls with
+  // the hero in both variants.
+  const bannerNode = boardBanner ? <BoardMismatchBanner banner={boardBanner} systemColors={systemColors} /> : null;
+
   // ── Material 3 branch ───────────────────────────────────────────────────────
   if (isMaterial) {
     const accent = brandColors.primary;
@@ -266,49 +297,52 @@ export function PlaylistDetailView({
           scrollEventThrottle={16}
           contentContainerStyle={{ paddingBottom: listPaddingBottom }}
           ListHeaderComponent={
-            <View onLayout={handleHeroLayout} style={styles.materialHero}>
-              <View
-                style={[
-                  styles.materialHeroBand,
-                  { paddingTop: headerBarHeight + spacing[4], backgroundColor: systemColors.secondaryBackground },
-                ]}
-              >
-                <View style={[styles.materialHeroEmojiCircle, { backgroundColor: systemColors.tertiaryBackground }]}>
-                  {hero.icon ? (
-                    <Text style={styles.materialHeroEmoji} allowFontScaling={false}>
-                      {hero.icon}
-                    </Text>
-                  ) : (
-                    <Icon name="tag" size={36} color={systemColors.secondaryLabel} />
-                  )}
-                </View>
-                <Text variant="title2" numberOfLines={2} color={systemColors.label} style={styles.materialHeroName}>
-                  {hero.name}
-                </Text>
-                <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.materialHeroMeta}>
-                  {t('detail.climbCount', { count: hero.climbCount })}
-                </Text>
-                {hero.followerLabel ? (
-                  <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.materialHeroMeta}>
-                    {hero.followerLabel}
+            <>
+              <View onLayout={handleHeroLayout} style={styles.materialHero}>
+                <View
+                  style={[
+                    styles.materialHeroBand,
+                    { paddingTop: headerBarHeight + spacing[4], backgroundColor: systemColors.secondaryBackground },
+                  ]}
+                >
+                  <View style={[styles.materialHeroEmojiCircle, { backgroundColor: systemColors.tertiaryBackground }]}>
+                    {hero.icon ? (
+                      <Text style={styles.materialHeroEmoji} allowFontScaling={false}>
+                        {hero.icon}
+                      </Text>
+                    ) : (
+                      <Icon name="tag" size={36} color={systemColors.secondaryLabel} />
+                    )}
+                  </View>
+                  <Text variant="title2" numberOfLines={2} color={systemColors.label} style={styles.materialHeroName}>
+                    {hero.name}
                   </Text>
+                  <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.materialHeroMeta}>
+                    {t('detail.climbCount', { count: hero.climbCount })}
+                  </Text>
+                  {hero.followerLabel ? (
+                    <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.materialHeroMeta}>
+                      {hero.followerLabel}
+                    </Text>
+                  ) : null}
+                </View>
+                {hero.description || hero.subtitle ? (
+                  <View style={styles.heroBelow}>
+                    {hero.description ? (
+                      <Text variant="footnote" numberOfLines={3} color={systemColors.secondaryLabel}>
+                        {hero.description}
+                      </Text>
+                    ) : null}
+                    {hero.subtitle ? (
+                      <Text variant="footnote" numberOfLines={1} color={systemColors.tertiaryLabel}>
+                        {hero.subtitle}
+                      </Text>
+                    ) : null}
+                  </View>
                 ) : null}
               </View>
-              {hero.description || hero.subtitle ? (
-                <View style={styles.heroBelow}>
-                  {hero.description ? (
-                    <Text variant="footnote" numberOfLines={3} color={systemColors.secondaryLabel}>
-                      {hero.description}
-                    </Text>
-                  ) : null}
-                  {hero.subtitle ? (
-                    <Text variant="footnote" numberOfLines={1} color={systemColors.tertiaryLabel}>
-                      {hero.subtitle}
-                    </Text>
-                  ) : null}
-                </View>
-              ) : null}
-            </View>
+              {bannerNode}
+            </>
           }
           ListFooterComponent={listFooterComponent}
           ListEmptyComponent={listEmptyComponent}
@@ -334,7 +368,7 @@ export function PlaylistDetailView({
               so we ask for the compact icon form (`actions(true)`) — `GlassIconButton`
               routes to a Paper `IconButton` here, fitting the bar. */}
           {actions?.(true)}
-          {climbs.length > 0 ? (
+          {climbs.length > 0 && !boardBanner ? (
             <Appbar.Action
               icon="play"
               color={accent as string}
@@ -451,7 +485,12 @@ export function PlaylistDetailView({
         contentInsetAdjustmentBehavior="never"
         automaticallyAdjustContentInsets={false}
         contentContainerStyle={{ paddingBottom: listPaddingBottom }}
-        ListHeaderComponent={header}
+        ListHeaderComponent={
+          <>
+            {header}
+            {bannerNode}
+          </>
+        }
         ListFooterComponent={listFooterComponent}
         ListEmptyComponent={listEmptyComponent}
       />
@@ -520,6 +559,44 @@ function MaterialEmptyState({
           {supporting}
         </Text>
       ) : null}
+    </View>
+  );
+}
+
+/** Switch-board banner for a read-only playlist whose board differs from the
+ *  active one: a board glyph + the prompt, then a filled CTA into `/boards`.
+ *  Lives above the (read-only) climb list in both variants. */
+function BoardMismatchBanner({
+  banner,
+  systemColors,
+}: {
+  banner: PlaylistBoardBanner;
+  systemColors: {
+    secondaryBackground: ColorValue;
+    label: ColorValue;
+    secondaryLabel: ColorValue;
+    separator: ColorValue;
+  };
+}) {
+  return (
+    <View
+      style={[
+        styles.banner,
+        { backgroundColor: systemColors.secondaryBackground, borderColor: systemColors.separator },
+      ]}
+    >
+      <View style={styles.bannerRow}>
+        <Icon name="boards.fill" size={22} color={systemColors.secondaryLabel} />
+        <View style={styles.bannerText}>
+          <Text variant="subheadline" color={systemColors.label} style={styles.bannerTitle}>
+            {banner.title}
+          </Text>
+          <Text variant="footnote" color={systemColors.secondaryLabel}>
+            {banner.subtitle}
+          </Text>
+        </View>
+      </View>
+      <Button title={banner.cta} onPress={banner.onPress} size="medium" style={styles.bannerButton} />
     </View>
   );
 }
@@ -672,6 +749,31 @@ const styles = StyleSheet.create({
   },
   materialEmptySupporting: {
     textAlign: 'center',
+  },
+  banner: {
+    marginHorizontal: spacing[4],
+    marginTop: spacing[2],
+    marginBottom: spacing[2],
+    padding: spacing[4],
+    borderRadius: borderRadius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    gap: spacing[3],
+  },
+  bannerRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing[3],
+  },
+  bannerText: {
+    flex: 1,
+    gap: 2,
+  },
+  bannerTitle: {
+    fontWeight: '600',
+    marginBottom: 2,
+  },
+  bannerButton: {
+    alignSelf: 'flex-start',
   },
   footer: {
     paddingVertical: 20,

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useState } from 'react';
+import { type ReactNode, useCallback, useRef, useState } from 'react';
 import {
   type ColorValue,
   type LayoutChangeEvent,
@@ -209,23 +209,30 @@ export function PlaylistDetailView({
   const handleActivate = useCallback((tapped: SchemaClimb) => onActivateClimb(toQueueClimb(tapped)), [onActivateClimb]);
 
   // Read-only mode (board mismatch): tapping a climb routes to the board
-  // switcher — the one action that lets the user actually climb it. The hook
-  // memoizes `boardBanner`, so this stays stable and doesn't churn the rows.
-  const handleSwitchBoard = useCallback(() => boardBanner?.onPress(), [boardBanner]);
+  // switcher — the one action that lets the user actually climb it. Read the
+  // banner through a ref so this callback (and thus `renderItem`) stays stable
+  // even if `boardBanner`'s identity churns — otherwise every FlashList row
+  // would re-render on a banner recreation.
+  const boardBannerRef = useRef(boardBanner);
+  boardBannerRef.current = boardBanner;
+  const handleSwitchBoard = useCallback(() => boardBannerRef.current?.onPress(), []);
+
+  // `renderItem` depends on this boolean, not the `boardBanner` object, so a
+  // banner identity change doesn't invalidate the memoized rows.
+  const readOnly = !!boardBanner;
 
   // Activate-all: queue the playlist from the top. Reuses the same row-tap path
   // (which seeds the suggestion source from the whole list), so swiping the play
   // drawer walks the playlist. No-op on an empty list or in read-only mode.
   const handleActivateAll = useCallback(() => {
-    if (boardBanner) return;
+    if (readOnly) return;
     const first = climbs[0];
     if (first) onActivateClimb(first);
-  }, [boardBanner, climbs, onActivateClimb]);
+  }, [readOnly, climbs, onActivateClimb]);
 
   const renderItem = useCallback(
     ({ item }: { item: Climb }) => {
       if (!renderBoard) return null;
-      const readOnly = !!boardBanner;
       return (
         <ClimbListRow
           climb={toSchemaClimb(item)}
@@ -240,7 +247,7 @@ export function PlaylistDetailView({
         />
       );
     },
-    [renderBoard, boardBanner, handleActivate, handleSwitchBoard],
+    [renderBoard, readOnly, handleActivate, handleSwitchBoard],
   );
 
   const baseColor = hero.color && isValidHexColor(hero.color) ? hero.color : PLAYLIST_COLORS[0];

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -114,8 +114,8 @@ vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({
 
 vi.mock('../../../theme/layout', () => ({ glassSize: { standard: 48, capsule: 36, hero: 56 } }));
 vi.mock('../../../theme/tokens', () => ({
-  spacing: { 1: 4, 2: 8, 4: 16, 5: 20, 12: 48 },
-  borderRadius: { xl: 24 },
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 12: 48 },
+  borderRadius: { lg: 12, xl: 24 },
 }));
 vi.mock('../../../theme/colors', () => ({
   withAlpha: (color: string, alpha: number) => `${color}|${alpha}`,
@@ -140,6 +140,13 @@ vi.mock('../../ActivityIndicator', () => ({
 }));
 
 vi.mock('../../ClimbListRow', () => ({ ClimbListRow: () => null }));
+
+// Button pulls in react-native-paper + expo-modules-core; stub it to a plain
+// button so the board-mismatch banner can render in jsdom.
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress }: { title: string; onPress?: () => void }) =>
+    createElement('button', { 'data-button': 'true', onClick: onPress }, title),
+}));
 
 vi.mock('../../ClimbListRowSkeleton', () => ({
   ClimbListRowSkeleton: () => createElement('div', { 'data-skeleton-row': 'true' }),
@@ -212,6 +219,7 @@ function makeProps(overrides: Partial<PlaylistDetailViewProps> = {}): PlaylistDe
       color: '#8C4A52',
     },
     climbs: [],
+    renderBoard: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 },
     isLoading: false,
     isFetchingNextPage: false,
     hasNextPage: false,
@@ -441,6 +449,46 @@ describe('PlaylistDetailView', () => {
       // (collapsed) icon form rather than the scroll-driven pill.
       expect(actions).toHaveBeenCalledWith(true);
       expect(container.querySelector('[data-action-collapsed="true"]')).not.toBeNull();
+    });
+  });
+
+  // ── Board-mismatch banner (read-only) ───────────────────────────────────────
+  describe('board mismatch banner', () => {
+    const banner = {
+      title: 'Switch to Kilter to climb this playlist',
+      subtitle: 'These are Kilter climbs. Switch boards to queue them.',
+      cta: 'Switch board',
+      onPress: vi.fn(),
+    };
+
+    beforeEach(() => {
+      banner.onPress.mockClear();
+    });
+
+    it('renders the banner title, subtitle and CTA when boardBanner is set', () => {
+      const { getByText } = render(<PlaylistDetailView {...makeProps({ climbs: [CLIMB], boardBanner: banner })} />);
+      expect(getByText(banner.title)).not.toBeNull();
+      expect(getByText(banner.subtitle)).not.toBeNull();
+      expect(getByText(banner.cta)).not.toBeNull();
+    });
+
+    it('clicking the banner CTA calls boardBanner.onPress', () => {
+      const { getByText } = render(<PlaylistDetailView {...makeProps({ climbs: [CLIMB], boardBanner: banner })} />);
+      fireEvent.click(getByText(banner.cta));
+      expect(banner.onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders no banner when boardBanner is absent', () => {
+      const { container } = render(<PlaylistDetailView {...makeProps({ climbs: [CLIMB] })} />);
+      expect(container.querySelector('[data-button]')).toBeNull();
+    });
+
+    it('hides the Material activate-all action while the banner is shown', () => {
+      ctrl.variant = 'material';
+      const { container } = render(<PlaylistDetailView {...makeProps({ climbs: [CLIMB], boardBanner: banner })} />);
+      // Queueing is blocked on a board mismatch, so the play-all action is gone
+      // even though the list has climbs.
+      expect(container.querySelector('[data-appbar-action="play"]')).toBeNull();
     });
   });
 });

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-render-board.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-render-board.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { usePlaylistRenderBoard } from '../use-playlist-render-board';
+
+type ActiveBoard = {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+} | null;
+
+type ResolvedBoard = { boardName: string; layoutId: number; sizeId: number; setIds: number[] } | null;
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  activeBoard: { boardName: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 } as ActiveBoard,
+  resolved: { boardName: 'tension', layoutId: 9, sizeId: 5, setIds: [1, 2] } as ResolvedBoard,
+  getBoardConfigForPlaylist: vi.fn(),
+}));
+
+vi.mock('expo-router', () => ({ useRouter: () => ({ push: mocks.push }) }));
+
+// t interpolates the board name so banner copy can be asserted to carry it.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts && 'board' in opts ? `${key}|${String(opts.board)}` : key,
+  }),
+}));
+
+vi.mock('@boardsesh/board-config', () => ({
+  formatBoardDisplayName: (boardType: string) => boardType.charAt(0).toUpperCase() + boardType.slice(1),
+}));
+
+vi.mock('../../../providers/drawer-host-provider', () => ({
+  useDrawerHost: () => ({ boardConfig: mocks.activeBoard }),
+}));
+
+vi.mock('../board-details-for-playlist', () => ({
+  getBoardConfigForPlaylist: (boardType: string, layoutId: number | null | undefined) =>
+    mocks.getBoardConfigForPlaylist(boardType, layoutId),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.activeBoard = { boardName: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 };
+  mocks.resolved = { boardName: 'tension', layoutId: 9, sizeId: 5, setIds: [1, 2] };
+  mocks.getBoardConfigForPlaylist.mockImplementation(() => mocks.resolved);
+});
+
+describe('usePlaylistRenderBoard', () => {
+  it('renders against the active board with no banner when the boards match', () => {
+    const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'kilter', layoutId: 1 }));
+    expect(result.current.renderBoard).toBe(mocks.activeBoard);
+    expect(result.current.banner).toBeNull();
+    // No need to resolve the playlist's own board when it matches the active one.
+    expect(mocks.getBoardConfigForPlaylist).not.toHaveBeenCalled();
+  });
+
+  it('matches on board name when the playlist carries no layout (Aurora circuit)', () => {
+    const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'kilter', layoutId: null }));
+    expect(result.current.renderBoard).toBe(mocks.activeBoard);
+    expect(result.current.banner).toBeNull();
+  });
+
+  it('resolves the playlist board read-only + banner on a board-name mismatch', () => {
+    const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'tension', layoutId: 9 }));
+    expect(result.current.renderBoard).toEqual({
+      boardName: 'tension',
+      layoutId: 9,
+      sizeId: 5,
+      setIds: '1,2',
+      angle: 40,
+    });
+    expect(result.current.banner?.title).toContain('Tension');
+    expect(result.current.banner?.subtitle).toContain('Tension');
+  });
+
+  it('treats a layout mismatch on the same board as a mismatch', () => {
+    mocks.resolved = { boardName: 'kilter', layoutId: 8, sizeId: 7, setIds: [3] };
+    const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'kilter', layoutId: 8 }));
+    expect(result.current.banner).not.toBeNull();
+    expect(result.current.renderBoard).toMatchObject({ boardName: 'kilter', layoutId: 8, setIds: '3' });
+  });
+
+  it('resolves read-only + banner when there is no active board', () => {
+    mocks.activeBoard = null;
+    const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'tension', layoutId: 9 }));
+    expect(result.current.banner).not.toBeNull();
+    // No active angle to fall back to → defaults to 0 (per-row angle is used).
+    expect(result.current.renderBoard).toMatchObject({ boardName: 'tension', angle: 0 });
+  });
+
+  it('shows the banner alone when the board cannot be resolved (e.g. MoonBoard)', () => {
+    mocks.resolved = null;
+    const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'moonboard', layoutId: 1 }));
+    expect(result.current.renderBoard).toBeNull();
+    expect(result.current.banner).not.toBeNull();
+  });
+
+  it('navigates to the board switcher when the banner CTA fires', () => {
+    const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'tension', layoutId: 9 }));
+    result.current.banner?.onPress();
+    expect(mocks.push).toHaveBeenCalledWith({ pathname: '/boards', params: { returnTo: '/(tabs)/discover' } });
+  });
+
+  it('always renders against the active board with no banner for smart playlists (null input)', () => {
+    const { result } = renderHook(() => usePlaylistRenderBoard(null));
+    expect(result.current.renderBoard).toBe(mocks.activeBoard);
+    expect(result.current.banner).toBeNull();
+    expect(mocks.getBoardConfigForPlaylist).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/playlists/use-playlist-render-board.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-render-board.ts
@@ -51,40 +51,27 @@ export function usePlaylistRenderBoard(
   const router = useRouter();
   const { t } = useTranslation('playlists');
 
-  // Read the primitives up front so the memo stays stable across the fresh
+  // Read the primitives up front so the memos stay stable across the fresh
   // `playlistBoard` object callers pass inline each render.
   const boardType = playlistBoard?.boardType ?? null;
   const layoutId = playlistBoard?.layoutId ?? null;
 
-  return useMemo(() => {
+  // Resolve the render board + read-only flag from the real board state only (no
+  // `t`/`router`), so `renderBoard`'s identity is stable across unrelated
+  // re-renders and never churns the FlashList rows that depend on it.
+  const { renderBoard, mismatch } = useMemo<{ renderBoard: PlaylistRenderBoard | null; mismatch: boolean }>(() => {
     // Smart playlists (no board): always the active board, no mismatch concept.
-    if (boardType == null) {
-      return { renderBoard: activeBoard, banner: null };
-    }
+    if (boardType == null) return { renderBoard: activeBoard, mismatch: false };
 
     const matchesActive =
       !!activeBoard && activeBoard.boardName === boardType && (layoutId == null || activeBoard.layoutId === layoutId);
+    if (matchesActive) return { renderBoard: activeBoard, mismatch: false };
 
-    if (matchesActive) {
-      return { renderBoard: activeBoard, banner: null };
-    }
-
-    // Mismatch or no active board → read-only against the playlist's own board.
-    const boardLabel = formatBoardDisplayName(boardType);
-    const banner: PlaylistBoardBanner = {
-      title: t('detail.boardMismatch.title', { board: boardLabel }),
-      subtitle: t('detail.boardMismatch.subtitle', { board: boardLabel }),
-      cta: t('detail.boardMismatch.cta'),
-      onPress: () => router.push({ pathname: '/boards', params: { returnTo: '/(tabs)/discover' } }),
-    };
-
+    // Mismatch or no active board → read-only against the playlist's own board
+    // (largest size + all sets). `null` when it can't resolve (e.g. MoonBoard),
+    // in which case the banner shows alone rather than a half-broken list.
     const resolved = getBoardConfigForPlaylist(boardType, layoutId);
-    if (!resolved) {
-      // Unbundled board (e.g. MoonBoard) — can't render the holds, so show the
-      // banner alone rather than a half-broken list.
-      return { renderBoard: null, banner };
-    }
-
+    if (!resolved) return { renderBoard: null, mismatch: true };
     return {
       renderBoard: {
         boardName: resolved.boardName,
@@ -95,7 +82,22 @@ export function usePlaylistRenderBoard(
         // at its own climb's angle (the angle its grade was baked at).
         angle: activeBoard?.angle ?? 0,
       },
-      banner,
+      mismatch: true,
     };
-  }, [activeBoard, boardType, layoutId, router, t]);
+  }, [activeBoard, boardType, layoutId]);
+
+  // Banner copy + navigation depend on `t`/`router`; kept in a separate memo so
+  // their (possible) identity churn can't recreate `renderBoard`.
+  const banner = useMemo<PlaylistBoardBanner | null>(() => {
+    if (!mismatch || boardType == null) return null;
+    const boardLabel = formatBoardDisplayName(boardType);
+    return {
+      title: t('detail.boardMismatch.title', { board: boardLabel }),
+      subtitle: t('detail.boardMismatch.subtitle', { board: boardLabel }),
+      cta: t('detail.boardMismatch.cta'),
+      onPress: () => router.push({ pathname: '/boards', params: { returnTo: '/(tabs)/discover' } }),
+    };
+  }, [mismatch, boardType, t, router]);
+
+  return { renderBoard, banner };
 }

--- a/packages/mobile/src/lib/playlists/use-playlist-render-board.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-render-board.ts
@@ -1,0 +1,101 @@
+// Decides which board a playlist-detail screen renders its climbs against, and
+// whether to gate queueing behind a board switch.
+//
+// Playlists carry only `boardType` + `layoutId`. When the active board matches,
+// rows render against the user's precise board (correct size/sets/angle) and
+// tapping queues normally. When it differs — or there is no active board — rows
+// render read-only against the playlist's own board (largest size + all sets,
+// via `getBoardConfigForPlaylist`, mirroring web's playlist rendering); a banner
+// prompts switching boards because the queue, play drawer, and BLE LEDs all
+// follow the single active board, so you genuinely must switch to climb it.
+
+import { useMemo } from 'react';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { formatBoardDisplayName } from '@boardsesh/board-config';
+import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
+import { getBoardConfigForPlaylist } from './board-details-for-playlist';
+
+/** The board a playlist's rows render against — same shape as the active board
+ *  config; `setIds` is the comma-joined string `ClimbListRow` expects. */
+export type PlaylistRenderBoard = BoardConfig;
+
+/** Shown above a read-only playlist list when its board differs from the active
+ *  board (or there is no active board). Strings are already translated. */
+export type PlaylistBoardBanner = {
+  title: string;
+  subtitle: string;
+  cta: string;
+  onPress: () => void;
+};
+
+export type UsePlaylistRenderBoardResult = {
+  /** Board the climb rows render against, or null when it can't be resolved (no
+   *  active board for a smart playlist; an unbundled board such as MoonBoard —
+   *  the banner still shows in that case). */
+  renderBoard: PlaylistRenderBoard | null;
+  /** Set when the list is read-only (board mismatch / no active board). */
+  banner: PlaylistBoardBanner | null;
+};
+
+/**
+ * Resolve the render board + optional mismatch banner for a playlist-detail
+ * screen. Pass the playlist's `{ boardType, layoutId }`, or `null` for smart
+ * playlists (they're computed relative to the active board, so they always
+ * render against it with no mismatch banner).
+ */
+export function usePlaylistRenderBoard(
+  playlistBoard: { boardType: string; layoutId?: number | null } | null,
+): UsePlaylistRenderBoardResult {
+  const { boardConfig: activeBoard } = useDrawerHost();
+  const router = useRouter();
+  const { t } = useTranslation('playlists');
+
+  // Read the primitives up front so the memo stays stable across the fresh
+  // `playlistBoard` object callers pass inline each render.
+  const boardType = playlistBoard?.boardType ?? null;
+  const layoutId = playlistBoard?.layoutId ?? null;
+
+  return useMemo(() => {
+    // Smart playlists (no board): always the active board, no mismatch concept.
+    if (boardType == null) {
+      return { renderBoard: activeBoard, banner: null };
+    }
+
+    const matchesActive =
+      !!activeBoard && activeBoard.boardName === boardType && (layoutId == null || activeBoard.layoutId === layoutId);
+
+    if (matchesActive) {
+      return { renderBoard: activeBoard, banner: null };
+    }
+
+    // Mismatch or no active board → read-only against the playlist's own board.
+    const boardLabel = formatBoardDisplayName(boardType);
+    const banner: PlaylistBoardBanner = {
+      title: t('detail.boardMismatch.title', { board: boardLabel }),
+      subtitle: t('detail.boardMismatch.subtitle', { board: boardLabel }),
+      cta: t('detail.boardMismatch.cta'),
+      onPress: () => router.push({ pathname: '/boards', params: { returnTo: '/(tabs)/discover' } }),
+    };
+
+    const resolved = getBoardConfigForPlaylist(boardType, layoutId);
+    if (!resolved) {
+      // Unbundled board (e.g. MoonBoard) — can't render the holds, so show the
+      // banner alone rather than a half-broken list.
+      return { renderBoard: null, banner };
+    }
+
+    return {
+      renderBoard: {
+        boardName: resolved.boardName,
+        layoutId: resolved.layoutId,
+        sizeId: resolved.sizeId,
+        setIds: resolved.setIds.join(','),
+        // List-level angle is unused in the read-only branch — each row renders
+        // at its own climb's angle (the angle its grade was baked at).
+        angle: activeBoard?.angle ?? 0,
+      },
+      banner,
+    };
+  }, [activeBoard, boardType, layoutId, router, t]);
+}

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -98,6 +98,11 @@
     "share": "Share playlist",
     "actions": "Playlist actions",
     "activateAll": "Queue every climb",
+    "boardMismatch": {
+      "title": "Switch to {{board}} to climb this playlist",
+      "subtitle": "These are {{board}} climbs. Switch boards to queue them.",
+      "cta": "Switch board"
+    },
     "menu": {
       "generate": "Generate",
       "edit": "Edit",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -98,6 +98,11 @@
     "share": "Compartir playlist",
     "actions": "Acciones de la playlist",
     "activateAll": "Poner en cola todos los bloques",
+    "boardMismatch": {
+      "title": "Cambia a {{board}} para escalar esta playlist",
+      "subtitle": "Estos son bloques de {{board}}. Cambia de tablero para ponerlos en cola.",
+      "cta": "Cambiar de tablero"
+    },
     "menu": {
       "generate": "Generar",
       "edit": "Editar",

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -98,6 +98,11 @@
     "share": "Partager la playlist",
     "actions": "Actions de la playlist",
     "activateAll": "Mettre toutes les voies en file",
+    "boardMismatch": {
+      "title": "Passez à {{board}} pour grimper cette playlist",
+      "subtitle": "Ce sont des voies {{board}}. Changez de planche pour les mettre en file.",
+      "cta": "Changer de planche"
+    },
     "menu": {
       "generate": "Générer",
       "edit": "Modifier",


### PR DESCRIPTION
## Problem

Fixes #2689. On mobile, the playlist-detail screens rendered every climb row, and queued every tapped climb, against the user's **active** board rather than the playlist's own board. When they differ (deep link, switching the active board mid-session, or no active board when signed-out), this caused real correctness bugs:

- **Wrong board art / holds / grades** — a Tension playlist rendered against Kilter art.
- **Queued onto the wrong board** — tapping lit the wrong wall over BLE.
- **Blank list under a non-zero count** — no active board → every row returned `null`.

## Fix

Render the climbs against the **playlist's own board**, mirroring what web already does. The repo already had the resolution helper (`getBoardConfigForPlaylist` — largest size + all sets, used today for the hero backdrop), so this is a small, board-correct change rather than a new policy.

- **New hook `usePlaylistRenderBoard`** decides the render board: the active board when it matches the playlist (tap queues normally), otherwise the playlist's own resolved board with a switch-board banner.
- **`PlaylistDetailView`** now takes `renderBoard` + `boardBanner` instead of reading the active board itself. On a mismatch the list goes **read-only**: rows render at each climb's own angle (the angle its grade was baked at — the thumbnail doesn't depend on angle), a banner prompts switching boards, and queueing (row tap + activate-all) is disabled. Tapping a read-only row or the banner CTA routes to `/boards`.
- **Smart playlists** are board-relative, so they always render against the active board with no banner.

Queueing stays gated on a mismatch because the queue, play drawer, and BLE LEDs all follow the single active board — you genuinely must switch boards to climb another board's playlist.

## Validation (Linux)

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` — 218 files / 1547 tests ✅ (new `use-playlist-render-board` hook test + extended `playlist-detail-view` banner tests; updated the route test's mocks)
- i18n catalog parity (`catalog-completeness`) ✅ — new `detail.boardMismatch.*` keys added to en-US / es / fr
- `vp check` (lint + format) ✅ — 0 errors
- `vp run check:mobile-bundle` ✅

## QA on device (macOS/sim)

1. Active board = Tension. Open a **Kilter** playlist (deep link, or switch the active board to Tension while a Kilter playlist detail is on the stack). Expect: rows show **Kilter** thumbnails/grades, a "Switch to Kilter to climb this playlist" banner above the list, and neither row taps nor the play-all action queue anything.
2. Tap the banner CTA (or any row) → lands on `/boards`. Switch to Kilter → reopen the playlist → rows render normally and tapping queues/lights the Kilter wall.
3. Signed-out: open a public playlist with no active board → read-only render + banner; CTA → `/boards`.
4. Matching board (active board == playlist board) → unchanged behavior; tapping queues and lights normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)