### PR TITLE
Fix painting holds while zoomed (create-climb + search hold-filter)

### DIFF
--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -189,6 +189,24 @@ const gesture = useMemo(
 ); // rebuild mid-gesture → RNGH stuck on iOS
 ```
 
+**Composing a pan overlay with per-element taps —
+`packages/mobile/src/components/create-climb/use-zoomed-hold-tap-gesture.ts`:**
+When a zoomed board mounts an `absoluteFill` pan overlay above tappable elements, the overlay
+swallows their touches (RNGH only offers a touch to the hit view + ancestors), so the overlay's
+gesture must resolve taps itself. Two non-obvious choices there:
+
+- **`Gesture.Race(pan, longPress, tap)`, not `Exclusive`.** `Exclusive` puts later gestures in a
+  `waitFor` on the pan, and a `Pan` only _fails_ on touch-up — so a `LongPress` could never activate
+  mid-hold (the role sheet would never open while held). With `Race`, the first gesture to activate
+  wins; gate the pan behind an `activeOffset` (8px here) so a stationary touch goes to tap/long-press
+  and only a real drag activates the pan. `activeOffsetX`/`activeOffsetY` are **OR'd** (crossing
+  either axis activates), so single-axis drags pan fine.
+- **Built once, reads everything live.** The composed gesture's `useMemo` deps are only stable
+  shared values + the pan; render-scoped values (the hit-target list, the JS callbacks) are read
+  through a `useRef` (same `callbacksRef` pattern as rule 5), so it never recomposes mid-session.
+  The screen→board inverse transform runs in the worklet off `scaleSV`/`translateXSV`/`translateYSV`
+  (mirrored container size for the center origin), then `runOnJS` resolves the nearest element once.
+
 ---
 
 ## 6. Warm board-art surfaces use the rasterized native-PNG path, not remote SVG

--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -11,6 +11,12 @@ import { overlays } from '../../theme/tokens';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
 import { HoldTargetLayer } from './HoldTargetLayer';
 import { PaintedHoldsLayer } from './PaintedHoldsLayer';
+import { buildHoldHitTargets } from './holdLayout';
+import { useZoomedHoldTapGesture } from './use-zoomed-hold-tap-gesture';
+
+/** Drag distance (px) before the zoom-pan activates, so a stationary paint tap
+ *  while zoomed isn't stolen by the pan. Matches the original editor's value. */
+const PAN_ACTIVATION_OFFSET = 8;
 
 type InteractiveCreateBoardProps = {
   boardName: BoardName;
@@ -64,10 +70,22 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
   overlay,
 }: InteractiveCreateBoardProps) {
   const { t } = useTranslation('common');
-  const { pinchGesture, zoomPanGesture, isZoomed, resetZoom, animatedZoomStyle } = useZoomPanGesture({
+  const {
+    pinchGesture,
+    zoomPanGesture,
+    isZoomed,
+    scaleSV,
+    translateXSV,
+    translateYSV,
+    containerWidthSV,
+    containerHeightSV,
+    resetZoom,
+    animatedZoomStyle,
+  } = useZoomPanGesture({
     enabled: true,
     containerWidth: renderWidth,
     containerHeight: renderHeight,
+    panActivationOffset: PAN_ACTIVATION_OFFSET,
   });
 
   const holdById = useMemo(() => {
@@ -75,6 +93,25 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
     for (const hold of holdTargets) map.set(hold.id, hold);
     return map;
   }, [holdTargets]);
+
+  // Hit circles for resolving a tap to a hold while zoomed (the pan overlay sits
+  // above the per-hold detectors, so it resolves taps itself — see #2687).
+  const hitTargets = useMemo(
+    () => buildHoldHitTargets(holdTargets, boardWidth, boardHeight, renderWidth, renderHeight, mirrored),
+    [holdTargets, boardWidth, boardHeight, renderWidth, renderHeight, mirrored],
+  );
+
+  const overlayGesture = useZoomedHoldTapGesture({
+    zoomPanGesture,
+    scaleSV,
+    translateXSV,
+    translateYSV,
+    containerWidthSV,
+    containerHeightSV,
+    hitTargets,
+    onTap: onPaint,
+    onLongPress: onLongPressHold,
+  });
 
   return (
     <View style={styles.root}>
@@ -119,9 +156,11 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
           {/* Pan-while-zoomed overlay: only mounted when zoomed so it doesn't
               claim 1-finger touches at rest (which would block the drawer's
               scroll/close). 2-finger pinches fall through via maxPointers(1).
-              While zoomed, reset to paint precise holds. */}
+              The overlay sits above the per-hold detectors, so its gesture also
+              resolves taps/long-presses to holds (Race with the pan) — without
+              that, painting and the role sheet are dead while zoomed (#2687). */}
           {isZoomed ? (
-            <GestureDetector gesture={zoomPanGesture}>
+            <GestureDetector gesture={overlayGesture}>
               <View style={StyleSheet.absoluteFill} />
             </GestureDetector>
           ) : null}

--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -12,11 +12,7 @@ import type { BoardHoldTarget } from '../../lib/create-board-holds';
 import { HoldTargetLayer } from './HoldTargetLayer';
 import { PaintedHoldsLayer } from './PaintedHoldsLayer';
 import { buildHoldHitTargets } from './holdLayout';
-import { useZoomedHoldTapGesture } from './use-zoomed-hold-tap-gesture';
-
-/** Drag distance (px) before the zoom-pan activates, so a stationary paint tap
- *  while zoomed isn't stolen by the pan. Matches the original editor's value. */
-const PAN_ACTIVATION_OFFSET = 8;
+import { useZoomedHoldTapGesture, PAN_ACTIVATION_OFFSET } from './use-zoomed-hold-tap-gesture';
 
 type InteractiveCreateBoardProps = {
   boardName: BoardName;

--- a/packages/mobile/src/components/create-climb/__tests__/holdLayout.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/holdLayout.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { buildHoldHitTargets, inverseTransformPoint, resolveHoldAtPoint } from '../holdLayout';
+import type { BoardHoldTarget } from '../../../lib/create-board-holds';
+
+/** Forward zoom transform (center origin), the exact thing inverseTransformPoint undoes. */
+function forward(
+  localX: number,
+  localY: number,
+  scale: number,
+  translateX: number,
+  translateY: number,
+  containerWidth: number,
+  containerHeight: number,
+): { x: number; y: number } {
+  const cx = containerWidth / 2;
+  const cy = containerHeight / 2;
+  return {
+    x: cx + scale * (localX - cx) + translateX,
+    y: cy + scale * (localY - cy) + translateY,
+  };
+}
+
+describe('inverseTransformPoint', () => {
+  it('recovers the worked example (renderWidth=300, scale=2, translateX=-50, local x=200 → screen 200)', () => {
+    const screen = forward(200, 400, 2, -50, 0, 300, 600);
+    expect(screen.x).toBe(200);
+    expect(screen.y).toBe(500);
+    const local = inverseTransformPoint(screen.x, screen.y, 2, -50, 0, 300, 600);
+    expect(local.x).toBeCloseTo(200, 6);
+    expect(local.y).toBeCloseTo(400, 6);
+  });
+
+  it('is the exact inverse of the forward transform across scales/translations', () => {
+    const cases = [
+      { scale: 1, tx: 0, ty: 0 },
+      { scale: 2.5, tx: -120, ty: 40 },
+      { scale: 4, tx: 200, ty: -200 },
+      { scale: 1.3, tx: 17, ty: -3 },
+    ];
+    for (const { scale, tx, ty } of cases) {
+      for (const [lx, ly] of [
+        [0, 0],
+        [150, 300],
+        [300, 600],
+        [73, 412],
+      ]) {
+        const s = forward(lx, ly, scale, tx, ty, 300, 600);
+        const back = inverseTransformPoint(s.x, s.y, scale, tx, ty, 300, 600);
+        expect(back.x).toBeCloseTo(lx, 6);
+        expect(back.y).toBeCloseTo(ly, 6);
+      }
+    }
+  });
+
+  it('returns the point unchanged at scale 1 with no translation', () => {
+    expect(inverseTransformPoint(120, 240, 1, 0, 0, 300, 600)).toEqual({ x: 120, y: 240 });
+  });
+});
+
+describe('buildHoldHitTargets', () => {
+  const holds: BoardHoldTarget[] = [{ id: 1, cx: 500, cy: 1000, r: 50 }];
+
+  it('places the centre in render px and uses tapDiameter/2 as the radius', () => {
+    // scale 300/1000=0.3, ringDiameter=50*2*0.3=30, tapDiameter=max(48,44)=48.
+    const [target] = buildHoldHitTargets(holds, 1000, 2000, 300, 600, false);
+    expect(target).toEqual({ holdId: 1, x: 150, y: 300, radius: 24 });
+  });
+
+  it('mirrors the x position when mirrored', () => {
+    const offset: BoardHoldTarget[] = [{ id: 2, cx: 250, cy: 500, r: 50 }];
+    const [plain] = buildHoldHitTargets(offset, 1000, 2000, 300, 600, false);
+    const [mirrored] = buildHoldHitTargets(offset, 1000, 2000, 300, 600, true);
+    expect(plain.x).toBeCloseTo(75, 6); // cxPct 25 → 0.25*300
+    expect(mirrored.x).toBeCloseTo(225, 6); // (100-25)% → 0.75*300
+    expect(mirrored.y).toBe(plain.y); // y is unaffected by mirroring
+  });
+
+  it('enforces the minimum tap diameter for tiny holds', () => {
+    const tiny: BoardHoldTarget[] = [{ id: 3, cx: 500, cy: 1000, r: 5 }];
+    const [target] = buildHoldHitTargets(tiny, 1000, 2000, 300, 600, false);
+    // ringDiameter=5*2*0.3=3, *1.6=4.8 < MIN_TAP_DIAMETER 44 → radius 22.
+    expect(target.radius).toBe(22);
+  });
+});
+
+describe('resolveHoldAtPoint', () => {
+  const targets = [
+    { holdId: 1, x: 150, y: 300, radius: 24 },
+    { holdId: 2, x: 160, y: 300, radius: 24 }, // overlaps #1
+  ];
+
+  it('returns the hold whose circle contains the point', () => {
+    expect(resolveHoldAtPoint(150, 300, targets)).toBe(1);
+  });
+
+  it('returns null when the point is outside every circle', () => {
+    expect(resolveHoldAtPoint(400, 300, targets)).toBeNull();
+  });
+
+  it('picks the nearest centre when tap circles overlap', () => {
+    expect(resolveHoldAtPoint(152, 300, targets)).toBe(1);
+    expect(resolveHoldAtPoint(158, 300, targets)).toBe(2);
+  });
+
+  it('returns null for an empty hit-target list', () => {
+    expect(resolveHoldAtPoint(150, 300, [])).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-zoomed-hold-tap-gesture.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/use-zoomed-hold-tap-gesture.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { SharedValue } from 'react-native-reanimated';
+import type { GestureType } from 'react-native-gesture-handler';
+
+// Chainable no-op gesture builder; Race tags its result so we can assert which
+// branch the hook returned without driving real gestures.
+const raceCalls: unknown[][] = [];
+vi.mock('react-native-gesture-handler', () => {
+  const builder: Record<string, unknown> = new Proxy({}, { get: () => () => builder });
+  return {
+    Gesture: {
+      Tap: () => builder,
+      LongPress: () => builder,
+      Race: (...members: unknown[]) => {
+        raceCalls.push(members);
+        return { composed: 'race', members };
+      },
+    },
+  };
+});
+
+vi.mock('react-native-reanimated', () => ({ runOnJS: (fn: unknown) => fn }));
+
+import { useZoomedHoldTapGesture, PAN_ACTIVATION_OFFSET } from '../use-zoomed-hold-tap-gesture';
+
+const sv = (value: number): SharedValue<number> => ({ value }) as SharedValue<number>;
+const barePan = { id: 'bare-pan' } as unknown as GestureType;
+
+function baseOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    zoomPanGesture: barePan,
+    scaleSV: sv(1),
+    translateXSV: sv(0),
+    translateYSV: sv(0),
+    containerWidthSV: sv(300),
+    containerHeightSV: sv(600),
+    hitTargets: [{ holdId: 1, x: 150, y: 300, radius: 24 }],
+    ...overrides,
+  };
+}
+
+describe('useZoomedHoldTapGesture', () => {
+  it('exports the default pan activation offset', () => {
+    expect(PAN_ACTIVATION_OFFSET).toBe(8);
+  });
+
+  it('returns the bare pan unchanged when no onTap (zone mode)', () => {
+    const { result } = renderHook(() => useZoomedHoldTapGesture(baseOptions()));
+    expect(result.current).toBe(barePan);
+  });
+
+  it('composes the pan with tap + long-press (Race, pan first) when onTap is provided', () => {
+    raceCalls.length = 0;
+    const onTap = vi.fn();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useZoomedHoldTapGesture(baseOptions({ onTap, onLongPress })));
+
+    expect(result.current).not.toBe(barePan);
+    expect((result.current as { composed?: string }).composed).toBe('race');
+    // Pan must be the first member so it gets first refusal on movement.
+    expect(raceCalls.at(-1)?.[0]).toBe(barePan);
+    expect(raceCalls.at(-1)).toHaveLength(3);
+  });
+
+  it('keeps the composed gesture stable across re-renders with the same inputs', () => {
+    const options = baseOptions({ onTap: vi.fn() });
+    const { result, rerender } = renderHook(() => useZoomedHoldTapGesture(options));
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/packages/mobile/src/components/create-climb/holdLayout.ts
+++ b/packages/mobile/src/components/create-climb/holdLayout.ts
@@ -54,3 +54,89 @@ export function holdGeometry(
   const tapDiameter = Math.max(ringDiameter * 1.6, MIN_TAP_DIAMETER);
   return { leftPct, topPct, ringDiameter, tapDiameter };
 }
+
+/**
+ * Invert the board's zoom transform to map a screen-space point (relative to the
+ * container's top-left) back into board-local, untransformed render px.
+ *
+ * The board is drawn with `transform: [translateX, translateY, scale]` and the
+ * default center transform-origin, so the forward map of a board-local point is
+ *   screen = center + scale * (local - center) + translate,  center = size / 2
+ * and this is its exact inverse:
+ *   local = center + (screen - translate - center) / scale
+ *
+ * Tap targets are laid out in the same untransformed space (percentages of the
+ * container), so a point returned here can be compared directly against
+ * `buildHoldHitTargets`. This is the pure, tested twin of the ~2-line worklet
+ * copy in use-zoomed-hold-tap-gesture (reanimated can't reliably call
+ * cross-module worklets — same split as clampTranslation). Keep in sync.
+ */
+export function inverseTransformPoint(
+  screenX: number,
+  screenY: number,
+  scale: number,
+  translateX: number,
+  translateY: number,
+  containerWidth: number,
+  containerHeight: number,
+): { x: number; y: number } {
+  const cx = containerWidth / 2;
+  const cy = containerHeight / 2;
+  return {
+    x: (screenX - translateX - cx) / scale + cx,
+    y: (screenY - translateY - cy) / scale + cy,
+  };
+}
+
+/** One hold's circular hit area in board-local, untransformed render px. */
+export type HoldHitTarget = {
+  holdId: number;
+  x: number;
+  y: number;
+  radius: number;
+};
+
+/**
+ * Precompute the circular hit area of every hold in board-local render px, so a
+ * tap mapped back through {@link inverseTransformPoint} can be resolved to a
+ * hold without per-tap geometry work. Reuses {@link holdGeometry}, so `mirrored`
+ * is already baked into the x position.
+ */
+export function buildHoldHitTargets(
+  holdTargets: BoardHoldTarget[],
+  boardWidth: number,
+  boardHeight: number,
+  renderWidth: number,
+  renderHeight: number,
+  mirrored: boolean,
+): HoldHitTarget[] {
+  return holdTargets.map((hold) => {
+    const geometry = holdGeometry(hold, boardWidth, boardHeight, renderWidth, mirrored);
+    return {
+      holdId: hold.id,
+      x: (geometry.leftPct / 100) * renderWidth,
+      y: (geometry.topPct / 100) * renderHeight,
+      radius: geometry.tapDiameter / 2,
+    };
+  });
+}
+
+/**
+ * Resolve a board-local point to the id of the nearest hold whose hit circle
+ * contains it, or `null` if none do. Nearest-center disambiguates the
+ * overlapping tap targets of a dense cluster — the case zooming exists to serve.
+ */
+export function resolveHoldAtPoint(x: number, y: number, hitTargets: HoldHitTarget[]): number | null {
+  let bestId: number | null = null;
+  let bestDistanceSquared = Infinity;
+  for (const target of hitTargets) {
+    const dx = x - target.x;
+    const dy = y - target.y;
+    const distanceSquared = dx * dx + dy * dy;
+    if (distanceSquared <= target.radius * target.radius && distanceSquared < bestDistanceSquared) {
+      bestDistanceSquared = distanceSquared;
+      bestId = target.holdId;
+    }
+  }
+  return bestId;
+}

--- a/packages/mobile/src/components/create-climb/use-zoomed-hold-tap-gesture.ts
+++ b/packages/mobile/src/components/create-climb/use-zoomed-hold-tap-gesture.ts
@@ -4,13 +4,20 @@ import { runOnJS, type SharedValue } from 'react-native-reanimated';
 import { resolveHoldAtPoint, type HoldHitTarget } from './holdLayout';
 
 // Match the per-hold detectors in HoldTarget.tsx so a tap while zoomed behaves
-// identically to a tap at rest. Keep in sync.
+// identically to a tap at rest. Keep in sync. As in HoldTarget, a release in the
+// 300–400ms gap between maxDuration and minDuration fires neither tap nor
+// long-press — intentional parity with the at-rest behaviour, not a new dead zone.
 const TAP_MAX_DURATION_MS = 300;
 const TAP_MAX_DISTANCE_PX = 15;
 const LONG_PRESS_MIN_DURATION_MS = 400;
 
 // Tap/LongPress default to a single pointer, so a 2-finger pinch fails them and
 // falls through to the ancestor pinch — same as HoldTarget.tsx at rest.
+
+/** Default drag distance (px) before the zoom-pan activates. Boards that compose
+ *  this hook pass it to useZoomPanGesture's `panActivationOffset`, so a stationary
+ *  tap stays under the tap detector instead of being eaten by the pan. */
+export const PAN_ACTIVATION_OFFSET = 8;
 
 type UseZoomedHoldTapGestureOptions = {
   /** The board's 1-finger zoom-pan, built with `panActivationOffset` so a

--- a/packages/mobile/src/components/create-climb/use-zoomed-hold-tap-gesture.ts
+++ b/packages/mobile/src/components/create-climb/use-zoomed-hold-tap-gesture.ts
@@ -1,0 +1,122 @@
+import { useMemo, useRef } from 'react';
+import { Gesture, type ComposedGesture, type GestureType } from 'react-native-gesture-handler';
+import { runOnJS, type SharedValue } from 'react-native-reanimated';
+import { resolveHoldAtPoint, type HoldHitTarget } from './holdLayout';
+
+// Match the per-hold detectors in HoldTarget.tsx so a tap while zoomed behaves
+// identically to a tap at rest. Keep in sync.
+const TAP_MAX_DURATION_MS = 300;
+const TAP_MAX_DISTANCE_PX = 15;
+const LONG_PRESS_MIN_DURATION_MS = 400;
+
+// Tap/LongPress default to a single pointer, so a 2-finger pinch fails them and
+// falls through to the ancestor pinch — same as HoldTarget.tsx at rest.
+
+type UseZoomedHoldTapGestureOptions = {
+  /** The board's 1-finger zoom-pan, built with `panActivationOffset` so a
+   *  stationary tap never crosses its activation threshold. */
+  zoomPanGesture: GestureType;
+  scaleSV: SharedValue<number>;
+  translateXSV: SharedValue<number>;
+  translateYSV: SharedValue<number>;
+  containerWidthSV: SharedValue<number>;
+  containerHeightSV: SharedValue<number>;
+  /** Hold hit circles in board-local render px (from buildHoldHitTargets). */
+  hitTargets: HoldHitTarget[];
+  /** Tap handler (paint / open picker). When omitted, the hook returns the bare
+   *  pan unchanged — used by zone mode, which has no per-hold taps. */
+  onTap?: (holdId: number) => void;
+  /** Long-press handler (role sheet). Falls back to onTap when omitted, matching
+   *  HoldTargetLayer which wires both. */
+  onLongPress?: (holdId: number) => void;
+};
+
+/**
+ * Compose per-hold tap + long-press into the zoomed pan overlay so painting and
+ * the role sheet work while zoomed.
+ *
+ * Why this hook exists: while zoomed an absoluteFill pan overlay sits above the
+ * transformed board, so RNGH never offers the touch to the per-hold detectors
+ * underneath (#2687). Here the overlay itself resolves taps: the worklet inverts
+ * the board's zoom transform to map the screen point into board-local px, then
+ * `resolveHoldAtPoint` (on the JS thread) finds the hold under it.
+ *
+ * Composition is `Gesture.Race(pan, longPress, tap)`, NOT `Exclusive`. Exclusive
+ * would make longPress/tap wait for the pan to fail, but the pan only fails on
+ * touch-up — so the 400ms long-press could never fire mid-hold. With Race the
+ * first gesture to activate wins: a stationary touch never crosses the pan's
+ * activeOffset, so tap (quick release) or longPress (≥400ms) wins; any real drag
+ * activates the pan first and cancels the others. The pan's `panActivationOffset`
+ * (set by the board via useZoomPanGesture) is what keeps a slightly-sloppy
+ * stationary tap from being stolen by the pan.
+ *
+ * The composed gesture is built ONCE per overlay mount: its deps are only stable
+ * shared values + the pan, and the JS handlers read render-scoped values
+ * (hitTargets, callbacks) through a ref. Rebuilding a live gesture mid-session
+ * has wedged iOS RNGH before (see use-carousel-gesture / use-zoom-pan-gesture
+ * comments); the overlay is mounted/unmounted wholesale on isZoomed instead.
+ */
+export function useZoomedHoldTapGesture({
+  zoomPanGesture,
+  scaleSV,
+  translateXSV,
+  translateYSV,
+  containerWidthSV,
+  containerHeightSV,
+  hitTargets,
+  onTap,
+  onLongPress,
+}: UseZoomedHoldTapGestureOptions): ComposedGesture | GestureType {
+  const hasTap = onTap != null;
+
+  const callbacksRef = useRef({ hitTargets, onTap, onLongPress });
+  callbacksRef.current = { hitTargets, onTap, onLongPress };
+
+  // Captured once by the gesture memo — only closes over the ref (stable).
+  const handleTap = (boardX: number, boardY: number) => {
+    const current = callbacksRef.current;
+    if (!current.onTap) return;
+    const holdId = resolveHoldAtPoint(boardX, boardY, current.hitTargets);
+    if (holdId != null) current.onTap(holdId);
+  };
+  const handleLongPress = (boardX: number, boardY: number) => {
+    const current = callbacksRef.current;
+    const handler = current.onLongPress ?? current.onTap;
+    if (!handler) return;
+    const holdId = resolveHoldAtPoint(boardX, boardY, current.hitTargets);
+    if (holdId != null) handler(holdId);
+  };
+
+  return useMemo(() => {
+    if (!hasTap) return zoomPanGesture;
+
+    const tap = Gesture.Tap()
+      .maxDuration(TAP_MAX_DURATION_MS)
+      .maxDistance(TAP_MAX_DISTANCE_PX)
+      .onStart((event) => {
+        'worklet';
+        // Inverse of animatedZoomStyle ([translate, scale], center origin). The
+        // tested twin is inverseTransformPoint in holdLayout.ts — keep in sync.
+        const cx = containerWidthSV.value / 2;
+        const cy = containerHeightSV.value / 2;
+        const boardX = (event.x - translateXSV.value - cx) / scaleSV.value + cx;
+        const boardY = (event.y - translateYSV.value - cy) / scaleSV.value + cy;
+        runOnJS(handleTap)(boardX, boardY);
+      });
+
+    const longPress = Gesture.LongPress()
+      .minDuration(LONG_PRESS_MIN_DURATION_MS)
+      .onStart((event) => {
+        'worklet';
+        const cx = containerWidthSV.value / 2;
+        const cy = containerHeightSV.value / 2;
+        const boardX = (event.x - translateXSV.value - cx) / scaleSV.value + cx;
+        const boardY = (event.y - translateYSV.value - cy) / scaleSV.value + cy;
+        runOnJS(handleLongPress)(boardX, boardY);
+      });
+
+    // handleTap/handleLongPress are intentionally not deps — captured once and
+    // read render-scoped values through callbacksRef (see use-carousel-gesture).
+    return Gesture.Race(zoomPanGesture, longPress, tap);
+  }, [hasTap, zoomPanGesture, scaleSV, translateXSV, translateYSV, containerWidthSV, containerHeightSV]);
+}

--- a/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
@@ -16,6 +16,12 @@ type UseZoomPanGestureOptions = {
   enabled?: boolean;
   containerWidth: number;
   containerHeight: number;
+  /** When set, the 1-finger zoom-pan only activates after the finger moves this
+   * many px in either axis. Use this when the pan is composed with stationary
+   * tap/long-press gestures on the same overlay (the interactive boards), so a
+   * slightly-sloppy stationary tap isn't stolen by the pan. Left unset, the pan
+   * keeps its default activation (the play-drawer carousel relies on that). */
+  panActivationOffset?: number;
 };
 
 type UseZoomPanGestureReturn = {
@@ -26,6 +32,16 @@ type UseZoomPanGestureReturn = {
   /** Live zoom scale on the UI thread, so an overlay inside the transform can
    * convert screen-pixel drag deltas into unscaled board-pixel deltas. */
   scaleSV: SharedValue<number>;
+  /** Live pan translation on the UI thread. With scaleSV + the container size,
+   * an overlay above the transform can invert animatedZoomStyle to map a screen
+   * tap back into board-local coordinates (see use-zoomed-hold-tap-gesture). */
+  translateXSV: SharedValue<number>;
+  translateYSV: SharedValue<number>;
+  /** Live container size on the UI thread — the transform's center origin
+   * (containerWidth/2, containerHeight/2). Mirrored so the inverse-transform
+   * worklet reads it without re-creating gesture objects on a layout change. */
+  containerWidthSV: SharedValue<number>;
+  containerHeightSV: SharedValue<number>;
   resetZoom: () => void;
   animatedZoomStyle: AnimatedStyle;
 };
@@ -57,6 +73,7 @@ export function useZoomPanGesture({
   enabled = true,
   containerWidth,
   containerHeight,
+  panActivationOffset,
 }: UseZoomPanGestureOptions): UseZoomPanGestureReturn {
   const scale = useSharedValue(MIN_SCALE);
   const translateX = useSharedValue(0);
@@ -197,32 +214,48 @@ export function useZoomPanGesture({
   // parent BottomSheetScrollView from scrolling. With maxPointers(1) it
   // also fails harmlessly during 2-finger pinches, so the outer pinch
   // gesture stays responsive even with this overlay above the board.
-  const zoomPanGesture = useMemo(
-    () =>
-      Gesture.Pan()
-        .minPointers(1)
-        .maxPointers(1)
-        .onStart(() => {
-          'worklet';
-          savedTranslateX.value = translateX.value;
-          savedTranslateY.value = translateY.value;
-        })
-        .onUpdate((event) => {
-          'worklet';
-          if (scale.value <= MIN_SCALE) return;
-          const newX = savedTranslateX.value + event.translationX;
-          const newY = savedTranslateY.value + event.translationY;
-          const clamped = clampTranslation(newX, newY, scale.value, containerWidthSV.value, containerHeightSV.value);
-          translateX.value = clamped.x;
-          translateY.value = clamped.y;
-        })
-        .onEnd(() => {
-          'worklet';
-          savedTranslateX.value = translateX.value;
-          savedTranslateY.value = translateY.value;
-        }),
-    [scale, translateX, translateY, savedTranslateX, savedTranslateY, containerWidthSV, containerHeightSV],
-  );
+  const zoomPanGesture = useMemo(() => {
+    const pan = Gesture.Pan()
+      .minPointers(1)
+      .maxPointers(1)
+      .onStart(() => {
+        'worklet';
+        savedTranslateX.value = translateX.value;
+        savedTranslateY.value = translateY.value;
+      })
+      .onUpdate((event) => {
+        'worklet';
+        if (scale.value <= MIN_SCALE) return;
+        const newX = savedTranslateX.value + event.translationX;
+        const newY = savedTranslateY.value + event.translationY;
+        const clamped = clampTranslation(newX, newY, scale.value, containerWidthSV.value, containerHeightSV.value);
+        translateX.value = clamped.x;
+        translateY.value = clamped.y;
+      })
+      .onEnd(() => {
+        'worklet';
+        savedTranslateX.value = translateX.value;
+        savedTranslateY.value = translateY.value;
+      });
+    // Composed with stationary tap/long-press on the interactive boards: require
+    // a deliberate drag so a stationary tap falls through to the tap detector
+    // instead of being eaten by the pan.
+    if (panActivationOffset != null) {
+      pan
+        .activeOffsetX([-panActivationOffset, panActivationOffset])
+        .activeOffsetY([-panActivationOffset, panActivationOffset]);
+    }
+    return pan;
+  }, [
+    scale,
+    translateX,
+    translateY,
+    savedTranslateX,
+    savedTranslateY,
+    containerWidthSV,
+    containerHeightSV,
+    panActivationOffset,
+  ]);
 
   const animatedZoomStyle = useAnimatedStyle(() => ({
     // [translate, scale] order: RN matrix-composes left-to-right, so scale
@@ -237,6 +270,10 @@ export function useZoomPanGesture({
     isZoomed,
     isZoomedSV,
     scaleSV: scale,
+    translateXSV: translateX,
+    translateYSV: translateY,
+    containerWidthSV,
+    containerHeightSV,
     resetZoom,
     animatedZoomStyle,
   };

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -120,8 +120,9 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
     containerWidthSV,
     containerHeightSV,
     hitTargets,
+    // Long-press falls back to onTap in the hook, so a held hold opens the
+    // picker too — same as HoldTargetLayer wiring both to onHoldTap at rest.
     onTap: onHoldTap,
-    onLongPress: onHoldTap,
   });
 
   const holdById = useMemo(() => {

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -8,10 +8,15 @@ import { BoardImageNative } from '../BoardImageNative';
 import { Text } from '../Text';
 import { useZoomPanGesture } from '../play-drawer/use-zoom-pan-gesture';
 import { HoldTargetLayer } from '../create-climb/HoldTargetLayer';
-import { holdGeometry } from '../create-climb/holdLayout';
+import { holdGeometry, buildHoldHitTargets } from '../create-climb/holdLayout';
+import { useZoomedHoldTapGesture } from '../create-climb/use-zoomed-hold-tap-gesture';
 import { overlays } from '../../theme/tokens';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
 import { SearchHoldFilterRings } from './SearchHoldFilterRings';
+
+/** Drag distance (px) before the zoom-pan activates, so a stationary hold tap
+ *  while zoomed isn't stolen by the pan. */
+const PAN_ACTIVATION_OFFSET = 8;
 
 /** Context handed to an overlay rendered inside the board's zoom transform. */
 export type FilterBoardTransformContext = {
@@ -76,10 +81,22 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   renderInTransform,
 }: InteractiveFilterBoardProps) {
   const { t } = useTranslation('common');
-  const { pinchGesture, zoomPanGesture, isZoomed, scaleSV, resetZoom, animatedZoomStyle } = useZoomPanGesture({
+  const {
+    pinchGesture,
+    zoomPanGesture,
+    isZoomed,
+    scaleSV,
+    translateXSV,
+    translateYSV,
+    containerWidthSV,
+    containerHeightSV,
+    resetZoom,
+    animatedZoomStyle,
+  } = useZoomPanGesture({
     enabled: true,
     containerWidth: renderWidth,
     containerHeight: renderHeight,
+    panActivationOffset: PAN_ACTIVATION_OFFSET,
   });
 
   // The picker uses a long-press-style commit, but holds here only need a single
@@ -90,6 +107,26 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
     () => ({ pinchGesture, scaleSV, renderWidth, renderHeight }),
     [pinchGesture, scaleSV, renderWidth, renderHeight],
   );
+
+  // Hit circles so the zoomed pan overlay can resolve a tap to a hold itself
+  // (it sits above the per-hold detectors — see #2687). Zone mode passes no
+  // onHoldTap, so the hook returns the bare pan and this is unused.
+  const hitTargets = useMemo(
+    () => buildHoldHitTargets(holdTargets, boardWidth, boardHeight, renderWidth, renderHeight, mirrored),
+    [holdTargets, boardWidth, boardHeight, renderWidth, renderHeight, mirrored],
+  );
+
+  const overlayGesture = useZoomedHoldTapGesture({
+    zoomPanGesture,
+    scaleSV,
+    translateXSV,
+    translateYSV,
+    containerWidthSV,
+    containerHeightSV,
+    hitTargets,
+    onTap: onHoldTap,
+    onLongPress: onHoldTap,
+  });
 
   const holdById = useMemo(() => {
     const map = new Map<number, BoardHoldTarget>();
@@ -168,9 +205,12 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
           {/* 1-finger pan-to-reposition the zoomed board. Sits ABOVE the board
               layer (so a drag over the bare board pans it) but BELOW the
               `renderInTransform` overlay layer (so the zone rectangle + corner
-              handles still win their touches while zoomed). */}
+              handles still win their touches while zoomed). In hold mode the
+              gesture also resolves taps/long-presses to holds (Race with the
+              pan) so the picker opens while zoomed (#2687); in zone mode
+              `overlayGesture` is the bare pan (no onHoldTap). */}
           {isZoomed ? (
-            <GestureDetector gesture={zoomPanGesture}>
+            <GestureDetector gesture={overlayGesture}>
               <View style={StyleSheet.absoluteFill} />
             </GestureDetector>
           ) : null}

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -9,14 +9,10 @@ import { Text } from '../Text';
 import { useZoomPanGesture } from '../play-drawer/use-zoom-pan-gesture';
 import { HoldTargetLayer } from '../create-climb/HoldTargetLayer';
 import { holdGeometry, buildHoldHitTargets } from '../create-climb/holdLayout';
-import { useZoomedHoldTapGesture } from '../create-climb/use-zoomed-hold-tap-gesture';
+import { useZoomedHoldTapGesture, PAN_ACTIVATION_OFFSET } from '../create-climb/use-zoomed-hold-tap-gesture';
 import { overlays } from '../../theme/tokens';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
 import { SearchHoldFilterRings } from './SearchHoldFilterRings';
-
-/** Drag distance (px) before the zoom-pan activates, so a stationary hold tap
- *  while zoomed isn't stolen by the pan. */
-const PAN_ACTIVATION_OFFSET = 8;
 
 /** Context handed to an overlay rendered inside the board's zoom transform. */
 export type FilterBoardTransformContext = {

--- a/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
@@ -41,6 +41,12 @@ vi.mock('../../play-drawer/use-zoom-pan-gesture', () => ({
   }),
 }));
 
+// The composed overlay gesture is exercised by holdLayout unit tests + device
+// QA; here we only assert the zoomed chrome, so return a placeholder gesture.
+vi.mock('../../create-climb/use-zoomed-hold-tap-gesture', () => ({
+  useZoomedHoldTapGesture: () => ({}),
+}));
+
 vi.mock('../../BoardImageNative', () => ({
   BoardImageNative: () => createElement('div', { 'data-board-image': 'true' }),
 }));

--- a/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
@@ -45,6 +45,7 @@ vi.mock('../../play-drawer/use-zoom-pan-gesture', () => ({
 // QA; here we only assert the zoomed chrome, so return a placeholder gesture.
 vi.mock('../../create-climb/use-zoomed-hold-tap-gesture', () => ({
   useZoomedHoldTapGesture: () => ({}),
+  PAN_ACTIVATION_OFFSET: 8,
 }));
 
 vi.mock('../../BoardImageNative', () => ({


### PR DESCRIPTION
Fixes #2687.

## Problem
While the board is pinch-zoomed in the create-climb editor, tapping a hold paints nothing and long-press (role sheet) is dead — you have to hit **Reset zoom** to paint, defeating the point of zooming into a dense cluster. The 1-finger pan overlay that mounts while zoomed sits *above* the per-hold tap detectors, and RNGH only offers a touch to the hit view + its ancestors, so the hold detectors are never candidates (and a stationary tap can't activate a `Pan`).

The **search hold-filter board** (`InteractiveFilterBoard`) has the identical bug — tapping a hold to open the picker is equally dead while zoomed. Both are fixed here via a shared hook + shared helpers.

## Fix
The zoomed overlay's gesture now also resolves taps to holds:
- A worklet inverts the board's zoom transform (`[translate, scale]`, center origin) to map the screen point into board-local px; `resolveHoldAtPoint` (JS thread) picks the **nearest** hold whose hit circle contains it.
- Composition is **`Gesture.Race(pan, longPress, tap)`** with the pan gated behind an **8px `activeOffset`**. A stationary touch never crosses the offset, so tap (quick) / long-press (≥400ms) win; a real drag activates the pan first and cancels them. `Exclusive` would gate long-press behind the pan's touch-up *failure*, so it could never fire mid-hold — hence Race.
- The overlay stays conditional on `isZoomed`, so idle drags still scroll/close the create drawer.

## Changes
- `use-zoom-pan-gesture.ts` — expose `translateXSV` / `translateYSV` / `containerWidthSV` / `containerHeightSV`, and an opt-in `panActivationOffset`. **The play-drawer carousel doesn't opt in, so its behaviour is unchanged.**
- `holdLayout.ts` — pure, unit-tested `inverseTransformPoint`, `buildHoldHitTargets`, `resolveHoldAtPoint` (the worklet keeps a ~2-line inline twin of the inverse, mirroring the existing `clampTranslation` inline/pure split).
- `use-zoomed-hold-tap-gesture.ts` (new, shared) — composes the overlay gesture. Built **once** per overlay mount; reads render-scoped values (hit targets, callbacks) through a ref so it never recomposes mid-session (the documented iOS RNGH wedge). Returns the bare pan when there's no tap handler (zone mode), so the hook call stays unconditional.
- Wired into both `InteractiveCreateBoard` and `InteractiveFilterBoard`.

## Tests
- New `holdLayout.test.ts`: inverse-transform round-trip + worked example, `buildHoldHitTargets` (incl. mirrored + min-tap-diameter), `resolveHoldAtPoint` (hit / miss / nearest-of-overlapping / empty).
- `vp run typecheck:mobile`, `vp run test:mobile` (1545 passed), `vp check`, `vp run check:mobile-bundle` (10.7 MB OK) all green.

## ⚠️ Device QA required
This is an RNGH gesture-arbitration change and CI can't exercise it. Checklist in `.boardsesh/qa-notes.md`. Key items: paint + long-press while zoomed (create editor and search hold-filter), nearest-hold selection in a dense cluster, drag still pans, idle drag still scrolls the create drawer, 2-finger pinch from a resting finger doesn't fire a spurious paint, zone mode unchanged, and the play-drawer carousel pan/swipe unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)