### PR TITLE
test(search): fix stale create-climb-filters unit tests (minRating + zone)

### DIFF
--- a/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
@@ -119,22 +119,19 @@ void describe('createClimbFilters: size filter', () => {
 });
 
 void describe('createClimbFilters: minRating', () => {
-  const ratingScaleCases: Array<{ minRating: number; expectedThreshold: string }> = [
-    { minRating: 1, expectedThreshold: '0.2' },
-    { minRating: 4, expectedThreshold: '0.8' },
-    { minRating: 5, expectedThreshold: '1' },
-  ];
-
-  for (const { minRating, expectedThreshold } of ratingScaleCases) {
-    void it(`scales minRating ${minRating} to stored threshold ${expectedThreshold}`, () => {
+  // quality_average is the canonical 1-5 scale, so minRating (1-5 whole stars) is
+  // compared directly. The old code divided by 5 (assuming a dead 0-1 scale), which
+  // made the filter a near no-op — these cases guard against that regression.
+  for (const minRating of [1, 4, 5]) {
+    void it(`compares minRating ${minRating} directly against quality_average (1-5 scale)`, () => {
       const filters = createClimbFilters(params, { minRating });
       assert.equal(filters.climbStatsConditions.length, 1);
 
       const rendered = sqlToString(filters.climbStatsConditions[0]);
       assert.match(rendered, /quality_average/);
-      assert.match(rendered, />=/);
-      assert.match(rendered, new RegExp(`>=\\s*${expectedThreshold}`));
-      assert.doesNotMatch(rendered, new RegExp(`>=\\s*${minRating}(?:\\D|$)`));
+      assert.match(rendered, new RegExp(`>=\\s*${minRating}(?:\\D|$)`));
+      // Must NOT divide by 5 anymore (old 0-1-scale threshold).
+      assert.doesNotMatch(rendered, new RegExp(`>=\\s*${minRating / 5}(?:\\D|$)`));
     });
   }
 
@@ -201,12 +198,20 @@ void describe('createClimbFilters: zone modes', () => {
     assert.doesNotMatch(rendered, /zone_bp\.set_id IN/);
   });
 
-  void it('ignores zoneMode when the zone box is empty or inverted', () => {
+  void it('fails closed when a requested zone box is inverted or empty', () => {
     const filters = createClimbFilters(params, {
       zoneBox: { edgeLeft: 80, edgeRight: 10, edgeBottom: 20, edgeTop: 120 },
       zoneMode: 'anyHold',
     });
 
+    // A requested-but-degenerate box must not return every climb — it fails closed
+    // (single `false` predicate), matching the tall/wide filters.
+    assert.equal(filters.zoneConditions.length, 1);
+    assert.match(sqlToString(filters.zoneConditions[0]), /false/i);
+  });
+
+  void it('adds no zone predicate when no zone box is requested', () => {
+    const filters = createClimbFilters(params, { zoneMode: 'anyHold' });
     assert.equal(filters.zoneConditions.length, 0);
   });
 });


### PR DESCRIPTION
Follow-up to #2735. That PR changed two behaviours in `create-climb-filters.ts` but left the `@boardsesh/db` unit suite asserting the old contract, so `tsx --test` is red (4 failures).

**Why CI was green anyway:** the `@boardsesh/db` package isn't in the root `vite.config.ts` test projects, so its node:test suite never runs in CI. The failures only surface when you run the db package's `tsx --test` suite locally. Wiring the db suite into CI is worth a separate follow-up — it would have caught this.

## Fixes
- **minRating** now compares `quality_average >= minRating` directly (canonical 1–5 scale) instead of `>= minRating/5`. Tests assert the direct comparison and guard against the `/5` regression.
- **zone**: an inverted/degenerate *requested* `zoneBox` now fails closed (single `false` predicate) instead of silently returning every climb. Added a positive control that an absent `zoneBox` still adds no predicate.

Full `@boardsesh/db` suite: **107 pass, 1 harness self-skip, 0 fail**.

Found by an adversarial multi-agent review of the #2735 diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
