### PR TITLE
feat(mobile): replace queue with playlist order on circuit/playlist tap

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -210,7 +210,16 @@ vi.mock('../../../../src/lib/graphql/operations', () => ({ SEARCH_CLIMBS: 'SEARC
 vi.mock('../../../../src/lib/graphql/client', () => ({ getHttpClient: () => ({ request: vi.fn() }) }));
 
 vi.mock('../../../../src/lib/playlists/use-playlist-activation', () => ({
-  usePlaylistActivation: () => mocks.activateClimb,
+  usePlaylistActivation: () => ({
+    activate: mocks.activateClimb,
+    queueReplaceSheet: {
+      visible: false,
+      futureQueueCount: 0,
+      isReplacing: false,
+      onCancel: vi.fn(),
+      onConfirm: vi.fn(),
+    },
+  }),
 }));
 
 vi.mock('../../../../src/lib/climb-types', () => ({

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -618,7 +618,7 @@ function ClimbListInner() {
   const handleClimbPress = useCallback(
     (climb: Climb) => {
       blurSearchInputs();
-      void activateClimbListClimb(toQueueClimb(climb));
+      void activateClimbListClimb.activate(toQueueClimb(climb));
     },
     [activateClimbListClimb, blurSearchInputs],
   );

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -31,6 +31,7 @@ import {
   PlaylistEditDoneButton,
   PlaylistOwnerToolbar,
   PlaylistBackFab,
+  PlaylistQueueReplaceSheet,
   type PlaylistFormValues,
 } from '../../../src/components/playlist';
 import { GlassIconButton } from '../../../src/components/GlassIconButton';
@@ -154,12 +155,13 @@ export default function PlaylistDetail() {
     [shouldOpenViewOnly, renderBoard],
   );
 
-  const activate = usePlaylistActivation({
+  const playlistActivation = usePlaylistActivation({
     sourceId: `playlist:${playlistUuid}`,
     allClimbs,
     fetchPage,
     viewOnlyBoard: resolveViewOnlyBoard,
     refreshErrorMessage: 'Failed to refresh playlist suggestions:',
+    replaceQueueOnActivate: true,
   });
 
   const isOwner = playlist?.userRole === 'owner';
@@ -616,7 +618,7 @@ export default function PlaylistDetail() {
         isFetchingNextPage={editMode ? false : query.isFetchingNextPage}
         hasNextPage={editMode ? false : (query.hasNextPage ?? false)}
         fetchNextPage={query.fetchNextPage}
-        onActivateClimb={activate}
+        onActivateClimb={playlistActivation.activate}
         emptyMessage={t('detail.empty')}
         actions={renderActions}
         editMode={editMode}
@@ -642,6 +644,8 @@ export default function PlaylistDetail() {
         onSubmit={handleEditSubmit}
         onClose={() => setEditVisible(false)}
       />
+
+      <PlaylistQueueReplaceSheet {...playlistActivation.queueReplaceSheet} />
     </>
   );
 }

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -101,7 +101,16 @@ vi.mock('../../../../src/providers/toast-provider', () => ({ useToast: () => ({ 
 vi.mock('../../../../src/lib/playlists/use-playlist-activation', () => ({
   usePlaylistActivation: (options: CapturedActivationOptions) => {
     playlistMocks.activationOptions = options;
-    return vi.fn();
+    return {
+      activate: vi.fn(),
+      queueReplaceSheet: {
+        visible: false,
+        futureQueueCount: 0,
+        isReplacing: false,
+        onCancel: vi.fn(),
+        onConfirm: vi.fn(),
+      },
+    };
   },
 }));
 vi.mock('../../../../src/lib/playlists/use-playlist-render-board', () => ({
@@ -146,6 +155,7 @@ vi.mock('../../../../src/components/playlist', () => ({
   PlaylistEditDoneButton: () => null,
   PlaylistOwnerToolbar: () => null,
   PlaylistBackFab: () => createElement('div', { 'data-back-fab': 'true' }),
+  PlaylistQueueReplaceSheet: () => null,
 }));
 
 import PlaylistDetail from '../[playlist_uuid]';

--- a/packages/mobile/app/(tabs)/discover/smart/[type].tsx
+++ b/packages/mobile/app/(tabs)/discover/smart/[type].tsx
@@ -16,6 +16,7 @@ import {
   PlaylistDetailView,
   SKELETON_PLACEHOLDERS,
   PlaylistBackFab,
+  PlaylistQueueReplaceSheet,
   type PlaylistDetailEmptyState,
 } from '../../../../src/components/playlist';
 import { getHttpClient } from '../../../../src/lib/graphql/client';
@@ -70,11 +71,12 @@ export default function SmartPlaylistDetail() {
     [smartType, userId],
   );
 
-  const activate = usePlaylistActivation({
+  const playlistActivation = usePlaylistActivation({
     sourceId: `smart:${smartType}:${userId}`,
     allClimbs,
     fetchPage,
     refreshErrorMessage: 'Failed to refresh smart playlist suggestions:',
+    replaceQueueOnActivate: true,
   });
 
   // Smart playlists are computed relative to the active board, so they always
@@ -135,18 +137,21 @@ export default function SmartPlaylistDetail() {
   }
 
   return (
-    <PlaylistDetailView
-      hero={hero}
-      climbs={allClimbs}
-      renderBoard={renderBoard}
-      isLoading={query.isLoading}
-      isFetchingNextPage={query.isFetchingNextPage}
-      hasNextPage={query.hasNextPage ?? false}
-      fetchNextPage={query.fetchNextPage}
-      onActivateClimb={activate}
-      emptyMessage={t('library.smart.empty')}
-      emptyState={emptyState}
-    />
+    <>
+      <PlaylistDetailView
+        hero={hero}
+        climbs={allClimbs}
+        renderBoard={renderBoard}
+        isLoading={query.isLoading}
+        isFetchingNextPage={query.isFetchingNextPage}
+        hasNextPage={query.hasNextPage ?? false}
+        fetchNextPage={query.fetchNextPage}
+        onActivateClimb={playlistActivation.activate}
+        emptyMessage={t('library.smart.empty')}
+        emptyState={emptyState}
+      />
+      <PlaylistQueueReplaceSheet {...playlistActivation.queueReplaceSheet} />
+    </>
   );
 }
 

--- a/packages/mobile/app/(tabs)/discover/smart/__tests__/[type].test.tsx
+++ b/packages/mobile/app/(tabs)/discover/smart/__tests__/[type].test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { Climb } from '@boardsesh/queue';
+
+// Parity guard for the smart-playlist detail screen: it must opt into whole-queue
+// replacement (replaceQueueOnActivate) and thread the queue-replace sheet through,
+// exactly like the regular playlist detail screen. The hook + sheet themselves are
+// unit-tested elsewhere; here we only assert the wiring.
+type CapturedOptions = { sourceId: string; replaceQueueOnActivate?: boolean };
+
+const smartMocks = vi.hoisted(() => ({
+  activationOptions: null as CapturedOptions | null,
+  activate: vi.fn<(climb: Climb) => Promise<void>>(),
+  queueReplaceSheet: {
+    visible: true,
+    futureQueueCount: 2,
+    isReplacing: false,
+    onCancel: vi.fn(),
+    onConfirm: vi.fn(),
+  },
+  allClimbs: [{ uuid: 'c-1', name: 'Boulder' }] as unknown as Climb[],
+}));
+
+vi.mock('expo-router', () => ({ useLocalSearchParams: () => ({ type: 'liked' }) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('@boardsesh/playlists-react', () => ({
+  useSmartPlaylist: () => ({
+    query: { isLoading: false, isFetchingNextPage: false, hasNextPage: false, fetchNextPage: vi.fn() },
+    allClimbs: smartMocks.allClimbs,
+    meta: { climbCount: 1, userName: 'Tester' },
+  }),
+}));
+
+vi.mock('@boardsesh/graphql/operations/playlists', () => ({ GET_SMART_PLAYLIST: 'GET_SMART_PLAYLIST' }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('../../../../../src/components/Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../../../src/components/Icon', () => ({ Icon: () => null }));
+vi.mock('../../../../../src/components/ClimbListRowSkeleton', () => ({ ClimbListRowSkeleton: () => null }));
+
+type DetailViewProps = { onActivateClimb?: (climb: Climb) => void };
+type SheetProps = { visible?: boolean; futureQueueCount?: number };
+vi.mock('../../../../../src/components/playlist', () => ({
+  SKELETON_PLACEHOLDERS: [],
+  PlaylistBackFab: () => null,
+  PlaylistDetailView: ({ onActivateClimb }: DetailViewProps) =>
+    createElement('button', {
+      'data-activate': 'true',
+      onClick: () => onActivateClimb?.({ uuid: 'c-1' } as unknown as Climb),
+    }),
+  PlaylistQueueReplaceSheet: ({ visible, futureQueueCount }: SheetProps) =>
+    createElement('div', { 'data-sheet': visible ? 'true' : 'false', 'data-future-count': String(futureQueueCount) }),
+}));
+
+vi.mock('../../../../../src/lib/graphql/client', () => ({ getHttpClient: () => ({ request: vi.fn() }) }));
+vi.mock('../../../../../src/lib/playlists/use-playlist-activation', () => ({
+  usePlaylistActivation: (options: CapturedOptions) => {
+    smartMocks.activationOptions = options;
+    return { activate: smartMocks.activate, queueReplaceSheet: smartMocks.queueReplaceSheet };
+  },
+}));
+vi.mock('../../../../../src/lib/playlists/use-playlist-render-board', () => ({
+  usePlaylistRenderBoard: () => ({ renderBoard: null }),
+}));
+vi.mock('../../../../../src/lib/climb-types', () => ({ toQueueClimbs: (climbs: unknown) => climbs }));
+vi.mock('../../../../../src/lib/smart-playlists', () => ({
+  smartPlaylistByType: () => ({
+    type: 'LIKED_CLIMBS',
+    titleI18nKey: 'library.smart.likedClimbs.title',
+    color: '#f00',
+    icon: 'favorite',
+  }),
+}));
+vi.mock('../../../../../src/lib/graphql/hooks', () => ({ useProfile: () => ({ data: { id: 'u-1' } }) }));
+vi.mock('../../../../../src/lib/graphql/use-auth-token', () => ({ useAuthToken: () => ({ isLoading: false }) }));
+vi.mock('../../../../../src/theme/ios-colors', () => ({ iosSystemColors: { systemGray4: '#C7C7CC' } }));
+
+import SmartPlaylistDetail from '../[type]';
+
+describe('SmartPlaylistDetail queue replacement wiring', () => {
+  it('activates with replaceQueueOnActivate and renders the queue-replace sheet', () => {
+    const { container } = render(<SmartPlaylistDetail />);
+
+    expect(smartMocks.activationOptions?.replaceQueueOnActivate).toBe(true);
+    expect(smartMocks.activationOptions?.sourceId).toBe('smart:LIKED_CLIMBS:u-1');
+
+    const sheet = container.querySelector('[data-sheet]');
+    expect(sheet?.getAttribute('data-sheet')).toBe('true');
+    expect(sheet?.getAttribute('data-future-count')).toBe('2');
+
+    fireEvent.click(container.querySelector('[data-activate]')!);
+    expect(smartMocks.activate).toHaveBeenCalledWith({ uuid: 'c-1' });
+  });
+});

--- a/packages/mobile/src/components/playlist/PlaylistQueueReplaceSheet.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistQueueReplaceSheet.tsx
@@ -1,0 +1,92 @@
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { ModalSheet } from '../ModalSheet';
+import { Text } from '../Text';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing } from '../../theme/tokens';
+
+type PlaylistQueueReplaceSheetProps = {
+  visible: boolean;
+  futureQueueCount: number;
+  isReplacing: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+// Confirmation before a playlist tap replaces the whole queue: replacing clears
+// the climbs queued after the current one, so warn first. Built on ModalSheet
+// (the shared @expo/ui native sheet wrapper) so it goes through the presentation
+// coordinator and never overlaps another native sheet. Pan-to-close is locked
+// while the replacement is in flight; the buttons drive the decision.
+export function PlaylistQueueReplaceSheet({
+  visible,
+  futureQueueCount,
+  isReplacing,
+  onCancel,
+  onConfirm,
+}: PlaylistQueueReplaceSheetProps) {
+  const { t } = useTranslation('playlists');
+  const { systemColors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <ModalSheet visible={visible} enableDynamicSizing enablePanDownToClose={!isReplacing} onClose={onCancel}>
+      <View style={[styles.content, { paddingBottom: insets.bottom + spacing[3] }]}>
+        <Icon name="queue" size={40} color={systemColors.secondaryLabel} />
+
+        <Text variant="title2" style={styles.title}>
+          {t('detail.queueReplace.title')}
+        </Text>
+
+        <Text variant="body" color={systemColors.secondaryLabel} style={styles.subtitle}>
+          {t('detail.queueReplace.message', { count: futureQueueCount })}
+        </Text>
+
+        <View style={styles.buttonRow}>
+          <Button
+            title={t('detail.queueReplace.cancel')}
+            variant="outlined"
+            onPress={onCancel}
+            disabled={isReplacing}
+            style={styles.button}
+          />
+          <Button
+            title={t('detail.queueReplace.confirm')}
+            onPress={onConfirm}
+            loading={isReplacing}
+            style={styles.button}
+          />
+        </View>
+      </View>
+    </ModalSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    alignItems: 'center',
+    paddingHorizontal: spacing[6],
+    paddingTop: spacing[4],
+    gap: spacing[3],
+  },
+  title: {
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  subtitle: {
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: spacing[3],
+    marginTop: spacing[4],
+    width: '100%',
+  },
+  button: {
+    flex: 1,
+  },
+});

--- a/packages/mobile/src/components/playlist/__tests__/playlist-queue-replace-sheet.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-queue-replace-sheet.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+function readPaddingBottom(style: unknown): number | undefined {
+  const layers = Array.isArray(style) ? style : [style];
+  for (const layer of layers) {
+    if (layer && typeof layer === 'object' && 'paddingBottom' in layer) {
+      return (layer as { paddingBottom?: number }).paddingBottom;
+    }
+  }
+  return undefined;
+}
+
+type ViewMockProps = { children?: ReactNode; style?: unknown };
+vi.mock('react-native', () => ({
+  View: ({ children, style }: ViewMockProps) =>
+    createElement('div', { 'data-view': 'true', 'data-pb': String(readPaddingBottom(style) ?? '') }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+type ModalSheetMockProps = {
+  children?: ReactNode;
+  visible?: boolean;
+  enableDynamicSizing?: boolean;
+  enablePanDownToClose?: boolean;
+  onClose?: () => void;
+};
+// ModalSheet presents imperatively in the real app; here we render its children
+// only while `visible` and expose a synthetic close button to exercise onClose.
+vi.mock('../../ModalSheet', () => ({
+  ModalSheet: ({ children, visible, enableDynamicSizing, enablePanDownToClose, onClose }: ModalSheetMockProps) =>
+    visible
+      ? createElement(
+          'div',
+          {
+            'data-sheet': 'true',
+            'data-dynamic': enableDynamicSizing ? 'true' : 'false',
+            'data-pan-close': enablePanDownToClose ? 'true' : 'false',
+          },
+          children,
+          createElement('button', { 'data-sheet-close': 'true', onClick: onClose }),
+        )
+      : null,
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { count?: number }) => (opts?.count != null ? `${key}:${opts.count}` : key),
+  }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryBackground: '#fff', secondaryLabel: '#888' } }),
+}));
+
+type TextMockProps = { children?: ReactNode };
+vi.mock('../../Text', () => ({
+  Text: ({ children }: TextMockProps) => createElement('span', { 'data-text': 'true' }, children),
+}));
+
+type ButtonMockProps = {
+  title: string;
+  onPress?: () => void;
+  variant?: string;
+  loading?: boolean;
+  disabled?: boolean;
+};
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress, variant, loading, disabled }: ButtonMockProps) =>
+    createElement('button', {
+      disabled,
+      onClick: onPress,
+      'data-button': title,
+      'data-variant': variant ?? 'filled',
+      'data-loading': loading ? 'true' : 'false',
+    }),
+}));
+
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 3: 12, 4: 16, 6: 24 },
+}));
+
+import { PlaylistQueueReplaceSheet } from '../PlaylistQueueReplaceSheet';
+
+function makeProps(overrides: Partial<Parameters<typeof PlaylistQueueReplaceSheet>[0]> = {}) {
+  return {
+    visible: true,
+    futureQueueCount: 3,
+    isReplacing: false,
+    onCancel: vi.fn(),
+    onConfirm: vi.fn(),
+    ...overrides,
+  };
+}
+
+const button = (root: HTMLElement, title: string) =>
+  root.querySelector(`[data-button="${title}"]`) as HTMLButtonElement | null;
+
+describe('PlaylistQueueReplaceSheet', () => {
+  it('renders nothing until it has been made visible', () => {
+    const { container } = render(<PlaylistQueueReplaceSheet {...makeProps({ visible: false })} />);
+    expect(container.querySelector('[data-sheet]')).toBeNull();
+  });
+
+  it('shows the queued-climb warning and both actions', () => {
+    const { container } = render(<PlaylistQueueReplaceSheet {...makeProps({ futureQueueCount: 5 })} />);
+    expect(container.querySelector('[data-icon="queue"]')).not.toBeNull();
+    expect(container.textContent).toContain('detail.queueReplace.title');
+    expect(container.textContent).toContain('detail.queueReplace.message:5');
+    expect(button(container, 'detail.queueReplace.cancel')).not.toBeNull();
+    expect(button(container, 'detail.queueReplace.confirm')).not.toBeNull();
+  });
+
+  it('sizes to content and pads past the safe-area bottom inset', () => {
+    const { container } = render(<PlaylistQueueReplaceSheet {...makeProps()} />);
+    expect(container.querySelector('[data-sheet]')?.getAttribute('data-dynamic')).toBe('true');
+    // insets.bottom (34) + spacing[3] (12)
+    expect(container.querySelector('[data-pb="46"]')).not.toBeNull();
+  });
+
+  it('fires cancel and confirm callbacks from the buttons', () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    const { container } = render(<PlaylistQueueReplaceSheet {...makeProps({ onCancel, onConfirm })} />);
+    fireEvent.click(button(container, 'detail.queueReplace.cancel')!);
+    fireEvent.click(button(container, 'detail.queueReplace.confirm')!);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('locks pan-to-close and shows loading while replacing', () => {
+    const { container } = render(<PlaylistQueueReplaceSheet {...makeProps({ isReplacing: true })} />);
+    expect(container.querySelector('[data-sheet]')?.getAttribute('data-pan-close')).toBe('false');
+    expect(button(container, 'detail.queueReplace.cancel')?.disabled).toBe(true);
+    expect(button(container, 'detail.queueReplace.confirm')?.getAttribute('data-loading')).toBe('true');
+  });
+
+  it('allows pan-to-close only while idle', () => {
+    const { container } = render(<PlaylistQueueReplaceSheet {...makeProps()} />);
+    expect(container.querySelector('[data-sheet]')?.getAttribute('data-pan-close')).toBe('true');
+  });
+
+  it('treats an external sheet close as cancellation', () => {
+    const onCancel = vi.fn();
+    const { container } = render(<PlaylistQueueReplaceSheet {...makeProps({ onCancel })} />);
+    fireEvent.click(container.querySelector('[data-sheet-close]')!);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/playlist/index.ts
+++ b/packages/mobile/src/components/playlist/index.ts
@@ -15,4 +15,5 @@ export { PlaylistFollowButton } from './PlaylistFollowButton';
 export { PlaylistEditDoneButton } from './PlaylistEditDoneButton';
 export { PlaylistOwnerToolbar } from './PlaylistOwnerToolbar';
 export { PlaylistActionsMenu } from './PlaylistActionsMenu';
+export { PlaylistQueueReplaceSheet } from './PlaylistQueueReplaceSheet';
 export { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
-import type { Climb } from '@boardsesh/queue';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
 import type { UsePlaylistClimbActivationOptions } from '@boardsesh/playlists-react';
 import { usePlaylistActivation } from '../use-playlist-activation';
 
@@ -14,14 +14,19 @@ type ActiveBoard = { boardType: string; layoutId: number; sizeId: number; setIds
 
 type SuggestionSource = { playlistUuid: string; activatedClimbUuid: string; boardKey: string } | null;
 
+type QueueState = { queue: ClimbQueueItem[]; currentClimbQueueItem: ClimbQueueItem | null };
+
 const mocks = vi.hoisted(() => ({
   setCurrentClimb: vi.fn(),
   setPlaylistSuggestionSource: vi.fn(),
   refreshPlaylistSuggestionSource: vi.fn(),
+  setQueue: vi.fn(),
+  showToast: vi.fn(),
   openPlayDrawer: vi.fn(),
   activeBoard: { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 } as ActiveBoard,
   activeClimbUuid: null as string | null,
   suggestionSource: null as SuggestionSource,
+  queueState: { queue: [], currentClimbQueueItem: null } as QueueState,
   activate: vi.fn<(climb: Climb) => Promise<void>>(),
   fetchSuggestion: vi.fn(),
   captured: undefined as UsePlaylistClimbActivationOptions | undefined,
@@ -36,18 +41,28 @@ vi.mock('@boardsesh/playlists-react', () => ({
     return mocks.activate;
   },
   fetchPlaylistSuggestionClimbs: (args: unknown) => mocks.fetchSuggestion(args),
+  isAbortError: (error: unknown) => error instanceof Error && error.name === 'AbortError',
+  PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE: 100,
 }));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueueActions: () => ({
     setCurrentClimb: mocks.setCurrentClimb,
     setPlaylistSuggestionSource: mocks.setPlaylistSuggestionSource,
     refreshPlaylistSuggestionSource: mocks.refreshPlaylistSuggestionSource,
+    setQueue: mocks.setQueue,
+    getQueueSnapshot: () => mocks.queueState,
   }),
   useActiveClimbUuid: () => mocks.activeClimbUuid,
   usePlaylistSuggestionSource: () => mocks.suggestionSource,
 }));
 vi.mock('../../../providers/drawer-host-provider', () => ({
   useDrawerHost: () => ({ openPlayDrawer: mocks.openPlayDrawer }),
+}));
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: mocks.showToast }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
 }));
 vi.mock('../../graphql/use-active-board', () => ({
   useActiveBoard: () => ({ data: mocks.activeBoard }),
@@ -78,12 +93,17 @@ function makeClimb(uuid: string): Climb {
   };
 }
 
+function makeQueueItem(uuid: string, climbUuid: string, suggested = false): ClimbQueueItem {
+  return { uuid, suggested, climb: makeClimb(climbUuid) } as unknown as ClimbQueueItem;
+}
+
 function renderActivation(
   fetchPage = vi.fn(),
   options: {
     allClimbs?: Climb[];
     sourceId?: string;
     viewOnlyBoard?: typeof VIEW_ONLY_BOARD | ((climb: Climb) => typeof VIEW_ONLY_BOARD | null) | null;
+    replaceQueueOnActivate?: boolean;
   } = {},
 ) {
   return renderHook(() =>
@@ -93,6 +113,7 @@ function renderActivation(
       fetchPage,
       viewOnlyBoard: options.viewOnlyBoard,
       refreshErrorMessage: 'refresh failed:',
+      replaceQueueOnActivate: options.replaceQueueOnActivate,
     }),
   );
 }
@@ -107,9 +128,15 @@ beforeEach(() => {
   mocks.activeBoard = { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 };
   mocks.activeClimbUuid = null;
   mocks.suggestionSource = null;
+  mocks.queueState = { queue: [], currentClimbQueueItem: null };
   mocks.captured = undefined;
   mocks.activate.mockResolvedValue(undefined);
   mocks.queueItemCounter = 0;
+  // Mirror real setQueue: it commits the new queue, so a later getQueueSnapshot
+  // reflects it (the replacement path re-checks the queue after seeding it).
+  mocks.setQueue.mockImplementation((queue: ClimbQueueItem[], currentClimbQueueItem?: ClimbQueueItem | null) => {
+    mocks.queueState = { queue, currentClimbQueueItem: currentClimbQueueItem ?? null };
+  });
 });
 
 describe('usePlaylistActivation (mobile wrapper)', () => {
@@ -139,7 +166,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
   it('opens the play drawer immediately on activate, before the queue state updates', async () => {
     const { result } = renderActivation();
     const climb = makeClimb('a');
-    await result.current(climb);
+    await result.current.activate(climb);
     // The drawer opens FIRST — before the shared activation's setCurrentClimb +
     // suggestion-source work — so BottomSheetModal.present() fires on the same
     // frame as the tap. `committedExternally` tells the drawer the caller already
@@ -154,7 +181,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
   it('dispatches the exact item the activation pinned', async () => {
     const { result } = renderActivation();
     const climb = makeClimb('a');
-    await result.current(climb);
+    await result.current.activate(climb);
 
     // The first dispatch reuses the item pinned during activate (same climb uuid),
     // so the drawer's nav anchor and the queue entry share one uuid.
@@ -166,7 +193,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
   it('reuses the pinned item once — a second dispatch builds a fresh item', async () => {
     const { result } = renderActivation();
     const climb = makeClimb('a');
-    await result.current(climb);
+    await result.current.activate(climb);
 
     const first = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
     const second = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
@@ -176,7 +203,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
 
   it('ignores the pinned item when the dispatched climb differs', async () => {
     const { result } = renderActivation();
-    await result.current(makeClimb('a'));
+    await result.current.activate(makeClimb('a'));
 
     const climbB = makeClimb('b');
     const item = await captured().queueApi!.setCurrentClimb(climbB, { playlistSuggestionSource: null });
@@ -186,7 +213,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
   it('activates through the shared queue on every tap (always-live, no preview gate)', async () => {
     const { result } = renderActivation();
     const climb = makeClimb('a');
-    await result.current(climb);
+    await result.current.activate(climb);
 
     // Every tap drives the shared activation — there is no non-driver preview
     // branch that skips it anymore.
@@ -200,7 +227,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     mocks.suggestionSource = { playlistUuid: 'playlist:pl-1', activatedClimbUuid: 'a', boardKey: 'kilter:1:2:3' };
     const { result } = renderActivation();
     const climb = makeClimb('a');
-    await result.current(climb);
+    await result.current.activate(climb);
 
     // Pure reopen — the shared activation does NOT run (re-activating would
     // duplicate it in the queue / pointlessly rebuild the same source).
@@ -215,7 +242,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     mocks.suggestionSource = { playlistUuid: 'climblist', activatedClimbUuid: 'a', boardKey: 'kilter:1:2:3' };
     const { result } = renderActivation();
     const climb = makeClimb('a');
-    await result.current(climb);
+    await result.current.activate(climb);
 
     expect(mocks.activate).toHaveBeenCalledWith(climb);
     expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { committedExternally: true });
@@ -241,7 +268,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     mocks.activeClimbUuid = 'b';
     const { result } = renderActivation();
     const climb = makeClimb('a');
-    await result.current(climb);
+    await result.current.activate(climb);
 
     // 'a' is not the active climb ('b' is), so this still starts a fresh pass.
     expect(mocks.activate).toHaveBeenCalledWith(climb);
@@ -254,7 +281,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     const fetchPage = vi.fn();
     const { result } = renderActivation(fetchPage, { allClimbs: [climbA, climbB], viewOnlyBoard: VIEW_ONLY_BOARD });
 
-    await result.current(climbA);
+    await result.current.activate(climbA);
 
     const viewOnlyOptions = mocks.openPlayDrawer.mock.calls[0][1];
     expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climbA, {
@@ -281,7 +308,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     );
     const { result } = renderActivation(vi.fn(), { allClimbs: [climb], viewOnlyBoard: viewOnlyResolver });
 
-    await result.current(climb);
+    await result.current.activate(climb);
 
     expect(viewOnlyResolver).toHaveBeenCalledWith(climb);
     expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, {
@@ -321,8 +348,124 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     mocks.activate.mockRejectedValue(new Error('boom'));
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { result } = renderActivation();
-    await expect(result.current(makeClimb('a'))).resolves.toBeUndefined();
+    await expect(result.current.activate(makeClimb('a'))).resolves.toBeUndefined();
     expect(errorSpy).toHaveBeenCalled();
     errorSpy.mockRestore();
+  });
+
+  describe('queue replacement (replaceQueueOnActivate)', () => {
+    it('seeds the tapped climb, then replaces the queue with the full playlist order', async () => {
+      const tapped = makeClimb('b');
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [makeClimb('a'), tapped, makeClimb('c')], hasMore: false });
+      const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      // The tapped climb is committed immediately (the drawer renders it), then
+      // the queue expands to the whole ordered playlist around it.
+      expect(mocks.openPlayDrawer).toHaveBeenCalledWith(tapped, { committedExternally: true });
+      await waitFor(() => {
+        const lastSetQueue = mocks.setQueue.mock.calls.at(-1);
+        expect(lastSetQueue?.[0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['a', 'b', 'c']);
+        expect(lastSetQueue?.[1].climb.uuid).toBe('b');
+      });
+      expect(fetchPage).toHaveBeenCalled();
+      expect(result.current.queueReplaceSheet.visible).toBe(false);
+    });
+
+    it('warns instead of replacing when the queue has manual future items', async () => {
+      const current = makeQueueItem('q-current', 'current');
+      const future = makeQueueItem('q-future', 'future');
+      mocks.queueState = { queue: [current, future], currentClimbQueueItem: current };
+      const fetchPage = vi.fn();
+      const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(makeClimb('b'));
+      });
+
+      expect(result.current.queueReplaceSheet.visible).toBe(true);
+      expect(result.current.queueReplaceSheet.futureQueueCount).toBe(1);
+      expect(mocks.setQueue).not.toHaveBeenCalled();
+      expect(fetchPage).not.toHaveBeenCalled();
+    });
+
+    it('warns for suggested future queue items because replacement still clears them', async () => {
+      const current = makeQueueItem('q-current', 'current');
+      const suggestedFuture = makeQueueItem('q-suggested', 'suggested', true);
+      mocks.queueState = { queue: [current, suggestedFuture], currentClimbQueueItem: current };
+      const { result } = renderActivation(vi.fn(), { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(makeClimb('b'));
+      });
+
+      expect(result.current.queueReplaceSheet.visible).toBe(true);
+      expect(result.current.queueReplaceSheet.futureQueueCount).toBe(1);
+      expect(mocks.setQueue).not.toHaveBeenCalled();
+    });
+
+    it('replaces the queue once the user confirms the warning', async () => {
+      const current = makeQueueItem('q-current', 'current');
+      const future = makeQueueItem('q-future', 'future');
+      mocks.queueState = { queue: [current, future], currentClimbQueueItem: current };
+      const tapped = makeClimb('b');
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [tapped, makeClimb('c')], hasMore: false });
+      const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+      expect(result.current.queueReplaceSheet.visible).toBe(true);
+
+      await act(async () => {
+        result.current.queueReplaceSheet.onConfirm();
+      });
+
+      await waitFor(() => {
+        expect(mocks.setQueue).toHaveBeenCalled();
+      });
+      const lastSetQueue = mocks.setQueue.mock.calls.at(-1);
+      expect(lastSetQueue?.[0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['b', 'c']);
+      await waitFor(() => {
+        expect(result.current.queueReplaceSheet.visible).toBe(false);
+      });
+    });
+
+    it('cancelling the warning leaves the queue untouched', async () => {
+      const current = makeQueueItem('q-current', 'current');
+      const future = makeQueueItem('q-future', 'future');
+      mocks.queueState = { queue: [current, future], currentClimbQueueItem: current };
+      const { result } = renderActivation(vi.fn(), { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(makeClimb('b'));
+      });
+      expect(result.current.queueReplaceSheet.visible).toBe(true);
+
+      act(() => {
+        result.current.queueReplaceSheet.onCancel();
+      });
+
+      expect(result.current.queueReplaceSheet.visible).toBe(false);
+      expect(mocks.setQueue).not.toHaveBeenCalled();
+    });
+
+    it('keeps the queue unchanged and shows a toast when the full playlist fetch fails', async () => {
+      const fetchPage = vi.fn().mockRejectedValue(new Error('network'));
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(makeClimb('b'));
+      });
+
+      await waitFor(() => {
+        expect(mocks.showToast).toHaveBeenCalledWith('detail.queueReplace.loadFailed', 'error');
+      });
+      errorSpy.mockRestore();
+    });
   });
 });

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -10,12 +10,24 @@
 // board climb list and swaps in a richer suggestion source so swiping through
 // the play drawer walks the whole playlist. Wrong-board playlists use a
 // view-only drawer path so they can be inspected without mutating the queue.
+//
+// Playlist-detail screens additionally opt into `replaceQueueOnActivate`: a tap
+// replaces the whole queue with the playlist order (tapped climb active) so
+// previous/next walk the circuit. Because that clears any future queue items, a
+// confirmation sheet warns first whenever the queue has items after the current.
 
-import { useCallback, useMemo, useRef } from 'react';
-import { usePlaylistClimbActivation, fetchPlaylistSuggestionClimbs } from '@boardsesh/playlists-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  usePlaylistClimbActivation,
+  fetchPlaylistSuggestionClimbs,
+  isAbortError,
+  PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
+} from '@boardsesh/playlists-react';
 import { createPlaylistSuggestionSource, getQueueBoardKey, type Climb, type ClimbQueueItem } from '@boardsesh/queue';
 import { useActiveClimbUuid, usePlaylistSuggestionSource, useQueueActions } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
+import { useToast } from '../../providers/toast-provider';
 import { useActiveBoard } from '../graphql/use-active-board';
 import { climbToQueueItem } from '../climb-to-queue-item';
 import { reportHandledError } from '../error-reporting';
@@ -56,19 +68,99 @@ export type UsePlaylistActivationOptions = {
   viewOnlyBoard?: PlaylistRenderBoard | ViewOnlyBoardResolver | null;
   /** Logged when the async suggestion refresh fails (non-abort). */
   refreshErrorMessage: string;
+  /** Replace the user's queue with the playlist order instead of suggestion-fallback navigation. */
+  replaceQueueOnActivate?: boolean;
 };
 
-/** Returns an `activate(climb)` callback to wire onto a climb row tap. */
+type PendingQueueReplacement = {
+  climb: Climb;
+  futureQueueCount: number;
+  loadedClimbs?: Climb[];
+  previewQueueItem?: ClimbQueueItem | null;
+};
+
+export type PlaylistQueueReplaceSheetState = {
+  visible: boolean;
+  futureQueueCount: number;
+  isReplacing: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export type PlaylistActivationResult = {
+  /** Callback to wire onto a climb row tap. */
+  activate: (climb: Climb) => Promise<void>;
+  /** Props for PlaylistQueueReplaceSheet. */
+  queueReplaceSheet: PlaylistQueueReplaceSheetState;
+};
+
+function countFutureQueueItems(queue: ClimbQueueItem[], currentClimbQueueItem: ClimbQueueItem | null): number {
+  const currentIndex = currentClimbQueueItem
+    ? queue.findIndex((queueItem) => queueItem.uuid === currentClimbQueueItem.uuid)
+    : -1;
+  const futureQueue = currentIndex >= 0 ? queue.slice(currentIndex + 1) : queue;
+  // Count every future item, suggestion-origin included: a whole-queue
+  // replacement clears them all, so the user must be warned about all of them.
+  return futureQueue.length;
+}
+
+function buildPlaylistQueue(
+  climbs: Climb[],
+  activatedClimb: Climb,
+  activatedQueueItem?: ClimbQueueItem | null,
+): { queue: ClimbQueueItem[]; currentItem: ClimbQueueItem } {
+  const queue: ClimbQueueItem[] = [];
+  let currentItem: ClimbQueueItem | null = null;
+  let includesActivatedClimb = false;
+  const reusableCurrentItem = activatedQueueItem?.climb.uuid === activatedClimb.uuid ? activatedQueueItem : null;
+  const seen = new Set<string>();
+
+  for (const climb of climbs) {
+    if (seen.has(climb.uuid)) continue;
+    seen.add(climb.uuid);
+    const item =
+      reusableCurrentItem && climb.uuid === activatedClimb.uuid
+        ? reusableCurrentItem
+        : climbToQueueItem(toSchemaClimb(climb));
+    queue.push(item);
+    if (climb.uuid === activatedClimb.uuid) {
+      includesActivatedClimb = true;
+      currentItem = item;
+    }
+  }
+
+  if (!includesActivatedClimb) {
+    currentItem = reusableCurrentItem ?? climbToQueueItem(toSchemaClimb(activatedClimb));
+    queue.push(currentItem);
+  }
+
+  if (!currentItem) {
+    currentItem = queue[0] ?? climbToQueueItem(toSchemaClimb(activatedClimb));
+    if (queue.length === 0) queue.push(currentItem);
+  }
+
+  return { queue, currentItem };
+}
+
+/** Returns playlist activation controls to wire onto a climb row tap. */
 export function usePlaylistActivation({
   sourceId,
   allClimbs,
   fetchPage,
   viewOnlyBoard,
   refreshErrorMessage,
-}: UsePlaylistActivationOptions): (climb: Climb) => Promise<void> {
-  const { setCurrentClimb, setPlaylistSuggestionSource, refreshPlaylistSuggestionSource } = useQueueActions();
+  replaceQueueOnActivate = false,
+}: UsePlaylistActivationOptions): PlaylistActivationResult {
+  const { setCurrentClimb, setPlaylistSuggestionSource, refreshPlaylistSuggestionSource, setQueue, getQueueSnapshot } =
+    useQueueActions();
   const { openPlayDrawer } = useDrawerHost();
+  const { showToast } = useToast();
+  const { t } = useTranslation('playlists');
   const activeBoard = useActiveBoard().data ?? null;
+
+  const [pendingReplacement, setPendingReplacement] = useState<PendingQueueReplacement | null>(null);
+  const [isReplacingQueue, setIsReplacingQueue] = useState(false);
+  const replacementAbortRef = useRef<AbortController | null>(null);
 
   // Mirror the active climb uuid + the live suggestion source into refs so the
   // returned callback can decide how to handle a re-tap of the already-active
@@ -161,6 +253,43 @@ export function usePlaylistActivation({
     [activeBoard, fetchPage],
   );
 
+  const fetchAllClimbsForBoard = useCallback(
+    async ({ signal }: { signal: AbortSignal }) => {
+      if (!activeBoard) return [];
+      const board = {
+        boardName: activeBoard.boardType,
+        layoutId: activeBoard.layoutId,
+        sizeId: activeBoard.sizeId,
+        setIds: activeBoard.setIds,
+        angle: activeBoard.angle,
+      };
+      const climbs: Climb[] = [];
+      let page = 0;
+      let hasMore = true;
+
+      while (hasMore && !signal.aborted) {
+        const pageResult = await fetchPage({
+          page,
+          pageSize: PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
+          board,
+          signal,
+        });
+        climbs.push(...pageResult.climbs);
+        hasMore = pageResult.hasMore;
+        page += 1;
+      }
+
+      return climbs;
+    },
+    [activeBoard, fetchPage],
+  );
+
+  useEffect(() => {
+    return () => {
+      replacementAbortRef.current?.abort();
+    };
+  }, []);
+
   const activate = usePlaylistClimbActivation({
     queueApi,
     sourceId,
@@ -173,13 +302,91 @@ export function usePlaylistActivation({
     refreshErrorMessage,
   });
 
+  const replaceQueueWithPlaylist = useCallback(
+    async (
+      climb: Climb,
+      options: {
+        allowClearingManualFuture?: boolean;
+        loadedClimbs?: Climb[];
+        previewQueueItem?: ClimbQueueItem | null;
+      } = {},
+    ) => {
+      replacementAbortRef.current?.abort();
+      const abortController = new AbortController();
+      replacementAbortRef.current = abortController;
+      setIsReplacingQueue(true);
+      try {
+        const climbs = options.loadedClimbs ?? (await fetchAllClimbsForBoard({ signal: abortController.signal }));
+        if (abortController.signal.aborted) return;
+        // Re-check live queue state after the async load: new future items may
+        // have landed while the ordered list streamed in, and replacement still
+        // clears them — so warn instead of clearing silently. Skipped once the
+        // user has confirmed (allowClearingManualFuture).
+        const { queue: latestQueue, currentClimbQueueItem: latestCurrent } = getQueueSnapshot();
+        const latestFutureQueueCount = countFutureQueueItems(latestQueue, latestCurrent);
+        if (!options.allowClearingManualFuture && latestFutureQueueCount > 0) {
+          setPendingReplacement({
+            climb,
+            futureQueueCount: latestFutureQueueCount,
+            loadedClimbs: climbs,
+            previewQueueItem: options.previewQueueItem ?? null,
+          });
+          return;
+        }
+        const { queue, currentItem } = buildPlaylistQueue(climbs, climb, options.previewQueueItem);
+        setQueue(queue, currentItem);
+        // The activate path already opened the drawer (committedExternally) on the
+        // seed queue; the confirm path opens it now that the climb is current.
+        if (!options.previewQueueItem) {
+          openPlayDrawer(toSchemaClimb(climb), { committedExternally: true });
+        }
+        setPendingReplacement(null);
+      } catch (error) {
+        if (isAbortError(error)) return;
+        console.error('Playlist queue replacement failed:', error);
+        reportHandledError(error, { tags: { source: 'playlist', op: 'replace-queue' } });
+        showToast(t('detail.queueReplace.loadFailed'), 'error');
+      } finally {
+        if (replacementAbortRef.current === abortController) {
+          replacementAbortRef.current = null;
+        }
+        setIsReplacingQueue(false);
+      }
+    },
+    [fetchAllClimbsForBoard, getQueueSnapshot, openPlayDrawer, setQueue, showToast, t],
+  );
+
+  const cancelQueueReplacement = useCallback(() => {
+    replacementAbortRef.current?.abort();
+    setPendingReplacement(null);
+    setIsReplacingQueue(false);
+  }, []);
+
+  const confirmQueueReplacement = useCallback(() => {
+    if (!pendingReplacement || isReplacingQueue) return;
+    // The queue can grow between opening the sheet and confirming. Re-read it and,
+    // if more future items appeared, bump the warning count and require another
+    // confirm so the user never clears items they haven't seen counted.
+    const { queue, currentClimbQueueItem } = getQueueSnapshot();
+    const latestFutureQueueCount = countFutureQueueItems(queue, currentClimbQueueItem);
+    if (latestFutureQueueCount > pendingReplacement.futureQueueCount) {
+      setPendingReplacement({ ...pendingReplacement, futureQueueCount: latestFutureQueueCount });
+      return;
+    }
+    void replaceQueueWithPlaylist(pendingReplacement.climb, {
+      allowClearingManualFuture: true,
+      loadedClimbs: pendingReplacement.loadedClimbs,
+      previewQueueItem: pendingReplacement.previewQueueItem,
+    });
+  }, [getQueueSnapshot, isReplacingQueue, pendingReplacement, replaceQueueWithPlaylist]);
+
   // Open the drawer immediately, then let the shared hook commit the climb. The
   // open and the synchronous setCurrentClimb dispatch land in the same React
   // batch, so the drawer (rendering from currentClimbQueueItem) paints the
   // activated climb on the first frame. `committedExternally` tells the drawer
   // the caller already dispatched, so it doesn't re-commit or treat this as a
   // preview.
-  return useCallback(
+  const activatePlaylistClimb = useCallback(
     (climb: Climb) => {
       const schemaClimb = toSchemaClimb(climb);
 
@@ -214,6 +421,28 @@ export function usePlaylistActivation({
         return Promise.resolve();
       }
 
+      // Replace-on-activate (playlist/circuit detail): swap the whole queue for the
+      // playlist order so previous/next walk the circuit. Replacement clears future
+      // queue items, so warn first when any exist; otherwise seed the queue with the
+      // tapped climb (committed, so the drawer renders it immediately) and expand to
+      // the full ordered list once it loads.
+      if (replaceQueueOnActivate) {
+        const target = resolveTarget(climb);
+        if (target) {
+          const { queue, currentClimbQueueItem } = getQueueSnapshot();
+          const futureQueueCount = countFutureQueueItems(queue, currentClimbQueueItem);
+          if (futureQueueCount > 0) {
+            replacementAbortRef.current?.abort();
+            setPendingReplacement({ climb, futureQueueCount });
+            return Promise.resolve();
+          }
+          const item = climbToQueueItem(schemaClimb);
+          setQueue([item], item);
+          openPlayDrawer(schemaClimb, { committedExternally: true });
+          return replaceQueueWithPlaylist(climb, { previewQueueItem: item });
+        }
+      }
+
       const isAlreadyActive = activeClimbUuidRef.current === climb.uuid;
       const source = playlistSuggestionSourceRef.current;
       const suggestionsAlreadyFollowThisList =
@@ -245,6 +474,31 @@ export function usePlaylistActivation({
         reportHandledError(error, { tags: { source: 'playlist', op: 'activate-climb' } });
       });
     },
-    [activate, allClimbs, openPlayDrawer, sourceId, viewOnlyBoard],
+    [
+      activate,
+      allClimbs,
+      getQueueSnapshot,
+      openPlayDrawer,
+      replaceQueueOnActivate,
+      replaceQueueWithPlaylist,
+      resolveTarget,
+      setQueue,
+      sourceId,
+      viewOnlyBoard,
+    ],
+  );
+
+  return useMemo(
+    () => ({
+      activate: activatePlaylistClimb,
+      queueReplaceSheet: {
+        visible: pendingReplacement !== null,
+        futureQueueCount: pendingReplacement?.futureQueueCount ?? 0,
+        isReplacing: isReplacingQueue,
+        onCancel: cancelQueueReplacement,
+        onConfirm: confirmQueueReplacement,
+      },
+    }),
+    [activatePlaylistClimb, cancelQueueReplacement, confirmQueueReplacement, isReplacingQueue, pendingReplacement],
   );
 }

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -189,6 +189,7 @@ type Snapshot = {
   playlistSuggestionSource: PlaylistSuggestionSource | null;
   addToQueue: ReturnType<typeof useQueue>['addToQueue'];
   removeFromQueue: ReturnType<typeof useQueue>['removeFromQueue'];
+  setQueue: ReturnType<typeof useQueue>['setQueue'];
   setCurrentClimb: ReturnType<typeof useQueue>['setCurrentClimb'];
   nextClimb: ReturnType<typeof useQueue>['nextClimb'];
   setPlaylistSuggestionSource: ReturnType<typeof useQueue>['setPlaylistSuggestionSource'];
@@ -283,6 +284,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
       playlistSuggestionSource,
       addToQueue: queue.addToQueue,
       removeFromQueue: queue.removeFromQueue,
+      setQueue: queue.setQueue,
       setCurrentClimb: queue.setCurrentClimb,
       nextClimb: queue.nextClimb,
       setPlaylistSuggestionSource: queue.setPlaylistSuggestionSource,
@@ -301,6 +303,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
     playlistSuggestionSource,
     queue.addToQueue,
     queue.removeFromQueue,
+    queue.setQueue,
     queue.setCurrentClimb,
     queue.nextClimb,
     queue.setPlaylistSuggestionSource,
@@ -1255,6 +1258,35 @@ describe('QueueProvider mutation-failure resync', () => {
     expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
     // Solo's "Action failed" toast must NOT fire in a party session.
     expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+  });
+
+  it('resyncs when setQueue fails in a session', async () => {
+    const snapshots: Snapshot[] = [];
+    const serverCurrent = makeQueueItem('server-current', 'climb-server-current');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([serverCurrent], serverCurrent), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+    queueMutations.setQueue.mockRejectedValueOnce(new Error('set queue failed'));
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      const localCurrent = makeQueueItem('local-current', 'climb-local-current');
+      snapshot.setQueue([localCurrent], localCurrent);
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('server-current');
+    });
+    expect(queueStateCalls).toBe(1);
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
   });
 
   it('does not resync or toast when a mutation fails with no active session', async () => {

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -127,6 +127,14 @@ type QueueContextValue = {
   clearQueue: () => void;
   /** Replace the entire queue (optimistic local UPDATE_QUEUE + best-effort party sync). */
   setQueue: (queue: ClimbQueueItem[], currentClimbQueueItem?: ClimbQueueItem | null) => void;
+  /**
+   * Read the live queue + current climb without subscribing to state. Stable
+   * identity (backed by the internal stateRef), so action-only consumers — e.g.
+   * playlist activation deciding whether replacing the queue would clear future
+   * items — can read the latest queue at tap time without re-rendering on every
+   * queue change.
+   */
+  getQueueSnapshot: () => { queue: ClimbQueueItem[]; currentClimbQueueItem: ClimbQueueItem | null };
   setCurrentClimb: (item: ClimbQueueItem, options?: SetCurrentClimbOptions) => void;
   nextClimb: () => void;
   previousClimb: () => void;
@@ -1410,18 +1418,26 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   }, [mutations, resyncQueueAfterMutationFailure]);
 
   // Replace the whole queue in one shot: optimistic local UPDATE_QUEUE (the
-  // source of truth for the user's queue) + a best-effort SET_QUEUE sync that
-  // no-ops in solo and broadcasts to party peers when a session exists. Same
-  // best-effort model as addToQueue — a sync failure leaves the local queue
-  // correct, so it must not toast.
+  // source of truth for the user's queue) + SET_QUEUE sync that no-ops in solo
+  // and broadcasts to party peers when a session exists. In party mode a sync
+  // failure would leave peers on the old queue, so reconcile like other failed
+  // session mutations.
   const setQueue = useCallback(
     (queue: ClimbQueueItem[], currentClimbQueueItem?: ClimbQueueItem | null) => {
       dispatch({ type: 'UPDATE_QUEUE', payload: { queue, currentClimbQueueItem: currentClimbQueueItem ?? null } });
       mutations.setQueue(queue, currentClimbQueueItem ?? undefined).catch((error) => {
         if (__DEV__) console.warn('[queue] setQueue sync failed', error);
+        void resyncQueueAfterMutationFailure();
       });
     },
-    [mutations],
+    [mutations, resyncQueueAfterMutationFailure],
+  );
+
+  // Stable live read of the queue + current climb (see QueueContextValue). Reads
+  // stateRef so callers get the latest without subscribing to state re-renders.
+  const getQueueSnapshot = useCallback(
+    () => ({ queue: stateRef.current.queue, currentClimbQueueItem: stateRef.current.currentClimbQueueItem }),
+    [],
   );
 
   // Optimistic local dispatch + correlated SET_CURRENT_CLIMB mutation. The
@@ -1632,6 +1648,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       reorderQueue,
       clearQueue,
       setQueue,
+      getQueueSnapshot,
       setCurrentClimb,
       nextClimb,
       previousClimb,
@@ -1655,6 +1672,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       reorderQueue,
       clearQueue,
       setQueue,
+      getQueueSnapshot,
       setCurrentClimb,
       nextClimb,
       previousClimb,

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -128,6 +128,14 @@
     "shareError": "Failed to share",
     "deleted": "Playlist deleted",
     "deleteFailed": "Failed to delete playlist",
+    "queueReplace": {
+      "title": "Start playlist?",
+      "message_one": "This will clear {{count}} queued climb after your current climb.",
+      "message_other": "This will clear {{count}} queued climbs after your current climb.",
+      "cancel": "Keep queue",
+      "confirm": "Start playlist",
+      "loadFailed": "Couldn't start playlist. Try again."
+    },
     "deleteConfirm": {
       "title": "Delete playlist?",
       "message": "This permanently deletes \"{{name}}\" and its climbs. This can't be undone.",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -128,6 +128,14 @@
     "shareError": "No se pudo compartir",
     "deleted": "Playlist eliminada",
     "deleteFailed": "No se pudo eliminar la playlist",
+    "queueReplace": {
+      "title": "¿Iniciar playlist?",
+      "message_one": "Esto borrará {{count}} bloque en cola después de tu bloque actual.",
+      "message_other": "Esto borrará {{count}} bloques en cola después de tu bloque actual.",
+      "cancel": "Mantener cola",
+      "confirm": "Iniciar playlist",
+      "loadFailed": "No se pudo iniciar la playlist. Inténtalo de nuevo."
+    },
     "deleteConfirm": {
       "title": "¿Eliminar playlist?",
       "message": "Esto elimina \"{{name}}\" y sus bloques de forma permanente. No se puede deshacer.",

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -128,6 +128,14 @@
     "shareError": "Impossible de partager",
     "deleted": "Playlist supprimée",
     "deleteFailed": "Impossible de supprimer la playlist",
+    "queueReplace": {
+      "title": "Lancer la playlist ?",
+      "message_one": "Cela supprimera {{count}} bloc en file après votre bloc actuel.",
+      "message_other": "Cela supprimera {{count}} blocs en file après votre bloc actuel.",
+      "cancel": "Garder la file",
+      "confirm": "Lancer la playlist",
+      "loadFailed": "Impossible de lancer la playlist. Réessayez."
+    },
     "deleteConfirm": {
       "title": "Supprimer la playlist ?",
       "message": "Cela supprime définitivement « {{name}} » et ses voies. Cette action est irréversible.",


### PR DESCRIPTION
## Summary

Closes #2757. A TestFlight tester reported that after opening a climb from a circuit you could only swipe left to the next boulder — swipe-right and the left button did nothing, so there was no way back to the boulders above.

The root cause: tapping a circuit/playlist climb only inserted that one climb into the real queue, so previous-navigation (queue-only) had no earlier item to target. This branch makes a tap on a playlist or smart-playlist detail screen **replace the whole queue with the playlist order** and activate the tapped climb, so previous/next walk the circuit through the real queue.

### What changed
- `usePlaylistActivation` gains `replaceQueueOnActivate`. On tap it seeds the queue with the tapped climb immediately (committed, so the play drawer paints it on the first frame), then expands to the full ordered board climb list once it loads.
- Replacing the queue clears the climbs queued **after** the current one, so a `PlaylistQueueReplaceSheet` confirmation warns first whenever any future queue items exist (suggestion-origin entries included — replacement clears those too). Pan-to-close is locked while a replacement is in flight, and the live future-item count is re-checked right before clearing.
- A whole-queue `setQueue` sync failure in a party session now reconciles against the server (and toasts) instead of leaving peers on the old queue.
- `queue-provider` exposes a stable `getQueueSnapshot()` so playlist activation can read the live queue at tap time without subscribing to every queue re-render.

### Rebase notes (for review)
- Rebased onto current `main`. `main` independently reworked playlist navigation so that the **committed active-board path stays queue-only** (no backward playlist "peek"); this branch's earlier backward-peek commits were dropped in favour of that, since whole-queue replacement is what actually fixes #2757.
- `main` removed `@gorhom/bottom-sheet` (#3167). `PlaylistQueueReplaceSheet` was migrated to the shared `ModalSheet` (Expo native sheet + presentation coordinator), so it can't overlap another native sheet.

## Release Notes

- Tap any climb in a circuit or playlist and the whole list drops into your queue in order — swipe right or hit back to revisit the boulders above, not just jump to the next one.
- A heads-up before a playlist takes over your queue, so you don't lose climbs you'd lined up.

## Test plan
- `vp run typecheck:mobile`
- `vp run test:mobile` — 362 files, 2705 tests pass
- `vp run check:mobile-bundle` — Android bundle OK
- `vp check` on all changed files — format + lint + types clean
- Tests cover activation, the confirmation sheet, the party-mode queue resync, and the playlist + smart-playlist screen wiring.