### PR TITLE
Make the Android/Material variant truly Material Design 3

### DIFF
--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -944,7 +944,7 @@ The public prop API must stay identical across both branches so call sites never
 
 - **Icons:** Paper resolves icons through the app's `@expo/vector-icons` MaterialCommunityIcons (wired via `PaperProvider settings.icon`), so pass the **MDI** name — bridge our semantic `IconName` with `iconMap[name].android` (`src/components/icon-map.ts`).
 - **Paper-backed today:** Button, SegmentedControl→`SegmentedButtons`, SwitchRow→`Switch`, Badge, GlassIconButton→`IconButton`, Card, Toast/QueueAddedSnackbar→`Snackbar`, SearchHeader→`Searchbar`.
-- **Token-skinned but palette-consistent** (they read the same `materialSurfaces` that feeds the Paper theme): `ListRow`, `GradeChip`, `MaterialTabBar`, gorhom sheets, `AccessoryBarSurface`.
+- **Token-skinned but palette-consistent** (they read the same `materialSurfaces` / `theme.m3` roles that feed the Paper theme): `ListRow`, `GradeChip`, `MaterialTabBar` (the bottom navigation bar), `MaterialTabs` (the Profile app bar's M3 primary tabs — equal-width labels + a sliding `m3.primary` underline, distinct from the bottom-nav `MaterialTabBar`), gorhom sheets, `AccessoryBarSurface`.
 - **Tests:** `react-native-paper` is aliased to a jsdom-safe stub (`test/react-native-paper-stub.tsx`) in `packages/mobile/vite.config.ts` — the same pattern as the posthog stub — so any suite can import a Paper-backed primitive. Component tests that assert Paper props register their own `vi.mock('react-native-paper', …)`, which takes precedence.
 
 ---

--- a/packages/mobile/src/components/SectionHeader.tsx
+++ b/packages/mobile/src/components/SectionHeader.tsx
@@ -3,6 +3,7 @@ import { Text } from './Text';
 import { Icon } from './Icon';
 import { PressableSurface } from './PressableSurface';
 import { useTheme } from '../providers/theme-provider';
+import { spacing } from '../theme/tokens';
 
 type SectionHeaderProps = {
   title: string;
@@ -51,9 +52,9 @@ export function SectionHeader({ title, actionLabel, onActionPress }: SectionHead
 
 const styles = StyleSheet.create({
   container: {
-    paddingHorizontal: 16,
-    paddingTop: 24,
-    paddingBottom: 8,
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[6],
+    paddingBottom: spacing[2],
   },
   containerWithAction: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/SectionHeader.tsx
+++ b/packages/mobile/src/components/SectionHeader.tsx
@@ -13,13 +13,21 @@ type SectionHeaderProps = {
 };
 
 export function SectionHeader({ title, actionLabel, onActionPress }: SectionHeaderProps) {
-  const { brandColors } = useTheme();
-  const displayTitle = Platform.OS === 'ios' ? title.toUpperCase() : title;
+  const { brandColors, variant, m3 } = useTheme();
+  const isMaterial = variant === 'material';
+  // M3 list/section headers are sentence-case titleSmall in onSurfaceVariant — not
+  // the iOS group-caption (uppercased, dimmed, tracked-out footnote). So Material
+  // drops the uppercasing + 0.6 opacity + letter-spacing and lifts to titleSmall.
+  const displayTitle = isMaterial ? title : Platform.OS === 'ios' ? title.toUpperCase() : title;
   const showAction = !!actionLabel && !!onActionPress;
 
   return (
     <View style={[styles.container, showAction && styles.containerWithAction]}>
-      <Text variant="footnote" style={styles.text}>
+      <Text
+        variant={isMaterial ? 'subheadline' : 'footnote'}
+        color={isMaterial ? m3.onSurfaceVariant : undefined}
+        style={isMaterial ? styles.materialText : styles.text}
+      >
         {displayTitle}
       </Text>
       {showAction ? (
@@ -55,6 +63,11 @@ const styles = StyleSheet.create({
   text: {
     opacity: 0.6,
     letterSpacing: 0.5,
+  },
+  // M3 titleSmall weight (the `subheadline` material scale is 14/400; titleSmall
+  // is 14/500). No opacity/letter-spacing — onSurfaceVariant carries the hierarchy.
+  materialText: {
+    fontWeight: '500',
   },
   action: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/Stepper.tsx
+++ b/packages/mobile/src/components/Stepper.tsx
@@ -25,14 +25,23 @@ function clampStepperValue(value: number, min: number, max: number): number {
  * divided by the parent). Clamps to [min, max] before reporting changes.
  */
 export function Stepper({ label, value, min, max, onChange, decreaseLabel, increaseLabel }: StepperProps) {
-  const { systemColors, brandColors, opacity: themeOpacity } = useTheme();
+  const { systemColors, brandColors, opacity: themeOpacity, variant, m3 } = useTheme();
+  const isMaterial = variant === 'material';
   const decrementDisabled = value <= min;
   const incrementDisabled = value >= max;
 
   const updateValue = (nextValue: number) => onChange(clampStepperValue(nextValue, min, max));
 
+  // Material: a tonal secondary-container pill with onSecondaryContainer glyphs
+  // and a state-layer ripple (Android), 48dp targets. Glass keeps the iOS
+  // tertiaryBackground fill + violet glyphs + scale feedback.
+  const controlsFill = isMaterial ? m3.secondaryContainer : systemColors.tertiaryBackground;
+  const dividerColor = isMaterial ? m3.outlineVariant : systemColors.separator;
+  const activeGlyph = isMaterial ? m3.onSecondaryContainer : brandColors.primary;
+  const buttonStyle = [styles.button, isMaterial && styles.buttonMaterial];
+
   return (
-    <View style={styles.row}>
+    <View style={[styles.row, isMaterial && styles.rowMaterial]}>
       <Text variant="body" style={styles.label}>
         {label}
       </Text>
@@ -40,29 +49,31 @@ export function Stepper({ label, value, min, max, onChange, decreaseLabel, incre
         <Text variant="body" color={systemColors.label} style={styles.value}>
           {value}
         </Text>
-        <View style={[styles.controls, { backgroundColor: systemColors.tertiaryBackground }]}>
+        <View style={[styles.controls, { backgroundColor: controlsFill }]}>
           <PressableSurface
             onPress={() => updateValue(value - 1)}
             disabled={decrementDisabled}
             feedback="scale"
+            rippleColor={isMaterial ? m3.onSecondaryContainer : undefined}
             hitSlop={2}
             accessibilityRole="button"
             accessibilityLabel={decreaseLabel}
-            style={[styles.button, decrementDisabled ? { opacity: themeOpacity.disabled } : null]}
+            style={[buttonStyle, decrementDisabled ? { opacity: themeOpacity.disabled } : null]}
           >
-            <Icon name="minus" size={16} color={decrementDisabled ? systemColors.tertiaryLabel : brandColors.primary} />
+            <Icon name="minus" size={16} color={decrementDisabled ? systemColors.tertiaryLabel : activeGlyph} />
           </PressableSurface>
-          <View style={[styles.controlDivider, { backgroundColor: systemColors.separator }]} />
+          <View style={[styles.controlDivider, { backgroundColor: dividerColor }]} />
           <PressableSurface
             onPress={() => updateValue(value + 1)}
             disabled={incrementDisabled}
             feedback="scale"
+            rippleColor={isMaterial ? m3.onSecondaryContainer : undefined}
             hitSlop={2}
             accessibilityRole="button"
             accessibilityLabel={increaseLabel}
-            style={[styles.button, incrementDisabled ? { opacity: themeOpacity.disabled } : null]}
+            style={[buttonStyle, incrementDisabled ? { opacity: themeOpacity.disabled } : null]}
           >
-            <Icon name="plus" size={16} color={incrementDisabled ? systemColors.tertiaryLabel : brandColors.primary} />
+            <Icon name="plus" size={16} color={incrementDisabled ? systemColors.tertiaryLabel : activeGlyph} />
           </PressableSurface>
         </View>
       </View>
@@ -79,6 +90,10 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
     minHeight: 44,
     gap: spacing[3],
+  },
+  // M3 lifts the row to a 48dp minimum so the taller ± targets sit comfortably.
+  rowMaterial: {
+    minHeight: 48,
   },
   label: {
     flex: 1,
@@ -109,5 +124,10 @@ const styles = StyleSheet.create({
     height: 36,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  // M3 ≥48dp touch target for the ± controls.
+  buttonMaterial: {
+    width: 48,
+    height: 48,
   },
 });

--- a/packages/mobile/src/components/Text.tsx
+++ b/packages/mobile/src/components/Text.tsx
@@ -9,6 +9,12 @@ type TextProps = RNTextProps & {
   color?: ColorValue;
 };
 
+/**
+ * Static fallback scale (the Liquid Glass / Apple HIG values). Used only when no
+ * ThemeProvider is mounted — e.g. the pre-provider root error boundary. Under a
+ * provider, `Text` reads the variant-resolved `theme.textStyles` so the Material
+ * variant gets the M3 (Roboto) scale.
+ */
 export const variantStyles = StyleSheet.create(textStyles);
 
 export function Text({ variant = 'body', color, style, ...props }: TextProps) {
@@ -18,12 +24,16 @@ export function Text({ variant = 'body', color, style, ...props }: TextProps) {
   // safe in the pre-provider error boundary (falls back to the RN default).
   const theme = useOptionalTheme();
   const resolvedColor = color ?? theme?.systemColors.label;
+  // Pull the type scale from the theme so the resolved per-UI-variant scale
+  // (HIG on Liquid Glass, M3 on Material) applies. Falls back to the static glass
+  // scale when no provider is mounted.
+  const typeStyle = theme?.textStyles[variant] ?? variantStyles[variant];
 
   return (
     <RNText
       allowFontScaling
       maxFontSizeMultiplier={1.5}
-      style={[variantStyles[variant], resolvedColor != null ? { color: resolvedColor } : undefined, style]}
+      style={[typeStyle, resolvedColor != null ? { color: resolvedColor } : undefined, style]}
       {...props}
     />
   );

--- a/packages/mobile/src/components/Toast.tsx
+++ b/packages/mobile/src/components/Toast.tsx
@@ -9,7 +9,12 @@ import { Icon } from './Icon';
 import type { IconName } from './icon-map';
 import { blendOpaque, withAlpha } from '../theme/colors';
 import { borderRadius, spacing } from '../theme/tokens';
-import { MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT, TAB_BAR_HEIGHT, TOOLBAR_RESERVE } from '../theme/layout';
+import {
+  MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
+  MATERIAL_TAB_BAR_HEIGHT,
+  TAB_BAR_HEIGHT,
+  TOOLBAR_RESERVE,
+} from '../theme/layout';
 import type { UiVariant } from '../theme/resolve-ui-variant';
 import { isTabsRoute } from '../lib/route-segments';
 import { useTheme } from '../providers/theme-provider';
@@ -63,8 +68,13 @@ function useToastBottomOffset(uiVariant: UiVariant) {
   const insets = useSafeAreaInsets();
   const segments = useSegments();
   const toolbarReserve = uiVariant === 'material' ? MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT : TOOLBAR_RESERVE;
+  // The Material variant's JS nav bar is the taller M3 80dp bar; Liquid Glass uses
+  // the 49pt iOS tab bar. This is an independent recomputation (it sits above
+  // QueueProvider, so it can't use computeBottomChromeMetrics) — keep the tab-bar
+  // term variant-aware to match, or the Material snackbar tucks under the nav bar.
+  const tabBarHeight = uiVariant === 'material' ? MATERIAL_TAB_BAR_HEIGHT : TAB_BAR_HEIGHT;
   return isTabsRoute(segments)
-    ? insets.bottom + TAB_BAR_HEIGHT + toolbarReserve + spacing[2]
+    ? insets.bottom + tabBarHeight + toolbarReserve + spacing[2]
     : insets.bottom + spacing[3];
 }
 

--- a/packages/mobile/src/components/__tests__/toast.test.tsx
+++ b/packages/mobile/src/components/__tests__/toast.test.tsx
@@ -81,6 +81,7 @@ vi.mock('../../theme/colors', () => ({
 vi.mock('../../theme/tokens', () => ({ borderRadius: { full: 999 }, spacing: { 2: 8, 3: 12, 4: 16 } }));
 vi.mock('../../theme/layout', () => ({
   MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT: 48,
+  MATERIAL_TAB_BAR_HEIGHT: 80,
   TAB_BAR_HEIGHT: 49,
   TOOLBAR_RESERVE: 56,
 }));
@@ -119,8 +120,12 @@ describe('Toast', () => {
   it('positions Material toasts above the docked climb bar and tab bar', () => {
     ctrl.variant = 'material';
     const { container } = render(<Toast toast={toast} onDismiss={() => {}} />);
+    // insets.bottom(34) + MATERIAL_TAB_BAR_HEIGHT(80) + active-context bar(48) +
+    // spacing[2](8) = 170. The tab-bar term is the taller M3 80dp nav bar, not the
+    // 49pt iOS bar, so the Material snackbar clears the nav bar rather than tucking
+    // under it.
     expect(container.querySelector('[data-paper-snackbar]')?.getAttribute('data-wrapper-style')).toContain(
-      '"bottom":139',
+      '"bottom":170',
     );
   });
 

--- a/packages/mobile/src/components/navigation/MaterialTabBar.tsx
+++ b/packages/mobile/src/components/navigation/MaterialTabBar.tsx
@@ -5,9 +5,9 @@ import { Text } from '../Text';
 import { PressableSurface } from '../PressableSurface';
 import { useTheme } from '../../providers/theme-provider';
 import { useSetMeasuredTabBarHeight } from '../../providers/tab-bar-height-provider';
-import { brandColors as staticBrandColors, withAlpha } from '../../theme/colors';
+import { brandColors as staticBrandColors } from '../../theme/colors';
 import { material } from '../../theme/tokens';
-import { TAB_BAR_HEIGHT } from '../../theme/layout';
+import { MATERIAL_TAB_BAR_HEIGHT } from '../../theme/layout';
 
 /**
  * Material 3 bottom navigation bar — the JS tab bar for the Material UI variant
@@ -18,14 +18,16 @@ import { TAB_BAR_HEIGHT } from '../../theme/layout';
  * screen's React Navigation options, so this stays a generic custom tab bar.
  */
 export function MaterialTabBar({ state, descriptors, navigation, insets }: BottomTabBarProps) {
-  const { systemColors, brandColors } = useTheme();
-  // Softened active state (closer to M3, which tints the indicator gently rather
-  // than using full primary): a lighter violet pill + a muted violet icon/label.
-  // Brand colours resolve per scheme (lifted #A78BFA in dark), so the active tab
-  // stays legible on the dark Material bar instead of dimming to the dark fill.
-  const activeColor = withAlpha(brandColors.primary, 0.8);
-  const inactiveColor = systemColors.secondaryLabel;
-  const indicatorColor = withAlpha(brandColors.primary, 0.1);
+  const { systemColors, brandColors, m3 } = useTheme();
+  // M3 navigation bar roles: the focused destination's icon sits on a
+  // secondaryContainer active-indicator pill (onSecondaryContainer glyph), its
+  // label lifts to onSurface, and inactive destinations use onSurfaceVariant for
+  // both icon and label. These read correctly on the tonal M3 surface in both
+  // schemes (the Paper palette resolves per scheme) — no manual alpha tinting.
+  const activeIconColor = m3.onSecondaryContainer;
+  const activeLabelColor = m3.onSurface;
+  const inactiveColor = m3.onSurfaceVariant;
+  const indicatorColor = m3.secondaryContainer;
 
   // Publish the real rendered height so the root-level queue bar docks flush against
   // it (rather than re-deriving the tab-bar top from TAB_BAR_HEIGHT + inset). #2611.
@@ -44,7 +46,7 @@ export function MaterialTabBar({ state, descriptors, navigation, insets }: Botto
           backgroundColor: systemColors.elevatedSurface,
           borderTopColor: systemColors.separator,
           paddingBottom: insets.bottom,
-          height: TAB_BAR_HEIGHT + insets.bottom,
+          height: MATERIAL_TAB_BAR_HEIGHT + insets.bottom,
         },
       ]}
     >
@@ -52,7 +54,8 @@ export function MaterialTabBar({ state, descriptors, navigation, insets }: Botto
         const { options } = descriptors[route.key];
         const focused = state.index === index;
         const label = typeof options.title === 'string' ? options.title : route.name;
-        const color = focused ? activeColor : inactiveColor;
+        const iconColor = focused ? activeIconColor : inactiveColor;
+        const labelColor = focused ? activeLabelColor : inactiveColor;
 
         const onPress = () => {
           const event = navigation.emit({ type: 'tabPress', target: route.key, canPreventDefault: true });
@@ -78,7 +81,7 @@ export function MaterialTabBar({ state, descriptors, navigation, insets }: Botto
             style={styles.item}
           >
             <View style={[styles.indicator, focused && { backgroundColor: indicatorColor }]}>
-              {options.tabBarIcon?.({ focused, color, size: 24 })}
+              {options.tabBarIcon?.({ focused, color: iconColor, size: 24 })}
               {options.tabBarBadge != null ? (
                 <View
                   testID="badge"
@@ -91,7 +94,7 @@ export function MaterialTabBar({ state, descriptors, navigation, insets }: Botto
                 />
               ) : null}
             </View>
-            <Text variant="caption2" color={color} numberOfLines={1}>
+            <Text variant="caption2" color={labelColor} numberOfLines={1}>
               {label}
             </Text>
           </PressableSurface>

--- a/packages/mobile/src/components/navigation/MaterialTabs.tsx
+++ b/packages/mobile/src/components/navigation/MaterialTabs.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useState } from 'react';
+import { type LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
+import { Text } from '../Text';
+import { PressableSurface } from '../PressableSurface';
+import { hapticSelection } from '../../lib/haptics';
+import { spacing } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
+
+// M3 primary-tab active-indicator: a 3dp underline sitting flush under the
+// active label. The container measures its own width via onLayout, so the
+// indicator width / offset are derived from equal-width tab slots.
+const INDICATOR_HEIGHT = 3;
+
+type MaterialTabOption<K extends string> = {
+  key: K;
+  label: string;
+};
+
+type MaterialTabsProps<K extends string> = {
+  options: MaterialTabOption<K>[];
+  selectedKey: K;
+  onSelect: (key: K) => void;
+  /** Accessibility label naming the group (announced when VoiceOver/TalkBack
+   *  enters the tab row). */
+  accessibilityLabel?: string;
+};
+
+function MaterialTab({
+  label,
+  selected,
+  onPress,
+  rippleColor,
+  activeColor,
+  inactiveColor,
+}: {
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+  rippleColor: string;
+  activeColor: string;
+  inactiveColor: string;
+}) {
+  return (
+    <PressableSurface
+      onPress={onPress}
+      feedback="none"
+      rippleColor={rippleColor}
+      accessibilityRole="tab"
+      accessibilityState={{ selected }}
+      accessibilityLabel={label}
+      style={styles.tab}
+    >
+      <Text variant="subheadline" color={selected ? activeColor : inactiveColor} style={styles.label}>
+        {label}
+      </Text>
+    </PressableSurface>
+  );
+}
+
+/**
+ * Material 3 primary tabs — a horizontal equal-width row of text labels with a
+ * sliding active-indicator underline. The flat M3 counterpart of the Liquid
+ * Glass `SegmentedControl`, sharing its generic prop API so call sites read the
+ * same. Each tab is an equal-width slot, so the indicator's width and offset are
+ * `containerWidth / N`; the offset animates with `withTiming` when the selection
+ * changes. The container measures its width via `onLayout`; before the first
+ * measurement the indicator is zero-width (no flash).
+ */
+export function MaterialTabs<K extends string = string>({
+  options,
+  selectedKey,
+  onSelect,
+  accessibilityLabel,
+}: MaterialTabsProps<K>) {
+  const { m3, brandColors } = useTheme();
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
+    setContainerWidth(event.nativeEvent.layout.width);
+  }, []);
+
+  const tabCount = options.length;
+  const activeIndex = Math.max(
+    0,
+    options.findIndex((option) => option.key === selectedKey),
+  );
+  // Equal-width slots: each tab and the indicator span containerWidth / N. Read
+  // as primitives so the worklet's deps stay length-free (the count and width
+  // are the only inputs that move the indicator).
+  const slotWidth = tabCount > 0 ? containerWidth / tabCount : 0;
+
+  // Animate only the horizontal offset; the width tracks the measured slot and
+  // doesn't need easing. translateX lands the indicator under the active tab.
+  const indicatorStyle = useAnimatedStyle(() => ({
+    width: slotWidth,
+    transform: [{ translateX: withTiming(activeIndex * slotWidth) }],
+  }));
+
+  const handleSelect = useCallback(
+    (key: K) => {
+      hapticSelection();
+      onSelect(key);
+    },
+    [onSelect],
+  );
+
+  return (
+    <View
+      style={styles.container}
+      onLayout={handleLayout}
+      accessibilityRole="tablist"
+      accessibilityLabel={accessibilityLabel}
+    >
+      <View style={styles.row}>
+        {options.map((option) => (
+          <MaterialTab
+            key={option.key}
+            label={option.label}
+            selected={option.key === selectedKey}
+            onPress={() => handleSelect(option.key)}
+            rippleColor={brandColors.primary}
+            activeColor={m3.primary}
+            inactiveColor={m3.onSurfaceVariant}
+          />
+        ))}
+      </View>
+      {slotWidth > 0 ? (
+        <Animated.View
+          pointerEvents="none"
+          style={[styles.indicator, { backgroundColor: m3.primary }, indicatorStyle]}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  tab: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing[3],
+  },
+  label: {
+    fontWeight: '600',
+  },
+  indicator: {
+    position: 'absolute',
+    left: 0,
+    bottom: 0,
+    height: INDICATOR_HEIGHT,
+    borderTopLeftRadius: INDICATOR_HEIGHT,
+    borderTopRightRadius: INDICATOR_HEIGHT,
+  },
+});

--- a/packages/mobile/src/components/navigation/MaterialTabs.tsx
+++ b/packages/mobile/src/components/navigation/MaterialTabs.tsx
@@ -73,7 +73,7 @@ export function MaterialTabs<K extends string = string>({
   onSelect,
   accessibilityLabel,
 }: MaterialTabsProps<K>) {
-  const { m3, brandColors } = useTheme();
+  const { m3 } = useTheme();
   const [containerWidth, setContainerWidth] = useState(0);
 
   const handleLayout = useCallback((event: LayoutChangeEvent) => {
@@ -119,7 +119,7 @@ export function MaterialTabs<K extends string = string>({
             label={option.label}
             selected={option.key === selectedKey}
             onPress={() => handleSelect(option.key)}
-            rippleColor={brandColors.primary}
+            rippleColor={m3.primary}
             activeColor={m3.primary}
             inactiveColor={m3.onSurfaceVariant}
           />

--- a/packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx
+++ b/packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx
@@ -98,15 +98,19 @@ vi.mock('../../../providers/theme-provider', () => ({
     // MaterialTabBar now reads the scheme-aware brand from the theme (lifted
     // tint in dark) rather than the static import.
     brandColors: { primary: '#FF3B30', success: '#6B9080' },
+    // M3 navigation-bar roles: active icon on a secondaryContainer pill, active
+    // label onSurface, inactive icon+label onSurfaceVariant.
+    m3: {
+      onSecondaryContainer: '#E8DEF8',
+      onSurface: '#E6E1E5',
+      onSurfaceVariant: '#CAC4D0',
+      secondaryContainer: '#4A4458',
+    },
   }),
 }));
 
 vi.mock('../../../theme/colors', () => ({
   brandColors: { primary: '#FF3B30', success: '#6B9080' },
-  withAlpha: (color: string, alpha: number) =>
-    `${color}${Math.round(alpha * 255)
-      .toString(16)
-      .padStart(2, '0')}`,
 }));
 
 vi.mock('../../../theme/tokens', () => ({
@@ -121,7 +125,7 @@ vi.mock('../../../theme/tokens', () => ({
 }));
 
 vi.mock('../../../theme/layout', () => ({
-  TAB_BAR_HEIGHT: 49,
+  MATERIAL_TAB_BAR_HEIGHT: 80,
 }));
 
 import { MaterialTabBar } from '../MaterialTabBar';

--- a/packages/mobile/src/components/navigation/__tests__/MaterialTabs.test.tsx
+++ b/packages/mobile/src/components/navigation/__tests__/MaterialTabs.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const haptics = vi.hoisted(() => ({ selection: vi.fn() }));
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  View: ({
+    children,
+    accessibilityRole,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    accessibilityRole?: string;
+    accessibilityLabel?: string;
+  }) => createElement('div', { role: accessibilityRole, 'aria-label': accessibilityLabel }, children),
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
+  useAnimatedStyle: () => ({}),
+  useDerivedValue: (fn: () => unknown) => ({ value: fn() }),
+  withTiming: (value: number) => value,
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+// PressableSurface forwards onPress to a button and mirrors the tab role /
+// selected state so the test can read them off the DOM (matching MaterialTabBar's
+// test double).
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({
+    children,
+    onPress,
+    accessibilityRole,
+    accessibilityState,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityRole?: string;
+    accessibilityState?: { selected?: boolean };
+    accessibilityLabel?: string;
+  }) =>
+    createElement(
+      'button',
+      {
+        onClick: onPress,
+        role: accessibilityRole,
+        'aria-selected': accessibilityState?.selected,
+        'aria-label': accessibilityLabel,
+      },
+      children,
+    ),
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: haptics.selection }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 3: 12 } }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    m3: { primary: '#6750A4', onSurfaceVariant: '#49454F' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+
+import { MaterialTabs } from '../MaterialTabs';
+
+const OPTIONS = [
+  { key: 'progress', label: 'Progress' },
+  { key: 'sessions', label: 'Sessions' },
+  { key: 'logbook', label: 'Logbook' },
+];
+
+function makeProps(over: Partial<Parameters<typeof MaterialTabs>[0]> = {}) {
+  return {
+    options: OPTIONS,
+    selectedKey: 'progress',
+    onSelect: vi.fn(),
+    accessibilityLabel: 'Dashboard',
+    ...over,
+  };
+}
+
+describe('MaterialTabs', () => {
+  it('renders all option labels', () => {
+    const { getByText } = render(<MaterialTabs {...makeProps()} />);
+    expect(getByText('Progress')).not.toBeNull();
+    expect(getByText('Sessions')).not.toBeNull();
+    expect(getByText('Logbook')).not.toBeNull();
+  });
+
+  it('marks the selected tab as selected and the rest as not selected', () => {
+    const { getAllByRole } = render(<MaterialTabs {...makeProps({ selectedKey: 'sessions' })} />);
+    const tabs = getAllByRole('tab');
+    expect(tabs[0].getAttribute('aria-selected')).toBe('false');
+    expect(tabs[1].getAttribute('aria-selected')).toBe('true');
+    expect(tabs[2].getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('uses each option label as its tab accessibility label', () => {
+    const { getAllByRole } = render(<MaterialTabs {...makeProps()} />);
+    const tabs = getAllByRole('tab');
+    expect(tabs.map((tab) => tab.getAttribute('aria-label'))).toEqual(['Progress', 'Sessions', 'Logbook']);
+  });
+
+  it('fires onSelect with the pressed tab key', () => {
+    const onSelect = vi.fn();
+    const { getAllByRole } = render(<MaterialTabs {...makeProps({ onSelect })} />);
+    const tabs = getAllByRole('tab');
+    fireEvent.click(tabs[2]);
+    expect(onSelect).toHaveBeenCalledWith('logbook');
+  });
+
+  it('exposes the group accessibility label on a tablist', () => {
+    const { getByRole } = render(<MaterialTabs {...makeProps({ accessibilityLabel: 'Dashboard' })} />);
+    expect(getByRole('tablist').getAttribute('aria-label')).toBe('Dashboard');
+  });
+});

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -47,6 +47,7 @@ vi.mock('../../../hooks/use-reduce-motion', () => ({ useReduceMotion: () => true
 vi.mock('../../../theme/animations', () => ({ timing: { fast: 150, normal: 250 } }));
 vi.mock('../../../theme/layout', () => ({
   MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT: 48,
+  MATERIAL_TAB_BAR_HEIGHT: 80,
   TAB_BAR_HEIGHT: 49,
   TOOLBAR_RESERVE: 74,
   TOOLBAR_SIDE_MARGIN: 16,

--- a/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
+++ b/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
@@ -1,7 +1,12 @@
+import { useCallback } from 'react';
+import { type LayoutChangeEvent, StyleSheet, View } from 'react-native';
 import { type SharedValue } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
+import { Appbar } from 'react-native-paper';
 import { CollapsingTopChrome, GlassToolbarAction } from '../chrome';
 import { Icon } from '../Icon';
+import { iconMap } from '../icon-map';
 import { useTheme } from '../../providers/theme-provider';
 
 // Record's defining action is the Start/End footer button, so the chrome's
@@ -25,12 +30,21 @@ type RecordTopChromeProps = {
 };
 
 /**
- * The Record tab's floating glass chrome. A thin wrapper over the shared
- * `CollapsingTopChrome` (mirroring `DiscoverTopChrome`) that injects the session
- * title plus the board / invite i18n strings. Record's primary action is the
- * Start/End footer button, so there's no create "+"; instead, while a session is
- * live it docks a share/invite control as the chrome's `trailingAction`. The
- * board pill, angle, and light islands come for free from `CollapsingTopChrome`.
+ * The Record tab's top chrome, routed by UI variant.
+ *
+ * Liquid Glass: a thin wrapper over the shared `CollapsingTopChrome` (mirroring
+ * `DiscoverTopChrome`) that injects the session title plus the board / invite
+ * i18n strings. Record's primary action is the Start/End footer button, so
+ * there's no create "+"; instead, while a session is live it docks a
+ * share/invite control as the chrome's `trailingAction`. The board pill, angle,
+ * and light islands come for free from `CollapsingTopChrome`.
+ *
+ * Material: an absolutely-positioned, `onHeightChange`-measured M3 small app bar
+ * (mirroring `ClimbTopChrome`) — the session title via `Appbar.Content` and (only
+ * while a session is live) a share `Appbar.Action`. The board is switched from the
+ * in-body `BoardSummaryCard` (which carries the full name · size · angle), so the
+ * app bar stays session-titled rather than duplicating a board switcher. There's
+ * no collapse on Material, so `scrollY` / `onPressTitle` are unused.
  */
 export function RecordTopChrome({
   title,
@@ -42,8 +56,50 @@ export function RecordTopChrome({
 }: RecordTopChromeProps) {
   const { t } = useTranslation('session');
   const { t: tBoards } = useTranslation('boards');
-  const { brandColors } = useTheme();
+  const { brandColors, systemColors, variant } = useTheme();
+  const insets = useSafeAreaInsets();
 
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => onHeightChange(event.nativeEvent.layout.height),
+    [onHeightChange],
+  );
+
+  if (variant === 'material') {
+    return (
+      <View
+        pointerEvents="box-none"
+        style={[
+          styles.materialContainer,
+          {
+            paddingTop: insets.top,
+            backgroundColor: systemColors.secondaryBackground,
+            borderBottomColor: systemColors.separator,
+          },
+        ]}
+        onLayout={handleLayout}
+      >
+        <Appbar.Header
+          statusBarHeight={0}
+          mode="small"
+          elevated
+          style={[styles.materialAppbar, { backgroundColor: systemColors.secondaryBackground }]}
+        >
+          <Appbar.Content title={title} color={systemColors.label as string} />
+          {onShare ? (
+            <Appbar.Action
+              icon={iconMap['person.badge.plus'].android}
+              color={systemColors.label as string}
+              onPress={onShare}
+              accessibilityLabel={t('mobile.session.invite')}
+            />
+          ) : null}
+        </Appbar.Header>
+      </View>
+    );
+  }
+
+  // Liquid-glass variant: the shared collapsing chrome with the session title,
+  // board pill, and (while live) the share/invite trailing action.
   const trailingAction = onShare ? (
     <GlassToolbarAction onPress={onShare} accessibilityLabel={t('mobile.session.invite')}>
       <Icon name="person.badge.plus" size={22} color={brandColors.primary} />
@@ -67,3 +123,18 @@ export function RecordTopChrome({
     />
   );
 }
+
+const styles = StyleSheet.create({
+  materialContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 20,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  materialAppbar: {
+    elevation: 0,
+    shadowOpacity: 0,
+  },
+});

--- a/packages/mobile/src/components/session-screen/SessionActionFooter.tsx
+++ b/packages/mobile/src/components/session-screen/SessionActionFooter.tsx
@@ -1,0 +1,135 @@
+import { useCallback } from 'react';
+import { type LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import { FAB } from 'react-native-paper';
+import { Button } from '../Button';
+import { PinnedActionBar } from '../PinnedActionBar';
+import { iconMap, type IconName } from '../icon-map';
+import { useTheme } from '../../providers/theme-provider';
+import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { spacing } from '../../theme/tokens';
+
+type SessionActionFooterProps = {
+  /** Visible label — the Start/End copy (Material renders it as the extended FAB
+   *  label; Liquid Glass as the pinned button title). */
+  label: string;
+  /** Glyph for the Material extended FAB (maps to its Android icon). */
+  materialIcon: IconName;
+  onPress: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  /** M3 FAB colour role for the action's prominence (primary = Start, secondary
+   *  = End). Maps to Paper's `variant`. */
+  emphasis: 'primary' | 'secondary';
+  /** Liquid Glass button style for the same action (filled = Start, outlined =
+   *  End). */
+  glassButtonVariant: 'filled' | 'outlined';
+  testID?: string;
+  /** Fires with the measured footer height (excluding the bottom-chrome offset)
+   *  so the host list reserves `measuredHeight + fixedFooterBottom`, matching the
+   *  PinnedActionBar contract. */
+  onHeightChange?: (height: number) => void;
+};
+
+/**
+ * The session Start/End footer action, routed by UI variant. Liquid Glass keeps
+ * the exact pinned glass toolbar + Button it always had; Material draws an M3
+ * extended FAB (Paper supplies its disabled / loading states) anchored bottom-end
+ * over the same bottom-chrome offset. Both branches measure their own height and
+ * report it through `onHeightChange`, so the host list reserves the right bottom
+ * inset either way (the existing `measuredHeight + fixedFooterBottom` contract).
+ */
+export function SessionActionFooter({
+  label,
+  materialIcon,
+  onPress,
+  disabled,
+  loading,
+  emphasis,
+  glassButtonVariant,
+  testID,
+  onHeightChange,
+}: SessionActionFooterProps) {
+  const { variant } = useTheme();
+
+  if (variant === 'material') {
+    return (
+      <SessionActionFooterMaterial
+        label={label}
+        materialIcon={materialIcon}
+        onPress={onPress}
+        disabled={disabled}
+        loading={loading}
+        emphasis={emphasis}
+        testID={testID}
+        onHeightChange={onHeightChange}
+      />
+    );
+  }
+
+  return (
+    <PinnedActionBar testID={testID} onHeightChange={onHeightChange}>
+      <Button
+        title={label}
+        onPress={onPress}
+        variant={glassButtonVariant}
+        size="large"
+        disabled={disabled}
+        loading={loading}
+      />
+    </PinnedActionBar>
+  );
+}
+
+function SessionActionFooterMaterial({
+  label,
+  materialIcon,
+  onPress,
+  disabled,
+  loading,
+  emphasis,
+  testID,
+  onHeightChange,
+}: Omit<SessionActionFooterProps, 'glassButtonVariant'>) {
+  const bottomChrome = useBottomChromeMetrics();
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      onHeightChange?.(event.nativeEvent.layout.height);
+    },
+    [onHeightChange],
+  );
+
+  // The FAB floats bottom-end over the same fixed-footer offset the glass bar
+  // used; the container is box-none so the list scrolls under it everywhere
+  // except the FAB itself. Measuring the container (not the FAB) keeps the host's
+  // reserved bottom inset honest.
+  return (
+    <View
+      testID={testID}
+      pointerEvents="box-none"
+      onLayout={onHeightChange ? handleLayout : undefined}
+      style={[styles.materialContainer, { bottom: bottomChrome.fixedFooterBottom }]}
+    >
+      <FAB
+        icon={iconMap[materialIcon].android}
+        label={label}
+        onPress={onPress}
+        disabled={disabled}
+        loading={loading}
+        variant={emphasis}
+        mode="elevated"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  materialContainer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    alignItems: 'flex-end',
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[3],
+  },
+});

--- a/packages/mobile/src/components/session-screen/__tests__/record-top-chrome.test.tsx
+++ b/packages/mobile/src/components/session-screen/__tests__/record-top-chrome.test.tsx
@@ -20,8 +20,17 @@ type ChromeProps = {
 // gating contract can be asserted directly.
 const chrome = vi.hoisted(() => ({ props: null as ChromeProps | null }));
 
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
 vi.mock('react-native-reanimated', () => ({}));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+// No `variant` → the glass branch runs, exercising the CollapsingTopChrome
+// forwarding contract below.
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({ brandColors: { primary: '#6D28D9' } }),
 }));

--- a/packages/mobile/src/components/session-screen/__tests__/record-top-chrome.test.tsx
+++ b/packages/mobile/src/components/session-screen/__tests__/record-top-chrome.test.tsx
@@ -19,6 +19,10 @@ type ChromeProps = {
 // Captures every prop CollapsingTopChrome receives so the wrapper's forwarding +
 // gating contract can be asserted directly.
 const chrome = vi.hoisted(() => ({ props: null as ChromeProps | null }));
+const ctrl = vi.hoisted(() => ({ variant: 'glass' as 'glass' | 'material' }));
+// Captures the Material app bar's title + actions so the material branch can be
+// asserted without a real Paper render.
+const appbar = vi.hoisted(() => ({ title: null as string | null, actions: [] as string[] }));
 
 vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
@@ -29,10 +33,30 @@ vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
-// No `variant` → the glass branch runs, exercising the CollapsingTopChrome
-// forwarding contract below.
+// `ctrl.variant` drives which branch renders: 'glass' (default) exercises the
+// CollapsingTopChrome forwarding contract; 'material' exercises the Paper app bar.
 vi.mock('../../../providers/theme-provider', () => ({
-  useTheme: () => ({ brandColors: { primary: '#6D28D9' } }),
+  useTheme: () => ({
+    brandColors: { primary: '#6D28D9' },
+    systemColors: { label: '#000', secondaryBackground: '#111', separator: '#333' },
+    variant: ctrl.variant,
+  }),
+}));
+vi.mock('react-native-paper', () => ({
+  Appbar: {
+    Header: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-appbar': 'true' }, children),
+    Content: ({ title }: { title?: string }) => {
+      appbar.title = title ?? null;
+      return createElement('div', { 'data-appbar-title': title ?? '' });
+    },
+    Action: ({ accessibilityLabel }: { accessibilityLabel?: string }) => {
+      if (accessibilityLabel) appbar.actions.push(accessibilityLabel);
+      return createElement('div', { 'data-appbar-action': accessibilityLabel ?? '' });
+    },
+  },
+}));
+vi.mock('../../icon-map', () => ({
+  iconMap: { 'person.badge.plus': { ios: 'person.badge.plus', android: 'account-plus-outline' } },
 }));
 vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
 vi.mock('../../chrome', () => ({
@@ -69,6 +93,9 @@ function makeProps(over: Partial<Parameters<typeof RecordTopChrome>[0]> = {}) {
 describe('RecordTopChrome', () => {
   beforeEach(() => {
     chrome.props = null;
+    ctrl.variant = 'glass';
+    appbar.title = null;
+    appbar.actions = [];
   });
 
   it('gates the create island off (canCreate=false)', () => {
@@ -105,5 +132,27 @@ describe('RecordTopChrome', () => {
     expect(shareButton).not.toBeNull();
     shareButton!.click();
     expect(onShare).toHaveBeenCalledTimes(1);
+  });
+
+  describe('material variant', () => {
+    beforeEach(() => {
+      ctrl.variant = 'material';
+    });
+
+    it('renders the Paper app bar with the session title (no CollapsingTopChrome)', () => {
+      const { container } = render(<RecordTopChrome {...makeProps({ title: 'Active session' })} />);
+      expect(container.querySelector('[data-appbar="true"]')).not.toBeNull();
+      expect(container.querySelector('[data-chrome="true"]')).toBeNull();
+      expect(appbar.title).toBe('Active session');
+    });
+
+    it('shows the share app-bar action only while a session is live (onShare set)', () => {
+      const { rerender } = render(<RecordTopChrome {...makeProps()} />);
+      expect(appbar.actions).not.toContain('mobile.session.invite');
+
+      appbar.actions = [];
+      rerender(<RecordTopChrome {...makeProps({ onShare: vi.fn() })} />);
+      expect(appbar.actions).toContain('mobile.session.invite');
+    });
   });
 });

--- a/packages/mobile/src/components/session-screen/__tests__/session-action-footer.test.tsx
+++ b/packages/mobile/src/components/session-screen/__tests__/session-action-footer.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const ctrl = vi.hoisted(() => ({ variant: 'glass' as 'glass' | 'material' }));
+// Captures the props the glass PinnedActionBar + Button and the Material FAB
+// receive so the test can assert the variant routing + the forwarded contract.
+const pinned = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+const button = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+const fab = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+
+vi.mock('react-native', () => ({
+  View: ({
+    children,
+    onLayout,
+    style,
+    testID,
+    pointerEvents,
+  }: {
+    children?: ReactNode;
+    onLayout?: (event: { nativeEvent: { layout: { height: number } } }) => void;
+    style?: unknown;
+    testID?: string;
+    pointerEvents?: string;
+  }) =>
+    createElement(
+      'div',
+      {
+        ...(testID ? { 'data-testid': testID } : {}),
+        'data-style': JSON.stringify(style),
+        'data-pointer-events': pointerEvents ?? '',
+        // Expose a way to fire the measured-height layout from the test.
+        'data-fire-layout': onLayout ? () => onLayout({ nativeEvent: { layout: { height: 72 } } }) : undefined,
+        ref: (node: (HTMLElement & { fireLayout?: () => void }) | null) => {
+          if (node && onLayout) node.fireLayout = () => onLayout({ nativeEvent: { layout: { height: 72 } } });
+        },
+      },
+      children,
+    ),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('react-native-paper', () => ({
+  FAB: (props: Record<string, unknown>) => {
+    fab.props = props;
+    return createElement('button', { 'data-fab': 'true', onClick: props.onPress as () => void }, String(props.label));
+  },
+}));
+
+vi.mock('../../PinnedActionBar', () => ({
+  PinnedActionBar: (props: { children?: ReactNode; testID?: string; onHeightChange?: (height: number) => void }) => {
+    pinned.props = props;
+    return createElement('div', { 'data-pinned': 'true', 'data-testid': props.testID }, props.children);
+  },
+}));
+
+vi.mock('../../Button', () => ({
+  Button: (props: Record<string, unknown>) => {
+    button.props = props;
+    return createElement(
+      'button',
+      { 'data-button': 'true', onClick: props.onPress as () => void },
+      String(props.title),
+    );
+  },
+}));
+
+vi.mock('../../icon-map', () => ({
+  iconMap: { 'play.fill': { ios: 'play.fill', android: 'play' }, flag: { ios: 'flag', android: 'flag-outline' } },
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ variant: ctrl.variant }) }));
+vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ fixedFooterBottom: 88 }),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 3: 12, 4: 16 } }));
+
+import { SessionActionFooter } from '../SessionActionFooter';
+
+function makeProps(over: Partial<Parameters<typeof SessionActionFooter>[0]> = {}) {
+  return {
+    label: 'Start session',
+    materialIcon: 'play.fill' as const,
+    onPress: vi.fn(),
+    emphasis: 'primary' as const,
+    glassButtonVariant: 'filled' as const,
+    testID: 'pre-session-footer',
+    onHeightChange: vi.fn(),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  ctrl.variant = 'glass';
+  pinned.props = null;
+  button.props = null;
+  fab.props = null;
+});
+
+describe('SessionActionFooter', () => {
+  describe('glass variant', () => {
+    it('renders the pinned glass bar + Button, forwarding testID / onHeightChange', () => {
+      const onHeightChange = vi.fn();
+      const { container } = render(<SessionActionFooter {...makeProps({ onHeightChange })} />);
+
+      expect(container.querySelector('[data-pinned="true"]')).not.toBeNull();
+      expect(container.querySelector('[data-fab="true"]')).toBeNull();
+      expect(pinned.props?.testID).toBe('pre-session-footer');
+      expect(pinned.props?.onHeightChange).toBe(onHeightChange);
+    });
+
+    it('maps label / glassButtonVariant / disabled / loading onto the Button', () => {
+      render(
+        <SessionActionFooter
+          {...makeProps({ label: 'End session', glassButtonVariant: 'outlined', disabled: true, loading: true })}
+        />,
+      );
+      expect(button.props?.title).toBe('End session');
+      expect(button.props?.variant).toBe('outlined');
+      expect(button.props?.size).toBe('large');
+      expect(button.props?.disabled).toBe(true);
+      expect(button.props?.loading).toBe(true);
+    });
+
+    it('fires onPress through the Button', () => {
+      const onPress = vi.fn();
+      const { container } = render(<SessionActionFooter {...makeProps({ onPress })} />);
+      fireEvent.click(container.querySelector('[data-button="true"]')!);
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('material variant', () => {
+    beforeEach(() => {
+      ctrl.variant = 'material';
+    });
+
+    it('renders the extended FAB (not the glass bar) with the Android icon + label', () => {
+      const { container } = render(<SessionActionFooter {...makeProps({ label: 'Start session' })} />);
+      expect(container.querySelector('[data-pinned="true"]')).toBeNull();
+      expect(container.querySelector('[data-fab="true"]')).not.toBeNull();
+      expect(fab.props?.icon).toBe('play'); // iconMap['play.fill'].android
+      expect(fab.props?.label).toBe('Start session');
+      expect(fab.props?.mode).toBe('elevated');
+    });
+
+    it('maps emphasis onto the FAB variant and forwards disabled / loading', () => {
+      render(
+        <SessionActionFooter
+          {...makeProps({ materialIcon: 'flag', emphasis: 'secondary', disabled: true, loading: true })}
+        />,
+      );
+      expect(fab.props?.icon).toBe('flag-outline');
+      expect(fab.props?.variant).toBe('secondary');
+      expect(fab.props?.disabled).toBe(true);
+      expect(fab.props?.loading).toBe(true);
+    });
+
+    it('anchors the container at fixedFooterBottom and lets taps pass through (box-none)', () => {
+      const { getByTestId } = render(<SessionActionFooter {...makeProps()} />);
+      const containerNode = getByTestId('pre-session-footer');
+      expect(containerNode.getAttribute('data-pointer-events')).toBe('box-none');
+      expect(containerNode.getAttribute('data-style')).toContain('"bottom":88');
+    });
+
+    it('reports the measured container height through onHeightChange', () => {
+      const onHeightChange = vi.fn();
+      const { getByTestId } = render(<SessionActionFooter {...makeProps({ onHeightChange })} />);
+      const containerNode = getByTestId('pre-session-footer') as HTMLElement & { fireLayout?: () => void };
+      containerNode.fireLayout?.();
+      expect(onHeightChange).toHaveBeenCalledWith(72);
+    });
+  });
+});

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -13,9 +13,7 @@ import { deriveIsDriver } from '@boardsesh/queue-runtime';
 import type { Climb, SessionDetailTick, SessionFeedParticipant } from '@boardsesh/shared-schema';
 import { getGradeTextColor } from '@boardsesh/play-view';
 import { formatTickRelativeTime, tickTimeMs } from '@boardsesh/profile-stats';
-import { Button } from '../../Button';
 import { Card } from '../../Card';
-import { PinnedActionBar } from '../../PinnedActionBar';
 import { ClimbListItemContent } from '../../ClimbListItemContent';
 import { EndSessionSheet } from '../../EndSessionSheet';
 import { Icon } from '../../Icon';
@@ -45,6 +43,7 @@ import { glassSize } from '../../../theme/layout';
 import { gradeBadgeColor } from '../../you/profile-chart-colors';
 import { hapticSelection } from '../../../lib/haptics';
 import { RecordTopChrome } from '../RecordTopChrome';
+import { SessionActionFooter } from '../SessionActionFooter';
 import { SessionAnalytics } from './SessionAnalytics';
 import { SessionLeaderboard } from './SessionLeaderboard';
 import { SessionPresenceRow } from './SessionPresenceRow';
@@ -241,7 +240,7 @@ const SessionHistoryRow = memo(function SessionHistoryRow({
 
 export function InSessionView({ showChrome = false, onShare, translateY, screenHeight }: InSessionViewProps) {
   const { t } = useTranslation('session');
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors, brandColors, variant } = useTheme();
   const insets = useSafeAreaInsets();
   const bottomChrome = useBottomChromeMetrics();
   const router = useRouter();
@@ -511,8 +510,10 @@ export function InSessionView({ showChrome = false, onShare, translateY, screenH
     <View style={styles.headerContent}>
       {/* The screen's identity in-body under the floating chrome, collapsing into
           the centred header capsule on scroll. Only meaningful in tab mode; the
-          overlay header strip already names the screen, so it's hidden there. */}
-      {showChrome ? (
+          overlay header strip already names the screen, so it's hidden there. On
+          Material the app bar owns the title, so the in-body large title is gated
+          off there too. */}
+      {showChrome && variant !== 'material' ? (
         <Text variant="largeTitle" style={styles.screenTitle}>
           {t('mobile.session.headerActive')}
         </Text>
@@ -622,14 +623,15 @@ export function InSessionView({ showChrome = false, onShare, translateY, screenH
         />
       ) : null}
 
-      <PinnedActionBar testID="in-session-footer" onHeightChange={setFooterHeight}>
-        <Button
-          title={t('mobile.session.inEndSession')}
-          onPress={() => setShowEndSession(true)}
-          variant="outlined"
-          size="large"
-        />
-      </PinnedActionBar>
+      <SessionActionFooter
+        testID="in-session-footer"
+        onHeightChange={setFooterHeight}
+        label={t('mobile.session.inEndSession')}
+        materialIcon="flag"
+        emphasis="secondary"
+        glassButtonVariant="outlined"
+        onPress={() => setShowEndSession(true)}
+      />
 
       <EndSessionSheet
         visible={showEndSession}

--- a/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, type ReactNode } from 'react';
 import { Pressable, StyleSheet, View, type ViewStyle } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import { Chip as PaperChip } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import type { BoardName, Grade } from '@boardsesh/shared-schema';
 import { getGradesForBoard } from '@boardsesh/board-config';
@@ -130,20 +131,43 @@ function getDefaultTargetGrade(boardName: BoardName | null): number {
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
-// Filled-rest-state chip (no faint border), matching the ClimbFilterSheet
-// `Chip`: the selected chip is a static-brand FILL with white text; the rest
-// state is the system fill so unselected chips stay legible.
-function Chip({
-  label,
-  selected,
-  onPress,
-  accessibilityLabel,
-}: {
+type ChipProps = {
   label: string;
   selected: boolean;
   onPress: () => void;
   accessibilityLabel?: string;
-}) {
+};
+
+// Filled-rest-state chip (no faint border), matching the ClimbFilterSheet
+// `Chip`: the selected chip is a static-brand FILL with white text; the rest
+// state is the system fill so unselected chips stay legible. On Material it
+// routes to the Paper M3 filter chip (secondaryContainer + checkmark when
+// selected) so it reads as a native M3 filter chip rather than an iOS pill.
+// Split into two sub-components (rather than an early return) so the glass
+// branch's reanimated hooks stay unconditional across a runtime variant flip.
+function Chip(props: ChipProps) {
+  const { variant } = useTheme();
+  return variant === 'material' ? <ChipMaterial {...props} /> : <ChipGlass {...props} />;
+}
+
+function ChipMaterial({ label, selected, onPress, accessibilityLabel }: ChipProps) {
+  return (
+    <PaperChip
+      mode="flat"
+      selected={selected}
+      showSelectedCheck
+      onPress={() => {
+        hapticSelection();
+        onPress();
+      }}
+      accessibilityLabel={accessibilityLabel ?? label}
+    >
+      {label}
+    </PaperChip>
+  );
+}
+
+function ChipGlass({ label, selected, onPress, accessibilityLabel }: ChipProps) {
   const { systemColors } = useTheme();
   const scale = useSharedValue(1);
   const animatedStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
@@ -183,12 +207,22 @@ type StepperRow = { key: string; node: ReactNode };
 // hairline-divided between rows, matching the ClimbFilterSheet groupedCard
 // pattern. Rows carry stable keys (the option field name), so no index keys.
 function GroupedSteppers({ rows }: { rows: StepperRow[] }) {
-  const { systemColors } = useTheme();
+  const { systemColors, variant, m3 } = useTheme();
+  const isMaterial = variant === 'material';
+  // Material: a filled tonal card (surfaceVariant) with outlineVariant dividers,
+  // instead of the iOS `${systemGray}14` inset-table look.
   return (
-    <View style={styles.groupedCard}>
+    <View style={[styles.groupedCard, isMaterial && { backgroundColor: m3.surfaceVariant }]}>
       {rows.map((row, index) => (
         <View key={row.key}>
-          {index > 0 ? <View style={[styles.groupDivider, { backgroundColor: systemColors.separator }]} /> : null}
+          {index > 0 ? (
+            <View
+              style={[
+                styles.groupDivider,
+                { backgroundColor: isMaterial ? m3.outlineVariant : systemColors.separator },
+              ]}
+            />
+          ) : null}
           {row.node}
         </View>
       ))}
@@ -227,7 +261,8 @@ export function GeneratorPickerCard({
   onChange,
 }: GeneratorPickerCardProps) {
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, variant, m3 } = useTheme();
+  const isMaterial = variant === 'material';
 
   const isKilterHomewall = boardName === 'kilter' && layoutId === KILTER_HOMEWALL_LAYOUT_ID;
   const showTallClimbsFilter = isKilterHomewall && sizeId != null && isKilterHomewallTallSizeId(sizeId);
@@ -489,7 +524,7 @@ export function GeneratorPickerCard({
         </View>
 
         {showTallClimbsFilter || showWideClimbsFilter ? (
-          <View style={styles.groupedCard}>
+          <View style={[styles.groupedCard, isMaterial && { backgroundColor: m3.surfaceVariant }]}>
             {showTallClimbsFilter ? (
               <SwitchRow
                 label={t('mobile.session.preGeneratorTallClimbsLabel')}
@@ -499,7 +534,12 @@ export function GeneratorPickerCard({
               />
             ) : null}
             {showTallClimbsFilter && showWideClimbsFilter ? (
-              <View style={[styles.groupDivider, { backgroundColor: systemColors.separator }]} />
+              <View
+                style={[
+                  styles.groupDivider,
+                  { backgroundColor: isMaterial ? m3.outlineVariant : systemColors.separator },
+                ]}
+              />
             ) : null}
             {showWideClimbsFilter ? (
               <SwitchRow
@@ -555,9 +595,7 @@ export function GeneratorPickerCard({
           ) : null}
 
           <View style={[styles.inset, styles.steppersInset]}>
-            <GroupedSteppers
-              rows={[...primarySteppers(selection.options), ...secondarySteppers(selection.options)]}
-            />
+            <GroupedSteppers rows={[...primarySteppers(selection.options), ...secondarySteppers(selection.options)]} />
           </View>
 
           <View style={[styles.inset, styles.tuningInset]}>

--- a/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
@@ -11,9 +11,7 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { track } from '../../../lib/analytics';
-import { Button } from '../../Button';
 import { Card } from '../../Card';
-import { PinnedActionBar } from '../../PinnedActionBar';
 import { SectionHeader } from '../../SectionHeader';
 import { Text } from '../../Text';
 import type { QueueItemRowBoard } from '../../QueueItemRow';
@@ -28,6 +26,7 @@ import { useDrawerHost } from '../../../providers/drawer-host-provider';
 import { useBottomChromeMetrics } from '../../../hooks/use-bottom-chrome-metrics';
 import { reportError } from '../../../lib/sentry';
 import { RecordTopChrome } from '../RecordTopChrome';
+import { SessionActionFooter } from '../SessionActionFooter';
 import { BoardSummaryCard } from './BoardSummaryCard';
 import { GeneratorPickerCard, type GeneratorSelection } from './GeneratorPickerCard';
 import { WorkoutPreviewRow } from './WorkoutPreviewRow';
@@ -54,7 +53,7 @@ function previewKeyExtractor(previewItem: PreviewItem): string {
 
 export function PreSessionView({ showChrome = false }: PreSessionViewProps) {
   const { t } = useTranslation('session');
-  const { systemColors } = useTheme();
+  const { systemColors, variant } = useTheme();
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const bottomChrome = useBottomChromeMetrics();
@@ -231,10 +230,13 @@ export function PreSessionView({ showChrome = false }: PreSessionViewProps) {
     () => (
       <View style={styles.header}>
         {/* The screen's identity in-body under the floating chrome, collapsing
-            into the centred header capsule as it scrolls up. */}
-        <Text variant="largeTitle" style={styles.screenTitle}>
-          {t('mobile.session.headerStart')}
-        </Text>
+            into the centred header capsule as it scrolls up. On Material the
+            app bar owns the title, so the in-body large title is gated off. */}
+        {variant === 'material' ? null : (
+          <Text variant="largeTitle" style={styles.screenTitle}>
+            {t('mobile.session.headerStart')}
+          </Text>
+        )}
 
         {/* The chrome pill owns board identity but collapses on scroll, so this
             keeps the full config (name · size · angle) persistently visible when a
@@ -277,6 +279,7 @@ export function PreSessionView({ showChrome = false }: PreSessionViewProps) {
       showPreviewSection,
       systemColors.secondaryLabel,
       t,
+      variant,
     ],
   );
 
@@ -323,16 +326,17 @@ export function PreSessionView({ showChrome = false }: PreSessionViewProps) {
         />
       ) : null}
 
-      <PinnedActionBar testID="pre-session-footer" onHeightChange={setFooterHeight}>
-        <Button
-          title={isStarting ? t('mobile.session.preStarting') : t('mobile.session.preStart')}
-          onPress={() => void handleStart()}
-          variant="filled"
-          size="large"
-          disabled={!canStart}
-          loading={isStarting}
-        />
-      </PinnedActionBar>
+      <SessionActionFooter
+        testID="pre-session-footer"
+        onHeightChange={setFooterHeight}
+        label={isStarting ? t('mobile.session.preStarting') : t('mobile.session.preStart')}
+        materialIcon="play.fill"
+        emphasis="primary"
+        glassButtonVariant="filled"
+        onPress={() => void handleStart()}
+        disabled={!canStart}
+        loading={isStarting}
+      />
     </View>
   );
 }

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -37,7 +37,7 @@ type LogbookTabProps = {
 
 export function LogbookTab({ userId, onScroll, topInset = 0, registerScrollToTop }: LogbookTabProps) {
   const { t } = useTranslation('you');
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors, brandColors, variant } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[4];
 
@@ -78,12 +78,15 @@ export function LogbookTab({ userId, onScroll, topInset = 0, registerScrollToTop
   // FlashList doesn't re-render the header on every LogbookTab render. Always
   // present so it sits above the empty state too.
   const listHeader = useMemo(
-    () => (
-      <Text variant="largeTitle" style={styles.screenTitle}>
-        {t('metadata.dashboard.title')}
-      </Text>
-    ),
-    [t],
+    // On Material the M3 app bar owns the title, so the in-body large title is
+    // gated off there to avoid a doubled title.
+    () =>
+      variant === 'material' ? null : (
+        <Text variant="largeTitle" style={styles.screenTitle}>
+          {t('metadata.dashboard.title')}
+        </Text>
+      ),
+    [t, variant],
   );
 
   if (!userId || feed.isPending) {

--- a/packages/mobile/src/components/you/ProfileTopChrome.tsx
+++ b/packages/mobile/src/components/you/ProfileTopChrome.tsx
@@ -1,21 +1,31 @@
-// Top chrome for the Profile ("You") tab. Composes the board-agnostic
-// CollapsingLargeTitleHeader (no board pill — unlike Climbs/Discover) with a
-// settings-gear island on the left, an optional filter island on the right (the
-// Progress sub-tab only), and the Progress/Sessions/Logbook segmented control as
-// its below-row content. The collapsing large title + glass islands degrade for
-// free on the Material variant via GlassSurface / SegmentedControl.
+// Top chrome for the Profile ("You") tab, routed by UI variant.
+//
+// Liquid Glass: the board-agnostic CollapsingLargeTitleHeader (no board pill —
+// unlike Climbs/Discover) with a settings-gear island on the left, an optional
+// filter island on the right (the Progress sub-tab only), and the
+// Progress/Sessions/Logbook segmented control (glass-track-wrapped) as its
+// below-row content.
+//
+// Material: an absolutely-positioned, onHeightChange-measured M3 small app bar
+// (mirroring ClimbTopChrome) — the dashboard title via Appbar.Content, settings
+// + (Progress-only) filter Appbar.Actions, and the MaterialTabs primary tabs as
+// the app bar's bottom row.
 
 import { useCallback, useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { type LayoutChangeEvent, StyleSheet, View } from 'react-native';
 import { type SharedValue } from 'react-native-reanimated';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
+import { Appbar } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../providers/theme-provider';
 import { useNativeGlass } from '../../hooks/use-native-glass';
 import { spacing, shadows } from '../../theme/tokens';
 import { Icon } from '../Icon';
+import { iconMap } from '../icon-map';
 import { GlassSurface } from '../GlassSurface';
 import { SegmentedControl } from '../SegmentedControl';
+import { MaterialTabs } from '../navigation/MaterialTabs';
 import { CollapsingLargeTitleHeader, GlassActionToolbar, GlassToolbarAction } from '../chrome';
 
 // The segmented control floats over the chrome's faded scrim with scrolling
@@ -27,22 +37,116 @@ const SEGMENT_TRACK_RADIUS = 10;
 export type ProfileTabKey = 'progress' | 'sessions' | 'logbook';
 
 type ProfileTopChromeProps = {
-  /** Selected sub-tab; drives the segmented control's pill. */
+  /** Selected sub-tab; drives the segmented control's pill / the active tab. */
   activeTab: ProfileTabKey;
   onSelectTab: (key: ProfileTabKey) => void;
   /** Tints the filter island accent when the Progress filters are narrowed. */
   hasActiveFilters: boolean;
   /** Open the Progress filter sheet (only reachable from the Progress sub-tab). */
   onOpenFilters: () => void;
-  /** Active sub-tab's scroll offset, driving the large title collapse. */
+  /** Active sub-tab's scroll offset, driving the large title collapse (glass only). */
   scrollY: SharedValue<number>;
-  /** Tapping the collapsed title capsule scrolls the active sub-tab to the top. */
+  /** Tapping the collapsed title capsule scrolls the active sub-tab to the top
+   *  (glass only). */
   onPressTitle: () => void;
   /** Report the measured chrome height so each sub-tab can inset its top padding. */
   onHeightChange: (height: number) => void;
 };
 
-export function ProfileTopChrome({
+export function ProfileTopChrome(props: ProfileTopChromeProps) {
+  const { variant } = useTheme();
+  return variant === 'material' ? <ProfileTopChromeMaterial {...props} /> : <ProfileTopChromeGlass {...props} />;
+}
+
+function useSegmentOptions() {
+  const { t } = useTranslation('you');
+  return useMemo(
+    () => [
+      { key: 'progress' as const, label: t('tabs.progress') },
+      { key: 'sessions' as const, label: t('tabs.sessions') },
+      { key: 'logbook' as const, label: t('tabs.logbook') },
+    ],
+    [t],
+  );
+}
+
+function ProfileTopChromeMaterial({
+  activeTab,
+  onSelectTab,
+  hasActiveFilters,
+  onOpenFilters,
+  onHeightChange,
+}: ProfileTopChromeProps) {
+  const { t } = useTranslation('you');
+  const router = useRouter();
+  const { systemColors, brandColors, m3 } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const dashboardTitle = t('metadata.dashboard.title');
+  const tabOptions = useSegmentOptions();
+
+  const handleOpenSettings = useCallback(() => {
+    router.push('/(tabs)/profile/more');
+  }, [router]);
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => onHeightChange(event.nativeEvent.layout.height),
+    [onHeightChange],
+  );
+
+  // The filter action only makes sense on Progress (the only sub-tab the filter
+  // sheet narrows); Sessions/Logbook show none.
+  const filterColor = hasActiveFilters ? (brandColors.primary as string) : (systemColors.label as string);
+
+  return (
+    <View
+      pointerEvents="box-none"
+      style={[
+        styles.materialContainer,
+        {
+          paddingTop: insets.top,
+          backgroundColor: systemColors.secondaryBackground,
+          borderBottomColor: systemColors.separator,
+        },
+      ]}
+      onLayout={handleLayout}
+    >
+      <Appbar.Header
+        statusBarHeight={0}
+        mode="small"
+        elevated
+        style={[styles.materialAppbar, { backgroundColor: systemColors.secondaryBackground }]}
+      >
+        <Appbar.Content title={dashboardTitle} color={systemColors.label as string} />
+        <Appbar.Action
+          icon={iconMap.settings.android}
+          color={systemColors.label as string}
+          onPress={handleOpenSettings}
+          accessibilityLabel={t('mobile.settings')}
+        />
+        {activeTab === 'progress' ? (
+          <Appbar.Action
+            icon={iconMap.filter.android}
+            color={filterColor}
+            onPress={onOpenFilters}
+            accessibilityLabel={t('mobile.filter.title')}
+          />
+        ) : null}
+      </Appbar.Header>
+
+      <View pointerEvents="box-none" style={[styles.materialTabsRow, { borderTopColor: m3.outlineVariant }]}>
+        <MaterialTabs
+          options={tabOptions}
+          selectedKey={activeTab}
+          onSelect={onSelectTab}
+          accessibilityLabel={dashboardTitle}
+        />
+      </View>
+    </View>
+  );
+}
+
+function ProfileTopChromeGlass({
   activeTab,
   onSelectTab,
   hasActiveFilters,
@@ -53,27 +157,15 @@ export function ProfileTopChrome({
 }: ProfileTopChromeProps) {
   const { t } = useTranslation('you');
   const router = useRouter();
-  const { systemColors, brandColors, variant } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const nativeGlass = useNativeGlass();
-  // On Material the segmented control is Paper's SegmentedButtons, which draws its
-  // own outlined container — a glass "track" behind it would double up (mismatched
-  // radii, double borders, violet-on-violet). So the track is glass-variant only.
-  const isMaterial = variant === 'material';
 
   const dashboardTitle = t('metadata.dashboard.title');
+  const segmentOptions = useSegmentOptions();
 
   const handleOpenSettings = useCallback(() => {
     router.push('/(tabs)/profile/more');
   }, [router]);
-
-  const segmentOptions = useMemo(
-    () => [
-      { key: 'progress' as const, label: t('tabs.progress') },
-      { key: 'sessions' as const, label: t('tabs.sessions') },
-      { key: 'logbook' as const, label: t('tabs.logbook') },
-    ],
-    [t],
-  );
 
   const leftActions = (
     <GlassActionToolbar actionCount={1}>
@@ -104,41 +196,29 @@ export function ProfileTopChrome({
       rightActions={rightActions}
     >
       <View pointerEvents="box-none" style={styles.segmentStack}>
-        {isMaterial ? (
-          // Paper SegmentedButtons owns its surface — render it bare on the scrim.
+        <View
+          style={[
+            styles.segmentTrack,
+            !nativeGlass && shadows.sm,
+            !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
+          ]}
+        >
+          <GlassSurface
+            glassEffectStyle="regular"
+            fallbackColor={systemColors.fill}
+            borderRadius={SEGMENT_TRACK_RADIUS}
+            style={StyleSheet.absoluteFill}
+            pointerEvents="none"
+          />
           <SegmentedControl
             options={segmentOptions}
             selectedKey={activeTab}
             onSelect={onSelectTab}
-            trackColor={systemColors.fill}
+            trackColor="transparent"
             textVariant="subheadline"
             accessibilityLabel={dashboardTitle}
           />
-        ) : (
-          <View
-            style={[
-              styles.segmentTrack,
-              !nativeGlass && shadows.sm,
-              !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
-            ]}
-          >
-            <GlassSurface
-              glassEffectStyle="regular"
-              fallbackColor={systemColors.fill}
-              borderRadius={SEGMENT_TRACK_RADIUS}
-              style={StyleSheet.absoluteFill}
-              pointerEvents="none"
-            />
-            <SegmentedControl
-              options={segmentOptions}
-              selectedKey={activeTab}
-              onSelect={onSelectTab}
-              trackColor="transparent"
-              textVariant="subheadline"
-              accessibilityLabel={dashboardTitle}
-            />
-          </View>
-        )}
+        </View>
       </View>
     </CollapsingLargeTitleHeader>
   );
@@ -153,5 +233,20 @@ const styles = StyleSheet.create({
     borderRadius: SEGMENT_TRACK_RADIUS,
     // Clip the absolutely-filled GlassSurface to the rounded corners on Android.
     overflow: 'hidden',
+  },
+  materialContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 20,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  materialAppbar: {
+    elevation: 0,
+    shadowOpacity: 0,
+  },
+  materialTabsRow: {
+    borderTopWidth: StyleSheet.hairlineWidth,
   },
 });

--- a/packages/mobile/src/components/you/ProgressTab.tsx
+++ b/packages/mobile/src/components/you/ProgressTab.tsx
@@ -37,7 +37,7 @@ export const ProgressTab = memo(function ProgressTab({
 }: ProgressTabProps) {
   const { t } = useTranslation('profile');
   const { t: tYou } = useTranslation('you');
-  const { systemColors, colorScheme, brandColors } = useTheme();
+  const { systemColors, colorScheme, brandColors, variant } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[6];
 
@@ -89,10 +89,13 @@ export const ProgressTab = memo(function ProgressTab({
       }
     >
       {/* The screen's identity, in-body under the floating chrome — collapses into
-          the header capsule as it scrolls up behind the glass. */}
-      <Text variant="largeTitle" style={styles.screenTitle}>
-        {dashboardTitle}
-      </Text>
+          the header capsule as it scrolls up behind the glass. On Material the M3
+          app bar owns the title, so it's gated off there to avoid a doubled title. */}
+      {variant === 'material' ? null : (
+        <Text variant="largeTitle" style={styles.screenTitle}>
+          {dashboardTitle}
+        </Text>
+      )}
 
       {totalAscents === 0 ? (
         <View style={styles.empty}>

--- a/packages/mobile/src/components/you/SessionsTab.tsx
+++ b/packages/mobile/src/components/you/SessionsTab.tsx
@@ -44,7 +44,7 @@ function sectionLabel(bucket: FeedRecencyBucket, t: TFunc): string {
 
 export function SessionsTab({ userId, onScroll, topInset = 0, registerScrollToTop }: SessionsTabProps) {
   const { t } = useTranslation('you');
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors, brandColors, variant } = useTheme();
   const router = useRouter();
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[4];
@@ -144,13 +144,17 @@ export function SessionsTab({ userId, onScroll, topInset = 0, registerScrollToTo
   const listHeader = useMemo(
     () => (
       <>
-        <Text variant="largeTitle" style={styles.screenTitle}>
-          {t('metadata.dashboard.title')}
-        </Text>
+        {/* On Material the M3 app bar owns the title, so the in-body large title is
+            gated off there to avoid a doubled title. */}
+        {variant === 'material' ? null : (
+          <Text variant="largeTitle" style={styles.screenTitle}>
+            {t('metadata.dashboard.title')}
+          </Text>
+        )}
         {sessions.length > 0 ? <SessionsFeedHeader sessions={sessions} now={now} /> : null}
       </>
     ),
-    [t, sessions, now],
+    [t, sessions, now, variant],
   );
 
   if (!userId || feed.isPending) {

--- a/packages/mobile/src/components/you/StatsSummaryCard.tsx
+++ b/packages/mobile/src/components/you/StatsSummaryCard.tsx
@@ -22,24 +22,51 @@ type StatsSummaryCardProps = {
 
 export function StatsSummaryCard({ statisticsSummary, hardestSend, hardestFlash, percentile }: StatsSummaryCardProps) {
   const { t } = useTranslation('profile');
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors, brandColors, variant, m3 } = useTheme();
+  const isMaterial = variant === 'material';
 
   const showPercentile = percentile != null && percentile.percentile > 0;
   // "Top X%" — invert the percentile, clamped so a 100th-percentile climber
   // reads "Top 0.1%" rather than "Top 0%".
   const topPercent = showPercentile ? Math.max(0.1, 100 - percentile.percentile) : 0;
 
+  // On Material the three tiles read as one tonal family (neutral · primary ·
+  // tertiary container) so they don't land as two saturated grade-coloured alert
+  // blocks; the vivid grade hue survives only as the small tick/flash glyph. On
+  // Liquid Glass the grade tiles stay full grade-coloured fills (the original).
+  const countTileColor = isMaterial ? m3.surfaceVariant : systemColors.fill;
+  const countTextColor = isMaterial ? m3.onSurfaceVariant : undefined;
+  const countLabelColor = isMaterial ? m3.onSurfaceVariant : systemColors.secondaryLabel;
+
   return (
     <Card style={styles.card}>
       <View style={styles.tiles}>
-        <View style={[styles.tile, { backgroundColor: systemColors.fill }]}>
-          <Text variant="title2">{statisticsSummary.totalAscents}</Text>
-          <Text variant="caption1" color={systemColors.secondaryLabel}>
+        <View style={[styles.tile, { backgroundColor: countTileColor }]}>
+          <Text variant="title2" color={countTextColor}>
+            {statisticsSummary.totalAscents}
+          </Text>
+          <Text variant="caption1" color={countLabelColor}>
             {t('stats.problems')}
           </Text>
         </View>
-        {hardestSend && <GradeTile highlight={hardestSend} label={t('stats.send')} icon="tick" />}
-        {hardestFlash && <GradeTile highlight={hardestFlash} label={t('stats.flash')} icon="flash" />}
+        {hardestSend && (
+          <GradeTile
+            highlight={hardestSend}
+            label={t('stats.send')}
+            icon="tick"
+            background={isMaterial ? m3.primaryContainer : undefined}
+            textColor={isMaterial ? m3.onPrimaryContainer : undefined}
+          />
+        )}
+        {hardestFlash && (
+          <GradeTile
+            highlight={hardestFlash}
+            label={t('stats.flash')}
+            icon="flash"
+            background={isMaterial ? m3.tertiaryContainer : undefined}
+            textColor={isMaterial ? m3.onTertiaryContainer : undefined}
+          />
+        )}
       </View>
 
       {showPercentile && (
@@ -71,20 +98,39 @@ export function StatsSummaryCard({ statisticsSummary, hardestSend, hardestFlash,
   );
 }
 
-function GradeTile({ highlight, label, icon }: { highlight: RawGradeHighlight; label: string; icon: IconName }) {
-  const background = gradeBadgeColor(highlight.label);
-  const textColor = getGradeTextColor(background);
+function GradeTile({
+  highlight,
+  label,
+  icon,
+  background,
+  textColor,
+}: {
+  highlight: RawGradeHighlight;
+  label: string;
+  icon: IconName;
+  /** Tonal container fill (Material). Glass falls back to the vivid grade fill. */
+  background?: string;
+  /** On-container text (Material). Glass falls back to the contrast-aware colour. */
+  textColor?: string;
+}) {
+  // Glass: the whole tile is the grade's vivid colour, text picks the contrast
+  // colour. Material: a tonal container carries the tile, so the grade hue lives
+  // only on the leading glyph (the small accent) and text uses the on-container role.
+  const gradeFill = gradeBadgeColor(highlight.label);
+  const tileBackground = background ?? gradeFill;
+  const onTile = textColor ?? getGradeTextColor(gradeFill);
+  const accentColor = background ? gradeFill : onTile;
   return (
-    <View style={[styles.tile, { backgroundColor: background }]}>
+    <View style={[styles.tile, { backgroundColor: tileBackground }]}>
       <View style={styles.gradeRow}>
-        <Icon name={icon} size={14} color={textColor} />
-        <Text variant="title3" color={textColor}>
+        <Icon name={icon} size={14} color={accentColor} />
+        <Text variant="title3" color={onTile}>
           {highlight.label}
         </Text>
       </View>
       {/* Match the grade/icon's contrast-aware colour; secondaryLabel is a grey
           that washes out on saturated grade tiles. Dim slightly for hierarchy. */}
-      <Text variant="caption1" color={textColor} style={styles.gradeTileLabel}>
+      <Text variant="caption1" color={onTile} style={styles.gradeTileLabel}>
         {label}
       </Text>
     </View>

--- a/packages/mobile/src/components/you/StatsSummaryCard.tsx
+++ b/packages/mobile/src/components/you/StatsSummaryCard.tsx
@@ -30,10 +30,11 @@ export function StatsSummaryCard({ statisticsSummary, hardestSend, hardestFlash,
   // reads "Top 0.1%" rather than "Top 0%".
   const topPercent = showPercentile ? Math.max(0.1, 100 - percentile.percentile) : 0;
 
-  // On Material the three tiles read as one tonal family (neutral · primary ·
-  // tertiary container) so they don't land as two saturated grade-coloured alert
-  // blocks; the vivid grade hue survives only as the small tick/flash glyph. On
-  // Liquid Glass the grade tiles stay full grade-coloured fills (the original).
+  // On Material the three tiles read as one tonal family (neutral surfaceVariant ·
+  // primary · secondary container — all brand violet, no amber) so they don't land
+  // as two saturated grade-coloured alert blocks; the vivid grade hue survives only
+  // as the small tick/flash glyph. On Liquid Glass the grade tiles stay full
+  // grade-coloured fills (the original).
   const countTileColor = isMaterial ? m3.surfaceVariant : systemColors.fill;
   const countTextColor = isMaterial ? m3.onSurfaceVariant : undefined;
   const countLabelColor = isMaterial ? m3.onSurfaceVariant : systemColors.secondaryLabel;
@@ -63,8 +64,8 @@ export function StatsSummaryCard({ statisticsSummary, hardestSend, hardestFlash,
             highlight={hardestFlash}
             label={t('stats.flash')}
             icon="flash"
-            background={isMaterial ? m3.tertiaryContainer : undefined}
-            textColor={isMaterial ? m3.onTertiaryContainer : undefined}
+            background={isMaterial ? m3.secondaryContainer : undefined}
+            textColor={isMaterial ? m3.onSecondaryContainer : undefined}
           />
         )}
       </View>

--- a/packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx
@@ -18,12 +18,24 @@ const segments = vi.hoisted(() => ({
     onSelect: (key: ProfileTabKey) => void;
   }>,
 }));
+// Captures the props the Material primary tabs receive so the material-branch
+// cases can assert the option set / selected key / selection forwarding.
+const materialTabs = vi.hoisted(() => ({
+  entries: [] as Array<{
+    options: Array<{ key: string; label: string }>;
+    selectedKey: string;
+    onSelect: (key: ProfileTabKey) => void;
+  }>,
+}));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
 }));
 vi.mock('react-native-reanimated', () => ({}));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 vi.mock('expo-router', () => ({ useRouter: () => router }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
@@ -31,14 +43,17 @@ vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { label: '#000', separator: '#ccc', fill: '#eee' },
     brandColors: { primary: '#6D28D9' },
+    m3: { primary: '#6750A4', onSurfaceVariant: '#49454F', outlineVariant: '#CAC4D0' },
     variant: ctrl.variant,
   }),
 }));
 vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
 vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8, 4: 16 }, shadows: { sm: {} } }));
 
-vi.mock('../../Icon', () => ({ Icon: ({ name, color }: { name: string; color?: string }) =>
-  createElement('span', { 'data-icon': name, 'data-icon-color': color ?? '' }) }));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name, color }: { name: string; color?: string }) =>
+    createElement('span', { 'data-icon': name, 'data-icon-color': color ?? '' }),
+}));
 vi.mock('../../GlassSurface', () => ({ GlassSurface: () => createElement('div', { 'data-glass': 'true' }) }));
 vi.mock('../../SegmentedControl', () => ({
   SegmentedControl: ({
@@ -54,6 +69,45 @@ vi.mock('../../SegmentedControl', () => ({
   }) => {
     segments.entries.push({ options, selectedKey, onSelect, trackColor });
     return createElement('div', { 'data-segmented': 'true', 'data-track': String(trackColor) });
+  },
+}));
+vi.mock('../../navigation/MaterialTabs', () => ({
+  MaterialTabs: ({
+    options,
+    selectedKey,
+    onSelect,
+  }: {
+    options: Array<{ key: string; label: string }>;
+    selectedKey: string;
+    onSelect: (key: ProfileTabKey) => void;
+  }) => {
+    materialTabs.entries.push({ options, selectedKey, onSelect });
+    return createElement('div', { 'data-material-tabs': 'true' });
+  },
+}));
+// Paper Appbar: render the title + actions so the material-branch cases can query
+// them via the accessibility label (mirroring the glass islands).
+vi.mock('react-native-paper', () => ({
+  Appbar: {
+    Header: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-appbar': 'true' }, children),
+    Content: ({ title }: { title?: string }) => createElement('div', { 'data-appbar-title': title ?? '' }),
+    Action: ({
+      icon,
+      color,
+      onPress,
+      accessibilityLabel,
+    }: {
+      icon?: string;
+      color?: string;
+      onPress?: () => void;
+      accessibilityLabel?: string;
+    }) =>
+      createElement('button', {
+        onClick: onPress,
+        'data-action': accessibilityLabel ?? '',
+        'data-icon': icon ?? '',
+        'data-icon-color': color ?? '',
+      }),
   },
 }));
 // Render the islands + children so the test can query them. The track-vs-bare
@@ -117,67 +171,126 @@ describe('ProfileTopChrome', () => {
     ctrl.variant = 'glass';
     router.push.mockClear();
     segments.entries = [];
+    materialTabs.entries = [];
   });
 
-  it('pushes the settings route when the settings island is pressed', () => {
-    const { container } = render(<ProfileTopChrome {...makeProps()} />);
-    fireEvent.click(settingsAction(container)!);
-    expect(router.push).toHaveBeenCalledWith('/(tabs)/profile/more');
+  describe('glass variant', () => {
+    it('pushes the settings route when the settings island is pressed', () => {
+      const { container } = render(<ProfileTopChrome {...makeProps()} />);
+      fireEvent.click(settingsAction(container)!);
+      expect(router.push).toHaveBeenCalledWith('/(tabs)/profile/more');
+    });
+
+    it('renders the filter island only on the Progress sub-tab', () => {
+      const { container, rerender } = render(<ProfileTopChrome {...makeProps({ activeTab: 'progress' })} />);
+      expect(filterAction(container)).not.toBeNull();
+
+      rerender(<ProfileTopChrome {...makeProps({ activeTab: 'sessions' })} />);
+      expect(filterAction(container)).toBeNull();
+
+      rerender(<ProfileTopChrome {...makeProps({ activeTab: 'logbook' })} />);
+      expect(filterAction(container)).toBeNull();
+    });
+
+    it('tints the filter glyph with the brand colour only when filters are active', () => {
+      const { container, rerender } = render(<ProfileTopChrome {...makeProps({ hasActiveFilters: false })} />);
+      expect(filterIcon(container)?.getAttribute('data-icon-color')).toBe('#000');
+
+      rerender(<ProfileTopChrome {...makeProps({ hasActiveFilters: true })} />);
+      expect(filterIcon(container)?.getAttribute('data-icon-color')).toBe('#6D28D9');
+    });
+
+    it('opens the filter sheet when the filter island is pressed', () => {
+      const onOpenFilters = vi.fn();
+      const { container } = render(<ProfileTopChrome {...makeProps({ onOpenFilters })} />);
+      fireEvent.click(filterAction(container)!);
+      expect(onOpenFilters).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the three options and selectedKey to the segmented control', () => {
+      render(<ProfileTopChrome {...makeProps({ activeTab: 'sessions' })} />);
+      const segment = segments.entries.at(-1)!;
+      expect(segment.options.map((option) => option.key)).toEqual(['progress', 'sessions', 'logbook']);
+      expect(segment.selectedKey).toBe('sessions');
+    });
+
+    it('forwards segment selection through onSelectTab', () => {
+      const onSelectTab = vi.fn();
+      render(<ProfileTopChrome {...makeProps({ onSelectTab })} />);
+      segments.entries.at(-1)!.onSelect('logbook');
+      expect(onSelectTab).toHaveBeenCalledWith('logbook');
+    });
+
+    it('wraps the segmented control in a glass track', () => {
+      const { container } = render(<ProfileTopChrome {...makeProps()} />);
+      // The glass branch mounts a GlassSurface track and a transparent track colour.
+      expect(container.querySelector('[data-slot="children"] [data-glass="true"]')).not.toBeNull();
+      expect(segments.entries.at(-1)!.trackColor).toBe('transparent');
+    });
+
+    it('does not render the Material app bar or primary tabs', () => {
+      const { container } = render(<ProfileTopChrome {...makeProps()} />);
+      expect(container.querySelector('[data-appbar="true"]')).toBeNull();
+      expect(container.querySelector('[data-material-tabs="true"]')).toBeNull();
+    });
   });
 
-  it('renders the filter island only on the Progress sub-tab', () => {
-    const { container, rerender } = render(<ProfileTopChrome {...makeProps({ activeTab: 'progress' })} />);
-    expect(filterAction(container)).not.toBeNull();
+  describe('material variant', () => {
+    beforeEach(() => {
+      ctrl.variant = 'material';
+    });
 
-    rerender(<ProfileTopChrome {...makeProps({ activeTab: 'sessions' })} />);
-    expect(filterAction(container)).toBeNull();
+    it('renders a Paper app bar with the dashboard title and the MaterialTabs row', () => {
+      const { container } = render(<ProfileTopChrome {...makeProps()} />);
+      expect(container.querySelector('[data-appbar="true"]')).not.toBeNull();
+      expect(container.querySelector('[data-appbar-title="metadata.dashboard.title"]')).not.toBeNull();
+      expect(container.querySelector('[data-material-tabs="true"]')).not.toBeNull();
+      // No glass segmented control / track on the material branch.
+      expect(container.querySelector('[data-segmented="true"]')).toBeNull();
+      expect(container.querySelector('[data-glass="true"]')).toBeNull();
+    });
 
-    rerender(<ProfileTopChrome {...makeProps({ activeTab: 'logbook' })} />);
-    expect(filterAction(container)).toBeNull();
-  });
+    it('pushes the settings route from the settings Appbar.Action', () => {
+      const { container } = render(<ProfileTopChrome {...makeProps()} />);
+      fireEvent.click(settingsAction(container)!);
+      expect(router.push).toHaveBeenCalledWith('/(tabs)/profile/more');
+    });
 
-  it('tints the filter glyph with the brand colour only when filters are active', () => {
-    const { container, rerender } = render(<ProfileTopChrome {...makeProps({ hasActiveFilters: false })} />);
-    expect(filterIcon(container)?.getAttribute('data-icon-color')).toBe('#000');
+    it('renders the filter Appbar.Action only on the Progress sub-tab', () => {
+      const { container, rerender } = render(<ProfileTopChrome {...makeProps({ activeTab: 'progress' })} />);
+      expect(filterAction(container)).not.toBeNull();
 
-    rerender(<ProfileTopChrome {...makeProps({ hasActiveFilters: true })} />);
-    expect(filterIcon(container)?.getAttribute('data-icon-color')).toBe('#6D28D9');
-  });
+      rerender(<ProfileTopChrome {...makeProps({ activeTab: 'sessions' })} />);
+      expect(filterAction(container)).toBeNull();
+    });
 
-  it('opens the filter sheet when the filter island is pressed', () => {
-    const onOpenFilters = vi.fn();
-    const { container } = render(<ProfileTopChrome {...makeProps({ onOpenFilters })} />);
-    fireEvent.click(filterAction(container)!);
-    expect(onOpenFilters).toHaveBeenCalledTimes(1);
-  });
+    it('tints the filter action with the brand colour only when filters are active', () => {
+      const { container, rerender } = render(<ProfileTopChrome {...makeProps({ hasActiveFilters: false })} />);
+      expect(filterAction(container)?.getAttribute('data-icon-color')).toBe('#000');
 
-  it('passes the three options and selectedKey to the segmented control', () => {
-    render(<ProfileTopChrome {...makeProps({ activeTab: 'sessions' })} />);
-    const segment = segments.entries.at(-1)!;
-    expect(segment.options.map((option) => option.key)).toEqual(['progress', 'sessions', 'logbook']);
-    expect(segment.selectedKey).toBe('sessions');
-  });
+      rerender(<ProfileTopChrome {...makeProps({ hasActiveFilters: true })} />);
+      expect(filterAction(container)?.getAttribute('data-icon-color')).toBe('#6D28D9');
+    });
 
-  it('forwards segment selection through onSelectTab', () => {
-    const onSelectTab = vi.fn();
-    render(<ProfileTopChrome {...makeProps({ onSelectTab })} />);
-    segments.entries.at(-1)!.onSelect('logbook');
-    expect(onSelectTab).toHaveBeenCalledWith('logbook');
-  });
+    it('opens the filter sheet from the filter Appbar.Action', () => {
+      const onOpenFilters = vi.fn();
+      const { container } = render(<ProfileTopChrome {...makeProps({ onOpenFilters })} />);
+      fireEvent.click(filterAction(container)!);
+      expect(onOpenFilters).toHaveBeenCalledTimes(1);
+    });
 
-  it('wraps the segmented control in a glass track on the glass variant', () => {
-    ctrl.variant = 'glass';
-    const { container } = render(<ProfileTopChrome {...makeProps()} />);
-    // The glass branch mounts a GlassSurface track and a transparent track colour.
-    expect(container.querySelector('[data-slot="children"] [data-glass="true"]')).not.toBeNull();
-    expect(segments.entries.at(-1)!.trackColor).toBe('transparent');
-  });
+    it('passes the three options and selectedKey to MaterialTabs', () => {
+      render(<ProfileTopChrome {...makeProps({ activeTab: 'sessions' })} />);
+      const tabs = materialTabs.entries.at(-1)!;
+      expect(tabs.options.map((option) => option.key)).toEqual(['progress', 'sessions', 'logbook']);
+      expect(tabs.selectedKey).toBe('sessions');
+    });
 
-  it('renders the bare segmented control (no glass track) on the material variant', () => {
-    ctrl.variant = 'material';
-    const { container } = render(<ProfileTopChrome {...makeProps()} />);
-    expect(container.querySelector('[data-slot="children"] [data-glass="true"]')).toBeNull();
-    // Material branch passes the fill colour, not transparent.
-    expect(segments.entries.at(-1)!.trackColor).toBe('#eee');
+    it('forwards tab selection through onSelectTab', () => {
+      const onSelectTab = vi.fn();
+      render(<ProfileTopChrome {...makeProps({ onSelectTab })} />);
+      materialTabs.entries.at(-1)!.onSelect('logbook');
+      expect(onSelectTab).toHaveBeenCalledWith('logbook');
+    });
   });
 });

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { computeBottomChromeMetrics } from '../bottom-chrome-metrics';
 import {
   MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
+  MATERIAL_TAB_BAR_HEIGHT,
   TAB_BAR_HEIGHT,
   TOOLBAR_GAP_ABOVE_TABBAR,
   TOOLBAR_RESERVE,
@@ -55,8 +56,9 @@ describe('computeBottomChromeMetrics', () => {
     });
     expect(metrics.jsQueueToolbarVisible).toBe(true);
     expect(metrics.jsQueueReserve).toBe(MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
-    expect(metrics.scrollBottomPadding).toBe(TAB_BAR_HEIGHT + MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
-    expect(metrics.floatingControlBottom).toBe(TAB_BAR_HEIGHT + MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
+    // Material clears its taller M3 nav bar (80) — not the iOS 49.
+    expect(metrics.scrollBottomPadding).toBe(MATERIAL_TAB_BAR_HEIGHT + MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
+    expect(metrics.floatingControlBottom).toBe(MATERIAL_TAB_BAR_HEIGHT + MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
     expect(metrics.fixedFooterBottom).toBe(MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT);
   });
 
@@ -117,8 +119,8 @@ describe('computeBottomChromeMetrics', () => {
       nativeAccessoryMounted: false,
     });
 
-    expect(metrics.tabBarBottom).toBe(24 + TAB_BAR_HEIGHT);
-    expect(metrics.scrollBottomPadding).toBe(24 + TAB_BAR_HEIGHT);
+    expect(metrics.tabBarBottom).toBe(24 + MATERIAL_TAB_BAR_HEIGHT);
+    expect(metrics.scrollBottomPadding).toBe(24 + MATERIAL_TAB_BAR_HEIGHT);
     expect(metrics.fixedFooterBottom).toBe(0);
   });
 

--- a/packages/mobile/src/hooks/bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/bottom-chrome-metrics.ts
@@ -1,6 +1,7 @@
 import type { UiVariant } from '../theme/resolve-ui-variant';
 import {
   MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
+  MATERIAL_TAB_BAR_HEIGHT,
   TAB_BAR_HEIGHT,
   TOOLBAR_GAP_ABOVE_TABBAR,
   TOOLBAR_RESERVE,
@@ -73,7 +74,11 @@ export function computeBottomChromeMetrics({
 }: BottomChromeInputs): BottomChromeMetrics {
   const nativeAccessoryVisible = nativeAccessoryMounted && hasCurrentClimb;
   const jsQueueToolbarVisible = hasCurrentClimb && !nativeAccessoryMounted;
-  const tabBarHeight = insideTabs ? TAB_BAR_HEIGHT : 0;
+  // The Material variant renders the taller M3 JS nav bar; Liquid Glass uses the
+  // native 49pt iOS tab bar. Floating overlays (FAB, snackbar) and scroll padding
+  // clear this height, so it has to track the real bar per variant.
+  const tabBarConstant = uiVariant === 'material' ? MATERIAL_TAB_BAR_HEIGHT : TAB_BAR_HEIGHT;
+  const tabBarHeight = insideTabs ? tabBarConstant : 0;
   const tabBarOverlaysContent = insideTabs && uiVariant !== 'material';
   // The Material bar reserves its full height even though it's tucked ~2px into the
   // tab bar (MATERIAL_TABBAR_OVERLAP in persistent-queue-bar), so its visible height

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -15,7 +15,9 @@ import {
   androidFallbackColors,
   materialSurfaces,
 } from '../theme/colors';
-import { textStyles, type TextVariant } from '../theme/typography';
+import { textStylesByVariant, type TextVariant, type TypeStyle } from '../theme/typography';
+import { buildPaperTheme } from '../theme/paper-theme';
+import type { MD3Theme } from 'react-native-paper';
 import {
   spacing,
   borderRadius,
@@ -69,7 +71,12 @@ type Theme = {
   colorScheme: ColorScheme;
   systemColors: ResolvedSystemColors;
   brandColors: ResolvedBrandColors;
-  textStyles: typeof textStyles;
+  /**
+   * Type scale resolved for the current UI variant (Apple HIG on Liquid Glass, M3
+   * on Material). Same keys/shape in both variants — only the sizes/weights
+   * differ — so it's typed structurally rather than to one variant's literals.
+   */
+  textStyles: Record<TextVariant, TypeStyle>;
   spacing: typeof spacing;
   borderRadius: typeof borderRadius;
   shadows: typeof shadows;
@@ -87,6 +94,16 @@ type Theme = {
   radii: Radii;
   /** Bottom-sheet chrome (scrim/handle/corners) for the current variant. */
   sheet: SheetChrome;
+  /**
+   * MD3 colour roles (the full Paper palette: primaryContainer, secondaryContainer,
+   * tertiaryContainer, onSurfaceVariant, outlineVariant, and the `elevation`
+   * level0–5 surface-tint ladder) for the current colour scheme. Only meaningful
+   * on the Material variant — Material-branch app components read these so they
+   * match the Paper components without re-deriving roles; Liquid Glass never reads
+   * it. Note: react-native-paper 5.15 predates MD3's `surfaceContainer*` tone
+   * roles, so use the `elevation.levelN` ladder for surface-container surfaces.
+   */
+  m3: MD3Theme['colors'];
 };
 
 const ThemeContext = createContext<Theme | null>(null);
@@ -237,6 +254,13 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     [uiVariantPreference, glassCapable],
   );
 
+  // MD3 colour roles for the current scheme, memoized so the Paper theme is built
+  // once per light/dark flip — not on every render — and shared with the rest of
+  // the Material chrome. `MaterialThemeProvider` builds the full MD3Theme from the
+  // same `buildPaperTheme(colorScheme)`; here we keep just the `.colors` palette
+  // for app components that aren't Paper consumers.
+  const m3Colors = useMemo<MD3Theme['colors']>(() => buildPaperTheme(colorScheme).colors, [colorScheme]);
+
   const theme = useMemo<Theme>(() => {
     const resolvedSystemColors = resolveSystemColors(colorScheme, variant);
 
@@ -244,7 +268,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       colorScheme,
       systemColors: resolvedSystemColors,
       brandColors: resolveBrandColors(colorScheme),
-      textStyles,
+      textStyles: textStylesByVariant[variant],
       spacing,
       borderRadius,
       shadows,
@@ -258,8 +282,9 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       setUiVariant,
       radii: radiiByVariant[variant],
       sheet: sheetChromeByVariant[variant],
+      m3: m3Colors,
     };
-  }, [colorScheme, variant, themeOverride, setThemeOverride, uiVariantPreference, setUiVariant]);
+  }, [colorScheme, variant, themeOverride, setThemeOverride, uiVariantPreference, setUiVariant, m3Colors]);
 
   // React 19 context provider syntax (Expo SDK 53+ / React 19)
   return <ThemeContext value={theme}>{children}</ThemeContext>;

--- a/packages/mobile/src/theme/__tests__/paper-theme.test.ts
+++ b/packages/mobile/src/theme/__tests__/paper-theme.test.ts
@@ -20,6 +20,11 @@ describe('buildPaperTheme', () => {
     expect(theme.colors.surface).toBe('#FFFFFF'); // secondaryBackground
     expect(theme.colors.error).toBe('#C81E1E');
     expect(theme.colors.elevation.level2).toBe('#FFFFFF'); // elevatedSurface (light)
+    // The two grade stat tiles use the brand-violet primary/secondary containers
+    // (not the vestigial amber tertiary), so they read as one tonal family.
+    expect(theme.colors.primaryContainer).toContain('109, 40, 217'); // brand violet #6D28D9
+    expect(theme.colors.secondaryContainer).toContain('109, 40, 217');
+    expect(theme.colors.onSecondaryContainer).toBe(theme.colors.onSurface);
   });
 
   it('uses the dark tonal surfaces for the dark scheme', () => {

--- a/packages/mobile/src/theme/layout.ts
+++ b/packages/mobile/src/theme/layout.ts
@@ -12,8 +12,16 @@
  * those components' internals.
  */
 
-/** Bottom tab bar height (excludes the safe-area inset). */
+/** Bottom tab bar height (excludes the safe-area inset). The Liquid Glass / native
+ *  iOS tab bar value; the Material JS nav bar uses {@link MATERIAL_TAB_BAR_HEIGHT}. */
 export const TAB_BAR_HEIGHT = 49;
+
+/** M3 navigation-bar content height (excludes the safe-area inset). The Material
+ *  variant's JS tab bar is taller than the iOS 49 — M3 spec is an 80dp bar that
+ *  fits the active-indicator pill, icon and label with room to breathe. Only the
+ *  Material variant reads this (in MaterialTabBar and the bottom-chrome metrics);
+ *  Liquid Glass stays on TAB_BAR_HEIGHT. */
+export const MATERIAL_TAB_BAR_HEIGHT = 80;
 
 /**
  * One height ladder for every glass FAB / capsule / pill, so the floating chrome

--- a/packages/mobile/src/theme/tokens.ts
+++ b/packages/mobile/src/theme/tokens.ts
@@ -111,8 +111,8 @@ export const material = {
   /** M3 pressed state-layer opacity, used to tint ripples. */
   pressedStateLayer: 0.12,
   navBar: {
-    /** Tonal pill behind the focused tab's icon. */
-    activeIndicatorWidth: 56,
+    /** Tonal pill behind the focused tab's icon (M3 spec: 64×32). */
+    activeIndicatorWidth: 64,
     activeIndicatorHeight: 32,
     activeIndicatorRadius: 16,
     /** Resting elevation of the solid Android nav surface. */

--- a/packages/mobile/src/theme/typography.ts
+++ b/packages/mobile/src/theme/typography.ts
@@ -9,7 +9,7 @@ import { type TextStyle } from 'react-native';
  * HIG's default Regular (400). This is intentional for brand identity.
  */
 
-type TypeStyle = Pick<TextStyle, 'fontSize' | 'fontWeight' | 'lineHeight'>;
+export type TypeStyle = Pick<TextStyle, 'fontSize' | 'fontWeight' | 'lineHeight'>;
 
 export const textStyles = {
   largeTitle: {
@@ -68,6 +68,86 @@ export const textStyles = {
     lineHeight: 13,
   },
 } as const satisfies Record<string, TypeStyle>;
+
+/**
+ * Material Design 3 (Roboto) type scale, used by the `material` UI variant. Same
+ * keys as `textStyles` so a `Text` of a given `variant` resolves to one or the
+ * other depending on `theme.variant`. The HIG scale's bold display weights drop
+ * to M3's regular/medium (M3 reserves heavy weights for true display roles), and
+ * sizes/line-heights track the closest MD3 role:
+ *
+ *   largeTitle → headlineMedium · title1 → headlineSmall · title2 → titleLarge
+ *   headline → titleMedium · body/callout → bodyLarge · subheadline → bodyMedium
+ *   footnote → bodySmall · caption1/caption2 → labelSmall
+ */
+export const materialTextStyles = {
+  largeTitle: {
+    fontSize: 28,
+    fontWeight: '400',
+    lineHeight: 36,
+  },
+  title1: {
+    fontSize: 24,
+    fontWeight: '400',
+    lineHeight: 32,
+  },
+  title2: {
+    fontSize: 22,
+    fontWeight: '400',
+    lineHeight: 28,
+  },
+  title3: {
+    fontSize: 22,
+    fontWeight: '500',
+    lineHeight: 28,
+  },
+  headline: {
+    fontSize: 16,
+    fontWeight: '500',
+    lineHeight: 24,
+  },
+  body: {
+    fontSize: 16,
+    fontWeight: '400',
+    lineHeight: 24,
+  },
+  callout: {
+    fontSize: 16,
+    fontWeight: '400',
+    lineHeight: 24,
+  },
+  subheadline: {
+    fontSize: 14,
+    fontWeight: '400',
+    lineHeight: 20,
+  },
+  footnote: {
+    fontSize: 12,
+    fontWeight: '400',
+    lineHeight: 16,
+  },
+  caption1: {
+    fontSize: 11,
+    fontWeight: '500',
+    lineHeight: 16,
+  },
+  caption2: {
+    fontSize: 11,
+    fontWeight: '500',
+    lineHeight: 16,
+  },
+} as const satisfies Record<keyof typeof textStyles, TypeStyle>;
+
+/**
+ * Type scale resolved per UI variant — mirrors `radiiByVariant`/
+ * `sheetChromeByVariant` in ./tokens. Liquid Glass keeps the Apple HIG scale
+ * unchanged; Material swaps in the M3 (Roboto) scale. Consumed via
+ * `theme.textStyles` (resolved in the provider) and read by `Text`.
+ */
+export const textStylesByVariant = {
+  liquidGlass: textStyles,
+  material: materialTextStyles,
+} as const satisfies Record<'liquidGlass' | 'material', Record<keyof typeof textStyles, TypeStyle>>;
 
 export type TextVariant = keyof typeof textStyles;
 

--- a/packages/mobile/test/react-native-paper-stub.tsx
+++ b/packages/mobile/test/react-native-paper-stub.tsx
@@ -28,6 +28,7 @@ export const Appbar = {
   Action: stub('appbar-action'),
 };
 export const SegmentedButtons = stub('segmented-buttons');
+export const FAB = stub('fab');
 export const ActivityIndicator = stub('activity-indicator');
 export const TouchableRipple = stub('touchable-ripple');
 


### PR DESCRIPTION
## What

The Record / Profile redesign (#2715) was built iOS-first (liquid glass / HIG). An M3 designer review found the **Android (Material) variant** read as "iOS with Roboto + ripple": only a handful of primitives branched to Paper M3, while the type scale, chips, section headers, stat-tile fills, the collapsing large-title chrome, and the bottom action bar were iOS transplants. This PR makes the Material variant native M3.

**Hard constraint, held throughout:** every change is gated on `variant === 'material'`. The `liquidGlass`/iOS path is **byte-identical** — verified by an iOS-simulator regression pass (Record + Profile pixel-unchanged) and two independent code reviews.

## How it's structured (A → B → C, foundation first)

**Phase A — theme foundation** (cascades everywhere)
- M3 (Roboto) type ramp resolved per variant in the theme provider, so `Text` applies M3 sizes/weights on Material and the unchanged HIG scale on glass. The key shift: M3 drops the HIG bold display weights to regular/medium for titles.
- Expose the full MD3 colour palette as `theme.m3` (memoized from `buildPaperTheme`) so Material-branch components read `primaryContainer`/`onSurfaceVariant`/`outlineVariant`/`elevation` roles directly. (Paper 5.15 predates the `surfaceContainer*` tones, so the elevation ladder stands in.)

**Phase B — component Material branches**
- `SectionHeader` → sentence-case `titleSmall` in `onSurfaceVariant` (drops the iOS uppercase / 0.6-opacity / letter-spacing group caption).
- `StatsSummaryCard` → the three stat tiles become one tonal family (surfaceVariant · primaryContainer · tertiaryContainer); the vivid grade hue survives only as the tick/flash glyph, instead of two saturated grade-coloured alert blocks.
- `GeneratorPickerCard` → Paper M3 filter chips (secondaryContainer + checkmark); the grouped stepper / tall-wide cards use a filled `surfaceVariant` tone with `outlineVariant` dividers.
- `Stepper` → tonal `secondaryContainer` ± pill with `onSecondaryContainer` glyphs, state-layer ripple, 48dp targets.
- `MaterialTabBar` → M3 80dp navigation bar with a `secondaryContainer` active-indicator pill (`onSecondaryContainer` icon, `onSurface` active label, `onSurfaceVariant` inactive). The bottom-chrome metrics (and the toast offset) now clear the taller Material bar per variant; glass keeps the 49pt iOS height.

**Phase C — navigation & chrome**
- `RecordTopChrome` / `ProfileTopChrome` → a Material `Appbar.Header` top app bar (mirroring the existing `ClimbTopChrome` material branch): screen title via `Appbar.Content`, with share / settings / (Progress-only) filter `Appbar.Action`s. No collapse animation, no floating glass islands. The screens' scroll/inset wiring is untouched (`scrollY` captured-but-unused; measured `chromeHeight` applied identically).
- `MaterialTabs` (new) → M3 primary tabs (equal-width labels + a sliding `m3.primary` underline, ripple) as the Profile app bar's bottom row, replacing the SegmentedButtons-as-navigation.
- `SessionActionFooter` (new) → routes the session Start/End footer to a Paper extended FAB on Material (icon + label, M3 disabled/loading for free) anchored bottom-end over `fixedFooterBottom`; glass keeps the pinned glass Button. Both measure their height so the list-inset contract holds.
- The in-body `largeTitle` is gated off on Material in the session screens and the three Profile sub-tabs (the app bar now owns the title) — fixes a doubled "You"/"Start a session" found on device.

## Validation

- `vp run typecheck:mobile` ✓
- `vp test run --project mobile` ✓ (1753 passed; added tests for `MaterialTabs`, `SessionActionFooter`, and the Material branches of `RecordTopChrome` / `ProfileTopChrome`, plus the variant-aware metrics)
- `vp run check:mobile-bundle` ✓
- **Android emulator (Material):** Record (M3 app bar, filter chips, extended FAB, M3 nav bar) and Profile (MaterialTabs, tonal stat tiles) verified on device.
- **iOS simulator (liquid glass) regression gate:** Record + Profile unchanged — uppercase section header, glass pill chips, full-width pinned Start button, glass segmented control, saturated grade tiles all preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)