### PR TITLE
Revive mobile anonymous-first browsing

### DIFF
--- a/packages/backend/src/__tests__/boards-serial-privacy.test.ts
+++ b/packages/backend/src/__tests__/boards-serial-privacy.test.ts
@@ -77,6 +77,15 @@ function setupDbSelect(rows: unknown[]) {
   mockDb.select.mockReturnValue({ from: mockFrom });
 }
 
+function setupDbSelectWithLimit(rows: unknown[]) {
+  const terminal = Object.assign(Promise.resolve(rows), {
+    limit: vi.fn().mockResolvedValue(rows),
+  });
+  const mockWhere = vi.fn().mockReturnValue(terminal);
+  const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+  mockDb.select.mockReturnValue({ from: mockFrom });
+}
+
 // Set up multiple sequential select calls (for enrichBoards which does many queries).
 // Each call to db.select().from()... resolves to the corresponding entry in `calls`.
 function setupDbSelectSequence(calls: unknown[][]) {
@@ -88,11 +97,12 @@ function setupDbSelectSequence(calls: unknown[][]) {
 
     // Build a chainable mock that supports .from().where(), .from().leftJoin().where(),
     // and .from().where().groupBy() — all resolving to `rows`.
+    const limitResult = Object.assign(Promise.resolve(rows), {
+      offset: vi.fn().mockResolvedValue(rows),
+    });
     const terminal = Object.assign(Promise.resolve(rows), {
       groupBy: vi.fn().mockResolvedValue(rows),
-      limit: vi.fn().mockImplementation(() => ({
-        offset: vi.fn().mockResolvedValue(rows),
-      })),
+      limit: vi.fn().mockReturnValue(limitResult),
     });
     const mockWhere = vi.fn().mockReturnValue(terminal);
     const mockLeftJoin = vi.fn().mockReturnValue({ where: mockWhere });
@@ -119,6 +129,111 @@ function setupDbLeftJoin(rows: unknown[]) {
   mockDb.select.mockReturnValue({ from: mockFrom });
   return { mockWhere, mockLeftJoin, mockFrom };
 }
+
+describe('direct board lookup privacy', () => {
+  const VALID_BOARD_UUID = '11111111-1111-4111-8111-111111111111';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null for defaultBoard when caller is anonymous and does no DB work', async () => {
+    const result = await socialBoardQueries.defaultBoard(null, {}, makeUnauthCtx());
+
+    expect(result).toBeNull();
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('returns null for private direct UUID lookup when caller is anonymous', async () => {
+    setupDbSelectWithLimit([makeDbBoard({ uuid: VALID_BOARD_UUID, isPublic: false, isUnlisted: false })]);
+
+    const result = await socialBoardQueries.board(null, { boardUuid: VALID_BOARD_UUID }, makeUnauthCtx());
+
+    expect(result).toBeNull();
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null for unlisted direct UUID lookup when caller is anonymous', async () => {
+    setupDbSelectWithLimit([makeDbBoard({ uuid: VALID_BOARD_UUID, isPublic: true, isUnlisted: true })]);
+
+    const result = await socialBoardQueries.board(null, { boardUuid: VALID_BOARD_UUID }, makeUnauthCtx());
+
+    expect(result).toBeNull();
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns public listed boards by UUID for anonymous callers', async () => {
+    const publicBoard = makeDbBoard({
+      uuid: VALID_BOARD_UUID,
+      isPublic: true,
+      isUnlisted: false,
+      name: 'Public Gym Board',
+      description: 'Open wall',
+      locationName: 'Downtown Gym',
+    });
+    setupDbSelectSequence([
+      [publicBoard],
+      [{ userId: 'owner-123', name: 'Owner', image: null, displayName: 'The Owner', avatarUrl: null }],
+      [{ totalAscents: 12, uniqueClimbers: 4 }],
+      [{ count: 3 }],
+      [{ count: 2 }],
+    ]);
+
+    const result = await socialBoardQueries.board(null, { boardUuid: VALID_BOARD_UUID }, makeUnauthCtx());
+
+    expect(result).toMatchObject({
+      uuid: VALID_BOARD_UUID,
+      name: 'Public Gym Board',
+      isPublic: true,
+      isUnlisted: false,
+      totalAscents: 12,
+      uniqueClimbers: 4,
+      followerCount: 3,
+      commentCount: 2,
+      isFollowedByMe: false,
+    });
+  });
+
+  it('returns null for private direct slug lookup when caller is anonymous', async () => {
+    setupDbSelectWithLimit([makeDbBoard({ slug: 'secret-board', isPublic: false, isUnlisted: false })]);
+
+    const result = await socialBoardQueries.boardBySlug(null, { slug: 'secret-board' }, makeUnauthCtx());
+
+    expect(result).toBeNull();
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null for unlisted direct slug lookup when caller is anonymous', async () => {
+    setupDbSelectWithLimit([makeDbBoard({ slug: 'hidden-board', isPublic: true, isUnlisted: true })]);
+
+    const result = await socialBoardQueries.boardBySlug(null, { slug: 'hidden-board' }, makeUnauthCtx());
+
+    expect(result).toBeNull();
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps authenticated direct UUID lookup behavior unchanged', async () => {
+    const privateBoard = makeDbBoard({ uuid: VALID_BOARD_UUID, isPublic: false, isUnlisted: true });
+    setupDbSelectSequence([
+      [privateBoard],
+      [{ userId: 'owner-123', name: 'Owner', image: null, displayName: 'The Owner', avatarUrl: null }],
+      [{ totalAscents: 1, uniqueClimbers: 1 }],
+      [{ count: 0 }],
+      [{ count: 0 }],
+      [{ count: 1 }],
+    ]);
+
+    const result = await socialBoardQueries.board(null, { boardUuid: VALID_BOARD_UUID }, makeAuthCtx('user-1'));
+
+    expect(result).toMatchObject({
+      uuid: VALID_BOARD_UUID,
+      name: 'Secret Home Wall',
+      isPublic: false,
+      isUnlisted: true,
+      isFollowedByMe: true,
+    });
+  });
+});
 
 describe('boardsBySerialNumbers privacy', () => {
   beforeEach(() => {

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -225,6 +225,10 @@ async function enrichBoard(
   };
 }
 
+function canReadBoardDirectly(board: typeof dbSchema.userBoards.$inferSelect, ctx: ConnectionContext): boolean {
+  return ctx.isAuthenticated || (board.isPublic && !board.isUnlisted);
+}
+
 /**
  * Batch-enrich multiple boards with computed fields using 6 total queries
  * instead of 6 per board. Used by list endpoints to avoid N+1.
@@ -621,10 +625,17 @@ export const socialBoardQueries = {
     const [board] = await db
       .select()
       .from(dbSchema.userBoards)
-      .where(and(eq(dbSchema.userBoards.uuid, boardUuid), isNull(dbSchema.userBoards.deletedAt)))
+      .where(
+        and(
+          eq(dbSchema.userBoards.uuid, boardUuid),
+          isNull(dbSchema.userBoards.deletedAt),
+          ...(ctx.isAuthenticated ? [] : [eq(dbSchema.userBoards.isPublic, true), eq(dbSchema.userBoards.isUnlisted, false)]),
+        ),
+      )
       .limit(1);
 
     if (!board) return null;
+    if (!canReadBoardDirectly(board, ctx)) return null;
     return enrichBoard(board, ctx.isAuthenticated ? ctx.userId : undefined);
   },
 
@@ -640,10 +651,17 @@ export const socialBoardQueries = {
     const [board] = await db
       .select()
       .from(dbSchema.userBoards)
-      .where(and(eq(dbSchema.userBoards.slug, slug), isNull(dbSchema.userBoards.deletedAt)))
+      .where(
+        and(
+          eq(dbSchema.userBoards.slug, slug),
+          isNull(dbSchema.userBoards.deletedAt),
+          ...(ctx.isAuthenticated ? [] : [eq(dbSchema.userBoards.isPublic, true), eq(dbSchema.userBoards.isUnlisted, false)]),
+        ),
+      )
       .limit(1);
 
     if (!board) return null;
+    if (!canReadBoardDirectly(board, ctx)) return null;
     return enrichBoard(board, ctx.isAuthenticated ? ctx.userId : undefined);
   },
 
@@ -1114,6 +1132,7 @@ export const socialBoardQueries = {
    * Get the user's default board
    */
   defaultBoard: async (_: unknown, _args: unknown, ctx: ConnectionContext) => {
+    if (!ctx.isAuthenticated) return null;
     requireAuthenticated(ctx);
     const userId = ctx.userId!;
 

--- a/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
+++ b/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
@@ -12,8 +12,10 @@ import { Icon } from '../../../src/components/Icon';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
 import { BoardImageNative } from '../../../src/components/BoardImageNative';
 import { LogAscentSheet } from '../../../src/components/LogAscentSheet';
+import { SignInPromptSheet } from '../../../src/components/SignInPromptSheet';
 import { useClimb, useToggleFavorite } from '../../../src/lib/graphql/hooks';
 import { useQueueSessionId, useQueueActions } from '../../../src/providers/queue-provider';
+import { useAuth } from '../../../src/providers/auth-provider';
 import { getBoardRenderData } from '../../../src/lib/board-details';
 import { hapticSuccess } from '../../../src/lib/haptics';
 import { track } from '../../../src/lib/analytics';
@@ -52,10 +54,12 @@ export default function ClimbDetail() {
 
   const { data: climb, isLoading } = useClimb(climbVariables);
   const toggleFavorite = useToggleFavorite();
+  const { isAuthenticated } = useAuth();
   const { sessionId } = useQueueSessionId();
   const { addToQueue } = useQueueActions();
   const { formatGrade } = useGradeFormat();
   const [showLogAscent, setShowLogAscent] = useState(false);
+  const [signInPromptVisible, setSignInPromptVisible] = useState(false);
 
   const boardDimensions = useMemo(() => {
     if (!boardName || !layoutId || !sizeId || !setIds) return null;
@@ -85,6 +89,10 @@ export default function ClimbDetail() {
 
   const handleToggleFavorite = useCallback(() => {
     if (!climb || !boardName) return;
+    if (!isAuthenticated) {
+      setSignInPromptVisible(true);
+      return;
+    }
     hapticSuccess();
     toggleFavorite.mutate({
       input: {
@@ -93,7 +101,15 @@ export default function ClimbDetail() {
         angle: Number(angle),
       },
     });
-  }, [climb, boardName, angle, toggleFavorite]);
+  }, [climb, boardName, angle, isAuthenticated, toggleFavorite]);
+
+  const handleLogAscentPress = useCallback(() => {
+    if (!isAuthenticated) {
+      setSignInPromptVisible(true);
+      return;
+    }
+    setShowLogAscent(true);
+  }, [isAuthenticated]);
 
   if (isLoading) {
     return (
@@ -244,7 +260,7 @@ export default function ClimbDetail() {
               icon="tick.outline"
               variant="outlined"
               size="medium"
-              onPress={() => setShowLogAscent(true)}
+              onPress={handleLogAscentPress}
               style={styles.secondaryButton}
             />
           </View>
@@ -268,6 +284,10 @@ export default function ClimbDetail() {
           consensusGradeName={climb.difficulty}
         />
       )}
+      <SignInPromptSheet
+        visible={signInPromptVisible}
+        onClose={() => setSignInPromptVisible(false)}
+      />
     </>
   );
 }

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -82,7 +82,7 @@ export default function DiscoverLibrary() {
   const insets = useSafeAreaInsets();
   const { isAuthenticated, isLoading: authLoading } = useAuth();
   const { data: token = null, isLoading: tokenLoading } = useAuthToken();
-  const { data: profile, isLoading: profileLoading } = useProfile();
+  const { data: profile, isLoading: profileLoading } = useProfile({ enabled: isAuthenticated });
   const { data: activeBoard, isLoading: activeBoardLoading } = useActiveBoard();
   const queryClient = useQueryClient();
 

--- a/packages/mobile/app/(tabs)/discover/smart/[type].tsx
+++ b/packages/mobile/app/(tabs)/discover/smart/[type].tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSmartPlaylist } from '@boardsesh/playlists-react';
 import {
@@ -11,6 +11,7 @@ import {
 } from '@boardsesh/graphql/operations/playlists';
 import { Text } from '../../../../src/components/Text';
 import { Icon } from '../../../../src/components/Icon';
+import { Button } from '../../../../src/components/Button';
 import { ClimbListRowSkeleton } from '../../../../src/components/ClimbListRowSkeleton';
 import {
   PlaylistDetailView,
@@ -25,6 +26,7 @@ import { toQueueClimbs } from '../../../../src/lib/climb-types';
 import { smartPlaylistByType } from '../../../../src/lib/smart-playlists';
 import { useProfile } from '../../../../src/lib/graphql/hooks';
 import { useAuthToken } from '../../../../src/lib/graphql/use-auth-token';
+import { useAuth } from '../../../../src/providers/auth-provider';
 import { iosSystemColors } from '../../../../src/theme/ios-colors';
 
 type SmartParams = {
@@ -33,8 +35,11 @@ type SmartParams = {
 
 export default function SmartPlaylistDetail() {
   const { type } = useLocalSearchParams<SmartParams>();
+  const router = useRouter();
   const { t } = useTranslation('playlists');
-  const { data: profile } = useProfile();
+  const { t: tCommon } = useTranslation('common');
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { data: profile } = useProfile({ enabled: isAuthenticated });
   const { isLoading: tokenLoading } = useAuthToken();
 
   const userId = profile?.id ?? '';
@@ -105,6 +110,22 @@ export default function SmartPlaylistDetail() {
         : undefined,
     [preset, t],
   );
+
+  if (!authLoading && !isAuthenticated) {
+    return (
+      <View style={styles.stateContainer}>
+        <PlaylistBackFab />
+        <Icon name="person" size={48} color={iosSystemColors.systemGray4} />
+        <Text variant="headline" style={styles.stateTitle}>
+          {tCommon('userDrawer.signInModalTitle')}
+        </Text>
+        <Text variant="subheadline" style={styles.stateSubtitle}>
+          {tCommon('userDrawer.signInModalDescription')}
+        </Text>
+        <Button title={tCommon('userDrawer.signIn')} onPress={() => router.push('/auth/login')} />
+      </View>
+    );
+  }
 
   if (!preset && !query.isLoading) {
     return (

--- a/packages/mobile/app/(tabs)/profile/index.tsx
+++ b/packages/mobile/app/(tabs)/profile/index.tsx
@@ -2,20 +2,30 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { View, StyleSheet, type NativeScrollEvent, type NativeSyntheticEvent } from 'react-native';
 import { useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import { useProfile, useYouProfileData } from '../../../src/lib/graphql/hooks';
+import { useAuth } from '../../../src/providers/auth-provider';
 import { useTheme } from '../../../src/providers/theme-provider';
+import { Icon } from '../../../src/components/Icon';
+import { Text } from '../../../src/components/Text';
+import { Button } from '../../../src/components/Button';
 import { ProfileTopChrome, type ProfileTabKey } from '../../../src/components/you/ProfileTopChrome';
 import { YouFilterSheet } from '../../../src/components/you/YouFilterSheet';
 import { ProgressTab } from '../../../src/components/you/ProgressTab';
 import { SessionsTab } from '../../../src/components/you/SessionsTab';
 import { LogbookTab } from '../../../src/components/you/LogbookTab';
+import { spacing } from '../../../src/theme/tokens';
 
 export default function YouScreen() {
   const { systemColors } = useTheme();
+  const router = useRouter();
+  const { t } = useTranslation('common');
+  const { isAuthenticated } = useAuth();
   const insets = useSafeAreaInsets();
 
-  const { data: profile } = useProfile();
+  const { data: profile } = useProfile({ enabled: isAuthenticated });
   const userId = profile?.id;
   const youData = useYouProfileData(userId);
 
@@ -73,6 +83,21 @@ export default function YouScreen() {
     filterSheetRef.current?.snapToIndex(0);
   }, []);
 
+  if (!isAuthenticated) {
+    return (
+      <View style={[styles.signInContainer, { backgroundColor: systemColors.background }]}>
+        <Icon name="person" size={48} color={systemColors.secondaryLabel} />
+        <Text variant="title3" style={styles.signInTitle}>
+          {t('userDrawer.signInModalTitle')}
+        </Text>
+        <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.signInDescription}>
+          {t('userDrawer.signInModalDescription')}
+        </Text>
+        <Button title={t('userDrawer.signIn')} onPress={() => router.push('/auth/login')} style={styles.signInButton} />
+      </View>
+    );
+  }
+
   return (
     <View style={[styles.container, { backgroundColor: systemColors.background }]}>
       <View style={styles.page}>
@@ -126,4 +151,21 @@ export default function YouScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   page: { flex: 1 },
+  signInContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing[6],
+  },
+  signInTitle: {
+    marginTop: spacing[3],
+    textAlign: 'center',
+  },
+  signInDescription: {
+    marginTop: spacing[2],
+    textAlign: 'center',
+  },
+  signInButton: {
+    marginTop: spacing[5],
+  },
 });

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -32,8 +32,8 @@ export default function MoreScreen() {
   const { t: tProfile } = useTranslation('profile');
   const { t: tPlaylists } = useTranslation('playlists');
   const { t: tSettings } = useTranslation('settings');
-  const { signOut } = useAuth();
-  const { data: profile } = useProfile();
+  const { signOut, isAuthenticated } = useAuth();
+  const { data: profile } = useProfile({ enabled: isAuthenticated });
   const { gradeFormat, setGradeFormat } = useGradeFormat();
   const glassCapable = useGlassCapability();
   const { localePreference, setLocalePreference } = useLocalePreference();
@@ -246,26 +246,40 @@ export default function MoreScreen() {
             {profile.email}
           </Text>
         ) : null}
-        <Pressable
-          style={[styles.signOut, { borderColor: systemColors.separator }]}
-          onPress={() => {
-            void signOut();
-          }}
-          accessibilityRole="button"
-        >
-          <Text variant="body" color={brandColors.error}>
-            {tProfile('mobile.signOut')}
-          </Text>
-        </Pressable>
-        <Pressable
-          style={styles.deleteAccount}
-          onPress={() => router.push('/(tabs)/profile/delete-account')}
-          accessibilityRole="button"
-        >
-          <Text variant="body" color={brandColors.error}>
-            {tSettings('deleteAccount.button')}
-          </Text>
-        </Pressable>
+        {isAuthenticated ? (
+          <>
+            <Pressable
+              style={[styles.signOut, { borderColor: systemColors.separator }]}
+              onPress={() => {
+                void signOut();
+              }}
+              accessibilityRole="button"
+            >
+              <Text variant="body" color={brandColors.error}>
+                {tProfile('mobile.signOut')}
+              </Text>
+            </Pressable>
+            <Pressable
+              style={styles.deleteAccount}
+              onPress={() => router.push('/(tabs)/profile/delete-account')}
+              accessibilityRole="button"
+            >
+              <Text variant="body" color={brandColors.error}>
+                {tSettings('deleteAccount.button')}
+              </Text>
+            </Pressable>
+          </>
+        ) : (
+          <Pressable
+            style={[styles.signOut, { borderColor: systemColors.separator }]}
+            onPress={() => router.push('/auth/login')}
+            accessibilityRole="button"
+          >
+            <Text variant="body" color={brandColors.primary}>
+              {t('userDrawer.signIn')}
+            </Text>
+          </Pressable>
+        )}
       </View>
     </ScrollView>
   );

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -18,7 +18,11 @@ import { BoardCarousel } from '../../src/components/board-discovery/BoardCarouse
 import { BoardModeCard, type ModeCardState } from '../../src/components/board-discovery/BoardModeCard';
 import { CustomBoardSheet, type BoardSeed } from '../../src/components/board-discovery/CustomBoardSheet';
 import { BluetoothQuickstartSheet } from '../../src/components/board-discovery/BluetoothQuickstartSheet';
-import { userBoardToItem, popularConfigToItem } from '../../src/components/board-discovery/board-items';
+import {
+  userBoardToItem,
+  popularConfigToItem,
+  popularItemToGuestBoard,
+} from '../../src/components/board-discovery/board-items';
 import type { DiscoveryBoardItem } from '../../src/components/board-discovery/BoardDiscoveryCard';
 import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
@@ -105,13 +109,16 @@ export default function BoardSelection() {
     [nearby?.boards, activeBoard?.uuid],
   );
   const popularItems = useMemo(
-    () => (popular?.configs ?? []).map(popularConfigToItem).filter((item): item is DiscoveryBoardItem => item !== null),
-    [popular?.configs],
+    () =>
+      (popular?.configs ?? [])
+        .map((config) => popularConfigToItem(config, activeBoard))
+        .filter((item): item is DiscoveryBoardItem => item !== null),
+    [popular?.configs, activeBoard],
   );
 
   // myBoards / nearby items carry the original UserBoard via uuid; look it up to
-  // activate. Popular/custom items have no UserBoard, so they go through the
-  // custom sheet (CREATE_BOARD) — see onSelectPopular.
+  // activate. Popular/custom configs synthesize a guest board when signed out,
+  // and persist or reuse a real board when signed in.
   const onSelectMyBoard = useCallback(
     (item: DiscoveryBoardItem) => {
       const board =
@@ -152,18 +159,25 @@ export default function BoardSelection() {
     [activateBoard],
   );
 
-  // A popular config has no UserBoard, so it routes through the custom builder
-  // (pre-seeded with the tapped config) which CREATEs it — or, if the user
-  // already owns that exact config, activates the existing board.
-  const onSelectPopular = useCallback((item: DiscoveryBoardItem) => {
-    setCustomSeed({
-      boardName: item.boardName,
-      layoutId: item.layoutId,
-      sizeId: item.sizeId,
-      setIds: item.setIds,
-    });
-    customSheetRef.current?.expand();
-  }, []);
+  // A popular config has no UserBoard. Guests get a local active board; signed-in
+  // users route through the pre-seeded builder so owned duplicates can be reused
+  // and new boards can be persisted.
+  const onSelectPopular = useCallback(
+    (item: DiscoveryBoardItem) => {
+      if (!isAuthenticated) {
+        void activateBoard(popularItemToGuestBoard(item));
+        return;
+      }
+      setCustomSeed({
+        boardName: item.boardName,
+        layoutId: item.layoutId,
+        sizeId: item.sizeId,
+        setIds: item.setIds,
+      });
+      customSheetRef.current?.expand();
+    },
+    [activateBoard, isAuthenticated],
+  );
 
   // Drive the Find Nearby card off both the location permission and the nearby
   // query: loading while resolving the fix or fetching, 'done' once results are
@@ -181,7 +195,7 @@ export default function BoardSelection() {
             ? 'unavailable'
             : 'idle';
 
-  if (isMyBoardsLoading) {
+  if (isAuthenticated && isMyBoardsLoading) {
     return (
       <View style={styles.centered}>
         <ActivityIndicator size="large" />
@@ -189,22 +203,7 @@ export default function BoardSelection() {
     );
   }
 
-  if (!isAuthenticated) {
-    return (
-      <ScrollView contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.centered}>
-        <Icon name="person" size={40} color={iosSystemColors.systemGray} />
-        <Text variant="headline" style={styles.stateTitle}>
-          {t('mobile.signInTitle')}
-        </Text>
-        <Text variant="subheadline" style={styles.stateSubtitle}>
-          {t('mobile.signInSubtitle')}
-        </Text>
-        <Button title={t('mobile.signInCta')} onPress={() => router.push('/auth/login')} style={styles.stateButton} />
-      </ScrollView>
-    );
-  }
-
-  if (isError) {
+  if (isAuthenticated && isError) {
     return (
       <ScrollView contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.centered}>
         <Icon name="error" size={40} color={iosSystemColors.systemRed} />
@@ -260,7 +259,7 @@ export default function BoardSelection() {
           </Section>
         ) : null}
 
-        {myBoardItems.length > 0 ? (
+        {isAuthenticated && myBoardItems.length > 0 ? (
           <Section title={t('mobile.discovery.yourBoardsTitle')}>
             <BoardCarousel items={myBoardItems} onSelect={onSelectMyBoard} />
           </Section>
@@ -272,7 +271,7 @@ export default function BoardSelection() {
           </Section>
         ) : null}
 
-        {myBoardItems.length === 0 && popularItems.length === 0 ? (
+        {nearbyItems.length === 0 && myBoardItems.length === 0 && popularItems.length === 0 ? (
           <View style={styles.emptyState}>
             <Text variant="headline" style={styles.emptyTitle}>
               {t('mobile.emptyTitle')}
@@ -290,6 +289,7 @@ export default function BoardSelection() {
         existingBoards={myBoards}
         onCreated={onCustomBoardResolved}
         onSelectExisting={onCustomBoardResolved}
+        isAuthenticated={isAuthenticated}
         onError={() => showToast(t('mobile.custom.createError'), 'error')}
       />
       <BluetoothQuickstartSheet

--- a/packages/mobile/app/share-beta.tsx
+++ b/packages/mobile/app/share-beta.tsx
@@ -40,7 +40,7 @@ export default function ShareBetaScreen() {
   const router = useRouter();
   const { isAuthenticated } = useAuth();
   const { showToast } = useToast();
-  const { data: profile } = useProfile();
+  const { data: profile } = useProfile({ enabled: isAuthenticated });
   const attach = useAttachBetaLink();
 
   // Best-effort: fetch the reel's thumbnail + caption so we can preview the post

--- a/packages/mobile/src/components/SignInPromptSheet.tsx
+++ b/packages/mobile/src/components/SignInPromptSheet.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { ModalSheet } from './ModalSheet';
+import { Icon } from './Icon';
+import { Text } from './Text';
+import { Button } from './Button';
+import { useTheme } from '../providers/theme-provider';
+import { spacing } from '../theme/tokens';
+
+type SignInPromptSheetProps = {
+  visible: boolean;
+  onClose: () => void;
+  title?: string;
+  description?: string;
+};
+
+export function SignInPromptSheet({ visible, onClose, title, description }: SignInPromptSheetProps) {
+  const router = useRouter();
+  const { t } = useTranslation('common');
+  const { systemColors, brandColors } = useTheme();
+  const sheetRef = useRef<BottomSheetModal>(null);
+  const isPresentedRef = useRef(false);
+
+  useEffect(() => {
+    if (visible && !isPresentedRef.current) {
+      sheetRef.current?.present();
+      isPresentedRef.current = true;
+    } else if (!visible && isPresentedRef.current) {
+      sheetRef.current?.dismiss();
+      isPresentedRef.current = false;
+    }
+  }, [visible]);
+
+  const handleDismiss = useCallback(() => {
+    isPresentedRef.current = false;
+    onClose();
+  }, [onClose]);
+
+  const handleSignIn = useCallback(() => {
+    onClose();
+    router.push('/auth/login');
+  }, [onClose, router]);
+
+  const copy = useMemo(
+    () => ({
+      title: title ?? t('userDrawer.signInModalTitle'),
+      description: description ?? t('userDrawer.signInModalDescription'),
+    }),
+    [description, t, title],
+  );
+
+  return (
+    <ModalSheet
+      ref={sheetRef}
+      snapPoints={['34%']}
+      onDismiss={handleDismiss}
+      enablePanDownToClose
+      contentContainerStyle={styles.content}
+    >
+      <View style={styles.content}>
+        <View style={[styles.iconCircle, { backgroundColor: systemColors.fill }]}>
+          <Icon name="person" size={24} color={brandColors.primary} />
+        </View>
+        <Text variant="title3" style={styles.title}>
+          {copy.title}
+        </Text>
+        <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.description}>
+          {copy.description}
+        </Text>
+        <Button title={t('userDrawer.signIn')} onPress={handleSignIn} size="large" style={styles.button} />
+      </View>
+    </ModalSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    alignItems: 'center',
+    paddingHorizontal: spacing[5],
+    paddingTop: spacing[4],
+    paddingBottom: spacing[6],
+  },
+  iconCircle: {
+    width: 52,
+    height: 52,
+    borderRadius: 26,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing[3],
+  },
+  title: {
+    textAlign: 'center',
+  },
+  description: {
+    textAlign: 'center',
+    marginTop: spacing[2],
+  },
+  button: {
+    alignSelf: 'stretch',
+    marginTop: spacing[5],
+  },
+});

--- a/packages/mobile/src/components/board-discovery/CustomBoardSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/CustomBoardSheet.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import type { BoardName, UserBoard } from '@boardsesh/shared-schema';
 import { SUPPORTED_BOARDS, ANGLES, normaliseSetIds } from '@boardsesh/board-config';
 import { useCreateBoard } from '../../lib/graphql/hooks';
+import { createGuestActiveBoard } from '../../lib/boards/guest-board';
 import {
   getBoardLayouts,
   getBoardSizesForLayoutId,
@@ -40,19 +41,19 @@ type CustomBoardSheetProps = {
   onCreated: (board: UserBoard) => void;
   /** The picked config matches a board the user already owns — activate it. */
   onSelectExisting: (board: UserBoard) => void;
+  isAuthenticated: boolean;
   onError: () => void;
 };
 
 /**
  * Custom-board builder: cascading board → layout → size → sets → angle, driven
  * entirely by static `@boardsesh/board-config` + `@boardsesh/board-constants`
- * data (no server query). Confirming persists the config via CREATE_BOARD —
- * the active board needs a real UserBoard (uuid/slug), matching the web flow —
- * unless the user already owns that exact config, in which case it activates
- * the existing board.
+ * data (no server query). Signed-in users persist the config via CREATE_BOARD
+ * unless they already own that exact config; guests get a local active board
+ * with a synthetic uuid so they can browse and drive a wall without an account.
  */
 export const CustomBoardSheet = forwardRef<BottomSheet, CustomBoardSheetProps>(function CustomBoardSheet(
-  { seed, existingBoards, onCreated, onSelectExisting, onError },
+  { seed, existingBoards, onCreated, onSelectExisting, isAuthenticated, onError },
   ref,
 ) {
   const { systemColors, brandColors: themeBrandColors } = useTheme();
@@ -121,7 +122,8 @@ export const CustomBoardSheet = forwardRef<BottomSheet, CustomBoardSheetProps>(f
     setSetIds((prev) => (prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]));
   };
 
-  const canCreate = layoutId != null && sizeId != null && setIds.length > 0 && !createBoard.isPending;
+  const canCreate =
+    layoutId != null && sizeId != null && setIds.length > 0 && (!isAuthenticated || !createBoard.isPending);
 
   const handleCreate = async () => {
     if (layoutId == null || sizeId == null || setIds.length === 0) return;
@@ -144,6 +146,27 @@ export const CustomBoardSheet = forwardRef<BottomSheet, CustomBoardSheetProps>(f
     }
 
     const layoutName = layouts.find((l) => l.id === layoutId)?.name ?? boardName;
+    const size = sizes.find((s) => s.id === sizeId);
+    const selectedSetIds = new Set(wireSetIds.split(','));
+    const setNames = sets.filter((set) => selectedSetIds.has(String(set.id))).map((set) => set.name);
+    if (!isAuthenticated) {
+      onCreated(
+        createGuestActiveBoard({
+          boardName,
+          layoutId,
+          sizeId,
+          setIds: wireSetIds,
+          angle,
+          displayName: layoutName,
+          layoutName,
+          sizeName: size?.name ?? null,
+          sizeDescription: size?.description ?? null,
+          setNames,
+        }),
+      );
+      return;
+    }
+
     try {
       const board = await createBoard.mutateAsync({
         boardType: boardName,
@@ -274,7 +297,7 @@ export const CustomBoardSheet = forwardRef<BottomSheet, CustomBoardSheetProps>(f
           variant="filled"
           size="large"
           disabled={!canCreate}
-          loading={createBoard.isPending}
+          loading={isAuthenticated && createBoard.isPending}
           style={styles.cta}
         />
       </ScrollView>

--- a/packages/mobile/src/components/board-discovery/__tests__/board-items.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-items.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
-import { userBoardToItem, popularConfigToItem, findOwnedBoardForConfig } from '../board-items';
+import { userBoardToItem, popularConfigToItem, popularItemToGuestBoard, findOwnedBoardForConfig } from '../board-items';
 
 const board = {
   uuid: 'b-1',
@@ -73,6 +73,37 @@ describe('popularConfigToItem', () => {
   it('drops a config whose board type is unsupported', () => {
     const bad = { ...config, boardType: 'xyz' } as unknown as PopularBoardConfig;
     expect(popularConfigToItem(bad)).toBeNull();
+  });
+
+  it('flags a popular config active when the active board matches the same tuple', () => {
+    const active = {
+      ...board,
+      uuid: 'guest-board:kilter:9:8:6,7',
+      boardType: 'tension',
+      layoutId: 9,
+      sizeId: 8,
+      setIds: '6,7',
+    } as unknown as UserBoard;
+    expect(popularConfigToItem(config, active)?.isActive).toBe(true);
+  });
+});
+
+describe('popularItemToGuestBoard', () => {
+  it('creates a local UserBoard for anonymous popular setup selection', () => {
+    const item = popularConfigToItem(config);
+    expect(item).not.toBeNull();
+    const guestBoard = popularItemToGuestBoard(item!);
+
+    expect(guestBoard).toMatchObject({
+      uuid: 'guest-board:tension:9:8:6,7',
+      boardType: 'tension',
+      layoutId: 9,
+      sizeId: 8,
+      setIds: '6,7',
+      name: 'Tension 8x10',
+      isOwned: false,
+      isPublic: true,
+    });
   });
 });
 

--- a/packages/mobile/src/components/board-discovery/board-items.ts
+++ b/packages/mobile/src/components/board-discovery/board-items.ts
@@ -2,8 +2,9 @@
 // single DiscoveryBoardItem the carousel renders. Keeps the screen free of
 // per-shape branching.
 
-import type { BoardName, UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
+import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import { toBoardName, normaliseSetIds } from '@boardsesh/board-config';
+import { createGuestActiveBoard } from '../../lib/boards/guest-board';
 import type { DiscoveryBoardItem } from './BoardDiscoveryCard';
 
 export function userBoardToItem(board: UserBoard, activeUuid?: string | null): DiscoveryBoardItem | null {
@@ -22,19 +23,42 @@ export function userBoardToItem(board: UserBoard, activeUuid?: string | null): D
   };
 }
 
-export function popularConfigToItem(config: PopularBoardConfig): DiscoveryBoardItem | null {
+export function popularConfigToItem(
+  config: PopularBoardConfig,
+  activeBoard?: UserBoard | null,
+): DiscoveryBoardItem | null {
   const boardName = toBoardName(config.boardType);
   if (boardName === null) return null;
+  const setIds = config.setIds.join(',');
   return {
     // Configs have no uuid — key on the config tuple.
     key: `popular:${config.boardType}:${config.layoutId}:${config.sizeId}:${config.setIds.join('-')}`,
     boardName,
     layoutId: config.layoutId,
     sizeId: config.sizeId,
-    setIds: config.setIds.join(','),
+    setIds,
     title: config.displayName,
     subtitle: config.sizeName ?? config.layoutName ?? config.boardType,
+    isActive:
+      activeBoard != null &&
+      boardMatchesConfig(activeBoard, {
+        boardType: config.boardType,
+        layoutId: config.layoutId,
+        sizeId: config.sizeId,
+        setIds,
+      }),
   };
+}
+
+export function popularItemToGuestBoard(item: DiscoveryBoardItem): UserBoard {
+  return createGuestActiveBoard({
+    boardName: item.boardName,
+    layoutId: item.layoutId,
+    sizeId: item.sizeId,
+    setIds: item.setIds,
+    displayName: item.title,
+    sizeName: item.subtitle,
+  });
 }
 
 /** A board config (the create/popular tuple), used to find an owned match. */
@@ -45,6 +69,15 @@ export type BoardConfigKey = {
   /** Comma-separated set ids, as stored on UserBoard. */
   setIds: string;
 };
+
+function boardMatchesConfig(board: UserBoard, config: BoardConfigKey): boolean {
+  return (
+    board.boardType === config.boardType &&
+    board.layoutId === config.layoutId &&
+    board.sizeId === config.sizeId &&
+    normaliseSetIds(board.setIds) === normaliseSetIds(config.setIds)
+  );
+}
 
 /**
  * The board the user already owns that exactly matches `config`, if any. Used to
@@ -58,11 +91,5 @@ export function findOwnedBoardForConfig(boards: UserBoard[], config: BoardConfig
   // order even for the user's own board. Without normalising, the match misses,
   // CREATE_BOARD fires, and the server inserts a near-duplicate UserBoard.
   const configSetIds = normaliseSetIds(config.setIds);
-  return boards.find(
-    (b) =>
-      b.boardType === config.boardType &&
-      b.layoutId === config.layoutId &&
-      b.sizeId === config.sizeId &&
-      normaliseSetIds(b.setIds) === configSetIds,
-  );
+  return boards.find((b) => boardMatchesConfig(b, { ...config, setIds: configSetIds }));
 }

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -97,7 +97,7 @@ export function useCreateClimbScreen({
   const { t } = useTranslation('climbs');
   const { isAuthenticated, saveClimb, updateClimb } = useBoardProvider();
   const auth = useAuth();
-  const { data: profile } = useProfile();
+  const { data: profile } = useProfile({ enabled: auth.isAuthenticated });
   const { setCurrentClimb } = useQueueActions();
   const bluetooth = useOptionalBluetoothContext();
   const { showToast } = useToast();

--- a/packages/mobile/src/components/onboarding/OnboardingGate.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingGate.tsx
@@ -3,6 +3,7 @@ import { router, useSegments } from 'expo-router';
 import * as Linking from 'expo-linking';
 import { hasSeenOnboarding } from '../../lib/onboarding/onboarding-storage';
 import { useProfile } from '../../lib/graphql/hooks';
+import { useAuth } from '../../providers/auth-provider';
 
 type OnboardingGateProps = {
   /** True once auth + fonts are resolved and the splash has hidden. */
@@ -20,9 +21,9 @@ const DEEP_LINK_SEGMENTS = new Set(['join', 'share-beta', 'session', 'auth', 'on
  * First-run gate. Once the app is ready (auth + fonts loaded, splash hidden) it
  * reads the persisted "seen" flag; if the walkthrough is unseen and the user
  * isn't mid deep-link / auth flow, it pushes the onboarding route once. Renders
- * nothing. Mounting it below AuthProvider means it only runs for an
- * authenticated session — an unauthenticated cold start is redirected to login
- * by the auth gate, and the walkthrough shows after they sign in.
+ * nothing. Guests can use the app anonymously, so the gate only evaluates after
+ * an authenticated profile resolves; signed-out users are left on their chosen
+ * route.
  *
  * The decision is keyed on the signed-in profile id, not the app process: on a
  * shared device a user can sign out and a different user sign in without a
@@ -30,6 +31,7 @@ const DEEP_LINK_SEGMENTS = new Set(['join', 'share-beta', 'session', 'auth', 'on
  */
 export function OnboardingGate({ ready }: OnboardingGateProps) {
   const segments = useSegments();
+  const { isAuthenticated } = useAuth();
   // Latest top-level segment for the async check, without re-running the effect
   // on every navigation — the gate decides once per app launch.
   const topSegmentRef = useRef<string | undefined>(segments[0]);
@@ -41,7 +43,7 @@ export function OnboardingGate({ ready }: OnboardingGateProps) {
   // relaunch; keying the decision on the profile id lets the new account get its
   // own first-run check. `undefined` while the profile loads — we only reset the
   // decision on a transition between two concrete ids.
-  const { data: profile } = useProfile();
+  const { data: profile } = useProfile({ enabled: isAuthenticated });
   const userId = profile?.id;
   const decidedForUserRef = useRef<string | undefined>(userId);
   if (userId !== undefined && userId !== decidedForUserRef.current) {
@@ -50,7 +52,7 @@ export function OnboardingGate({ ready }: OnboardingGateProps) {
   }
 
   useEffect(() => {
-    if (!ready || decidedRef.current) return;
+    if (!ready || !isAuthenticated || decidedRef.current) return;
     decidedRef.current = true;
 
     let cancelled = false;
@@ -87,7 +89,7 @@ export function OnboardingGate({ ready }: OnboardingGateProps) {
     };
     // `userId` is here so the effect re-runs after a sign-out/sign-in resets
     // `decidedRef` above — the new account gets its own first-run evaluation.
-  }, [ready, userId]);
+  }, [ready, isAuthenticated, userId]);
 
   return null;
 }

--- a/packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx
@@ -9,6 +9,7 @@ const getInitialURLMock = vi.hoisted(() => vi.fn());
 // Controllable signed-in profile: the gate keys its first-run decision on the
 // profile id, so tests drive sign-out/sign-in by swapping this id.
 const profileCtrl = vi.hoisted(() => ({ id: undefined as string | undefined }));
+const authCtrl = vi.hoisted(() => ({ isAuthenticated: true }));
 
 vi.mock('expo-router', () => ({
   router: { push: pushMock },
@@ -23,6 +24,9 @@ vi.mock('../../../lib/onboarding/onboarding-storage', () => ({
 vi.mock('../../../lib/graphql/hooks', () => ({
   useProfile: () => ({ data: profileCtrl.id ? { id: profileCtrl.id } : undefined }),
 }));
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: authCtrl.isAuthenticated }),
+}));
 
 import { OnboardingGate } from '../OnboardingGate';
 
@@ -35,11 +39,21 @@ describe('OnboardingGate', () => {
     getInitialURLMock.mockResolvedValue(null);
     segmentsCtrl.segments = ['(tabs)', 'climbs'];
     profileCtrl.id = undefined;
+    authCtrl.isAuthenticated = true;
   });
 
   it('does nothing until the app is ready', async () => {
     hasSeenMock.mockResolvedValue(false);
     render(<OnboardingGate ready={false} />);
+    await Promise.resolve();
+    expect(hasSeenMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing while signed out', async () => {
+    hasSeenMock.mockResolvedValue(false);
+    authCtrl.isAuthenticated = false;
+    render(<OnboardingGate ready />);
     await Promise.resolve();
     expect(hasSeenMock).not.toHaveBeenCalled();
     expect(pushMock).not.toHaveBeenCalled();

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -27,12 +27,14 @@ import { computeFirstScreenHeight } from './play-drawer-layout';
 import { AngleSelectorSheet } from './AngleSelectorSheet';
 import { ClimbActionsSheet } from '../ClimbActionsSheet';
 import { BleControlSheet } from '../ble/BleControlSheet';
+import { SignInPromptSheet } from '../SignInPromptSheet';
 import { disconnectAllBluetooth } from '../../lib/ble/bluetooth-status-store';
 import { GlassSheetBackground } from '../GlassSheetBackground';
 import { Icon } from '../Icon';
 import { useIsPartyPreviewOnly, usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useToast } from '../../providers/toast-provider';
+import { useAuth } from '../../providers/auth-provider';
 import { useToggleFavorite, useFavoriteStatus } from '../../lib/graphql/hooks';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useShareClimb } from '../../hooks/use-share-climb';
@@ -132,6 +134,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const [isTickBarActive, setIsTickBarActive] = useState(false);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [activeSubDrawer, setActiveSubDrawer] = useState<ActiveSubDrawer>('none');
+  const [signInPromptVisible, setSignInPromptVisible] = useState(false);
   const [bleControlOpen, setBleControlOpen] = useState(false);
   const [pendingClimbUuid, setPendingClimbUuid] = useState<string | null>(null);
   const [belowFoldContentRequested, setBelowFoldContentRequested] = useState(false);
@@ -161,6 +164,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   } = useQueue();
   const playlistSuggestionSource = usePlaylistSuggestionSource();
   const bluetooth = useOptionalBluetoothContext();
+  const { isAuthenticated } = useAuth();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
   const { formatGrade } = useGradeFormat();
 
@@ -201,7 +205,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   // on open, and a single tap can't invert reality (the previous always-false
   // local state silently un-favorited already-favorited climbs).
   const { data: serverFavorited } = useFavoriteStatus(boardName, displayedClimb?.uuid ?? null, angle, {
-    enabled: isSheetOpen,
+    enabled: isAuthenticated && isSheetOpen,
   });
   const isFavorited = favoriteOverride ?? serverFavorited ?? false;
   const lightbulbState = useMemo(
@@ -454,6 +458,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
 
   const handleToggleFavorite = useCallback(() => {
     if (!displayedClimb) return;
+    if (!isAuthenticated) {
+      setSignInPromptVisible(true);
+      return;
+    }
     hapticSuccess();
     const nextIsFavorited = !isFavorited;
     const previousOverride = favoriteOverride;
@@ -491,7 +499,18 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         },
       },
     );
-  }, [displayedClimb, isFavorited, favoriteOverride, boardName, layoutId, angle, toggleFavoriteMutate, showToast, t]);
+  }, [
+    displayedClimb,
+    isAuthenticated,
+    isFavorited,
+    favoriteOverride,
+    boardName,
+    layoutId,
+    angle,
+    toggleFavoriteMutate,
+    showToast,
+    t,
+  ]);
 
   const handleLightbulb = useCallback(() => {
     const pressAction = derivePlayDrawerLightbulbPressAction({
@@ -674,16 +693,24 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   }, []);
 
   const handleTickFabPress = useCallback(() => {
+    if (!isAuthenticated) {
+      setSignInPromptVisible(true);
+      return;
+    }
     resetZoomRef.current?.();
     setIsTickBarActive(true);
-  }, []);
+  }, [isAuthenticated]);
 
   // Long-press now opens the same QuickTickBar as a short press; LogAscentSheet
   // has been retired in favour of a single ticking surface (see PR #2366).
   const handleTickFabLongPress = useCallback(() => {
+    if (!isAuthenticated) {
+      setSignInPromptVisible(true);
+      return;
+    }
     resetZoomRef.current?.();
     setIsTickBarActive(true);
-  }, []);
+  }, [isAuthenticated]);
 
   const handleTickBarDismiss = useCallback(() => {
     setIsTickBarActive(false);
@@ -963,6 +990,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
           onClose={() => setBleControlOpen(false)}
         />
       )}
+      <SignInPromptSheet
+        visible={signInPromptVisible}
+        onClose={() => setSignInPromptVisible(false)}
+      />
     </>
   );
 });

--- a/packages/mobile/src/lib/__tests__/active-board-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/active-board-store.test.ts
@@ -59,6 +59,30 @@ describe('active-board-store', () => {
     await expect(getStoredActiveBoard()).resolves.toBeNull();
   });
 
+  it('clears authenticated active boards on signed-out launch', async () => {
+    const { getStoredActiveBoard, setStoredActiveBoard, clearStoredAuthenticatedActiveBoard } =
+      await import('../active-board-store');
+    await setStoredActiveBoard(board);
+    await clearStoredAuthenticatedActiveBoard();
+    await expect(getStoredActiveBoard()).resolves.toBeNull();
+  });
+
+  it('preserves guest active boards on signed-out launch', async () => {
+    const { getStoredActiveBoard, setStoredActiveBoard, clearStoredAuthenticatedActiveBoard } =
+      await import('../active-board-store');
+    const { createGuestActiveBoard } = await import('../boards/guest-board');
+    const guestBoard = createGuestActiveBoard({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 2,
+      setIds: '3,4',
+      displayName: 'Guest Kilter',
+    });
+    await setStoredActiveBoard(guestBoard);
+    await clearStoredAuthenticatedActiveBoard();
+    await expect(getStoredActiveBoard()).resolves.toEqual(guestBoard);
+  });
+
   it('overwrites a previously stored board on switch', async () => {
     const { getStoredActiveBoard, setStoredActiveBoard } = await import('../active-board-store');
     await setStoredActiveBoard(board);

--- a/packages/mobile/src/lib/active-board-store.ts
+++ b/packages/mobile/src/lib/active-board-store.ts
@@ -19,6 +19,7 @@
 
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { getPreference, setPreference, removePreference } from './preference-store';
+import { isGuestActiveBoard } from './boards/guest-board-id';
 
 const ACTIVE_BOARD_KEY = 'boardsesh_active_board_v2';
 
@@ -32,4 +33,10 @@ export function setStoredActiveBoard(board: UserBoard): Promise<void> {
 
 export function clearStoredActiveBoard(): Promise<void> {
   return removePreference(ACTIVE_BOARD_KEY);
+}
+
+export async function clearStoredAuthenticatedActiveBoard(): Promise<void> {
+  const activeBoard = await getStoredActiveBoard();
+  if (isGuestActiveBoard(activeBoard)) return;
+  await clearStoredActiveBoard();
 }

--- a/packages/mobile/src/lib/boards/__tests__/guest-board.test.ts
+++ b/packages/mobile/src/lib/boards/__tests__/guest-board.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { createGuestActiveBoard, GUEST_BOARD_UUID_PREFIX, isGuestActiveBoard } from '../guest-board';
+
+describe('guest active boards', () => {
+  it('builds a stable local UserBoard from a board config', () => {
+    const board = createGuestActiveBoard({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '4,2,4',
+      angle: 40,
+      displayName: 'Guest setup',
+    });
+
+    expect(board.uuid).toBe(`${GUEST_BOARD_UUID_PREFIX}kilter:1:10:2,4`);
+    expect(board.slug).toBe('guest-kilter-1-10-2-4');
+    expect(board.setIds).toBe('2,4');
+    expect(board.name).toBe('Guest setup');
+    expect(board.ownerId).toBe('');
+    expect(board.isOwned).toBe(false);
+    expect(board.serialNumber).toBeNull();
+    expect(isGuestActiveBoard(board)).toBe(true);
+  });
+
+  it('does not treat normal server boards as guest boards', () => {
+    expect(isGuestActiveBoard({ uuid: '11111111-1111-4111-8111-111111111111' })).toBe(false);
+    expect(isGuestActiveBoard(null)).toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/boards/guest-board-id.ts
+++ b/packages/mobile/src/lib/boards/guest-board-id.ts
@@ -1,0 +1,5 @@
+export const GUEST_BOARD_UUID_PREFIX = 'guest-board:';
+
+export function isGuestActiveBoard(board: { uuid?: string | null } | null | undefined): boolean {
+  return typeof board?.uuid === 'string' && board.uuid.startsWith(GUEST_BOARD_UUID_PREFIX);
+}

--- a/packages/mobile/src/lib/boards/guest-board.ts
+++ b/packages/mobile/src/lib/boards/guest-board.ts
@@ -1,0 +1,95 @@
+import type { BoardName, UserBoard } from '@boardsesh/shared-schema';
+import { ANGLES, normaliseSetIds } from '@boardsesh/board-config';
+import { getBoardLayouts, getBoardSetsForLayoutAndSize, getBoardSizesForLayoutId } from '../custom-board-options';
+import { GUEST_BOARD_UUID_PREFIX, isGuestActiveBoard } from './guest-board-id';
+
+export { GUEST_BOARD_UUID_PREFIX, isGuestActiveBoard };
+
+type GuestBoardInput = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle?: number;
+  displayName?: string | null;
+  layoutName?: string | null;
+  sizeName?: string | null;
+  sizeDescription?: string | null;
+  setNames?: string[] | null;
+  totalAscents?: number;
+};
+
+function resolveGuestAngle(boardName: BoardName, requestedAngle: number | undefined): number {
+  const supportedAngles = ANGLES[boardName] ?? [];
+  if (requestedAngle != null && supportedAngles.includes(requestedAngle)) return requestedAngle;
+  if (supportedAngles.includes(40)) return 40;
+  return supportedAngles[0] ?? 0;
+}
+
+function slugPart(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'board'
+  );
+}
+
+export function createGuestActiveBoard(input: GuestBoardInput): UserBoard {
+  const setIds = normaliseSetIds(input.setIds);
+  const selectedSetIds = new Set(setIds.split(','));
+  const layout = input.layoutName
+    ? null
+    : getBoardLayouts(input.boardName).find((candidate) => candidate.id === input.layoutId);
+  const size = input.sizeName
+    ? null
+    : getBoardSizesForLayoutId(input.boardName, input.layoutId).find((candidate) => candidate.id === input.sizeId);
+  const setNames =
+    input.setNames ??
+    getBoardSetsForLayoutAndSize(input.boardName, input.layoutId, input.sizeId)
+      .filter((set) => selectedSetIds.has(String(set.id)))
+      .map((set) => set.name);
+  const layoutName = input.layoutName ?? layout?.name ?? null;
+  const sizeName = input.sizeName ?? size?.name ?? null;
+  const sizeDescription = input.sizeDescription ?? size?.description ?? null;
+  const displayName = input.displayName?.trim() || layoutName || input.boardName;
+  const uuid = `${GUEST_BOARD_UUID_PREFIX}${input.boardName}:${input.layoutId}:${input.sizeId}:${setIds}`;
+
+  return {
+    uuid,
+    slug: `guest-${slugPart(input.boardName)}-${input.layoutId}-${input.sizeId}-${setIds.replace(/,/g, '-')}`,
+    ownerId: '',
+    ownerDisplayName: undefined,
+    ownerAvatarUrl: undefined,
+    boardType: input.boardName,
+    layoutId: input.layoutId,
+    sizeId: input.sizeId,
+    setIds,
+    name: displayName,
+    description: null,
+    locationName: null,
+    latitude: null,
+    longitude: null,
+    isPublic: true,
+    isUnlisted: false,
+    hideLocation: true,
+    isOwned: false,
+    angle: resolveGuestAngle(input.boardName, input.angle),
+    isAngleAdjustable: (ANGLES[input.boardName] ?? []).length > 1,
+    createdAt: '1970-01-01T00:00:00.000Z',
+    layoutName,
+    sizeName,
+    sizeDescription,
+    setNames,
+    totalAscents: input.totalAscents ?? 0,
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+    gymId: null,
+    gymUuid: null,
+    gymName: null,
+    distanceMeters: null,
+    serialNumber: null,
+  };
+}

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -4,13 +4,17 @@ import { renderHook, render, waitFor, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+const { routeSegments, redirectMock } = vi.hoisted(() => ({
+  routeSegments: { current: [] as string[] },
+  redirectMock: vi.fn((_props: { href: string }) => null),
+}));
+
 // expo-router and react-native both reach for the native runtime; stub the
-// thin surface AuthProvider consumes. `useSegments` returning `[]` keeps the
-// provider out of its `<Redirect>` branches so the child tree renders and the
-// auth context becomes readable.
+// thin surface AuthProvider consumes. Tests mutate routeSegments for routing
+// branches; default `[]` renders the child tree.
 vi.mock('expo-router', () => ({
-  useSegments: () => [] as string[],
-  Redirect: () => null,
+  useSegments: () => routeSegments.current,
+  Redirect: (props: { href: string }) => redirectMock(props),
 }));
 
 vi.mock('react-native', () => ({
@@ -49,8 +53,10 @@ vi.mock('../../lib/session-store', () => ({
 }));
 
 const clearStoredActiveBoardMock = vi.fn();
+const clearStoredAuthenticatedActiveBoardMock = vi.fn();
 vi.mock('../../lib/active-board-store', () => ({
   clearStoredActiveBoard: () => clearStoredActiveBoardMock(),
+  clearStoredAuthenticatedActiveBoard: () => clearStoredAuthenticatedActiveBoardMock(),
 }));
 
 const resetHttpClientMock = vi.fn();
@@ -86,6 +92,9 @@ describe('AuthProvider.signOut', () => {
     authSignOutMock.mockReset();
     clearStoredSessionIdMock.mockReset();
     clearStoredActiveBoardMock.mockReset();
+    clearStoredAuthenticatedActiveBoardMock.mockReset();
+    routeSegments.current = [];
+    redirectMock.mockClear();
     resetHttpClientMock.mockReset();
     disposeWsClientMock.mockReset();
     reportErrorMock.mockReset();
@@ -96,6 +105,7 @@ describe('AuthProvider.signOut', () => {
     authSignOutMock.mockResolvedValue(undefined);
     clearStoredSessionIdMock.mockResolvedValue(undefined);
     clearStoredActiveBoardMock.mockResolvedValue(undefined);
+    clearStoredAuthenticatedActiveBoardMock.mockResolvedValue(undefined);
   });
 
   it('clears every cached React Query so cached data does not bleed into the next user', async () => {
@@ -164,6 +174,8 @@ describe('AuthProvider forced sign-out registration', () => {
     getAuthTokenMock.mockReset();
     isTokenExpiringSoonMock.mockReset();
     setOnForcedSignOutMock.mockReset();
+    routeSegments.current = [];
+    redirectMock.mockClear();
     getAuthTokenMock.mockResolvedValue('jwt-token');
     isTokenExpiringSoonMock.mockResolvedValue(false);
   });
@@ -195,6 +207,9 @@ describe('AuthProvider.checkAuth signed-out cleanup', () => {
     authSignOutMock.mockReset();
     clearStoredSessionIdMock.mockReset();
     clearStoredActiveBoardMock.mockReset();
+    clearStoredAuthenticatedActiveBoardMock.mockReset();
+    routeSegments.current = [];
+    redirectMock.mockClear();
     resetHttpClientMock.mockReset();
     disposeWsClientMock.mockReset();
     ensureFreshTokenMock.mockReset();
@@ -207,6 +222,7 @@ describe('AuthProvider.checkAuth signed-out cleanup', () => {
     ensureFreshTokenMock.mockResolvedValue(true);
     clearStoredSessionIdMock.mockResolvedValue(undefined);
     clearStoredActiveBoardMock.mockResolvedValue(undefined);
+    clearStoredAuthenticatedActiveBoardMock.mockResolvedValue(undefined);
   });
 
   // The #2685 bug: an expiry-triggered logout (token within the expiry window,
@@ -250,11 +266,10 @@ describe('AuthProvider.checkAuth signed-out cleanup', () => {
   });
 
   // Relaunch guard: if the app is killed before the next user signs in, the
-  // React Query cache is empty but the persisted board/session id survive. A
-  // signed-out cold start must clear those so user B can't inherit user A's
-  // stored board. The heavy in-memory cleanup stays gated behind the
-  // authenticated transition (nothing to wipe on a cold start).
-  it('clears persisted board/session on a signed-out cold start (relaunch guard)', async () => {
+  // React Query cache is empty but persisted auth/session state can survive.
+  // A signed-out cold start clears the session and only clears non-guest active
+  // boards, preserving a local anonymous board choice across launches.
+  it('clears signed-out launch stores without wiping guest boards unconditionally', async () => {
     getAuthTokenMock.mockResolvedValue(null);
 
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -263,14 +278,44 @@ describe('AuthProvider.checkAuth signed-out cleanup', () => {
         <AuthProvider>{children}</AuthProvider>
       </QueryClientProvider>
     );
-    // Provider returns its <Redirect> branch (children never mount), so assert
-    // via the mocks rather than a hook snapshot.
     render(wrapper({ children: null }));
 
-    await waitFor(() => expect(clearStoredActiveBoardMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(clearStoredAuthenticatedActiveBoardMock).toHaveBeenCalledTimes(1));
     expect(clearStoredSessionIdMock).toHaveBeenCalledTimes(1);
+    expect(clearStoredActiveBoardMock).not.toHaveBeenCalled();
     expect(resetHttpClientMock).not.toHaveBeenCalled();
     expect(disposeWsClientMock).not.toHaveBeenCalled();
+  });
+
+  it('renders non-auth children when signed out', async () => {
+    getAuthTokenMock.mockResolvedValue(null);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <div>guest app</div>
+        </AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(getByText('guest app')).toBeTruthy());
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it('redirects authenticated users away from auth routes', async () => {
+    routeSegments.current = ['auth', 'login'];
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <div>signed in app</div>
+        </AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(redirectMock).toHaveBeenCalledWith({ href: '/(tabs)/climbs' }));
   });
 });
 
@@ -280,6 +325,9 @@ describe('AuthProvider.checkAuth keychain read failure', () => {
     isTokenExpiringSoonMock.mockReset();
     clearStoredSessionIdMock.mockReset();
     clearStoredActiveBoardMock.mockReset();
+    clearStoredAuthenticatedActiveBoardMock.mockReset();
+    routeSegments.current = [];
+    redirectMock.mockClear();
     reportErrorMock.mockReset();
     isTokenExpiringSoonMock.mockResolvedValue(false);
   });
@@ -327,6 +375,7 @@ describe('AuthProvider.checkAuth keychain read failure', () => {
 
     await waitFor(() => expect(onReady).toHaveBeenCalled());
     expect(clearStoredActiveBoardMock).not.toHaveBeenCalled();
+    expect(clearStoredAuthenticatedActiveBoardMock).not.toHaveBeenCalled();
     expect(clearStoredSessionIdMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -36,6 +36,10 @@ const climbActions = vi.hoisted(() => ({
   props: null as null | Record<string, unknown>,
 }));
 
+const auth = vi.hoisted(() => ({
+  isAuthenticated: true,
+}));
+
 const activeBoard = vi.hoisted(() => ({
   stored: {
     uuid: 'board-1',
@@ -128,6 +132,13 @@ vi.mock('../../components/AddToPlaylistSheet', () => ({
 }));
 vi.mock('../../components/QueueAddedSnackbar', () => ({
   QueueAddedSnackbar: () => createElement('div', { 'data-queue-snackbar': 'true' }),
+}));
+vi.mock('../../components/SignInPromptSheet', () => ({
+  SignInPromptSheet: () => createElement('div', { 'data-sign-in-prompt': 'true' }),
+}));
+
+vi.mock('../auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: auth.isAuthenticated }),
 }));
 
 vi.mock('../queue-provider', async () => {
@@ -228,6 +239,7 @@ describe('DrawerHostProvider queue sheet wall-control gating', () => {
     queue.setCurrentClimb.mockClear();
     queue.addToQueue.mockClear();
     queue.setSessionBoardPath.mockClear();
+    auth.isAuthenticated = true;
     activeBoard.setActiveBoard.mockClear();
     playDrawer.open.mockClear();
     playDrawer.close.mockClear();

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -18,7 +18,7 @@ import { setOnForcedSignOut } from '../lib/auth-interceptor';
 import { resetHttpClient } from '../lib/graphql/client';
 import { disposeWsClient } from '../lib/graphql/ws-client';
 import { clearStoredSessionId } from '../lib/session-store';
-import { clearStoredActiveBoard } from '../lib/active-board-store';
+import { clearStoredActiveBoard, clearStoredAuthenticatedActiveBoard } from '../lib/active-board-store';
 import { ACTIVE_BOARD_QUERY_KEY } from '../lib/graphql/use-active-board';
 
 type AuthState = {
@@ -61,11 +61,16 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
 
   // Persisted (SecureStore/AsyncStorage-backed) per-user state that outlives a
   // relaunch. allSettled (not all) so one failing delete can't abort the rest.
-  // These are the only sign-out leftovers that can carry a previous user across
-  // a cold start on a shared device, so a signed-out checkAuth clears them even
-  // when there's no live in-session cache to wipe (see handleSignedOutTransition).
+  // The active board is user-scoped during an authenticated session, so real
+  // auth transitions clear it. A logged-out cold start preserves deliberately
+  // local guest boards, but still clears any real board left behind by a prior
+  // authenticated user.
   const clearPersistedUserStores = useCallback(
     () => Promise.allSettled([clearStoredSessionId(), clearStoredActiveBoard()]),
+    [],
+  );
+  const clearSignedOutLaunchStores = useCallback(
+    () => Promise.allSettled([clearStoredSessionId(), clearStoredAuthenticatedActiveBoard()]),
     [],
   );
 
@@ -105,10 +110,10 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       await runSignedOutCleanup();
     } else {
       resetAnalyticsForSignedOutTransition();
-      await clearPersistedUserStores();
+      await clearSignedOutLaunchStores();
       setIsAuthenticated(false);
     }
-  }, [runSignedOutCleanup, clearPersistedUserStores, resetAnalyticsForSignedOutTransition]);
+  }, [runSignedOutCleanup, clearSignedOutLaunchStores, resetAnalyticsForSignedOutTransition]);
 
   const checkAuth = useCallback(async () => {
     try {
@@ -248,9 +253,6 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
 
   const inAuthGroup = segments[0] === 'auth';
 
-  if (!isAuthenticated && !inAuthGroup) {
-    return <Redirect href="/auth/login" />;
-  }
   if (isAuthenticated && inAuthGroup) {
     return <Redirect href="/(tabs)/climbs" />;
   }

--- a/packages/mobile/src/providers/bluetooth-provider-wrapper.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider-wrapper.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { BluetoothProvider } from './bluetooth-provider';
 import { useActiveBoard } from '../lib/graphql/use-active-board';
+import { isGuestActiveBoard } from '../lib/boards/guest-board-id';
 import { LiveActivityBridge } from '../lib/live-activity/live-activity-bridge';
 
 /**
@@ -25,6 +26,7 @@ import { LiveActivityBridge } from '../lib/live-activity/live-activity-bridge';
  */
 export function BluetoothProviderWrapper({ children }: { children: ReactNode }) {
   const { data: activeBoard } = useActiveBoard();
+  const boardUuid = activeBoard && !isGuestActiveBoard(activeBoard) ? activeBoard.uuid : undefined;
 
   return (
     <BluetoothProvider
@@ -32,7 +34,7 @@ export function BluetoothProviderWrapper({ children }: { children: ReactNode }) 
       layoutId={activeBoard?.layoutId}
       sizeId={activeBoard?.sizeId}
       setIds={activeBoard?.setIds}
-      boardUuid={activeBoard?.uuid}
+      boardUuid={boardUuid}
     >
       {activeBoard ? (
         <LiveActivityBridge

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -26,11 +26,13 @@ import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-boa
 import { track } from '../lib/analytics';
 import { ClimbActionsSheet } from '../components/ClimbActionsSheet';
 import { AddToPlaylistSheet } from '../components/AddToPlaylistSheet';
+import { SignInPromptSheet } from '../components/SignInPromptSheet';
 import { useToggleFavorite, useProfile } from '../lib/graphql/hooks';
 import { favoritesStore } from '@boardsesh/climb-actions';
 import { climbToQueueItem } from '../lib/climb-to-queue-item';
 import { useIsPartyPreviewOnly, useQueueActions, useQueueSessionControls } from './queue-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
+import { useAuth } from './auth-provider';
 
 export type BoardConfig = {
   boardName: string;
@@ -103,13 +105,15 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const [logAscentInput, setLogAscentInput] = useState<LogAscentInput | null>(null);
   const [climbActions, setClimbActions] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const [playlistClimb, setPlaylistClimb] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
+  const [signInPromptVisible, setSignInPromptVisible] = useState(false);
+  const { isAuthenticated } = useAuth();
   const { addToQueue, setSessionBoardPath, setCurrentClimb } = useQueueActions();
   const { sessionId } = useQueueSessionControls();
   const isPartyPreviewOnly = useIsPartyPreviewOnly();
   const setActiveBoard = useSetActiveBoard();
   const { visible: snackbarVisible, nonce: snackbarNonce, dismissSnackbar } = useQueueSnackbar();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
-  const { data: profile } = useProfile();
+  const { data: profile } = useProfile({ enabled: isAuthenticated });
 
   // Climb to open after the boardConfig override has committed. We can't
   // open synchronously inside openPlayDrawer when an override is supplied
@@ -211,9 +215,16 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     [activeBoard, boardConfigOverride, sessionId, setActiveBoard, setSessionBoardPath],
   );
 
-  const openLogAscent = useCallback((input: LogAscentInput) => {
-    setLogAscentInput(input);
-  }, []);
+  const openLogAscent = useCallback(
+    (input: LogAscentInput) => {
+      if (!isAuthenticated) {
+        setSignInPromptVisible(true);
+        return;
+      }
+      setLogAscentInput(input);
+    },
+    [isAuthenticated],
+  );
 
   const dismissLogAscent = useCallback(() => setLogAscentInput(null), []);
 
@@ -247,6 +258,10 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
 
   const handleClimbActionsToggleFavorite = useCallback(() => {
     if (!climbActions) return;
+    if (!isAuthenticated) {
+      setSignInPromptVisible(true);
+      return;
+    }
     const isNowFavorited = !favoritesStore.getIsFavorited(climbActions.climb.uuid);
     track(SHARED_EVENTS.FavoriteToggle, {
       action: isNowFavorited ? 'added' : 'removed',
@@ -262,10 +277,14 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
         angle: climbActions.boardConfig.angle,
       },
     });
-  }, [climbActions, toggleFavoriteMutate]);
+  }, [climbActions, isAuthenticated, toggleFavoriteMutate]);
 
   const handleClimbActionsTick = useCallback(() => {
     if (!climbActions) return;
+    if (!isAuthenticated) {
+      setSignInPromptVisible(true);
+      return;
+    }
     setLogAscentInput({
       climbUuid: climbActions.climb.uuid,
       boardName: climbActions.boardConfig.boardName,
@@ -277,7 +296,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       setIds: climbActions.boardConfig.setIds,
       consensusGradeName: climbActions.climb.difficulty,
     });
-  }, [climbActions]);
+  }, [climbActions, isAuthenticated]);
 
   // Present the always-mounted queue sheet imperatively. Calling `present()`
   // synchronously from the handler (rather than from a `visible`-prop effect)
@@ -355,6 +374,10 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     (item: ClimbQueueItem) => {
       const boardConfig = activeBoardConfigRef.current;
       if (!boardConfig) return;
+      if (!isAuthenticated) {
+        setSignInPromptVisible(true);
+        return;
+      }
       setLogAscentInput({
         climbUuid: item.climb.uuid,
         boardName: boardConfig.boardName,
@@ -368,7 +391,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
         consensusGradeName: item.climb.difficulty,
       });
     },
-    [sessionId],
+    [isAuthenticated, sessionId],
   );
 
   const value = useMemo<DrawerHostValue>(
@@ -463,6 +486,10 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
         nonce={snackbarNonce}
         onDismiss={dismissSnackbar}
         onOpen={handleSnackbarOpen}
+      />
+      <SignInPromptSheet
+        visible={signInPromptVisible}
+        onClose={() => setSignInPromptVisible(false)}
       />
     </DrawerHostContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Allow signed-out mobile users to enter the app, pick boards, browse climbs, queue climbs, and open the play drawer without a login redirect.
- Add local guest active-board support for popular/custom board configs, preserving guest boards across signed-out cold starts while clearing real user boards at auth boundaries.
- Gate Favorite and Log Ascent behind a shared sign-in prompt, and avoid authenticated profile/favorite queries when signed out.
- Update backend direct board/defaultBoard resolvers so anonymous callers only see public listed boards and get `null` for `defaultBoard`.

Closes #2638

## Validation
- `vp test run packages/mobile/src/providers/__tests__/auth-provider.test.tsx packages/mobile/src/lib/__tests__/active-board-store.test.ts packages/mobile/src/lib/boards/__tests__/guest-board.test.ts packages/mobile/src/components/board-discovery/__tests__/board-items.test.ts packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx`
- `vp test run packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx`
- `vp test --project mobile`
- `vp test run packages/backend/src/__tests__/boards-serial-privacy.test.ts`
- `vp run typecheck:mobile`
- `vp run typecheck:backend`
- `vp run check:mobile-bundle`