### PR TITLE
Instrument searchClimbs latency in the backend

### DIFF
--- a/packages/backend/src/graphql/resolvers/climbs/__tests__/search-metrics.test.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/__tests__/search-metrics.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
+import { logger } from '../../../../utils/logger';
+import { logSearchClimbsMetrics, type SearchClimbsMetricDimensions } from '../search-metrics';
+
+const SLOW_MS = 350; // above the 300ms threshold
+const FAST_MS = 12; // below the threshold
+
+const baseDimensions: SearchClimbsMetricDimensions = {
+  boardName: 'kilter',
+  angle: 40,
+  page: 0,
+  pageSize: 20,
+  sortBy: 'ascents',
+  cacheable: true,
+  resultCount: 21,
+};
+
+function parsePayload(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown> {
+  const call = spy.mock.calls[0];
+  // logger is called as (message, jsonPayloadString)
+  return JSON.parse(call[1] as string) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('logSearchClimbsMetrics', () => {
+  it('warns with slow=true and the structured payload when over the threshold', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+
+    logSearchClimbsMetrics('searchClimbs.climbs', SLOW_MS, 'db', baseDimensions);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy.mock.calls[0][0]).toContain('SLOW searchClimbs.climbs');
+
+    const payload = parsePayload(warnSpy);
+    expect(payload).toMatchObject({
+      type: 'search_climbs_metrics',
+      operation: 'searchClimbs.climbs',
+      durationMs: SLOW_MS,
+      source: 'db',
+      slow: true,
+      boardName: 'kilter',
+      angle: 40,
+      page: 0,
+      pageSize: 20,
+      sortBy: 'ascents',
+      cacheable: true,
+      resultCount: 21,
+    });
+  });
+
+  it('rounds the duration before logging', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    vi.spyOn(logger, 'info').mockImplementation(() => logger);
+
+    logSearchClimbsMetrics('searchClimbs.climbs', 412.7, 'db', baseDimensions);
+
+    expect(parsePayload(warnSpy).durationMs).toBe(413);
+  });
+
+  it('does not warn for a fast call and stays silent outside development', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+
+    logSearchClimbsMetrics('searchClimbs.climbs', FAST_MS, 'redis', baseDimensions);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs a fast call at info in development with slow=false', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+
+    logSearchClimbsMetrics('searchClimbs.totalCount', FAST_MS, 'redis', {
+      ...baseDimensions,
+      resultCount: undefined,
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+
+    const payload = parsePayload(infoSpy);
+    expect(payload).toMatchObject({
+      operation: 'searchClimbs.totalCount',
+      source: 'redis',
+      slow: false,
+    });
+    // totalCount carries no resultCount
+    expect(payload.resultCount).toBeUndefined();
+  });
+
+  it('threads the source through for each origin', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+
+    for (const source of ['db', 'redis', 'precomputed'] as const) {
+      infoSpy.mockClear();
+      logSearchClimbsMetrics('searchClimbs.climbs', FAST_MS, source, baseDimensions);
+      expect(parsePayload(infoSpy).source).toBe(source);
+    }
+  });
+});

--- a/packages/backend/src/graphql/resolvers/climbs/field-resolvers.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/field-resolvers.ts
@@ -2,11 +2,28 @@ import type { Climb } from '@boardsesh/shared-schema';
 import { searchClimbs as searchClimbsQuery, countClimbs } from '../../../db/queries/climbs/index';
 import type { ClimbSearchContext } from '../shared/types';
 import { searchCache, DEFAULT_SEARCH_CACHE_TTL } from '../../../services/search-cache';
+import {
+  logSearchClimbsMetrics,
+  type SearchClimbsMetricDimensions,
+  type SearchClimbsMetricSource,
+} from './search-metrics';
 
 type CachedClimbsResult = {
   climbs: Climb[];
   hasMore: boolean;
 };
