### PR TITLE
Show the Boardsesh logo on the mobile login screen

### DIFF
--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -11,6 +11,7 @@ import {
   type TextInput as RNTextInput,
 } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -180,6 +181,7 @@ export default function LoginScreen() {
         keyboardDismissMode="interactive"
       >
         <View style={styles.header}>
+          <Image source={require('../../assets/splash-icon.png')} style={styles.logo} contentFit="contain" />
           <Text style={[styles.title, { color: theme.brandColors.primary }]}>Boardsesh</Text>
           <Text style={styles.subtitle}>{t('nativeStart.tagline')}</Text>
         </View>
@@ -266,6 +268,7 @@ export default function LoginScreen() {
 const styles = StyleSheet.create({
   container: { flexGrow: 1, justifyContent: 'center', padding: 24 },
   header: { alignItems: 'center', marginBottom: 32 },
+  logo: { width: 96, height: 96, marginBottom: 16 },
   title: { fontSize: 34, fontWeight: '700', marginBottom: 8 },
   subtitle: { fontSize: 17, opacity: 0.7 },
   form: { gap: 12 },

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -181,7 +181,12 @@ export default function LoginScreen() {
         keyboardDismissMode="interactive"
       >
         <View style={styles.header}>
-          <Image source={require('../../assets/splash-icon.png')} style={styles.logo} contentFit="contain" />
+          <Image
+            source={require('../../assets/splash-icon.png')}
+            style={styles.logo}
+            contentFit="contain"
+            accessible={false}
+          />
           <Text style={[styles.title, { color: theme.brandColors.primary }]}>Boardsesh</Text>
           <Text style={styles.subtitle}>{t('nativeStart.tagline')}</Text>
         </View>


### PR DESCRIPTION
## Summary

The mobile login screen previously showed only the word "Boardsesh" as a text header. This renders the Boardsesh logo (the existing `packages/mobile/assets/splash-icon.png`, a transparent RGBA PNG of the purple X-mark) above the title via `expo-image`, keeping the splash screen and login logo automatically in sync without duplicating the asset.

- Logo is 96×96 with `contentFit="contain"`, centered above the existing title and tagline.
- Title text is kept since the logo is a glyph, not a wordmark.
- No accessibility label: the logo is decorative and the "Boardsesh" text right below carries the name.
- Transparent background works on both light and dark color schemes.

## Validation

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 224 files, 1600 tests, all pass
- `vp check` on the changed file — no lint/format issues
- `vp run check:mobile-bundle` — iOS and Android Metro bundles OK; `assets/splash-icon.png` confirmed in the exported bundle

https://claude.ai/code/session_01FLV7EE3HyXECUhKJK91r3W

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLV7EE3HyXECUhKJK91r3W)_