### PR TITLE
Tighten play-drawer lightbulb reconnect (review follow-ups)

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -166,6 +166,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const { boardName, layoutId, sizeId, setIds, angle } = boardConfig;
   const bluetoothConnected = bluetooth?.isConnected ?? false;
   const bluetoothLoading = bluetooth?.loading ?? false;
+  // Single source for "is a board's BLE available at all" so the lightbulb's
+  // accessibility label and its press action stay in lockstep — both read this
+  // instead of one checking `bluetooth` and the other `bluetooth !== null`.
+  const hasBluetooth = bluetooth !== null;
 
   usePlayDrawerWakeLock(isSheetOpen);
 
@@ -484,7 +488,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
 
   const handleLightbulb = useCallback(() => {
     const pressAction = derivePlayDrawerLightbulbPressAction({
-      hasBluetooth: bluetooth !== null,
+      hasBluetooth,
       hasDisplayedClimb: displayedClimb !== null,
       isPersistentSessionActive: lightbulbState.isPersistentSessionActive,
       isDriver: lightbulbState.isDriver,
@@ -514,6 +518,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
 
     if (pressAction === 'reconnect_ble') {
       if (!bluetooth) return;
+      // Ignore taps while a connect is already in flight, matching the climbs-list
+      // lightbulb (use-lightbulb-toggle.ts). The connect() in-flight ref also guards,
+      // but bailing here avoids a misleading haptic and a dead tap.
+      if (bluetoothLoading) return;
       // Party driver whose BLE link was stolen — reconnect to the remembered board
       // without releasing wall control, so it relights in one tap. No control
       // changes hands here, and connect() already emits BluetoothConnectionSuccess,
@@ -612,6 +620,8 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     });
   }, [
     bluetooth,
+    hasBluetooth,
+    bluetoothLoading,
     driverParticipantId,
     participantId,
     lightbulbState.isPersistentSessionActive,
@@ -724,8 +734,9 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     if (!lightbulbState.isPersistentSessionActive) return undefined;
     if (lightbulbState.isDriver) {
       // Still the driver but the board link dropped — the tap reconnects, not
-      // releases, so the label must match (see derivePlayDrawerLightbulbPressAction).
-      if (bluetooth && !bluetoothConnected) return t('playView.actionBar.lightbulb.reconnect');
+      // releases, so the label must match (see derivePlayDrawerLightbulbPressAction,
+      // which keys the reconnect action off this same hasBluetooth condition).
+      if (hasBluetooth && !bluetoothConnected) return t('playView.actionBar.lightbulb.reconnect');
       if (!displayedClimb) return t('playView.actionBar.lightbulb.driving');
       return t('playView.actionBar.lightbulb.drivingNamed', { name: displayedClimb.name });
     }
@@ -735,7 +746,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     displayedClimb,
     lightbulbState.isDriver,
     lightbulbState.isPersistentSessionActive,
-    bluetooth,
+    hasBluetooth,
     bluetoothConnected,
     t,
   ]);

--- a/packages/mobile/src/components/play-drawer/__tests__/lightbulb-control.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/lightbulb-control.test.ts
@@ -119,6 +119,10 @@ describe('play drawer lightbulb control', () => {
   });
 
   it('derives the lightbulb tap action', () => {
+    // Party driver with no BLE on this client at all (bluetooth === null): the
+    // driver branch can't reconnect, so it falls back to release. This is the
+    // `if (args.hasBluetooth) return 'reconnect_ble'` else-branch in
+    // derivePlayDrawerLightbulbPressAction — kept reachable on purpose.
     expect(
       derivePlayDrawerLightbulbPressAction({
         hasBluetooth: false,


### PR DESCRIPTION
Follow-up to #2701 (already merged) addressing three review comments on the play-drawer lightbulb BLE-sync change.

## Changes

1. **Missing `bluetoothLoading` guard in the `reconnect_ble` handler** — `handleLightbulb`'s reconnect branch now bails on `bluetoothLoading` before calling `connect()`, matching the climbs-list lightbulb (`use-lightbulb-toggle.ts`). The downstream in-flight ref already prevented a second scan, but the tap (and its haptic) went through first; this keeps the two bulbs consistent. `bluetoothLoading` added to the `useCallback` deps to avoid a stale closure.

2. **Label/action used different names for the same concept** — added a single `hasBluetooth = bluetooth !== null` boolean read by both the accessibility-label memo and `derivePlayDrawerLightbulbPressAction`. Previously the label checked `bluetooth` (object identity) while the press action used `hasBluetooth` (boolean); they were accidentally equivalent, but a one-sided change would have desynced the label from the action.

3. **Untracked test intent** — annotated the `hasBluetooth: false` driver case in `lightbulb-control.test.ts` so its link to the `reconnect_ble` else-branch (the "no BLE on this client → release" fallback) is explicit.

## Validation

- `vp check` (lint + format, incl. react-hooks exhaustive-deps) — pass on changed files
- `vp run typecheck:mobile` — pass
- `vp test run --project mobile` — 1537 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_016JC3iv6NFWQUNs4MouZtMy)_