### PR TITLE
[codex] Fix iOS RN TestFlight signing

### DIFF
--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -97,32 +97,6 @@ jobs:
         working-directory: packages/mobile/ios
         run: pod install
 
-      - name: Configure per-target code signing
-        run: |
-          ruby <<'RUBY'
-          require 'xcodeproj'
-          project = Xcodeproj::Project.open('packages/mobile/ios/Boardsesh.xcodeproj')
-
-          profiles = {
-            'Boardsesh'        => 'Boardsesh App Store Distribution Second',
-            'BoardseshWidgets' => 'Boardsesh Widgets App Store Distribution',
-          }
-
-          project.targets.each do |target|
-            next unless profiles.key?(target.name)
-            target.build_configurations.each do |config|
-              next unless config.name == 'Release'
-              config.build_settings['CODE_SIGN_STYLE']                = 'Manual'
-              config.build_settings['DEVELOPMENT_TEAM']               = '9L3HKPZBH3'
-              config.build_settings['CODE_SIGN_IDENTITY']             = 'Apple Distribution'
-              config.build_settings['PROVISIONING_PROFILE_SPECIFIER'] = profiles[target.name]
-            end
-          end
-
-          project.save
-          puts 'Per-target code signing configured for: ' + profiles.keys.join(', ')
-          RUBY
-
       - name: Compute build number
         id: build_number
         run: |
@@ -130,6 +104,21 @@ jobs:
           bn=$(( offset + ${{ github.run_number }} ))
           echo "value=$bn" >> "$GITHUB_OUTPUT"
           echo "Build number: $bn"
+
+      - name: Resolve mobile app version
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+
+          const appConfig = fs.readFileSync('packages/mobile/app.config.ts', 'utf8');
+          const versionMatch = appConfig.match(/\bversion:\s*['"]([^'"]+)['"]/);
+          if (!versionMatch) {
+            throw new Error('Could not find version in packages/mobile/app.config.ts');
+          }
+
+          const version = versionMatch[1];
+          fs.appendFileSync(process.env.GITHUB_ENV, `BOARDSESH_MOBILE_VERSION=${version}\n`);
+          NODE
 
       - name: Set build number
         working-directory: packages/mobile/ios
@@ -159,22 +148,161 @@ jobs:
       - name: Install provisioning profiles
         env:
           APP_PROFILE_BASE64: ${{ secrets.IOS_APP_PROVISIONING_PROFILE_BASE64 }}
-          WIDGET_PROFILE_BASE64: ${{ secrets.IOS_WIDGET_PROVISIONING_PROFILE_BASE64 }}
+          WIDGETS_PROFILE_BASE64: ${{ secrets.IOS_WIDGETS_PROVISIONING_PROFILE_BASE64 || secrets.IOS_WIDGET_PROVISIONING_PROFILE_BASE64 }}
+          SHARE_EXTENSION_PROFILE_BASE64: ${{ secrets.IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64 }}
         run: |
