### PR TITLE
fix(mobile): don't resync the queue when switching climbs gets throttled

### DIFF
--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -1801,7 +1801,10 @@ describe('QueueProvider mutation-failure resync', () => {
     const snapshots: Snapshot[] = [];
     const first = makeQueueItem('item-1', 'climb-1');
     const second = makeQueueItem('item-2', 'climb-2');
-    routeHttpRequest(queueStateResponse([first, second], first));
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([first, second], first), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
     queueMutations.reorderQueueItem.mockRejectedValueOnce(makeRateLimitedError());
 
     renderProvider((snapshot) => snapshots.push(snapshot));
@@ -1828,6 +1831,46 @@ describe('QueueProvider mutation-failure resync', () => {
     await waitFor(() => {
       expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
     });
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+    // reorderQueue rolls back locally and never reaches
+    // resyncQueueAfterMutationFailure — assert the refetch stays at zero so
+    // that stays true if the handler is ever rewritten.
+    expect(queueStateCalls).toBe(0);
+  });
+
+  it('toasts "slow down" when a solo setCurrentClimb is rate-limited', async () => {
+    const snapshots: Snapshot[] = [];
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([]), { onQueueStateCall: () => (queueStateCalls += 1) });
+    queueMutations.setCurrentClimb.mockRejectedValueOnce(makeRateLimitedError());
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    // End the session so the next activation runs with no active session.
+    await act(async () => {
+      await snapshots.at(-1)?.endSession();
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBeNull();
+    });
+    toast.showToast.mockClear();
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.setCurrentClimb(makeQueueItem('solo-current', 'climb-solo-current'));
+    });
+
+    // Solo used to get a blanket "Action failed" here; a throttled solo call is
+    // still a rate limit, so it gets the same gentle wording as a party one.
+    await waitFor(() => {
+      expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
+    });
+    expect(queueStateCalls).toBe(0);
     expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
   });
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -1874,6 +1874,41 @@ describe('QueueProvider mutation-failure resync', () => {
     expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
   });
 
