### PR TITLE
fix(ble): harden iOS connect lifecycle in BoardBleManager

### DIFF
--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -22,6 +22,8 @@ enum BoardBleError: LocalizedError {
     case notConnected
     case invalidHex
     case writeCancelled
+    case superseded
+    case writeTimedOut
 
     var errorDescription: String? {
         switch self {
@@ -41,6 +43,10 @@ enum BoardBleError: LocalizedError {
             return "Invalid hex payload"
         case .writeCancelled:
             return "BLE write cancelled"
+        case .superseded:
+            return "Bluetooth connection attempt was superseded by a newer one"
+        case .writeTimedOut:
+            return "BLE write timed out waiting for the board to accept data"
         }
     }
 }
@@ -64,6 +70,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private let chunkSize = 20
     private let chunkDelay: TimeInterval = 0.005
     private let connectTimeout: TimeInterval = 8
+    // How long a write parked on `canSendWriteWithoutResponse` may wait for
+    // peripheralIsReady before the queue is failed. Generous: a healthy link
+    // drains its transmit buffer in milliseconds.
+    private let writeResumeTimeout: TimeInterval = 5
 
     private lazy var centralManager = CBCentralManager(
         delegate: self,
@@ -97,6 +107,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var writeGeneration: UInt64 = 0
     private var isWriting = false
     private var pendingWriteResume: (() -> Void)?
+    private var pendingWriteResumeWatchdog: DispatchWorkItem?
     private var configuration: BoardBleConfiguration?
     private lazy var readyWaiters = WaiterPool(queue: bleQueue)
     private lazy var drainWaiters = WaiterPool(queue: bleQueue)
@@ -342,6 +353,15 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         stopScanOnBleQueue()
         failQueuedWrites(BoardBleError.writeCancelled)
+        // Settle any still-pending connect before starting this one. Silently
+        // overwriting pendingConnectCompletion would orphan the prior attempt's
+        // JS promise (it would never resolve), and its still-scheduled timeout
+        // work item could later misfire against THIS attempt: for a different
+        // target device the old peripheral's generation entry survives the
+        // bump below, so the stale timeout's guards both pass and it would
+        // call completePendingConnect against the new completion.
+        // completePendingConnect also cancels that stale timeout work item.
+        completePendingConnect(.failure(BoardBleError.superseded))
         connectionGeneration += 1
         let generation = connectionGeneration
         intentionalDisconnectGenerations.removeValue(forKey: peripheral.identifier)
@@ -608,14 +628,39 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
+        // More than one restored peripheral means a superseded connect attempt
+        // was still mid-flight at suspension. Keep only the first; cancel the
+        // rest so they don't linger as system-held connections — these boards
+        // are last-connection-wins, so a phantom link blocks the wall.
+        for extra in peripherals.dropFirst() {
+            logger.info("Cancelling extra restored BLE peripheral \(extra.identifier.uuidString, privacy: .public)")
+            central.cancelPeripheralConnection(extra)
+        }
+
         let deviceId = peripheral.identifier.uuidString
         connectionGeneration += 1
-        peripheralGenerations[peripheral.identifier] = connectionGeneration
         discoveredPeripherals[deviceId] = peripheral
-        connectedPeripheral = peripheral
         peripheral.delegate = self
-        logger.info("Restored BLE peripheral \(deviceId, privacy: .public)")
-        peripheral.discoverServices([uartServiceUuid])
+
+        switch peripheral.state {
+        case .connected:
+            peripheralGenerations[peripheral.identifier] = connectionGeneration
+            connectedPeripheral = peripheral
+            logger.info("Restored BLE peripheral \(deviceId, privacy: .public)")
+            peripheral.discoverServices([uartServiceUuid])
+        case .connecting:
+            // The restored connect request is still pending; didConnect will
+            // run service discovery when the link comes up (the generation set
+            // here keeps its guard satisfied).
+            peripheralGenerations[peripheral.identifier] = connectionGeneration
+            connectedPeripheral = peripheral
+            logger.info("Restored BLE peripheral \(deviceId, privacy: .public) still connecting")
+        default:
+            // Disconnected or disconnecting: nothing usable to restore, and
+            // adopting it would leave a half-open connectedPeripheral with no
+            // write characteristic.
+            logger.info("Restored BLE peripheral \(deviceId, privacy: .public) not connected (state=\(peripheral.state.rawValue, privacy: .public)); ignoring")
+        }
     }
 
     func centralManager(
@@ -713,29 +758,53 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // MARK: - CBPeripheralDelegate
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        guard connectedPeripheral?.identifier == peripheral.identifier else { return }
+        // Identity AND generation, mirroring didConnect: a stale discovery
+        // callback from a superseded connect attempt to the same device must
+        // not complete the newer attempt early.
+        guard connectedPeripheral?.identifier == peripheral.identifier,
+              peripheralGenerations[peripheral.identifier] == connectionGeneration
+        else { return }
         if let error {
-            completePendingConnect(.failure(error))
+            failConnectionSetup(peripheral, error: error)
             return
         }
 
         guard let service = peripheral.services?.first(where: { $0.uuid == uartServiceUuid }) else {
-            completePendingConnect(.failure(BoardBleError.uartServiceMissing))
+            failConnectionSetup(peripheral, error: BoardBleError.uartServiceMissing)
             return
         }
 
         peripheral.discoverCharacteristics([uartWriteCharacteristicUuid], for: service)
     }
 
+    /// A connection that reached service discovery but can't become
+    /// write-ready is useless — tear it down instead of leaving a half-open
+    /// peripheral (`connectedPeripheral` set, `writeCharacteristic` nil) that
+    /// blocks later reconnects. Settles the pending JS connect when one exists
+    /// (picker connect / widget reconnect); during state restoration there is
+    /// no pending completion and the teardown itself is the fix.
+    private func failConnectionSetup(_ peripheral: CBPeripheral, error: Error) {
+        logger.error("BLE connection setup failed for \(peripheral.identifier.uuidString, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        peripheralGenerations.removeValue(forKey: peripheral.identifier)
+        if connectedPeripheral?.identifier == peripheral.identifier {
+            connectedPeripheral = nil
+            writeCharacteristic = nil
+        }
+        centralManager.cancelPeripheralConnection(peripheral)
+        completePendingConnect(.failure(error))
+    }
+
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
-        guard connectedPeripheral?.identifier == peripheral.identifier else { return }
+        guard connectedPeripheral?.identifier == peripheral.identifier,
+              peripheralGenerations[peripheral.identifier] == connectionGeneration
+        else { return }
         if let error {
-            completePendingConnect(.failure(error))
+            failConnectionSetup(peripheral, error: error)
             return
         }
 
         guard let characteristic = service.characteristics?.first(where: { $0.uuid == uartWriteCharacteristicUuid }) else {
-            completePendingConnect(.failure(BoardBleError.writeCharacteristicMissing))
+            failConnectionSetup(peripheral, error: BoardBleError.writeCharacteristicMissing)
             return
         }
 
@@ -764,6 +833,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        pendingWriteResumeWatchdog?.cancel()
+        pendingWriteResumeWatchdog = nil
         let resume = pendingWriteResume
         pendingWriteResume = nil
         resume?()
@@ -911,6 +982,18 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                     writeGeneration: writeGeneration
                 )
             }
