### PR TITLE
[codex] fix android record tab first render

### DIFF
--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -157,7 +157,7 @@ describe('TabLayout', () => {
     expect(container.querySelector('[data-bottom-accessory="true"]')).toBeNull();
   });
 
-  it('keeps the Record tab lazy outside Android dev builds', () => {
+  it('keeps the Record tab lazy outside Android builds', () => {
     cfg.variant = 'material';
 
     render(<TabLayout />);
@@ -165,7 +165,7 @@ describe('TabLayout', () => {
     expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options?.lazy).not.toBe(false);
   });
 
-  it('eager-mounts the Record tab on Android dev builds', () => {
+  it('eager-mounts the Record tab on Android builds', () => {
     cfg.variant = 'material';
     cfg.platformOS = 'android';
 

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -55,7 +55,7 @@ export default function TabLayout() {
   // doesn't re-render the tab tree on every queue change.
   const hasCurrentClimb = useHasActiveClimb();
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
-  const eagerMountRecord = __DEV__ && Platform.OS === 'android';
+  const eagerMountRecord = Platform.OS === 'android';
 
   if (variant === 'material') {
     return (
@@ -70,8 +70,8 @@ export default function TabLayout() {
             title: tSession('mobile.session.recordTab'),
             tabBarIcon: materialTabIcon('record-circle', 'record-circle-outline'),
             tabBarBadge: showRecordBadge ? '' : undefined,
-            // Android Fast Refresh can stall the first lazy mount of this nested
-            // stack in Metro. Keep production cold start lazy.
+            // Android can stall the first lazy mount of this nested stack,
+            // leaving the Record tab blank until another tab forces a remount.
             lazy: eagerMountRecord ? false : undefined,
           }}
         />


### PR DESCRIPTION
## Summary

- Eager-mount the Android Material Record tab so its nested session stack is ready on first open.
- Keep non-Android Material behavior lazy.
- Update the tab layout unit test names to match the Android-wide behavior.

## Root Cause

The Record tab was only eager-mounted on Android dev builds. Android production builds could still hit the lazy first-mount stall, leaving the Record/session tab blank until another tab switch caused the screen to mount again.

## Validation

Blocked locally because this worktree has no installed dependencies:

- `vp test --project mobile packages/mobile/app/\(tabs\)/__tests__/tab-layout.test.tsx` stops before running tests because `vite-plus` cannot be resolved from `node_modules`.
- `vp run typecheck` stops because `graphql-codegen` is missing from `node_modules`.

Manual QA target: Android app, default Material UI, fresh launch, open Record tab first and confirm the session screen renders immediately.