### PR TITLE
[codex] Fix circuit previous navigation

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
@@ -189,4 +189,45 @@ describe('QueueProvider angle-change re-grade of the playlist suggestion peek', 
     expect(fetchedUuids).toContain('climb-next');
     expect(fetchedUuids).not.toContain('climb-current');
   });
+
+  it('re-grades the previous source climb to the live board angle and patches the source', async () => {
+    // Current climb is already at the live angle (25); the previous playlist
+    // climb carries a stale grade baked at 40, so it must be re-graded to 25.
+    const previousClimb = makeClimb('climb-previous', 40, 'V8');
+    const currentClimb = makeClimb('climb-current', 25, 'V3');
+    const source: PlaylistSuggestionSource = {
+      playlistUuid: 'playlist-1',
+      activatedClimbUuid: 'climb-current',
+      boardKey: 'kilter:1:10:1,2',
+      climbs: [previousClimb, currentClimb],
+    };
+
+    http.request.mockImplementation(async (_query: string, variables: { climbUuid: string; angle: number }) => {
+      if (variables.climbUuid === 'climb-previous' && variables.angle === 25) {
+        return { climb: makeClimb('climb-previous', 25, 'V6') };
+      }
+      return { climb: null };
+    });
+
+    const snapshots: Snapshot[] = [];
+    render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot: (snap) => snapshots.push(snap) })));
+
+    await waitFor(() => expect(snapshots.at(-1)).toBeTruthy());
+
+    await act(async () => {
+      snapshots.at(-1)?.setCurrentClimb(makeItem(currentClimb), { playlistSuggestionSource: source });
+    });
+
+    await waitFor(() => {
+      const patched = snapshots
+        .at(-1)
+        ?.playlistSuggestionSource?.climbs.find((climb) => climb.uuid === 'climb-previous');
+      expect(patched?.angle).toBe(25);
+      expect(patched?.difficulty).toBe('V6');
+    });
+
+    const fetchedUuids = http.request.mock.calls.map((call) => (call[1] as { climbUuid: string }).climbUuid);
+    expect(fetchedUuids).toContain('climb-previous');
+    expect(fetchedUuids).not.toContain('climb-current');
+  });
 });

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -107,6 +107,19 @@ const queueMutations = vi.hoisted(() => ({
   setSessionBoardPath: vi.fn(async () => {}),
 }));
 
+const crypto = vi.hoisted(() => {
+  let uuidCounter = 0;
+  return {
+    randomUUID: vi.fn(() => {
+      uuidCounter += 1;
+      return `test-uuid-${uuidCounter}`;
+    }),
+    reset: () => {
+      uuidCounter = 0;
+    },
+  };
+});
+
 const wallConfirm = vi.hoisted(() => ({
   emitWallConfirm: vi.fn(),
 }));
