### PR TITLE
fix(mobile/ios): fix pod install failure — add :modular_headers for GoogleUtilities and RecaptchaInterop

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -362,6 +362,12 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       // entitlement-merge ordering concern like the share-intent dedup above —
       // it sets its own distinct keys.
       './plugins/with-healthkit',
+      // AppCheckCore (pulled in by Google Sign-In) is a Swift pod that depends
+      // on GoogleUtilities and RecaptchaInterop, which don't define modules by
+      // default. Without this fix CocoaPods refuses to link them as static
+      // libraries and pod install fails. The plugin patches the generated
+      // Podfile to add :modular_headers => true for both pods.
+      './plugins/with-podfile-app-check-fix',
       // org/project make `expo prebuild` write a valid ios/sentry.properties so
       // the build-phase source-map + dSYM upload can find the Sentry project.
       // The auth token is supplied via the SENTRY_AUTH_TOKEN env var in CI

--- a/packages/mobile/plugins/with-podfile-app-check-fix.js
+++ b/packages/mobile/plugins/with-podfile-app-check-fix.js
@@ -1,0 +1,42 @@
+const { createRunOncePlugin, withDangerousMod } = require('expo/config-plugins');
+const path = require('node:path');
+const fs = require('node:fs');
+
+// AppCheckCore (pulled in by @react-native-google-signin/google-signin via
+// FirebaseAppCheck) is a Swift pod that imports GoogleUtilities and
+// RecaptchaInterop. CocoaPods refuses to link them as static libraries when
+// they don't define modules. Adding :modular_headers => true makes CocoaPods
+// generate module maps for them so AppCheckCore can import them cleanly.
+const PODS = ['GoogleUtilities', 'RecaptchaInterop'];
+const MARKER = '# boardsesh: app-check-modular-headers';
+
+function withPodfileAppCheckFix(config) {
+  return withDangerousMod(config, [
+    'ios',
+    (modConfig) => {
+      const podfilePath = path.join(modConfig.modRequest.platformProjectRoot, 'Podfile');
+      let podfile = fs.readFileSync(podfilePath, 'utf8');
+
+      if (podfile.includes(MARKER)) {
+        return modConfig;
+      }
+
+      const anchor = 'use_expo_modules!';
+      const anchorIndex = podfile.indexOf(anchor);
+      if (anchorIndex === -1) {
+        console.warn('[with-podfile-app-check-fix] use_expo_modules! not found in Podfile — skipping fix.');
+        return modConfig;
+      }
+
+      const insertAfter = anchorIndex + anchor.length;
+      const declarations = PODS.map((pod) => `  pod '${pod}', :modular_headers => true`).join('\n');
+      const insertion = `\n${MARKER}\n${declarations}`;
+
+      podfile = podfile.slice(0, insertAfter) + insertion + podfile.slice(insertAfter);
+      fs.writeFileSync(podfilePath, podfile);
+      return modConfig;
+    },
+  ]);
+}
+
+module.exports = createRunOncePlugin(withPodfileAppCheckFix, 'with-podfile-app-check-fix', '1.0.0');


### PR DESCRIPTION
## Summary

- Adds a new config plugin `with-podfile-app-check-fix.js` that patches the Expo-generated `Podfile` during `expo prebuild`
- Registers the plugin in `app.config.ts` after `with-healthkit`
- The plugin inserts `pod 'GoogleUtilities', :modular_headers => true` and `pod 'RecaptchaInterop', :modular_headers => true` immediately after `use_expo_modules!` in the target block

## Root cause

The `ios-testflight-rn` job was failing at `pod install` with:

```
The Swift pod `AppCheckCore` depends upon `GoogleUtilities` and `RecaptchaInterop`,
which do not define modules. To opt into those targets generating module maps
(which is necessary to import them from Swift when building as static libraries),
you may set `use_modular_headers!` globally in your Podfile, or specify
`:modular_headers => true` for particular dependencies.
```

`AppCheckCore` is pulled in transitively by `@react-native-google-signin/google-signin` (via FirebaseAppCheck). It's a Swift pod that imports `GoogleUtilities` and `RecaptchaInterop`, which are ObjC/C pods that don't generate module maps by default. CocoaPods refuses to link them as static libraries without module maps — hence the hard failure.

## Fix

Adding `:modular_headers => true` to those two explicit pod declarations in the Podfile makes CocoaPods emit module maps, which satisfies `AppCheckCore`'s import requirements. The fix is targeted (two pods only, not `use_modular_headers!` globally) to avoid breaking unrelated pods.

The plugin is idempotent: it checks for a marker comment before patching so repeated `expo prebuild` runs don't double-insert.

## Test plan

- [ ] `ios-testflight-rn` CI job passes `pod install` step
- [ ] Archive + TestFlight upload succeeds end-to-end

https://claude.ai/code/session_01EAF7PWGp5qBzgWHheMrQdv

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAF7PWGp5qBzgWHheMrQdv)_