### PR TITLE
fix(mobile): create the iOS beta share extension (target-name collision)

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -302,6 +302,16 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       // provisioning profiles for both com.boardsesh.app.share-extension and
       // com.boardsesh.app.widgets on the next native build (NOT deliverable via
       // OTA). androidIntentFilters only accepts text/* | image/* | video/* | */*.
+      //
+      // iosShareExtensionName MUST NOT sanitize to the main app target name
+      // 'Boardsesh' (Expo names the main target after `name`, project is
+      // Boardsesh.xcodeproj). expo-share-intent derives the extension's Xcode
+      // target name from this value via .replace(/[^a-zA-Z0-9]/g,''), then bails
+      // ("already exists … Skipping") if a target with that name exists — so
+      // 'Boardsesh' collided with the main app and the extension was silently
+      // never created (the share option never appeared in any iOS build). The
+      // raw value is also the extension's CFBundleDisplayName, i.e. the label in
+      // the share sheet's top app-icon row, so keep it short to avoid truncation.
       [
         'expo-share-intent',
         {
@@ -309,7 +319,7 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
             NSExtensionActivationSupportsWebURLWithMaxCount: 1,
             NSExtensionActivationSupportsText: true,
           },
-          iosShareExtensionName: 'Boardsesh',
+          iosShareExtensionName: 'Boardsesh Beta',
           iosAppGroupIdentifier: 'group.com.boardsesh.app',
           androidIntentFilters: ['text/*'],
         },


### PR DESCRIPTION
## What & why

The "share a beta reel from Instagram/TikTok into Boardsesh" share-sheet entry **never appeared** on any iOS build — TestFlight, preview, or local dev. PR #2572 wired up the feature correctly at the JS layer, but the OS share-sheet entry is **purely native**: it only exists if the iOS Share Extension *target* is generated, embedded, and signed at build time. It wasn't.

## Root cause — silent Xcode target-name collision

`app.config.ts` set `iosShareExtensionName: 'Boardsesh'`.

- `expo-share-intent` derives the Share Extension's **Xcode target name** from that value: `'Boardsesh'.replace(/[^a-zA-Z0-9]/g,'')` → `'Boardsesh'`.
- Expo names the **main app target** `Boardsesh` (`Boardsesh.xcodeproj`; see `scripts/prepare-rn-ios-tests.mjs` `APP_TARGET_NAME = 'Boardsesh'`).
- The plugin's idempotency guard does `pbxProject.pbxTargetByName('Boardsesh')`, finds the **main app target**, logs `already exists … Skipping`, and **never creates the share extension target**.

So every iOS prebuild produced a binary with no share extension → the option can't appear in any build. (OTA can't add a native target either, so layering the new JS over an old binary also showed nothing — secondary, but the collision is primary.) Existing tests cover the JS provider + the app-group dedup plugin only; nothing runs a real prebuild to assert the target exists, so it slipped through.

## Fix (one line)

`iosShareExtensionName: 'Boardsesh'` → `'Boardsesh Beta'`:
- sanitized target name `BoardseshBeta` ≠ `Boardsesh` → no collision → the extension target is created and embedded;
- the raw value is also the extension's `CFBundleDisplayName` (the share-sheet label), kept short so it doesn't truncate in the top app-icon row.

Kept a Share Extension (the right pattern for sharing a URL into an app) rather than building an Action Extension. Instagram/TikTok-only filtering stays in JS (`isBetaVideoUrl` in `ShareTargetProvider`) — host-matching in the `NSExtensionActivationRule` predicate is fragile and would risk reintroducing the "never appears" bug. Activation rules, the app-group dedup plugin, Android intent filters, and all JS are unchanged.

## Verification

Clean `expo prebuild --clean -p ios` (with the fix):
- log: `[expo-share-intent] Successfully created BoardseshBeta target with files` — the `Boardsesh already exists … Skipping` message is **gone**;
- project now has 3 native targets (`Boardsesh`, `BoardseshBeta`, `BoardseshWidgets`);
- `BoardseshBeta.appex` is embedded into the main app (`Copy Files`, `dstSubfolderSpec = 13` = PlugIns), bundle id `com.boardsesh.app.share-extension`;
- `ShareExtension-Info.plist`: `NSExtensionPointIdentifier = com.apple.share-services` + `NSExtensionActivationSupportsWebURLWithMaxCount`/`...SupportsText`, `CFBundleDisplayName = Boardsesh Beta`.

Also: `vp run typecheck:mobile` ✓ · `vp run test:mobile` (1753 passed) ✓ · `vp run check:mobile-bundle` (Android OK) ✓.

## ⚠️ Required to actually ship (the config change is inert without these)

- **Fresh native build — not OTA.** A native target cannot be delivered via EAS Update. Cut a new preview/production build and install the binary.
- **EAS credentials for two extensions.** We now have two app extensions (`BoardseshWidgets` + the share extension). Ensure provisioning profiles exist for **both** `com.boardsesh.app.widgets` and `com.boardsesh.app.share-extension` (run `eas credentials` / let `eas build` auto-provision; confirm the `com.boardsesh.app.share-extension` App ID is created).
- **Local dev:** `scripts/mobile-ios-run.ts` only prebuilds when `packages/mobile/ios` is missing. On an existing checkout, run `cd packages/mobile && npx expo prebuild --clean -p ios` (or delete `packages/mobile/ios`) before `vp run mobile:ios` so the rename takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)