### PR TITLE
Remove TestFlight prefix from feedback issue titles

### DIFF
--- a/scripts/__tests__/testflight-feedback-to-issues.test.ts
+++ b/scripts/__tests__/testflight-feedback-to-issues.test.ts
@@ -117,6 +117,7 @@ describe('buildIssueDraft', () => {
     );
 
     expect(draft.marker).toBe(testFlightMarker('screenshot', 'screenshot-1'));
+    expect(draft.title).toBe('Screenshot feedback: Queue button disappears after I add a climb.');
     expect(draft.labels).toEqual(['testflight', 'ios', 'feedback', 'screenshot']);
     expect(draft.body).toContain('<!-- testflight-feedback:screenshot:screenshot-1 -->');
     expect(draft.body).toContain('email: [redacted]');
@@ -129,6 +130,7 @@ describe('buildIssueDraft', () => {
   it('splits long crash logs into follow-up comments', () => {
     const draft = buildIssueDraft(crashFeedback({ crashLog: `name: Marco\n${'crash line\n'.repeat(7000)}` }));
 
+    expect(draft.title).toBe('Crash feedback: It crashes when I open party mode.');
     expect(draft.labels).toEqual(['testflight', 'ios', 'feedback', 'crash']);
     expect(draft.body).toContain('Crash log is split across');
     expect(draft.body).not.toContain('Marco');

--- a/scripts/testflight-feedback-to-issues.ts
+++ b/scripts/testflight-feedback-to-issues.ts
@@ -621,7 +621,7 @@ function buildScreenshotIssueDraft(feedback: TestFlightScreenshotFeedback): Issu
   const title = buildIssueTitle('Screenshot feedback', feedback);
   const bodyParts = [
     marker,
-    'TestFlight screenshot feedback submitted by a beta tester.',
+    'Screenshot feedback submitted by a beta tester.',
     '',
     formatComment(feedback.comment),
     '',
@@ -645,7 +645,7 @@ function buildCrashIssueDraft(feedback: TestFlightCrashFeedback): IssueDraft {
   const redactedLog = feedback.crashLog ? redactSensitiveText(feedback.crashLog) : null;
   const bodyWithoutLog = [
     marker,
-    'TestFlight crash feedback submitted by a beta tester.',
+    'Crash feedback submitted by a beta tester.',
     '',
     formatComment(feedback.comment),
     '',

--- a/scripts/testflight-feedback-to-issues.ts
+++ b/scripts/testflight-feedback-to-issues.ts
@@ -618,7 +618,7 @@ export function buildIssueDraft(feedback: TestFlightFeedback): IssueDraft {
 
 function buildScreenshotIssueDraft(feedback: TestFlightScreenshotFeedback): IssueDraft {
   const marker = testFlightMarker(feedback.kind, feedback.id);
-  const title = buildIssueTitle('TestFlight screenshot feedback', feedback);
+  const title = buildIssueTitle('Screenshot feedback', feedback);
   const bodyParts = [
     marker,
     'TestFlight screenshot feedback submitted by a beta tester.',
@@ -641,7 +641,7 @@ function buildScreenshotIssueDraft(feedback: TestFlightScreenshotFeedback): Issu
 
 function buildCrashIssueDraft(feedback: TestFlightCrashFeedback): IssueDraft {
   const marker = testFlightMarker(feedback.kind, feedback.id);
-  const title = buildIssueTitle('TestFlight crash feedback', feedback);
+  const title = buildIssueTitle('Crash feedback', feedback);
   const redactedLog = feedback.crashLog ? redactSensitiveText(feedback.crashLog) : null;
   const bodyWithoutLog = [
     marker,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Issue titles from the TestFlight feedback importer no longer include "TestFlight" in the prefix — the `testflight` label already signals the source
- `TestFlight crash feedback: ...` → `Crash feedback: ...`
- `TestFlight screenshot feedback: ...` → `Screenshot feedback: ...`

## Test plan

- [ ] Run `vp test run --project web` to confirm no test regressions
- [ ] Manually trigger the importer in dry-run mode and verify new titles match the new format

https://claude.ai/code/session_01LRAoq9HF9weyzs4H6jAjsY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRAoq9HF9weyzs4H6jAjsY)_