### PR TITLE
Tighten sessionLiveness contract: two-value SessionStatus enum

### DIFF
--- a/docs/entity-structure.md
+++ b/docs/entity-structure.md
@@ -239,19 +239,19 @@ A session represents a climbing session on one or more boards — the real-time 
 
 **Current properties:**
 
-| Property             | Type               | Notes                                           |
-| -------------------- | ------------------ | ----------------------------------------------- |
-| `id`                 | `text`             | PK                                              |
-| `board_path`         | `text`             | `/{board_type}/{layout_id}/{size_id}/{set_ids}` |
-| `created_at`         | `timestamp`        | DEFAULT now()                                   |
-| `last_activity`      | `timestamp`        | DEFAULT now(), updated on interaction           |
+| Property             | Type               | Notes                                                                   |
+| -------------------- | ------------------ | ----------------------------------------------------------------------- |
+| `id`                 | `text`             | PK                                                                      |
+| `board_path`         | `text`             | `/{board_type}/{layout_id}/{size_id}/{set_ids}`                         |
+| `created_at`         | `timestamp`        | DEFAULT now()                                                           |
+| `last_activity`      | `timestamp`        | DEFAULT now(), updated on interaction                                   |
 | `status`             | `text`             | 'active', 'ended' (legacy CHECK also permits 'inactive', never written) |
-| `latitude`           | `double precision` | Nullable, for discovery                         |
-| `longitude`          | `double precision` | Nullable, for discovery                         |
-| `discoverable`       | `boolean`          | DEFAULT false                                   |
-| `created_by_user_id` | `text`             | FK → users.id, SET NULL                         |
-| `name`               | `text`             | Nullable, display name                          |
-| `board_id`           | `bigint`           | FK → user_boards.id, SET NULL                   |
+| `latitude`           | `double precision` | Nullable, for discovery                                                 |
+| `longitude`          | `double precision` | Nullable, for discovery                                                 |
+| `discoverable`       | `boolean`          | DEFAULT false                                                           |
+| `created_by_user_id` | `text`             | FK → users.id, SET NULL                                                 |
+| `name`               | `text`             | Nullable, display name                                                  |
+| `board_id`           | `bigint`           | FK → user_boards.id, SET NULL                                           |
 
 **Planned additions:**
 

--- a/docs/entity-structure.md
+++ b/docs/entity-structure.md
@@ -245,7 +245,7 @@ A session represents a climbing session on one or more boards — the real-time 
 | `board_path`         | `text`             | `/{board_type}/{layout_id}/{size_id}/{set_ids}` |
 | `created_at`         | `timestamp`        | DEFAULT now()                                   |
 | `last_activity`      | `timestamp`        | DEFAULT now(), updated on interaction           |
-| `status`             | `text`             | 'active', 'inactive', 'ended'                   |
+| `status`             | `text`             | 'active', 'ended' (legacy CHECK also permits 'inactive', never written) |
 | `latitude`           | `double precision` | Nullable, for discovery                         |
 | `longitude`          | `double precision` | Nullable, for discovery                         |
 | `discoverable`       | `boolean`          | DEFAULT false                                   |

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -476,6 +476,17 @@ Because the sweep mutates rows asynchronously to any connected clients, no `Sess
 
 The frontend displays the summary in a dialog when the session ends, and optionally as a feed item in the activity feed.
 
+### Cold-Start Liveness Check (`sessionLiveness`)
+
+The mobile app persists the active session id (expo-secure-store) and tries to restore it on cold start. Before rejoining it must tell two states apart that look identical to the presence-gated `session` query: an **ended** session (drop the stored id) and a **dormant-but-active** one in the WARM or DORMANT lifecycle states above (restore it). `session` returns null for any empty roster, so it can't make that call — and blindly sending `JOIN_SESSION` against an ended id recreates the room as an empty zombie (#2683).
+
+The `sessionLiveness(sessionId)` query exists solely for this disambiguation:
+
+- It is a plain SELECT of the durable `board_sessions` row (`id`, `status`, `endedAt`) on the read path — no Redis, no room-manager involvement, so it can never resurrect hot state. It returns `null` for an unknown id.
+- `status` is the two-value `SessionStatus` enum (`active` | `ended`). The legacy DB CHECK from backend migration `0005_session_status_tracking.sql` still permits `'inactive'`, but nothing has ever written it (presence moved to Redis); the resolver normalizes such a row to `active`, which is the restore-safe reading.
+- It requires no auth by design: it exposes only existence + ended-state, and auth may not be restored yet at cold start. This is also why mobile can't reuse the web flow described above — the `GET_SESSION_SUMMARY` pre-flight requires an authenticated caller.
+- Client behaviour (`packages/mobile/src/providers/queue-provider.tsx`): ended or missing → clear the stored id; alive → restore; fetch failure (offline cold start) → restore optimistically so the queue still comes back, since a dead session stays escapable via End Session.
+
 ### Multi-Board Sessions
 
 Sessions can be linked to multiple boards within the same gym via the `sessionBoards` junction table. This is validated at creation time:

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -476,16 +476,16 @@ Because the sweep mutates rows asynchronously to any connected clients, no `Sess
 
 The frontend displays the summary in a dialog when the session ends, and optionally as a feed item in the activity feed.
 
-### Cold-Start Liveness Check (`sessionLiveness`)
+### Cold-Start Status Check (`sessionStatus`)
 
 The mobile app persists the active session id (expo-secure-store) and tries to restore it on cold start. Before rejoining it must tell two states apart that look identical to the presence-gated `session` query: an **ended** session (drop the stored id) and a **dormant-but-active** one in the WARM or DORMANT lifecycle states above (restore it). `session` returns null for any empty roster, so it can't make that call — and blindly sending `JOIN_SESSION` against an ended id recreates the room as an empty zombie (#2683).
 
-The `sessionLiveness(sessionId)` query exists solely for this disambiguation:
+The `sessionStatus(sessionId)` query exists solely for this disambiguation:
 
-- It is a plain SELECT of the durable `board_sessions` row (`id`, `status`, `endedAt`) on the read path — no Redis, no room-manager involvement, so it can never resurrect hot state. It returns `null` for an unknown id.
-- `status` is the two-value `SessionStatus` enum (`active` | `ended`). The legacy DB CHECK from backend migration `0005_session_status_tracking.sql` still permits `'inactive'`, but nothing has ever written it (presence moved to Redis); the resolver normalizes such a row to `active`, which is the restore-safe reading.
+- It is a plain SELECT of the durable `board_sessions` row on the read path — no Redis, no room-manager involvement, so it can never resurrect hot state. It returns the two-value `SessionStatus` enum directly (`active` | `ended`), or `null` for an unknown id.
+- The resolver owns the ended-ness reading: a row is `ended` when `status = 'ended'` **or** `endedAt` is set (insurance against a manually skewed row — both writers set the two together). Everything else reads as `active`, including the `'inactive'` value the legacy DB CHECK from backend migration `0005_session_status_tracking.sql` still permits but nothing has ever written (presence moved to Redis) — a dormant row is the restore-safe case this query exists to preserve.
 - It requires no auth by design: it exposes only existence + ended-state, and auth may not be restored yet at cold start. This is also why mobile can't reuse the web flow described above — the `GET_SESSION_SUMMARY` pre-flight requires an authenticated caller.