@@ -121,7 +134,7 @@ vi.mock('react-native', () => ({
 }));
 
 vi.mock('expo-crypto', () => ({
-  randomUUID: () => 'test-correlation-id',
+  randomUUID: crypto.randomUUID,
 }));
 
 vi.mock('@boardsesh/graphql-client', async (importOriginal) => ({
@@ -193,6 +206,7 @@ type Snapshot = {
   removeFromQueue: ReturnType<typeof useQueue>['removeFromQueue'];
   setCurrentClimb: ReturnType<typeof useQueue>['setCurrentClimb'];
   nextClimb: ReturnType<typeof useQueue>['nextClimb'];
+  previousClimb: ReturnType<typeof useQueue>['previousClimb'];
   setPlaylistSuggestionSource: ReturnType<typeof useQueue>['setPlaylistSuggestionSource'];
   joinSession: (sessionId: string, opts: Parameters<ReturnType<typeof useQueue>['joinSession']>[1]) => Promise<void>;
   endSession: () => Promise<unknown>;
@@ -285,6 +299,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
       removeFromQueue: queue.removeFromQueue,
       setCurrentClimb: queue.setCurrentClimb,
       nextClimb: queue.nextClimb,
+      previousClimb: queue.previousClimb,
       setPlaylistSuggestionSource: queue.setPlaylistSuggestionSource,
       joinSession: queue.joinSession,
       endSession: queue.endSession,
@@ -304,6 +319,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
     queue.removeFromQueue,
     queue.setCurrentClimb,
     queue.nextClimb,
+    queue.previousClimb,
     queue.setPlaylistSuggestionSource,
     queue.joinSession,
     queue.endSession,
@@ -345,6 +361,8 @@ function renderProviderWithSelectors(
 
 describe('QueueProvider session update subscription', () => {
   beforeEach(() => {
+    crypto.reset();
+    crypto.randomUUID.mockClear();
     ws.reset();
     ws.client.on.mockClear();
     ws.client.subscribe.mockClear();
@@ -848,6 +866,90 @@ describe('QueueProvider session update subscription', () => {
       expect(latestSnapshot?.state.currentClimbQueueItem?.uuid).not.toBe('playlist-peek:climb-following');
       expect(latestSnapshot?.playlistSuggestionSource).toEqual(playlistSuggestionSource);
     });
+  });
+
+  it('materializes repeated previous playlist suggestions before the current queue item', async () => {
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const firstItem = makeQueueItem('queue-first-source', 'climb-first', { suggested: true });
+    const previousItem = makeQueueItem('queue-previous-source', 'climb-previous', { suggested: true });
+    const currentItem = makeQueueItem('queue-current', 'climb-current');
+    const playlistSuggestionSource: PlaylistSuggestionSource = {
+      playlistUuid: 'playlist-1',
+      activatedClimbUuid: currentItem.climb.uuid,
+      boardKey: 'kilter:1:10:1,2',
+      climbs: [firstItem.climb, previousItem.climb, currentItem.climb],
+    };
+    const preparedSnapshot = snapshots.at(-1);
+    if (!preparedSnapshot) throw new Error('queue snapshot was not captured');
+
+    act(() => {
+      preparedSnapshot.setCurrentClimb(currentItem, { playlistSuggestionSource });
+    });
+
+    await waitFor(() => {
+      const latestSnapshot = snapshots.at(-1);
+      expect(latestSnapshot?.state.currentClimbQueueItem?.uuid).toBe('queue-current');
+      expect(latestSnapshot?.playlistSuggestionSource).toEqual(playlistSuggestionSource);
+    });
+
+    const activeSnapshot = snapshots.at(-1);
+    if (!activeSnapshot) throw new Error('prepared queue snapshot was not captured');
+    act(() => {
+      activeSnapshot.previousClimb();
+    });
+
+    await waitFor(() => {
+      const latestSnapshot = snapshots.at(-1);
+      expect(latestSnapshot?.state.currentClimbQueueItem?.climb.uuid).toBe('climb-previous');
+      expect(latestSnapshot?.state.currentClimbQueueItem?.uuid).not.toBe('playlist-peek:climb-previous');
+      expect(latestSnapshot?.state.currentClimbQueueItem?.suggested).toBe(true);
+      expect(latestSnapshot?.state.queue.map((item) => item.climb.uuid)).toEqual(['climb-previous', 'climb-current']);
+      expect(latestSnapshot?.playlistSuggestionSource).toEqual(playlistSuggestionSource);
+    });
+
+    const previousSnapshot = snapshots.at(-1);
+    if (!previousSnapshot) throw new Error('previous queue snapshot was not captured');
+    act(() => {
+      previousSnapshot.previousClimb();
+    });
+
+    await waitFor(() => {
+      const latestSnapshot = snapshots.at(-1);
+      expect(latestSnapshot?.state.currentClimbQueueItem?.climb.uuid).toBe('climb-first');
+      expect(latestSnapshot?.state.currentClimbQueueItem?.uuid).not.toBe('playlist-peek:climb-first');
+      expect(latestSnapshot?.state.currentClimbQueueItem?.suggested).toBe(true);
+      expect(latestSnapshot?.state.queue.map((item) => item.climb.uuid)).toEqual([
+        'climb-first',
+        'climb-previous',
+        'climb-current',
+      ]);
+      expect(latestSnapshot?.playlistSuggestionSource).toEqual(playlistSuggestionSource);
+    });
+
+    expect(queueMutations.addQueueItem).toHaveBeenCalledWith(
+      expect.objectContaining({ climb: expect.objectContaining({ uuid: 'climb-previous' }) }),
+      0,
+    );
+    expect(queueMutations.addQueueItem).toHaveBeenCalledWith(
+      expect.objectContaining({ climb: expect.objectContaining({ uuid: 'climb-first' }) }),
+      0,
+    );
+    expect(queueMutations.setCurrentClimb).toHaveBeenCalledWith(
+      expect.objectContaining({ climb: expect.objectContaining({ uuid: 'climb-previous' }) }),
+      false,
+      expect.any(String),
+    );
+    expect(queueMutations.setCurrentClimb).toHaveBeenCalledWith(
+      expect.objectContaining({ climb: expect.objectContaining({ uuid: 'climb-first' }) }),
+      false,
+      expect.any(String),
+    );
   });
 
   it('rolls back optimistic releaseControl state when the mutation fails', async () => {

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -70,7 +70,11 @@ import { getDeviceTimezone } from '../lib/device-timezone';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
 import { getStoredSessionId, setStoredSessionId, clearStoredSessionId } from '../lib/session-store';
 import { getStoredQueueSnapshot, setStoredQueueSnapshot, clearStoredQueueSnapshot } from '../lib/queue-snapshot-store';
-import { emitWallConfirm, findPreviousQueueItem, findNextQueueItemWithSuggestions } from '@boardsesh/play-view';
+import {
+  emitWallConfirm,
+  findNextQueueItemWithSuggestions,
+  findPreviousQueueItemWithSuggestions,
+} from '@boardsesh/play-view';
 import { toClimbQueueItem, type SubscriptionQueueItem } from '../lib/queue-conversion';
 import { toMobileSessionRuntimeEvent } from '../lib/session-runtime-event';
 import { climbToQueueItem, toClimbInput } from '../lib/climb-to-queue-item';
@@ -79,6 +83,13 @@ import { reportError } from '../lib/error-reporting';
 import { extractGraphqlMessage, isGraphqlRateLimitedError } from '../lib/graphql/extract-error-message';
 import { useToast } from './toast-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
+
+const POSITION_BEFORE_CURRENT = 'beforeCurrent';
+
+function materializePlaylistPeekItem(item: ClimbQueueItem): ClimbQueueItem {
+  // Synthetic playlist-peek uuids are UI-only; persistence/sync must receive a real queue item.
+  return climbToQueueItem(item.climb as unknown as Parameters<typeof climbToQueueItem>[0], { suggested: true });
+}
 
 export type StartSessionConfig = {
   name?: string;
@@ -1309,18 +1320,24 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     };
     state.queue.forEach(consider);
     consider(state.currentClimbQueueItem);
-    // Also re-grade the single displayed playlist peek (the next-up suggestion
-    // shown at the queue tail). It lives in playlistSuggestionSource.climbs —
-    // NOT in state.queue — so the queue-only pass above never touches it, and
-    // the bar/drawer would keep showing the activation-angle grade until the
-    // peek is committed. Only the next-up climb is ever displayed, so re-grade
-    // that one alone; re-grading the whole source could be hundreds of climbs.
-    const peekItem = findNextQueueItemWithSuggestions(
+    // Also re-grade the displayed playlist peeks. They live in
+    // playlistSuggestionSource.climbs — NOT in state.queue — so the queue-only
+    // pass above never touches them, and the bar/drawer would keep showing the
+    // activation-angle grade until a peek is committed. Only immediate
+    // previous/next peeks are ever displayed, so re-grade those alone; re-grading
+    // the whole source could be hundreds of climbs.
+    const nextPeekItem = findNextQueueItemWithSuggestions(
       state.queue,
       state.currentClimbQueueItem,
       playlistSuggestionSourceRef.current,
     );
-    if (peekItem && isPlaylistPeekQueueItemUuid(peekItem.uuid)) consider(peekItem);
+    if (nextPeekItem && isPlaylistPeekQueueItemUuid(nextPeekItem.uuid)) consider(nextPeekItem);
+    const previousPeekItem = findPreviousQueueItemWithSuggestions(
+      state.queue,
+      state.currentClimbQueueItem,
+      playlistSuggestionSourceRef.current,
+    );
+    if (previousPeekItem && isPlaylistPeekQueueItemUuid(previousPeekItem.uuid)) consider(previousPeekItem);
     if (uuids.size === 0) return undefined;
 
     const targetUuids = [...uuids];
@@ -1522,17 +1539,43 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // CurrentClimbChanged event (same id in `serverCorrelationId`) is suppressed
   // instead of re-applied.
   const dispatchSetCurrent = useCallback(
-    (item: ClimbQueueItem, shouldAddToQueue: boolean, playlistSuggestionSource?: PlaylistSuggestionSource | null) => {
+    (
+      item: ClimbQueueItem,
+      shouldAddToQueue: boolean,
+      playlistSuggestionSource?: PlaylistSuggestionSource | null,
+      addPosition?: typeof POSITION_BEFORE_CURRENT,
+    ) => {
       const correlationId = coordinator.generateCorrelationId();
+      const shouldInsertBeforeCurrent = shouldAddToQueue && addPosition === POSITION_BEFORE_CURRENT;
+      const currentQueueIndex = stateRef.current.currentClimbQueueItem
+        ? stateRef.current.queue.findIndex(
+            (queueItem) => queueItem.uuid === stateRef.current.currentClimbQueueItem?.uuid,
+          )
+        : -1;
+      const queuedInsertPosition = currentQueueIndex >= 0 ? currentQueueIndex : undefined;
+      if (shouldInsertBeforeCurrent) {
+        dispatch({ type: 'DELTA_ADD_QUEUE_ITEM', payload: { item, position: queuedInsertPosition } });
+      }
       dispatch({
         type: 'DELTA_UPDATE_CURRENT_CLIMB',
         // playlistSuggestionSource is client-only state — when present the
         // reducer sets it + prunes suggested-after-current; when undefined it's
         // left unchanged. It is intentionally NOT sent to the server mutation.
-        payload: { item, shouldAddToQueue, isServerEvent: false, correlationId, playlistSuggestionSource },
+        payload: {
+          item,
+          shouldAddToQueue: shouldInsertBeforeCurrent ? false : shouldAddToQueue,
+          isServerEvent: false,
+          correlationId,
+          playlistSuggestionSource,
+        },
       });
       coordinator.trackPendingMutation(correlationId);
-      mutations.setCurrentClimb(item, shouldAddToQueue, correlationId).catch(() => {
+      const syncCurrentClimb = shouldInsertBeforeCurrent
+        ? mutations
+            .addQueueItem(item, queuedInsertPosition)
+            .then(() => mutations.setCurrentClimb(item, false, correlationId))
+        : mutations.setCurrentClimb(item, shouldAddToQueue, correlationId);
+      syncCurrentClimb.catch(() => {
         // In a party session the current-climb change never reached peers —
         // reconcile against the server (and toast that we refreshed) so this
         // client's current climb can't silently diverge. Solo keeps the prior
@@ -1578,16 +1621,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     );
     if (!nextItem) return;
     if (isPlaylistPeekQueueItemUuid(nextItem.uuid)) {
-      // Mirror web: turn the transient peek into a real queue item with a fresh
-      // uuid so the synthetic `playlist-peek:<uuid>` never reaches the WS
-      // mutation (toQueueItemInput sends item.uuid verbatim). suggested:true so
-      // suggestion pruning still treats it as suggestion-origin. The peek climb
-      // is the queue package's wide Climb; climbToQueueItem only reads the
-      // ClimbInput subset, so the cast is runtime-safe.
-      const realItem = climbToQueueItem(nextItem.climb as unknown as Parameters<typeof climbToQueueItem>[0], {
-        suggested: true,
-      });
-      dispatchSetCurrent(realItem, true);
+      dispatchSetCurrent(materializePlaylistPeekItem(nextItem), true);
     } else {
       dispatchSetCurrent(nextItem, false);
     }
@@ -1595,8 +1629,17 @@ export function QueueProvider({ children }: { children: ReactNode }) {
 
   const previousClimb = useCallback(() => {
     const { queue, currentClimbQueueItem } = stateRef.current;
-    const prevItem = findPreviousQueueItem(queue, currentClimbQueueItem);
-    if (prevItem) dispatchSetCurrent(prevItem, false);
+    const prevItem = findPreviousQueueItemWithSuggestions(
+      queue,
+      currentClimbQueueItem,
+      playlistSuggestionSourceRef.current,
+    );
+    if (!prevItem) return;
+    if (isPlaylistPeekQueueItemUuid(prevItem.uuid)) {
+      dispatchSetCurrent(materializePlaylistPeekItem(prevItem), true, undefined, POSITION_BEFORE_CURRENT);
+    } else {
+      dispatchSetCurrent(prevItem, false);
+    }
   }, [dispatchSetCurrent]);
 
   const setPlaylistSuggestionSource = useCallback((source: PlaylistSuggestionSource | null) => {

--- a/packages/shared/play-view/src/__tests__/queue-navigation.test.ts
+++ b/packages/shared/play-view/src/__tests__/queue-navigation.test.ts
@@ -6,6 +6,7 @@ import {
   findPreviousQueueItem,
   computeNavigationState,
   findNextQueueItemWithSuggestions,
+  findPreviousQueueItemWithSuggestions,
   computeNavigationStateWithSuggestions,
 } from '../queue-navigation';
 
@@ -225,6 +226,44 @@ describe('findNextQueueItemWithSuggestions', () => {
   });
 });
 
+describe('findPreviousQueueItemWithSuggestions', () => {
+  it('returns the real previous queue item when one exists', () => {
+    const previous = makeClimb('source-previous');
+    const current = makeClimb('current');
+    const queue = [itemFor(makeClimb('queued-previous')), itemFor(current)];
+    const source = makeSource(current, [previous, current]);
+    expect(findPreviousQueueItemWithSuggestions(queue, queue[1], source)).toBe(queue[0]);
+  });
+
+  it('falls back to the previous playlist climb when the queue has no previous item', () => {
+    const previous = makeClimb('previous');
+    const current = makeClimb('current');
+    const queue = [itemFor(current)];
+    const source = makeSource(current, [previous, current]);
+    const peek = findPreviousQueueItemWithSuggestions(queue, queue[0], source);
+    expect(peek?.uuid).toBe(getPlaylistPeekQueueItemUuid(previous.uuid));
+    expect(peek?.climb.uuid).toBe('previous');
+    expect(peek?.suggested).toBe(true);
+  });
+
+  it('falls back to the previous playlist climb for an orphan current item', () => {
+    const previous = makeClimb('previous');
+    const current = makeClimb('current');
+    const orphan = itemFor(current);
+    const source = makeSource(current, [previous, current]);
+    const peek = findPreviousQueueItemWithSuggestions([], orphan, source);
+    expect(peek?.climb.uuid).toBe('previous');
+  });
+
+  it('returns null when the current playlist climb is first', () => {
+    const current = makeClimb('current');
+    const next = makeClimb('next');
+    const queue = [itemFor(current)];
+    const source = makeSource(current, [current, next]);
+    expect(findPreviousQueueItemWithSuggestions(queue, queue[0], source)).toBeNull();
+  });
+});
+
 describe('computeNavigationStateWithSuggestions', () => {
   it('matches computeNavigationState when source is null', () => {
     const items = [makeItem('a'), makeItem('b'), makeItem('c')];
@@ -242,9 +281,22 @@ describe('computeNavigationStateWithSuggestions', () => {
     expect(state.canNext).toBe(true);
     expect(state.nextItem?.climb.uuid).toBe('y');
     expect(state.nextItem?.suggested).toBe(true);
-    // previous + remainingCount stay queue-based.
+    // No earlier playlist item, so previous stays unavailable.
     expect(state.canPrevious).toBe(false);
     expect(state.prevItem).toBeNull();
+    expect(state.remainingCount).toBe(0);
+  });
+
+  it('lights up canPrevious from a suggestion at the start of the queue', () => {
+    const previous = makeClimb('previous');
+    const current = makeClimb('current');
+    const queue = [itemFor(current)];
+    const source = makeSource(current, [previous, current]);
+    const state = computeNavigationStateWithSuggestions(queue, queue[0], source);
+    expect(state.canPrevious).toBe(true);
+    expect(state.prevItem?.climb.uuid).toBe('previous');
+    expect(state.prevItem?.suggested).toBe(true);
+    expect(state.canNext).toBe(false);
     expect(state.remainingCount).toBe(0);
   });
 });

--- a/packages/shared/play-view/src/queue-navigation.ts
+++ b/packages/shared/play-view/src/queue-navigation.ts
@@ -79,6 +79,18 @@ function getNextPlaylistClimb(
   return source.climbs[index + 1] ?? null;
 }
 
+/** The playlist climb immediately before `currentClimbUuid` in the source's
+ * ordered list, or null if the current climb isn't in the playlist or is first. */
+function getPreviousPlaylistClimb(
+  source: PlaylistSuggestionSource | null,
+  currentClimbUuid: string | undefined,
+): Climb | null {
+  if (!source || !currentClimbUuid) return null;
+  const index = source.climbs.findIndex((climb) => climb.uuid === currentClimbUuid);
+  if (index <= 0) return null;
+  return source.climbs[index - 1] ?? null;
+}
+
 /** Wrap a suggested climb as a transient "peek" queue item. */
 function toPeekItem(climb: Climb): ClimbQueueItem {
   return { climb, addedBy: null, uuid: getPlaylistPeekQueueItemUuid(climb.uuid), suggested: true };
@@ -121,10 +133,31 @@ export function findNextQueueItemWithSuggestions(
 }
 
 /**
- * computeNavigationState that lights up canNext/nextItem from playlist
- * suggestions when the queue is exhausted. canPrevious/prevItem stay queue-only
- * (web has no backward suggestion fall-through). remainingCount stays
- * queue-based to match web's action-bar remaining count.
+ * Like findPreviousQueueItem, but when the current item has no real predecessor
+ * in the queue, fall through to the previous playlist climb in the ordered
+ * suggestion source. Queue items still win, so swiping back through existing
+ * history does not duplicate climbs.
+ */
+export function findPreviousQueueItemWithSuggestions(
+  queue: ClimbQueue,
+  currentClimbQueueItem: ClimbQueueItem | null,
+  source: PlaylistSuggestionSource | null,
+): ClimbQueueItem | null {
+  if (!currentClimbQueueItem) return null;
+
+  const currentIndex = queue.findIndex(({ uuid }) => uuid === currentClimbQueueItem.uuid);
+  if (currentIndex > 0) {
+    return queue[currentIndex - 1];
+  }
+
+  const previousClimb = getPreviousPlaylistClimb(source, currentClimbQueueItem.climb?.uuid);
+  return previousClimb ? toPeekItem(previousClimb) : null;
+}
+
+/**
+ * computeNavigationState that lights up next/previous from playlist suggestions
+ * when the queue lacks that neighbor. remainingCount stays queue-based to match
+ * the action-bar count.
  */
 export function computeNavigationStateWithSuggestions(
   queue: ClimbQueue,
@@ -132,7 +165,7 @@ export function computeNavigationStateWithSuggestions(
   source: PlaylistSuggestionSource | null,
 ): NavigationState {
   const nextItem = findNextQueueItemWithSuggestions(queue, currentClimbQueueItem, source);
-  const prevItem = findPreviousQueueItem(queue, currentClimbQueueItem);
+  const prevItem = findPreviousQueueItemWithSuggestions(queue, currentClimbQueueItem, source);
 
   const currentIndex = currentClimbQueueItem ? queue.findIndex(({ uuid }) => uuid === currentClimbQueueItem.uuid) : -1;
   const remainingCount = currentIndex >= 0 ? queue.length - currentIndex - 1 : queue.length;


### PR DESCRIPTION
## Summary

Fixes #2757.

- Enables previous navigation from playlist/circuit sources when the active climb has an earlier item in the ordered source but no real previous queue item.
- Keeps queue history authoritative: a real previous queue item still wins over source fallback navigation.
- Materializes previous playlist peeks as real suggested queue items before the current queue item, so repeated previous navigation walks backward through the circuit instead of bouncing.
- Re-grades both displayed previous and next playlist peeks after board-angle changes.
- Adds shared navigation coverage plus mobile queue-provider regression tests for repeated previous navigation and previous-peek regrading.

## Root Cause

Forward circuit navigation already used `PlaylistSuggestionSource` to synthesize the next climb when the queue had no successor. Previous navigation stayed queue-only, so opening a climb from the middle of a circuit left the previous button and right-swipe disabled even though the ordered circuit source had earlier climbs.

## QA / Review Follow-Up

The QA and code-review passes found two issues in the first iteration:

- Repeated previous navigation could bounce because materialized previous peeks were appended after the current item.
- Previous synthetic source climbs were not included in the angle re-grade path.

Both are fixed in the current PR head.

## Validation

- `vp test run --reporter=agent packages/shared/play-view/src/__tests__/queue-navigation.test.ts packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx` passed: 3 files, 63 tests.
- `vp check packages/shared/play-view/src/queue-navigation.ts packages/shared/play-view/src/__tests__/queue-navigation.test.ts packages/mobile/src/providers/queue-provider.tsx packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx` passed.
- `vp run typecheck:mobile` passed.
- `vp run test:mobile` passed: 249 files, 1812 tests.
- `vp run check:mobile-bundle` passed for iOS and Android.
- `vp run check:mobile-simulator` skipped: iOS simulator unavailable (`xcrun simctl` not visible in this shell).
- `vp run mobile:screenshot` skipped: iOS simulator unavailable.

Note: full `vp check` currently reports pre-existing formatting drift in unrelated files outside this PR; the touched files pass scoped `vp check`.

## QA

Metro is running from the issue worktree with QA notes loaded from `.boardsesh/qa-notes.md`:

`http://marcos-macbook-pro-2-1.tailedd9d5.ts.net:8090`