### PR TITLE
[codex] Harden mobile play drawer board rendering

### DIFF
--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -44,8 +44,13 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
   dimBackground,
   recyclingKey,
 }: LayeredClimbImageProps) {
+  const shouldShowEmptyFallback = backgroundPaths.length === 0 && missingBackgroundCount === 0;
+
   return (
     <View style={[styles.stack, mirrored && styles.mirrored]}>
+      {shouldShowEmptyFallback && (
+        <View testID="layered-climb-image-empty-fallback" style={[styles.layer, styles.emptyLayer]} />
+      )}
       {backgroundPaths.map((path) => (
         <Image
           key={path}
@@ -116,7 +121,10 @@ const styles = StyleSheet.create({
   // so loud it looks like a crash. The whole point of the no-network
   // rule is that broken renders must be visible-broken.
   missingLayer: {
-    backgroundColor: 'rgba(120, 120, 128, 0.18)',
+    backgroundColor: 'rgba(120, 120, 128, 0.28)',
+  },
+  emptyLayer: {
+    backgroundColor: 'rgba(120, 120, 128, 0.28)',
   },
   // Subtle list-only board scrim. Tunable: drop dimBackground if the filled
   // hold style already separates the climb on a given board / in light mode.

--- a/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type ViewMockProps = { children?: ReactNode; testID?: string };
+
+vi.mock('react-native', () => ({
+  View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('expo-image', () => ({
+  Image: ({ source, testID }: { source: { uri: string }; testID?: string }) =>
+    createElement('img', { src: source.uri, 'data-testid': testID ?? 'expo-image' }),
+}));
+
+import { LayeredClimbImage } from '../LayeredClimbImage';
+
+describe('LayeredClimbImage', () => {
+  it('renders a visible backing layer when no image layer is available yet', () => {
+    const { container } = render(createElement(LayeredClimbImage, { overlayUri: null, backgroundPaths: [] }));
+
+    expect(container.querySelector('[data-testid="layered-climb-image-empty-fallback"]')).toBeTruthy();
+  });
+
+  it('keeps the backing layer behind an overlay when the background is unavailable', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, { overlayUri: 'file:///overlay.png', backgroundPaths: [] }),
+    );
+
+    expect(container.querySelector('[data-testid="layered-climb-image-empty-fallback"]')).toBeTruthy();
+    expect(container.querySelector('img[src="file:///overlay.png"]')).toBeTruthy();
+  });
+
+  it('does not render the empty backing layer when a real background path is present', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, { overlayUri: null, backgroundPaths: ['/bundled/kilter.webp'] }),
+    );
+
+    expect(container.querySelector('[data-testid="layered-climb-image-empty-fallback"]')).toBeNull();
+    expect(container.querySelector('img[src="file:///bundled/kilter.webp"]')).toBeTruthy();
+  });
+
+  it('lets missing-background placeholders own the fallback state', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, { overlayUri: null, backgroundPaths: [], missingBackgroundCount: 1 }),
+    );
+
+    expect(container.querySelector('[data-testid="layered-climb-image-empty-fallback"]')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/play-drawer/BoardRenderUnavailable.tsx
+++ b/packages/mobile/src/components/play-drawer/BoardRenderUnavailable.tsx
@@ -1,0 +1,54 @@
+import { memo, useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { reportError } from '../../lib/sentry';
+import { iosSystemColors } from '../../theme/ios-colors';
+
+type BoardRenderUnavailableProps = {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  climbUuid?: string | null;
+  climbName?: string | null;
+};
+
+export const BoardRenderUnavailable = memo(function BoardRenderUnavailable({
+  boardName,
+  layoutId,
+  sizeId,
+  setIds,
+  climbUuid,
+  climbName,
+}: BoardRenderUnavailableProps) {
+  useEffect(() => {
+    reportError(new Error('Play drawer board render data unavailable'), {
+      tags: {
+        feature: 'mobile_play_drawer',
+        boardName,
+      },
+      extra: {
+        layoutId,
+        sizeId,
+        setIds,
+        climbUuid,
+        climbName,
+      },
+    });
+  }, [boardName, climbName, climbUuid, layoutId, setIds, sizeId]);
+
+  return (
+    <View
+      testID="play-drawer-board-unavailable"
+      style={styles.container}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    />
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: `${iosSystemColors.systemGray}33`,
+  },
+});

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -17,6 +17,7 @@ import { climbToQueueItem } from '../../lib/climb-to-queue-item';
 import type { ActiveSubDrawer } from '@boardsesh/play-view';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { DeferredBoard } from './DeferredBoard';
+import { BoardRenderUnavailable } from './BoardRenderUnavailable';
 import { PlaybackControls } from './PlaybackControls';
 import { useMobilePlayback } from './use-mobile-playback';
 import { PlayDrawerHeader } from './PlayDrawerHeader';
@@ -807,7 +808,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
                 />
 
                 <View style={styles.boardSection}>
-                  {boardRenderData && (
+                  {boardRenderData ? (
                     <DeferredBoard
                       open={isSheetOpen}
                       boardName={boardName as BoardName}
@@ -826,6 +827,15 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
                       onSwipePrevious={handlePrev}
                       onResetZoomReady={handleResetZoomReady}
                       enabled={!isTickBarActive}
+                    />
+                  ) : (
+                    <BoardRenderUnavailable
+                      boardName={boardName}
+                      layoutId={layoutId}
+                      sizeId={sizeId}
+                      setIds={setIds}
+                      climbUuid={displayedClimb.uuid}
+                      climbName={displayedClimb.name}
                     />
                   )}
                 </View>

--- a/packages/mobile/src/components/play-drawer/__tests__/board-render-unavailable.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/board-render-unavailable.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const reportError = vi.hoisted(() => vi.fn());
+
+type ViewMockProps = { children?: ReactNode; testID?: string };
+
+vi.mock('react-native', () => ({
+  View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('../../../lib/sentry', () => ({
+  reportError,
+}));
+
+vi.mock('../../../theme/ios-colors', () => ({
+  iosSystemColors: {
+    systemGray: '#8E8E93',
+  },
+}));
+
+import { BoardRenderUnavailable } from '../BoardRenderUnavailable';
+
+describe('BoardRenderUnavailable', () => {
+  beforeEach(() => {
+    reportError.mockClear();
+  });
+
+  it('renders a visible board-slot fallback and reports board context', () => {
+    const { container } = render(
+      createElement(BoardRenderUnavailable, {
+        boardName: 'kilter',
+        layoutId: 8,
+        sizeId: 17,
+        setIds: '26',
+        climbUuid: '1AFD857976594253A2D9ACB0B06B6360',
+        climbName: 'orbit',
+      }),
+    );
+
+    expect(container.querySelector('[data-testid="play-drawer-board-unavailable"]')).toBeTruthy();
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
+      tags: {
+        feature: 'mobile_play_drawer',
+        boardName: 'kilter',
+      },
+      extra: {
+        layoutId: 8,
+        sizeId: 17,
+        setIds: '26',
+        climbUuid: '1AFD857976594253A2D9ACB0B06B6360',
+        climbName: 'orbit',
+      },
+    });
+  });
+});

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -8,6 +8,7 @@ import {
   tryGetBackgroundPathsSync,
   type BackgroundVariant,
 } from '../lib/background-image-cache';
+import { reportError } from '../lib/sentry';
 
 /**
  * Bump when the Rust renderer output format changes. v2 marks the
@@ -598,6 +599,21 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
           `[useNativeClimbRender] render failed for ${currentCacheKey}:`,
           error instanceof Error ? error.message : String(error),
         );
+        reportError(error, {
+          tags: {
+            feature: 'mobile_board_renderer',
+            boardName,
+          },
+          extra: {
+            layoutId,
+            sizeId,
+            setIds,
+            filledStyle,
+            renderWidth,
+            framesLength: frames.length,
+            cacheKey: currentCacheKey,
+          },
+        });
       });
     // nativeRender is intentionally excluded from deps: this effect *sets* it,
     // and the only meaningful re-trigger is a cacheKey change.

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -641,7 +641,6 @@
       "betaVideosDescription": "Only climbs with a beta video",
       "searchSetters": "Search setters",
       "noSetters": "No setters yet",
-      "cancel": "Cancel",
       "done": "Done",
       "clearAll": "Clear all"
     },

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -77,7 +77,6 @@
       "climbs": "Climbs",
       "climb": "Climb",
       "profile": "Profile",
-      "setters": "Setters",
       "holdFilter": "Hold types",
       "zoneFilter": "Board region"
     }

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -641,7 +641,6 @@
       "betaVideosDescription": "Solo vías con un vídeo de beta",
       "searchSetters": "Buscar equipadores",
       "noSetters": "Sin equipadores",
-      "cancel": "Cancelar",
       "done": "Listo",
       "clearAll": "Borrar todo"
     },

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -275,7 +275,6 @@
       "climbs": "Bloques",
       "climb": "Bloque",
       "profile": "Perfil",
-      "setters": "Equipadores",
       "holdFilter": "Tipos de presa",
       "zoneFilter": "Zona del muro"
     }

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -641,7 +641,6 @@
       "betaVideosDescription": "Uniquement les voies avec une vidéo de beta",
       "searchSetters": "Rechercher des ouvreurs",
       "noSetters": "Aucun ouvreur",
-      "cancel": "Annuler",
       "done": "OK",
       "clearAll": "Tout effacer"
     },

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -77,7 +77,6 @@
       "climbs": "Blocs",
       "climb": "Bloc",
       "profile": "Profil",
-      "setters": "Ouvreurs",
       "holdFilter": "Types de prise",
       "zoneFilter": "Zone du mur"
     }


### PR DESCRIPTION
Fixes #2755

## Summary
- Add a visible board-slot fallback when the layered climb image has no background image available yet.
- Render a play-drawer fallback and report Sentry context when board render data is unavailable.
- Report native board renderer failures with board, layout, set, sizing, and cache context.
- Remove orphan mobile i18n keys that blocked the staged hook.

## Validation
- `vp run test:mobile -- layered-climb-image board-render-unavailable deferred-board use-native-climb-render background-image-cache board-renderer-shim` (full mobile suite: 251 files, 1815 tests)
- `vp run typecheck:mobile`
- `vp run check:mobile-bundle`
- `vp run check:i18n:orphans`
- `vp staged`

## QA
- Issue: TestFlight feedback screenshot showed Kilter climb `orbit` opening with a blank board area.
- Local Metro URL: http://marcos-macbook-pro-2-1.tailedd9d5.ts.net:8095
- QA notes: `.boardsesh/qa-notes.md`

## Notes
- Full `vp check` was also run, but it stopped on pre-existing formatting drift in unrelated files outside this PR scope.