### PR TITLE
Reject JOIN_SESSION for server-ended sessions (#2696)

### DIFF
--- a/packages/backend/src/__tests__/session-persistence.test.ts
+++ b/packages/backend/src/__tests__/session-persistence.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
+import { GraphQLError } from 'graphql';
 import { v4 as uuidv4 } from 'uuid';
 import { roomManager } from '../services/room-manager';
 import { db } from '../db/client';
@@ -438,7 +439,7 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
       expect(result.queue[0]?.uuid).toBe(climb.uuid);
     });
 
-    it('should not restore ended sessions from Postgres', async () => {
+    it('refuses to join an ended session instead of resurrecting it', async () => {
       const sessionId = uuidv4();
       const boardPath = '/kilter/1/2/3/40';
 
@@ -446,15 +447,24 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
       await registerAndJoinSession('client-1', sessionId, boardPath, 'User1');
       await roomManager.endSession(sessionId);
 
-      // Clear in-memory state
+      // Clear in-memory state (simulate a fresh instance / Redis expiry)
       roomManager.reset();
       await roomManager.initialize(mockRedis);
 
-      // Try to rejoin ended session - should create a new session instead of restoring
-      const result = await registerAndJoinSession('client-2', sessionId, boardPath, 'User2');
+      // Register, then assert the join itself is rejected (do NOT use
+      // registerAndJoinSession — we need to assert on the join call).
+      await roomManager.registerClient('client-2', 'User2');
+      const error = await roomManager.joinSession('client-2', sessionId, boardPath, 'User2').catch((err) => err);
+      expect(error).toBeInstanceOf(GraphQLError);
+      expect((error as GraphQLError).extensions?.code).toBe('SESSION_ENDED');
 
-      // Session should be created fresh (empty queue)
-      expect(result.queue).toHaveLength(0);
+      // No zombie room: the durable row is still ended, and the rejected joiner
+      // never became a live participant.
+      const [row] = await db.select().from(sessions).where(eq(sessions.id, sessionId)).limit(1);
+      expect(row?.status).toBe('ended');
+      expect(row?.endedAt).not.toBeNull();
+      const users = await roomManager.getSessionUsers(sessionId);
+      expect(users.some((user) => user.id === 'client-2')).toBe(false);
     });
   });
 

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -1,3 +1,4 @@
+import { GraphQLError } from 'graphql';
 import type { ClimbQueueItem, SessionUser } from '@boardsesh/shared-schema';
 import { db } from '../../db/client';
 import { sessions, boardSessionParticipants, type Session } from '../../db/schema';
@@ -7,6 +8,7 @@ import type { ConnectedClient, LocalSessionParticipant } from './types';
 import { restoreSessionWithLock } from './session-restoration';
 import type { WriteScheduler } from './write-scheduler';
 import { logger } from '../../utils/logger';
