### PR TITLE
Make play-drawer lightbulb follow real BLE state

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -512,6 +512,16 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       return;
     }
 
+    if (pressAction === 'reconnect_ble') {
+      if (!bluetooth) return;
+      // Party driver whose BLE link was stolen — reconnect to the remembered board
+      // without releasing wall control, so it relights in one tap. No control
+      // changes hands here, and connect() already emits BluetoothConnectionSuccess,
+      // so we don't fire 'Wall Control Taken' (which would inflate party-take counts).
+      void bluetooth.connect(undefined, undefined, bluetooth.reconnectSerialForCurrentBoard ?? undefined);
+      return;
+    }
+
     if (pressAction === 'connect_solo') {
       if (!bluetooth) return;
       track('Wall Control Taken', {
@@ -713,12 +723,22 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const lightbulbAccessibilityLabel = useMemo(() => {
     if (!lightbulbState.isPersistentSessionActive) return undefined;
     if (lightbulbState.isDriver) {
+      // Still the driver but the board link dropped — the tap reconnects, not
+      // releases, so the label must match (see derivePlayDrawerLightbulbPressAction).
+      if (bluetooth && !bluetoothConnected) return t('playView.actionBar.lightbulb.reconnect');
       if (!displayedClimb) return t('playView.actionBar.lightbulb.driving');
       return t('playView.actionBar.lightbulb.drivingNamed', { name: displayedClimb.name });
     }
     if (!displayedClimb) return t('playView.actionBar.lightbulb.take');
     return t('playView.actionBar.lightbulb.takeNamed', { name: displayedClimb.name });
-  }, [displayedClimb, lightbulbState.isDriver, lightbulbState.isPersistentSessionActive, t]);
+  }, [
+    displayedClimb,
+    lightbulbState.isDriver,
+    lightbulbState.isPersistentSessionActive,
+    bluetooth,
+    bluetoothConnected,
+    t,
+  ]);
 
   return (
     <>

--- a/packages/mobile/src/components/play-drawer/__tests__/lightbulb-control.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/lightbulb-control.test.ts
@@ -65,13 +65,32 @@ describe('play drawer lightbulb control', () => {
     });
   });
 
