### PR TITLE
fix(session): give boulder switching its own rate-limit headroom (#2763)

### DIFF
--- a/packages/backend/src/__tests__/apply-rate-limit.test.ts
+++ b/packages/backend/src/__tests__/apply-rate-limit.test.ts
@@ -4,16 +4,24 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { GraphQLError } from 'graphql';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
-import { applyRateLimit } from '../graphql/resolvers/shared/helpers';
+import { applyRateLimit, RATE_LIMIT_SESSION, RATE_LIMIT_PLAYBACK } from '../graphql/resolvers/shared/helpers';
+import { RateLimitError } from '../utils/rate-limiter';
 
-// Mock rate limiter utilities so we can inspect which keys are used
+// Mock rate limiter utilities so we can inspect which keys are used. Spread the
+// real module so the genuine RateLimitError class survives — applyRateLimit
+// branches on `error instanceof RateLimitError` to build the coded error.
 const mockCheckRateLimit = vi.fn();
 const mockCheckRateLimitRedis = vi.fn().mockResolvedValue(undefined);
 
-vi.mock('../utils/rate-limiter', () => ({
-  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
-}));
+vi.mock('../utils/rate-limiter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/rate-limiter')>();
+  return {
+    ...actual,
+    checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  };
+});
 
 vi.mock('../utils/redis-rate-limiter', () => ({
   checkRateLimitRedis: (...args: unknown[]) => mockCheckRateLimitRedis(...args),
@@ -105,5 +113,50 @@ describe('applyRateLimit key selection', () => {
 
     expect(mockCheckRateLimit).toHaveBeenCalledWith('ws-anon-456', 5);
     expect(mockCheckRateLimitRedis).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyRateLimit structured RATE_LIMITED error (#2763)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rethrows a coded GraphQLError carrying retryAfterSeconds when a bucket is exceeded', async () => {
+    mockCheckRateLimit.mockImplementationOnce(() => {
+      throw new RateLimitError(22);
+    });
+    const ctx: ConnectionContext = { connectionId: 'ws-1', isAuthenticated: true, userId: 'user-1' };
+
+    const error = await applyRateLimit(ctx, RATE_LIMIT_SESSION, 'session').catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(GraphQLError);
+    expect((error as GraphQLError).extensions).toMatchObject({
+      code: 'RATE_LIMITED',
+      operation: 'session',
+      retryAfterSeconds: 22,
+    });
+    // Message text is preserved for older clients that still string-match.
+    expect((error as GraphQLError).message).toMatch(/Rate limit exceeded/);
+  });
+
+  it('passes non-rate-limit errors through untouched', async () => {
+    const boom = new Error('redis exploded');
+    mockCheckRateLimit.mockImplementationOnce(() => {
+      throw boom;
+    });
+    const ctx: ConnectionContext = { connectionId: 'ws-2', isAuthenticated: false };
+
+    await expect(applyRateLimit(ctx, RATE_LIMIT_SESSION, 'session')).rejects.toBe(boom);
+  });
+
+  it('gives interactive session + playback traffic far more headroom than the 60/min default', () => {
+    // The crux of the fix: queue/wall mutations and playback no longer share the
+    // 60/min `default` bucket that a two-person session exhausted by switching.
+    expect(RATE_LIMIT_SESSION).toBeGreaterThan(60);
+    expect(RATE_LIMIT_PLAYBACK).toBeGreaterThanOrEqual(RATE_LIMIT_SESSION);
   });
 });

--- a/packages/backend/src/__tests__/rate-limiter.test.ts
+++ b/packages/backend/src/__tests__/rate-limiter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
-import { checkRateLimit, cleanupRateLimit, getRateLimitStatus } from '../utils/rate-limiter';
+import { checkRateLimit, cleanupRateLimit, getRateLimitStatus, RateLimitError } from '../utils/rate-limiter';
 
 describe('In-memory rate limiter', () => {
   beforeEach(() => {
@@ -45,6 +45,22 @@ describe('In-memory rate limiter', () => {
         expect.fail('should have thrown');
       } catch (err) {
         expect((err as Error).message).toMatch(/Try again in \d+ seconds/);
+      }
+    });
+
+    it('throws a RateLimitError carrying structured retryAfterSeconds (#2763)', () => {
+      for (let i = 0; i < 5; i++) {
+        checkRateLimit('test-conn', 5, 60_000);
+      }
+      // 10s elapsed of a 60s window → 50s remain.
+      vi.advanceTimersByTime(10_000);
+
+      try {
+        checkRateLimit('test-conn', 5, 60_000);
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(RateLimitError);
+        expect((err as RateLimitError).retryAfterSeconds).toBe(50);
       }
     });
 

--- a/packages/backend/src/__tests__/redis-rate-limiter.test.ts
+++ b/packages/backend/src/__tests__/redis-rate-limiter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { checkRateLimitRedis } from '../utils/redis-rate-limiter';
+import { RateLimitError } from '../utils/rate-limiter';
 
 // Use vi.hoisted() so mock variables are available when vi.mock factories run
 const { mockEval, mockIsRedisConnected, mockCheckRateLimit } = vi.hoisted(() => ({
@@ -19,9 +20,16 @@ vi.mock('../redis/client', () => ({
   },
 }));
 
-vi.mock('../utils/rate-limiter', () => ({
-  checkRateLimit: mockCheckRateLimit,
-}));
+// Spread the real module so the genuine RateLimitError class survives — both
+// checkRateLimitRedis (which throws it) and its catch (`instanceof RateLimitError`)
+// depend on the real class, not the mocked checkRateLimit.
+vi.mock('../utils/rate-limiter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/rate-limiter')>();
+  return {
+    ...actual,
+    checkRateLimit: mockCheckRateLimit,
+  };
+});
 
 describe('checkRateLimitRedis', () => {
   beforeEach(() => {
@@ -150,7 +158,9 @@ describe('checkRateLimitRedis', () => {
     });
 
     it('re-throws rate limit errors even when Redis has issues', async () => {
-      mockEval.mockRejectedValue(new Error('Rate limit exceeded. Try again in 30 seconds.'));
+      // A RateLimitError surfacing from the eval path must never be swallowed as
+      // a Redis failure — it's the throttle signal, detected by instanceof.
+      mockEval.mockRejectedValue(new RateLimitError(30));
 
       await expect(checkRateLimitRedis('user-1', 'vote', 30, 60_000)).rejects.toThrow('Rate limit exceeded');
     });

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -2,7 +2,16 @@ import type { ConnectionContext, ClimbQueueItem, QueueState } from '@boardsesh/s
 import { roomManager, VersionConflictError } from '../../../services/room-manager';
 import { pubsub } from '../../../pubsub/index';
 import { setCurrentClimbAndPublish } from '../../../services/queue-navigation';
-import { requireSession, applyRateLimit, validateInput, MAX_RETRIES } from '../shared/helpers';
+import {
+  requireSession,
+  applyRateLimit,
+  validateInput,
+  MAX_RETRIES,
+  RATE_LIMIT_SESSION,
+  RATE_LIMIT_SESSION_OP,
+  RATE_LIMIT_PLAYBACK,
+  RATE_LIMIT_PLAYBACK_OP,
+} from '../shared/helpers';
 import {
   ClimbQueueItemSchema,
   QueueIndexSchema,
@@ -26,7 +35,7 @@ export const queueMutations = {
     ctx: ConnectionContext,
   ) => {
     const startTime = performance.now();
-    await applyRateLimit(ctx); // Apply default rate limit
+    await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
     const sessionId = requireSession(ctx);
 
     // Validate input
@@ -123,7 +132,7 @@ export const queueMutations = {
    */
   removeQueueItem: async (_: unknown, { uuid }: { uuid: string }, ctx: ConnectionContext) => {
     const startTime = performance.now();
-    await applyRateLimit(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
     const sessionId = requireSession(ctx);
 
     // Validate input
@@ -160,7 +169,7 @@ export const queueMutations = {
     ctx: ConnectionContext,
   ) => {
     const startTime = performance.now();
-    await applyRateLimit(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
     const sessionId = requireSession(ctx);
 
     // Validate inputs
@@ -216,7 +225,7 @@ export const queueMutations = {
     ctx: ConnectionContext,
   ) => {
     const startTime = performance.now();
-    await applyRateLimit(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
     const sessionId = requireSession(ctx);
 
     // Validate input
@@ -267,7 +276,7 @@ export const queueMutations = {
    */
   mirrorCurrentClimb: async (_: unknown, { mirrored }: { mirrored: boolean }, ctx: ConnectionContext) => {
     const startTime = performance.now();
-    await applyRateLimit(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
     const sessionId = requireSession(ctx);
 
     const currentState = await roomManager.getQueueState(sessionId);
@@ -317,7 +326,7 @@ export const queueMutations = {
     ctx: ConnectionContext,
   ) => {
     const startTime = performance.now();
-    await applyRateLimit(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
     const sessionId = requireSession(ctx);
 
     // Validate input
@@ -432,7 +441,7 @@ export const queueMutations = {
     },
     ctx: ConnectionContext,
   ) => {
-    await applyRateLimit(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_PLAYBACK, RATE_LIMIT_PLAYBACK_OP);
     const sessionId = requireSession(ctx);
 
     const currentState = await roomManager.getQueueState(sessionId);

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -10,6 +10,8 @@ import {
   requireSessionMember,
   applyRateLimit,
   validateInput,
+  RATE_LIMIT_SESSION,
+  RATE_LIMIT_SESSION_OP,
 } from '../shared/helpers';
 import {
   SessionIdSchema,
@@ -405,7 +407,7 @@ export const sessionMutations = {
    * provided.
    */
   takeControl: async (_: unknown, { climb }: { climb?: ClimbQueueItem | null }, ctx: ConnectionContext) => {
-    await applyRateLimit(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
     const sessionId = requireSession(ctx);
     await requireSessionMember(ctx, sessionId);
     if (climb !== null && climb !== undefined) {
@@ -521,7 +523,7 @@ export const sessionMutations = {
    * `sessionId` argument.
    */
   setSessionBoardSerial: async (_: unknown, { serial }: { serial: string }, ctx: ConnectionContext) => {
-    await applyRateLimit(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
     // Session identity from the WebSocket context (WS-implicit pattern); no
     // sessionId argument.
     const sessionId = requireSession(ctx);
@@ -565,7 +567,7 @@ export const sessionMutations = {
    * WebSocket connection context — no `sessionId` argument.
    */
   setSessionBoardPath: async (_: unknown, { boardPath }: { boardPath: string }, ctx: ConnectionContext) => {
-    await applyRateLimit(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
     const sessionId = requireSession(ctx);
     validateInput(BoardPathSchema, boardPath, 'boardPath');
     await requireSessionMember(ctx, sessionId);
@@ -639,7 +641,7 @@ export const sessionMutations = {
    * only when the clear actually happened.
    */
   releaseControl: async (_: unknown, __: unknown, ctx: ConnectionContext) => {
-    await applyRateLimit(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
     const sessionId = requireSession(ctx);
     await requireSessionMember(ctx, sessionId);
 

--- a/packages/backend/src/graphql/resolvers/shared/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/shared/helpers.ts
@@ -1,5 +1,6 @@
 import type { ConnectionContext } from '@boardsesh/shared-schema';
-import { checkRateLimit } from '../../../utils/rate-limiter';
+import { GraphQLError } from 'graphql';
+import { checkRateLimit, RateLimitError } from '../../../utils/rate-limiter';
 import { checkRateLimitRedis } from '../../../utils/redis-rate-limiter';
 import { getContext } from '../../context';
 import { getDistributedState } from '../../../services/distributed-state';
@@ -28,6 +29,28 @@ export const SESSION_MEMBER_RETRY_CONFIG = {
   maxRetries: 8,
   initialDelayMs: 50,
 } as const;
+
+/**
+ * Per-user rate-limit ceilings (requests/minute) for interactive party-session
+ * traffic, on dedicated buckets separate from the shared `default` (60/min).
+ *
+ * Before #2763 every queue + wall-control mutation shared `default`, so a
+ * two-person session exhausted it just by switching boulders (each swipe fans
+ * out to ~2 mutations; the setCurrentClimb coalescer also fires addQueueItem
+ * for superseded swipes) — every subsequent action then failed for up to 60s,
+ * surfacing as "the connection fails every time we switch boulders".
+ *
+ * `RATE_LIMIT_SESSION` covers user-gesture-driven queue + wall-control
+ * mutations; `RATE_LIMIT_PLAYBACK` isolates the per-frame publishPlaybackState
+ * broadcast so a playing variable-speed climb can't starve climb switching.
+ * Both are well above any human gesture rate (with fan-out) yet still cap a
+ * runaway client. Mirrors the existing per-operation buckets for
+ * `confirmClimbOnWall` and `search-climbs`.
+ */
+export const RATE_LIMIT_SESSION_OP = 'session';
+export const RATE_LIMIT_SESSION = 240;
+export const RATE_LIMIT_PLAYBACK_OP = 'playback';
+export const RATE_LIMIT_PLAYBACK = 600;
 
 /**
  * Helper to require a session context.
@@ -168,11 +191,27 @@ export async function applyRateLimit(ctx: ConnectionContext, limit?: number, ope
   } else {
     key = ctx.connectionId;
   }
-  checkRateLimit(key, maxRequests);
 
-  // Tier 2: Distributed Redis rate limiting (authenticated users only)
-  if (ctx.isAuthenticated && ctx.userId) {
-    await checkRateLimitRedis(ctx.userId, operation, maxRequests, 60_000);
+  // Surface a structured RATE_LIMITED error (with retryAfterSeconds) so clients
+  // can branch on `extensions.code` instead of message-string matching, and the
+  // generic "Action failed" toast can be replaced with a specific, gentle
+  // message. Mirrors the CLIMB_IS_DUPLICATE extension pattern. The message text
+  // is preserved for older clients. See #2763.
+  try {
+    // Tier 1: Synchronous in-memory rate limiting (fast path, per-instance)
+    checkRateLimit(key, maxRequests);
+
+    // Tier 2: Distributed Redis rate limiting (authenticated users only)
+    if (ctx.isAuthenticated && ctx.userId) {
+      await checkRateLimitRedis(ctx.userId, operation, maxRequests, 60_000);
+    }
+  } catch (error) {
+    if (error instanceof RateLimitError) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: 'RATE_LIMITED', operation, retryAfterSeconds: error.retryAfterSeconds },
+      });
+    }
+    throw error;
   }
 }
 

--- a/packages/backend/src/utils/rate-limiter.ts
+++ b/packages/backend/src/utils/rate-limiter.ts
@@ -8,6 +8,22 @@ type RateLimitEntry = {
   resetAt: number;
 };
 
+/**
+ * Thrown when a caller exceeds its window. Carries `retryAfterSeconds` so the
+ * GraphQL layer (`applyRateLimit`) can surface a structured `RATE_LIMITED`
+ * error instead of forcing clients to string-match the message. The message
+ * text is kept stable for older clients that still read it.
+ */
+export class RateLimitError extends Error {
+  readonly retryAfterSeconds: number;
+
+  constructor(retryAfterSeconds: number) {
+    super(`Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`);
+    this.name = 'RateLimitError';
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
 // Store rate limit state per connection
 const rateLimitMap = new Map<string, RateLimitEntry>();
 
@@ -42,7 +58,7 @@ export function checkRateLimit(
   // Check if limit exceeded
   if (entry.count >= maxRequests) {
     const retryAfterSeconds = Math.ceil((entry.resetAt - now) / 1000);
-    throw new Error(`Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`);
+    throw new RateLimitError(retryAfterSeconds);
   }
 
   // Increment counter

--- a/packages/backend/src/utils/redis-rate-limiter.ts
+++ b/packages/backend/src/utils/redis-rate-limiter.ts
@@ -1,5 +1,5 @@
 import { redisClientManager } from '../redis/client';
-import { checkRateLimit } from './rate-limiter';
+import { checkRateLimit, RateLimitError } from './rate-limiter';
 import { logger } from './logger';
 
 /**
@@ -51,11 +51,11 @@ export async function checkRateLimitRedis(
 
     if (count > maxRequests) {
       const retryAfterSeconds = Math.ceil((windowMs - (Date.now() % windowMs)) / 1000);
-      throw new Error(`Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`);
+      throw new RateLimitError(retryAfterSeconds);
     }
   } catch (err) {
     // If the error is our rate limit error, re-throw it
-    if (err instanceof Error && err.message.startsWith('Rate limit exceeded')) {
+    if (err instanceof RateLimitError) {
       throw err;
     }
     // Otherwise Redis failed — fall back to in-memory

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -4,6 +4,7 @@ import { createElement, useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import type { SessionStatus, SessionUser, UserBoard } from '@boardsesh/shared-schema';
+import { GraphQLOperationError } from '@boardsesh/graphql-client';
 
 const ws = vi.hoisted(() => {
   type WsEventName = 'connected' | 'closed';
@@ -123,7 +124,8 @@ vi.mock('expo-crypto', () => ({
   randomUUID: () => 'test-correlation-id',
 }));
 
-vi.mock('@boardsesh/graphql-client', () => ({
+vi.mock('@boardsesh/graphql-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/graphql-client')>()),
   execute: graph.execute,
 }));
 
@@ -707,6 +709,41 @@ describe('QueueProvider session update subscription', () => {
       expect(latestSnapshot?.state.queue.map((item) => item.uuid)).not.toContain('queue-fail');
     });
     expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+  });
+
+  it('shows the gentle rate-limit toast (not the generic failure) when takeControl is throttled (#2763)', async () => {
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const queueItem = makeQueueItem('queue-rl', 'climb-rl');
+    // The backend throttles interactive session mutations with this coded error
+    // when a burst (rapid boulder switching) trips a bucket.
+    const rateLimited = new GraphQLOperationError([
+      {
+        message: 'Rate limit exceeded. Try again in 22 seconds.',
+        extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 22 },
+      },
+    ]);
+    queueMutations.takeControl.mockRejectedValueOnce(rateLimited);
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+
+    await expect(snapshot.takeControl(queueItem)).rejects.toBe(rateLimited);
+
+    // Optimistic driver/climb still rolls back to match the server.
+    await waitFor(() => {
+      const latestSnapshot = snapshots.at(-1);
+      expect(latestSnapshot?.driverParticipantId).toBeNull();
+      expect(latestSnapshot?.state.currentClimbQueueItem).toBeNull();
+      expect(latestSnapshot?.state.queue.map((item) => item.uuid)).not.toContain('queue-rl');
+    });
+    // Specific, gentle copy instead of the alarming generic "Action failed".
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
   });
 
   it('preserves suggested playlist items when takeControl rollback restores the queue', async () => {

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -43,7 +43,7 @@ import {
 } from '@boardsesh/queue-runtime';
 import { useQueueMutations, type PublishPlaybackStateInput } from '@boardsesh/queue-react';
 import type { SessionSummary, SubscriptionQueueEvent, SessionUser, UserBoard } from '@boardsesh/shared-schema';
-import { execute } from '@boardsesh/graphql-client';
+import { execute, GraphQLOperationError, isRateLimitedExtension } from '@boardsesh/graphql-client';
 import { buildBoardPath, parseBoardPath } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { JOIN_SESSION, LEAVE_SESSION } from '@boardsesh/graphql/operations/queue-session';
@@ -88,6 +88,24 @@ export type StartSessionConfig = {
 };
 
 const JOIN_SESSION_RETRY_BACKOFF_MS = [1_000, 2_500, 5_000] as const;
+
+// A party-session queue/wall mutation that fails because the backend throttled
+// it (RATE_LIMITED) is transient — the optimistic state already applied and a
+// peer-resync or the next gesture reconciles. Show a specific, gentle "slow
+// down" message rather than the alarming generic "Action failed" toast (which
+// a beta tester read as "the connection fails every time we switch boulders",
+// #2763). Any other failure keeps the generic toast.
+function showQueueMutationErrorToast(
+  error: unknown,
+  t: (key: string) => string,
+  showToast: (message: string, variant: 'error') => void,
+): void {
+  if (error instanceof GraphQLOperationError && isRateLimitedExtension(error.extensions)) {
+    showToast(t('mobile.queue.rateLimited'), 'error');
+  } else {
+    showToast(t('mobile.queue.actionFailed'), 'error');
+  }
+}
 
 type QueueContextValue = {
   state: QueueState;
@@ -1202,7 +1220,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
           );
         }
         if (wallControlOperationRef.current === plan.operationId) {
-          showToast(t('mobile.queue.actionFailed'), 'error');
+          showQueueMutationErrorToast(error, t, showToast);
         }
         throw error;
       }
@@ -1251,7 +1269,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
           shouldOptimisticallyRelease: plan.shouldOptimisticallyRelease,
         })
       ) {
-        showToast(t('mobile.queue.actionFailed'), 'error');
+        showQueueMutationErrorToast(error, t, showToast);
       }
       throw error;
     }
@@ -1457,7 +1475,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         // to the pre-reorder order — that matches the server, which never applied
         // the move — and surface the failure.
         dispatch({ type: 'UPDATE_QUEUE', payload: { queue: previousQueue, currentClimbQueueItem: previousCurrent } });
-        showToast(t('mobile.queue.actionFailed'), 'error');
+        showQueueMutationErrorToast(error, t, showToast);
       });
     },
     [mutations, showToast, t],

--- a/packages/shared/graphql-client/src/errors.ts
+++ b/packages/shared/graphql-client/src/errors.ts
@@ -13,6 +13,8 @@ export type GraphQLErrorExtensions = {
   code?: string;
   existingClimbUuid?: string | null;
   existingClimbName?: string | null;
+  // Seconds until the rate-limit window resets (carried by RATE_LIMITED).
+  retryAfterSeconds?: number;
   [key: string]: unknown;
 };
 
@@ -27,6 +29,18 @@ export function isClimbDuplicateExtension(
   existingClimbName?: string | null;
 } {
   return extensions?.code === 'CLIMB_IS_DUPLICATE';
+}
+
+/**
+ * Type guard for the RATE_LIMITED extension shape. The backend throttles
+ * per-user, per-operation; when a burst trips a bucket the resolver rejects
+ * with this code so callers can show a specific "slow down" message and read
+ * `retryAfterSeconds` instead of swallowing it into a generic failure toast.
+ */
+export function isRateLimitedExtension(
+  extensions: GraphQLErrorExtensions | null | undefined,
+): extensions is GraphQLErrorExtensions & { code: 'RATE_LIMITED'; retryAfterSeconds?: number } {
+  return extensions?.code === 'RATE_LIMITED';
 }
 
 /**

--- a/packages/shared/graphql-client/src/index.ts
+++ b/packages/shared/graphql-client/src/index.ts
@@ -10,7 +10,7 @@ export {
 } from './constants';
 
 export type { GraphQLErrorExtensions } from './errors';
-export { GraphQLOperationError, isClimbDuplicateExtension } from './errors';
+export { GraphQLOperationError, isClimbDuplicateExtension, isRateLimitedExtension } from './errors';
 
 export { getOperationName } from './operation-name';
 

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -299,6 +299,7 @@
       "sessionCreateError": "Couldn't create session",
       "noBoardSelected": "Pick a board first",
       "actionFailed": "Action failed. Try again.",
+      "rateLimited": "Too many changes too fast. Give it a sec.",
       "endSession": "End session",
       "endSessionConfirm": "Are you sure you want to end this session?",
       "climbCount_one": "{{count}} climb",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -299,6 +299,7 @@
       "sessionCreateError": "No se pudo crear la sesión",
       "noBoardSelected": "Selecciona un board primero",
       "actionFailed": "Acción fallida. Inténtalo de nuevo.",
+      "rateLimited": "Demasiados cambios muy rápido. Espera un momento.",
       "endSession": "Terminar sesión",
       "endSessionConfirm": "¿Estás seguro de que quieres terminar esta sesión?",
       "climbCount_one": "{{count}} bloque",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -299,6 +299,7 @@
       "sessionCreateError": "Impossible de créer la session",
       "noBoardSelected": "Choisissez d'abord un board",
       "actionFailed": "Action échouée. Réessayez.",
+      "rateLimited": "Trop de changements trop vite. Attends un instant.",
       "endSession": "Terminer la session",
       "endSessionConfirm": "Êtes-vous sûr de vouloir terminer cette session ?",
       "climbCount_one": "{{count}} bloc",


### PR DESCRIPTION
## Problem

TestFlight tester (#2763): *"Me and my friend tried session, the connection fails everytime we try to switch boulders."* The screenshot shows the red **"Action failed. Try again."** toast on the play view.

It isn't a connection failure — it's **rate limiting**. Every interactive session mutation (`setCurrentClimb`, `addQueueItem`, `removeQueueItem`, `reorderQueueItem`, `mirrorCurrentClimb`, `takeControl`, `releaseControl`, **and per-frame `publishPlaybackState`**) shared the **60 req/min `default` bucket**. Active two-person play exhausts it just by switching boulders (each swipe fans out to ~2 mutations; the `setCurrentClimb` coalescer also fires `addQueueItem` for superseded swipes). Once tripped, *every* mutation fails for up to 60s, and the mobile client swallowed `Rate limit exceeded` into the generic "Action failed" toast.

Higher-churn ops (`confirmClimbOnWall`, `search-climbs`) were already given their own buckets; the queue/wall mutations never were.

### Confirmed in Sentry — `BOARDSESH-73`
`GraphQLOperationError: Rate limit exceeded. Try again in 22 seconds.`
- release **`com.boardsesh.app@2.0.0+100241`** (the exact build in the issue) · **iOS 26.5** · 3 users, 26 occurrences
- last occurrence **2026-06-11 13:48:40** — 66s before the tester submitted the screenshot
- breadcrumbs: bursts of POSTs to `ws.boardsesh.com/graphql`

## Fix

**Backend**
- Move queue + wall-control mutations to a dedicated `session` bucket (**240/min**) and `publishPlaybackState` to its own `playback` bucket (**600/min**) — mirroring the existing per-operation buckets. Anti-abuse limits (join/create/end session, `setQueue`) unchanged.
- `checkRateLimit`/`checkRateLimitRedis` throw a `RateLimitError` carrying `retryAfterSeconds`; `applyRateLimit` rethrows it as a coded `GraphQLError` (`extensions.code = 'RATE_LIMITED'`). Message text preserved for older clients.

**Mobile / shared**
- New `isRateLimitedExtension` guard in `@boardsesh/graphql-client` (mirrors `isClimbDuplicateExtension`).
- `takeControl` / `releaseControl` / `reorderQueue` now show a specific, gentle toast (`mobile.queue.rateLimited`, added to all locales) instead of the alarming generic "Action failed". Optimistic rollback unchanged.

## Verification
- Typecheck: backend, mobile, shared — all pass.
- Tests: backend rate-limiter / apply-rate-limit / redis-rate-limiter (structured error + bucket headroom), take-control / publish-playback / wall-confirm, mobile queue-provider suite (incl. a new "throttled `takeControl` shows the gentle toast, not the generic failure" test), i18n catalog parity — all green.
- `vp check` (format + lint) clean.

> Note: `BOARDSESH-74` ("Must be in a session", Android, different build) is a separate, lower-frequency issue — out of scope here.

Fixes #2763

🤖 Generated with [Claude Code](https://claude.com/claude-code)