+          set -euo pipefail
+
+          install_profile() {
+            local secret_name="$1"
+            local profile_label="$2"
+            local profile_name_env="$3"
+            local profile_bundle_id_env="$4"
+            local expected_bundle_id="$5"
+            local profile_base64="${!secret_name:-}"
+            local profiles_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
+
+            if [ -z "$profile_base64" ]; then
+              echo "::error::Missing $secret_name for the $profile_label provisioning profile."
+              exit 1
+            fi
+
+            mkdir -p "$profiles_dir"
+
+            local profile_file="$RUNNER_TEMP/${profile_label}.mobileprovision"
+            local plist_file="$RUNNER_TEMP/${profile_label}.plist"
+
+            printf '%s' "$profile_base64" | base64 --decode > "$profile_file"
+            if ! security cms -D -i "$profile_file" > "$plist_file"; then
+              echo "::error::$secret_name did not decode to a valid .mobileprovision file."
+              exit 1
+            fi
+
+            local profile_uuid
+            local profile_name
+            local application_identifier
+            local bundle_id
+
+            profile_uuid=$(/usr/libexec/PlistBuddy -c 'Print UUID' "$plist_file")
+            profile_name=$(/usr/libexec/PlistBuddy -c 'Print Name' "$plist_file")
+            application_identifier=$(/usr/libexec/PlistBuddy -c 'Print Entitlements:application-identifier' "$plist_file")
+            bundle_id="${application_identifier#*.}"
+
+            if [ "$bundle_id" != "$expected_bundle_id" ]; then
+              echo "::error::$profile_label profile is for $bundle_id, expected $expected_bundle_id."
+              exit 1
+            fi
+
+            cp "$profile_file" "$profiles_dir/$profile_uuid.mobileprovision"
+            {
+              echo "$profile_name_env=$profile_name"
+              echo "$profile_bundle_id_env=$bundle_id"
+            } >> "$GITHUB_ENV"
+
+            echo "Installed $profile_label provisioning profile: $profile_name ($bundle_id)"
+          }
+
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          echo "$APP_PROFILE_BASE64" | base64 --decode \
-            > ~/Library/MobileDevice/Provisioning\ Profiles/app.mobileprovision
-          echo "$WIDGET_PROFILE_BASE64" | base64 --decode \
-            > ~/Library/MobileDevice/Provisioning\ Profiles/widget.mobileprovision
+
+          install_profile APP_PROFILE_BASE64 app IOS_APP_PROFILE_NAME IOS_APP_PROFILE_BUNDLE_ID com.boardsesh.app
+          install_profile WIDGETS_PROFILE_BASE64 widgets IOS_WIDGETS_PROFILE_NAME IOS_WIDGETS_PROFILE_BUNDLE_ID com.boardsesh.app.widgets
+          install_profile SHARE_EXTENSION_PROFILE_BASE64 share-extension IOS_SHARE_EXTENSION_PROFILE_NAME IOS_SHARE_EXTENSION_PROFILE_BUNDLE_ID com.boardsesh.app.share-extension
+
+      - name: Configure per-target code signing
+        run: |
+          ruby <<'RUBY'
+          require 'xcodeproj'
+          project = Xcodeproj::Project.open('packages/mobile/ios/Boardsesh.xcodeproj')
+
+          profiles = {
+            'Boardsesh' => ENV.fetch('IOS_APP_PROFILE_NAME'),
+            'BoardseshWidgets' => ENV.fetch('IOS_WIDGETS_PROFILE_NAME'),
+            'BoardseshBeta' => ENV.fetch('IOS_SHARE_EXTENSION_PROFILE_NAME'),
+          }
+
+          configured_targets = []
+
+          project.targets.each do |target|
+            next unless profiles.key?(target.name)
+
+            target.build_configurations.each do |config|
+              next unless config.name == 'Release'
+
+              config.build_settings['CODE_SIGN_STYLE'] = 'Manual'
+              config.build_settings['DEVELOPMENT_TEAM'] = '9L3HKPZBH3'
+              config.build_settings['CODE_SIGN_IDENTITY'] = 'Apple Distribution'
+              config.build_settings['PROVISIONING_PROFILE_SPECIFIER'] = profiles[target.name]
+            end
+
+            configured_targets << target.name
+          end
+
+          missing_targets = profiles.keys - configured_targets
+          unless missing_targets.empty?
+            raise "Missing expected Xcode targets for signing: #{missing_targets.join(', ')}"
+          end
+
+          project.save
+          puts 'Per-target code signing configured for: ' + configured_targets.join(', ')
+          RUBY
+
+      - name: Write export options
+        run: |
+          cat > "$EXPORT_OPTIONS_PLIST" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>app-store-connect</string>
+              <key>teamID</key>
+              <string>9L3HKPZBH3</string>
+              <key>signingStyle</key>
+              <string>manual</string>
+              <key>provisioningProfiles</key>
+              <dict>
+                  <key>$IOS_APP_PROFILE_BUNDLE_ID</key>
+                  <string>$IOS_APP_PROFILE_NAME</string>
+                  <key>$IOS_WIDGETS_PROFILE_BUNDLE_ID</key>
+                  <string>$IOS_WIDGETS_PROFILE_NAME</string>
+                  <key>$IOS_SHARE_EXTENSION_PROFILE_BUNDLE_ID</key>
+                  <string>$IOS_SHARE_EXTENSION_PROFILE_NAME</string>
+              </dict>
+              <key>uploadBitcode</key>
+              <false/>
+              <key>uploadSymbols</key>
+              <true/>
+              <key>destination</key>
+              <string>upload</string>
+          </dict>
+          </plist>
+          PLIST
 
       - name: Setup App Store Connect API key
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
         run: |
+          set -euo pipefail
+
+          if [ -z "$APP_STORE_CONNECT_API_KEY_ID" ]; then
+            echo "::error::Missing APP_STORE_CONNECT_API_KEY_ID."
+            exit 1
+          fi
+
+          if [ -z "$APP_STORE_CONNECT_API_KEY_BASE64" ]; then
+            echo "::error::Missing APP_STORE_CONNECT_API_KEY_BASE64."
+            exit 1
+          fi
+
           mkdir -p ~/.private_keys