-- Client behaviour (`packages/mobile/src/providers/queue-provider.tsx`): ended or missing → clear the stored id; alive → restore; fetch failure (offline cold start) → restore optimistically so the queue still comes back, since a dead session stays escapable via End Session.
+- Client behaviour (`packages/mobile/src/providers/queue-provider.tsx`): anything but `active` (so `ended` or `null`) → clear the stored id; `active` → restore; fetch failure (offline cold start) → restore optimistically so the queue still comes back, since a dead session stays escapable via End Session.
 
 ### Multi-Board Sessions
 

--- a/packages/backend/src/__tests__/session-liveness-query.test.ts
+++ b/packages/backend/src/__tests__/session-liveness-query.test.ts
@@ -49,6 +49,14 @@ describe('sessionLiveness query', () => {
     expect(result).toEqual({ id: 'session-1', status: 'active', endedAt: null });
   });
 
+  it("normalizes a legacy 'inactive' row to active (CHECK-permitted, never written; restore-safe)", async () => {
+    dbClient.limit.mockResolvedValue([{ id: 'session-1', status: 'inactive', endedAt: null }]);
+
+    const result = await sessionQueries.sessionLiveness({}, { sessionId: 'session-1' });
+
+    expect(result).toEqual({ id: 'session-1', status: 'active', endedAt: null });
+  });
+
   it('reports an ended session (ISO endedAt) even with zero connected participants', async () => {
     dbClient.limit.mockResolvedValue([
       { id: 'session-1', status: 'ended', endedAt: new Date('2026-06-10T12:00:00.000Z') },

--- a/packages/backend/src/__tests__/session-status-query.test.ts
+++ b/packages/backend/src/__tests__/session-status-query.test.ts
@@ -1,7 +1,7 @@
 /**
- * Tests for the sessionLiveness query (#2683).
+ * Tests for the sessionStatus query (#2683).
  *
- * sessionLiveness reads the durable session row so an ended session reads as
+ * sessionStatus reads the durable session row so an ended session reads as
  * ended even when no participants are connected — unlike `session`, which
  * returns null for any empty roster and so can't tell an ended session apart
  * from a dormant-but-active solo session. Clients call it on cold start to
@@ -31,7 +31,7 @@ vi.mock('../db/client', () => ({ db: dbClient.db, dbRead: dbClient.db }));
 
 import { sessionQueries } from '../graphql/resolvers/sessions/queries';
 
-describe('sessionLiveness query', () => {
+describe('sessionStatus query', () => {
   beforeEach(() => {
     // limit holds per-test return values, so reset it; the chain stubs keep
     // their mockReturnThis impl but get their call history cleared.
@@ -41,42 +41,48 @@ describe('sessionLiveness query', () => {
     dbClient.db.where.mockClear();
   });
 
-  it('returns active liveness for a live session row', async () => {
-    dbClient.limit.mockResolvedValue([{ id: 'session-1', status: 'active', endedAt: null }]);
+  it('returns active for a live session row', async () => {
+    dbClient.limit.mockResolvedValue([{ status: 'active', endedAt: null }]);
 
-    const result = await sessionQueries.sessionLiveness({}, { sessionId: 'session-1' });
+    const result = await sessionQueries.sessionStatus({}, { sessionId: 'session-1' });
 
-    expect(result).toEqual({ id: 'session-1', status: 'active', endedAt: null });
+    expect(result).toBe('active');
   });
 
   it("normalizes a legacy 'inactive' row to active (CHECK-permitted, never written; restore-safe)", async () => {
-    dbClient.limit.mockResolvedValue([{ id: 'session-1', status: 'inactive', endedAt: null }]);
+    dbClient.limit.mockResolvedValue([{ status: 'inactive', endedAt: null }]);
 
-    const result = await sessionQueries.sessionLiveness({}, { sessionId: 'session-1' });
+    const result = await sessionQueries.sessionStatus({}, { sessionId: 'session-1' });
 
-    expect(result).toEqual({ id: 'session-1', status: 'active', endedAt: null });
+    expect(result).toBe('active');
   });
 
-  it('reports an ended session (ISO endedAt) even with zero connected participants', async () => {
-    dbClient.limit.mockResolvedValue([
-      { id: 'session-1', status: 'ended', endedAt: new Date('2026-06-10T12:00:00.000Z') },
-    ]);
+  it('reports an ended session even with zero connected participants', async () => {
+    dbClient.limit.mockResolvedValue([{ status: 'ended', endedAt: new Date('2026-06-10T12:00:00.000Z') }]);
 
-    const result = await sessionQueries.sessionLiveness({}, { sessionId: 'session-1' });
+    const result = await sessionQueries.sessionStatus({}, { sessionId: 'session-1' });
 
-    expect(result).toEqual({ id: 'session-1', status: 'ended', endedAt: '2026-06-10T12:00:00.000Z' });
+    expect(result).toBe('ended');
+  });
+
+  it('treats a skewed row with endedAt set but status not updated as ended', async () => {
+    dbClient.limit.mockResolvedValue([{ status: 'active', endedAt: new Date('2026-06-10T12:00:00.000Z') }]);
+
+    const result = await sessionQueries.sessionStatus({}, { sessionId: 'session-1' });
+
+    expect(result).toBe('ended');
   });
 
   it('returns null when the session row does not exist', async () => {
     dbClient.limit.mockResolvedValue([]);
 
-    const result = await sessionQueries.sessionLiveness({}, { sessionId: 'session-gone' });
+    const result = await sessionQueries.sessionStatus({}, { sessionId: 'session-gone' });
 
     expect(result).toBeNull();
   });
 
   it('rejects a malformed session id before querying', async () => {
-    await expect(sessionQueries.sessionLiveness({}, { sessionId: 'bad id!' })).rejects.toThrow();
+    await expect(sessionQueries.sessionStatus({}, { sessionId: 'bad id!' })).rejects.toThrow();
     expect(dbClient.limit).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/graphql/resolvers/sessions/queries.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/queries.ts
@@ -1,4 +1,4 @@
-import type { ConnectionContext, EventsReplayResponse, SessionLiveness, SessionStatus } from '@boardsesh/shared-schema';
+import type { ConnectionContext, EventsReplayResponse, SessionLiveness } from '@boardsesh/shared-schema';
 import { eq } from 'drizzle-orm';
 import { roomManager, type DiscoverableSession } from '../../../services/room-manager';
 import { pubsub } from '../../../pubsub/index';
@@ -152,9 +152,14 @@ export const sessionQueries = {
     if (!row) return null;
     return {
       id: row.id,
-      // status is a free-text column constrained by a DB CHECK to
-      // ('active','inactive','ended'); narrow the string for callers.
-      status: row.status as SessionStatus,
+      // The legacy DB CHECK (backend migration 0005) still permits 'inactive',
+      // but nothing writes it — presence moved to Redis and the durable row is
+      // only ever 'active' or 'ended'. Normalize anyway: a non-member value
+      // would fail GraphQL enum serialization (error response, which the
+      // mobile client treats as "can't verify" and restores optimistically,
+      // with error noise), and a hypothetical dormant 'inactive' row is
+      // exactly the restore-safe case this query exists to preserve (#2683).
+      status: row.status === 'ended' ? 'ended' : 'active',
       endedAt: row.endedAt ? row.endedAt.toISOString() : null,
     };
   },

--- a/packages/backend/src/graphql/resolvers/sessions/queries.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/queries.ts
@@ -1,4 +1,4 @@
-import type { ConnectionContext, EventsReplayResponse, SessionLiveness } from '@boardsesh/shared-schema';
+import type { ConnectionContext, EventsReplayResponse, SessionStatus } from '@boardsesh/shared-schema';
 import { eq } from 'drizzle-orm';
 import { roomManager, type DiscoverableSession } from '../../../services/room-manager';
 import { pubsub } from '../../../pubsub/index';
@@ -139,28 +139,25 @@ export const sessionQueries = {
    * tell an ended session apart from a dormant-but-active one. Clients call this
    * on cold start to decide whether to restore or drop a persisted session id
    * (#2683). No auth: it exposes only existence + ended-state, and auth may not
-   * be restored yet at cold start.
+   * be restored yet at cold start. Returns the bare SessionStatus enum; null
+   * means no such session.
    */
-  sessionLiveness: async (_: unknown, { sessionId }: { sessionId: string }): Promise<SessionLiveness | null> => {
+  sessionStatus: async (_: unknown, { sessionId }: { sessionId: string }): Promise<SessionStatus | null> => {
     validateInput(SessionIdSchema, sessionId, 'sessionId');
     const rows = await dbRead
-      .select({ id: sessions.id, status: sessions.status, endedAt: sessions.endedAt })
+      .select({ status: sessions.status, endedAt: sessions.endedAt })
       .from(sessions)
       .where(eq(sessions.id, sessionId))
       .limit(1);
     const row = rows[0];
     if (!row) return null;
-    return {
-      id: row.id,
-      // The legacy DB CHECK (backend migration 0005) still permits 'inactive',
-      // but nothing writes it — presence moved to Redis and the durable row is
-      // only ever 'active' or 'ended'. Normalize anyway: a non-member value
-      // would fail GraphQL enum serialization (error response, which the
-      // mobile client treats as "can't verify" and restores optimistically,
-      // with error noise), and a hypothetical dormant 'inactive' row is
-      // exactly the restore-safe case this query exists to preserve (#2683).
-      status: row.status === 'ended' ? 'ended' : 'active',
-      endedAt: row.endedAt ? row.endedAt.toISOString() : null,
-    };
+    // Ended-ness is the only durable signal. endedAt is ORed in as insurance
+    // against a skewed row (endSession and the inactivity sweep set status and
+    // endedAt together, so it can only diverge via manual edits). Everything
+    // else — including 'inactive', which the legacy DB CHECK (backend
+    // migration 0005) still permits but nothing writes — normalizes to
+    // 'active': a dormant row is exactly the restore-safe case this query
+    // exists to preserve (#2683).
+    return row.status === 'ended' || row.endedAt != null ? 'ended' : 'active';
   },
 };

--- a/packages/db/src/schema/app/sessions.ts
+++ b/packages/db/src/schema/app/sessions.ts
@@ -26,6 +26,7 @@ export const boardSessions = pgTable(
     lastActivity: timestamp('last_activity').defaultNow().notNull(),
     // Persistent lifecycle status. Live active/inactive presence is tracked in Redis;
     // SQL only uses ended/not-ended for durable history and discovery filtering.
+    // (A legacy CHECK from backend migration 0005 also permits 'inactive' — never written.)
     status: text('status').default('active').notNull(),
     // GPS coordinates for session discovery
     latitude: doublePrecision('latitude'),

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -19,7 +19,7 @@ import type {
   FollowConnection,
   TickStatus,
   SessionUser,
-  SessionLiveness,
+  SessionStatus,
   SessionFeedParticipant,
   SessionGradeDistributionItem,
 } from '@boardsesh/shared-schema';
@@ -599,19 +599,16 @@ export type GetSessionQueryResponse = {
 // Presence-independent lifecycle check, read on cold start to decide whether a
 // persisted session id should be restored or dropped (#2683). Unlike GET_SESSION
 // (gated on live roster, so an ended session and a dormant-but-active solo
-// session both read as null), this hits the durable session row.
-export const SESSION_LIVENESS = gql`
-  query SessionLiveness($sessionId: ID!) {
-    sessionLiveness(sessionId: $sessionId) {
-      id
-      status
-      endedAt
-    }
+// session both read as null), this hits the durable session row. Returns the
+// SessionStatus enum directly; null means the session does not exist.
+export const SESSION_STATUS = gql`
+  query SessionStatus($sessionId: ID!) {
+    sessionStatus(sessionId: $sessionId)
   }
 `;
 
-export type SessionLivenessQueryResponse = {
-  sessionLiveness: SessionLiveness | null;
+export type SessionStatusQueryResponse = {
+  sessionStatus: SessionStatus | null;
 };
 
 // Authoritative queue snapshot for the active session, fetched after a queue

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -19,7 +19,7 @@ import type {
   FollowConnection,
   TickStatus,
   SessionUser,
-  SessionStatus,
+  SessionLiveness,
   SessionFeedParticipant,
   SessionGradeDistributionItem,
 } from '@boardsesh/shared-schema';
@@ -610,14 +610,8 @@ export const SESSION_LIVENESS = gql`
   }
 `;
 
-export type SessionLivenessResult = {
-  id: string;
-  status: SessionStatus;
-  endedAt: string | null;
-};
-
 export type SessionLivenessQueryResponse = {
-  sessionLiveness: SessionLivenessResult | null;
+  sessionLiveness: SessionLiveness | null;
 };
 
 // Authoritative queue snapshot for the active session, fetched after a queue

--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -143,13 +143,11 @@ describe('QueueProvider clearSession notifyServer', () => {
     sessionStore.getStoredSessionId.mockResolvedValue('session-1');
     sessionStore.clearStoredSessionId.mockClear();
     http.request.mockReset();
-    // Cold-start restore verifies session liveness via SESSION_LIVENESS (#2683);
+    // Cold-start restore verifies the session via SESSION_STATUS (#2683);
     // keep the stored session active so these tests land in-session before
     // clearSession.
     http.request.mockImplementation(async (operation: string) =>
-      operation.includes('SessionLiveness')
-        ? { sessionLiveness: { id: 'session-1', status: 'active', endedAt: null } }
-        : {},
+      operation.includes('SessionStatus') ? { sessionStatus: 'active' } : {},
     );
     graph.execute.mockReset();
     // joinSession resolves the active session; leaveSession resolves true.
@@ -226,12 +224,12 @@ describe('QueueProvider clearSession notifyServer', () => {
         if (hangNextQueueState) return new Promise<never>(() => {});
         return Promise.resolve({ session: { queueState: { queue: [], currentClimbQueueItem: null } } });
       }
-      // Cold-start liveness check keeps the stored session alive (#2683). This
-      // replaces the beforeEach mock wholesale, so it must answer SessionLiveness
-      // itself — otherwise the restore guard sees no liveness row and clears the
+      // Cold-start status check keeps the stored session alive (#2683). This
+      // replaces the beforeEach mock wholesale, so it must answer SessionStatus
+      // itself — otherwise the restore guard sees no status and clears the
       // stored session before the test gets in-session.
-      if (operationText.includes('SessionLiveness')) {
-        return Promise.resolve({ sessionLiveness: { id: 'session-1', status: 'active', endedAt: null } });
+      if (operationText.includes('SessionStatus')) {
+        return Promise.resolve({ sessionStatus: 'active' });
       }
       if (operationText.includes('GetSession')) {
         return Promise.resolve({ session: { id: 'session-1', endedAt: null } });

--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -226,7 +226,13 @@ describe('QueueProvider clearSession notifyServer', () => {
         if (hangNextQueueState) return new Promise<never>(() => {});
         return Promise.resolve({ session: { queueState: { queue: [], currentClimbQueueItem: null } } });
       }
-      // Cold-start liveness check keeps the stored session alive (#2683).
+      // Cold-start liveness check keeps the stored session alive (#2683). This
+      // replaces the beforeEach mock wholesale, so it must answer SessionLiveness
+      // itself — otherwise the restore guard sees no liveness row and clears the
+      // stored session before the test gets in-session.
+      if (operationText.includes('SessionLiveness')) {
+        return Promise.resolve({ sessionLiveness: { id: 'session-1', status: 'active', endedAt: null } });
+      }
       if (operationText.includes('GetSession')) {
         return Promise.resolve({ session: { id: 'session-1', endedAt: null } });
       }

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -190,10 +190,10 @@ const user = (overrides: Partial<SessionUser> = {}): SessionUser => ({
   ...overrides,
 });
 
-// Response shape for the cold-start SESSION_LIVENESS check. status 'active'
-// (endedAt null) means restore the session; 'ended' means drop the stored id.
-const livenessResponse = (id: string, status: SessionStatus = 'active', endedAt: string | null = null) => ({
-  sessionLiveness: { id, status, endedAt },
+// Response for the cold-start SESSION_STATUS probe. 'active' means restore the
+// session; 'ended' or null (no such session row) means drop the stored id.
+const statusResponse = (status: SessionStatus | null = 'active') => ({
+  sessionStatus: status,
 });
 
 function makeQueueItem(uuid: string, climbUuid = uuid, options: { suggested?: boolean } = {}): ClimbQueueItem {
@@ -344,12 +344,12 @@ describe('QueueProvider session update subscription', () => {
     sessionStore.clearStoredSessionId.mockClear();
     graph.execute.mockReset();
     http.request.mockReset();
-    // The restore effect verifies session liveness via SESSION_LIVENESS before
+    // The restore effect verifies the session via SESSION_STATUS before
     // rejoining (#2683). Default to an active session so existing tests still
     // auto-restore into session-1; END_SESSION keeps its endSession shape.
     http.request.mockImplementation((operation: string) =>
-      operation.includes('SessionLiveness')
-        ? Promise.resolve(livenessResponse('session-1'))
+      operation.includes('SessionStatus')
+        ? Promise.resolve(statusResponse())
         : Promise.resolve({ endSession: { sessionId: 'session-1' } }),
     );
     graph.execute.mockResolvedValue({
@@ -832,8 +832,8 @@ describe('QueueProvider session update subscription', () => {
   it('drops a server-ended stored session on cold start without rejoining (#2683)', async () => {
     sessionStore.getStoredSessionId.mockResolvedValue('session-ended');
     http.request.mockImplementation((operation: string) =>
-      operation.includes('SessionLiveness')
-        ? Promise.resolve(livenessResponse('session-ended', 'ended', '2026-06-10T12:00:00.000Z'))
+      operation.includes('SessionStatus')
+        ? Promise.resolve(statusResponse('ended'))
         : Promise.resolve({ endSession: { sessionId: 'session-ended' } }),
     );
 
@@ -850,13 +850,13 @@ describe('QueueProvider session update subscription', () => {
     expect(ws.getSessionUpdatesSink()).toBeNull();
   });
 
-  it('drops a stored session whose status is ended even if endedAt is null (#2683)', async () => {
-    // A partial-ended row (status flipped, timestamp not yet set) must still be
-    // treated as ended — the status check, not just endedAt, gates the clear.
+  it('drops a stored session whose row no longer exists (#2683)', async () => {
+    // sessionStatus returns null for an unknown session id — same outcome as
+    // ended: clear the stored id instead of recreating a zombie room.
     sessionStore.getStoredSessionId.mockResolvedValue('session-ended');
     http.request.mockImplementation((operation: string) =>
-      operation.includes('SessionLiveness')
-        ? Promise.resolve(livenessResponse('session-ended', 'ended', null))
+      operation.includes('SessionStatus')
+        ? Promise.resolve(statusResponse(null))
         : Promise.resolve({ endSession: { sessionId: 'session-ended' } }),
     );
 
@@ -870,9 +870,9 @@ describe('QueueProvider session update subscription', () => {
     expect(graph.execute).not.toHaveBeenCalled();
   });
 
-  it('restores optimistically when the liveness check fails (offline cold start)', async () => {
+  it('restores optimistically when the status check fails (offline cold start)', async () => {
     http.request.mockImplementation((operation: string) =>
-      operation.includes('SessionLiveness')
+      operation.includes('SessionStatus')
         ? Promise.reject(new Error('offline'))
         : Promise.resolve({ endSession: { sessionId: 'session-1' } }),
     );
@@ -880,7 +880,7 @@ describe('QueueProvider session update subscription', () => {
     const snapshots: Snapshot[] = [];
     renderProvider((snapshot) => snapshots.push(snapshot));
 
-    // Can't verify liveness offline, so the stored id is still applied...
+    // Can't verify the session offline, so the stored id is still applied...
     await waitFor(() => {
       expect(snapshots.at(-1)?.sessionId).toBe('session-1');
     });
@@ -1151,10 +1151,10 @@ describe('QueueProvider mutation-failure resync', () => {
         options.onQueueStateCall?.();
         return queueStateResponse;
       }
-      // Cold-start liveness check (#2683) — keep the session active so restore
+      // Cold-start status check (#2683) — keep the session active so restore
       // lands in-session for these resync tests.
-      if (operation.includes('SessionLiveness')) {
-        return livenessResponse('session-1');
+      if (operation.includes('SessionStatus')) {
+        return statusResponse();
       }
       return { endSession: { sessionId: 'session-1' } };
     });
@@ -1316,9 +1316,9 @@ describe('QueueProvider mutation-failure resync', () => {
         queueStateCalls += 1;
         throw new Error('resync fetch failed');
       }
-      // Cold-start liveness check (#2683) — active so restore lands in-session.
-      if (operation.includes('SessionLiveness')) {
-        return livenessResponse('session-1');
+      // Cold-start status check (#2683) — active so restore lands in-session.
+      if (operation.includes('SessionStatus')) {
+        return statusResponse();
       }
       return { endSession: { sessionId: 'session-1' } };
     });

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -3,7 +3,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import { createElement, useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
-import type { SessionUser, UserBoard } from '@boardsesh/shared-schema';
+import type { SessionStatus, SessionUser, UserBoard } from '@boardsesh/shared-schema';
 
 const ws = vi.hoisted(() => {
   let sessionUpdatesSink: { next: (payload: { data?: { sessionUpdates?: unknown } }) => void } | null = null;
@@ -192,7 +192,7 @@ const user = (overrides: Partial<SessionUser> = {}): SessionUser => ({
 
 // Response shape for the cold-start SESSION_LIVENESS check. status 'active'
 // (endedAt null) means restore the session; 'ended' means drop the stored id.
-const livenessResponse = (id: string, status: 'active' | 'ended' = 'active', endedAt: string | null = null) => ({
+const livenessResponse = (id: string, status: SessionStatus = 'active', endedAt: string | null = null) => ({
   sessionLiveness: { id, status, endedAt },
 });
 

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -55,14 +55,14 @@ import {
   CREATE_SESSION,
   END_SESSION,
   GET_CLIMB,
-  SESSION_LIVENESS,
+  SESSION_STATUS,
   GET_SESSION_QUEUE_STATE,
   type CreateSessionMutationResponse,
   type EndSessionMutationResponse,
   type SessionUpdateEvent,
   type SessionLiveStatsEvent,
   type GetClimbQueryResponse,
-  type SessionLivenessQueryResponse,
+  type SessionStatusQueryResponse,
   type GetSessionQueueStateQueryResponse,
 } from '../lib/graphql/operations';
 import { getStoredActiveBoard } from '../lib/active-board-store';
@@ -528,18 +528,17 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       try {
         // Verify the stored session is still alive before rejoining. Without
         // this, JOIN_SESSION recreates a server-ended room as an empty zombie
-        // and we land in InSessionView with no peers (#2683). Liveness reads the
-        // durable session row (sessionLiveness), NOT the presence-gated `session`
-        // query — that one returns null for any empty session, so it can't tell
-        // an ended session apart from a dormant-but-active solo session.
-        // SessionStatus is two-valued ('active' | 'ended'), so the 'ended'
-        // check is exhaustive; the endedAt OR is belt-and-braces against a
-        // skewed row (both writers set status and endedAt together).
-        const { sessionLiveness } = await getHttpClient().request<SessionLivenessQueryResponse>(SESSION_LIVENESS, {
+        // and we land in InSessionView with no peers (#2683). sessionStatus
+        // reads the durable session row, NOT the presence-gated `session`
+        // query — that one returns null for any empty session, so it can't
+        // tell an ended session apart from a dormant-but-active solo session.
+        // null means the session row no longer exists; anything but 'active'
+        // means drop the stored id.
+        const { sessionStatus } = await getHttpClient().request<SessionStatusQueryResponse>(SESSION_STATUS, {
           sessionId: storedId,
         });
         if (cancelled) return;
-        if (!sessionLiveness || sessionLiveness.status === 'ended' || sessionLiveness.endedAt != null) {
+        if (sessionStatus !== 'active') {
           if (__DEV__) {
             console.info(`[session] stored session ${storedId} ended/missing; clearing`);
           }
@@ -548,11 +547,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         }
         setSessionId(storedId);
       } catch (err) {
-        // Offline cold start: can't verify liveness, so restore optimistically
-        // so the queue still comes back. A genuinely-dead session stays
-        // escapable via End Session.
+        // Offline cold start: can't verify the session status, so restore
+        // optimistically so the queue still comes back. A genuinely-dead
+        // session stays escapable via End Session.
         if (__DEV__) {
-          console.warn('[session] liveness check failed; restoring optimistically', err);
+          console.warn('[session] status check failed; restoring optimistically', err);
         }
         if (!cancelled) setSessionId(storedId);
       }

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -532,6 +532,9 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         // durable session row (sessionLiveness), NOT the presence-gated `session`
         // query — that one returns null for any empty session, so it can't tell
         // an ended session apart from a dormant-but-active solo session.
+        // SessionStatus is two-valued ('active' | 'ended'), so the 'ended'
+        // check is exhaustive; the endedAt OR is belt-and-braces against a
+        // skewed row (both writers set status and endedAt together).
         const { sessionLiveness } = await getHttpClient().request<SessionLivenessQueryResponse>(SESSION_LIVENESS, {
           sessionId: storedId,
         });

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -375,6 +375,18 @@ type Session {
 }
 
 """
+Durable session lifecycle status. Lowercase values match the strings stored
+in board_sessions.status so resolvers and clients pass them through without
+mapping (same convention as TickStatus).
+"""
+enum SessionStatus {
+  "Live or dormant; safe for a client to restore on cold start"
+  active
+  "Explicitly ended, or auto-finished by the inactivity sweep"
+  ended
+}
+
+"""
 Durable lifecycle status of a session, independent of live presence.
 Backed by the persisted session row rather than Redis, so an ended session
 is reported as ended even when no participants are currently connected.
@@ -382,8 +394,8 @@ is reported as ended even when no participants are currently connected.
 type SessionLiveness {
   "Unique session identifier"
   id: ID!
-  "Durable lifecycle status: 'active' or 'ended'"
-  status: String!
+  "Durable lifecycle status"
+  status: SessionStatus!
   "When the session was ended (ISO 8601); null while still active"
   endedAt: String
 }

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -375,29 +375,17 @@ type Session {
 }
 
 """
-Durable session lifecycle status. Lowercase values match the strings stored
-in board_sessions.status so resolvers and clients pass them through without
-mapping (same convention as TickStatus).
+Durable session lifecycle status, independent of live presence. Backed by
+the persisted session row rather than Redis, so an ended session reads as
+ended even when no participants are currently connected. Lowercase values
+match the strings stored in board_sessions.status so resolvers and clients
+pass them through without mapping (same convention as TickStatus).
 """
 enum SessionStatus {
   "Live or dormant; safe for a client to restore on cold start"
   active
   "Explicitly ended, or auto-finished by the inactivity sweep"
   ended
-}
-
-"""
-Durable lifecycle status of a session, independent of live presence.
-Backed by the persisted session row rather than Redis, so an ended session
-is reported as ended even when no participants are currently connected.
-"""
-type SessionLiveness {
-  "Unique session identifier"
-  id: ID!
-  "Durable lifecycle status"
-  status: SessionStatus!
-  "When the session was ended (ISO 8601); null while still active"
-  endedAt: String
 }
 
 """
@@ -3576,7 +3564,7 @@ type Query {
   session does not exist. Clients use this on cold start to decide whether
   to restore or drop a persisted session id.
   """
-  sessionLiveness(sessionId: ID!): SessionLiveness
+  sessionStatus(sessionId: ID!): SessionStatus
 
   # ============================================
   # Board Configuration Queries

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -3199,7 +3199,7 @@ export type Query = {
    * session does not exist. Clients use this on cold start to decide whether
    * to restore or drop a persisted session id.
    */
-  sessionLiveness?: Maybe<SessionLiveness>;
+  sessionStatus?: Maybe<SessionStatus>;
   /**
    * Get a session summary (stats, grade distribution, participants).
    * Available for ended sessions or active sessions with ticks.
@@ -3626,7 +3626,7 @@ export type QuerySessionGroupedFeedArgs = {
 };
 
 /** Root query type for all read operations. */
-export type QuerySessionLivenessArgs = {
+export type QuerySessionStatusArgs = {
   sessionId: Scalars['ID']['input'];
 };
 
@@ -4279,21 +4279,6 @@ export type SessionHardestClimb = {
   grade: Scalars['String']['output'];
 };
 
-/**
- * Durable lifecycle status of a session, independent of live presence.
- * Backed by the persisted session row rather than Redis, so an ended session
- * is reported as ended even when no participants are currently connected.
- */
-export type SessionLiveness = {
-  __typename?: 'SessionLiveness';
-  /** When the session was ended (ISO 8601); null while still active */
-  endedAt?: Maybe<Scalars['String']['output']>;
-  /** Unique session identifier */
-  id: Scalars['ID']['output'];
-  /** Durable lifecycle status */
-  status: SessionStatus;
-};
-
 /** Participant stats in a session summary. */
 export type SessionParticipant = {
   __typename?: 'SessionParticipant';
@@ -4339,9 +4324,11 @@ export type SessionStatsUpdated = {
 };
 
 /**
- * Durable session lifecycle status. Lowercase values match the strings stored
- * in board_sessions.status so resolvers and clients pass them through without
- * mapping (same convention as TickStatus).
+ * Durable session lifecycle status, independent of live presence. Backed by
+ * the persisted session row rather than Redis, so an ended session reads as
+ * ended even when no participants are currently connected. Lowercase values
+ * match the strings stored in board_sessions.status so resolvers and clients
+ * pass them through without mapping (same convention as TickStatus).
  */
 export type SessionStatus =
   /** Live or dormant; safe for a client to restore on cold start */
@@ -5557,7 +5544,6 @@ export type ResolversTypes = ResolversObject<{
   SessionGradeCount: ResolverTypeWrapper<SessionGradeCount>;
   SessionGradeDistributionItem: ResolverTypeWrapper<SessionGradeDistributionItem>;
   SessionHardestClimb: ResolverTypeWrapper<SessionHardestClimb>;
-  SessionLiveness: ResolverTypeWrapper<SessionLiveness>;
   SessionParticipant: ResolverTypeWrapper<SessionParticipant>;
   SessionStatsUpdated: ResolverTypeWrapper<SessionStatsUpdated>;
   SessionStatus: SessionStatus;
@@ -5811,7 +5797,6 @@ export type ResolversParentTypes = ResolversObject<{
   SessionGradeCount: SessionGradeCount;
   SessionGradeDistributionItem: SessionGradeDistributionItem;
   SessionHardestClimb: SessionHardestClimb;
-  SessionLiveness: SessionLiveness;
   SessionParticipant: SessionParticipant;
   SessionStatsUpdated: SessionStatsUpdated;
   SessionSummary: SessionSummary;
@@ -7876,11 +7861,11 @@ export type QueryResolvers<
     ContextType,
     Partial<QuerySessionGroupedFeedArgs>
   >;
-  sessionLiveness?: Resolver<
-    Maybe<ResolversTypes['SessionLiveness']>,
+  sessionStatus?: Resolver<
+    Maybe<ResolversTypes['SessionStatus']>,
     ParentType,
     ContextType,
-    RequireFields<QuerySessionLivenessArgs, 'sessionId'>
+    RequireFields<QuerySessionStatusArgs, 'sessionId'>
   >;
   sessionSummary?: Resolver<
     Maybe<ResolversTypes['SessionSummary']>,
@@ -8334,16 +8319,6 @@ export type SessionHardestClimbResolvers<
   climbName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   climbUuid?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   grade?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type SessionLivenessResolvers<
-  ContextType = ConnectionContext,
-  ParentType extends ResolversParentTypes['SessionLiveness'] = ResolversParentTypes['SessionLiveness'],
-> = ResolversObject<{
-  endedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  status?: Resolver<ResolversTypes['SessionStatus'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -8896,7 +8871,6 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   SessionGradeCount?: SessionGradeCountResolvers<ContextType>;
   SessionGradeDistributionItem?: SessionGradeDistributionItemResolvers<ContextType>;
   SessionHardestClimb?: SessionHardestClimbResolvers<ContextType>;
-  SessionLiveness?: SessionLivenessResolvers<ContextType>;
   SessionParticipant?: SessionParticipantResolvers<ContextType>;
   SessionStatsUpdated?: SessionStatsUpdatedResolvers<ContextType>;
   SessionSummary?: SessionSummaryResolvers<ContextType>;

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4290,8 +4290,8 @@ export type SessionLiveness = {
   endedAt?: Maybe<Scalars['String']['output']>;
   /** Unique session identifier */
   id: Scalars['ID']['output'];
-  /** Durable lifecycle status: 'active' or 'ended' */
-  status: Scalars['String']['output'];
+  /** Durable lifecycle status */
+  status: SessionStatus;
 };
 
 /** Participant stats in a session summary. */
@@ -4337,6 +4337,17 @@ export type SessionStatsUpdated = {
   /** Total sends (flash + send) */
   totalSends: Scalars['Int']['output'];
 };
+
+/**
+ * Durable session lifecycle status. Lowercase values match the strings stored
+ * in board_sessions.status so resolvers and clients pass them through without
+ * mapping (same convention as TickStatus).
+ */
+export type SessionStatus =
+  /** Live or dormant; safe for a client to restore on cold start */
+  | 'active'
+  /** Explicitly ended, or auto-finished by the inactivity sweep */
+  | 'ended';
 
 /** Summary of a completed session including stats, grade distribution, and participants. */
 export type SessionSummary = {
@@ -5549,6 +5560,7 @@ export type ResolversTypes = ResolversObject<{
   SessionLiveness: ResolverTypeWrapper<SessionLiveness>;
   SessionParticipant: ResolverTypeWrapper<SessionParticipant>;
   SessionStatsUpdated: ResolverTypeWrapper<SessionStatsUpdated>;
+  SessionStatus: SessionStatus;
   SessionSummary: ResolverTypeWrapper<SessionSummary>;
   SessionUser: ResolverTypeWrapper<SessionUser>;
   SetCommunitySettingInput: SetCommunitySettingInput;
@@ -8331,7 +8343,7 @@ export type SessionLivenessResolvers<
 > = ResolversObject<{
   endedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['SessionStatus'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -40,7 +40,7 @@ export const queriesTypeDefs = /* GraphQL */ `
     session does not exist. Clients use this on cold start to decide whether
     to restore or drop a persisted session id.
     """
-    sessionLiveness(sessionId: ID!): SessionLiveness
+    sessionStatus(sessionId: ID!): SessionStatus
 
     # ============================================
     # Board Configuration Queries

--- a/packages/shared-schema/src/schema/session.ts
+++ b/packages/shared-schema/src/schema/session.ts
@@ -64,6 +64,18 @@ export const sessionTypeDefs = /* GraphQL */ `
   }
 
   """
+  Durable session lifecycle status. Lowercase values match the strings stored
+  in board_sessions.status so resolvers and clients pass them through without
+  mapping (same convention as TickStatus).
+  """
+  enum SessionStatus {
+    "Live or dormant; safe for a client to restore on cold start"
+    active
+    "Explicitly ended, or auto-finished by the inactivity sweep"
+    ended
+  }
+
+  """
   Durable lifecycle status of a session, independent of live presence.
   Backed by the persisted session row rather than Redis, so an ended session
   is reported as ended even when no participants are currently connected.
@@ -71,8 +83,8 @@ export const sessionTypeDefs = /* GraphQL */ `
   type SessionLiveness {
     "Unique session identifier"
     id: ID!
-    "Durable lifecycle status: 'active' or 'ended'"
-    status: String!
+    "Durable lifecycle status"
+    status: SessionStatus!
     "When the session was ended (ISO 8601); null while still active"
     endedAt: String
   }

--- a/packages/shared-schema/src/schema/session.ts
+++ b/packages/shared-schema/src/schema/session.ts
@@ -64,29 +64,17 @@ export const sessionTypeDefs = /* GraphQL */ `
   }
 
   """
-  Durable session lifecycle status. Lowercase values match the strings stored
-  in board_sessions.status so resolvers and clients pass them through without
-  mapping (same convention as TickStatus).
+  Durable session lifecycle status, independent of live presence. Backed by
+  the persisted session row rather than Redis, so an ended session reads as
+  ended even when no participants are currently connected. Lowercase values
+  match the strings stored in board_sessions.status so resolvers and clients
+  pass them through without mapping (same convention as TickStatus).
   """
   enum SessionStatus {
     "Live or dormant; safe for a client to restore on cold start"
     active
     "Explicitly ended, or auto-finished by the inactivity sweep"
     ended
-  }
-
-  """
-  Durable lifecycle status of a session, independent of live presence.
-  Backed by the persisted session row rather than Redis, so an ended session
-  is reported as ended even when no participants are currently connected.
-  """
-  type SessionLiveness {
-    "Unique session identifier"
-    id: ID!
-    "Durable lifecycle status"
-    status: SessionStatus!
-    "When the session was ended (ISO 8601); null while still active"
-    endedAt: String
   }
 
   """

--- a/packages/shared-schema/src/types/session.ts
+++ b/packages/shared-schema/src/types/session.ts
@@ -44,12 +44,19 @@ export type SessionSummary = {
   goal?: string | null;
 };
 
-/** Durable session lifecycle status (DB CHECK: board_sessions.status). */
-export type SessionStatus = 'active' | 'inactive' | 'ended';
+/**
+ * Durable session lifecycle status. Only 'active' and 'ended' are ever
+ * written: live presence moved to Redis, so the abandoned 'inactive' value
+ * survives only in the legacy DB CHECK (backend migration
+ * 0005_session_status_tracking.sql). The sessionLiveness resolver normalizes
+ * any such legacy row to 'active'.
+ */
+export type SessionStatus = 'active' | 'ended';
 
 /** Durable lifecycle status of a session, independent of live presence. */
 export type SessionLiveness = {
   id: string;
   status: SessionStatus;
-  endedAt?: string | null;
+  /** ISO 8601 end timestamp; null while the session has not ended. */
+  endedAt: string | null;
 };

--- a/packages/shared-schema/src/types/session.ts
+++ b/packages/shared-schema/src/types/session.ts
@@ -48,15 +48,7 @@ export type SessionSummary = {
  * Durable session lifecycle status. Only 'active' and 'ended' are ever
  * written: live presence moved to Redis, so the abandoned 'inactive' value
  * survives only in the legacy DB CHECK (backend migration
- * 0005_session_status_tracking.sql). The sessionLiveness resolver normalizes
+ * 0005_session_status_tracking.sql). The sessionStatus resolver normalizes
  * any such legacy row to 'active'.
  */
 export type SessionStatus = 'active' | 'ended';
-
-/** Durable lifecycle status of a session, independent of live presence. */
-export type SessionLiveness = {
-  id: string;
-  status: SessionStatus;
-  /** ISO 8601 end timestamp; null while the session has not ended. */
-  endedAt: string | null;
-};

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -3196,7 +3196,7 @@ export type Query = {
    * session does not exist. Clients use this on cold start to decide whether
    * to restore or drop a persisted session id.
    */
-  sessionLiveness?: Maybe<SessionLiveness>;
+  sessionStatus?: Maybe<SessionStatus>;
   /**
    * Get a session summary (stats, grade distribution, participants).
    * Available for ended sessions or active sessions with ticks.
@@ -3623,7 +3623,7 @@ export type QuerySessionGroupedFeedArgs = {
 };
 
 /** Root query type for all read operations. */
-export type QuerySessionLivenessArgs = {
+export type QuerySessionStatusArgs = {
   sessionId: Scalars['ID']['input'];
 };
 
@@ -4276,21 +4276,6 @@ export type SessionHardestClimb = {
   grade: Scalars['String']['output'];
 };
 
-/**
- * Durable lifecycle status of a session, independent of live presence.
- * Backed by the persisted session row rather than Redis, so an ended session
- * is reported as ended even when no participants are currently connected.
- */
-export type SessionLiveness = {
-  __typename?: 'SessionLiveness';
-  /** When the session was ended (ISO 8601); null while still active */
-  endedAt?: Maybe<Scalars['String']['output']>;
-  /** Unique session identifier */
-  id: Scalars['ID']['output'];
-  /** Durable lifecycle status */
-  status: SessionStatus;
-};
-
 /** Participant stats in a session summary. */
 export type SessionParticipant = {
   __typename?: 'SessionParticipant';
@@ -4336,9 +4321,11 @@ export type SessionStatsUpdated = {
 };
 
 /**
- * Durable session lifecycle status. Lowercase values match the strings stored
- * in board_sessions.status so resolvers and clients pass them through without
- * mapping (same convention as TickStatus).
+ * Durable session lifecycle status, independent of live presence. Backed by
+ * the persisted session row rather than Redis, so an ended session reads as
+ * ended even when no participants are currently connected. Lowercase values
+ * match the strings stored in board_sessions.status so resolvers and clients
+ * pass them through without mapping (same convention as TickStatus).
  */
 export type SessionStatus =
   /** Live or dormant; safe for a client to restore on cold start */

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -4287,8 +4287,8 @@ export type SessionLiveness = {
   endedAt?: Maybe<Scalars['String']['output']>;
   /** Unique session identifier */
   id: Scalars['ID']['output'];
-  /** Durable lifecycle status: 'active' or 'ended' */
-  status: Scalars['String']['output'];
+  /** Durable lifecycle status */
+  status: SessionStatus;
 };
 
 /** Participant stats in a session summary. */
@@ -4334,6 +4334,17 @@ export type SessionStatsUpdated = {
   /** Total sends (flash + send) */
   totalSends: Scalars['Int']['output'];
 };
+
+/**
+ * Durable session lifecycle status. Lowercase values match the strings stored
+ * in board_sessions.status so resolvers and clients pass them through without
+ * mapping (same convention as TickStatus).
+ */
+export type SessionStatus =
+  /** Live or dormant; safe for a client to restore on cold start */
+  | 'active'
+  /** Explicitly ended, or auto-finished by the inactivity sweep */
+  | 'ended';
 
 /** Summary of a completed session including stats, grade distribution, and participants. */
 export type SessionSummary = {


### PR DESCRIPTION
Follow-up to #2699, addressing the remaining review feedback plus an approach review.

## Approach change 1: remove `'inactive'` instead of guarding around it

The review asked to either document `'inactive'` as restore-safe or guard `status !== 'active'`. Investigation showed durable `'inactive'` is a fossil of an abandoned design: backend migration `0005_session_status_tracking.sql` envisioned writing it ("no users, in Redis"), but the shipped implementation tracks live presence via Redis sets + grace timers. The durable row only ever holds `'active'` (insert default) or `'ended'` (set together with `endedAt` by `endSession` and the inactivity sweep), and `session-persistence.test.ts` asserts the row is never marked inactive on last leave.

Since we're pre-GA, `SessionStatus` is narrowed to `'active' | 'ended'`. Note the suggested `status !== 'active'` guard would have been wrong-direction: a hypothetical dormant `'inactive'` session is exactly the restore-safe case the liveness check exists to preserve — dropping it would reintroduce the #2683 UX.

No DB change: the 3-value CHECK exists only in the legacy applied migration (drizzle models no CHECK), so it stays put and the resolver normalizes any legacy `'inactive'` row to `'active'`, pinned by a resolver test.

## Approach change 2: `sessionLiveness` → `sessionStatus` returning the bare enum

With the status narrowed to two values, the `SessionLiveness` wrapper object carried nothing the client used: `id` echoed the query argument, and the client's `endedAt != null` belt-and-braces folds into the resolver. The query is now simply:

```graphql
sessionStatus(sessionId: ID!): SessionStatus  # active | ended; null = no such session
```

- The resolver owns ended-ness in one place: `status = 'ended'` **or** `endedAt` set (skewed-row insurance, pinned by a new test case); everything else — including legacy `'inactive'` — reads as `active`.
- The mobile cold-start guard collapses to `sessionStatus !== 'active'`.
- The `SessionLiveness` GraphQL type and shared TS type are deleted outright.

## Feedback items addressed

- **`inactive` not handled in the liveness guard** → value removed from the type; guard now exhaustive (see above).
- **`status: String!` instead of an enum** → `enum SessionStatus { active ended }`, lowercase values matching the DB strings (same convention as `TickStatus`), so resolver and client pass strings through unchanged.
- **`SessionLivenessResult` duplicates `SessionLiveness`** → both are gone; mobile types the response with the shared `SessionStatus` enum directly.
- **`endedAt` optionality inconsistency** → moot; `endedAt` no longer crosses the wire (the resolver folds it into the status reading).
- **Docs** → new "Cold-Start Status Check (`sessionStatus`)" subsection in `docs/websocket-implementation.md` (purpose, why the presence-gated `session` query can't serve it, unauthenticated-by-design rationale, client behaviour); corrected status values in `docs/entity-structure.md`.

## Bonus fix: test that shipped broken in #2699

`queue-provider-leave-session.test.tsx > resets the resync single-flight guard` fails deterministically on `main` (verified at the #2699 merge commit): it replaces the `beforeEach` http mock wholesale but never answers the cold-start probe — so the guard clears the stored session before the test gets in-session. The test-local mock now answers the probe with an active status.

## Validation

- `vp run codegen` regenerated (CI `codegen-drift` covered)
- `vp run typecheck` (full) — clean
- Backend: `session-status-query` (active / legacy-`inactive` / ended / skewed-row / missing / malformed-id) + `operations-schema-validation` — 29/29 (`SKIP_TEST_INFRA=1`; Docker Hub pulls rate-limited in the sandbox, both suites are pure-mock)
- Mobile: full suite 1573/1573 (was 1572/1573 on `main` due to the broken test above)
- `vp check` formatting clean on all touched files (16 files of pre-existing drift on `main` left alone)
- `vp run check:mobile-bundle` — android bundle OK

https://claude.ai/code/session_01V5ZFq66ukwCDe6qUbXzmYr