### PR TITLE
mobile: capture uncaught JS errors + recover from worklet-serialization crashes

### DIFF
--- a/packages/mobile/src/lib/__tests__/global-error-capture.test.ts
+++ b/packages/mobile/src/lib/__tests__/global-error-capture.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  installGlobalErrorCapture,
+  resetGlobalErrorCaptureForTests,
+  type GlobalErrorCaptureDeps,
+} from '../global-error-capture';
+
+type GlobalErrorHandler = (error: unknown, isFatal?: boolean) => void;
+
+function installFakeErrorUtils() {
+  let handler: GlobalErrorHandler = () => {};
+  const previousHandler = vi.fn<GlobalErrorHandler>();
+  handler = previousHandler;
+  const errorUtils = {
+    getGlobalHandler: () => handler,
+    setGlobalHandler: (next: GlobalErrorHandler) => {
+      handler = next;
+    },
+  };
+  (globalThis as { ErrorUtils?: typeof errorUtils }).ErrorUtils = errorUtils;
+  // Return the dispatcher (the handler our code installs) lazily.
+  return {
+    previousHandler,
+    dispatch: (error: unknown, isFatal?: boolean) => handler(error, isFatal),
+  };
+}
+
+describe('installGlobalErrorCapture', () => {
+  let report: ReturnType<typeof vi.fn<GlobalErrorCaptureDeps['report']>>;
+  let flush: ReturnType<typeof vi.fn<NonNullable<GlobalErrorCaptureDeps['flush']>>>;
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetGlobalErrorCaptureForTests();
+    report = vi.fn<GlobalErrorCaptureDeps['report']>();
+    flush = vi.fn<NonNullable<GlobalErrorCaptureDeps['flush']>>(() => Promise.resolve(true));
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    delete (globalThis as { ErrorUtils?: unknown }).ErrorUtils;
+  });
+
+  it('recovers from a worklet-serialization fatal instead of re-throwing it', () => {
+    const { previousHandler, dispatch } = installFakeErrorUtils();
+    installGlobalErrorCapture({ report, flush, isDev: false });
+
+    const error = new Error('Trying to access property `foo` of an object which cannot be sent to the UI runtime');
+    dispatch(error, true);
+
+    expect(report).toHaveBeenCalledOnce();
+    expect(report.mock.calls[0][1]).toMatchObject({ tags: { kind: 'worklet-serialization' } });
+    expect(flush).toHaveBeenCalledOnce();
+    // The whole point: the original (fatal) handler is NOT invoked, so RN doesn't abort.
+    expect(previousHandler).not.toHaveBeenCalled();
+  });
+
+  it('matches serialization failures by stack when the message is generic', () => {
+    const { previousHandler, dispatch } = installFakeErrorUtils();
+    installGlobalErrorCapture({ report, flush, isDev: false });
+
+    const error = new Error('Object could not be cloned');
+    error.stack = 'Error\n  at makeShareableCloneRecursive (worklets.js:1:1)';
+    dispatch(error, true);
+
+    expect(report).toHaveBeenCalledOnce();
+    expect(previousHandler).not.toHaveBeenCalled();
+  });
+
+  it('passes ordinary fatals through to the previous handler', () => {
+    const { previousHandler, dispatch } = installFakeErrorUtils();
+    installGlobalErrorCapture({ report, flush, isDev: false });
+
+    const error = new Error('undefined is not a function');
+    dispatch(error, true);
+
+    expect(previousHandler).toHaveBeenCalledWith(error, true);
+    // Sentry's own handler (the previous one) captures it — we don't double-report.
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  it('does not swallow in dev (keeps the red box)', () => {
+    const { previousHandler, dispatch } = installFakeErrorUtils();
+    installGlobalErrorCapture({ report, flush, isDev: true });
+
+    const error = new Error('cannot be sent to the UI runtime');
+    dispatch(error, true);
+
+    expect(previousHandler).toHaveBeenCalledWith(error, true);
+  });
+
+  it('logs the full message and stack for every error', () => {
+    const { dispatch } = installFakeErrorUtils();
+    installGlobalErrorCapture({ report, flush, isDev: false });
+
+    dispatch(new Error('boom'), false);
+
+    expect(consoleError).toHaveBeenCalledOnce();
+    expect(String(consoleError.mock.calls[0][0])).toContain('boom');
+  });
+
+  it('no-ops when ErrorUtils is unavailable', () => {
+    delete (globalThis as { ErrorUtils?: unknown }).ErrorUtils;
+    expect(() => installGlobalErrorCapture({ report, flush, isDev: false })).not.toThrow();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/global-error-capture.test.ts
+++ b/packages/mobile/src/lib/__tests__/global-error-capture.test.ts
@@ -68,6 +68,29 @@ describe('installGlobalErrorCapture', () => {
     expect(previousHandler).not.toHaveBeenCalled();
   });
 
+  it('does not swallow a bare "UI thread" fatal without a serialization token', () => {
+    const { previousHandler, dispatch } = installFakeErrorUtils();
+    installGlobalErrorCapture({ report, flush, isDev: false });
+
+    // A native threading error, not a worklet serialization failure.
+    const error = new Error('Attempted to call a method on the UI thread from a background thread');
+    dispatch(error, true);
+
+    expect(previousHandler).toHaveBeenCalledWith(error, true);
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  it('swallows "UI runtime" only when paired with a serialization token', () => {
+    const { previousHandler, dispatch } = installFakeErrorUtils();
+    installGlobalErrorCapture({ report, flush, isDev: false });
+
+    const error = new Error('Value passed to the UI runtime could not be serialized');
+    dispatch(error, true);
+
+    expect(report).toHaveBeenCalledOnce();
+    expect(previousHandler).not.toHaveBeenCalled();
+  });
+
   it('passes ordinary fatals through to the previous handler', () => {
     const { previousHandler, dispatch } = installFakeErrorUtils();
     installGlobalErrorCapture({ report, flush, isDev: false });

--- a/packages/mobile/src/lib/global-error-capture.ts
+++ b/packages/mobile/src/lib/global-error-capture.ts
@@ -29,9 +29,11 @@ export type GlobalErrorCaptureDeps = {
 
 // react-native-worklets / Reanimated serialization failures. The thrown message
 // varies by version ("…cannot be sent to the UI runtime/thread", references to
-// the (de)serialization helpers), so match generously across message + stack.
+// the (de)serialization helpers), so match generously across message + stack —
+// but only on signatures specific to the serialization path, never a bare
+// "worklet" mention (that would swallow unrelated fatals).
 const WORKLET_SERIALIZATION_PATTERN =
-  /cannot be (sent|serialized|cloned|copied)|UI (runtime|thread)|extractSerializable|makeShareable|makeSerializable|ValueUnpacker|\bworklet\b/i;
+  /cannot be (sent|serialized|cloned|copied)|UI (runtime|thread)|extractSerializable|makeShareable|makeSerializable|ValueUnpacker/i;
 
 function toError(value: unknown): Error {
   if (value instanceof Error) return value;

--- a/packages/mobile/src/lib/global-error-capture.ts
+++ b/packages/mobile/src/lib/global-error-capture.ts
@@ -27,13 +27,23 @@ export type GlobalErrorCaptureDeps = {
   isDev: boolean;
 };
 
-// react-native-worklets / Reanimated serialization failures. The thrown message
-// varies by version ("…cannot be sent to the UI runtime/thread", references to
-// the (de)serialization helpers), so match generously across message + stack —
-// but only on signatures specific to the serialization path, never a bare
-// "worklet" mention (that would swallow unrelated fatals).
-const WORKLET_SERIALIZATION_PATTERN =
-  /cannot be (sent|serialized|cloned|copied)|UI (runtime|thread)|extractSerializable|makeShareable|makeSerializable|ValueUnpacker/i;
+// Self-sufficient serialization signatures from react-native-worklets /
+// Reanimated's clone path. The thrown message varies by version, so match
+// generously across message + stack — but only on tokens specific to the
+// serialization path.
+const SERIALIZATION_SIGNATURE =
+  /cannot be (sent|serialized|cloned|copied)|extractSerializable|makeShareable|makeSerializable|ValueUnpacker/i;
+
+// "UI runtime"/"UI thread" shows up in unrelated native threading errors too, so
+// it must NOT classify a fatal on its own — only when paired with a
+// serialization token. (A bare "worklet" mention is likewise excluded: it would
+// swallow unrelated crashes in *-worklet.ts files.)
+const UI_RUNTIME_HINT = /UI (runtime|thread)/i;
+const SERIALIZATION_HINT = /serializ|shareable|unpack|\bclone/i;
+
+function isWorkletSerializationError(text: string): boolean {
+  return SERIALIZATION_SIGNATURE.test(text) || (UI_RUNTIME_HINT.test(text) && SERIALIZATION_HINT.test(text));
+}
 
 function toError(value: unknown): Error {
   if (value instanceof Error) return value;
@@ -64,7 +74,7 @@ export function installGlobalErrorCapture(deps: GlobalErrorCaptureDeps): void {
   errorUtils.setGlobalHandler((error: unknown, isFatal?: boolean) => {
     const normalized = toError(error);
     const haystack = `${normalized.message ?? ''}\n${normalized.stack ?? ''}`;
-    const isWorkletSerialization = WORKLET_SERIALIZATION_PATTERN.test(haystack);
+    const isWorkletSerialization = isWorkletSerializationError(haystack);
 
     // Always surface the full error to the device log.
     console.error(
@@ -82,7 +92,9 @@ export function installGlobalErrorCapture(deps: GlobalErrorCaptureDeps): void {
           level: 'error',
           tags: { mechanism: 'global-error-capture', kind: 'worklet-serialization' },
         });
-        void deps.flush?.();
+        // Swallow any flush rejection here: an unhandled rejection would loop
+        // back through this same global handler as re-entrant noise.
+        void deps.flush?.().catch(() => {});
       } catch {
         // Reporting must never become a secondary crash.
       } finally {

--- a/packages/mobile/src/lib/global-error-capture.ts
+++ b/packages/mobile/src/lib/global-error-capture.ts
@@ -1,0 +1,101 @@
+// Catches uncaught JS errors that React error boundaries can't — specifically
+// the ones thrown on the JS thread during microtask draining (Promise
+// continuations, Reanimated worklet creation). The BLE-connect crash is exactly
+// this shape: react-native-worklets fails to serialize a value to the UI runtime
+// (`extractSerializableOrThrow` inside `makeShareableCloneRecursive`), the throw
+// is uncaught, and React Native escalates it to a fatal `RCTFatal` abort.
+//
+// We wrap the global handler to (1) always log the full message + stack so a
+// TestFlight reproduction is diagnosable from Console.app even when Sentry isn't
+// delivering, and (2) recover from worklet-serialization fatals instead of
+// aborting the whole app — a value that can't cross to the UI runtime should
+// degrade the animation, not SIGABRT.
+
+type GlobalErrorHandler = (error: unknown, isFatal?: boolean) => void;
+
+type ErrorUtilsLike = {
+  getGlobalHandler: () => GlobalErrorHandler;
+  setGlobalHandler: (handler: GlobalErrorHandler) => void;
+};
+
+export type GlobalErrorCaptureDeps = {
+  /** Forward to the crash backend (Sentry). No-op when Sentry is disabled. */
+  report: (error: Error, context: { level: 'fatal' | 'error'; tags: Record<string, string> }) => void;
+  /** Best-effort flush so a report survives a later hard crash. */
+  flush?: () => Promise<unknown>;
+  /** In dev we keep the red box (don't swallow) — it's more useful than recovery. */
+  isDev: boolean;
+};
+
+// react-native-worklets / Reanimated serialization failures. The thrown message
+// varies by version ("…cannot be sent to the UI runtime/thread", references to
+// the (de)serialization helpers), so match generously across message + stack.
+const WORKLET_SERIALIZATION_PATTERN =
+  /cannot be (sent|serialized|cloned|copied)|UI (runtime|thread)|extractSerializable|makeShareable|makeSerializable|ValueUnpacker|\bworklet\b/i;
+
+function toError(value: unknown): Error {
+  if (value instanceof Error) return value;
+  if (typeof value === 'string') return new Error(value);
+  try {
+    return new Error(JSON.stringify(value));
+  } catch {
+    return new Error(String(value));
+  }
+}
+
+let installed = false;
+
+/**
+ * Wrap the React Native global error handler. Idempotent and safe to call when
+ * `ErrorUtils` is unavailable (e.g. under the test runner) — it no-ops.
+ */
+export function installGlobalErrorCapture(deps: GlobalErrorCaptureDeps): void {
+  if (installed) return;
+  const errorUtils = (globalThis as { ErrorUtils?: ErrorUtilsLike }).ErrorUtils;
+  if (!errorUtils) return;
+  installed = true;
+
+  const previousHandler = errorUtils.getGlobalHandler();
+  // Guards against the reporting path itself throwing back into this handler.
+  let reentrant = false;
+
+  errorUtils.setGlobalHandler((error: unknown, isFatal?: boolean) => {
+    const normalized = toError(error);
+    const haystack = `${normalized.message ?? ''}\n${normalized.stack ?? ''}`;
+    const isWorkletSerialization = WORKLET_SERIALIZATION_PATTERN.test(haystack);
+
+    // Always surface the full error to the device log.
+    console.error(
+      `[global-error-capture] ${isFatal ? 'FATAL' : 'non-fatal'}` +
+        `${isWorkletSerialization ? ' worklet-serialization' : ''}: ${normalized.message ?? ''}\n${normalized.stack ?? ''}`,
+    );
+
+    // Recover from worklet-serialization fatals rather than aborting the app.
+    const shouldRecover = isWorkletSerialization && isFatal === true && !deps.isDev;
+
+    if (shouldRecover && !reentrant) {
+      reentrant = true;
+      try {
+        deps.report(normalized, {
+          level: 'error',
+          tags: { mechanism: 'global-error-capture', kind: 'worklet-serialization' },
+        });
+        void deps.flush?.();
+      } catch {
+        // Reporting must never become a secondary crash.
+      } finally {
+        reentrant = false;
+      }
+      return;
+    }
+
+    // Everything else falls through to the previous handler (Sentry's, then RN's
+    // default), preserving normal fatal/red-box behaviour and Sentry capture.
+    previousHandler(error, isFatal);
+  });
+}
+
+/** Test-only: reset the install latch so each test starts clean. */
+export function resetGlobalErrorCaptureForTests(): void {
+  installed = false;
+}

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react';
 import * as Sentry from '@sentry/react-native';
+import { installGlobalErrorCapture } from './global-error-capture';
 
 const sentryDsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
 
@@ -13,6 +14,11 @@ if (isSentryEnabled) {
   Sentry.init({
     dsn: sentryDsn,
     tracesSampleRate: 0.1,
+    // Explicit so a future option change can't silently turn either off. Native
+    // crash handling persists SIGABRT/native crashes and uploads them on the
+    // next launch; attachStacktrace gives captureMessage calls a stack too.
+    enableNativeCrashHandling: true,
+    attachStacktrace: true,
     // release/dist are intentionally left unset so @sentry/react-native
     // auto-detects them from the native build (CFBundleShortVersionString +
     // CFBundleVersion). Those are the exact values `sentry-cli react-native
@@ -21,6 +27,16 @@ if (isSentryEnabled) {
     // uploaded artifacts and break symbolication.
   });
 }
+
+// Wrap the RN global error handler regardless of whether Sentry is enabled: the
+// console logging and worklet-serialization recovery are valuable even with no
+// DSN (dev / DSN-less builds). Installed after Sentry.init so it wraps Sentry's
+// handler rather than being clobbered by it.
+installGlobalErrorCapture({
+  report: (error, context) => reportError(error, context),
+  flush: () => (isSentryEnabled ? Sentry.flush() : Promise.resolve(true)),
+  isDev: __DEV__,
+});
 
 /**
  * Report an error to Sentry if it is active. No-op otherwise. The optional


### PR DESCRIPTION
## Why

Two TestFlight crash reports (Boardsesh **2.0.0 / build 100228**, iPhone 16, iOS 26.5) are the **same crash**, and the reporter says it **crashes every time they try to connect to Bluetooth**.

Both native traces show the same shape:

- `EXC_CRASH (SIGABRT)` from `RCTFatal` → `-[RCTExceptionsManager reportFatal:…]` → `reportException:` — React Native turning an **unhandled JS exception into a fatal native abort**.
- The JS thread is inside `hermes…drainJobs()` → `drainMicrotasks` → `RuntimeScheduler::performMicrotaskCheckpoint`, i.e. a **Promise/async continuation** (matches "happens on connect", which is async).
- Crash #1 pins the throw site explicitly: `react-native-worklets` `extractSerializableOrThrow` ← `makeSerializableObject` ← `JSIWorkletsModuleProxy::get`. That is **Reanimated's `makeShareableCloneRecursive` failing to serialize a value to the UI runtime** because some leaf is non-serializable.

A native crash trace can't name the exact JS line — that information (the worklets error message naming the offending property/type, plus the symbolicated JS stack) lives in the **runtime error**, which Sentry should be capturing but currently isn't ("I don't see anything in Sentry").

## What this PR does (diagnostics + resilience — does not yet fix the root cause)

- **`src/lib/global-error-capture.ts`** — wraps the RN global error handler (a React error boundary can't catch a microtask throw). It:
  - always logs the full `error.message` + stack to the device log, so a TestFlight reproduction is diagnosable from Console.app even while Sentry isn't delivering events;
  - **recovers from worklet-serialization fatals instead of aborting the whole app** — a value that can't cross to the UI runtime should degrade the animation, not SIGABRT. Gated to non-dev (keeps the red box in dev) and re-entrancy-guarded.
- **`src/lib/sentry.ts`** — makes init explicit (`enableNativeCrashHandling`, `attachStacktrace`) and installs the capture after `Sentry.init` so it wraps Sentry's handler.
- Unit tests for the capture/recovery/pass-through behaviour.

Because the crash is JS, this ships to the existing TestFlight build over-the-air via EAS Update (`vp run mobile:publish`) — no new native binary needed.

## Still to do (separate, once the message is captured)

1. **Verify the Sentry pipeline.** The native `SentryCrash` monitors *are* running in the crashed process, yet nothing surfaces. Prime suspect: the runtime DSN's numeric project (`…/4510644930150400`) may not be the same Sentry project that source maps/dSYMs upload to (`organization: boardsesh, project: boardsesh` in `app.config.ts`). Confirm `SENTRY_AUTH_TOKEN` is set for the iOS TestFlight build too. **Needs Sentry dashboard access.**
2. **Fix the root cause** once the captured message names the offending property/component (expected: a non-serializable value reaching a worklet in the connect → device-picker render, or the gorhom `BottomSheetModal` + `BottomSheetFlatList` + `FullWindowOverlay` + Reanimated-4/New-Arch combo the picker uses).

## Validation

- `vp run typecheck:mobile` ✅
- `vp test run --project mobile` (global-error-capture) — 6/6 ✅
- `vp check` — my files clean (pre-existing formatting issues elsewhere untouched)

https://claude.ai/code/session_01R3e8xa8XaNaTt4THAVtCQv

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3e8xa8XaNaTt4THAVtCQv)_