### PR TITLE
fix(mobile): reset resync guard on teardown and harden favorite rollback

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -39,6 +39,7 @@ import { getBoardRenderData } from '../../lib/board-details';
 import { hapticSuccess } from '../../lib/haptics';
 import { usePlayDrawerWakeLock } from './use-play-drawer-wake-lock';
 import { useDeferredSheetOpen } from './use-deferred-sheet-open';
+import { resolveFavoriteRollback } from './favorite-rollback';
 import {
   buildPlayDrawerBoardLayout,
   derivePlayDrawerLightbulbPressAction,
@@ -473,9 +474,12 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
           setFavoriteOverride(response.toggleFavorite.favorited);
         },
         // Roll back the optimistic flip and tell the user it didn't stick, rather
-        // than leaving the heart diverged from the server.
+        // than leaving the heart diverged from the server. Only undo OUR flip,
+        // though: if a newer tap (or a climb change, which resets the override to
+        // null) has since moved the heart, this late error must not clobber the
+        // current state with this tap's stale previous value.
         onError: () => {
-          setFavoriteOverride(previousOverride);
+          setFavoriteOverride((current) => resolveFavoriteRollback(current, nextIsFavorited, previousOverride));
           showToast(t('playView.favoriteError'), 'error');
         },
       },

--- a/packages/mobile/src/components/play-drawer/__tests__/favorite-rollback.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/favorite-rollback.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+
+import { resolveFavoriteRollback } from '../favorite-rollback';
+
+// A failed favorite toggle rolls the optimistic override back to its pre-tap
+// value — but only when that optimistic value is still the one on screen. A
+// newer tap or a climb change (which resets the override to null) must win over
+// a late error, otherwise the heart diverges from what the user sees.
+describe('resolveFavoriteRollback', () => {
+  it('rolls back to the previous value when our optimistic flip is still shown', () => {
+    // Tapped an unfavorited climb (previous null → optimistic true); the toggle
+    // failed and nothing else moved the heart, so undo back to null.
+    expect(resolveFavoriteRollback(true, true, null)).toBe(null);
+    // Same, starting from a concrete previous override.
+    expect(resolveFavoriteRollback(false, false, true)).toBe(true);
+  });
+
+  it('leaves a newer tap untouched instead of clobbering it', () => {
+    // First tap set optimistic true, a second tap has since moved the override
+    // back to false. The first tap's late error must not resurrect null.
+    expect(resolveFavoriteRollback(false, true, null)).toBe(false);
+  });
+
+  it('does not resurrect a stale value onto a climb that has since changed', () => {
+    // The climb changed mid-flight, resetting the override to null. A late error
+    // from the previous climb must leave the new climb showing its own status.
+    expect(resolveFavoriteRollback(null, true, false)).toBe(null);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/favorite-rollback.ts
+++ b/packages/mobile/src/components/play-drawer/favorite-rollback.ts
@@ -1,0 +1,11 @@
+// Decides what the optimistic favorite override should roll back to after a
+// failed toggle. Returns `previous` only when `current` is still the optimistic
+// value this toggle set — otherwise a newer tap / climb change owns the state
+// and we leave it untouched.
+export function resolveFavoriteRollback(
+  current: boolean | null,
+  optimistic: boolean,
+  previous: boolean | null,
+): boolean | null {
+  return current === optimistic ? previous : current;
+}

--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -3,6 +3,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import { createElement, useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { UserBoard } from '@boardsesh/shared-schema';
+import type { ClimbQueueItem } from '@boardsesh/queue';
 
 // Self-contained QueueProvider harness scoped to clearSession's notifyServer
 // option: an intentional session switch must emit LEAVE_SESSION so peers see
@@ -95,14 +96,21 @@ import { QueueProvider, useQueue, useQueueSessionId } from '../queue-provider';
 type Snapshot = {
   sessionId: string | null;
   clearSession: ReturnType<typeof useQueue>['clearSession'];
+  joinSession: ReturnType<typeof useQueue>['joinSession'];
+  addToQueue: ReturnType<typeof useQueue>['addToQueue'];
 };
 
 function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
   const queue = useQueue();
   const { sessionId } = useQueueSessionId();
   useEffect(() => {
-    onSnapshot({ sessionId, clearSession: queue.clearSession });
-  }, [sessionId, queue.clearSession, onSnapshot]);
+    onSnapshot({
+      sessionId,
+      clearSession: queue.clearSession,
+      joinSession: queue.joinSession,
+      addToQueue: queue.addToQueue,
+    });
+  }, [sessionId, queue.clearSession, queue.joinSession, queue.addToQueue, onSnapshot]);
   return null;
 }
 
@@ -110,6 +118,15 @@ function leaveSessionCalls() {
   return graph.execute.mock.calls.filter((call) => {
     const operation = call[1] as { query?: string } | undefined;
     return typeof operation?.query === 'string' && operation.query.includes('leaveSession');
+  });
+}
+
+// resyncQueueFromServer is the only thing that fires GET_SESSION_QUEUE_STATE, so
+// counting these calls tracks how many mutation-failure resyncs actually ran.
+function queueStateCalls() {
+  return http.request.mock.calls.filter((call) => {
+    const operation = call[0];
+    return typeof operation === 'string' && operation.includes('GetSessionQueueState');
   });
 }
 
@@ -191,5 +208,66 @@ describe('QueueProvider clearSession notifyServer', () => {
 
     // A failed leave must not block the local reset — the switch still proceeds.
     await waitFor(() => expect(snapshots.at(-1)?.sessionId).toBeNull());
+  });
+
+  it('resets the resync single-flight guard so the next session can still resync', async () => {
+    // A resync fetch that never settles (hung connection) leaves the single-flight
+    // guard set. clearSession must reset it — otherwise the guard, carried across a
+    // session switch on a still-mounted provider, blocks every future resync.
+    let hangNextQueueState = false;
+    http.request.mockImplementation((operation: unknown) => {
+      const operationText = typeof operation === 'string' ? operation : '';
+      // Match GetSessionQueueState before the generic GetSession branch — its name
+      // contains 'GetSession' too.
+      if (operationText.includes('GetSessionQueueState')) {
+        // The first resync hangs (pins the guard true); later resyncs resolve.
+        if (hangNextQueueState) return new Promise<never>(() => {});
+        return Promise.resolve({ session: { queueState: { queue: [], currentClimbQueueItem: null } } });
+      }
+      // Cold-start liveness check keeps the stored session alive (#2683).
+      if (operationText.includes('GetSession')) {
+        return Promise.resolve({ session: { id: 'session-1', endedAt: null } });
+      }
+      return Promise.resolve({});
+    });
+
+    const queueItem: ClimbQueueItem = {
+      uuid: 'queue-item-resync',
+      // angle matches the active board (40) so the re-grade effect leaves it alone.
+      climb: { uuid: 'climb-resync', name: 'Test', mirrored: false, angle: 40 } as ClimbQueueItem['climb'],
+    };
+
+    const snapshots: Snapshot[] = [];
+    render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot: (snap) => snapshots.push(snap) })));
+    await waitFor(() => expect(snapshots.at(-1)?.sessionId).toBe('session-1'));
+
+    // First mutation fails → resync fires and hangs, pinning the guard true.
+    hangNextQueueState = true;
+    queueMutations.addQueueItem.mockRejectedValueOnce(new Error('ws down'));
+    await act(async () => {
+      snapshots.at(-1)?.addToQueue(queueItem);
+    });
+    await waitFor(() => expect(queueStateCalls()).toHaveLength(1));
+
+    // Switch sessions: clearSession (must reset the guard) then rejoin the same id.
+    hangNextQueueState = false;
+    await act(async () => {
+      await snapshots.at(-1)?.clearSession();
+    });
+    await act(async () => {
+      await snapshots.at(-1)?.joinSession('session-1', {
+        boardPath: '/kilter/1/10/1,2/40/list',
+        userBoard: activeBoard.stored,
+      });
+    });
+    await waitFor(() => expect(snapshots.at(-1)?.sessionId).toBe('session-1'));
+
+    // Second mutation fails → the resync must run again. Without the reset the
+    // stale guard early-returns and this stays at 1 (the regression).
+    queueMutations.addQueueItem.mockRejectedValueOnce(new Error('ws down again'));
+    await act(async () => {
+      snapshots.at(-1)?.addToQueue(queueItem);
+    });
+    await waitFor(() => expect(queueStateCalls()).toHaveLength(2));
   });
 });

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -1475,6 +1475,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         if (__DEV__) console.warn('[queue] leaveSession on switch failed', error);
       }
     }
