### PR TITLE
[codex] Hide unsupported Mini MoonBoard custom option

### DIFF
--- a/packages/mobile/src/lib/__tests__/custom-board-options.test.ts
+++ b/packages/mobile/src/lib/__tests__/custom-board-options.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { getAllLayouts } from '@boardsesh/board-constants/product-sizes';
+import { MOONBOARD_LAYOUTS } from '@boardsesh/board-config';
 import {
   getBoardLayouts,
   getBoardSetsForLayoutAndSize,
@@ -21,7 +22,7 @@ describe('custom board options', () => {
       'MoonBoard Masters 2017',
       'MoonBoard Masters 2019',
     ]);
-    expect(layouts.map((layout) => layout.id)).not.toContain(6);
+    expect(layouts.map((layout) => layout.id)).not.toContain(MOONBOARD_LAYOUTS['mini-moonboard-2020'].id);
   });
 
   it('returns the MoonBoard standard size for known layouts', () => {

--- a/packages/mobile/src/lib/__tests__/custom-board-options.test.ts
+++ b/packages/mobile/src/lib/__tests__/custom-board-options.test.ts
@@ -12,7 +12,7 @@ describe('custom board options', () => {
     expect(getBoardLayouts('kilter')).toEqual(getAllLayouts('kilter'));
   });
 
-  it('returns MoonBoard layouts for the custom board selector', () => {
+  it('returns supported MoonBoard layouts for the custom board selector', () => {
     const layouts = getBoardLayouts('moonboard');
     expect(layouts.map((layout) => layout.name)).toEqual([
       'MoonBoard 2010',
@@ -20,8 +20,8 @@ describe('custom board options', () => {
       'MoonBoard 2024',
       'MoonBoard Masters 2017',
       'MoonBoard Masters 2019',
-      'Mini MoonBoard 2020',
     ]);
+    expect(layouts.map((layout) => layout.id)).not.toContain(6);
   });
 
   it('returns the MoonBoard standard size for known layouts', () => {

--- a/packages/mobile/src/lib/custom-board-options.ts
+++ b/packages/mobile/src/lib/custom-board-options.ts
@@ -17,6 +17,8 @@ import {
   type MoonBoardLayoutKey,
 } from '@boardsesh/board-config';
 
+const HIDDEN_CUSTOM_MOONBOARD_LAYOUT_IDS = new Set<number>([MOONBOARD_LAYOUTS['mini-moonboard-2020'].id]);
+
 const MOONBOARD_PRODUCT_SIZE: ProductSizeData = {
   id: MOONBOARD_SIZE.id,
   name: MOONBOARD_SIZE.name,
@@ -34,11 +36,13 @@ function getMoonBoardLayoutKey(layoutId: number): MoonBoardLayoutKey | null {
 
 export function getBoardLayouts(boardName: BoardName): LayoutData[] {
   if (boardName === 'moonboard') {
-    return Object.values(MOONBOARD_LAYOUTS).map((layout) => ({
-      id: layout.id,
-      name: layout.name,
-      productId: MOONBOARD_PRODUCT_SIZE.productId,
-    }));
+    return Object.values(MOONBOARD_LAYOUTS)
+      .filter((layout) => !HIDDEN_CUSTOM_MOONBOARD_LAYOUT_IDS.has(layout.id))
+      .map((layout) => ({
+        id: layout.id,
+        name: layout.name,
+        productId: MOONBOARD_PRODUCT_SIZE.productId,
+      }));
   }
 
   return getAllLayouts(boardName);


### PR DESCRIPTION
## Summary

- Hide Mini MoonBoard 2020 from the mobile custom-board layout picker.
- Keep shared MoonBoard metadata untouched so existing/imported Mini MoonBoard records can still resolve outside the create-new-board selector.
- Update the custom-board options regression test to assert the unsupported layout is absent.

Closes #2688.

## Validation

- `vp test run --project mobile packages/mobile/src/lib/__tests__/custom-board-options.test.ts --reporter=agent`
- `vp run typecheck:mobile`
- `vp run test:mobile`
- `vp run check:mobile-bundle`
- `vp check packages/mobile/src/lib/custom-board-options.ts packages/mobile/src/lib/__tests__/custom-board-options.test.ts`
- `vp run check:mobile-simulator` skipped: no `xcrun simctl` available in this shell.
- `vp run mobile:screenshot` skipped: no iOS simulator available.

## Notes

- Full `vp check` currently reports pre-existing formatting issues in unrelated files, so I did not bulk-format outside this change.