### PR TITLE
[codex] Handle nullable Aurora import draft state

### DIFF
--- a/packages/web/app/lib/data-sync/aurora/__tests__/json-import.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/json-import.test.ts
@@ -427,6 +427,10 @@ describe('Aurora export climb name resolution', () => {
     ).toBe('emoji-name');
   });
 
+  it('normalizes DB climb names before checking the question-mark placeholder positions', () => {
+    expect(doesBoardClimbNameMatchAuroraQuestionPlaceholder('Friend Forever?', 'Ｆriend Forever👭')).toBe(true);
+  });
+
   it('checks the candidate against the specific export question-mark pattern', () => {
     expect(doesBoardClimbNameMatchAuroraQuestionPlaceholder('A?B', 'A😀B')).toBe(true);
     expect(doesBoardClimbNameMatchAuroraQuestionPlaceholder('AB?', 'A😀B')).toBe(false);
@@ -454,6 +458,14 @@ describe('Aurora export climb name resolution', () => {
         'current-user',
       ),
     ).toBe(false);
+  });
+
+  it('allows null isDraft catalog rows as non-draft matches', () => {
+    expect(
+      isClimbNameResolutionCandidateAllowed(
+        candidate({ uuid: 'null-draft-catalog', name: 'Stige-spillet', isDraft: null, isListed: false, userId: null }),
+      ),
+    ).toBe(true);
   });
 
   it("allows the current user's own climbs but rejects another user's drafts", () => {

--- a/packages/web/app/lib/data-sync/aurora/json-import.ts
+++ b/packages/web/app/lib/data-sync/aurora/json-import.ts
@@ -215,7 +215,7 @@ export function doesBoardClimbNameMatchAuroraQuestionPlaceholder(exportName: str
   const boardClimbKey = normalizeBoardClimbNameForAuroraExportResolution(boardClimbName);
   if (exportKey !== boardClimbKey) return false;
 
-  return buildQuestionPlaceholderRegExp(exportName).test(boardClimbName);
+  return buildQuestionPlaceholderRegExp(exportName.normalize('NFKC')).test(boardClimbName.normalize('NFKC'));
 }
 
 // Escape LIKE/ILIKE metacharacters so export names are matched literally except
@@ -236,16 +236,17 @@ export function isClimbNameResolutionCandidateAllowed(
   candidate: ClimbNameResolutionCandidate,
   userId?: string,
 ): boolean {
-  const isNonDraft = candidate.isDraft === false;
+  const isNonDraft = candidate.isDraft !== true;
   const isCatalogOrPublic = isNonDraft && (candidate.isListed === true || candidate.userId == null);
   const isUsersOwnClimb = userId != null && candidate.userId === userId;
   return isCatalogOrPublic || isUsersOwnClimb;
 }
 
 function getClimbNameResolutionCandidateTier(candidate: ClimbNameResolutionCandidate, userId?: string): number {
-  if (candidate.isDraft === false && candidate.isListed === true) return 4;
-  if (userId != null && candidate.userId === userId) return 3;
-  if (candidate.isDraft === false && candidate.userId == null) return 2;
+  const isNonDraft = candidate.isDraft !== true;
+  if (isNonDraft && candidate.isListed === true) return 3;
+  if (userId != null && candidate.userId === userId) return 2;
+  if (isNonDraft && candidate.userId == null) return 1;
   return 0;
 }
 
@@ -429,7 +430,7 @@ async function resolveClimbNames(
   const nameToMatch = new Map<string, ClimbNameResolutionMatch>();
 
   const eligibleCatalogOrPublicFilter = and(
-    eq(boardClimbs.isDraft, false),
+    or(eq(boardClimbs.isDraft, false), isNull(boardClimbs.isDraft)),
     or(eq(boardClimbs.isListed, true), isNull(boardClimbs.userId)),
   );
 


### PR DESCRIPTION
## What changed

- Treat nullable `board_climbs.is_draft` as non-draft for Aurora catalog resolution instead of silently rejecting those rows.
- Apply NFKC normalization before the emoji-placeholder regex position check.
- Compact resolver source tiers from `4/3/2/0` to `3/2/1/0` without changing ranking semantics.
- Added regression coverage for nullable draft catalog rows and NFKC-normalized placeholder matching.

## Why

Follow-up review on the Aurora JSON import emoji-name fix found nullable draft-state and Unicode-normalization edge cases that could leave valid catalog rows unresolved.

## Validation

- `vp test run --reporter=agent packages/web/app/lib/data-sync/aurora/__tests__/json-import.test.ts packages/web/app/lib/data-sync/aurora/__tests__/json-import-stream.test.ts` passed: 2 files, 96 tests.
- `vp run typecheck:web` passed.
- `git diff --check` passed for the changed importer files.