### PR TITLE
Default session recording on in the open TestFlight beta

### DIFF
--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -57,6 +57,11 @@ jobs:
       # build time; without this, analytics.ts sees no key and isAnalyticsEnabled is
       # false, so every track() silently no-ops (the app shipped zero events before).
       EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+      # Opt this build (the open TestFlight beta) into session recording ON by
+      # default. session-recording-preference reads this to set the default; an
+      # explicit off from the Privacy toggle still wins. Production App Store
+      # builds omit this var, so recording stays opt-in there.
+      EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON: 'true'
 
     steps:
       - name: Checkout repository
@@ -79,6 +84,7 @@ jobs:
           EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
           EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
           EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
+          EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON=$EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON
           EOF
 
       - name: Expo prebuild (generate ios/)

--- a/packages/mobile/src/components/analytics/AnalyticsProvider.tsx
+++ b/packages/mobile/src/components/analytics/AnalyticsProvider.tsx
@@ -18,10 +18,11 @@ const styles = StyleSheet.create({ root: { flex: 1 } });
 export function AnalyticsProvider({ children }: { children: ReactNode }) {
   const client = getAnalyticsClient();
 
-  // Restore the user's session-recording opt-in at startup. Off by default —
-  // this only resumes recording for someone who previously turned diagnostics on.
-  // No-op when analytics is disabled (setSessionRecordingEnabled guards on a null
-  // client). Runs once.
+  // Apply the session-recording preference at startup. The default follows the
+  // build: ON in the open TestFlight beta, OFF (opt-in) elsewhere — and an
+  // explicit choice from the Privacy toggle overrides it. Starts recording when
+  // the resolved preference is on. No-op when analytics is disabled
+  // (setSessionRecordingEnabled guards on a null client). Runs once.
   useEffect(() => {
     loadSessionRecordingEnabled()
       .then((enabled) => {

--- a/packages/mobile/src/lib/__tests__/session-recording-preference.test.ts
+++ b/packages/mobile/src/lib/__tests__/session-recording-preference.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@react-native-async-storage/async-storage', () => {
+  let storage: Record<string, string> = {};
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage[key] = value;
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        delete storage[key];
+      }),
+      __reset: () => {
+        storage = {};
+      },
+      __setRaw: (key: string, value: string) => {
+        storage[key] = value;
+      },
+    },
+  };
+});
+
+const FLAG = 'EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON';
+
+describe('session-recording-preference', () => {
+  const originalFlag = process.env[FLAG];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __reset: () => void;
+    };
+    asyncStorage.__reset();
+  });
+
+  afterEach(() => {
+    if (originalFlag === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = originalFlag;
+  });
+
+  it('defaults ON when the build flag is set and nothing is stored', async () => {
+    process.env[FLAG] = 'true';
+    const { loadSessionRecordingEnabled } = await import('../session-recording-preference');
+    await expect(loadSessionRecordingEnabled()).resolves.toBe(true);
+  });
+
+  it('defaults OFF when the build flag is unset and nothing is stored', async () => {
+    delete process.env[FLAG];
+    const { loadSessionRecordingEnabled } = await import('../session-recording-preference');
+    await expect(loadSessionRecordingEnabled()).resolves.toBe(false);
+  });
+
+  it('honours an explicit OFF choice even when the build flag is on', async () => {
+    process.env[FLAG] = 'true';
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __setRaw: (key: string, value: string) => void;
+    };
+    asyncStorage.__setRaw('sessionRecordingEnabled', JSON.stringify(false));
+
+    const { loadSessionRecordingEnabled } = await import('../session-recording-preference');
+    await expect(loadSessionRecordingEnabled()).resolves.toBe(false);
+  });
+
+  it('honours an explicit ON choice when the build flag is off', async () => {
+    delete process.env[FLAG];
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __setRaw: (key: string, value: string) => void;
+    };
+    asyncStorage.__setRaw('sessionRecordingEnabled', JSON.stringify(true));
+
+    const { loadSessionRecordingEnabled } = await import('../session-recording-preference');
+    await expect(loadSessionRecordingEnabled()).resolves.toBe(true);
+  });
+
+  it('persists the user choice over the build default', async () => {
+    process.env[FLAG] = 'true';
+    const { loadSessionRecordingEnabled, setSessionRecordingEnabledPreference } =
+      await import('../session-recording-preference');
+    await setSessionRecordingEnabledPreference(false);
+    await expect(loadSessionRecordingEnabled()).resolves.toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -40,13 +40,15 @@ function getClient(): PostHog | null {
   // don't be surprised to see a few lifecycle events on a transient anon id.
   client = new PostHog(apiKey, {
     host,
-    // Session replay stays OFF by construction: `enableSessionReplay` defaults
-    // false, so the SDK NEVER auto-records — capture only ever begins when a user
-    // opts in via setSessionRecordingEnabled() → startSessionRecording(), which
-    // lazily initialises the native replay SDK. The masking below is what gets
-    // applied at that point: text inputs + images stay masked (the app has auth
-    // forms and white dark-mode input fields), and console capture is left on so
-    // the BLE console.warn/error lines land on the replay timeline.
+    // `enableSessionReplay` defaults false, so the SDK never auto-records —
+    // capture only begins when we call setSessionRecordingEnabled() →
+    // startSessionRecording(), which lazily initialises the native replay SDK.
+    // We drive that at startup from the resolved preference (on by default in the
+    // open TestFlight beta, opt-in otherwise — see session-recording-preference).
+    // The masking below is what gets applied at that point: text inputs + images
+    // stay masked (the app has auth forms and white dark-mode input fields), and
+    // console capture is left on so the BLE console.warn/error lines land on the
+    // replay timeline.
     sessionReplayConfig: {
       maskAllTextInputs: true,
       maskAllImages: true,
@@ -56,8 +58,9 @@ function getClient(): PostHog | null {
   return client;
 }
 
-// Opt-in diagnostics session recording. Off by default — nothing records until a
-// climber turns it on (see session-recording-preference). startSessionRecording()
+// Start/stop session recording. The resolved preference decides whether it runs
+// (on by default in the open TestFlight beta, opt-in otherwise — see
+// session-recording-preference); this just applies it. startSessionRecording()
 // lazily initialises the native replay SDK with the masking config above;
 // stopSessionRecording() halts it. No-op when analytics is disabled (dev / no
 // key) because getClient() returns null. Safe to call before the client is built

--- a/packages/mobile/src/lib/env.ts
+++ b/packages/mobile/src/lib/env.ts
@@ -1,2 +1,8 @@
 export const BACKEND_URL = process.env.EXPO_PUBLIC_BACKEND_URL ?? 'https://ws.boardsesh.com';
 export const WEB_BASE_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'https://www.boardsesh.com';
+
+// Whether session recording is ON by default. Only builds that opt in set this —
+// the open TestFlight beta does, via ios-testflight-rn.yml. Production App Store
+// builds leave it unset, so recording stays opt-in there. The shipped value is
+// inlined at build time (EXPO_PUBLIC_* vars bake into the JS bundle).
+export const SESSION_RECORDING_DEFAULTS_ON = process.env.EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON === 'true';

--- a/packages/mobile/src/lib/session-recording-preference.ts
+++ b/packages/mobile/src/lib/session-recording-preference.ts
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useSyncExternalStore } from 'react';
 import { getPreference, setPreference } from './preference-store';
+import { SESSION_RECORDING_DEFAULTS_ON } from './env';
 
-// Whether the user has opted in to PostHog session recording. OFF by default —
-// nothing records until the climber flips the diagnostics toggle themselves
-// (we surface it for people hitting Bluetooth issues). Persisted so the choice
-// survives restarts; the value is restored and applied at app startup.
+// Whether the user has opted in to PostHog session recording. The default
+// follows the build: ON in opted-in builds (the open TestFlight beta sets
+// EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON), OFF (opt-in) everywhere else. An
+// explicit choice from the Privacy toggle always wins over the default and is
+// persisted so it survives restarts; the value is restored and applied at app
+// startup.
 //
 // Structure mirrors `grade-format-preference.ts`: a module-level store read via
 // `useSyncExternalStore` with a referentially-stable cached snapshot (rebuilt
@@ -14,12 +17,12 @@ const STORAGE_KEY = 'sessionRecordingEnabled';
 
 type SessionRecordingSnapshot = { enabled: boolean; loaded: boolean };
 
-let current = false;
+let current = SESSION_RECORDING_DEFAULTS_ON;
 let hasLoaded = false;
 let snapshot: SessionRecordingSnapshot = { enabled: current, loaded: hasLoaded };
 const listeners = new Set<() => void>();
 
-const SERVER_SNAPSHOT: SessionRecordingSnapshot = { enabled: false, loaded: false };
+const SERVER_SNAPSHOT: SessionRecordingSnapshot = { enabled: SESSION_RECORDING_DEFAULTS_ON, loaded: false };
 
 function notify(): void {
   snapshot = { enabled: current, loaded: hasLoaded };
@@ -32,7 +35,9 @@ export async function loadSessionRecordingEnabled(): Promise<boolean> {
   // A `setSessionRecordingEnabledPreference` may have raced in while we awaited
   // storage; honour the user's choice over the (now stale) persisted value.
   if (hasLoaded) return current;
-  current = stored === true;
+  // An explicit stored choice (true/false) wins; an absent value falls back to
+  // the build default (on in the beta, off otherwise).
+  current = typeof stored === 'boolean' ? stored : SESSION_RECORDING_DEFAULTS_ON;
   hasLoaded = true;
   notify();
   return current;

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -39,9 +39,9 @@
         "description": "System follows your device language."
       },
       "diagnostics": {
-        "title": "Diagnostics",
-        "recording": "Help fix Bluetooth",
-        "recordingDescription": "When the board keeps dropping, flip this on. We'll record your screen and the Bluetooth connection so we can see what's going wrong. Your typing stays hidden, and it's off until you turn it on."
+        "title": "Privacy",
+        "recording": "Help us improve",
+        "recordingDescription": "Send anonymous, masked session recordings so we can squash bugs faster. Your typing and photos stay hidden. Flip it off whenever you like."
       }
     },
     "onboarding": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -237,9 +237,9 @@
         "description": "Sistema usa el idioma de tu dispositivo."
       },
       "diagnostics": {
-        "title": "Diagnóstico",
-        "recording": "Ayúdanos a arreglar el Bluetooth",
-        "recordingDescription": "Cuando la tabla se desconecte una y otra vez, activa esto. Grabaremos tu pantalla y la conexión Bluetooth para ver qué falla. Lo que escribes queda oculto, y está apagado hasta que lo enciendas."
+        "title": "Privacidad",
+        "recording": "Ayúdanos a mejorar",
+        "recordingDescription": "Envía grabaciones de sesión anónimas y enmascaradas para que corrijamos errores más rápido. Lo que escribes y tus fotos quedan ocultos. Desactívalo cuando quieras."
       }
     },
     "onboarding": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -39,9 +39,9 @@
         "description": "Système suit la langue de votre appareil."
       },
       "diagnostics": {
-        "title": "Diagnostic",
-        "recording": "Aidez-nous à régler le Bluetooth",
-        "recordingDescription": "Quand le mur décroche sans arrêt, activez ceci. On enregistre votre écran et la connexion Bluetooth pour voir ce qui cloche. Ce que vous tapez reste masqué, et c'est désactivé tant que vous ne l'activez pas."
+        "title": "Confidentialité",
+        "recording": "Aidez-nous à nous améliorer",
+        "recordingDescription": "Envoyez des enregistrements de session anonymes et masqués pour qu'on corrige les bugs plus vite. Ce que vous tapez et vos photos restent masqués. Désactivez quand vous voulez."
       }
     },
     "onboarding": {


### PR DESCRIPTION
PostHog session recording on mobile was opt-in (default off) behind a
Bluetooth-specific "Help fix Bluetooth" toggle. Flip it to opt-out so the
open beta captures real sessions for bug-hunting, while keeping a way to
turn it off.

The new default is scoped to the open TestFlight beta only via a build-time
flag (EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON), set in ios-testflight-rn.yml
and inlined into the bundle — the same pattern as the Sentry/PostHog keys.
Production App Store builds omit it, so recording stays opt-in there. An
explicit choice from the toggle always wins over the default.

Rename the toggle to the generic "Help us improve" and the section to
"Privacy" across en-US/es/fr, with copy that no longer references Bluetooth.

The toggle's start/stop logic is unchanged; only the default and copy move.
Adds unit coverage for the default-vs-stored-choice resolution.