### PR TITLE
Wire up self-hosted OTA (expo-open-ota) for the production channel

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -48,6 +48,13 @@ jobs:
       EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
       EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
       EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
+      # Self-hosted OTA (expo-open-ota). EXPO_UPDATES_URL is the server's manifest
+      # endpoint (e.g. https://ota.boardsesh.com/manifest), set as a repo variable
+      # so the domain isn't hardcoded; until it's set, app.config.ts falls back to
+      # the EAS URL and OTA stays inert (harmless). The channel is baked into the
+      # binary via AndroidManifest by `expo prebuild`. See docs/mobile-ota-updates.md.
+      EXPO_UPDATES_CHANNEL: production
+      EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
       # NOTE: currently inert at runtime — the mobile app has no
       # @sentry/react-native wiring (no Sentry.init, no src/lib/sentry.ts), so this
       # DSN is not read by the running app; client-side errors go to PostHog only

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -47,6 +47,13 @@ jobs:
       EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
       EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
       EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
+      # Self-hosted OTA (expo-open-ota). EXPO_UPDATES_URL is the server's manifest
+      # endpoint (e.g. https://ota.boardsesh.com/manifest), set as a repo variable
+      # so the domain isn't hardcoded; until it's set, app.config.ts falls back to
+      # the EAS URL and OTA stays inert (harmless). The channel is baked into the
+      # binary via Expo.plist by `expo prebuild`. See docs/mobile-ota-updates.md.
+      EXPO_UPDATES_CHANNEL: production
+      EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
       # NOTE: currently inert at runtime — the mobile app has no
       # @sentry/react-native wiring (no Sentry.init, no src/lib/sentry.ts), so this
       # DSN is not read by the running app; client-side errors go to PostHog only

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ dist
 # misc
 .DS_Store
 *.pem
+# Self-hosted OTA code signing: the public certificate is committed so the app
+# can verify update signatures; the private/public signing keys stay server-only.
+!packages/mobile/certs/certificate.pem
+packages/mobile/certs/private-key.pem
+packages/mobile/certs/public-key.pem
 /tmp/
 
 # debug

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,3 +262,7 @@ Four preview channels (`preview-1` ... `preview-4`), one per test device. Publis
 CI: `mobile-eas-update.yml` auto-publishes on every push to a non-main branch touching `packages/mobile/` or shared packages, and comments on the PR. `EXPO_TOKEN` secret required.
 
 A new preview build is only needed when native deps change (new Expo plugin, new native module, SDK bump). JS/TS changes ride OTA.
+
+### OTA production distribution (self-hosted expo-open-ota)
+
+Production/TestFlight builds use **self-hosted** OTA, not EAS hosting — see `docs/mobile-ota-updates.md`. TestFlight/Play builds (bare `expo prebuild`) bake in `EXPO_UPDATES_CHANNEL: production` and point `updates.url` at our expo-open-ota server (`EXPO_UPDATES_URL`). Publish a production update from `main` with `vp run mobile:publish -- --channel production` (runs `eoas publish`; needs `EXPO_UPDATES_URL` + `EXPO_TOKEN`). Preview builds stay on the EAS free tier (above). runtimeVersion uses the `appVersion` policy, so bumping `version` in `app.config.ts` requires a fresh native build before OTAs for that version flow.

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -18,9 +18,12 @@ there's no MAU/bandwidth billing.
 | Publish        | `vp run mobile:publish` (→ `eas update`) | `vp run mobile:publish -- --channel production` (→ `eoas publish`)                              |
 
 The split is decided in `packages/mobile/app.config.ts` (`resolveUpdatesConfig`): when
-`EAS_BUILD` is set it returns the EAS URL; otherwise it uses `EXPO_UPDATES_URL` (the self-hosted
-server). Until `EXPO_UPDATES_URL` is set, it falls back to the EAS URL so builds still succeed and
-OTA is simply inert.
+`EAS_BUILD` is set it returns the EAS URL; otherwise it uses the self-hosted server — but **only
+when both `EXPO_UPDATES_URL` and the signing cert `certs/certificate.pem` are present** (fail
+closed). Until both exist it falls back to the EAS URL so builds still succeed and OTA is simply
+inert. The cert gate matters: baking the self-hosted update URL into a binary _without_ code
+signing would let a compromised manifest host (or a network MITM) push arbitrary JS to every
+install, since the device couldn't verify the manifest came from us.
 
 ## How the production path works
 
