### PR TITLE
[codex] create playlists from add sheet

### DIFF
--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -138,6 +138,7 @@ function AddToPlaylistSheet({
 
   const handleDismiss = useCallback(() => {
     isPresentedRef.current = false;
+    setCreateVisible(false);
     onClose();
   }, [onClose]);
 
@@ -233,7 +234,6 @@ const styles = StyleSheet.create({
   },
   headerTitle: {
     flex: 1,
-    flexShrink: 1,
   },
   createButton: {
     width: 34,

--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -13,7 +13,7 @@ import { useToast } from '../providers/toast-provider';
 import { usePlaylistsContext, type Playlist } from '../providers/playlists-provider';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
-import { spacing } from '../theme/tokens';
+import { borderRadius, spacing } from '../theme/tokens';
 
 type AddToPlaylistSheetProps = {
   visible: boolean;
@@ -152,6 +152,16 @@ function AddToPlaylistSheet({
     onClose();
   }, [onClose]);
 
+  const handleShowCreate = useCallback(() => {
+    setCreateVisible(true);
+  }, []);
+
+  const handleCloseCreate = useCallback(() => {
+    createRequestIdRef.current += 1;
+    setCreateVisible(false);
+    setCreating(false);
+  }, []);
+
   const snapPoints = useMemo(() => ['50%', '90%'], []);
 
   return (
@@ -174,7 +184,7 @@ function AddToPlaylistSheet({
           </Text>
           {climb && isAuthenticated ? (
             <Pressable
-              onPress={() => setCreateVisible(true)}
+              onPress={handleShowCreate}
               accessibilityRole="button"
               accessibilityLabel={t('actions.playlist.popover.createNew')}
               hitSlop={8}
@@ -225,7 +235,7 @@ function AddToPlaylistSheet({
         visible={createVisible}
         submitting={creating}
         onSubmit={handleCreatePlaylist}
-        onClose={() => setCreateVisible(false)}
+        onClose={handleCloseCreate}
       />
     </>
   );
@@ -246,9 +256,9 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   createButton: {
-    width: 34,
-    height: 34,
-    borderRadius: 17,
+    width: spacing[8],
+    height: spacing[8],
+    borderRadius: borderRadius.full,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -139,6 +139,7 @@ function AddToPlaylistSheet({
   const handleDismiss = useCallback(() => {
     isPresentedRef.current = false;
     setCreateVisible(false);
+    setCreating(false);
     onClose();
   }, [onClose]);
 

--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { ActivityIndicator, View, StyleSheet } from 'react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ActivityIndicator, Pressable, View, StyleSheet } from 'react-native';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
@@ -8,6 +8,7 @@ import { ClimbPreviewCard } from './ClimbPreviewCard';
 import { ListRow } from './ListRow';
 import { Icon } from './Icon';
 import { Text } from './Text';
+import { PlaylistFormSheet, type PlaylistFormValues } from './playlist';
 import { useToast } from '../providers/toast-provider';
 import { usePlaylistsContext, type Playlist } from '../providers/playlists-provider';
 import { useTheme } from '../providers/theme-provider';
@@ -45,7 +46,9 @@ function AddToPlaylistSheet({
   const { t } = useTranslation('climbs');
   const { brandColors, systemColors } = useTheme();
   const { showToast } = useToast();
-  const { playlists, addToPlaylist, isLoading, isAuthenticated } = usePlaylistsContext();
+  const { playlists, addToPlaylist, createPlaylist, isLoading, isAuthenticated } = usePlaylistsContext();
+  const [createVisible, setCreateVisible] = useState(false);
+  const [creating, setCreating] = useState(false);
   const sheetRef = useRef<BottomSheetModal>(null);
   // Track presented state so we never dismiss() a not-presented modal (gorhom
   // then no-ops the next present()). Mirrors LogAscentSheet.
@@ -91,6 +94,48 @@ function AddToPlaylistSheet({
     [climb, angle, addToPlaylist, showToast, t, onClose],
   );
 
+  const handleCreatePlaylist = useCallback(
+    async (values: PlaylistFormValues) => {
+      if (!climb) return;
+      setCreating(true);
+      try {
+        const created = await createPlaylist(values.name, values.description, values.color, values.icon, {
+          boardType: boardName,
+          layoutId,
+        });
+        setCreateVisible(false);
+        try {
+          await addToPlaylist(created.uuid, climb.uuid, angle);
+          showToast(t('actions.playlist.toast.createdNamed', { name: created.name }), 'success');
+          onClose();
+        } catch (error) {
+          if (__DEV__) {
+            console.warn('[playlist] created playlist but failed to add climb', {
+              playlistUuid: created.uuid,
+              climbUuid: climb.uuid,
+              angle,
+              error,
+            });
+          }
+          showToast(t('actions.playlist.toast.addFailed'), 'error');
+        }
+      } catch (error) {
+        if (__DEV__) {
+          console.warn('[playlist] create playlist from add sheet failed', {
+            climbUuid: climb.uuid,
+            boardName,
+            layoutId,
+            error,
+          });
+        }
+        showToast(t('actions.playlist.toast.createFailed'), 'error');
+      } finally {
+        setCreating(false);
+      }
+    },
+    [climb, createPlaylist, boardName, layoutId, addToPlaylist, angle, showToast, t, onClose],
+  );
+
   const handleDismiss = useCallback(() => {
     isPresentedRef.current = false;
     onClose();
@@ -99,58 +144,79 @@ function AddToPlaylistSheet({
   const snapPoints = useMemo(() => ['50%', '90%'], []);
 
   return (
-    <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss} enablePanDownToClose scrollable>
-      {climb && (
-        <ClimbPreviewCard
-          climb={climb}
-          boardName={boardName}
-          layoutId={layoutId}
-          sizeId={sizeId}
-          setIds={setIds}
-          angle={angle}
-        />
-      )}
-      <View style={styles.header}>
-        <Icon name="playlist" size={20} color={systemColors.accent} />
-        <Text variant="headline" style={styles.headerTitle}>
-          {t('actions.playlist.popover.title')}
-        </Text>
-      </View>
+    <>
+      <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss} enablePanDownToClose scrollable>
+        {climb && (
+          <ClimbPreviewCard
+            climb={climb}
+            boardName={boardName}
+            layoutId={layoutId}
+            sizeId={sizeId}
+            setIds={setIds}
+            angle={angle}
+          />
+        )}
+        <View style={styles.header}>
+          <Icon name="playlist" size={20} color={systemColors.accent} />
+          <Text variant="headline" style={styles.headerTitle}>
+            {t('actions.playlist.popover.title')}
+          </Text>
+          {climb && isAuthenticated ? (
+            <Pressable
+              onPress={() => setCreateVisible(true)}
+              accessibilityRole="button"
+              accessibilityLabel={t('actions.playlist.popover.createNew')}
+              hitSlop={8}
+              style={[styles.createButton, { backgroundColor: systemColors.fill }]}
+            >
+              <Icon name="plus" size={18} color={brandColors.primary} />
+            </Pressable>
+          ) : null}
+        </View>
 
-      {!climb ? null : !isAuthenticated ? (
-        <View style={styles.message}>
-          <Text variant="subheadline" color={iosSystemColors.systemGray}>
-            {t('actions.playlist.popover.signInBlurb')}
-          </Text>
-        </View>
-      ) : isLoading ? (
-        <View style={styles.message}>
-          <ActivityIndicator />
-        </View>
-      ) : playlists.length === 0 ? (
-        <View style={styles.message}>
-          <Text variant="subheadline" color={iosSystemColors.systemGray}>
-            {t('actions.playlist.popover.empty')}
-          </Text>
-        </View>
-      ) : (
-        playlists.map((playlist, index) => {
-          const accent = validHexColor(playlist.color);
-          return (
-            <ListRow
-              key={playlist.id}
-              title={playlist.name}
-              subtitle={t('multiboardList.count', { count: playlist.climbCount })}
-              leading={<Icon name="playlist" size={22} color={accent ?? brandColors.primary} />}
-              onPress={() => {
-                void handleAddToPlaylist(playlist);
-              }}
-              showSeparator={index < playlists.length - 1}
-            />
-          );
-        })
-      )}
-    </ModalSheet>
+        {!climb ? null : !isAuthenticated ? (
+          <View style={styles.message}>
+            <Text variant="subheadline" color={iosSystemColors.systemGray}>
+              {t('actions.playlist.popover.signInBlurb')}
+            </Text>
+          </View>
+        ) : isLoading ? (
+          <View style={styles.message}>
+            <ActivityIndicator />
+          </View>
+        ) : playlists.length === 0 ? (
+          <View style={styles.message}>
+            <Text variant="subheadline" color={iosSystemColors.systemGray}>
+              {t('actions.playlist.popover.empty')}
+            </Text>
+          </View>
+        ) : (
+          playlists.map((playlist, index) => {
+            const accent = validHexColor(playlist.color);
+            return (
+              <ListRow
+                key={playlist.id}
+                title={playlist.name}
+                subtitle={t('multiboardList.count', { count: playlist.climbCount })}
+                leading={<Icon name="playlist" size={22} color={accent ?? brandColors.primary} />}
+                onPress={() => {
+                  void handleAddToPlaylist(playlist);
+                }}
+                showSeparator={index < playlists.length - 1}
+              />
+            );
+          })
+        )}
+      </ModalSheet>
+
+      <PlaylistFormSheet
+        mode="create"
+        visible={createVisible}
+        submitting={creating}
+        onSubmit={handleCreatePlaylist}
+        onClose={() => setCreateVisible(false)}
+      />
+    </>
   );
 }
 
@@ -166,7 +232,15 @@ const styles = StyleSheet.create({
     paddingBottom: spacing[3],
   },
   headerTitle: {
+    flex: 1,
     flexShrink: 1,
+  },
+  createButton: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   message: {
     alignItems: 'center',

--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -53,6 +53,7 @@ function AddToPlaylistSheet({
   // Track presented state so we never dismiss() a not-presented modal (gorhom
   // then no-ops the next present()). Mirrors LogAscentSheet.
   const isPresentedRef = useRef(false);
+  const createRequestIdRef = useRef(0);
 
   useEffect(() => {
     if (visible && climb && !isPresentedRef.current) {
@@ -97,18 +98,24 @@ function AddToPlaylistSheet({
   const handleCreatePlaylist = useCallback(
     async (values: PlaylistFormValues) => {
       if (!climb) return;
+      const createRequestId = createRequestIdRef.current + 1;
+      createRequestIdRef.current = createRequestId;
+      const isCurrentCreateRequest = () => createRequestIdRef.current === createRequestId && isPresentedRef.current;
       setCreating(true);
       try {
         const created = await createPlaylist(values.name, values.description, values.color, values.icon, {
           boardType: boardName,
           layoutId,
         });
+        if (!isCurrentCreateRequest()) return;
         setCreateVisible(false);
         try {
           await addToPlaylist(created.uuid, climb.uuid, angle);
+          if (!isCurrentCreateRequest()) return;
           showToast(t('actions.playlist.toast.createdNamed', { name: created.name }), 'success');
           onClose();
         } catch (error) {
+          if (!isCurrentCreateRequest()) return;
           if (__DEV__) {
             console.warn('[playlist] created playlist but failed to add climb', {
               playlistUuid: created.uuid,
@@ -120,6 +127,7 @@ function AddToPlaylistSheet({
           showToast(t('actions.playlist.toast.addFailed'), 'error');
         }
       } catch (error) {
+        if (!isCurrentCreateRequest()) return;
         if (__DEV__) {
           console.warn('[playlist] create playlist from add sheet failed', {
             climbUuid: climb.uuid,
@@ -130,7 +138,7 @@ function AddToPlaylistSheet({
         }
         showToast(t('actions.playlist.toast.createFailed'), 'error');
       } finally {
-        setCreating(false);
+        if (createRequestIdRef.current === createRequestId) setCreating(false);
       }
     },
     [climb, createPlaylist, boardName, layoutId, addToPlaylist, angle, showToast, t, onClose],
@@ -138,6 +146,7 @@ function AddToPlaylistSheet({
 
   const handleDismiss = useCallback(() => {
     isPresentedRef.current = false;
+    createRequestIdRef.current += 1;
     setCreateVisible(false);
     setCreating(false);
     onClose();

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -319,7 +319,7 @@ describe('AddToPlaylistSheet', () => {
     const created = { ...playlist, uuid: 'p-new', id: 'p-new', name: 'Projects', climbCount: 0 };
     playlistContext.createPlaylist.mockResolvedValueOnce(created);
     playlistContext.addToPlaylist.mockRejectedValueOnce(new Error('add failed'));
-    const { getByLabelText, onClose } = renderSheet();
+    const { getByLabelText, queryByLabelText, onClose } = renderSheet();
 
     fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
     fireEvent.click(getByLabelText('submit-created-playlist'));
@@ -327,6 +327,7 @@ describe('AddToPlaylistSheet', () => {
     await waitFor(() => {
       expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-new', 'climb-1', 40);
     });
+    expect(queryByLabelText('submit-created-playlist')).toBeNull();
     expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.addFailed', 'error');
     expect(onClose).not.toHaveBeenCalled();
   });

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import { createElement, forwardRef, useImperativeHandle, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/shared-schema';
 import type { Playlist } from '@boardsesh/graphql/operations/playlists';
@@ -37,7 +37,10 @@ vi.mock('@gorhom/bottom-sheet', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string, options?: Record<string, unknown>) =>
+      key === 'actions.playlist.toast.createdNamed' && typeof options?.name === 'string'
+        ? `${key} ${options.name}`
+        : key,
   }),
 }));
 
@@ -204,7 +207,7 @@ describe('AddToPlaylistSheet', () => {
     await waitFor(() => {
       expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-new', 'climb-1', 40);
     });
-    expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.createdNamed', 'success');
+    expect(toast.showToast).toHaveBeenCalledWith(expect.stringContaining('Projects'), 'success');
     expect(onClose).toHaveBeenCalled();
   });
 
@@ -258,10 +261,13 @@ describe('AddToPlaylistSheet', () => {
     fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
     expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('false');
 
-    createDeferred.resolve(created);
-    await waitFor(() => {
-      expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-new', 'climb-1', 40);
+    await act(async () => {
+      createDeferred.resolve(created);
+      await createDeferred.promise;
     });
+    expect(playlistContext.addToPlaylist).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('false');
   });
 
   it('keeps the add sheet open when playlist creation succeeds but adding the climb fails', async () => {

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -64,7 +64,8 @@ vi.mock('../../theme/ios-colors', () => ({
 }));
 
 vi.mock('../../theme/tokens', () => ({
-  spacing: { 2: 8, 3: 12, 4: 16, 6: 24 },
+  borderRadius: { full: 9999 },
+  spacing: { 2: 8, 3: 12, 4: 16, 6: 24, 8: 32 },
 }));
 
 vi.mock('../ModalSheet', () => ({
@@ -104,26 +105,33 @@ vi.mock('../playlist', () => ({
     visible,
     submitting,
     onSubmit,
+    onClose,
   }: {
     visible: boolean;
     submitting?: boolean;
     onSubmit: (values: { name: string; description?: string; color?: string; icon?: string }) => void;
+    onClose: () => void;
   }) =>
     visible
       ? createElement(
-          'button',
-          {
-            'aria-label': 'submit-created-playlist',
-            'data-submitting': submitting ? 'true' : 'false',
-            onClick: () =>
-              onSubmit({
-                name: 'Projects',
-                description: 'Moon projects',
-                color: '#ff00ff',
-                icon: 'star',
-              }),
-          },
-          'submit create',
+          'div',
+          null,
+          createElement(
+            'button',
+            {
+              'aria-label': 'submit-created-playlist',
+              'data-submitting': submitting ? 'true' : 'false',
+              onClick: () =>
+                onSubmit({
+                  name: 'Projects',
+                  description: 'Moon projects',
+                  color: '#ff00ff',
+                  icon: 'star',
+                }),
+            },
+            'submit create',
+          ),
+          createElement('button', { 'aria-label': 'close-created-playlist-form', onClick: onClose }, 'close create'),
         )
       : null,
 }));
@@ -217,7 +225,7 @@ describe('AddToPlaylistSheet', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('keeps existing playlist rows adding the climb', async () => {
+  it('adds the current climb to an existing playlist row', async () => {
     playlistContext.playlists = [playlist];
     playlistContext.addToPlaylist.mockResolvedValueOnce(undefined);
     const { getByLabelText, onClose } = renderSheet();
@@ -273,6 +281,37 @@ describe('AddToPlaylistSheet', () => {
     });
     expect(playlistContext.addToPlaylist).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('false');
+  });
+
+  it('resets the create sheet when the create form is closed mid-create', async () => {
+    const created = { ...playlist, uuid: 'p-new', id: 'p-new', name: 'Projects', climbCount: 0 };
+    const createDeferred = deferred<typeof created>();
+    playlistContext.createPlaylist.mockReturnValueOnce(createDeferred.promise);
+    playlistContext.addToPlaylist.mockResolvedValueOnce(undefined);
+    const { getByLabelText, queryByLabelText, onClose } = renderSheet();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    fireEvent.click(getByLabelText('submit-created-playlist'));
+
+    await waitFor(() => {
+      expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('true');
+    });
+
+    fireEvent.click(getByLabelText('close-created-playlist-form'));
+
+    expect(queryByLabelText('submit-created-playlist')).toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('false');
+
+    await act(async () => {
+      createDeferred.resolve(created);
+      await createDeferred.promise;
+    });
+    expect(playlistContext.addToPlaylist).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
     expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('false');
   });
 

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -115,7 +115,13 @@ vi.mock('../playlist', () => ({
           {
             'aria-label': 'submit-created-playlist',
             'data-submitting': submitting ? 'true' : 'false',
-            onClick: () => onSubmit({ name: 'Projects', description: undefined, color: undefined, icon: undefined }),
+            onClick: () =>
+              onSubmit({
+                name: 'Projects',
+                description: 'Moon projects',
+                color: '#ff00ff',
+                icon: 'star',
+              }),
           },
           'submit create',
         )
@@ -195,7 +201,7 @@ describe('AddToPlaylistSheet', () => {
     fireEvent.click(getByLabelText('submit-created-playlist'));
 
     await waitFor(() => {
-      expect(playlistContext.createPlaylist).toHaveBeenCalledWith('Projects', undefined, undefined, undefined, {
+      expect(playlistContext.createPlaylist).toHaveBeenCalledWith('Projects', 'Moon projects', '#ff00ff', 'star', {
         boardType: 'kilter',
         layoutId: 1,
       });

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -236,16 +236,32 @@ describe('AddToPlaylistSheet', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('hides the create sheet when the add sheet is dismissed', () => {
+  it('resets the create sheet when the add sheet is dismissed mid-create', async () => {
+    const created = { ...playlist, uuid: 'p-new', id: 'p-new', name: 'Projects', climbCount: 0 };
+    const createDeferred = deferred<typeof created>();
+    playlistContext.createPlaylist.mockReturnValueOnce(createDeferred.promise);
+    playlistContext.addToPlaylist.mockResolvedValueOnce(undefined);
     const { getByLabelText, queryByLabelText, onClose } = renderSheet();
 
     fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
-    expect(getByLabelText('submit-created-playlist')).not.toBeNull();
+    fireEvent.click(getByLabelText('submit-created-playlist'));
+
+    await waitFor(() => {
+      expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('true');
+    });
 
     fireEvent.click(getByLabelText('dismiss-add-to-playlist-sheet'));
 
     expect(queryByLabelText('submit-created-playlist')).toBeNull();
     expect(onClose).toHaveBeenCalled();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('false');
+
+    createDeferred.resolve(created);
+    await waitFor(() => {
+      expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-new', 'climb-1', 40);
+    });
   });
 
   it('keeps the add sheet open when playlist creation succeeds but adding the climb fails', async () => {

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { createElement, forwardRef, useImperativeHandle, type ReactNode } from 'react';
+import type { Climb } from '@boardsesh/shared-schema';
+import type { Playlist } from '@boardsesh/graphql/operations/playlists';
+
+const playlistContext = vi.hoisted(() => ({
+  playlists: [] as Playlist[],
+  addToPlaylist: vi.fn(),
+  createPlaylist: vi.fn(),
+  isLoading: false,
+  isAuthenticated: true,
+}));
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+
+vi.mock('react-native', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-spinner': 'true' }),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('@gorhom/bottom-sheet', () => ({
+  BottomSheetModal: function BottomSheetModal() {
+    return null;
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    brandColors: { primary: '#6D28D9' },
+    systemColors: { accent: '#6D28D9', fill: '#eeeeee' },
+  }),
+}));
+
+vi.mock('../../providers/toast-provider', () => ({
+  useToast: () => toast,
+}));
+
+vi.mock('../../providers/playlists-provider', () => ({
+  usePlaylistsContext: () => playlistContext,
+}));
+
+vi.mock('../../theme/ios-colors', () => ({
+  iosSystemColors: { systemGray: '#8E8E93' },
+}));
+
+vi.mock('../../theme/tokens', () => ({
+  spacing: { 2: 8, 3: 12, 4: 16, 6: 24 },
+}));
+
+vi.mock('../ModalSheet', () => ({
+  ModalSheet: forwardRef(function ModalSheet({ children }: { children?: ReactNode }, ref) {
+    useImperativeHandle(ref, () => ({ present: vi.fn(), dismiss: vi.fn() }));
+    return createElement('div', { 'data-modal-sheet': 'true' }, children);
+  }),
+}));
+
+vi.mock('../ClimbPreviewCard', () => ({
+  ClimbPreviewCard: () => createElement('div', { 'data-climb-preview': 'true' }),
+}));
+
+vi.mock('../ListRow', () => ({
+  ListRow: ({ title, subtitle, onPress }: { title: string; subtitle?: string; onPress?: () => void }) =>
+    createElement('button', { onClick: onPress, 'aria-label': title }, `${title}${subtitle ? ` ${subtitle}` : ''}`),
+}));
+
+vi.mock('../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+
+vi.mock('../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../playlist', () => ({
+  PlaylistFormSheet: ({
+    visible,
+    submitting,
+    onSubmit,
+  }: {
+    visible: boolean;
+    submitting?: boolean;
+    onSubmit: (values: { name: string; description?: string; color?: string; icon?: string }) => void;
+  }) =>
+    visible
+      ? createElement(
+          'button',
+          {
+            'aria-label': 'submit-created-playlist',
+            'data-submitting': submitting ? 'true' : 'false',
+            onClick: () => onSubmit({ name: 'Projects', description: undefined, color: undefined, icon: undefined }),
+          },
+          'submit create',
+        )
+      : null,
+}));
+
+import { AddToPlaylistSheet } from '../AddToPlaylistSheet';
+
+const climb = {
+  uuid: 'climb-1',
+  name: 'Big Move',
+  frames: '',
+  angle: 40,
+} as Climb;
+
+const playlist = {
+  id: 'p-1',
+  uuid: 'p-1',
+  name: 'Hard Crimps',
+  climbCount: 3,
+  isPublic: false,
+  boardType: 'kilter',
+  layoutId: 1,
+  followerCount: 0,
+  isFollowedByMe: false,
+  isPinnedByMe: false,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+} satisfies Playlist;
+
+function renderSheet(onClose = vi.fn()) {
+  return {
+    onClose,
+    ...render(
+      <AddToPlaylistSheet
+        visible
+        climb={climb}
+        boardName="kilter"
+        layoutId={1}
+        sizeId={10}
+        setIds="1,2"
+        angle={40}
+        onClose={onClose}
+      />,
+    ),
+  };
+}
+
+describe('AddToPlaylistSheet', () => {
+  beforeEach(() => {
+    playlistContext.playlists = [];
+    playlistContext.isLoading = false;
+    playlistContext.isAuthenticated = true;
+    playlistContext.addToPlaylist.mockReset();
+    playlistContext.createPlaylist.mockReset();
+    toast.showToast.mockReset();
+  });
+
+  it('creates a playlist from the sheet and adds the current climb to it', async () => {
+    const created = { ...playlist, uuid: 'p-new', id: 'p-new', name: 'Projects', climbCount: 0 };
+    playlistContext.createPlaylist.mockResolvedValueOnce(created);
+    playlistContext.addToPlaylist.mockResolvedValueOnce(undefined);
+    const { getByLabelText, onClose } = renderSheet();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    fireEvent.click(getByLabelText('submit-created-playlist'));
+
+    await waitFor(() => {
+      expect(playlistContext.createPlaylist).toHaveBeenCalledWith('Projects', undefined, undefined, undefined, {
+        boardType: 'kilter',
+        layoutId: 1,
+      });
+      expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-new', 'climb-1', 40);
+    });
+    expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.createdNamed', 'success');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('keeps existing playlist rows adding the climb', async () => {
+    playlistContext.playlists = [playlist];
+    playlistContext.addToPlaylist.mockResolvedValueOnce(undefined);
+    const { getByLabelText, onClose } = renderSheet();
+
+    fireEvent.click(getByLabelText('Hard Crimps'));
+
+    await waitFor(() => {
+      expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-1', 'climb-1', 40);
+    });
+    expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.added', 'success');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('keeps the add sheet open when playlist creation succeeds but adding the climb fails', async () => {
+    const created = { ...playlist, uuid: 'p-new', id: 'p-new', name: 'Projects', climbCount: 0 };
+    playlistContext.createPlaylist.mockResolvedValueOnce(created);
+    playlistContext.addToPlaylist.mockRejectedValueOnce(new Error('add failed'));
+    const { getByLabelText, onClose } = renderSheet();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    fireEvent.click(getByLabelText('submit-created-playlist'));
+
+    await waitFor(() => {
+      expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-new', 'climb-1', 40);
+    });
+    expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.addFailed', 'error');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('keeps the create sheet open when playlist creation fails', async () => {
+    playlistContext.createPlaylist.mockRejectedValueOnce(new Error('create failed'));
+    const { getByLabelText, onClose } = renderSheet();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    fireEvent.click(getByLabelText('submit-created-playlist'));
+
+    await waitFor(() => {
+      expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.createFailed', 'error');
+    });
+    expect(getByLabelText('submit-created-playlist')).not.toBeNull();
+    expect(playlistContext.addToPlaylist).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not show the create action for signed-out users', () => {
+    playlistContext.isAuthenticated = false;
+    const { queryByLabelText, getByText } = renderSheet();
+
+    expect(queryByLabelText('actions.playlist.popover.createNew')).toBeNull();
+    expect(getByText('actions.playlist.popover.signInBlurb')).not.toBeNull();
+  });
+});

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -65,9 +65,17 @@ vi.mock('../../theme/tokens', () => ({
 }));
 
 vi.mock('../ModalSheet', () => ({
-  ModalSheet: forwardRef(function ModalSheet({ children }: { children?: ReactNode }, ref) {
+  ModalSheet: forwardRef(function ModalSheet(
+    { children, onDismiss }: { children?: ReactNode; onDismiss?: () => void },
+    ref,
+  ) {
     useImperativeHandle(ref, () => ({ present: vi.fn(), dismiss: vi.fn() }));
-    return createElement('div', { 'data-modal-sheet': 'true' }, children);
+    return createElement(
+      'div',
+      { 'data-modal-sheet': 'true' },
+      children,
+      createElement('button', { 'aria-label': 'dismiss-add-to-playlist-sheet', onClick: onDismiss }, 'dismiss'),
+    );
   }),
 }));
 
@@ -135,6 +143,16 @@ const playlist = {
   updatedAt: '2026-01-01T00:00:00Z',
 } satisfies Playlist;
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
 function renderSheet(onClose = vi.fn()) {
   return {
     onClose,
@@ -165,7 +183,8 @@ describe('AddToPlaylistSheet', () => {
 
   it('creates a playlist from the sheet and adds the current climb to it', async () => {
     const created = { ...playlist, uuid: 'p-new', id: 'p-new', name: 'Projects', climbCount: 0 };
-    playlistContext.createPlaylist.mockResolvedValueOnce(created);
+    const createDeferred = deferred<typeof created>();
+    playlistContext.createPlaylist.mockReturnValueOnce(createDeferred.promise);
     playlistContext.addToPlaylist.mockResolvedValueOnce(undefined);
     const { getByLabelText, onClose } = renderSheet();
 
@@ -177,6 +196,12 @@ describe('AddToPlaylistSheet', () => {
         boardType: 'kilter',
         layoutId: 1,
       });
+      expect(getByLabelText('submit-created-playlist').getAttribute('data-submitting')).toBe('true');
+    });
+
+    createDeferred.resolve(created);
+
+    await waitFor(() => {
       expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-new', 'climb-1', 40);
     });
     expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.createdNamed', 'success');
@@ -194,6 +219,32 @@ describe('AddToPlaylistSheet', () => {
       expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-1', 'climb-1', 40);
     });
     expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.added', 'success');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes the add sheet and shows an error when adding an existing playlist row fails', async () => {
+    playlistContext.playlists = [playlist];
+    playlistContext.addToPlaylist.mockRejectedValueOnce(new Error('add failed'));
+    const { getByLabelText, onClose } = renderSheet();
+
+    fireEvent.click(getByLabelText('Hard Crimps'));
+
+    await waitFor(() => {
+      expect(playlistContext.addToPlaylist).toHaveBeenCalledWith('p-1', 'climb-1', 40);
+    });
+    expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.addFailed', 'error');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('hides the create sheet when the add sheet is dismissed', () => {
+    const { getByLabelText, queryByLabelText, onClose } = renderSheet();
+
+    fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
+    expect(getByLabelText('submit-created-playlist')).not.toBeNull();
+
+    fireEvent.click(getByLabelText('dismiss-add-to-playlist-sheet'));
+
+    expect(queryByLabelText('submit-created-playlist')).toBeNull();
     expect(onClose).toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/components/__tests__/board-renderer.test.ts
+++ b/packages/mobile/src/components/__tests__/board-renderer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { convertLitUpHoldsStringToMap, HOLD_STATE_MAP } from '@boardsesh/board-constants';
 import type { BoardHold, HoldPlacement } from '../board-renderer/types';
 
 // ── Type structure tests ────────────────────────────────────────────────
@@ -78,13 +79,11 @@ describe('HoldPlacement type structure', () => {
 });
 
 describe('board-constants imports', () => {
-  it('convertLitUpHoldsStringToMap is importable and is a function', async () => {
-    const { convertLitUpHoldsStringToMap } = await import('@boardsesh/board-constants');
+  it('convertLitUpHoldsStringToMap is importable and is a function', () => {
     expect(typeof convertLitUpHoldsStringToMap).toBe('function');
   });
 
-  it('HOLD_STATE_MAP is importable and is an object with board keys', async () => {
-    const { HOLD_STATE_MAP } = await import('@boardsesh/board-constants');
+  it('HOLD_STATE_MAP is importable and is an object with board keys', () => {
     expect(typeof HOLD_STATE_MAP).toBe('object');
     expect(HOLD_STATE_MAP).not.toBeNull();
     // Should have at least kilter and tension entries
@@ -92,8 +91,7 @@ describe('board-constants imports', () => {
     expect('tension' in HOLD_STATE_MAP).toBe(true);
   });
 
-  it('convertLitUpHoldsStringToMap returns empty object for empty frames', async () => {
-    const { convertLitUpHoldsStringToMap } = await import('@boardsesh/board-constants');
+  it('convertLitUpHoldsStringToMap returns empty object for empty frames', () => {
     const result = convertLitUpHoldsStringToMap('', 'kilter');
     expect(result).toEqual({});
   });

--- a/packages/mobile/src/components/you/__tests__/social-tab.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/social-tab.test.tsx
@@ -156,7 +156,8 @@ vi.mock('../../../providers/theme-provider', () => ({
       separator: '#ddd',
     },
     brandColors: { primary: '#6D28D9' },
-    variant: 'glass',
+    features: { inBodyLargeTitle: true, filtersInTopChrome: false, summaryExcludesGradeFilter: false },
+    variant: 'liquidGlass',
   }),
 }));
 vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
@@ -326,6 +326,32 @@ describe('useMobileClimbActionsData', () => {
       });
     });
 
+    it('can create against a supplied board snapshot instead of the live active board', async () => {
+      const created = mkPlaylist('p-new', 'Moon Projects');
+      requestMock.mockResolvedValueOnce({ allUserPlaylists: { playlists: [] } });
+      requestMock.mockResolvedValueOnce({ createPlaylist: created });
+
+      const { Wrapper } = makeWrapper();
+      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
+      await waitFor(() => expect(requestMock).toHaveBeenCalledWith(GET_ALL_USER_PLAYLISTS, expect.anything()));
+
+      await result.current.playlistsProviderProps.createPlaylist('Moon Projects', undefined, undefined, undefined, {
+        boardType: 'moonboard',
+        layoutId: 6,
+      });
+
+      expect(requestMock).toHaveBeenCalledWith(CREATE_PLAYLIST, {
+        input: {
+          boardType: 'moonboard',
+          layoutId: 6,
+          name: 'Moon Projects',
+          description: undefined,
+          color: undefined,
+          icon: undefined,
+        },
+      });
+    });
+
     it('optimistically prepends the new playlist to the cached list', async () => {
       const existing = mkPlaylist('p-old', 'Stuff');
       const created = mkPlaylist('p-new', 'Project');
@@ -343,6 +369,62 @@ describe('useMobileClimbActionsData', () => {
       // The cached list — same key the query above wrote to — should now lead
       // with the freshly-created playlist without waiting for a refetch.
       expect(queryClient.getQueryData<Playlist[]>(['userPlaylists'])).toEqual([created, existing]);
+    });
+
+    it('does not duplicate the created playlist if it is already cached', async () => {
+      const existing = mkPlaylist('p-old', 'Stuff');
+      const cachedCreated = mkPlaylist('p-new', 'Draft Project');
+      const created = { ...cachedCreated, name: 'Project' };
+      requestMock.mockResolvedValueOnce({ allUserPlaylists: { playlists: [cachedCreated, existing] } });
+      requestMock.mockResolvedValueOnce({ createPlaylist: created });
+
+      const { queryClient, Wrapper } = makeWrapper();
+      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
+      await waitFor(() => expect(result.current.playlistsProviderProps.playlists).toEqual([cachedCreated, existing]));
+
+      await act(async () => {
+        await result.current.playlistsProviderProps.createPlaylist('Project');
+      });
+
+      expect(queryClient.getQueryData<Playlist[]>(['userPlaylists'])).toEqual([created, existing]);
+    });
+
+    it('cancels an in-flight playlist fetch before optimistically prepending the created playlist', async () => {
+      const created = mkPlaylist('p-new', 'Project');
+      requestMock.mockImplementation((document) => {
+        if (document === GET_ALL_USER_PLAYLISTS) return new Promise(() => undefined);
+        if (document === CREATE_PLAYLIST) return Promise.resolve({ createPlaylist: created });
+        return Promise.reject(new Error('Unexpected request'));
+      });
+
+      const { queryClient, Wrapper } = makeWrapper();
+      const cancelSpy = vi.spyOn(queryClient, 'cancelQueries');
+      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
+      await waitFor(() => expect(requestMock).toHaveBeenCalledWith(GET_ALL_USER_PLAYLISTS, expect.anything()));
+
+      await act(async () => {
+        await result.current.playlistsProviderProps.createPlaylist('Project');
+      });
+
+      expect(cancelSpy).toHaveBeenCalledWith({ queryKey: ['userPlaylists'] });
+      expect(queryClient.getQueryData<Playlist[]>(['userPlaylists'])).toEqual([created]);
+    });
+
+    it('does not cancel the playlist fetch when playlist creation fails', async () => {
+      requestMock.mockImplementation((document) => {
+        if (document === GET_ALL_USER_PLAYLISTS) return new Promise(() => undefined);
+        if (document === CREATE_PLAYLIST) return Promise.reject(new Error('create failed'));
+        return Promise.reject(new Error('Unexpected request'));
+      });
+
+      const { queryClient, Wrapper } = makeWrapper();
+      const cancelSpy = vi.spyOn(queryClient, 'cancelQueries');
+      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
+      await waitFor(() => expect(requestMock).toHaveBeenCalledWith(GET_ALL_USER_PLAYLISTS, expect.anything()));
+
+      await expect(result.current.playlistsProviderProps.createPlaylist('Project')).rejects.toThrow('create failed');
+
+      expect(cancelSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
@@ -36,6 +36,7 @@ import {
 import { getHttpClient } from '../client';
 import { useAuth } from '../../../providers/auth-provider';
 import { useActiveBoard } from '../use-active-board';
+import type { PlaylistCreateBoard } from '../../../providers/playlists-provider';
 
 const PLAYLISTS_QUERY_KEY = ['userPlaylists'] as const;
 
@@ -77,7 +78,13 @@ type MobileClimbActionsData = {
     playlistMemberships: Map<string, Set<string>>;
     addToPlaylist: (playlistId: string, climbUuid: string, angle: number) => Promise<void>;
     removeFromPlaylist: (playlistId: string, climbUuid: string) => Promise<void>;
-    createPlaylist: (name: string, description?: string, color?: string, icon?: string) => Promise<Playlist>;
+    createPlaylist: (
+      name: string,
+      description?: string,
+      color?: string,
+      icon?: string,
+      board?: PlaylistCreateBoard,
+    ) => Promise<Playlist>;
     isLoading: boolean;
     isAuthenticated: boolean;
     refreshPlaylists: () => Promise<void>;
@@ -157,8 +164,14 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
   });
 
   const createPlaylistMutation = useMutation({
-    mutationFn: async (vars: { name: string; description?: string; color?: string; icon?: string }) => {
-      const { activeBoard: board } = mutationDepsRef.current;
+    mutationFn: async (vars: {
+      name: string;
+      description?: string;
+      color?: string;
+      icon?: string;
+      board?: PlaylistCreateBoard;
+    }) => {
+      const board = vars.board ?? mutationDepsRef.current.activeBoard;
       if (!board) throw new Error('Cannot create playlist: no active board selected.');
       // CreatePlaylistInput types layoutId as Int! — sending undefined would
       // round-trip a 400 from the server. Throw locally so the call site sees
@@ -205,12 +218,27 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
   }, []);
 
   const createPlaylist = useCallback(
-    async (name: string, description?: string, color?: string, icon?: string): Promise<Playlist> => {
-      const created = await createPlaylistMutateRef.current({ name, description, color, icon });
+    async (
+      name: string,
+      description?: string,
+      color?: string,
+      icon?: string,
+      board?: PlaylistCreateBoard,
+    ): Promise<Playlist> => {
+      const created = await createPlaylistMutateRef.current({ name, description, color, icon, board });
+      const { queryClient: client } = mutationDepsRef.current;
+      // The picker query can still be in flight when a user creates from the
+      // sheet. Cancel it after create succeeds but before the optimistic prepend
+      // so a failed create does not disturb the only in-flight picker load, while
+      // an older page response still cannot overwrite the created playlist.
+      await client.cancelQueries({ queryKey: PLAYLISTS_QUERY_KEY });
       // Optimistically prepend to the cached list so the picker shows the new
       // playlist immediately, without waiting for a refetch round-trip.
-      const { queryClient: client } = mutationDepsRef.current;
-      client.setQueryData<Playlist[]>(PLAYLISTS_QUERY_KEY, (prev) => (prev ? [created, ...prev] : [created]));
+      client.setQueryData<Playlist[]>(PLAYLISTS_QUERY_KEY, (prev) => {
+        const withoutCreated =
+          prev?.filter((playlist) => playlist.uuid !== created.uuid && playlist.id !== created.id) ?? [];
+        return [created, ...withoutCreated];
+      });
       return created;
     },
     [],

--- a/packages/mobile/src/providers/__tests__/playlists-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/playlists-provider.test.tsx
@@ -132,7 +132,7 @@ describe('PlaylistsProvider', () => {
     );
     const { result } = renderHook(() => usePlaylistsContext(), { wrapper });
     await result.current.createPlaylist('Projects');
-    expect(createPlaylist).toHaveBeenCalledWith('Projects', undefined, undefined, undefined);
+    expect(createPlaylist).toHaveBeenCalledWith('Projects', undefined, undefined, undefined, undefined);
     expect(trackMock).toHaveBeenCalledTimes(1);
     expect(trackMock).toHaveBeenCalledWith('Create Playlist', {
       playlistId: 'p-new',

--- a/packages/mobile/src/providers/__tests__/playlists-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/playlists-provider.test.tsx
@@ -142,6 +142,17 @@ describe('PlaylistsProvider', () => {
     });
   });
 
+  it('forwards board context when createPlaylist receives one', async () => {
+    const createPlaylist = vi.fn(async (name: string) => mkPlaylist('p-board', name));
+    const boardContext = { boardType: 'kilter' as const, layoutId: 1 };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <PlaylistsProvider createPlaylist={createPlaylist}>{children}</PlaylistsProvider>
+    );
+    const { result } = renderHook(() => usePlaylistsContext(), { wrapper });
+    await result.current.createPlaylist('Projects', 'Moon projects', '#ff00ff', 'star', boardContext);
+    expect(createPlaylist).toHaveBeenCalledWith('Projects', 'Moon projects', '#ff00ff', 'star', boardContext);
+  });
+
   it('usePlaylistsContext throws when called outside a provider', () => {
     expect(() => renderHook(() => usePlaylistsContext())).toThrow(/must be used within a PlaylistsProvider/);
   });

--- a/packages/mobile/src/providers/playlists-provider.tsx
+++ b/packages/mobile/src/providers/playlists-provider.tsx
@@ -7,13 +7,14 @@
 
 import { createContext, useContext, useCallback, useMemo, type ReactNode } from 'react';
 import type { Playlist } from '@boardsesh/graphql/operations/playlists';
+import type { BoardName } from '@boardsesh/shared-schema';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../lib/analytics';
 
 export type { Playlist } from '@boardsesh/graphql/operations/playlists';
 
 export type PlaylistCreateBoard = {
-  boardType: string;
+  boardType: BoardName;
   layoutId: number;
 };
 

--- a/packages/mobile/src/providers/playlists-provider.tsx
+++ b/packages/mobile/src/providers/playlists-provider.tsx
@@ -12,12 +12,23 @@ import { track } from '../lib/analytics';
 
 export type { Playlist } from '@boardsesh/graphql/operations/playlists';
 
+export type PlaylistCreateBoard = {
+  boardType: string;
+  layoutId: number;
+};
+
 type PlaylistsContextValue = {
   playlists: Playlist[];
   getPlaylistsForClimb: (climbUuid: string) => Set<string>;
   addToPlaylist: (playlistId: string, climbUuid: string, angle: number) => Promise<void>;
   removeFromPlaylist: (playlistId: string, climbUuid: string) => Promise<void>;
-  createPlaylist: (name: string, description?: string, color?: string, icon?: string) => Promise<Playlist>;
+  createPlaylist: (
+    name: string,
+    description?: string,
+    color?: string,
+    icon?: string,
+    board?: PlaylistCreateBoard,
+  ) => Promise<Playlist>;
   isLoading: boolean;
   isAuthenticated: boolean;
   refreshPlaylists: () => Promise<void>;
@@ -46,7 +57,13 @@ type PlaylistsProviderProps = {
   playlistMemberships?: Map<string, Set<string>>;
   addToPlaylist?: (playlistId: string, climbUuid: string, angle: number) => Promise<void>;
   removeFromPlaylist?: (playlistId: string, climbUuid: string) => Promise<void>;
-  createPlaylist?: (name: string, description?: string, color?: string, icon?: string) => Promise<Playlist>;
+  createPlaylist?: (
+    name: string,
+    description?: string,
+    color?: string,
+    icon?: string,
+    board?: PlaylistCreateBoard,
+  ) => Promise<Playlist>;
   isLoading?: boolean;
   isAuthenticated?: boolean;
   refreshPlaylists?: () => Promise<void>;
@@ -76,8 +93,14 @@ export function PlaylistsProvider({
   );
 
   const trackedCreatePlaylist = useCallback(
-    async (name: string, description?: string, color?: string, icon?: string): Promise<Playlist> => {
-      const created = await createPlaylist(name, description, color, icon);
+    async (
+      name: string,
+      description?: string,
+      color?: string,
+      icon?: string,
+      board?: PlaylistCreateBoard,
+    ): Promise<Playlist> => {
+      const created = await createPlaylist(name, description, color, icon, board);
       track(SHARED_EVENTS.CreatePlaylist, {
         playlistId: created.id,
         hasDescription: !!description,


### PR DESCRIPTION
## What changed

- Added a plus action to the React Native add-to-playlist sheet for signed-in users.
- Reused the existing playlist form sheet so users can create a playlist in-place and immediately add the current climb to it.
- Allowed mobile playlist creation to use the sheet's board/layout snapshot instead of only the live active board.
- Cancelled stale `userPlaylists` fetches after successful create and before optimistic cache prepend so an older picker load cannot hide the new playlist.
- De-duped the created playlist during optimistic cache prepend so a near-simultaneous cache update cannot show duplicate rows.
- Stabilized the mobile board-renderer import test by using the same static import path production code uses.
- Added regression coverage for create/add success, create failure, add-after-create failure, signed-out behavior, stale-query cancellation, and duplicate-cache prevention.

## Issue

Addresses the primary TestFlight feedback in #2754: users can now add a new playlist from the playlist picker section instead of leaving the flow.

## Validation

- `vp check --fix packages/mobile/src/components/AddToPlaylistSheet.tsx packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx packages/mobile/src/providers/playlists-provider.tsx packages/mobile/src/providers/__tests__/playlists-provider.test.tsx packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx packages/mobile/src/components/__tests__/board-renderer.test.ts`
- `vp test run --project mobile --reporter=agent packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx packages/mobile/src/providers/__tests__/playlists-provider.test.tsx packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx packages/mobile/src/components/__tests__/board-renderer.test.ts` (4 files, 43 tests)
- `vp run typecheck:mobile`
- `vp run test:mobile` (250 files, 1819 tests)

## QA

- Started mobile dev server with QA notes loaded from `.boardsesh/qa-notes.md`.
- Metro URL: `http://marcos-macbook-pro-2-1.tailedd9d5.ts.net:8084`.
- QA subagent and code-review subagent completed; their actionable findings were fixed and rechecked.