### PR TITLE
Fix workout-mode climb refresh to pick a truly random climb

### DIFF
--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-pool.test.ts
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-pool.test.ts
@@ -164,13 +164,10 @@ describe('refreshSlotInState', () => {
     // Pyramid/ladder workouts put different grades in different slots. Refreshing
     // a grade-18 row must always land on another grade-18 climb, never the
     // grade-17 slot's climbs — the pool is keyed by slot.grade.
-    let state = buildState(
-      { 17: ['g17-a', 'g17-b', 'g17-c'], 18: ['g18-a', 'g18-b', 'g18-c'] },
-      [
-        [17, 0],
-        [18, 1],
-      ],
-    );
+    let state = buildState({ 17: ['g17-a', 'g17-b', 'g17-c'], 18: ['g18-a', 'g18-b', 'g18-c'] }, [
+      [17, 0],
+      [18, 1],
+    ]);
     const grade18Uuid = state.items[1].item.uuid; // queue-item uuid is preserved across refreshes
     const fetchPool = vi.fn();
 

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-pool.test.ts
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-pool.test.ts
@@ -12,6 +12,7 @@ vi.mock('expo-crypto', () => ({ randomUUID: cryptoMock.randomUUID }));
 
 import {
   buildPools,
+  pickRandomUnused,
   pickUnused,
   refreshSlotInState,
   selectItemsFromPools,
@@ -62,6 +63,31 @@ describe('pickUnused', () => {
   });
 });
 
+describe('pickRandomUnused', () => {
+  it('returns a climb not in the used set', () => {
+    const pool = [makeClimb('a'), makeClimb('b'), makeClimb('c')];
+    const picked = pickRandomUnused(pool, new Set(['a']));
+    expect(picked).not.toBeNull();
+    expect(['b', 'c']).toContain(picked?.uuid);
+  });
+
+  it('returns null when every climb is used', () => {
+    const pool = [makeClimb('a'), makeClimb('b')];
+    expect(pickRandomUnused(pool, new Set(['a', 'b']))).toBeNull();
+  });
+
+  it('can pick a non-first unused climb (not just the first like pickUnused)', () => {
+    const pool = [makeClimb('a'), makeClimb('b'), makeClimb('c'), makeClimb('d')];
+    // Unused candidates are [b, c, d]; index 2 → 'd'. A value of 0.9 lands there.
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.9);
+    try {
+      expect(pickRandomUnused(pool, new Set(['a']))?.uuid).toBe('d');
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+});
+
 describe('selectItemsFromPools', () => {
   it('picks a distinct climb per slot when the pool is large enough', () => {
     const pools = new Map([[10, [makeClimb('a'), makeClimb('b'), makeClimb('c')]]]);
@@ -106,6 +132,32 @@ describe('refreshSlotInState', () => {
     expect(next.items[0].item.climb.uuid).toBe('b'); // genuinely different climb
     expect(fetchPool).not.toHaveBeenCalled(); // cache had an unused climb
     expect(next.usedUuids).toEqual(new Set(['b']));
+  });
+
+  it('re-rolls across the pool instead of toggling between two climbs', async () => {
+    // One slot, five-climb pool → initial pick is 'a'. The old first-unused
+    // refresh toggled a↔b forever; a random pick reaches the rest of the pool.
+    let state = buildState({ 10: ['a', 'b', 'c', 'd', 'e'] }, [[10, 0]]);
+    expect(state.items[0].item.climb.uuid).toBe('a');
+    const fetchPool = vi.fn();
+
+    // Refresh 1: unused = [b, c, d, e]; 0.3 * 4 → index 1 → 'c'.
+    // Refresh 2: unused = [a, b, d, e]; 0.8 * 4 → index 3 → 'e'.
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValueOnce(0.3).mockReturnValueOnce(0.8);
+    try {
+      const seen = new Set([state.items[0].item.climb.uuid]);
+      for (let refresh = 0; refresh < 2; refresh++) {
+        const targetUuid = state.items[0].item.uuid;
+        const result = await refreshSlotInState(state, targetUuid, ctx, fetchPool);
+        expect(result.changed).toBe(true);
+        state = result.state;
+        seen.add(state.items[0].item.climb.uuid);
+      }
+      expect(seen).toEqual(new Set(['a', 'c', 'e'])); // three distinct climbs, not an a↔b toggle
+      expect(fetchPool).not.toHaveBeenCalled();
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 
   it('never re-picks a climb already shown in another row (cache miss → refetch)', async () => {

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-pool.test.ts
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-preview-pool.test.ts
@@ -160,6 +160,35 @@ describe('refreshSlotInState', () => {
     }
   });
 
+  it('refreshes within the slot grade and never crosses into another grade', async () => {
+    // Pyramid/ladder workouts put different grades in different slots. Refreshing
+    // a grade-18 row must always land on another grade-18 climb, never the
+    // grade-17 slot's climbs — the pool is keyed by slot.grade.
+    let state = buildState(
+      { 17: ['g17-a', 'g17-b', 'g17-c'], 18: ['g18-a', 'g18-b', 'g18-c'] },
+      [
+        [17, 0],
+        [18, 1],
+      ],
+    );
+    const grade18Uuid = state.items[1].item.uuid; // queue-item uuid is preserved across refreshes
+    const fetchPool = vi.fn();
+
+    const seen = new Set<string>([state.items[1].item.climb.uuid]);
+    for (let refresh = 0; refresh < 8; refresh++) {
+      const result = await refreshSlotInState(state, grade18Uuid, ctx, fetchPool);
+      expect(result.changed).toBe(true);
+      state = result.state;
+      const refreshedUuid = state.items[1].item.climb.uuid;
+      expect(refreshedUuid.startsWith('g18-')).toBe(true); // stayed on grade 18
+      seen.add(refreshedUuid);
+      expect(state.items[0].item.climb.uuid.startsWith('g17-')).toBe(true); // grade-17 row untouched
+    }
+    expect(seen.size).toBeGreaterThan(1); // re-rolled within grade 18 rather than sticking
+    expect([...seen].every((uuid) => uuid.startsWith('g18-'))).toBe(true); // every pick stayed on grade
+    expect(fetchPool).not.toHaveBeenCalled(); // cache always had an unused grade-18 climb
+  });
+
   it('never re-picks a climb already shown in another row (cache miss → refetch)', async () => {
     // Two slots at grade 10, pool exactly [a, b] → rows show a and b (both used).
     const state = buildState({ 10: ['a', 'b'] }, [

--- a/packages/mobile/src/components/session-screen/pre-session/workout-preview-pool.ts
+++ b/packages/mobile/src/components/session-screen/pre-session/workout-preview-pool.ts
@@ -55,6 +55,17 @@ export function pickUnused(pool: readonly Climb[], used: ReadonlySet<string>): C
 }
 
 /**
+ * A uniformly random climb in `pool` whose uuid isn't in `used`, or null. Used
+ * by refresh so re-rolling the same row reaches across the whole grade pool
+ * instead of toggling between the lowest-index climbs `pickUnused` would return.
+ */
+export function pickRandomUnused(pool: readonly Climb[], used: ReadonlySet<string>): Climb | null {
+  const candidates = pool.filter((climb) => !used.has(climb.uuid));
+  if (candidates.length === 0) return null;
+  return candidates[Math.floor(Math.random() * candidates.length)];
+}
+
+/**
  * Fetch one shuffled pool per unique grade in the plan. Round-trips stay
  * proportional to the workout shape (unique grades), not the climb count.
  */
@@ -99,11 +110,13 @@ export function selectItemsFromPools(
 export type RefreshSlotResult = { state: WorkoutPreviewData; changed: boolean };
 
 /**
- * Swap a single preview row for a different climb at the same grade. Prefers the
- * cached pool (no network); refetches+reshuffles that grade once if the cache is
- * exhausted of unused climbs; allows a differing repeat only as a last resort.
- * Keeps the queue-item uuid (swaps `.climb`) so the row keeps its identity and
- * highlight — mirroring DELTA_REPLACE_QUEUE_ITEM.
+ * Swap a single preview row for a different climb at the same grade. Picks a
+ * random unused climb from the cached pool (no network) so repeated refreshes of
+ * one row keep re-rolling across the whole pool rather than toggling between two
+ * climbs; refetches+reshuffles that grade once if the cache is exhausted of
+ * unused climbs; allows a differing repeat only as a last resort. Keeps the
+ * queue-item uuid (swaps `.climb`) so the row keeps its identity and highlight —
+ * mirroring DELTA_REPLACE_QUEUE_ITEM.
  */
 export async function refreshSlotInState(
   state: WorkoutPreviewData,
@@ -122,14 +135,14 @@ export async function refreshSlotInState(
   const cachedPool = pools.get(grade) ?? [];
   // Exclude every climb currently shown (including this row's own) so the refresh
   // lands on a genuinely different climb that isn't already on screen elsewhere.
-  let nextClimb = pickUnused(cachedPool, state.usedUuids);
+  let nextClimb = pickRandomUnused(cachedPool, state.usedUuids);
   let refreshedPool: Climb[] | null = null;
 
   // 1) Cache exhausted of unused climbs → refetch + reshuffle this grade once.
   if (!nextClimb) {
     refreshedPool = shuffleInPlace((await fetchPool(grade, ctx)).slice());
     pools.set(grade, refreshedPool);
-    nextClimb = pickUnused(refreshedPool, state.usedUuids);
+    nextClimb = pickRandomUnused(refreshedPool, state.usedUuids);
   }
 
   // 2) Tiny catalog: everything at this grade is already shown somewhere. Accept


### PR DESCRIPTION
## Problem

In the mobile pre-session **workout preview**, the per-row refresh button wasn't actually random. As reported:

> It picks one "extra" climb at each grade then swaps it out with that one. The climb you just removed becomes the new "extra" climb. This makes it so you don't regenerate a random climb in its place.

## Root cause

In `packages/mobile/src/components/session-screen/pre-session/workout-preview-pool.ts`:

- `buildPools` shuffles each grade's candidate pool **once** at build time.
- `pickUnused(pool, used)` always returns the **first** climb in that fixed order whose uuid isn't currently shown.
- `refreshSlotInState` picked via `pickUnused`, then recomputed `usedUuids` from the on-screen items — which frees the just-removed climb.

Because selection was "first unused in a static order," the displaced climb (an early pool index) immediately became the first-unused candidate again on the next refresh. With one slot at a grade this is a strict 2-cycle (`a ↔ b`); with more slots it still cycles through the lowest-index climbs. The pool holds up to 50 climbs per grade, so users expect many alternatives but only ever saw one.

## Fix

Add `pickRandomUnused(pool, used)` and use it at both pick sites in `refreshSlotInState`, so each refresh lands on a uniformly random unused climb across the whole grade pool. Initial generation (`selectItemsFromPools`) keeps deterministic `pickUnused` — it walks a freshly shuffled pool for distinct sequential picks and relies on ordering for `failedCount` accounting.

A single refresh already returned a different climb (the old uuid stays in `usedUuids` at pick time); this change fixes the **repeated**-refresh case.

No web changes — web has no per-climb refresh. No shared-package changes (this file is mobile-only by design).

## Tests

- New `pickRandomUnused` block: returns an unused candidate, returns null when all used, and (with `Math.random` stubbed) picks a non-first unused climb.
- Regression test: one slot, five-climb pool, repeated refreshes reach three distinct climbs instead of toggling `a ↔ b`.
- Existing `refreshSlotInState`/`selectItemsFromPools` tests stay green.

## Validation

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 1693 passed
- `workout-preview-pool` suite — 14 passed

https://claude.ai/code/session_017RjYJiHyeg1GbZr7cvtSvd

---
_Generated by [Claude Code](https://claude.ai/code/session_017RjYJiHyeg1GbZr7cvtSvd)_