### PR TITLE
[codex] Add mobile search heatmap filters

### DIFF
--- a/packages/backend/src/db/queries/climbs/hold-heatmap.ts
+++ b/packages/backend/src/db/queries/climbs/hold-heatmap.ts
@@ -1,0 +1,167 @@
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { boardseshTicks } from '@boardsesh/db/schema';
+import { createClimbFilters, type BoardRouteParams, type ClimbSearchParams } from '@boardsesh/db/queries';
+import { dbRead } from '../../client';
+import { UNIFIED_TABLES } from '../util/table-select';
+
+export type HoldHeatmapPoint = {
+  holdId: number;
+  totalUses: number;
+  startingUses: number;
+  totalAscents: number;
+  handUses: number;
+  footUses: number;
+  finishUses: number;
+  averageDifficulty: number | null;
+  userAscents?: number;
+  userAttempts?: number;
+};
+
+type RawHoldHeatmapRow = {
+  holdId: number | string | bigint | null;
+  totalUses: number | string | bigint | null;
+  startingUses: number | string | bigint | null;
+  totalAscents: number | string | bigint | null;
+  handUses: number | string | bigint | null;
+  footUses: number | string | bigint | null;
+  finishUses: number | string | bigint | null;
+  averageDifficulty: number | string | null;
+  userAscents?: number | string | bigint | null;
+  userAttempts?: number | string | bigint | null;
+};
+
+export async function getHoldHeatmapData(
+  params: BoardRouteParams,
+  searchParams: ClimbSearchParams,
+  userId?: string,
+): Promise<HoldHeatmapPoint[]> {
+  const { climbs, climbStats, climbHolds } = UNIFIED_TABLES;
+  const filters = createClimbFilters(params, searchParams, userId);
+  const personalProgressFiltersEnabled =
+    searchParams.hideAttempted ||
+    searchParams.hideCompleted ||
+    searchParams.showOnlyAttempted ||
+    searchParams.showOnlyCompleted;
+
+  let holdStats: RawHoldHeatmapRow[];
+
+  if (personalProgressFiltersEnabled && userId) {
+    holdStats = await dbRead
+      .select({
+        holdId: climbHolds.holdId,
+        totalUses: sql<number>`COUNT(DISTINCT ${climbHolds.climbUuid})`,
+        // In user-filtered mode this is the user's matching climb count per hold.
+        totalAscents: sql<number>`COUNT(DISTINCT ${climbHolds.climbUuid})`,
+        startingUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'STARTING' THEN 1 ELSE 0 END)`,
+        handUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'HAND' THEN 1 ELSE 0 END)`,
+        footUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FOOT' THEN 1 ELSE 0 END)`,
+        finishUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FINISH' THEN 1 ELSE 0 END)`,
+        averageDifficulty: sql<number>`AVG(${climbStats.displayDifficulty})`,
+      })
+      .from(climbHolds)
+      .innerJoin(climbs, and(...filters.getClimbHoldsJoinConditions()))
+      .leftJoin(climbStats, and(...filters.getHoldHeatmapClimbStatsConditions()))
+      .where(
+        and(...filters.getClimbWhereConditions(), ...filters.getSizeConditions(), ...filters.getClimbStatsConditions()),
+      )
+      .groupBy(climbHolds.holdId);
+  } else {
+    holdStats = await dbRead
+      .select({
+        holdId: climbHolds.holdId,
+        totalUses: sql<number>`COUNT(DISTINCT ${climbHolds.climbUuid})`,
+        totalAscents: sql<number>`SUM(${climbStats.ascensionistCount})`,
+        startingUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'STARTING' THEN 1 ELSE 0 END)`,
+        handUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'HAND' THEN 1 ELSE 0 END)`,
+        footUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FOOT' THEN 1 ELSE 0 END)`,
+        finishUses: sql<number>`SUM(CASE WHEN ${climbHolds.holdState} = 'FINISH' THEN 1 ELSE 0 END)`,
+        averageDifficulty: sql<number>`AVG(${climbStats.displayDifficulty})`,
+      })
+      .from(climbHolds)
+      .innerJoin(climbs, and(...filters.getClimbHoldsJoinConditions()))
+      .leftJoin(climbStats, and(...filters.getHoldHeatmapClimbStatsConditions()))
+      .where(
+        and(...filters.getClimbWhereConditions(), ...filters.getSizeConditions(), ...filters.getClimbStatsConditions()),
+      )
+      .groupBy(climbHolds.holdId);
+  }
+
+  if (userId && !personalProgressFiltersEnabled) {
+    const [userAscentsRows, userAttemptsRows] = await Promise.all([
+      dbRead
+        .select({
+          holdId: climbHolds.holdId,
+          userAscents: sql<number>`COUNT(*)`,
+        })
+        .from(boardseshTicks)
+        .innerJoin(
+          climbHolds,
+          and(eq(boardseshTicks.climbUuid, climbHolds.climbUuid), eq(climbHolds.boardType, params.board_name)),
+        )
+        .where(
+          and(
+            eq(boardseshTicks.userId, userId),
+            eq(boardseshTicks.boardType, params.board_name),
+            eq(boardseshTicks.angle, params.angle),
+            inArray(boardseshTicks.status, ['flash', 'send']),
+          ),
+        )
+        .groupBy(climbHolds.holdId),
+      dbRead
+        .select({
+          holdId: climbHolds.holdId,
+          userAttempts: sql<number>`SUM(${boardseshTicks.attemptCount})`,
+        })
+        .from(boardseshTicks)
+        .innerJoin(
+          climbHolds,
+          and(eq(boardseshTicks.climbUuid, climbHolds.climbUuid), eq(climbHolds.boardType, params.board_name)),
+        )
+        .where(
+          and(
+            eq(boardseshTicks.userId, userId),
+            eq(boardseshTicks.boardType, params.board_name),
+            eq(boardseshTicks.angle, params.angle),
+          ),
+        )
+        .groupBy(climbHolds.holdId),
+    ]);
+
+    const ascentsByHold = new Map(userAscentsRows.map((row) => [Number(row.holdId), Number(row.userAscents ?? 0)]));
+    const attemptsByHold = new Map(userAttemptsRows.map((row) => [Number(row.holdId), Number(row.userAttempts ?? 0)]));
+
+    holdStats = holdStats.map((stat) => ({
+      ...stat,
+      userAscents: ascentsByHold.get(Number(stat.holdId)) ?? 0,
+      userAttempts: attemptsByHold.get(Number(stat.holdId)) ?? 0,
+    }));
+  } else if (personalProgressFiltersEnabled && userId) {
+    holdStats = holdStats.map((stat) => ({
+      ...stat,
+      userAscents: Number(stat.totalAscents ?? 0),
+      userAttempts: Number(stat.totalUses ?? 0),
+    }));
+  }
+
+  return holdStats.map((stat) => normalizeStats(stat, userId));
+}
+
+function normalizeStats(stats: RawHoldHeatmapRow, userId?: string): HoldHeatmapPoint {
+  const result: HoldHeatmapPoint = {
+    holdId: Number(stats.holdId),
+    totalUses: Number(stats.totalUses ?? 0),
+    totalAscents: Number(stats.totalAscents ?? 0),
+    startingUses: Number(stats.startingUses ?? 0),
+    handUses: Number(stats.handUses ?? 0),
+    footUses: Number(stats.footUses ?? 0),
+    finishUses: Number(stats.finishUses ?? 0),
+    averageDifficulty: stats.averageDifficulty == null ? null : Number(stats.averageDifficulty),
+  };
+
+  if (userId) {
+    result.userAscents = Number(stats.userAscents ?? 0);
+    result.userAttempts = Number(stats.userAttempts ?? 0);
+  }
+
+  return result;
+}

