### PR TITLE
fix(search): correctness + hardening for the climb search hot path

### DIFF
--- a/packages/backend/src/__tests__/climb-queries.test.ts
+++ b/packages/backend/src/__tests__/climb-queries.test.ts
@@ -445,4 +445,158 @@ describe('Climb Query Functions', () => {
       expect(result).toBeDefined();
     });
   });
+
+  // Regression coverage for the search-climbs hardening PR. Each test seeds its own
+  // climbs (and stats/holds where needed) and asserts on membership filtered to the
+  // shared prefix, so it tolerates whatever else lives in the test DB.
+  describe('search-climbs hardening', () => {
+    const PREFIX = 'search-hardening-';
+    const id = (suffix: string) => PREFIX + suffix;
+    // Boulders default to true, so frames_count NULL/1 climbs match without extra params.
+    const kilter1 = (overrides: Partial<ParsedBoardRouteParameters> = {}): ParsedBoardRouteParameters => ({
+      board_name: 'kilter',
+      layout_id: 1,
+      size_id: 7,
+      set_ids: [1],
+      angle: 40,
+      ...overrides,
+    });
+
+    beforeAll(async () => {
+      // board_climbs: hold A/B (anchored-LIKE), rating HI/LO, popular PN/PO (isolated
+      // on size/set 99), drafts predicate N, driver-types T, projects-only PROJ.
+      await db.execute(sql`
+        INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, frames_count, is_draft, is_listed, edge_left, edge_right, edge_bottom, edge_top, created_at, required_set_ids, compatible_size_ids)
+        VALUES
+          (${id('hold-a')}, 'kilter', 1, 'sh', 'Hold A', 'p30r12p1200r13', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7]),
+          (${id('hold-b')}, 'kilter', 1, 'sh', 'Hold B', 'p130r12p1200r13', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7]),
+          (${id('rating-hi')}, 'kilter', 1, 'sh', 'Rating Hi', 'p500r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7]),
+          (${id('rating-lo')}, 'kilter', 1, 'sh', 'Rating Lo', 'p501r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7]),
+          (${id('pop-null')}, 'kilter', 1, 'sh', 'Pop Null', 'p99r12', NULL, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[99], ARRAY[99]),
+          (${id('pop-one')}, 'kilter', 1, 'sh', 'Pop One', 'p99r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[99], ARRAY[99]),
+          (${id('draft-pred')}, 'kilter', 1, 'sh', 'Draft Pred', 'p502r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7]),
+          (${id('types')}, 'kilter', 1, 'sh', 'Types', 'p503r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7]),
+          (${id('proj')}, 'kilter', 1, 'sh', 'Proj', 'p504r12', 1, false, true, 10, 100, 10, 150, '2024-01-01', ARRAY[1], ARRAY[7])
+        ON CONFLICT DO NOTHING
+      `);
+
+      await db.execute(sql`
+        INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, ascensionist_count, difficulty_average, quality_average)
+        VALUES
+          ('kilter', ${id('rating-hi')}, 40, 20.0, 10, 20.0, 4.5),
+          ('kilter', ${id('rating-lo')}, 40, 20.0, 10, 20.0, 1.5),
+          ('kilter', ${id('pop-null')}, 40, 20.0, 9999, 20.0, 4.0),
+          ('kilter', ${id('pop-one')}, 40, 20.0, 1, 20.0, 4.0),
+          ('kilter', ${id('types')}, 40, 20.0, 42, 20.5, 4.5)
+        ON CONFLICT DO NOTHING
+      `);
+
+      await db.execute(sql`
+        INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)
+        VALUES
+          ('kilter', ${id('hold-a')}, 30, 0, 'HAND'),
+          ('kilter', ${id('hold-a')}, 1200, 0, 'FINISH'),
+          ('kilter', ${id('hold-b')}, 130, 0, 'HAND'),
+          ('kilter', ${id('hold-b')}, 1200, 0, 'FINISH')
+        ON CONFLICT DO NOTHING
+      `);
+    });
+
+    afterAll(async () => {
+      await db.execute(sql`DELETE FROM board_climb_holds WHERE climb_uuid LIKE ${PREFIX + '%'}`);
+      await db.execute(sql`DELETE FROM board_climb_stats WHERE climb_uuid LIKE ${PREFIX + '%'}`);
+      await db.execute(sql`DELETE FROM board_climbs WHERE uuid LIKE ${PREFIX + '%'}`);
+    });
+
+    describe('anchored hold LIKE (F1)', () => {
+      it('ANY include matches the exact hold, not a longer placement id', async () => {
+        const result = await searchClimbs(kilter1(), {
+          page: 0,
+          pageSize: 100,
+          sortBy: 'creation',
+          holdsFilter: { hold_30: { ANY: 'include' } },
+        });
+        const uuids = result.climbs.map((c) => c.uuid);
+        // hold 30 must match p30r… (A) but NOT p130r… (B).
+        expect(uuids).toContain(id('hold-a'));
+        expect(uuids).not.toContain(id('hold-b'));
+      });
+
+      it('ANY exclude drops the exact hold, not a longer placement id', async () => {
+        const result = await searchClimbs(kilter1(), {
+          page: 0,
+          pageSize: 100,
+          sortBy: 'creation',
+          holdsFilter: { hold_30: { ANY: 'exclude' } },
+        });
+        const uuids = result.climbs.map((c) => c.uuid);
+        // Excluding hold 30 must keep B (uses 130, not 30) and drop A.
+        expect(uuids).toContain(id('hold-b'));
+        expect(uuids).not.toContain(id('hold-a'));
+      });
+    });
+
+    describe('minRating on the 1-5 scale (F2)', () => {
+      it('minRating=4 keeps a 4.5-quality climb and drops a 1.5-quality climb', async () => {
+        const result = await searchClimbs(kilter1(), { page: 0, pageSize: 100, minRating: 4 });
+        const uuids = result.climbs.map((c) => c.uuid);
+        expect(uuids).toContain(id('rating-hi'));
+        expect(uuids).not.toContain(id('rating-lo'));
+      });
+    });
+
+    describe('popular sort counts NULL frames_count (F4)', () => {
+      it('ranks a NULL-frames_count climb by its ascents instead of pushing it last', async () => {
+        const result = await searchClimbs(kilter1({ size_id: 99, set_ids: [99] }), {
+          page: 0,
+          pageSize: 100,
+          sortBy: 'popular',
+          sortOrder: 'desc',
+        });
+        const uuids = result.climbs.map((c) => c.uuid);
+        const nullIdx = uuids.indexOf(id('pop-null'));
+        const oneIdx = uuids.indexOf(id('pop-one'));
+        expect(nullIdx).toBeGreaterThanOrEqual(0);
+        expect(oneIdx).toBeGreaterThanOrEqual(0);
+        // pop-null has far more ascents, so with NULL counted it sorts first.
+        expect(nullIdx).toBeLessThan(oneIdx);
+      });
+    });
+
+    describe('unified drafts predicate (F7)', () => {
+      it('applies the size filter when onlyDrafts is set without a userId', async () => {
+        // No userId → not a real drafts query → behaves like a normal listed search,
+        // so the size filter must reject a climb that does not fit the requested size.
+        const noFit = await searchClimbs(kilter1({ size_id: 999 }), { page: 0, pageSize: 100, onlyDrafts: true });
+        expect(noFit.climbs.map((c) => c.uuid)).not.toContain(id('draft-pred'));
+
+        const fits = await searchClimbs(kilter1(), { page: 0, pageSize: 100, onlyDrafts: true });
+        expect(fits.climbs.map((c) => c.uuid)).toContain(id('draft-pred'));
+      });
+    });
+
+    describe('driver type fidelity (F9)', () => {
+      it('maps numeric/bigint columns to the expected runtime shapes', async () => {
+        const result = await searchClimbs(kilter1(), { page: 0, pageSize: 100, sortBy: 'ascents', sortOrder: 'desc' });
+        const row = result.climbs.find((c) => c.uuid === id('types'));
+        expect(row).toBeDefined();
+        // ascensionist_count: bigint → coerced to a JS number.
+        expect(row!.ascensionist_count).toBe(42);
+        // quality_average: ROUND(::numeric,2) → preserved as the driver's "4.50" string.
+        expect(row!.quality_average).toBe('4.50');
+        // difficulty_id 20 → grade label; difficulty_error ROUND(20.5-20.0,2) → "0.50".
+        expect(row!.difficulty).toBe('6c/V5');
+        expect(row!.difficulty_error).toBe('0.50');
+        expect(typeof row!.stars).toBe('number');
+      });
+    });
+
+    describe('countClimbs projectsOnly keeps stats-less climbs (F3)', () => {
+      it('counts a climb with no board_climb_stats row under projectsOnly', async () => {
+        const count = await countClimbs(kilter1(), { page: 0, pageSize: 100, projectsOnly: true });
+        // PROJ has no stats row; projectsOnly must still count it (join retained).
+        expect(count).toBeGreaterThanOrEqual(1);
+      });
+    });
+  });
 });

