### PR TITLE
Verify latest production migration after migrate

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -316,6 +316,7 @@ jobs:
       - name: Run database migrations
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          VERIFY_MIGRATION_JOURNAL: '1'
         run: bun run --filter=@boardsesh/db db:migrate
 
   deploy-web:

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -8,7 +8,17 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-type AppliedMigrationCountRow = {
+type MigrationJournalEntry = {
+  tag: string;
+  when: number;
+};
+
+type MigrationJournal = {
+  entries: MigrationJournalEntry[];
+};
+
+type LatestAppliedMigrationRow = {
+  latestCreatedAt: number | string | bigint | null;
   appliedMigrationCount: number | string | bigint | null;
 };
 
@@ -60,24 +70,48 @@ async function runMigrations() {
 
     const migrationsFolder = path.resolve(__dirname, '../drizzle');
     const journalPath = path.join(migrationsFolder, 'meta', '_journal.json');
-    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8')) as MigrationJournal;
+    const latestJournalEntry = journal.entries.reduce<MigrationJournalEntry | null>(
+      (latestEntry, entry) => (!latestEntry || entry.when > latestEntry.when ? entry : latestEntry),
+      null,
+    );
+    if (!latestJournalEntry) {
+      throw new Error('Migration journal is empty');
+    }
     console.info(`📋 Found ${journal.entries.length} migrations in journal`);
 
     await migrate(db, { migrationsFolder });
 
-    const appliedMigrationRows = await client<AppliedMigrationCountRow[]>`
-      SELECT COUNT(*)::int AS "appliedMigrationCount"
+    if (process.env.VERIFY_MIGRATION_JOURNAL === '1') {
+      const appliedMigrationRows = await client<LatestAppliedMigrationRow[]>`
+      SELECT
+        MAX(created_at)::bigint AS "latestCreatedAt",
+        COUNT(*)::int AS "appliedMigrationCount"
       FROM drizzle."__drizzle_migrations"
     `;
-    const appliedMigrationCount = Number(appliedMigrationRows[0]?.appliedMigrationCount ?? 0);
-    if (appliedMigrationCount !== journal.entries.length) {
-      throw new Error(
-        `Migration count verification failed: database has ${appliedMigrationCount} applied migrations, ` +
-          `but the bundled journal has ${journal.entries.length}.`,
+      const latestAppliedCreatedAt = Number(appliedMigrationRows[0]?.latestCreatedAt ?? 0);
+      const appliedMigrationCount = Number(appliedMigrationRows[0]?.appliedMigrationCount ?? 0);
+
+      if (latestAppliedCreatedAt < latestJournalEntry.when) {
+        throw new Error(
+          `Latest migration verification failed: database latest created_at is ${latestAppliedCreatedAt}, ` +
+            `but bundled latest migration ${latestJournalEntry.tag} has created_at ${latestJournalEntry.when}.`,
+        );
+      }
+
+      if (appliedMigrationCount !== journal.entries.length) {
+        console.warn(
+          `⚠️ Migration table has ${appliedMigrationCount} rows for ${journal.entries.length} journal entries; ` +
+            `continuing because latest migration ${latestJournalEntry.tag} is applied.`,
+        );
+      }
+
+      console.info(
+        `✅ Verified latest migration ${latestJournalEntry.tag} is applied ` +
+          `(created_at ${latestAppliedCreatedAt}; ${appliedMigrationCount}/${journal.entries.length} rows recorded)`,
       );
     }
 
-    console.info(`✅ Verified ${appliedMigrationCount} applied migrations`);
     console.info('✅ Migrations completed successfully');
   } catch (error) {
     console.error('❌ Migration failed:', error);


### PR DESCRIPTION
## Summary

- Change production migration verification from exact row count to latest-applied migration timestamp.
- Enable that verification only in the production deploy workflow via `VERIFY_MIGRATION_JOURNAL=1`.
- Keep local/dev migrations from failing on prebuilt or restored DB migration metadata.

## Why

The previous hotfix moved migration safety into the `migrate` job, but the first implementation required `COUNT(*)` in `drizzle.__drizzle_migrations` to equal the bundled journal length.

Production currently has historical gaps in that table: the latest migration is applied, but the table has 117 rows while the bundled journal has 122 entries. That count mismatch made the production `migrate` job fail even though Drizzle had already applied the latest migration in the earlier deploy.

This version checks the thing the deploy actually needs: after `db:migrate`, the latest applied `created_at` in `drizzle.__drizzle_migrations` must be at least the latest bundled journal `when`. If it is older, the migration job fails and both deploy jobs remain gated. If the latest migration is applied but historical row count is off, the job logs a warning and continues.

## Validation

- `vp check --fix packages/db/scripts/migrate.ts .github/workflows/production-deploy.yml`
- `vp run typecheck:db`
