### PR TITLE
fix(ble): Android session-service teardown + BLE JS polish

### DIFF
--- a/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/BoardSessionActionReceiver.kt
+++ b/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/BoardSessionActionReceiver.kt
@@ -20,6 +20,6 @@ class BoardSessionActionReceiver : BroadcastReceiver() {
         }
         val currentIndex = intent.getIntExtra(BoardSessionService.EXTRA_CURRENT_INDEX, 0)
         val correlationId = intent.getStringExtra(BoardSessionService.EXTRA_CORRELATION_ID) ?: ""
-        SessionPresenceModule.dispatchQueueNavigate(context.applicationContext, action, currentIndex, correlationId)
+        SessionPresenceModule.dispatchQueueNavigate(action, currentIndex, correlationId)
     }
 }

--- a/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/BoardSessionService.kt
+++ b/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/BoardSessionService.kt
@@ -24,6 +24,10 @@ class BoardSessionService : Service() {
 
     private var channelName: String = "Active climbing session"
     private var channelDescription: String = ""
+    // True once ACTION_START delivered a localized channel name. Other entries
+    // (UPDATE/STOP/null-intent restart on a cold process) still carry the
+    // English defaults above and must never rename an existing channel.
+    private var channelNameLocalized: Boolean = false
     private var contentTitleFallback: String = "Climbing session"
     private var previousLabel: String = "Previous"
     private var nextLabel: String = "Next"
@@ -41,7 +45,10 @@ class BoardSessionService : Service() {
         // 5 s startForeground() deadline.
         when (intent?.action) {
             ACTION_START -> {
-                channelName = intent.getStringExtra(EXTRA_CHANNEL_NAME) ?: channelName
+                intent.getStringExtra(EXTRA_CHANNEL_NAME)?.let {
+                    channelName = it
+                    channelNameLocalized = true
+                }
                 channelDescription = intent.getStringExtra(EXTRA_CHANNEL_DESC) ?: channelDescription
                 contentTitleFallback = intent.getStringExtra(EXTRA_TITLE_FALLBACK) ?: contentTitleFallback
                 previousLabel = intent.getStringExtra(EXTRA_PREV_LABEL) ?: previousLabel
@@ -122,7 +129,14 @@ class BoardSessionService : Service() {
     private fun ensureChannel() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         val manager = getSystemService(NotificationManager::class.java) ?: return
-        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+        val existing = manager.getNotificationChannel(CHANNEL_ID)
+        if (existing != null) {
+            // Re-create only when ACTION_START delivered a fresh localized name
+            // that differs — createNotificationChannel on an existing id updates
+            // name/description, so a device-locale change doesn't leave the old
+            // language in system Settings forever.
+            if (!channelNameLocalized || existing.name?.toString() == channelName) return
+        }
         val channel = NotificationChannel(CHANNEL_ID, channelName, NotificationManager.IMPORTANCE_LOW).apply {
             description = channelDescription
             setShowBadge(false)

--- a/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceController.kt
+++ b/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceController.kt
@@ -98,8 +98,34 @@ internal class SessionPresenceController(
     }
 
     fun endSession() {
+        val hadActiveSession = sessionActive
         sessionActive = false
-        context.stopService(Intent(context, BoardSessionService::class.java))
+        val stopIntent = Intent(context, BoardSessionService::class.java).apply {
+            action = BoardSessionService.ACTION_STOP
+        }
+        if (!hadActiveSession) {
+            // No session window, so no startForegroundService() token can be
+            // outstanding; a plain stopService is a safe no-op teardown.
+            context.stopService(stopIntent)
+            return
+        }
+        // Tear down through the service's own ACTION_STOP path rather than
+        // stopService(): if the start token from startSession() is still
+        // pending (onStartCommand hasn't run yet), stopService() bypasses
+        // onStartCommand and leaves that token dangling — Android 12-14 can
+        // then kill the process with ForegroundServiceDidNotStartInTimeException.
+        // ACTION_STOP promotes first, satisfying every outstanding token, then
+        // stops itself (BoardSessionService.onStartCommand).
+        try {
+            startForegroundService(context, stopIntent)
+        } catch (error: Exception) {
+            // Nothing promotable (service already gone and app backgrounded):
+            // there is no dangling token in that state either, so falling back
+            // to a plain stopService is safe.
+            val errorName = error.javaClass.simpleName.ifBlank { error.javaClass.name }
+            Log.w(TAG, "ACTION_STOP startForegroundService failed ($errorName), falling back to stopService: ${error.message}")
+            context.stopService(stopIntent)
+        }
     }
 
     // startForegroundService() throws ForegroundServiceStartNotAllowedException on

--- a/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceModule.kt
+++ b/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceModule.kt
@@ -1,7 +1,5 @@
 package com.boardsesh.liveactivity
 
-import android.content.Context
-import android.content.Intent
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.records.Field
@@ -46,8 +44,6 @@ class SessionUpdateOptions : Record {
  */
 class SessionPresenceModule : Module() {
 
-    private val pendingEvents = ConcurrentLinkedQueue<Map<String, Any?>>()
-
     @Volatile
     private var hasListeners = false
 
@@ -78,8 +74,13 @@ class SessionPresenceModule : Module() {
 
         OnCreate { instance = WeakReference(this@SessionPresenceModule) }
         OnDestroy {
-            instance = null
-            pendingEvents.clear()
+            // Guard against a reload race where the replacement module's
+            // OnCreate ran before this instance's OnDestroy. pendingEvents is
+            // deliberately NOT cleared: it is process-static so a navigate
+            // tapped during the React-host gap replays once JS reattaches.
+            if (instance?.get() === this@SessionPresenceModule) {
+                instance = null
+            }
         }
 
         // Buffer navigate events that arrive before JS attaches a listener (e.g.
@@ -114,8 +115,7 @@ class SessionPresenceModule : Module() {
         if (hasListeners) {
             sendEvent("queueNavigate", event)
         } else {
-            if (pendingEvents.size >= MAX_BUFFERED_EVENTS) pendingEvents.poll()
-            pendingEvents.add(event)
+            buffer(event)
         }
     }
 
@@ -129,29 +129,38 @@ class SessionPresenceModule : Module() {
     companion object {
         private const val MAX_BUFFERED_EVENTS = 32
 
+        // Process-static (not per-instance) so a navigate tapped while the
+        // React host is being torn down or recreated survives the module
+        // instance and replays once the next instance's JS listener attaches.
+        private val pendingEvents = ConcurrentLinkedQueue<Map<String, Any?>>()
+
         @Volatile
         private var instance: WeakReference<SessionPresenceModule>? = null
+
+        private fun buffer(event: Map<String, Any?>) {
+            if (pendingEvents.size >= MAX_BUFFERED_EVENTS) pendingEvents.poll()
+            pendingEvents.add(event)
+        }
 
         /**
          * Called by BoardSessionActionReceiver when a Previous/Next notification
          * action is tapped. Routes to the live module (buffering if JS isn't
-         * listening yet); if the JS process is gone, brings the app to the
-         * foreground so the user can act.
+         * listening yet); with no live module the event is buffered for replay
+         * on reattach. The old fallback — startActivity from the receiver — was
+         * a notification trampoline, which Android 12+ blocks for targetSdk
+         * 31+: the launch silently no-oped and the tap was lost entirely.
          */
-        fun dispatchQueueNavigate(context: Context, action: String, currentIndex: Int, correlationId: String) {
-            val module = instance?.get()
+        fun dispatchQueueNavigate(action: String, currentIndex: Int, correlationId: String) {
             val event = mapOf(
                 "action" to action,
                 "currentIndex" to currentIndex,
                 "correlationId" to correlationId,
             )
+            val module = instance?.get()
             if (module != null) {
                 module.emit(event)
             } else {
-                context.packageManager.getLaunchIntentForPackage(context.packageName)?.let { launch ->
-                    launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    context.startActivity(launch)
-                }
+                buffer(event)
             }
         }
     }

--- a/packages/mobile/modules/live-activity/android/src/test/java/com/boardsesh/liveactivity/SessionPresenceControllerTest.kt
+++ b/packages/mobile/modules/live-activity/android/src/test/java/com/boardsesh/liveactivity/SessionPresenceControllerTest.kt
@@ -163,12 +163,48 @@ class SessionPresenceControllerTest {
 
     @Test
     @Config(sdk = [30])
-    fun `endSession deactivates the session`() {
-        val (controller, _) = recordingController()
+    fun `endSession deactivates and tears down via ACTION_STOP`() {
+        val (controller, launchedIntents) = recordingController()
         controller.startSession(null)
 
         controller.endSession()
 
+        // Teardown must go through the service's promote-then-stop ACTION_STOP
+        // path (not stopService): a start token from startSession may still be
+        // pending, and bypassing onStartCommand leaves it dangling — the
+        // ForegroundServiceDidNotStartInTimeException kill on Android 12-14.
         assertFalse(controller.sessionActive)
+        assertEquals(BoardSessionService.ACTION_STOP, launchedIntents.last().action)
+    }
+
+    @Test
+    @Config(sdk = [31])
+    fun `endSession falls back to stopService when ACTION_STOP delivery throws`() {
+        var failNextLaunch = false
+        val controller = SessionPresenceController(application) { _, _ ->
+            if (failNextLaunch) throw fgsNotAllowed()
+        }
+        controller.startSession(null)
+
+        // Service already gone and app backgrounded: the ACTION_STOP delivery
+        // throws, but the session must still end locally without rethrowing.
+        failNextLaunch = true
+        controller.endSession()
+
+        assertFalse(controller.sessionActive)
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `endSession without an active session skips the foreground start`() {
+        val (controller, launchedIntents) = recordingController()
+
+        // No session window means no pending start token; ACTION_STOP via
+        // startForegroundService would briefly promote a fresh service just to
+        // stop it (a notification flash), so this path must stay stopService.
+        controller.endSession()
+
+        assertFalse(controller.sessionActive)
+        assertTrue(launchedIntents.isEmpty())
     }
 }

--- a/packages/mobile/src/components/__tests__/ble-control-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/ble-control-sheet.test.tsx
@@ -40,6 +40,7 @@ const baseProps = {
   visible: true,
   onReassert: vi.fn(),
   onClearLights: vi.fn(),
+  supportsClearLights: true,
   onDisconnect: vi.fn(),
   onClose: vi.fn(),
 };
@@ -82,5 +83,13 @@ describe('BleControlSheet', () => {
     expect(baseProps.onDisconnect).toHaveBeenCalledTimes(1);
     expect(baseProps.onClearLights).not.toHaveBeenCalled();
     expect(baseProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the turn-off row when the board cannot encode a clear frame (MoonBoard)', () => {
+    const { queryByText, getByText } = render(<BleControlSheet {...baseProps} supportsClearLights={false} />);
+    expect(queryByText('lightControl.turnOffAll')).toBeNull();
+    // The other controls stay available.
+    expect(getByText('ble.relightBoard')).toBeDefined();
+    expect(getByText('lightControl.disconnect')).toBeDefined();
   });
 });

--- a/packages/mobile/src/components/ble/BleControlSheet.tsx
+++ b/packages/mobile/src/components/ble/BleControlSheet.tsx
@@ -15,6 +15,13 @@ type BleControlSheetProps = {
   onReassert: () => void;
   /** Clear every LED on the wall, keeping the connection alive. */
   onClearLights: () => void;
+  /**
+   * Whether the connected board can encode a clear-all frame. MoonBoard's
+   * protocol has no "clear" packet (an empty frame is a deliberate no-op in
+   * sendFramesToBoard, matching web), so the row is hidden rather than left
+   * as a silent dead tap.
+   */
+  supportsClearLights: boolean;
   /** Drop the BLE connection. */
   onDisconnect: () => void;
   onClose: () => void;
@@ -23,7 +30,14 @@ type BleControlSheetProps = {
 // Secondary BLE controls (Re-light / Turn off all lights / Disconnect) revealed
 // by long-pressing the lightbulb — keeps the destructive Disconnect behind a
 // labelled menu.
-function BleControlSheet({ visible, onReassert, onClearLights, onDisconnect, onClose }: BleControlSheetProps) {
+function BleControlSheet({
+  visible,
+  onReassert,
+  onClearLights,
+  supportsClearLights,
+  onDisconnect,
+  onClose,
+}: BleControlSheetProps) {
   const { t: tSettings } = useTranslation('settings');
   const { t: tCommon } = useTranslation('common');
   const { brandColors, systemColors } = useTheme();
@@ -63,12 +77,14 @@ function BleControlSheet({ visible, onReassert, onClearLights, onDisconnect, onC
           onPress={handleReassert}
           showSeparator
         />
-        <ListRow
-          title={tCommon('lightControl.turnOffAll')}
-          leading={<Icon name="lightbulb.slash" size={22} color={systemColors.secondaryLabel} />}
-          onPress={handleClearLights}
-          showSeparator
-        />
+        {supportsClearLights && (
+          <ListRow
+            title={tCommon('lightControl.turnOffAll')}
+            leading={<Icon name="lightbulb.slash" size={22} color={systemColors.secondaryLabel} />}
+            onPress={handleClearLights}
+            showSeparator
+          />
+        )}
         <ListRow
           title={tCommon('lightControl.disconnect')}
           leading={<Icon name="bluetooth.off" size={22} color={iosSystemColors.systemRed} />}

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -958,6 +958,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
           visible={bleControlOpen}
           onReassert={bluetooth.reassertWall}
           onClearLights={() => void bluetooth.clearBoard()}
+          supportsClearLights={boardName !== 'moonboard'}
           onDisconnect={disconnectAllBluetooth}
           onClose={() => setBleControlOpen(false)}
         />

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, AppState } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
@@ -261,6 +261,20 @@ export function useBoardBluetooth({
   // config-switch effect tell a genuine board/layout/size change (tear down)
   // from an unrelated re-render (no-op), and is the key cleared on every drop.
   const connectedConfigKeyRef = useRef<string | null>(null);
+  // What connect() pushed as its initialFrames write, if any. The AutoSender
+  // (mounted right after isConnected flips true) reads this one-shot seed so a
+  // byte-identical current climb doesn't get re-sent immediately on connect —
+  // a redundant full-frame write plus a doubled success haptic.
+  const connectInitialSendRef = useRef<{ frames: string; mirrored: boolean } | null>(null);
+
+  // ledColorOverrides narrowed to string values, shared by the connect and
+  // adoption configureBoard calls so both push identical overrides natively.
+  const sanitizedColorOverrides = useMemo(() => {
+    if (!ledColorOverrides) return undefined;
+    return Object.fromEntries(
+      Object.entries(ledColorOverrides).filter(([, value]) => typeof value === 'string') as [string, string][],
+    );
+  }, [ledColorOverrides]);
 
   const [pickerState, setPickerState] = useState<PickerState | null>(null);
   const pickerRejectRef = useRef<((error: Error) => void) | null>(null);
@@ -583,14 +597,7 @@ export function useBoardBluetooth({
               sizeId,
               apiLevel: apiLevelRef.current,
               deviceName: connection.deviceName,
-              colorOverrides: ledColorOverrides
-                ? Object.fromEntries(
-                    Object.entries(ledColorOverrides).filter(([, value]) => typeof value === 'string') as [
-                      string,
-                      string,
-                    ][],
-                  )
-                : undefined,
+              colorOverrides: sanitizedColorOverrides,
             });
           } catch (error) {
             console.warn('[BLE] Failed to push board configuration to native side:', error);
@@ -625,9 +632,14 @@ export function useBoardBluetooth({
           setLastConnectedBoard({ serial: parsedSerial, configKey: boardConfigKey(boardName, layoutId, sizeId) });
         }
 
-        // Send initial frames if provided
+        // Send initial frames if provided; seed the AutoSender's dedup with
+        // what was written so it doesn't immediately repeat the identical
+        // frame (and its success haptic) when it mounts on isConnected.
         if (initialFrames) {
           await sendFramesToBoard(initialFrames, mirrored);
+          connectInitialSendRef.current = { frames: initialFrames, mirrored: !!mirrored };
+        } else {
+          connectInitialSendRef.current = null;
         }
 
         connectedConfigKeyRef.current =
@@ -714,6 +726,7 @@ export function useBoardBluetooth({
       onConnectionChange,
       onConnectSuccess,
       sendFramesToBoard,
+      sanitizedColorOverrides,
       devicePicker,
       t,
       tCommon,
@@ -812,7 +825,14 @@ export function useBoardBluetooth({
       unsubDisconnectRef.current = adapter.onDisconnect(handleDisconnection);
       adapterRef.current = adapter;
       void adapter
-        .configureBoard({ boardName, layoutId, sizeId, apiLevel: apiLevelRef.current, deviceName })
+        .configureBoard({
+          boardName,
+          layoutId,
+          sizeId,
+          apiLevel: apiLevelRef.current,
+          deviceName,
+          colorOverrides: sanitizedColorOverrides,
+        })
         .catch(() => {});
 
       const serial = deviceName ? (parseSerialNumber(deviceName) ?? null) : (rememberedBoard?.serial ?? null);
@@ -831,8 +851,14 @@ export function useBoardBluetooth({
     // null = platform/binary without the adoption surface — nothing to do.
     if (!connectedSubscription) return;
 
+    // The subscriptions are removed in the cleanup, but an in-flight
+    // getConnectedDevice promise can't be cancelled — without this flag it
+    // would adopt (create an adapter, setState) after the effect was torn
+    // down by an unmount or a config change.
+    let cancelled = false;
     const checkNativeConnection = () => {
       void getNativeBleConnectedDevice().then((device) => {
+        if (cancelled) return;
         if (device) adopt(device.deviceId, device.name);
       });
     };
@@ -843,10 +869,20 @@ export function useBoardBluetooth({
     });
 
     return () => {
+      cancelled = true;
       connectedSubscription.remove();
       appStateSubscription.remove();
     };
-  }, [boardName, layoutId, sizeId, devicePicker, handleDisconnection, onConnectionChange, onConnectSuccess]);
+  }, [
+    boardName,
+    layoutId,
+    sizeId,
+    devicePicker,
+    handleDisconnection,
+    onConnectionChange,
+    onConnectSuccess,
+    sanitizedColorOverrides,
+  ]);
 
   // Serial to silently reconnect to for the board currently in view, or null
   // when nothing is remembered or the user switched boards (in which case the
@@ -887,5 +923,6 @@ export function useBoardBluetooth({
     sendFramesToBoard,
     pickerState,
     reconnectSerialForCurrentBoard,
+    connectInitialSendRef,
   };
 }

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -54,7 +54,9 @@ function getGraphqlWsUrl(): string {
 //
 // Lifecycle: starts a session presence when (iOS or Android) + (session active)
 // + (board selected) + (queue has content) + (the native surface is available —
-// Live Activities authorized on iOS, POST_NOTIFICATIONS granted on Android).
+// Live Activities authorized on iOS; always true on Android, where the
+// foreground service runs regardless of POST_NOTIFICATIONS and notification
+// visibility is the OS's separate concern).
 // Pushes initial state, then watches the serialized queue (full update) and
 // current climb (lightweight update). On iOS this drives ActivityKit; on Android
 // it drives the foreground service + ongoing notification (the SessionPresence

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -43,6 +43,7 @@ const bluetooth = vi.hoisted(() => {
       sendFramesToBoard: vi.fn(async () => true as boolean | undefined),
       pickerState: null as PickerState | null,
       reconnectSerialForCurrentBoard: null,
+      connectInitialSendRef: { current: null as { frames: string; mirrored: boolean } | null },
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;
@@ -196,6 +197,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
     bluetooth.state.reconnectSerialForCurrentBoard = null;
     bluetooth.state.sendFramesToBoard.mockReset();
     bluetooth.state.sendFramesToBoard.mockResolvedValue(true);
+    bluetooth.state.connectInitialSendRef.current = null;
     bluetooth.useBoardBluetooth.mockClear();
   });
 
@@ -212,6 +214,36 @@ describe('BluetoothProvider wall-confirm integration', () => {
 
     expect(wallConfirm.emitWallConfirm).toHaveBeenCalledWith('climb-1');
     expect(queue.confirmClimbOnWall).toHaveBeenCalledWith('climb-1');
+  });
+
+  it('skips the duplicate send when connect() already wrote the same frames, but still confirms', async () => {
+    // connect(initialFrames) wrote the current climb before the AutoSender
+    // mounted; the seed must suppress the byte-identical re-send (and its
+    // doubled haptic) while still confirming the wall state.
+    bluetooth.state.connectInitialSendRef.current = { frames: 'p1r12', mirrored: false };
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(wallConfirm.emitWallConfirm).toHaveBeenCalledWith('climb-1');
+    });
+
+    expect(bluetooth.state.sendFramesToBoard).not.toHaveBeenCalled();
+    // One-shot: the seed is consumed on first pickup.
+    expect(bluetooth.state.connectInitialSendRef.current).toBeNull();
+  });
+
+  it('still sends when connect() wrote different frames than the current climb', async () => {
+    // e.g. the create-climb editor connected with its in-progress frames; the
+    // queue's current climb differs, so the AutoSender must not be suppressed.
+    bluetooth.state.connectInitialSendRef.current = { frames: 'p9r15', mirrored: false };
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('p1r12', false, expect.any(AbortSignal));
+    });
+    expect(bluetooth.state.connectInitialSendRef.current).toBeNull();
   });
 
   it('keeps the local wall confirm in solo mode without sending a session mutation', async () => {

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -82,10 +82,14 @@ function BluetoothAutoSender({
   sendFramesToBoard,
   onWallConfirmed,
   reassertNonce,
+  connectInitialSendRef,
 }: {
   sendFramesToBoard: (frames: string, mirrored?: boolean, signal?: AbortSignal) => Promise<boolean | undefined>;
   onWallConfirmed: (climbUuid: string) => void;
   reassertNonce: number;
+  // One-shot seed: what connect() already wrote as initialFrames, so the
+  // freshly mounted AutoSender doesn't repeat a byte-identical first send.
+  connectInitialSendRef: React.MutableRefObject<{ frames: string; mirrored: boolean } | null>;
 }) {
   const { state } = useQueue();
   const { currentClimbQueueItem } = state;
@@ -151,6 +155,24 @@ function BluetoothAutoSender({
         while (toSend) {
           if (signal?.aborted) return;
           const item = toSend;
+
+          // connect() may have just written these exact frames as its
+          // initialFrames (connect-and-light flows like the play drawer).
+          // Seed the dedup signature so this freshly mounted AutoSender
+          // doesn't immediately repeat the byte-identical write and
+          // double-fire the success haptic. One-shot — and a pending
+          // reassert below still wins and forces a re-push.
+          const connectSend = connectInitialSendRef.current;
+          if (connectSend) {
+            connectInitialSendRef.current = null;
+            if (
+              lastSentSignatureRef.current === null &&
+              connectSend.frames === item.climb.frames &&
+              connectSend.mirrored === !!item.climb.mirrored
+            ) {
+              lastSentSignatureRef.current = `${item.climb.uuid}::${item.climb.frames}::${item.climb.mirrored ? 1 : 0}`;
+            }
+          }
 
           // Honour a pending reassert exactly when the climb is picked up —
           // clearing the signature here (rather than in the effect) survives an
@@ -279,16 +301,24 @@ export function BluetoothProvider({
     );
   }, [boardName, layoutId, sizeId, setIds]);
 
-  const { isConnected, loading, connect, disconnect, sendFramesToBoard, pickerState, reconnectSerialForCurrentBoard } =
-    useBoardBluetooth({
-      boardName,
-      layoutId,
-      sizeId,
-      setIds,
-      boardUuid,
-      holdsData,
-      onConnectSuccess: handleConnectSuccess,
-    });
+  const {
+    isConnected,
+    loading,
+    connect,
+    disconnect,
+    sendFramesToBoard,
+    pickerState,
+    reconnectSerialForCurrentBoard,
+    connectInitialSendRef,
+  } = useBoardBluetooth({
+    boardName,
+    layoutId,
+    sizeId,
+    setIds,
+    boardUuid,
+    holdsData,
+    onConnectSuccess: handleConnectSuccess,
+  });
 
   const resolvedPickerBoards = useResolvedBleDeviceBoards(pickerState?.devices ?? EMPTY_PICKER_DEVICES);
   const currentBoardConfig = useMemo(() => {
@@ -562,6 +592,7 @@ export function BluetoothProvider({
           sendFramesToBoard={sendFramesToBoard}
           onWallConfirmed={handleWallConfirmed}
           reassertNonce={reassertNonce}
+          connectInitialSendRef={connectInitialSendRef}
         />
       )}
       {children}

--- a/packages/shared/ble-protocol/src/__tests__/aurora.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/aurora.test.ts
@@ -229,4 +229,22 @@ describe('getAuroraBluetoothPacket', () => {
     const result = getAuroraBluetoothPacket(frames, placements, 'kilter', 3);
     expect(result.skippedRoleCount).toBe(1);
   });
+
+  it('honours a 6-digit hex color override', () => {
+    // Kilter role 12 = STARTING; override its colour with pure red.
+    const result = getAuroraBluetoothPacket('p100r12', { 100: 5 }, 'kilter', 3, { STARTING: '#FF0000' });
+    // Body: [ONLY, posLow, posHigh, color]; encodeColorV3('FF0000') = 224.
+    expect(result.packet).toEqual(Uint8Array.from(wrapBytes([84, 5, 0, 224])));
+  });
+
+  it('falls back to the canonical color for a malformed override', () => {
+    const placements = { 100: 5 };
+    const canonical = getAuroraBluetoothPacket('p100r12', placements, 'kilter', 3);
+    // Shorthand hex would parseInt('' , 16) = NaN in the encoder and stream a
+    // garbage byte to the wall — the override must be ignored, not honoured.
+    const shorthand = getAuroraBluetoothPacket('p100r12', placements, 'kilter', 3, { STARTING: '#fff' });
+    const named = getAuroraBluetoothPacket('p100r12', placements, 'kilter', 3, { STARTING: 'red' });
+    expect(shorthand.packet).toEqual(canonical.packet);
+    expect(named.packet).toEqual(canonical.packet);
+  });
 });

--- a/packages/shared/ble-protocol/src/aurora.ts
+++ b/packages/shared/ble-protocol/src/aurora.ts
@@ -18,6 +18,10 @@ export type LedPlacements = Record<number, number>;
  */
 export type LedColorOverrides = Partial<Record<HoldState, string>>;
 
+// The colour encoders parseInt fixed 2-char slices, so only exactly six hex
+// digits (after an optional leading '#') produce valid bytes.
+const SIX_DIGIT_HEX_PATTERN = /^[0-9a-fA-F]{6}$/;
+
 // --- API v3 command bytes (3 bytes per LED, 16-bit positions) ---
 const V3_PACKET_MIDDLE = 81; // 'Q'
 const V3_PACKET_FIRST = 82; // 'R'
@@ -236,7 +240,13 @@ export const getAuroraBluetoothPacket = (
     }
 
     const overrideForState = colorOverrides?.[state.name];
-    const colorSource = overrideForState ?? state.color;
+    // Overrides arrive from app config; anything but 6-digit hex (shorthand
+    // "#fff", a named color) would parseInt to NaN bytes in the colour
+    // encoders and stream garbage to the wall. Fall back to the canonical
+    // state colour instead of honouring a malformed override.
+    const sanitizedOverride =
+      overrideForState && SIX_DIGIT_HEX_PATTERN.test(overrideForState.replace('#', '')) ? overrideForState : undefined;
+    const colorSource = sanitizedOverride ?? state.color;
     const color = colorSource.replace('#', '');
     ledEntries.push({ position: ledPosition, color });
   });

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -370,7 +370,6 @@
     "devicesFound_other": "{{count}} boards found",
     "noDevicesFound": "No boards found nearby",
     "cancel": "Cancel",
-    "unknownBoard": "Unknown Board",
     "connectBoard": "Connect Board",
     "relightBoard": "Re-light board",
     "holdForControls": "Hold for board controls",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -370,7 +370,6 @@
     "devicesFound_other": "{{count}} tableros encontrados",
     "noDevicesFound": "No se encontraron tableros cercanos",
     "cancel": "Cancelar",
-    "unknownBoard": "Tablero desconocido",
     "connectBoard": "Conectar tablero",
     "relightBoard": "Reiluminar tablero",
     "holdForControls": "Mantén pulsado para los controles",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -370,7 +370,6 @@
     "devicesFound_other": "{{count}} panneaux trouvés",
     "noDevicesFound": "Aucun panneau trouvé à proximité",
     "cancel": "Annuler",
-    "unknownBoard": "Panneau inconnu",
     "connectBoard": "Connecter le panneau",
     "relightBoard": "Rallumer le panneau",
     "holdForControls": "Maintenir pour les commandes",


### PR DESCRIPTION
## Context

Companion to #2720 (iOS connect-lifecycle hardening). The same deep BLE review found two Android service-lifecycle bugs and a handful of small JS-layer issues. Kotlin changes need a native build; the JS/TS changes ride OTA.

## Android foreground service

**1. `endSession` bypassed the service's own safe-stop path (Android 12–14 crash risk).**
`SessionPresenceController.endSession` called `stopService()`, which skips `onStartCommand` — so a start token still pending from `startSession` (the 5s `startForeground` obligation) was left dangling, the exact `ForegroundServiceDidNotStartInTimeException` scenario the service's ACTION_STOP promote-then-stop path was written to prevent. Production just never used that path. `endSession` now delivers ACTION_STOP via `startForegroundService`, falling back to `stopService` only when delivery throws or no session window is open (no token can be outstanding in either state). The controller tests now cover the production teardown path plus both fallbacks.

**2. Notification-action fallback was a blocked trampoline.**
With no live module instance, a Previous/Next tap fell back to `startActivity` from the broadcast receiver — a notification trampoline, blocked for targetSdk 31+, so the tap silently did nothing and the navigation was lost. The fallback is gone; the `queueNavigate` buffer is now process-static (companion-owned, survives module recreation), so a tap during a React-host gap replays once JS reattaches.

**3. Channel re-localization.** The notification channel kept its first-ever locale's name in system Settings forever. ACTION_START now updates name/description when it delivers different localized strings — gated on explicitly-delivered extras so an ACTION_STOP promote on a cold process (which only has the English defaults) can never rename a localized channel back.

**4. Stale contract comment.** `use-live-activity.ts` claimed `isAvailable` reflects POST_NOTIFICATIONS on Android; native always returns true by design. Comment corrected. (Also verified: the legacy `BLUETOOTH`/`BLUETOOTH_ADMIN` permissions for pre-31 devices are injected by react-native-ble-plx's config plugin — no manifest change needed.)

## BLE JS layer

**5. Double-send + double haptic on connect.** `connect(initialFrames)` wrote the frames, then `setIsConnected(true)` mounted the AutoSender whose dedup ref starts null — so the identical frame went to the wall twice and `hapticSuccess` fired twice. `connect` now hands the AutoSender a one-shot seed (matched on frames + mirror); a non-matching seed (create-climb editor frames) and a pending reassert both still send normally. Covered by two new real-component tests.

**6. "Turn off all lights" hidden on MoonBoard** — its protocol can't encode a clear frame (`sendFramesToBoard('')` is a deliberate no-op there, matching web), so the row was a silent dead tap.

**7. Latent fixes:** the native-adoption path now passes `ledColorOverrides` to `configureBoard` like the connect path (and connect's dep array includes the overrides — stale closure); an in-flight `getConnectedDevice` resolution can no longer adopt/setState after the effect was torn down; and `@boardsesh/ble-protocol` falls back to the canonical state colour when an override isn't 6-digit hex instead of streaming `parseInt → NaN` bytes to the wall (with encoder regression tests).

**8. Drive-by:** removed the orphaned `settings ble.unknownBoard` catalog key (en/es/fr) — its last reference was removed on main and `check:i18n:orphans` blocks every commit until it's gone.

## Validation

- `vp run typecheck:mobile`, `vp run typecheck:shared` — pass
- `vp run test:mobile` — 1688 tests pass (includes the new seed/sheet tests)
- ble-protocol suite — pass, including the new override-sanitization tests
- `vp run check:mobile-bundle` — Android bundle OK
- `vp run check:i18n:orphans` — clean
- Kotlin Robolectric tests (updated for the new endSession paths) run in CI via `android-pr-rn.yml`; there's no local Kotlin runner.
- Worth a device pass on Android 14: start session → end session immediately (no FGS crash), and notification Next/Prev during a dev reload (event replays on reattach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)