### PR TITLE
DB-backed sessionLiveness for cold-start restore (follow-up to #2693)

### DIFF
--- a/packages/backend/src/__tests__/session-liveness-query.test.ts
+++ b/packages/backend/src/__tests__/session-liveness-query.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the sessionLiveness query (#2683).
+ *
+ * sessionLiveness reads the durable session row so an ended session reads as
+ * ended even when no participants are connected — unlike `session`, which
+ * returns null for any empty roster and so can't tell an ended session apart
+ * from a dormant-but-active solo session. Clients call it on cold start to
+ * decide whether to restore or drop a persisted session id.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const dbClient = vi.hoisted(() => {
+  const limit = vi.fn();
+  return {
+    limit,
+    db: {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit,
+    },
+  };
+});
+
+// Mock connection-opening modules so importing the resolver barrel is side-effect-free.
+vi.mock('../services/room-manager', () => ({ roomManager: {} }));
+vi.mock('../pubsub/index', () => ({ pubsub: {} }));
+vi.mock('../services/distributed-state', () => ({ getDistributedState: () => null }));
+vi.mock('../db/client', () => ({ db: dbClient.db, dbRead: dbClient.db }));
+
+import { sessionQueries } from '../graphql/resolvers/sessions/queries';
+
+describe('sessionLiveness query', () => {
+  beforeEach(() => {
+    dbClient.limit.mockReset();
+  });
+
+  it('returns active liveness for a live session row', async () => {
+    dbClient.limit.mockResolvedValue([{ id: 'session-1', status: 'active', endedAt: null }]);
+
+    const result = await sessionQueries.sessionLiveness({}, { sessionId: 'session-1' });
+
+    expect(result).toEqual({ id: 'session-1', status: 'active', endedAt: null });
+  });
+
+  it('reports an ended session (ISO endedAt) even with zero connected participants', async () => {
+    dbClient.limit.mockResolvedValue([
+      { id: 'session-1', status: 'ended', endedAt: new Date('2026-06-10T12:00:00.000Z') },
+    ]);
+
+    const result = await sessionQueries.sessionLiveness({}, { sessionId: 'session-1' });
+
+    expect(result).toEqual({ id: 'session-1', status: 'ended', endedAt: '2026-06-10T12:00:00.000Z' });
+  });
+
+  it('returns null when the session row does not exist', async () => {
+    dbClient.limit.mockResolvedValue([]);
+
+    const result = await sessionQueries.sessionLiveness({}, { sessionId: 'session-gone' });
+
+    expect(result).toBeNull();
+  });
+
+  it('rejects a malformed session id before querying', async () => {
+    await expect(sessionQueries.sessionLiveness({}, { sessionId: 'bad id!' })).rejects.toThrow();
+    expect(dbClient.limit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/__tests__/session-liveness-query.test.ts
+++ b/packages/backend/src/__tests__/session-liveness-query.test.ts
@@ -33,7 +33,12 @@ import { sessionQueries } from '../graphql/resolvers/sessions/queries';
 
 describe('sessionLiveness query', () => {
   beforeEach(() => {
+    // limit holds per-test return values, so reset it; the chain stubs keep
+    // their mockReturnThis impl but get their call history cleared.
     dbClient.limit.mockReset();
+    dbClient.db.select.mockClear();
+    dbClient.db.from.mockClear();
+    dbClient.db.where.mockClear();
   });
 
   it('returns active liveness for a live session row', async () => {

--- a/packages/backend/src/graphql/resolvers/sessions/queries.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/queries.ts
@@ -1,4 +1,5 @@
-import type { ConnectionContext, EventsReplayResponse } from '@boardsesh/shared-schema';
+import type { ConnectionContext, EventsReplayResponse, SessionLiveness } from '@boardsesh/shared-schema';
+import { eq } from 'drizzle-orm';
 import { roomManager, type DiscoverableSession } from '../../../services/room-manager';
 import { pubsub } from '../../../pubsub/index';
 import { validateInput, requireSessionMember, requireAuthenticated } from '../shared/helpers';
@@ -6,6 +7,8 @@ import { SessionIdSchema, LatitudeSchema, LongitudeSchema, RadiusMetersSchema } 
 import { generateSessionSummary } from './session-summary';
 import { getDistributedState } from '../../../services/distributed-state';
 import { buildSessionPayload } from './helpers';
+import { db } from '../../../db/client';
+import { sessions } from '../../../db/schema';
 
 export const sessionQueries = {
   /**
@@ -127,5 +130,30 @@ export const sessionQueries = {
     requireAuthenticated(ctx);
     validateInput(SessionIdSchema, sessionId, 'sessionId');
     return generateSessionSummary(sessionId);
+  },
+
+  /**
+   * Presence-independent lifecycle check. Reads the durable session row so an
+   * ended session reads as ended even with zero connected participants — unlike
+   * `session`, which returns null whenever the live roster is empty and so can't
+   * tell an ended session apart from a dormant-but-active one. Clients call this
+   * on cold start to decide whether to restore or drop a persisted session id
+   * (#2683). No auth: it exposes only existence + ended-state, and auth may not
+   * be restored yet at cold start.
+   */
+  sessionLiveness: async (_: unknown, { sessionId }: { sessionId: string }): Promise<SessionLiveness | null> => {
+    validateInput(SessionIdSchema, sessionId, 'sessionId');
+    const rows = await db
+      .select({ id: sessions.id, status: sessions.status, endedAt: sessions.endedAt })
+      .from(sessions)
+      .where(eq(sessions.id, sessionId))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      id: row.id,
+      status: row.status,
+      endedAt: row.endedAt ? row.endedAt.toISOString() : null,
+    };
   },
 };

--- a/packages/backend/src/graphql/resolvers/sessions/queries.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/queries.ts
@@ -1,4 +1,4 @@
-import type { ConnectionContext, EventsReplayResponse, SessionLiveness } from '@boardsesh/shared-schema';
+import type { ConnectionContext, EventsReplayResponse, SessionLiveness, SessionStatus } from '@boardsesh/shared-schema';
 import { eq } from 'drizzle-orm';
 import { roomManager, type DiscoverableSession } from '../../../services/room-manager';
 import { pubsub } from '../../../pubsub/index';
@@ -7,7 +7,7 @@ import { SessionIdSchema, LatitudeSchema, LongitudeSchema, RadiusMetersSchema } 
 import { generateSessionSummary } from './session-summary';
 import { getDistributedState } from '../../../services/distributed-state';
 import { buildSessionPayload } from './helpers';
-import { db } from '../../../db/client';
+import { dbRead } from '../../../db/client';
 import { sessions } from '../../../db/schema';
 
 export const sessionQueries = {
@@ -143,7 +143,7 @@ export const sessionQueries = {
    */
   sessionLiveness: async (_: unknown, { sessionId }: { sessionId: string }): Promise<SessionLiveness | null> => {
     validateInput(SessionIdSchema, sessionId, 'sessionId');
-    const rows = await db
+    const rows = await dbRead
       .select({ id: sessions.id, status: sessions.status, endedAt: sessions.endedAt })
       .from(sessions)
       .where(eq(sessions.id, sessionId))
@@ -152,7 +152,9 @@ export const sessionQueries = {
     if (!row) return null;
     return {
       id: row.id,
-      status: row.status,
+      // status is a free-text column constrained by a DB CHECK to
+      // ('active','inactive','ended'); narrow the string for callers.
+      status: row.status as SessionStatus,
       endedAt: row.endedAt ? row.endedAt.toISOString() : null,
     };
   },

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -595,6 +595,30 @@ export type GetSessionQueryResponse = {
   session: SessionPreview | null;
 };
 
+// Presence-independent lifecycle check, read on cold start to decide whether a
+// persisted session id should be restored or dropped (#2683). Unlike GET_SESSION
+// (gated on live roster, so an ended session and a dormant-but-active solo
+// session both read as null), this hits the durable session row.
+export const SESSION_LIVENESS = gql`
+  query SessionLiveness($sessionId: ID!) {
+    sessionLiveness(sessionId: $sessionId) {
+      id
+      status
+      endedAt
+    }
+  }
+`;
+
+export type SessionLivenessResult = {
+  id: string;
+  status: string;
+  endedAt: string | null;
+};
+
+export type SessionLivenessQueryResponse = {
+  sessionLiveness: SessionLivenessResult | null;
+};
+
 // Authoritative queue snapshot for the active session, fetched after a queue
 // mutation fails so the local optimistic delta can't silently diverge from
 // peers until the next reconnect FullSync. The shape mirrors the FullSync

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -19,6 +19,7 @@ import type {
   FollowConnection,
   TickStatus,
   SessionUser,
+  SessionStatus,
   SessionFeedParticipant,
   SessionGradeDistributionItem,
 } from '@boardsesh/shared-schema';
@@ -611,7 +612,7 @@ export const SESSION_LIVENESS = gql`
 
 export type SessionLivenessResult = {
   id: string;
-  status: string;
+  status: SessionStatus;
   endedAt: string | null;
 };
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -126,12 +126,14 @@ describe('QueueProvider clearSession notifyServer', () => {
     sessionStore.getStoredSessionId.mockResolvedValue('session-1');
     sessionStore.clearStoredSessionId.mockClear();
     http.request.mockReset();
-    // Cold-start restore verifies session liveness via GET_SESSION (#2683); keep
-    // the stored session alive so these tests land in-session before clearSession.
-    http.request.mockImplementation(async (operation: unknown) => {
-      const operationText = typeof operation === 'string' ? operation : '';
-      return operationText.includes('GetSession') ? { session: { id: 'session-1', endedAt: null } } : {};
-    });
+    // Cold-start restore verifies session liveness via SESSION_LIVENESS (#2683);
+    // keep the stored session active so these tests land in-session before
+    // clearSession.
+    http.request.mockImplementation(async (operation: string) =>
+      operation.includes('SessionLiveness')
+        ? { sessionLiveness: { id: 'session-1', status: 'active', endedAt: null } }
+        : {},
+    );
     graph.execute.mockReset();
     // joinSession resolves the active session; leaveSession resolves true.
     graph.execute.mockResolvedValue({

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -190,18 +190,10 @@ const user = (overrides: Partial<SessionUser> = {}): SessionUser => ({
   ...overrides,
 });
 
-// Shape returned by the GET_SESSION liveness check during cold-start restore.
-// endedAt: null means the session is still live and should be rejoined.
-const aliveSession = (id: string, endedAt: string | null = null) => ({
-  id,
-  name: null,
-  boardPath: '/kilter/1/10/1,2/40/list',
-  color: null,
-  goal: null,
-  startedAt: '2026-01-01T00:00:00.000Z',
-  endedAt,
-  driverParticipantId: null,
-  users: [],
+// Response shape for the cold-start SESSION_LIVENESS check. status 'active'
+// (endedAt null) means restore the session; 'ended' means drop the stored id.
+const livenessResponse = (id: string, status: 'active' | 'ended' = 'active', endedAt: string | null = null) => ({
+  sessionLiveness: { id, status, endedAt },
 });
 
 function makeQueueItem(uuid: string, climbUuid = uuid, options: { suggested?: boolean } = {}): ClimbQueueItem {
@@ -352,14 +344,12 @@ describe('QueueProvider session update subscription', () => {
     sessionStore.clearStoredSessionId.mockClear();
     graph.execute.mockReset();
     http.request.mockReset();
-    // The restore effect verifies session liveness via GET_SESSION before
-    // rejoining (#2683). Default to an alive session so existing tests still
+    // The restore effect verifies session liveness via SESSION_LIVENESS before
+    // rejoining (#2683). Default to an active session so existing tests still
     // auto-restore into session-1; END_SESSION keeps its endSession shape.
-    // GetSessionQueueState (resync) shares the GetSession prefix, so exclude it
-    // here — the resync tests route http.request themselves.
-    http.request.mockImplementation((query: string) =>
-      typeof query === 'string' && query.includes('GetSession') && !query.includes('GetSessionQueueState')
-        ? Promise.resolve({ session: aliveSession('session-1') })
+    http.request.mockImplementation((operation: string) =>
+      operation.includes('SessionLiveness')
+        ? Promise.resolve(livenessResponse('session-1'))
         : Promise.resolve({ endSession: { sessionId: 'session-1' } }),
     );
     graph.execute.mockResolvedValue({
@@ -841,9 +831,9 @@ describe('QueueProvider session update subscription', () => {
 
   it('drops a server-ended stored session on cold start without rejoining (#2683)', async () => {
     sessionStore.getStoredSessionId.mockResolvedValue('session-ended');
-    http.request.mockImplementation((query: string) =>
-      typeof query === 'string' && query.includes('GetSession')
-        ? Promise.resolve({ session: aliveSession('session-ended', '2026-06-10T12:00:00.000Z') })
+    http.request.mockImplementation((operation: string) =>
+      operation.includes('SessionLiveness')
+        ? Promise.resolve(livenessResponse('session-ended', 'ended', '2026-06-10T12:00:00.000Z'))
         : Promise.resolve({ endSession: { sessionId: 'session-ended' } }),
     );
 
@@ -861,8 +851,8 @@ describe('QueueProvider session update subscription', () => {
   });
 
   it('restores optimistically when the liveness check fails (offline cold start)', async () => {
-    http.request.mockImplementation((query: string) =>
-      typeof query === 'string' && query.includes('GetSession')
+    http.request.mockImplementation((operation: string) =>
+      operation.includes('SessionLiveness')
         ? Promise.reject(new Error('offline'))
         : Promise.resolve({ endSession: { sessionId: 'session-1' } }),
     );
@@ -1136,16 +1126,15 @@ describe('QueueProvider mutation-failure resync', () => {
   // authoritative snapshot while everything else keeps the default endSession
   // response.
   function routeHttpRequest(queueStateResponse: unknown, options: { onQueueStateCall?: () => void } = {}) {
-    http.request.mockImplementation(async (operation: unknown) => {
-      const operationText = typeof operation === 'string' ? operation : '';
-      if (operationText.includes('GetSessionQueueState')) {
+    http.request.mockImplementation(async (operation: string) => {
+      if (operation.includes('GetSessionQueueState')) {
         options.onQueueStateCall?.();
         return queueStateResponse;
       }
-      // Cold-start liveness check (#2683) — keep the session alive so restore
+      // Cold-start liveness check (#2683) — keep the session active so restore
       // lands in-session for these resync tests.
-      if (operationText.includes('GetSession')) {
-        return { session: aliveSession('session-1') };
+      if (operation.includes('SessionLiveness')) {
+        return livenessResponse('session-1');
       }
       return { endSession: { sessionId: 'session-1' } };
     });
@@ -1302,15 +1291,14 @@ describe('QueueProvider mutation-failure resync', () => {
   it('does not retry-loop when the resync fetch itself fails', async () => {
     const snapshots: Snapshot[] = [];
     let queueStateCalls = 0;
-    http.request.mockImplementation(async (operation: unknown) => {
-      const operationText = typeof operation === 'string' ? operation : '';
-      if (operationText.includes('GetSessionQueueState')) {
+    http.request.mockImplementation(async (operation: string) => {
+      if (operation.includes('GetSessionQueueState')) {
         queueStateCalls += 1;
         throw new Error('resync fetch failed');
       }
-      // Cold-start liveness check (#2683) — alive so restore lands in-session.
-      if (operationText.includes('GetSession')) {
-        return { session: aliveSession('session-1') };
+      // Cold-start liveness check (#2683) — active so restore lands in-session.
+      if (operation.includes('SessionLiveness')) {
+        return livenessResponse('session-1');
       }
       return { endSession: { sessionId: 'session-1' } };
     });

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -850,6 +850,26 @@ describe('QueueProvider session update subscription', () => {
     expect(ws.getSessionUpdatesSink()).toBeNull();
   });
 
+  it('drops a stored session whose status is ended even if endedAt is null (#2683)', async () => {
+    // A partial-ended row (status flipped, timestamp not yet set) must still be
+    // treated as ended — the status check, not just endedAt, gates the clear.
+    sessionStore.getStoredSessionId.mockResolvedValue('session-ended');
+    http.request.mockImplementation((operation: string) =>
+      operation.includes('SessionLiveness')
+        ? Promise.resolve(livenessResponse('session-ended', 'ended', null))
+        : Promise.resolve({ endSession: { sessionId: 'session-ended' } }),
+    );
+
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(sessionStore.clearStoredSessionId).toHaveBeenCalled();
+    });
+    expect(snapshots.at(-1)?.sessionId).toBeNull();
+    expect(graph.execute).not.toHaveBeenCalled();
+  });
+
   it('restores optimistically when the liveness check fails (offline cold start)', async () => {
     http.request.mockImplementation((operation: string) =>
       operation.includes('SessionLiveness')

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -55,14 +55,14 @@ import {
   CREATE_SESSION,
   END_SESSION,
   GET_CLIMB,
-  GET_SESSION,
+  SESSION_LIVENESS,
   GET_SESSION_QUEUE_STATE,
   type CreateSessionMutationResponse,
   type EndSessionMutationResponse,
   type SessionUpdateEvent,
   type SessionLiveStatsEvent,
   type GetClimbQueryResponse,
-  type GetSessionQueryResponse,
+  type SessionLivenessQueryResponse,
   type GetSessionQueueStateQueryResponse,
 } from '../lib/graphql/operations';
 import { getStoredActiveBoard } from '../lib/active-board-store';
@@ -528,12 +528,15 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       try {
         // Verify the stored session is still alive before rejoining. Without
         // this, JOIN_SESSION recreates a server-ended room as an empty zombie
-        // and we land in InSessionView with no peers (#2683).
-        const { session } = await getHttpClient().request<GetSessionQueryResponse>(GET_SESSION, {
+        // and we land in InSessionView with no peers (#2683). Liveness reads the
+        // durable session row (sessionLiveness), NOT the presence-gated `session`
+        // query — that one returns null for any empty session, so it can't tell
+        // an ended session apart from a dormant-but-active solo session.
+        const { sessionLiveness } = await getHttpClient().request<SessionLivenessQueryResponse>(SESSION_LIVENESS, {
           sessionId: storedId,
         });
         if (cancelled) return;
-        if (!session || session.endedAt != null) {
+        if (!sessionLiveness || sessionLiveness.status === 'ended' || sessionLiveness.endedAt != null) {
           if (__DEV__) {
             console.info(`[session] stored session ${storedId} ended/missing; clearing`);
           }

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -375,6 +375,20 @@ type Session {
 }
 
 """
+Durable lifecycle status of a session, independent of live presence.
+Backed by the persisted session row rather than Redis, so an ended session
+is reported as ended even when no participants are currently connected.
+"""
+type SessionLiveness {
+  "Unique session identifier"
+  id: ID!
+  "Durable lifecycle status: 'active' or 'ended'"
+  status: String!
+  "When the session was ended (ISO 8601); null while still active"
+  endedAt: String
+}
+
+"""
 A session that can be discovered by nearby users via GPS.
 """
 type DiscoverableSession {
@@ -3542,6 +3556,15 @@ type Query {
   Available for ended sessions or active sessions with ticks.
   """
   sessionSummary(sessionId: ID!): SessionSummary
+
+  """
+  Lightweight, presence-independent lifecycle check for a session.
+  Reads the durable session row (not live Redis presence), so it tells an
+  ended session apart from one that is merely empty. Returns null when the
+  session does not exist. Clients use this on cold start to decide whether
+  to restore or drop a persisted session id.
+  """
+  sessionLiveness(sessionId: ID!): SessionLiveness
 
   # ============================================
   # Board Configuration Queries

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -3193,6 +3193,14 @@ export type Query = {
    */
   sessionGroupedFeed: SessionFeedResult;
   /**
+   * Lightweight, presence-independent lifecycle check for a session.
+   * Reads the durable session row (not live Redis presence), so it tells an
+   * ended session apart from one that is merely empty. Returns null when the
+   * session does not exist. Clients use this on cold start to decide whether
+   * to restore or drop a persisted session id.
+   */
+  sessionLiveness?: Maybe<SessionLiveness>;
+  /**
    * Get a session summary (stats, grade distribution, participants).
    * Available for ended sessions or active sessions with ticks.
    */
@@ -3615,6 +3623,11 @@ export type QuerySessionDetailArgs = {
 /** Root query type for all read operations. */
 export type QuerySessionGroupedFeedArgs = {
   input?: InputMaybe<ActivityFeedInput>;
+};
+
+/** Root query type for all read operations. */
+export type QuerySessionLivenessArgs = {
+  sessionId: Scalars['ID']['input'];
 };
 
 /** Root query type for all read operations. */
@@ -4264,6 +4277,21 @@ export type SessionHardestClimb = {
   climbUuid: Scalars['String']['output'];
   /** Grade name */
   grade: Scalars['String']['output'];
+};
+
+/**
+ * Durable lifecycle status of a session, independent of live presence.
+ * Backed by the persisted session row rather than Redis, so an ended session
+ * is reported as ended even when no participants are currently connected.
+ */
+export type SessionLiveness = {
+  __typename?: 'SessionLiveness';
+  /** When the session was ended (ISO 8601); null while still active */
+  endedAt?: Maybe<Scalars['String']['output']>;
+  /** Unique session identifier */
+  id: Scalars['ID']['output'];
+  /** Durable lifecycle status: 'active' or 'ended' */
+  status: Scalars['String']['output'];
 };
 
 /** Participant stats in a session summary. */
@@ -5518,6 +5546,7 @@ export type ResolversTypes = ResolversObject<{
   SessionGradeCount: ResolverTypeWrapper<SessionGradeCount>;
   SessionGradeDistributionItem: ResolverTypeWrapper<SessionGradeDistributionItem>;
   SessionHardestClimb: ResolverTypeWrapper<SessionHardestClimb>;
+  SessionLiveness: ResolverTypeWrapper<SessionLiveness>;
   SessionParticipant: ResolverTypeWrapper<SessionParticipant>;
   SessionStatsUpdated: ResolverTypeWrapper<SessionStatsUpdated>;
   SessionSummary: ResolverTypeWrapper<SessionSummary>;
@@ -5770,6 +5799,7 @@ export type ResolversParentTypes = ResolversObject<{
   SessionGradeCount: SessionGradeCount;
   SessionGradeDistributionItem: SessionGradeDistributionItem;
   SessionHardestClimb: SessionHardestClimb;
+  SessionLiveness: SessionLiveness;
   SessionParticipant: SessionParticipant;
   SessionStatsUpdated: SessionStatsUpdated;
   SessionSummary: SessionSummary;
@@ -7834,6 +7864,12 @@ export type QueryResolvers<
     ContextType,
     Partial<QuerySessionGroupedFeedArgs>
   >;
+  sessionLiveness?: Resolver<
+    Maybe<ResolversTypes['SessionLiveness']>,
+    ParentType,
+    ContextType,
+    RequireFields<QuerySessionLivenessArgs, 'sessionId'>
+  >;
   sessionSummary?: Resolver<
     Maybe<ResolversTypes['SessionSummary']>,
     ParentType,
@@ -8286,6 +8322,16 @@ export type SessionHardestClimbResolvers<
   climbName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   climbUuid?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   grade?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type SessionLivenessResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['SessionLiveness'] = ResolversParentTypes['SessionLiveness'],
+> = ResolversObject<{
+  endedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -8838,6 +8884,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   SessionGradeCount?: SessionGradeCountResolvers<ContextType>;
   SessionGradeDistributionItem?: SessionGradeDistributionItemResolvers<ContextType>;
   SessionHardestClimb?: SessionHardestClimbResolvers<ContextType>;
+  SessionLiveness?: SessionLivenessResolvers<ContextType>;
   SessionParticipant?: SessionParticipantResolvers<ContextType>;
   SessionStatsUpdated?: SessionStatsUpdatedResolvers<ContextType>;
   SessionSummary?: SessionSummaryResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -33,6 +33,15 @@ export const queriesTypeDefs = /* GraphQL */ `
     """
     sessionSummary(sessionId: ID!): SessionSummary
 
+    """
+    Lightweight, presence-independent lifecycle check for a session.
+    Reads the durable session row (not live Redis presence), so it tells an
+    ended session apart from one that is merely empty. Returns null when the
+    session does not exist. Clients use this on cold start to decide whether
+    to restore or drop a persisted session id.
+    """
+    sessionLiveness(sessionId: ID!): SessionLiveness
+
     # ============================================
     # Board Configuration Queries
     # ============================================

--- a/packages/shared-schema/src/schema/session.ts
+++ b/packages/shared-schema/src/schema/session.ts
@@ -64,6 +64,20 @@ export const sessionTypeDefs = /* GraphQL */ `
   }
 
   """
+  Durable lifecycle status of a session, independent of live presence.
+  Backed by the persisted session row rather than Redis, so an ended session
+  is reported as ended even when no participants are currently connected.
+  """
+  type SessionLiveness {
+    "Unique session identifier"
+    id: ID!
+    "Durable lifecycle status: 'active' or 'ended'"
+    status: String!
+    "When the session was ended (ISO 8601); null while still active"
+    endedAt: String
+  }
+
+  """
   A session that can be discovered by nearby users via GPS.
   """
   type DiscoverableSession {

--- a/packages/shared-schema/src/types/session.ts
+++ b/packages/shared-schema/src/types/session.ts
@@ -43,3 +43,10 @@ export type SessionSummary = {
   durationMinutes?: number | null;
   goal?: string | null;
 };
+
+/** Durable lifecycle status of a session, independent of live presence. */
+export type SessionLiveness = {
+  id: string;
+  status: string;
+  endedAt?: string | null;
+};

--- a/packages/shared-schema/src/types/session.ts
+++ b/packages/shared-schema/src/types/session.ts
@@ -44,9 +44,12 @@ export type SessionSummary = {
   goal?: string | null;
 };
 
+/** Durable session lifecycle status (DB CHECK: board_sessions.status). */
+export type SessionStatus = 'active' | 'inactive' | 'ended';
+
 /** Durable lifecycle status of a session, independent of live presence. */
 export type SessionLiveness = {
   id: string;
-  status: string;
+  status: SessionStatus;
   endedAt?: string | null;
 };

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -3190,6 +3190,14 @@ export type Query = {
    */
   sessionGroupedFeed: SessionFeedResult;
   /**
+   * Lightweight, presence-independent lifecycle check for a session.
+   * Reads the durable session row (not live Redis presence), so it tells an
+   * ended session apart from one that is merely empty. Returns null when the
+   * session does not exist. Clients use this on cold start to decide whether
+   * to restore or drop a persisted session id.
+   */
+  sessionLiveness?: Maybe<SessionLiveness>;
+  /**
    * Get a session summary (stats, grade distribution, participants).
    * Available for ended sessions or active sessions with ticks.
    */
@@ -3612,6 +3620,11 @@ export type QuerySessionDetailArgs = {
 /** Root query type for all read operations. */
 export type QuerySessionGroupedFeedArgs = {
   input?: InputMaybe<ActivityFeedInput>;
+};
+
+/** Root query type for all read operations. */
+export type QuerySessionLivenessArgs = {
+  sessionId: Scalars['ID']['input'];
 };
 
 /** Root query type for all read operations. */
@@ -4261,6 +4274,21 @@ export type SessionHardestClimb = {
   climbUuid: Scalars['String']['output'];
   /** Grade name */
   grade: Scalars['String']['output'];
+};
+
+/**
+ * Durable lifecycle status of a session, independent of live presence.
+ * Backed by the persisted session row rather than Redis, so an ended session
+ * is reported as ended even when no participants are currently connected.
+ */
+export type SessionLiveness = {
+  __typename?: 'SessionLiveness';
+  /** When the session was ended (ISO 8601); null while still active */
+  endedAt?: Maybe<Scalars['String']['output']>;
+  /** Unique session identifier */
+  id: Scalars['ID']['output'];
+  /** Durable lifecycle status: 'active' or 'ended' */
+  status: Scalars['String']['output'];
 };
 
 /** Participant stats in a session summary. */


### PR DESCRIPTION
Follow-up to #2693, addressing the review feedback there. Stacked on `claude/cold-start-session-liveness-2683` (base will retarget to `main` once #2693 merges).

## Why
Codex's P1 on #2693 was correct: that PR's cold-start check used the **presence-gated** `session` query, which returns `null` whenever the live roster is empty. That's true for an *ended* session **and** for a *dormant-but-active solo* session whose socket dropped on force-quit — so `!session → clear` would wipe an active solo session on every cold start. The two cases are indistinguishable through `session`, so the fix needs a presence-independent read of the durable session row.

## What
- **New `sessionLiveness(sessionId): SessionLiveness` query** (backend + schema). Reads `board_sessions.status`/`endedAt` directly — a plain `SELECT`, no room-manager / Redis involvement, so it can't resurrect anything. No auth: it exposes only existence + ended-state, and auth may not be restored yet at cold start.
- **Client restore** now clears the stored id only on a *positive* ended/missing signal (`status === 'ended'`, `endedAt` set, or no row) and restores active sessions — including empty solo ones. Offline cold start still restores optimistically.
- Replaces the `GET_SESSION` check from #2693. `GET_SESSION` stays for the join-confirmation preview (`use-session-detail.ts`).

## Review feedback resolved
- **Codex P1** (false-clear of live solo sessions) — fixed by the DB-backed read.
- **Claude #1/#2** (brittle `includes('GetSession')` mock routing + inconsistent param typing) — the new `SessionLiveness` op name shares no prefix with `GetSessionQueueState`, so the substring routing is unambiguous and the mock typing is now consistent across both harnesses.
- **Claude #3** (`cancelled` guard) — retained.
- **Claude #4 / backend zombie-join** — tracked separately in #2696 (server still recreates ended rooms for any client; out of scope here).

## Tests / validation
- New backend test: `sessionLiveness` returns active / ended (ISO `endedAt`) / null-when-missing, and rejects a malformed id before querying.
- Mobile provider tests updated to the new op; ended-session-dropped + offline-optimistic-restore still covered.
- `vp run typecheck` (all packages) ✓ · `vp run test:mobile` 1537 ✓ · backend `sessionLiveness` test ✓ · `vp run check:mobile-bundle` OK ✓ · `vp run codegen` committed (codegen-drift clean) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