+            // Watchdog: peripheralIsReady is the ONLY resume signal, and a
+            // marginal link can simply never deliver it (without ever
+            // disconnecting either). Unbounded, `isWriting` would stay true
+            // forever and the wall would freeze until a manual disconnect.
+            let watchdog = DispatchWorkItem { [weak self] in
+                guard let self, self.pendingWriteResume != nil else { return }
+                self.logger.error("BLE write stalled: peripheral never became ready for write-without-response; failing queued writes")
+                self.failQueuedWrites(BoardBleError.writeTimedOut)
+            }
+            pendingWriteResumeWatchdog?.cancel()
+            pendingWriteResumeWatchdog = watchdog
+            bleQueue.asyncAfter(deadline: .now() + writeResumeTimeout, execute: watchdog)
             return
         }
 
@@ -931,6 +1014,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         writeQueue = []
         isWriting = false
         pendingWriteResume = nil
+        pendingWriteResumeWatchdog?.cancel()
+        pendingWriteResumeWatchdog = nil
         for request in queuedWrites {
             request.completion(error)
         }

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -23,6 +23,7 @@ public class BoardBleModule: Module {
     private let bufferQueue = DispatchQueue(label: "com.boardsesh.app.BoardBleModule.buffer")
     private var pendingEvents: [PendingEvent] = []
     private var hasListener = false
+    private var isDraining = false
 
     public func definition() -> ModuleDefinition {
         Name("BoardBle")
@@ -61,12 +62,8 @@ public class BoardBleModule: Module {
         OnStartObserving {
             self.bufferQueue.sync {
                 self.hasListener = true
-                let buffered = self.pendingEvents
-                self.pendingEvents = []
-                for event in buffered {
-                    self.sendEvent(event.name, event.body)
-                }
             }
+            self.drainPendingEvents()
         }
 
         OnStopObserving {
@@ -164,17 +161,36 @@ public class BoardBleModule: Module {
 
     private func emitOrBuffer(name: String, body: [String: Any]) {
         bufferQueue.sync {
-            if hasListener {
-                sendEvent(name, body)
-            } else {
-                pendingEvents.append(PendingEvent(name: name, body: body))
-                // Cap buffer growth in case the JS layer never attaches.
-                // Scan results are the only high-volume event and they're
-                // safely discarded if old.
-                if pendingEvents.count > 200 {
-                    pendingEvents.removeFirst(pendingEvents.count - 200)
-                }
+            pendingEvents.append(PendingEvent(name: name, body: body))
+            // Cap buffer growth in case the JS layer never attaches.
+            // Scan results are the only high-volume event and they're
+            // safely discarded if old.
+            if pendingEvents.count > 200 {
+                pendingEvents.removeFirst(pendingEvents.count - 200)
             }
+        }
+        drainPendingEvents()
+    }
+
+    /// Sends buffered events FIFO while a listener is attached. `sendEvent`
+    /// runs OUTSIDE `bufferQueue` so a synchronously re-entrant emission can
+    /// never deadlock the serial queue; `isDraining` keeps the drain
+    /// single-flight so concurrent callers can't interleave events out of
+    /// order.
+    private func drainPendingEvents() {
+        while true {
+            let next: PendingEvent? = bufferQueue.sync {
+                guard hasListener, !isDraining, !pendingEvents.isEmpty else { return nil }
+                isDraining = true
+                return pendingEvents.removeFirst()
+            }
+            guard let next else { return }
+            sendEvent(next.name, next.body)
+            let hasMore: Bool = bufferQueue.sync {
+                isDraining = false
+                return hasListener && !pendingEvents.isEmpty
+            }
+            if !hasMore { return }
         }
     }
 }

--- a/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -52,6 +52,7 @@ public class LiveActivityModule: Module {
     private let bufferQueue = DispatchQueue(label: "com.boardsesh.LiveActivityModule.buffer")
     private var pendingEvents: [PendingEvent] = []
     private var hasListener = false
+    private var isDraining = false
 
     public func definition() -> ModuleDefinition {
         Name("LiveActivity")
@@ -68,12 +69,8 @@ public class LiveActivityModule: Module {
         OnStartObserving {
             self.bufferQueue.sync {
                 self.hasListener = true
-                let buffered = self.pendingEvents
-                self.pendingEvents = []
-                for event in buffered {
-                    self.sendEvent(event.name, event.body)
-                }
             }
+            self.drainPendingEvents()
         }
 
         OnStopObserving {
@@ -110,14 +107,33 @@ public class LiveActivityModule: Module {
 
     private func emitOrBuffer(name: String, body: [String: Any]) {
         bufferQueue.sync {
-            if hasListener {
-                sendEvent(name, body)
-            } else {
-                pendingEvents.append(PendingEvent(name: name, body: body))
-                if pendingEvents.count > 32 {
-                    pendingEvents.removeFirst(pendingEvents.count - 32)
-                }
+            pendingEvents.append(PendingEvent(name: name, body: body))
+            if pendingEvents.count > 32 {
+                pendingEvents.removeFirst(pendingEvents.count - 32)
             }
+        }
+        drainPendingEvents()
+    }
+
+    /// Sends buffered events FIFO while a listener is attached. `sendEvent`
+    /// runs OUTSIDE `bufferQueue` so a synchronously re-entrant emission can
+    /// never deadlock the serial queue; `isDraining` keeps the drain
+    /// single-flight so concurrent callers can't interleave events out of
+    /// order.
+    private func drainPendingEvents() {
+        while true {
+            let next: PendingEvent? = bufferQueue.sync {
+                guard hasListener, !isDraining, !pendingEvents.isEmpty else { return nil }
+                isDraining = true
+                return pendingEvents.removeFirst()
+            }
+            guard let next else { return }
+            sendEvent(next.name, next.body)
+            let hasMore: Bool = bufferQueue.sync {
+                isDraining = false
+                return hasListener && !pendingEvents.isEmpty
+            }
+            if !hasMore { return }
         }
     }
 
@@ -538,6 +554,7 @@ public class LiveActivityModule: Module {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         request.httpBody = jsonData
+        request.timeoutInterval = 15
 
         URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
             if let error = error {

--- a/packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift
+++ b/packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift
@@ -341,6 +341,11 @@ final class SessionWebSocketManager {
 
         let task = self.urlSession.webSocketTask(with: url, protocols: ["graphql-transport-ws"])
         self.webSocketTask = task
+        // Measure ping freshness from connect time. Without this, the first
+        // ping-timeout window after a reconnect compares against the stale
+        // pre-disconnect timestamp and can immediately tear the new socket
+        // down if the server is quiet, churning through reconnect attempts.
+        self.lastMessageReceived = Date()
         task.resume()
         self.sendConnectionInit()
         self.listenForMessages(for: task)


### PR DESCRIPTION
## Context

A deep review of the BLE stack (the core product feature) found the realistic causes of two field-report patterns — hung connect attempts and "widget moved but the wall didn't" — concentrated in `BoardBleManager.swift`'s connect lifecycle. This PR fixes those plus three smaller items in the same module. Swift-only: ships with the next native build, not OTA.

## Fixes

**1. Concurrent connect orphaned the previous JS promise (high).**
`connectOnBleQueue` had no in-flight guard: a second connect overwrote `pendingConnectCompletion`, so the first `connect()` promise never settled. Worse, the superseded attempt's timeout work item was never cancelled — when switching to a *different* board its guards both still passed, so it would wrongly fail the **new** attempt with `connectTimedOut`. Now a still-pending attempt is settled with a new `superseded` error before the new one starts (which also cancels the stale work item via `completePendingConnect`).

**2. State restoration could half-restore.**
`willRestoreState` kept only `peripherals.first` (extras leaked as system-held phantom connections — these boards are last-connection-wins), called `discoverServices` even on a still-`.connecting` peripheral, and a swallowed discovery error left `connectedPeripheral` set with no write characteristic. Now: extra restored peripherals are cancelled, discovery only runs on `.connected`, `.connecting` waits for `didConnect`, and disconnected peripherals are ignored.

**3. Discovery failures left a half-open connection (also outside restore).**
Service/characteristic discovery errors only rejected the JS promise; the peripheral stayed connected at system level with `writeCharacteristic == nil`. New `failConnectionSetup` tears it down (cancel + clear state) so a later reconnect starts clean.

**4. Discovery callbacks lacked the generation guard `didConnect` already has.**
A stale same-device discovery callback from a superseded attempt could complete the newer attempt early. Both callbacks now check `peripheralGenerations[...] == connectionGeneration`.

**5. Parked write back-pressure had no watchdog.**
When `canSendWriteWithoutResponse` was false, `peripheralIsReady` was the *only* resume signal; a marginal link that never delivers it (and never disconnects) froze the write queue (`isWriting` stuck true) until a manual disconnect. A 5s watchdog now fails the queued writes with `writeTimedOut`; the next auto-send recovers.

**Smaller:** event-buffer drain moved outside the `bufferQueue` lock in `BoardBleModule`/`LiveActivityModule` (single-flight, FIFO-preserving — removes a latent re-entrancy deadlock); `SessionWebSocketManager` resets `lastMessageReceived` on connection open so the first ping window after a reconnect doesn't measure from the stale pre-disconnect timestamp; push-token unregister gets the same 15s `timeoutInterval` as registration.

## Not changed

- No auto-reconnect added anywhere — the last-connection-wins / user-initiated-only design is untouched.
- The widget-target Swift duplicates (`SharedConstants`, `SharedKeychain`, intents, `WidgetNetworking`) are not among the edited files, so no mirroring was needed.

## Validation

- `vp run typecheck:mobile` and `vp check` pass (Swift isn't compiled by either; CI's iOS build gates compilation).
- Needs a device pass on the Mac before merge: board connect → rapid board-switch in the picker (old promise should reject with "superseded", new connect should succeed), widget lightbulb reconnect, background relaunch via Live Activity intent, and a normal session write path.
- There are no Swift unit tests for `BoardBleManager` today; adding a golden-byte encoding parity test vs `@boardsesh/ble-protocol` is worth a follow-up but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)