--- a/packages/backend/src/__tests__/climb-search-validation.test.ts
+++ b/packages/backend/src/__tests__/climb-search-validation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { MAX_SEARCH_PAGE } from '@boardsesh/db/queries';
+import { ClimbSearchInputSchema } from '../validation/schemas';
+
+const base = {
+  boardName: 'kilter' as const,
+  layoutId: 1,
+  sizeId: 7,
+  setIds: '1',
+  angle: 40,
+};
+
+describe('ClimbSearchInputSchema page bound', () => {
+  it('accepts pages up to MAX_SEARCH_PAGE', () => {
+    expect(ClimbSearchInputSchema.safeParse({ ...base, page: 0 }).success).toBe(true);
+    expect(ClimbSearchInputSchema.safeParse({ ...base, page: MAX_SEARCH_PAGE }).success).toBe(true);
+  });
+
+  it('rejects pages past MAX_SEARCH_PAGE to block deep-OFFSET abuse', () => {
+    const result = ClimbSearchInputSchema.safeParse({ ...base, page: MAX_SEARCH_PAGE + 1 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.message === 'Page number too large')).toBe(true);
+    }
+  });
+});
+
+describe('ClimbSearchInputSchema holdsFilter cap', () => {
+  it('accepts a realistic number of hold filters', () => {
+    const holdsFilter: Record<string, { ANY: 'include' }> = {};
+    for (let holdId = 1; holdId <= 50; holdId++) holdsFilter[`hold_${holdId}`] = { ANY: 'include' };
+    expect(ClimbSearchInputSchema.safeParse({ ...base, holdsFilter }).success).toBe(true);
+  });
+
+  it('rejects an oversized holdsFilter record', () => {
+    const holdsFilter: Record<string, { ANY: 'include' }> = {};
+    for (let holdId = 1; holdId <= 400; holdId++) holdsFilter[`hold_${holdId}`] = { ANY: 'include' };
+    const result = ClimbSearchInputSchema.safeParse({ ...base, holdsFilter });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.message === 'Too many hold filters')).toBe(true);
+    }
+  });
+});

--- a/packages/backend/src/db/queries/climbs/count-climbs.ts
+++ b/packages/backend/src/db/queries/climbs/count-climbs.ts
@@ -1,5 +1,5 @@
 import { sql, and } from 'drizzle-orm';
-import { db } from '../../client';
+import { dbRead } from '../../client';
 import { boardClimbs, boardClimbStats } from '@boardsesh/db/schema';
 import { createClimbFilters, type BoardRouteParams, type ClimbSearchParams } from '@boardsesh/db/queries';
 import { logger } from '../../../utils/logger';
