### PR TITLE
fix(search): map stars from the canonical 1-5 quality scale (was saturating at 15)

### DIFF
--- a/packages/backend/src/__tests__/climb-stars.test.ts
+++ b/packages/backend/src/__tests__/climb-stars.test.ts
@@ -2,23 +2,23 @@ import { describe, expect, it } from 'vite-plus/test';
 import { getClimbStars } from '@boardsesh/db/queries';
 
 describe('getClimbStars', () => {
-  it('keeps Aurora board quality on the 0-15 queue scale', () => {
-    expect(getClimbStars('kilter', 3)).toBe(15);
-    expect(getClimbStars('tension', '2.4')).toBe(12);
+  it('maps the canonical 1-5 quality average straight to a 0-5 star count', () => {
+    expect(getClimbStars(3)).toBe(3);
+    expect(getClimbStars('2.4')).toBe(2);
+    expect(getClimbStars(4.5)).toBe(5);
+    expect(getClimbStars('4.2')).toBe(4);
+    expect(getClimbStars(5)).toBe(5);
   });
 
-  it('scales MoonBoard native 0-5 ratings onto the 0-15 queue scale', () => {
-    expect(getClimbStars('moonboard', 5)).toBe(15);
-    expect(getClimbStars('moonboard', '4.2')).toBe(13);
+  it('caps out-of-range ratings at 5 stars', () => {
+    expect(getClimbStars(8)).toBe(5);
+    expect(getClimbStars('5.6')).toBe(5);
   });
 
-  it('caps unexpected ratings at the queue schema maximum', () => {
-    expect(getClimbStars('moonboard', 8)).toBe(15);
-    expect(getClimbStars('kilter', 5)).toBe(15);
-  });
-
-  it('defaults missing ratings to zero stars', () => {
-    expect(getClimbStars('moonboard', null)).toBe(0);
-    expect(getClimbStars('kilter', 'not-a-number')).toBe(0);
+  it('treats unrated climbs as zero stars', () => {
+    expect(getClimbStars(0)).toBe(0);
+    expect(getClimbStars(-1)).toBe(0);
+    expect(getClimbStars(null)).toBe(0);
+    expect(getClimbStars('not-a-number')).toBe(0);
   });
 });

--- a/packages/backend/src/db/queries/climbs/get-climb.ts
+++ b/packages/backend/src/db/queries/climbs/get-climb.ts
@@ -71,7 +71,7 @@ export const getClimbByUuid = async (params: GetClimbParams): Promise<Climb | nu
       ascensionist_count: Number(row.ascensionist_count || 0),
       difficulty: getGradeLabel(row.difficulty_id),
       quality_average: row.quality_average?.toString() || '0',
-      stars: getClimbStars(params.board_name, row.quality_average),
+      stars: getClimbStars(row.quality_average),
       difficulty_error: row.difficulty_error?.toString() || '0',
       benchmark_difficulty:
         row.benchmark_difficulty && row.benchmark_difficulty > 0 ? row.benchmark_difficulty.toString() : null,

--- a/packages/backend/src/graphql/resolvers/favorites/favorite-climbs-query.ts
+++ b/packages/backend/src/graphql/resolvers/favorites/favorite-climbs-query.ts
@@ -102,7 +102,7 @@ export const favoriteClimbsQuery = {
       ascensionist_count: Number(result.ascensionist_count || 0),
       difficulty: getGradeLabel(result.difficulty_id),
       quality_average: result.quality_average?.toString() || '0',
-      stars: getClimbStars(boardName, result.quality_average),
+      stars: getClimbStars(result.quality_average),
       difficulty_error: result.difficulty_error?.toString() || '0',
       benchmark_difficulty:
         result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,

--- a/packages/backend/src/graphql/resolvers/playlists/helpers/hydrate-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/helpers/hydrate-climbs.ts
@@ -123,7 +123,7 @@ export async function hydrateClimbsByRefs(refs: ClimbRef[], options?: HydrateCli
       ascensionist_count: Number(row.ascensionist_count || 0),
       difficulty: getGradeLabel(row.difficulty_id),
       quality_average: row.quality_average?.toString() || '0',
-      stars: getClimbStars(boardName, row.quality_average),
+      stars: getClimbStars(row.quality_average),
       difficulty_error: row.difficulty_error?.toString() || '0',
       benchmark_difficulty:
         row.benchmark_difficulty && row.benchmark_difficulty > 0 ? row.benchmark_difficulty.toString() : null,

--- a/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
@@ -106,7 +106,7 @@ async function fetchSpecificBoardClimbs(
     ascensionist_count: Number(result.ascensionist_count || 0),
     difficulty: getGradeLabel(result.difficulty_id),
     quality_average: result.quality_average?.toString() || '0',
-    stars: getClimbStars(boardName, result.quality_average),
+    stars: getClimbStars(result.quality_average),
     difficulty_error: result.difficulty_error?.toString() || '0',
     benchmark_difficulty:
       result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,

--- a/packages/backend/src/graphql/resolvers/social/setter-follows.ts
+++ b/packages/backend/src/graphql/resolvers/social/setter-follows.ts
@@ -302,7 +302,7 @@ export const setterFollowQueries = {
         ascensionist_count: Number(result.ascensionist_count || 0),
         difficulty: getGradeLabel(result.difficulty_id),
         quality_average: result.quality_average?.toString() || '0',
-        stars: getClimbStars(boardName, result.quality_average),
+        stars: getClimbStars(result.quality_average),
         difficulty_error: result.difficulty_error?.toString() || '0',
         benchmark_difficulty:
           result.benchmark_difficulty && result.benchmark_difficulty > 0
@@ -404,7 +404,7 @@ export const setterFollowQueries = {
           ascensionist_count: Number(result.ascensionist_count || 0),
           difficulty: getGradeLabel(result.difficulty_id),
           quality_average: result.quality_average?.toString() || '0',
-          stars: getClimbStars(boardName, result.quality_average),
+          stars: getClimbStars(result.quality_average),
           difficulty_error: result.difficulty_error?.toString() || '0',
           benchmark_difficulty:
             result.benchmark_difficulty && result.benchmark_difficulty > 0
@@ -584,7 +584,7 @@ export const setterFollowQueries = {
         ascensionist_count: Number(result.ascensionist_count || 0),
         difficulty: getGradeLabel(result.difficulty_id),
         quality_average: result.quality_average?.toString() || '0',
-        stars: getClimbStars(boardName, result.quality_average),
+        stars: getClimbStars(result.quality_average),
         difficulty_error: result.difficulty_error?.toString() || '0',
         benchmark_difficulty:
           result.benchmark_difficulty && result.benchmark_difficulty > 0

--- a/packages/backend/src/services/__tests__/search-cache.test.ts
+++ b/packages/backend/src/services/__tests__/search-cache.test.ts
@@ -77,7 +77,7 @@ describe('SearchCacheService', () => {
       const key = service.buildCacheKey(makeRouteParams(), {}, 'results');
 
       expect(key).toBeTruthy();
-      expect(key.startsWith('boardsesh:climb-search:v3:results:')).toBe(true);
+      expect(key.startsWith('boardsesh:climb-search:v4:results:')).toBe(true);
     });
 
     it('matches expected key format', () => {
@@ -88,7 +88,7 @@ describe('SearchCacheService', () => {
       // boardsesh:climb-search:version:suffix:board:layout:size:sets:angle:hash
       expect(segments[0]).toBe('boardsesh');
       expect(segments[1]).toBe('climb-search');
-      expect(segments[2]).toBe('v3');
+      expect(segments[2]).toBe('v4');
       expect(segments[3]).toBe('results');
       expect(segments[4]).toBe('kilter');
       expect(segments[5]).toBe('1');

--- a/packages/backend/src/services/search-cache.ts
+++ b/packages/backend/src/services/search-cache.ts
@@ -10,8 +10,10 @@ export const DEFAULT_SEARCH_CACHE_TTL = 86400;
  * Bump when a code change alters search result *content* for an existing key.
  * v3: anchored hold LIKE (`%p<id>r%`), minRating compared on the 1-5 scale,
  * popular-sort counting NULL frames_count, name ILIKE escaping, zone fail-closed.
+ * v4: stars field now maps quality_average (1-5) straight to 0-5 instead of the
+ * old x5/x3 0-15 scale (was saturating at 15).
  */
-const CACHE_VERSION = 'v3';
+const CACHE_VERSION = 'v4';
 
 /**
  * Recursively sorts the keys of an object so that JSON.stringify produces

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -52,6 +52,9 @@ export const ClimbInputSchema = z.object({
     .max(20)
     .nullish()
     .transform((v) => v ?? ''),
+  // getClimbStars now emits 0-5, but keep the upper bound at 15 so queue items
+  // persisted (IndexedDB) or in flight from before that change — which carry the
+  // old 0-15 stars — still validate and sync instead of being rejected.
   stars: z
     .number()
     .min(0)

--- a/packages/db/src/queries/climbs/climb-stars.ts
+++ b/packages/db/src/queries/climbs/climb-stars.ts
@@ -1,18 +1,22 @@
-import type { BoardName } from '@boardsesh/shared-schema';
+const MAX_CLIMB_STARS = 5;
 
-const MAX_CLIMB_STARS = 15;
-const MOONBOARD_QUALITY_TO_STARS = 3;
-const AURORA_QUALITY_TO_STARS = 5;
-
-export function getClimbStars(
-  boardName: BoardName | null | undefined,
-  qualityAverage: number | string | null | undefined,
-): number {
+/**
+ * Convert a climb's quality_average into an integer 0-5 star count.
+ *
+ * quality_average is the canonical 1-5 scale on every board (migrations
+ * 0115/0116 backfilled Aurora's 1-3 ratings to 1-5; Kilter Grips and MoonBoard
+ * are native 1-5), so the rating maps straight to a star count — round and
+ * clamp to 0-5. Unrated climbs (quality <= 0, null, or NaN) get 0 stars.
+ *
+ * Historically this multiplied by a per-board factor (Aurora x5, MoonBoard x3)
+ * to fold differing source scales onto a 0-15 "queue scale". Those scales are
+ * now unified, so the multiplier only saturated the result (4.5 x 5 -> 22 -> 15)
+ * and the board argument is no longer needed.
+ */
+export function getClimbStars(qualityAverage: number | string | null | undefined): number {
   const quality = Number(qualityAverage);
   if (!Number.isFinite(quality) || quality <= 0) {
     return 0;
   }
-
-  const multiplier = boardName === 'moonboard' ? MOONBOARD_QUALITY_TO_STARS : AURORA_QUALITY_TO_STARS;
-  return Math.min(MAX_CLIMB_STARS, Math.round(quality * multiplier));
+  return Math.min(MAX_CLIMB_STARS, Math.round(quality));
 }

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -51,7 +51,7 @@ function mapResultToClimbRow(result: RawSelectResult, params: BoardRouteParams):
     ascensionist_count: Number(result.ascensionist_count || 0),
     difficulty: getGradeLabel(toIntegerOrNull(result.difficulty_id)),
     quality_average: result.quality_average?.toString() || '0',
-    stars: getClimbStars(params.board_name, result.quality_average),
+    stars: getClimbStars(result.quality_average),
     difficulty_error: result.difficulty_error?.toString() || '0',
     benchmark_difficulty:
       result.benchmark_difficulty && result.benchmark_difficulty > 0 ? result.benchmark_difficulty.toString() : null,

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -30,7 +30,7 @@ type Climb {
   difficulty: String!
   "Average quality rating from users"
   quality_average: String!
-  "Star rating (0-3)"
+  "Star rating (0-5), rounded from quality_average"
   stars: Float!
   "Difficulty uncertainty/spread"
   difficulty_error: String!

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -476,7 +476,7 @@ export type Climb = {
   quality_average: Scalars['String']['output'];
   /** Username of the person who created this climb */
   setter_username: Scalars['String']['output'];
-  /** Star rating (0-3) */
+  /** Star rating (0-5), rounded from quality_average */
   stars: Scalars['Float']['output'];
   /** Number of times the current user has sent this climb */
   userAscents?: Maybe<Scalars['Int']['output']>;

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -26,7 +26,7 @@ export const climbTypeDefs = /* GraphQL */ `
     difficulty: String!
     "Average quality rating from users"
     quality_average: String!
-    "Star rating (0-3)"
+    "Star rating (0-5), rounded from quality_average"
     stars: Float!
     "Difficulty uncertainty/spread"
     difficulty_error: String!

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -473,7 +473,7 @@ export type Climb = {
   quality_average: Scalars['String']['output'];
   /** Username of the person who created this climb */
   setter_username: Scalars['String']['output'];
-  /** Star rating (0-3) */
+  /** Star rating (0-5), rounded from quality_average */
   stars: Scalars['Float']['output'];
   /** Number of times the current user has sent this climb */
   userAscents?: Maybe<Scalars['Int']['output']>;

--- a/packages/web/app/lib/api-docs/openapi-registry.ts
+++ b/packages/web/app/lib/api-docs/openapi-registry.ts
@@ -68,7 +68,7 @@ export const ClimbSchema = z
     ascensionist_count: z.number().describe('Number of people who have completed this climb'),
     difficulty: z.string().describe('Difficulty grade of the climb'),
     quality_average: z.string().describe('Average quality rating'),
-    stars: z.number().describe('Star rating (0-3)'),
+    stars: z.number().describe('Star rating (0-5), rounded from quality_average'),
     difficulty_error: z.string().describe('Difficulty uncertainty/spread'),
     litUpHoldsMap: LitUpHoldsMapSchema.describe('Map of holds to light up on the board'),
     mirrored: z.boolean().optional().describe('Whether the climb is displayed mirrored'),

--- a/packages/web/app/lib/db/queries/climbs/search-climbs.ts
+++ b/packages/web/app/lib/db/queries/climbs/search-climbs.ts
@@ -76,10 +76,10 @@ function _getCachedFn(boardName: BoardName, revalidate: number): CachedClimbSear
   const key = `${boardName}:${revalidate}`;
   let fn = _cacheRegistry.get(key);
   if (!fn) {
-    // v4: search result content changed (anchored hold LIKE, minRating 1-5 scale,
-    // popular-sort NULL frames_count, name ILIKE escaping, zone fail-closed). Keep in
-    // lockstep with the backend Redis CACHE_VERSION bump.
-    fn = unstable_cache(_executeClimbSearch, [`climb-search-v4:${boardName}`], {
+    // Bumped when search result content changes; keep in lockstep with the backend
+    // Redis CACHE_VERSION. v4: hold LIKE / minRating / popular NULL / ILIKE / zone.
+    // v5: stars now maps quality_average 1-5 to 0-5 (was the saturating 0-15 scale).
+    fn = unstable_cache(_executeClimbSearch, [`climb-search-v5:${boardName}`], {
       revalidate,
       tags: ['climb-search', getBoardClimbSearchTag(boardName)],
     });


### PR DESCRIPTION
The `stars` integer field was the loose end from the search hardening work: same root cause as the minRating bug.

`getClimbStars` multiplied `quality_average` by a per-board factor (Aurora ×5, MoonBoard ×3) onto a 0–15 "queue scale". That made sense when Aurora quality was a 0–1 fraction, but **all boards now store `quality_average` on the canonical 1–5 scale** (migrations 0115/0116), so ×5 saturated nearly every climb at the 15 cap (4.5 × 5 = 22 → 15).

- The **web** climb card was unaffected — it renders `formatQuality(quality_average)` directly.
- The **mobile** climb-detail screen renders the `stars` integer (`stars.toFixed(1)`), so it showed a nonsensical **"15.0"** for almost every climb.

## Change
- `getClimbStars` now returns `round(quality_average)` clamped to **0–5**, and drops the now-vestigial `boardName` argument (updated all 8 call sites — search, get-climb, favorites, playlists ×2, social ×3).
- Rewrote `climb-stars.test.ts` for the 0–5 contract.
- Fixed the stale **"Star rating (0-3)"** docs in the GraphQL SDL + OpenAPI registry (regenerated GraphQL types) to "0-5". Kept the queue `stars` zod bound at `max(15)` so queue items persisted in IndexedDB / in flight with the old 0–15 values still validate and sync.
- Bumped the Redis `CACHE_VERSION` (v4) and web `unstable_cache` key (v5) — `stars` is part of cached search results.

## Validation
`vp run typecheck:{backend,web}` clean; `climb-stars` (3) + `search-cache` (15) green; full `@boardsesh/db` suite green. The 22 `integration.test.ts` failures are the pre-existing environmental WS "socket hang up" failures — confirmed reproducing on clean `main`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
