### PR TITLE
chore: upgrade claude-code-action to v1.0.142

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.99
+        uses: anthropics/claude-code-action@v1.0.142
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
## Summary

- Bumps `anthropics/claude-code-action` from `v1.0.99` to `v1.0.142` in `.github/workflows/claude-code-review.yml`

## Test plan

- [ ] Verify the Claude Code Review action triggers correctly on the next PR

https://claude.ai/code/session_01Vkw35U4xjBePpcHHrkjejE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vkw35U4xjBePpcHHrkjejE)_