### PR TITLE
[codex] Extract mobile queue climb carousel hook

### DIFF
--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -3,7 +3,7 @@
 // rows. Tap opens the PlayDrawer; horizontal swipe steps the queue (prev/next)
 // with the neighbouring climb peeking in. The pill's background adapts to the UI
 // variant (Liquid Glass / Material / fallback) via AccessoryBarSurface; the
-// swipe/peek/tap behaviour is shared with the native accessory via useQueueCarousel.
+// swipe/peek/tap behaviour is shared with the native accessory via useQueueClimbCarousel.
 
 import { useMemo, type ReactNode } from 'react';
 import { View, StyleSheet, type ColorValue } from 'react-native';
@@ -19,7 +19,7 @@ import { useTheme } from '../../providers/theme-provider';
 import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
 import { AccessoryBarSurface, type AccessoryBarSurfaceTreatment } from './AccessoryBarSurface';
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
-import { useQueueCarousel } from './use-queue-carousel';
+import { useQueueClimbCarousel } from './use-queue-climb-carousel';
 
 type ClimbLabelProps = {
   climb: Climb;
@@ -89,10 +89,9 @@ export function ClimbCapsule({
     previousItem,
     nextItem,
     canPeek,
-    handleNext,
-    handlePrevious,
     swipeAccessibilityActions,
-  } = useQueueCarousel();
+    onAccessibilityAction,
+  } = useQueueClimbCarousel();
 
   const currentClimb = currentItem?.climb ?? null;
   const previousClimb = previousItem?.climb ?? null;
@@ -147,10 +146,7 @@ export function ClimbCapsule({
           accessibilityRole="button"
           accessibilityLabel={currentClimb.name}
           accessibilityActions={swipeAccessibilityActions}
-          onAccessibilityAction={(event) => {
-            if (event.nativeEvent.actionName === 'next') handleNext();
-            else if (event.nativeEvent.actionName === 'previous') handlePrevious();
-          }}
+          onAccessibilityAction={onAccessibilityAction}
         >
           <Animated.View style={[styles.labelSlot, { right: labelRight }, currentLabelStyle]}>
             <ClimbLabel

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -10,7 +10,7 @@ import { glassSize } from '../../theme/layout';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { Text } from '../Text';
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
-import { useQueueCarousel } from './use-queue-carousel';
+import { useQueueClimbCarousel } from './use-queue-climb-carousel';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
 
 type AccessoryPlacement = 'regular' | 'inline';
@@ -68,7 +68,7 @@ function climbFromItem(item: ClimbQueueItem | null | undefined): Climb | null {
  * Content for the iOS 26 tab-bar bottom accessory (Liquid Glass variant only).
  * UIKit supplies the glass platter, so this stays bare: current climb + tick,
  * with the same swipe/peek carousel as the floating capsule (shared via
- * useQueueCarousel). Its plain grade + board thumbnail are tuned for the platter,
+ * useQueueClimbCarousel). Its plain grade + board thumbnail are tuned for the platter,
  * so they intentionally differ from the floating capsule's colorized grade.
  */
 export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryClimbRowProps) {
@@ -85,10 +85,9 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
     previousItem,
     nextItem,
     canPeek,
-    handleNext,
-    handlePrevious,
     swipeAccessibilityActions,
-  } = useQueueCarousel();
+    onAccessibilityAction,
+  } = useQueueClimbCarousel();
 
   const currentClimb = climbFromItem(currentItem);
   const previousClimb = climbFromItem(previousItem);
@@ -111,10 +110,7 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
           accessibilityRole="button"
           accessibilityLabel={currentClimb.name}
           accessibilityActions={swipeAccessibilityActions}
-          onAccessibilityAction={(event) => {
-            if (event.nativeEvent.actionName === 'next') handleNext();
-            else if (event.nativeEvent.actionName === 'previous') handlePrevious();
-          }}
+          onAccessibilityAction={onAccessibilityAction}
         >
           <Animated.View style={[styles.labelSlot, currentLabelStyle]}>
             <ClimbLabel

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -139,7 +139,7 @@ vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: queue.state, nextClimb: queue.nextClimb, previousClimb: queue.previousClimb }),
   usePlaylistSuggestionSource: () => null,
   // Default to driver (not preview-only); these tests encode the bar's wiring,
