### PR TITLE
[codex] Add mobile profile social tab

### DIFF
--- a/packages/mobile/app/(tabs)/profile/index.tsx
+++ b/packages/mobile/app/(tabs)/profile/index.tsx
@@ -10,6 +10,7 @@ import { YouFilterSheet } from '../../../src/components/you/YouFilterSheet';
 import { ProgressTab } from '../../../src/components/you/ProgressTab';
 import { SessionsTab } from '../../../src/components/you/SessionsTab';
 import { LogbookTab } from '../../../src/components/you/LogbookTab';
+import { SocialTab } from '../../../src/components/you/SocialTab';
 
 export default function YouScreen() {
   const { systemColors } = useTheme();
@@ -94,6 +95,14 @@ export default function YouScreen() {
         ) : null}
         {activeTab === 'logbook' ? (
           <LogbookTab
+            userId={userId}
+            onScroll={handleScroll}
+            topInset={chromeHeight}
+            registerScrollToTop={registerScrollToTop}
+          />
+        ) : null}
+        {activeTab === 'social' ? (
+          <SocialTab
             userId={userId}
             onScroll={handleScroll}
             topInset={chromeHeight}

--- a/packages/mobile/src/components/you/ProfileTopChrome.tsx
+++ b/packages/mobile/src/components/you/ProfileTopChrome.tsx
@@ -34,7 +34,7 @@ import { CollapsingLargeTitleHeader, GlassActionToolbar, GlassToolbarAction } fr
 // capsule's treatment). 10 leaves a hair of glass around the thumb's radius-7 tile.
 const SEGMENT_TRACK_RADIUS = 10;
 
-export type ProfileTabKey = 'progress' | 'sessions' | 'logbook';
+export type ProfileTabKey = 'progress' | 'sessions' | 'logbook' | 'social';
 
 type ProfileTopChromeProps = {
   /** Selected sub-tab; drives the segmented control's pill / the active tab. */
@@ -65,6 +65,7 @@ function useSegmentOptions() {
       { key: 'progress' as const, label: t('tabs.progress') },
       { key: 'sessions' as const, label: t('tabs.sessions') },
       { key: 'logbook' as const, label: t('tabs.logbook') },
+      { key: 'social' as const, label: t('tabs.social') },
     ],
     [t],
   );

--- a/packages/mobile/src/components/you/SocialTab.tsx
+++ b/packages/mobile/src/components/you/SocialTab.tsx
@@ -1,0 +1,435 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  TextInput,
+  View,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from 'react-native';
+import { FlashList, type FlashListRef } from '@shopify/flash-list';
+import { useTranslation } from 'react-i18next';
+import type { PublicUserProfile, UserSearchResult } from '@boardsesh/shared-schema';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { Avatar } from '../Avatar';
+import { ListRow } from '../ListRow';
+import { Button } from '../Button';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { SegmentedControl } from '../SegmentedControl';
+import {
+  useFollowers,
+  useFollowing,
+  usePublicProfile,
+  useSearchUsers,
+  useToggleUserFollow,
+} from '../../lib/graphql/hooks';
+import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { borderRadius, spacing } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
+
+type SocialMode = 'followers' | 'following' | 'search';
+
+type SocialPerson = PublicUserProfile & {
+  recentAscentCount?: number;
+};
+
+type SocialTabProps = {
+  userId: string | undefined;
+  onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  topInset?: number;
+  registerScrollToTop?: (scrollToTop: (() => void) | null) => void;
+};
+
+const EMPTY_PEOPLE: SocialPerson[] = [];
+
+export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop }: SocialTabProps) {
+  const { t } = useTranslation('you');
+  const { systemColors, brandColors, variant } = useTheme();
+  const bottomChrome = useBottomChromeMetrics();
+  const paddingBottom = bottomChrome.scrollBottomPadding + spacing[4];
+
+  const [mode, setMode] = useState<SocialMode>('followers');
+  const [searchQuery, setSearchQuery] = useState('');
+  const trimmedSearchQuery = searchQuery.trim();
+
+  const listRef = useRef<FlashListRef<SocialPerson>>(null);
+  useEffect(() => {
+    if (!registerScrollToTop) return;
+    registerScrollToTop(() => listRef.current?.scrollToTop({ animated: true }));
+    return () => registerScrollToTop(null);
+  }, [listRef, registerScrollToTop]);
+
+  const publicProfile = usePublicProfile(userId);
+  const followers = useFollowers(userId, mode === 'followers');
+  const following = useFollowing(userId, mode === 'following');
+  const search = useSearchUsers(trimmedSearchQuery, mode === 'search');
+  const toggleFollow = useToggleUserFollow(userId);
+
+  const followerCount = publicProfile.data?.followerCount ?? 0;
+  const followingCount = publicProfile.data?.followingCount ?? 0;
+
+  const people = useMemo<SocialPerson[]>(() => {
+    if (mode === 'followers') {
+      return followers.data?.pages.flatMap((page) => page.users) ?? EMPTY_PEOPLE;
+    }
+
+    if (mode === 'following') {
+      return following.data?.pages.flatMap((page) => page.users) ?? EMPTY_PEOPLE;
+    }
+
+    return (
+      search.data?.pages.flatMap((page) =>
+        page.results.map((result: UserSearchResult) => ({
+          ...result.user,
+          recentAscentCount: result.recentAscentCount,
+        })),
+      ) ?? EMPTY_PEOPLE
+    );
+  }, [followers.data, following.data, mode, search.data]);
+
+  const activeQuery = mode === 'followers' ? followers : mode === 'following' ? following : search;
+  const showSearchHint = mode === 'search' && trimmedSearchQuery.length < 2;
+  const showInitialSpinner = !showSearchHint && activeQuery.isPending && people.length === 0;
+  const isRefreshing = publicProfile.isRefetching || activeQuery.isRefetching;
+
+  const segmentOptions = useMemo(
+    () => [
+      { key: 'followers' as const, label: t('mobile.social.followers') },
+      { key: 'following' as const, label: t('mobile.social.following') },
+      { key: 'search' as const, label: t('mobile.social.findFriends') },
+    ],
+    [t],
+  );
+
+  const handleRefresh = useCallback(() => {
+    void publicProfile.refetch();
+    void activeQuery.refetch();
+  }, [activeQuery, publicProfile]);
+
+  const handleEndReached = useCallback(() => {
+    if (activeQuery.hasNextPage && !activeQuery.isFetchingNextPage) void activeQuery.fetchNextPage();
+  }, [activeQuery]);
+
+  const handleToggleFollow = useCallback(
+    (person: PublicUserProfile) => {
+      if (person.id === userId) return;
+      toggleFollow.mutate({ userId: person.id, isFollowedByMe: person.isFollowedByMe });
+    },
+    [toggleFollow, userId],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: SocialPerson }) => {
+      const isCurrentUser = item.id === userId;
+      const isRowMutating = toggleFollow.isPending && toggleFollow.variables?.userId === item.id;
+
+      return (
+        <ListRow
+          title={item.displayName || t('mobile.unknownName')}
+          subtitle={personSubtitle(item, t)}
+          leading={<Avatar uri={item.avatarUrl} name={item.displayName} size={36} />}
+          trailing={
+            isCurrentUser ? (
+              <Text variant="footnote" color={systemColors.secondaryLabel}>
+                {t('mobile.social.you')}
+              </Text>
+            ) : (
+              <Button
+                title={item.isFollowedByMe ? t('mobile.social.followingAction') : t('mobile.social.followAction')}
+                size="small"
+                variant={item.isFollowedByMe ? 'outlined' : 'filled'}
+                loading={isRowMutating}
+                disabled={isRowMutating}
+                onPress={() => handleToggleFollow(item)}
+              />
+            )
+          }
+        />
+      );
+    },
+    [
+      handleToggleFollow,
+      systemColors.secondaryLabel,
+      t,
+      toggleFollow.isPending,
+      toggleFollow.variables?.userId,
+      userId,
+    ],
+  );
+
+  const header = useMemo(
+    () => (
+      <View>
+        {variant === 'material' ? null : (
+          <Text variant="largeTitle" style={styles.screenTitle}>
+            {t('metadata.dashboard.title')}
+          </Text>
+        )}
+
+        <View style={styles.summaryRow}>
+          <SocialStatCard
+            label={t('mobile.social.followers')}
+            value={followerCount}
+            icon="people"
+            active={mode === 'followers'}
+            onPress={() => setMode('followers')}
+          />
+          <SocialStatCard
+            label={t('mobile.social.following')}
+            value={followingCount}
+            icon="person.badge.plus"
+            active={mode === 'following'}
+            onPress={() => setMode('following')}
+          />
+        </View>
+
+        <View style={styles.segmentWrap}>
+          <SegmentedControl
+            options={segmentOptions}
+            selectedKey={mode}
+            onSelect={setMode}
+            trackColor={systemColors.fill}
+            accessibilityLabel={t('mobile.social.title')}
+          />
+        </View>
+
+        {mode === 'search' ? (
+          <View style={styles.searchWrap}>
+            <View style={[styles.searchField, { backgroundColor: systemColors.fill }]}>
+              <Icon name="search" size={18} color={systemColors.secondaryLabel} />
+              <TextInput
+                value={searchQuery}
+                onChangeText={setSearchQuery}
+                placeholder={t('mobile.social.searchPlaceholder')}
+                placeholderTextColor={iosSystemColors.systemGray}
+                autoCapitalize="none"
+                autoCorrect={false}
+                returnKeyType="search"
+                accessibilityLabel={t('mobile.social.searchPlaceholder')}
+                style={[styles.searchInput, { color: systemColors.label }]}
+              />
+              {searchQuery.length > 0 ? (
+                <Pressable
+                  onPress={() => setSearchQuery('')}
+                  hitSlop={8}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('mobile.social.clearSearch')}
+                >
+                  <Icon name="close" size={16} color={systemColors.secondaryLabel} />
+                </Pressable>
+              ) : null}
+            </View>
+          </View>
+        ) : null}
+      </View>
+    ),
+    [
+      followerCount,
+      followingCount,
+      mode,
+      searchQuery,
+      segmentOptions,
+      systemColors.fill,
+      systemColors.label,
+      systemColors.secondaryLabel,
+      t,
+      variant,
+    ],
+  );
+
+  if (!userId) {
+    return (
+      <View style={[styles.centered, { paddingTop: topInset }]}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.flex}>
+      <FlashList
+        ref={listRef}
+        data={showInitialSpinner || showSearchHint ? EMPTY_PEOPLE : people}
+        renderItem={renderItem}
+        keyExtractor={(person) => person.id}
+        onScroll={onScroll}
+        scrollEventThrottle={16}
+        contentInsetAdjustmentBehavior="never"
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={0.5}
+        contentContainerStyle={{ paddingTop: topInset, paddingBottom }}
+        scrollIndicatorInsets={{ top: topInset }}
+        ListHeaderComponent={header}
+        refreshControl={
+          <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} tintColor={brandColors.primary} />
+        }
+        ListEmptyComponent={
+          showInitialSpinner ? (
+            <View style={styles.stateBlock}>
+              <ActivityIndicator size="large" />
+            </View>
+          ) : (
+            <SocialEmptyState mode={mode} query={trimmedSearchQuery} />
+          )
+        }
+        ListFooterComponent={
+          activeQuery.isFetchingNextPage ? (
+            <View style={styles.footer}>
+              <ActivityIndicator size="small" />
+            </View>
+          ) : null
+        }
+      />
+    </View>
+  );
+}
+
+function personSubtitle(person: SocialPerson, t: (key: string, options?: Record<string, unknown>) => string) {
+  if (person.recentAscentCount != null) {
+    return t('mobile.social.recentAscents', { count: person.recentAscentCount });
+  }
+
+  return [
+    t('mobile.social.followerCount', { count: person.followerCount }),
+    t('mobile.social.followingCount', { count: person.followingCount }),
+  ].join(' · ');
+}
+
+function SocialStatCard({
+  label,
+  value,
+  icon,
+  active,
+  onPress,
+}: {
+  label: string;
+  value: number;
+  icon: 'people' | 'person.badge.plus';
+  active: boolean;
+  onPress: () => void;
+}) {
+  const { systemColors, brandColors } = useTheme();
+  const color = active ? brandColors.primary : systemColors.secondaryLabel;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`${value} ${label}`}
+      style={({ pressed }) => [
+        styles.statCard,
+        {
+          backgroundColor: systemColors.secondaryBackground,
+          borderColor: active ? brandColors.primary : systemColors.separator,
+        },
+        pressed && { opacity: 0.75 },
+      ]}
+    >
+      <Icon name={icon} size={20} color={color} />
+      <Text variant="title3" style={styles.statValue}>
+        {value.toLocaleString()}
+      </Text>
+      <Text variant="footnote" color={systemColors.secondaryLabel}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function SocialEmptyState({ mode, query }: { mode: SocialMode; query: string }) {
+  const { t } = useTranslation('you');
+  const { systemColors } = useTheme();
+
+  const title =
+    mode === 'followers'
+      ? t('mobile.social.emptyFollowers')
+      : mode === 'following'
+        ? t('mobile.social.emptyFollowing')
+        : query.length < 2
+          ? t('mobile.social.searchHint')
+          : t('mobile.social.emptySearch');
+
+  return (
+    <View style={styles.stateBlock}>
+      <Icon name={mode === 'search' ? 'search' : 'people'} size={48} color={systemColors.tertiaryLabel} />
+      <Text variant="headline" style={styles.stateTitle}>
+        {title}
+      </Text>
+      {mode === 'search' && query.length >= 2 ? (
+        <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.stateSubtitle}>
+          {t('mobile.social.emptySearchBody', { query })}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  screenTitle: {
+    paddingHorizontal: spacing[4],
+    paddingTop: 0,
+    paddingBottom: spacing[2],
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[1],
+  },
+  statCard: {
+    flex: 1,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: borderRadius.lg,
+    padding: spacing[4],
+    gap: spacing[1],
+  },
+  statValue: {
+    fontWeight: '700',
+  },
+  segmentWrap: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[4],
+    paddingBottom: spacing[2],
+  },
+  searchWrap: {
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[2],
+  },
+  searchField: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    minHeight: 42,
+    borderRadius: 10,
+    paddingHorizontal: spacing[3],
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 17,
+    paddingVertical: 0,
+  },
+  stateBlock: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: spacing[16],
+    paddingHorizontal: spacing[8],
+    gap: spacing[2],
+  },
+  stateTitle: {
+    marginTop: spacing[3],
+    opacity: 0.65,
+    textAlign: 'center',
+  },
+  stateSubtitle: {
+    textAlign: 'center',
+  },
+  footer: {
+    paddingVertical: spacing[5],
+    alignItems: 'center',
+  },
+});

