### PR TITLE
[codex] Polish mobile queue/search chrome

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -8,7 +8,7 @@ import {
   type NativeSyntheticEvent,
 } from 'react-native';
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
-import { useSharedValue } from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Stack, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -68,6 +68,7 @@ import { track } from '../../../src/lib/analytics';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
 import { glassSize } from '../../../src/theme/layout';
+import { timing } from '../../../src/theme/animations';
 
 const PAGE_SIZE = 30;
 // Soft character budget for the glass filter-summary title: include whole filter
@@ -183,6 +184,11 @@ function ClimbListInner() {
   const useNativeSearch = useNativeAccessoryActive();
 
   const listPaddingBottom = bottomChrome.scrollBottomPadding;
+  const listBottomSpacerHeight = useSharedValue(listPaddingBottom);
+  useEffect(() => {
+    listBottomSpacerHeight.value = withTiming(listPaddingBottom, { duration: timing.normal });
+  }, [listBottomSpacerHeight, listPaddingBottom]);
+  const listBottomSpacerStyle = useAnimatedStyle(() => ({ height: listBottomSpacerHeight.value }));
   const filterFabNativeAccessoryDrop = bottomChrome.nativeAccessoryVisible ? glassSize.standard * 2 : 0;
   const filterFabMinimumBottom = bottomChrome.nativeAccessoryVisible
     ? insets.bottom + spacing[2]
@@ -349,6 +355,7 @@ function ClimbListInner() {
         setRestoredKey(boardKey);
       })
       .catch(() => {
+        if (cancelled) return;
         replaceSearch(DEFAULT_CLIMB_FILTER_STATE, '', DEFAULT_CLIMB_BOARD_FILTER_STATE);
         visibleSearchTextRef.current = '';
         applyVisibleSearchText('');
@@ -735,6 +742,16 @@ function ClimbListInner() {
     ],
   );
 
+  const listFooter = useMemo(
+    () => (
+      <View>
+        {isFetchingNextPage ? <ClimbListSkeletonRows count={FOOTER_SKELETON_ROW_COUNT} /> : null}
+        <Animated.View pointerEvents="none" style={listBottomSpacerStyle} />
+      </View>
+    ),
+    [isFetchingNextPage, listBottomSpacerStyle],
+  );
+
   const stackOptions = useMemo(
     () =>
       useNativeSearch
@@ -852,7 +869,7 @@ function ClimbListInner() {
         // inset and the list pads manually by the measured chrome height. Leaving
         // this 'automatic' would double-inset under the (invisible) native header.
         contentInsetAdjustmentBehavior="never"
-        contentContainerStyle={{ paddingTop: searchBarHeight, paddingBottom: listPaddingBottom }}
+        contentContainerStyle={{ paddingTop: searchBarHeight }}
         scrollIndicatorInsets={{ top: searchBarHeight }}
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="interactive"
@@ -860,7 +877,7 @@ function ClimbListInner() {
           <RefreshControl refreshing={isRefetching} onRefresh={handleRefresh} tintColor={brandColors.primary} />
         }
         ListHeaderComponent={listHeader}
-        ListFooterComponent={isFetchingNextPage ? <ClimbListSkeletonRows count={FOOTER_SKELETON_ROW_COUNT} /> : null}
+        ListFooterComponent={listFooter}
         ListEmptyComponent={
           showInitialSkeletons ? (
             <ClimbListSkeletonRows count={INITIAL_SKELETON_ROW_COUNT} />

--- a/packages/mobile/src/components/GlassIconButton.tsx
+++ b/packages/mobile/src/components/GlassIconButton.tsx
@@ -3,11 +3,13 @@ import {
   type AccessibilityActionEvent,
   type AccessibilityActionInfo,
   type ColorValue,
+  type StyleProp,
   StyleSheet,
   View,
+  type ViewStyle,
 } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
-import { IconButton as PaperIconButton, Badge as PaperBadge } from 'react-native-paper';
+import { IconButton as PaperIconButton } from 'react-native-paper';
 import { GlassSurface } from './GlassSurface';
 import { PressableSurface } from './PressableSurface';
 import { Icon } from './Icon';
@@ -53,6 +55,14 @@ type GlassIconButtonProps = {
   active?: boolean;
 };
 
+const MAX_BADGE_COUNT = 99;
+const BADGE_MAX_FONT_SIZE_MULTIPLIER = 1;
+
+function formatBadgeCount(badgeCount: number | undefined): string | null {
+  if (badgeCount == null || badgeCount <= 0) return null;
+  return badgeCount > MAX_BADGE_COUNT ? `${MAX_BADGE_COUNT}+` : String(badgeCount);
+}
+
 /**
  * Circular icon button shared by the climb-list search row (filter, create) and
  * the bottom-bar search FAB. Routes to a Material 3 `IconButton` on the Material
@@ -69,8 +79,9 @@ export function GlassIconButton(props: GlassIconButtonProps) {
  * (see material-theme-provider), so we hand it the `.android` MDI name. Paper's
  * `IconButton` renders a single glyph — the Liquid Glass cross-fade morph
  * (`secondaryIconName` / `active`) has no Material equivalent and is dropped
- * here; the static `iconName` is shown instead. The count badge is overlaid via
- * Paper's `Badge` in an outer wrapper so the round target can't crop it.
+ * here; the static `iconName` is shown instead. The count badge uses the same
+ * owned overlay as the Liquid Glass path so clamping and Dynamic Type limits
+ * stay identical across variants.
  */
 function GlassIconButtonMaterial({
   iconName,
@@ -86,7 +97,7 @@ function GlassIconButtonMaterial({
   disabled = false,
   size = glassSize.standard,
 }: GlassIconButtonProps) {
-  const showBadge = badgeCount != null && badgeCount > 0;
+  const badgeLabel = formatBadgeCount(badgeCount);
 
   return (
     <View style={[styles.wrapper, { width: size, height: size }]}>
@@ -110,11 +121,7 @@ function GlassIconButtonMaterial({
         accessibilityActions={accessibilityActions}
         onAccessibilityAction={onAccessibilityAction}
       />
-      {showBadge ? (
-        <PaperBadge style={styles.materialBadge} visible>
-          {badgeCount}
-        </PaperBadge>
-      ) : null}
+      {badgeLabel ? <BadgeLabel label={badgeLabel} style={styles.materialBadge} /> : null}
     </View>
   );
 }
@@ -147,7 +154,7 @@ function GlassIconButtonGlass({
   active = false,
 }: GlassIconButtonProps) {
   const reduceMotion = useReduceMotion();
-  const showBadge = badgeCount != null && badgeCount > 0;
+  const badgeLabel = formatBadgeCount(badgeCount);
   const suppressPressRef = useRef(false);
   const releaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -236,13 +243,22 @@ function GlassIconButtonGlass({
         )}
       </PressableSurface>
 
-      {showBadge ? (
-        <View style={[styles.badge, { backgroundColor: brandColors.primary }]} pointerEvents="none">
-          <Text variant="caption2" color={iosSystemColors.white} style={styles.badgeText}>
-            {badgeCount}
-          </Text>
-        </View>
-      ) : null}
+      {badgeLabel ? <BadgeLabel label={badgeLabel} /> : null}
+    </View>
+  );
+}
+
+function BadgeLabel({ label, style }: { label: string; style?: StyleProp<ViewStyle> }) {
+  return (
+    <View style={[styles.badge, style, { backgroundColor: brandColors.primary }]} pointerEvents="none">
+      <Text
+        variant="caption2"
+        color={iosSystemColors.white}
+        maxFontSizeMultiplier={BADGE_MAX_FONT_SIZE_MULTIPLIER}
+        style={styles.badgeText}
+      >
+        {label}
+      </Text>
     </View>
   );
 }

--- a/packages/mobile/src/components/__tests__/glass-icon-button.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-icon-button.test.tsx
@@ -13,7 +13,7 @@ vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
 }));
 
-// Paper IconButton / Badge → DOM nodes exposing the props the material test asserts on.
+// Paper IconButton → DOM node exposing the props the material test asserts on.
 vi.mock('react-native-paper', () => ({
   IconButton: ({
     icon,
@@ -32,7 +32,6 @@ vi.mock('react-native-paper', () => ({
       disabled,
       'data-label': accessibilityLabel,
     }),
-  Badge: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-paper-badge': 'true' }, children),
 }));
 
 vi.mock('react-native-reanimated', () => ({
@@ -86,7 +85,15 @@ vi.mock('../Icon', () => ({
 }));
 
 vi.mock('../Text', () => ({
-  Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
+  Text: ({ children, maxFontSizeMultiplier }: { children?: ReactNode; maxFontSizeMultiplier?: number }) =>
+    createElement(
+      'span',
+      {
+        'data-text': 'true',
+        'data-max-font-size-multiplier': maxFontSizeMultiplier == null ? '' : String(maxFontSizeMultiplier),
+      },
+      children,
+    ),
 }));
 
 // GlassIconButton reads only `variant` from the theme; its count badge is a
@@ -134,6 +141,13 @@ describe('GlassIconButton (Liquid Glass variant)', () => {
     expect(container.textContent).toContain('3');
     rerender(<GlassIconButton {...base} iconName="filter" badgeCount={0} />);
     expect(container.textContent).not.toContain('3');
+  });
+
+  it('clamps large badges and caps badge text scaling', () => {
+    const { container } = render(<GlassIconButton {...base} iconName="filter" badgeCount={150} />);
+    const badgeText = container.querySelector('[data-text]');
+    expect(badgeText?.textContent).toBe('99+');
+    expect(badgeText?.getAttribute('data-max-font-size-multiplier')).toBe('1');
   });
 
   it('forwards accessibilityLabel and accessibilityHint', () => {
@@ -219,11 +233,13 @@ describe('GlassIconButton (Material variant)', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it('overlays a Paper Badge only when badgeCount > 0', () => {
+  it('overlays a clamped badge only when badgeCount > 0', () => {
     const { container, rerender } = render(<GlassIconButton {...base} iconName="filter" badgeCount={3} />);
-    expect(container.querySelector('[data-paper-badge]')?.textContent).toBe('3');
+    expect(container.querySelector('[data-text]')?.textContent).toBe('3');
+    rerender(<GlassIconButton {...base} iconName="filter" badgeCount={150} />);
+    expect(container.querySelector('[data-text]')?.textContent).toBe('99+');
     rerender(<GlassIconButton {...base} iconName="filter" badgeCount={0} />);
-    expect(container.querySelector('[data-paper-badge]')).toBeNull();
+    expect(container.querySelector('[data-text]')).toBeNull();
   });
 
   it('passes disabled through to the Paper IconButton', () => {

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -12,6 +12,7 @@ import Animated from 'react-native-reanimated';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { Climb } from '@boardsesh/queue';
 import { TOOLBAR_CAPSULE_HEIGHT, TOOLBAR_CAPSULE_MAX_WIDTH } from '../../theme/layout';
+import { spacing } from '../../theme/tokens';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { Text } from '../Text';
@@ -120,8 +121,8 @@ export function ClimbCapsule({
 
   const capsuleRadius = surfaceTreatment === 'docked' ? 0 : height / 2;
   // Reserve room on the right so the name/grade never slide under the inline tick.
-  const endActionReservedWidth = endAction ? endActionSize + 8 : 0;
-  const labelRight = 16 + endActionReservedWidth;
+  const endActionReservedWidth = endAction ? endActionSize + spacing[2] : 0;
+  const labelRight = spacing[4] + endActionReservedWidth;
 
   // The docked Material bar stays on a neutral M3 surface (a step above the tab bar
   // via elevation) and marks the grade with a vivid leading colour stripe — distinct
@@ -205,7 +206,7 @@ const styles = StyleSheet.create({
     left: 0,
     top: 0,
     bottom: 0,
-    width: 4,
+    width: spacing[1],
   },
   // Centered-pill cap; omitted on the full-width Material bar.
   capsuleCap: {
@@ -215,31 +216,31 @@ const styles = StyleSheet.create({
     flex: 1,
     overflow: 'hidden',
     justifyContent: 'center',
-    paddingHorizontal: 16,
+    paddingHorizontal: spacing[4],
   },
   labelSlot: {
     position: 'absolute',
-    left: 16,
-    right: 16,
+    left: spacing[4],
+    right: spacing[4],
     justifyContent: 'center',
   },
   peekSlot: {
     position: 'absolute',
-    left: 16,
-    right: 16,
+    left: spacing[4],
+    right: spacing[4],
     justifyContent: 'center',
   },
   endActionSlot: {
     position: 'absolute',
     top: 0,
-    right: 8,
+    right: spacing[2],
     alignItems: 'center',
     justifyContent: 'center',
   },
   labelInner: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
+    gap: spacing[2],
   },
   gradeText: {
     // Colorized like the list rows; right-aligned with a reserved min width

--- a/packages/mobile/src/components/queue-control/QueueBottomAccessory.tsx
+++ b/packages/mobile/src/components/queue-control/QueueBottomAccessory.tsx
@@ -2,12 +2,13 @@ import { useMemo } from 'react';
 import { StyleSheet, useWindowDimensions, View } from 'react-native';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import { useQueue } from '../../providers/queue-provider';
-import { glassSize } from '../../theme/layout';
+import {
+  glassSize,
+  NATIVE_BOTTOM_ACCESSORY_MAX_WIDTH,
+  NATIVE_BOTTOM_ACCESSORY_SCREEN_GUTTER,
+} from '../../theme/layout';
 import { NativeAccessoryClimbRow } from './NativeAccessoryClimbRow';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
-
-const ACCESSORY_MAX_WIDTH = 344;
-const ACCESSORY_SCREEN_GUTTER = 32;
 
 /**
  * iOS 26 tab-bar bottom accessory content. UIKit supplies the outer Liquid Glass
@@ -24,7 +25,10 @@ export function QueueBottomAccessory() {
   const currentClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
 
   const accessoryWidth = useMemo(() => {
-    return Math.max(glassSize.standard * 2, Math.min(ACCESSORY_MAX_WIDTH, screenWidth - ACCESSORY_SCREEN_GUTTER));
+    return Math.max(
+      glassSize.standard * 2,
+      Math.min(NATIVE_BOTTOM_ACCESSORY_MAX_WIDTH, screenWidth - NATIVE_BOTTOM_ACCESSORY_SCREEN_GUTTER),
+    );
   }, [screenWidth]);
 
   if (!currentClimb) return null;

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -165,7 +165,11 @@ vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn(), hapticSelection: 
 
 vi.mock('../../../theme/colors', () => ({ withAlpha: (color: string) => `${color}29` }));
 vi.mock('../../../theme/layout', () => ({ TOOLBAR_CAPSULE_HEIGHT: 52, TOOLBAR_CAPSULE_MAX_WIDTH: 260 }));
-vi.mock('../../../theme/tokens', () => ({ shadows: { sm: {} } }));
+vi.mock('../../../theme/tokens', () => ({
+  opacity: { peek: 0.62 },
+  shadows: { sm: {} },
+  spacing: { 1: 4, 2: 8, 4: 16 },
+}));
 vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
 // AccessoryBarSurface (the capsule background) resolves the surface via this —
 // force the glass branch so the GlassSurface mock renders and `[data-glass]`

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -205,6 +205,7 @@ vi.mock('../../../hooks/use-reduce-motion', () => ({ useReduceMotion: () => fals
 vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn(), hapticSelection: vi.fn() }));
 
 vi.mock('../../../theme/tokens', () => ({
+  opacity: { peek: 0.62 },
   spacing: { 1: 4, 2: 8, 3: 12, 10: 40 },
   borderRadius: { md: 8 },
 }));

--- a/packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx
@@ -22,7 +22,8 @@ vi.mock('react-native', () => ({
         ? (styleEntry as { width?: unknown }).width
         : null;
     }, null);
-    return createElement('div', { 'data-width': width == null ? '' : String(width) }, children);
+    const dataWidth = typeof width === 'number' || typeof width === 'string' ? String(width) : '';
+    return createElement('div', { 'data-width': dataWidth }, children);
   },
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
   useWindowDimensions: () => ({ width: 402, height: 874, scale: 3, fontScale: 1 }),
@@ -33,6 +34,8 @@ vi.mock('../../../providers/queue-provider', () => ({
 }));
 vi.mock('../../../theme/layout', () => ({
   glassSize: { standard: 56, inline: 44, capsule: 52 },
+  NATIVE_BOTTOM_ACCESSORY_MAX_WIDTH: 344,
+  NATIVE_BOTTOM_ACCESSORY_SCREEN_GUTTER: 32,
 }));
 vi.mock('../NativeAccessoryClimbRow', () => ({
   NativeAccessoryClimbRow: ({ placement, width }: { placement: 'regular' | 'inline'; width: number }) =>

--- a/packages/mobile/src/components/queue-control/__tests__/use-queue-climb-carousel.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-queue-climb-carousel.test.tsx
@@ -79,6 +79,7 @@ vi.mock('../use-wall-or-queue-climb', () => ({
   useWallOrQueueCurrentClimb: (localClimb: unknown) => wall.climb ?? localClimb,
   useIsWallPinned: () => wall.pinned,
 }));
+vi.mock('../../../theme/tokens', () => ({ opacity: { peek: 0.62 } }));
 
 import { useQueueClimbCarousel } from '../use-queue-climb-carousel';
 

--- a/packages/mobile/src/components/queue-control/use-queue-climb-carousel.ts
+++ b/packages/mobile/src/components/queue-control/use-queue-climb-carousel.ts
@@ -9,6 +9,7 @@ import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { useIsPartyPreviewOnly, usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { hapticLight, hapticSelection } from '../../lib/haptics';
+import { opacity } from '../../theme/tokens';
 import { useCarouselGesture } from '../play-drawer/use-carousel-gesture';
 import { useWallOrQueueCurrentClimb, useIsWallPinned } from './use-wall-or-queue-climb';
 
@@ -206,11 +207,11 @@ export function useQueueClimbCarousel(
   // sidesteps the Android "derived value doesn't rebuild on width change" symptom.
   const nextPeekStyle = useAnimatedStyle(() => {
     if (translateX.value === 0) return { opacity: 0, transform: [{ translateX: widthSV.value }] };
-    return { opacity: 1, transform: [{ translateX: Math.max(0, widthSV.value + translateX.value) }] };
+    return { opacity: opacity.peek, transform: [{ translateX: Math.max(0, widthSV.value + translateX.value) }] };
   });
   const prevPeekStyle = useAnimatedStyle(() => {
     if (translateX.value === 0) return { opacity: 0, transform: [{ translateX: -widthSV.value }] };
-    return { opacity: 1, transform: [{ translateX: Math.min(0, -widthSV.value + translateX.value) }] };
+    return { opacity: opacity.peek, transform: [{ translateX: Math.min(0, -widthSV.value + translateX.value) }] };
   });
 
   const swipeAccessibilityActions: AccessibilityActionInfo[] = [

--- a/packages/mobile/src/components/search/ClimbFilterFab.tsx
+++ b/packages/mobile/src/components/search/ClimbFilterFab.tsx
@@ -1,7 +1,10 @@
-import { Pressable, StyleSheet, View } from 'react-native';
+import { useEffect } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import type { Grade } from '@boardsesh/shared-schema';
 import type { GradeBound } from '@boardsesh/climb-filters';
 import { spacing } from '../../theme/tokens';
+import { timing } from '../../theme/animations';
 import { FILTER_FAB_SIZE, FilterButton } from './FilterButton';
 import { GradeRangeRail } from '../grade';
 
@@ -28,6 +31,17 @@ export function ClimbFilterFab({
   onCloseGrade,
   onGradeChange,
 }: ClimbFilterFabProps) {
+  const animatedBottom = useSharedValue(bottom);
+
+  useEffect(() => {
+    animatedBottom.value = withTiming(bottom, { duration: timing.normal });
+  }, [animatedBottom, bottom]);
+
+  const fabSlotStyle = useAnimatedStyle(() => ({ bottom: animatedBottom.value }));
+  const gradeRailSlotStyle = useAnimatedStyle(() => ({
+    bottom: animatedBottom.value + FILTER_FAB_SIZE + spacing[2],
+  }));
+
   return (
     <>
       {gradeRailVisible ? (
@@ -39,16 +53,13 @@ export function ClimbFilterFab({
         />
       ) : null}
       {gradeRailVisible ? (
-        <View
-          pointerEvents="box-none"
-          style={[styles.gradeRailSlot, { bottom: bottom + FILTER_FAB_SIZE + spacing[2] }]}
-        >
+        <Animated.View pointerEvents="box-none" style={[styles.gradeRailSlot, gradeRailSlotStyle]}>
           <GradeRangeRail grades={grades} bound={bound} onChange={onGradeChange} onRequestClose={onCloseGrade} />
-        </View>
+        </Animated.View>
       ) : null}
-      <View pointerEvents="box-none" style={[styles.fabSlot, { bottom }]}>
+      <Animated.View pointerEvents="box-none" style={[styles.fabSlot, fabSlotStyle]}>
         <FilterButton activeFilterCount={activeFilterCount} onPress={onOpenFilters} onLongPress={onOpenGrade} />
-      </View>
+      </Animated.View>
     </>
   );
 }
@@ -66,6 +77,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: spacing[4],
     right: spacing[4],
+    bottom: 0,
     zIndex: 20,
   },
   fabSlot: {

--- a/packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx
@@ -7,11 +7,18 @@ import type { GradeBound } from '@boardsesh/climb-filters';
 vi.mock('react-native', () => ({
   Pressable: ({ onPress }: { onPress?: () => void }) =>
     createElement('button', { onClick: onPress, 'data-dismiss': 'true' }),
-  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
 }));
 
+vi.mock('react-native-reanimated', () => ({
+  default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
+  useAnimatedStyle: () => ({}),
+  useSharedValue: (initial: number) => ({ value: initial }),
+  withTiming: (value: number) => value,
+}));
+
 vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8, 4: 16 } }));
+vi.mock('../../../theme/animations', () => ({ timing: { normal: 250 } }));
 vi.mock('../FilterButton', () => ({
   FILTER_FAB_SIZE: 48,
   FilterButton: ({

--- a/packages/mobile/src/theme/layout.ts
+++ b/packages/mobile/src/theme/layout.ts
@@ -66,6 +66,12 @@ export const TOOLBAR_SIDE_MARGIN = 16;
 /** Gap between the toolbar's floating elements. */
 export const TOOLBAR_GAP = 8;
 
+/** Max readable width for UIKit's iOS 26 bottom accessory content. */
+export const NATIVE_BOTTOM_ACCESSORY_MAX_WIDTH = 344;
+
+/** Total horizontal screen gutter reserved around UIKit's iOS 26 bottom accessory. */
+export const NATIVE_BOTTOM_ACCESSORY_SCREEN_GUTTER = 32;
+
 /** Lift between the floating toolbar and the tab bar below it, so the islands
  *  read as floating (the old opaque queue bar sat flush against the tab bar). */
 export const TOOLBAR_GAP_ABOVE_TABBAR = 10;

--- a/packages/mobile/src/theme/tokens.ts
+++ b/packages/mobile/src/theme/tokens.ts
@@ -74,6 +74,7 @@ export const shadows = {
 
 export const opacity = {
   subtle: 0.7,
+  peek: 0.62,
   disabled: 0.5,
 } as const;
 


### PR DESCRIPTION
## Summary

Refs #2567.

- Move mobile queue/accessory sizing and carousel spacing toward named layout/spacing tokens.
- Clamp `GlassIconButton` badge text at `99+` and cap the owned badge text scaling in both Liquid Glass and Material paths.
- Dim queue climb carousel peek labels with a shared opacity token.
- Animate the climbs list bottom spacer and filter FAB/grade rail bottom offset when current-climb chrome appears or clears.
- Add the cancelled guard to the per-board last-search restore fallback.

## Validation

- `vp test run packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx packages/mobile/src/components/__tests__/glass-icon-button.test.tsx packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx packages/mobile/src/components/queue-control/__tests__/use-queue-carousel.test.tsx packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts`
- `vp run typecheck:mobile`
- `vp check packages/mobile/app/'(tabs)'/climbs/index.tsx packages/mobile/src/components/GlassIconButton.tsx packages/mobile/src/components/__tests__/glass-icon-button.test.tsx packages/mobile/src/components/queue-control/ClimbCapsule.tsx packages/mobile/src/components/queue-control/QueueBottomAccessory.tsx packages/mobile/src/components/queue-control/use-queue-carousel.ts packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx packages/mobile/src/components/queue-control/__tests__/use-queue-carousel.test.tsx packages/mobile/src/components/search/ClimbFilterFab.tsx packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx packages/mobile/src/theme/layout.ts packages/mobile/src/theme/tokens.ts`
- `vp run check:mobile-bundle`
- Direct escalated `scripts/mobile-simulator-check.sh` smoke: Expo prebuild, CocoaPods, iOS simulator build, install, launch on booted iPhone 17 Pro, and 30s crash-pattern log scan passed.
- After rebasing onto `origin/main` at `3765d9563`: `vp test run packages/mobile/src/components/queue-control/__tests__/use-queue-climb-carousel.test.tsx packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx packages/mobile/src/components/__tests__/glass-icon-button.test.tsx packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx`

## QA / Review

- Code-review subagent found the queue bottom accessory test mock needed the new layout constants; fixed in `100e957b` after rebase.
- QA subagent found no blocking code defect from static/test coverage. A simulator smoke check now passes, but manual visual QA is still needed for the full issue matrix: FlashList inset behavior, native accessory clearance, SE-class layout, and Dynamic Type.

## Notes

- Full `vp check` is currently blocked by existing repo-wide format/lint/type findings outside this PR's files.
- `vp run dev` could not start because Docker is not running/reachable, so the dev database could not be brought up. `.boardsesh/qa-notes.md` is present locally for the dev orchestrator once Docker is available.
- `vp run check:mobile-simulator` skipped inside the task runner because it could not access `xcrun simctl`; running the script outside the sandbox with the build cache redirected to ignored `.boardsesh/` succeeded.
- During the simulator smoke, Expo reused an existing Metro server on port 8081 from another worktree, so this validates native build/install/launch/log health rather than a full visual pass of this branch.