### PR TITLE
[codex] Restore mobile discover playlist shelves

### DIFF
--- a/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
@@ -12,6 +12,15 @@ type PlaylistItem = {
   creatorName?: string;
   color?: string;
   icon?: string;
+  isPinnedByMe?: boolean;
+};
+
+type DiscoverOptions = {
+  generatedRecommendation?: boolean;
+  boardType?: string;
+  layoutId?: number;
+  sizeId?: number;
+  angle?: number;
 };
 
 // Mutable hook return values — each test sets the slice it needs. The two
@@ -24,7 +33,7 @@ const userHook = vi.hoisted(() => ({
   loadMore: vi.fn(),
   refetch: vi.fn(),
 }));
-const forYouHook = vi.hoisted(() => ({
+const exactForYouHook = vi.hoisted(() => ({
   popular: [] as PlaylistItem[],
   recent: [] as PlaylistItem[],
   isLoading: false,
@@ -42,15 +51,24 @@ const communityHook = vi.hoisted(() => ({
   loadMore: vi.fn(),
   refetch: vi.fn(),
 }));
+const pinnedHook = vi.hoisted(() => ({
+  pinned: [] as PlaylistItem[],
+  refetch: vi.fn(),
+}));
 const createPlaylist = vi.hoisted(() => vi.fn());
+const pinPlaylist = vi.hoisted(() => vi.fn());
+const unpinPlaylist = vi.hoisted(() => vi.fn());
+const discoverOptions = vi.hoisted(() => [] as DiscoverOptions[]);
 
 vi.mock('@boardsesh/playlists-react', () => ({
   useUserPlaylists: () => userHook,
-  useDiscoverPlaylists: (options: { generatedRecommendation?: boolean }) =>
-    options.generatedRecommendation ? forYouHook : communityHook,
-  usePinnedPlaylists: () => ({ pinned: [], refetch: vi.fn() }),
+  useDiscoverPlaylists: (options: DiscoverOptions) => {
+    discoverOptions.push(options);
+    return options.generatedRecommendation ? exactForYouHook : communityHook;
+  },
+  usePinnedPlaylists: () => pinnedHook,
   useSmartPlaylistCounts: () => ({ data: [], isLoading: false }),
-  usePlaylistMutations: () => ({ createPlaylist, pinPlaylist: vi.fn(), unpinPlaylist: vi.fn() }),
+  usePlaylistMutations: () => ({ createPlaylist, pinPlaylist, unpinPlaylist }),
 }));
 
 // @tanstack/react-query is NOT mocked — the create flow writes to the real
@@ -105,7 +123,7 @@ vi.mock('../../../../src/providers/toast-provider', () => ({
 vi.mock('../../../../src/lib/graphql/use-auth-token', () => ({ useAuthToken: () => ({ data: 'token' }) }));
 vi.mock('../../../../src/lib/graphql/hooks', () => ({ useProfile: () => ({ data: { id: 'me' } }) }));
 vi.mock('../../../../src/lib/graphql/use-active-board', () => ({
-  useActiveBoard: () => ({ data: { boardType: 'kilter', layoutId: 1 } }),
+  useActiveBoard: () => ({ data: { boardType: 'kilter', layoutId: 1, sizeId: 10, angle: 40 } }),
 }));
 vi.mock('../../../../src/hooks/use-bottom-chrome-metrics', () => ({
   useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
@@ -140,16 +158,32 @@ vi.mock('../../../../src/components/ActivityIndicator', () => ({
   ActivityIndicator: () => createElement('div', { 'data-spinner': 'true' }),
 }));
 vi.mock('../../../../src/components/SectionHeader', () => ({
-  SectionHeader: ({ title }: { title: string }) => createElement('div', { 'data-section': title }),
+  SectionHeader: ({ title, actionLabel }: { title: string; actionLabel?: string }) =>
+    createElement('h2', { 'data-section': title }, actionLabel ? `${title} ${actionLabel}` : title),
 }));
 // The form sheet exposes a submit button driving onSubmit with fixed form
 // values, so the test can trigger the create flow without the real sheet UI.
 const FORM_VALUES = { name: 'Crimps', description: '', color: undefined, icon: undefined, isPublic: false };
 vi.mock('../../../../src/components/playlist', () => ({
-  PlaylistCard: ({ name, metaLabel }: { name: string; metaLabel?: string }) =>
-    createElement('div', { 'data-card': name }, metaLabel ? `${name} ${metaLabel}` : name),
+  PlaylistCard: ({
+    name,
+    metaLabel,
+    isPinned,
+    onTogglePin,
+  }: {
+    name: string;
+    metaLabel?: string;
+    isPinned?: boolean;
+    onTogglePin?: () => void;
+  }) =>
+    createElement(
+      'div',
+      { 'data-card': name, 'data-pinned': isPinned ? 'true' : 'false' },
+      createElement('span', null, metaLabel ? `${name} ${metaLabel}` : name),
+      onTogglePin ? createElement('button', { 'aria-label': `pin-${name}`, onClick: onTogglePin }, 'pin') : null,
+    ),
   PlaylistScrollSection: ({ children, title }: { children?: ReactNode; title: string }) =>
-    createElement('div', { 'data-scroll-section': title }, children),
+    createElement('section', { 'data-scroll-section': title }, createElement('h2', null, title), children),
   PlaylistFormSheet: ({ onSubmit }: { onSubmit: (values: typeof FORM_VALUES) => void }) =>
     createElement('button', { 'aria-label': 'submit-create', onClick: () => onSubmit(FORM_VALUES) }, 'submit'),
 }));
@@ -178,17 +212,22 @@ beforeEach(() => {
   userHook.isLoading = false;
   userHook.hasError = false;
   userHook.refetch.mockClear();
-  forYouHook.popular = [];
-  forYouHook.recent = [];
-  forYouHook.isLoading = false;
-  forYouHook.hasError = false;
-  forYouHook.refetch.mockClear();
+  exactForYouHook.popular = [];
+  exactForYouHook.recent = [];
+  exactForYouHook.isLoading = false;
+  exactForYouHook.hasError = false;
+  exactForYouHook.refetch.mockClear();
   communityHook.popular = [];
   communityHook.recent = [];
   communityHook.isLoading = false;
   communityHook.hasError = false;
   communityHook.refetch.mockClear();
+  pinnedHook.pinned = [];
+  pinnedHook.refetch.mockClear();
   createPlaylist.mockReset();
+  pinPlaylist.mockReset();
+  unpinPlaylist.mockReset();
+  discoverOptions.length = 0;
 });
 
 describe('DiscoverLibrary error handling', () => {
@@ -210,16 +249,16 @@ describe('DiscoverLibrary error handling', () => {
 
     fireEvent.click(getByLabelText('library.errors.tryAgain'));
     expect(communityHook.refetch).toHaveBeenCalledTimes(1);
-    expect(forYouHook.refetch).not.toHaveBeenCalled();
+    expect(exactForYouHook.refetch).not.toHaveBeenCalled();
     expect(userHook.refetch).not.toHaveBeenCalled();
   });
 
   it('retries only the forYou stream when only it failed', () => {
-    forYouHook.hasError = true;
+    exactForYouHook.hasError = true;
     const { getByLabelText } = renderHub();
 
     fireEvent.click(getByLabelText('library.errors.tryAgain'));
-    expect(forYouHook.refetch).toHaveBeenCalledTimes(1);
+    expect(exactForYouHook.refetch).toHaveBeenCalledTimes(1);
     expect(communityHook.refetch).not.toHaveBeenCalled();
     expect(userHook.refetch).not.toHaveBeenCalled();
   });
@@ -232,16 +271,15 @@ describe('DiscoverLibrary error handling', () => {
     expect(queryByText('library.errors.loadTitle')).toBeNull();
   });
 
-  it('shows the default smart cards instead of the empty state when all sections succeed with no playlists', () => {
+  it('shows the empty state when all sections succeed with no playlists', () => {
     const { getByText, queryByText } = renderHub();
 
-    expect(getByText('library.smart.likedClimbs.title')).toBeTruthy();
-    expect(queryByText('library.empty.title')).toBeNull();
+    expect(getByText('library.empty.title')).toBeTruthy();
     expect(queryByText('library.errors.loadTitle')).toBeNull();
   });
 
   it('renders for-you and community playlists from separate discover streams', () => {
-    forYouHook.popular = [{ uuid: 'generated', name: 'Fresh for you', climbCount: 4 }];
+    exactForYouHook.popular = [{ uuid: 'generated', name: 'Fresh for you', climbCount: 4 }];
     communityHook.popular = [
       { uuid: 'community', name: 'Setter picks', climbCount: 7, creatorId: 'creator-2', creatorName: 'Jess' },
     ];
@@ -250,6 +288,108 @@ describe('DiscoverLibrary error handling', () => {
 
     expect(getByText('Fresh for you')).toBeTruthy();
     expect(getByText('Setter picks library.communityByline')).toBeTruthy();
+  });
+
+  it('requests generated playlists for the active board size and angle', () => {
+    renderHub();
+
+    expect(discoverOptions).toContainEqual(
+      expect.objectContaining({
+        generatedRecommendation: true,
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        angle: 40,
+      }),
+    );
+  });
+
+  it('renders pinned grid, owned playlists, generated, and community in order', () => {
+    pinnedHook.pinned = [{ uuid: 'pinned', name: 'Pinned list', climbCount: 2, isPinnedByMe: true }];
+    userHook.playlists = [
+      { uuid: 'pinned', name: 'Pinned list', climbCount: 2, isPinnedByMe: true },
+      { uuid: 'owned', name: 'Project drawer', climbCount: 5, isPinnedByMe: false },
+    ];
+    exactForYouHook.popular = [{ uuid: 'generated', name: 'Fresh for you', climbCount: 4 }];
+    communityHook.popular = [
+      { uuid: 'community', name: 'Setter picks', climbCount: 7, creatorId: 'creator-2', creatorName: 'Jess' },
+    ];
+
+    const { container, getByText } = renderHub();
+    const bodyText = container.textContent ?? '';
+    const pinnedIndex = bodyText.indexOf('library.sections.pinned');
+    const pinnedItemIndex = bodyText.indexOf('Pinned list');
+    const userPlaylistsIndex = bodyText.indexOf('library.allPlaylists.title');
+    const forYouIndex = bodyText.indexOf('library.sections.forYou');
+    const communityIndex = bodyText.indexOf('library.sections.community');
+
+    expect(getByText('Pinned list')).toBeTruthy();
+    expect(getByText('Project drawer')).toBeTruthy();
+    expect(pinnedIndex).toBeGreaterThanOrEqual(0);
+    expect(pinnedItemIndex).toBeGreaterThan(pinnedIndex);
+    expect(pinnedItemIndex).toBeLessThan(userPlaylistsIndex);
+    expect(userPlaylistsIndex).toBeLessThan(forYouIndex);
+    expect(forYouIndex).toBeLessThan(communityIndex);
+  });
+
+  it('does not render an empty generated shelf when generated playlists are empty', () => {
+    userHook.playlists = [{ uuid: 'owned', name: 'Project drawer', climbCount: 5, isPinnedByMe: false }];
+    communityHook.popular = [
+      { uuid: 'community', name: 'Setter picks', climbCount: 7, creatorId: 'creator-2', creatorName: 'Jess' },
+    ];
+
+    const { queryByText } = renderHub();
+
+    expect(queryByText('library.sections.forYou')).toBeNull();
+  });
+
+  it('does not show see all in the pinned header', () => {
+    pinnedHook.pinned = [{ uuid: 'pinned', name: 'Pinned list', climbCount: 2, isPinnedByMe: true }];
+    userHook.playlists = [
+      { uuid: 'pinned', name: 'Pinned list', climbCount: 2, isPinnedByMe: true },
+      { uuid: 'owned', name: 'Project drawer', climbCount: 5, isPinnedByMe: false },
+    ];
+
+    const { container } = renderHub();
+    const pinnedHeader = container.querySelector('[data-section="library.sections.pinned"]');
+
+    expect(pinnedHeader?.textContent).toBe('library.sections.pinned');
+  });
+
+  it('shows pin controls on generated and community playlist cards', async () => {
+    exactForYouHook.popular = [{ uuid: 'generated', name: 'Fresh for you', climbCount: 4 }];
+    communityHook.popular = [
+      { uuid: 'community', name: 'Setter picks', climbCount: 7, creatorId: 'creator-2', creatorName: 'Jess' },
+    ];
+    pinPlaylist.mockResolvedValue(true);
+
+    const { getByLabelText } = renderHub();
+
+    await act(async () => {
+      fireEvent.click(getByLabelText('pin-Fresh for you'));
+    });
+    await act(async () => {
+      fireEvent.click(getByLabelText('pin-Setter picks'));
+    });
+
+    expect(pinPlaylist).toHaveBeenCalledWith('generated');
+    expect(pinPlaylist).toHaveBeenCalledWith('community');
+    expect(pinnedHook.refetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('caps the pinned grid at eight playlists', () => {
+    pinnedHook.pinned = Array.from({ length: 9 }, (_, index) => ({
+      uuid: `pinned-${index}`,
+      name: `Pinned ${index + 1}`,
+      climbCount: index,
+      isPinnedByMe: true,
+    }));
+
+    const { getByText, queryByText } = renderHub();
+
+    expect(getByText('Pinned 1')).toBeTruthy();
+    expect(getByText('Pinned 8')).toBeTruthy();
+    expect(queryByText('Pinned 9')).toBeNull();
   });
 });
 

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -9,7 +9,6 @@ import {
   useDiscoverPlaylists,
   useUserPlaylists,
   usePinnedPlaylists,
-  useSmartPlaylistCounts,
   usePlaylistMutations,
 } from '@boardsesh/playlists-react';
 import type { DiscoverablePlaylist, Playlist } from '@boardsesh/graphql/operations/playlists';
@@ -24,7 +23,6 @@ import {
   type PlaylistFormValues,
 } from '../../../src/components/playlist';
 import { DiscoverTopChrome } from '../../../src/components/chrome';
-import { DEFAULT_PINNED_SMART_PLAYLIST_TYPES, SMART_PLAYLISTS } from '../../../src/lib/smart-playlists';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useTheme } from '../../../src/providers/theme-provider';
 import { useToast } from '../../../src/providers/toast-provider';
@@ -73,21 +71,14 @@ export default function DiscoverLibrary() {
     listRef.current?.scrollTo({ y: 0, animated: true });
   }, [listRef]);
 
-  // Smart-playlist counts supply the badge counts for the built-in "Your Picks"
-  // defaults. The default cards still render at zero.
-  const { data: smartCounts, isLoading: smartCountsLoading } = useSmartPlaylistCounts({
-    token: effectiveToken,
-    tokenLoading,
-    isAuthenticated,
-  });
-
   // Owned playlists (paginated). Feeds the "See all" affordance and receives
-  // refreshes after creates/pin changes; the visible Your Picks section only
-  // renders defaults + real pins.
+  // refreshes after creates/pin changes.
   const {
     playlists: userPlaylists,
     isLoading: userLoading,
+    isLoadingMore: userLoadingMore,
     hasError: userError,
+    loadMore: loadMoreUser,
     refetch: refetchUser,
   } = useUserPlaylists({
     token: effectiveToken,
@@ -164,26 +155,18 @@ export default function DiscoverLibrary() {
     return merged;
   }, [communityPopular, communityRecent, userId]);
 
-  const smartCountsByType = useMemo(
-    () => new Map((smartCounts ?? []).map((smartCount) => [smartCount.type, smartCount.count])),
-    [smartCounts],
+  const pinnedPlaylistUuids = useMemo(
+    () => new Set(pinnedPlaylists.map((playlist) => playlist.uuid)),
+    [pinnedPlaylists],
   );
+  const visiblePinnedPlaylists = useMemo(() => pinnedPlaylists.slice(0, 8), [pinnedPlaylists]);
 
-  const defaultSmartCards = useMemo(() => {
-    if (!userId) return [];
-    return DEFAULT_PINNED_SMART_PLAYLIST_TYPES.map((smartPlaylistType) => {
-      const preset = SMART_PLAYLISTS.find((smartPlaylist) => smartPlaylist.type === smartPlaylistType);
-      if (!preset) return null;
-      return { preset, count: smartCountsByType.get(smartPlaylistType) ?? 0 };
-    }).filter((entry): entry is { preset: (typeof SMART_PLAYLISTS)[number]; count: number } => entry !== null);
-  }, [userId, smartCountsByType]);
+  const unpinnedUserPlaylists = useMemo(() => {
+    return userPlaylists.filter((playlist) => !pinnedPlaylistUuids.has(playlist.uuid));
+  }, [pinnedPlaylistUuids, userPlaylists]);
 
   const goToPlaylist = useCallback((uuid: string) => {
     router.push(`/(tabs)/discover/${uuid}`);
-  }, []);
-
-  const goToSmart = useCallback((type: string) => {
-    router.push(`/(tabs)/discover/smart/${type}`);
   }, []);
 
   const { showToast } = useToast();
@@ -243,22 +226,35 @@ export default function DiscoverLibrary() {
     [createBoard, createPlaylist, queryClient, showToast, t, refetchUser],
   );
 
-  // Pin / unpin straight from a "Your Picks" card. The shared-hook arrays
-  // aren't ours to mutate optimistically, so refetch both lists once the
-  // mutation lands and let the pinned ordering + icon re-derive.
-  const handleToggleCardPin = useCallback(
-    async (playlist: Playlist) => {
+  const togglePlaylistPin = useCallback(
+    async (playlistUuid: string, isPinned: boolean) => {
       try {
-        if (playlist.isPinnedByMe) await unpinPlaylist(playlist.uuid);
-        else await pinPlaylist(playlist.uuid);
+        if (isPinned) await unpinPlaylist(playlistUuid);
+        else await pinPlaylist(playlistUuid);
         refetchUser();
         refetchPinned();
-      } catch (err) {
-        console.error('Failed to toggle pin:', err);
-        showToast(t(playlist.isPinnedByMe ? 'library.pin.unpinFailed' : 'library.pin.pinFailed'), 'error');
+      } catch {
+        showToast(t(isPinned ? 'library.pin.unpinFailed' : 'library.pin.pinFailed'), 'error');
       }
     },
-    [pinPlaylist, unpinPlaylist, refetchUser, refetchPinned, showToast, t],
+    [pinPlaylist, refetchPinned, refetchUser, showToast, t, unpinPlaylist],
+  );
+
+  // Pin / unpin straight from a playlist card. The shared-hook arrays aren't
+  // ours to mutate optimistically, so refetch both lists once the mutation lands
+  // and let the pinned ordering + icon re-derive.
+  const handleToggleCardPin = useCallback(
+    (playlist: Playlist) => {
+      void togglePlaylistPin(playlist.uuid, playlist.isPinnedByMe);
+    },
+    [togglePlaylistPin],
+  );
+
+  const handleToggleDiscoverPin = useCallback(
+    (playlistUuid: string) => {
+      void togglePlaylistPin(playlistUuid, pinnedPlaylistUuids.has(playlistUuid));
+    },
+    [pinnedPlaylistUuids, togglePlaylistPin],
   );
 
   // Refresh owned + pinned when returning to the tab (e.g. after editing,
@@ -290,7 +286,7 @@ export default function DiscoverLibrary() {
     pinnedPlaylists.length === 0 &&
     forYouItems.length === 0 &&
     communityItems.length === 0 &&
-    !smartCountsLoading;
+    !userLoading;
 
   const handleRetryLoad = useCallback(() => {
     if (userError) refetchUser();
@@ -337,29 +333,12 @@ export default function DiscoverLibrary() {
           </Pressable>
         ) : null}
 
-        {/* Your Picks — built-in smart defaults + real pinned playlists only. */}
-        {isAuthenticated && (defaultSmartCards.length > 0 || pinnedPlaylists.length > 0) ? (
+        {/* Pinned — dense grid capped at four rows of two. */}
+        {isAuthenticated && visiblePinnedPlaylists.length > 0 ? (
           <View style={styles.section}>
-            <SectionHeader
-              title={t('library.sections.smart')}
-              actionLabel={userPlaylists.length > 0 ? t('library.allPlaylists.seeAll') : undefined}
-              onActionPress={userPlaylists.length > 0 ? () => router.push('/(tabs)/discover/all') : undefined}
-            />
+            <SectionHeader title={t('library.sections.pinned')} />
             <View style={styles.grid}>
-              {defaultSmartCards.map(({ preset, count }, index) => (
-                <View key={preset.slug} style={styles.gridItem}>
-                  <PlaylistCard
-                    name={t(preset.titleI18nKey)}
-                    climbCount={count}
-                    color={preset.color}
-                    icon={preset.icon}
-                    variant="grid"
-                    index={index}
-                    onPress={() => goToSmart(preset.type)}
-                  />
-                </View>
-              ))}
-              {pinnedPlaylists.map((playlist, index) => (
+              {visiblePinnedPlaylists.map((playlist, index) => (
                 <View key={playlist.uuid} style={styles.gridItem}>
                   <PlaylistCard
                     name={playlist.name}
@@ -367,7 +346,7 @@ export default function DiscoverLibrary() {
                     color={playlist.color}
                     icon={playlist.icon}
                     variant="grid"
-                    index={defaultSmartCards.length + index}
+                    index={index}
                     onPress={() => goToPlaylist(playlist.uuid)}
                     isPinned={playlist.isPinnedByMe}
                     onTogglePin={() => handleToggleCardPin(playlist)}
@@ -376,6 +355,33 @@ export default function DiscoverLibrary() {
               ))}
             </View>
           </View>
+        ) : null}
+
+        {/* My Playlists — user's own playlists, excluding the pinned grid above. */}
+        {isAuthenticated && (userLoading || unpinnedUserPlaylists.length > 0) ? (
+          <PlaylistScrollSection
+            title={t('library.allPlaylists.title')}
+            actionLabel={userPlaylists.length > 0 ? t('library.allPlaylists.seeAll') : undefined}
+            onActionPress={userPlaylists.length > 0 ? () => router.push('/(tabs)/discover/all') : undefined}
+            loading={userLoading && unpinnedUserPlaylists.length === 0}
+            isLoadingMore={userLoadingMore}
+            onEndReached={loadMoreUser}
+          >
+            {unpinnedUserPlaylists.map((playlist, index) => (
+              <PlaylistCard
+                key={playlist.uuid}
+                name={playlist.name}
+                climbCount={playlist.climbCount}
+                color={playlist.color}
+                icon={playlist.icon}
+                variant="scroll"
+                index={index}
+                onPress={() => goToPlaylist(playlist.uuid)}
+                isPinned={playlist.isPinnedByMe}
+                onTogglePin={() => handleToggleCardPin(playlist)}
+              />
+            ))}
+          </PlaylistScrollSection>
         ) : null}
 
         {/* For You — generated recommendation playlists. */}
@@ -396,6 +402,8 @@ export default function DiscoverLibrary() {
                 variant="scroll"
                 index={index}
                 onPress={() => goToPlaylist(playlist.uuid)}
+                isPinned={isAuthenticated && pinnedPlaylistUuids.has(playlist.uuid)}
+                onTogglePin={isAuthenticated ? () => handleToggleDiscoverPin(playlist.uuid) : undefined}
               />
             ))}
           </PlaylistScrollSection>
@@ -423,6 +431,8 @@ export default function DiscoverLibrary() {
                 })}
                 index={index}
                 onPress={() => goToPlaylist(playlist.uuid)}
+                isPinned={isAuthenticated && pinnedPlaylistUuids.has(playlist.uuid)}
+                onTogglePin={isAuthenticated ? () => handleToggleDiscoverPin(playlist.uuid) : undefined}
               />
             ))}
           </PlaylistScrollSection>
@@ -458,10 +468,9 @@ export default function DiscoverLibrary() {
         !forYouLoading &&
         !communityLoading &&
         !profileLoading &&
-        !smartCountsLoading &&
         !showLoadError &&
-        defaultSmartCards.length === 0 &&
         pinnedPlaylists.length === 0 &&
+        userPlaylists.length === 0 &&
         forYouItems.length === 0 &&
         communityItems.length === 0 ? (
           <View style={styles.emptyContainer}>
@@ -477,7 +486,8 @@ export default function DiscoverLibrary() {
 
         {/* Initial spinner before any section has resolved. */}
         {(authLoading || tokenLoading) &&
-        defaultSmartCards.length === 0 &&
+        pinnedPlaylists.length === 0 &&
+        userPlaylists.length === 0 &&
         forYouItems.length === 0 &&
         communityItems.length === 0 ? (
           <View style={styles.loadingContainer}>

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -19,6 +19,7 @@
     },
     "sections": {
       "jumpBackIn": "Jump Back In",
+      "pinned": "Pinned",
       "smart": "Your Picks",
       "discover": "Discover",
       "forYou": "For You",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -19,6 +19,7 @@
     },
     "sections": {
       "jumpBackIn": "Continúa donde lo dejaste",
+      "pinned": "Fijadas",
       "smart": "Tus selecciones",
       "discover": "Descubre",
       "forYou": "Para ti",

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -19,6 +19,7 @@
     },
     "sections": {
       "jumpBackIn": "Reprendre",
+      "pinned": "Épinglées",
       "smart": "Vos sélections",
       "discover": "Découvrir",
       "forYou": "Pour vous",


### PR DESCRIPTION
## Summary

Restores the mobile Discover playlist layout after the generated-playlists follow-up regressed the section structure.

- Adds a dense top `Pinned` grid capped at 8 playlists, displayed as four rows of two at most.
- Adds the `Pinned` section title to English, Spanish, and French playlist catalogs.
- Removes the `See all` action from the pinned header.
- Adds a `My Playlists` horizontal shelf below pinned playlists, with the existing `See all` action and pagination.
- Keeps generated `For You` playlists and `Community Playlists` as the next two horizontal shelves.
- Keeps `For You` generated playlists scoped to the active board's layout, biggest size id, and active angle, and hides the shelf instead of rendering an empty header when no exact generated playlists are returned.
- Shows the pin control on generated and community playlist cards when the user is signed in.
- Adds focused regression tests for section order, active size/angle generated filtering, empty generated shelves, pinned-grid cap, pinned header action, and generated/community card pinning.

## Validation

- `vp test --project mobile run --reporter=agent 'packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx'`
- `vp test run --reporter=agent 'packages/shared/i18n/src/__tests__/catalog-completeness.test.ts'`
- `vp run typecheck:mobile` (passed outside the sandbox after Bun could not create its IPC shared-memory channel inside the sandbox)
- `git diff --check`

## Notes

The original PR was merged, so this branch is rebased onto `main`; the PR diff is one follow-up commit touching the mobile Discover screen, its focused test, and playlist locale catalogs.