### PR TITLE
fix(mobile): render iOS 26 bottom accessory when set after the tab bar appears

### DIFF
--- a/patches/react-native-screens@4.25.2.patch
+++ b/patches/react-native-screens@4.25.2.patch
@@ -1,3 +1,6 @@
+diff --git a/node_modules/react-native-screens/.bun-tag-4d17c8a3a14d1b96 b/.bun-tag-4d17c8a3a14d1b96
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/ios/helpers/scroll-view/RNSScrollViewFinder.h b/ios/helpers/scroll-view/RNSScrollViewFinder.h
 index 04d40b38bad73bedd79c6aa8b85125dc79093db7..ea25d1b0b36fcc6afeed44b5d603b8cbd15be6c0 100644
 --- a/ios/helpers/scroll-view/RNSScrollViewFinder.h
@@ -94,3 +97,56 @@ index 2434c612951a40bd1ecfcc476acebb9a9a6b500e..1045352774b126b0766c74fe5f800b62
 +}
 +
  @end
+diff --git a/ios/tabs/host/RNSTabsHostComponentView.mm b/ios/tabs/host/RNSTabsHostComponentView.mm
+index b92035cde75611c1e31998d9592cf019ef80544c..3b6595f5ae4fd64523cc64eec1bfe3609fa8435d 100644
+--- a/ios/tabs/host/RNSTabsHostComponentView.mm
++++ b/ios/tabs/host/RNSTabsHostComponentView.mm
+@@ -216,11 +216,48 @@ namespace react = facebook::react;
+       } else {
+         [_controller setBottomAccessory:nil animated:YES];
+       }
++      // rnscreens_bottomAccessoryDynamicAttachFix
++      [self rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance];
+     }
+ #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV && !TARGET_OS_VISION
+   }
+ }
+ 
++// rnscreens_bottomAccessoryDynamicAttachFix
++// iOS 26's UITabBarController.setBottomAccessory lays the accessory in for free
++// when it's set during the controller's initial setup, but NOT when it's set
++// after the tab bar has already appeared — UIKit attaches it to the controller
++// yet doesn't lay it in until the tab bar is otherwise invalidated. In the
++// Boardsesh app this surfaces solo: the bottom accessory is mounted only once a
++// current climb exists, so the very first climb set (while the user is already
++// on a tab) attaches an accessory that never renders until something else
++// (a tab-item badge, a tab change) re-lays-out the bar. Force the layout pass
++// ourselves whenever we touch the accessory after the host is on screen. A
++// deferred re-assert covers the accessory content being sized asynchronously by
++// the shadow-state proxy (the first synchronous pass can lay in a zero-size
++// accessory before its frame KVO lands).
++- (void)rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance
++{
++  if (self.window == nil) {
++    // Initial mount (accessory present from the start) lays in for free — only
++    // the post-appearance attach needs the nudge.
++    return;
++  }
++  UIView *controllerView = _controller.view;
++  [controllerView setNeedsLayout];
++  [controllerView layoutIfNeeded];
++  __weak __typeof__(self) weakSelf = self;
++  dispatch_async(dispatch_get_main_queue(), ^{
++    __typeof__(self) strongSelf = weakSelf;
++    if (strongSelf == nil) {
++      return;
++    }
++    UIView *deferredControllerView = strongSelf->_controller.view;
++    [deferredControllerView setNeedsLayout];
++    [deferredControllerView layoutIfNeeded];
++  });
++}
++
+ - (void)markChildUpdated
+ {
+   [self updateContainer];

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -53,6 +53,12 @@ export const RULES: readonly PatchRule[] = [
     sentinels: ['rnscreens_contentScrollViewForEdge', 'findScrollViewDeepFirstFrom'],
     patchedKey: 'react-native-screens@4.25.2',
   },
+  {
+    package: 'react-native-screens',
+    file: 'ios/tabs/host/RNSTabsHostComponentView.mm',
+    sentinels: ['rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance'],
+    patchedKey: 'react-native-screens@4.25.2',
+  },
 ];
 
 /**


### PR DESCRIPTION
## Problem

On the Liquid Glass variant (iOS 26), setting a climb active **while not in a party session** stopped showing the current climb in the native bottom accessory ("accessory bar"). In a session it shows and updates fine. Regression from #2728-era commit `82186be62`.

## Root cause

`82186be62` gated the accessory mount on a current climb to stop an empty glass capsule rendering at rest:

```diff
- {nativeAccessoryActive ? (
+ {nativeAccessoryActive && hasCurrentClimb ? (
```

That turns `NativeTabs.BottomAccessory` into a **dynamic mount**. The JS side is provably correct in solo — `setCurrentClimb` → `dispatchSetCurrent` dispatches `DELTA_UPDATE_CURRENT_CLIMB` locally and unconditionally, the reducer sets `currentClimbQueueItem` with no session gating, and the presence-only `useHasActiveClimb` selector flips and re-renders the tab layout (covered by `tab-layout.test.tsx`). There is a single `QueueProvider` feeding both the play drawer and the tab layout.

So the `<NativeTabs.BottomAccessory>` element renders in solo — the failure is at the **native layer**. react-native-screens calls `[_controller setBottomAccessory:… animated:YES]` when the accessory child mounts, but iOS 26's `UITabBarController.setBottomAccessory`, when set **after** the tab bar has already appeared (solo: the first climb is set while you're already on a tab), attaches the accessory to the controller without laying it in until the bar is otherwise invalidated.

Why it "works in session": joining forces a tab-bar refresh (the Record-tab badge appears) and/or the session screen is an out-of-`(tabs)` route where the JS `PersistentQueueBar` owns the climb chrome — either masks the native dynamic-attach.

## Fix

Patch `RNSTabsHostComponentView.updateContainer` (via the repo's existing bun `patchedDependencies` flow) to force the tab bar to lay the accessory in when it's set after the host is on screen — a synchronous layout pass plus a deferred re-assert (the accessory content is sized asynchronously by the shadow-state proxy). Gated on `self.window != nil` so the initial-mount path (accessory present from the start, which already lays in for free) is untouched.

**No JS change** — the queue state already flips correctly; the `_layout.tsx` gate stays as-is so the empty capsule is still hidden at rest.

### Files
- `patches/react-native-screens@4.25.2.patch` — new hunk adding `rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance` (regenerated with `bun patch`, not hand-edited).
- `scripts/mobile-patches-check.ts` — new `RULES` entry so `vp run check:mobile-patches` verifies the hunk applied.

## Verification
- ✅ `vp run mobile:ios` — native build succeeds, 0 errors; the patched `RNSTabsHostComponentView.mm` compiles clean.
- ✅ `vp run check:mobile-patches` (2 patches applied), `vp run typecheck:mobile`, `vp run test:mobile` (1758 tests), lint/format.
- ✅ On iOS 26.5 sim: at-rest solo state shows no empty capsule (gate still working).
- ⏳ On-device behavioral check (solo: tap a climb → capsule appears immediately) — the dynamic native attach needs a tap to drive; confirming on the booted sim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)