### PR TITLE
[codex] Reset mobile create-climb identity on angle change

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -267,6 +267,9 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       'expo-apple-authentication',
       // Native Google Sign-In — only when an iosUrlScheme is resolvable (see above).
       ...googleSignInPlugin,
+      // GoogleSignIn pulls AppCheckCore, a Swift pod whose transitive ObjC deps
+      // need module maps under static-library CocoaPods integration.
+      './plugins/with-google-swift-static-pod-headers',
       'expo-localization',
       [
         'expo-location',

--- a/packages/mobile/plugins/__tests__/with-google-swift-static-pod-headers.test.ts
+++ b/packages/mobile/plugins/__tests__/with-google-swift-static-pod-headers.test.ts
@@ -1,0 +1,73 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+type GoogleSwiftStaticPodHeadersPlugin = {
+  applyGoogleSwiftStaticPodHeaders(contents: string): string;
+  MODULAR_HEADER_PODS: string[];
+};
+
+const plugin = require('../with-google-swift-static-pod-headers.js') as GoogleSwiftStaticPodHeadersPlugin;
+
+describe('with-google-swift-static-pod-headers', () => {
+  it('adds modular header declarations after use_expo_modules', () => {
+    const podfile = `
+target 'Boardsesh' do
+  use_expo_modules!
+  use_frameworks! :linkage => :static
+end
+`;
+
+    const updated = plugin.applyGoogleSwiftStaticPodHeaders(podfile);
+
+    expect(updated).toContain(
+      [
+        '  use_expo_modules!',
+        '  # AppCheckCore is Swift and these transitive ObjC pods need module maps when linked statically.',
+        "  pod 'GoogleUtilities', :modular_headers => true",
+        "  pod 'RecaptchaInterop', :modular_headers => true",
+        '  use_frameworks! :linkage => :static',
+      ].join('\n'),
+    );
+  });
+
+  it('is idempotent when both modular header declarations already exist', () => {
+    const podfile = `
+target 'Boardsesh' do
+  use_expo_modules!
+  pod 'GoogleUtilities', :modular_headers => true
+  pod 'RecaptchaInterop', :modular_headers => true
+end
+`;
+
+    expect(plugin.applyGoogleSwiftStaticPodHeaders(podfile)).toBe(podfile);
+  });
+
+  it('adds only the missing declaration when one pod is already configured', () => {
+    const podfile = `
+target 'Boardsesh' do
+  use_expo_modules!
+  pod 'GoogleUtilities', :modular_headers => true
+end
+`;
+
+    const updated = plugin.applyGoogleSwiftStaticPodHeaders(podfile);
+
+    expect(updated.match(/pod 'GoogleUtilities'/g)).toHaveLength(1);
+    expect(updated.match(/pod 'RecaptchaInterop'/g)).toHaveLength(1);
+  });
+
+  it('fails loudly if Expo changes the generated Podfile shape', () => {
+    expect(() => plugin.applyGoogleSwiftStaticPodHeaders("target 'Boardsesh' do\nend\n")).toThrow(
+      'Could not find use_expo_modules! in generated Podfile.',
+    );
+  });
+
+  it('fails loudly if the insertion marker has no trailing line break', () => {
+    expect(() => plugin.applyGoogleSwiftStaticPodHeaders("target 'Boardsesh' do\n  use_expo_modules!")).toThrow(
+      'Could not insert modular-header pods after use_expo_modules!; Podfile has no line break.',
+    );
+  });
+});

--- a/packages/mobile/plugins/with-google-swift-static-pod-headers.js
+++ b/packages/mobile/plugins/with-google-swift-static-pod-headers.js
@@ -1,0 +1,43 @@
+const { createRunOncePlugin, withPodfile } = require('expo/config-plugins');
+
+const MODULAR_HEADER_PODS = ['GoogleUtilities', 'RecaptchaInterop'];
+const INSERTION_MARKER = 'use_expo_modules!';
+const COMMENT = '  # AppCheckCore is Swift and these transitive ObjC pods need module maps when linked statically.';
+
+function podDeclaration(podName) {
+  return `  pod '${podName}', :modular_headers => true`;
+}
+
+function hasModularHeaderDeclaration(contents, podName) {
+  const escapedPodName = podName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`pod\\s+['"]${escapedPodName}['"][^\\n]*:modular_headers\\s*=>\\s*true`).test(contents);
+}
+
+function applyGoogleSwiftStaticPodHeaders(contents) {
+  const missingPods = MODULAR_HEADER_PODS.filter((podName) => !hasModularHeaderDeclaration(contents, podName));
+  if (missingPods.length === 0) return contents;
+
+  const insertionIndex = contents.indexOf(INSERTION_MARKER);
+  if (insertionIndex === -1) {
+    throw new Error(`Could not find ${INSERTION_MARKER} in generated Podfile.`);
+  }
+
+  const lineEndIndex = contents.indexOf('\n', insertionIndex);
+  if (lineEndIndex === -1) {
+    throw new Error(`Could not insert modular-header pods after ${INSERTION_MARKER}; Podfile has no line break.`);
+  }
+
+  const insertedBlock = [COMMENT, ...missingPods.map(podDeclaration)].join('\n');
+  return `${contents.slice(0, lineEndIndex + 1)}${insertedBlock}\n${contents.slice(lineEndIndex + 1)}`;
+}
+
+function withGoogleSwiftStaticPodHeaders(config) {
+  return withPodfile(config, (modConfig) => {
+    modConfig.modResults.contents = applyGoogleSwiftStaticPodHeaders(modConfig.modResults.contents);
+    return modConfig;
+  });
+}
+
+module.exports = createRunOncePlugin(withGoogleSwiftStaticPodHeaders, 'with-google-swift-static-pod-headers', '1.0.0');
+module.exports.applyGoogleSwiftStaticPodHeaders = applyGoogleSwiftStaticPodHeaders;
+module.exports.MODULAR_HEADER_PODS = MODULAR_HEADER_PODS;

