### PR TITLE
[codex] Fix mobile Record session badge

### DIFF
--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -10,7 +10,7 @@ const cfg = vi.hoisted(() => ({
   hasCurrentClimb: false,
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
   platformOS: 'ios' as 'ios' | 'android',
-  materialScreens: [] as Array<{ name: string; options?: { lazy?: boolean } }>,
+  materialScreens: [] as Array<{ name: string; options?: { lazy?: boolean; tabBarBadge?: unknown } }>,
 }));
 
 vi.mock('react-native', () => ({
@@ -39,7 +39,7 @@ vi.mock('../../../src/components/queue-control/QueueBottomAccessory', () => ({
 }));
 
 vi.mock('../../../src/theme/colors', () => ({
-  brandColors: { success: '#047857' },
+  brandColors: { primaryFill: '#6D28D9', success: '#047857' },
 }));
 
 vi.mock('../../../src/providers/theme-provider', () => ({
@@ -55,7 +55,7 @@ vi.mock('expo-router', () => {
   const Tabs = Object.assign(
     ({ children }: { children?: ReactNode }) => createElement('nav', { 'data-tabs-material': 'true' }, children),
     {
-      Screen: ({ name, options }: { name: string; options?: { lazy?: boolean } }) => {
+      Screen: ({ name, options }: { name: string; options?: { lazy?: boolean; tabBarBadge?: unknown } }) => {
         const screen = { name, options };
         const existingIndex = cfg.materialScreens.findIndex((entry) => entry.name === name);
         if (existingIndex === -1) cfg.materialScreens.push(screen);
@@ -83,7 +83,8 @@ vi.mock('expo-router/unstable-native-tabs', () => {
     {
       Icon: () => createElement('span', { 'data-icon': 'true' }),
       Label: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
-      Badge: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-badge': 'true' }, children),
+      Badge: ({ children, selectedBackgroundColor }: { children?: ReactNode; selectedBackgroundColor?: string }) =>
+        createElement('span', { 'data-badge': 'true', 'data-bg': selectedBackgroundColor ?? '' }, children),
     },
   );
 
@@ -178,15 +179,49 @@ describe('TabLayout', () => {
     cfg.sessionId = 'session-1';
     const { container } = render(<TabLayout />);
     const recordTrigger = container.querySelector('[data-trigger="record"]') as HTMLElement;
+    const badge = recordTrigger.querySelector('[data-badge="true"]');
 
-    expect(recordTrigger.querySelector('[data-badge="true"]')).not.toBeNull();
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute('data-bg')).toBe('#6D28D9');
+    expect(badge?.textContent).toBe('•');
   });
 
   it('renders the Record badge when Bluetooth is connected', () => {
     cfg.bluetoothConnected = true;
     const { container } = render(<TabLayout />);
     const recordTrigger = container.querySelector('[data-trigger="record"]') as HTMLElement;
+    const badge = recordTrigger.querySelector('[data-badge="true"]');
 
-    expect(recordTrigger.querySelector('[data-badge="true"]')).not.toBeNull();
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute('data-bg')).toBe('#047857');
+    expect(badge?.textContent).toBe(' ');
+  });
+
+  it('prefers the live-session Record badge when Bluetooth is also connected', () => {
+    cfg.bluetoothConnected = true;
+    cfg.sessionId = 'session-1';
+    const { container } = render(<TabLayout />);
+    const recordTrigger = container.querySelector('[data-trigger="record"]') as HTMLElement;
+    const badge = recordTrigger.querySelector('[data-badge="true"]');
+
+    expect(badge?.getAttribute('data-bg')).toBe('#6D28D9');
+  });
+
+  it('passes the session badge kind to the Material tab bar', () => {
+    cfg.variant = 'material';
+    cfg.sessionId = 'session-1';
+
+    render(<TabLayout />);
+
+    expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options?.tabBarBadge).toBe('session');
+  });
+
+  it('passes the bluetooth badge kind to the Material tab bar', () => {
+    cfg.variant = 'material';
+    cfg.bluetoothConnected = true;
+
+    render(<TabLayout />);
+
+    expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options?.tabBarBadge).toBe('bluetooth');
   });
 });

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -19,6 +19,7 @@ export const unstable_settings = { initialRouteName: 'climbs' };
 
 type TabIconProps = { focused: boolean; color: ColorValue; size: number };
 type MaterialIconName = ComponentProps<typeof MaterialCommunityIcons>['name'];
+type RecordBadgeKind = 'session' | 'bluetooth';
 
 // Material (MaterialCommunityIcons) glyphs for the JS tab bar, mirroring the
 // SF Symbols / md hints used by the native tab bar. Rendered on all platforms in
@@ -43,8 +44,8 @@ export default function TabLayout() {
   const { variant } = useTheme();
   const nativeAccessoryActive = useNativeAccessoryActive();
 
-  // Record-tab status cue: a badge when a board is connected over Bluetooth or a
-  // session is live.
+  // Record-tab status cue. A live session is the stronger signal; Bluetooth-only
+  // keeps the existing green dot.
   const isBluetoothConnected = useBluetoothConnectedStatus();
   // sessionId-only subscription: the tab layout renders the whole NativeTabs
   // tree inline, so reading the volatile useQueue() here re-rendered every tab
@@ -54,7 +55,9 @@ export default function TabLayout() {
   // queue mutations or climb-to-climb nav), so gating the accessory mount on it
   // doesn't re-render the tab tree on every queue change.
   const hasCurrentClimb = useHasActiveClimb();
-  const showRecordBadge = isBluetoothConnected || sessionId !== null;
+  const recordBadgeKind: RecordBadgeKind | null =
+    sessionId !== null ? 'session' : isBluetoothConnected ? 'bluetooth' : null;
+  const recordBadgeColor = recordBadgeKind === 'session' ? brandColors.primaryFill : brandColors.success;
   const eagerMountRecord = Platform.OS === 'android';
 
   if (variant === 'material') {
@@ -69,7 +72,7 @@ export default function TabLayout() {
           options={{
             title: tSession('mobile.session.recordTab'),
             tabBarIcon: materialTabIcon('record-circle', 'record-circle-outline'),
-            tabBarBadge: showRecordBadge ? '' : undefined,
+            tabBarBadge: recordBadgeKind ?? undefined,
             // Android can stall the first lazy mount of this nested stack,
             // leaving the Record tab blank until another tab forces a remount.
             lazy: eagerMountRecord ? false : undefined,
@@ -113,8 +116,10 @@ export default function TabLayout() {
       <NativeTabs.Trigger name="record">
         <NativeTabs.Trigger.Icon sf="record.circle" md="radio_button_checked" />
         <NativeTabs.Trigger.Label>{tSession('mobile.session.recordTab')}</NativeTabs.Trigger.Label>
-        {showRecordBadge ? (
-          <NativeTabs.Trigger.Badge selectedBackgroundColor={brandColors.success}> </NativeTabs.Trigger.Badge>
+        {recordBadgeKind ? (
+          <NativeTabs.Trigger.Badge selectedBackgroundColor={recordBadgeColor}>
+            {recordBadgeKind === 'session' ? '•' : ' '}
+          </NativeTabs.Trigger.Badge>
         ) : null}
       </NativeTabs.Trigger>
 

--- a/packages/mobile/src/components/navigation/MaterialTabBar.tsx
+++ b/packages/mobile/src/components/navigation/MaterialTabBar.tsx
@@ -9,6 +9,8 @@ import { brandColors as staticBrandColors } from '../../theme/colors';
 import { material } from '../../theme/tokens';
 import { MATERIAL_TAB_BAR_HEIGHT } from '../../theme/layout';
 
+type RecordBadgeKind = 'session' | 'bluetooth';
+
 /**
  * Material 3 bottom navigation bar — the JS tab bar for the Material UI variant
  * (the Liquid Glass variant uses the native `NativeTabs` instead). Built from the
@@ -56,6 +58,8 @@ export function MaterialTabBar({ state, descriptors, navigation, insets }: Botto
         const label = typeof options.title === 'string' ? options.title : route.name;
         const iconColor = focused ? activeIconColor : inactiveColor;
         const labelColor = focused ? activeLabelColor : inactiveColor;
+        const badgeKind: RecordBadgeKind | null =
+          options.tabBarBadge === 'session' ? 'session' : options.tabBarBadge != null ? 'bluetooth' : null;
 
         const onPress = () => {
           const event = navigation.emit({ type: 'tabPress', target: route.key, canPreventDefault: true });
@@ -82,14 +86,18 @@ export function MaterialTabBar({ state, descriptors, navigation, insets }: Botto
           >
             <View style={[styles.indicator, focused && { backgroundColor: indicatorColor }]}>
               {options.tabBarIcon?.({ focused, color: iconColor, size: 24 })}
-              {options.tabBarBadge != null ? (
+              {badgeKind ? (
                 <View
                   testID="badge"
                   style={[
-                    styles.badge,
-                    // Badge dot is a FILL (no text on it) → static light brand
-                    // success, not the scheme-lifted theme value.
-                    { backgroundColor: staticBrandColors.success, borderColor: systemColors.elevatedSurface },
+                    badgeKind === 'session' ? styles.sessionBadge : styles.bluetoothBadge,
+                    {
+                      // Bluetooth remains the established green dot; a live
+                      // session gets the brand-filled pill so the Record tab no
+                      // longer uses one green indicator for two states.
+                      backgroundColor: badgeKind === 'session' ? brandColors.primaryFill : staticBrandColors.success,
+                      borderColor: systemColors.elevatedSurface,
+                    },
                   ]}
                 />
               ) : null}
@@ -129,11 +137,20 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  badge: {
+  bluetoothBadge: {
     position: 'absolute',
     top: 2,
     right: 10,
     width: 9,
+    height: 9,
+    borderRadius: 5,
+    borderWidth: 1.5,
+  },
+  sessionBadge: {
+    position: 'absolute',
+    top: 2,
+    right: 8,
+    width: 16,
     height: 9,
     borderRadius: 5,
     borderWidth: 1.5,

--- a/packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx
+++ b/packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx
@@ -97,7 +97,7 @@ vi.mock('../../../providers/theme-provider', () => ({
     },
     // MaterialTabBar now reads the scheme-aware brand from the theme (lifted
     // tint in dark) rather than the static import.
-    brandColors: { primary: '#FF3B30', success: '#6B9080' },
+    brandColors: { primary: '#FF3B30', primaryFill: '#B3261E', success: '#6B9080' },
     // M3 navigation-bar roles: active icon on a secondaryContainer pill, active
     // label onSurface, inactive icon+label onSurfaceVariant.
     m3: {
@@ -110,7 +110,7 @@ vi.mock('../../../providers/theme-provider', () => ({
 }));
 
 vi.mock('../../../theme/colors', () => ({
-  brandColors: { primary: '#FF3B30', success: '#6B9080' },
+  brandColors: { primary: '#FF3B30', primaryFill: '#B3261E', success: '#6B9080' },
 }));
 
 vi.mock('../../../theme/tokens', () => ({
@@ -189,11 +189,35 @@ beforeEach(() => {
 describe('MaterialTabBar', () => {
   describe('badge rendering', () => {
     it('renders a badge dot when tabBarBadge is set', () => {
-      const props = makeProps({ tabBarBadge: '' });
+      const props = makeProps({ tabBarBadge: 'bluetooth' });
       const { queryByTestId } = render(
         <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
       );
       expect(queryByTestId('badge')).not.toBeNull();
+    });
+
+    it('renders the bluetooth badge as the established green dot', () => {
+      const props = makeProps({ tabBarBadge: 'bluetooth' });
+      const { queryByTestId } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
+      const badgeStyle = queryByTestId('badge')?.getAttribute('data-style') ?? '';
+
+      expect(badgeStyle).toContain('"width":9');
+      expect(badgeStyle).toContain('"height":9');
+      expect(badgeStyle).toContain('"backgroundColor":"#6B9080"');
+    });
+
+    it('renders the session badge as a primary pill', () => {
+      const props = makeProps({ tabBarBadge: 'session' });
+      const { queryByTestId } = render(
+        <MaterialTabBar {...(props as unknown as Parameters<typeof MaterialTabBar>[0])} />,
+      );
+      const badgeStyle = queryByTestId('badge')?.getAttribute('data-style') ?? '';
+
+      expect(badgeStyle).toContain('"width":16');
+      expect(badgeStyle).toContain('"height":9');
+      expect(badgeStyle).toContain('"backgroundColor":"#B3261E"');
     });
 
     it('does not render a badge when tabBarBadge is undefined', () => {

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -28,11 +28,29 @@ type ClimbLabelProps = {
   gradeColor: string;
   showThumbnail: boolean;
   boardConfig: BoardConfig | null;
+  showSessionReturnCue?: boolean;
+  sessionCueColor: ColorValue;
 };
 
-function ClimbLabel({ climb, labelColor, formattedGrade, gradeColor, showThumbnail, boardConfig }: ClimbLabelProps) {
+function ClimbLabel({
+  climb,
+  labelColor,
+  formattedGrade,
+  gradeColor,
+  showThumbnail,
+  boardConfig,
+  showSessionReturnCue = false,
+  sessionCueColor,
+}: ClimbLabelProps) {
   return (
     <View style={styles.labelInner}>
+      {showSessionReturnCue ? (
+        <View
+          testID="session-return-cue"
+          pointerEvents="none"
+          style={[styles.sessionReturnCue, { backgroundColor: sessionCueColor }]}
+        />
+      ) : null}
       {showThumbnail ? <AccessoryClimbThumbnail climb={climb} boardConfig={boardConfig} /> : null}
       <Text
         variant="subheadline"
@@ -76,7 +94,7 @@ export function ClimbCapsule({
   endActionSize = 0,
   surfaceTreatment = 'floating',
 }: ClimbCapsuleProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { boardConfig } = useDrawerHost();
   const { formatGrade } = useGradeFormat();
   const {
@@ -91,6 +109,8 @@ export function ClimbCapsule({
     canPeek,
     handleNext,
     handlePrevious,
+    handleReturnToSession,
+    returnToSessionAvailable,
     swipeAccessibilityActions,
   } = useQueueCarousel();
 
@@ -150,6 +170,7 @@ export function ClimbCapsule({
           onAccessibilityAction={(event) => {
             if (event.nativeEvent.actionName === 'next') handleNext();
             else if (event.nativeEvent.actionName === 'previous') handlePrevious();
+            else if (event.nativeEvent.actionName === 'returnToSession') handleReturnToSession();
           }}
         >
           <Animated.View style={[styles.labelSlot, { right: labelRight }, currentLabelStyle]}>
@@ -160,6 +181,8 @@ export function ClimbCapsule({
               gradeColor={grades.currentColor}
               showThumbnail={showThumbnail}
               boardConfig={boardConfig}
+              showSessionReturnCue={returnToSessionAvailable}
+              sessionCueColor={brandColors.primaryFill}
             />
           </Animated.View>
           {nextClimb && canPeek ? (
@@ -171,6 +194,7 @@ export function ClimbCapsule({
                 gradeColor={grades.nextColor}
                 showThumbnail={showThumbnail}
                 boardConfig={boardConfig}
+                sessionCueColor={brandColors.primaryFill}
               />
             </Animated.View>
           ) : null}
@@ -183,6 +207,7 @@ export function ClimbCapsule({
                 gradeColor={grades.previousColor}
                 showThumbnail={showThumbnail}
                 boardConfig={boardConfig}
+                sessionCueColor={brandColors.primaryFill}
               />
             </Animated.View>
           ) : null}
@@ -240,6 +265,12 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
+  },
+  sessionReturnCue: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    flexShrink: 0,
   },
   gradeText: {
     // Colorized like the list rows; right-aligned with a reserved min width

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -29,11 +29,28 @@ type ClimbLabelProps = {
   formattedGrade: string | null;
   showThumbnail: boolean;
   boardConfig: BoardConfig | null;
+  showSessionReturnCue?: boolean;
+  sessionCueColor: ColorValue;
 };
 
-function ClimbLabel({ climb, labelColor, formattedGrade, showThumbnail, boardConfig }: ClimbLabelProps) {
+function ClimbLabel({
+  climb,
+  labelColor,
+  formattedGrade,
+  showThumbnail,
+  boardConfig,
+  showSessionReturnCue = false,
+  sessionCueColor,
+}: ClimbLabelProps) {
   return (
     <View style={styles.labelInner}>
+      {showSessionReturnCue ? (
+        <View
+          testID="session-return-cue"
+          pointerEvents="none"
+          style={[styles.sessionReturnCue, { backgroundColor: sessionCueColor }]}
+        />
+      ) : null}
       {showThumbnail ? <AccessoryClimbThumbnail climb={climb} boardConfig={boardConfig} /> : null}
       <Text
         variant="subheadline"
@@ -73,7 +90,7 @@ function climbFromItem(item: ClimbQueueItem | null | undefined): Climb | null {
  */
 export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryClimbRowProps) {
   const { boardConfig } = useDrawerHost();
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { formatGrade } = useGradeFormat();
   const {
     onLayout,
@@ -87,6 +104,8 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
     canPeek,
     handleNext,
     handlePrevious,
+    handleReturnToSession,
+    returnToSessionAvailable,
     swipeAccessibilityActions,
   } = useQueueCarousel();
 
@@ -114,6 +133,7 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
           onAccessibilityAction={(event) => {
             if (event.nativeEvent.actionName === 'next') handleNext();
             else if (event.nativeEvent.actionName === 'previous') handlePrevious();
+            else if (event.nativeEvent.actionName === 'returnToSession') handleReturnToSession();
           }}
         >
           <Animated.View style={[styles.labelSlot, currentLabelStyle]}>
@@ -123,6 +143,8 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
               formattedGrade={currentFormattedGrade}
               showThumbnail={showThumbnail}
               boardConfig={boardConfig}
+              showSessionReturnCue={returnToSessionAvailable}
+              sessionCueColor={brandColors.primaryFill}
             />
           </Animated.View>
           {nextQueueClimb && canPeek ? (
@@ -133,6 +155,7 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
                 formattedGrade={nextFormattedGrade}
                 showThumbnail={showThumbnail}
                 boardConfig={boardConfig}
+                sessionCueColor={brandColors.primaryFill}
               />
             </Animated.View>
           ) : null}
@@ -144,6 +167,7 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
                 formattedGrade={previousFormattedGrade}
                 showThumbnail={showThumbnail}
                 boardConfig={boardConfig}
+                sessionCueColor={brandColors.primaryFill}
               />
             </Animated.View>
           ) : null}
@@ -189,6 +213,12 @@ const styles = StyleSheet.create({
     gap: spacing[2],
     paddingLeft: spacing[2],
     paddingRight: spacing[1],
+  },
+  sessionReturnCue: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    flexShrink: 0,
   },
   name: {
     flex: 1,

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -10,10 +10,13 @@ const queue = vi.hoisted(() => ({
     currentClimbQueueItem: null as ClimbQueueItem | null,
     queue: [] as ClimbQueueItem[],
   },
+  sessionId: null as string | null,
   nextClimb: vi.fn(),
   previousClimb: vi.fn(),
 }));
 const drawer = vi.hoisted(() => ({ openPlayDrawer: vi.fn() }));
+const router = vi.hoisted(() => ({ navigate: vi.fn() }));
+const route = vi.hoisted(() => ({ segments: ['(tabs)', 'climbs'] as string[] }));
 
 // Injectable navigation result so tests drive the suggestion-aware canNext/nextItem
 // the capsule reads from computeNavigationStateWithSuggestions.
@@ -132,11 +135,13 @@ vi.mock('../../GlassSurface', () => ({
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { label: '#111111', separator: '#cccccc', elevatedSurface: '#f0f0f0' },
+    brandColors: { primaryFill: '#6D28D9' },
   }),
 }));
 
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: queue.state, nextClimb: queue.nextClimb, previousClimb: queue.previousClimb }),
+  useQueueSessionId: () => ({ sessionId: queue.sessionId }),
   usePlaylistSuggestionSource: () => null,
   // Default to driver (not preview-only); these tests encode the bar's wiring,
   // not party gating — that is covered in use-queue-carousel.test.tsx.
@@ -145,6 +150,11 @@ vi.mock('../../../providers/queue-provider', () => ({
 
 vi.mock('../../../providers/drawer-host-provider', () => ({
   useDrawerHost: () => ({ openPlayDrawer: drawer.openPlayDrawer, boardConfig: null }),
+}));
+
+vi.mock('expo-router', () => ({
+  useRouter: () => router,
+  useSegments: () => route.segments,
 }));
 
 // The board thumbnail pulls in board-details/native render deps; the capsule
@@ -207,6 +217,9 @@ describe('ClimbCapsule', () => {
     nav.result = { canNext: false, canPrevious: false, nextItem: null, prevItem: null, remainingCount: 0 };
     queue.state.currentClimbQueueItem = null;
     queue.state.queue = [];
+    queue.sessionId = null;
+    route.segments = ['(tabs)', 'climbs'];
+    router.navigate.mockClear();
     drawer.openPlayDrawer.mockClear();
     queue.nextClimb.mockClear();
     queue.previousClimb.mockClear();
@@ -227,6 +240,29 @@ describe('ClimbCapsule', () => {
     const { container } = render(<ClimbCapsule />);
     expect(container.textContent).toContain('The Crimp Ladder');
     expect(container.querySelector('[data-glass]')).not.toBeNull();
+  });
+
+  it('shows a session-return cue when a live session can be resumed from another tab', () => {
+    const item = makeItem(makeClimb({ name: 'The Crimp Ladder' }));
+    queue.state.currentClimbQueueItem = item;
+    queue.state.queue = [item];
+    queue.sessionId = 'session-1';
+
+    const { container } = render(<ClimbCapsule />);
+
+    expect(container.querySelector('[data-testid="session-return-cue"]')).not.toBeNull();
+  });
+
+  it('hides the session-return cue on the Record tab', () => {
+    const item = makeItem(makeClimb({ name: 'The Crimp Ladder' }));
+    queue.state.currentClimbQueueItem = item;
+    queue.state.queue = [item];
+    queue.sessionId = 'session-1';
+    route.segments = ['(tabs)', 'record'];
+
+    const { container } = render(<ClimbCapsule />);
+
+    expect(container.querySelector('[data-testid="session-return-cue"]')).toBeNull();
   });
 
   it('colorizes the grade text with the grade colour (not a white-on-pill style)', () => {

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -10,6 +10,7 @@ const queue = vi.hoisted(() => ({
     currentClimbQueueItem: null as ClimbQueueItem | null,
     queue: [] as ClimbQueueItem[],
   },
+  sessionId: null as string | null,
   nextClimb: vi.fn(),
   previousClimb: vi.fn(),
 }));
@@ -18,6 +19,9 @@ const drawer = vi.hoisted(() => ({
   boardConfig: null as BoardConfig | null,
   openPlayDrawer: vi.fn(),
 }));
+
+const router = vi.hoisted(() => ({ navigate: vi.fn() }));
+const route = vi.hoisted(() => ({ segments: ['(tabs)', 'climbs'] as string[] }));
 
 const boardRender = vi.hoisted(() => ({
   boardWidth: 1080,
@@ -54,6 +58,7 @@ vi.mock('react-native', () => ({
     accessibilityLabel,
     accessibilityActions,
     onLayout,
+    testID,
   }: {
     children?: ReactNode;
     style?: unknown;
@@ -61,6 +66,7 @@ vi.mock('react-native', () => ({
     accessibilityLabel?: string;
     accessibilityActions?: ReadonlyArray<{ name: string; label?: string }>;
     onLayout?: (event: { nativeEvent: { layout: { width: number; height: number } } }) => void;
+    testID?: string;
   }) => {
     // jsdom never lays out, so simulate the swipe viewport being measured —
     // otherwise width stays 0, canPeek is false, and the peek slots never render.
@@ -104,6 +110,7 @@ vi.mock('react-native', () => ({
         'data-actions': Array.isArray(accessibilityActions)
           ? accessibilityActions.map((action) => action.name).join(',')
           : '',
+        ...(testID ? { 'data-testid': testID } : {}),
       },
       children,
     );
@@ -177,6 +184,7 @@ vi.mock('../../Text', () => ({
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { label: '#111111' },
+    brandColors: { primaryFill: '#6D28D9' },
   }),
 }));
 
@@ -186,6 +194,7 @@ vi.mock('../../../providers/queue-provider', () => ({
     nextClimb: queue.nextClimb,
     previousClimb: queue.previousClimb,
   }),
+  useQueueSessionId: () => ({ sessionId: queue.sessionId }),
   usePlaylistSuggestionSource: () => null,
   // Default to driver (not preview-only); these tests encode the bar's wiring,
   // not party gating — that is covered in use-queue-carousel.test.tsx.
@@ -194,6 +203,11 @@ vi.mock('../../../providers/queue-provider', () => ({
 
 vi.mock('../../../providers/drawer-host-provider', () => ({
   useDrawerHost: () => ({ boardConfig: drawer.boardConfig, openPlayDrawer: drawer.openPlayDrawer }),
+}));
+
+vi.mock('expo-router', () => ({
+  useRouter: () => router,
+  useSegments: () => route.segments,
 }));
 
 vi.mock('../../../hooks/use-grade-format', () => ({
@@ -327,6 +341,9 @@ describe('NativeAccessoryClimbRow', () => {
     drawer.boardConfig = makeBoardConfig();
     boardRender.boardWidth = 1080;
     boardRender.boardHeight = 1920;
+    queue.sessionId = null;
+    route.segments = ['(tabs)', 'climbs'];
+    router.navigate.mockClear();
     queue.nextClimb.mockClear();
     queue.previousClimb.mockClear();
     drawer.openPlayDrawer.mockClear();
@@ -443,6 +460,23 @@ describe('NativeAccessoryClimbRow', () => {
 
     expect(tick).not.toBeNull();
     expect(tick?.closest('[data-gesture="true"]')).toBeNull();
+  });
+
+  it('shows a session-return cue when a live session can be resumed from another tab', () => {
+    queue.sessionId = 'session-1';
+
+    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+
+    expect(container.querySelector('[data-testid="session-return-cue"]')).not.toBeNull();
+  });
+
+  it('hides the session-return cue on the Record tab', () => {
+    queue.sessionId = 'session-1';
+    route.segments = ['(tabs)', 'record'];
+
+    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+
+    expect(container.querySelector('[data-testid="session-return-cue"]')).toBeNull();
   });
 
   it('surfaces the suggestion-aware next item as a peek and a "next" accessibility action', () => {

--- a/packages/mobile/src/components/queue-control/__tests__/use-queue-carousel.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-queue-carousel.test.tsx
@@ -10,10 +10,15 @@ const queue = vi.hoisted(() => ({
     currentClimbQueueItem: null as ClimbQueueItem | null,
     queue: [] as ClimbQueueItem[],
   },
+  sessionId: null as string | null,
   nextClimb: vi.fn(),
   previousClimb: vi.fn(),
   isPartyPreviewOnly: false,
 }));
+
+const drawer = vi.hoisted(() => ({ openPlayDrawer: vi.fn() }));
+const router = vi.hoisted(() => ({ navigate: vi.fn() }));
+const route = vi.hoisted(() => ({ segments: ['(tabs)', 'climbs'] as string[] }));
 
 const nav = vi.hoisted(() => ({
   result: {
@@ -31,12 +36,18 @@ const gestureCalls = vi.hoisted(() => ({ last: null as Record<string, unknown> |
 
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: queue.state, nextClimb: queue.nextClimb, previousClimb: queue.previousClimb }),
+  useQueueSessionId: () => ({ sessionId: queue.sessionId }),
   usePlaylistSuggestionSource: () => null,
   useIsPartyPreviewOnly: () => queue.isPartyPreviewOnly,
 }));
 
 vi.mock('../../../providers/drawer-host-provider', () => ({
-  useDrawerHost: () => ({ openPlayDrawer: vi.fn() }),
+  useDrawerHost: () => ({ openPlayDrawer: drawer.openPlayDrawer }),
+}));
+
+vi.mock('expo-router', () => ({
+  useRouter: () => router,
+  useSegments: () => route.segments,
 }));
 
 vi.mock('@boardsesh/play-view', () => ({
@@ -96,7 +107,11 @@ describe('useQueueCarousel party-preview gating', () => {
   beforeEach(() => {
     queue.nextClimb.mockClear();
     queue.previousClimb.mockClear();
+    queue.sessionId = null;
     queue.isPartyPreviewOnly = false;
+    drawer.openPlayDrawer.mockClear();
+    router.navigate.mockClear();
+    route.segments = ['(tabs)', 'climbs'];
     gestureCalls.last = null;
     const current = makeItem('current');
     const next = makeItem('next');
@@ -157,5 +172,43 @@ describe('useQueueCarousel party-preview gating', () => {
     // Preview, not blackout: the next/previous peek items still render.
     expect(result.current.nextItem?.uuid).toBe('next');
     expect(result.current.previousItem?.uuid).toBe('current');
+  });
+
+  it('returns to the Record tab on primary tap during an active session outside Record', () => {
+    queue.sessionId = 'session-1';
+    const { result } = renderHook(() => useQueueCarousel());
+
+    result.current.handlePrimaryPress();
+
+    expect(router.navigate).toHaveBeenCalledWith('/(tabs)/record');
+    expect(drawer.openPlayDrawer).not.toHaveBeenCalled();
+    expect(result.current.returnToSessionAvailable).toBe(true);
+    expect(result.current.swipeAccessibilityActions.map((action) => action.name)).toContain('returnToSession');
+  });
+
+  it('keeps primary tap on the play drawer when no session is active', () => {
+    const { result } = renderHook(() => useQueueCarousel());
+
+    result.current.handlePrimaryPress();
+
+    expect(drawer.openPlayDrawer).toHaveBeenCalledWith(queue.state.currentClimbQueueItem?.climb, {
+      setAsCurrent: false,
+    });
+    expect(router.navigate).not.toHaveBeenCalled();
+    expect(result.current.returnToSessionAvailable).toBe(false);
+  });
+
+  it('keeps primary tap on the play drawer when already on the Record tab', () => {
+    queue.sessionId = 'session-1';
+    route.segments = ['(tabs)', 'record'];
+    const { result } = renderHook(() => useQueueCarousel());
+
+    result.current.handlePrimaryPress();
+
+    expect(drawer.openPlayDrawer).toHaveBeenCalledWith(queue.state.currentClimbQueueItem?.climb, {
+      setAsCurrent: false,
+    });
+    expect(router.navigate).not.toHaveBeenCalled();
+    expect(result.current.returnToSessionAvailable).toBe(false);
   });
 });

--- a/packages/mobile/src/components/queue-control/use-queue-carousel.ts
+++ b/packages/mobile/src/components/queue-control/use-queue-carousel.ts
@@ -1,12 +1,18 @@
 import { useCallback, useMemo, useState } from 'react';
 import { type LayoutChangeEvent } from 'react-native';
+import { useRouter, useSegments } from 'expo-router';
 import { Gesture, type ComposedGesture } from 'react-native-gesture-handler';
 import { runOnJS, useAnimatedStyle, useSharedValue, type AnimatedStyle } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import { computeNavigationStateWithSuggestions } from '@boardsesh/play-view';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
-import { useIsPartyPreviewOnly, usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
+import {
+  useIsPartyPreviewOnly,
+  usePlaylistSuggestionSource,
+  useQueue,
+  useQueueSessionId,
+} from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { hapticLight, hapticSelection } from '../../lib/haptics';
 import { useCarouselGesture } from '../play-drawer/use-carousel-gesture';
@@ -40,7 +46,10 @@ export type QueueCarousel = {
   canNext: boolean;
   handleNext: () => void;
   handlePrevious: () => void;
-  /** Prev/next exposed as a11y actions (swipe is invisible to VoiceOver). */
+  handlePrimaryPress: () => void;
+  handleReturnToSession: () => void;
+  returnToSessionAvailable: boolean;
+  /** Return-to-session + prev/next exposed as a11y actions for hidden gestures. */
   swipeAccessibilityActions: AccessibilityAction[];
 };
 
@@ -55,6 +64,9 @@ export function useQueueCarousel(): QueueCarousel {
   // previousClimb and overwrite the driver's wall climb for everyone.
   const isPartyPreviewOnly = useIsPartyPreviewOnly();
   const { openPlayDrawer } = useDrawerHost();
+  const { sessionId } = useQueueSessionId();
+  const router = useRouter();
+  const segments = useSegments();
   const { t } = useTranslation('session');
   const reduceMotion = useReduceMotion();
 
@@ -104,6 +116,22 @@ export function useQueueCarousel(): QueueCarousel {
     openPlayDrawer(currentClimbQueueItem.climb, { setAsCurrent: false });
   }, [openPlayDrawer, currentClimbQueueItem]);
 
+  const returnToSessionAvailable = sessionId !== null && !segments.includes('record');
+
+  const handleReturnToSession = useCallback(() => {
+    if (sessionId === null) return;
+    hapticLight();
+    router.navigate('/(tabs)/record');
+  }, [router, sessionId]);
+
+  const handlePrimaryPress = useCallback(() => {
+    if (returnToSessionAvailable) {
+      handleReturnToSession();
+      return;
+    }
+    handleOpenPlay();
+  }, [handleOpenPlay, handleReturnToSession, returnToSessionAvailable]);
+
   const { gesture: panGesture, translateX } = useCarouselGesture({
     onSwipeNext: handleNext,
     onSwipePrevious: handlePrevious,
@@ -120,9 +148,9 @@ export function useQueueCarousel(): QueueCarousel {
         .maxDuration(250)
         .onEnd(() => {
           'worklet';
-          runOnJS(handleOpenPlay)();
+          runOnJS(handlePrimaryPress)();
         }),
-    [handleOpenPlay],
+    [handlePrimaryPress],
   );
 
   // Swipe up to open the drawer — a quick alternative to tapping (like dragging a
@@ -176,6 +204,7 @@ export function useQueueCarousel(): QueueCarousel {
   });
 
   const swipeAccessibilityActions: AccessibilityAction[] = [
+    ...(returnToSessionAvailable ? [{ name: 'returnToSession', label: t('mobile.queue.returnToSession') }] : []),
     ...(canPrevious ? [{ name: 'previous', label: t('mobile.queue.previousClimb') }] : []),
     ...(canNext ? [{ name: 'next', label: t('mobile.queue.nextClimb') }] : []),
   ];
@@ -194,6 +223,9 @@ export function useQueueCarousel(): QueueCarousel {
     canNext,
     handleNext,
     handlePrevious,
+    handlePrimaryPress,
+    handleReturnToSession,
+    returnToSessionAvailable,
     swipeAccessibilityActions,
   };
 }

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -304,6 +304,7 @@
       "climbCount_one": "{{count}} climb",
       "climbCount_other": "{{count}} climbs",
       "logAscent": "Log ascent",
+      "returnToSession": "Return to session",
       "nextClimb": "Next climb",
       "previousClimb": "Previous climb",
       "alreadyLogged": "Logged",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -304,6 +304,7 @@
       "climbCount_one": "{{count}} bloque",
       "climbCount_other": "{{count}} bloques",
       "logAscent": "Registrar ascenso",
+      "returnToSession": "Volver a la sesión",
       "nextClimb": "Siguiente bloque",
       "previousClimb": "Bloque anterior",
       "alreadyLogged": "Registrado",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -304,6 +304,7 @@
       "climbCount_one": "{{count}} bloc",
       "climbCount_other": "{{count}} blocs",
       "logAscent": "Enregistrer l'ascension",
+      "returnToSession": "Revenir à la session",
       "nextClimb": "Bloc suivant",
       "previousClimb": "Bloc précédent",
       "alreadyLogged": "Enregistré",


### PR DESCRIPTION
## Summary

- Split the Record tab status badge into live-session vs Bluetooth-only states.
- Render live sessions with a distinct primary badge treatment while keeping Bluetooth as the existing green dot.
- Add a live-session cue to the current-climb capsule/accessory; tapping it returns to the Record tab from other tabs, while swipe-up still opens the play drawer.

## Root Cause

The Record tab used one boolean badge for both `isBluetoothConnected` and `sessionId !== null`, so a green dot meant either board-connected or live-session. After the full-screen session overlay was removed, there was also no one-tap way back to an active session from other tabs.

## Validation

- `vp test run 'packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx' packages/mobile/src/components/navigation/__tests__/MaterialTabBar.test.tsx packages/mobile/src/components/queue-control/__tests__/use-queue-carousel.test.tsx packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx`
- `vp run typecheck:mobile`
- `vp run check:i18n`
- `vp run test:mobile`
- `vp run check:mobile-bundle`
- `vp staged`
- `vp run check:mobile-simulator` skipped on this host: no `xcrun simctl`; bundle check covered the Linux-safe path.

Note: broad `vp check` currently reports unrelated pre-existing formatting issues outside this PR's files, so I used the repo's staged pre-commit path (`vp staged`) for the actual hook-equivalent pass.

Closes #2563.