+  it('still shows the generic failure when a solo setCurrentClimb fails for any other reason', async () => {
+    const snapshots: Snapshot[] = [];
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([]), { onQueueStateCall: () => (queueStateCalls += 1) });
+    queueMutations.setCurrentClimb.mockRejectedValueOnce(new Error('set current failed'));
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    await act(async () => {
+      await snapshots.at(-1)?.endSession();
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBeNull();
+    });
+    toast.showToast.mockClear();
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.setCurrentClimb(makeQueueItem('solo-current', 'climb-solo-current'));
+    });
+
+    // Routing solo through showQueueMutationErrorToast must not change what a
+    // plain failure looks like — only the rate-limited case gets new wording.
+    await waitFor(() => {
+      expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+    });
+    expect(queueStateCalls).toBe(0);
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
+  });
+
   it('resyncs when setQueue fails in a session', async () => {
     const snapshots: Snapshot[] = [];
     const serverCurrent = makeQueueItem('server-current', 'climb-server-current');

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -213,6 +213,17 @@ import { clearStoredSessionId } from '../../lib/session-store';
 import { track } from '../../lib/analytics';
 import { bumpAuthTransportRevision } from '../../lib/auth-transport-revision';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { GraphQLOperationError } from '@boardsesh/graphql-client';
+
+/** The error `execute()` rejects with when the backend's rate-limit gate fires. */
+function makeRateLimitedError(retryAfterSeconds = 4): GraphQLOperationError {
+  return new GraphQLOperationError([
+    {
+      message: `Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`,
+      extensions: { code: 'RATE_LIMITED', retryAfterSeconds },
+    },
+  ]);
+}
 
 type Snapshot = {
   state: ReturnType<typeof useQueue>['state'];
@@ -223,6 +234,7 @@ type Snapshot = {
   playlistSuggestionSource: PlaylistSuggestionSource | null;
   addToQueue: ReturnType<typeof useQueue>['addToQueue'];
   removeFromQueue: ReturnType<typeof useQueue>['removeFromQueue'];
+  reorderQueue: ReturnType<typeof useQueue>['reorderQueue'];
   setQueue: ReturnType<typeof useQueue>['setQueue'];
   setCurrentClimb: ReturnType<typeof useQueue>['setCurrentClimb'];
   nextClimb: ReturnType<typeof useQueue>['nextClimb'];
@@ -319,6 +331,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
       playlistSuggestionSource,
       addToQueue: queue.addToQueue,
       removeFromQueue: queue.removeFromQueue,
+      reorderQueue: queue.reorderQueue,
       setQueue: queue.setQueue,
       setCurrentClimb: queue.setCurrentClimb,
       nextClimb: queue.nextClimb,
@@ -339,6 +352,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
     playlistSuggestionSource,
     queue.addToQueue,
     queue.removeFromQueue,
+    queue.reorderQueue,
     queue.setQueue,
     queue.setCurrentClimb,
     queue.nextClimb,
@@ -1747,6 +1761,73 @@ describe('QueueProvider mutation-failure resync', () => {
     expect(queueStateCalls).toBe(1);
     expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
     // Solo's "Action failed" toast must NOT fire in a party session.
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+  });
+
+  it('toasts "slow down" and keeps the local climb when setCurrentClimb is rate-limited in a session', async () => {
+    const snapshots: Snapshot[] = [];
+    const serverCurrent = makeQueueItem('server-current', 'climb-server-current');
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([serverCurrent], serverCurrent), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+    queueMutations.setCurrentClimb.mockRejectedValueOnce(makeRateLimitedError());
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.setCurrentClimb(makeQueueItem('local-current', 'climb-local-current'));
+    });
+
+    await waitFor(() => {
+      expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
+    });
+    // The rate-limit gate throws before the resolver runs, so there is nothing
+    // to reconcile — the local pointer stays put and no refetch is fired into
+    // the limiter that just throttled us.
+    expect(queueStateCalls).toBe(0);
+    expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('local-current');
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.outOfSyncRefreshed', 'error');
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
+  });
+
+  it('toasts "slow down" rather than the generic failure when reorderQueue is rate-limited', async () => {
+    const snapshots: Snapshot[] = [];
+    const first = makeQueueItem('item-1', 'climb-1');
+    const second = makeQueueItem('item-2', 'climb-2');
+    routeHttpRequest(queueStateResponse([first, second], first));
+    queueMutations.reorderQueueItem.mockRejectedValueOnce(makeRateLimitedError());
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+    });
+
+    // Seed a two-item queue locally so there is something to reorder.
+    act(() => {
+      snapshots.at(-1)?.setQueue([first, second], first);
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue).toHaveLength(2);
+    });
+    toast.showToast.mockClear();
+
+    const snapshot = snapshots.at(-1);
+    if (!snapshot) throw new Error('queue snapshot was not captured');
+    act(() => {
+      snapshot.reorderQueue('item-1', 0, 1);
+    });
+
+    await waitFor(() => {
+      expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
+    });
     expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.actionFailed', 'error');
   });
 

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -17,7 +17,7 @@ import type {
 import { createJoinSessionTracker, type QueueSyncGate } from '@boardsesh/queue-runtime';
 import { useQueueMutations, type PublishPlaybackStateInput } from '@boardsesh/queue-react';
 import type { SubscriptionQueueEvent, SessionUser } from '@boardsesh/shared-schema';
-import { execute, GraphQLOperationError, isRateLimitedExtension } from '@boardsesh/graphql-client';
+import { execute, isRateLimitedError } from '@boardsesh/graphql-client';
 import { buildBoardPath } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { JOIN_SESSION, UPDATE_USERNAME } from '@boardsesh/graphql/operations/queue-session';
@@ -95,7 +95,11 @@ function showQueueMutationErrorToast(
   t: (key: string) => string,
   showToast: (message: string, variant: 'error') => void,
 ): void {
-  if (error instanceof GraphQLOperationError && isRateLimitedExtension(error.extensions)) {
+  // Classify via the shared `isRateLimitedError` so every caller agrees on what
+  // counts as a rate limit. It also catches the nested-`graphqlErrors` and
+  // legacy message-only shapes that a bare `extensions.code` check misses, so a
+  // pre-#2777 server still gets the gentle toast instead of "Action failed".
+  if (isRateLimitedError(error)) {
     // Rate-limiting is expected user-pacing, not a bug — toast only, no report.
     showToast(t('mobile.queue.rateLimited'), 'error');
   } else {
@@ -894,15 +898,23 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // of the previously-skipped slot can't re-broadcast an item we've moved off.
       pendingUnsyncedCurrentRef.current = null;
       coordinator.trackPendingMutation(correlationId);
-      mutations.setCurrentClimb(item, shouldAddToQueue, correlationId).catch(() => {
-        // In a party session the current-climb change never reached peers —
-        // reconcile against the server (and toast that we refreshed) so this
-        // client's current climb can't silently diverge. Solo keeps the prior
-        // best-effort "Action failed" toast (there's no server to reconcile).
-        if (sessionIdRef.current) {
+      mutations.setCurrentClimb(item, shouldAddToQueue, correlationId).catch((error: unknown) => {
+        // A throttled current-climb change is not a divergence: the rate-limit
+        // gate throws before the resolver runs, so the server still holds the
+        // climb it held a moment ago and the next activation (or any peer's
+        // broadcast) re-establishes it. Resyncing here would yank the user back
+        // to the previous boulder mid-swipe and fire another query into the
+        // limiter that just throttled us — which is what #2763 was reported as
+        // ("the connection fails every time we try to switch boulders"). Show
+        // the gentle "slow down" toast instead and leave the local pointer put.
+        if (sessionIdRef.current && !isRateLimitedError(error)) {
+          // Any other party-session failure means peers really did diverge —
+          // reconcile against the server (and toast that we refreshed).
           void resyncQueueAfterMutationFailure();
         } else {
-          showToast(t('mobile.queue.actionFailed'), 'error');
+          // Solo (no server to reconcile) and the rate-limited party case both
+          // land here: toast only, no resync.
+          showQueueMutationErrorToast(error, t, showToast);
         }
       });
     },

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -669,6 +669,15 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // server and tell the user their queue was refreshed. In solo (no session)
   // the local queue is authoritative, so keep the existing best-effort
   // behaviour: dev-log only, no resync, no toast.
+  //
+  // Callers here (add/remove/setQueue/clearQueue) reconcile on ANY error,
+  // rate limits included. They change queue *content* and have no local
+  // rollback, so skipping reconciliation would leave the item in your queue
+  // and absent from your crew's — permanently and silently. `setCurrentClimb`
+  // deliberately does NOT resync when throttled: it moves a pointer that
+  // self-heals on the next activation or peer broadcast, so reconciling there
+  // only yanked the climber off the boulder they just picked. `reorderQueue`
+  // never reaches this path at all — it rolls back locally instead.
   const resyncQueueAfterMutationFailure = useCallback(async () => {
     if (!sessionIdRef.current) return;
     const refreshed = await resyncQueueFromServerRef.current();


### PR DESCRIPTION
Rebased onto current `main` and rescoped. The original branch was six weeks stale; the unrelated Strava i18n and integrations-registry edits it carried have been dropped, and the `releaseControl` test it added is gone because `releaseControl` no longer exists anywhere in `packages/mobile` or `@boardsesh/queue-react`.

## What was wrong

In a party session, `setCurrentClimb`'s catch called `resyncQueueAfterMutationFailure()` for **every** failure, including `RATE_LIMITED`:

```ts
if (sessionIdRef.current) {
  void resyncQueueAfterMutationFailure();   // ← also fired on RATE_LIMITED
} else {
  showToast(t('mobile.queue.actionFailed'), 'error');
}
```

The rate-limit gate (`applyRateLimit`, `packages/backend/src/graphql/resolvers/shared/helpers.ts:471`) throws *before* the resolver does any work, so a throttled `setCurrentClimb` leaves the server exactly where it was. There is nothing to reconcile. Resyncing anyway did three bad things at once: yanked the climber back to the previous boulder mid-swipe, showed the alarming "Queue was out of sync. Refreshed from your crew." toast, and fired another query into the limiter that had just throttled us.

That is precisely how #2763 was reported — *"Me and my friend tried session, the connection fails everytime we try to switch boulders."*

## What changed

`setCurrentClimb` now routes the rate-limited case to the gentle `mobile.queue.rateLimited` toast and leaves the local pointer alone; the next activation or any peer's broadcast re-establishes it. Every other party-session failure still resyncs.

`showQueueMutationErrorToast` now classifies with the shared `isRateLimitedError()` instead of a bare `extensions.code` check. One definition of "is this a rate limit" across all call sites, and it also catches the nested-`graphqlErrors` and legacy message-only shapes — so a pre-#2777 server gets the gentle toast rather than "Action failed".

No new i18n keys: `mobile.queue.rateLimited` already exists in `en-US`, `es`, and `fr`.

## The sibling catch sites — checked, deliberately left alone

`resyncQueueAfterMutationFailure` has five other callers. I looked at each rather than fixing one and leaving the rest:

| Site | Verdict |
|---|---|
| `addToQueue` | **Keeps resyncing on any error.** Changes queue *content* with no local rollback. Skipping reconciliation would leave the climb in your queue and absent from everyone else's, permanently and silently. |
| `removeFromQueue` | **Keeps resyncing.** Same reasoning — a dropped item would linger on peers. |
| `setQueue` | **Keeps resyncing.** Replaces the whole queue; divergence here is the most visible of all. |
| `clearQueue` | **Keeps resyncing.** Coalesced single resync after `Promise.allSettled`; same content argument. |
| `reorderQueue` | **Already correct.** It rolls back to the pre-reorder order and calls `showQueueMutationErrorToast` — never resyncs. Only missing coverage, which this PR adds. |

The distinction that matters: `setCurrentClimb` moves a *pointer* that self-heals on the next activation or peer broadcast, so dropping the reconciliation costs nothing. The other four change queue *content* with no rollback path, so reconciliation is the only thing keeping the crew's queues consistent. Trading a correct-but-noisy toast for a silent permanent divergence would be a worse bug than the one being fixed.

## Follow-up worth filing separately

At those four content sites, a rate-limited mutation now fires a resync query that is itself likely to be throttled, so `resyncQueueFromServer()` returns falsy and **no toast fires at all** — the user gets silence. Fixing that properly means giving the resync path its own backoff rather than changing which errors reach it, which is a different change from this one. Filed as #3929.

## Testing

- `setCurrentClimb` rate-limited in a party session: keeps the local climb, fires **zero** queue-state refetches, shows the gentle toast, and shows neither `outOfSyncRefreshed` nor `actionFailed`. Verified this fails on `main` without the fix (stash-revert run) — it is a real regression guard, not a vacuous assertion.
- `reorderQueue` rate-limited: shows the gentle toast, not the generic failure. This one passes with and without the fix; it is coverage for existing untested behaviour, as the original PR intended.

## Validation

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 542 files, 4473 tests, all passing
- `vp check` — clean for both touched files

`vp check` does flag `packages/mobile/public/index.html`, which is **pre-existing on `main`** and untouched here (this PR modifies exactly two files). Left for a housekeeping PR.

## Release Notes

Switching boulders in a session no longer throws you back to the previous climb. If you and your crew are flicking through problems fast enough for the server to ask you to slow down, you now get a quiet "Too many changes too fast. Give it a sec." instead of the alarming "Queue was out of sync. Refreshed from your crew." — and your climb stays put.
