### PR TITLE
Owner edit mode for playlists — reorder + remove climbs (iOS glass + M3)

### DIFF
--- a/packages/backend/src/__tests__/playlist-reorder-math.test.ts
+++ b/packages/backend/src/__tests__/playlist-reorder-math.test.ts
@@ -50,6 +50,17 @@ describe('computePlaylistReorderWrites', () => {
     expect(computePlaylistReorderWrites(denseRows(), 'a', 0)).toEqual([]);
   });
 
+  it('returns no writes for a no-op move even on a gappy list (no needless compaction)', () => {
+    const gappy: ReorderRow<number>[] = [
+      { id: 1, climbUuid: 'a', position: 0 },
+      { id: 2, climbUuid: 'b', position: 5 },
+      { id: 3, climbUuid: 'c', position: 10 },
+    ];
+    // Ask to move 'b' to its own rank (1) — a true no-op must not renumber the
+    // gaps away.
+    expect(computePlaylistReorderWrites(gappy, 'b', 1)).toEqual([]);
+  });
+
   it('handles gappy positions (left by deletions) by renumbering to dense', () => {
     // Positions 0,5,10 (gaps) — move the last (rank 2) to the front.
     const gappy: ReorderRow<number>[] = [

--- a/packages/backend/src/__tests__/playlist-reorder-math.test.ts
+++ b/packages/backend/src/__tests__/playlist-reorder-math.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { computePlaylistReorderWrites, type ReorderRow } from '../graphql/resolvers/playlists/helpers/reorder';
+
+/** Dense list A,B,C,D,E at positions 0..4. */
+function denseRows(): ReorderRow<number>[] {
+  return [
+    { id: 1, climbUuid: 'a', position: 0 },
+    { id: 2, climbUuid: 'b', position: 1 },
+    { id: 3, climbUuid: 'c', position: 2 },
+    { id: 4, climbUuid: 'd', position: 3 },
+    { id: 5, climbUuid: 'e', position: 4 },
+  ];
+}
+
+describe('computePlaylistReorderWrites', () => {
+  it('moves a climb to the front and renumbers densely', () => {
+    // [A,B,C,D,E] → move E (index 4) to 0 → [E,A,B,C,D].
+    const writes = computePlaylistReorderWrites(denseRows(), 'e', 0);
+    expect(writes).toEqual([
+      { id: 5, position: 0 },
+      { id: 1, position: 1 },
+      { id: 2, position: 2 },
+      { id: 3, position: 3 },
+      { id: 4, position: 4 },
+    ]);
+  });
+
+  it('writes only the rows that actually shift for an interior move', () => {
+    // Move D (index 3) up to index 2 → [A,B,D,C,E]. Only D and C shift.
+    const writes = computePlaylistReorderWrites(denseRows(), 'd', 2);
+    expect(writes).toEqual([
+      { id: 4, position: 2 },
+      { id: 3, position: 3 },
+    ]);
+  });
+
+  it('clamps an out-of-range index to the last position', () => {
+    // Move A (index 0) to 99 → clamp to 4 → [B,C,D,E,A]; every row shifts.
+    const writes = computePlaylistReorderWrites(denseRows(), 'a', 99);
+    expect(writes).toEqual([
+      { id: 2, position: 0 },
+      { id: 3, position: 1 },
+      { id: 4, position: 2 },
+      { id: 5, position: 3 },
+      { id: 1, position: 4 },
+    ]);
+  });
+
+  it('returns no writes for a no-op move', () => {
+    expect(computePlaylistReorderWrites(denseRows(), 'a', 0)).toEqual([]);
+  });
+
+  it('handles gappy positions (left by deletions) by renumbering to dense', () => {
+    // Positions 0,5,10 (gaps) — move the last (rank 2) to the front.
+    const gappy: ReorderRow<number>[] = [
+      { id: 1, climbUuid: 'a', position: 0 },
+      { id: 2, climbUuid: 'b', position: 5 },
+      { id: 3, climbUuid: 'c', position: 10 },
+    ];
+    const writes = computePlaylistReorderWrites(gappy, 'c', 0);
+    expect(writes).toEqual([
+      { id: 3, position: 0 },
+      { id: 1, position: 1 },
+      { id: 2, position: 2 },
+    ]);
+  });
+
+  it('throws when the climb is not in the playlist', () => {
+    expect(() => computePlaylistReorderWrites(denseRows(), 'missing', 0)).toThrow('Climb not found in playlist');
+  });
+});

--- a/packages/backend/src/__tests__/playlist-reorder.test.ts
+++ b/packages/backend/src/__tests__/playlist-reorder.test.ts
@@ -44,9 +44,10 @@ function createMockChain(resolveValue: unknown = []): Record<string, unknown> {
 type ClimbRow = { id: number; climbUuid: string; position: number };
 
 /**
- * Mock a transaction whose `tx.select(...).orderBy()` yields `rows` and whose
- * `tx.update(...).set(x)` records `x`. The resolver renumbers via the update
- * chain; capturing every `set` arg lets us assert the positions written.
+ * Mock a transaction whose `tx.select(...).for('update')` yields `rows` and
+ * whose `tx.update(...).set(x)` records `x`. The resolver does at most two
+ * updates: one batched `{ position: <CASE sql> }` for the shifted climbs, then
+ * the parent playlist's `{ updatedAt }`.
  */
 function primeTransaction(rows: ClimbRow[]) {
   const setCalls: Array<Record<string, unknown>> = [];
@@ -68,9 +69,9 @@ function primeTransaction(rows: ClimbRow[]) {
   return { setCalls };
 }
 
-/** Positions written to playlistClimbs rows, in write order. */
-function writtenPositions(setCalls: Array<Record<string, unknown>>): number[] {
-  return setCalls.filter((call) => 'position' in call).map((call) => call.position as number);
+/** How many of the captured updates rewrote climb positions (the batched CASE). */
+function positionUpdateCount(setCalls: Array<Record<string, unknown>>): number {
+  return setCalls.filter((call) => 'position' in call).length;
 }
 
 const ROWS: ClimbRow[] = [
@@ -82,11 +83,10 @@ const ROWS: ClimbRow[] = [
 describe('reorderPlaylistClimb mutation', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('moves a climb to a new index and renumbers positions densely', async () => {
+  it('renumbers via a single batched position update and bumps the playlist', async () => {
     mockDb.select.mockReturnValueOnce(createMockChain([{ id: 1 }])); // ownership
     const { setCalls } = primeTransaction(ROWS.map((row) => ({ ...row })));
 
-    // Move climb-c (currently last) to the front → [C, A, B].
     const result = await playlistMutations.reorderPlaylistClimb(
       null,
       { input: { playlistId: 'p-uuid', climbUuid: 'climb-c', newIndex: 0 } },
@@ -94,51 +94,13 @@ describe('reorderPlaylistClimb mutation', () => {
     );
 
     expect(result).toBe(true);
-    // Every row shifts, so all three are rewritten to dense 0,1,2.
-    expect(writtenPositions(setCalls)).toEqual([0, 1, 2]);
+    // Exactly one position rewrite (the CASE statement), not a write per row.
+    expect(positionUpdateCount(setCalls)).toBe(1);
     // The parent playlist's updatedAt is bumped as the final set.
     expect('updatedAt' in setCalls[setCalls.length - 1]).toBe(true);
   });
 
-  it('clamps an out-of-range index to the last position', async () => {
-    mockDb.select.mockReturnValueOnce(createMockChain([{ id: 1 }]));
-    const { setCalls } = primeTransaction(ROWS.map((row) => ({ ...row })));
-
-    // newIndex past the end → clamp to 2. Move climb-a to the end → [B, C, A].
-    const result = await playlistMutations.reorderPlaylistClimb(
-      null,
-      { input: { playlistId: 'p-uuid', climbUuid: 'climb-a', newIndex: 99 } },
-      makeCtx(),
-    );
-
-    expect(result).toBe(true);
-    expect(writtenPositions(setCalls)).toEqual([0, 1, 2]);
-  });
-
-  it('writes only the rows that actually shift for an interior move', async () => {
-    mockDb.select.mockReturnValueOnce(createMockChain([{ id: 1 }]));
-    const fiveRows: ClimbRow[] = [
-      { id: 1, climbUuid: 'climb-a', position: 0 },
-      { id: 2, climbUuid: 'climb-b', position: 1 },
-      { id: 3, climbUuid: 'climb-c', position: 2 },
-      { id: 4, climbUuid: 'climb-d', position: 3 },
-      { id: 5, climbUuid: 'climb-e', position: 4 },
-    ];
-    const { setCalls } = primeTransaction(fiveRows);
-
-    // Move climb-d (index 3) up to index 2 → [A, B, D, C, E]. Only D and C shift;
-    // A, B, E keep their positions and must not be rewritten.
-    const result = await playlistMutations.reorderPlaylistClimb(
-      null,
-      { input: { playlistId: 'p-uuid', climbUuid: 'climb-d', newIndex: 2 } },
-      makeCtx(),
-    );
-
-    expect(result).toBe(true);
-    expect(writtenPositions(setCalls)).toEqual([2, 3]);
-  });
-
-  it('writes no position changes for a no-op move but still succeeds', async () => {
+  it('skips the position update for a no-op move but still bumps the playlist', async () => {
     mockDb.select.mockReturnValueOnce(createMockChain([{ id: 1 }]));
     const { setCalls } = primeTransaction(ROWS.map((row) => ({ ...row })));
 
@@ -150,7 +112,7 @@ describe('reorderPlaylistClimb mutation', () => {
     );
 
     expect(result).toBe(true);
-    expect(writtenPositions(setCalls)).toEqual([]);
+    expect(positionUpdateCount(setCalls)).toBe(0);
     expect('updatedAt' in setCalls[setCalls.length - 1]).toBe(true);
   });
 

--- a/packages/backend/src/__tests__/playlist-reorder.test.ts
+++ b/packages/backend/src/__tests__/playlist-reorder.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+
+const { mockDb } = vi.hoisted(() => {
+  const mockDb = {
+    execute: vi.fn(),
+    select: vi.fn(),
+    insert: vi.fn(),
+    delete: vi.fn(),
+    update: vi.fn(),
+    transaction: vi.fn(),
+  };
+  return { mockDb };
+});
+
+vi.mock('../db/client', () => ({ db: mockDb }));
+vi.mock('../utils/rate-limiter', () => ({ checkRateLimit: vi.fn() }));
+vi.mock('../utils/redis-rate-limiter', () => ({ checkRateLimitRedis: vi.fn() }));
+
+import { playlistMutations } from '../graphql/resolvers/playlists/mutations';
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: true,
+    userId: 'user-123',
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+/** A thenable Drizzle-style chain resolving to `resolveValue` when awaited. */
+function createMockChain(resolveValue: unknown = []): Record<string, unknown> {
+  const chain: Record<string, unknown> = {};
+  const methods = ['select', 'from', 'where', 'innerJoin', 'limit', 'orderBy', 'for', 'set', 'update', 'returning'];
+  chain.then = (resolve: (value: unknown) => unknown) => Promise.resolve(resolveValue).then(resolve);
+  for (const method of methods) chain[method] = vi.fn((..._args: unknown[]) => chain);
+  return chain;
+}
+
+type ClimbRow = { id: number; climbUuid: string; position: number };
+
+/**
+ * Mock a transaction whose `tx.select(...).orderBy()` yields `rows` and whose
+ * `tx.update(...).set(x)` records `x`. The resolver renumbers via the update
+ * chain; capturing every `set` arg lets us assert the positions written.
+ */
+function primeTransaction(rows: ClimbRow[]) {
+  const setCalls: Array<Record<string, unknown>> = [];
+  const selectChain = createMockChain(rows);
+  const tx = {
+    select: vi.fn(() => selectChain),
+    update: vi.fn(() => {
+      const chain: Record<string, unknown> = {};
+      chain.set = vi.fn((arg: Record<string, unknown>) => {
+        setCalls.push(arg);
+        return chain;
+      });
+      chain.where = vi.fn(() => chain);
+      chain.then = (resolve: (value: unknown) => unknown) => Promise.resolve([]).then(resolve);
+      return chain;
+    }),
+  };
+  mockDb.transaction.mockImplementationOnce(async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx));
+  return { setCalls };
+}
+
+/** Positions written to playlistClimbs rows, in write order. */
+function writtenPositions(setCalls: Array<Record<string, unknown>>): number[] {
+  return setCalls.filter((call) => 'position' in call).map((call) => call.position as number);
+}
+
+const ROWS: ClimbRow[] = [
+  { id: 1, climbUuid: 'climb-a', position: 0 },
+  { id: 2, climbUuid: 'climb-b', position: 1 },
+  { id: 3, climbUuid: 'climb-c', position: 2 },
+];
+
+describe('reorderPlaylistClimb mutation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('moves a climb to a new index and renumbers positions densely', async () => {
+    mockDb.select.mockReturnValueOnce(createMockChain([{ id: 1 }])); // ownership
+    const { setCalls } = primeTransaction(ROWS.map((row) => ({ ...row })));
+
+    // Move climb-c (currently last) to the front → [C, A, B].
+    const result = await playlistMutations.reorderPlaylistClimb(
+      null,
+      { input: { playlistId: 'p-uuid', climbUuid: 'climb-c', newIndex: 0 } },
+      makeCtx(),
+    );
+
+    expect(result).toBe(true);
+    // Every row shifts, so all three are rewritten to dense 0,1,2.
+    expect(writtenPositions(setCalls)).toEqual([0, 1, 2]);
+    // The parent playlist's updatedAt is bumped as the final set.
+    expect('updatedAt' in setCalls[setCalls.length - 1]).toBe(true);
+  });
+
+  it('clamps an out-of-range index to the last position', async () => {
+    mockDb.select.mockReturnValueOnce(createMockChain([{ id: 1 }]));
+    const { setCalls } = primeTransaction(ROWS.map((row) => ({ ...row })));
+
+    // newIndex past the end → clamp to 2. Move climb-a to the end → [B, C, A].
+    const result = await playlistMutations.reorderPlaylistClimb(
+      null,
+      { input: { playlistId: 'p-uuid', climbUuid: 'climb-a', newIndex: 99 } },
+      makeCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(writtenPositions(setCalls)).toEqual([0, 1, 2]);
+  });
+
+  it('writes only the rows that actually shift for an interior move', async () => {
+    mockDb.select.mockReturnValueOnce(createMockChain([{ id: 1 }]));
+    const fiveRows: ClimbRow[] = [
+      { id: 1, climbUuid: 'climb-a', position: 0 },
+      { id: 2, climbUuid: 'climb-b', position: 1 },
+      { id: 3, climbUuid: 'climb-c', position: 2 },
+      { id: 4, climbUuid: 'climb-d', position: 3 },
+      { id: 5, climbUuid: 'climb-e', position: 4 },
+    ];
+    const { setCalls } = primeTransaction(fiveRows);
+
+    // Move climb-d (index 3) up to index 2 → [A, B, D, C, E]. Only D and C shift;
+    // A, B, E keep their positions and must not be rewritten.
+    const result = await playlistMutations.reorderPlaylistClimb(
+      null,
+      { input: { playlistId: 'p-uuid', climbUuid: 'climb-d', newIndex: 2 } },
+      makeCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(writtenPositions(setCalls)).toEqual([2, 3]);
+  });
+
+  it('writes no position changes for a no-op move but still succeeds', async () => {
+    mockDb.select.mockReturnValueOnce(createMockChain([{ id: 1 }]));
+    const { setCalls } = primeTransaction(ROWS.map((row) => ({ ...row })));
+
+    // climb-a is already at index 0.
+    const result = await playlistMutations.reorderPlaylistClimb(
+      null,
+      { input: { playlistId: 'p-uuid', climbUuid: 'climb-a', newIndex: 0 } },
+      makeCtx(),
+    );
+
+    expect(result).toBe(true);
+    expect(writtenPositions(setCalls)).toEqual([]);
+    expect('updatedAt' in setCalls[setCalls.length - 1]).toBe(true);
+  });
+
+  it('throws when the climb is not in the playlist', async () => {
+    mockDb.select.mockReturnValueOnce(createMockChain([{ id: 1 }]));
+    primeTransaction(ROWS.map((row) => ({ ...row })));
+
+    await expect(
+      playlistMutations.reorderPlaylistClimb(
+        null,
+        { input: { playlistId: 'p-uuid', climbUuid: 'climb-missing', newIndex: 0 } },
+        makeCtx(),
+      ),
+    ).rejects.toThrow('Climb not found in playlist');
+  });
+
+  it('rejects a non-owner before touching the transaction', async () => {
+    mockDb.select.mockReturnValueOnce(createMockChain([])); // no ownership row
+
+    await expect(
+      playlistMutations.reorderPlaylistClimb(
+        null,
+        { input: { playlistId: 'p-uuid', climbUuid: 'climb-a', newIndex: 0 } },
+        makeCtx(),
+      ),
+    ).rejects.toThrow('you do not have permission');
+
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it('requires authentication', async () => {
+    await expect(
+      playlistMutations.reorderPlaylistClimb(
+        null,
+        { input: { playlistId: 'p-uuid', climbUuid: 'climb-a', newIndex: 0 } },
+        makeCtx({ isAuthenticated: false, userId: undefined }),
+      ),
+    ).rejects.toThrow();
+
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/graphql/resolvers/playlists/helpers/reorder.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/helpers/reorder.ts
@@ -1,0 +1,49 @@
+/** A playlist climb row as far as reordering cares: its id and current position. */
+export type ReorderRow<Id> = {
+  id: Id;
+  climbUuid: string;
+  position: number;
+};
+
+/** The minimal set of rows to rewrite, with their new dense positions. */
+export type ReorderWrite<Id> = {
+  id: Id;
+  position: number;
+};
+
+/**
+ * Compute the position writes for moving `climbUuid` to `newIndex` within an
+ * already-ordered list (`rows` must be sorted by current position).
+ *
+ * The result renumbers the list to a dense `0..n-1` but returns ONLY the rows
+ * whose position actually changes — so the caller can persist them in a single
+ * batched statement. Deriving the move from ranks (not raw position values)
+ * makes it robust to the position gaps that deletions leave behind.
+ *
+ * Throws if `climbUuid` isn't in the list.
+ */
+export function computePlaylistReorderWrites<Id>(
+  rows: ReadonlyArray<ReorderRow<Id>>,
+  climbUuid: string,
+  newIndex: number,
+): ReorderWrite<Id>[] {
+  const oldIndex = rows.findIndex((row) => row.climbUuid === climbUuid);
+  if (oldIndex === -1) {
+    throw new Error('Climb not found in playlist');
+  }
+
+  // Clamp the target into range; a no-op move yields an empty write set.
+  const targetIndex = Math.min(Math.max(newIndex, 0), rows.length - 1);
+
+  const reordered = [...rows];
+  const [moved] = reordered.splice(oldIndex, 1);
+  reordered.splice(targetIndex, 0, moved);
+
+  const writes: ReorderWrite<Id>[] = [];
+  for (let index = 0; index < reordered.length; index++) {
+    if (reordered[index].position !== index) {
+      writes.push({ id: reordered[index].id, position: index });
+    }
+  }
+  return writes;
+}

--- a/packages/backend/src/graphql/resolvers/playlists/helpers/reorder.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/helpers/reorder.ts
@@ -32,8 +32,13 @@ export function computePlaylistReorderWrites<Id>(
     throw new Error('Climb not found in playlist');
   }
 
-  // Clamp the target into range; a no-op move yields an empty write set.
+  // Clamp the target into range; a true no-op move yields an empty write set —
+  // short-circuit so a misbehaving client sending the current index can't make
+  // us renumber (and rewrite) a gappy list for no reason.
   const targetIndex = Math.min(Math.max(newIndex, 0), rows.length - 1);
+  if (targetIndex === oldIndex) {
+    return [];
+  }
 
   const reordered = [...rows];
   const [moved] = reordered.splice(oldIndex, 1);

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -1,4 +1,4 @@
-import { eq, and, asc, sql } from 'drizzle-orm';
+import { eq, and, asc, inArray, sql } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
@@ -15,6 +15,7 @@ import {
 } from '../../../validation/schemas';
 import { getPlaylistFollowStats } from './queries';
 import { verifyPlaylistAccess } from './helpers/enrichment';
+import { computePlaylistReorderWrites } from './helpers/reorder';
 
 export const playlistMutations = {
   /**
@@ -381,27 +382,29 @@ export const playlistMutations = {
         .orderBy(asc(dbSchema.playlistClimbs.position), asc(dbSchema.playlistClimbs.addedAt))
         .for('update');
 
-      const oldIndex = rows.findIndex((row) => row.climbUuid === validatedInput.climbUuid);
-      if (oldIndex === -1) {
-        throw new Error('Climb not found in playlist');
-      }
+      // Throws if the climb isn't in the playlist; returns only the rows whose
+      // position actually shifts (dense 0..n-1 renumber).
+      const writes = computePlaylistReorderWrites(rows, validatedInput.climbUuid, validatedInput.newIndex);
 
-      // Clamp the target into range; a no-op move still falls through to the
-      // updatedAt bump below (cheap, and keeps the mutation idempotent-friendly).
-      const targetIndex = Math.min(Math.max(validatedInput.newIndex, 0), rows.length - 1);
-      const [moved] = rows.splice(oldIndex, 1);
-      rows.splice(targetIndex, 0, moved);
-
-      // Renumber to a dense 0..n-1, writing only the rows that actually shifted.
-      // The position column has no unique constraint, so transient equal
-      // positions mid-loop are fine.
-      for (let index = 0; index < rows.length; index++) {
-        if (rows[index].position !== index) {
-          await tx
-            .update(dbSchema.playlistClimbs)
-            .set({ position: index })
-            .where(eq(dbSchema.playlistClimbs.id, rows[index].id));
-        }
+      // Persist every shifted row in ONE statement — a `CASE id WHEN … THEN …`
+      // update — rather than a write per row. A move to the front of a 100-climb
+      // playlist is then a single round-trip, not ~99. The position column has no
+      // unique constraint, so the intermediate state never collides.
+      if (writes.length > 0) {
+        const idColumn = dbSchema.playlistClimbs.id;
+        const positionCase = sql`case ${idColumn} ${sql.join(
+          writes.map((write) => sql`when ${write.id} then ${write.position}`),
+          sql` `,
+        )} end`;
+        await tx
+          .update(dbSchema.playlistClimbs)
+          .set({ position: positionCase })
+          .where(
+            inArray(
+              idColumn,
+              writes.map((write) => write.id),
+            ),
+          );
       }
 
       await tx.update(dbSchema.playlists).set({ updatedAt: new Date() }).where(eq(dbSchema.playlists.id, playlistId));

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql } from 'drizzle-orm';
+import { eq, and, asc, sql } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
@@ -9,6 +9,7 @@ import {
   UpdatePlaylistInputSchema,
   AddClimbToPlaylistInputSchema,
   RemoveClimbFromPlaylistInputSchema,
+  ReorderPlaylistClimbInputSchema,
   FollowPlaylistInputSchema,
   PinPlaylistInputSchema,
 } from '../../../validation/schemas';
@@ -331,6 +332,80 @@ export const playlistMutations = {
 
     // Update playlist updatedAt
     await db.update(dbSchema.playlists).set({ updatedAt: new Date() }).where(eq(dbSchema.playlists.id, playlistId));
+
+    return true;
+  },
+
+  /**
+   * Reorder a climb within a playlist by moving it to a new 0-based index.
+   *
+   * Single-move semantics: the server derives the climb's current index from the
+   * DB (so position gaps left by prior deletions don't matter, and the client
+   * never has to send a stale oldIndex), splices it to the clamped target index,
+   * then renumbers positions to a dense 0..n-1. Only rows whose position actually
+   * changed are written.
+   */
+  reorderPlaylistClimb: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
+    requireAuthenticated(ctx);
+    const validatedInput = validateInput(ReorderPlaylistClimbInputSchema, input, 'input');
+
+    const userId = ctx.userId!;
+
+    // Check ownership/access (same userId-match gate as add/remove climb).
+    const ownership = await db
+      .select({ id: dbSchema.playlists.id })
+      .from(dbSchema.playlistOwnership)
+      .innerJoin(dbSchema.playlists, eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId))
+      .where(and(eq(dbSchema.playlists.uuid, validatedInput.playlistId), eq(dbSchema.playlistOwnership.userId, userId)))
+      .limit(1);
+
+    if (ownership.length === 0) {
+      throw new Error('Playlist not found or you do not have permission to edit it');
+    }
+
+    const playlistId = ownership[0].id;
+
+    await db.transaction(async (tx) => {
+      // Full ordered list — the same order clients see (position, then addedAt).
+      // `for('update')` locks these rows for the transaction so two overlapping
+      // reorders on the same playlist can't both read the same snapshot and have
+      // the second renumber clobber the first (silently losing a move).
+      const rows = await tx
+        .select({
+          id: dbSchema.playlistClimbs.id,
+          climbUuid: dbSchema.playlistClimbs.climbUuid,
+          position: dbSchema.playlistClimbs.position,
+        })
+        .from(dbSchema.playlistClimbs)
+        .where(eq(dbSchema.playlistClimbs.playlistId, playlistId))
+        .orderBy(asc(dbSchema.playlistClimbs.position), asc(dbSchema.playlistClimbs.addedAt))
+        .for('update');
+
+      const oldIndex = rows.findIndex((row) => row.climbUuid === validatedInput.climbUuid);
+      if (oldIndex === -1) {
+        throw new Error('Climb not found in playlist');
+      }
+
+      // Clamp the target into range; a no-op move still falls through to the
+      // updatedAt bump below (cheap, and keeps the mutation idempotent-friendly).
+      const targetIndex = Math.min(Math.max(validatedInput.newIndex, 0), rows.length - 1);
+      const [moved] = rows.splice(oldIndex, 1);
+      rows.splice(targetIndex, 0, moved);
+
+      // Renumber to a dense 0..n-1, writing only the rows that actually shifted.
+      // The position column has no unique constraint, so transient equal
+      // positions mid-loop are fine.
+      for (let index = 0; index < rows.length; index++) {
+        if (rows[index].position !== index) {
+          await tx
+            .update(dbSchema.playlistClimbs)
+            .set({ position: index })
+            .where(eq(dbSchema.playlistClimbs.id, rows[index].id));
+        }
+      }
+
+      await tx.update(dbSchema.playlists).set({ updatedAt: new Date() }).where(eq(dbSchema.playlists.id, playlistId));
+    });
 
     return true;
   },

--- a/packages/backend/src/validation/schemas/playlists.ts
+++ b/packages/backend/src/validation/schemas/playlists.ts
@@ -44,6 +44,12 @@ export const RemoveClimbFromPlaylistInputSchema = z.object({
   climbUuid: ExternalUUIDSchema,
 });
 
+export const ReorderPlaylistClimbInputSchema = z.object({
+  playlistId: z.string().min(1),
+  climbUuid: ExternalUUIDSchema,
+  newIndex: z.number().int().min(0),
+});
+
 export const GetUserPlaylistsInputSchema = z.object({
   boardType: BoardNameSchema,
   layoutId: z.number().int().positive(),

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -149,6 +149,11 @@ export default function PlaylistDetail() {
   const [editClimbs, setEditClimbs] = useState<Climb[]>([]);
   const editClimbsRef = useRef<Climb[]>([]);
   const pendingEditClimbsRef = useRef(false);
+  // Always-current view of the loaded climbs so enterEditMode — which runs
+  // asynchronously after the actions sheet finishes dismissing — seeds from the
+  // latest data, not the snapshot captured when the menu opened.
+  const allClimbsRef = useRef(allClimbs);
+  allClimbsRef.current = allClimbs;
 
   const setEditList = useCallback((list: Climb[]) => {
     editClimbsRef.current = list;
@@ -156,9 +161,9 @@ export default function PlaylistDetail() {
   }, []);
 
   const enterEditMode = useCallback(() => {
-    setEditList(allClimbs);
+    setEditList(allClimbsRef.current);
     setEditMode(true);
-  }, [allClimbs, setEditList]);
+  }, [setEditList]);
 
   const exitEditMode = useCallback(() => {
     setEditMode(false);
@@ -171,13 +176,16 @@ export default function PlaylistDetail() {
     async (climbUuid: string, newIndex: number) => {
       const current = editClimbsRef.current;
       const oldIndex = current.findIndex((climb) => climb.uuid === climbUuid);
-      if (oldIndex === -1 || oldIndex === newIndex) return;
+      if (oldIndex === -1) return;
+      // Clamp — the screen-reader actions can ask for an index past either edge.
+      const target = Math.max(0, Math.min(newIndex, current.length - 1));
+      if (oldIndex === target) return;
       const next = [...current];
       const [moved] = next.splice(oldIndex, 1);
-      next.splice(newIndex, 0, moved);
+      next.splice(target, 0, moved);
       setEditList(next);
       try {
-        await reorderPlaylistClimb({ playlistId: playlistUuid, climbUuid, newIndex });
+        await reorderPlaylistClimb({ playlistId: playlistUuid, climbUuid, newIndex: target });
       } catch (err) {
         console.error('Failed to reorder playlist climb:', err);
         // Only wholesale-restore the pre-move snapshot if no other edit landed in

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -3,7 +3,8 @@ import { View, StyleSheet, Alert, Pressable } from 'react-native';
 import { useLocalSearchParams, useNavigation } from 'expo-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { usePlaylistClimbs, usePlaylistMutations } from '@boardsesh/playlists-react';
+import { usePlaylistClimbs, usePlaylistMutations, usePlaylistItemMutations } from '@boardsesh/playlists-react';
+import type { Climb } from '@boardsesh/queue';
 import {
   GET_PLAYLIST,
   GET_PLAYLIST_CLIMBS,
@@ -22,6 +23,8 @@ import {
   PlaylistFormSheet,
   PlaylistActionsMenu,
   PlaylistFollowButton,
+  PlaylistEditDoneButton,
+  PlaylistOwnerToolbar,
   PlaylistBackFab,
   type PlaylistFormValues,
 } from '../../../src/components/playlist';
@@ -51,6 +54,7 @@ export default function PlaylistDetail() {
   const { systemColors, brandColors } = useTheme();
   const { updatePlaylist, deletePlaylist, pinPlaylist, unpinPlaylist, followPlaylist, unfollowPlaylist } =
     usePlaylistMutations();
+  const { reorderPlaylistClimb, removeClimbFromPlaylist } = usePlaylistItemMutations();
 
   // Playlist metadata for the hero (name, climb count, colour, icon, ownership,
   // pin/follow state).
@@ -135,6 +139,104 @@ export default function PlaylistDetail() {
   const [editVisible, setEditVisible] = useState(false);
   const [actionsVisible, setActionsVisible] = useState(false);
   const [savingEdit, setSavingEdit] = useState(false);
+
+  // Climbs edit mode (reorder + remove). `editClimbs` is a frozen snapshot of the
+  // loaded list seeded on entry; the list renders from it while editing so
+  // moves/removals show instantly. A ref mirrors it for the async handlers' reads
+  // and revert snapshots. Pagination is paused while editing (v1 edits the loaded
+  // window); on exit we invalidate so the canonical server order reloads.
+  const [editMode, setEditMode] = useState(false);
+  const [editClimbs, setEditClimbs] = useState<Climb[]>([]);
+  const editClimbsRef = useRef<Climb[]>([]);
+  const pendingEditClimbsRef = useRef(false);
+
+  const setEditList = useCallback((list: Climb[]) => {
+    editClimbsRef.current = list;
+    setEditClimbs(list);
+  }, []);
+
+  const enterEditMode = useCallback(() => {
+    setEditList(allClimbs);
+    setEditMode(true);
+  }, [allClimbs, setEditList]);
+
+  const exitEditMode = useCallback(() => {
+    setEditMode(false);
+    setEditList([]);
+    void queryClient.invalidateQueries({ queryKey: ['playlistClimbs', playlistUuid] });
+    void queryClient.invalidateQueries({ queryKey: ['playlist', playlistUuid] });
+  }, [setEditList, queryClient, playlistUuid]);
+
+  const handleReorderClimb = useCallback(
+    async (climbUuid: string, newIndex: number) => {
+      const current = editClimbsRef.current;
+      const oldIndex = current.findIndex((climb) => climb.uuid === climbUuid);
+      if (oldIndex === -1 || oldIndex === newIndex) return;
+      const next = [...current];
+      const [moved] = next.splice(oldIndex, 1);
+      next.splice(newIndex, 0, moved);
+      setEditList(next);
+      try {
+        await reorderPlaylistClimb({ playlistId: playlistUuid, climbUuid, newIndex });
+      } catch (err) {
+        console.error('Failed to reorder playlist climb:', err);
+        // Only wholesale-restore the pre-move snapshot if no other edit landed in
+        // the meantime; otherwise a concurrent op's optimistic state would be
+        // clobbered, so reconcile from the server instead.
+        if (editClimbsRef.current === next) {
+          setEditList(current);
+        } else {
+          void queryClient.invalidateQueries({ queryKey: ['playlistClimbs', playlistUuid] });
+        }
+        showToast(t('editClimbs.reorderFailed'), 'error');
+      }
+    },
+    [reorderPlaylistClimb, playlistUuid, setEditList, queryClient, showToast, t],
+  );
+
+  const handleRemoveClimb = useCallback(
+    (climbUuid: string) => {
+      const target = editClimbsRef.current.find((climb) => climb.uuid === climbUuid);
+      Alert.alert(
+        t('editClimbs.removeConfirm.title'),
+        t('editClimbs.removeConfirm.message', { name: target?.name ?? '' }),
+        [
+          { text: t('editClimbs.removeConfirm.cancel'), style: 'cancel' },
+          {
+            text: t('editClimbs.removeConfirm.confirm'),
+            style: 'destructive',
+            onPress: async () => {
+              const current = editClimbsRef.current;
+              const next = current.filter((climb) => climb.uuid !== climbUuid);
+              if (next.length === current.length) return;
+              setEditList(next);
+              // Optimistically decrement the hero climb count.
+              queryClient.setQueryData<Playlist | null>(['playlist', playlistUuid], (prev) =>
+                prev ? { ...prev, climbCount: Math.max(0, prev.climbCount - 1) } : prev,
+              );
+              try {
+                await removeClimbFromPlaylist({ playlistId: playlistUuid, climbUuid });
+              } catch (err) {
+                console.error('Failed to remove playlist climb:', err);
+                // Restore only if no concurrent edit landed since; otherwise
+                // reconcile from the server so we don't clobber it.
+                if (editClimbsRef.current === next) {
+                  setEditList(current);
+                } else {
+                  void queryClient.invalidateQueries({ queryKey: ['playlistClimbs', playlistUuid] });
+                }
+                queryClient.setQueryData<Playlist | null>(['playlist', playlistUuid], (prev) =>
+                  prev ? { ...prev, climbCount: prev.climbCount + 1 } : prev,
+                );
+                showToast(t('editClimbs.removeFailed'), 'error');
+              }
+            },
+          },
+        ],
+      );
+    },
+    [removeClimbFromPlaylist, playlistUuid, setEditList, queryClient, showToast, t],
+  );
 
   // Re-seed interactive state whenever the cached playlist changes — including
   // after a mutation writes its response back via setQueryData. Safe because the
@@ -265,12 +367,20 @@ export default function PlaylistDetail() {
     ]);
   }, [playlist, deletePlaylist, queryClient, playlistUuid, showToast, t, navigation]);
 
-  // Hand the menu → edit sheet off sequentially: close the menu first, then
-  // open the edit sheet from the menu's onClose. Opening both in one tick would
-  // animate two gorhom sheets (and their backdrops) at once.
-  const pendingEditRef = useRef(false);
-  const openEdit = useCallback(() => {
-    pendingEditRef.current = true;
+  // Cog (shown in edit mode) → open the edit-details sheet directly. No menu is
+  // involved, so no sheet-handoff dance is needed.
+  const openEditDetails = useCallback(() => setEditVisible(true), []);
+
+  // Collapsed overflow menu (owner): Pin toggles in place; Delete confirms; Edit
+  // enters the climbs edit mode once the menu sheet has dismissed (deferred via
+  // the pending ref so the sheet's exit animation doesn't fight the top-bar swap).
+  const menuTogglePin = useCallback(() => {
+    setActionsVisible(false);
+    handleTogglePin();
+  }, [handleTogglePin]);
+
+  const menuEnterEdit = useCallback(() => {
+    pendingEditClimbsRef.current = true;
     setActionsVisible(false);
   }, []);
 
@@ -281,18 +391,44 @@ export default function PlaylistDetail() {
 
   const handleActionsClose = useCallback(() => {
     setActionsVisible(false);
-    if (pendingEditRef.current) {
-      pendingEditRef.current = false;
-      setEditVisible(true);
+    if (pendingEditClimbsRef.current) {
+      pendingEditClimbsRef.current = false;
+      enterEditMode();
     }
-  }, []);
+  }, [enterEditMode]);
 
-  // Floating action FABs over the hero (the native header bar is gone): follow
-  // (public non-owner) + pin (auth) + owner more-menu. Rendered with the current
-  // collapse state so the follow control swaps to an icon FAB in header mode.
+  // Floating controls over the hero. Owners get a pin · edit · delete glass
+  // toolbar that collapses to a single overflow ⋯ on scroll (and always on
+  // Material, which asks for the collapsed form). Non-owners keep follow + pin.
+  // Edit mode replaces everything with Done.
   const renderActions = useCallback(
-    (collapsed: boolean) =>
-      playlist ? (
+    (collapsed: boolean) => {
+      if (!playlist) return null;
+      if (editMode) {
+        return <PlaylistEditDoneButton onPress={exitEditMode} collapsed={collapsed} />;
+      }
+      if (isOwner) {
+        if (collapsed) {
+          return (
+            <GlassIconButton
+              iconName="more"
+              iconColor={systemColors.label}
+              onPress={() => setActionsVisible(true)}
+              accessibilityLabel={t('detail.actions')}
+              fallbackColor={systemColors.fill}
+            />
+          );
+        }
+        return (
+          <PlaylistOwnerToolbar
+            isPinned={isPinned}
+            onTogglePin={handleTogglePin}
+            onEdit={enterEditMode}
+            onDelete={handleDelete}
+          />
+        );
+      }
+      return (
         <>
           {isAuthenticated && isFollowable ? (
             <PlaylistFollowButton
@@ -314,27 +450,23 @@ export default function PlaylistDetail() {
               fallbackColor={systemColors.fill}
             />
           ) : null}
-          {isOwner ? (
-            <GlassIconButton
-              iconName="more"
-              iconColor={systemColors.label}
-              onPress={() => setActionsVisible(true)}
-              accessibilityLabel={t('detail.actions')}
-              fallbackColor={systemColors.fill}
-            />
-          ) : null}
         </>
-      ) : null,
+      );
+    },
     [
       playlist,
+      editMode,
+      exitEditMode,
+      isOwner,
+      isPinned,
+      handleTogglePin,
+      enterEditMode,
+      handleDelete,
       isAuthenticated,
       isFollowable,
       isFollowing,
       handleToggleFollow,
       followLoading,
-      isPinned,
-      handleTogglePin,
-      isOwner,
       systemColors,
       brandColors,
       t,
@@ -422,21 +554,28 @@ export default function PlaylistDetail() {
     <>
       <PlaylistDetailView
         hero={hero}
-        climbs={allClimbs}
+        climbs={editMode ? editClimbs : allClimbs}
         renderBoard={renderBoard}
         boardBanner={boardBanner}
         isLoading={query.isLoading}
-        isFetchingNextPage={query.isFetchingNextPage}
-        hasNextPage={query.hasNextPage ?? false}
+        // Pagination is paused while editing the loaded window.
+        isFetchingNextPage={editMode ? false : query.isFetchingNextPage}
+        hasNextPage={editMode ? false : (query.hasNextPage ?? false)}
         fetchNextPage={query.fetchNextPage}
         onActivateClimb={activate}
         emptyMessage={t('detail.empty')}
         actions={renderActions}
+        editMode={editMode}
+        onReorderClimb={handleReorderClimb}
+        onRemoveClimb={handleRemoveClimb}
+        onEditDetails={openEditDetails}
       />
 
       <PlaylistActionsMenu
         visible={actionsVisible}
-        onEdit={openEdit}
+        isPinned={isPinned}
+        onTogglePin={menuTogglePin}
+        onEdit={menuEnterEdit}
         onDelete={openDelete}
         onClose={handleActionsClose}
       />

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -225,9 +225,10 @@ export default function PlaylistDetail() {
                 } else {
                   void queryClient.invalidateQueries({ queryKey: ['playlistClimbs', playlistUuid] });
                 }
-                queryClient.setQueryData<Playlist | null>(['playlist', playlistUuid], (prev) =>
-                  prev ? { ...prev, climbCount: prev.climbCount + 1 } : prev,
-                );
+                // Reconcile the climb count from the server rather than adding 1
+                // back — a manual +1 would overshoot if a concurrent add already
+                // bumped the count.
+                void queryClient.invalidateQueries({ queryKey: ['playlist', playlistUuid] });
                 showToast(t('editClimbs.removeFailed'), 'error');
               }
             },

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -33,6 +33,10 @@ vi.mock('@boardsesh/playlists-react', () => ({
     followPlaylist: vi.fn(),
     unfollowPlaylist: vi.fn(),
   }),
+  usePlaylistItemMutations: () => ({
+    reorderPlaylistClimb: vi.fn(),
+    removeClimbFromPlaylist: vi.fn(),
+  }),
 }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
@@ -94,6 +98,8 @@ vi.mock('../../../../src/components/playlist', () => ({
   PlaylistFormSheet: () => null,
   PlaylistActionsMenu: () => null,
   PlaylistFollowButton: () => null,
+  PlaylistEditDoneButton: () => null,
+  PlaylistOwnerToolbar: () => null,
   PlaylistBackFab: () => createElement('div', { 'data-back-fab': 'true' }),
 }));
 

--- a/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
@@ -25,7 +25,14 @@ type PlaylistActionsMenuProps = {
  * wires Pin → toggle pin, Edit → enter the climbs reorder/remove mode, and
  * Delete → the confirm Alert.
  */
-export function PlaylistActionsMenu({ visible, isPinned, onTogglePin, onEdit, onDelete, onClose }: PlaylistActionsMenuProps) {
+export function PlaylistActionsMenu({
+  visible,
+  isPinned,
+  onTogglePin,
+  onEdit,
+  onDelete,
+  onClose,
+}: PlaylistActionsMenuProps) {
   const { t } = useTranslation('playlists');
   const { systemColors, brandColors } = useTheme();
   const sheetRef = useRef<BottomSheetModal>(null);
@@ -57,7 +64,11 @@ export function PlaylistActionsMenu({ visible, isPinned, onTogglePin, onEdit, on
         <ListRow
           title={isPinned ? t('library.pin.unpin') : t('library.pin.pin')}
           leading={
-            <Icon name={isPinned ? 'pin.fill' : 'pin'} size={22} color={isPinned ? brandColors.primary : systemColors.accent} />
+            <Icon
+              name={isPinned ? 'pin.fill' : 'pin'}
+              size={22}
+              color={isPinned ? brandColors.primary : systemColors.accent}
+            />
           }
           onPress={onTogglePin}
           showSeparator

--- a/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
@@ -11,25 +11,30 @@ import { spacing } from '../../theme/tokens';
 
 type PlaylistActionsMenuProps = {
   visible: boolean;
+  isPinned: boolean;
+  onTogglePin: () => void;
+  /** Enter the climbs edit mode (reorder + remove). */
   onEdit: () => void;
   onDelete: () => void;
   onClose: () => void;
 };
 
 /**
- * Owner-only action sheet for the playlist detail (Edit / Delete). The parent
- * wires Edit → open the form sheet and Delete → the confirm Alert.
+ * Owner overflow sheet — the collapsed form of the hero's pin · edit · delete
+ * toolbar, shown once the hero scrolls away (and always on Material). The parent
+ * wires Pin → toggle pin, Edit → enter the climbs reorder/remove mode, and
+ * Delete → the confirm Alert.
  */
-export function PlaylistActionsMenu({ visible, onEdit, onDelete, onClose }: PlaylistActionsMenuProps) {
+export function PlaylistActionsMenu({ visible, isPinned, onTogglePin, onEdit, onDelete, onClose }: PlaylistActionsMenuProps) {
   const { t } = useTranslation('playlists');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const sheetRef = useRef<BottomSheetModal>(null);
   // Track presented state so we never call dismiss() on a not-presented modal
   // (which leaves gorhom in a state where the next present() is a no-op — the
   // "nothing happens" bug). Mirrors LogAscentSheet.
   const isPresentedRef = useRef(false);
-  // 30% leaves room for the two rows on short screens (e.g. iPhone SE landscape).
-  const snapPoints = useMemo(() => ['30%'], []);
+  // 36% leaves room for the three rows on short screens (e.g. iPhone SE landscape).
+  const snapPoints = useMemo(() => ['36%'], []);
 
   useEffect(() => {
     if (visible && !isPresentedRef.current) {
@@ -50,7 +55,15 @@ export function PlaylistActionsMenu({ visible, onEdit, onDelete, onClose }: Play
     <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss}>
       <View style={styles.content}>
         <ListRow
-          title={t('detail.menu.edit')}
+          title={isPinned ? t('library.pin.unpin') : t('library.pin.pin')}
+          leading={
+            <Icon name={isPinned ? 'pin.fill' : 'pin'} size={22} color={isPinned ? brandColors.primary : systemColors.accent} />
+          }
+          onPress={onTogglePin}
+          showSeparator
+        />
+        <ListRow
+          title={t('detail.menu.editClimbs')}
           leading={<Icon name="edit" size={22} color={systemColors.accent} />}
           onPress={onEdit}
           showSeparator

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -284,6 +284,7 @@ export function PlaylistDetailView({
             rowIndex={index}
             drag={dragControls}
             onRemove={onRemoveClimb ?? noopRemove}
+            onReorder={onReorderClimb ?? noopReorder}
           />
         );
       }
@@ -301,7 +302,17 @@ export function PlaylistDetailView({
         />
       );
     },
-    [renderBoard, editMode, editBoard, dragControls, onRemoveClimb, readOnly, handleActivate, handleSwitchBoard],
+    [
+      renderBoard,
+      editMode,
+      editBoard,
+      dragControls,
+      onRemoveClimb,
+      onReorderClimb,
+      readOnly,
+      handleActivate,
+      handleSwitchBoard,
+    ],
   );
 
   // Cog shown beside the playlist name only in edit mode — opens the

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -517,7 +517,12 @@ export function PlaylistDetailView({
             <Icon name="tag" size={40} color={iosSystemColors.white} />
           )}
           <View style={styles.heroNameRow}>
-            <Text variant="title2" numberOfLines={2} color={iosSystemColors.white} style={[styles.heroName, styles.heroNameFlex]}>
+            <Text
+              variant="title2"
+              numberOfLines={2}
+              color={iosSystemColors.white}
+              style={[styles.heroName, styles.heroNameFlex]}
+            >
               {hero.name}
             </Text>
             {renderEditDetailsCog(iosSystemColors.white)}

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -1,9 +1,10 @@
-import { type ReactNode, useCallback, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 import {
   type ColorValue,
   type LayoutChangeEvent,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
+  Pressable,
   View,
   StyleSheet,
 } from 'react-native';
@@ -31,6 +32,8 @@ import { ClimbListRow } from '../ClimbListRow';
 import { ClimbListRowSkeleton } from '../ClimbListRowSkeleton';
 import { GlassIconButton } from '../GlassIconButton';
 import { Button } from '../Button';
+import { PlaylistEditClimbRow } from './PlaylistEditClimbRow';
+import { usePlaylistDrag } from './use-playlist-drag';
 import { PlaylistBoardBackdrop } from './PlaylistBoardBackdrop';
 import { buildHeroGradient, shiftLightness } from './playlist-gradient';
 import { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';
@@ -115,7 +118,19 @@ export type PlaylistDetailViewProps = {
    *  the colour header bar takes over. The back FAB on the left is always
    *  rendered; absent here = a back-only top bar. */
   actions?: (collapsed: boolean) => ReactNode;
+  /** Owner edit mode: rows swap to the reorder/remove treatment, tap-to-activate
+   *  is disabled, and pagination is paused (the host passes a frozen list). */
+  editMode?: boolean;
+  /** Move a climb to a new 0-based index in the (loaded) list. */
+  onReorderClimb?: (climbUuid: string, newIndex: number) => void;
+  /** Remove a climb from the playlist (the host confirms + mutates). */
+  onRemoveClimb?: (climbUuid: string) => void;
+  /** In edit mode, a cog next to the playlist name opens the edit-details sheet. */
+  onEditDetails?: () => void;
 };
+
+const noopReorder = (_climbUuid: string, _newIndex: number) => {};
+const noopRemove = (_climbUuid: string) => {};
 
 /**
  * Shared hero + paginated climb list for the playlist-detail and
@@ -147,6 +162,10 @@ export function PlaylistDetailView({
   emptyMessage,
   emptyState,
   actions,
+  editMode = false,
+  onReorderClimb,
+  onRemoveClimb,
+  onEditDetails,
 }: PlaylistDetailViewProps) {
   const { t } = useTranslation('playlists');
   const { t: tCommon } = useTranslation('common');
@@ -230,9 +249,44 @@ export function PlaylistDetailView({
     if (first) onActivateClimb(first);
   }, [readOnly, climbs, onActivateClimb]);
 
+  // List-level drag-to-reorder for edit mode. Always instantiated (hooks can't be
+  // conditional); only the edit rows wire up its handles. `isDragging` locks the
+  // list scroll while a row is lifted so scroll never fights the drag.
+  const { isDragging, controls: dragControls } = usePlaylistDrag({
+    reorder: onReorderClimb ?? noopReorder,
+    itemCount: climbs.length,
+  });
+
+  // Stable board object for the memoized edit rows (a fresh inline object each
+  // render would defeat their memoization).
+  const editBoard = useMemo(
+    () =>
+      renderBoard
+        ? {
+            boardName: renderBoard.boardName as BoardName,
+            layoutId: renderBoard.layoutId,
+            sizeId: renderBoard.sizeId,
+            setIds: renderBoard.setIds,
+            angle: renderBoard.angle,
+          }
+        : null,
+    [renderBoard],
+  );
+
   const renderItem = useCallback(
-    ({ item }: { item: Climb }) => {
+    ({ item, index }: { item: Climb; index: number }) => {
       if (!renderBoard) return null;
+      if (editMode && editBoard) {
+        return (
+          <PlaylistEditClimbRow
+            climb={item}
+            board={editBoard}
+            rowIndex={index}
+            drag={dragControls}
+            onRemove={onRemoveClimb ?? noopRemove}
+          />
+        );
+      }
       return (
         <ClimbListRow
           climb={toSchemaClimb(item)}
@@ -247,8 +301,24 @@ export function PlaylistDetailView({
         />
       );
     },
-    [renderBoard, readOnly, handleActivate, handleSwitchBoard],
+    [renderBoard, editMode, editBoard, dragControls, onRemoveClimb, readOnly, handleActivate, handleSwitchBoard],
   );
+
+  // Cog shown beside the playlist name only in edit mode — opens the
+  // edit-details sheet (name / colour / icon / visibility). Tinted to match the
+  // hero text of the current variant (white on glass, label on Material).
+  const renderEditDetailsCog = (color: ColorValue) =>
+    editMode && onEditDetails ? (
+      <Pressable
+        onPress={onEditDetails}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel={t('editClimbs.editDetailsAria')}
+        style={styles.heroCog}
+      >
+        <Icon name="settings" size={22} color={color} />
+      </Pressable>
+    ) : null;
 
   const baseColor = hero.color && isValidHexColor(hero.color) ? hero.color : PLAYLIST_COLORS[0];
 
@@ -298,6 +368,8 @@ export function PlaylistDetailView({
           data={climbs}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
+          extraData={editMode}
+          scrollEnabled={!isDragging}
           onEndReached={handleEndReached}
           onEndReachedThreshold={0.5}
           onScroll={handleScroll}
@@ -321,9 +393,12 @@ export function PlaylistDetailView({
                       <Icon name="tag" size={36} color={systemColors.secondaryLabel} />
                     )}
                   </View>
-                  <Text variant="title2" numberOfLines={2} color={systemColors.label} style={styles.materialHeroName}>
-                    {hero.name}
-                  </Text>
+                  <View style={styles.materialHeroNameRow}>
+                    <Text variant="title2" numberOfLines={2} color={systemColors.label} style={styles.materialHeroName}>
+                      {hero.name}
+                    </Text>
+                    {renderEditDetailsCog(systemColors.label)}
+                  </View>
                   <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.materialHeroMeta}>
                     {t('detail.climbCount', { count: hero.climbCount })}
                   </Text>
@@ -375,7 +450,7 @@ export function PlaylistDetailView({
               so we ask for the compact icon form (`actions(true)`) — `GlassIconButton`
               routes to a Paper `IconButton` here, fitting the bar. */}
           {actions?.(true)}
-          {climbs.length > 0 && !boardBanner ? (
+          {climbs.length > 0 && !boardBanner && !editMode ? (
             <Appbar.Action
               icon="play"
               color={accent as string}
@@ -441,9 +516,12 @@ export function PlaylistDetailView({
           ) : (
             <Icon name="tag" size={40} color={iosSystemColors.white} />
           )}
-          <Text variant="title2" numberOfLines={2} color={iosSystemColors.white} style={styles.heroName}>
-            {hero.name}
-          </Text>
+          <View style={styles.heroNameRow}>
+            <Text variant="title2" numberOfLines={2} color={iosSystemColors.white} style={[styles.heroName, styles.heroNameFlex]}>
+              {hero.name}
+            </Text>
+            {renderEditDetailsCog(iosSystemColors.white)}
+          </View>
           <Text variant="subheadline" color={iosSystemColors.white} style={styles.heroBannerMeta}>
             {t('detail.climbCount', { count: hero.climbCount })}
           </Text>
@@ -481,6 +559,8 @@ export function PlaylistDetailView({
         data={climbs}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
+        extraData={editMode}
+        scrollEnabled={!isDragging}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         onScroll={handleScroll}
@@ -688,6 +768,21 @@ const styles = StyleSheet.create({
     textShadowOffset: { width: 0, height: 1 },
     textShadowRadius: 3,
   },
+  heroNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  heroNameFlex: {
+    flexShrink: 1,
+  },
+  heroCog: {
+    width: 32,
+    height: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
   heroBannerMeta: {
     marginTop: 2,
     opacity: 0.85,
@@ -744,8 +839,15 @@ const styles = StyleSheet.create({
     fontSize: 36,
     lineHeight: 44,
   },
+  materialHeroNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[2],
+  },
   materialHeroName: {
     textAlign: 'center',
+    flexShrink: 1,
   },
   materialHeroMeta: {
     marginTop: 2,

--- a/packages/mobile/src/components/playlist/PlaylistEditClimbRow.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistEditClimbRow.tsx
@@ -1,0 +1,157 @@
+import { memo, useCallback, useMemo } from 'react';
+import { Pressable, View, StyleSheet, type LayoutChangeEvent } from 'react-native';
+import Animated, { useAnimatedStyle, withSpring } from 'react-native-reanimated';
+import { GestureDetector } from 'react-native-gesture-handler';
+import { useTranslation } from 'react-i18next';
+import type { BoardName } from '@boardsesh/shared-schema';
+import type { Climb } from '@boardsesh/queue';
+import { Icon } from '../Icon';
+import { ClimbListItemContent } from '../ClimbListItemContent';
+import { THUMBNAIL_WIDTH } from '../ClimbListThumbnail';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing } from '../../theme/tokens';
+import { springs } from '../../theme/animations';
+import { useTheme } from '../../providers/theme-provider';
+import { hapticMedium } from '../../lib/haptics';
+import { rowReorderShift } from '../play-drawer/queue-drag-math';
+import type { PlaylistDragControls } from './use-playlist-drag';
+
+// Leading remove control + trailing drag handle slots. The separator starts
+// under the climb name (after the remove slot + thumbnail) so it lines up with
+// the name column, matching the queue row idiom.
+const CONTROL_SLOT_WIDTH = 36;
+const SEPARATOR_INSET = spacing[3] + CONTROL_SLOT_WIDTH + spacing[3] + THUMBNAIL_WIDTH + spacing[3];
+
+export type PlaylistEditRowBoard = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
+
+type PlaylistEditClimbRowProps = {
+  climb: Climb;
+  board: PlaylistEditRowBoard;
+  /** This row's index within the editable list (drag coordinate). */
+  rowIndex: number;
+  drag: PlaylistDragControls;
+  onRemove: (climbUuid: string) => void;
+};
+
+function PlaylistEditClimbRowComponent({ climb, board, rowIndex, drag, onRemove }: PlaylistEditClimbRowProps) {
+  const { systemColors } = useTheme();
+  const { t } = useTranslation('playlists');
+
+  const handleRemove = useCallback(() => {
+    hapticMedium();
+    onRemove(climb.uuid);
+  }, [climb.uuid, onRemove]);
+
+  // Long-press drag gesture for this row's handle. Memoized on the row's
+  // identity so it doesn't churn as the list re-renders.
+  const dragHandleGesture = useMemo(() => drag.makeHandleGesture(rowIndex, climb.uuid), [drag, rowIndex, climb.uuid]);
+
+  // Lift the dragged row and shift its siblings to open a gap — reads the
+  // list-level drag shared values on the UI thread (outside React's render).
+  const dragShared = drag.shared;
+  const dragAnimatedStyle = useAnimatedStyle(() => {
+    if (dragShared.activeUuid.value === null) {
+      return { transform: [{ translateY: 0 }], zIndex: 0, elevation: 0 };
+    }
+    if (dragShared.activeUuid.value === climb.uuid) {
+      return {
+        transform: [{ translateY: dragShared.dragTranslateY.value }, { scale: 1.02 }],
+        zIndex: 30,
+        elevation: 10,
+      };
+    }
+    const shift = rowReorderShift(
+      rowIndex,
+      dragShared.activeRowIndex.value,
+      dragShared.targetRowIndex.value,
+      dragShared.rowHeight.value,
+    );
+    return { transform: [{ translateY: withSpring(shift, springs.interactive) }], zIndex: 0, elevation: 0 };
+  });
+
+  const handleRowLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      drag.onRowHeight(event.nativeEvent.layout.height);
+    },
+    [drag],
+  );
+
+  return (
+    <Animated.View style={dragAnimatedStyle} onLayout={handleRowLayout}>
+      <View style={[styles.row, { backgroundColor: systemColors.secondaryBackground }]}>
+        {/* Leading: red remove control */}
+        <Pressable
+          onPress={handleRemove}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={t('editClimbs.removeAria', { name: climb.name })}
+          style={({ pressed }) => [styles.controlSlot, pressed && styles.pressed]}
+        >
+          <Icon name="minus.circle" size={24} color={iosSystemColors.systemRed} />
+        </Pressable>
+
+        {/* Center: shared climb visual (thumbnail + name/subtitle + grade). Ascent
+            status is dropped in edit mode to keep the row focused on curation. */}
+        <ClimbListItemContent
+          climb={climb}
+          boardName={board.boardName}
+          layoutId={board.layoutId}
+          sizeId={board.sizeId}
+          setIds={board.setIds}
+          angle={board.angle}
+          showAscentStatus={false}
+        />
+
+        {/* Trailing: drag handle */}
+        <GestureDetector gesture={dragHandleGesture}>
+          <View
+            style={styles.controlSlot}
+            accessibilityRole="adjustable"
+            accessibilityLabel={t('editClimbs.dragHandleAria', { name: climb.name })}
+          >
+            <Icon name="drag.handle" size={22} color={iosSystemColors.systemGray} />
+          </View>
+        </GestureDetector>
+      </View>
+
+      <View style={[styles.separator, { marginLeft: SEPARATOR_INSET, backgroundColor: systemColors.separator }]} />
+    </Animated.View>
+  );
+}
+
+/**
+ * A climb row in the playlist edit list: a red remove control on the leading
+ * edge and a drag handle on the trailing edge, around the shared climb visual.
+ * Memoized — the actively-dragged row reacts via the drag shared values on the UI
+ * thread, so a drag never re-renders the rest of the list.
+ */
+export const PlaylistEditClimbRow = memo(PlaylistEditClimbRowComponent);
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: spacing[3],
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[3],
+  },
+  controlSlot: {
+    width: CONTROL_SLOT_WIDTH,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  pressed: {
+    opacity: 0.6,
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+  },
+});

--- a/packages/mobile/src/components/playlist/PlaylistEditClimbRow.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistEditClimbRow.tsx
@@ -1,5 +1,12 @@
 import { memo, useCallback, useMemo } from 'react';
-import { Pressable, View, StyleSheet, type LayoutChangeEvent } from 'react-native';
+import {
+  Pressable,
+  View,
+  StyleSheet,
+  type AccessibilityActionEvent,
+  type AccessibilityActionInfo,
+  type LayoutChangeEvent,
+} from 'react-native';
 import Animated, { useAnimatedStyle, withSpring } from 'react-native-reanimated';
 import { GestureDetector } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +29,11 @@ import type { PlaylistDragControls } from './use-playlist-drag';
 const CONTROL_SLOT_WIDTH = 36;
 const SEPARATOR_INSET = spacing[3] + CONTROL_SLOT_WIDTH + spacing[3] + THUMBNAIL_WIDTH + spacing[3];
 
+// VoiceOver / TalkBack adjustable actions on the drag handle: swipe up/down (iOS)
+// or the increment/decrement gestures (Android) move the climb one slot, so
+// screen-reader users can reorder without performing the pan gesture.
+const REORDER_A11Y_ACTIONS: readonly AccessibilityActionInfo[] = [{ name: 'increment' }, { name: 'decrement' }];
+
 export type PlaylistEditRowBoard = {
   boardName: BoardName;
   layoutId: number;
@@ -37,9 +49,19 @@ type PlaylistEditClimbRowProps = {
   rowIndex: number;
   drag: PlaylistDragControls;
   onRemove: (climbUuid: string) => void;
+  /** Move this climb to a new index — used by the screen-reader adjustable
+   *  actions (the pan gesture commits through `drag`). */
+  onReorder: (climbUuid: string, newIndex: number) => void;
 };
 
-function PlaylistEditClimbRowComponent({ climb, board, rowIndex, drag, onRemove }: PlaylistEditClimbRowProps) {
+function PlaylistEditClimbRowComponent({
+  climb,
+  board,
+  rowIndex,
+  drag,
+  onRemove,
+  onReorder,
+}: PlaylistEditClimbRowProps) {
   const { systemColors } = useTheme();
   const { t } = useTranslation('playlists');
 
@@ -47,6 +69,17 @@ function PlaylistEditClimbRowComponent({ climb, board, rowIndex, drag, onRemove 
     hapticMedium();
     onRemove(climb.uuid);
   }, [climb.uuid, onRemove]);
+
+  // Screen-reader reorder: increment moves the climb one slot down the list,
+  // decrement one slot up. The host clamps to the list bounds and no-ops at the
+  // edges, so an out-of-range target here is harmless.
+  const handleAccessibilityAction = useCallback(
+    (event: AccessibilityActionEvent) => {
+      const delta = event.nativeEvent.actionName === 'increment' ? 1 : -1;
+      onReorder(climb.uuid, rowIndex + delta);
+    },
+    [onReorder, climb.uuid, rowIndex],
+  );
 
   // Long-press drag gesture for this row's handle. Memoized on the row's
   // identity so it doesn't churn as the list re-renders.
@@ -114,6 +147,8 @@ function PlaylistEditClimbRowComponent({ climb, board, rowIndex, drag, onRemove 
             style={styles.controlSlot}
             accessibilityRole="adjustable"
             accessibilityLabel={t('editClimbs.dragHandleAria', { name: climb.name })}
+            accessibilityActions={REORDER_A11Y_ACTIONS}
+            onAccessibilityAction={handleAccessibilityAction}
           >
             <Icon name="drag.handle" size={22} color={iosSystemColors.systemGray} />
           </View>

--- a/packages/mobile/src/components/playlist/PlaylistEditDoneButton.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistEditDoneButton.tsx
@@ -1,0 +1,97 @@
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { GlassSurface } from '../GlassSurface';
+import { GlassIconButton } from '../GlassIconButton';
+import { PressableSurface } from '../PressableSurface';
+import { Icon } from '../Icon';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { useNativeGlass } from '../../hooks/use-native-glass';
+import { shadows } from '../../theme/tokens';
+import { glassSize } from '../../theme/layout';
+
+const PILL_HEIGHT = glassSize.standard;
+const PILL_RADIUS = PILL_HEIGHT / 2;
+
+type PlaylistEditDoneButtonProps = {
+  onPress: () => void;
+  /** In the collapsed colour-header mode (and on Material's app bar) render as an
+   *  icon-only glass FAB to match the other action FABs; expanded, a glass pill
+   *  with the "Done" label. */
+  collapsed?: boolean;
+};
+
+/**
+ * Exit-edit-mode control for the owned playlist detail. A Liquid Glass pill —
+ * `✓ Done` — that collapses to an icon-only glass FAB once the gradient hero
+ * scrolls into the colour header bar (and on the Material app bar). Mirrors
+ * `PlaylistFollowButton` so the two share the same chrome.
+ */
+export function PlaylistEditDoneButton({ onPress, collapsed }: PlaylistEditDoneButtonProps) {
+  const { t } = useTranslation('playlists');
+  const { systemColors, brandColors } = useTheme();
+  const nativeGlass = useNativeGlass();
+  const label = t('editClimbs.done');
+
+  if (collapsed) {
+    return (
+      <GlassIconButton
+        iconName="check.small"
+        iconColor={brandColors.primary}
+        onPress={onPress}
+        accessibilityLabel={label}
+        fallbackColor={systemColors.fill}
+      />
+    );
+  }
+
+  return (
+    <PressableSurface
+      onPress={onPress}
+      feedback="scale"
+      scaleTo={0.96}
+      hitSlop={4}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={styles.press}
+    >
+      <View
+        style={[
+          styles.pill,
+          !nativeGlass && shadows.sm,
+          !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
+        ]}
+      >
+        <GlassSurface
+          glassEffectStyle="regular"
+          fallbackColor={systemColors.fill}
+          borderRadius={PILL_RADIUS}
+          style={StyleSheet.absoluteFill}
+          pointerEvents="none"
+        />
+        <Icon name="check.small" size={18} color={brandColors.primary} />
+        <Text variant="subheadline" color={brandColors.primary} style={styles.label}>
+          {label}
+        </Text>
+      </View>
+    </PressableSurface>
+  );
+}
+
+const styles = StyleSheet.create({
+  press: {
+    height: PILL_HEIGHT,
+    justifyContent: 'center',
+  },
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: PILL_HEIGHT,
+    borderRadius: PILL_RADIUS,
+    paddingHorizontal: 16,
+    gap: 6,
+  },
+  label: {
+    fontWeight: '600',
+  },
+});

--- a/packages/mobile/src/components/playlist/PlaylistOwnerToolbar.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistOwnerToolbar.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from 'react-i18next';
+import { GlassActionToolbar, GlassToolbarAction } from '../chrome';
+import { Icon } from '../Icon';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { hapticSelection } from '../../lib/haptics';
+
+type PlaylistOwnerToolbarProps = {
+  isPinned: boolean;
+  onTogglePin: () => void;
+  /** Enter the climbs edit mode (reorder + remove). */
+  onEdit: () => void;
+  onDelete: () => void;
+};
+
+/**
+ * Owner action island for the expanded playlist hero: pin · edit · delete, in a
+ * single floating glass toolbar (the same vocabulary the Climbs / Discover
+ * chromes use). Collapses to a single overflow ⋯ once the hero scrolls away —
+ * the caller swaps this out for that icon at the collapsed breakpoint.
+ *
+ * The island floats over the colour hero, so every glyph is white — the single
+ * vibrant tint Apple prescribes for glass controls over colour content. Pin
+ * state is carried by the glyph (pin vs pin.fill), not a colour.
+ */
+export function PlaylistOwnerToolbar({ isPinned, onTogglePin, onEdit, onDelete }: PlaylistOwnerToolbarProps) {
+  const { t } = useTranslation('playlists');
+
+  return (
+    <GlassActionToolbar actionCount={3}>
+      <GlassToolbarAction
+        onPress={() => {
+          hapticSelection();
+          onTogglePin();
+        }}
+        accessibilityLabel={isPinned ? t('library.pin.unpinAriaLabel') : t('library.pin.pinAriaLabel')}
+      >
+        <Icon name={isPinned ? 'pin.fill' : 'pin'} size={22} color={iosSystemColors.white} />
+      </GlassToolbarAction>
+      <GlassToolbarAction onPress={onEdit} accessibilityLabel={t('detail.menu.editClimbs')}>
+        <Icon name="edit" size={22} color={iosSystemColors.white} />
+      </GlassToolbarAction>
+      <GlassToolbarAction onPress={onDelete} accessibilityLabel={t('detail.menu.delete')}>
+        <Icon name="delete" size={22} color={iosSystemColors.white} />
+      </GlassToolbarAction>
+    </GlassActionToolbar>
+  );
+}

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -24,6 +24,15 @@ vi.mock('react-native', () => ({
     if (onLayout) attrs['data-has-layout'] = 'true';
     return createElement('div', attrs, children);
   },
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
   StyleSheet: {
     create: (s: Record<string, unknown>) => s,
     absoluteFill: {},
@@ -189,6 +198,18 @@ vi.mock('../../GlassIconButton', () => ({
 
 vi.mock('../PlaylistBoardBackdrop', () => ({
   PlaylistBoardBackdrop: ({ boardType }: { boardType: string }) => createElement('div', { 'data-backdrop': boardType }),
+}));
+
+// Edit-mode helpers pull in react-native-gesture-handler / reanimated worklets
+// that don't parse under jsdom; the view defaults editMode off, so stub them.
+vi.mock('../use-playlist-drag', () => ({
+  usePlaylistDrag: () => ({
+    isDragging: false,
+    controls: { shared: {}, onRowHeight: () => {}, makeHandleGesture: () => ({}) },
+  }),
+}));
+vi.mock('../PlaylistEditClimbRow', () => ({
+  PlaylistEditClimbRow: () => null,
 }));
 
 // Use real playlist-gradient and playlist-colors (pure TS, no RN imports).

--- a/packages/mobile/src/components/playlist/__tests__/use-playlist-drag.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/use-playlist-drag.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// `usePlaylistDrag` reaches for reanimated shared values, gesture-handler
+// gestures, and haptics — all UI-thread / native concerns. Stub them so the hook
+// runs in node and we can assert what matters: the returned controls keep a
+// stable identity across re-renders (so memoized rows don't churn), and
+// `isDragging` starts false.
+
+// Mirror reanimated's real contract: useSharedValue returns the SAME mutable ref
+// across re-renders (backed by useRef). That stable identity is what lets the
+// memoized `shared` bag and `controls` keep a stable identity.
+vi.mock('react-native-reanimated', async () => {
+  const { useRef } = await import('react');
+  return {
+    useSharedValue: (initial: unknown) => {
+      const ref = useRef<{ value: unknown } | null>(null);
+      if (ref.current === null) ref.current = { value: initial };
+      return ref.current;
+    },
+    runOnJS:
+      (fn: (...args: unknown[]) => unknown) =>
+      (...args: unknown[]) =>
+        fn(...args),
+  };
+});
+
+// A chainable Gesture.Pan() builder: every method returns the same builder so
+// `.activateAfterLongPress(...).onStart(...).onUpdate(...)` resolves.
+vi.mock('react-native-gesture-handler', () => {
+  const makeBuilder = () => {
+    const builder: Record<string, (...args: unknown[]) => unknown> = {};
+    const proxy: typeof builder = new Proxy(builder, { get: () => () => proxy });
+    return proxy;
+  };
+  return {
+    Gesture: { Pan: () => makeBuilder() },
+  };
+});
+
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+
+import { usePlaylistDrag } from '../use-playlist-drag';
+
+type Options = Parameters<typeof usePlaylistDrag>[0];
+
+// A single stable reorder ref across re-renders — mirrors the screen's
+// `useCallback`'d handler.
+const reorder = vi.fn();
+
+function makeOptions(overrides: Partial<Options> = {}): Options {
+  return { reorder, itemCount: 5, ...overrides };
+}
+
+describe('usePlaylistDrag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the result and controls identity stable across unrelated re-renders', () => {
+    const { result, rerender } = renderHook((props: Options) => usePlaylistDrag(props), {
+      initialProps: makeOptions(),
+    });
+
+    const firstResult = result.current;
+    const firstControls = result.current.controls;
+    const firstShared = result.current.controls.shared;
+    const firstMakeHandle = result.current.controls.makeHandleGesture;
+    const firstOnRowHeight = result.current.controls.onRowHeight;
+
+    rerender(makeOptions());
+
+    expect(result.current).toBe(firstResult);
+    expect(result.current.controls).toBe(firstControls);
+    expect(result.current.controls.shared).toBe(firstShared);
+    expect(result.current.controls.makeHandleGesture).toBe(firstMakeHandle);
+    expect(result.current.controls.onRowHeight).toBe(firstOnRowHeight);
+  });
+
+  it('keeps the row-facing controls stable when the item count changes', () => {
+    const { result, rerender } = renderHook((props: Options) => usePlaylistDrag(props), {
+      initialProps: makeOptions({ itemCount: 5 }),
+    });
+
+    const firstControls = result.current.controls;
+
+    // A remove (which changes itemCount) must not churn the controls identity —
+    // rows would needlessly re-render otherwise.
+    rerender(makeOptions({ itemCount: 4 }));
+
+    expect(result.current.controls).toBe(firstControls);
+  });
+
+  it('starts not-dragging and builds a handle gesture without flipping isDragging', () => {
+    const { result } = renderHook((props: Options) => usePlaylistDrag(props), { initialProps: makeOptions() });
+
+    expect(result.current.isDragging).toBe(false);
+    const controlsBeforeDrag = result.current.controls;
+
+    const gesture = result.current.controls.makeHandleGesture(2, 'climb-c');
+    expect(gesture).toBeDefined();
+    expect(result.current.isDragging).toBe(false);
+    expect(result.current.controls).toBe(controlsBeforeDrag);
+  });
+
+  it('exposes a shared bag with the five drag coordinate values at rest', () => {
+    const { result } = renderHook((props: Options) => usePlaylistDrag(props), { initialProps: makeOptions() });
+    const { shared } = result.current.controls;
+
+    expect(shared.activeUuid.value).toBeNull();
+    expect(shared.dragTranslateY.value).toBe(0);
+    expect(shared.activeRowIndex.value).toBe(-1);
+    expect(shared.targetRowIndex.value).toBe(-1);
+    expect(typeof shared.rowHeight.value).toBe('number');
+  });
+});

--- a/packages/mobile/src/components/playlist/index.ts
+++ b/packages/mobile/src/components/playlist/index.ts
@@ -13,5 +13,7 @@ export { PlaylistBackFab } from './PlaylistBackFab';
 export { PlaylistFormSheet, type PlaylistFormValues } from './PlaylistFormSheet';
 export { PlaylistPinButton } from './PlaylistPinButton';
 export { PlaylistFollowButton } from './PlaylistFollowButton';
+export { PlaylistEditDoneButton } from './PlaylistEditDoneButton';
+export { PlaylistOwnerToolbar } from './PlaylistOwnerToolbar';
 export { PlaylistActionsMenu } from './PlaylistActionsMenu';
 export { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';

--- a/packages/mobile/src/components/playlist/use-playlist-drag.ts
+++ b/packages/mobile/src/components/playlist/use-playlist-drag.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Gesture, type GestureType } from 'react-native-gesture-handler';
+import { useSharedValue, runOnJS, type SharedValue } from 'react-native-reanimated';
+import { hapticSelection } from '../../lib/haptics';
+import { dropRowIndex } from '../play-drawer/queue-drag-math';
+
+// Press-and-hold this long on a handle before the drag arms — long enough that a
+// quick flick scrolls the list instead of lifting a row. Matches the queue.
+const LONG_PRESS_MS = 120;
+// Fallback row height until the first row reports its measured height.
+const DEFAULT_ROW_HEIGHT = 96;
+
+export type PlaylistDragShared = {
+  activeUuid: SharedValue<string | null>;
+  dragTranslateY: SharedValue<number>;
+  activeRowIndex: SharedValue<number>;
+  targetRowIndex: SharedValue<number>;
+  rowHeight: SharedValue<number>;
+};
+
+/**
+ * Row-facing drag controls passed down to every `PlaylistEditClimbRow`. Identity
+ * stays stable across renders (every member is memoized) so a memoized row only
+ * re-renders when its own props change, never on drag start/end.
+ */
+export type PlaylistDragControls = {
+  shared: PlaylistDragShared;
+  /** Report a row's measured height (call once from onLayout). */
+  onRowHeight: (height: number) => void;
+  /** Build the long-press drag Pan for a row's handle. */
+  makeHandleGesture: (rowIndex: number, uuid: string) => GestureType;
+};
+
+export type UsePlaylistDragOptions = {
+  /**
+   * Commit a single move (loaded-list indices). Internalised via a ref so an
+   * unstable (non-`useCallback`) function doesn't churn `controls`.
+   */
+  reorder: (uuid: string, newIndex: number) => void;
+  /** Number of rows in the editable list (drag clamps to [0, itemCount - 1]). */
+  itemCount: number;
+};
+
+export type UsePlaylistDragResult = {
+  /** True while a row is lifted — drives the list scroll lock. */
+  isDragging: boolean;
+  /** Stable row-facing controls (no `isDragging`); safe for memoized rows. */
+  controls: PlaylistDragControls;
+};
+
+/**
+ * Custom long-press drag-to-reorder for the playlist edit list. One instance per
+ * list (so the dragged row and its siblings share a coordinate space). Each row's
+ * ≡ handle gets a `Gesture.Pan().activateAfterLongPress` from `makeHandleGesture`;
+ * the row reads `shared` to lift itself and shift siblings to open a gap. On
+ * release it commits `(uuid, newIndex)`. Simpler than the queue's hook: the whole
+ * loaded list is reorderable, so a row index maps straight to a list index.
+ */
+export function usePlaylistDrag({ reorder, itemCount }: UsePlaylistDragOptions): UsePlaylistDragResult {
+  const activeUuid = useSharedValue<string | null>(null);
+  const dragTranslateY = useSharedValue(0);
+  const activeRowIndex = useSharedValue(-1);
+  const targetRowIndex = useSharedValue(-1);
+  const rowHeight = useSharedValue(DEFAULT_ROW_HEIGHT);
+  const lastRowIndexSV = useSharedValue(itemCount - 1);
+  const [isDragging, setIsDragging] = useState(false);
+
+  useEffect(() => {
+    lastRowIndexSV.value = itemCount - 1;
+  }, [itemCount, lastRowIndexSV]);
+
+  // Read on the JS thread at commit time. A ref keeps `commit` stable regardless
+  // of whether the caller wrapped `reorder` in useCallback.
+  const reorderRef = useRef(reorder);
+  reorderRef.current = reorder;
+
+  const onRowHeight = useCallback(
+    (height: number) => {
+      if (height > 0 && Math.abs(rowHeight.value - height) > 1) {
+        rowHeight.value = height;
+      }
+    },
+    [rowHeight],
+  );
+
+  const commit = useCallback((uuid: string, fromRowIndex: number, toRowIndex: number) => {
+    if (toRowIndex !== fromRowIndex && toRowIndex >= 0) {
+      reorderRef.current(uuid, toRowIndex);
+    }
+  }, []);
+
+  const makeHandleGesture = useCallback(
+    (rowIndex: number, uuid: string): GestureType =>
+      Gesture.Pan()
+        .activateAfterLongPress(LONG_PRESS_MS)
+        .onStart(() => {
+          'worklet';
+          activeUuid.value = uuid;
+          activeRowIndex.value = rowIndex;
+          targetRowIndex.value = rowIndex;
+          dragTranslateY.value = 0;
+          runOnJS(setIsDragging)(true);
+          runOnJS(hapticSelection)();
+        })
+        .onUpdate((event) => {
+          'worklet';
+          dragTranslateY.value = event.translationY;
+          const height = rowHeight.value || DEFAULT_ROW_HEIGHT;
+          const next = dropRowIndex(rowIndex, event.translationY, height, 0, lastRowIndexSV.value);
+          if (next !== targetRowIndex.value) {
+            targetRowIndex.value = next;
+            runOnJS(hapticSelection)();
+          }
+        })
+        .onEnd(() => {
+          'worklet';
+          runOnJS(commit)(uuid, rowIndex, targetRowIndex.value);
+        })
+        .onFinalize(() => {
+          'worklet';
+          activeUuid.value = null;
+          dragTranslateY.value = 0;
+          activeRowIndex.value = -1;
+          targetRowIndex.value = -1;
+          runOnJS(setIsDragging)(false);
+        }),
+    [activeUuid, activeRowIndex, targetRowIndex, dragTranslateY, rowHeight, lastRowIndexSV, commit],
+  );
+
+  const shared = useMemo<PlaylistDragShared>(
+    () => ({ activeUuid, dragTranslateY, activeRowIndex, targetRowIndex, rowHeight }),
+    [activeUuid, dragTranslateY, activeRowIndex, targetRowIndex, rowHeight],
+  );
+
+  const controls = useMemo<PlaylistDragControls>(
+    () => ({ shared, onRowHeight, makeHandleGesture }),
+    [shared, onRowHeight, makeHandleGesture],
+  );
+
+  return useMemo<UsePlaylistDragResult>(() => ({ isDragging, controls }), [isDragging, controls]);
+}

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -1502,6 +1502,18 @@ input RemoveClimbFromPlaylistInput {
 }
 
 """
+Input for reordering a climb within a playlist (single move).
+"""
+input ReorderPlaylistClimbInput {
+  "Playlist ID"
+  playlistId: ID!
+  "Climb UUID to move"
+  climbUuid: String!
+  "Target 0-based index in the playlist's full ordered list"
+  newIndex: Int!
+}
+
+"""
 Input for getting user's playlists.
 """
 input GetUserPlaylistsInput {
@@ -4385,6 +4397,11 @@ type Mutation {
   Remove a climb from a playlist.
   """
   removeClimbFromPlaylist(input: RemoveClimbFromPlaylistInput!): Boolean!
+
+  """
+  Reorder a climb within a playlist by moving it to a new index (owner/editor).
+  """
+  reorderPlaylistClimb(input: ReorderPlaylistClimbInput!): Boolean!
 
   """
   Update only lastAccessedAt for a playlist (does not update updatedAt).

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1935,6 +1935,8 @@ export type Mutation = {
   removeGymMember: Scalars['Boolean']['output'];
   /** Remove a climb from the queue by its queue item UUID. */
   removeQueueItem: Scalars['Boolean']['output'];
+  /** Reorder a climb within a playlist by moving it to a new index (owner/editor). */
+  reorderPlaylistClimb: Scalars['Boolean']['output'];
   /** Move a queue item from one position to another. */
   reorderQueueItem: Scalars['Boolean']['output'];
   /** Replace a queue item with a new one (same UUID). */
@@ -2312,6 +2314,11 @@ export type MutationRemoveGymMemberArgs = {
 /** Root mutation type for all write operations. */
 export type MutationRemoveQueueItemArgs = {
   uuid: Scalars['ID']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationReorderPlaylistClimbArgs = {
+  input: ReorderPlaylistClimbInput;
 };
 
 /** Root mutation type for all write operations. */
@@ -3887,6 +3894,16 @@ export type RemoveGymMemberInput = {
   gymUuid: Scalars['ID']['input'];
   /** User ID to remove */
   userId: Scalars['ID']['input'];
+};
+
+/** Input for reordering a climb within a playlist (single move). */
+export type ReorderPlaylistClimbInput = {
+  /** Climb UUID to move */
+  climbUuid: Scalars['String']['input'];
+  /** Target 0-based index in the playlist's full ordered list */
+  newIndex: Scalars['Int']['input'];
+  /** Playlist ID */
+  playlistId: Scalars['ID']['input'];
 };
 
 export type ResolveProposalInput = {
@@ -5516,6 +5533,7 @@ export type ResolversTypes = ResolversObject<{
   RegisterControllerInput: RegisterControllerInput;
   RemoveClimbFromPlaylistInput: RemoveClimbFromPlaylistInput;
   RemoveGymMemberInput: RemoveGymMemberInput;
+  ReorderPlaylistClimbInput: ReorderPlaylistClimbInput;
   ResolveProposalInput: ResolveProposalInput;
   RevokeRoleInput: RevokeRoleInput;
   SaveAuroraCredentialInput: SaveAuroraCredentialInput;
@@ -5770,6 +5788,7 @@ export type ResolversParentTypes = ResolversObject<{
   RegisterControllerInput: RegisterControllerInput;
   RemoveClimbFromPlaylistInput: RemoveClimbFromPlaylistInput;
   RemoveGymMemberInput: RemoveGymMemberInput;
+  ReorderPlaylistClimbInput: ReorderPlaylistClimbInput;
   ResolveProposalInput: ResolveProposalInput;
   RevokeRoleInput: RevokeRoleInput;
   SaveAuroraCredentialInput: SaveAuroraCredentialInput;
@@ -6994,6 +7013,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationRemoveQueueItemArgs, 'uuid'>
+  >;
+  reorderPlaylistClimb?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationReorderPlaylistClimbArgs, 'input'>
   >;
   reorderQueueItem?: Resolver<
     ResolversTypes['Boolean'],

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -263,6 +263,11 @@ export const mutationsTypeDefs = /* GraphQL */ `
     removeClimbFromPlaylist(input: RemoveClimbFromPlaylistInput!): Boolean!
 
     """
+    Reorder a climb within a playlist by moving it to a new index (owner/editor).
+    """
+    reorderPlaylistClimb(input: ReorderPlaylistClimbInput!): Boolean!
+
+    """
     Update only lastAccessedAt for a playlist (does not update updatedAt).
     """
     updatePlaylistLastAccessed(playlistId: ID!): Boolean!

--- a/packages/shared-schema/src/schema/playlists.ts
+++ b/packages/shared-schema/src/schema/playlists.ts
@@ -130,6 +130,18 @@ export const playlistsTypeDefs = /* GraphQL */ `
   }
 
   """
+  Input for reordering a climb within a playlist (single move).
+  """
+  input ReorderPlaylistClimbInput {
+    "Playlist ID"
+    playlistId: ID!
+    "Climb UUID to move"
+    climbUuid: String!
+    "Target 0-based index in the playlist's full ordered list"
+    newIndex: Int!
+  }
+
+  """
   Input for getting user's playlists.
   """
   input GetUserPlaylistsInput {

--- a/packages/shared/graphql/src/generated/gql.ts
+++ b/packages/shared/graphql/src/generated/gql.ts
@@ -68,6 +68,7 @@ type Documents = {
   '\n  mutation DeletePlaylist($playlistId: ID!) {\n    deletePlaylist(playlistId: $playlistId)\n  }\n': typeof types.DeletePlaylistDocument;
   '\n  mutation AddClimbToPlaylist($input: AddClimbToPlaylistInput!) {\n    addClimbToPlaylist(input: $input) {\n      id\n      playlistId\n      climbUuid\n      angle\n      position\n      addedAt\n    }\n  }\n': typeof types.AddClimbToPlaylistDocument;
   '\n  mutation RemoveClimbFromPlaylist($input: RemoveClimbFromPlaylistInput!) {\n    removeClimbFromPlaylist(input: $input)\n  }\n': typeof types.RemoveClimbFromPlaylistDocument;
+  '\n  mutation ReorderPlaylistClimb($input: ReorderPlaylistClimbInput!) {\n    reorderPlaylistClimb(input: $input)\n  }\n': typeof types.ReorderPlaylistClimbDocument;
   '\n  query GetPlaylistClimbs($input: GetPlaylistClimbsInput!) {\n    playlistClimbs(input: $input) {\n      climbs {\n        uuid\n        layoutId\n        boardType\n        setter_username\n        name\n        description\n        frames\n        framesCount\n        framesPace\n        angle\n        ascensionist_count\n        difficulty\n        quality_average\n        stars\n        difficulty_error\n        benchmark_difficulty\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.GetPlaylistClimbsDocument;
   '\n  query DiscoverPlaylists($input: DiscoverPlaylistsInput!) {\n    discoverPlaylists(input: $input) {\n      playlists {\n        id\n        uuid\n        boardType\n        layoutId\n        name\n        description\n        color\n        icon\n        createdAt\n        updatedAt\n        climbCount\n        creatorId\n        creatorName\n      }\n      totalCount\n      hasMore\n    }\n  }\n': typeof types.DiscoverPlaylistsDocument;
   '\n  query GetPlaylistCreators($input: GetPlaylistCreatorsInput!) {\n    playlistCreators(input: $input) {\n      userId\n      displayName\n      playlistCount\n    }\n  }\n': typeof types.GetPlaylistCreatorsDocument;
@@ -231,6 +232,8 @@ const documents: Documents = {
     types.AddClimbToPlaylistDocument,
   '\n  mutation RemoveClimbFromPlaylist($input: RemoveClimbFromPlaylistInput!) {\n    removeClimbFromPlaylist(input: $input)\n  }\n':
     types.RemoveClimbFromPlaylistDocument,
+  '\n  mutation ReorderPlaylistClimb($input: ReorderPlaylistClimbInput!) {\n    reorderPlaylistClimb(input: $input)\n  }\n':
+    types.ReorderPlaylistClimbDocument,
   '\n  query GetPlaylistClimbs($input: GetPlaylistClimbsInput!) {\n    playlistClimbs(input: $input) {\n      climbs {\n        uuid\n        layoutId\n        boardType\n        setter_username\n        name\n        description\n        frames\n        framesCount\n        framesPace\n        angle\n        ascensionist_count\n        difficulty\n        quality_average\n        stars\n        difficulty_error\n        benchmark_difficulty\n      }\n      totalCount\n      hasMore\n    }\n  }\n':
     types.GetPlaylistClimbsDocument,
   '\n  query DiscoverPlaylists($input: DiscoverPlaylistsInput!) {\n    discoverPlaylists(input: $input) {\n      playlists {\n        id\n        uuid\n        boardType\n        layoutId\n        name\n        description\n        color\n        icon\n        createdAt\n        updatedAt\n        climbCount\n        creatorId\n        creatorName\n      }\n      totalCount\n      hasMore\n    }\n  }\n':
@@ -675,6 +678,12 @@ export function graphql(
 export function graphql(
   source: '\n  mutation RemoveClimbFromPlaylist($input: RemoveClimbFromPlaylistInput!) {\n    removeClimbFromPlaylist(input: $input)\n  }\n',
 ): (typeof documents)['\n  mutation RemoveClimbFromPlaylist($input: RemoveClimbFromPlaylistInput!) {\n    removeClimbFromPlaylist(input: $input)\n  }\n'];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  mutation ReorderPlaylistClimb($input: ReorderPlaylistClimbInput!) {\n    reorderPlaylistClimb(input: $input)\n  }\n',
+): (typeof documents)['\n  mutation ReorderPlaylistClimb($input: ReorderPlaylistClimbInput!) {\n    reorderPlaylistClimb(input: $input)\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1932,6 +1932,8 @@ export type Mutation = {
   removeGymMember: Scalars['Boolean']['output'];
   /** Remove a climb from the queue by its queue item UUID. */
   removeQueueItem: Scalars['Boolean']['output'];
+  /** Reorder a climb within a playlist by moving it to a new index (owner/editor). */
+  reorderPlaylistClimb: Scalars['Boolean']['output'];
   /** Move a queue item from one position to another. */
   reorderQueueItem: Scalars['Boolean']['output'];
   /** Replace a queue item with a new one (same UUID). */
@@ -2309,6 +2311,11 @@ export type MutationRemoveGymMemberArgs = {
 /** Root mutation type for all write operations. */
 export type MutationRemoveQueueItemArgs = {
   uuid: Scalars['ID']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationReorderPlaylistClimbArgs = {
+  input: ReorderPlaylistClimbInput;
 };
 
 /** Root mutation type for all write operations. */
@@ -3884,6 +3891,16 @@ export type RemoveGymMemberInput = {
   gymUuid: Scalars['ID']['input'];
   /** User ID to remove */
   userId: Scalars['ID']['input'];
+};
+
+/** Input for reordering a climb within a playlist (single move). */
+export type ReorderPlaylistClimbInput = {
+  /** Climb UUID to move */
+  climbUuid: Scalars['String']['input'];
+  /** Target 0-based index in the playlist's full ordered list */
+  newIndex: Scalars['Int']['input'];
+  /** Playlist ID */
+  playlistId: Scalars['ID']['input'];
 };
 
 export type ResolveProposalInput = {
@@ -6138,6 +6155,12 @@ export type RemoveClimbFromPlaylistMutationVariables = Exact<{
 }>;
 
 export type RemoveClimbFromPlaylistMutation = { __typename?: 'Mutation'; removeClimbFromPlaylist: boolean };
+
+export type ReorderPlaylistClimbMutationVariables = Exact<{
+  input: ReorderPlaylistClimbInput;
+}>;
+
+export type ReorderPlaylistClimbMutation = { __typename?: 'Mutation'; reorderPlaylistClimb: boolean };
 
 export type GetPlaylistClimbsQueryVariables = Exact<{
   input: GetPlaylistClimbsInput;
@@ -9979,6 +10002,42 @@ export const RemoveClimbFromPlaylistDocument = {
     },
   ],
 } as unknown as DocumentNode<RemoveClimbFromPlaylistMutation, RemoveClimbFromPlaylistMutationVariables>;
+export const ReorderPlaylistClimbDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'ReorderPlaylistClimb' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'input' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'ReorderPlaylistClimbInput' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'reorderPlaylistClimb' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'input' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'input' } },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ReorderPlaylistClimbMutation, ReorderPlaylistClimbMutationVariables>;
 export const GetPlaylistClimbsDocument = {
   kind: 'Document',
   definitions: [

--- a/packages/shared/graphql/src/operations/playlists.ts
+++ b/packages/shared/graphql/src/operations/playlists.ts
@@ -146,6 +146,13 @@ export const REMOVE_CLIMB_FROM_PLAYLIST = gql`
   }
 `;
 
+// Reorder a climb within a playlist (single move to a new 0-based index)
+export const REORDER_PLAYLIST_CLIMB = gql`
+  mutation ReorderPlaylistClimb($input: ReorderPlaylistClimbInput!) {
+    reorderPlaylistClimb(input: $input)
+  }
+`;
+
 // Get climbs in a playlist with full climb data
 export const GET_PLAYLIST_CLIMBS = gql`
   query GetPlaylistClimbs($input: GetPlaylistClimbsInput!) {
@@ -378,6 +385,20 @@ export type RemoveClimbFromPlaylistMutationVariables = {
 
 export type RemoveClimbFromPlaylistMutationResponse = {
   removeClimbFromPlaylist: boolean;
+};
+
+export type ReorderPlaylistClimbInput = {
+  playlistId: string;
+  climbUuid: string;
+  newIndex: number;
+};
+
+export type ReorderPlaylistClimbMutationVariables = {
+  input: ReorderPlaylistClimbInput;
+};
+
+export type ReorderPlaylistClimbMutationResponse = {
+  reorderPlaylistClimb: boolean;
 };
 
 export type GetPlaylistClimbsInput = {

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -31,6 +31,8 @@
       "noResults": "No playlists match \"{{query}}\""
     },
     "pin": {
+      "pin": "Pin",
+      "unpin": "Unpin",
       "pinAriaLabel": "Pin playlist",
       "unpinAriaLabel": "Unpin playlist",
       "pinFailed": "Failed to pin playlist",
@@ -105,6 +107,7 @@
     },
     "menu": {
       "generate": "Generate",
+      "editClimbs": "Edit climbs",
       "edit": "Edit",
       "delete": "Delete"
     },
@@ -138,6 +141,20 @@
       "loadDescription": "There was an error loading this playlist. Please try again.",
       "tryAgain": "Try Again"
     }
+  },
+  "editClimbs": {
+    "done": "Done",
+    "editDetailsAria": "Edit playlist details",
+    "removeAria": "Remove {{name}}",
+    "dragHandleAria": "Drag to reorder {{name}}",
+    "removeConfirm": {
+      "title": "Remove climb?",
+      "message": "Remove \"{{name}}\" from this playlist?",
+      "confirm": "Remove",
+      "cancel": "Cancel"
+    },
+    "removeFailed": "Couldn't remove the climb",
+    "reorderFailed": "Couldn't save the new order"
   },
   "edit": {
     "title": "Edit Playlist",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -31,6 +31,8 @@
       "noResults": "Ninguna lista coincide con \"{{query}}\""
     },
     "pin": {
+      "pin": "Fijar",
+      "unpin": "Desfijar",
       "pinAriaLabel": "Fijar playlist",
       "unpinAriaLabel": "Desfijar playlist",
       "pinFailed": "No se pudo fijar la playlist",
@@ -105,6 +107,7 @@
     },
     "menu": {
       "generate": "Generar",
+      "editClimbs": "Editar bloques",
       "edit": "Editar",
       "delete": "Eliminar"
     },
@@ -138,6 +141,20 @@
       "loadDescription": "Hubo un error al cargar esta playlist. Inténtalo de nuevo.",
       "tryAgain": "Reintentar"
     }
+  },
+  "editClimbs": {
+    "done": "Listo",
+    "editDetailsAria": "Editar detalles de la playlist",
+    "removeAria": "Quitar {{name}}",
+    "dragHandleAria": "Arrastra para reordenar {{name}}",
+    "removeConfirm": {
+      "title": "¿Quitar bloque?",
+      "message": "¿Quitar \"{{name}}\" de esta playlist?",
+      "confirm": "Quitar",
+      "cancel": "Cancelar"
+    },
+    "removeFailed": "No se pudo quitar el bloque",
+    "reorderFailed": "No se pudo guardar el nuevo orden"
   },
   "edit": {
     "title": "Editar lista",

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -31,6 +31,8 @@
       "noResults": "Aucune liste ne correspond à « {{query}} »"
     },
     "pin": {
+      "pin": "Épingler",
+      "unpin": "Désépingler",
       "pinAriaLabel": "Épingler la playlist",
       "unpinAriaLabel": "Désépingler la playlist",
       "pinFailed": "Échec de l'épinglage de la playlist",
@@ -105,6 +107,7 @@
     },
     "menu": {
       "generate": "Générer",
+      "editClimbs": "Modifier les blocs",
       "edit": "Modifier",
       "delete": "Supprimer"
     },
@@ -138,6 +141,20 @@
       "loadDescription": "Erreur lors du chargement de cette playlist. Réessayez.",
       "tryAgain": "Réessayer"
     }
+  },
+  "editClimbs": {
+    "done": "Terminé",
+    "editDetailsAria": "Modifier les détails de la playlist",
+    "removeAria": "Retirer {{name}}",
+    "dragHandleAria": "Faites glisser pour réorganiser {{name}}",
+    "removeConfirm": {
+      "title": "Retirer le bloc ?",
+      "message": "Retirer « {{name}} » de cette playlist ?",
+      "confirm": "Retirer",
+      "cancel": "Annuler"
+    },
+    "removeFailed": "Impossible de retirer le bloc",
+    "reorderFailed": "Impossible d'enregistrer le nouvel ordre"
   },
   "edit": {
     "title": "Modifier la playlist",

--- a/packages/shared/playlists-react/src/__tests__/use-playlist-item-mutations.test.tsx
+++ b/packages/shared/playlists-react/src/__tests__/use-playlist-item-mutations.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { PlaylistsAdapterProvider, type ExecutePlaylistsGraphQL, type PlaylistsAdapter } from '../adapter';
+import { noopRecentsAdapter } from '../recents-adapter';
+import { usePlaylistItemMutations } from '../use-playlist-item-mutations';
+import { REORDER_PLAYLIST_CLIMB, REMOVE_CLIMB_FROM_PLAYLIST } from '@boardsesh/graphql/operations/playlists';
+
+function buildWrapper(executeGraphQL: ExecutePlaylistsGraphQL) {
+  const fullAdapter: PlaylistsAdapter = { executeGraphQL, recents: noopRecentsAdapter };
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <PlaylistsAdapterProvider value={fullAdapter}>{children}</PlaylistsAdapterProvider>
+  );
+  return { wrapper };
+}
+
+describe('usePlaylistItemMutations (shared)', () => {
+  it('reorderPlaylistClimb sends REORDER_PLAYLIST_CLIMB with {input} and returns the boolean', async () => {
+    const executeGraphQL = vi.fn(async () => ({ reorderPlaylistClimb: true })) as unknown as ExecutePlaylistsGraphQL;
+    const { wrapper } = buildWrapper(executeGraphQL);
+    const { result } = renderHook(() => usePlaylistItemMutations(), { wrapper });
+
+    const input = { playlistId: 'p1', climbUuid: 'c1', newIndex: 2 };
+    await expect(result.current.reorderPlaylistClimb(input)).resolves.toBe(true);
+    expect(executeGraphQL).toHaveBeenCalledWith(REORDER_PLAYLIST_CLIMB, { input });
+  });
+
+  it('removeClimbFromPlaylist sends REMOVE_CLIMB_FROM_PLAYLIST with {input} and returns the boolean', async () => {
+    const executeGraphQL = vi.fn(async () => ({ removeClimbFromPlaylist: true })) as unknown as ExecutePlaylistsGraphQL;
+    const { wrapper } = buildWrapper(executeGraphQL);
+    const { result } = renderHook(() => usePlaylistItemMutations(), { wrapper });
+
+    const input = { playlistId: 'p1', climbUuid: 'c1' };
+    await expect(result.current.removeClimbFromPlaylist(input)).resolves.toBe(true);
+    expect(executeGraphQL).toHaveBeenCalledWith(REMOVE_CLIMB_FROM_PLAYLIST, { input });
+  });
+
+  it('prefers the explicit executeGraphQL option over the adapter', async () => {
+    const adapterExec = vi.fn(async () => ({ reorderPlaylistClimb: false })) as unknown as ExecutePlaylistsGraphQL;
+    const override = vi.fn(async () => ({ reorderPlaylistClimb: true })) as unknown as ExecutePlaylistsGraphQL;
+    const { wrapper } = buildWrapper(adapterExec);
+    const { result } = renderHook(() => usePlaylistItemMutations({ executeGraphQL: override }), { wrapper });
+
+    await expect(result.current.reorderPlaylistClimb({ playlistId: 'p1', climbUuid: 'c1', newIndex: 0 })).resolves.toBe(
+      true,
+    );
+    expect(override).toHaveBeenCalledTimes(1);
+    expect(adapterExec).not.toHaveBeenCalled();
+  });
+
+  it('keeps the returned callbacks stable across re-renders', () => {
+    const executeGraphQL = vi.fn(async () => ({ reorderPlaylistClimb: true })) as unknown as ExecutePlaylistsGraphQL;
+    const { wrapper } = buildWrapper(executeGraphQL);
+    const { result, rerender } = renderHook(() => usePlaylistItemMutations(), { wrapper });
+
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+    expect(result.current.reorderPlaylistClimb).toBe(first.reorderPlaylistClimb);
+    expect(result.current.removeClimbFromPlaylist).toBe(first.removeClimbFromPlaylist);
+  });
+
+  it('throws when no PlaylistsAdapterProvider is mounted', () => {
+    expect(() => renderHook(() => usePlaylistItemMutations())).toThrow(/PlaylistsAdapterProvider/);
+  });
+});

--- a/packages/shared/playlists-react/src/__tests__/use-playlist-item-mutations.test.tsx
+++ b/packages/shared/playlists-react/src/__tests__/use-playlist-item-mutations.test.tsx
@@ -35,6 +35,20 @@ describe('usePlaylistItemMutations (shared)', () => {
     expect(executeGraphQL).toHaveBeenCalledWith(REMOVE_CLIMB_FROM_PLAYLIST, { input });
   });
 
+  it('propagates a rejected executeGraphQL (no error swallowing)', async () => {
+    const boom = new Error('network down');
+    const executeGraphQL = vi.fn(async () => {
+      throw boom;
+    }) as unknown as ExecutePlaylistsGraphQL;
+    const { wrapper } = buildWrapper(executeGraphQL);
+    const { result } = renderHook(() => usePlaylistItemMutations(), { wrapper });
+
+    await expect(result.current.reorderPlaylistClimb({ playlistId: 'p1', climbUuid: 'c1', newIndex: 0 })).rejects.toBe(
+      boom,
+    );
+    await expect(result.current.removeClimbFromPlaylist({ playlistId: 'p1', climbUuid: 'c1' })).rejects.toBe(boom);
+  });
+
   it('prefers the explicit executeGraphQL option over the adapter', async () => {
     const adapterExec = vi.fn(async () => ({ reorderPlaylistClimb: false })) as unknown as ExecutePlaylistsGraphQL;
     const override = vi.fn(async () => ({ reorderPlaylistClimb: true })) as unknown as ExecutePlaylistsGraphQL;

--- a/packages/shared/playlists-react/src/index.ts
+++ b/packages/shared/playlists-react/src/index.ts
@@ -45,6 +45,10 @@ export type {
 export { usePlaylistMutations } from './use-playlist-mutations';
 export type { UsePlaylistMutationsOptions, UsePlaylistMutationsResult } from './use-playlist-mutations';
 
+// Item-level mutation callbacks (reorder / remove climb).
+export { usePlaylistItemMutations } from './use-playlist-item-mutations';
+export type { UsePlaylistItemMutationsOptions, UsePlaylistItemMutationsResult } from './use-playlist-item-mutations';
+
 // Suggestion-refresh helper (also reachable via the
 // ./fetch-playlist-suggestion-climbs subpath).
 export {

--- a/packages/shared/playlists-react/src/use-playlist-item-mutations.ts
+++ b/packages/shared/playlists-react/src/use-playlist-item-mutations.ts
@@ -1,0 +1,63 @@
+import { useCallback, useMemo } from 'react';
+import {
+  REORDER_PLAYLIST_CLIMB,
+  REMOVE_CLIMB_FROM_PLAYLIST,
+  type ReorderPlaylistClimbInput,
+  type ReorderPlaylistClimbMutationResponse,
+  type ReorderPlaylistClimbMutationVariables,
+  type RemoveClimbFromPlaylistInput,
+  type RemoveClimbFromPlaylistMutationResponse,
+  type RemoveClimbFromPlaylistMutationVariables,
+} from '@boardsesh/graphql/operations/playlists';
+import { usePlaylistsAdapter, type ExecutePlaylistsGraphQL } from './adapter';
+
+export type UsePlaylistItemMutationsOptions = {
+  /** Override the adapter's `executeGraphQL` (used in tests). */
+  executeGraphQL?: ExecutePlaylistsGraphQL;
+};
+
+export type UsePlaylistItemMutationsResult = {
+  /** Move a climb to a new 0-based index in the playlist's ordered list. */
+  reorderPlaylistClimb: (input: ReorderPlaylistClimbInput) => Promise<boolean>;
+  /** Remove a climb from the playlist. */
+  removeClimbFromPlaylist: (input: RemoveClimbFromPlaylistInput) => Promise<boolean>;
+};
+
+/**
+ * Renderer-agnostic item-level playlist mutations (reorder / remove) shared by
+ * web and mobile. Mirrors `use-playlist-mutations.ts`: each method forwards the
+ * matching GraphQL document through the adapter's `executeGraphQL` and returns
+ * the unwrapped payload. Owns NO optimistic state, toasts, or cache
+ * invalidation — those stay platform/screen concerns.
+ */
+export function usePlaylistItemMutations(options?: UsePlaylistItemMutationsOptions): UsePlaylistItemMutationsResult {
+  const adapter = usePlaylistsAdapter();
+  const executeGraphQL = options?.executeGraphQL ?? adapter.executeGraphQL;
+
+  const reorderPlaylistClimb = useCallback(
+    async (input: ReorderPlaylistClimbInput): Promise<boolean> => {
+      const response = await executeGraphQL<
+        ReorderPlaylistClimbMutationResponse,
+        ReorderPlaylistClimbMutationVariables
+      >(REORDER_PLAYLIST_CLIMB, { input });
+      return response.reorderPlaylistClimb;
+    },
+    [executeGraphQL],
+  );
+
+  const removeClimbFromPlaylist = useCallback(
+    async (input: RemoveClimbFromPlaylistInput): Promise<boolean> => {
+      const response = await executeGraphQL<
+        RemoveClimbFromPlaylistMutationResponse,
+        RemoveClimbFromPlaylistMutationVariables
+      >(REMOVE_CLIMB_FROM_PLAYLIST, { input });
+      return response.removeClimbFromPlaylist;
+    },
+    [executeGraphQL],
+  );
+
+  return useMemo(
+    () => ({ reorderPlaylistClimb, removeClimbFromPlaylist }),
+    [reorderPlaylistClimb, removeClimbFromPlaylist],
+  );
+}


### PR DESCRIPTION
## What

Playlist owners can now reorder and remove the climbs inside their playlists, on both the iOS (glass) and Android (Material 3) variants.

- A **pin · edit · delete** glass toolbar floats over the hero, and **collapses to a single overflow ⋯** once the hero scrolls away (and always on Material's app bar). Toolbar glyphs are white — the single vibrant tint Apple prescribes for glass controls over colour content.
- **Edit** enters an edit mode: each row gets a red ⊖ remove control on the leading edge and a ≡ drag handle on the trailing edge; **Done** exits. A **cog** beside the playlist name (edit mode only) opens the existing edit-details sheet.
- Drag-to-reorder reuses the queue's proven drag math (`dropRowIndex` / `rowReorderShift`) via a focused `usePlaylistDrag`; list scroll is locked while a row is lifted.

## Backend — additive & backwards compatible

The only backend change is one new mutation, so the **shipped app fleet is unaffected** (older clients never call it):

```graphql
reorderPlaylistClimb(input: ReorderPlaylistClimbInput!): Boolean!
```

Single-move semantics: the server derives the climb's current index from the DB (robust to the position gaps `removeClimbFromPlaylist` leaves), splices to the target index, and renumbers positions to a dense `0..n-1` in a transaction. `SELECT … FOR UPDATE` locks the rows so two overlapping reorders can't lose a move; only rows that actually shift are written. Removal reuses the existing `removeClimbFromPlaylist`. Existing `playlistClimbs` ordering (`position ASC, addedAt ASC`) is unchanged.

> ⚠️ **Deploy order:** the backend must be deployed before any app build that calls `reorderPlaylistClimb` (additive, so deploying ahead of the app is safe).

## Shared

- `REORDER_PLAYLIST_CLIMB` GraphQL document + types.
- `usePlaylistItemMutations` (reorder + remove) — renderer-agnostic, mirrors `usePlaylistMutations`.

## Notes / known limitations

- v1 edits the **loaded** window: pagination is paused in edit mode, and reorder indices map into the currently-loaded prefix. Exit invalidates `playlistClimbs` so the canonical server order reloads.
- Optimistic reorder/remove use a guarded revert that won't clobber a concurrent edit (falls back to server reconciliation).

## Tests

- Backend: `playlist-reorder.test.ts` — renumber correctness, interior-move writes only shifted rows, clamp, no-op, climb-not-found, non-owner rejected, auth required (7).
- Mobile: existing `playlist-detail-view` / `playlist-uuid` suites updated for the new wiring.
- Full validation green: typecheck (all), mobile suite (1610), backend reorder (7), i18n parity + orphans, Metro bundle, lint (no new errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)