--- a/packages/backend/src/db/queries/climbs/index.ts
+++ b/packages/backend/src/db/queries/climbs/index.ts
@@ -1,7 +1,9 @@
 export { searchClimbs } from './search-climbs';
 export { countClimbs } from './count-climbs';
 export { getClimbByUuid } from './get-climb';
+export { getHoldHeatmapData } from './hold-heatmap';
 export { matchClimbByFrames } from './match-climb-by-frames';
+export type { HoldHeatmapPoint } from './hold-heatmap';
 // Re-export shared types for backward compatibility
 export type {
   ClimbSearchParams,

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -3,6 +3,7 @@ import {
   type CheckMoonBoardClimbDuplicatesInput,
   type ClimbSearchInput,
   type ConnectionContext,
+  type HoldHeatmapPoint,
   type SetterStat,
   type SetterStatsInput,
   type SimilarClimb,
@@ -17,6 +18,7 @@ import {
   type ClimbSearchParams,
   type ParsedBoardRouteParameters,
   getClimbByUuid,
+  getHoldHeatmapData,
   mapSearchInputToParams,
 } from '../../../db/queries/climbs/index';
 import { isValidBoardName } from '../../../db/queries/util/table-select';
@@ -215,6 +217,44 @@ export const climbQueries = {
       userId,
       _isCacheable: !hasUserSpecificFilters && isCacheableBoard,
     };
+  },
+
+  /**
+   * Aggregate hold usage for the interactive search board heatmap.
+   * Uses the same ClimbSearchInput mapper as searchClimbs so the overlay matches
+   * the currently staged filters in the mobile search sheet.
+   */
+  holdHeatmap: async (
+    _: unknown,
+    { input }: { input: ClimbSearchInput },
+    ctx: ConnectionContext,
+  ): Promise<HoldHeatmapPoint[]> => {
+    await applyRateLimit(ctx, 30, 'hold-heatmap');
+    const validated = validateInput(ClimbSearchInputSchema, input, 'input');
+
+    if (!isValidBoardName(validated.boardName)) {
+      throw new Error(`Invalid board name: ${validated.boardName}. Must be one of: ${SUPPORTED_BOARDS.join(', ')}`);
+    }
+
+    // MoonBoard search can use typed hold filters, but the heatmap aggregation is
+    // based on unified board_climb_holds rows that MoonBoard imports don't yet guarantee.
+    if (validated.boardName === 'moonboard') return [];
+
+    const setIds = validated.setIds
+      .split(',')
+      .map((id) => parseInt(id.trim(), 10))
+      .filter((id) => !isNaN(id));
+
+    const params: ParsedBoardRouteParameters = {
+      board_name: validated.boardName,
+      layout_id: validated.layoutId,
+      size_id: validated.sizeId,
+      set_ids: setIds,
+      angle: validated.angle,
+    };
+
+    const searchParams: ClimbSearchParams = mapSearchInputToParams(validated);
+    return getHoldHeatmapData(params, searchParams, ctx.isAuthenticated ? ctx.userId : undefined);
   },
 
   /**

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -209,6 +209,13 @@ export function ClimbFilterSheet({
       debouncedEdits.boardFilters,
     );
   }, [boardConfig, debouncedEdits, searchName]);
+  const liveHeatmapInput = useMemo(() => {
+    if (!boardConfig) return null;
+    return mergeBoardFilters(
+      toClimbSearchInput(localFilters, boardConfig, { page: 0, pageSize: 1 }, { name: searchName }),
+      localBoardFilters,
+    );
+  }, [boardConfig, localFilters, localBoardFilters, searchName]);
   const { data: previewCount } = useSearchClimbsCount(
     previewInput ?? { boardName: '', layoutId: 0, sizeId: 0, setIds: '', angle: 0 },
     !!previewInput,
@@ -859,6 +866,7 @@ export function ClimbFilterSheet({
               visible={activeChildSheet === 'holds'}
               boardConfig={boardConfig}
               holdsFilter={localBoardFilters.holdsFilter ?? {}}
+              heatmapInput={liveHeatmapInput}
               onHoldsFilterChange={handleHoldsFilterChange}
               onClose={closeChildSheet}
               onDismiss={handleChildSheetDismiss}
@@ -871,6 +879,7 @@ export function ClimbFilterSheet({
               zoneBox={localBoardFilters.zoneBox ?? null}
               zoneMode={localBoardFilters.zoneMode ?? 'allHolds'}
               holdsFilter={localBoardFilters.holdsFilter ?? {}}
+              heatmapInput={liveHeatmapInput}
               onZoneFilterChange={handleZoneFilterChange}
               onClose={closeChildSheet}
               onDismiss={handleChildSheetDismiss}

--- a/packages/mobile/src/components/search/HeatmapControls.tsx
+++ b/packages/mobile/src/components/search/HeatmapControls.tsx
@@ -1,0 +1,98 @@
+import { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../Button';
+import { SegmentedControl } from '../SegmentedControl';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing } from '../../theme/tokens';
+import type { SearchHeatmapMode } from './SearchHeatmapOverlay';
+
+type HeatmapControlsProps = {
+  available: boolean;
+  enabled: boolean;
+  loading: boolean;
+  mode: SearchHeatmapMode;
+  onEnabledChange: (enabled: boolean) => void;
+  onModeChange: (mode: SearchHeatmapMode) => void;
+};
+
+export function HeatmapControls({
+  available,
+  enabled,
+  loading,
+  mode,
+  onEnabledChange,
+  onModeChange,
+}: HeatmapControlsProps) {
+  const { t } = useTranslation('climbs');
+  const { systemColors } = useTheme();
+  const modeOptions = useMemo(
+    () => [
+      { key: 'total' as const, label: t('mobile.heatmap.total') },
+      { key: 'start' as const, label: t('mobile.heatmap.start') },
+      { key: 'handsFeet' as const, label: t('mobile.heatmap.handsFeet') },
+      { key: 'finish' as const, label: t('mobile.heatmap.finish') },
+    ],
+    [t],
+  );
+
+  if (!available) {
+    return (
+      <View style={styles.container}>
+        <Button
+          title={t('mobile.heatmap.unavailable')}
+          onPress={() => undefined}
+          variant="outlined"
+          size="small"
+          icon="flame"
+          disabled
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Button
+        title={loading ? t('mobile.heatmap.loading') : enabled ? t('mobile.heatmap.hide') : t('mobile.heatmap.show')}
+        onPress={() => onEnabledChange(!enabled)}
+        variant={enabled ? 'filled' : 'outlined'}
+        size="small"
+        icon="flame"
+        loading={loading}
+      />
+      {enabled ? (
+        <View style={styles.modeGroup}>
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.modeLabel}>
+            {t('mobile.heatmap.modeLabel')}
+          </Text>
+          <SegmentedControl
+            options={modeOptions}
+            selectedKey={mode}
+            onSelect={onModeChange}
+            textVariant="footnote"
+            trackColor={systemColors.fill}
+            accessibilityLabel={t('mobile.heatmap.modeLabel')}
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[2],
+    gap: spacing[2],
+    alignItems: 'center',
+  },
+  modeGroup: {
+    alignSelf: 'stretch',
+    gap: spacing[1],
+  },
+  modeLabel: {
+    textAlign: 'center',
+  },
+});

--- a/packages/mobile/src/components/search/HoldFilterEditorSheet.tsx
+++ b/packages/mobile/src/components/search/HoldFilterEditorSheet.tsx
@@ -6,13 +6,23 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { getLayout } from '@boardsesh/board-constants/product-sizes';
 import { countFilteredHolds, toggleHoldFilterType, type BoardSearchConfig } from '@boardsesh/climb-filters';
-import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType, HoldsFilter } from '@boardsesh/shared-schema';
+import type {
+  BoardName,
+  ClimbSearchInput,
+  HoldFilterEntry,
+  HoldFilterMode,
+  HoldFilterType,
+  HoldsFilter,
+} from '@boardsesh/shared-schema';
 import { ModalSheet } from '../ModalSheet';
 import { Text } from '../Text';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { InteractiveFilterBoard } from './InteractiveFilterBoard';
 import { HoldFilterPicker } from './HoldFilterPicker';
+import { HeatmapControls } from './HeatmapControls';
+import type { SearchHeatmapMode } from './SearchHeatmapOverlay';
 import { useTheme } from '../../providers/theme-provider';
+import { useHoldHeatmap } from '../../lib/graphql/hooks';
 import { getCreateBoardHolds, parseSetIdsParam } from '../../lib/create-board-holds';
 import { track } from '../../lib/analytics';
 import { spacing } from '../../theme/tokens';
@@ -21,6 +31,7 @@ type HoldFilterEditorSheetProps = {
   visible: boolean;
   boardConfig: BoardSearchConfig;
   holdsFilter: HoldsFilter;
+  heatmapInput?: ClimbSearchInput | null;
   onHoldsFilterChange: (holdsFilter: HoldsFilter) => void;
   onClose: () => void;
   onDismiss: () => void;
@@ -34,6 +45,7 @@ export function HoldFilterEditorSheet({
   visible,
   boardConfig,
   holdsFilter,
+  heatmapInput = null,
   onHoldsFilterChange,
   onClose,
   onDismiss,
@@ -48,6 +60,13 @@ export function HoldFilterEditorSheet({
   const [activeHoldId, setActiveHoldId] = useState<number | null>(null);
   const [applyMode, setApplyMode] = useState<HoldFilterMode>('include');
   const [contentReady, setContentReady] = useState(false);
+  const [heatmapEnabled, setHeatmapEnabled] = useState(false);
+  const [heatmapMode, setHeatmapMode] = useState<SearchHeatmapMode>('total');
+  const heatmapAvailable = boardName !== 'moonboard' && heatmapInput != null;
+  const { data: heatmapData, isFetching: heatmapLoading } = useHoldHeatmap(
+    heatmapInput,
+    heatmapEnabled && heatmapAvailable,
+  );
 
   useEffect(() => {
     if (visible) {
@@ -57,6 +76,7 @@ export function HoldFilterEditorSheet({
     } else {
       setActiveHoldId(null);
       setContentReady(false);
+      setHeatmapEnabled(false);
       sheetRef.current?.dismiss();
     }
     return undefined;
@@ -177,10 +197,21 @@ export function HoldFilterEditorSheet({
                   activeHoldId={activeHoldId}
                   onHoldTap={handleHoldTap}
                   showHoldMarkers={false}
+                  heatmapData={heatmapEnabled ? heatmapData : undefined}
+                  heatmapMode={heatmapEnabled ? heatmapMode : undefined}
                   renderWidth={boardRender.width}
                   renderHeight={boardRender.height}
                 />
               </View>
+
+              <HeatmapControls
+                available={heatmapAvailable}
+                enabled={heatmapEnabled}
+                loading={heatmapLoading}
+                mode={heatmapMode}
+                onEnabledChange={setHeatmapEnabled}
+                onModeChange={setHeatmapMode}
+              />
 
               <View style={[styles.footer, { paddingBottom: insets.bottom + spacing[3] }]}>
                 <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.footerText}>

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { View, StyleSheet, Pressable } from 'react-native';
 import Animated, { runOnJS, type SharedValue } from 'react-native-reanimated';
 import { Gesture, GestureDetector, type GestureType } from 'react-native-gesture-handler';
-import type { BoardName, HoldsFilter } from '@boardsesh/shared-schema';
+import type { BoardName, HoldHeatmapPoint, HoldsFilter } from '@boardsesh/shared-schema';
 import { BoardImageNative } from '../BoardImageNative';
 import { Text } from '../Text';
 import { useZoomPanGesture } from '../play-drawer/use-zoom-pan-gesture';
@@ -13,6 +13,7 @@ import { useZoomedHoldTapGesture, PAN_ACTIVATION_OFFSET } from '../create-climb/
 import { overlays } from '../../theme/tokens';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
 import { SearchHoldFilterRings } from './SearchHoldFilterRings';
+import { SearchHeatmapOverlay, type SearchHeatmapMode } from './SearchHeatmapOverlay';
 
 /** Context handed to an overlay rendered inside the board's zoom transform. */
 export type FilterBoardTransformContext = {
@@ -34,6 +35,9 @@ type InteractiveFilterBoardProps = {
   holdTargets: BoardHoldTarget[];
   /** Hold-type filter rings, when this board edits hold types. Omit for zone mode. */
   holdsFilter?: HoldsFilter;
+  /** Optional usage heatmap rendered beneath hold filter rings and tap targets. */
+  heatmapData?: HoldHeatmapPoint[];
+  heatmapMode?: SearchHeatmapMode;
   /** The hold the picker is currently editing — drawn with a bright ring. */
   activeHoldId?: number | null;
   /** Tap handler that opens the hold picker. Omit to disable hold taps (zone mode). */
@@ -75,6 +79,8 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   boardHeight,
   holdTargets,
   holdsFilter,
+  heatmapData,
+  heatmapMode,
   activeHoldId = null,
   onHoldTap,
   showHoldMarkers = true,
@@ -207,6 +213,17 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
               boardHeight={boardHeight}
               mirrored={mirrored}
             />
+            {heatmapData && heatmapMode ? (
+              <SearchHeatmapOverlay
+                heatmapData={heatmapData}
+                mode={heatmapMode}
+                holdTargets={holdTargets}
+                boardWidth={boardWidth}
+                boardHeight={boardHeight}
+                measuredWidth={renderWidth}
+                mirrored={mirrored}
+              />
+            ) : null}
             {holdsFilter ? (
               <SearchHoldFilterRings
                 boardName={boardName}

--- a/packages/mobile/src/components/search/SearchHeatmapOverlay.tsx
+++ b/packages/mobile/src/components/search/SearchHeatmapOverlay.tsx
@@ -1,0 +1,145 @@
+import React, { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import type { HoldHeatmapPoint } from '@boardsesh/shared-schema';
+import type { BoardHoldTarget } from '../../lib/create-board-holds';
+import { holdGeometry } from '../create-climb/holdLayout';
+
+export type SearchHeatmapMode = 'total' | 'start' | 'handsFeet' | 'finish';
+
+type SearchHeatmapOverlayProps = {
+  heatmapData: HoldHeatmapPoint[];
+  mode: SearchHeatmapMode;
+  holdTargets: BoardHoldTarget[];
+  boardWidth: number;
+  boardHeight: number;
+  measuredWidth: number;
+  mirrored: boolean;
+};
+
+type HeatmapMarker = {
+  holdId: number;
+  leftPct: number;
+  topPct: number;
+  diameter: number;
+  innerDiameter: number;
+  color: string;
+  opacity: number;
+};
+
+const HEATMAP_COLORS = ['#2DD4BF', '#A3E635', '#FACC15', '#FB923C', '#EF4444'] as const;
+
+export const SearchHeatmapOverlay = React.memo(function SearchHeatmapOverlay({
+  heatmapData,
+  mode,
+  holdTargets,
+  boardWidth,
+  boardHeight,
+  measuredWidth,
+  mirrored,
+}: SearchHeatmapOverlayProps) {
+  const markers = useMemo(() => {
+    if (measuredWidth <= 0 || heatmapData.length === 0) return [];
+    const statsByHold = new Map(heatmapData.map((point) => [point.holdId, point]));
+    const rawMarkers = holdTargets
+      .map((hold) => {
+        const point = statsByHold.get(hold.id);
+        const value = point ? valueForMode(point, mode) : 0;
+        if (value <= 0) return null;
+        const geometry = holdGeometry(hold, boardWidth, boardHeight, measuredWidth, mirrored, 1.2);
+        return { holdId: hold.id, value, geometry };
+      })
+      .filter((marker): marker is NonNullable<typeof marker> => marker != null);
+
+    const maxValue = Math.max(1, ...rawMarkers.map((marker) => marker.value));
+    const logMax = Math.log1p(maxValue);
+
+    return rawMarkers.map<HeatmapMarker>(({ holdId, value, geometry }) => {
+      const ratio = Math.max(0, Math.min(1, Math.log1p(value) / logMax));
+      const diameter = Math.max(geometry.ringDiameter * (2.1 + ratio * 1.4), 12);
+      const innerDiameter = Math.max(geometry.ringDiameter * (0.8 + ratio * 0.35), 5);
+      return {
+        holdId,
+        leftPct: geometry.leftPct,
+        topPct: geometry.topPct,
+        diameter,
+        innerDiameter,
+        color: colorForRatio(ratio),
+        opacity: 0.24 + ratio * 0.46,
+      };
+    });
+  }, [heatmapData, mode, holdTargets, boardWidth, boardHeight, measuredWidth, mirrored]);
+
+  if (markers.length === 0) return null;
+
+  return (
+    <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+      {markers.map((marker) => {
+        const radius = marker.diameter / 2;
+        const innerRadius = marker.innerDiameter / 2;
+        return (
+          <React.Fragment key={marker.holdId}>
+            <View
+              pointerEvents="none"
+              style={[
+                styles.absolute,
+                {
+                  left: `${marker.leftPct}%`,
+                  top: `${marker.topPct}%`,
+                  width: marker.diameter,
+                  height: marker.diameter,
+                  marginLeft: -radius,
+                  marginTop: -radius,
+                  borderRadius: radius,
+                  backgroundColor: marker.color,
+                  opacity: marker.opacity,
+                },
+              ]}
+            />
+            <View
+              pointerEvents="none"
+              style={[
+                styles.absolute,
+                {
+                  left: `${marker.leftPct}%`,
+                  top: `${marker.topPct}%`,
+                  width: marker.innerDiameter,
+                  height: marker.innerDiameter,
+                  marginLeft: -innerRadius,
+                  marginTop: -innerRadius,
+                  borderRadius: innerRadius,
+                  backgroundColor: marker.color,
+                  opacity: Math.min(0.95, marker.opacity + 0.2),
+                },
+              ]}
+            />
+          </React.Fragment>
+        );
+      })}
+    </View>
+  );
+});
+
+function valueForMode(point: HoldHeatmapPoint, mode: SearchHeatmapMode): number {
+  switch (mode) {
+    case 'start':
+      return point.startingUses;
+    case 'handsFeet':
+      return point.handUses + point.footUses;
+    case 'finish':
+      return point.finishUses;
+    case 'total':
+    default:
+      return point.totalUses;
+  }
+}
+
+function colorForRatio(ratio: number): string {
+  const index = Math.min(HEATMAP_COLORS.length - 1, Math.floor(ratio * HEATMAP_COLORS.length));
+  return HEATMAP_COLORS[index];
+}
+
+const styles = StyleSheet.create({
+  absolute: {
+    position: 'absolute',
+  },
+});

--- a/packages/mobile/src/components/search/ZoneFilterEditorSheet.tsx
+++ b/packages/mobile/src/components/search/ZoneFilterEditorSheet.tsx
@@ -12,7 +12,7 @@ import {
   type HoldPositionLookup,
 } from '@boardsesh/climb-filters';
 import { getLayout } from '@boardsesh/board-constants';
-import type { BoardName, HoldsFilter, ZoneBoxInput, ZoneMatchMode } from '@boardsesh/shared-schema';
+import type { BoardName, ClimbSearchInput, HoldsFilter, ZoneBoxInput, ZoneMatchMode } from '@boardsesh/shared-schema';
 import { ModalSheet } from '../ModalSheet';
 import { Text } from '../Text';
 import { ActivityIndicator } from '../ActivityIndicator';
@@ -21,7 +21,10 @@ import { SegmentedControl } from '../SegmentedControl';
 import { GlassSurface } from '../GlassSurface';
 import { InteractiveFilterBoard, type FilterBoardTransformContext } from './InteractiveFilterBoard';
 import { ZoneOverlay, type ZoneCornerLabels } from './ZoneOverlay';
+import { HeatmapControls } from './HeatmapControls';
+import type { SearchHeatmapMode } from './SearchHeatmapOverlay';
 import { useTheme } from '../../providers/theme-provider';
+import { useHoldHeatmap } from '../../lib/graphql/hooks';
 import { getCreateBoardHolds, parseSetIdsParam } from '../../lib/create-board-holds';
 import { track } from '../../lib/analytics';
 import { hapticSelection } from '../../lib/haptics';
@@ -39,6 +42,7 @@ type ZoneFilterEditorSheetProps = {
   zoneBox: ZoneBoxInput | null;
   zoneMode: ZoneMatchMode;
   holdsFilter: HoldsFilter;
+  heatmapInput?: ClimbSearchInput | null;
   onZoneFilterChange: (selection: ZoneFilterEditorSelection) => void;
   onClose: () => void;
   onDismiss: () => void;
@@ -54,6 +58,7 @@ export function ZoneFilterEditorSheet({
   zoneBox,
   zoneMode,
   holdsFilter,
+  heatmapInput = null,
   onZoneFilterChange,
   onClose,
   onDismiss,
@@ -66,6 +71,13 @@ export function ZoneFilterEditorSheet({
   const boardName = boardConfig.boardName as BoardName;
   const layoutName = getLayout(boardName, boardConfig.layoutId)?.name ?? '';
   const [contentReady, setContentReady] = useState(false);
+  const [heatmapEnabled, setHeatmapEnabled] = useState(false);
+  const [heatmapMode, setHeatmapMode] = useState<SearchHeatmapMode>('total');
+  const heatmapAvailable = boardName !== 'moonboard' && heatmapInput != null;
+  const { data: heatmapData, isFetching: heatmapLoading } = useHoldHeatmap(
+    heatmapInput,
+    heatmapEnabled && heatmapAvailable,
+  );
 
   const selectionRef = useRef({ zoneBox, zoneMode, holdsFilter });
   selectionRef.current = { zoneBox, zoneMode, holdsFilter };
@@ -77,6 +89,7 @@ export function ZoneFilterEditorSheet({
       return () => clearTimeout(timeout);
     } else {
       setContentReady(false);
+      setHeatmapEnabled(false);
       sheetRef.current?.dismiss();
     }
     return undefined;
@@ -261,9 +274,20 @@ export function ZoneFilterEditorSheet({
                 holdTargets={boardHolds.holdTargets}
                 renderWidth={boardRender.width}
                 renderHeight={boardRender.height}
+                heatmapData={heatmapEnabled ? heatmapData : undefined}
+                heatmapMode={heatmapEnabled ? heatmapMode : undefined}
                 renderInTransform={renderZoneOverlay}
               />
             </View>
+
+            <HeatmapControls
+              available={heatmapAvailable}
+              enabled={heatmapEnabled}
+              loading={heatmapLoading}
+              mode={heatmapMode}
+              onEnabledChange={setHeatmapEnabled}
+              onModeChange={setHeatmapMode}
+            />
 
             {zoneEnabled ? (
               <GlassSurface

--- a/packages/mobile/src/components/search/__tests__/hold-filter-editor-sheet.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/hold-filter-editor-sheet.test.tsx
@@ -44,10 +44,40 @@ vi.mock('../../ActivityIndicator', () => ({
   ActivityIndicator: () => createElement('div', { 'data-spinner': 'true' }),
 }));
 
-type BoardMockProps = { onHoldTap?: (holdId: number) => void };
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress, disabled }: { title: string; onPress: () => void; disabled?: boolean }) =>
+    createElement('button', { onClick: disabled ? undefined : onPress, disabled }, title),
+}));
+
+vi.mock('../../SegmentedControl', () => ({
+  SegmentedControl: ({
+    options,
+    onSelect,
+  }: {
+    options: ReadonlyArray<{ key: string; label: string }>;
+    onSelect: (key: string) => void;
+  }) =>
+    createElement(
+      'div',
+      { 'data-segmented': 'true' },
+      options.map((option) =>
+        createElement('button', { key: option.key, onClick: () => onSelect(option.key) }, option.label),
+      ),
+    ),
+}));
+
+type BoardMockProps = { onHoldTap?: (holdId: number) => void; heatmapData?: unknown[]; heatmapMode?: string };
 vi.mock('../InteractiveFilterBoard', () => ({
-  InteractiveFilterBoard: ({ onHoldTap }: BoardMockProps) =>
-    createElement('button', { 'data-board': 'true', onClick: () => onHoldTap?.(42) }, 'board'),
+  InteractiveFilterBoard: ({ onHoldTap, heatmapData, heatmapMode }: BoardMockProps) =>
+    createElement(
+      'button',
+      {
+        'data-board': 'true',
+        'data-heatmap-mode': heatmapData?.length ? (heatmapMode ?? '') : '',
+        onClick: () => onHoldTap?.(42),
+      },
+      'board',
+    ),
 }));
 
 type PickerMockProps = {
@@ -93,6 +123,23 @@ vi.mock('@boardsesh/board-constants/product-sizes', () => ({
 
 vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
 
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useHoldHeatmap: () => ({
+    data: [
+      {
+        holdId: 42,
+        totalUses: 2,
+        startingUses: 1,
+        totalAscents: 8,
+        handUses: 1,
+        footUses: 1,
+        finishUses: 0,
+      },
+    ],
+    isFetching: false,
+  }),
+}));
+
 vi.mock('../../../theme/tokens', () => ({
   spacing: { 2: 8, 3: 12, 4: 16 },
 }));
@@ -121,6 +168,15 @@ function renderSheet(overrides: Partial<Parameters<typeof HoldFilterEditorSheet>
       visible
       boardConfig={boardConfig}
       holdsFilter={{}}
+      heatmapInput={{
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+        angle: 40,
+        page: 0,
+        pageSize: 1,
+      }}
       onHoldsFilterChange={vi.fn()}
       onClose={vi.fn()}
       onDismiss={vi.fn()}
@@ -167,5 +223,18 @@ describe('HoldFilterEditorSheet', () => {
     fireEvent.click(container.querySelector('[data-picker-hold-id="42"]') as HTMLButtonElement);
 
     expect(onHoldsFilterChange).toHaveBeenCalledWith({ 42: { HAND: 'include' } });
+  });
+
+  it('passes heatmap data to the board after enabling the overlay', () => {
+    const { container, getByText } = renderSheet();
+
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+    expect(container.querySelector('[data-board="true"]')?.getAttribute('data-heatmap-mode')).toBe('');
+
+    fireEvent.click(getByText('mobile.heatmap.show'));
+
+    expect(container.querySelector('[data-board="true"]')?.getAttribute('data-heatmap-mode')).toBe('total');
   });
 });

--- a/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
@@ -75,6 +75,10 @@ vi.mock('../SearchHoldFilterRings', () => ({
   SearchHoldFilterRings: () => createElement('div', { 'data-rings': 'true' }),
 }));
 
+vi.mock('../SearchHeatmapOverlay', () => ({
+  SearchHeatmapOverlay: () => createElement('div', { 'data-heatmap': 'true' }),
+}));
+
 vi.mock('../../Text', () => ({
   Text: ({ children }: ChildrenProps) => createElement('span', null, children),
 }));
@@ -122,6 +126,7 @@ type Overrides = {
   activeHoldId?: number | null;
   onHoldTap?: (id: number) => void;
   showHoldMarkers?: boolean;
+  heatmap?: boolean;
 };
 
 function renderBoard(overrides: Overrides = {}) {
@@ -139,6 +144,22 @@ function renderBoard(overrides: Overrides = {}) {
       activeHoldId={overrides.activeHoldId ?? null}
       onHoldTap={onHoldTap}
       showHoldMarkers={overrides.showHoldMarkers}
+      heatmapData={
+        overrides.heatmap
+          ? [
+              {
+                holdId: 10,
+                totalUses: 4,
+                startingUses: 2,
+                totalAscents: 20,
+                handUses: 3,
+                footUses: 1,
+                finishUses: 0,
+              },
+            ]
+          : undefined
+      }
+      heatmapMode={overrides.heatmap ? 'total' : undefined}
       renderWidth={400}
       renderHeight={500}
     />,
@@ -173,6 +194,11 @@ describe('InteractiveFilterBoard', () => {
     expect(holdLayer?.getAttribute('data-show-all-holds')).toBe('true');
     expect(holdLayer?.getAttribute('data-show-hold-markers')).toBe('false');
     expect(container.querySelectorAll('[data-hold-id]').length).toBe(holdTargets.length);
+  });
+
+  it('renders the heatmap overlay when data and mode are provided', () => {
+    const { container } = renderBoard({ heatmap: true });
+    expect(container.querySelector('[data-heatmap="true"]')).not.toBeNull();
   });
 
   it('hides the pan overlay and reset button while not zoomed', () => {

--- a/packages/mobile/src/components/search/__tests__/zone-filter-editor-sheet.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/zone-filter-editor-sheet.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render } from '@testing-library/react';
 import { createElement, forwardRef, type ReactNode } from 'react';
-import type { HoldsFilter, ZoneBoxInput, ZoneMatchMode } from '@boardsesh/shared-schema';
+import type { HoldsFilter, ZoneBoxInput } from '@boardsesh/shared-schema';
 import type { BoardSearchConfig } from '@boardsesh/climb-filters';
 import type { FilterBoardTransformContext } from '../InteractiveFilterBoard';
 
@@ -62,8 +62,8 @@ vi.mock('../../ActivityIndicator', () => ({
 }));
 
 vi.mock('../../Button', () => ({
-  Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
-    createElement('button', { onClick: onPress }, title),
+  Button: ({ title, onPress, disabled }: { title: string; onPress: () => void; disabled?: boolean }) =>
+    createElement('button', { onClick: disabled ? undefined : onPress, disabled }, title),
 }));
 
 vi.mock('../../SegmentedControl', () => ({
@@ -71,8 +71,8 @@ vi.mock('../../SegmentedControl', () => ({
     options,
     onSelect,
   }: {
-    options: ReadonlyArray<{ key: ZoneMatchMode; label: string }>;
-    onSelect: (key: ZoneMatchMode) => void;
+    options: ReadonlyArray<{ key: string; label: string }>;
+    onSelect: (key: string) => void;
   }) =>
     createElement(
       'div',
@@ -87,12 +87,16 @@ vi.mock('../../GlassSurface', () => ({
   GlassSurface: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-glass': 'true' }, children),
 }));
 
-type BoardMockProps = { renderInTransform?: (context: FilterBoardTransformContext) => ReactNode };
+type BoardMockProps = {
+  renderInTransform?: (context: FilterBoardTransformContext) => ReactNode;
+  heatmapData?: unknown[];
+  heatmapMode?: string;
+};
 vi.mock('../InteractiveFilterBoard', () => ({
-  InteractiveFilterBoard: ({ renderInTransform }: BoardMockProps) =>
+  InteractiveFilterBoard: ({ renderInTransform, heatmapData, heatmapMode }: BoardMockProps) =>
     createElement(
       'div',
-      { 'data-board': 'true' },
+      { 'data-board': 'true', 'data-heatmap-mode': heatmapData?.length ? (heatmapMode ?? '') : '' },
       renderInTransform?.({
         pinchGesture: {},
         scaleSV: {},
@@ -135,6 +139,23 @@ vi.mock('@boardsesh/board-constants', () => ({
 vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
 vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
 
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useHoldHeatmap: () => ({
+    data: [
+      {
+        holdId: 10,
+        totalUses: 2,
+        startingUses: 1,
+        totalAscents: 8,
+        handUses: 1,
+        footUses: 1,
+        finishUses: 0,
+      },
+    ],
+    isFetching: false,
+  }),
+}));
+
 vi.mock('../../../theme/tokens', () => ({
   overlays: { scrim: 'rgba(0,0,0,0.35)' },
   spacing: { 2: 8, 3: 12, 4: 16 },
@@ -166,6 +187,15 @@ function renderSheet(overrides: Partial<Parameters<typeof ZoneFilterEditorSheet>
       zoneBox={null}
       zoneMode="allHolds"
       holdsFilter={{}}
+      heatmapInput={{
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+        angle: 40,
+        page: 0,
+        pageSize: 1,
+      }}
       onZoneFilterChange={vi.fn()}
       onClose={vi.fn()}
       onDismiss={vi.fn()}
@@ -238,5 +268,18 @@ describe('ZoneFilterEditorSheet', () => {
       zoneMode: 'allHolds',
       holdsFilter: zoneState.prunedFilter,
     });
+  });
+
+  it('passes heatmap data to the board after enabling the overlay', () => {
+    const { container, getByText } = renderSheet();
+
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+    expect(container.querySelector('[data-board="true"]')?.getAttribute('data-heatmap-mode')).toBe('');
+
+    fireEvent.click(getByText('mobile.heatmap.show'));
+
+    expect(container.querySelector('[data-board="true"]')?.getAttribute('data-heatmap-mode')).toBe('total');
   });
 });

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -44,6 +44,7 @@ import {
   GET_ANGLES,
   SEARCH_CLIMBS,
   SEARCH_CLIMBS_COUNT,
+  HOLD_HEATMAP,
   GET_SETTER_STATS,
   GET_CLIMB,
   GET_SESSION_SUMMARY,
@@ -60,6 +61,7 @@ import {
   type GetAnglesQueryResponse,
   type SearchClimbsQueryResponse,
   type SearchClimbsCountQueryResponse,
+  type HoldHeatmapQueryResponse,
   type GetSetterStatsQueryResponse,
   type GetClimbQueryResponse,
   type GetClimbQueryVariables,
@@ -219,6 +221,17 @@ export function useSearchClimbsCount(input: ClimbSearchInput, enabled = true) {
     enabled,
     // Hold the last count while a new filter set is in flight so the bar /
     // "Show N" button doesn't flicker to blank on every filter change.
+    placeholderData: (previous) => previous,
+  });
+}
+
+export function useHoldHeatmap(input: ClimbSearchInput | null, enabled = true) {
+  return useQuery({
+    queryKey: ['holdHeatmap', input],
+    queryFn: () => getHttpClient().request<HoldHeatmapQueryResponse>(HOLD_HEATMAP, { input: input! }),
+    select: (data) => data.holdHeatmap,
+    enabled: enabled && input != null,
+    staleTime: 5 * 60 * 1000,
     placeholderData: (previous) => previous,
   });
 }

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -6,6 +6,7 @@ import type {
   Climb,
   ClimbSearchInput,
   Grade,
+  HoldHeatmapPoint,
   SetterStat,
   SetterStatsInput,
   Angle,
@@ -374,6 +375,31 @@ export type SearchClimbsCountQueryResponse = {
   searchClimbs: {
     totalCount: number;
   };
+};
+
+export const HOLD_HEATMAP = gql`
+  query HoldHeatmap($input: ClimbSearchInput!) {
+    holdHeatmap(input: $input) {
+      holdId
+      totalUses
+      startingUses
+      totalAscents
+      handUses
+      footUses
+      finishUses
+      averageDifficulty
+      userAscents
+      userAttempts
+    }
+  }
+`;
+
+export type HoldHeatmapQueryVariables = {
+  input: ClimbSearchInput;
+};
+
+export type HoldHeatmapQueryResponse = {
+  holdHeatmap: HoldHeatmapPoint[];
 };
 
 export const GET_CLIMB = gql`

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -204,6 +204,33 @@ type ClimbSearchResult {
 }
 
 """
+Per-hold aggregate usage for the search heatmap overlay.
+Counts respect the same filters supplied to ClimbSearchInput.
+"""
+type HoldHeatmapPoint {
+  "Board hold identifier"
+  holdId: Int!
+  "Number of matching climbs using this hold"
+  totalUses: Int!
+  "Number of matching climbs using this hold as a start"
+  startingUses: Int!
+  "Total community ascents across matching climbs using this hold"
+  totalAscents: Int!
+  "Number of matching climbs using this hold as a hand"
+  handUses: Int!
+  "Number of matching climbs using this hold as a foot"
+  footUses: Int!
+  "Number of matching climbs using this hold as a finish"
+  finishUses: Int!
+  "Average displayed difficulty across matching climbs using this hold"
+  averageDifficulty: Float
+  "Current user's sends on climbs using this hold, when authenticated"
+  userAscents: Int
+  "Current user's attempts on climbs using this hold, when authenticated"
+  userAttempts: Int
+}
+
+"""
 Input for fetching setter usernames with their climb counts.
 Used to power the setter filter autocomplete in the search drawer.
 """
@@ -3611,6 +3638,12 @@ type Query {
   Supports filtering by difficulty, setter, holds, and more.
   """
   searchClimbs(input: ClimbSearchInput!): ClimbSearchResult!
+
+  """
+  Per-hold usage aggregates for drawing a search heatmap on the board.
+  Accepts the same filters as searchClimbs.
+  """
+  holdHeatmap(input: ClimbSearchInput!): [HoldHeatmapPoint!]!
 
   """
   Check whether MoonBoard climbs with exact hold-role selections already exist.

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1708,6 +1708,34 @@ export type GymMembersInput = {
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
 
+/**
+ * Per-hold aggregate usage for the search heatmap overlay.
+ * Counts respect the same filters supplied to ClimbSearchInput.
+ */
+export type HoldHeatmapPoint = {
+  __typename?: 'HoldHeatmapPoint';
+  /** Average displayed difficulty across matching climbs using this hold */
+  averageDifficulty?: Maybe<Scalars['Float']['output']>;
+  /** Number of matching climbs using this hold as a finish */
+  finishUses: Scalars['Int']['output'];
+  /** Number of matching climbs using this hold as a foot */
+  footUses: Scalars['Int']['output'];
+  /** Number of matching climbs using this hold as a hand */
+  handUses: Scalars['Int']['output'];
+  /** Board hold identifier */
+  holdId: Scalars['Int']['output'];
+  /** Number of matching climbs using this hold as a start */
+  startingUses: Scalars['Int']['output'];
+  /** Total community ascents across matching climbs using this hold */
+  totalAscents: Scalars['Int']['output'];
+  /** Number of matching climbs using this hold */
+  totalUses: Scalars['Int']['output'];
+  /** Current user's sends on climbs using this hold, when authenticated */
+  userAscents?: Maybe<Scalars['Int']['output']>;
+  /** Current user's attempts on climbs using this hold, when authenticated */
+  userAttempts?: Maybe<Scalars['Int']['output']>;
+};
+
 /** Statistics for a specific board layout. */
 export type LayoutStats = {
   __typename?: 'LayoutStats';
@@ -3097,6 +3125,11 @@ export type Query = {
   /** Get members of a gym. */
   gymMembers: GymMemberConnection;
   /**
+   * Per-hold usage aggregates for drawing a search heatmap on the board.
+   * Accepts the same filters as searchClimbs.
+   */
+  holdHeatmap: Array<HoldHeatmapPoint>;
+  /**
    * Check if the current user follows a specific user.
    * Requires authentication.
    */
@@ -3508,6 +3541,11 @@ export type QueryGymBySlugArgs = {
 /** Root query type for all read operations. */
 export type QueryGymMembersArgs = {
   input: GymMembersInput;
+};
+
+/** Root query type for all read operations. */
+export type QueryHoldHeatmapArgs = {
+  input: ClimbSearchInput;
 };
 
 /** Root query type for all read operations. */
@@ -5485,6 +5523,7 @@ export type ResolversTypes = ResolversObject<{
   GymMemberConnection: ResolverTypeWrapper<GymMemberConnection>;
   GymMemberRole: GymMemberRole;
   GymMembersInput: GymMembersInput;
+  HoldHeatmapPoint: ResolverTypeWrapper<HoldHeatmapPoint>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   JSON: ResolverTypeWrapper<Scalars['JSON']['output']>;
@@ -5743,6 +5782,7 @@ export type ResolversParentTypes = ResolversObject<{
   GymMember: GymMember;
   GymMemberConnection: GymMemberConnection;
   GymMembersInput: GymMembersInput;
+  HoldHeatmapPoint: HoldHeatmapPoint;
   ID: Scalars['ID']['output'];
   Int: Scalars['Int']['output'];
   JSON: Scalars['JSON']['output'];
@@ -6684,6 +6724,23 @@ export type GymMemberConnectionResolvers<
   hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   members?: Resolver<Array<ResolversTypes['GymMember']>, ParentType, ContextType>;
   totalCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type HoldHeatmapPointResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['HoldHeatmapPoint'] = ResolversParentTypes['HoldHeatmapPoint'],
+> = ResolversObject<{
+  averageDifficulty?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  finishUses?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  footUses?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  handUses?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  holdId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  startingUses?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  totalAscents?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  totalUses?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  userAscents?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  userAttempts?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -7750,6 +7807,12 @@ export type QueryResolvers<
     ParentType,
     ContextType,
     RequireFields<QueryGymMembersArgs, 'input'>
+  >;
+  holdHeatmap?: Resolver<
+    Array<ResolversTypes['HoldHeatmapPoint']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryHoldHeatmapArgs, 'input'>
   >;
   isFollowing?: Resolver<
     ResolversTypes['Boolean'],
@@ -8854,6 +8917,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   GymConnection?: GymConnectionResolvers<ContextType>;
   GymMember?: GymMemberResolvers<ContextType>;
   GymMemberConnection?: GymMemberConnectionResolvers<ContextType>;
+  HoldHeatmapPoint?: HoldHeatmapPointResolvers<ContextType>;
   JSON?: GraphQLScalarType;
   LayoutStats?: LayoutStatsResolvers<ContextType>;
   LeaderChanged?: LeaderChangedResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -200,6 +200,33 @@ export const climbTypeDefs = /* GraphQL */ `
   }
 
   """
+  Per-hold aggregate usage for the search heatmap overlay.
+  Counts respect the same filters supplied to ClimbSearchInput.
+  """
+  type HoldHeatmapPoint {
+    "Board hold identifier"
+    holdId: Int!
+    "Number of matching climbs using this hold"
+    totalUses: Int!
+    "Number of matching climbs using this hold as a start"
+    startingUses: Int!
+    "Total community ascents across matching climbs using this hold"
+    totalAscents: Int!
+    "Number of matching climbs using this hold as a hand"
+    handUses: Int!
+    "Number of matching climbs using this hold as a foot"
+    footUses: Int!
+    "Number of matching climbs using this hold as a finish"
+    finishUses: Int!
+    "Average displayed difficulty across matching climbs using this hold"
+    averageDifficulty: Float
+    "Current user's sends on climbs using this hold, when authenticated"
+    userAscents: Int
+    "Current user's attempts on climbs using this hold, when authenticated"
+    userAttempts: Int
+  }
+
+  """
   Input for fetching setter usernames with their climb counts.
   Used to power the setter filter autocomplete in the search drawer.
   """

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -67,6 +67,12 @@ export const queriesTypeDefs = /* GraphQL */ `
     searchClimbs(input: ClimbSearchInput!): ClimbSearchResult!
 
     """
+    Per-hold usage aggregates for drawing a search heatmap on the board.
+    Accepts the same filters as searchClimbs.
+    """
+    holdHeatmap(input: ClimbSearchInput!): [HoldHeatmapPoint!]!
+
+    """
     Check whether MoonBoard climbs with exact hold-role selections already exist.
     Returns one result per submitted candidate.
     """

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -160,6 +160,19 @@ export type ClimbSearchResult = {
   hasMore: boolean;
 };
 
+export type HoldHeatmapPoint = {
+  holdId: number;
+  totalUses: number;
+  startingUses: number;
+  totalAscents: number;
+  handUses: number;
+  footUses: number;
+  finishUses: number;
+  averageDifficulty?: number | null;
+  userAscents?: number | null;
+  userAttempts?: number | null;
+};
+
 export type SetterStatsInput = {
   boardName: string;
   layoutId: number;

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1705,6 +1705,34 @@ export type GymMembersInput = {
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
 
+/**
+ * Per-hold aggregate usage for the search heatmap overlay.
+ * Counts respect the same filters supplied to ClimbSearchInput.
+ */
+export type HoldHeatmapPoint = {
+  __typename?: 'HoldHeatmapPoint';
+  /** Average displayed difficulty across matching climbs using this hold */
+  averageDifficulty?: Maybe<Scalars['Float']['output']>;
+  /** Number of matching climbs using this hold as a finish */
+  finishUses: Scalars['Int']['output'];
+  /** Number of matching climbs using this hold as a foot */
+  footUses: Scalars['Int']['output'];
+  /** Number of matching climbs using this hold as a hand */
+  handUses: Scalars['Int']['output'];
+  /** Board hold identifier */
+  holdId: Scalars['Int']['output'];
+  /** Number of matching climbs using this hold as a start */
+  startingUses: Scalars['Int']['output'];
+  /** Total community ascents across matching climbs using this hold */
+  totalAscents: Scalars['Int']['output'];
+  /** Number of matching climbs using this hold */
+  totalUses: Scalars['Int']['output'];
+  /** Current user's sends on climbs using this hold, when authenticated */
+  userAscents?: Maybe<Scalars['Int']['output']>;
+  /** Current user's attempts on climbs using this hold, when authenticated */
+  userAttempts?: Maybe<Scalars['Int']['output']>;
+};
+
 /** Statistics for a specific board layout. */
 export type LayoutStats = {
   __typename?: 'LayoutStats';
@@ -3094,6 +3122,11 @@ export type Query = {
   /** Get members of a gym. */
   gymMembers: GymMemberConnection;
   /**
+   * Per-hold usage aggregates for drawing a search heatmap on the board.
+   * Accepts the same filters as searchClimbs.
+   */
+  holdHeatmap: Array<HoldHeatmapPoint>;
+  /**
    * Check if the current user follows a specific user.
    * Requires authentication.
    */
@@ -3505,6 +3538,11 @@ export type QueryGymBySlugArgs = {
 /** Root query type for all read operations. */
 export type QueryGymMembersArgs = {
   input: GymMembersInput;
+};
+
+/** Root query type for all read operations. */
+export type QueryHoldHeatmapArgs = {
+  input: ClimbSearchInput;
 };
 
 /** Root query type for all read operations. */

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -777,6 +777,17 @@
         "any": "Any"
       }
     },
+    "heatmap": {
+      "show": "Show heatmap",
+      "hide": "Hide heatmap",
+      "loading": "Loading heatmap",
+      "unavailable": "Heatmap unavailable",
+      "modeLabel": "Heatmap metric",
+      "total": "All",
+      "start": "Starts",
+      "handsFeet": "Hands/feet",
+      "finish": "Finishes"
+    },
     "zoneFilter": {
       "title": "Board region",
       "summaryActive": "On",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -777,6 +777,17 @@
         "any": "Cualquiera"
       }
     },
+    "heatmap": {
+      "show": "Mostrar mapa",
+      "hide": "Ocultar mapa",
+      "loading": "Cargando mapa",
+      "unavailable": "Mapa no disponible",
+      "modeLabel": "Métrica del mapa",
+      "total": "Todo",
+      "start": "Inicios",
+      "handsFeet": "Manos/pies",
+      "finish": "Finales"
+    },
     "zoneFilter": {
       "title": "Zona del muro",
       "summaryActive": "Activada",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -777,6 +777,17 @@
         "any": "Toute"
       }
     },
+    "heatmap": {
+      "show": "Afficher la carte",
+      "hide": "Masquer la carte",
+      "loading": "Chargement",
+      "unavailable": "Carte indisponible",
+      "modeLabel": "Mesure de la carte",
+      "total": "Tout",
+      "start": "Départs",
+      "handsFeet": "Mains/pieds",
+      "finish": "Arrivées"
+    },
     "zoneFilter": {
       "title": "Zone du mur",
       "summaryActive": "Activée",


### PR DESCRIPTION
## What changed

- Added a GraphQL `holdHeatmap(input:)` query that reuses the existing climb search input and shared filter mapping.
- Added mobile React Query/GraphQL plumbing for hold heatmap data.
- Added a mobile heatmap overlay and controls to the Hold types and Board region filter sheets.
- Added focused component tests, generated GraphQL types, and i18n strings for the heatmap controls.

## Why

Issue #2502 already had interactive hold and zone filtering on mobile, but heatmap support was still web-only. This brings the heatmap onto the same mobile board-filter surface without adding another route.

Fixes #2502

## Validation

- `vp test run packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx packages/mobile/src/components/search/__tests__/hold-filter-editor-sheet.test.tsx packages/mobile/src/components/search/__tests__/zone-filter-editor-sheet.test.tsx`
- `vp run typecheck:backend`
- `vp run typecheck:mobile`
- `vp run typecheck:shared`
- `vp run check:i18n`
- `vp test run --project mobile`
- `vp run check:mobile-bundle`

QA notes were loaded into the mobile dev server from `.boardsesh/qa-notes.md`.