### PR TITLE
[codex] Fix Aurora JSON import emoji name resolution

### DIFF
--- a/docs/aurora-sync.md
+++ b/docs/aurora-sync.md
@@ -346,7 +346,11 @@ Since the Kilter backend has been shut down, API-based sync is no longer availab
 
 Climb names are resolved via `board_climbs` table using a composite index on `(board_type, name)`. When multiple climbs share the same name (rare), the one with the highest `ascensionist_count` is chosen.
 
-Unresolvable names (delisted climbs, typos) are returned to the user in the result dialog so they know which entries could not be imported.
+Exact non-draft Aurora catalog matches remain importable even if the climb has since been delisted in Boardsesh. This keeps historical logbook data importable without making the delisted climb appear in public search.
+
+Some Aurora exports replace emoji with literal `?` characters in climb names. After exact matching, the importer tries a narrow fallback for still-unresolved names containing `?`: it gathers candidates with an escaped `ILIKE` pattern, strips emoji from DB names, strips question marks from export names, and only accepts normalized exact matches. This recovers names such as `Friend Forever?` → `Friend Forever👭` without broad fuzzy matching.
+
+Unresolvable names (missing climbs, renamed climbs, typos) are returned to the user in the result dialog so they know which entries could not be imported.
 
 ## Migration from Vercel Cron
 

--- a/docs/aurora-sync.md
+++ b/docs/aurora-sync.md
@@ -344,7 +344,7 @@ Since the Kilter backend has been shut down, API-based sync is no longer availab
 
 ### Climb Name Resolution
 
-Climb names are resolved via `board_climbs` table using a composite index on `(board_type, name)`. When multiple climbs share the same name (rare), the one with the highest `ascensionist_count` is chosen.
+Climb names are resolved via `board_climbs` table using a composite index on `(board_type, name)`. When multiple climbs share the same name (rare), listed public climbs are preferred first, then the importing user's own climbs, then unlisted Aurora catalog climbs. Within the same tier, the climb with the highest `ascensionist_count` is chosen.
 
 Exact non-draft Aurora catalog matches remain importable even if the climb has since been delisted in Boardsesh. This keeps historical logbook data importable without making the delisted climb appear in public search.
 

--- a/packages/web/app/lib/data-sync/aurora/__tests__/json-import.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/json-import.test.ts
@@ -8,6 +8,11 @@ import {
   convertHoldsToFrames,
   computeEdgesFromHolds,
   generateClimbImportUuid,
+  normalizeAuroraExportClimbNameForResolution,
+  normalizeBoardClimbNameForAuroraExportResolution,
+  isClimbNameResolutionCandidateAllowed,
+  resolveQuestionPlaceholderClimbNameForCandidates,
+  type ClimbNameResolutionCandidate,
 } from '../json-import';
 
 // Mock server-only and DB modules to avoid server-component import errors
