### PR TITLE
fix(mobile): make iOS social login work and stop logging failures as 'cancel'

### DIFF
--- a/packages/mobile/app/auth/__tests__/callback-i18n.test.tsx
+++ b/packages/mobile/app/auth/__tests__/callback-i18n.test.tsx
@@ -11,7 +11,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const analytics = vi.hoisted(() => ({ track: vi.fn() }));
 const router = vi.hoisted(() => ({ replace: vi.fn() }));
-const params = vi.hoisted(() => ({ transferToken: undefined as string | undefined }));
+const params = vi.hoisted(() => ({
+  transferToken: undefined as string | undefined,
+  error: undefined as string | undefined,
+}));
 
 vi.mock('../../../src/lib/analytics', () => ({ track: analytics.track }));
 
@@ -23,13 +26,15 @@ vi.mock('react-native', () => ({
 }));
 
 vi.mock('expo-router', () => ({
-  useLocalSearchParams: () => ({ transferToken: params.transferToken }),
+  useLocalSearchParams: () => ({ transferToken: params.transferToken, error: params.error }),
   useRouter: () => router,
 }));
 
 // `t` echoes the key, so any English literal left in the component would show
-// up verbatim and fail the assertions below.
-vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+// up verbatim and fail the assertions below. Stable identity (like the real
+// hook's) so the effect depending on it doesn't re-fire on every render.
+const stableT = vi.hoisted(() => (key: string) => key);
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: stableT }) }));
 
 const auth = vi.hoisted(() => ({
   exchangeTransferToken: vi.fn(async () => ({ success: false, error: 'Invalid or expired transfer token' })),
@@ -39,8 +44,11 @@ vi.mock('../../../src/lib/auth', () => ({
   getPendingOAuthProvider: () => 'apple',
 }));
 vi.mock('../../../src/lib/native-auth-analytics', () => ({ classifyNativeAuthFailureReason: () => 'invalid_token' }));
+// Stable across renders like the real provider's useCallback — a fresh fn per
+// render would re-fire the effect after setError's re-render and double-track.
+const refreshAuthStateMock = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock('../../../src/providers/auth-provider', () => ({
-  useAuth: () => ({ refreshAuthState: vi.fn(async () => {}) }),
+  useAuth: () => ({ refreshAuthState: refreshAuthStateMock }),
 }));
 vi.mock('../../../src/providers/theme-provider', () => ({ useTheme: () => ({ brandColors: { error: '#FF3B30' } }) }));
 
@@ -51,6 +59,7 @@ beforeEach(() => {
   router.replace.mockClear();
   auth.exchangeTransferToken.mockClear();
   params.transferToken = undefined;
+  params.error = undefined;
 });
 
 describe('AuthCallback localization', () => {
@@ -69,6 +78,19 @@ describe('AuthCallback localization', () => {
     // The old screen prefixed every error with hardcoded 'Sign in failed:'.
     expect(container.textContent).not.toContain('Sign in failed');
     expect(container.textContent).not.toContain('No transfer token received');
+    // A genuinely missing token (no server error param) is this screen's to report.
+    expect(analytics.track).toHaveBeenCalledTimes(1);
+  });
+
+  // When the server deep-links an explicit error (?error=session_missing),
+  // login.tsx tracks it with the precise reason from the same URL; this screen
+  // mounting via expo-router's auto-route must not double-count the attempt.
+  it('shows the error but does not track when the server sent an explicit error param', async () => {
+    params.transferToken = undefined;
+    params.error = 'session_missing';
+    const { container } = render(createElement(AuthCallback));
+    await waitFor(() => expect(container.textContent).toContain('callback.noTransferToken'));
+    expect(analytics.track).not.toHaveBeenCalled();
   });
 
   it('renders a translated generic message instead of raw server error text', async () => {

--- a/packages/mobile/app/auth/__tests__/callback-i18n.test.tsx
+++ b/packages/mobile/app/auth/__tests__/callback-i18n.test.tsx
@@ -34,7 +34,10 @@ vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => k
 const auth = vi.hoisted(() => ({
   exchangeTransferToken: vi.fn(async () => ({ success: false, error: 'Invalid or expired transfer token' })),
 }));
-vi.mock('../../../src/lib/auth', () => ({ exchangeTransferToken: auth.exchangeTransferToken }));
+vi.mock('../../../src/lib/auth', () => ({
+  exchangeTransferToken: auth.exchangeTransferToken,
+  getPendingOAuthProvider: () => 'apple',
+}));
 vi.mock('../../../src/lib/native-auth-analytics', () => ({ classifyNativeAuthFailureReason: () => 'invalid_token' }));
 vi.mock('../../../src/providers/auth-provider', () => ({
   useAuth: () => ({ refreshAuthState: vi.fn(async () => {}) }),
@@ -76,8 +79,8 @@ describe('AuthCallback localization', () => {
     expect(container.textContent).not.toContain('Invalid or expired transfer token');
   });
 
-  // Android mounts this screen twice for one login: expo-router routes the
-  // deep link AND login.tsx routes here with openAuthSessionAsync's URL. The
+  // This screen mounts twice for one login: expo-router routes the callback
+  // deep link AND login.tsx routes here with the URL startSignIn resolved. The
   // module-level exchangedTokens set must keep the duplicate mount from
   // replaying the one-time token — the duplicate shows the spinner, never a
   // "token already used" failure.

--- a/packages/mobile/app/auth/callback.tsx
+++ b/packages/mobile/app/auth/callback.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { exchangeTransferToken } from '../../src/lib/auth';
+import { exchangeTransferToken, getPendingOAuthProvider } from '../../src/lib/auth';
 import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../../src/lib/analytics';
@@ -10,10 +10,10 @@ import { useAuth } from '../../src/providers/auth-provider';
 import { useTheme } from '../../src/providers/theme-provider';
 
 // Transfer tokens are one-time use, and this screen can mount twice for the
-// same token: on Android the callback deep link is routed by expo-router AND
-// the login screen routes here explicitly with the URL openAuthSessionAsync
-// returned. Module-level so a remount can't replay (and fail) the exchange —
-// the duplicate mount just shows the spinner until AuthProvider redirects.
+// same token: the callback deep link is routed by expo-router AND the login
+// screen routes here explicitly with the callback URL startSignIn resolved.
+// Module-level so a remount can't replay (and fail) the exchange — the
+// duplicate mount just shows the spinner until AuthProvider redirects.
 // Never cleared: one short string per login attempt for the process lifetime
 // is negligible, and clearing would reopen the replay window.
 const exchangedTokens = new Set<string>();
@@ -29,10 +29,18 @@ export default function AuthCallback() {
   const theme = useTheme();
 
   useEffect(() => {
+    // The transfer-token exchange doesn't echo the OAuth provider back, so
+    // attribute events to the attempt startSignIn recorded. Without this,
+    // social Login Succeeded events have no auth_method and disappear from
+    // every per-method funnel.
+    const authMethod = getPendingOAuthProvider() ?? undefined;
+
     if (!transferToken) {
-      // auth_method is unknown here — the OAuth provider isn't echoed back on the
-      // transfer-token exchange (same reason Login Succeeded omits it).
-      track(SHARED_EVENTS.LoginFailed, { flow: 'native', failure_reason: 'no_transfer_token' });
+      track(SHARED_EVENTS.LoginFailed, {
+        auth_method: authMethod,
+        flow: 'native',
+        failure_reason: 'no_transfer_token',
+      });
       setError(t('callback.noTransferToken'));
       return;
     }
@@ -43,18 +51,22 @@ export default function AuthCallback() {
     exchangeTransferToken(transferToken)
       .then(async (result) => {
         if (result.success) {
-          track(SHARED_EVENTS.LoginSucceeded, { flow: 'native' });
+          track(SHARED_EVENTS.LoginSucceeded, { auth_method: authMethod, flow: 'native' });
           await refreshAuthState();
           router.replace('/(tabs)/climbs');
         } else {
-          track(SHARED_EVENTS.LoginFailed, { flow: 'native', failure_reason: classifyNativeAuthFailureReason(result) });
+          track(SHARED_EVENTS.LoginFailed, {
+            auth_method: authMethod,
+            flow: 'native',
+            failure_reason: classifyNativeAuthFailureReason(result, 'exchange'),
+          });
           // result.error is a raw English/server string; show a translated
           // generic message instead (mirrors login.tsx's networkError pattern).
           setError(t('callback.failed'));
         }
       })
       .catch(() => {
-        track(SHARED_EVENTS.LoginFailed, { flow: 'native', failure_reason: 'exception' });
+        track(SHARED_EVENTS.LoginFailed, { auth_method: authMethod, flow: 'native', failure_reason: 'exception' });
         setError(t('callback.unexpectedError'));
       });
   }, [transferToken, router, refreshAuthState, t]);

--- a/packages/mobile/app/auth/callback.tsx
+++ b/packages/mobile/app/auth/callback.tsx
@@ -19,7 +19,10 @@ import { useTheme } from '../../src/providers/theme-provider';
 const exchangedTokens = new Set<string>();
 
 export default function AuthCallback() {
-  const { transferToken } = useLocalSearchParams<{ transferToken: string }>();
+  const { transferToken, error: serverCallbackError } = useLocalSearchParams<{
+    transferToken: string;
+    error?: string;
+  }>();
   const { t } = useTranslation('auth');
   // Holds a translated, user-facing failure message — never raw server text,
   // which the backend returns in English only.
@@ -36,11 +39,17 @@ export default function AuthCallback() {
     const authMethod = getPendingOAuthProvider() ?? undefined;
 
     if (!transferToken) {
-      track(SHARED_EVENTS.LoginFailed, {
-        auth_method: authMethod,
-        flow: 'native',
-        failure_reason: 'no_transfer_token',
-      });
+      // When the server deep-links an explicit error (session_missing /
+      // token_issue_failed), login.tsx already tracked it with the precise
+      // reason from the same URL — expo-router just also routed it here.
+      // Tracking again would double-count one failed attempt.
+      if (!serverCallbackError) {
+        track(SHARED_EVENTS.LoginFailed, {
+          auth_method: authMethod,
+          flow: 'native',
+          failure_reason: 'no_transfer_token',
+        });
+      }
       setError(t('callback.noTransferToken'));
       return;
     }
@@ -69,7 +78,7 @@ export default function AuthCallback() {
         track(SHARED_EVENTS.LoginFailed, { auth_method: authMethod, flow: 'native', failure_reason: 'exception' });
         setError(t('callback.unexpectedError'));
       });
-  }, [transferToken, router, refreshAuthState, t]);
+  }, [transferToken, serverCallbackError, router, refreshAuthState, t]);
 
   if (error) {
     return (

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -99,7 +99,7 @@ export default function LoginScreen() {
       if (!result.success) {
         track(SHARED_EVENTS.LoginFailed, {
           auth_method: 'credentials',
-          failure_reason: classifyNativeAuthFailureReason(result),
+          failure_reason: classifyNativeAuthFailureReason(result, 'credentials'),
         });
         if (result.error === 'network') {
           setError(t('nativeStart.networkError'));
@@ -129,13 +129,17 @@ export default function LoginScreen() {
     setOauthInProgress(true);
     setError(null);
     track(SHARED_EVENTS.LoginAttempted, { auth_method: provider, flow: 'native' });
+    // duration_ms separates a human abandoning the browser (seconds-to-minutes)
+    // from the flow dying programmatically (sub-second) — the iOS 26 auth-session
+    // bug surfaced as 100–250ms "cancels" that looked like user action.
+    const attemptStartedAt = Date.now();
     try {
       const result = await signIn(provider);
       if (result.type === 'success') {
-        // On iOS the auth session consumes the callback redirect and returns it
-        // here instead of delivering a deep link, so we must route the transfer
-        // token to /auth/callback ourselves. On Android the deep link can also
-        // arrive via expo-router; the callback screen dedupes the exchange.
+        // The browser result is one of two delivery paths for the callback URL
+        // (the other is the OS deep link expo-router routes to /auth/callback);
+        // route the transfer token there ourselves and let the callback screen
+        // dedupe the exchange.
         const { transferToken, error: callbackError } = parseAuthCallbackParams(result.url);
         if (transferToken) {
           router.replace({ pathname: '/auth/callback', params: { transferToken } });
@@ -146,16 +150,32 @@ export default function LoginScreen() {
             auth_method: provider,
             flow: 'native',
             failure_reason: callbackError ?? 'no_transfer_token',
+            duration_ms: Date.now() - attemptStartedAt,
           });
           setError(t('nativeStart.oauthError'));
         }
         return;
       }
-      // Everything else never reaches /auth/callback, so it's only observable
-      // here. cancel/dismiss is the user closing the system sheet; track every
-      // non-success type so the funnel sees the Attempted→Succeeded drop-off
-      // instead of a silent gap.
-      track(SHARED_EVENTS.LoginFailed, { auth_method: provider, flow: 'native', failure_reason: result.type });
+      // cancel/dismiss: the user closed the browser (iOS) or system sheet
+      // (Android) without completing OAuth. Programmatic failures no longer
+      // land here — startSignIn throws them into the catch below.
+      track(SHARED_EVENTS.LoginFailed, {
+        auth_method: provider,
+        flow: 'native',
+        failure_reason: result.type,
+        duration_ms: Date.now() - attemptStartedAt,
+      });
+    } catch (oauthError) {
+      // e.g. the in-app browser failed to open or another one is already
+      // presented. Previously an unhandled rejection with no event.
+      track(SHARED_EVENTS.LoginFailed, {
+        auth_method: provider,
+        flow: 'native',
+        failure_reason: 'exception',
+        failure_detail: oauthError instanceof Error ? oauthError.message : undefined,
+        duration_ms: Date.now() - attemptStartedAt,
+      });
+      setError(t('nativeStart.oauthError'));
     } finally {
       setOauthInProgress(false);
     }

--- a/packages/mobile/src/lib/__tests__/auth-session-race.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-session-race.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+import { raceBrowserSignIn, type AuthSessionRaceIo } from '../auth-session-race';
+
+const CALLBACK_PREFIX = 'com.boardsesh.app://auth/callback';
+const AUTH_URL = 'https://www.boardsesh.com/auth/native-start?provider=apple';
+
+// Harness exposing the registered URL listener and a controllable browser
+// promise, so each test can fire the deep link / close the browser in any order.
+function createIoHarness() {
+  let urlListener: ((event: { url: string }) => void) | null = null;
+  let resolveBrowser: (() => void) | null = null;
+  let rejectBrowser: ((reason: unknown) => void) | null = null;
+
+  const removeListener = vi.fn(() => {
+    urlListener = null;
+  });
+  const dismissBrowser = vi.fn(() => Promise.resolve());
+  const io: AuthSessionRaceIo = {
+    addUrlListener: (listener) => {
+      urlListener = listener;
+      return { remove: removeListener };
+    },
+    openBrowser: () =>
+      new Promise<void>((resolve, reject) => {
+        resolveBrowser = resolve;
+        rejectBrowser = reject;
+      }),
+    dismissBrowser,
+  };
+
+  return {
+    io,
+    removeListener,
+    dismissBrowser,
+    fireDeepLink: (url: string) => urlListener?.({ url }),
+    closeBrowser: () => resolveBrowser?.(),
+    failBrowser: (reason: unknown) => rejectBrowser?.(reason),
+  };
+}
+
+describe('raceBrowserSignIn', () => {
+  it('resolves success with the callback URL and dismisses the browser when the deep link arrives', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    const callbackUrl = `${CALLBACK_PREFIX}?transferToken=tok-1`;
+    harness.fireDeepLink(callbackUrl);
+
+    await expect(racePromise).resolves.toEqual({ type: 'success', url: callbackUrl });
+    expect(harness.dismissBrowser).toHaveBeenCalledTimes(1);
+    expect(harness.removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores deep links that are not the auth callback', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    harness.fireDeepLink('com.boardsesh.app://join/some-session');
+    harness.fireDeepLink(`${CALLBACK_PREFIX}?transferToken=tok-2`);
+
+    await expect(racePromise).resolves.toEqual({
+      type: 'success',
+      url: `${CALLBACK_PREFIX}?transferToken=tok-2`,
+    });
+  });
+
+  it('resolves cancel when the browser closes without a callback deep link', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    harness.closeBrowser();
+
+    await expect(racePromise).resolves.toEqual({ type: 'cancel' });
+    expect(harness.dismissBrowser).not.toHaveBeenCalled();
+    expect(harness.removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the success result when the dismissed browser later resolves', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    harness.fireDeepLink(`${CALLBACK_PREFIX}?transferToken=tok-3`);
+    // dismissBrowser() closing the browser resolves openBrowser afterwards.
+    harness.closeBrowser();
+
+    await expect(racePromise).resolves.toEqual({
+      type: 'success',
+      url: `${CALLBACK_PREFIX}?transferToken=tok-3`,
+    });
+  });
+
+  it('resolves error with the message when the browser fails to open', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    harness.failBrowser(new Error('Another WebBrowser is already being presented.'));
+
+    await expect(racePromise).resolves.toEqual({
+      type: 'error',
+      message: 'Another WebBrowser is already being presented.',
+    });
+    expect(harness.removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a generic message for non-Error rejections', async () => {
+    const harness = createIoHarness();
+    const racePromise = raceBrowserSignIn(harness.io, AUTH_URL, CALLBACK_PREFIX);
+
+    harness.failBrowser('boom');
+
+    await expect(racePromise).resolves.toEqual({ type: 'error', message: 'browser failed to open' });
+  });
+});

--- a/packages/mobile/src/lib/__tests__/auth-session-race.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-session-race.test.ts
@@ -82,11 +82,31 @@ describe('raceBrowserSignIn', () => {
     harness.fireDeepLink(`${CALLBACK_PREFIX}?transferToken=tok-3`);
     // dismissBrowser() closing the browser resolves openBrowser afterwards.
     harness.closeBrowser();
+    await Promise.resolve();
 
     await expect(racePromise).resolves.toEqual({
       type: 'success',
       url: `${CALLBACK_PREFIX}?transferToken=tok-3`,
     });
+    // Promise resolve() is idempotent, so the value alone can't prove the
+    // double-settle guard held — the listener teardown running once can.
+    expect(harness.removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles error and removes the listener when openBrowser throws synchronously', async () => {
+    const harness = createIoHarness();
+    const throwingIo: AuthSessionRaceIo = {
+      ...harness.io,
+      openBrowser: () => {
+        throw new Error('no browser available');
+      },
+    };
+
+    await expect(raceBrowserSignIn(throwingIo, AUTH_URL, CALLBACK_PREFIX)).resolves.toEqual({
+      type: 'error',
+      message: 'no browser available',
+    });
+    expect(harness.removeListener).toHaveBeenCalledTimes(1);
   });
 
   it('resolves error with the message when the browser fails to open', async () => {

--- a/packages/mobile/src/lib/__tests__/auth.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.test.ts
@@ -3,28 +3,60 @@ import { classifyNativeAuthFailureReason } from '../native-auth-analytics';
 
 describe('classifyNativeAuthFailureReason', () => {
   it('maps native credential and transfer failures to low-cardinality analytics reasons', () => {
-    expect(classifyNativeAuthFailureReason({ success: false, status: null, error: 'network' })).toBe('network');
+    expect(classifyNativeAuthFailureReason({ success: false, status: null, error: 'network' }, 'credentials')).toBe(
+      'network',
+    );
     expect(
-      classifyNativeAuthFailureReason({ success: false, status: 400, error: 'email and password are required' }),
+      classifyNativeAuthFailureReason(
+        { success: false, status: 400, error: 'email and password are required' },
+        'credentials',
+      ),
     ).toBe('invalid_request');
-    expect(classifyNativeAuthFailureReason({ success: false, status: 401, error: 'Invalid credentials' })).toBe(
+    expect(
+      classifyNativeAuthFailureReason(
+        { success: false, status: 409, error: 'Transfer token has already been used' },
+        'exchange',
+      ),
+    ).toBe('transfer_token_replay');
+    expect(
+      classifyNativeAuthFailureReason({ success: false, status: 429, error: 'Rate limit exceeded' }, 'exchange'),
+    ).toBe('rate_limited');
+    expect(
+      classifyNativeAuthFailureReason(
+        { success: false, status: 503, error: 'Service temporarily overloaded' },
+        'exchange',
+      ),
+    ).toBe('service_unavailable');
+    expect(
+      classifyNativeAuthFailureReason({ success: false, status: 500, error: 'Internal server error' }, 'exchange'),
+    ).toBe('server_error');
+    expect(classifyNativeAuthFailureReason({ success: false, status: 418, error: 'teapot' }, 'exchange')).toBe(
+      'http_error',
+    );
+  });
+
+  // Regression: the classifier used to string-match the 401 body against
+  // 'Invalid credentials', but the backend says 'Invalid email or password' —
+  // every real wrong-password attempt was logged as invalid_transfer_token.
+  it('classifies a 401 by which exchange failed, not by server copy', () => {
+    expect(
+      classifyNativeAuthFailureReason(
+        { success: false, status: 401, error: 'Invalid email or password' },
+        'credentials',
+      ),
+    ).toBe('invalid_credentials');
+    expect(
+      classifyNativeAuthFailureReason(
+        { success: false, status: 401, error: 'Invalid or expired transfer token' },
+        'exchange',
+      ),
+    ).toBe('invalid_transfer_token');
+    // Even an unexpected body keeps the right bucket for its endpoint.
+    expect(classifyNativeAuthFailureReason({ success: false, status: 401, error: 'Unauthorized' }, 'credentials')).toBe(
       'invalid_credentials',
     );
-    expect(
-      classifyNativeAuthFailureReason({ success: false, status: 401, error: 'Invalid or expired transfer token' }),
-    ).toBe('invalid_transfer_token');
-    expect(
-      classifyNativeAuthFailureReason({ success: false, status: 409, error: 'Transfer token has already been used' }),
-    ).toBe('transfer_token_replay');
-    expect(classifyNativeAuthFailureReason({ success: false, status: 429, error: 'Rate limit exceeded' })).toBe(
-      'rate_limited',
+    expect(classifyNativeAuthFailureReason({ success: false, status: 401, error: 'Unauthorized' }, 'exchange')).toBe(
+      'invalid_transfer_token',
     );
-    expect(
-      classifyNativeAuthFailureReason({ success: false, status: 503, error: 'Service temporarily overloaded' }),
-    ).toBe('service_unavailable');
-    expect(classifyNativeAuthFailureReason({ success: false, status: 500, error: 'Internal server error' })).toBe(
-      'server_error',
-    );
-    expect(classifyNativeAuthFailureReason({ success: false, status: 418, error: 'teapot' })).toBe('http_error');
   });
 });

--- a/packages/mobile/src/lib/auth-session-race.ts
+++ b/packages/mobile/src/lib/auth-session-race.ts
@@ -1,0 +1,61 @@
+// Drives the iOS sign-in hand-off: open the OAuth page in an in-app browser
+// and wait for the OS deep link that the server's callback page fires
+// (com.boardsesh.app://auth/callback?transferToken=...). All platform I/O is
+// injected so unit tests need no expo-web-browser or react-native mocks.
+//
+// Why not WebBrowser.openAuthSessionAsync: its ASWebAuthenticationSession can
+// fail to present (observed as 100–250ms failures on iOS 26 devices — expo's
+// presentation anchor is the deprecated UIApplication.shared.keyWindow), and
+// expo-web-browser collapses every such failure into {type: 'cancel'},
+// indistinguishable from the user closing the sheet. SFSafariViewController +
+// an OS deep link is the same hand-off the legacy Capacitor app shipped with,
+// and the server's deep-link callback page was built for it.
+
+export type AuthSessionRaceResult =
+  | { type: 'success'; url: string }
+  | { type: 'cancel' }
+  | { type: 'error'; message: string };
+
+type UrlEventSubscription = { remove: () => void };
+
+export type AuthSessionRaceIo = {
+  addUrlListener: (listener: (event: { url: string }) => void) => UrlEventSubscription;
+  openBrowser: (url: string) => Promise<unknown>;
+  dismissBrowser: () => Promise<unknown>;
+};
+
+export function raceBrowserSignIn(
+  io: AuthSessionRaceIo,
+  authUrl: string,
+  callbackUrlPrefix: string,
+): Promise<AuthSessionRaceResult> {
+  return new Promise((resolve) => {
+    let subscription: UrlEventSubscription | null = null;
+    let settled = false;
+    const settle = (result: AuthSessionRaceResult) => {
+      if (settled) return;
+      settled = true;
+      subscription?.remove();
+      resolve(result);
+    };
+
+    subscription = io.addUrlListener(({ url }) => {
+      if (!url.startsWith(callbackUrlPrefix)) return;
+      // Close the browser left behind under the deep-link hand-off. Best-effort:
+      // its own resolution below is a no-op once settled.
+      io.dismissBrowser().catch(() => {});
+      settle({ type: 'success', url });
+    });
+
+    io.openBrowser(authUrl).then(
+      // Resolves when the browser closes. Reaching this un-settled means no
+      // callback deep link arrived — the user closed it without finishing.
+      () => settle({ type: 'cancel' }),
+      (openBrowserError: unknown) =>
+        settle({
+          type: 'error',
+          message: openBrowserError instanceof Error ? openBrowserError.message : 'browser failed to open',
+        }),
+    );
+  });
+}

--- a/packages/mobile/src/lib/auth-session-race.ts
+++ b/packages/mobile/src/lib/auth-session-race.ts
@@ -47,15 +47,23 @@ export function raceBrowserSignIn(
       settle({ type: 'success', url });
     });
 
-    io.openBrowser(authUrl).then(
-      // Resolves when the browser closes. Reaching this un-settled means no
-      // callback deep link arrived — the user closed it without finishing.
-      () => settle({ type: 'cancel' }),
-      (openBrowserError: unknown) =>
-        settle({
-          type: 'error',
-          message: openBrowserError instanceof Error ? openBrowserError.message : 'browser failed to open',
-        }),
-    );
+    const settleOpenFailure = (openBrowserError: unknown) =>
+      settle({
+        type: 'error',
+        message: openBrowserError instanceof Error ? openBrowserError.message : 'browser failed to open',
+      });
+
+    try {
+      io.openBrowser(authUrl).then(
+        // Resolves when the browser closes. Reaching this un-settled means no
+        // callback deep link arrived — the user closed it without finishing.
+        () => settle({ type: 'cancel' }),
+        settleOpenFailure,
+      );
+    } catch (openBrowserError) {
+      // A synchronous throw would otherwise leak the URL listener and hang
+      // the returned promise forever.
+      settleOpenFailure(openBrowserError);
+    }
   });
 }

--- a/packages/mobile/src/lib/auth.ts
+++ b/packages/mobile/src/lib/auth.ts
@@ -1,20 +1,57 @@
+import { Linking, Platform } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 import { createTimeoutSignal } from './abort-timeout';
+import { raceBrowserSignIn } from './auth-session-race';
 import { storeTokens, clearTokens, getRefreshToken } from './auth-store';
 import { BACKEND_URL, WEB_BASE_URL } from './env';
 
 export type AuthProvider = 'google' | 'apple';
 
-// Returns the WebBrowser result because it's the only reliable way to receive
-// the callback. On iOS the in-app auth session consumes the redirect to the
-// callback scheme and returns it as `{ type: 'success', url }` — the URL is
-// never delivered to the app as a deep link, so the caller must parse
-// `result.url` (see parseAuthCallbackParams) and route the transfer token to
-// /auth/callback itself. Cancel/dismiss is likewise only observable here.
+const AUTH_CALLBACK_URL = 'com.boardsesh.app://auth/callback';
+
+// The transfer-token exchange doesn't echo the OAuth provider back, so the
+// callback screen reads the in-flight attempt's provider from here to attribute
+// its Login Succeeded/Failed events. Overwritten by each new attempt.
+let pendingOAuthProvider: AuthProvider | null = null;
+
+export function getPendingOAuthProvider(): AuthProvider | null {
+  return pendingOAuthProvider;
+}
+
+// The two platforms deliver the OAuth callback differently:
+// - Android: openAuthSessionAsync's custom tab. The callback arrives both as
+//   the resolved result URL and as an expo-router deep link; the callback
+//   screen dedupes the exchange.
+// - iOS: a plain SFSafariViewController raced against the OS deep link the
+//   server's callback page fires (see auth-session-race.ts for why
+//   openAuthSessionAsync is deliberately avoided here). Expo Router also
+//   routes the deep link to /auth/callback; the same dedupe applies.
 export async function startSignIn(provider: AuthProvider): Promise<WebBrowser.WebBrowserAuthSessionResult> {
+  pendingOAuthProvider = provider;
   const callbackUrl = encodeURIComponent('/api/auth/native/callback?next=/');
   const url = `${WEB_BASE_URL}/auth/native-start?provider=${provider}&callbackUrl=${callbackUrl}`;
-  return WebBrowser.openAuthSessionAsync(url, 'com.boardsesh.app://auth/callback');
+
+  if (Platform.OS !== 'ios') {
+    return WebBrowser.openAuthSessionAsync(url, AUTH_CALLBACK_URL);
+  }
+
+  const result = await raceBrowserSignIn(
+    {
+      addUrlListener: (listener) => Linking.addEventListener('url', listener),
+      openBrowser: (browserUrl) => WebBrowser.openBrowserAsync(browserUrl),
+      dismissBrowser: () => WebBrowser.dismissBrowser(),
+    },
+    url,
+    AUTH_CALLBACK_URL,
+  );
+  if (result.type === 'error') {
+    // Surfaces in the login screen's catch, which reports the message as
+    // failure_detail — the old flow filed browser failures under 'cancel'.
+    throw new Error(result.message);
+  }
+  return result.type === 'success'
+    ? { type: 'success', url: result.url }
+    : { type: WebBrowser.WebBrowserResultType.CANCEL };
 }
 
 type NativeAuthFailure = { success: false; status: number | null; error: string };

--- a/packages/mobile/src/lib/native-auth-analytics.ts
+++ b/packages/mobile/src/lib/native-auth-analytics.ts
@@ -10,13 +10,23 @@ export type NativeAuthFailureReason =
   | 'http_error'
   | 'exception';
 
+// Which backend exchange produced the failure. A 401 means "invalid
+// credentials" on /auth/native/credentials but "invalid or expired transfer
+// token" on /auth/native/exchange — classify by the call site instead of
+// string-matching server copy (which silently broke when the backend's 401
+// body said 'Invalid email or password').
+export type NativeAuthFailureSource = 'credentials' | 'exchange';
+
 type NativeAuthFailure = { success: false; status: number | null; error: string };
 
-export function classifyNativeAuthFailureReason(failure: NativeAuthFailure): NativeAuthFailureReason {
+export function classifyNativeAuthFailureReason(
+  failure: NativeAuthFailure,
+  source: NativeAuthFailureSource,
+): NativeAuthFailureReason {
   if (failure.error === 'network') return 'network';
   if (failure.status === 400) return 'invalid_request';
   if (failure.status === 401) {
-    return failure.error === 'Invalid credentials' ? 'invalid_credentials' : 'invalid_transfer_token';
+    return source === 'credentials' ? 'invalid_credentials' : 'invalid_transfer_token';
   }
   if (failure.status === 409) return 'transfer_token_replay';
   if (failure.status === 429) return 'rate_limited';


### PR DESCRIPTION
## Root cause

Sign in with Apple/Google in the RN app has had **near-zero success since TestFlight launch**, with every failure logged as `failure_reason='cancel'`. Three separate bugs stacked:

1. **The 'cancel' events are not cancellations.** expo-web-browser maps *every* ASWebAuthenticationSession failure to `{type:'cancel'}` (`WebAuthSession.swift:29` — `"type": callbackUrl != nil ? "success" : "cancel"`), and `login.tsx` forwarded `result.type` raw into `failure_reason`. PostHog shows the two heavy retriers (24×/15×, builds 100219/100220, both iOS 26.5.1) failing **100–250 ms** after `Login Attempted` — the auth sheet never opened. expo's presentation anchor is the deprecated `UIApplication.shared.keyWindow ?? ASPresentationAnchor()`, which fails to provide a foreground-scene window on iOS 26 (apps are now built with Xcode 26 / UIScene lifecycle).
2. **The successes were invisible.** `callback.tsx` logged `Login Succeeded` without `auth_method`, so the two social logins that *did* complete (iOS 26.5.1 build 100205 via Apple, Android 16 via Google) never showed up in any per-method funnel. This also proves the rest of the pipeline works: prod has both providers configured (`/api/auth/providers-config` → `{"google":true,"apple":true}`), the NextAuth signin POST 302s to Google with correct PKCE/state/callback cookies (verified with curl), and the transfer-token exchange works.
3. **The `invalid_transfer_token` blips on credentials logins were mislabeled typos.** The classifier string-matched the 401 body against `'Invalid credentials'`, but the backend sends `'Invalid email or password'` (`packages/backend/src/handlers/native-auth.ts:21`) — every real wrong-password attempt fell into the `invalid_transfer_token` bucket. Matches "2 people, both recovered on retry".

## Fix (JS/TS only — **ships OTA, no native build needed**)

- **iOS**: drop `openAuthSessionAsync` entirely. Open `/auth/native-start` in SFSafariViewController (`openBrowserAsync`) and race it against the `com.boardsesh.app://auth/callback` deep link (`auth-session-race.ts`, pure + unit-tested). This is the same hand-off the legacy Capacitor app shipped with — the server's deep-link callback page (`packages/web/app/api/auth/native/callback/route.ts`) was explicitly built for it. **Android unchanged** (confirmed working end-to-end).
- **Telemetry**: callback-screen events now carry `auth_method`; OAuth failures carry `duration_ms` (a ~150 ms "cancel" is a programmatic failure, a 30 s one is a human); browser-open failures surface as `exception` + `failure_detail` instead of an unhandled rejection.
- **Classifier**: 401s are classified by endpoint (`credentials` vs `exchange`), not server copy.

## Validation

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` — 237 files, 1692 tests ✅ (new: `auth-session-race.test.ts`, expanded 401 classifier regression cases)
- `vp run check:mobile-bundle` ✅ (10.7 MB)
- `vp check` ✅ on changed files (16 remaining complaints are pre-existing drift on main, untouched here)
- Device QA pending (Linux box): see the QA-notes comment below — test Apple + Google on an iOS 26 device (the broken case), genuine-cancel path, wrong-password path, and confirm PostHog now shows `auth_method` on `Login Succeeded`.

## Follow-ups (out of scope)

- Native Sign in with Apple (`expo-apple-authentication` + entitlement) and native Google Sign-In — the long-term UX answer; needs a fresh build, a Google iOS OAuth client, and a backend JWKS-verify endpoint.
- Upstream issue/patch for expo-web-browser's deprecated `keyWindow` presentation anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
