### PR TITLE
[codex] fix mobile record session queue chrome

### DIFF
--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -476,11 +476,13 @@ export function InSessionView({
 
   const [isEnding, setIsEnding] = useState(false);
   // End moved to the top chrome's trailing slot, so the bottom edge keeps only the
-  // climb accessory + tab bar (no third glass band). The history list reserves the
-  // bottom offset so its last row clears them: Liquid Glass anchors to the raw
-  // safe-area inset (on iOS 26 it already includes the tab bar + accessory — see the
-  // on-device evidence in PreSessionView); Material uses the fixed-footer reserve.
-  const footerBottom = variant === 'material' ? bottomChrome.fixedFooterBottom : insets.bottom;
+  // global current-climb chrome + tab bar (no third glass band). NativeTabs/Liquid
+  // Glass anchors to the raw UIKit safe-area inset (on iOS 26 it already includes
+  // the tab bar + native accessory — see the on-device evidence in PreSessionView).
+  // When the native accessory is unavailable, the JS queue capsule still floats
+  // above that inset, so add only its reserve and avoid double-counting the tab bar.
+  const listBottomPadding =
+    variant === 'material' ? bottomChrome.fixedFooterBottom : insets.bottom + bottomChrome.jsQueueReserve;
 
   const handleConfirmEnd = useCallback(async () => {
     setIsEnding(true);
@@ -624,7 +626,7 @@ export function InSessionView({
       contentContainerStyle={{
         paddingHorizontal: spacing[4],
         paddingTop: listPaddingTop,
-        paddingBottom: footerBottom,
+        paddingBottom: listBottomPadding,
       }}
       scrollIndicatorInsets={{ top: showChrome ? chromeHeight : 0 }}
       showsVerticalScrollIndicator={false}

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
@@ -12,8 +12,13 @@ const list = vi.hoisted(() => ({
 const bottomChrome = vi.hoisted(() => ({
   metrics: {
     fixedFooterBottom: 88,
+    jsQueueReserve: 0,
     tabBarBottom: 50,
   },
+}));
+
+const theme = vi.hoisted(() => ({
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
 }));
 
 // Controllable endSession + a captured view of the EndSessionSheet props, so the
@@ -99,6 +104,7 @@ vi.mock('../../../Text', () => ({
 }));
 vi.mock('../../../../providers/theme-provider', () => ({
   useTheme: () => ({
+    variant: theme.variant,
     systemColors: {
       background: '#000',
       secondaryBackground: '#111',
@@ -150,7 +156,8 @@ import { InSessionView } from '../InSessionView';
 describe('InSessionView footer', () => {
   beforeEach(() => {
     list.contentContainerStyle = null;
-    bottomChrome.metrics = { fixedFooterBottom: 88, tabBarBottom: 50 };
+    bottomChrome.metrics = { fixedFooterBottom: 88, jsQueueReserve: 0, tabBarBottom: 50 };
+    theme.variant = 'liquidGlass';
     queue.endSession.mockReset();
     queue.endSession.mockResolvedValue(null);
     sheet.isEnding = false;
@@ -164,6 +171,25 @@ describe('InSessionView footer', () => {
     // safe-area inset (the native tab bar + climb accessory are already in it on the
     // Liquid Glass path) — no extra footer height.
     expect(list.contentContainerStyle?.paddingBottom).toBe(130);
+  });
+
+  it('adds the JS queue capsule reserve on Liquid Glass fallback devices', () => {
+    bottomChrome.metrics = { fixedFooterBottom: 196, jsQueueReserve: 66, tabBarBottom: 50 };
+
+    render(createElement(InSessionView));
+
+    // NativeTabs has already expanded the safe-area inset for the tab bar; the
+    // fallback JS current-climb capsule is the only extra chrome to reserve.
+    expect(list.contentContainerStyle?.paddingBottom).toBe(196);
+  });
+
+  it('uses the fixed-footer reserve for the Material active-context bar', () => {
+    theme.variant = 'material';
+    bottomChrome.metrics = { fixedFooterBottom: 88, jsQueueReserve: 48, tabBarBottom: 50 };
+
+    render(createElement(InSessionView));
+
+    expect(list.contentContainerStyle?.paddingBottom).toBe(88);
   });
 
   it('renders no in-session bottom action bar', () => {


### PR DESCRIPTION
Closes #2562.

## Summary

- Keep the global current-climb chrome as the single current climb + tick owner on the Record tab.
- Adjust `InSessionView` bottom padding so Liquid Glass fallback devices reserve the JS queue capsule without double-counting the NativeTabs safe-area/tab-bar inset.
- Add regression coverage for native Liquid Glass, fallback JS capsule, Material active-context bar, and the absence of an in-session bottom action bar.

## Validation

- `vp test run packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx`
- `vp check packages/mobile/src/components/session-screen/in-session/InSessionView.tsx packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx`
- `vp run typecheck:mobile`
- `vp run dev:mobile` started successfully with QA notes loaded from `.boardsesh/qa-notes.md`; Metro: `http://vibetunnel-2.tailedd9d5.ts.net:8082`

## Notes

- Full `vp check` currently fails on unrelated existing mainline formatting/lint issues outside this PR's files, so I kept fixes scoped to the issue files.