### PR TITLE
fix(mobile): guard onLayout re-render, add overloads, extend test

### DIFF
--- a/packages/mobile/src/components/queue-control/__tests__/use-queue-climb-carousel.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-queue-climb-carousel.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LayoutChangeEvent } from 'react-native';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 
 // Hoisted provider/nav spies so each test drives party-preview gating + the
@@ -176,6 +177,14 @@ describe('useQueueClimbCarousel party-preview gating', () => {
     expect(gestureCalls.last?.boardWidth).toBe(320);
     expect(gestureCalls.last?.enabled).toBe(true);
     expect(gestureCalls.last?.reduceMotion).toBe(true);
+
+    // A layout event with a conflicting width must not override the configured value.
+    act(() => {
+      result.current.onLayout({ nativeEvent: { layout: { width: 0 } } } as LayoutChangeEvent);
+    });
+
+    expect(result.current.canPeek).toBe(true);      // configuredWidth=320 still in effect
+    expect(gestureCalls.last?.boardWidth).toBe(320); // widthSV not overwritten to 0
   });
 
   it('still surfaces the peek labels so a non-driver can SEE the next climb', () => {

--- a/packages/mobile/src/components/queue-control/use-queue-climb-carousel.ts
+++ b/packages/mobile/src/components/queue-control/use-queue-climb-carousel.ts
@@ -49,6 +49,9 @@ type QueueClimbCarouselOptions = {
   reduceMotion?: boolean;
 };
 
+export function useQueueClimbCarousel(): QueueClimbCarousel;
+export function useQueueClimbCarousel(width: number, reduceMotion?: boolean): QueueClimbCarousel;
+export function useQueueClimbCarousel(options: QueueClimbCarouselOptions): QueueClimbCarousel;
 export function useQueueClimbCarousel(
   viewportWidthOrOptions?: number | QueueClimbCarouselOptions,
   reduceMotionOverride?: boolean,
@@ -172,9 +175,10 @@ export function useQueueClimbCarousel(
 
   const onLayout = useCallback(
     (event: LayoutChangeEvent) => {
+      if (configuredWidth != null) return;
       const measured = event.nativeEvent.layout.width;
       setMeasuredWidth(measured);
-      widthSV.value = configuredWidth ?? measured;
+      widthSV.value = measured;
     },
     [configuredWidth, widthSV],
   );


### PR DESCRIPTION
## Summary

- **Spurious re-render**: `onLayout` unconditionally called `setMeasuredWidth` even when `configuredWidth` was provided, queuing a useless state update on every layout event. Fixed with an early return — the existing `useEffect` already keeps `widthSV` in sync when `configuredWidth` is active.
- **Silent param conflict**: Calling `useQueueClimbCarousel({ width: 320 }, true)` silently dropped `true`. Added three TypeScript overload signatures so `(QueueClimbCarouselOptions, boolean)` is a compile-time error.
- **Test gap**: Extended the "accepts explicit viewport width" test to fire an `onLayout` event with `width: 0` after setup and assert `canPeek` stays `true` and `boardWidth` stays `320`, pinning the "configured width wins" contract.

## Test plan

- [ ] `vp run typecheck:mobile` — overloads compile; `(options, boolean)` is now a type error
- [ ] `vp run test:mobile` — extended test and all existing tests pass
- [ ] Manual smoke: `ClimbCapsule` and `NativeAccessoryClimbRow` (both use `onLayout` with no explicit width) still measure and peek correctly

https://claude.ai/code/session_012o4AvHFpVBYZgwyyNNC5M7

---
_Generated by [Claude Code](https://claude.ai/code/session_012o4AvHFpVBYZgwyyNNC5M7)_