@@ -357,6 +362,95 @@ describe('dedup key consistency', () => {
       'ascents',
     );
     expect(id1).toBe(id2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Aurora export climb name resolution
+// ---------------------------------------------------------------------------
+
+describe('Aurora export climb name resolution', () => {
+  function candidate(
+    overrides: Partial<ClimbNameResolutionCandidate> & Pick<ClimbNameResolutionCandidate, 'uuid' | 'name'>,
+  ): ClimbNameResolutionCandidate {
+    return {
+      ascensionistCount: 0,
+      isListed: true,
+      isDraft: false,
+      userId: null,
+      ...overrides,
+    };
+  }
+
+  it('normalizes Aurora question-mark placeholders to match DB emoji names', () => {
+    expect(normalizeAuroraExportClimbNameForResolution('Friend Forever?')).toBe(
+      normalizeBoardClimbNameForAuroraExportResolution('Friend Forever👭'),
+    );
+    expect(normalizeAuroraExportClimbNameForResolution('?sssshht, Kyle!')).toBe(
+      normalizeBoardClimbNameForAuroraExportResolution('🤫sssshht, Kyle!'),
+    );
+    expect(normalizeAuroraExportClimbNameForResolution('????NEVER LET GO ROSE!????')).toBe(
+      normalizeBoardClimbNameForAuroraExportResolution('🚢🌹🚢🌹NEVER LET GO ROSE!🌹🚢🌹🚢'),
+    );
+  });
+
+  it('resolves exported names whose emoji were replaced by question marks', () => {
+    expect(
+      resolveQuestionPlaceholderClimbNameForCandidates('Friend Forever?', [
+        candidate({ uuid: 'friend-forever', name: 'Friend Forever👭', ascensionistCount: 15178 }),
+      ]),
+    ).toBe('friend-forever');
+
+    expect(
+      resolveQuestionPlaceholderClimbNameForCandidates('?sssshht, Kyle!', [
+        candidate({ uuid: 'sssshht-kyle', name: '🤫sssshht, Kyle!', ascensionistCount: 597 }),
+      ]),
+    ).toBe('sssshht-kyle');
+
+    expect(
+      resolveQuestionPlaceholderClimbNameForCandidates('????NEVER LET GO ROSE!????', [
+        candidate({ uuid: 'rose', name: '🚢🌹🚢🌹NEVER LET GO ROSE!🌹🚢🌹🚢', ascensionistCount: 7711 }),
+      ]),
+    ).toBe('rose');
+  });
+
+  it('does not fuzzy-match unrelated question-mark names', () => {
+    expect(
+      resolveQuestionPlaceholderClimbNameForCandidates('Dad?', [
+        candidate({ uuid: 'dad-dancing', name: 'Dad Dancing 6a+' }),
+        candidate({ uuid: 'hi-dad', name: 'Hi hungry, I’m dad.' }),
+      ]),
+    ).toBeNull();
+  });
+
+  it('allows exact delisted catalog rows but not another user-owned private climb', () => {
+    expect(
+      isClimbNameResolutionCandidateAllowed(
+        candidate({ uuid: 'unlisted-catalog', name: 'Stige-spillet', isListed: false, userId: null }),
+      ),
+    ).toBe(true);
+
+    expect(
+      isClimbNameResolutionCandidateAllowed(
+        candidate({ uuid: 'other-user-private', name: 'Private Project', isListed: false, userId: 'other-user' }),
+        'current-user',
+      ),
+    ).toBe(false);
+  });
+
+  it('prefers listed public matches over unlisted catalog matches', () => {
+    expect(
+      resolveQuestionPlaceholderClimbNameForCandidates('Friend Forever?', [
+        candidate({
+          uuid: 'unlisted-popular',
+          name: 'Friend Forever👭',
+          ascensionistCount: 99999,
+          isListed: false,
+          userId: null,
+        }),
+        candidate({ uuid: 'listed-less-popular', name: 'Friend Forever👭', ascensionistCount: 1 }),
+      ]),
+    ).toBe('listed-less-popular');
   });
 });
 

--- a/packages/web/app/lib/data-sync/aurora/__tests__/json-import.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/json-import.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeAuroraExportClimbNameForResolution,
   normalizeBoardClimbNameForAuroraExportResolution,
   isClimbNameResolutionCandidateAllowed,
+  doesBoardClimbNameMatchAuroraQuestionPlaceholder,
   resolveQuestionPlaceholderClimbNameForCandidates,
   type ClimbNameResolutionCandidate,
 } from '../json-import';
@@ -414,6 +415,23 @@ describe('Aurora export climb name resolution', () => {
     ).toBe('rose');
   });
 
