### PR TITLE
Handle GraphQL rate limits on reconnect

### DIFF
--- a/packages/backend/src/__tests__/rate-limiter.test.ts
+++ b/packages/backend/src/__tests__/rate-limiter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { GraphQLError } from 'graphql';
 import { checkRateLimit, cleanupRateLimit, getRateLimitStatus } from '../utils/rate-limiter';
 
 describe('In-memory rate limiter', () => {
@@ -44,7 +45,12 @@ describe('In-memory rate limiter', () => {
         checkRateLimit('test-conn', 5, 60_000);
         expect.fail('should have thrown');
       } catch (err) {
-        expect((err as Error).message).toMatch(/Try again in \d+ seconds/);
+        expect(err).toBeInstanceOf(GraphQLError);
+        expect((err as GraphQLError).message).toMatch(/Try again in \d+ seconds/);
+        expect((err as GraphQLError).extensions).toMatchObject({
+          code: 'RATE_LIMITED',
+          retryAfterSeconds: 50,
+        });
       }
     });
 

--- a/packages/backend/src/__tests__/redis-rate-limiter.test.ts
+++ b/packages/backend/src/__tests__/redis-rate-limiter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { GraphQLError } from 'graphql';
 import { checkRateLimitRedis } from '../utils/redis-rate-limiter';
 
 // Use vi.hoisted() so mock variables are available when vi.mock factories run
@@ -66,6 +67,21 @@ describe('checkRateLimitRedis', () => {
       mockEval.mockResolvedValue(31); // over limit of 30
 
       await expect(checkRateLimitRedis('user-1', 'vote', 30, 60_000)).rejects.toThrow('Rate limit exceeded');
+    });
+
+    it('throws a structured GraphQL rate-limit error', async () => {
+      mockEval.mockResolvedValue(31);
+
+      try {
+        await checkRateLimitRedis('user-1', 'vote', 30, 60_000);
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(GraphQLError);
+        expect((err as GraphQLError).extensions).toMatchObject({
+          code: 'RATE_LIMITED',
+          retryAfterSeconds: 60,
+        });
+      }
     });
 
     it('uses correct window bucket based on current time', async () => {

--- a/packages/backend/src/utils/error-handler.ts
+++ b/packages/backend/src/utils/error-handler.ts
@@ -1,3 +1,4 @@
+import { GraphQLError } from 'graphql';
 import { logger } from './logger';
 /**
  * Error handling utilities for preventing information disclosure.
@@ -21,6 +22,10 @@ export async function wrapDatabaseOperation<T>(operation: () => Promise<T>, cont
 
     // Check for specific error types we want to handle specially
     if (error instanceof Error) {
+      if (error instanceof GraphQLError) {
+        throw error;
+      }
+
       // Preserve version conflict errors (these are expected)
       if (error.name === 'VersionConflictError') {
         throw error;

--- a/packages/backend/src/utils/rate-limit-error.ts
+++ b/packages/backend/src/utils/rate-limit-error.ts
@@ -1,0 +1,19 @@
+import { GraphQLError } from 'graphql';
+
+export const RATE_LIMITED_CODE = 'RATE_LIMITED';
+
+export function createRateLimitGraphQLError(retryAfterSeconds: number): GraphQLError {
+  return new GraphQLError(`Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`, {
+    extensions: {
+      code: RATE_LIMITED_CODE,
+      retryAfterSeconds,
+    },
+  });
+}
+
+export function isRateLimitError(error: unknown): boolean {
+  if (error instanceof GraphQLError && error.extensions?.code === RATE_LIMITED_CODE) {
+    return true;
+  }
+  return error instanceof Error && error.message.startsWith('Rate limit exceeded');
+}

--- a/packages/backend/src/utils/rate-limiter.ts
+++ b/packages/backend/src/utils/rate-limiter.ts
@@ -3,6 +3,8 @@
  * Uses a sliding window algorithm with per-connection tracking.
  */
 
+import { createRateLimitGraphQLError } from './rate-limit-error';
+
 type RateLimitEntry = {
   count: number;
   resetAt: number;
@@ -42,7 +44,7 @@ export function checkRateLimit(
   // Check if limit exceeded
   if (entry.count >= maxRequests) {
     const retryAfterSeconds = Math.ceil((entry.resetAt - now) / 1000);
-    throw new Error(`Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`);
+    throw createRateLimitGraphQLError(retryAfterSeconds);
   }
 
   // Increment counter

--- a/packages/backend/src/utils/redis-rate-limiter.ts
+++ b/packages/backend/src/utils/redis-rate-limiter.ts
@@ -1,5 +1,6 @@
 import { redisClientManager } from '../redis/client';
 import { checkRateLimit } from './rate-limiter';
+import { createRateLimitGraphQLError, isRateLimitError } from './rate-limit-error';
 import { logger } from './logger';
 
 /**
@@ -51,11 +52,11 @@ export async function checkRateLimitRedis(
 
     if (count > maxRequests) {
       const retryAfterSeconds = Math.ceil((windowMs - (Date.now() % windowMs)) / 1000);
-      throw new Error(`Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`);
+      throw createRateLimitGraphQLError(retryAfterSeconds);
     }
   } catch (err) {
     // If the error is our rate limit error, re-throw it
-    if (err instanceof Error && err.message.startsWith('Rate limit exceeded')) {
+    if (isRateLimitError(err)) {
       throw err;
     }
     // Otherwise Redis failed — fall back to in-memory

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -88,6 +88,7 @@ export type StartSessionConfig = {
 };
 
 const JOIN_SESSION_RETRY_BACKOFF_MS = [1_000, 2_500, 5_000] as const;
+const RATE_LIMIT_TOAST_DEBOUNCE_MS = 10_000;
 
 type QueueContextValue = {
   state: QueueState;
@@ -538,6 +539,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const clearSessionRef = useRef<(options?: { notifyServer?: boolean }) => Promise<void>>(async () => {});
   const locallyEndingSessionIdRef = useRef<string | null>(null);
   const suppressedRemoteEndSessionIdRef = useRef<string | null>(null);
+  const lastRateLimitToastAtRef = useRef(0);
 
   // Transient queue-event listeners. PlaybackStateChanged (route playback
   // party-sync) doesn't mutate queue state, so the play-drawer orchestrator
@@ -853,6 +855,14 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     // failed" on a swipe-to-queue or a rapid current-climb change is noise.
     onBestEffortError: (action, error) => {
       if (__DEV__) console.warn(`[queue] best-effort ${action} failed`, error);
+    },
+    onRateLimited: ({ attempt }) => {
+      if (attempt < 2) return;
+      const now = Date.now();
+      if (now - lastRateLimitToastAtRef.current < RATE_LIMIT_TOAST_DEBOUNCE_MS) return;
+      lastRateLimitToastAtRef.current = now;
+      // i18n-keep session:mobile.queue.rateLimitCatchUp — called through `tRef.current`.
+      showToastRef.current(tRef.current('mobile.queue.rateLimitCatchUp'), 'warning');
     },
   });
 

--- a/packages/shared/graphql-client/src/__tests__/execute.test.ts
+++ b/packages/shared/graphql-client/src/__tests__/execute.test.ts
@@ -1,23 +1,25 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Client, Sink } from 'graphql-ws';
 import { execute } from '../execute';
-import { GraphQLOperationError } from '../errors';
+import { GraphQLOperationError, RateLimitError } from '../errors';
 
 type FakeClient = Client & {
   emit: (payload: Parameters<NonNullable<Sink['next']>>[0]) => void;
   emitError: (err: unknown) => void;
   emitComplete: () => void;
   unsubscribe: ReturnType<typeof vi.fn>;
+  subscribeMock: ReturnType<typeof vi.fn>;
 };
 
 function makeFakeClient(): FakeClient {
   let currentSink: Sink | null = null;
   const unsubscribe = vi.fn();
+  const subscribeMock = vi.fn((_op: unknown, sink: Sink) => {
+    currentSink = sink;
+    return unsubscribe;
+  });
   const client = {
-    subscribe: (_op: unknown, sink: Sink) => {
-      currentSink = sink;
-      return unsubscribe;
-    },
+    subscribe: subscribeMock,
     on: () => () => {},
     iterate: () => {
       throw new Error('not used');
@@ -30,7 +32,13 @@ function makeFakeClient(): FakeClient {
     emitError: (err: unknown) => currentSink?.error?.(err),
     emitComplete: () => currentSink?.complete?.(),
     unsubscribe,
+    subscribeMock,
   }) as FakeClient;
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe('execute', () => {
@@ -98,5 +106,92 @@ describe('execute', () => {
     await expect(promise).resolves.toEqual({ ok: true });
     expect(clearSpy).toHaveBeenCalled();
     clearSpy.mockRestore();
+  });
+
+  it('retries structured rate-limit errors and notifies before the next attempt', async () => {
+    const client = makeFakeClient();
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const onRateLimited = vi.fn();
+
+    const promise = execute<{ ok: boolean }>(
+      client,
+      { query: 'mutation Foo { ok }' },
+      {
+        timeoutMs: 100,
+        rateLimitJitterMs: 0,
+        sleep,
+        onRateLimited,
+      },
+    );
+
+    client.emit({
+      data: null,
+      errors: [
+        {
+          message: 'Rate limit exceeded. Try again in 4 seconds.',
+          extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 4 },
+        },
+      ],
+    });
+    await flushMicrotasks();
+
+    expect(sleep).toHaveBeenCalledWith(4000);
+    expect(onRateLimited).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 1,
+        maxAttempts: 2,
+        operationName: 'Foo',
+        retryAfterMs: 4000,
+      }),
+    );
+    expect(client.subscribeMock).toHaveBeenCalledTimes(2);
+
+    client.emit({ data: { ok: true } });
+    client.emitComplete();
+
+    await expect(promise).resolves.toEqual({ ok: true });
+  });
+
+  it('rejects with RateLimitError once the retry budget is exhausted', async () => {
+    const client = makeFakeClient();
+    const promise = execute(
+      client,
+      { query: 'mutation Foo { ok }' },
+      {
+        timeoutMs: 100,
+        rateLimitRetries: 0,
+        rateLimitJitterMs: 0,
+      },
+    );
+
+    client.emit({
+      data: null,
+      errors: [
+        {
+          message: 'Rate limit exceeded. Try again in 9 seconds.',
+          extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 9 },
+        },
+      ],
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(RateLimitError);
+    await expect(promise).rejects.toMatchObject({ retryAfterSeconds: 9 });
+  });
+
+  it('parses legacy plain-message rate-limit errors', async () => {
+    const client = makeFakeClient();
+    const promise = execute(
+      client,
+      { query: 'mutation Foo { ok }' },
+      {
+        timeoutMs: 100,
+        rateLimitRetries: 0,
+      },
+    );
+
+    client.emitError(new Error('Rate limit exceeded. Try again in 2 seconds.'));
+
+    await expect(promise).rejects.toBeInstanceOf(RateLimitError);
+    await expect(promise).rejects.toMatchObject({ retryAfterSeconds: 2 });
   });
 });

--- a/packages/shared/graphql-client/src/__tests__/subscribe.test.ts
+++ b/packages/shared/graphql-client/src/__tests__/subscribe.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Client, Sink } from 'graphql-ws';
+import { subscribe } from '../subscribe';
+import { GraphQLOperationError, RateLimitError } from '../errors';
+
+type FakeClient = Client & {
+  emit: (payload: Parameters<NonNullable<Sink['next']>>[0]) => void;
+  emitError: (err: unknown) => void;
+};
+
+function makeFakeClient(): FakeClient {
+  let currentSink: Sink | null = null;
+  const client = {
+    subscribe: (_op: unknown, sink: Sink) => {
+      currentSink = sink;
+      return vi.fn();
+    },
+    on: () => () => {},
+    iterate: () => {
+      throw new Error('not used');
+    },
+    dispose: async () => {},
+    terminate: () => {},
+  } as unknown as Client;
+
+  return Object.assign(client, {
+    emit: (payload: Parameters<NonNullable<Sink['next']>>[0]) => currentSink?.next?.(payload),
+    emitError: (err: unknown) => currentSink?.error?.(err),
+  }) as FakeClient;
+}
+
+function makeErrorSink(onError: Sink['error']): Sink<unknown> {
+  return {
+    next: vi.fn(),
+    error: onError,
+    complete: vi.fn(),
+  };
+}
+
+describe('subscribe', () => {
+  it('surfaces structured rate-limit errors as RateLimitError without retrying', () => {
+    const client = makeFakeClient();
+    const onError = vi.fn();
+
+    subscribe(client, { query: 'subscription Foo { ok }' }, makeErrorSink(onError));
+
+    client.emit({
+      data: null,
+      errors: [
+        {
+          message: 'Rate limit exceeded. Try again in 7 seconds.',
+          extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 7 },
+        },
+      ],
+    });
+
+    expect(onError).toHaveBeenCalledWith(expect.any(RateLimitError));
+    expect(onError.mock.calls[0][0]).toMatchObject({ retryAfterSeconds: 7 });
+  });
+
+  it('preserves non-rate-limit GraphQL extensions in GraphQLOperationError', () => {
+    const client = makeFakeClient();
+    const onError = vi.fn();
+
+    subscribe(client, { query: 'subscription Foo { ok }' }, makeErrorSink(onError));
+
+    client.emit({
+      data: null,
+      errors: [{ message: 'bad', extensions: { code: 'NOPE' } }],
+    });
+
+    expect(onError).toHaveBeenCalledWith(expect.any(GraphQLOperationError));
+    expect(onError.mock.calls[0][0]).toMatchObject({ extensions: { code: 'NOPE' } });
+  });
+
+  it('parses legacy rate-limit messages from the error callback', () => {
+    const client = makeFakeClient();
+    const onError = vi.fn();
+
+    subscribe(client, { query: 'subscription Foo { ok }' }, makeErrorSink(onError));
+
+    client.emitError([{ message: 'Rate limit exceeded. Try again in 3 seconds.' }]);
+
+    expect(onError).toHaveBeenCalledWith(expect.any(RateLimitError));
+    expect(onError.mock.calls[0][0]).toMatchObject({ retryAfterSeconds: 3 });
+  });
+});

--- a/packages/shared/graphql-client/src/errors.ts
+++ b/packages/shared/graphql-client/src/errors.ts
@@ -13,6 +13,7 @@ export type GraphQLErrorExtensions = {
   code?: string;
   existingClimbUuid?: string | null;
   existingClimbName?: string | null;
+  retryAfterSeconds?: number | string | null;
   [key: string]: unknown;
 };
 
@@ -27,6 +28,15 @@ export function isClimbDuplicateExtension(
   existingClimbName?: string | null;
 } {
   return extensions?.code === 'CLIMB_IS_DUPLICATE';
+}
+
+export function isRateLimitExtension(
+  extensions: GraphQLErrorExtensions | null | undefined,
+): extensions is GraphQLErrorExtensions & {
+  code: 'RATE_LIMITED';
+  retryAfterSeconds?: number | string | null;
+} {
+  return extensions?.code === 'RATE_LIMITED';
 }
 
 /**
@@ -51,4 +61,96 @@ export class GraphQLOperationError extends Error {
     const coded = graphqlErrors.find((err) => err.extensions && typeof err.extensions.code === 'string');
     this.extensions = coded?.extensions ?? graphqlErrors[0]?.extensions ?? null;
   }
+}
+
+export class RateLimitError extends Error {
+  readonly retryAfterSeconds: number | null;
+  readonly extensions: GraphQLErrorExtensions | null;
+  readonly cause: unknown;
+
+  constructor(
+    message: string,
+    retryAfterSeconds: number | null,
+    extensions: GraphQLErrorExtensions | null,
+    cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'RateLimitError';
+    this.retryAfterSeconds = retryAfterSeconds;
+    this.extensions = extensions;
+    this.cause = cause;
+  }
+}
+
+const RATE_LIMIT_MESSAGE_PATTERN = /rate limit exceeded(?:\.?\s*try again in\s+(\d+(?:\.\d+)?)\s+seconds?)?/i;
+
+function parseRetryAfterSeconds(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, value);
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return Math.max(0, parsed);
+    }
+  }
+  return null;
+}
+
+function parseRetryAfterFromMessage(message: string): number | null {
+  const match = RATE_LIMIT_MESSAGE_PATTERN.exec(message);
+  if (!match) return null;
+  return parseRetryAfterSeconds(match[1]);
+}
+
+function rateLimitFromGraphqlErrors(
+  graphqlErrors: ReadonlyArray<{ message: string; extensions?: GraphQLErrorExtensions }>,
+  cause: unknown,
+): RateLimitError | null {
+  for (const graphqlError of graphqlErrors) {
+    if (isRateLimitExtension(graphqlError.extensions)) {
+      return new RateLimitError(
+        graphqlError.message,
+        parseRetryAfterSeconds(graphqlError.extensions.retryAfterSeconds),
+        graphqlError.extensions,
+        cause,
+      );
+    }
+  }
+
+  for (const graphqlError of graphqlErrors) {
+    if (RATE_LIMIT_MESSAGE_PATTERN.test(graphqlError.message)) {
+      return new RateLimitError(
+        graphqlError.message,
+        parseRetryAfterFromMessage(graphqlError.message),
+        graphqlError.extensions ?? null,
+        cause,
+      );
+    }
+  }
+
+  return null;
+}
+
+export function parseRateLimitError(error: unknown): RateLimitError | null {
+  if (error instanceof RateLimitError) {
+    return error;
+  }
+
+  if (error instanceof GraphQLOperationError) {
+    return rateLimitFromGraphqlErrors(error.graphqlErrors, error);
+  }
+
+  if (Array.isArray(error) && error.length > 0 && typeof error[0]?.message === 'string') {
+    return rateLimitFromGraphqlErrors(
+      error as ReadonlyArray<{ message: string; extensions?: GraphQLErrorExtensions }>,
+      error,
+    );
+  }
+
+  if (error instanceof Error && RATE_LIMIT_MESSAGE_PATTERN.test(error.message)) {
+    return new RateLimitError(error.message, parseRetryAfterFromMessage(error.message), null, error);
+  }
+
+  return null;
 }

--- a/packages/shared/graphql-client/src/execute.ts
+++ b/packages/shared/graphql-client/src/execute.ts
@@ -1,7 +1,59 @@
 import type { Client } from 'graphql-ws';
-import { GraphQLOperationError } from './errors';
+import { GraphQLOperationError, parseRateLimitError, type RateLimitError } from './errors';
 import { getOperationName } from './operation-name';
 import { MUTATION_TIMEOUT_MS } from './constants';
+
+const DEFAULT_RATE_LIMIT_RETRIES = 2;
+const DEFAULT_RATE_LIMIT_DELAY_MS = 1000;
+const RATE_LIMIT_RETRY_DELAY_CAP_MS = 30_000;
+const RATE_LIMIT_RETRY_JITTER_MS = 250;
+
+export type RateLimitRetryEvent = {
+  error: RateLimitError;
+  attempt: number;
+  maxAttempts: number;
+  retryAfterMs: number;
+  operationName: string;
+};
+
+export type ExecuteOptions = {
+  timeoutMs?: number;
+  rateLimitRetries?: number;
+  maxRateLimitDelayMs?: number;
+  rateLimitJitterMs?: number;
+  onRateLimited?: (event: RateLimitRetryEvent) => void;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+function normalizeExecuteOptions(timeoutOrOptions: number | ExecuteOptions | undefined): Required<ExecuteOptions> {
+  if (typeof timeoutOrOptions === 'number') {
+    return {
+      timeoutMs: timeoutOrOptions,
+      rateLimitRetries: DEFAULT_RATE_LIMIT_RETRIES,
+      maxRateLimitDelayMs: RATE_LIMIT_RETRY_DELAY_CAP_MS,
+      rateLimitJitterMs: RATE_LIMIT_RETRY_JITTER_MS,
+      onRateLimited: () => {},
+      sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    };
+  }
+
+  return {
+    timeoutMs: timeoutOrOptions?.timeoutMs ?? MUTATION_TIMEOUT_MS,
+    rateLimitRetries: timeoutOrOptions?.rateLimitRetries ?? DEFAULT_RATE_LIMIT_RETRIES,
+    maxRateLimitDelayMs: timeoutOrOptions?.maxRateLimitDelayMs ?? RATE_LIMIT_RETRY_DELAY_CAP_MS,
+    rateLimitJitterMs: timeoutOrOptions?.rateLimitJitterMs ?? RATE_LIMIT_RETRY_JITTER_MS,
+    onRateLimited: timeoutOrOptions?.onRateLimited ?? (() => {}),
+    sleep: timeoutOrOptions?.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
+  };
+}
+
+function getRetryAfterMs(error: RateLimitError, options: Required<ExecuteOptions>): number {
+  const retryAfterMs =
+    error.retryAfterSeconds === null ? DEFAULT_RATE_LIMIT_DELAY_MS : Math.max(0, error.retryAfterSeconds * 1000);
+  const cappedRetryAfterMs = Math.min(retryAfterMs, options.maxRateLimitDelayMs);
+  const jitterMs = options.rateLimitJitterMs > 0 ? Math.round(Math.random() * options.rateLimitJitterMs) : 0;
+  return cappedRetryAfterMs + jitterMs;
+}
 
 /**
  * Execute a GraphQL mutation (or one-shot query) over a graphql-ws client.
@@ -9,70 +61,105 @@ import { MUTATION_TIMEOUT_MS } from './constants';
  * graphql-ws models everything as subscriptions: a mutation emits one `next`
  * payload, then `complete`. We resolve with the captured payload on
  * `complete`, reject on `error`, and apply a wall-clock timeout to keep the
- * caller from hanging if the connection is wedged. Caller can pass a custom
- * `timeoutMs` for long-running queries.
+ * caller from hanging if the connection is wedged. Rate-limit failures retry
+ * with a fresh timeout for each attempt so the wait itself cannot trip the
+ * mutation timeout.
  */
 export function execute<TData = unknown, TVariables = Record<string, unknown>>(
   client: Client,
   operation: { query: string; variables?: TVariables },
-  timeoutMs: number = MUTATION_TIMEOUT_MS,
+  timeoutOrOptions: number | ExecuteOptions = MUTATION_TIMEOUT_MS,
 ): Promise<TData> {
   const opName = getOperationName(operation, 'mutation');
+  const options = normalizeExecuteOptions(timeoutOrOptions);
 
-  return new Promise<TData>((resolve, reject) => {
-    let result: TData | undefined;
-    let hasResolved = false;
-    let unsubscribe: (() => void) | undefined;
+  async function executeWithRetries(): Promise<TData> {
+    let retriesUsed = 0;
 
-    const timer = setTimeout(() => {
-      settle(() => reject(new Error(`GraphQL mutation '${opName}' timed out after ${timeoutMs}ms`)));
-    }, timeoutMs);
+    while (true) {
+      try {
+        return await executeOnce(options.timeoutMs);
+      } catch (error) {
+        const rateLimitError = parseRateLimitError(error);
+        if (!rateLimitError) {
+          throw error;
+        }
+        if (retriesUsed >= options.rateLimitRetries) {
+          throw rateLimitError;
+        }
 
-    function settle(fn: () => void) {
-      if (hasResolved) return;
-      hasResolved = true;
-      clearTimeout(timer);
-      unsubscribe?.();
-      fn();
+        retriesUsed += 1;
+        const retryAfterMs = getRetryAfterMs(rateLimitError, options);
+        options.onRateLimited({
+          error: rateLimitError,
+          attempt: retriesUsed,
+          maxAttempts: options.rateLimitRetries,
+          retryAfterMs,
+          operationName: opName,
+        });
+        await options.sleep(retryAfterMs);
+      }
     }
+  }
 
-    unsubscribe = client.subscribe<TData>(
-      { query: operation.query, variables: operation.variables as Record<string, unknown> },
-      {
-        next: (data) => {
-          if ('data' in data) {
-            result = data.data as TData;
-          }
-          if (data.errors) {
-            const errors = data.errors;
-            settle(() => reject(new GraphQLOperationError(errors)));
-          }
-        },
-        error: (err) => {
-          settle(() => {
-            // graphql-ws also reports server-emitted GraphQL errors through the
-            // error callback when the server closes the stream with them (e.g.
-            // single-error mutation rejects). Preserve extensions in that path
-            // too, otherwise fall back to a generic Error.
-            if (Array.isArray(err) && err.length > 0 && typeof err[0]?.message === 'string') {
-              reject(new GraphQLOperationError(err));
-            } else if (err instanceof Error) {
-              reject(err);
-            } else {
-              reject(new Error(String(err)));
+  function executeOnce(timeoutMs: number): Promise<TData> {
+    return new Promise<TData>((resolve, reject) => {
+      let result: TData | undefined;
+      let hasResolved = false;
+      let unsubscribe: (() => void) | undefined;
+
+      const timer = setTimeout(() => {
+        settle(() => reject(new Error(`GraphQL mutation '${opName}' timed out after ${timeoutMs}ms`)));
+      }, timeoutMs);
+
+      function settle(fn: () => void) {
+        if (hasResolved) return;
+        hasResolved = true;
+        clearTimeout(timer);
+        unsubscribe?.();
+        fn();
+      }
+
+      unsubscribe = client.subscribe<TData>(
+        { query: operation.query, variables: operation.variables as Record<string, unknown> },
+        {
+          next: (data) => {
+            if ('data' in data) {
+              result = data.data as TData;
             }
-          });
-        },
-        complete: () => {
-          settle(() => {
-            if (result === undefined) {
-              reject(new Error(`GraphQL operation '${opName}' completed without data`));
-              return;
+            if (data.errors) {
+              const errors = data.errors;
+              settle(() => reject(new GraphQLOperationError(errors)));
             }
-            resolve(result);
-          });
+          },
+          error: (err) => {
+            settle(() => {
+              // graphql-ws also reports server-emitted GraphQL errors through the
+              // error callback when the server closes the stream with them (e.g.
+              // single-error mutation rejects). Preserve extensions in that path
+              // too, otherwise fall back to a generic Error.
+              if (Array.isArray(err) && err.length > 0 && typeof err[0]?.message === 'string') {
+                reject(new GraphQLOperationError(err));
+              } else if (err instanceof Error) {
+                reject(err);
+              } else {
+                reject(new Error(String(err)));
+              }
+            });
+          },
+          complete: () => {
+            settle(() => {
+              if (result === undefined) {
+                reject(new Error(`GraphQL operation '${opName}' completed without data`));
+                return;
+              }
+              resolve(result);
+            });
+          },
         },
-      },
-    );
-  });
+      );
+    });
+  }
+
+  return executeWithRetries();
 }

--- a/packages/shared/graphql-client/src/index.ts
+++ b/packages/shared/graphql-client/src/index.ts
@@ -10,10 +10,17 @@ export {
 } from './constants';
 
 export type { GraphQLErrorExtensions } from './errors';
-export { GraphQLOperationError, isClimbDuplicateExtension } from './errors';
+export {
+  GraphQLOperationError,
+  RateLimitError,
+  isClimbDuplicateExtension,
+  isRateLimitExtension,
+  parseRateLimitError,
+} from './errors';
 
 export { getOperationName } from './operation-name';
 
+export type { ExecuteOptions, RateLimitRetryEvent } from './execute';
 export { execute } from './execute';
 export { subscribe } from './subscribe';
 

--- a/packages/shared/graphql-client/src/subscribe.ts
+++ b/packages/shared/graphql-client/src/subscribe.ts
@@ -1,4 +1,5 @@
 import type { Client, Sink } from 'graphql-ws';
+import { GraphQLOperationError, parseRateLimitError } from './errors';
 
 /**
  * Subscribe to a GraphQL subscription and receive events via callback.
@@ -19,14 +20,21 @@ export function subscribe<TData = unknown, TVariables = Record<string, unknown>>
           sink.next?.(data.data);
         }
         if (data.errors) {
-          sink.error?.(new Error(data.errors.map((e) => e.message).join(', ')));
+          const operationError = new GraphQLOperationError(data.errors);
+          sink.error?.(parseRateLimitError(operationError) ?? operationError);
         }
       },
       error: (error) => {
         // graphql-ws passes raw DOM Events (ErrorEvent/CloseEvent) when the WebSocket
         // connection fails. Always forward a proper Error so callers and Sentry never
         // receive "Event `Event` (type=error) captured as promise rejection".
-        sink.error?.(error instanceof Error ? error : new Error(String(error)));
+        if (Array.isArray(error) && error.length > 0 && typeof error[0]?.message === 'string') {
+          const operationError = new GraphQLOperationError(error);
+          sink.error?.(parseRateLimitError(operationError) ?? operationError);
+          return;
+        }
+        const normalizedError = error instanceof Error ? error : new Error(String(error));
+        sink.error?.(parseRateLimitError(normalizedError) ?? normalizedError);
       },
       complete: () => {
         sink.complete?.();

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -223,7 +223,8 @@
     "tickHistoryClimb": "Log a tick for {{name}}"
   },
   "queueProvider": {
-    "offlineLimitReached": "You've hit the offline up-next limit. Reconnect to sync your climbs."
+    "offlineLimitReached": "You've hit the offline up-next limit. Reconnect to sync your climbs.",
+    "rateLimitCatchUp": "Slow down — catching up..."
   },
   "driverToast": {
     "firstDriver": "{{newDriver}} is driving the wall.",
@@ -295,6 +296,7 @@
       "removeClimb": "Remove climb",
       "positionLabel": "position {{position}}",
       "syncError": "Queue sync error",
+      "rateLimitCatchUp": "Slow down — catching up...",
       "outOfSyncRefreshed": "Queue was out of sync. Refreshed from your crew.",
       "sessionCreateError": "Couldn't create session",
       "noBoardSelected": "Pick a board first",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -223,7 +223,8 @@
     "tickHistoryClimb": "Registrar un tick para {{name}}"
   },
   "queueProvider": {
-    "offlineLimitReached": "Has alcanzado el límite de la cola sin conexión. Vuelve a conectarte para sincronizar tus vías."
+    "offlineLimitReached": "Has alcanzado el límite de la cola sin conexión. Vuelve a conectarte para sincronizar tus vías.",
+    "rateLimitCatchUp": "Ve más despacio: poniéndonos al día..."
   },
   "driverToast": {
     "firstDriver": "{{newDriver}} está manejando la pared.",
@@ -295,6 +296,7 @@
       "removeClimb": "Eliminar bloque",
       "positionLabel": "posición {{position}}",
       "syncError": "Error de sincronización de cola",
+      "rateLimitCatchUp": "Ve más despacio: poniéndonos al día...",
       "outOfSyncRefreshed": "La cola estaba desincronizada. Se actualizó con tu grupo.",
       "sessionCreateError": "No se pudo crear la sesión",
       "noBoardSelected": "Selecciona un board primero",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -223,7 +223,8 @@
     "tickHistoryClimb": "Enregistrer une croix pour {{name}}"
   },
   "queueProvider": {
-    "offlineLimitReached": "Tu as atteint la limite hors ligne de la file d'attente. Reconnecte-toi pour synchroniser tes blocs."
+    "offlineLimitReached": "Tu as atteint la limite hors ligne de la file d'attente. Reconnecte-toi pour synchroniser tes blocs.",
+    "rateLimitCatchUp": "Ralentis : on se remet à jour..."
   },
   "driverToast": {
     "firstDriver": "{{newDriver}} pilote le mur.",
@@ -295,6 +296,7 @@
       "removeClimb": "Supprimer le bloc",
       "positionLabel": "position {{position}}",
       "syncError": "Erreur de synchronisation de la file",
+      "rateLimitCatchUp": "Ralentis : on se remet à jour...",
       "outOfSyncRefreshed": "La file était désynchronisée. Actualisée depuis ton groupe.",
       "sessionCreateError": "Impossible de créer la session",
       "noBoardSelected": "Choisissez d'abord un board",

--- a/packages/shared/queue-react/src/create-queue-mutations.ts
+++ b/packages/shared/queue-react/src/create-queue-mutations.ts
@@ -22,7 +22,7 @@
 // setSessionBoardSerial, setSessionBoardPath) no-op on BOTH platforms when
 // there is no active session.
 
-import type { Client } from '@boardsesh/graphql-client';
+import type { Client, RateLimitRetryEvent } from '@boardsesh/graphql-client';
 import { execute } from '@boardsesh/graphql-client';
 import type { ClimbQueueItemInput } from '@boardsesh/shared-schema';
 import { createSetCurrentClimbCoalescer } from '@boardsesh/queue-runtime';
@@ -76,6 +76,8 @@ export type QueueMutationsDeps<TItem> = {
   ensureReady?: (capturedSessionId: string | null) => Promise<string | null>;
   /** Sink for swallowed transport errors (best-effort actions + coalescer drains). */
   onBestEffortError?: (action: string, error: unknown) => void;
+  /** Platform UI hook for rate-limit retry notifications. */
+  onRateLimited?: (event: RateLimitRetryEvent) => void;
 };
 
 export type QueueMutationsActions<TItem> = {
@@ -132,9 +134,17 @@ export type QueueMutationsActions<TItem> = {
 };
 
 export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): QueueMutationsActions<TItem> {
-  const { getClient, getSessionId, toQueueItemInput, ensureReady, onBestEffortError } = deps;
+  const { getClient, getSessionId, toQueueItemInput, ensureReady, onBestEffortError, onRateLimited } = deps;
 
   type Ready = { client: Client; sessionId: string };
+  type Operation<TVariables = Record<string, unknown>> = { query: string; variables?: TVariables };
+
+  function executeQueueMutation<TData = unknown, TVariables = Record<string, unknown>>(
+    client: Client,
+    operation: Operation<TVariables>,
+  ): Promise<TData> {
+    return execute<TData, TVariables>(client, operation, { onRateLimited });
+  }
 
   // Core mutating actions. Web (no ensureReady) THROWS when disconnected;
   // mobile (ensureReady) silently no-ops by returning null. `allowCreate`
@@ -196,7 +206,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
         // session is fatal (throws), unlike mobile which lazily creates above.
         throw new Error(NOT_CONNECTED);
       }
-      await execute(client, {
+      await executeQueueMutation(client, {
         query: SET_CURRENT_CLIMB,
         variables: {
           item: args.item ? toQueueItemInput(args.item) : null,
@@ -215,7 +225,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
         const sessionId = await ensureReady(capturedSessionId);
         if (!sessionId) return;
       }
-      await execute(client, {
+      await executeQueueMutation(client, {
         query: ADD_QUEUE_ITEM,
         variables: { item: toQueueItemInput(item) },
       });
@@ -228,7 +238,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     addQueueItem: async (item, position) => {
       const ready = await resolveCore({ allowCreate: true });
       if (!ready) return;
-      await execute(ready.client, {
+      await executeQueueMutation(ready.client, {
         query: ADD_QUEUE_ITEM,
         variables: { item: toQueueItemInput(item), position },
       });
@@ -237,13 +247,13 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     removeQueueItem: async (uuid) => {
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
-      await execute(ready.client, { query: REMOVE_QUEUE_ITEM, variables: { uuid } });
+      await executeQueueMutation(ready.client, { query: REMOVE_QUEUE_ITEM, variables: { uuid } });
     },
 
     reorderQueueItem: async (uuid, oldIndex, newIndex) => {
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
-      await execute(ready.client, { query: REORDER_QUEUE_ITEM, variables: { uuid, oldIndex, newIndex } });
+      await executeQueueMutation(ready.client, { query: REORDER_QUEUE_ITEM, variables: { uuid, oldIndex, newIndex } });
     },
 
     setCurrentClimb: async (item, shouldAddToQueue, correlationId) => {
@@ -258,7 +268,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     mirrorCurrentClimb: async (mirrored) => {
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
-      await execute(ready.client, { query: MIRROR_CURRENT_CLIMB, variables: { mirrored } });
+      await executeQueueMutation(ready.client, { query: MIRROR_CURRENT_CLIMB, variables: { mirrored } });
     },
 
     publishPlaybackState: async (input) => {
@@ -268,7 +278,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       const ready = await resolveCurrent();
       if (!ready) return;
       try {
-        await execute(ready.client, { query: PUBLISH_PLAYBACK_STATE, variables: { input } });
+        await executeQueueMutation(ready.client, { query: PUBLISH_PLAYBACK_STATE, variables: { input } });
       } catch (error) {
         // Best-effort — losing one broadcast just means peers briefly run out
         // of sync until the next event. Don't surface to user.
@@ -279,7 +289,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     setQueue: async (queue, currentClimbQueueItem) => {
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
-      await execute(ready.client, {
+      await executeQueueMutation(ready.client, {
         query: SET_QUEUE,
         variables: {
           queue: queue.map(toQueueItemInput),
@@ -291,7 +301,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     replaceQueueItem: async (uuid, item) => {
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
-      await execute(ready.client, {
+      await executeQueueMutation(ready.client, {
         query: REPLACE_QUEUE_ITEM,
         variables: { uuid, item: toQueueItemInput(item) },
       });
@@ -300,7 +310,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     takeControl: async (climb) => {
       const ready = await resolveCurrent();
       if (!ready) return;
-      await execute(ready.client, {
+      await executeQueueMutation(ready.client, {
         query: TAKE_CONTROL,
         variables: { climb: climb ? toQueueItemInput(climb) : null },
       });
@@ -309,14 +319,14 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
     releaseControl: async () => {
       const ready = await resolveCurrent();
       if (!ready) return;
-      await execute(ready.client, { query: RELEASE_CONTROL, variables: {} });
+      await executeQueueMutation(ready.client, { query: RELEASE_CONTROL, variables: {} });
     },
 
     confirmClimbOnWall: async (climbUuid) => {
       const ready = await resolveCurrent();
       if (!ready) return;
       try {
-        await execute(ready.client, { query: CONFIRM_CLIMB_ON_WALL, variables: { climbUuid } });
+        await executeQueueMutation(ready.client, { query: CONFIRM_CLIMB_ON_WALL, variables: { climbUuid } });
       } catch (error) {
         onBestEffortError?.('confirmClimbOnWall', error);
       }
@@ -326,7 +336,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       const ready = await resolveCurrent();
       if (!ready) return;
       try {
-        await execute(ready.client, { query: SET_SESSION_BOARD_SERIAL, variables: { serial } });
+        await executeQueueMutation(ready.client, { query: SET_SESSION_BOARD_SERIAL, variables: { serial } });
       } catch (error) {
         onBestEffortError?.('setSessionBoardSerial', error);
       }
@@ -336,7 +346,7 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       const ready = await resolveCurrent();
       if (!ready) return;
       try {
-        await execute(ready.client, { query: SET_SESSION_BOARD_PATH, variables: { boardPath } });
+        await executeQueueMutation(ready.client, { query: SET_SESSION_BOARD_PATH, variables: { boardPath } });
       } catch (error) {
         onBestEffortError?.('setSessionBoardPath', error);
       }

--- a/packages/shared/queue-react/src/use-queue-mutations.ts
+++ b/packages/shared/queue-react/src/use-queue-mutations.ts
@@ -35,6 +35,7 @@ export function useQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Queue
           ? (capturedSessionId) => depsRef.current.ensureReady!(capturedSessionId)
           : undefined,
         onBestEffortError: (action, error) => depsRef.current.onBestEffortError?.(action, error),
+        onRateLimited: (event) => depsRef.current.onRateLimited?.(event),
       }),
     [hasEnsureReady],
   );

--- a/packages/web/app/components/graphql-queue/hooks/__tests__/use-offline-reconciliation.test.ts
+++ b/packages/web/app/components/graphql-queue/hooks/__tests__/use-offline-reconciliation.test.ts
@@ -136,6 +136,17 @@ describe('useOfflineReconciliation', () => {
     });
   }
 
+  async function advanceReplayDelay(count: number) {
+    for (let index = 0; index < count; index++) {
+      await act(async () => {
+        vi.advanceTimersByTime(75);
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+  }
+
   // --- Additions-only reconciliation (server wins, multi-user, sequence changed) ---
 
   describe('additions-only reconciliation (server wins)', () => {
@@ -196,6 +207,7 @@ describe('useOfflineReconciliation', () => {
           },
         });
       });
+      await advanceReplayDelay(1);
 
       // Should use individual addQueueItem, NOT setQueue
       expect(mockAddQueueItem).toHaveBeenCalledTimes(2);
@@ -223,6 +235,7 @@ describe('useOfflineReconciliation', () => {
           },
         });
       });
+      await advanceReplayDelay(1);
 
       expect(mockAddQueueItem).toHaveBeenCalledTimes(1);
       expect(mockAddQueueItem).toHaveBeenCalledWith(item1);
@@ -253,6 +266,7 @@ describe('useOfflineReconciliation', () => {
           },
         });
       });
+      await advanceReplayDelay(2);
 
       expect(mockAddQueueItem).toHaveBeenCalledTimes(3);
       expect(mockClearBuffer).toHaveBeenCalled();

--- a/packages/web/app/components/graphql-queue/hooks/use-offline-reconciliation.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-offline-reconciliation.ts
@@ -3,6 +3,7 @@ import type { SubscriptionQueueEvent, SessionUser } from '@boardsesh/shared-sche
 import type { ClimbQueueItem } from '../../queue-control/types';
 
 const RECONCILIATION_TIMEOUT_MS = 15000;
+const REPLAY_MUTATION_DELAY_MS = 75;
 
 export type UseOfflineReconciliationParams = {
   offlineBuffer: {
@@ -124,14 +125,21 @@ export function useOfflineReconciliation({
     async function reconcileAdditionsOnly(serverQueue: ClimbQueueItem[]) {
       const pending = offlineBuffer.getBufferedAdditions();
       const serverUuids = new Set(serverQueue.map((item) => item.uuid));
+      let attemptedSendCount = 0;
 
       for (const item of pending) {
         if (isSuperseded()) return;
         if (serverUuids.has(item.uuid)) continue;
+        if (attemptedSendCount > 0) {
+          await new Promise((resolve) => setTimeout(resolve, REPLAY_MUTATION_DELAY_MS));
+          if (isSuperseded()) return;
+        }
         try {
           await persistentSession.addQueueItem(item);
         } catch (error) {
           console.error('[OfflineReconciliation] Failed to add buffered item:', item.climb?.name, error);
+        } finally {
+          attemptedSendCount++;
         }
       }
 

--- a/packages/web/app/components/persistent-session/hooks/use-queue-mutations.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-queue-mutations.ts
@@ -1,11 +1,15 @@
 import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   useQueueMutations as useSharedQueueMutations,
   type QueueMutationsActions as SharedQueueMutationsActions,
 } from '@boardsesh/queue-react';
+import { useSnackbar } from '../../providers/snackbar-provider';
 import type { Client } from '../../graphql-queue/graphql-client';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
 import { type Session, toClimbQueueItemInput } from '../types';
+
+const RATE_LIMIT_TOAST_DEBOUNCE_MS = 10_000;
 
 type UseQueueMutationsArgs = {
   client: Client | null;
@@ -20,10 +24,13 @@ type UseQueueMutationsArgs = {
 export type QueueMutationsActions = SharedQueueMutationsActions<LocalClimbQueueItem>;
 
 export function useQueueMutations({ client, session }: UseQueueMutationsArgs): QueueMutationsActions {
+  const { showMessage } = useSnackbar();
+  const { t } = useTranslation('session');
   // Refs keep the injected getters reading live values without recreating the
   // shared hook's callbacks on every render.
   const clientRef = useRef(client);
   const sessionRef = useRef(session);
+  const lastRateLimitToastAtRef = useRef(0);
   clientRef.current = client;
   sessionRef.current = session;
 
@@ -36,6 +43,13 @@ export function useQueueMutations({ client, session }: UseQueueMutationsArgs): Q
     toQueueItemInput: toClimbQueueItemInput,
     onBestEffortError: (action, error) => {
       console.error(`Failed to ${action}:`, error);
+    },
+    onRateLimited: ({ attempt }) => {
+      if (attempt < 2) return;
+      const now = Date.now();
+      if (now - lastRateLimitToastAtRef.current < RATE_LIMIT_TOAST_DEBOUNCE_MS) return;
+      lastRateLimitToastAtRef.current = now;
+      showMessage(t('queueProvider.rateLimitCatchUp'), 'warning');
     },
   });
 }


### PR DESCRIPTION
Closes #2655

## Summary
- Add structured backend `RATE_LIMITED` GraphQL errors with retry metadata and preserve them through error handling.
- Teach `@boardsesh/graphql-client` to parse structured and legacy rate-limit errors, retry queries/mutations with bounded delay, and surface typed subscription errors without reconnect storms.
- Wire queue catch-up rate-limit notifications into web/mobile and pace offline replay mutation sends.
- Remove two pre-existing orphaned mobile i18n keys that blocked the staged i18n hook.

## Validation
- `vp staged`
- `vp test run --project graphql-client --reporter=agent`
- `SKIP_TEST_INFRA=1 vp test run --project backend --reporter=agent src/__tests__/rate-limiter.test.ts src/__tests__/redis-rate-limiter.test.ts`
- `vp test run --project web --reporter=agent app/components/graphql-queue/hooks/__tests__/use-offline-reconciliation.test.ts`
- `vp run typecheck:shared`
- `vp run typecheck:backend`
- `vp run typecheck:mobile`
- `vp run typecheck:web`
- Earlier full `vp run test:mobile` passed before the final rebase/test-helper polish.

## QA
- Local QA notes: `.boardsesh/qa-notes.md`
- Mobile Metro started on `http://marcos-macbook-pro-2-1.tailedd9d5.ts.net:8084` for this worktree.