### PR TITLE
Fix #2690: surface framesCount/framesPace from searchClimbs

### DIFF
--- a/packages/backend/src/__tests__/search-climbs-frames.test.ts
+++ b/packages/backend/src/__tests__/search-climbs-frames.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import type { BoardRouteParams, ClimbSearchParams } from '@boardsesh/db/queries';
+
+// Regression guard for issue #2690: searchClimbs must select and surface
+// frames_count/frames_pace so multi-frame climbs reached via search play back
+// at their authored pace instead of the default. The bug was a missing column
+// in the DB projection + mapping; this test drives the real shared query
+// against a stubbed drizzle client and asserts both the projection and output.
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../db/client', () => ({
+  db: mockDb,
+  dbRead: mockDb,
+}));
+
+import { searchClimbs } from '../db/queries/climbs/search-climbs';
+
+const params: BoardRouteParams = {
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 10,
+  set_ids: [1, 20],
+  angle: 40,
+};
+
+// One raw search row in the snake_case shape `mapResultToClimbRow` consumes.
+// frames_count > 1 / frames_pace > 0 stand in for a multi-frame route.
+function rawRow(uuid: string) {
+  return {
+    uuid,
+    setter_username: 'alice',
+    userId: null,
+    name: 'Multi-frame Route',
+    frames: 'p1r1,p2r1',
+    is_draft: false,
+    angle: 40,
+    ascensionist_count: '5',
+    difficulty_id: 20,
+    quality_average: 4.5,
+    difficulty_error: 0.1,
+    benchmark_difficulty: null,
+    description: '',
+    created_at: null,
+    published_at: null,
+    frames_count: 2,
+    frames_pace: 1200,
+  };
+}
+
+// Chainable drizzle stub: every builder method returns the same chain, and the
+// chain is awaitable, resolving to the canned rows. Covers both query paths
+// (innerJoin for stats-driven, leftJoin for standard) plus offset.
+function makeChain(rows: unknown[]): Record<string, unknown> {
+  const chain: Record<string, unknown> = {};
+  const methods = ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'offset'];
+  chain.then = (resolve: (value: unknown) => unknown) => Promise.resolve(rows).then(resolve);
+  for (const method of methods) {
+    chain[method] = vi.fn(() => chain);
+  }
+  return chain;
+}
+
+function capturedSelectKeys(): string[] {
+  const firstCallArg = mockDb.select.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+  return firstCallArg ? Object.keys(firstCallArg) : [];
+}
+
+describe('searchClimbs surfaces frames_count/frames_pace (issue #2690)', () => {
+  beforeEach(() => {
+    mockDb.select.mockReset();
+  });
+
+  it('projects and maps frame fields on the stats-driven path', async () => {
+    // Default sort (ascents DESC), page 0, no stats filters -> stats-driven path.
+    // pageSize 1 + 2 rows -> hasMore, so it returns without the standard fallback.
+    mockDb.select.mockReturnValue(makeChain([rawRow('c1'), rawRow('c2')]));
+
+    const searchParams: ClimbSearchParams = { page: 0, pageSize: 1 };
+    const result = await searchClimbs(params, searchParams);
+
+    expect(capturedSelectKeys()).toContain('frames_count');
+    expect(capturedSelectKeys()).toContain('frames_pace');
+    expect(result.climbs[0].framesCount).toBe(2);
+    expect(result.climbs[0].framesPace).toBe(1200);
+  });
+
+  it('projects and maps frame fields on the standard path', async () => {
+    // 'creation' sort forces the standard (LEFT JOIN) path.
+    mockDb.select.mockReturnValue(makeChain([rawRow('c1'), rawRow('c2')]));
+
+    const searchParams: ClimbSearchParams = { page: 0, pageSize: 1, sortBy: 'creation' };
+    const result = await searchClimbs(params, searchParams);
+
+    expect(capturedSelectKeys()).toContain('frames_count');
+    expect(capturedSelectKeys()).toContain('frames_pace');
+    expect(result.climbs[0].framesCount).toBe(2);
+    expect(result.climbs[0].framesPace).toBe(1200);
+  });
+});

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -22,6 +22,8 @@ type RawSelectResult = {
   description: string | null;
   created_at: string | null;
   published_at: string | null;
+  frames_count: number | null;
+  frames_pace: number | null;
 };
 
 function mapResultToClimbRow(result: RawSelectResult, params: BoardRouteParams): ClimbRow {
@@ -43,6 +45,8 @@ function mapResultToClimbRow(result: RawSelectResult, params: BoardRouteParams):
     description: result.description || '',
     created_at: result.created_at,
     published_at: result.published_at,
+    framesCount: result.frames_count ?? null,
+    framesPace: result.frames_pace ?? null,
   };
 }
 
