### PR TITLE
[codex] Harden mobile rnscreens scroll fallback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -729,6 +729,9 @@
   "patchedDependencies": {
     "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch",
   },
+  "overrides": {
+    "react-native-screens": "4.25.2",
+  },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "vite-plus": "^0.1.19",
     "vitest": "^4.1.5"
   },
+  "overrides": {
+    "react-native-screens": "4.25.2"
+  },
   "engines": {
     "node": "22.x"
   },

--- a/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
@@ -1,8 +1,13 @@
+// @vitest-environment jsdom
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
 
 const cfg = vi.hoisted(() => ({
   platformOS: 'ios' as 'ios' | 'android',
+  reactNativeMinor: 82 as number | undefined,
   liquidGlassAvailable: true,
+  nativeTabs: {} as unknown,
   bottomAccessory: {} as unknown,
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
 }));
@@ -12,6 +17,9 @@ vi.mock('react-native', () => ({
     get OS() {
       return cfg.platformOS;
     },
+    get constants() {
+      return { reactNativeVersion: { minor: cfg.reactNativeMinor } };
+    },
   },
 }));
 
@@ -20,10 +28,14 @@ vi.mock('expo-glass-effect', () => ({
 }));
 
 vi.mock('expo-router/unstable-native-tabs', () => ({
-  NativeTabs: {
-    get BottomAccessory() {
-      return cfg.bottomAccessory;
-    },
+  get NativeTabs() {
+    if (cfg.nativeTabs == null) {
+      return cfg.nativeTabs;
+    }
+
+    return {
+      BottomAccessory: cfg.bottomAccessory,
+    };
   },
 }));
 
@@ -36,7 +48,9 @@ import { isBottomAccessoryAvailable, useNativeAccessoryActive } from '../use-bot
 describe('use-bottom-accessory', () => {
   beforeEach(() => {
     cfg.platformOS = 'ios';
+    cfg.reactNativeMinor = 82;
     cfg.liquidGlassAvailable = true;
+    cfg.nativeTabs = {};
     cfg.bottomAccessory = {};
     cfg.variant = 'liquidGlass';
   });
@@ -45,7 +59,15 @@ describe('use-bottom-accessory', () => {
     expect(isBottomAccessoryAvailable()).toBe(true);
   });
 
+  it('does not require React Native minor 82 or newer', () => {
+    cfg.reactNativeMinor = 81;
+
+    expect(isBottomAccessoryAvailable()).toBe(true);
+  });
+
   it('does not require the React Native minor version to be present', () => {
+    cfg.reactNativeMinor = undefined;
+
     expect(isBottomAccessoryAvailable()).toBe(true);
   });
 
@@ -67,11 +89,26 @@ describe('use-bottom-accessory', () => {
     expect(isBottomAccessoryAvailable()).toBe(false);
   });
 
+  it('returns false when the NativeTabs export is missing', () => {
+    cfg.nativeTabs = null;
+
+    expect(isBottomAccessoryAvailable()).toBe(false);
+  });
+
+  it('returns false when the NativeTabs export is undefined', () => {
+    cfg.nativeTabs = undefined;
+
+    expect(isBottomAccessoryAvailable()).toBe(false);
+  });
+
   it('only reports the native accessory active for the Liquid Glass variant', () => {
-    expect(useNativeAccessoryActive()).toBe(true);
+    const { result, rerender } = renderHook(() => useNativeAccessoryActive());
+
+    expect(result.current).toBe(true);
 
     cfg.variant = 'material';
+    rerender();
 
-    expect(useNativeAccessoryActive()).toBe(false);
+    expect(result.current).toBe(false);
   });
 });

--- a/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cfg = vi.hoisted(() => ({
+  platformOS: 'ios' as 'ios' | 'android',
+  liquidGlassAvailable: true,
+  bottomAccessory: {} as unknown,
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
+}));
+
+vi.mock('react-native', () => ({
+  Platform: {
+    get OS() {
+      return cfg.platformOS;
+    },
+  },
+}));
+
+vi.mock('expo-glass-effect', () => ({
+  isLiquidGlassAvailable: () => cfg.liquidGlassAvailable,
+}));
+
+vi.mock('expo-router/unstable-native-tabs', () => ({
+  NativeTabs: {
+    get BottomAccessory() {
+      return cfg.bottomAccessory;
+    },
+  },
+}));
+
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ variant: cfg.variant }),
+}));
+
+import { isBottomAccessoryAvailable, useNativeAccessoryActive } from '../use-bottom-accessory';
+
+describe('use-bottom-accessory', () => {
+  beforeEach(() => {
+    cfg.platformOS = 'ios';
+    cfg.liquidGlassAvailable = true;
+    cfg.bottomAccessory = {};
+    cfg.variant = 'liquidGlass';
+  });
+
+  it('uses the native BottomAccessory export as the capability check', () => {
+    expect(isBottomAccessoryAvailable()).toBe(true);
+  });
+
+  it('does not require the React Native minor version to be present', () => {
+    expect(isBottomAccessoryAvailable()).toBe(true);
+  });
+
+  it('returns false outside iOS', () => {
+    cfg.platformOS = 'android';
+
+    expect(isBottomAccessoryAvailable()).toBe(false);
+  });
+
+  it('returns false when Liquid Glass is unavailable', () => {
+    cfg.liquidGlassAvailable = false;
+
+    expect(isBottomAccessoryAvailable()).toBe(false);
+  });
+
+  it('returns false when the native accessory export is missing', () => {
+    cfg.bottomAccessory = null;
+
+    expect(isBottomAccessoryAvailable()).toBe(false);
+  });
+
+  it('only reports the native accessory active for the Liquid Glass variant', () => {
+    expect(useNativeAccessoryActive()).toBe(true);
+
+    cfg.variant = 'material';
+
+    expect(useNativeAccessoryActive()).toBe(false);
+  });
+});