@@ -57,11 +60,13 @@ so `EXPO_UPDATES_URL` must be present. Kept manual on purpose: a `main` push alr
    Railway/object-storage rules in `CLAUDE.md`).
 2. **Code-signing keys** — from `packages/mobile/`:
    ```sh
-   bunx eoas generate-certs
+   bunx eoas@2 generate-certs
    ```
    Produces `certs/certificate.pem` (commit — already whitelisted in `.gitignore`),
    `certs/private-key.pem` + `certs/public-key.pem` (**never commit** — gitignored; these go to
-   the server).
+   the server). The committed cert is what flips production builds onto the self-hosted path:
+   `resolveUpdatesConfig` stays on EAS until the cert exists, so generate + commit it before
+   relying on the `EXPO_UPDATES_URL` variable.
 3. **Deploy the server** — [Railway template](https://axelmarciano.github.io/expo-open-ota/docs/deployment/railway)
    or Docker/Helm. Required env (see the
    [env reference](https://axelmarciano.github.io/expo-open-ota/docs/reference/environment)):
@@ -83,10 +88,12 @@ so `EXPO_UPDATES_URL` must be present. Kept manual on purpose: a `main` push alr
 
 ## Verify end to end
 
-1. Local config check: `cd packages/mobile && EXPO_UPDATES_URL=https://example.test/manifest
-EXPO_UPDATES_CHANNEL=production bunx expo prebuild --platform ios --clean --no-install`, then
-   confirm `ios/Boardsesh/Supporting/Expo.plist` has `EXUpdatesRequestHeaders` →
-   `expo-channel-name=production`. Repeat `--platform android` and grep `AndroidManifest.xml`.
+1. Local config check (the cert gate means you must generate certs first, else the config falls
+   back to EAS and injects no channel header): `cd packages/mobile && bunx eoas@2 generate-certs`,
+   then `EXPO_UPDATES_URL=https://example.test/manifest EXPO_UPDATES_CHANNEL=production bunx expo
+prebuild --platform ios --clean --no-install`, then confirm `ios/Boardsesh/Supporting/Expo.plist`
+   has `EXUpdatesRequestHeaders` → `expo-channel-name=production` and an `EXUpdatesCodeSigning*`
+   entry. Repeat `--platform android` and grep `AndroidManifest.xml`.
 2. Ship one native TestFlight build from `main` (bakes in channel + server URL + cert).
 3. Make a trivial JS change, run the publish command above, relaunch the TestFlight app, and
    confirm the OTA downloads and applies.

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -1,0 +1,98 @@
+# Mobile OTA updates (production: self-hosted expo-open-ota)
+
+How JS/TS-only fixes reach the `packages/mobile` app without a new native build.
+
+`expo-updates` speaks an open protocol, so we self-host the manifest + asset server with
+[expo-open-ota](https://github.com/axelmarciano/expo-open-ota) instead of paying for EAS Update
+hosting. The only thing we keep from Expo is a **free** account/token — the server uses Expo's
+API for channel↔branch metadata, but serves manifests and bundles from our own storage, so
+there's no MAU/bandwidth billing.
+
+## Two hosting paths (don't mix them up)
+
+|                | Preview / dev                            | Production                                                                                      |
+| -------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Built by       | `eas build` (`mobile:preview-build`)     | bare `expo prebuild` + xcodebuild/gradle (the `ios-testflight-rn` / `android-apk-rn` workflows) |
+| Hosting        | EAS free tier (`u.expo.dev`)             | self-hosted expo-open-ota                                                                       |
+| Channel source | `channel` in `eas.json`                  | `expo-channel-name` request header baked in by `expo prebuild`                                  |
+| Publish        | `vp run mobile:publish` (→ `eas update`) | `vp run mobile:publish -- --channel production` (→ `eoas publish`)                              |
+
+The split is decided in `packages/mobile/app.config.ts` (`resolveUpdatesConfig`): when
+`EAS_BUILD` is set it returns the EAS URL; otherwise it uses `EXPO_UPDATES_URL` (the self-hosted
+server). Until `EXPO_UPDATES_URL` is set, it falls back to the EAS URL so builds still succeed and
+OTA is simply inert.
+
+## How the production path works
+
+1. **Build time** (`expo prebuild`): `EXPO_UPDATES_CHANNEL=production` →
+   `updates.requestHeaders['expo-channel-name'] = 'production'` is injected into `Expo.plist`
+   (`EXUpdatesRequestHeaders`) and `AndroidManifest.xml`. `updates.url` points at our server. The
+   public code-signing cert (`certs/certificate.pem`) is embedded.
+2. **Runtime**: on launch the app asks `<server>/manifest` with its channel + runtimeVersion
+   headers. The server returns the latest signed update on the branch mapped to that channel; the
+   app verifies the signature against the embedded cert and applies it on next launch.
+3. **runtimeVersion** uses the `appVersion` policy (= the `version` in `app.config.ts`, `2.0.0`).
+   An update only reaches a binary with the **same** runtimeVersion. **Bumping `version` requires
+   a fresh native build (TestFlight/Play) before OTAs for that version flow** — and any change to
+   native code/deps always needs a new build, never OTA.
+
+## Publishing a production update
+
+From `main`, once the server is deployed and you're logged in (`bunx eas login`, or `EXPO_TOKEN`
+set):
+
+```sh
+EXPO_UPDATES_URL=https://ota.boardsesh.com/manifest \
+  vp run mobile:publish -- --channel production --message "fix: <what>"
+```
+
+This runs `eoas publish --branch production`, which does an `expo export` and uploads the bundle
+to our storage via the server. `eoas` reads the server URL from `updates.url` in `app.config.ts`,
+so `EXPO_UPDATES_URL` must be present. Kept manual on purpose: a `main` push already triggers the
+~60-min native builds, and a JS-only fix shouldn't force a native rebuild.
+
+## One-time setup (infra — done outside this repo)
+
+1. **Storage bucket** — S3-compatible (Cloudflare R2 / S3 / Spaces). Keep it portable (see the
+   Railway/object-storage rules in `CLAUDE.md`).
+2. **Code-signing keys** — from `packages/mobile/`:
+   ```sh
+   bunx eoas generate-certs
+   ```
+   Produces `certs/certificate.pem` (commit — already whitelisted in `.gitignore`),
+   `certs/private-key.pem` + `certs/public-key.pem` (**never commit** — gitignored; these go to
+   the server).
+3. **Deploy the server** — [Railway template](https://axelmarciano.github.io/expo-open-ota/docs/deployment/railway)
+   or Docker/Helm. Required env (see the
+   [env reference](https://axelmarciano.github.io/expo-open-ota/docs/reference/environment)):
+   - `BASE_URL` = `https://ota.boardsesh.com`
+   - `JWT_SECRET` = random string
+   - `EXPO_APP_ID` = `87499648-655e-4fb8-9856-65da37e55fb1` (our Expo project id)
+   - `EXPO_ACCESS_TOKEN` = an Expo token (same value as the `EXPO_TOKEN` CI secret)
+   - `CACHE_MODE` = `local` (or `redis`)
+   - `STORAGE_MODE` = `s3`, plus `S3_BUCKET_NAME`, `AWS_REGION`, `AWS_BASE_ENDPOINT` (R2), and
+     `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+   - `KEYS_STORAGE_TYPE` = `environment`, plus `PUBLIC_EXPO_KEY_B64` / `PRIVATE_EXPO_KEY_B64`
+     (base64 of the keys from step 2)
+   - optional: `USE_DASHBOARD=true` + `ADMIN_PASSWORD` for the monitoring web UI
+4. **DNS** — point `ota.boardsesh.com` at the deployed server (CDN-front if desired).
+5. **GitHub config** — set repo **variable** `EXPO_UPDATES_URL=https://ota.boardsesh.com/manifest`
+   (consumed by both release workflows) and confirm the `EXPO_TOKEN` secret exists.
+6. **Channel/branch** — create the `production` channel + branch on the Expo project (the server
+   reads the mapping from Expo's API) and map channel `production` → branch `production`.
+
+## Verify end to end
+
+1. Local config check: `cd packages/mobile && EXPO_UPDATES_URL=https://example.test/manifest
+EXPO_UPDATES_CHANNEL=production bunx expo prebuild --platform ios --clean --no-install`, then
+   confirm `ios/Boardsesh/Supporting/Expo.plist` has `EXUpdatesRequestHeaders` →
+   `expo-channel-name=production`. Repeat `--platform android` and grep `AndroidManifest.xml`.
+2. Ship one native TestFlight build from `main` (bakes in channel + server URL + cert).
+3. Make a trivial JS change, run the publish command above, relaunch the TestFlight app, and
+   confirm the OTA downloads and applies.
+
+## Deferred
+
+- **`beta` channel**: TestFlight on `beta`, App Store on `production`, promote at GA.
+- **Migrate the preview/dev-branch flow + in-app `BranchSwitcher`** (`src/lib/eas-api.ts`) off EAS
+  hosting onto expo-open-ota, to drop the Expo dependency entirely.

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -11,10 +11,10 @@ const HEALTH_UPDATE_USAGE_DESCRIPTION = 'Boardsesh saves your finished climbing 
 const HEALTH_SHARE_USAGE_DESCRIPTION =
   'Boardsesh reads your body weight to estimate calories and your saved Boardsesh workouts to prevent duplicates.';
 
-// Public code-signing certificate for self-hosted OTA. `npx eoas generate-certs`
+// Public code-signing certificate for self-hosted OTA. `bunx eoas@2 generate-certs`
 // writes certs/certificate.pem (committed) + the private/public keys (server-only,
-// gitignored). Gate on its presence so `expo prebuild` doesn't fail before the
-// cert has been generated and committed.
+// gitignored). Its presence is a hard gate (see resolveUpdatesConfig) so we never
+// ship a self-hosted OTA binary that can't verify update signatures.
 const CODE_SIGNING_CERT_PATH = './certs/certificate.pem';
 
 // Resolves the expo-updates block. Two distinct hosting paths:
@@ -22,10 +22,11 @@ const CODE_SIGNING_CERT_PATH = './certs/certificate.pem';
 //     free-tier hosting at u.expo.dev — channel comes from eas.json. Unchanged.
 //   • Production builds (bare `expo prebuild` in the TestFlight/Android
 //     workflows) point at our self-hosted expo-open-ota server. The server URL
-//     is supplied via EXPO_UPDATES_URL; until that's set (infra not yet wired)
-//     we fall back to the EAS URL so the build still succeeds and OTA is simply
-//     inert. `eoas publish` also reads updates.url to find the server, so the
-//     same env var must be present at publish time.
+//     is supplied via EXPO_UPDATES_URL and the path is gated on the signing cert
+//     existing (fail closed — see below). Until both are in place we fall back to
+//     the EAS URL so the build still succeeds and OTA is simply inert. `eoas
+//     publish` also reads updates.url to find the server, so the same env var
+//     must be present at publish time.
 function resolveUpdatesConfig(easProjectId: string): ExpoConfig['updates'] {
   const easUrl = `https://u.expo.dev/${easProjectId}`;
 
@@ -34,12 +35,20 @@ function resolveUpdatesConfig(easProjectId: string): ExpoConfig['updates'] {
   }
 
   const selfHostUrl = process.env.EXPO_UPDATES_URL;
-  if (!selfHostUrl) {
+  const certExists = existsSync(resolve(process.cwd(), CODE_SIGNING_CERT_PATH));
+
+  // Fail closed: only point a production binary at the self-hosted server when
+  // BOTH the server URL and the public signing cert are present. Baking the
+  // self-hosted update URL without code signing would let a compromised manifest
+  // host (or a network MITM) push arbitrary JS to every installed app — the
+  // device would have no way to verify the manifest came from us. Until the cert
+  // is generated and committed we stay on the EAS URL (nothing is published there
+  // for production, so OTA is simply inert), keeping every build safe to ship.
+  if (!selfHostUrl || !certExists) {
     return { url: easUrl };
   }
 
   const channel = process.env.EXPO_UPDATES_CHANNEL;
-  const certExists = existsSync(resolve(process.cwd(), CODE_SIGNING_CERT_PATH));
 
   return {
     url: selfHostUrl,
@@ -49,12 +58,8 @@ function resolveUpdatesConfig(easProjectId: string): ExpoConfig['updates'] {
     ...(channel ? { requestHeaders: { 'expo-channel-name': channel } } : {}),
     // Verifies the manifest signature on-device so a compromised manifest host
     // can't push arbitrary JS. Private key lives only on the server.
-    ...(certExists
-      ? {
-          codeSigningCertificate: CODE_SIGNING_CERT_PATH,
-          codeSigningMetadata: { keyid: 'main', alg: 'rsa-v1_5-sha256' as const },
-        }
-      : {}),
+    codeSigningCertificate: CODE_SIGNING_CERT_PATH,
+    codeSigningMetadata: { keyid: 'main', alg: 'rsa-v1_5-sha256' as const },
   };
 }
 

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -1,4 +1,6 @@
 import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { ExpoConfig, ConfigContext } from 'expo/config';
 
 const DEFAULT_EAS_PROJECT_ID = '87499648-655e-4fb8-9856-65da37e55fb1';
@@ -8,6 +10,53 @@ const ANDROID_PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=co
 const HEALTH_UPDATE_USAGE_DESCRIPTION = 'Boardsesh saves your finished climbing sessions to Apple Health as workouts.';
 const HEALTH_SHARE_USAGE_DESCRIPTION =
   'Boardsesh reads your body weight to estimate calories and your saved Boardsesh workouts to prevent duplicates.';
+
+// Public code-signing certificate for self-hosted OTA. `npx eoas generate-certs`
+// writes certs/certificate.pem (committed) + the private/public keys (server-only,
+// gitignored). Gate on its presence so `expo prebuild` doesn't fail before the
+// cert has been generated and committed.
+const CODE_SIGNING_CERT_PATH = './certs/certificate.pem';
+
+// Resolves the expo-updates block. Two distinct hosting paths:
+//   • Preview/dev builds (made with `eas build`, EAS_BUILD set) stay on EAS
+//     free-tier hosting at u.expo.dev — channel comes from eas.json. Unchanged.
+//   • Production builds (bare `expo prebuild` in the TestFlight/Android
+//     workflows) point at our self-hosted expo-open-ota server. The server URL
+//     is supplied via EXPO_UPDATES_URL; until that's set (infra not yet wired)
+//     we fall back to the EAS URL so the build still succeeds and OTA is simply
+//     inert. `eoas publish` also reads updates.url to find the server, so the
+//     same env var must be present at publish time.
+function resolveUpdatesConfig(easProjectId: string): ExpoConfig['updates'] {
+  const easUrl = `https://u.expo.dev/${easProjectId}`;
+
+  if (process.env.EAS_BUILD) {
+    return { url: easUrl };
+  }
+
+  const selfHostUrl = process.env.EXPO_UPDATES_URL;
+  if (!selfHostUrl) {
+    return { url: easUrl };
+  }
+
+  const channel = process.env.EXPO_UPDATES_CHANNEL;
+  const certExists = existsSync(resolve(process.cwd(), CODE_SIGNING_CERT_PATH));
+
+  return {
+    url: selfHostUrl,
+    enabled: true,
+    // Written into Expo.plist (EXUpdatesRequestHeaders) and AndroidManifest by
+    // `expo prebuild`; the self-hosted server maps this channel to a branch.
+    ...(channel ? { requestHeaders: { 'expo-channel-name': channel } } : {}),
+    // Verifies the manifest signature on-device so a compromised manifest host
+    // can't push arbitrary JS. Private key lives only on the server.
+    ...(certExists
+      ? {
+          codeSigningCertificate: CODE_SIGNING_CERT_PATH,
+          codeSigningMetadata: { keyid: 'main', alg: 'rsa-v1_5-sha256' as const },
+        }
+      : {}),
+  };
+}
 
 function resolveDevMetadata(): {
   branchName: string | null;
@@ -150,7 +199,7 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
     ...(EAS_PROJECT_ID
       ? {
           runtimeVersion: { policy: 'appVersion' as const },
-          updates: { url: `https://u.expo.dev/${EAS_PROJECT_ID}` },
+          updates: resolveUpdatesConfig(EAS_PROJECT_ID),
         }
       : {}),
     ios: {

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -1,15 +1,23 @@
 /// <reference types="node" />
 
 /**
- * Publishes an EAS Update for the current branch so testers on the "preview"
- * build can receive it OTA. Each git branch gets its own EAS Update branch,
- * meaning multiple worktrees can publish independently and testers switch
- * between them by scanning a QR code or selecting the branch in the app.
+ * Publishes an OTA update for the mobile app. Two modes:
+ *
+ *   Preview (default) — `eas update` to EAS free-tier hosting (u.expo.dev).
+ *     Each git branch gets its own EAS Update branch, so multiple worktrees
+ *     publish independently and testers switch between them in-app.
+ *
+ *   Production (`--channel <name>`) — `eoas publish` to our self-hosted
+ *     expo-open-ota server. Requires EXPO_UPDATES_URL (the server's manifest
+ *     endpoint — eoas derives the upload host from updates.url in app.config)
+ *     and EXPO_TOKEN (Expo API auth for branch/channel mapping). The channel
+ *     name maps to a same-named branch on the server.
  *
  * Usage:
- *   vp run mobile:publish              # publishes to current git branch
- *   vp run mobile:publish -- --branch my-feature  # explicit branch name
- *   vp run mobile:publish -- --message "fix nav bug"  # custom update message
+ *   vp run mobile:publish                              # preview: current git branch
+ *   vp run mobile:publish -- --branch my-feature       # preview: explicit branch
+ *   vp run mobile:publish -- --message "fix nav bug"   # custom update message
+ *   vp run mobile:publish -- --channel production      # production: self-hosted OTA
  */
 
 import { execFileSync, spawnSync } from 'node:child_process';
@@ -56,10 +64,81 @@ function getCommitSubject(): string {
   }
 }
 
-function parseArgs(args: string[]): { branch: string | null; message: string | null; platform: string } {
+function publishToSelfHostedChannel(channelName: string, platform: string, explicitMessage: string | null): never {
+  const serverUrl = process.env.EXPO_UPDATES_URL;
+  if (!serverUrl) {
+    console.error('[mobile:publish] --channel requires EXPO_UPDATES_URL (the expo-open-ota manifest endpoint,');
+    console.error('[mobile:publish] e.g. https://ota.boardsesh.com/manifest). eoas derives the upload host from it.');
+    console.error('[mobile:publish] See docs/mobile-ota-updates.md.');
+    process.exit(1);
+  }
+  if (!process.env.EXPO_TOKEN) {
+    console.error('[mobile:publish] --channel requires EXPO_TOKEN (Expo API auth for branch/channel mapping).');
+    console.error('[mobile:publish] Run `bunx eas login` locally, or set EXPO_TOKEN in CI.');
+    process.exit(1);
+  }
+
+  const commitHash = getShortCommitHash();
+  const commitSubject = getCommitSubject();
+  const updateMessage = explicitMessage ?? `${commitHash} ${commitSubject}`.trim();
+
+  // eoas publish targets a server branch; the channel baked into the binary
+  // maps to a same-named branch (channel "production" → branch "production").
+  const eoasArgs = [
+    'eoas@latest',
+    'publish',
+    '--branch',
+    channelName,
+    '--platform',
+    platform,
+    '--message',
+    updateMessage,
+    '--nonInteractive',
+    // The repo uses bun; force bunx so eoas spawns `bunx expo export` regardless
+    // of the nearest package.json's packageManager field.
+    '--packageRunner',
+    'bunx',
+  ];
+
+  console.log(`[mobile:publish] Mode:     production (self-hosted expo-open-ota)`);
+  console.log(`[mobile:publish] Server:   ${serverUrl}`);
+  console.log(`[mobile:publish] Branch:   ${channelName}`);
+  console.log(`[mobile:publish] Message:  ${updateMessage}`);
+  console.log(`[mobile:publish] Platform: ${platform}`);
+  console.log('');
+  console.log(`[mobile:publish] Running: bunx ${eoasArgs.join(' ')}`);
+  console.log('');
+
+  const result = spawnSync('bunx', eoasArgs, {
+    cwd: MOBILE_DIR,
+    stdio: 'inherit',
+    // EXPO_UPDATES_URL must resolve in app.config so eoas finds the server;
+    // EAS_BUILD must stay unset so the self-hosted updates block is selected.
+    env: { ...process.env },
+  });
+
+  if (result.status !== 0) {
+    console.error('');
+    console.error('[mobile:publish] eoas publish failed.');
+    process.exit(result.status ?? 1);
+  }
+
+  console.log('');
+  console.log(`[mobile:publish] Published to self-hosted channel "${channelName}".`);
+  console.log(`[mobile:publish] Testers on a build baked with this channel receive it on next launch.`);
+  process.exit(0);
+}
+
+function parseArgs(args: string[]): {
+  branch: string | null;
+  message: string | null;
+  platform: string;
+  channel: string | null;
+} {
   let branch: string | null = null;
   let message: string | null = null;
   let platform = 'all';
+  let channel: string | null = null;
 
   for (let index = 0; index < args.length; index++) {
     const argument = args[index];
@@ -71,6 +150,15 @@ function parseArgs(args: string[]): { branch: string | null; message: string | n
     }
     if (argument.startsWith('--branch=')) {
       branch = argument.slice('--branch='.length);
+      continue;
+    }
+
+    if (argument === '--channel' || argument === '-c') {
+      channel = args[++index] ?? null;
+      continue;
+    }
+    if (argument.startsWith('--channel=')) {
+      channel = argument.slice('--channel='.length);
       continue;
     }
 
@@ -93,16 +181,22 @@ function parseArgs(args: string[]): { branch: string | null; message: string | n
     }
   }
 
-  return { branch, message, platform };
+  return { branch, message, platform, channel };
 }
 
 const VALID_PLATFORMS = ['ios', 'android', 'all'] as const;
 
-const { branch: explicitBranch, message: explicitMessage, platform } = parseArgs(process.argv.slice(2));
+const { branch: explicitBranch, message: explicitMessage, platform, channel } = parseArgs(process.argv.slice(2));
 
 if (!VALID_PLATFORMS.includes(platform as (typeof VALID_PLATFORMS)[number])) {
   console.error(`[mobile:publish] Invalid platform "${platform}". Must be one of: ${VALID_PLATFORMS.join(', ')}`);
   process.exit(1);
+}
+
+// Production path: publish to the self-hosted expo-open-ota server via eoas.
+// The channel name maps to a same-named branch on the server.
+if (channel) {
+  publishToSelfHostedChannel(channel, platform, explicitMessage);
 }
 
 const branchName = explicitBranch ?? resolveCurrentBranchName();

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -84,8 +84,11 @@ function publishToSelfHostedChannel(channelName: string, platform: string, expli
 
   // eoas publish targets a server branch; the channel baked into the binary
   // maps to a same-named branch (channel "production" → branch "production").
+  // Pin the major (matches the eas-cli@16 convention below): eoas 3.x is already
+  // in alpha, and an unpinned @latest could pull a breaking release into the
+  // production publish path with no change in this repo.
   const eoasArgs = [
-    'eoas@latest',
+    'eoas@2',
     'publish',
     '--branch',
     channelName,
@@ -109,12 +112,17 @@ function publishToSelfHostedChannel(channelName: string, platform: string, expli
   console.log(`[mobile:publish] Running: bunx ${eoasArgs.join(' ')}`);
   console.log('');
 
+  // EXPO_UPDATES_URL must resolve in app.config so eoas finds the server.
+  // EAS_BUILD must be unset or app.config returns the EAS URL and eoas would
+  // publish against the wrong host — strip it defensively so a stray value in
+  // the caller's env can't redirect a production publish.
+  const eoasEnv = { ...process.env };
+  delete eoasEnv.EAS_BUILD;
+
   const result = spawnSync('bunx', eoasArgs, {
     cwd: MOBILE_DIR,
     stdio: 'inherit',
-    // EXPO_UPDATES_URL must resolve in app.config so eoas finds the server;
-    // EAS_BUILD must stay unset so the self-hosted updates block is selected.
-    env: { ...process.env },
+    env: eoasEnv,
   });
 
   if (result.status !== 0) {


### PR DESCRIPTION
## What this does

TestFlight/Play builds are made with bare `expo prebuild` (not `eas build`), so the OTA **channel was never baked into the binary** — `expo-updates` had nothing to poll and OTA silently never connected. This wires up OTA and points the production path at a **self-hosted [expo-open-ota](https://github.com/axelmarciano/expo-open-ota) server** instead of paid EAS Update hosting (the app keeps a free Expo account/token only for channel↔branch metadata; manifests + bundles serve from our own storage, so no MAU/bandwidth billing).

Preview/dev builds and the in-app BranchSwitcher are untouched — they stay on the EAS free tier.

### Code changes
- **`packages/mobile/app.config.ts`** — `resolveUpdatesConfig()` gates the `updates` block: `eas build` → EAS URL (preview unchanged); bare prebuild + `EXPO_UPDATES_URL` → self-hosted server with the `expo-channel-name` header + code signing (gated on `certs/certificate.pem` existing). Falls back to the EAS URL until infra is wired, so **builds never break before the server exists.**
- **`ios-testflight-rn.yml` / `android-apk-rn.yml`** — inject `EXPO_UPDATES_CHANNEL=production` + `EXPO_UPDATES_URL` (from a repo variable) before prebuild.
- **`scripts/mobile-publish.ts`** — `--channel <name>` publishes via `eoas publish` to the self-hosted server; default git-branch path still uses `eas update`.
- **`.gitignore`** — commit `certs/certificate.pem`, keep signing keys server-only.
- **`docs/mobile-ota-updates.md`** + CLAUDE.md — architecture + runbook.

### Validation
`typecheck:mobile` ✅ · `vp check` lint clean ✅ · mobile tests pass (one pre-existing flaky `queue-provider-leave-session` timing test, unrelated). Confirmed the config gate resolves correctly across all three env paths (no-env fallback → EAS URL; `EAS_BUILD=1` → EAS URL; self-host+channel → server URL + `expo-channel-name: production`).

---

## Pickup-later: standing up the server (needs cloud/DNS/Expo credentials)

OTA stays **inert until the server exists** — this PR is safe to merge first.

**1. Generate signing keys** (from `packages/mobile/`):
```sh
bunx eoas generate-certs
git add certs/certificate.pem            # commit the public cert
base64 -i certs/public-key.pem  | tr -d '\n'   # → PUBLIC_EXPO_KEY_B64
base64 -i certs/private-key.pem | tr -d '\n'   # → PRIVATE_EXPO_KEY_B64
```

**2. Storage** — create a Cloudflare R2 bucket (cheapest, S3-compatible) + an R2 API token, or use S3.

**3. Deploy expo-open-ota on Railway** with these env vars:

| Var | Value |
|---|---|
| `JWT_SECRET` | `openssl rand -hex 32` |
| `EXPO_APP_ID` | `87499648-655e-4fb8-9856-65da37e55fb1` |
| `EXPO_ACCESS_TOKEN` | Expo access token (expo.dev → Settings → Access tokens) |
| `PUBLIC_EXPO_KEY_B64` / `PRIVATE_EXPO_KEY_B64` | base64 of the keys from step 1 |
| `S3_BUCKET_NAME` | your bucket |
| `AWS_REGION` | `auto` (R2) or real region (S3) |
| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | storage keys |
| `STORAGE_MODE` | `s3` |
| `KEYS_STORAGE_TYPE` | `environment` |
| `CACHE_MODE` | `local` |
| `BASE_URL` | `${{ RAILWAY_PUBLIC_DOMAIN }}` (add `https://`) or `https://ota.boardsesh.com` |
| `AWS_BASE_ENDPOINT` | only for R2: `https://<account-id>.r2.cloudflarestorage.com` |
| `USE_DASHBOARD` + `ADMIN_PASSWORD` | optional — monitoring web UI |

Leave **blank**: all `CLOUDFRONT_*` and all `AWSSM_*`.

**4. DNS** — point `ota.boardsesh.com` at the Railway service (optional; can use the Railway domain).

**5. GitHub** — set repo **variable** `EXPO_UPDATES_URL` = `<BASE_URL>/manifest` (must match `BASE_URL` origin + `/manifest`). Confirm the `EXPO_TOKEN` secret exists.

**6. Expo project** — create the `production` channel + branch and map them.

### Then it works
Native TestFlight build from `main` (bakes in channel + server URL + cert) → ship JS-only fixes with:
```sh
vp run mobile:publish -- --channel production --message "fix: ..."
```

> ⚠️ `runtimeVersion` uses the `appVersion` policy (`2.0.0`). Bumping `version` in `app.config.ts` requires a fresh native build before OTAs for that version flow.

## Deferred (follow-up)
- `beta` channel: TestFlight on `beta`, App Store on `production`, promote at GA.
- Migrate the preview/dev flow + in-app `BranchSwitcher` off EAS entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
