### PR TITLE
[codex] Fix mobile For You smart playlist pins

### DIFF
--- a/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -13,6 +13,11 @@ type PlaylistItem = {
   color?: string;
   icon?: string;
   isPinnedByMe?: boolean;
+};
+
+type SmartCountItem = {
+  type: string;
+  count: number;
 };
 
 type DiscoverOptions = {
@@ -42,6 +47,12 @@ const exactForYouHook = vi.hoisted(() => ({
   loadMore: vi.fn(),
   refetch: vi.fn(),
 }));
+const smartCountsHook = vi.hoisted(() => ({
+  data: undefined as SmartCountItem[] | undefined,
+  isLoading: false,
+  isError: false,
+  refetch: vi.fn(),
+}));
 const communityHook = vi.hoisted(() => ({
   popular: [] as PlaylistItem[],
   recent: [] as PlaylistItem[],
@@ -59,6 +70,13 @@ const createPlaylist = vi.hoisted(() => vi.fn());
 const pinPlaylist = vi.hoisted(() => vi.fn());
 const unpinPlaylist = vi.hoisted(() => vi.fn());
 const discoverOptions = vi.hoisted(() => [] as DiscoverOptions[]);
+const asyncStorage = vi.hoisted(() => ({
+  storage: new Map<string, string>(),
+  getItem: vi.fn(async (key: string) => asyncStorage.storage.get(key) ?? null),
+  setItem: vi.fn(async (key: string, value: string) => {
+    asyncStorage.storage.set(key, value);
+  }),
+}));
 
 vi.mock('@boardsesh/playlists-react', () => ({
   useUserPlaylists: () => userHook,
@@ -67,8 +85,15 @@ vi.mock('@boardsesh/playlists-react', () => ({
     return options.generatedRecommendation ? exactForYouHook : communityHook;
   },
   usePinnedPlaylists: () => pinnedHook,
-  useSmartPlaylistCounts: () => ({ data: [], isLoading: false }),
+  useSmartPlaylistCounts: () => smartCountsHook,
   usePlaylistMutations: () => ({ createPlaylist, pinPlaylist, unpinPlaylist }),
+}));
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: asyncStorage.getItem,
+    setItem: asyncStorage.setItem,
+  },
 }));
 
 // @tanstack/react-query is NOT mocked — the create flow writes to the real
@@ -132,6 +157,34 @@ vi.mock('../../../../src/lib/smart-playlists', () => ({
   DEFAULT_PINNED_SMART_PLAYLIST_TYPES: ['LIKED_CLIMBS', 'FIVE_STARS'],
   SMART_PLAYLISTS: [
     {
+      type: 'RECOMMENDED_CROWD_FAVORITES',
+      slug: 'crowd-favorites',
+      icon: '🔥',
+      color: '#D65A4F',
+      titleI18nKey: 'library.smart.crowdFavorites.title',
+    },
+    {
+      type: 'RECOMMENDED_HIDDEN_GEMS',
+      slug: 'hidden-gems',
+      icon: '💎',
+      color: '#9C27B0',
+      titleI18nKey: 'library.smart.hiddenGems.title',
+    },
+    {
+      type: 'RECOMMENDED_AT_LEVEL',
+      slug: 'at-your-level',
+      icon: '📈',
+      color: '#5FB27A',
+      titleI18nKey: 'library.smart.atYourLevel.title',
+    },
+    {
+      type: 'RECOMMENDED_FRESH',
+      slug: 'fresh',
+      icon: '🌱',
+      color: '#FBBF24',
+      titleI18nKey: 'library.smart.fresh.title',
+    },
+    {
       type: 'LIKED_CLIMBS',
       slug: 'liked-climbs',
       icon: '❤️',
@@ -144,6 +197,20 @@ vi.mock('../../../../src/lib/smart-playlists', () => ({
       icon: '⭐',
       color: '#FBBF24',
       titleI18nKey: 'library.smart.fiveStars.title',
+    },
+    {
+      type: 'MOST_REPEATED',
+      slug: 'most-repeated',
+      icon: '🔁',
+      color: '#9C27B0',
+      titleI18nKey: 'library.smart.mostRepeated.title',
+    },
+    {
+      type: 'PROJECTS',
+      slug: 'projects',
+      icon: '🎯',
+      color: '#2563EB',
+      titleI18nKey: 'library.smart.projects.title',
     },
   ],
 }));
@@ -217,6 +284,22 @@ beforeEach(() => {
   exactForYouHook.isLoading = false;
   exactForYouHook.hasError = false;
   exactForYouHook.refetch.mockClear();
+  smartCountsHook.data = [
+    { type: 'RECOMMENDED_CROWD_FAVORITES', count: 748 },
+    { type: 'RECOMMENDED_HIDDEN_GEMS', count: 1178 },
+    { type: 'RECOMMENDED_AT_LEVEL', count: 719 },
+    { type: 'RECOMMENDED_FRESH', count: 5485 },
+    { type: 'FIVE_STARS', count: 523 },
+    { type: 'MOST_REPEATED', count: 292 },
+    { type: 'PROJECTS', count: 92 },
+    { type: 'LIKED_CLIMBS', count: 46 },
+  ];
+  smartCountsHook.isLoading = false;
+  smartCountsHook.isError = false;
+  smartCountsHook.refetch.mockClear();
+  asyncStorage.storage.clear();
+  asyncStorage.getItem.mockClear();
+  asyncStorage.setItem.mockClear();
   communityHook.popular = [];
   communityHook.recent = [];
   communityHook.isLoading = false;
@@ -232,6 +315,7 @@ beforeEach(() => {
 
 describe('DiscoverLibrary error handling', () => {
   it('shows a load-error state with a retry (not the empty state) when a section fails and the hub is empty', () => {
+    smartCountsHook.data = undefined;
     userHook.hasError = true;
     const { getByText, queryByText, getByLabelText } = renderHub();
 
@@ -244,6 +328,7 @@ describe('DiscoverLibrary error handling', () => {
   });
 
   it('retries only the community stream when only it failed', () => {
+    smartCountsHook.data = undefined;
     communityHook.hasError = true;
     const { getByLabelText } = renderHub();
 
@@ -253,12 +338,13 @@ describe('DiscoverLibrary error handling', () => {
     expect(userHook.refetch).not.toHaveBeenCalled();
   });
 
-  it('retries only the forYou stream when only it failed', () => {
-    exactForYouHook.hasError = true;
+  it('retries only the for-you smart count stream when only it failed', () => {
+    smartCountsHook.data = undefined;
+    smartCountsHook.isError = true;
     const { getByLabelText } = renderHub();
 
     fireEvent.click(getByLabelText('library.errors.tryAgain'));
-    expect(exactForYouHook.refetch).toHaveBeenCalledTimes(1);
+    expect(smartCountsHook.refetch).toHaveBeenCalledTimes(1);
     expect(communityHook.refetch).not.toHaveBeenCalled();
     expect(userHook.refetch).not.toHaveBeenCalled();
   });
@@ -271,46 +357,59 @@ describe('DiscoverLibrary error handling', () => {
     expect(queryByText('library.errors.loadTitle')).toBeNull();
   });
 
-  it('shows the empty state when all sections succeed with no playlists', () => {
-    const { getByText, queryByText } = renderHub();
-
-    expect(getByText('library.empty.title')).toBeTruthy();
-    expect(queryByText('library.errors.loadTitle')).toBeNull();
-  });
-
-  it('renders for-you and community playlists from separate discover streams', () => {
-    exactForYouHook.popular = [{ uuid: 'generated', name: 'Fresh for you', climbCount: 4 }];
+  it('renders for-you smart cards and community playlists', () => {
     communityHook.popular = [
       { uuid: 'community', name: 'Setter picks', climbCount: 7, creatorId: 'creator-2', creatorName: 'Jess' },
     ];
 
     const { getByText } = renderHub();
 
-    expect(getByText('Fresh for you')).toBeTruthy();
+    expect(getByText('library.smart.crowdFavorites.title')).toBeTruthy();
+    expect(getByText('library.smart.hiddenGems.title')).toBeTruthy();
+    expect(getByText('library.smart.atYourLevel.title')).toBeTruthy();
+    expect(getByText('library.smart.fresh.title')).toBeTruthy();
+    expect(getByText('library.smart.fiveStars.title')).toBeTruthy();
+    expect(getByText('library.smart.mostRepeated.title')).toBeTruthy();
+    expect(getByText('library.smart.projects.title')).toBeTruthy();
+    expect(getByText('library.smart.likedClimbs.title')).toBeTruthy();
     expect(getByText('Setter picks library.communityByline')).toBeTruthy();
   });
 
-  it('requests generated playlists for the active board size and angle', () => {
-    renderHub();
+  it('orders for-you smart cards in the mobile product order', () => {
+    const { container } = renderHub();
+    const forYouSection = container.querySelector('[data-scroll-section="library.sections.forYou"]');
+    const sectionText = forYouSection?.textContent ?? '';
+    const expectedTitles = [
+      'library.smart.likedClimbs.title',
+      'library.smart.fiveStars.title',
+      'library.smart.projects.title',
+      'library.smart.mostRepeated.title',
+      'library.smart.crowdFavorites.title',
+      'library.smart.hiddenGems.title',
+      'library.smart.atYourLevel.title',
+      'library.smart.fresh.title',
+    ];
 
-    expect(discoverOptions).toContainEqual(
-      expect.objectContaining({
-        generatedRecommendation: true,
-        boardType: 'kilter',
-        layoutId: 1,
-        sizeId: 10,
-        angle: 40,
-      }),
-    );
+    let previousIndex = -1;
+    for (const title of expectedTitles) {
+      const currentIndex = sectionText.indexOf(title);
+      expect(currentIndex).toBeGreaterThan(previousIndex);
+      previousIndex = currentIndex;
+    }
   });
 
-  it('renders pinned grid, owned playlists, generated, and community in order', () => {
+  it('does not request generated discover playlists for the for-you shelf', () => {
+    renderHub();
+
+    expect(discoverOptions).not.toContainEqual(expect.objectContaining({ generatedRecommendation: true }));
+  });
+
+  it('renders pinned grid, owned playlists, for-you smart cards, and community in order', () => {
     pinnedHook.pinned = [{ uuid: 'pinned', name: 'Pinned list', climbCount: 2, isPinnedByMe: true }];
     userHook.playlists = [
       { uuid: 'pinned', name: 'Pinned list', climbCount: 2, isPinnedByMe: true },
       { uuid: 'owned', name: 'Project drawer', climbCount: 5, isPinnedByMe: false },
     ];
-    exactForYouHook.popular = [{ uuid: 'generated', name: 'Fresh for you', climbCount: 4 }];
     communityHook.popular = [
       { uuid: 'community', name: 'Setter picks', climbCount: 7, creatorId: 'creator-2', creatorName: 'Jess' },
     ];
@@ -332,15 +431,16 @@ describe('DiscoverLibrary error handling', () => {
     expect(forYouIndex).toBeLessThan(communityIndex);
   });
 
-  it('does not render an empty generated shelf when generated playlists are empty', () => {
+  it('renders for-you smart cards when generated discover playlists are empty', () => {
     userHook.playlists = [{ uuid: 'owned', name: 'Project drawer', climbCount: 5, isPinnedByMe: false }];
     communityHook.popular = [
       { uuid: 'community', name: 'Setter picks', climbCount: 7, creatorId: 'creator-2', creatorName: 'Jess' },
     ];
 
-    const { queryByText } = renderHub();
+    const { getByText } = renderHub();
 
-    expect(queryByText('library.sections.forYou')).toBeNull();
+    expect(getByText('library.sections.forYou')).toBeTruthy();
+    expect(getByText('library.smart.crowdFavorites.title')).toBeTruthy();
   });
 
   it('does not show see all in the pinned header', () => {
@@ -356,8 +456,7 @@ describe('DiscoverLibrary error handling', () => {
     expect(pinnedHeader?.textContent).toBe('library.sections.pinned');
   });
 
-  it('shows pin controls on generated and community playlist cards', async () => {
-    exactForYouHook.popular = [{ uuid: 'generated', name: 'Fresh for you', climbCount: 4 }];
+  it('shows pin controls on community playlist cards', async () => {
     communityHook.popular = [
       { uuid: 'community', name: 'Setter picks', climbCount: 7, creatorId: 'creator-2', creatorName: 'Jess' },
     ];
@@ -366,15 +465,76 @@ describe('DiscoverLibrary error handling', () => {
     const { getByLabelText } = renderHub();
 
     await act(async () => {
-      fireEvent.click(getByLabelText('pin-Fresh for you'));
-    });
-    await act(async () => {
       fireEvent.click(getByLabelText('pin-Setter picks'));
     });
 
-    expect(pinPlaylist).toHaveBeenCalledWith('generated');
     expect(pinPlaylist).toHaveBeenCalledWith('community');
-    expect(pinnedHook.refetch).toHaveBeenCalledTimes(2);
+    expect(pinnedHook.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('pins for-you smart cards into the pinned grid without calling playlist pin mutations', async () => {
+    const { container, findByLabelText } = renderHub();
+
+    fireEvent.click(await findByLabelText('pin-library.smart.likedClimbs.title'));
+
+    const bodyText = container.textContent ?? '';
+    const pinnedIndex = bodyText.indexOf('library.sections.pinned');
+    const pinnedSmartIndex = bodyText.indexOf('library.smart.likedClimbs.title');
+    const pinnedSmartLastIndex = bodyText.lastIndexOf('library.smart.likedClimbs.title');
+    const forYouIndex = bodyText.indexOf('library.sections.forYou');
+    const forYouSection = container.querySelector('[data-scroll-section="library.sections.forYou"]');
+
+    expect(pinnedIndex).toBeGreaterThanOrEqual(0);
+    expect(pinnedSmartIndex).toBeGreaterThan(pinnedIndex);
+    expect(pinnedSmartIndex).toBeLessThan(forYouIndex);
+    expect(pinnedSmartLastIndex).toBe(pinnedSmartIndex);
+    expect(forYouSection?.textContent).not.toContain('library.smart.likedClimbs.title');
+    expect(asyncStorage.setItem).toHaveBeenCalledWith(
+      'boardsesh_pinned_smart_playlists_v1_me',
+      JSON.stringify(['LIKED_CLIMBS']),
+    );
+    expect(pinPlaylist).not.toHaveBeenCalled();
+    expect(unpinPlaylist).not.toHaveBeenCalled();
+  });
+
+  it('shows a retry when smart counts fail even with stored smart pins', async () => {
+    smartCountsHook.data = undefined;
+    smartCountsHook.isError = true;
+    asyncStorage.storage.set('boardsesh_pinned_smart_playlists_v1_me', JSON.stringify(['LIKED_CLIMBS']));
+
+    const { findByText, queryByText } = renderHub();
+
+    expect(await findByText('library.errors.loadTitle')).toBeTruthy();
+    expect(queryByText('library.sections.pinned')).toBeNull();
+  });
+
+  it('reserves pinned-grid slots for regular playlist pins when many smart playlists are pinned', async () => {
+    pinnedHook.pinned = Array.from({ length: 8 }, (_, index) => ({
+      uuid: `pinned-${index}`,
+      name: `Pinned ${index + 1}`,
+      climbCount: index,
+      isPinnedByMe: true,
+    }));
+    asyncStorage.storage.set(
+      'boardsesh_pinned_smart_playlists_v1_me',
+      JSON.stringify([
+        'LIKED_CLIMBS',
+        'FIVE_STARS',
+        'PROJECTS',
+        'MOST_REPEATED',
+        'RECOMMENDED_CROWD_FAVORITES',
+        'RECOMMENDED_HIDDEN_GEMS',
+        'RECOMMENDED_AT_LEVEL',
+        'RECOMMENDED_FRESH',
+      ]),
+    );
+
+    const { getByText, queryByText } = renderHub();
+
+    await waitFor(() => expect(getByText('library.smart.mostRepeated.title')).toBeTruthy());
+    expect(getByText('Pinned 1')).toBeTruthy();
+    expect(getByText('Pinned 4')).toBeTruthy();
+    expect(queryByText('Pinned 5')).toBeNull();
   });
 
   it('caps the pinned grid at eight playlists', () => {

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, Pressable, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import Animated, { useAnimatedRef, useAnimatedScrollHandler, useSharedValue } from 'react-native-reanimated';
 import { useQueryClient } from '@tanstack/react-query';
 import { router, useFocusEffect } from 'expo-router';
@@ -9,9 +10,10 @@ import {
   useDiscoverPlaylists,
   useUserPlaylists,
   usePinnedPlaylists,
+  useSmartPlaylistCounts,
   usePlaylistMutations,
 } from '@boardsesh/playlists-react';
-import type { DiscoverablePlaylist, Playlist } from '@boardsesh/graphql/operations/playlists';
+import type { DiscoverablePlaylist, Playlist, SmartPlaylistType } from '@boardsesh/graphql/operations/playlists';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
@@ -23,6 +25,7 @@ import {
   type PlaylistFormValues,
 } from '../../../src/components/playlist';
 import { DiscoverTopChrome } from '../../../src/components/chrome';
+import { SMART_PLAYLISTS, type SmartPlaylistPresentation } from '../../../src/lib/smart-playlists';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useTheme } from '../../../src/providers/theme-provider';
 import { useToast } from '../../../src/providers/toast-provider';
@@ -32,6 +35,45 @@ import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
 import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
+
+const FOR_YOU_SMART_PLAYLIST_TYPES: SmartPlaylistType[] = [
+  'LIKED_CLIMBS',
+  'FIVE_STARS',
+  'PROJECTS',
+  'MOST_REPEATED',
+  'RECOMMENDED_CROWD_FAVORITES',
+  'RECOMMENDED_HIDDEN_GEMS',
+  'RECOMMENDED_AT_LEVEL',
+  'RECOMMENDED_FRESH',
+];
+
+const PINNED_SMART_PLAYLISTS_STORAGE_PREFIX = 'boardsesh_pinned_smart_playlists_v1';
+
+function isForYouSmartPlaylistType(value: unknown): value is SmartPlaylistType {
+  return typeof value === 'string' && FOR_YOU_SMART_PLAYLIST_TYPES.includes(value as SmartPlaylistType);
+}
+
+function parsePinnedSmartPlaylistTypes(raw: string | null): SmartPlaylistType[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const seen = new Set<SmartPlaylistType>();
+    const pinnedTypes: SmartPlaylistType[] = [];
+    for (const maybeType of parsed) {
+      if (!isForYouSmartPlaylistType(maybeType) || seen.has(maybeType)) continue;
+      seen.add(maybeType);
+      pinnedTypes.push(maybeType);
+    }
+    return pinnedTypes;
+  } catch {
+    return [];
+  }
+}
+
+function pinnedSmartPlaylistsStorageKey(userId: string): string {
+  return `${PINNED_SMART_PLAYLISTS_STORAGE_PREFIX}_${userId}`;
+}
 
 export default function DiscoverLibrary() {
   const { t } = useTranslation('playlists');
@@ -53,8 +95,6 @@ export default function DiscoverLibrary() {
   // not-yet-onboarded user still sees community playlists.
   const filterBoardType = activeBoard?.boardType;
   const filterLayoutId = activeBoard?.layoutId;
-  const filterSizeId = activeBoard?.sizeId;
-  const filterAngle = activeBoard?.angle;
 
   // Measured top-chrome height so the scroll content clears the floating islands
   // (seeded to the safe-area top + a row, like the Climbs list).
@@ -70,6 +110,17 @@ export default function DiscoverLibrary() {
   const handleScrollToTop = useCallback(() => {
     listRef.current?.scrollTo({ y: 0, animated: true });
   }, [listRef]);
+
+  const {
+    data: smartCounts,
+    isLoading: smartCountsLoading,
+    isError: smartCountsError,
+    refetch: refetchSmartCounts,
+  } = useSmartPlaylistCounts({
+    token: effectiveToken,
+    tokenLoading,
+    isAuthenticated,
+  });
 
   // Owned playlists (paginated). Feeds the "See all" affordance and receives
   // refreshes after creates/pin changes.
@@ -94,25 +145,6 @@ export default function DiscoverLibrary() {
     candidatePlaylists: [],
   });
 
-  // Generated recommendation playlists (popular + recent streams, merged).
-  const {
-    popular: forYouPopular,
-    recent: forYouRecent,
-    isLoading: forYouLoading,
-    isLoadingMore: forYouLoadingMore,
-    hasError: forYouError,
-    loadMore: loadMoreForYou,
-    refetch: refetchForYou,
-  } = useDiscoverPlaylists({
-    boardType: filterBoardType,
-    layoutId: filterLayoutId,
-    sizeId: filterSizeId,
-    angle: filterAngle,
-    pageSize: 10,
-    generatedRecommendation: true,
-    enabled: !activeBoardLoading,
-  });
-
   // Community playlists (popular + recent streams, merged).
   const {
     popular: communityPopular,
@@ -130,18 +162,6 @@ export default function DiscoverLibrary() {
     enabled: !activeBoardLoading,
   });
 
-  // Merge generated popular + recent, de-duped.
-  const forYouItems = useMemo(() => {
-    const merged: DiscoverablePlaylist[] = [];
-    const seen = new Set<string>();
-    for (const playlist of [...forYouPopular, ...forYouRecent]) {
-      if (seen.has(playlist.uuid)) continue;
-      seen.add(playlist.uuid);
-      merged.push(playlist);
-    }
-    return merged;
-  }, [forYouPopular, forYouRecent]);
-
   // Merge community popular + recent, de-duped and excluding the current user's own.
   const communityItems = useMemo(() => {
     const merged: DiscoverablePlaylist[] = [];
@@ -155,11 +175,110 @@ export default function DiscoverLibrary() {
     return merged;
   }, [communityPopular, communityRecent, userId]);
 
+  const smartCountsByType = useMemo(
+    () => new Map((smartCounts ?? []).map((smartCount) => [smartCount.type, smartCount.count])),
+    [smartCounts],
+  );
+
+  const [pinnedSmartPlaylistTypes, setPinnedSmartPlaylistTypes] = useState<SmartPlaylistType[]>([]);
+  const [smartPinsHydrated, setSmartPinsHydrated] = useState(false);
+  const pinnedSmartPlaylistTypesRef = useRef<SmartPlaylistType[]>([]);
+  const smartPinsTouchedRef = useRef(false);
+
+  useEffect(() => {
+    smartPinsTouchedRef.current = false;
+    setSmartPinsHydrated(false);
+    if (!userId) {
+      pinnedSmartPlaylistTypesRef.current = [];
+      setPinnedSmartPlaylistTypes([]);
+      setSmartPinsHydrated(true);
+      return;
+    }
+
+    let cancelled = false;
+    AsyncStorage.getItem(pinnedSmartPlaylistsStorageKey(userId))
+      .then((raw) => {
+        if (cancelled || smartPinsTouchedRef.current) return;
+        const loadedPinnedTypes = parsePinnedSmartPlaylistTypes(raw);
+        pinnedSmartPlaylistTypesRef.current = loadedPinnedTypes;
+        setPinnedSmartPlaylistTypes(loadedPinnedTypes);
+        setSmartPinsHydrated(true);
+      })
+      .catch(() => {
+        if (cancelled || smartPinsTouchedRef.current) return;
+        pinnedSmartPlaylistTypesRef.current = [];
+        setPinnedSmartPlaylistTypes([]);
+        setSmartPinsHydrated(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  const persistPinnedSmartPlaylistTypes = useCallback(
+    (nextPinnedTypes: SmartPlaylistType[]) => {
+      if (!userId) return;
+      void AsyncStorage.setItem(pinnedSmartPlaylistsStorageKey(userId), JSON.stringify(nextPinnedTypes)).catch(() => {
+        // Non-critical preference write; keep the in-memory pin state usable.
+      });
+    },
+    [userId],
+  );
+
+  const handleToggleSmartPin = useCallback(
+    (smartPlaylistType: SmartPlaylistType) => {
+      if (!smartPinsHydrated) return;
+      smartPinsTouchedRef.current = true;
+      const previousPinnedTypes = pinnedSmartPlaylistTypesRef.current;
+      const nextPinnedTypes = previousPinnedTypes.includes(smartPlaylistType)
+        ? previousPinnedTypes.filter((pinnedType) => pinnedType !== smartPlaylistType)
+        : [smartPlaylistType, ...previousPinnedTypes.filter((pinnedType) => pinnedType !== smartPlaylistType)];
+      pinnedSmartPlaylistTypesRef.current = nextPinnedTypes;
+      setPinnedSmartPlaylistTypes(nextPinnedTypes);
+      persistPinnedSmartPlaylistTypes(nextPinnedTypes);
+    },
+    [persistPinnedSmartPlaylistTypes, smartPinsHydrated],
+  );
+
+  const forYouSmartCards = useMemo(() => {
+    if (!userId || smartCounts == null) return [];
+    return FOR_YOU_SMART_PLAYLIST_TYPES.map((smartPlaylistType) => {
+      if (pinnedSmartPlaylistTypes.includes(smartPlaylistType)) return null;
+      const preset = SMART_PLAYLISTS.find((smartPlaylist) => smartPlaylist.type === smartPlaylistType);
+      if (!preset) return null;
+      return { preset, count: smartCountsByType.get(smartPlaylistType) ?? 0 };
+    }).filter((entry): entry is { preset: (typeof SMART_PLAYLISTS)[number]; count: number } => entry !== null);
+  }, [pinnedSmartPlaylistTypes, smartCounts, smartCountsByType, userId]);
+
+  const pinnedSmartPlaylistTypeSet = useMemo(() => new Set(pinnedSmartPlaylistTypes), [pinnedSmartPlaylistTypes]);
+
+  const pinnedSmartCards = useMemo(() => {
+    if (!userId || smartCounts == null) return [];
+    return pinnedSmartPlaylistTypes
+      .map((smartPlaylistType) => {
+        const preset = SMART_PLAYLISTS.find((smartPlaylist) => smartPlaylist.type === smartPlaylistType);
+        if (!preset) return null;
+        return { preset, count: smartCountsByType.get(smartPlaylistType) ?? 0 };
+      })
+      .filter((entry): entry is { preset: SmartPlaylistPresentation; count: number } => entry !== null);
+  }, [pinnedSmartPlaylistTypes, smartCounts, smartCountsByType, userId]);
+
   const pinnedPlaylistUuids = useMemo(
     () => new Set(pinnedPlaylists.map((playlist) => playlist.uuid)),
     [pinnedPlaylists],
   );
-  const visiblePinnedPlaylists = useMemo(() => pinnedPlaylists.slice(0, 8), [pinnedPlaylists]);
+  const visiblePinnedSmartLimit =
+    pinnedSmartCards.length > 0 && pinnedPlaylists.length > 0 ? 8 - Math.min(pinnedPlaylists.length, 4) : 8;
+  const visiblePinnedSmartCards = useMemo(
+    () => pinnedSmartCards.slice(0, visiblePinnedSmartLimit),
+    [pinnedSmartCards, visiblePinnedSmartLimit],
+  );
+  const visiblePinnedPlaylists = useMemo(
+    () => pinnedPlaylists.slice(0, Math.max(8 - visiblePinnedSmartCards.length, 0)),
+    [pinnedPlaylists, visiblePinnedSmartCards.length],
+  );
+  const hasVisiblePinnedItems = visiblePinnedSmartCards.length + visiblePinnedPlaylists.length > 0;
 
   const unpinnedUserPlaylists = useMemo(() => {
     return userPlaylists.filter((playlist) => !pinnedPlaylistUuids.has(playlist.uuid));
@@ -167,6 +286,10 @@ export default function DiscoverLibrary() {
 
   const goToPlaylist = useCallback((uuid: string) => {
     router.push(`/(tabs)/discover/${uuid}`);
+  }, []);
+
+  const goToSmartPlaylist = useCallback((smartPlaylistType: SmartPlaylistType) => {
+    router.push(`/(tabs)/discover/smart/${smartPlaylistType}`);
   }, []);
 
   const { showToast } = useToast();
@@ -281,18 +404,18 @@ export default function DiscoverLibrary() {
   // — show a retry rather than the "no playlists yet" empty state, which would
   // mislead a user who actually has playlists into thinking they have none.
   const showLoadError =
-    (userError || forYouError || communityError) &&
+    (userError || smartCountsError || communityError) &&
     userPlaylists.length === 0 &&
-    pinnedPlaylists.length === 0 &&
-    forYouItems.length === 0 &&
+    !hasVisiblePinnedItems &&
+    forYouSmartCards.length === 0 &&
     communityItems.length === 0 &&
     !userLoading;
 
   const handleRetryLoad = useCallback(() => {
     if (userError) refetchUser();
-    if (forYouError) refetchForYou();
+    if (smartCountsError) void refetchSmartCounts();
     if (communityError) refetchCommunity();
-  }, [userError, forYouError, communityError, refetchUser, refetchForYou, refetchCommunity]);
+  }, [userError, smartCountsError, communityError, refetchUser, refetchSmartCounts, refetchCommunity]);
 
   return (
     <View style={styles.flex}>
@@ -334,10 +457,25 @@ export default function DiscoverLibrary() {
         ) : null}
 
         {/* Pinned — dense grid capped at four rows of two. */}
-        {isAuthenticated && visiblePinnedPlaylists.length > 0 ? (
+        {isAuthenticated && hasVisiblePinnedItems ? (
           <View style={styles.section}>
             <SectionHeader title={t('library.sections.pinned')} />
             <View style={styles.grid}>
+              {visiblePinnedSmartCards.map(({ preset, count }, index) => (
+                <View key={preset.type} style={styles.gridItem}>
+                  <PlaylistCard
+                    name={t(preset.titleI18nKey)}
+                    climbCount={count}
+                    color={preset.color}
+                    icon={preset.icon}
+                    variant="grid"
+                    index={index}
+                    onPress={() => goToSmartPlaylist(preset.type)}
+                    isPinned={pinnedSmartPlaylistTypeSet.has(preset.type)}
+                    onTogglePin={smartPinsHydrated ? () => handleToggleSmartPin(preset.type) : undefined}
+                  />
+                </View>
+              ))}
               {visiblePinnedPlaylists.map((playlist, index) => (
                 <View key={playlist.uuid} style={styles.gridItem}>
                   <PlaylistCard
@@ -346,7 +484,7 @@ export default function DiscoverLibrary() {
                     color={playlist.color}
                     icon={playlist.icon}
                     variant="grid"
-                    index={index}
+                    index={visiblePinnedSmartCards.length + index}
                     onPress={() => goToPlaylist(playlist.uuid)}
                     isPinned={playlist.isPinnedByMe}
                     onTogglePin={() => handleToggleCardPin(playlist)}
@@ -384,26 +522,21 @@ export default function DiscoverLibrary() {
           </PlaylistScrollSection>
         ) : null}
 
-        {/* For You — generated recommendation playlists. */}
-        {forYouLoading || forYouItems.length > 0 ? (
-          <PlaylistScrollSection
-            title={t('library.sections.forYou')}
-            loading={forYouLoading && forYouItems.length === 0}
-            isLoadingMore={forYouLoadingMore}
-            onEndReached={loadMoreForYou}
-          >
-            {forYouItems.map((playlist, index) => (
+        {/* For You — the same smart-playlist cards as web, in mobile product order. */}
+        {isAuthenticated && userId && (smartCountsLoading || forYouSmartCards.length > 0) ? (
+          <PlaylistScrollSection title={t('library.sections.forYou')} loading={smartCountsLoading}>
+            {forYouSmartCards.map(({ preset, count }, index) => (
               <PlaylistCard
-                key={playlist.uuid}
-                name={playlist.name}
-                climbCount={playlist.climbCount}
-                color={playlist.color}
-                icon={playlist.icon}
+                key={preset.type}
+                name={t(preset.titleI18nKey)}
+                climbCount={count}
+                color={preset.color}
+                icon={preset.icon}
                 variant="scroll"
                 index={index}
-                onPress={() => goToPlaylist(playlist.uuid)}
-                isPinned={isAuthenticated && pinnedPlaylistUuids.has(playlist.uuid)}
-                onTogglePin={isAuthenticated ? () => handleToggleDiscoverPin(playlist.uuid) : undefined}
+                onPress={() => goToSmartPlaylist(preset.type)}
+                isPinned={pinnedSmartPlaylistTypeSet.has(preset.type)}
+                onTogglePin={smartPinsHydrated ? () => handleToggleSmartPin(preset.type) : undefined}
               />
             ))}
           </PlaylistScrollSection>
@@ -465,13 +598,13 @@ export default function DiscoverLibrary() {
         {/* Empty state: signed in, nothing anywhere, nothing loading, no error. */}
         {isAuthenticated &&
         !userLoading &&
-        !forYouLoading &&
+        !smartCountsLoading &&
         !communityLoading &&
         !profileLoading &&
         !showLoadError &&
-        pinnedPlaylists.length === 0 &&
+        !hasVisiblePinnedItems &&
         userPlaylists.length === 0 &&
-        forYouItems.length === 0 &&
+        forYouSmartCards.length === 0 &&
         communityItems.length === 0 ? (
           <View style={styles.emptyContainer}>
             <Icon name="playlist" size={48} color={iosSystemColors.systemGray4} />
@@ -486,9 +619,9 @@ export default function DiscoverLibrary() {
 
         {/* Initial spinner before any section has resolved. */}
         {(authLoading || tokenLoading) &&
-        pinnedPlaylists.length === 0 &&
+        !hasVisiblePinnedItems &&
         userPlaylists.length === 0 &&
-        forYouItems.length === 0 &&
+        forYouSmartCards.length === 0 &&
         communityItems.length === 0 ? (
           <View style={styles.loadingContainer}>
             <ActivityIndicator size="large" />


### PR DESCRIPTION
## Summary

Follow-up to the merged mobile Discover shelves PR.

- Replaces the mobile `For You` shelf with the eight smart playlists only, in this order: Liked Climbs, Five Stars, Projects, Most Repeated, Crowd Favorites, Hidden Gems, At Your Level, Fresh.
- Stops requesting generated recommendation playlists for `For You`, so generated/community copies no longer appear there.
- Lets `For You` smart cards be pinned from the top-right card control; pinned smart cards move into the dense top `Pinned` grid and are removed from `For You` to avoid duplicates.
- Persists smart-card pins locally per signed-in user, waits for hydration before enabling smart-pin toggles, and waits for smart-count data before rendering pinned smart cards so counts do not flash as zero.
- Keeps regular playlist pins server-backed and reserves pinned-grid slots for regular pinned playlists when smart pins fill the grid.

## Validation

- `vp test --project mobile run --reporter=agent 'packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx'`
- `vp test run --reporter=agent 'packages/shared/i18n/src/__tests__/catalog-completeness.test.ts'`
- `vp run typecheck:mobile`
- `git diff --check`

## Review Notes

Ran three code-review subagents. Two completed with findings around duplicate smart cards, loading/error behavior, hydration, and pinned-grid slot priority; those findings are fixed and covered by regression tests. The third review pass did not return after repeated waits and was shut down.