--- a/packages/mobile/src/components/you/SocialTab.tsx
+++ b/packages/mobile/src/components/you/SocialTab.tsx
@@ -44,6 +44,7 @@ type SocialTabProps = {
 };
 
 const EMPTY_PEOPLE: SocialPerson[] = [];
+const SEARCH_DEBOUNCE_MS = 300;
 
 export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop }: SocialTabProps) {
   const { t } = useTranslation('you');
@@ -54,6 +55,12 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
   const [mode, setMode] = useState<SocialMode>('followers');
   const [searchQuery, setSearchQuery] = useState('');
   const trimmedSearchQuery = searchQuery.trim();
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedSearchQuery(trimmedSearchQuery), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [trimmedSearchQuery]);
 
   const listRef = useRef<FlashListRef<SocialPerson>>(null);
   useEffect(() => {
@@ -65,7 +72,7 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
   const publicProfile = usePublicProfile(userId);
   const followers = useFollowers(userId, mode === 'followers');
   const following = useFollowing(userId, mode === 'following');
-  const search = useSearchUsers(trimmedSearchQuery, mode === 'search');
+  const search = useSearchUsers(debouncedSearchQuery, mode === 'search');
   const toggleFollow = useToggleUserFollow(userId);
 
   const followerCount = publicProfile.data?.followerCount ?? 0;
@@ -92,8 +99,12 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
 
   const activeQuery = mode === 'followers' ? followers : mode === 'following' ? following : search;
   const showSearchHint = mode === 'search' && trimmedSearchQuery.length < 2;
-  const showInitialSpinner = !showSearchHint && activeQuery.isPending && people.length === 0;
-  const isRefreshing = publicProfile.isRefetching || activeQuery.isRefetching;
+  const searchIsDebouncing =
+    mode === 'search' && trimmedSearchQuery.length >= 2 && debouncedSearchQuery !== trimmedSearchQuery;
+  const canRefetchActiveQuery = mode !== 'search' || (debouncedSearchQuery.length >= 2 && !searchIsDebouncing);
+  const showInitialSpinner = searchIsDebouncing || (!showSearchHint && activeQuery.isPending && people.length === 0);
+  const showError = !showSearchHint && !searchIsDebouncing && activeQuery.isError && people.length === 0;
+  const isRefreshing = publicProfile.isRefetching || (canRefetchActiveQuery && activeQuery.isRefetching);
 
   const segmentOptions = useMemo(
     () => [
@@ -106,12 +117,14 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
 
   const handleRefresh = useCallback(() => {
     void publicProfile.refetch();
-    void activeQuery.refetch();
-  }, [activeQuery, publicProfile]);
+    if (canRefetchActiveQuery) void activeQuery.refetch();
+  }, [activeQuery, canRefetchActiveQuery, publicProfile]);
 
   const handleEndReached = useCallback(() => {
-    if (activeQuery.hasNextPage && !activeQuery.isFetchingNextPage) void activeQuery.fetchNextPage();
-  }, [activeQuery]);
+    if (canRefetchActiveQuery && activeQuery.hasNextPage && !activeQuery.isFetchingNextPage) {
+      void activeQuery.fetchNextPage();
+    }
+  }, [activeQuery, canRefetchActiveQuery]);
 
   const handleToggleFollow = useCallback(
     (person: PublicUserProfile) => {
@@ -252,7 +265,7 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
     <View style={styles.flex}>
       <FlashList
         ref={listRef}
-        data={showInitialSpinner || showSearchHint ? EMPTY_PEOPLE : people}
+        data={showInitialSpinner || showSearchHint || showError ? EMPTY_PEOPLE : people}
         renderItem={renderItem}
         keyExtractor={(person) => person.id}
         onScroll={onScroll}
@@ -271,6 +284,8 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
             <View style={styles.stateBlock}>
               <ActivityIndicator size="large" />
             </View>
+          ) : showError ? (
+            <SocialErrorState onRetry={handleRefresh} />
           ) : (
             <SocialEmptyState mode={mode} query={trimmedSearchQuery} />
           )
@@ -367,6 +382,34 @@ function SocialEmptyState({ mode, query }: { mode: SocialMode; query: string }) 
   );
 }
 