-  it('uses driver state for the party lightbulb', () => {
+  it('keeps the party lightbulb unlit when the driver has no BLE link', () => {
+    // Driver in a session but the board link was stolen — the bulb must go unlit,
+    // matching the climbs-list bulb, instead of staying lit on wall-control alone.
     expect(
       derivePlayDrawerLightbulbState({
         sessionId: 'session-1',
         driverParticipantId: 'participant-1',
         participantId: 'participant-1',
         isBluetoothConnected: false,
+        isBluetoothLoading: false,
+        pendingClimbUuid: null,
+      }),
+    ).toEqual({
+      isPersistentSessionActive: true,
+      isDriver: true,
+      lightbulbActive: false,
+      lightbulbPending: false,
+    });
+
+    // Driver with the board connected — lit.
+    expect(
+      derivePlayDrawerLightbulbState({
+        sessionId: 'session-1',
+        driverParticipantId: 'participant-1',
+        participantId: 'participant-1',
+        isBluetoothConnected: true,
         isBluetoothLoading: false,
         pendingClimbUuid: null,
       }),
@@ -145,6 +164,7 @@ describe('play drawer lightbulb control', () => {
         isBluetoothConnected: true,
       }),
     ).toBe('reassert_solo');
+    // Party driver whose link was stolen reconnects BLE in one tap, keeping control.
     expect(
       derivePlayDrawerLightbulbPressAction({
         hasBluetooth: true,
@@ -152,6 +172,16 @@ describe('play drawer lightbulb control', () => {
         isPersistentSessionActive: true,
         isDriver: true,
         isBluetoothConnected: false,
+      }),
+    ).toBe('reconnect_ble');
+    // Party driver still connected releases wall control.
+    expect(
+      derivePlayDrawerLightbulbPressAction({
+        hasBluetooth: true,
+        hasDisplayedClimb: true,
+        isPersistentSessionActive: true,
+        isDriver: true,
+        isBluetoothConnected: true,
       }),
     ).toBe('release_party');
     expect(

--- a/packages/mobile/src/components/play-drawer/lightbulb-control.ts
+++ b/packages/mobile/src/components/play-drawer/lightbulb-control.ts
@@ -10,7 +10,13 @@ export type PlayDrawerLightbulbState = {
   lightbulbPending: boolean;
 };
 
-export type PlayDrawerLightbulbPressAction = 'noop' | 'release_party' | 'connect_solo' | 'reassert_solo' | 'take_party';
+export type PlayDrawerLightbulbPressAction =
+  | 'noop'
+  | 'release_party'
+  | 'reconnect_ble'
+  | 'connect_solo'
+  | 'reassert_solo'
+  | 'take_party';
 
 export function derivePlayDrawerLightbulbState(args: {
   sessionId: string | null;
@@ -30,7 +36,11 @@ export function derivePlayDrawerLightbulbState(args: {
   return {
     isPersistentSessionActive,
     isDriver,
-    lightbulbActive: isPersistentSessionActive ? isDriver : args.isBluetoothConnected,
+    // "Lit" follows the real BLE link in both modes, matching the climbs-list
+    // lightbulb. In solo mode deriveIsDriver is always true, so this collapses to
+    // isBluetoothConnected; in a party session it stays unlit unless you both hold
+    // wall control and have the board connected, so a stolen link unlights it.
+    lightbulbActive: isDriver && args.isBluetoothConnected,
     lightbulbPending: args.isBluetoothLoading || args.pendingClimbUuid !== null,
   };
 }
@@ -55,7 +65,14 @@ export function derivePlayDrawerLightbulbPressAction(args: {
   isBluetoothConnected: boolean;
 }): PlayDrawerLightbulbPressAction {
   if (args.isPersistentSessionActive) {
-    if (args.isDriver) return 'release_party';
+    if (args.isDriver) {
+      if (args.isBluetoothConnected) return 'release_party';
+      // Driver but the link was stolen — reconnect and keep wall control, so it
+      // takes one tap (not two: release then re-take) to relight the board.
+      if (args.hasBluetooth) return 'reconnect_ble';
+      // No BLE on this client at all — releasing control is the only action left.
+      return 'release_party';
+    }
     return args.hasDisplayedClimb ? 'take_party' : 'noop';
   }
   if (!args.hasBluetooth) return 'noop';

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -440,6 +440,7 @@
       "lightbulb": {
         "drivingNamed": "You’re driving “{{name}}”. Tap to release control.",
         "driving": "You’re driving. Tap to release control.",
+        "reconnect": "Board disconnected. Tap to reconnect.",
         "takeNamed": "Take wall control and send “{{name}}”",
         "take": "Take wall control",
         "coachmark": "Send to the wall"

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -440,6 +440,7 @@
       "lightbulb": {
         "drivingNamed": "Estás controlando “{{name}}”. Toca para soltar.",
         "driving": "Estás controlando. Toca para soltar.",
+        "reconnect": "Tablero desconectado. Toca para reconectar.",
         "takeNamed": "Tomar el control y enviar “{{name}}”",
         "take": "Tomar el control del muro",
         "coachmark": "Enviar al muro"

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -440,6 +440,7 @@
       "lightbulb": {
         "drivingNamed": "Tu contrôles «{{name}}». Touche pour relâcher.",
         "driving": "Tu contrôles. Touche pour relâcher.",
+        "reconnect": "Tableau déconnecté. Touche pour reconnecter.",
         "takeNamed": "Prendre le contrôle et envoyer «{{name}}»",
         "take": "Prendre le contrôle du mur",
         "coachmark": "Envoyer au mur"


### PR DESCRIPTION
## Problem

When another climber/device grabs a last-connection-wins board (the `BluetoothConnectionStolen` path), the **climbs-list** lightbulb correctly goes unlit, but the **play-drawer** lightbulb stays lit and takes two taps to reconnect.

The two lightbulbs read different state:

- **List page** (`use-lightbulb-toggle.ts`): lit = `bluetooth.isConnected`; one tap toggles connect/disconnect. The correct, leading behaviour.
- **Play drawer** (`derivePlayDrawerLightbulbState`): in a **party session** lit came from `isDriver` (wall-control owner) and ignored `isBluetoothConnected`. So a stolen link left you still the "driver" → bulb stayed lit, and the first tap resolved to `release_party`, the second to `take_party` — hence the double tap. (Solo mode already read `isBluetoothConnected`, so the bug only showed inside a party session.)

## Fix

Approach (chosen with the issue reporter): **keep the party take/release wall-control semantics, but make the lit state and the reconnect tap follow the real BLE link.**

- `lightbulb-control.ts`
  - Lit state is now `isDriver && isBluetoothConnected`. In solo mode `deriveIsDriver` is always `true`, so this collapses to `isBluetoothConnected` — identical to today and to the list page. In a party session the bulb now goes unlit the instant the link drops.
  - New `reconnect_ble` press action: a party driver whose link was stolen reconnects in one tap **without** releasing wall control. Take/release/preview semantics are otherwise unchanged; the degenerate no-board case still falls back to `release_party`.
- `PlayDrawer.tsx`
  - `handleLightbulb` gains a `reconnect_ble` branch that reconnects to the remembered board. It deliberately does **not** emit `Wall Control Taken` (no control changes hands, and `connect()` already emits `BluetoothConnectionSuccess`).
  - Accessibility label now says "Board disconnected. Tap to reconnect." for a disconnected driver instead of the stale "Tap to release control."
- New `playView.actionBar.lightbulb.reconnect` string added to all three locales (`en-US`, `es`, `fr`).

## Known trade-off

A party driver whose link is down can no longer release wall control in a single tap — the tap reconnects first (matching the list page). Releasing is now reconnect-then-release (two taps), the same total as before, just reordered. Flagging in case a dedicated release escape-hatch is wanted later.

## Validation

- `vp run typecheck:mobile` — pass
- `vp check` (lint + format) — pass on changed files
- `vp test run --project mobile` — 1537 passed (updated `lightbulb-control.test.ts` covers the new lit-state and press-action matrix)
- shared i18n `catalog-completeness.test.ts` — 28 passed (locale parity)

Manual check still worth doing on a real two-client last-connection-wins board: as party driver with BLE connected, have a second device grab the board; confirm the drawer bulb goes unlit (matching the list page) and a single tap reconnects without releasing control.


---
_Generated by [Claude Code](https://claude.ai/code/session_016JC3iv6NFWQUNs4MouZtMy)_