### PR TITLE
Fix mobile play drawer board render

### DIFF
--- a/packages/mobile/src/components/BoardImageNative.tsx
+++ b/packages/mobile/src/components/BoardImageNative.tsx
@@ -67,6 +67,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
     renderWidth,
   });
 
+  const allowDownscaling = renderWidth == null;
   const containerStyle: ViewStyle = {
     width: '100%',
     aspectRatio: boardWidth / boardHeight,
@@ -80,6 +81,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
         backgroundPaths={backgroundPaths}
         missingBackgroundCount={missingBackgroundCount}
         mirrored={mirrored}
+        allowDownscaling={allowDownscaling}
       />
     </View>
   );

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -22,6 +22,12 @@ type LayeredClimbImageProps = {
    */
   dimBackground?: boolean;
   recyclingKey?: string;
+  /**
+   * Passed through to expo-image. Full-size play-view renders use native-size
+   * sources and need downscaling to fit the board box; pre-sized thumbnails pass
+   * false because their sources already match the surface.
+   */
+  allowDownscaling?: boolean;
 };
 
 /**
@@ -43,6 +49,7 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
   mirrored,
   dimBackground,
   recyclingKey,
+  allowDownscaling = true,
 }: LayeredClimbImageProps) {
   return (
     <View style={[styles.stack, mirrored && styles.mirrored]}>
@@ -53,11 +60,7 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
           style={styles.layer}
           contentFit="contain"
           cachePolicy="memory-disk"
-          // Skip expo-image's main-thread downscale resample (the iOS app
-          // hang). Sources are already sized to the surface — thumb-variant
-          // backgrounds for the list, native-res for the play view — so
-          // there's nothing large to downscale; the CALayer scales to fit.
-          allowDownscaling={false}
+          allowDownscaling={allowDownscaling}
         />
       ))}
       {missingBackgroundCount > 0 &&
@@ -84,10 +87,7 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
           recyclingKey={recyclingKey}
           cachePolicy="memory-disk"
           transition={150}
-          // Overlay PNG is rasterized at the surface size (small for the
-          // list/accessory, native for play) so no main-thread downscale
-          // is needed — skip expo-image's resample.
-          allowDownscaling={false}
+          allowDownscaling={allowDownscaling}
         />
       )}
     </View>

--- a/packages/mobile/src/components/__tests__/board-image-native-downscaling.test.tsx
+++ b/packages/mobile/src/components/__tests__/board-image-native-downscaling.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type ViewProps = { children?: ReactNode };
+vi.mock('react-native', () => ({
+  View: ({ children }: ViewProps) => createElement('div', null, children),
+}));
+
+vi.mock('../../hooks/use-native-climb-render', () => ({
+  useNativeClimbRender: () => ({
+    overlayUri: 'file:///overlay.png',
+    backgroundPaths: ['/background.webp'],
+    missingBackgroundCount: 0,
+  }),
+}));
+
+type LayeredClimbImageProps = { allowDownscaling?: boolean };
+vi.mock('../LayeredClimbImage', () => ({
+  LayeredClimbImage: ({ allowDownscaling }: LayeredClimbImageProps) =>
+    createElement('div', {
+      'data-testid': 'layered-climb-image',
+      'data-allow-downscaling': String(allowDownscaling),
+    }),
+}));
+
+import { BoardImageNative } from '../BoardImageNative';
+
+const baseProps = {
+  frames: 'p1145r15',
+  boardName: 'kilter' as const,
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,20',
+  boardWidth: 1080,
+  boardHeight: 1920,
+};
+
+describe('BoardImageNative downscaling policy', () => {
+  it('allows downscaling for full-size play-view renders', () => {
+    const { getByTestId } = render(createElement(BoardImageNative, baseProps));
+
+    expect(getByTestId('layered-climb-image').getAttribute('data-allow-downscaling')).toBe('true');
+  });
+
+  it('disables downscaling when callers request a pre-sized renderWidth', () => {
+    const { getByTestId } = render(createElement(BoardImageNative, { ...baseProps, renderWidth: 400 }));
+
+    expect(getByTestId('layered-climb-image').getAttribute('data-allow-downscaling')).toBe('false');
+  });
+});

--- a/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type ViewProps = { children?: ReactNode };
+vi.mock('react-native', () => ({
+  View: ({ children }: ViewProps) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+type ImageProps = {
+  source?: { uri?: string };
+  allowDownscaling?: boolean;
+};
+vi.mock('expo-image', () => ({
+  Image: ({ source, allowDownscaling }: ImageProps) =>
+    createElement('img', {
+      'data-uri': source?.uri ?? '',
+      'data-allow-downscaling': String(allowDownscaling),
+    }),
+}));
+
+import { LayeredClimbImage } from '../LayeredClimbImage';
+
+function renderedImages(container: HTMLElement) {
+  return Array.from(container.querySelectorAll('img'));
+}
+
+describe('LayeredClimbImage', () => {
+  it('allows downscaling by default so full-size board renders can fit their box', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        backgroundPaths: ['/background.webp'],
+      }),
+    );
+
+    expect(renderedImages(container).map((image) => image.getAttribute('data-allow-downscaling'))).toEqual([
+      'true',
+      'true',
+    ]);
+  });
+
+  it('can disable downscaling for pre-sized thumbnail sources', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        backgroundPaths: ['/background.webp'],
+        allowDownscaling: false,
+      }),
+    );
+
+    expect(renderedImages(container).map((image) => image.getAttribute('data-allow-downscaling'))).toEqual([
+      'false',
+      'false',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Restore expo-image downscaling for full-size mobile play drawer board renders.
- Keep downscaling disabled for pre-sized thumbnail/accessory renders by deriving the policy from `renderWidth`.
- Add focused component coverage for the BoardImageNative -> LayeredClimbImage downscaling policy.

Closes #2755

## Validation
- `vp staged`
- `vp test run --project mobile --reporter=agent packages/mobile/src/components/__tests__/layered-climb-image.test.tsx packages/mobile/src/components/__tests__/board-image-native-downscaling.test.tsx`
- `vp run typecheck:mobile`
- `vp run test:mobile` (251 files, 1814 tests)
- `vp run check:mobile-bundle` (iOS 10.6 MB, Android 10.9 MB)
- `vp run check:mobile-patches`
- `vp run check:mobile-simulator` skipped: iOS simulator unavailable (`xcrun simctl` missing)
- `vp run mobile:screenshot` skipped: iOS simulator unavailable

## Manual QA
- Local QA notes written to `.boardsesh/qa-notes.md`.
- Metro started with `vp run dev:mobile -- --port 8094`: `http://marcos-macbook-pro-2-1.tailedd9d5.ts.net:8094`.