+function SocialErrorState({ onRetry }: { onRetry: () => void }) {
+  const { t } = useTranslation('you');
+  const { systemColors, brandColors } = useTheme();
+
+  return (
+    <View style={styles.stateBlock}>
+      <Icon name="error" size={48} color={systemColors.tertiaryLabel} />
+      <Text variant="headline" style={styles.stateTitle}>
+        {t('mobile.social.loadError')}
+      </Text>
+      <Pressable
+        onPress={onRetry}
+        accessibilityRole="button"
+        accessibilityLabel={t('mobile.social.retry')}
+        style={({ pressed }) => [
+          styles.retryButton,
+          { borderColor: brandColors.primary },
+          pressed && { backgroundColor: `${brandColors.primary}1A` },
+        ]}
+      >
+        <Text variant="footnote" color={brandColors.primary}>
+          {t('mobile.social.retry')}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   flex: { flex: 1 },
   centered: { flex: 1, alignItems: 'center', justifyContent: 'center' },
@@ -431,5 +474,12 @@ const styles = StyleSheet.create({
   footer: {
     paddingVertical: spacing[5],
     alignItems: 'center',
+  },
+  retryButton: {
+    marginTop: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+    borderRadius: borderRadius.full,
+    borderWidth: StyleSheet.hairlineWidth,
   },
 });

--- a/packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx
@@ -207,10 +207,10 @@ describe('ProfileTopChrome', () => {
       expect(onOpenFilters).toHaveBeenCalledTimes(1);
     });
 
-    it('passes the three options and selectedKey to the segmented control', () => {
+    it('passes the profile tab options and selectedKey to the segmented control', () => {
       render(<ProfileTopChrome {...makeProps({ activeTab: 'sessions' })} />);
       const segment = segments.entries.at(-1)!;
-      expect(segment.options.map((option) => option.key)).toEqual(['progress', 'sessions', 'logbook']);
+      expect(segment.options.map((option) => option.key)).toEqual(['progress', 'sessions', 'logbook', 'social']);
       expect(segment.selectedKey).toBe('sessions');
     });
 
@@ -279,10 +279,10 @@ describe('ProfileTopChrome', () => {
       expect(onOpenFilters).toHaveBeenCalledTimes(1);
     });
 
-    it('passes the three options and selectedKey to MaterialTabs', () => {
+    it('passes the profile tab options and selectedKey to MaterialTabs', () => {
       render(<ProfileTopChrome {...makeProps({ activeTab: 'sessions' })} />);
       const tabs = materialTabs.entries.at(-1)!;
-      expect(tabs.options.map((option) => option.key)).toEqual(['progress', 'sessions', 'logbook']);
+      expect(tabs.options.map((option) => option.key)).toEqual(['progress', 'sessions', 'logbook', 'social']);
       expect(tabs.selectedKey).toBe('sessions');
     });
 

--- a/packages/mobile/src/components/you/__tests__/social-tab.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/social-tab.test.tsx
@@ -1,0 +1,267 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, forwardRef, useImperativeHandle, type ReactNode } from 'react';
+
+const social = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  latestSearchQuery: '',
+}));
+
+const follower = {
+  id: 'follower-1',
+  displayName: 'Ada Lovelace',
+  avatarUrl: null,
+  followerCount: 1,
+  followingCount: 2,
+  isFollowedByMe: true,
+};
+
+const following = {
+  id: 'following-1',
+  displayName: 'Grace Hopper',
+  avatarUrl: null,
+  followerCount: 3,
+  followingCount: 4,
+  isFollowedByMe: true,
+};
+
+const searchResult = {
+  user: {
+    id: 'friend-1',
+    displayName: 'Marco',
+    avatarUrl: null,
+    followerCount: 5,
+    followingCount: 6,
+    isFollowedByMe: false,
+  },
+  recentAscentCount: 7,
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      const count = Number(options?.count ?? 0);
+      const translations: Record<string, string> = {
+        'metadata.dashboard.title': 'You',
+        'mobile.unknownName': 'Climber',
+        'mobile.social.title': 'Social',
+        'mobile.social.followers': 'Followers',
+        'mobile.social.following': 'Following',
+        'mobile.social.findFriends': 'Find friends',
+        'mobile.social.searchPlaceholder': 'Search climbers',
+        'mobile.social.clearSearch': 'Clear search',
+        'mobile.social.you': 'You',
+        'mobile.social.followAction': 'Follow',
+        'mobile.social.followingAction': 'Following',
+        'mobile.social.emptyFollowers': 'No followers yet',
+        'mobile.social.emptyFollowing': 'Not following anyone yet',
+        'mobile.social.searchHint': 'Type at least 2 characters to search climbers',
+        'mobile.social.emptySearch': 'No climbers found',
+      };
+      if (key === 'mobile.social.followerCount') return `${count} follower${count === 1 ? '' : 's'}`;
+      if (key === 'mobile.social.followingCount') return `${count} following`;
+      if (key === 'mobile.social.recentAscents') return `${count} ascents this month`;
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+  TextInput: ({
+    value,
+    onChangeText,
+    placeholder,
+  }: {
+    value?: string;
+    onChangeText?: (value: string) => void;
+    placeholder?: string;
+  }) =>
+    createElement('input', {
+      value: value ?? '',
+      placeholder,
+      onChange: (event: { target: { value: string } }) => onChangeText?.(event.target.value),
+    }),
+  RefreshControl: () => null,
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('@shopify/flash-list', () => ({
+  FlashList: forwardRef(
+    (
+      {
+        data,
+        renderItem,
+        ListHeaderComponent,
+        ListEmptyComponent,
+        ListFooterComponent,
+      }: {
+        data?: unknown[];
+        renderItem: (input: { item: unknown; index: number }) => ReactNode;
+        ListHeaderComponent?: ReactNode;
+        ListEmptyComponent?: ReactNode;
+        ListFooterComponent?: ReactNode;
+      },
+      ref,
+    ) => {
+      useImperativeHandle(ref, () => ({ scrollToTop: vi.fn() }));
+      return createElement(
+        'div',
+        null,
+        ListHeaderComponent,
+        data?.length
+          ? data.map((item, index) => createElement('div', { key: index }, renderItem({ item, index })))
+          : ListEmptyComponent,
+        ListFooterComponent,
+      );
+    },
+  ),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      fill: '#eee',
+      label: '#000',
+      secondaryLabel: '#666',
+      tertiaryLabel: '#999',
+      secondaryBackground: '#fff',
+      separator: '#ddd',
+    },
+    brandColors: { primary: '#6D28D9' },
+    variant: 'glass',
+  }),
+}));
+vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+}));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 8: 32, 16: 64 },
+  borderRadius: { lg: 12 },
+}));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#999' } }));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }),
+}));
+vi.mock('../../Avatar', () => ({ Avatar: () => createElement('div', { 'data-avatar': 'true' }) }));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-spinner': 'true' }),
+}));
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
+    createElement('button', { onClick: onPress }, title),
+}));
+vi.mock('../../ListRow', () => ({
+  ListRow: ({ title, subtitle, trailing }: { title: string; subtitle?: string; trailing?: ReactNode }) =>
+    createElement(
+      'div',
+      null,
+      createElement('span', null, title),
+      subtitle ? createElement('span', null, subtitle) : null,
+      trailing,
+    ),
+}));
+vi.mock('../../SegmentedControl', () => ({
+  SegmentedControl: ({
+    options,
+    onSelect,
+  }: {
+    options: Array<{ key: string; label: string }>;
+    onSelect: (key: 'followers' | 'following' | 'search') => void;
+  }) =>
+    createElement(
+      'div',
+      null,
+      options.map((option) =>
+        createElement('button', { key: option.key, onClick: () => onSelect(option.key as never) }, option.label),
+      ),
+    ),
+}));
+
+vi.mock('../../../lib/graphql/hooks', () => ({
+  usePublicProfile: () => ({
+    data: { followerCount: 1, followingCount: 1 },
+    isRefetching: false,
+    refetch: vi.fn(),
+  }),
+  useFollowers: () => ({
+    data: { pages: [{ users: [follower], hasMore: false, totalCount: 1 }] },
+    isPending: false,
+    isRefetching: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    refetch: vi.fn(),
+    fetchNextPage: vi.fn(),
+  }),
+  useFollowing: () => ({
+    data: { pages: [{ users: [following], hasMore: false, totalCount: 1 }] },
+    isPending: false,
+    isRefetching: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    refetch: vi.fn(),
+    fetchNextPage: vi.fn(),
+  }),
+  useSearchUsers: (query: string) => {
+    social.latestSearchQuery = query;
+    return {
+      data: query.length >= 2 ? { pages: [{ results: [searchResult], hasMore: false, totalCount: 1 }] } : undefined,
+      isPending: false,
+      isRefetching: false,
+      isFetchingNextPage: false,
+      hasNextPage: false,
+      refetch: vi.fn(),
+      fetchNextPage: vi.fn(),
+    };
+  },
+  useToggleUserFollow: () => ({
+    mutate: social.mutate,
+    isPending: false,
+    variables: undefined,
+  }),
+}));
+
+import { SocialTab } from '../SocialTab';
+
+describe('SocialTab', () => {
+  beforeEach(() => {
+    social.mutate.mockReset();
+    social.latestSearchQuery = '';
+  });
+
+  it('shows follower rows by default', () => {
+    const { getByText } = render(<SocialTab userId="me" />);
+
+    expect(getByText('Ada Lovelace')).toBeTruthy();
+    expect(getByText('1 follower · 2 following')).toBeTruthy();
+  });
+
+  it('searches climbers and follows a result from the Find friends segment', () => {
+    const { getByText, getByPlaceholderText } = render(<SocialTab userId="me" />);
+
+    fireEvent.click(getByText('Find friends'));
+    expect(getByText('Type at least 2 characters to search climbers')).toBeTruthy();
+
+    fireEvent.change(getByPlaceholderText('Search climbers'), { target: { value: 'ma' } });
+
+    expect(social.latestSearchQuery).toBe('ma');
+    expect(getByText('Marco')).toBeTruthy();
+    expect(getByText('7 ascents this month')).toBeTruthy();
+
+    fireEvent.click(getByText('Follow'));
+    expect(social.mutate).toHaveBeenCalledWith({ userId: 'friend-1', isFollowedByMe: false });
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/social-tab.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/social-tab.test.tsx
@@ -1,11 +1,17 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { act, render, fireEvent } from '@testing-library/react';
 import { createElement, forwardRef, useImperativeHandle, type ReactNode } from 'react';
 
 const social = vi.hoisted(() => ({
   mutate: vi.fn(),
   latestSearchQuery: '',
+  publicProfileRefetch: vi.fn(),
+  followersRefetch: vi.fn(),
+  followingRefetch: vi.fn(),
+  searchRefetch: vi.fn(),
+  refresh: null as (() => void) | null,
+  searchError: false,
 }));
 
 const follower = {
@@ -58,6 +64,8 @@ vi.mock('react-i18next', () => ({
         'mobile.social.emptyFollowing': 'Not following anyone yet',
         'mobile.social.searchHint': 'Type at least 2 characters to search climbers',
         'mobile.social.emptySearch': 'No climbers found',
+        'mobile.social.loadError': "Couldn't load climbers",
+        'mobile.social.retry': 'Try again',
       };
       if (key === 'mobile.social.followerCount') return `${count} follower${count === 1 ? '' : 's'}`;
       if (key === 'mobile.social.followingCount') return `${count} following`;
@@ -92,7 +100,10 @@ vi.mock('react-native', () => ({
       placeholder,
       onChange: (event: { target: { value: string } }) => onChangeText?.(event.target.value),
     }),
-  RefreshControl: () => null,
+  RefreshControl: ({ onRefresh }: { onRefresh?: () => void }) => {
+    social.refresh = onRefresh ?? null;
+    return null;
+  },
   StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
 }));
 
@@ -102,12 +113,14 @@ vi.mock('@shopify/flash-list', () => ({
       {
         data,
         renderItem,
+        refreshControl,
         ListHeaderComponent,
         ListEmptyComponent,
         ListFooterComponent,
       }: {
         data?: unknown[];
         renderItem: (input: { item: unknown; index: number }) => ReactNode;
+        refreshControl?: ReactNode;
         ListHeaderComponent?: ReactNode;
         ListEmptyComponent?: ReactNode;
         ListFooterComponent?: ReactNode;
@@ -119,6 +132,7 @@ vi.mock('@shopify/flash-list', () => ({
         'div',
         null,
         ListHeaderComponent,
+        refreshControl,
         data?.length
           ? data.map((item, index) => createElement('div', { key: index }, renderItem({ item, index })))
           : ListEmptyComponent,
@@ -147,7 +161,7 @@ vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({
 }));
 vi.mock('../../../theme/tokens', () => ({
   spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 8: 32, 16: 64 },
-  borderRadius: { lg: 12 },
+  borderRadius: { lg: 12, full: 9999 },
 }));
 vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#999' } }));
 vi.mock('../../Text', () => ({
@@ -195,35 +209,41 @@ vi.mock('../../../lib/graphql/hooks', () => ({
   usePublicProfile: () => ({
     data: { followerCount: 1, followingCount: 1 },
     isRefetching: false,
-    refetch: vi.fn(),
+    refetch: social.publicProfileRefetch,
   }),
   useFollowers: () => ({
     data: { pages: [{ users: [follower], hasMore: false, totalCount: 1 }] },
     isPending: false,
+    isError: false,
     isRefetching: false,
     isFetchingNextPage: false,
     hasNextPage: false,
-    refetch: vi.fn(),
+    refetch: social.followersRefetch,
     fetchNextPage: vi.fn(),
   }),
   useFollowing: () => ({
     data: { pages: [{ users: [following], hasMore: false, totalCount: 1 }] },
     isPending: false,
+    isError: false,
     isRefetching: false,
     isFetchingNextPage: false,
     hasNextPage: false,
-    refetch: vi.fn(),
+    refetch: social.followingRefetch,
     fetchNextPage: vi.fn(),
   }),
   useSearchUsers: (query: string) => {
     social.latestSearchQuery = query;
     return {
-      data: query.length >= 2 ? { pages: [{ results: [searchResult], hasMore: false, totalCount: 1 }] } : undefined,
+      data:
+        query.length >= 2 && !social.searchError
+          ? { pages: [{ results: [searchResult], hasMore: false, totalCount: 1 }] }
+          : undefined,
       isPending: false,
+      isError: social.searchError,
       isRefetching: false,
       isFetchingNextPage: false,
       hasNextPage: false,
-      refetch: vi.fn(),
+      refetch: social.searchRefetch,
       fetchNextPage: vi.fn(),
     };
   },
@@ -238,8 +258,19 @@ import { SocialTab } from '../SocialTab';
 
 describe('SocialTab', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     social.mutate.mockReset();
     social.latestSearchQuery = '';
+    social.publicProfileRefetch.mockReset();
+    social.followersRefetch.mockReset();
+    social.followingRefetch.mockReset();
+    social.searchRefetch.mockReset();
+    social.refresh = null;
+    social.searchError = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('shows follower rows by default', () => {
@@ -249,13 +280,18 @@ describe('SocialTab', () => {
     expect(getByText('1 follower · 2 following')).toBeTruthy();
   });
 
-  it('searches climbers and follows a result from the Find friends segment', () => {
+  it('debounces climber search and follows a result from the Find friends segment', () => {
     const { getByText, getByPlaceholderText } = render(<SocialTab userId="me" />);
 
     fireEvent.click(getByText('Find friends'));
     expect(getByText('Type at least 2 characters to search climbers')).toBeTruthy();
 
     fireEvent.change(getByPlaceholderText('Search climbers'), { target: { value: 'ma' } });
+    expect(social.latestSearchQuery).toBe('');
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
 
     expect(social.latestSearchQuery).toBe('ma');
     expect(getByText('Marco')).toBeTruthy();
@@ -263,5 +299,36 @@ describe('SocialTab', () => {
 
     fireEvent.click(getByText('Follow'));
     expect(social.mutate).toHaveBeenCalledWith({ userId: 'friend-1', isFollowedByMe: false });
+  });
+
+  it('does not refetch disabled search queries on pull-to-refresh', () => {
+    const { getByText, getByPlaceholderText } = render(<SocialTab userId="me" />);
+
+    fireEvent.click(getByText('Find friends'));
+    fireEvent.change(getByPlaceholderText('Search climbers'), { target: { value: 'm' } });
+
+    act(() => {
+      social.refresh?.();
+    });
+
+    expect(social.publicProfileRefetch).toHaveBeenCalledOnce();
+    expect(social.searchRefetch).not.toHaveBeenCalled();
+  });
+
+  it('shows a retryable error state for failed searches', () => {
+    social.searchError = true;
+    const { getByText, getByPlaceholderText } = render(<SocialTab userId="me" />);
+
+    fireEvent.click(getByText('Find friends'));
+    fireEvent.change(getByPlaceholderText('Search climbers'), { target: { value: 'ma' } });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(getByText("Couldn't load climbers")).toBeTruthy();
+
+    fireEvent.click(getByText('Try again'));
+    expect(social.publicProfileRefetch).toHaveBeenCalledOnce();
+    expect(social.searchRefetch).toHaveBeenCalledOnce();
   });
 });

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -444,6 +444,16 @@ export {
   useSessionGroupedFeed,
 } from './use-you-data';
 export { useYouProfileData } from './use-you-profile-data';
-export { useVote, useBulkVoteSummaries, useComments, useAddComment } from './use-social';
+export {
+  usePublicProfile,
+  useFollowers,
+  useFollowing,
+  useSearchUsers,
+  useToggleUserFollow,
+  useVote,
+  useBulkVoteSummaries,
+  useComments,
+  useAddComment,
+} from './use-social';
 export { useSessionDetail, useSessionPreview } from './use-session-detail';
 export { useDeleteAccountInfo, useDeleteAccount } from './use-delete-account';

--- a/packages/mobile/src/lib/graphql/hooks/use-social.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-social.ts
@@ -1,18 +1,124 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   VOTE,
   GET_COMMENTS,
   ADD_COMMENT,
   GET_BULK_VOTE_SUMMARIES,
+  GET_PUBLIC_PROFILE,
+  GET_FOLLOWERS,
+  GET_FOLLOWING,
+  SEARCH_USERS,
+  FOLLOW_USER,
+  UNFOLLOW_USER,
   type VoteMutationResponse,
   type VoteMutationVariables,
   type GetCommentsQueryResponse,
   type AddCommentMutationResponse,
   type AddCommentMutationVariables,
   type GetBulkVoteSummariesQueryResponse,
+  type GetPublicProfileQueryResponse,
+  type GetFollowersQueryResponse,
+  type GetFollowingQueryResponse,
+  type SearchUsersQueryResponse,
+  type FollowUserMutationResponse,
+  type FollowUserMutationVariables,
+  type UnfollowUserMutationResponse,
+  type UnfollowUserMutationVariables,
 } from '@boardsesh/graphql/operations';
 import type { SocialEntityType } from '@boardsesh/shared-schema';
 import { getHttpClient } from '../client';
+
+const SOCIAL_PAGE_SIZE = 30;
+
+/** Public social profile for a user, including follower/following counts. */
+export function usePublicProfile(userId: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: ['publicProfile', userId],
+    queryFn: async () => {
+      const response = await getHttpClient().request<GetPublicProfileQueryResponse>(GET_PUBLIC_PROFILE, { userId });
+      return response.publicProfile;
+    },
+    enabled: enabled && !!userId,
+  });
+}
+
+/** Followers for a user profile, paginated by offset. */
+export function useFollowers(userId: string | undefined, enabled = true) {
+  return useInfiniteQuery({
+    queryKey: ['followers', userId],
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const response = await getHttpClient().request<GetFollowersQueryResponse>(GET_FOLLOWERS, {
+        input: { userId, limit: SOCIAL_PAGE_SIZE, offset: pageParam },
+      });
+      return response.followers;
+    },
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.hasMore ? allPages.reduce((sum, page) => sum + page.users.length, 0) : undefined,
+    enabled: enabled && !!userId,
+  });
+}
+
+/** Users a profile follows, paginated by offset. */
+export function useFollowing(userId: string | undefined, enabled = true) {
+  return useInfiniteQuery({
+    queryKey: ['following', userId],
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const response = await getHttpClient().request<GetFollowingQueryResponse>(GET_FOLLOWING, {
+        input: { userId, limit: SOCIAL_PAGE_SIZE, offset: pageParam },
+      });
+      return response.following;
+    },
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.hasMore ? allPages.reduce((sum, page) => sum + page.users.length, 0) : undefined,
+    enabled: enabled && !!userId,
+  });
+}
+
+/** Search Boardsesh users by display name. Disabled until the query has 2 chars. */
+export function useSearchUsers(query: string, enabled = true) {
+  const trimmedQuery = query.trim();
+
+  return useInfiniteQuery({
+    queryKey: ['searchUsers', trimmedQuery],
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const response = await getHttpClient().request<SearchUsersQueryResponse>(SEARCH_USERS, {
+        input: { query: trimmedQuery, limit: SOCIAL_PAGE_SIZE, offset: pageParam },
+      });
+      return response.searchUsers;
+    },
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.hasMore ? allPages.reduce((sum, page) => sum + page.results.length, 0) : undefined,
+    enabled: enabled && trimmedQuery.length >= 2,
+  });
+}
+
+export function useToggleUserFollow(currentUserId: string | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ userId, isFollowedByMe }: { userId: string; isFollowedByMe: boolean }) => {
+      if (isFollowedByMe) {
+        const variables: UnfollowUserMutationVariables = { input: { userId } };
+        const response = await getHttpClient().request<UnfollowUserMutationResponse>(UNFOLLOW_USER, variables);
+        return response.unfollowUser;
+      }
+
+      const variables: FollowUserMutationVariables = { input: { userId } };
+      const response = await getHttpClient().request<FollowUserMutationResponse>(FOLLOW_USER, variables);
+      return response.followUser;
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({ queryKey: ['publicProfile', variables.userId] });
+      if (currentUserId) void queryClient.invalidateQueries({ queryKey: ['publicProfile', currentUserId] });
+      void queryClient.invalidateQueries({ queryKey: ['followers'] });
+      void queryClient.invalidateQueries({ queryKey: ['following'] });
+      void queryClient.invalidateQueries({ queryKey: ['searchUsers'] });
+    },
+  });
+}
 
 /**
  * Cast a vote on a social entity (e.g. a session). Returns the updated

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -22,6 +22,7 @@ import type {
   SessionStatus,
   SessionFeedParticipant,
   SessionGradeDistributionItem,
+  UserSearchConnection,
 } from '@boardsesh/shared-schema';
 import type { SubscriptionQueueItem } from '../queue-conversion';
 
@@ -847,6 +848,35 @@ export type GetFollowingQueryVariables = {
 
 export type GetFollowingQueryResponse = {
   following: FollowConnection;
+};
+
+export const SEARCH_USERS = gql`
+  query SearchUsers($input: SearchUsersInput!) {
+    searchUsers(input: $input) {
+      results {
+        user {
+          id
+          displayName
+          avatarUrl
+          followerCount
+          followingCount
+          isFollowedByMe
+        }
+        recentAscentCount
+        matchReason
+      }
+      totalCount
+      hasMore
+    }
+  }
+`;
+
+export type SearchUsersQueryVariables = {
+  input: { query: string; boardType?: string; limit?: number; offset?: number };
+};
+
+export type SearchUsersQueryResponse = {
+  searchUsers: UserSearchConnection;
 };
 
 export const FOLLOW_USER = gql`

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -641,7 +641,6 @@
       "betaVideosDescription": "Only climbs with a beta video",
       "searchSetters": "Search setters",
       "noSetters": "No setters yet",
-      "cancel": "Cancel",
       "done": "Done",
       "clearAll": "Clear all"
     },

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -77,7 +77,6 @@
       "climbs": "Climbs",
       "climb": "Climb",
       "profile": "Profile",
-      "setters": "Setters",
       "holdFilter": "Hold types",
       "zoneFilter": "Board region"
     }

--- a/packages/shared/i18n/locales/en-US/you.json
+++ b/packages/shared/i18n/locales/en-US/you.json
@@ -16,7 +16,8 @@
   "tabs": {
     "progress": "Progress",
     "sessions": "Sessions",
-    "logbook": "Logbook"
+    "logbook": "Logbook",
+    "social": "Social"
   },
   "progress": {
     "title": "Progress"
@@ -43,6 +44,27 @@
     },
     "progress": {
       "empty": "Nothing logged yet — your stats show up once you start ticking climbs."
+    },
+    "social": {
+      "title": "Social",
+      "followers": "Followers",
+      "following": "Following",
+      "findFriends": "Find friends",
+      "searchPlaceholder": "Search climbers",
+      "clearSearch": "Clear search",
+      "you": "You",
+      "followAction": "Follow",
+      "followingAction": "Following",
+      "followerCount_one": "{{count}} follower",
+      "followerCount_other": "{{count}} followers",
+      "followingCount": "{{count}} following",
+      "recentAscents_one": "{{count}} ascent this month",
+      "recentAscents_other": "{{count}} ascents this month",
+      "emptyFollowers": "No followers yet",
+      "emptyFollowing": "Not following anyone yet",
+      "searchHint": "Type at least 2 characters to search climbers",
+      "emptySearch": "No climbers found",
+      "emptySearchBody": "No climbers match \"{{query}}\"."
     },
     "comments": {
       "title": "Comments",

--- a/packages/shared/i18n/locales/en-US/you.json
+++ b/packages/shared/i18n/locales/en-US/you.json
@@ -64,7 +64,9 @@
       "emptyFollowing": "Not following anyone yet",
       "searchHint": "Type at least 2 characters to search climbers",
       "emptySearch": "No climbers found",
-      "emptySearchBody": "No climbers match \"{{query}}\"."
+      "emptySearchBody": "No climbers match \"{{query}}\".",
+      "loadError": "Couldn't load climbers",
+      "retry": "Try again"
     },
     "comments": {
       "title": "Comments",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -641,7 +641,6 @@
       "betaVideosDescription": "Solo vías con un vídeo de beta",
       "searchSetters": "Buscar equipadores",
       "noSetters": "Sin equipadores",
-      "cancel": "Cancelar",
       "done": "Listo",
       "clearAll": "Borrar todo"
     },

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -275,7 +275,6 @@
       "climbs": "Bloques",
       "climb": "Bloque",
       "profile": "Perfil",
-      "setters": "Equipadores",
       "holdFilter": "Tipos de presa",
       "zoneFilter": "Zona del muro"
     }

--- a/packages/shared/i18n/locales/es/you.json
+++ b/packages/shared/i18n/locales/es/you.json
@@ -64,7 +64,9 @@
       "emptyFollowing": "Aún no sigues a nadie",
       "searchHint": "Escribe al menos 2 caracteres para buscar escaladores",
       "emptySearch": "No se encontraron escaladores",
-      "emptySearchBody": "Ningún escalador coincide con \"{{query}}\"."
+      "emptySearchBody": "Ningún escalador coincide con \"{{query}}\".",
+      "loadError": "No se pudieron cargar los escaladores",
+      "retry": "Inténtalo de nuevo"
     },
     "comments": {
       "title": "Comentarios",

--- a/packages/shared/i18n/locales/es/you.json
+++ b/packages/shared/i18n/locales/es/you.json
@@ -16,7 +16,8 @@
   "tabs": {
     "progress": "Progreso",
     "sessions": "Sesiones",
-    "logbook": "Historial"
+    "logbook": "Historial",
+    "social": "Social"
   },
   "progress": {
     "title": "Progreso"
@@ -43,6 +44,27 @@
     },
     "progress": {
       "empty": "Nada registrado todavía — tus estadísticas aparecen cuando empieces a registrar vías."
+    },
+    "social": {
+      "title": "Social",
+      "followers": "Seguidores",
+      "following": "Siguiendo",
+      "findFriends": "Buscar amigos",
+      "searchPlaceholder": "Buscar escaladores",
+      "clearSearch": "Limpiar búsqueda",
+      "you": "Tú",
+      "followAction": "Seguir",
+      "followingAction": "Siguiendo",
+      "followerCount_one": "{{count}} seguidor",
+      "followerCount_other": "{{count}} seguidores",
+      "followingCount": "{{count}} siguiendo",
+      "recentAscents_one": "{{count}} ascenso este mes",
+      "recentAscents_other": "{{count}} ascensos este mes",
+      "emptyFollowers": "Aún no tienes seguidores",
+      "emptyFollowing": "Aún no sigues a nadie",
+      "searchHint": "Escribe al menos 2 caracteres para buscar escaladores",
+      "emptySearch": "No se encontraron escaladores",
+      "emptySearchBody": "Ningún escalador coincide con \"{{query}}\"."
     },
     "comments": {
       "title": "Comentarios",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -641,7 +641,6 @@
       "betaVideosDescription": "Uniquement les voies avec une vidéo de beta",
       "searchSetters": "Rechercher des ouvreurs",
       "noSetters": "Aucun ouvreur",
-      "cancel": "Annuler",
       "done": "OK",
       "clearAll": "Tout effacer"
     },

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -77,7 +77,6 @@
       "climbs": "Blocs",
       "climb": "Bloc",
       "profile": "Profil",
-      "setters": "Ouvreurs",
       "holdFilter": "Types de prise",
       "zoneFilter": "Zone du mur"
     }

--- a/packages/shared/i18n/locales/fr/you.json
+++ b/packages/shared/i18n/locales/fr/you.json
@@ -16,7 +16,8 @@
   "tabs": {
     "progress": "Progression",
     "sessions": "Sessions",
-    "logbook": "Carnet"
+    "logbook": "Carnet",
+    "social": "Social"
   },
   "progress": {
     "title": "Progression"
@@ -43,6 +44,27 @@
     },
     "progress": {
       "empty": "Rien d'enregistré pour l'instant — tes stats apparaissent dès que tu coches des voies."
+    },
+    "social": {
+      "title": "Social",
+      "followers": "Abonnés",
+      "following": "Abonnements",
+      "findFriends": "Trouver des amis",
+      "searchPlaceholder": "Chercher des grimpeurs",
+      "clearSearch": "Effacer la recherche",
+      "you": "Vous",
+      "followAction": "Suivre",
+      "followingAction": "Suivi",
+      "followerCount_one": "{{count}} abonné",
+      "followerCount_other": "{{count}} abonnés",
+      "followingCount": "{{count}} abonnements",
+      "recentAscents_one": "{{count}} croix ce mois-ci",
+      "recentAscents_other": "{{count}} croix ce mois-ci",
+      "emptyFollowers": "Aucun abonné pour le moment",
+      "emptyFollowing": "Aucun abonnement pour le moment",
+      "searchHint": "Tape au moins 2 caractères pour chercher des grimpeurs",
+      "emptySearch": "Aucun grimpeur trouvé",
+      "emptySearchBody": "Aucun grimpeur ne correspond à \"{{query}}\"."
     },
     "comments": {
       "title": "Commentaires",

--- a/packages/shared/i18n/locales/fr/you.json
+++ b/packages/shared/i18n/locales/fr/you.json
@@ -64,7 +64,9 @@
       "emptyFollowing": "Aucun abonnement pour le moment",
       "searchHint": "Tape au moins 2 caractères pour chercher des grimpeurs",
       "emptySearch": "Aucun grimpeur trouvé",
-      "emptySearchBody": "Aucun grimpeur ne correspond à \"{{query}}\"."
+      "emptySearchBody": "Aucun grimpeur ne correspond à \"{{query}}\".",
+      "loadError": "Impossible de charger les grimpeurs",
+      "retry": "Réessaie"
     },
     "comments": {
       "title": "Commentaires",


### PR DESCRIPTION
## Summary

Fixes #2753.

Adds a Social segment to the React Native Profile tab so signed-in users can view followers, view following, and search for climbers directly from the profile surface.

## What changed

- Added mobile GraphQL operations/hooks for `publicProfile`, `followers`, `following`, `searchUsers`, and follow/unfollow toggling.
- Added `SocialTab` with follower/following counts, paginated people lists, debounced climber search, empty states, error/retry states, pull-to-refresh, and follow buttons.
- Extended the Profile tab chrome to include `Social` alongside Progress, Sessions, and Logbook.
- Hardened search refresh/fetch-more guards so stale debounced searches cannot refetch after the live query becomes too short.
- Added explicit follow/unfollow action labels, larger tap targets, typed GraphQL variables, and focused hook coverage for pagination, disabled short searches, mutations, and cache invalidation.
- Removed orphaned `you` namespace i18n keys that blocked the staged check.

## Root cause

The backend already exposed social profile, follower/following, and user-search operations, but the RN profile screen only surfaced Progress, Sessions, and Logbook. There was no mobile entry point for followers/following or friend search.

## Validation

- Rebased on latest `origin/main` (`3765d9563`).
- `vp test packages/mobile/src/components/you/__tests__/social-tab.test.tsx packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx packages/mobile/src/lib/graphql/hooks/__tests__/use-social.test.tsx` (3 files, 26 tests)
- `vp staged`
- `vp run typecheck:mobile` still fails on unrelated existing `@boardsesh/board-presence-react` resolution/type errors in board-presence files.
- Ran 3 code-review subagents after the rebase; findings were addressed in `7e7dcf520`.