+
+/** Pull the stable latency dimensions out of the search context. */
+function metricDimensions(parent: ClimbSearchContext): Omit<SearchClimbsMetricDimensions, 'resultCount'> {
+  return {
+    boardName: parent.params.board_name,
+    angle: parent.params.angle,
+    page: parent.searchParams.page ?? 0,
+    pageSize: parent.searchParams.pageSize ?? 20,
+    sortBy: parent.searchParams.sortBy ?? 'ascents',
+    cacheable: parent._isCacheable ?? false,
+  };
+}
 
 /**
  * Field-level resolvers for ClimbSearchResult
@@ -18,8 +35,17 @@ export const climbFieldResolvers = {
    * Uses Redis caching for anonymous queries and in-memory caching to avoid duplicate queries
    */
   climbs: async (parent: ClimbSearchContext): Promise<Climb[]> => {
+    const startTime = performance.now();
+    const finalize = (climbs: Climb[], source: SearchClimbsMetricSource): Climb[] => {
+      logSearchClimbsMetrics('searchClimbs.climbs', performance.now() - startTime, source, {
+        ...metricDimensions(parent),
+        resultCount: climbs.length,
+      });
+      return climbs;
+    };
+
     if (parent._cachedClimbs !== undefined) {
-      return parent._cachedClimbs;
+      return finalize(parent._cachedClimbs, 'precomputed');
     }
 
     // User-specific queries bypass Redis cache entirely
@@ -27,7 +53,7 @@ export const climbFieldResolvers = {
       const result = await searchClimbsQuery(parent.params, parent.searchParams, parent.userId);
       parent._cachedClimbs = result.climbs;
       parent._cachedHasMore = result.hasMore;
-      return result.climbs;
+      return finalize(result.climbs, 'db');
     }
 
     const cacheKey = searchCache.buildCacheKey(parent.params, parent.searchParams, 'climbs');
@@ -35,7 +61,7 @@ export const climbFieldResolvers = {
     if (cached) {
       parent._cachedClimbs = cached.climbs;
       parent._cachedHasMore = cached.hasMore;
-      return cached.climbs;
+      return finalize(cached.climbs, 'redis');
     }
 
     // Cache miss — query DB and store in Redis
@@ -44,7 +70,7 @@ export const climbFieldResolvers = {
     parent._cachedHasMore = result.hasMore;
 
     searchCache.setCachedResult(cacheKey, { climbs: result.climbs, hasMore: result.hasMore }, DEFAULT_SEARCH_CACHE_TTL);
-    return result.climbs;
+    return finalize(result.climbs, 'db');
   },
 
   /**
@@ -52,28 +78,39 @@ export const climbFieldResolvers = {
    * Uses Redis caching for anonymous queries
    */
   totalCount: async (parent: ClimbSearchContext): Promise<number> => {
+    const startTime = performance.now();
+    const finalize = (count: number, source: SearchClimbsMetricSource): number => {
+      logSearchClimbsMetrics(
+        'searchClimbs.totalCount',
+        performance.now() - startTime,
+        source,
+        metricDimensions(parent),
+      );
+      return count;
+    };
+
     if (parent._cachedTotalCount !== undefined) {
-      return parent._cachedTotalCount;
+      return finalize(parent._cachedTotalCount, 'precomputed');
     }
 
     if (!parent._isCacheable) {
       const count = await countClimbs(parent.params, parent.searchParams, parent.userId);
       parent._cachedTotalCount = count;
-      return count;
+      return finalize(count, 'db');
     }
 
     const cacheKey = searchCache.buildCacheKey(parent.params, parent.searchParams, 'count');
     const cached = await searchCache.getCachedResult<number>(cacheKey);
     if (cached !== null) {
       parent._cachedTotalCount = cached;
-      return cached;
+      return finalize(cached, 'redis');
     }
 
     const count = await countClimbs(parent.params, parent.searchParams, parent.userId);
     parent._cachedTotalCount = count;
 
     searchCache.setCachedResult(cacheKey, count, DEFAULT_SEARCH_CACHE_TTL);
-    return count;
+    return finalize(count, 'db');
   },
 
   /**

--- a/packages/backend/src/graphql/resolvers/climbs/search-metrics.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/search-metrics.ts
@@ -1,0 +1,50 @@
+import { logger } from '../../../utils/logger';
+
+// searchClimbs is the app's hottest query and the React Native app fires it on every page
+// of infinite scroll. Reads run heavier than the 200ms mutation bar, so use a slightly
+// higher slow threshold before surfacing a warning in production logs.
+const SLOW_SEARCH_CLIMBS_THRESHOLD_MS = 300;
+
+/** Where a resolved field came from, so we can read cache-hit rate from the logs. */
+export type SearchClimbsMetricSource = 'db' | 'redis' | 'precomputed';
+
+export type SearchClimbsMetricDimensions = {
+  boardName: string;
+  angle: number;
+  page: number;
+  pageSize: number;
+  sortBy: string;
+  cacheable: boolean;
+  /** Number of climbs returned — only set for the climbs field. */
+  resultCount?: number;
+};
+
+/**
+ * Emit a structured latency line for a searchClimbs field resolver.
+ *
+ * Mirrors logMutationMetrics: slow calls warn (and reach production logs/Sentry forwarding
+ * rules), everything else logs at info only in development. The JSON payload is queryable
+ * by `type: 'search_climbs_metrics'` alongside `mutation_metrics`.
+ */
+export function logSearchClimbsMetrics(
+  operation: 'searchClimbs.climbs' | 'searchClimbs.totalCount',
+  durationMs: number,
+  source: SearchClimbsMetricSource,
+  dimensions: SearchClimbsMetricDimensions,
+) {
+  const rounded = Math.round(durationMs);
+  const payload = {
+    type: 'search_climbs_metrics',
+    operation,
+    durationMs: rounded,
+    source,
+    slow: rounded > SLOW_SEARCH_CLIMBS_THRESHOLD_MS,
+    ...dimensions,
+  };
+
+  if (rounded > SLOW_SEARCH_CLIMBS_THRESHOLD_MS) {
+    logger.warn(`[SearchClimbsMetrics] SLOW ${operation}: ${rounded}ms`, JSON.stringify(payload));
+  } else if (process.env.NODE_ENV === 'development') {
+    logger.info(`[SearchClimbsMetrics] ${operation}: ${rounded}ms`, JSON.stringify(payload));
+  }
+}


### PR DESCRIPTION
## Why

`searchClimbs` is the hottest GraphQL query in the backend — the React Native app fires one request per page of infinite scroll, plus a separate `totalCount` query. It already carries the highest rate limit (120/min/identity) and a dual-path DB design plus Redis caching, all motivated by latency. Despite that, it had **no latency instrumentation**: the only timing metrics in the backend were for queue *mutations* (`logMutationMetrics`). When the mobile app feels slow, we had no way to see how long the search DB calls take in production, or whether the Redis cache is actually being hit.

## What

The DB work for `searchClimbs` runs lazily in the `climbs` and `totalCount` field resolvers (`field-resolvers.ts`), which also handle Redis caching — so that's where the timing belongs.

- **New helper** `search-metrics.ts` (`logSearchClimbsMetrics`), modeled on the existing `mutation-metrics.ts`: structured winston log, `warn` on slow (>300ms), `info` in dev, JSON payload queryable by `type: 'search_climbs_metrics'` alongside `mutation_metrics`.
- **Instrumented field resolvers**: each return path is timed and tagged with a `source` — `db`, `redis`, or `precomputed` — so we get both query latency and Redis cache-hit rate from one log line. Dimensions: `boardName`, `angle`, `page`, `pageSize`, `sortBy`, `cacheable`, and `resultCount` (climbs only). Caching behaviour is unchanged — instrumentation only observes.
- **Unit test** `search-metrics.test.ts` covering the slow/fast thresholds, dev-only info gating, rounding, and `source` threading.

## Scope (confirmed with requester)

- Resolver-level only — no changes to the shared `@boardsesh/db` package (web SSR shares it).
- Logs only — no Sentry/PostHog forwarding.

Deferred: plumbing the DB search path (stats-driven / standard / page-0 fallback) out of `@boardsesh/db`, which would be the most diagnostic dimension but touches the shared package.

## Verification

- `vp run typecheck:backend` — clean.
- `vp test run --project backend search-metrics` (with `SKIP_TEST_INFRA=1`, pure unit test) — 5/5 pass.
- `vp lint` + `vp fmt --check` on the changed files — clean.

https://claude.ai/code/session_01JDN6LgMTC3CjHQEmkdoZHa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDN6LgMTC3CjHQEmkdoZHa)_