@@ -22,7 +22,9 @@ export const countClimbs = async (
 ): Promise<number> => {
   const filters = createClimbFilters(params, searchParams, userId);
 
-  const isDraftsQuery = !!searchParams.onlyDrafts;
+  // Same unified drafts predicate searchClimbs uses (onlyDrafts AND a userId), so the
+  // size/stats filters are skipped here only when they're skipped there.
+  const isDraftsQuery = filters.isOnlyDrafts;
 
   const whereConditions = [
     ...filters.getClimbWhereConditions(),
@@ -33,14 +35,25 @@ export const countClimbs = async (
     ...(isDraftsQuery ? [] : filters.getClimbStatsConditions()),
   ];
 
+  // This broad LEFT JOIN count is the same plan shape that exhausted /dev/shm in the
+  // PR #1969 incident — a filtered count goes parallel (Gather) and each worker
+  // allocates a DSM segment. Disable per-gather parallelism inside a transaction
+  // (SET LOCAL needs a transaction; the client runs prepare:false behind PgBouncer
+  // transaction pooling), mirroring searchClimbs' standardSearch guard. Reproduced
+  // live on prod: a bare board_climbs aggregate raised "could not resize shared
+  // memory segment". The unused board_climb_stats join is left in place — Postgres
+  // already eliminates it via the stats PK when no condition references stats columns
+  // (verified by the EXPLAIN harness), so there's nothing to hand-optimize.
   try {
-    const result = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(boardClimbs)
-      .leftJoin(boardClimbStats, and(...filters.getClimbStatsJoinConditions()))
-      .where(and(...whereConditions));
-
-    return Number(result[0]?.count ?? 0);
+    return await dbRead.transaction(async (tx) => {
+      await tx.execute(sql`SET LOCAL max_parallel_workers_per_gather = 0`);
+      const result = await tx
+        .select({ count: sql<number>`count(*)` })
+        .from(boardClimbs)
+        .leftJoin(boardClimbStats, and(...filters.getClimbStatsJoinConditions()))
+        .where(and(...whereConditions));
+      return Number(result[0]?.count ?? 0);
+    });
   } catch (error) {
     logger.error('Error in countClimbs:', error);
     throw error;

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -144,6 +144,10 @@ export const climbQueries = {
     { input }: { input: ClimbSearchInput },
     ctx: ConnectionContext,
   ): Promise<ClimbSearchContext> => {
+    // 120/min/identity. This is the app's hottest query and infinite scroll fires one
+    // request per page, so the limit sits well above any interactive cadence while
+    // capping abuse (deep-OFFSET pages, holdsFilter floods) on an anonymous endpoint.
+    await applyRateLimit(ctx, 120, 'search-climbs');
     validateInput(ClimbSearchInputSchema, input, 'input');
 
     // Validate board name

--- a/packages/backend/src/services/__tests__/search-cache.test.ts
+++ b/packages/backend/src/services/__tests__/search-cache.test.ts
@@ -77,7 +77,7 @@ describe('SearchCacheService', () => {
       const key = service.buildCacheKey(makeRouteParams(), {}, 'results');
 
       expect(key).toBeTruthy();
-      expect(key.startsWith('boardsesh:climb-search:v2:results:')).toBe(true);
+      expect(key.startsWith('boardsesh:climb-search:v3:results:')).toBe(true);
     });
 
     it('matches expected key format', () => {
@@ -88,7 +88,7 @@ describe('SearchCacheService', () => {
       // boardsesh:climb-search:version:suffix:board:layout:size:sets:angle:hash
       expect(segments[0]).toBe('boardsesh');
       expect(segments[1]).toBe('climb-search');
-      expect(segments[2]).toBe('v2');
+      expect(segments[2]).toBe('v3');
       expect(segments[3]).toBe('results');
       expect(segments[4]).toBe('kilter');
       expect(segments[5]).toBe('1');

--- a/packages/backend/src/services/search-cache.ts
+++ b/packages/backend/src/services/search-cache.ts
@@ -6,8 +6,12 @@ import { logger } from '../utils/logger';
 /** Default TTL for cached search results: 24 hours. */
 export const DEFAULT_SEARCH_CACHE_TTL = 86400;
 
-/** Bump when the cached data shape changes to invalidate all stale entries. */
-const CACHE_VERSION = 'v2';
+/**
+ * Bump when a code change alters search result *content* for an existing key.
+ * v3: anchored hold LIKE (`%p<id>r%`), minRating compared on the 1-5 scale,
+ * popular-sort counting NULL frames_count, name ILIKE escaping, zone fail-closed.
+ */
+const CACHE_VERSION = 'v3';
 
 /**
  * Recursively sorts the keys of an object so that JSON.stringify produces

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
+import { MAX_SEARCH_PAGE } from '@boardsesh/db/queries';
 import { ExternalUUIDSchema, BoardNameSchema } from './primitives';
+
+// Cap holdsFilter entries: each ANY entry becomes a LIKE scan over board_climbs.frames
+// (no trigram index there), so an unbounded record is a cheap amplification vector on
+// an anonymous endpoint. 300 is far above any board layout's usable hold count, so it
+// never rejects a real per-hold selection.
+const MAX_HOLD_FILTER_ENTRIES = 300;
 
 /**
  * Climb validation schema (simplified for input)
@@ -106,7 +113,7 @@ export const ClimbSearchInputSchema = z.object({
   sizeId: z.number().int().positive('Size ID must be positive'),
   setIds: z.string().min(1, 'Set IDs cannot be empty'),
   angle: z.number().int(),
-  page: z.number().int().min(0).optional(),
+  page: z.number().int().min(0).max(MAX_SEARCH_PAGE, 'Page number too large').optional(),
   pageSize: z.number().int().min(1).max(100, 'Page size cannot exceed 100').optional(),
   gradeAccuracy: z.string().optional(),
   minGrade: z.number().int().optional(),
@@ -142,6 +149,9 @@ export const ClimbSearchInputSchema = z.object({
         })
         .strict(),
     )
+    .refine((holds) => Object.keys(holds).length <= MAX_HOLD_FILTER_ENTRIES, {
+      message: 'Too many hold filters',
+    })
     .optional(),
   hideAttempted: z.boolean().optional(),
   hideCompleted: z.boolean().optional(),

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -56,6 +56,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "bun scripts/migrate.ts",
     "test": "tsx --test scripts/**/*.test.ts src/**/*.test.ts",
+    "test:explain": "tsx --test src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts",
     "db:studio": "drizzle-kit studio",
     "db:import-moonboard": "tsx scripts/import-moonboard-problems.ts",
     "db:import-aurora-unified": "tsx scripts/import-aurora-board-unified.ts",

--- a/packages/db/src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts
@@ -1,0 +1,219 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { and, sql } from 'drizzle-orm';
+import { searchClimbs } from '../search-climbs';
+import { createClimbFilters } from '../create-climb-filters';
+import { boardClimbs, boardClimbStats } from '../../../schema/index';
+import type { DbInstance } from '../../../client/postgres';
+import type { BoardRouteParams, ClimbSearchParams } from '../types';
+
+/**
+ * EXPLAIN-based plan-shape regression harness for the hottest query in the app.
+ *
+ * Opt-in: only runs when EXPLAIN_DB_URL points at a realistic dev DB (postgres:17
+ * with full Kilter/Tension/MoonBoard data — `vp run db:up`, then read the URL from
+ * .boardsesh/dev-db.env). Without it the suite self-skips so CI and dataless
+ * machines stay green. NEVER point this at the backend test DB (empty postgres:15,
+ * no covering indexes) — empty-table plans are seq scans regardless of indexes.
+ *
+ *   vp run db:up
+ *   cd packages/db && EXPLAIN_DB_URL=postgres://postgres:password@<host>:5432/main bun run test:explain
+ *
+ * It captures the EXACT parameterised SQL the app generates (via a drizzle query
+ * logger — no hand-reconstruction for searchClimbs, so the harness can't drift
+ * from runtime), runs EXPLAIN (FORMAT JSON), and asserts COARSE plan invariants
+ * only (index used, no seq scan, SET LOCAL present). It never compares plan text.
+ *
+ * Set EXPLAIN_ANALYZE=1 for human-read timings (logged, never asserted).
+ */
+const EXPLAIN_DB_URL = process.env.EXPLAIN_DB_URL;
+const RUN_ANALYZE = process.env.EXPLAIN_ANALYZE === '1';
+
+const PARAMS: BoardRouteParams = {
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 10,
+  set_ids: [1, 20],
+  angle: 40,
+};
+
+type PlanNode = { type: string; index?: string; rel?: string };
+
+function collectNodes(plan: Record<string, unknown>, acc: PlanNode[] = []): PlanNode[] {
+  if (!plan || typeof plan !== 'object') return acc;
+  if (typeof plan['Node Type'] === 'string') {
+    acc.push({
+      type: plan['Node Type'] as string,
+      index: plan['Index Name'] as string | undefined,
+      rel: plan['Relation Name'] as string | undefined,
+    });
+  }
+  for (const child of (plan['Plans'] as Record<string, unknown>[] | undefined) ?? []) collectNodes(child, acc);
+  return acc;
+}
+
+type Captured = { query: string; params: unknown[] };
+
+if (!EXPLAIN_DB_URL) {
+  void describe('search-climbs EXPLAIN harness', () => {
+    void it('skipped — set EXPLAIN_DB_URL to a full-data dev DB to run', { skip: true }, () => {});
+  });
+} else {
+  const client = postgres(EXPLAIN_DB_URL, { prepare: false, max: 2, idle_timeout: 5 });
+  const captured: Captured[] = [];
+  const db = drizzle(client, {
+    logger: { logQuery: (query, params) => captured.push({ query, params }) },
+  }) as unknown as DbInstance;
+
+  const tableSelects = (statements: Captured[]) =>
+    statements.filter((c) => /select/i.test(c.query) && /board_climb/i.test(c.query) && !/^\s*explain/i.test(c.query));
+
+  async function explainNodes(query: string, params: unknown[], standard: boolean): Promise<PlanNode[]> {
+    let rows: postgres.RowList<Record<string, unknown>[]>;
+    if (standard) {
+      // Mirror the runtime planner settings of standardSearch's transaction.
+      rows = await client.begin(async (tx) => {
+        await tx.unsafe('SET LOCAL max_parallel_workers_per_gather = 0');
+        return tx.unsafe(`EXPLAIN (FORMAT JSON) ${query}`, params as never[]);
+      });
+    } else {
+      rows = await client.unsafe(`EXPLAIN (FORMAT JSON) ${query}`, params as never[]);
+    }
+    const planWrapper = rows[0]['QUERY PLAN'] as Array<{ Plan: Record<string, unknown> }>;
+    return collectNodes(planWrapper[0].Plan);
+  }
+
+  async function runSearch(searchParams: ClimbSearchParams): Promise<Captured[]> {
+    captured.length = 0;
+    await searchClimbs(db, PARAMS, searchParams);
+    return [...captured];
+  }
+
+  // Reconstruct countClimbs' query shape (it lives in packages/backend and can't be
+  // imported here). Keep in sync with packages/backend/.../count-climbs.ts.
+  function buildCountSql(searchParams: ClimbSearchParams): { text: string; params: unknown[] } {
+    const filters = createClimbFilters(PARAMS, searchParams, undefined);
+    const isDraftsQuery = !!searchParams.onlyDrafts;
+    const whereConditions = [
+      ...filters.getClimbWhereConditions(),
+      ...(isDraftsQuery ? [] : filters.getSizeConditions()),
+      ...(isDraftsQuery ? [] : filters.getClimbStatsConditions()),
+    ];
+    const built = db
+      .select({ count: sql<number>`count(*)` })
+      .from(boardClimbs)
+      .leftJoin(boardClimbStats, and(...filters.getClimbStatsJoinConditions()))
+      .where(and(...whereConditions))
+      .toSQL();
+    return { text: built.sql, params: built.params };
+  }
+
+  const indexNames = (nodes: PlanNode[]) => nodes.filter((n) => n.index).map((n) => n.index as string);
+  const hasSeqScanOnBoardTable = (nodes: PlanNode[]) =>
+    nodes.some((n) => n.type === 'Seq Scan' && /board_climb/.test(n.rel ?? ''));
+
+  async function logTiming(label: string, capture: Captured): Promise<void> {
+    try {
+      const rows = await client.unsafe(
+        `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${capture.query}`,
+        capture.params as never[],
+      );
+      const plan = (rows[0]['QUERY PLAN'] as Array<Record<string, unknown>>)[0];
+      // eslint-disable-next-line no-console
+      console.log(`[explain] ${label}: ${JSON.stringify(plan['Execution Time'])} ms`);
+    } catch {
+      /* timing is best-effort */
+    }
+  }
+
+  void describe('search-climbs EXPLAIN harness (dev DB)', () => {
+    // Fresh stats so the planner's choices are trustworthy. The dev-db image ships
+    // without a post-import ANALYZE; a cold pull otherwise plans on stale stats.
+    void it('prepares stats (ANALYZE)', async () => {
+      await client.unsafe('ANALYZE board_climb_stats');
+      await client.unsafe('ANALYZE board_climbs');
+      await client.unsafe('ANALYZE board_climb_holds');
+    });
+
+    void it('hot path (ascents DESC, page 0) scans the ascents covering index, no seq scan', async () => {
+      const selects = tableSelects(await runSearch({ page: 0, pageSize: 20, sortBy: 'ascents', sortOrder: 'desc' }));
+      assert.ok(selects.length >= 1, 'expected a stats-driven SELECT');
+      const nodes = await explainNodes(selects[0].query, selects[0].params, false);
+      assert.ok(
+        indexNames(nodes).some((n) => /ascents_covering/.test(n)),
+        `hot path should use an ascents covering index; saw: ${indexNames(nodes).join(', ')}`,
+      );
+      assert.equal(hasSeqScanOnBoardTable(nodes), false, 'hot path must not seq-scan a board table');
+      if (RUN_ANALYZE) await logTiming('hot path', selects[0]);
+    });
+
+    void it('quality DESC page 0 scans the quality covering index, no seq scan', async () => {
+      const selects = tableSelects(await runSearch({ page: 0, pageSize: 20, sortBy: 'quality', sortOrder: 'desc' }));
+      assert.ok(selects.length >= 1);
+      const nodes = await explainNodes(selects[0].query, selects[0].params, false);
+      assert.ok(
+        indexNames(nodes).some((n) => /quality_covering/.test(n)),
+        `quality path should use a quality covering index; saw: ${indexNames(nodes).join(', ')}`,
+      );
+      assert.equal(hasSeqScanOnBoardTable(nodes), false);
+    });
+
+    void it('stats-driven deep page (page 3) still uses the ascents covering index', async () => {
+      const selects = tableSelects(await runSearch({ page: 3, pageSize: 20, sortBy: 'ascents', sortOrder: 'desc' }));
+      assert.ok(selects.length >= 1);
+      const nodes = await explainNodes(selects[0].query, selects[0].params, false);
+      assert.ok(indexNames(nodes).some((n) => /ascents_covering/.test(n)));
+    });
+
+    void it('standard path (name sort) runs SET LOCAL before the SELECT and avoids a parallel Gather', async () => {
+      const statements = await runSearch({ page: 0, pageSize: 20, sortBy: 'name', sortOrder: 'asc' });
+      const setLocalIdx = statements.findIndex((s) =>
+        /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i.test(s.query),
+      );
+      const selectIdx = statements.findIndex((s) => /select/i.test(s.query) && /board_climb/i.test(s.query));
+      assert.ok(setLocalIdx >= 0, 'standard path must issue SET LOCAL max_parallel_workers_per_gather = 0');
+      assert.ok(setLocalIdx < selectIdx, 'SET LOCAL must run before the SELECT');
+      const selects = tableSelects(statements);
+      const nodes = await explainNodes(selects[0].query, selects[0].params, true);
+      assert.equal(
+        nodes.some((n) => /Gather/.test(n.type)),
+        false,
+        'standard path must not produce a parallel Gather under the SET LOCAL guard',
+      );
+    });
+
+    void it('count without stats filters drops the board_climb_stats LEFT JOIN (PG join elimination)', async () => {
+      const { text, params } = buildCountSql({ page: 0, pageSize: 20 });
+      const nodes = await explainNodes(text, params, false);
+      assert.equal(
+        nodes.some((n) => /board_climb_stats/.test(n.rel ?? '')),
+        false,
+        'PG should eliminate the unused stats join when no condition references stats columns',
+      );
+    });
+
+    void it('count with a stats filter keeps the board_climb_stats join', async () => {
+      const { text, params } = buildCountSql({ page: 0, pageSize: 20, minAscents: 50 });
+      const nodes = await explainNodes(text, params, false);
+      assert.ok(
+        nodes.some((n) => /board_climb_stats/.test(n.rel ?? '')),
+        'a minAscents count must still join board_climb_stats',
+      );
+    });
+
+    void it('count with projectsOnly keeps the board_climb_stats join (stats column referenced in WHERE)', async () => {
+      const { text, params } = buildCountSql({ page: 0, pageSize: 20, projectsOnly: true });
+      const nodes = await explainNodes(text, params, false);
+      assert.ok(
+        nodes.some((n) => /board_climb_stats/.test(n.rel ?? '')),
+        'projectsOnly references stats.ascensionist_count via COALESCE — join must be retained',
+      );
+    });
+
+    void it('closes the pool', async () => {
+      await client.end();
+    });
+  });
+}

--- a/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chooseSearchPath, getStatsDrivenSort } from '../search-climbs';
+import { chooseSearchPath, getStatsDrivenSort, clampSearchPage, MAX_SEARCH_PAGE } from '../search-climbs';
 
 const baseInput = {
   statsDrivenSort: 'ascents' as const,
@@ -18,6 +18,30 @@ void describe('getStatsDrivenSort', () => {
     assert.equal(getStatsDrivenSort('ascents', 'asc'), null);
     assert.equal(getStatsDrivenSort('quality', 'asc'), null);
     assert.equal(getStatsDrivenSort('creation', 'desc'), null);
+  });
+});
+
+void describe('clampSearchPage', () => {
+  void it('defaults undefined and non-finite input to 0', () => {
+    assert.equal(clampSearchPage(undefined), 0);
+    assert.equal(clampSearchPage(NaN), 0);
+    assert.equal(clampSearchPage(Infinity), 0);
+  });
+
+  void it('floors negative pages to 0', () => {
+    assert.equal(clampSearchPage(-1), 0);
+    assert.equal(clampSearchPage(-9999), 0);
+  });
+
+  void it('passes through valid pages and truncates fractions', () => {
+    assert.equal(clampSearchPage(0), 0);
+    assert.equal(clampSearchPage(7), 7);
+    assert.equal(clampSearchPage(3.9), 3);
+  });
+
+  void it('caps pages above MAX_SEARCH_PAGE to prevent deep-OFFSET abuse', () => {
+    assert.equal(clampSearchPage(MAX_SEARCH_PAGE + 1), MAX_SEARCH_PAGE);
+    assert.equal(clampSearchPage(10_000_000), MAX_SEARCH_PAGE);
   });
 });
 

--- a/packages/db/src/queries/climbs/create-climb-filters.ts
+++ b/packages/db/src/queries/climbs/create-climb-filters.ts
@@ -68,6 +68,14 @@ function buildKilterHomewallWideHoldIdsBySet(): ReadonlyMap<number, readonly num
   return wideHoldIdsBySet;
 }
 
+// Escape LIKE/ILIKE metacharacters so user-supplied search text is matched
+// literally. Postgres' default escape character is backslash, so `\%`, `\_`,
+// and `\\` match the literal character. The value is bound as a parameter (not
+// a SQL literal), so this is the only escaping layer needed.
+function escapeLikePattern(input: string): string {
+  return input.replace(/[\\%_]/g, (char) => `\\${char}`);
+}
+
 // Board constants are generated static data in the deployed bundle, so this
 // production cache is intentionally never invalidated.
 let kilterHomewallWideHoldIdsBySet: ReadonlyMap<number, readonly number[]> | null = null;
@@ -207,8 +215,12 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
   }
 
   if (searchParams.minRating) {
-    // qualityAverage is stored from 0-1; minRating arrives as whole stars from 1-5.
-    climbStatsConditions.push(sql`${boardClimbStats.qualityAverage} >= ${searchParams.minRating / 5}`);
+    // qualityAverage is canonical 1-5 (migrations 0115/0116 backfilled Aurora's 1-3
+    // scale to 1-5; MoonBoard is native 0-5), and minRating arrives as whole stars
+    // 1-5, so compare directly. The old `/5` divisor assumed a 0-1 scale and made the
+    // filter a near no-op — minRating=4 became threshold 0.8, which kept ~every rated
+    // climb (verified on prod: 348014/348014 kilter rows passed).
+    climbStatsConditions.push(sql`${boardClimbStats.qualityAverage} >= ${searchParams.minRating}`);
   }
 
   if (searchParams.gradeAccuracy) {
@@ -223,8 +235,11 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
     climbStatsConditions.push(sql`${boardClimbStats.benchmarkDifficulty} > 0`);
   }
 
-  // Name search condition
-  const nameCondition: SQL[] = searchParams.name ? [sql`${boardClimbs.name} ILIKE ${`%${searchParams.name}%`}`] : [];
+  // Name search condition. Escape LIKE metacharacters so a search for "50%" or
+  // "a_b" matches literally instead of treating %/_ as wildcards.
+  const nameCondition: SQL[] = searchParams.name
+    ? [sql`${boardClimbs.name} ILIKE ${`%${escapeLikePattern(searchParams.name)}%`}`]
+    : [];
 
   // Setter name filter condition
   const setterNameCondition: SQL[] =
@@ -233,9 +248,18 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
       : [];
 
   // Hold filter conditions
+  // Match the exact `p<holdId>r` token, not a bare `<holdId>r` substring. Frames
+  // are concatenated `p<placementId>r<roleCode>` tokens (see board-constants
+  // hold-states), so `%30r%` also matches `p130r…`/`p230r…` — wrongly including
+  // (and via notLike wrongly excluding) climbs that don't use the hold. Anchoring
+  // on the leading `p` fixes it on every board, since every token starts with `p`.
+  // Measured on prod: `hold_1` via the old pattern falsely matched ~230k kilter climbs.
+  // (A future migration may switch this to a board_climb_holds EXISTS probe, but that
+  // table is not yet complete — ~8.9k kilter climbs lack holds rows — so the anchored
+  // LIKE is the correct fix today.)
   const holdConditions: SQL[] = [
-    ...anyHolds.map((holdId) => like(boardClimbs.frames, `%${holdId}r%`)),
-    ...notHolds.map((holdId) => notLike(boardClimbs.frames, `%${holdId}r%`)),
+    ...anyHolds.map((holdId) => like(boardClimbs.frames, `%p${holdId}r%`)),
+    ...notHolds.map((holdId) => notLike(boardClimbs.frames, `%p${holdId}r%`)),
   ];
 
   // State-specific hold conditions — use board_climb_holds. Multiple types
@@ -284,11 +308,16 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
   // extend outside the zone while still using an expansion hold inside it.
   // Direct db-layer callers bypass GraphQL validation, so re-check the box.
   const zoneBox = searchParams.zoneBox;
+  const hasZoneBox = !!zoneBox;
   const validZoneBox =
     zoneBox && zoneBox.edgeRight > zoneBox.edgeLeft && zoneBox.edgeTop > zoneBox.edgeBottom ? zoneBox : null;
   const zoneMode = searchParams.zoneMode === 'anyHold' ? 'anyHold' : 'allHolds';
   const zoneConditions: SQL[] = [];
-  if (validZoneBox) {
+  if (hasZoneBox && !validZoneBox) {
+    // A zone was requested but the box is degenerate (crafted/stale params). Fail
+    // closed like the tall/wide filters below rather than returning every climb.
+    zoneConditions.push(sql`false`);
+  } else if (validZoneBox) {
     if (zoneMode === 'anyHold') {
       const zonePlacementSetCondition =
         params.board_name === 'moonboard' || params.set_ids.length === 0
@@ -530,6 +559,13 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
   };
 
   return {
+    // True only when this is genuinely a user's drafts query (onlyDrafts AND a
+    // userId to own them). Callers MUST derive their isDraftsQuery flag from this,
+    // not from `!!searchParams.onlyDrafts`: onlyDrafts without a userId is not a
+    // drafts query, and the two predicates disagreeing made searchClimbs skip the
+    // size/stats filters and force creation sort while the filters still required
+    // listed non-drafts. See searchClimbs / countClimbs.
+    isOnlyDrafts: Boolean(isOnlyDrafts),
     getClimbWhereConditions: () => [
       ...baseConditions,
       ...nameCondition,

--- a/packages/db/src/queries/climbs/index.ts
+++ b/packages/db/src/queries/climbs/index.ts
@@ -1,4 +1,4 @@
-export { searchClimbs } from './search-climbs';
+export { searchClimbs, MAX_SEARCH_PAGE, clampSearchPage } from './search-climbs';
 export { createClimbFilters } from './create-climb-filters';
 export { getClimbStars } from './climb-stars';
 export { getGradeLabel } from './grade-lookup';

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -6,6 +6,12 @@ import { getClimbStars } from './climb-stars';
 import { getGradeLabel } from './grade-lookup';
 import type { BoardRouteParams, ClimbSearchParams, ClimbRow, ClimbSearchResult } from './types';
 
+// Runtime shape of a search row. postgres.js returns numeric/bigint columns as
+// JS strings (no `types` parser is configured), so the ROUND(...::numeric) and
+// bigint expressions arrive as strings even though SQL treats them as numbers.
+// These annotations are deliberately `number | string` so downstream code can't
+// assume a JS number and silently string-concatenate. doublePrecision columns
+// (benchmark_difficulty) do come back as real JS numbers.
 type RawSelectResult = {
   uuid: string;
   setter_username: string | null;
@@ -15,9 +21,9 @@ type RawSelectResult = {
   is_draft: boolean | null;
   angle: number | null;
   ascensionist_count: string | null;
-  difficulty_id: number | null;
-  quality_average: number | null;
-  difficulty_error: number | null;
+  difficulty_id: number | string | null;
+  quality_average: number | string | null;
+  difficulty_error: number | string | null;
   benchmark_difficulty: number | null;
   description: string | null;
   created_at: string | null;
@@ -25,6 +31,14 @@ type RawSelectResult = {
   frames_count: number | null;
   frames_pace: number | null;
 };
+
+// difficulty_id arrives as a string like "15" from the driver; coerce to an integer
+// for the GRADE_MAP lookup instead of relying on JS object-key coercion.
+function toIntegerOrNull(value: number | string | null): number | null {
+  if (value === null || value === undefined) return null;
+  const numeric = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(numeric) ? Math.round(numeric) : null;
+}
 
 function mapResultToClimbRow(result: RawSelectResult, params: BoardRouteParams): ClimbRow {
   return {
@@ -35,7 +49,7 @@ function mapResultToClimbRow(result: RawSelectResult, params: BoardRouteParams):
     frames: result.frames || '',
     angle: params.angle,
     ascensionist_count: Number(result.ascensionist_count || 0),
-    difficulty: getGradeLabel(result.difficulty_id),
+    difficulty: getGradeLabel(toIntegerOrNull(result.difficulty_id)),
     quality_average: result.quality_average?.toString() || '0',
     stars: getClimbStars(params.board_name, result.quality_average),
     difficulty_error: result.difficulty_error?.toString() || '0',
@@ -55,6 +69,20 @@ type SearchDb = DbInstance | TransactionDb;
 type SearchDbTransaction = DbInstance['transaction'];
 type SearchDbExecute = (query: unknown) => Promise<unknown>;
 export type StatsDrivenSort = 'ascents' | 'quality';
+
+/**
+ * Upper bound on the page index. 500 pages × the 100-row pageSize cap is a 50k-row
+ * worst-case OFFSET on the index-ordered path — bounded and cheap; legitimate UI
+ * paging never approaches it. The API layer rejects pages past this; the shared
+ * query clamps as a backstop for SSR/direct callers that bypass that validation,
+ * so a crafted `page=10_000_000` can't force an OFFSET-200M serial scan per request.
+ */
+export const MAX_SEARCH_PAGE = 500;
+
+export function clampSearchPage(page: number | undefined): number {
+  if (!Number.isFinite(page)) return 0;
+  return Math.min(Math.max(Math.trunc(page as number), 0), MAX_SEARCH_PAGE);
+}
 
 export function getStatsDrivenSort(sortBy: string, sortOrder: 'asc' | 'desc'): StatsDrivenSort | null {
   if (sortOrder !== 'desc') return null;
@@ -89,16 +117,20 @@ export const searchClimbs = async (
   searchParams: ClimbSearchParams,
   userId?: string,
 ): Promise<ClimbSearchResult> => {
-  const page = searchParams.page ?? 0;
+  const page = clampSearchPage(searchParams.page);
   const pageSize = searchParams.pageSize ?? 20;
 
   const filters = createClimbFilters(params, searchParams, userId);
+  // Derive from the filter builder's unified predicate (onlyDrafts AND a userId),
+  // not `!!searchParams.onlyDrafts` — otherwise onlyDrafts-without-userId makes this
+  // skip the size/stats filters and force creation sort while the filters still
+  // require listed non-drafts. See filters.isOnlyDrafts.
+  const isDraftsQuery = filters.isOnlyDrafts;
 
   // Drafts never have stats, so force creation sort (stats-based sorts would be meaningless)
-  const sortBy = searchParams.onlyDrafts ? 'creation' : searchParams.sortBy || 'ascents';
+  const sortBy = isDraftsQuery ? 'creation' : searchParams.sortBy || 'ascents';
   const sortOrder = searchParams.sortOrder === 'asc' ? 'asc' : 'desc';
   const statsDrivenSort = getStatsDrivenSort(sortBy, sortOrder);
-  const isDraftsQuery = !!searchParams.onlyDrafts;
 
   const hasStatsFilters = filters.getClimbStatsConditions().length > 0;
   if (!statsDrivenSort) {
@@ -231,10 +263,11 @@ async function statsDrivenSearch(
     is_draft: boardClimbs.isDraft,
     angle: boardClimbStats.angle,
     ascensionist_count: boardClimbStats.ascensionistCount,
-    difficulty_id: sql<number | null>`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
-    quality_average: sql<number | null>`ROUND(${boardClimbStats.qualityAverage}::numeric, 2)`,
+    // ROUND(::numeric) returns text over the wire (see RawSelectResult).
+    difficulty_id: sql<number | string | null>`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
+    quality_average: sql<number | string | null>`ROUND(${boardClimbStats.qualityAverage}::numeric, 2)`,
     difficulty_error: sql<
-      number | null
+      number | string | null
     >`ROUND(${boardClimbStats.difficultyAverage}::numeric - ${boardClimbStats.displayDifficulty}::numeric, 2)`,
     benchmark_difficulty: boardClimbStats.benchmarkDifficulty,
     description: boardClimbs.description,
@@ -351,7 +384,7 @@ async function runStandardSearch(
             AND ${boardClimbs.layoutId} = ${params.layout_id}
             AND ${boardClimbs.isListed} = true
             AND ${boardClimbs.isDraft} = false
-            AND ${boardClimbs.framesCount} = 1
+            AND (${boardClimbs.framesCount} = 1 OR ${boardClimbs.framesCount} IS NULL)
           )`,
             ),
           )
@@ -389,10 +422,11 @@ async function runStandardSearch(
     is_draft: boardClimbs.isDraft,
     angle: boardClimbStats.angle,
     ascensionist_count: boardClimbStats.ascensionistCount,
-    difficulty_id: sql<number | null>`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
-    quality_average: sql<number | null>`ROUND(${boardClimbStats.qualityAverage}::numeric, 2)`,
+    // ROUND(::numeric) returns text over the wire (see RawSelectResult).
+    difficulty_id: sql<number | string | null>`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
+    quality_average: sql<number | string | null>`ROUND(${boardClimbStats.qualityAverage}::numeric, 2)`,
     difficulty_error: sql<
-      number | null
+      number | string | null
     >`ROUND(${boardClimbStats.difficultyAverage}::numeric - ${boardClimbStats.displayDifficulty}::numeric, 2)`,
     benchmark_difficulty: boardClimbStats.benchmarkDifficulty,
     description: boardClimbs.description,

--- a/packages/web/app/lib/db/queries/climbs/search-climbs.ts
+++ b/packages/web/app/lib/db/queries/climbs/search-climbs.ts
@@ -76,7 +76,10 @@ function _getCachedFn(boardName: BoardName, revalidate: number): CachedClimbSear
   const key = `${boardName}:${revalidate}`;
   let fn = _cacheRegistry.get(key);
   if (!fn) {
-    fn = unstable_cache(_executeClimbSearch, [`climb-search-v3:${boardName}`], {
+    // v4: search result content changed (anchored hold LIKE, minRating 1-5 scale,
+    // popular-sort NULL frames_count, name ILIKE escaping, zone fail-closed). Keep in
+    // lockstep with the backend Redis CACHE_VERSION bump.
+    fn = unstable_cache(_executeClimbSearch, [`climb-search-v4:${boardName}`], {
       revalidate,
       tags: ['climb-search', getBoardClimbSearchTag(boardName)],
     });


### PR DESCRIPTION
Reviewed `packages/db/src/queries/climbs/search-climbs.ts` — the app's most-used query (every board list page; web SSR + GraphQL + mobile) — end to end, plus its filter builder, the count query, every caller, and git history. Premises were verified with `EXPLAIN` against the full-data dev DB and the prod read-replica.

## Correctness fixes
- **Hold filter false-positives (every board).** The ANY/NOT hold filter used `LIKE '%<id>r%'` on `board_climbs.frames`, which matches longer placement ids. Frames are concatenated `p<placementId>r<roleCode>` tokens, so `%30r%` also matches `p130r…`. Measured on prod: `hold_1` via the old pattern falsely matched **~230k kilter climbs**; exclude-filters wrongly dropped climbs too. Now anchored on the leading `p` (`%p<id>r%`).
- **minRating was a near no-op.** `quality_average` is the canonical **1–5** scale (migrations 0115/0116), but the filter compared `>= minRating/5`, assuming a dead 0–1 scale. Prod: minRating=4 → threshold 0.8 kept **348014/348014** rated kilter climbs. Now compares `>= minRating` directly.
- **Popular sort dropped legacy boulders.** The popular-sort aggregate hardcoded `frames_count = 1`, excluding NULL-`frames_count` climbs that the boulders filter treats as boulders. Now counts NULL too.
- **Drafts predicate skew.** `searchClimbs`/`countClimbs` derived `isDraftsQuery` from `!!onlyDrafts` while the filter builder used `onlyDrafts AND userId` — so `onlyDrafts` without a userId skipped the size/stats filters and forced creation sort while still requiring listed non-drafts. Both now derive from one unified `filters.isOnlyDrafts`.
- **Name ILIKE** now escapes `%`/`_`/`\`; an invalid **zoneBox fails closed** (matches the tall/wide filters) instead of returning every climb.

## Incident hardening (PR #1969 class)
- **`countClimbs` had no parallel guard.** It runs the same broad LEFT JOIN count whose parallel plan exhausted `/dev/shm` in PR #1969 — **reproduced live on the prod replica** (`could not resize shared memory segment`). It now disables per-gather parallelism inside a transaction (`SET LOCAL`), mirroring `searchClimbs`, and runs on `dbRead`. The unused stats join is left in place: Postgres already eliminates it via the stats PK when no condition references stats columns (verified by the new EXPLAIN harness).
- **DoS surface.** `page` had no upper bound (deep `OFFSET` per request) and `holdsFilter` no entry cap. Added `MAX_SEARCH_PAGE=500` (clamped in the shared query + a zod max), a 300-entry holdsFilter cap, and a 120/min rate limit on the `searchClimbs` resolver.

## Robustness
- `RawSelectResult` is now honest: postgres.js returns numeric/bigint as **strings**, so the `ROUND()` columns are typed `number | string` with explicit integer coercion for the grade lookup. No output change — a real-driver integration test pins the exact strings (e.g. `quality_average === '4.50'`).

## Tests & infra
- New **opt-in EXPLAIN plan-shape harness** (`packages/db`, `EXPLAIN_DB_URL`-gated, self-skips in CI) asserting the covering-index scans, the `SET LOCAL` guard, and PG's count join-elimination.
- Backend integration tests for each fix; `clampSearchPage` unit tests; zod page/holdsFilter bound tests.
- Bumped the Redis `CACHE_VERSION` (v3) and the web `unstable_cache` key (v4) since result content changes.

## Validation
`vp run typecheck:{db,backend,web}` clean; full backend suite (1324) + db unit tests green; harness 9/9 against the dev DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)