--- a/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
@@ -111,4 +111,12 @@ describe('use-bottom-accessory', () => {
 
     expect(result.current).toBe(false);
   });
+
+  it('does not report the native accessory active when the capability is unavailable', () => {
+    cfg.platformOS = 'android';
+
+    const { result } = renderHook(() => useNativeAccessoryActive());
+
+    expect(result.current).toBe(false);
+  });
 });

--- a/packages/mobile/src/hooks/use-bottom-accessory.ts
+++ b/packages/mobile/src/hooks/use-bottom-accessory.ts
@@ -1,15 +1,15 @@
 import { Platform } from 'react-native';
 import { isLiquidGlassAvailable } from 'expo-glass-effect';
+import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import { useTheme } from '../providers/theme-provider';
 
 /**
  * Whether the device *can* host `NativeTabs.BottomAccessory` — the pure
- * capability check (iOS 26 + RN ≥ 0.82). The native accessory is tied to the
- * system Liquid Glass tab bar, so it only exists on that path.
+ * capability check. The native accessory is tied to the system Liquid Glass tab
+ * bar, so it only exists on that path.
  */
 export function isBottomAccessoryAvailable(): boolean {
-  const reactNativeMinor = Platform.constants.reactNativeVersion?.minor ?? 0;
-  return Platform.OS === 'ios' && reactNativeMinor >= 82 && isLiquidGlassAvailable();
+  return Platform.OS === 'ios' && NativeTabs?.BottomAccessory != null && isLiquidGlassAvailable();
 }
 
 /**

--- a/patches/react-native-screens@4.25.2.patch
+++ b/patches/react-native-screens@4.25.2.patch
@@ -32,7 +32,7 @@ index 2434c612951a40bd1ecfcc476acebb9a9a6b500e..6d23e2e466cc602560aa101b91bb7c76
  
  @implementation RNSScrollViewFinder
  
-@@ -41,4 +43,116 @@
+@@ -41,4 +43,119 @@
    return nil;
  }
  

--- a/patches/react-native-screens@4.25.2.patch
+++ b/patches/react-native-screens@4.25.2.patch
@@ -36,6 +36,9 @@ index 2434c612951a40bd1ecfcc476acebb9a9a6b500e..6d23e2e466cc602560aa101b91bb7c76
    return nil;
  }
  
++// Bound the fallback DFS so unusual hierarchies cannot turn UIKit's scroll-view
++// query into an unbounded traversal. Normal RNScreens + tab/FlashList nesting is
++// shallow; 24 leaves room for extra wrapper views while still failing closed.
 +static const NSInteger RNSManagedContentScrollViewSearchMaxDepth = 24;
 +
 +static BOOL RNSViewIsManagedContentRoot(UIView *view)

--- a/patches/react-native-screens@4.25.2.patch
+++ b/patches/react-native-screens@4.25.2.patch
@@ -5,48 +5,82 @@ diff --git a/ios/helpers/scroll-view/RNSScrollViewFinder.h b/ios/helpers/scroll-
 index 04d40b38bad73bedd79c6aa8b85125dc79093db7..ea25d1b0b36fcc6afeed44b5d603b8cbd15be6c0 100644
 --- a/ios/helpers/scroll-view/RNSScrollViewFinder.h
 +++ b/ios/helpers/scroll-view/RNSScrollViewFinder.h
-@@ -25,4 +25,14 @@
+@@ -25,4 +25,15 @@
   */
  + (nullable UIScrollView *)findContentScrollViewWithDelegatingToProvider:(nullable UIView *)view;
  
 +/**
-+ * Depth-first search for the first UIScrollView anywhere in the subtree (visiting every child, not just the first).
-+ * Unlike `findScrollViewInFirstDescendantChainFrom`, this finds scroll views that virtualized lists (FlashList,
-+ * LegendList) nest below a non-scroll container, which UIKit's first-child heuristic misses. Used as the fallback
-+ * for `-[UIViewController contentScrollViewForEdge:]` so the iOS 26 tab-bar minimize can track those lists.
++ * Searches for the content UIScrollView inside an RNScreens-managed subtree.
++ * The traversal delegates to `RNSContentScrollViewProviding` before falling back
++ * to a bounded depth-first UIScrollView walk. It only returns blind UIScrollView
++ * matches after entering an `RNSScreenView` / content-scroll-provider subtree,
++ * so unrelated UIViewController trees are left untouched.
 + *
 + * When `view == nil`, it should also return `nil`.
 + */