-  // not party gating — that is covered in use-queue-carousel.test.tsx.
+  // not party gating — that is covered in use-queue-climb-carousel.test.tsx.
   useIsPartyPreviewOnly: () => false,
 }));
 

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -188,7 +188,7 @@ vi.mock('../../../providers/queue-provider', () => ({
   }),
   usePlaylistSuggestionSource: () => null,
   // Default to driver (not preview-only); these tests encode the bar's wiring,
-  // not party gating — that is covered in use-queue-carousel.test.tsx.
+  // not party gating — that is covered in use-queue-climb-carousel.test.tsx.
   useIsPartyPreviewOnly: () => false,
 }));
 

--- a/packages/mobile/src/components/queue-control/__tests__/use-queue-climb-carousel.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-queue-climb-carousel.test.tsx
@@ -71,7 +71,9 @@ vi.mock('../../play-drawer/use-carousel-gesture', () => ({
 vi.mock('../../../hooks/use-reduce-motion', () => ({ useReduceMotion: () => false }));
 vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn(), hapticSelection: vi.fn() }));
 
-import { useQueueCarousel } from '../use-queue-carousel';
+import { useQueueClimbCarousel } from '../use-queue-climb-carousel';
+
+type AccessibilityActionHandler = ReturnType<typeof useQueueClimbCarousel>['onAccessibilityAction'];
 
 function makeItem(uuid: string): ClimbQueueItem {
   return {
@@ -92,7 +94,11 @@ function makeItem(uuid: string): ClimbQueueItem {
   };
 }
 
-describe('useQueueCarousel party-preview gating', () => {
+function makeAccessibilityAction(actionName: string): Parameters<AccessibilityActionHandler>[0] {
+  return { nativeEvent: { actionName } } as Parameters<AccessibilityActionHandler>[0];
+}
+
+describe('useQueueClimbCarousel party-preview gating', () => {
   beforeEach(() => {
     queue.nextClimb.mockClear();
     queue.previousClimb.mockClear();
@@ -106,7 +112,7 @@ describe('useQueueCarousel party-preview gating', () => {
   });
 
   it('drives the shared current climb when the user IS the driver (not preview-only)', () => {
-    const { result } = renderHook(() => useQueueCarousel());
+    const { result } = renderHook(() => useQueueClimbCarousel());
 
     result.current.handleNext();
     result.current.handlePrevious();
@@ -119,21 +125,34 @@ describe('useQueueCarousel party-preview gating', () => {
     expect(result.current.swipeAccessibilityActions.map((action) => action.name)).toEqual(['previous', 'next']);
   });
 
+  it('routes VoiceOver prev/next actions through the shared step handlers', () => {
+    const { result } = renderHook(() => useQueueClimbCarousel());
+
+    result.current.onAccessibilityAction(makeAccessibilityAction('next'));
+    result.current.onAccessibilityAction(makeAccessibilityAction('previous'));
+
+    expect(queue.nextClimb).toHaveBeenCalledTimes(1);
+    expect(queue.previousClimb).toHaveBeenCalledTimes(1);
+  });
+
   it('does NOT mutate the shared current climb when party preview-only (gesture path)', () => {
     queue.isPartyPreviewOnly = true;
-    const { result } = renderHook(() => useQueueCarousel());
+    const { result } = renderHook(() => useQueueClimbCarousel());
 
     result.current.handleNext();
     result.current.handlePrevious();
+    result.current.onAccessibilityAction(makeAccessibilityAction('next'));
+    result.current.onAccessibilityAction(makeAccessibilityAction('previous'));
 
-    // Non-driver: the bar swipe must not call into the session mutation path.
+    // Non-driver: neither the bar swipe nor the a11y actions can call into the
+    // shared-session mutation path.
     expect(queue.nextClimb).not.toHaveBeenCalled();
     expect(queue.previousClimb).not.toHaveBeenCalled();
   });
 
   it('disables swipe + a11y prev/next for a preview-only member', () => {
     queue.isPartyPreviewOnly = true;
-    const { result } = renderHook(() => useQueueCarousel());
+    const { result } = renderHook(() => useQueueClimbCarousel());
 
     // The exported flags that gate the swipe and the VoiceOver actions are off,
     // even though the underlying navigation reports next/previous are available.
@@ -144,15 +163,24 @@ describe('useQueueCarousel party-preview gating', () => {
 
   it('passes the gated swipe flags into the pan gesture (RNGH cannot commit a step)', () => {
     queue.isPartyPreviewOnly = true;
-    renderHook(() => useQueueCarousel());
+    renderHook(() => useQueueClimbCarousel());
 
     expect(gestureCalls.last?.canSwipeNext).toBe(false);
     expect(gestureCalls.last?.canSwipePrevious).toBe(false);
   });
 
+  it('accepts explicit viewport width and reduce-motion overrides', () => {
+    const { result } = renderHook(() => useQueueClimbCarousel(320, true));
+
+    expect(result.current.canPeek).toBe(true);
+    expect(gestureCalls.last?.boardWidth).toBe(320);
+    expect(gestureCalls.last?.enabled).toBe(true);
+    expect(gestureCalls.last?.reduceMotion).toBe(true);
+  });
+
   it('still surfaces the peek labels so a non-driver can SEE the next climb', () => {
     queue.isPartyPreviewOnly = true;
-    const { result } = renderHook(() => useQueueCarousel());
+    const { result } = renderHook(() => useQueueClimbCarousel());
 
     // Preview, not blackout: the next/previous peek items still render.
     expect(result.current.nextItem?.uuid).toBe('next');

--- a/packages/mobile/src/components/queue-control/use-queue-climb-carousel.ts
+++ b/packages/mobile/src/components/queue-control/use-queue-climb-carousel.ts
@@ -1,5 +1,5 @@
-import { useCallback, useMemo, useState } from 'react';
-import { type LayoutChangeEvent } from 'react-native';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type AccessibilityActionEvent, type AccessibilityActionInfo, type LayoutChangeEvent } from 'react-native';
 import { Gesture, type ComposedGesture } from 'react-native-gesture-handler';
 import { runOnJS, useAnimatedStyle, useSharedValue, type AnimatedStyle } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
@@ -11,8 +11,6 @@ import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { hapticLight, hapticSelection } from '../../lib/haptics';
 import { useCarouselGesture } from '../play-drawer/use-carousel-gesture';
 
-type AccessibilityAction = { name: string; label: string };
-
 /**
  * The shared "current climb" carousel behind the floating queue capsule
  * (`ClimbCapsule`) and the iOS 26 native bottom accessory
@@ -22,7 +20,7 @@ type AccessibilityAction = { name: string; label: string };
  * composition, peek animation, a11y actions) so the two presentational wrappers
  * keep only their own labels and chrome.
  */
-export type QueueCarousel = {
+export type QueueClimbCarousel = {
   /** Measure the swipe viewport so the peek offsets are width-relative. */
   onLayout: (event: LayoutChangeEvent) => void;
   /** Tap (open) ∪ swipe-up (open) ∪ horizontal pan (prev/next). */
@@ -41,10 +39,20 @@ export type QueueCarousel = {
   handleNext: () => void;
   handlePrevious: () => void;
   /** Prev/next exposed as a11y actions (swipe is invisible to VoiceOver). */
-  swipeAccessibilityActions: AccessibilityAction[];
+  swipeAccessibilityActions: AccessibilityActionInfo[];
+  /** Shared handler for the prev/next a11y actions. */
+  onAccessibilityAction: (event: AccessibilityActionEvent) => void;
 };
 
-export function useQueueCarousel(): QueueCarousel {
+type QueueClimbCarouselOptions = {
+  width?: number;
+  reduceMotion?: boolean;
+};
+
+export function useQueueClimbCarousel(
+  viewportWidthOrOptions?: number | QueueClimbCarouselOptions,
+  reduceMotionOverride?: boolean,
+): QueueClimbCarousel {
   const { state, nextClimb, previousClimb } = useQueue();
   const playlistSuggestionSource = usePlaylistSuggestionSource();
   // Party non-drivers may only preview — stepping the current climb is a
@@ -56,9 +64,17 @@ export function useQueueCarousel(): QueueCarousel {
   const isPartyPreviewOnly = useIsPartyPreviewOnly();
   const { openPlayDrawer } = useDrawerHost();
   const { t } = useTranslation('session');
-  const reduceMotion = useReduceMotion();
+  const systemReduceMotion = useReduceMotion();
 
-  const [width, setWidth] = useState(0);
+  const configuredWidth =
+    typeof viewportWidthOrOptions === 'number' ? viewportWidthOrOptions : viewportWidthOrOptions?.width;
+  const reduceMotion =
+    typeof viewportWidthOrOptions === 'object'
+      ? (viewportWidthOrOptions.reduceMotion ?? systemReduceMotion)
+      : (reduceMotionOverride ?? systemReduceMotion);
+
+  const [measuredWidth, setMeasuredWidth] = useState(0);
+  const width = configuredWidth ?? measuredWidth;
   // Mirror the measured viewport width into a shared value so the peek-offset
   // worklets read it on the UI thread instead of capturing the React-state
   // primitive. On Android's new architecture the derived-value worklet does not
@@ -67,6 +83,12 @@ export function useQueueCarousel(): QueueCarousel {
   // `boardWidthSV` in use-carousel-gesture.ts.
   const widthSV = useSharedValue(0);
   const { currentClimbQueueItem, queue } = state;
+
+  useEffect(() => {
+    if (configuredWidth != null) {
+      widthSV.value = configuredWidth;
+    }
+  }, [configuredWidth, widthSV]);
 
   // Suggestion-aware so the capsule carousel matches the play drawer: at the
   // queue tail of an active playlist, `nextItem` falls through to the next
@@ -151,10 +173,10 @@ export function useQueueCarousel(): QueueCarousel {
   const onLayout = useCallback(
     (event: LayoutChangeEvent) => {
       const measured = event.nativeEvent.layout.width;
-      setWidth(measured);
-      widthSV.value = measured;
+      setMeasuredWidth(measured);
+      widthSV.value = configuredWidth ?? measured;
     },
-    [widthSV],
+    [configuredWidth, widthSV],
   );
 
   const currentLabelStyle = useAnimatedStyle(() => ({ transform: [{ translateX: translateX.value }] }));
@@ -175,10 +197,23 @@ export function useQueueCarousel(): QueueCarousel {
     return { opacity: 1, transform: [{ translateX: Math.min(0, -widthSV.value + translateX.value) }] };
   });
 
-  const swipeAccessibilityActions: AccessibilityAction[] = [
+  const swipeAccessibilityActions: AccessibilityActionInfo[] = [
     ...(canPrevious ? [{ name: 'previous', label: t('mobile.queue.previousClimb') }] : []),
     ...(canNext ? [{ name: 'next', label: t('mobile.queue.nextClimb') }] : []),
   ];
+
+  const onAccessibilityAction = useCallback(
+    (event: AccessibilityActionEvent) => {
+      if (event.nativeEvent.actionName === 'next') {
+        handleNext();
+        return;
+      }
+      if (event.nativeEvent.actionName === 'previous') {
+        handlePrevious();
+      }
+    },
+    [handleNext, handlePrevious],
+  );
 
   return {
     onLayout,
@@ -195,5 +230,6 @@ export function useQueueCarousel(): QueueCarousel {
     handleNext,
     handlePrevious,
     swipeAccessibilityActions,
+    onAccessibilityAction,
   };
 }


### PR DESCRIPTION
## Summary

Closes #2566.

- Rename the shared queue-control carousel hook to `useQueueClimbCarousel` so its role is explicit.
- Move the shared VoiceOver prev/next action handler into the hook, leaving `ClimbCapsule` and `NativeAccessoryClimbRow` as presentational wrappers.
- Preserve the auto-measured call path while also supporting the issue-requested explicit `useQueueClimbCarousel(width, reduceMotion)` signature.

## Validation

- `vp test run --project mobile packages/mobile/src/components/queue-control/__tests__/use-queue-climb-carousel.test.tsx packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx --reporter=agent`
- `vp run typecheck:mobile`
- `vp run test:mobile`
- `vp run check:mobile-bundle`
- `vp run check:mobile-simulator` skipped: iOS simulator not available in this shell
- `vp run mobile:screenshot` skipped: iOS simulator not available in this shell
- `vp staged`

## Review notes

QA and code-review subagents both flagged the renamed hook/test files being untracked before staging; the final commit includes both renames explicitly. QA also flagged the literal `width, reduceMotion` hook signature, which is now supported.