--- a/packages/mobile/src/components/create-climb/__tests__/save-button-view.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/save-button-view.test.ts
@@ -25,6 +25,15 @@ describe('deriveSaveButtonView', () => {
     });
   });
 
+  it('loading: disabled while edit data is loading', () => {
+    expect(deriveSaveButtonView('loading', t)).toEqual({
+      title: 'mobile.create.save.loading',
+      icon: null,
+      disabled: true,
+      tint: 'primary',
+    });
+  });
+
   it('justSaved: green confirmation with a check, re-enabled', () => {
     expect(deriveSaveButtonView('justSaved', t)).toEqual({
       title: 'mobile.create.save.done',
@@ -53,7 +62,7 @@ describe('deriveSaveButtonView', () => {
   });
 
   it('every state is distinct in at least one of label/icon/disabled/tint', () => {
-    const states: SaveButtonState[] = ['ready', 'saving', 'justSaved', 'editLocked', 'login'];
+    const states: SaveButtonState[] = ['ready', 'saving', 'loading', 'justSaved', 'editLocked', 'login'];
     const fingerprints = states.map((state) => {
       const view = deriveSaveButtonView(state, t);
       return `${view.title}|${view.icon}|${view.disabled}|${view.tint}`;

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const crypto = vi.hoisted(() => {
+  let index = 0;
+  const randomUUID = vi.fn(() => `preview-${++index}`);
+  return {
+    randomUUID,
+    reset: () => {
+      index = 0;
+      randomUUID.mockClear();
+    },
+  };
+});
+
+const boardProvider = vi.hoisted(() => ({
+  isAuthenticated: true,
+  saveClimb: vi.fn(),
+  updateClimb: vi.fn(),
+}));
+const queue = vi.hoisted(() => ({ setCurrentClimb: vi.fn() }));
+const router = vi.hoisted(() => ({ push: vi.fn() }));
+const editClimb = vi.hoisted(() => ({ data: undefined as unknown }));
+
+const createClimb = vi.hoisted(() => ({
+  litUpHoldsMap: { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } },
+  setHoldState: vi.fn(),
+  generateFramesString: vi.fn(() => 'p1r12p2r13p3r14'),
+  startingCount: 1,
+  finishCount: 1,
+  isValid: true,
+  resetHolds: vi.fn(),
+  loadHolds: vi.fn(),
+  undo: vi.fn(),
+  redo: vi.fn(),
+  canUndo: false,
+  canRedo: false,
+}));
+
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: () => ({ remove: () => {} }) },
+}));
+vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('expo-crypto', () => ({ randomUUID: crypto.randomUUID }));
+vi.mock('expo-router', () => ({ useRouter: () => router }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+vi.mock('@boardsesh/shared-schema', () => ({
+  isNoMatchClimb: () => false,
+  withNoMatch: (description: string | null | undefined) => description ?? '',
+}));
+vi.mock('@boardsesh/create-climb-react', () => ({
+  useCreateClimb: () => createClimb,
+  computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
+  computeEditLocked: () => false,
+  buildInitialHoldsMap: () => ({}),
+}));
+vi.mock('@boardsesh/board-react', () => ({
+  useBoardProvider: () => ({
+    isAuthenticated: boardProvider.isAuthenticated,
+    saveClimb: boardProvider.saveClimb,
+    updateClimb: boardProvider.updateClimb,
+  }),
+  isDuplicateClimbError: () => false,
+}));
+vi.mock('@boardsesh/graphql-client', () => ({
+  GraphQLOperationError: class GraphQLOperationError extends Error {},
+}));
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ refreshAuthState: vi.fn() }),
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: { displayName: 'Tester' } }),
+  useClimb: () => ({ data: editClimb.data }),
+}));
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueueActions: () => ({ setCurrentClimb: queue.setCurrentClimb }),
+}));
+vi.mock('../../../providers/bluetooth-provider', () => ({
+  useOptionalBluetoothContext: () => null,
+}));
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+vi.mock('../../../lib/climb-to-queue-item', () => ({
+  climbToQueueItem: (climb: { uuid: string; angle: number }, options: { uuid: string }) => ({ climb, options }),
+}));
+vi.mock('../../../lib/create-climb-draft-store', () => ({
+  loadDraft: vi.fn(async () => null),
+  saveDraft: vi.fn(async () => {}),
+  clearDraft: vi.fn(async () => {}),
+  createClimbDraftKey: (board: { angle: number }) => `draft-${board.angle}`,
+}));
+vi.mock('../brush-roles', () => ({
+  getPaintRoles: () => ['HAND', 'STARTING', 'FINISH'],
+}));
+
+import { useCreateClimbScreen, type CreateClimbBoard } from '../use-create-climb-screen';
+import { deriveSaveButtonView } from '../save-button-view';
+
+const BOARD_25: CreateClimbBoard = {
+  boardName: 'kilter',
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,2',
+  angle: 25,
+};
+const BOARD_40: CreateClimbBoard = { ...BOARD_25, angle: 40 };
+
+type QueuePayload = {
+  climb: { uuid: string; angle: number };
+  options: { uuid: string };
+};
+
+beforeEach(() => {
+  crypto.reset();
+  boardProvider.isAuthenticated = true;
+  boardProvider.saveClimb.mockReset();
+  boardProvider.updateClimb.mockReset();
+  queue.setCurrentClimb.mockClear();
+  router.push.mockClear();
+  editClimb.data = undefined;
+  createClimb.setHoldState.mockClear();
+  createClimb.generateFramesString.mockClear();
+  createClimb.resetHolds.mockClear();
+  createClimb.loadHolds.mockClear();
+  createClimb.undo.mockClear();
+  createClimb.redo.mockClear();
+});
+
+describe('useCreateClimbScreen angle changes', () => {
+  it('drops the saved climb identity and uses a fresh queue uuid after a new-climb angle change', async () => {
+    boardProvider.saveClimb.mockResolvedValueOnce({
+      uuid: 'saved-at-25',
+      createdAt: null,
+      publishedAt: null,
+      isDraft: true,
+    });
+    boardProvider.saveClimb.mockResolvedValueOnce({
+      uuid: 'saved-at-40',
+      createdAt: null,
+      publishedAt: null,
+      isDraft: true,
+    });
+
+    const { result, rerender } = renderHook(
+      ({ board }: { board: CreateClimbBoard }) => useCreateClimbScreen({ board }),
+      { initialProps: { board: BOARD_25 } },
+    );
+
+    act(() => result.current.setName('Angle-sensitive draft'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(boardProvider.saveClimb).toHaveBeenCalledWith(expect.objectContaining({ angle: 25 }));
+    queue.setCurrentClimb.mockClear();
+    createClimb.resetHolds.mockClear();
+    createClimb.loadHolds.mockClear();
+
+    rerender({ board: BOARD_40 });
+    await act(async () => {});
+
+    expect(result.current.litUpHoldsMap).toBe(createClimb.litUpHoldsMap);
+    expect(result.current.name).toBe('Angle-sensitive draft');
+    expect(createClimb.resetHolds).not.toHaveBeenCalled();
+    expect(createClimb.loadHolds).not.toHaveBeenCalled();
+
+    act(() => result.current.handleSetActive());
+
+    const payload = queue.setCurrentClimb.mock.calls[0]?.[0] as QueuePayload | undefined;
+    expect(payload?.options.uuid).toBe('preview-2');
+    expect(payload?.climb.uuid).toBe('preview-2');
+    expect(payload?.climb.angle).toBe(40);
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(boardProvider.saveClimb).toHaveBeenCalledTimes(2);
+    expect(boardProvider.saveClimb).toHaveBeenLastCalledWith(expect.objectContaining({ angle: 40 }));
+    expect(boardProvider.updateClimb).not.toHaveBeenCalled();
+  });
+
+  it('keeps the loaded saved climb in edit mode when the board angle changes', async () => {
+    editClimb.data = {
+      uuid: 'existing-climb',
+      name: 'Existing climb',
+      description: '',
+      frames: 'p1r12',
+      is_draft: false,
+      created_at: '2026-01-01T00:00:00.000Z',
+      published_at: '2026-01-02T00:00:00.000Z',
+    };
+    boardProvider.updateClimb.mockResolvedValue({
+      uuid: 'existing-climb',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      publishedAt: '2026-01-02T00:00:00.000Z',
+      isDraft: false,
+    });
+
+    const { result, rerender } = renderHook(
+      ({ board }: { board: CreateClimbBoard }) => useCreateClimbScreen({ board, editClimbUuid: 'existing-climb' }),
+      { initialProps: { board: BOARD_25 } },
+    );
+
+    await waitFor(() => expect(result.current.name).toBe('Existing climb'));
+    act(() => result.current.setName('Edited at new angle'));
+
+    rerender({ board: BOARD_40 });
+    await act(async () => {});
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(boardProvider.updateClimb).toHaveBeenCalledWith(
+      expect.objectContaining({ uuid: 'existing-climb', angle: 40 }),
+    );
+    expect(boardProvider.saveClimb).not.toHaveBeenCalled();
+  });
+
+  it('does not create a new climb if edit save is tapped before the existing climb loads', async () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD_25, editClimbUuid: 'existing-climb' }));
+
+    act(() => result.current.setName('Premature edit save'));
+    expect(deriveSaveButtonView(result.current.saveState, (key) => key).disabled).toBe(true);
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(boardProvider.saveClimb).not.toHaveBeenCalled();
+    expect(boardProvider.updateClimb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/create-climb/save-button-view.ts
+++ b/packages/mobile/src/components/create-climb/save-button-view.ts
@@ -8,24 +8,27 @@ export type SaveButtonView = {
   title: string;
   /** Leading icon, or null when the button shows none. */
   icon: 'check.small' | 'lock' | null;
-  /** Whether the press is suppressed (saving in flight / locked from editing). */
+  /** Whether the press is suppressed. */
   disabled: boolean;
   /** Which brand colour the filled button takes. */
   tint: 'primary' | 'success';
 };
 
 /**
- * Map the save state machine to the Save button's appearance. Pure so the five
- * states (ready, saving, justSaved, editLocked, login) can be unit-tested
+ * Map the save state machine to the Save button's appearance. Pure so the six
+ * states (ready, saving, loading, justSaved, editLocked, login) can be unit-tested
  * without a renderer. Each state is visually distinct: `login` prompts sign-in,
- * `editLocked` shows a lock, `justSaved` turns green with a check, `saving`
- * disables, `ready` is the plain primary action. Keys are static literals so the
- * i18n orphan checker still sees them.
+ * `editLocked` shows a lock, `justSaved` turns green with a check, `saving` shows
+ * request progress, `loading` disables while edit data loads, and `ready` is the
+ * plain primary action. Keys are static literals so the i18n orphan checker still
+ * sees them.
  */
 export function deriveSaveButtonView(state: SaveButtonState, t: TranslateSave): SaveButtonView {
   switch (state) {
     case 'saving':
       return { title: t('mobile.create.save.saving'), icon: null, disabled: true, tint: 'primary' };
+    case 'loading':
+      return { title: t('mobile.create.save.loading'), icon: null, disabled: true, tint: 'primary' };
     case 'justSaved':
       return { title: t('mobile.create.save.done'), icon: 'check.small', disabled: false, tint: 'success' };
     case 'editLocked':

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -35,7 +35,7 @@ import { getPaintRoles, type BrushRole } from './brush-roles';
 
 // The save button's visual state, derived from auth + the saved-climb snapshot +
 // in-flight state. Lives here (the controller computes it) so the UI imports it.
-export type SaveButtonState = 'ready' | 'saving' | 'justSaved' | 'editLocked' | 'login';
+export type SaveButtonState = 'ready' | 'saving' | 'loading' | 'justSaved' | 'editLocked' | 'login';
 
 export type CreateClimbBoard = {
   boardName: BoardName;
@@ -165,6 +165,7 @@ export function useCreateClimbScreen({
   // active" updates the same queue slot instead of appending a new item each tap.
   const previewUuidRef = useRef<string | null>(null);
   if (!previewUuidRef.current) previewUuidRef.current = randomUUID();
+  const previousAngleRef = useRef(board.angle);
   // Tracked so the just-saved confirmation timer is cleared on unmount.
   const justSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(
@@ -173,6 +174,24 @@ export function useCreateClimbScreen({
     },
     [],
   );
+
+  // The route keeps this screen mounted across angle-only changes so paint state
+  // and typed metadata remain the current WIP. Saved/provisional climb identities
+  // are angle-scoped; angle-specific draft restore remains mount-only so a later
+  // angle toggle cannot overwrite in-memory edits.
+  useEffect(() => {
+    if (previousAngleRef.current === board.angle) return;
+    previousAngleRef.current = board.angle;
+    if (isEditing) return;
+    setSavedClimb(null);
+    setPublishDuplicateError(null);
+    setJustSaved(false);
+    if (justSavedTimerRef.current) {
+      clearTimeout(justSavedTimerRef.current);
+      justSavedTimerRef.current = null;
+    }
+    previewUuidRef.current = randomUUID();
+  }, [board.angle, isEditing]);
 
   // ---- Edit mode: fetch the climb and seed the editor once. ----
   const editVariables = useMemo(
@@ -404,10 +423,11 @@ export function useCreateClimbScreen({
   const saveState: SaveButtonState = useMemo(() => {
     if (!isAuthenticated) return 'login';
     if (isSaving) return 'saving';
+    if (isEditing && !savedClimb) return 'loading';
     if (justSaved) return 'justSaved';
     if (editLocked) return 'editLocked';
     return 'ready';
-  }, [isAuthenticated, isSaving, justSaved, editLocked]);
+  }, [isAuthenticated, isSaving, isEditing, savedClimb, justSaved, editLocked]);
 
   // Signal the screen should focus the header name field (e.g. on a save with
   // no name yet). The name input lives in the drawer header, not a settings sheet.
@@ -420,6 +440,7 @@ export function useCreateClimbScreen({
       return;
     }
     if (editLocked) return;
+    if (isEditing && !savedClimb) return;
     if (!isValid) return;
     if (name.trim() === '') {
       requestFocusName();
@@ -522,6 +543,7 @@ export function useCreateClimbScreen({
     isAuthenticated,
     router,
     editLocked,
+    isEditing,
     isValid,
     name,
     canUpdate,

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -47,6 +47,6 @@ export default defineConfig({
     // `// @vitest-environment jsdom` pragma — needed to render React
     // providers in tests. Pure-logic tests stay node-env (faster).
     // app/** covers Expo Router layout/screen tests (e.g. (tabs)/__tests__/).
-    include: ['src/**/*.test.{ts,tsx}', 'app/**/*.test.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx}', 'app/**/*.test.{ts,tsx}', 'plugins/**/*.test.{ts,tsx}'],
   },
 });

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -741,6 +741,7 @@
       "save": {
         "idle": "Save",
         "login": "Sign in to save",
+        "loading": "Loading…",
         "saving": "Saving…",
         "done": "Saved",
         "draftToast": "Draft saved",

--- a/packages/shared/i18n/locales/en-US/feed.json
+++ b/packages/shared/i18n/locales/en-US/feed.json
@@ -26,8 +26,6 @@
       "signInTitle": "Sign in to see your feed",
       "signInBody": "Follow climbers to see their sessions and daily sends here.",
       "searchAction": "Find climbers",
-      "closeSearch": "Close climber search",
-      "findClimbersTitle": "Find climbers",
       "emptyTitle": "No sessions yet",
       "emptyBody": "Follow climbers to fill this with sessions and daily sends.",
       "unknownClimb": "Unknown climb",

--- a/packages/shared/i18n/locales/en-US/profile.json
+++ b/packages/shared/i18n/locales/en-US/profile.json
@@ -51,7 +51,6 @@
     "problems": "problems",
     "send": "send",
     "flash": "flash",
-    "redpoint": "redpoint",
     "percentile": "Percentile",
     "topPercent": "Top {{value}}%",
     "moreSentThan": "More problems sent than {{value}}% of climbers",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -741,6 +741,7 @@
       "save": {
         "idle": "Guardar",
         "login": "Inicia sesión para guardar",
+        "loading": "Cargando…",
         "saving": "Guardando…",
         "done": "Guardado",
         "draftToast": "Borrador guardado",

--- a/packages/shared/i18n/locales/es/feed.json
+++ b/packages/shared/i18n/locales/es/feed.json
@@ -26,8 +26,6 @@
       "signInTitle": "Inicia sesión para ver tu feed",
       "signInBody": "Sigue a escaladores y equipadores para ver sus encadenes y bloques nuevos aquí.",
       "searchAction": "Buscar escaladores",
-      "closeSearch": "Cerrar búsqueda de escaladores",
-      "findClimbersTitle": "Buscar escaladores",
       "emptyTitle": "Aún no hay actividad",
       "emptyBody": "Sigue a escaladores y equipadores para llenar esto.",
       "unknownClimb": "Bloque desconocido",

--- a/packages/shared/i18n/locales/es/profile.json
+++ b/packages/shared/i18n/locales/es/profile.json
@@ -51,7 +51,6 @@
     "problems": "bloques",
     "send": "encadene",
     "flash": "flash",
-    "redpoint": "trabajado",
     "percentile": "Percentil",
     "topPercent": "Top {{value}}%",
     "moreSentThan": "Más bloques encadenados que el {{value}}% de los escaladores",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -741,6 +741,7 @@
       "save": {
         "idle": "Enregistrer",
         "login": "Connectez-vous pour enregistrer",
+        "loading": "Chargement…",
         "saving": "Enregistrement…",
         "done": "Enregistré",
         "draftToast": "Brouillon enregistré",

--- a/packages/shared/i18n/locales/fr/feed.json
+++ b/packages/shared/i18n/locales/fr/feed.json
@@ -26,8 +26,6 @@
       "signInTitle": "Connectez-vous pour voir votre fil",
       "signInBody": "Suivez des grimpeurs et des ouvreurs pour voir leurs enchaînements et nouveaux blocs ici.",
       "searchAction": "Chercher des grimpeurs",
-      "closeSearch": "Fermer la recherche de grimpeurs",
-      "findClimbersTitle": "Chercher des grimpeurs",
       "emptyTitle": "Aucune activité pour le moment",
       "emptyBody": "Suivez des grimpeurs et des ouvreurs pour remplir ce fil.",
       "unknownClimb": "Bloc inconnu",

--- a/packages/shared/i18n/locales/fr/profile.json
+++ b/packages/shared/i18n/locales/fr/profile.json
@@ -51,7 +51,6 @@
     "problems": "blocs",
     "send": "enchaînement",
     "flash": "flash",
-    "redpoint": "après-travail",
     "percentile": "Percentile",
     "topPercent": "Top {{value}} %",
     "moreSentThan": "Plus de blocs enchaînés que {{value}} % des grimpeurs",


### PR DESCRIPTION
## Summary

- Reset the mobile create-climb saved/provisional identity when only the board angle changes, while keeping the editor mounted so painted holds and undo history survive session sync.
- Keep edit-mode saves disabled until the existing climb snapshot has loaded, preventing a premature tap from creating a new climb.
- Add hook-level regression coverage for Set Active, second Save-after-angle-change, paint-state preservation, and the edit-mode guard.
- Add a targeted Expo Podfile config plugin for the AppCheckCore static Swift dependency path so `GoogleUtilities` and `RecaptchaInterop` are emitted with modular headers in iOS CI.
- Remove two orphaned mobile i18n keys across locales so the staged hook passes.

Fixes #2654.

## Validation

- `vp test run --reporter=agent packages/mobile/src/components/create-climb/__tests__` — 9 files, 38 tests passed
- `vp run typecheck:mobile`
- `vp run test:mobile` — 251 files, 1817 tests passed
- `vp run check:mobile-bundle` — iOS and Android bundles OK
- `vp run check:mobile-simulator` (skipped: no `xcrun simctl` available)
- `vp run mobile:screenshot` (skipped: no iOS simulator available)
- `vp run check:i18n:orphans`
- `vp staged`

## QA / Review

- Mobile Metro is running for manual QA at `http://marcos-macbook-pro-2-1.tailedd9d5.ts.net:8089`.
- QA notes are loaded from `.boardsesh/qa-notes.md` in this worktree.
- Code-review and QA subagents ran; their concrete findings were addressed with the Save-after-angle-change assertions, paint-state assertions, and edit-mode early-save guard.
- Latest GitHub Actions runs for `74a7cd11af946f4dbe51b471bddd8cca08d7f8e2` were queued after the CI Podfile fix push.