@@ -198,6 +202,8 @@ async function statsDrivenSearch(
     description: boardClimbs.description,
     created_at: boardClimbs.createdAt,
     published_at: boardClimbs.publishedAt,
+    frames_count: boardClimbs.framesCount,
+    frames_pace: boardClimbs.framesPace,
   };
 
   const results: RawSelectResult[] = (await db
@@ -313,6 +319,8 @@ async function standardSearch(
     description: boardClimbs.description,
     created_at: boardClimbs.createdAt,
     published_at: boardClimbs.publishedAt,
+    frames_count: boardClimbs.framesCount,
+    frames_pace: boardClimbs.framesPace,
   };
 
   const orderByClause = sortOrder === 'asc' ? sql`${sortColumn} ASC NULLS FIRST` : sql`${sortColumn} DESC NULLS LAST`;

--- a/packages/db/src/queries/climbs/types.ts
+++ b/packages/db/src/queries/climbs/types.ts
@@ -192,4 +192,8 @@ export type ClimbRow = {
   is_draft: boolean;
   created_at: string | null;
   published_at: string | null;
+  /** Animation frame count (1 for static climbs, >1 for variable-speed routes/circuits). */
+  framesCount: number | null;
+  /** Per-frame playback pace in Aurora's native unit (treated as ms). 0/null when unset. */
+  framesPace: number | null;
 };

--- a/packages/shared/graphql/src/operations/climb-search.ts
+++ b/packages/shared/graphql/src/operations/climb-search.ts
@@ -24,6 +24,8 @@ const CLIMB_SEARCH_FIELDS = `
   is_no_match
   published_at
   created_at
+  framesCount
+  framesPace
 `;
 
 const CLIMB_DRAFT_FIELDS = `
@@ -52,6 +54,8 @@ const CLIMB_DETAIL_FIELDS = `
   is_draft
   created_at
   published_at
+  framesCount
+  framesPace
 `;
 
 export const SEARCH_CLIMBS = gql`


### PR DESCRIPTION
Closes #2690.

## Problem

Multi-frame climbs (LED animation sequences / variable-speed routes) reached through **search** played back at the default 750ms pace instead of their authored frame pace, on both web and mobile. The shared climb-search query never selected or mapped the `frames_count` / `frames_pace` columns, so `framesCount` / `framesPace` came back `undefined` and the playback layer (`useClimbFrames`) fell through to `DEFAULT_PACE_MS`. Holds lit correctly — only the animation timing was wrong.

The single-climb path (`getClimbByUuid`) already did this correctly; search just never caught up.

## Fix

- **`packages/db`** — add `frames_count` / `frames_pace` to the search projection (both the stats-driven and standard query paths), the raw row type, and `mapResultToClimbRow`; add `framesCount` / `framesPace` to the `ClimbRow` type. Mirrors the existing `getClimbByUuid` pattern. The backend GraphQL resolver and the web SSR query both spread `...row`, so they pick this up automatically.
- **`packages/shared/graphql`** — the issue assumed client selections were already correct, but only mobile requested the fields. Added `framesCount` / `framesPace` to the web `CLIMB_SEARCH_FIELDS` (covers client-side pagination/filtered search) and `CLIMB_DETAIL_FIELDS` fragments. Mobile was already correct — no change.
- **`packages/backend`** — regression test that drives the real shared query against a stubbed drizzle client and asserts (a) the `.select(...)` projection includes the frame columns and (b) the fields surface on output, for both query paths.

## Why this resolves both platforms

| Path | Covered by |
|------|-----------|
| Backend GraphQL resolver (mobile + web client) | `ClimbRow` fix (resolver spreads `...row`) |
| Web SSR initial search | `ClimbRow` fix (SSR spreads `...row`) |
| Web client-side search (pagination/filter) | web `CLIMB_SEARCH_FIELDS` fragment |
| Web detail/view page | web `CLIMB_DETAIL_FIELDS` fragment |
| Mobile search | already requested the fields |

## Validation

- `vp run typecheck` — pass
- `vp test run --project backend` — 1263 pass (incl. new regression test)
- `vp test run --project graphql` — 20 pass
- `vp check` — edited files clean

The 750ms fallback stays as-is: it's the correct behaviour for static climbs and for climbs that genuinely have `framesPace = 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)