-          echo "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode \
-            > ~/.private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8
+          key_path="$HOME/.private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          printf '%s' "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > "$key_path"
+
+          if ! grep -q 'BEGIN PRIVATE KEY' "$key_path"; then
+            echo "::error::APP_STORE_CONNECT_API_KEY_BASE64 did not decode to an App Store Connect private key."
+            exit 1
+          fi
 
       # The @sentry/react-native build phases upload JS source maps + native
       # dSYMs during `xcodebuild archive`. Without a token the upload errors and
@@ -195,8 +323,6 @@ jobs:
 
       - name: Archive
         env:
-          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           # Consumed by the @sentry/react-native build phases (sentry-cli). The
           # SENTRY_DISABLE_AUTO_UPLOAD gate above (via $GITHUB_ENV) decides whether
           # the upload actually runs.
@@ -208,10 +334,6 @@ jobs:
             -configuration Release \
             -archivePath "$ARCHIVE_PATH" \
             -destination "generic/platform=iOS" \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath ~/.private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8 \
-            -authenticationKeyID "$APP_STORE_CONNECT_API_KEY_ID" \
-            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
             CURRENT_PROJECT_VERSION=${{ steps.build_number.outputs.value }} \
             DEVELOPMENT_TEAM=9L3HKPZBH3
 
@@ -220,6 +342,11 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
+          if [ -z "$APP_STORE_CONNECT_ISSUER_ID" ]; then
+            echo "::error::Missing APP_STORE_CONNECT_ISSUER_ID."
+            exit 1
+          fi
+
           xcodebuild -exportArchive \
             -archivePath "$ARCHIVE_PATH" \
             -exportOptionsPlist "$EXPORT_OPTIONS_PLIST" \
@@ -237,6 +364,24 @@ jobs:
           path: packages/mobile/ios/build/export/*.ipa
           retention-days: 30
           if-no-files-found: warn
+
+      - name: Notify deployments channel
+        if: github.ref == 'refs/heads/main' && success()
+        env:
+          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          BUILD_NUMBER: ${{ steps.build_number.outputs.value }}
+        run: |
+          if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
+            echo "DISCORD_DEPLOY_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          CONTENT=$(printf '📱 **iOS RN TestFlight uploaded** on `%s`\n• version: %s\n• build: %s\n<%s>' \
+            "${COMMIT_SHA:0:7}" "$BOARDSESH_MOBILE_VERSION" "$BUILD_NUMBER" "$RUN_URL")
+          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
+            | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
+              echo "::warning::Failed to post Discord notification (see status above)"
 
       - name: Clean up keychain and credentials
         if: always()

--- a/packages/mobile/ExportOptions.plist
+++ b/packages/mobile/ExportOptions.plist
@@ -14,6 +14,8 @@
         <string>Boardsesh App Store Distribution Second</string>
         <key>com.boardsesh.app.widgets</key>
         <string>Boardsesh Widgets App Store Distribution</string>
+        <key>com.boardsesh.app.share-extension</key>
+        <string>Boardsesh Share Extension App Store Distribution</string>
     </dict>
     <key>uploadBitcode</key>
     <false/>


### PR DESCRIPTION
## What changed

- Hardened the RN iOS TestFlight workflow so provisioning profile secrets are decoded, parsed, and checked against the expected bundle IDs before Xcode runs.
- Configured manual signing for all generated release targets: `Boardsesh`, `BoardseshWidgets`, and the share extension target `BoardseshBeta`.
- Rewrote export options from the installed profile names so export/upload signs the app, widget, and share extension consistently.
- Added early App Store Connect API key validation.
- Added a best-effort deployments-channel notification after a successful iOS RN TestFlight upload, matching the Android RN release workflow style.
- Added `com.boardsesh.app.share-extension` to the checked-in `packages/mobile/ExportOptions.plist`.

## Root cause

The failing main run died during `xcodebuild archive` because the RN iOS workflow only configured manual signing for the app and widget target. The generated share extension target is named `BoardseshBeta`, so Xcode fell back to provisioning updates for `com.boardsesh.app.share-extension` and failed. The log also showed `widget.mobileprovision` missing a UUID, which is consistent with an empty or malformed profile secret being decoded silently.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ios-testflight-rn.yml')"`
- `plutil -lint packages/mobile/ExportOptions.plist`
- `vp check --no-lint --no-error-on-unmatched-pattern .github/workflows/ios-testflight-rn.yml packages/mobile/ExportOptions.plist`
- `git diff --check`

Full `vp check` reaches repo checks but still fails on 18 pre-existing formatting issues outside this PR's files.

## Follow-up before rerun

Make sure `IOS_SHARE_EXTENSION_PROVISIONING_PROFILE_BASE64` exists in the Production environment and contains an App Store distribution profile for `com.boardsesh.app.share-extension`. The workflow now fails early with a clear message if it is missing or points at the wrong bundle ID.