-++ (nullable UIScrollView *)findScrollViewDeepFirstFrom:(nullable UIView *)view;
+++ (nullable UIScrollView *)findContentScrollViewInManagedSubtreeFrom:(nullable UIView *)view;
 +
  @end
 diff --git a/ios/helpers/scroll-view/RNSScrollViewFinder.mm b/ios/helpers/scroll-view/RNSScrollViewFinder.mm
-index 2434c612951a40bd1ecfcc476acebb9a9a6b500e..1045352774b126b0766c74fe5f800b62acc53033 100644
+index 2434c612951a40bd1ecfcc476acebb9a9a6b500e..6d23e2e466cc602560aa101b91bb7c7657d196cb 100644
 --- a/ios/helpers/scroll-view/RNSScrollViewFinder.mm
 +++ b/ios/helpers/scroll-view/RNSScrollViewFinder.mm
-@@ -1,4 +1,5 @@
+@@ -1,4 +1,6 @@
  #import "RNSScrollViewFinder.h"
++#import <objc/message.h>
 +#import <objc/runtime.h>
  
  @implementation RNSScrollViewFinder
  
-@@ -41,4 +42,66 @@
+@@ -41,4 +43,116 @@
    return nil;
  }
  
-++ (nullable UIScrollView *)findScrollViewDeepFirstFrom:(nullable UIView *)view
++static const NSInteger RNSManagedContentScrollViewSearchMaxDepth = 24;
++
++static BOOL RNSViewIsManagedContentRoot(UIView *view)
 +{
-+  if (view == nil) {
++  Class screenViewClass = NSClassFromString(@"RNSScreenView");
++  return (screenViewClass != Nil && [view isKindOfClass:screenViewClass]) ||
++      [view respondsToSelector:@selector(findContentScrollView)];
++}
++
+++ (nullable UIScrollView *)findContentScrollViewInManagedSubtreeFrom:(nullable UIView *)view
++{
++  return [RNSScrollViewFinder findContentScrollViewInManagedSubtreeFrom:view
++                                                         remainingDepth:RNSManagedContentScrollViewSearchMaxDepth
++                                                    insideManagedSubtree:NO];
++}
++
+++ (nullable UIScrollView *)findContentScrollViewInManagedSubtreeFrom:(nullable UIView *)view
++                                                     remainingDepth:(NSInteger)remainingDepth
++                                                insideManagedSubtree:(BOOL)insideManagedSubtree
++{
++  if (view == nil || remainingDepth < 0) {
 +    return nil;
 +  }
-+  if ([view isKindOfClass:UIScrollView.class]) {
++
++  BOOL isManagedSubtree = insideManagedSubtree || RNSViewIsManagedContentRoot(view);
++
++  if (isManagedSubtree && [view respondsToSelector:@selector(findContentScrollView)]) {
++    UIScrollView *provided =
++        [static_cast<id<RNSContentScrollViewProviding>>(view) findContentScrollView];
++    if (provided != nil) {
++      return provided;
++    }
++  }
++
++  if (isManagedSubtree && [view isKindOfClass:UIScrollView.class]) {
 +    return static_cast<UIScrollView *>(view);
 +  }
-+  // Visit children in order, fully descending each branch first. The climbs list
-+  // (FlashList) is the first child of its screen, so this reaches its nested
-+  // scroll view before any shallower chrome scroll view (e.g. a grade rail).
++
++  // Visit children in order, fully descending each managed branch first. The
++  // climbs list (FlashList) nests its UIScrollView below non-scroll containers,
++  // so UIKit's first-child heuristic misses it.
 +  for (UIView *subview in view.subviews) {
-+    UIScrollView *found = [RNSScrollViewFinder findScrollViewDeepFirstFrom:subview];
++    UIScrollView *found = [RNSScrollViewFinder findContentScrollViewInManagedSubtreeFrom:subview
++                                                                        remainingDepth:remainingDepth - 1
++                                                                   insideManagedSubtree:isManagedSubtree];
 +    if (found != nil) {
 +      return found;
 +    }
@@ -62,9 +96,23 @@ index 2434c612951a40bd1ecfcc476acebb9a9a6b500e..1045352774b126b0766c74fe5f800b62
 +// selected tab's view controller vends via -contentScrollViewForEdge:. UIKit
 +// resolves that for plain RN ScrollView/FlatList, but misses FlashList's nested
 +// UIScrollView, so the climbs tab never minimizes. Swizzle the getter to fall
-+// back to a deep search when UIKit returns nil — leaving every case UIKit
-+// already handles untouched. Installed once at load (the category is compiled
-+// into the RNScreens static lib, so +load runs at app launch).
++// back to a bounded RNScreens-managed search when UIKit returns nil — leaving
++// every case UIKit already handles untouched.
++static UIScrollView *RNSContentScrollViewForEdgeFallback(
++    UIViewController *self,
++    SEL _cmd,
++    NSDirectionalRectEdge edge) API_AVAILABLE(ios(17.0))
++{
++  SEL originalSelectorAfterSwizzle = NSSelectorFromString(@"rnscreens_contentScrollViewForEdge:");
++  using ContentScrollViewForEdgeMsgSend = UIScrollView *(*)(id, SEL, NSDirectionalRectEdge);
++  UIScrollView *resolved =
++      reinterpret_cast<ContentScrollViewForEdgeMsgSend>(objc_msgSend)(self, originalSelectorAfterSwizzle, edge);
++  if (resolved != nil) {
++    return resolved;
++  }
++  return [RNSScrollViewFinder findContentScrollViewInManagedSubtreeFrom:self.viewIfLoaded];
++}
++
 +@interface UIViewController (RNSContentScrollViewFallback)
 +@end
 +
@@ -73,27 +121,31 @@ index 2434c612951a40bd1ecfcc476acebb9a9a6b500e..1045352774b126b0766c74fe5f800b62
 ++ (void)load
 +{
 +  if (@available(iOS 26.0, *)) {
-+    static dispatch_once_t onceToken;
-+    dispatch_once(&onceToken, ^{
-+      SEL originalSelector = @selector(contentScrollViewForEdge:);
-+      SEL swizzledSelector = @selector(rnscreens_contentScrollViewForEdge:);
-+      Method originalMethod = class_getInstanceMethod(UIViewController.class, originalSelector);
-+      Method swizzledMethod = class_getInstanceMethod(UIViewController.class, swizzledSelector);
-+      if (originalMethod != NULL && swizzledMethod != NULL) {
-+        method_exchangeImplementations(originalMethod, swizzledMethod);
++    // Use a process-wide selector-keyed marker, not a per-image dispatch_once.
++    // If two react-native-screens copies are linked, the second +load must not
++    // exchange the IMPs back.
++    SEL installedKey = NSSelectorFromString(@"rnscreens_contentScrollViewFallbackInstalled");
++    @synchronized (UIViewController.class) {
++      if ([objc_getAssociatedObject(UIViewController.class, installedKey) boolValue]) {
++        return;
 +      }
-+    });
++      SEL originalSelector = @selector(contentScrollViewForEdge:);
++      SEL fallbackSelector = NSSelectorFromString(@"rnscreens_contentScrollViewForEdge:");
++      Method originalMethod = class_getInstanceMethod(UIViewController.class, originalSelector);
++      if (originalMethod != NULL &&
++          class_addMethod(
++              UIViewController.class,
++              fallbackSelector,
++              reinterpret_cast<IMP>(RNSContentScrollViewForEdgeFallback),
++              method_getTypeEncoding(originalMethod))) {
++        Method fallbackMethod = class_getInstanceMethod(UIViewController.class, fallbackSelector);
++        if (fallbackMethod != NULL) {
++          method_exchangeImplementations(originalMethod, fallbackMethod);
++          objc_setAssociatedObject(UIViewController.class, installedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
++        }
++      }
++    }
 +  }
-+}
-+
-+- (nullable UIScrollView *)rnscreens_contentScrollViewForEdge:(NSDirectionalRectEdge)edge API_AVAILABLE(ios(17.0))
-+{
-+  // After the exchange this calls UIKit's original implementation.
-+  UIScrollView *resolved = [self rnscreens_contentScrollViewForEdge:edge];
-+  if (resolved != nil) {
-+    return resolved;
-+  }
-+  return [RNSScrollViewFinder findScrollViewDeepFirstFrom:self.viewIfLoaded];
 +}
 +
  @end

--- a/patches/react-native-screens@4.25.2.patch
+++ b/patches/react-native-screens@4.25.2.patch
@@ -104,7 +104,7 @@ index 2434c612951a40bd1ecfcc476acebb9a9a6b500e..6d23e2e466cc602560aa101b91bb7c76
 +static UIScrollView *RNSContentScrollViewForEdgeFallback(
 +    UIViewController *self,
 +    SEL _cmd,
-+    NSDirectionalRectEdge edge) API_AVAILABLE(ios(17.0))
++    NSDirectionalRectEdge edge) API_AVAILABLE(ios(26.0))
 +{
 +  SEL originalSelectorAfterSwizzle = NSSelectorFromString(@"rnscreens_contentScrollViewForEdge:");
 +  using ContentScrollViewForEdgeMsgSend = UIScrollView *(*)(id, SEL, NSDirectionalRectEdge);
@@ -128,24 +128,24 @@ index 2434c612951a40bd1ecfcc476acebb9a9a6b500e..6d23e2e466cc602560aa101b91bb7c76
 +    // If two react-native-screens copies are linked, the second +load must not
 +    // exchange the IMPs back.
 +    SEL installedKey = NSSelectorFromString(@"rnscreens_contentScrollViewFallbackInstalled");
-+    @synchronized (UIViewController.class) {
-+      if ([objc_getAssociatedObject(UIViewController.class, installedKey) boolValue]) {
-+        return;
-+      }
-+      SEL originalSelector = @selector(contentScrollViewForEdge:);
-+      SEL fallbackSelector = NSSelectorFromString(@"rnscreens_contentScrollViewForEdge:");
-+      Method originalMethod = class_getInstanceMethod(UIViewController.class, originalSelector);
-+      if (originalMethod != NULL &&
-+          class_addMethod(
-+              UIViewController.class,
-+              fallbackSelector,
-+              reinterpret_cast<IMP>(RNSContentScrollViewForEdgeFallback),
-+              method_getTypeEncoding(originalMethod))) {
-+        Method fallbackMethod = class_getInstanceMethod(UIViewController.class, fallbackSelector);
-+        if (fallbackMethod != NULL) {
-+          method_exchangeImplementations(originalMethod, fallbackMethod);
-+          objc_setAssociatedObject(UIViewController.class, installedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-+        }
++    // +load is serialized by the Objective-C runtime; avoid taking another lock.
++    // The associated marker still prevents duplicate linked copies from re-swizzling.
++    if ([objc_getAssociatedObject(UIViewController.class, installedKey) boolValue]) {
++      return;
++    }
++    SEL originalSelector = @selector(contentScrollViewForEdge:);
++    SEL fallbackSelector = NSSelectorFromString(@"rnscreens_contentScrollViewForEdge:");
++    Method originalMethod = class_getInstanceMethod(UIViewController.class, originalSelector);
++    if (originalMethod != NULL &&
++        class_addMethod(
++            UIViewController.class,
++            fallbackSelector,
++            reinterpret_cast<IMP>(RNSContentScrollViewForEdgeFallback),
++            method_getTypeEncoding(originalMethod))) {
++      Method fallbackMethod = class_getInstanceMethod(UIViewController.class, fallbackSelector);
++      if (fallbackMethod != NULL) {
++        method_exchangeImplementations(originalMethod, fallbackMethod);
++        objc_setAssociatedObject(UIViewController.class, installedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 +      }
 +    }
 +  }

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -12,10 +12,11 @@
  *
  * For react-native-screens specifically, the patch adds a
  * `-[UIViewController contentScrollViewForEdge:]` fallback (the
- * `rnscreens_contentScrollViewForEdge` swizzle + `findScrollViewDeepFirstFrom`
- * deep search) so the iOS 26 tab-bar minimize tracks the climbs FlashList. Drop
- * the patch and the tab bar just stops minimizing — invisible to typecheck, the
- * Metro bundle, and every existing test, all the way into TestFlight.
+ * `rnscreens_contentScrollViewForEdge` swizzle +
+ * `findContentScrollViewInManagedSubtreeFrom` bounded search) so the iOS 26
+ * tab-bar minimize tracks the climbs FlashList. Drop the patch and the tab bar
+ * just stops minimizing — invisible to typecheck, the Metro bundle, and every
+ * existing test, all the way into TestFlight.
  *
  * This check resolves the COPY packages/mobile actually uses (the same one
  * CocoaPods compiles) and asserts the patch's sentinel symbols are present in
@@ -50,7 +51,12 @@ export const RULES: readonly PatchRule[] = [
   {
     package: 'react-native-screens',
     file: 'ios/helpers/scroll-view/RNSScrollViewFinder.mm',
-    sentinels: ['rnscreens_contentScrollViewForEdge', 'findScrollViewDeepFirstFrom'],
+    sentinels: [
+      'rnscreens_contentScrollViewForEdge',
+      'rnscreens_contentScrollViewFallbackInstalled',
+      'findContentScrollViewInManagedSubtreeFrom',
+      'RNSManagedContentScrollViewSearchMaxDepth',
+    ],
     patchedKey: 'react-native-screens@4.25.2',
   },
   {


### PR DESCRIPTION
## Summary

Fixes #2564.

- Hardens the `react-native-screens@4.25.2` iOS `contentScrollViewForEdge:` fallback so it only returns blind scroll-view matches inside an RNScreens-managed subtree.
- Bounds the fallback DFS, prefers `RNSContentScrollViewProviding`, and makes the swizzle process-idempotent with a selector-keyed marker plus `class_addMethod`.
- Pins `react-native-screens` through a root override so Expo Router cannot resolve a second copy outside the patched version.
- Switches the mobile bottom accessory gate from React Native minor sniffing to `NativeTabs?.BottomAccessory != null && isLiquidGlassAvailable()` and adds focused tests.
- Updates the native patch guard sentinels to assert the hardened symbols are present.

## Validation

- `git apply --check /private/tmp/rnscreens-ios-only.patch` against upstream `react-native-screens@4.25.2` iOS sources
- `vp run check:mobile-patches`
- `vp test run --project mobile packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts --reporter=agent`
- `vp run typecheck:mobile`
- `vp test run --project mobile --reporter=agent` (250 files, 1816 tests)
- `vp check package.json packages/mobile/src/hooks/use-bottom-accessory.ts packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts scripts/mobile-patches-check.ts`

## Notes

- Full `vp check` currently fails on unrelated pre-existing formatting drift in 21 files from `origin/main`; this PR keeps that churn out of scope.
- Metro was started for QA on `http://marcos-macbook-pro-2-1.tailedd9d5.ts.net:8083` with QA notes loaded from `.boardsesh/qa-notes.md`.
- Manual iOS 26 physical-device validation is still required for tab-bar minimize and first-mount bottom accessory behavior.