+    // A resync fetch that never settles (hung connection) would leave the
+    // single-flight guard stuck true; a mounted provider carries that across a
+    // session switch and would block every future resync. Reset at the teardown
+    // boundary so the next session always starts clean.
+    resyncInFlightRef.current = false;
     sessionIdRef.current = null;
     setSessionId(null);
     dispatch({


### PR DESCRIPTION
Two correctness fixes in the mobile queue / play-drawer, from review feedback. Both are mobile-only (web uses different patterns).

## 1. Resync single-flight guard never reset on session teardown

`resyncInFlightRef` (in `packages/mobile/src/providers/queue-provider.tsx`) coalesces mutation-failure resyncs. It's set `true` before a `GET_SESSION_QUEUE_STATE` fetch and cleared in a `finally`, so it self-clears in normal operation. The gap: if that fetch never settles (a hung connection with no timeout) and the user switches sessions, the `QueueProvider` stays mounted across the switch, so the ref carries `true` into the next session and permanently blocks every future resync.

`clearSession` already resets `sessionIdRef`, `sessionId`, the queue, and the playlist source — this adds the resync guard to that same teardown reset, so a fresh session always starts clean.

## 2. Favorite-toggle rollback could clobber a newer optimistic value

In `PlayDrawer.tsx`, `handleToggleFavorite` captured `previousOverride` and, on error, unconditionally restored it. If a second tap — or a swipe to a different climb, which resets the override to `null` — landed before the first mutation's `onError` fired, that late rollback overwrote the *current* displayed state with the *previous* tap's value. The cross-climb case is the concrete one: a late error from climb A's mutation could write A's stale value onto climb B's heart.

The `onError` rollback now uses a functional update via a new pure helper `resolveFavoriteRollback(current, optimistic, previous)`, which only rolls back when our optimistic value is still the one displayed; otherwise a newer tap / climb change owns the state and it's left untouched. `onSuccess` (server reconciliation) is unchanged.

## Tests

- `favorite-rollback.test.ts` — unit tests: rolls back, doesn't clobber a newer tap, doesn't resurrect a stale value after a climb change.
- `queue-provider-leave-session.test.tsx` — new regression test: hangs the first resync to pin the guard, switches sessions (`clearSession` + `joinSession`), and asserts the next mutation-failure still fires a fresh `GetSessionQueueState`. Fails without the reset (stays at one call).

## Validation

- `vp run typecheck:mobile` — pass
- `vp test run --project mobile` — 1541 tests pass (218 files)
- `vp run check:mobile-bundle` — Android bundle OK (10.7 MB)
- `vp check` on the five changed files — format + lint clean

https://claude.ai/code/session_01LyQsfxtV8JYH6AytBF7ySm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyQsfxtV8JYH6AytBF7ySm)_