### PR TITLE
fix(mobile): hide queue bar peeks at rest so they can't stack on the current climb

### DIFF
--- a/packages/mobile/src/components/queue-control/use-queue-carousel.ts
+++ b/packages/mobile/src/components/queue-control/use-queue-carousel.ts
@@ -1,15 +1,9 @@
 import { useCallback, useMemo, useState } from 'react';
 import { type LayoutChangeEvent } from 'react-native';
 import { Gesture, type ComposedGesture } from 'react-native-gesture-handler';
-import {
-  runOnJS,
-  useAnimatedStyle,
-  useDerivedValue,
-  useSharedValue,
-  type AnimatedStyle,
-} from 'react-native-reanimated';
+import { runOnJS, useAnimatedStyle, useSharedValue, type AnimatedStyle } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
-import { computePeekOffset, computeNavigationStateWithSuggestions } from '@boardsesh/play-view';
+import { computeNavigationStateWithSuggestions } from '@boardsesh/play-view';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { useIsPartyPreviewOnly, usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
@@ -164,14 +158,22 @@ export function useQueueCarousel(): QueueCarousel {
   );
 
   const currentLabelStyle = useAnimatedStyle(() => ({ transform: [{ translateX: translateX.value }] }));
-  const nextPeekX = useDerivedValue(() =>
-    computePeekOffset({ direction: 'next', swipeOffset: translateX.value, viewportWidth: widthSV.value }),
-  );
-  const prevPeekX = useDerivedValue(() =>
-    computePeekOffset({ direction: 'prev', swipeOffset: translateX.value, viewportWidth: widthSV.value }),
-  );
-  const nextPeekStyle = useAnimatedStyle(() => ({ transform: [{ translateX: nextPeekX.value }] }));
-  const prevPeekStyle = useAnimatedStyle(() => ({ transform: [{ translateX: prevPeekX.value }] }));
+  // Peek labels are hidden + parked off-screen at rest (translateX 0) and only
+  // shown while a swipe/commit is in flight — so a stale or zero measured width
+  // can never stack them on the current label. Mirrors SwipeBoardCarousel's
+  // peekStyle guard. The offset math is inlined from computePeekOffset in
+  // @boardsesh/play-view (cross-module worklet calls are avoided elsewhere too —
+  // see clampTranslation in use-zoom-pan-gesture.ts); the shared fn stays the
+  // canonical spec + test target. Reading widthSV/translateX directly here also
+  // sidesteps the Android "derived value doesn't rebuild on width change" symptom.
+  const nextPeekStyle = useAnimatedStyle(() => {
+    if (translateX.value === 0) return { opacity: 0, transform: [{ translateX: widthSV.value }] };
+    return { opacity: 1, transform: [{ translateX: Math.max(0, widthSV.value + translateX.value) }] };
+  });
+  const prevPeekStyle = useAnimatedStyle(() => {
+    if (translateX.value === 0) return { opacity: 0, transform: [{ translateX: -widthSV.value }] };
+    return { opacity: 1, transform: [{ translateX: Math.min(0, -widthSV.value + translateX.value) }] };
+  });
 
   const swipeAccessibilityActions: AccessibilityAction[] = [
     ...(canPrevious ? [{ name: 'previous', label: t('mobile.queue.previousClimb') }] : []),


### PR DESCRIPTION
## Problem

The now-climbing accessory bar — both the floating capsule and the iOS 26 native bottom accessory — sometimes ends up garbled: several climb names and grades render on top of each other at the bar's center (overlapping names + "V2"/"V3" + tick). Reported on **both iOS and Android**, on the **latest build**, triggered by **swiping between climbs**.

![screenshot in the issue describes the overlap]

## Root cause

The bar stacks three absolutely-positioned label slots in one box — current, next-peek, prev-peek — separated *only* by a `translateX` of ±(measured bar width) computed by `computePeekOffset`. For all three to pile up at center, the offset worklet has to be computing with `viewportWidth ≈ 0` **even though the bar is laid out at full width** (the text is legible) — i.e. `widthSV` is read stale/zero inside the worklet while the views render full-size, so both peeks collapse to `translateX 0`, fully opaque, on top of the current label.

`cd42618bc` mirrored the width into a shared value and gated peeks on `canPeek = width > 0`, which reduced but didn't eliminate it — the peeks had **no at-rest visibility guard**, so any offset landing near 0 still showed them.

## Fix

This repo already solved the identical problem in the sibling board carousel: `SwipeBoardCarousel`'s `peekStyle` returns `opacity: 0` (parked off-screen) whenever `translateX.value === 0`, and only shows the peek with a computed offset during an active swipe. The queue accessory bar never got that guard.

Ported it to `useQueueCarousel`:
- `nextPeekStyle`/`prevPeekStyle` are now `opacity: 0` + parked off-screen at rest, `opacity: 1` only while `translateX !== 0`.
- The peek offset math is inlined (matching the `clampTranslation` clone in `use-zoom-pan-gesture.ts`), recomputed live inside `useAnimatedStyle` on each `translateX` tick — which also removes the intermediate `useDerivedValue` layer and sidesteps the Android "derived value doesn't rebuild on width change" symptom.
- `computePeekOffset` stays in `@boardsesh/play-view` as the canonical spec + test target.

At rest (and at every commit, where the gesture hard-sets `translateX = 0`) the peeks are invisible, so a stale/zero measured width can no longer produce a visible overlap.

## Scope
- One file: `packages/mobile/src/components/queue-control/use-queue-carousel.ts`. `ClimbCapsule`/`NativeAccessoryClimbRow` consume the styles unchanged (opacity rides along).
- `SwipeBoardCarousel` already has the guard and is left as-is.
- No behavior change to the suggestion-aware "peek past the queue tail" — the suggested next still renders, just hidden at rest like any peek.

## Validation
- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 243 files / 1737 tests pass
- `vp run check:mobile-bundle` — Android bundle OK (10.7 MB)
- Manual: needs an on-device pass swiping rapidly (incl. interrupting the commit) on iOS sim + Android emulator to confirm no stacked text at rest and clean slide-in/out during the swipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)