+  it('requires the DB candidate to contain emoji where Aurora exported question marks', () => {
+    expect(doesBoardClimbNameMatchAuroraQuestionPlaceholder('Friend Forever?', 'Friend Forever👭')).toBe(true);
+    expect(doesBoardClimbNameMatchAuroraQuestionPlaceholder('Friend Forever?', 'Friend Forever')).toBe(false);
+
+    expect(
+      resolveQuestionPlaceholderClimbNameForCandidates('Friend Forever?', [
+        candidate({ uuid: 'plain-base-name', name: 'Friend Forever', ascensionistCount: 99999 }),
+        candidate({ uuid: 'emoji-name', name: 'Friend Forever👭', ascensionistCount: 1 }),
+      ]),
+    ).toBe('emoji-name');
+  });
+
+  it('checks the candidate against the specific export question-mark pattern', () => {
+    expect(doesBoardClimbNameMatchAuroraQuestionPlaceholder('A?B', 'A😀B')).toBe(true);
+    expect(doesBoardClimbNameMatchAuroraQuestionPlaceholder('AB?', 'A😀B')).toBe(false);
+  });
+
   it('does not fuzzy-match unrelated question-mark names', () => {
     expect(
       resolveQuestionPlaceholderClimbNameForCandidates('Dad?', [
@@ -438,6 +456,22 @@ describe('Aurora export climb name resolution', () => {
     ).toBe(false);
   });
 
+  it("allows the current user's own climbs but rejects another user's drafts", () => {
+    expect(
+      isClimbNameResolutionCandidateAllowed(
+        candidate({ uuid: 'own-draft', name: 'Project', isDraft: true, isListed: false, userId: 'current-user' }),
+        'current-user',
+      ),
+    ).toBe(true);
+
+    expect(
+      isClimbNameResolutionCandidateAllowed(
+        candidate({ uuid: 'other-draft', name: 'Project', isDraft: true, isListed: false, userId: 'other-user' }),
+        'current-user',
+      ),
+    ).toBe(false);
+  });
+
   it('prefers listed public matches over unlisted catalog matches', () => {
     expect(
       resolveQuestionPlaceholderClimbNameForCandidates('Friend Forever?', [
@@ -451,6 +485,32 @@ describe('Aurora export climb name resolution', () => {
         candidate({ uuid: 'listed-less-popular', name: 'Friend Forever👭', ascensionistCount: 1 }),
       ]),
     ).toBe('listed-less-popular');
+  });
+
+  it("prefers the current user's own climb over an unlisted catalog match", () => {
+    expect(
+      resolveQuestionPlaceholderClimbNameForCandidates(
+        'Friend Forever?',
+        [
+          candidate({
+            uuid: 'unlisted-catalog',
+            name: 'Friend Forever👭',
+            ascensionistCount: 99999,
+            isListed: false,
+            userId: null,
+          }),
+          candidate({
+            uuid: 'own-climb',
+            name: 'Friend Forever👭',
+            ascensionistCount: 1,
+            isDraft: true,
+            isListed: false,
+            userId: 'current-user',
+          }),
+        ],
+        'current-user',
+      ),
+    ).toBe('own-climb');
   });
 });
 

--- a/packages/web/app/lib/data-sync/aurora/json-import.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { eq, and, or, inArray, sql } from 'drizzle-orm';
+import { eq, and, or, inArray, sql, isNull, ilike } from 'drizzle-orm';
 import { getDb } from '@/app/lib/db/db';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import {
@@ -17,6 +17,8 @@ import type { AuroraBoardName } from '@boardsesh/shared-schema';
 import { populateDenormalizedColumns } from '@boardsesh/db/queries';
 
 const BATCH_SIZE = 100;
+const FALLBACK_NAME_CHUNK_SIZE = 50;
+const MIN_FALLBACK_NAME_KEY_LENGTH = 3;
 
 // ---------------------------------------------------------------------------
 // Zod schema for the Aurora JSON export format
@@ -80,6 +82,21 @@ export const auroraExportSchema = z.object({
 export type AuroraExportData = z.infer<typeof auroraExportSchema>;
 
 type BoardType = AuroraBoardName;
+
+export type ClimbNameResolutionCandidate = {
+  uuid: string;
+  name: string | null;
+  ascensionistCount: number | null;
+  isListed: boolean | null;
+  isDraft: boolean | null;
+  userId: string | null;
+};
+
+type ClimbNameResolutionMatch = {
+  uuid: string;
+  count: number;
+  tier: number;
+};
 
 // ---------------------------------------------------------------------------
 // Import result types
@@ -156,6 +173,106 @@ export function generateJsonImportAuroraId(
     .digest('hex')
     .slice(0, 32);
   return `json-import-${hash}`;
+}
+
+// ---------------------------------------------------------------------------
+// Climb name normalization
+// ---------------------------------------------------------------------------
+
+const VARIATION_SELECTOR_AND_JOINER_PATTERN = /[\u200d\ufe0e\ufe0f]/gu;
+const EMOJI_AND_PRESENTATION_PATTERN = /[\p{Extended_Pictographic}\p{Emoji_Presentation}\u200d\ufe0e\ufe0f]/gu;
+
+function compactResolutionName(value: string): string {
+  return value.normalize('NFKC').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+export function normalizeAuroraExportClimbNameForResolution(name: string): string {
+  return compactResolutionName(name.replace(/\?/g, '').replace(VARIATION_SELECTOR_AND_JOINER_PATTERN, ''));
+}
+
+export function normalizeBoardClimbNameForAuroraExportResolution(name: string): string {
+  return compactResolutionName(name.replace(EMOJI_AND_PRESENTATION_PATTERN, ''));
+}
+
+// Escape LIKE/ILIKE metacharacters so export names are matched literally except
+// for Aurora's `?` placeholders, which we intentionally turn into wildcards.
+function escapeLikePattern(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/[_%]/g, (match) => `\\${match}`);
+}
+
+function buildQuestionPlaceholderLikePattern(name: string): string | null {
+  const normalizedKey = normalizeAuroraExportClimbNameForResolution(name);
+  if (normalizedKey.length < MIN_FALLBACK_NAME_KEY_LENGTH) return null;
+
+  const pattern = escapeLikePattern(name).replace(/\?+/g, '%');
+  return pattern.includes('%') ? pattern : null;
+}
+
+export function isClimbNameResolutionCandidateAllowed(
+  candidate: ClimbNameResolutionCandidate,
+  userId?: string,
+): boolean {
+  const isNonDraft = candidate.isDraft === false;
+  const isCatalogOrPublic = isNonDraft && (candidate.isListed === true || candidate.userId == null);
+  const isUsersOwnClimb = userId != null && candidate.userId === userId;
+  return isCatalogOrPublic || isUsersOwnClimb;
+}
+
+function getClimbNameResolutionCandidateTier(candidate: ClimbNameResolutionCandidate, userId?: string): number {
+  if (candidate.isDraft === false && candidate.isListed === true) return 3;
+  if (candidate.isDraft === false && candidate.userId == null) return 2;
+  if (userId != null && candidate.userId === userId) return 1;
+  return 0;
+}
+
+function isBetterClimbNameResolutionCandidate(
+  candidate: ClimbNameResolutionCandidate,
+  candidateMatch: ClimbNameResolutionMatch,
+  existingMatch?: ClimbNameResolutionMatch,
+): boolean {
+  if (!existingMatch) return true;
+  if (candidateMatch.tier !== existingMatch.tier) return candidateMatch.tier > existingMatch.tier;
+  if (candidateMatch.count !== existingMatch.count) return candidateMatch.count > existingMatch.count;
+  return candidate.uuid < existingMatch.uuid;
+}
+
+function addClimbNameResolutionCandidate(
+  nameToMatch: Map<string, ClimbNameResolutionMatch>,
+  exportName: string,
+  candidate: ClimbNameResolutionCandidate,
+  userId?: string,
+): void {
+  if (!candidate.name || !isClimbNameResolutionCandidateAllowed(candidate, userId)) return;
+
+  const candidateMatch: ClimbNameResolutionMatch = {
+    uuid: candidate.uuid,
+    count: candidate.ascensionistCount ?? 0,
+    tier: getClimbNameResolutionCandidateTier(candidate, userId),
+  };
+  const existingMatch = nameToMatch.get(exportName);
+
+  if (isBetterClimbNameResolutionCandidate(candidate, candidateMatch, existingMatch)) {
+    nameToMatch.set(exportName, candidateMatch);
+  }
+}
+
+export function resolveQuestionPlaceholderClimbNameForCandidates(
+  exportName: string,
+  candidates: ClimbNameResolutionCandidate[],
+  userId?: string,
+): string | null {
+  const exportKey = normalizeAuroraExportClimbNameForResolution(exportName);
+  if (exportKey.length < MIN_FALLBACK_NAME_KEY_LENGTH) return null;
+
+  const nameToMatch = new Map<string, ClimbNameResolutionMatch>();
+  for (const candidate of candidates) {
+    if (!candidate.name) continue;
+    const candidateKey = normalizeBoardClimbNameForAuroraExportResolution(candidate.name);
+    if (candidateKey !== exportKey) continue;
+    addClimbNameResolutionCandidate(nameToMatch, exportName, candidate, userId);
+  }
+
+  return nameToMatch.get(exportName)?.uuid ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -285,28 +402,36 @@ async function resolveClimbNames(
 ): Promise<Map<string, string>> {
   if (climbNames.length === 0) return new Map();
 
-  // Track best match across all chunks: name -> { uuid, ascensionistCount, isPublic }
-  const nameToMatch = new Map<string, { uuid: string; count: number; isPublic: boolean }>();
+  // Track best match across all chunks.
+  const nameToMatch = new Map<string, ClimbNameResolutionMatch>();
+
+  const eligibleCatalogOrPublicFilter = and(
+    eq(boardClimbs.isDraft, false),
+    or(eq(boardClimbs.isListed, true), isNull(boardClimbs.userId)),
+  );
 
   // Batch in chunks of 500 to avoid overly large IN clauses
   const chunkSize = 500;
   for (let i = 0; i < climbNames.length; i += chunkSize) {
     const chunk = climbNames.slice(i, i + chunkSize);
 
-    // Query public climbs with stats to pick the most popular when duplicates exist
-    const publicFilter = and(
+    // Query exact name matches with stats to pick the most popular when
+    // duplicates exist. Aurora catalog climbs can be delisted after a user
+    // logged them, so non-draft catalog rows stay eligible even when
+    // is_listed=false.
+    const catalogOrPublicFilter = and(
       eq(boardClimbs.boardType, boardType),
       inArray(boardClimbs.name, chunk),
-      eq(boardClimbs.isListed, true),
-      eq(boardClimbs.isDraft, false),
+      eligibleCatalogOrPublicFilter,
     );
 
-    // Also match user's own drafts so ascents/circuits referencing their climbs resolve
-    const userDraftFilter = userId
+    // Also match the user's own imported/local climbs so ascents/circuits
+    // referencing them resolve.
+    const userOwnedFilter = userId
       ? and(eq(boardClimbs.boardType, boardType), inArray(boardClimbs.name, chunk), eq(boardClimbs.userId, userId))
       : undefined;
 
-    const whereClause = userDraftFilter ? or(publicFilter, userDraftFilter) : publicFilter;
+    const whereClause = userOwnedFilter ? or(catalogOrPublicFilter, userOwnedFilter) : catalogOrPublicFilter;
 
     const results = await db
       .select({
@@ -315,6 +440,7 @@ async function resolveClimbNames(
         ascensionistCount: boardClimbStats.ascensionistCount,
         isListed: boardClimbs.isListed,
         isDraft: boardClimbs.isDraft,
+        userId: boardClimbs.userId,
       })
       .from(boardClimbs)
       .leftJoin(
@@ -325,26 +451,96 @@ async function resolveClimbNames(
 
     for (const row of results) {
       if (!row.name) continue;
-
-      const count = row.ascensionistCount ?? 0;
-      const isPublic = row.isListed === true && row.isDraft === false;
-      const existing = nameToMatch.get(row.name);
-
-      // Prefer public climbs over drafts; among same type prefer higher ascensionist count
-      if (!existing) {
-        nameToMatch.set(row.name, { uuid: row.uuid, count, isPublic });
-      } else if (isPublic && !existing.isPublic) {
-        // Public always wins over draft
-        nameToMatch.set(row.name, { uuid: row.uuid, count, isPublic });
-      } else if (isPublic === existing.isPublic && count > existing.count) {
-        // Same visibility tier: pick higher count
-        nameToMatch.set(row.name, { uuid: row.uuid, count, isPublic });
-      }
+      addClimbNameResolutionCandidate(nameToMatch, row.name, row, userId);
     }
+  }
+
+  const unresolvedQuestionNames = climbNames.filter((name) => !nameToMatch.has(name) && name.includes('?'));
+  if (unresolvedQuestionNames.length > 0) {
+    await resolveQuestionPlaceholderClimbNames(
+      db,
+      boardType,
+      unresolvedQuestionNames,
+      eligibleCatalogOrPublicFilter,
+      nameToMatch,
+      userId,
+    );
   }
 
   // Convert to simple name -> uuid map
   return new Map([...nameToMatch].map(([name, match]) => [name, match.uuid]));
+}
+
+async function resolveQuestionPlaceholderClimbNames(
+  db: PgDatabase<PgQueryResultHKT, Record<string, unknown>>,
+  boardType: BoardType,
+  climbNames: string[],
+  eligibleCatalogOrPublicFilter: ReturnType<typeof and>,
+  nameToMatch: Map<string, ClimbNameResolutionMatch>,
+  userId?: string,
+): Promise<void> {
+  const fallbackRequests = climbNames
+    .map((name) => ({
+      name,
+      normalizedKey: normalizeAuroraExportClimbNameForResolution(name),
+      pattern: buildQuestionPlaceholderLikePattern(name),
+    }))
+    .filter(
+      (
+        request,
+      ): request is {
+        name: string;
+        normalizedKey: string;
+        pattern: string;
+      } => request.pattern != null && request.normalizedKey.length >= MIN_FALLBACK_NAME_KEY_LENGTH,
+    );
+
+  for (let i = 0; i < fallbackRequests.length; i += FALLBACK_NAME_CHUNK_SIZE) {
+    const chunk = fallbackRequests.slice(i, i + FALLBACK_NAME_CHUNK_SIZE);
+    const namesByNormalizedKey = new Map<string, string[]>();
+    const patterns = new Set<string>();
+
+    for (const request of chunk) {
+      patterns.add(request.pattern);
+      const names = namesByNormalizedKey.get(request.normalizedKey) ?? [];
+      names.push(request.name);
+      namesByNormalizedKey.set(request.normalizedKey, names);
+    }
+
+    const namePatternFilters = [...patterns].map((pattern) => ilike(boardClimbs.name, pattern));
+    const userOwnedFilter = userId ? eq(boardClimbs.userId, userId) : undefined;
+    const eligibilityFilter = userOwnedFilter
+      ? or(eligibleCatalogOrPublicFilter, userOwnedFilter)
+      : eligibleCatalogOrPublicFilter;
+
+    const results = await db
+      .select({
+        uuid: boardClimbs.uuid,
+        name: boardClimbs.name,
+        ascensionistCount: boardClimbStats.ascensionistCount,
+        isListed: boardClimbs.isListed,
+        isDraft: boardClimbs.isDraft,
+        userId: boardClimbs.userId,
+      })
+      .from(boardClimbs)
+      .leftJoin(
+        boardClimbStats,
+        and(eq(boardClimbStats.climbUuid, boardClimbs.uuid), eq(boardClimbStats.boardType, boardClimbs.boardType)),
+      )
+      .where(and(eq(boardClimbs.boardType, boardType), eligibilityFilter, or(...namePatternFilters)));
+
+    for (const row of results) {
+      if (!row.name) continue;
+
+      const candidateKey = normalizeBoardClimbNameForAuroraExportResolution(row.name);
+      const exportNames = namesByNormalizedKey.get(candidateKey);
+      if (!exportNames) continue;
+
+      for (const exportName of exportNames) {
+        addClimbNameResolutionCandidate(nameToMatch, exportName, row, userId);
+      }
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/web/app/lib/data-sync/aurora/json-import.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import.ts
@@ -181,6 +181,7 @@ export function generateJsonImportAuroraId(
 
 const VARIATION_SELECTOR_AND_JOINER_PATTERN = /[\u200d\ufe0e\ufe0f]/gu;
 const EMOJI_AND_PRESENTATION_PATTERN = /[\p{Extended_Pictographic}\p{Emoji_Presentation}\u200d\ufe0e\ufe0f]/gu;
+const EMOJI_PLACEHOLDER_REGEX_SOURCE = '[\\p{Extended_Pictographic}\\p{Emoji_Presentation}\\u200d\\ufe0e\\ufe0f]+';
 
 function compactResolutionName(value: string): string {
   return value.normalize('NFKC').replace(/\s+/g, ' ').trim().toLowerCase();
@@ -192,6 +193,29 @@ export function normalizeAuroraExportClimbNameForResolution(name: string): strin
 
 export function normalizeBoardClimbNameForAuroraExportResolution(name: string): string {
   return compactResolutionName(name.replace(EMOJI_AND_PRESENTATION_PATTERN, ''));
+}
+
+function boardClimbNameHasEmojiForAuroraExportResolution(name: string): boolean {
+  return name.replace(EMOJI_AND_PRESENTATION_PATTERN, '') !== name;
+}
+
+function escapeRegExpPattern(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildQuestionPlaceholderRegExp(name: string): RegExp {
+  const source = name.split(/\?+/g).map(escapeRegExpPattern).join(EMOJI_PLACEHOLDER_REGEX_SOURCE);
+  return new RegExp(`^${source}$`, 'u');
+}
+
+export function doesBoardClimbNameMatchAuroraQuestionPlaceholder(exportName: string, boardClimbName: string): boolean {
+  if (!boardClimbNameHasEmojiForAuroraExportResolution(boardClimbName)) return false;
+
+  const exportKey = normalizeAuroraExportClimbNameForResolution(exportName);
+  const boardClimbKey = normalizeBoardClimbNameForAuroraExportResolution(boardClimbName);
+  if (exportKey !== boardClimbKey) return false;
+
+  return buildQuestionPlaceholderRegExp(exportName).test(boardClimbName);
 }
 
 // Escape LIKE/ILIKE metacharacters so export names are matched literally except
@@ -219,9 +243,9 @@ export function isClimbNameResolutionCandidateAllowed(
 }
 
 function getClimbNameResolutionCandidateTier(candidate: ClimbNameResolutionCandidate, userId?: string): number {
-  if (candidate.isDraft === false && candidate.isListed === true) return 3;
+  if (candidate.isDraft === false && candidate.isListed === true) return 4;
+  if (userId != null && candidate.userId === userId) return 3;
   if (candidate.isDraft === false && candidate.userId == null) return 2;
-  if (userId != null && candidate.userId === userId) return 1;
   return 0;
 }
 
@@ -267,8 +291,7 @@ export function resolveQuestionPlaceholderClimbNameForCandidates(
   const nameToMatch = new Map<string, ClimbNameResolutionMatch>();
   for (const candidate of candidates) {
     if (!candidate.name) continue;
-    const candidateKey = normalizeBoardClimbNameForAuroraExportResolution(candidate.name);
-    if (candidateKey !== exportKey) continue;
+    if (!doesBoardClimbNameMatchAuroraQuestionPlaceholder(exportName, candidate.name)) continue;
     addClimbNameResolutionCandidate(nameToMatch, exportName, candidate, userId);
   }
 
@@ -497,14 +520,10 @@ async function resolveQuestionPlaceholderClimbNames(
 
   for (let i = 0; i < fallbackRequests.length; i += FALLBACK_NAME_CHUNK_SIZE) {
     const chunk = fallbackRequests.slice(i, i + FALLBACK_NAME_CHUNK_SIZE);
-    const namesByNormalizedKey = new Map<string, string[]>();
     const patterns = new Set<string>();
 
     for (const request of chunk) {
       patterns.add(request.pattern);
-      const names = namesByNormalizedKey.get(request.normalizedKey) ?? [];
-      names.push(request.name);
-      namesByNormalizedKey.set(request.normalizedKey, names);
     }
 
     const namePatternFilters = [...patterns].map((pattern) => ilike(boardClimbs.name, pattern));
@@ -532,12 +551,9 @@ async function resolveQuestionPlaceholderClimbNames(
     for (const row of results) {
       if (!row.name) continue;
 
-      const candidateKey = normalizeBoardClimbNameForAuroraExportResolution(row.name);
-      const exportNames = namesByNormalizedKey.get(candidateKey);
-      if (!exportNames) continue;
-
-      for (const exportName of exportNames) {
-        addClimbNameResolutionCandidate(nameToMatch, exportName, row, userId);
+      for (const request of chunk) {
+        if (!doesBoardClimbNameMatchAuroraQuestionPlaceholder(request.name, row.name)) continue;
+        addClimbNameResolutionCandidate(nameToMatch, request.name, row, userId);
       }
     }
   }


### PR DESCRIPTION
## What changed

- Added a constrained fallback for Aurora JSON export climb names where emoji were replaced with literal `?` characters.
- Allows exact non-draft Aurora catalog matches to import even if the climb has since been delisted from public search, including nullable `is_draft` catalog rows.
- Tightened fallback matching after review so candidates must actually contain emoji/presentation characters and must match the specific export-name placeholder pattern after NFKC normalization.
- Added focused tests for emoji placeholder matching, unrelated `?` names, candidate eligibility, nullable draft state, source ranking, and collision cases.
- Documented the importer behavior in `docs/aurora-sync.md`.

## Why

A user export at `~/Downloads/export-jakobromo.json` had Kilter logbook entries whose climb names no longer exactly matched Boardsesh rows because Aurora exported some emoji as `?`. The importer only resolved exact names, so those historical ticks were reported as unresolved.

## Validation

- `vp test run --reporter=agent packages/web/app/lib/data-sync/aurora/__tests__/json-import.test.ts packages/web/app/lib/data-sync/aurora/__tests__/json-import-stream.test.ts` passed: 2 files, 96 tests.
- `vp run typecheck:web` passed.
- `git diff --check` passed for changed importer files.
- Read-only DB/export verification for `~/Downloads/export-jakobromo.json`: 647 referenced names, 8 exact unresolved, 8 resolved by stricter emoji fallback, final unresolved list empty.
- `vp check` still reports 20 pre-existing formatting issues outside this PR scope; the changed files are not in that final failure list.

## Review

Ran three independent code-review subagents. They found placeholder overmatching, source-tier ranking, and test coverage gaps; those were addressed in commit `21b5aa820`. Follow-up review notes about nullable draft state, NFKC regex matching, and tier readability were addressed in commit `c6c37b26f`.