+import { markErrorReported } from '../../utils/sentry-dedupe';
 
 /**
  * Register a new client connection.
@@ -100,6 +102,25 @@ export async function joinSession(
   if (!client) {
     throw new Error('Client not registered');
   }
+
+  // Refuse to resurrect a server-ended session (#2696). The Postgres row is the
+  // durable source of truth (Redis only holds live presence), so a stale/ended
+  // session id must not be treated as "new" and recreated as an empty zombie
+  // room. Mirror the sessionStatus resolver's predicate. Runs before any client
+  // state is mutated or the current session is left, so a failed join here
+  // never disturbs a session the client is already in.
+  const existingSession = await getSessionById(sessionId);
+  if (existingSession && (existingSession.status === 'ended' || existingSession.endedAt !== null)) {
+    const endedError = new GraphQLError('This session has ended', {
+      extensions: { code: 'SESSION_ENDED' },
+    });
+    // Expected client condition (stale/offline rejoin), not a server fault —
+    // keep it out of Sentry's generic capture loop.
+    markErrorReported(endedError);
+    logger.info(`[RoomManager] Rejecting JOIN_SESSION for ended session ${sessionId}`);
+    throw endedError;
+  }
+
   // SECURITY: Never trust a client-supplied participantId. SessionUser.id is
   // broadcast to every peer in the session, so accepting an arbitrary
   // participantId here lets any member impersonate any other participant
@@ -149,9 +170,9 @@ export async function joinSession(
         );
       }
     } else {
-      // No Redis, check Postgres directly for session existence
-      const pgSession = await getSessionById(sessionId);
-      if (!pgSession || pgSession.status === 'ended') {
+      // No Redis: a missing Postgres row means this is a brand-new session.
+      // Ended rows were already rejected by the guard at the top of joinSession.
+      if (!existingSession) {
         isNewSession = true;
         logger.info(
           `[RoomManager] Creating new session ${sessionId} with ${initialQueue?.length || 0} initial queue items`,

--- a/packages/web/app/components/persistent-session/__tests__/join-ended-session.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/join-ended-session.test.tsx
@@ -1,0 +1,188 @@
+import 'fake-indexeddb/auto';
+import { openDB } from 'idb';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
+import type { BoardDetails } from '@/app/lib/types';
+import { PersistentSessionProvider, usePersistentSession } from '../persistent-session-context';
+import { execute, GraphQLOperationError } from '../../graphql-queue/graphql-client';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock the WebSocket/GraphQL layer. `execute` is driven per-test to simulate
+// the server refusing an ended-session join. `GraphQLOperationError` is the
+// REAL class (the source branches on `instanceof`), pulled from the pure shared
+// package so importing it doesn't drag in browser globals.
+vi.mock('../../graphql-queue/graphql-client', async () => {
+  const shared = await vi.importActual<typeof import('@boardsesh/graphql-client')>('@boardsesh/graphql-client');
+  return {
+    createGraphQLClient: vi.fn(() => ({ dispose: vi.fn() })),
+    execute: vi.fn(),
+    subscribe: vi.fn(() => vi.fn()),
+    GraphQLOperationError: shared.GraphQLOperationError,
+  };
+});
+
+// The real DEFAULT_BACKEND_URL is null in jsdom, which short-circuits the
+// connect() effect before it can fire JOIN_SESSION. Override it so the join
+// path actually runs in this test.
+vi.mock('../types', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../types')>();
+  return { ...actual, DEFAULT_BACKEND_URL: 'ws://localhost:9999/graphql' };
+});
+
+// HTTP client used by the mount staleness pre-flight. Default seeded in
+// beforeEach to report a still-active session so restore proceeds to connect().
+const { mockHttpRequest } = vi.hoisted(() => ({ mockHttpRequest: vi.fn() }));
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: vi.fn(() => ({ request: mockHttpRequest })),
+}));
+
+const { mockWsAuth } = vi.hoisted(() => ({
+  mockWsAuth: { token: 'test-token' as string | null, isLoading: false },
+}));
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => mockWsAuth,
+}));
+
+vi.mock('../../party-manager/party-profile-context', () => ({
+  usePartyProfile: () => ({ profile: { id: 'test-user' }, username: 'tester', avatarUrl: null }),
+  PartyProfileProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock('@/app/utils/hash', () => ({
+  computeQueueStateHash: () => 'mock-hash',
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ACTIVE_SESSION_KEY = 'activeSession';
+const PREFS_DB_NAME = 'boardsesh-user-preferences';
+const PREFS_STORE_NAME = 'preferences';
+
+function buildSessionSummary(sessionId: string) {
+  return {
+    sessionId,
+    endedAt: null,
+    startedAt: null,
+    durationMinutes: 0,
+    totalSends: 0,
+    totalAttempts: 0,
+    gradeDistribution: [],
+    hardestClimb: null,
+    participants: [],
+    goal: null,
+  };
+}
+
+function createTestBoardDetails(overrides?: Partial<BoardDetails>): BoardDetails {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 10,
+    set_ids: '1,2',
+    images_to_holds: {},
+    holdsData: {},
+    edge_left: 0,
+    edge_right: 100,
+    edge_bottom: 0,
+    edge_top: 100,
+    boardHeight: 100,
+    boardWidth: 100,
+    layout_name: 'Original',
+    size_name: '12x12',
+    ...overrides,
+  } as BoardDetails;
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <PersistentSessionProvider>{children}</PersistentSessionProvider>
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(async () => {
+  mockHttpRequest.mockReset();
+  mockWsAuth.token = 'test-token';
+  mockWsAuth.isLoading = false;
+
+  try {
+    const prefsDb = await openDB(PREFS_DB_NAME, 1, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(PREFS_STORE_NAME)) {
+          db.createObjectStore(PREFS_STORE_NAME);
+        }
+      },
+    });
+    await prefsDb.clear(PREFS_STORE_NAME);
+    prefsDb.close();
+  } catch {
+    // DB may not exist yet
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+describe('JOIN_SESSION SESSION_ENDED handling (#2696)', () => {
+  it('drops the stored session when the server reports the session has ended', async () => {
+    const sessionId = 'session-server-ended';
+    const sessionInfo = {
+      sessionId,
+      boardPath: '/kilter/1/10/1,2/40/list',
+      boardDetails: createTestBoardDetails(),
+      parsedParams: {
+        board_name: 'kilter' as const,
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1, 2],
+        angle: 40,
+      },
+    };
+    await setPreference(ACTIVE_SESSION_KEY, sessionInfo);
+
+    // Pre-flight says still-active, so the provider restores it and opens a WS
+    // connection (which fires JOIN_SESSION).
+    mockHttpRequest.mockResolvedValue({ sessionSummary: buildSessionSummary(sessionId) });
+
+    // The backend refuses the join: the session was server-ended (#2696).
+    vi.mocked(execute).mockRejectedValue(
+      new GraphQLOperationError([{ message: 'This session has ended', extensions: { code: 'SESSION_ENDED' } }]),
+    );
+
+    const { result } = renderHook(() => usePersistentSession(), { wrapper: createWrapper() });
+
+    // JOIN_SESSION was attempted...
+    await waitFor(() => {
+      expect(execute).toHaveBeenCalled();
+    });
+
+    // ...and the SESSION_ENDED response dropped the stored session instead of
+    // resurrecting it.
+    await waitFor(() => {
+      expect(result.current.activeSession).toBeNull();
+    });
+    const stored = await getPreference(ACTIVE_SESSION_KEY);
+    expect(stored).toBeNull();
+  });
+});

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -1,5 +1,11 @@
 import { useState, useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
-import { type Client, createGraphQLClient, execute, subscribe } from '../../graphql-queue/graphql-client';
+import {
+  type Client,
+  createGraphQLClient,
+  execute,
+  subscribe,
+  GraphQLOperationError,
+} from '../../graphql-queue/graphql-client';
 import {
   INITIAL_RETRY_DELAY_MS,
   MAX_RETRY_DELAY_MS,
@@ -494,6 +500,17 @@ export function useSessionLifecycle({
 
         return joinedSession;
       } catch (err) {
+        // The server refuses to resurrect an ended session (#2696). Drop the
+        // stored session immediately instead of treating it as a transient
+        // failure and burning several backoff retries on a dead session.
+        if (err instanceof GraphQLOperationError && err.extensions?.code === 'SESSION_ENDED') {
+          if (DEBUG) console.info('[PersistentSession] Session has ended; clearing stored session');
+          removePreference(ACTIVE_SESSION_KEY).catch(() => {});
+          if (mountedRef.current) {
+            setActiveSession(null);
+          }
+          return null;
+        }
         console.error('[PersistentSession] JoinSession failed:', err);
         return null;
       }


### PR DESCRIPTION
Fixes #2696.

## Problem

`JOIN_SESSION` treated "not in Redis" as "new session" without consulting the durable `board_sessions.status`. A client that issued `JOIN_SESSION` against a stale/**ended** session id resurrected a fresh, empty zombie room: queue mutations broadcast into a dead room and ticks got stamped after the session's `endedAt`.

This is the backend half of #2683. The mobile client already guards its own cold-start restore via the `sessionStatus` pre-check (PR #2693), but the server-side hole was still open for the web app (which restores from `ACTIVE_SESSION_KEY` and calls `JOIN_SESSION` directly) and any other client.

## Fix

**Backend** — add a guard at the top of `roomManager.joinSession` (`client-lifecycle.ts`), the single chokepoint covering the Redis hot-cache, Redis-restore, and no-Redis paths. It reads the durable Postgres row and, when `status === 'ended'` or `endedAt` is set, throws a `GraphQLError` with `extensions.code: 'SESSION_ENDED'` instead of creating a room:

- Mirrors the predicate already used by the `sessionStatus` resolver (`status === 'ended' || endedAt != null`).
- Runs **before** any client state is mutated or `leaveSessionFn` fires, so a failed join never disturbs a session the client is already in.
- Flagged via `markErrorReported` so this expected client condition stays out of Sentry's generic capture loop.
- The no-Redis branch now reuses that single read instead of fetching the row twice.

**Web** — the persistent-session restore loop now drops the stored session immediately on `SESSION_ENDED` (mirroring the existing `CLIMB_IS_DUPLICATE` `extensions.code` pattern) instead of swallowing it into a `TransientJoinError` and burning several backoff retries on a dead session.

No mobile change needed — its `sessionStatus` cold-start guard already prevents the ended-session join.

## Behaviour preserved

- Genuinely new session id (no Postgres row) → guard passes → normal new-session creation (incl. "start party mode with initial queue").
- Active/dormant session → joins/restores as before.

## Tests

- `session-persistence.test.ts`: replaced the test that encoded the buggy behaviour (asserted a fresh empty queue) with one asserting the join is rejected (`SESSION_ENDED`), the durable row stays `ended`, and the rejected joiner never becomes a participant.
- New `join-ended-session.test.tsx`: drives the web restore path (mocking `DEFAULT_BACKEND_URL` truthy so `connect()` runs in jsdom) and asserts a `SESSION_ENDED` join response clears the stored session.

## Verification

- `vp run typecheck:backend`, `vp run typecheck:web` — pass.
- `vp test run --project backend session-persistence` — 26 pass.
- `vp test run --project web join-ended-session persistent-session-restore` — 12 pass.
- `vp check` — my files are clean (the 16 unrelated pre-existing formatting hits are untouched).

Note: `integration.test.ts` has 22 pre-existing failures in this environment (the daemon WebSocket isn't reachable locally — `closeCode 1006`); verified identical on `main` with these changes stashed, so they're unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)