### PR TITLE
test(mobile/ble): verify pre-JOIN empty-roster window through derivePreviewOnly

### DIFF
--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -3,6 +3,7 @@ import { act, render, waitFor, cleanup } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createElement, type ReactNode } from 'react';
 import type { ClimbQueueItem } from '@boardsesh/queue';
+import { derivePreviewOnly } from '@boardsesh/queue-runtime';
 import type { BoardSerialConfig } from '@boardsesh/graphql/operations';
 import type { ResolvedBoardEntry } from '../../lib/ble/resolve-serials';
 import type { PickerState } from '../../lib/ble/use-board-bluetooth';
@@ -30,7 +31,10 @@ const queue = vi.hoisted(() => ({
   sessionId: 'session-1' as string | null,
   driverParticipantId: 'participant-self' as string | null,
   participantId: 'participant-self' as string | null,
-  isPartyPreviewOnly: false,
+  // Live roster size — 0 during the pre-JOIN window (unseeded), >1 once JOIN
+  // resolves. Used by the useIsPartyPreviewOnly mock via derivePreviewOnly so
+  // tests exercise the actual gating logic rather than a hand-wired boolean.
+  sessionUserCount: 2,
   lastConnectedBoardSerial: null as string | null,
   confirmClimbOnWall: vi.fn(async () => {}),
   setSessionBoardSerial: vi.fn(async () => {}),
@@ -131,7 +135,15 @@ vi.mock('../queue-provider', () => ({
     confirmClimbOnWall: queue.confirmClimbOnWall,
     setSessionBoardSerial: queue.setSessionBoardSerial,
   }),
-  useIsPartyPreviewOnly: () => queue.isPartyPreviewOnly,
+  // Derive from the real derivePreviewOnly so tests exercise the actual gating
+  // path, including the participantId-null / empty-roster pre-JOIN window.
+  useIsPartyPreviewOnly: () =>
+    derivePreviewOnly({
+      isSessionActive: queue.sessionId !== null,
+      participantId: queue.participantId,
+      driverParticipantId: queue.driverParticipantId,
+      sessionUserCount: queue.sessionUserCount,
+    }),
 }));
 
 const boardDetails = vi.hoisted(() => ({
@@ -199,7 +211,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
     queue.sessionId = 'session-1';
     queue.driverParticipantId = 'participant-self';
     queue.participantId = 'participant-self';
-    queue.isPartyPreviewOnly = false;
+    queue.sessionUserCount = 2;
     queue.lastConnectedBoardSerial = null;
     queue.confirmClimbOnWall.mockClear();
     queue.setSessionBoardSerial.mockClear();
@@ -278,7 +290,6 @@ describe('BluetoothProvider wall-confirm integration', () => {
 
   it('does not auto-send shared climb updates while connected as a party non-driver', async () => {
     queue.driverParticipantId = 'participant-other';
-    queue.isPartyPreviewOnly = true;
 
     renderProvider();
 
@@ -294,7 +305,6 @@ describe('BluetoothProvider wall-confirm integration', () => {
 
   it('starts auto-sending once a connected party participant becomes the driver', async () => {
     queue.driverParticipantId = 'participant-other';
-    queue.isPartyPreviewOnly = true;
     const { rerender } = renderProvider();
 
     await waitFor(() => {
@@ -304,7 +314,6 @@ describe('BluetoothProvider wall-confirm integration', () => {
 
     await act(async () => {
       queue.driverParticipantId = 'participant-self';
-      queue.isPartyPreviewOnly = false;
       rerender(
         createElement(BluetoothProvider, {
           boardName: 'kilter',
@@ -342,7 +351,6 @@ describe('BluetoothProvider wall-confirm integration', () => {
 
     await act(async () => {
       queue.driverParticipantId = 'participant-other';
-      queue.isPartyPreviewOnly = true;
       rerender(
         createElement(BluetoothProvider, {
           boardName: 'kilter',
@@ -365,10 +373,15 @@ describe('BluetoothProvider wall-confirm integration', () => {
   });
 
   it('keeps auto-sending while a restored session is waiting for JOIN to resolve identity', async () => {
+    // Simulate the pre-JOIN window: sessionId is restored from storage (truthy)
+    // but participantId and driverParticipantId are both null, and the roster is
+    // empty (sessionUserCount = 0) because JOIN hasn't returned yet. With an
+    // unseeded roster, derivePreviewOnly must return false so BluetoothAutoSender
+    // mounts and the eventual wall driver can auto-send immediately on JOIN.
     queue.sessionId = 'session-1';
     queue.driverParticipantId = null;
     queue.participantId = null;
-    queue.isPartyPreviewOnly = false;
+    queue.sessionUserCount = 0;
 
     renderProvider();
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The test added in #2774 for the cold-start re-join scenario mocked `isPartyPreviewOnly = false` directly, bypassing `derivePreviewOnly` entirely. The test would pass even if `derivePreviewOnly` had a regression returning `true` for the empty-roster window (`participantId` null, `sessionUserCount = 0`).
- Replaced the hand-wired `isPartyPreviewOnly` boolean mock with a real `derivePreviewOnly` call keyed on `sessionId`/`participantId`/`driverParticipantId`/`sessionUserCount`.
- The restored-session test now sets `sessionUserCount = 0` (unseeded pre-JOIN roster) and exercises the actual gating path, confirming an empty roster allows BLE auto-send regardless of `participantId` being null.
- Non-driver tests simplified: only `driverParticipantId` needs to change — `isPartyPreviewOnly` is derived automatically.

## Test plan

- [ ] `vp test run --project mobile` — all bluetooth-provider tests pass, including the restored-session scenario exercised through the real `derivePreviewOnly`
- [ ] The test `keeps auto-sending while a restored session is waiting for JOIN to resolve identity` now uses `sessionUserCount = 0` rather than a hand-wired `isPartyPreviewOnly = false`, proving the unseeded-roster code path in `derivePreviewOnly` is what keeps BLE unblocked

https://claude.ai/code/session_01T5KKfKJMCHk5FBZSMw4grj
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5KKfKJMCHk5FBZSMw4grj)_